### PR TITLE
fix: Prevent server crash from malformed response_format schemas

### DIFF
--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -591,8 +591,13 @@ def build_json_system_prompt(
             )
             if description:
                 prompt += f"Purpose: {description}\n"
+            try:
+                schema_str = json.dumps(schema, indent=2)
+            except (TypeError, ValueError) as e:
+                logger.warning(f"Failed to serialize JSON schema: {e}")
+                schema_str = str(schema)
             prompt += (
-                f"\nJSON Schema:\n```json\n{json.dumps(schema, indent=2)}\n```\n\n"
+                f"\nJSON Schema:\n```json\n{schema_str}\n```\n\n"
                 "STRICT RULES:\n"
                 "- Start response with {{ or [\n"
                 "- NO text before or after JSON\n"
@@ -609,8 +614,13 @@ def build_json_system_prompt(
         )
         if description:
             prompt += f"Purpose: {description}\n"
+        try:
+            schema_str = json.dumps(schema, indent=2)
+        except (TypeError, ValueError) as e:
+            logger.warning(f"Failed to serialize JSON schema: {e}")
+            schema_str = str(schema)
         prompt += (
-            f"\nJSON Schema:\n```json\n{json.dumps(schema, indent=2)}\n```\n\n"
+            f"\nJSON Schema:\n```json\n{schema_str}\n```\n\n"
             "RULES:\n"
             "- Start response with { or [\n"
             "- NO text before or after JSON\n"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1514,7 +1514,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Handle response_format - inject system prompt if needed
     response_format = request.response_format
     if response_format:
-        json_instruction = build_json_system_prompt(response_format)
+        try:
+            json_instruction = build_json_system_prompt(response_format)
+        except Exception as e:
+            logger.warning(f"Failed to build JSON system prompt: {e}")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid response_format schema: {e}",
+            )
         if json_instruction:
             # Inject JSON instruction into messages
             messages = _inject_json_instruction(messages, json_instruction)
@@ -1626,12 +1633,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:
         json_input = cleaned_text or output.text
-        _, parsed_json, is_valid, error = parse_json_output(json_input, response_format)
-        if parsed_json is not None:
-            # Return JSON as string
-            cleaned_text = json.dumps(parsed_json)
-        if not is_valid:
-            logger.warning(f"JSON validation failed: {error}")
+        try:
+            _, parsed_json, is_valid, error = parse_json_output(json_input, response_format)
+            if parsed_json is not None:
+                # Return JSON as string
+                cleaned_text = json.dumps(parsed_json)
+            if not is_valid:
+                logger.warning(f"JSON validation failed: {error}")
+        except Exception as e:
+            logger.warning(f"JSON output parsing failed: {e}")
+            # Don't crash — return the raw text as-is
 
     # Determine finish reason
     finish_reason = "tool_calls" if tool_calls else output.finish_reason


### PR DESCRIPTION
## Summary
- Wrap `json.dumps(schema)` in `build_json_system_prompt()` with try/except to gracefully handle unserializable schemas
- Wrap `build_json_system_prompt()` call in server with try/except → returns HTTP 400 instead of 500 crash
- Wrap `parse_json_output()` call in server with try/except → returns raw text instead of crashing

## Context
This is item #3 (Grammar 异常兜底) from the optimization plan. Malformed `response_format` schemas from clients could crash the server with unhandled TypeError/ValueError exceptions.

## Test plan
- [ ] Send request with invalid JSON schema in `response_format` → should get HTTP 400
- [ ] Send request with valid JSON schema → should work as before
- [ ] `pytest tests/` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)