### PR TITLE
fix: Preserve markdown newlines in streaming and fix empty content with Qwen3 parser

### DIFF
--- a/tests/test_streaming_newlines.py
+++ b/tests/test_streaming_newlines.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for streaming markdown newline preservation and reasoning parser behavior.
+
+Reproduces two bugs reported by users:
+1. Markdown newlines stripped in streaming mode (whitespace-only chunks dropped)
+2. Qwen3 reasoning parser eating all content when model doesn't use <think> tags
+
+These tests exercise the reasoning parser directly, independent of the HTTP server.
+"""
+
+import pytest
+
+from vllm_mlx.reasoning import DeltaMessage, get_parser
+
+
+class TestQwen3NoTagStreaming:
+    """Test Qwen3 parser behavior when model output has NO <think> tags.
+
+    Bug: When --reasoning-parser qwen3 is active but the model doesn't
+    emit <think> tags (e.g., 8-bit quantized models that think inline),
+    ALL output goes to reasoning stream and content is empty.
+    """
+
+    @pytest.fixture
+    def parser(self):
+        return get_parser("qwen3")()
+
+    def test_no_tags_streaming_corrected_by_finalize(self, parser):
+        """When no <think> tags appear, finalize_streaming corrects to content.
+
+        During streaming, the base parser defaults all output to reasoning
+        (to support implicit think mode where </think> hasn't arrived yet).
+        At stream end, finalize_streaming detects no tags were ever seen and
+        emits the full text as a content correction.
+        """
+        parser.reset_state()
+
+        text = "Hello! Here is a markdown example:\n\n# Heading\n\n- Item 1\n- Item 2\n"
+
+        accumulated = ""
+        reasoning_parts = []
+
+        for char in text:
+            prev = accumulated
+            accumulated += char
+            result = parser.extract_reasoning_streaming(prev, accumulated, char)
+            if result and result.reasoning:
+                reasoning_parts.append(result.reasoning)
+
+        # During streaming: everything goes to reasoning (correct — can't know
+        # yet whether </think> will come)
+        assert "".join(reasoning_parts) == text
+
+        # finalize_streaming corrects: no tags seen → reclassify as content
+        correction = parser.finalize_streaming(accumulated)
+        assert correction is not None
+        assert correction.content == text
+
+    def test_no_tags_nonstreaming_is_fine(self, parser):
+        """Non-streaming extraction correctly handles no-tag output."""
+        text = "Hello! Here is a markdown example."
+        reasoning, content = parser.extract_reasoning(text)
+        assert reasoning is None
+        assert content == text
+
+    def test_with_tags_still_works(self, parser):
+        """Ensure fix doesn't break normal <think>...</think> flow."""
+        parser.reset_state()
+
+        tokens = ["<think>", "Let me think", "</think>", "The answer is 42."]
+        accumulated = ""
+        content_parts = []
+        reasoning_parts = []
+
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result:
+                if result.content:
+                    content_parts.append(result.content)
+                if result.reasoning:
+                    reasoning_parts.append(result.reasoning)
+
+        assert "Let me think" in "".join(reasoning_parts)
+        assert "The answer is 42." in "".join(content_parts)
+
+    def test_short_no_tags_finalized_as_content(self, parser):
+        """Short no-tag output (under threshold) should be corrected by finalize."""
+        parser.reset_state()
+
+        text = "Short answer."
+        accumulated = ""
+
+        for char in text:
+            prev = accumulated
+            accumulated += char
+            parser.extract_reasoning_streaming(prev, accumulated, char)
+
+        # finalize_streaming should emit correction
+        correction = parser.finalize_streaming(accumulated)
+        assert correction is not None
+        assert correction.content == text
+
+    def test_implicit_mode_still_works(self, parser):
+        """Ensure fix doesn't break implicit mode (only </think> in output)."""
+        parser.reset_state()
+
+        tokens = ["thinking", " about ", "it", "</think>", "The answer."]
+        accumulated = ""
+        content_parts = []
+        reasoning_parts = []
+
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result:
+                if result.content:
+                    content_parts.append(result.content)
+                if result.reasoning:
+                    reasoning_parts.append(result.reasoning)
+
+        assert "thinking about it" in "".join(reasoning_parts)
+        assert "The answer." in "".join(content_parts)
+
+
+class TestNewlinePreservation:
+    """Test that newline-only chunks survive the streaming pipeline.
+
+    Bug: `\n` chunks were being dropped by whitespace suppression,
+    breaking markdown formatting (headings, bullet lists, code blocks).
+    """
+
+    @pytest.fixture
+    def parser(self):
+        return get_parser("qwen3")()
+
+    def test_newline_chunks_in_content(self, parser):
+        """Newlines in content stream should not be dropped."""
+        parser.reset_state()
+
+        # Simulate: <think>ok</think>Hello\n\n# Heading\n
+        tokens = ["<think>", "ok", "</think>", "Hello", "\n", "\n", "# Heading", "\n"]
+        accumulated = ""
+        content_parts = []
+
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result and result.content is not None:
+                content_parts.append(result.content)
+
+        full = "".join(content_parts)
+        # Newlines should be preserved
+        assert "\n\n" in full, f"Double newline lost in streaming. Got: {full!r}"
+        assert "# Heading" in full
+
+    def test_newline_only_delta_not_dropped(self, parser):
+        """A delta that is exactly '\n' should produce content, not be skipped."""
+        parser.reset_state()
+
+        # After think tags, a \n-only delta should be content
+        prev = "<think>x</think>Hello"
+        delta = "\n"
+        curr = prev + delta
+
+        # First process up to "Hello" so parser knows we're past </think>
+        accumulated = ""
+        for char in prev:
+            p = accumulated
+            accumulated += char
+            parser.extract_reasoning_streaming(p, accumulated, char)
+
+        # Now the \n delta
+        result = parser.extract_reasoning_streaming(prev, curr, delta)
+        assert result is not None, "Newline delta should not be None"
+        assert result.content == "\n", f"Expected content='\\n', got {result!r}"
+
+
+class TestDeepSeekNoTagComparison:
+    """Verify DeepSeek-R1 already handles no-tag case correctly (for reference)."""
+
+    @pytest.fixture
+    def parser(self):
+        return get_parser("deepseek_r1")()
+
+    def test_no_tags_streaming_becomes_content(self, parser):
+        """DeepSeek-R1 correctly switches to content after threshold."""
+        parser.reset_state()
+
+        text = "This is a regular response without any thinking tags. It should be content."
+        accumulated = ""
+        content_parts = []
+        reasoning_parts = []
+
+        for char in text:
+            prev = accumulated
+            accumulated += char
+            result = parser.extract_reasoning_streaming(prev, accumulated, char)
+            if result:
+                if result.content:
+                    content_parts.append(result.content)
+                if result.reasoning:
+                    reasoning_parts.append(result.reasoning)
+
+        full_content = "".join(content_parts)
+        # DeepSeek-R1 has NO_TAG_CONTENT_THRESHOLD = 64, so after 64 chars
+        # it starts treating as content
+        assert len(full_content) > 0, "DeepSeek should have content for no-tag output"

--- a/tests/test_streaming_simulator.py
+++ b/tests/test_streaming_simulator.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+End-to-end streaming simulator that reproduces the server's SSE pipeline.
+
+Simulates the full flow: model tokens → reasoning parser → content filtering
+→ SSE emission → client-side reassembly.
+
+Tests three scenarios matching real-world usage:
+1. Normal Qwen3 with <think> tags (should work)
+2. OpenCode implicit think mode (<think> in prompt, only </think> in output)
+3. No-tag model (8-bit quantized, never emits <think> tags)
+4. Markdown with newlines (the original bug report)
+
+Each test checks both the streaming content AND the final assembled output.
+"""
+
+import pytest
+
+from vllm_mlx.reasoning import get_parser
+
+
+def simulate_server_streaming(tokens: list[str], use_reasoning_parser: str = "qwen3"):
+    """
+    Simulate the server's streaming pipeline from server.py.
+
+    This mirrors the actual logic in stream_chat_completion():
+    - Reasoning parser extracts content/reasoning from each delta
+    - Reasoning-only chunks are DROPPED (line 2615: `if not content: continue`)
+    - finalize_streaming correction is emitted at the end
+    - Empty-string content is filtered (line 2729)
+
+    Returns:
+        list of SSE content strings the client would receive
+    """
+    parser = get_parser(use_reasoning_parser)()
+    parser.reset_state()
+
+    accumulated_text = ""
+    sse_chunks = []  # What the client receives as content
+
+    for i, token in enumerate(tokens):
+        delta_text = token
+        is_finished = (i == len(tokens) - 1)
+
+        previous_text = accumulated_text
+        accumulated_text += delta_text
+
+        delta_msg = parser.extract_reasoning_streaming(
+            previous_text, accumulated_text, delta_text
+        )
+
+        if delta_msg is None:
+            continue
+
+        content = delta_msg.content
+        reasoning = delta_msg.reasoning
+
+        # Skip empty-string content (server.py line 2729)
+        if content is not None and content == "":
+            content = None
+
+        # Server line 2615: skip if no content and not finished
+        finish_reason = "stop" if is_finished else None
+        if not content and not finish_reason:
+            continue
+
+        if content:
+            sse_chunks.append(content)
+
+    # Server line 2761: finalize_streaming correction
+    if hasattr(parser, 'finalize_streaming'):
+        correction = parser.finalize_streaming(accumulated_text)
+        if correction and correction.content:
+            sse_chunks.append(correction.content)
+
+    return sse_chunks
+
+
+class TestScenario1_ExplicitThinkTags:
+    """Normal Qwen3 usage with <think>reasoning</think>content."""
+
+    def test_basic_think_then_content(self):
+        """Standard flow: think tags → reasoning extracted, content streamed."""
+        tokens = ["<think>", "Let me ", "analyze.", "</think>", "The ", "answer ", "is 42."]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "The answer is 42." in full
+        assert "<think>" not in full
+        assert "analyze" not in full  # reasoning should NOT be in content
+
+    def test_multiline_reasoning_then_content(self):
+        tokens = [
+            "<think>", "Step 1\n", "Step 2\n", "Step 3\n", "</think>",
+            "# Result\n", "\n", "The answer is **42**.\n",
+        ]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "# Result" in full
+        assert "Step 1" not in full  # reasoning excluded
+        assert "\n" in full  # newlines preserved
+
+
+class TestScenario2_ImplicitThinkMode:
+    """OpenCode injects <think> in prompt. Only </think> appears in output.
+
+    This is the most critical scenario — OpenCode/Cursor/Continue.dev all do this.
+    The model output starts with reasoning text (no <think>), then </think>, then content.
+    """
+
+    def test_short_implicit_reasoning(self):
+        """Short reasoning (< 64 chars) before </think>."""
+        tokens = ["Let ", "me ", "think.", "</think>", "Answer: ", "42"]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "Answer: 42" in full
+        assert "Let me think" not in full  # reasoning excluded from content
+
+    def test_long_implicit_reasoning(self):
+        """Long reasoning (> 64 chars) before </think>.
+
+        This is the critical regression test — the NO_TAG_CONTENT_THRESHOLD
+        must NOT kick in and start routing reasoning as content.
+        """
+        # Generate reasoning > 64 chars
+        reasoning_tokens = [
+            "Let me think about this problem step by step.\n",  # 47 chars
+            "First, I need to consider the constraints.\n",     # 44 chars (total: 91)
+            "Then apply the algorithm.\n",                       # 27 chars (total: 118)
+            "Finally verify the result.\n",                      # 28 chars (total: 146)
+        ]
+        content_tokens = ["The ", "answer ", "is ", "42."]
+
+        tokens = reasoning_tokens + ["</think>"] + content_tokens
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+
+        # Content should have ONLY the actual content
+        assert "The answer is 42." in full
+        # Reasoning should NOT leak into content
+        assert "Let me think" not in full, f"Reasoning leaked into content: {full!r}"
+        assert "constraints" not in full, f"Reasoning leaked into content: {full!r}"
+        assert "algorithm" not in full, f"Reasoning leaked into content: {full!r}"
+
+    def test_very_long_implicit_reasoning(self):
+        """Very long reasoning (> 500 chars) before </think>."""
+        reasoning = "Analyzing step by step. " * 30  # ~720 chars
+        # Break into tokens
+        reasoning_tokens = [reasoning[i:i+20] for i in range(0, len(reasoning), 20)]
+        content_tokens = ["Here is the answer."]
+
+        tokens = reasoning_tokens + ["</think>"] + content_tokens
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+
+        assert "Here is the answer." in full
+        assert "Analyzing" not in full, f"Reasoning leaked: {full!r}"
+
+
+class TestScenario3_NoTagModel:
+    """Model never emits <think> tags (e.g., 8-bit quantized Qwen3).
+
+    This is the original user-reported bug: content is empty because
+    the reasoning parser classifies everything as reasoning.
+    """
+
+    def test_short_no_tag_output(self):
+        """Short output (< 64 chars) with no tags at all."""
+        tokens = ["Hello ", "world!"]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert full == "Hello world!", f"Expected 'Hello world!', got {full!r}"
+
+    def test_long_no_tag_output(self):
+        """Long output (> 64 chars) with no tags — the core bug."""
+        text = "Here is a markdown example:\n\n# Heading\n\n- Item 1\n- Item 2\n\nDone."
+        tokens = [text[i:i+5] for i in range(0, len(text), 5)]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+
+        assert "# Heading" in full, f"Content missing: {full!r}"
+        assert "- Item 1" in full, f"Content missing: {full!r}"
+        assert "Done." in full, f"Content missing: {full!r}"
+        # ALL text should be in content, nothing lost
+        assert full == text, f"Content mismatch:\n  Expected: {text!r}\n  Got:      {full!r}"
+
+    def test_very_long_no_tag_output(self):
+        """Very long output with no tags — no chars should be lost."""
+        text = "The quick brown fox. " * 20  # 420 chars
+        tokens = [text[i:i+10] for i in range(0, len(text), 10)]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert full == text, f"Length mismatch: expected {len(text)}, got {len(full)}"
+
+    def test_no_tag_with_newlines(self):
+        """No-tag output with markdown newlines — the original Reddit bug."""
+        tokens = [
+            "# Title", "\n", "\n",
+            "Some text.", "\n", "\n",
+            "- bullet 1", "\n",
+            "- bullet 2", "\n", "\n",
+            "```python", "\n",
+            "print('hello')", "\n",
+            "```", "\n",
+        ]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+
+        assert "# Title\n\n" in full, f"Heading newlines lost: {full!r}"
+        assert "- bullet 1\n- bullet 2" in full, f"Bullets lost: {full!r}"
+        assert "```python\nprint('hello')\n```" in full, f"Code block lost: {full!r}"
+
+    def test_no_tag_emojis(self):
+        """Emoji characters should pass through correctly."""
+        tokens = ["Hello ", "🎉", " ", "🚀", " world!"]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "🎉" in full
+        assert "🚀" in full
+
+
+class TestScenario4_NewlinePreservation:
+    """Test that newline-only chunks survive the pipeline.
+
+    Original bug: \n chunks were dropped by whitespace suppression.
+    """
+
+    def test_newline_between_paragraphs(self):
+        """Double newline between paragraphs must be preserved."""
+        tokens = ["<think>", "ok", "</think>", "Para 1.", "\n", "\n", "Para 2."]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "Para 1.\n\nPara 2." in full, f"Newlines lost: {full!r}"
+
+    def test_newline_in_markdown_list(self):
+        tokens = ["<think>", "ok", "</think>", "- a", "\n", "- b", "\n", "- c"]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "- a\n- b\n- c" in full
+
+    def test_newline_in_code_block(self):
+        tokens = [
+            "<think>", "ok", "</think>",
+            "```", "\n", "line1", "\n", "line2", "\n", "```",
+        ]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "```\nline1\nline2\n```" in full
+
+
+class TestScenario5_EdgeCases:
+    """Edge cases and mixed scenarios."""
+
+    def test_empty_think_tags(self):
+        """<think></think>content — empty reasoning."""
+        tokens = ["<think>", "</think>", "Just content."]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert full == "Just content."
+
+    def test_deepseek_no_tag_threshold(self):
+        """DeepSeek-R1 should also handle no-tag output correctly."""
+        text = "A regular response without thinking tags, should be content."
+        tokens = [text[i:i+5] for i in range(0, len(text), 5)]
+        chunks = simulate_server_streaming(tokens, use_reasoning_parser="deepseek_r1")
+        full = "".join(chunks)
+        assert full == text, f"DeepSeek no-tag mismatch: {full!r}"
+
+    def test_single_char_no_tag(self):
+        """Single character output, no tags."""
+        chunks = simulate_server_streaming(["Y"], use_reasoning_parser="qwen3")
+        full = "".join(chunks)
+        assert full == "Y"
+
+    def test_whitespace_only_not_emitted_as_content(self):
+        """Pure empty string should be filtered, but whitespace should pass."""
+        tokens = ["<think>", "ok", "</think>", "a", "\n", "\t", "b"]
+        chunks = simulate_server_streaming(tokens)
+        full = "".join(chunks)
+        assert "a\n\tb" in full

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -9,6 +9,7 @@ Supports implicit reasoning mode where <think> is injected in the prompt
 by AI agents (e.g., OpenCode) and only </think> appears in the output.
 """
 
+from .base import DeltaMessage
 from .think_parser import BaseThinkingReasoningParser
 
 
@@ -62,3 +63,27 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
 
         # Use base class implementation (handles both explicit and implicit)
         return super().extract_reasoning(model_output)
+
+    def finalize_streaming(
+        self, accumulated_text: str
+    ) -> DeltaMessage | None:
+        """
+        Finalize streaming output.
+
+        If no tags were ever seen, the base class classified everything as
+        reasoning (to support implicit think mode where <think> is in the
+        prompt). But if </think> never appeared either, the model simply
+        doesn't use think tags — all output should have been content.
+
+        Emit a correction chunk with the full text as content. The server
+        emits this as a final SSE chunk so the client receives the complete
+        response.
+
+        This is safe because:
+        - Explicit think (<think>...<think>content): _saw_any_tag is True, no correction
+        - Implicit think (reasoning</think>content): _saw_any_tag is True, no correction
+        - No tags at all: _saw_any_tag is False, correction emitted
+        """
+        if not self._saw_any_tag and accumulated_text:
+            return DeltaMessage(content=accumulated_text)
+        return None

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2567,10 +2567,6 @@ async def stream_chat_completion(
             if tool_parser and content:
                 if not tool_markup_possible and "<" not in content:
                     tool_accumulated_text += content
-                    # Suppress whitespace-only content when tools are active;
-                    # avoids emitting stray newlines before tool call XML.
-                    if not content.strip():
-                        continue
                 else:
                     if not tool_markup_possible:
                         tool_markup_possible = True
@@ -2728,8 +2724,9 @@ async def stream_chat_completion(
                 content = _think_buffer
                 _think_buffer = ""
 
-            # Skip whitespace-only content chunks (no meaningful content)
-            if content and not content.strip():
+            # Skip empty-string content but preserve whitespace/newlines
+            # (newlines are significant for markdown formatting)
+            if content is not None and content == "":
                 content = None
 
             # Compute finish reason


### PR DESCRIPTION
## Summary

- **Bug 1**: Markdown newlines (`\n`) were stripped in streaming mode — two whitespace suppression locations in `server.py` dropped whitespace-only content chunks, breaking headings, bullet lists, and code blocks
- **Bug 2**: Streaming content was empty when using `--reasoning-parser qwen3` with models that don't emit `<think>` tags (e.g., quantized models) — the base parser classified everything as reasoning, leaving content empty
- Adds `finalize_streaming()` to Qwen3 parser that emits a correction chunk when no think tags were ever seen, safely handling all three modes (explicit think, implicit think/OpenCode, no tags)

## Test plan

- [x] 25 new unit + simulator tests covering all scenarios
- [x] 336 existing reasoning parser tests still pass
- [x] Live server tested with 4 configurations (before/after × with/without reasoning parser)
- [x] Verified: explicit `<think>` mode works, implicit think mode (OpenCode) works, non-streaming unaffected, emoji passthrough works, tool calls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)