### PR TITLE
fix: engine state tracking and None guards for cache layers

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -320,6 +320,7 @@ class BatchedEngine(BaseEngine):
         )
 
         await self._engine.engine.start()
+        self._engine_started = True
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
@@ -337,6 +338,7 @@ class BatchedEngine(BaseEngine):
         self._processor = None
         self._mllm_instance = None
         self._loaded = False
+        self._engine_started = False
         logger.info("BatchedEngine stopped")
 
     def _apply_chat_template(

--- a/vllm_mlx/engine/hybrid.py
+++ b/vllm_mlx/engine/hybrid.py
@@ -110,6 +110,7 @@ class HybridEngine(BaseEngine):
         # State
         self._loaded = False
         self._is_mllm = False
+        self._batched_engine_started: bool = True
 
     @property
     def model_name(self) -> str:
@@ -253,7 +254,7 @@ class HybridEngine(BaseEngine):
                 # Switching to batched mode
                 if self._batched and self._batched._engine:
                     # Start BatchedEngine's engine loop if not started yet (lazy start)
-                    if not getattr(self, "_batched_engine_started", True):
+                    if not self._batched_engine_started:
                         logger.info("HybridEngine: starting BatchedEngine (lazy start)")
                         await self._batched._engine.engine.start()
                         self._batched_engine_started = True

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -74,6 +74,8 @@ def _array_memory(arr) -> int:
     Returns:
         Estimated memory in bytes.
     """
+    if arr is None:
+        return 0
     if hasattr(arr, "shape") and hasattr(arr, "dtype"):
         dtype = arr.dtype
         if hasattr(dtype, "size"):
@@ -104,6 +106,8 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
     total_bytes = 0
 
     for layer_cache in cache:
+        if layer_cache is None:
+            continue
         # Handle different cache object types
         # Check dict first since dicts have .keys() method that would match below
         if isinstance(layer_cache, dict) and "state" in layer_cache:
@@ -273,6 +277,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
 
     trimmed: list[Any] = []
     for layer_cache in cache:
+        if layer_cache is None:
+            trimmed.append(layer_cache)
+            continue
         if QuantizedKVCache is not None and isinstance(layer_cache, QuantizedKVCache):
             tc = QuantizedKVCache.__new__(QuantizedKVCache)
             tc.keys = layer_cache.keys
@@ -298,6 +305,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
 
 def _needs_kv_trim(layer: Any) -> bool:
     """Check if a cache layer has oversized KV arrays (duck-typed, no MLX import)."""
+    if layer is None:
+        return False
     keys = getattr(layer, "keys", None)
     offset = getattr(layer, "offset", None)
     if keys is None or offset is None:
@@ -359,6 +368,9 @@ def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> li
 
     quantized = []
     for layer in cache:
+        if layer is None:
+            quantized.append(layer)
+            continue
         if isinstance(layer, KVCache) and layer.keys is not None:
             quantized.append(layer.to_quantized(group_size=group_size, bits=bits))
         else:
@@ -373,6 +385,9 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
 
     result = []
     for layer in cache:
+        if layer is None:
+            result.append(layer)
+            continue
         if isinstance(layer, QuantizedKVCache) and layer.keys is not None:
             kv = KVCache()
             kv.keys = mx.dequantize(


### PR DESCRIPTION
## Summary
- **BatchedEngine**: `_engine_started` flag not updated in `start()`/`stop()` — state was stale after direct calls
- **HybridEngine**: `_batched_engine_started` relied on `getattr(self, ..., True)` instead of proper `__init__` — replaced with direct attribute
- **memory_cache**: 6 functions that iterate cache layers now guard against `None` entries, preventing AttributeError crashes

## What was reviewed and rejected
These fixes were extracted from 6 external review commits (by GLM-5 via aider). The following changes were rejected:
- `__repr__` methods on 5 dataclasses (cosmetic noise)
- O(1) image index in mllm_cache (premature optimization)
- Removing `sorted()` from image hash functions (broke cache semantics + tests)
- Rewriting test assertions to match broken code
- Security arg pattern removal (weakened defense-in-depth)
- `is_finished` explicit set (broke forward-compatibility)
- Early termination bloat in prefix matching
- SHA256 comment, docstring corruption, cosmetic type changes

## Test plan
- [x] 215 tests pass (hybrid, batched, mllm, memory_cache, security suites)
- [x] No existing test assertions changed


🤖 Generated with [Claude Code](https://claude.com/claude-code)