### PR TITLE
fix: cloud routing + prefix cache for non-trimmable models

### DIFF
--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -316,6 +316,10 @@ class MLXLanguageModel:
         Peeks at the cache overlap to determine how many tokens would need
         prefilling. Used by cloud routing to decide whether to offload.
 
+        For non-trimmable caches (DeltaNet/Mamba), the cache will be
+        recreated from scratch on the next call, so new_tokens == total_tokens
+        regardless of prefix overlap.
+
         Returns:
             (total_tokens, new_tokens) tuple
         """
@@ -328,6 +332,11 @@ class MLXLanguageModel:
         full_token_ids = self.tokenizer.encode(
             prompt, add_special_tokens=add_special_tokens
         )
+
+        # Non-trimmable caches get fully recreated — no prefix reuse
+        if self._prompt_cache is not None and not self._cache_is_trimmable():
+            return len(full_token_ids), len(full_token_ids)
+
         common_len = self._find_common_prefix_len(full_token_ids)
         return len(full_token_ids), len(full_token_ids) - common_len
 

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -326,14 +326,13 @@ class PrefixCacheManager:
                 del parent[tok]
 
     def _can_trim_cache(self, prompt_cache: list[Any]) -> bool:
-        """Check if cache can be trimmed."""
+        """Check if all cache layers can be trimmed."""
         if not prompt_cache:
             return False
-        # Check if first cache layer has is_trimmable method
-        first_cache = prompt_cache[0]
-        if hasattr(first_cache, "is_trimmable"):
-            return first_cache.is_trimmable()
-        return hasattr(first_cache, "trim")
+        return all(
+            c.is_trimmable() if hasattr(c, "is_trimmable") else hasattr(c, "trim")
+            for c in prompt_cache
+        )
 
     def _trim_cache(self, prompt_cache: list[Any], num_tokens: int) -> list[Any]:
         """Trim cache by removing num_tokens from the end."""


### PR DESCRIPTION
## Summary
- `estimate_new_tokens()` now returns full token count for non-trimmable models (DeltaNet/Mamba), since `_prepare_cache_for_prompt()` recreates the cache from scratch — cloud router was incorrectly treating these as cache hits and keeping large requests local
- `PrefixCacheManager._can_trim_cache()` now checks all cache layers instead of only the first — mixed-cache models with trimmable first layer but non-trimmable later layers were returning dirty recurrent state from prefix cache

## Changes
- `vllm_mlx/models/llm.py`: `estimate_new_tokens()` checks `_cache_is_trimmable()` and short-circuits to `new_tokens == total_tokens` when cache will be recreated
- `vllm_mlx/prefix_cache.py`: `_can_trim_cache()` uses `all(...)` over every layer instead of `prompt_cache[0].is_trimmable()`

## Test plan
- [x] 62 existing cache + prefix cache tests pass
- [x] No regressions in full test suite (357 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)