### PR TITLE
fix: cache mutation, CacheList detection, HybridEngine trust_remote_code

### DIFF
--- a/tests/test_cloud_router.py
+++ b/tests/test_cloud_router.py
@@ -446,6 +446,9 @@ class MockCacheEntry:
     def trim(self, amount: int) -> None:
         self._offset = max(0, self._offset - amount)
 
+    def is_trimmable(self) -> bool:
+        return True
+
 
 class TestMLXLanguageModelEstimateNewTokens:
     """Tests for MLXLanguageModel.estimate_new_tokens method."""

--- a/vllm_mlx/engine/hybrid.py
+++ b/vllm_mlx/engine/hybrid.py
@@ -135,7 +135,9 @@ class HybridEngine(BaseEngine):
         logger.info(f"HybridEngine loading shared model: {self._model_name}")
 
         # Load model once using mlx-lm
-        self._shared_model, self._shared_tokenizer = load(self._model_name)
+        self._shared_model, self._shared_tokenizer = load(
+            self._model_name, trust_remote_code=self._trust_remote_code
+        )
 
         # Check if MLLM
         from ..api.utils import is_mllm_model

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -554,7 +554,7 @@ class MemoryAwarePrefixCache:
             excess = n_cached - n_requested
 
             has_non_trimmable = any(
-                not (hasattr(lc, "offset") and hasattr(lc, "keys"))
+                not (lc.is_trimmable() if hasattr(lc, "is_trimmable") else hasattr(lc, "trim"))
                 for lc in best_super.cache
             )
 
@@ -639,7 +639,7 @@ class MemoryAwarePrefixCache:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
             has_non_trimmable = any(
-                not (hasattr(lc, "offset") and hasattr(lc, "keys"))
+                not (lc.is_trimmable() if hasattr(lc, "is_trimmable") else hasattr(lc, "trim"))
                 for lc in best_lcp_entry.cache
             )
             logger.debug(

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -189,8 +189,9 @@ class PrefixCacheManager:
                 self.stats.hits += 1
                 self.stats.tokens_saved += len(tokens)
                 self._touch_lru(tokens_tuple)
-                # No copy needed - MLX arrays are immutable
-                return cache_entry.prompt_cache, []
+                # Deep copy: cache objects have mutable offset/state that
+                # generation will modify in-place, corrupting the stored entry.
+                return copy.deepcopy(cache_entry.prompt_cache), []
 
         if shorter:
             # Shorter prefix cached - return cache and remaining tokens
@@ -200,8 +201,8 @@ class PrefixCacheManager:
                 self.stats.tokens_saved += len(shorter)
                 self._touch_lru(tuple(shorter))
                 remaining = tokens[len(shorter) :]
-                # No copy needed - MLX arrays are immutable
-                return cache_entry.prompt_cache, remaining
+                # Deep copy: same reason as exact match above.
+                return copy.deepcopy(cache_entry.prompt_cache), remaining
 
         if longer:
             # Longer prefix cached - trim to match and return


### PR DESCRIPTION
## Summary

Three P2 bug fixes from code review:

- **prefix_cache.py**: `fetch()` returned live cache objects — generation mutates offset/state in-place, corrupting stored entries for future lookups. Now returns `copy.deepcopy()`.
- **memory_cache.py**: Trimmability check used attribute sniffing (`hasattr(lc, "offset") and hasattr(lc, "keys")`). `CacheList(KVCache, KVCache)` wrappers don't expose these on the outer object, causing false "non-trimmable" classification. Now uses `is_trimmable()` method (consistent with upstream mlx-lm).
- **hybrid.py**: `load()` call on line 138 didn't pass `trust_remote_code`, so models requiring custom code (e.g., Qwen3 with DeltaNet layers) would fail in HybridEngine mode.

## Files changed

- `vllm_mlx/prefix_cache.py` — deep copy on exact and shorter fetch paths
- `vllm_mlx/memory_cache.py` — `is_trimmable()` at lines 556 and 641
- `vllm_mlx/engine/hybrid.py` — pass `trust_remote_code=self._trust_remote_code` to `load()`
- `tests/test_cloud_router.py` — add `is_trimmable()` to `MockCacheEntry`

## Test plan

- [x] 972 tests pass (2 unrelated failures: `test_event_loop` needs running server, `test_platform` needs torch)
- [ ] Manual: verify CacheList-wrapped KVCache models hit prefix cache (previously skipped)
- [ ] Manual: verify HybridEngine loads models with `trust_remote_code=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)