### PR TITLE
test: regression coverage for PR #16 fixes

### DIFF
--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -154,6 +154,54 @@ class TestStart:
             mock_batched._inject_shared_model.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_start_passes_trust_remote_code(self):
+        """Regression: load() must receive trust_remote_code from engine config."""
+        mock_simple = _make_mock_simple()
+        mock_batched = _make_mock_batched()
+        mock_model, mock_tok = MagicMock(), MagicMock()
+        mock_load = MagicMock(return_value=(mock_model, mock_tok))
+
+        with (
+            patch("vllm_mlx.engine.hybrid.load", mock_load),
+            patch("vllm_mlx.api.utils.is_mllm_model", return_value=False),
+            patch("vllm_mlx.engine.hybrid.SimpleEngine", return_value=mock_simple),
+            patch("vllm_mlx.engine.hybrid.BatchedEngine", return_value=mock_batched),
+            patch("vllm_mlx.engine.hybrid.get_registry"),
+        ):
+            from vllm_mlx.engine.hybrid import HybridEngine
+
+            engine = HybridEngine(model_name="test_model", trust_remote_code=True)
+            await engine.start()
+
+            mock_load.assert_called_once_with(
+                "test_model", trust_remote_code=True
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_trust_remote_code_false(self):
+        """trust_remote_code=False must also be forwarded to load()."""
+        mock_simple = _make_mock_simple()
+        mock_batched = _make_mock_batched()
+        mock_model, mock_tok = MagicMock(), MagicMock()
+        mock_load = MagicMock(return_value=(mock_model, mock_tok))
+
+        with (
+            patch("vllm_mlx.engine.hybrid.load", mock_load),
+            patch("vllm_mlx.api.utils.is_mllm_model", return_value=False),
+            patch("vllm_mlx.engine.hybrid.SimpleEngine", return_value=mock_simple),
+            patch("vllm_mlx.engine.hybrid.BatchedEngine", return_value=mock_batched),
+            patch("vllm_mlx.engine.hybrid.get_registry"),
+        ):
+            from vllm_mlx.engine.hybrid import HybridEngine
+
+            engine = HybridEngine(model_name="test_model", trust_remote_code=False)
+            await engine.start()
+
+            mock_load.assert_called_once_with(
+                "test_model", trust_remote_code=False
+            )
+
+    @pytest.mark.asyncio
     async def test_start_mllm_mode(self):
         mock_batched = _make_mock_batched()
         mock_model, mock_tok = MagicMock(), MagicMock()

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -423,6 +423,108 @@ class TestMemoryAwarePrefixCache:
         assert len(cache) <= 3
 
 
+class TestCacheListTrimmability:
+    """Regression tests: CacheList wrappers must be recognized as trimmable."""
+
+    class TrimmableLayer:
+        """Mock layer that reports is_trimmable() = True (like CacheList(KVCache, KVCache))."""
+
+        def __init__(self, key_bytes: int, value_bytes: int, offset: int = 10):
+            self.keys = MockArray(key_bytes)
+            self.values = MockArray(value_bytes)
+            self._offset = offset
+
+        @property
+        def offset(self):
+            return self._offset
+
+        @offset.setter
+        def offset(self, val):
+            self._offset = val
+
+        def is_trimmable(self) -> bool:
+            return True
+
+    class NonTrimmableLayer:
+        """Mock layer that reports is_trimmable() = False (like ArraysCache for DeltaNet)."""
+
+        def __init__(self, nbytes: int = 100):
+            self.keys = MockArray(nbytes)
+            self.values = MockArray(nbytes)
+
+        def is_trimmable(self) -> bool:
+            return False
+
+    @pytest.fixture
+    def model(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def cache(self, model):
+        config = MemoryCacheConfig(max_memory_mb=10, max_entries=10)
+        return MemoryAwarePrefixCache(model, config)
+
+    def test_supersequence_trimmable_cachelist_hits(self, cache):
+        """CacheList with is_trimmable()=True must allow supersequence trim, not skip."""
+        # Store a longer sequence
+        long_tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+        kv = [self.TrimmableLayer(500, 500, offset=8)]
+        cache.store(long_tokens, kv)
+
+        # Fetch a shorter prefix — triggers supersequence path
+        short_tokens = [1, 2, 3, 4, 5]
+        result, remaining = cache.fetch(short_tokens)
+
+        # With the old attribute-sniffing bug, CacheList wrappers (no .offset/.keys
+        # on outer object) would be classified as non-trimmable and this would miss.
+        assert result is not None, (
+            "Supersequence match was skipped — CacheList misclassified as non-trimmable"
+        )
+        assert remaining == []
+
+    def test_supersequence_non_trimmable_skipped(self, cache):
+        """Non-trimmable layers (is_trimmable()=False) must still be skipped."""
+        long_tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+        kv = [self.NonTrimmableLayer()]
+        cache.store(long_tokens, kv)
+
+        short_tokens = [1, 2, 3, 4, 5]
+        result, remaining = cache.fetch(short_tokens)
+
+        # Non-trimmable: should NOT return a supersequence match
+        assert result is None
+        assert remaining == short_tokens
+
+    def test_lcp_trimmable_cachelist_hits(self, cache):
+        """CacheList with is_trimmable()=True must allow LCP trim path."""
+        # Store tokens that share a prefix but diverge
+        stored = [1, 2, 3, 4, 5, 10, 11, 12]
+        kv = [self.TrimmableLayer(500, 500, offset=8)]
+        cache.store(stored, kv)
+
+        # Request tokens that share prefix [1,2,3,4,5] but diverge after
+        requested = [1, 2, 3, 4, 5, 20, 21]
+        result, remaining = cache.fetch(requested)
+
+        # LCP path should find shared prefix and trim excess
+        assert result is not None, (
+            "LCP match was skipped — CacheList misclassified as non-trimmable"
+        )
+        assert remaining == [20, 21]
+
+    def test_lcp_non_trimmable_skipped(self, cache):
+        """Non-trimmable layers must prevent LCP trim path."""
+        stored = [1, 2, 3, 4, 5, 10, 11, 12]
+        kv = [self.NonTrimmableLayer()]
+        cache.store(stored, kv)
+
+        requested = [1, 2, 3, 4, 5, 20, 21]
+        result, remaining = cache.fetch(requested)
+
+        assert result is None
+        assert remaining == requested
+
+
 class TestGetAvailableMemory:
     """Tests for _get_available_memory helper."""
 

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -212,15 +212,44 @@ class TestPrefixCacheManager:
         # Stats should also be reset
         assert cache_manager.stats.hits == 0
 
-    def test_cache_no_copy(self, cache_manager):
-        """Test that fetched cache is a reference (no copy) — MLX arrays are immutable."""
-        original = [[1, 2, 3]]
+    def test_fetch_returns_deep_copy(self, cache_manager):
+        """Test that fetched cache is a deep copy — mutations must not corrupt stored entry."""
+
+        class MutableLayer:
+            def __init__(self, offset):
+                self.offset = offset
+
+        original = [MutableLayer(10)]
         cache_manager.store_cache([1, 2], original)
 
+        # Fetch and mutate the returned copy
         cache, _ = cache_manager.fetch_cache([1, 2])
+        assert cache is not original
+        cache[0].offset = 999
 
-        # Returns the same object (no deep copy overhead)
-        assert cache is original
+        # Fetch again — stored entry must be unchanged
+        cache2, _ = cache_manager.fetch_cache([1, 2])
+        assert cache2[0].offset == 10, "Stored cache entry was corrupted by mutation"
+
+    def test_fetch_shorter_prefix_returns_deep_copy(self, cache_manager):
+        """Test that shorter prefix fetch also returns a deep copy."""
+
+        class MutableLayer:
+            def __init__(self, offset):
+                self.offset = offset
+
+        original = [MutableLayer(20)]
+        cache_manager.store_cache([1, 2, 3], original)
+
+        # Fetch shorter prefix
+        cache, remaining = cache_manager.fetch_cache([1, 2, 3, 4, 5])
+        assert remaining == [4, 5]
+        assert cache is not original
+        cache[0].offset = 999
+
+        # Fetch again — stored entry must be unchanged
+        cache2, _ = cache_manager.fetch_cache([1, 2, 3])
+        assert cache2[0].offset == 20, "Stored cache entry was corrupted by mutation"
 
     def test_multiple_prefixes(self, cache_manager):
         """Test multiple different prefixes."""


### PR DESCRIPTION
## Summary

Adds regression tests covering the three fixes in PR #16 that previously had no dedicated test coverage.

- **test_prefix_cache.py**: 2 new tests — exact match and shorter prefix fetch both return deep copies; mutating returned cache does not corrupt stored entry
- **test_memory_cache.py**: 4 new tests — `TestCacheListTrimmability` class verifies `is_trimmable()` detection in supersequence and LCP paths for both trimmable (CacheList-like) and non-trimmable (ArraysCache-like) layers
- **test_hybrid.py**: 2 new tests — `trust_remote_code=True` and `trust_remote_code=False` both forwarded to `mlx_lm.load()`

## Test plan

- [x] 105 tests pass in the 3 modified files
- [x] 1792 tests pass in full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)