### PR TITLE
fix: MLLM image hash order, per-request sampling, cache deep copy

### DIFF
--- a/tests/test_mllm_cache.py
+++ b/tests/test_mllm_cache.py
@@ -144,10 +144,13 @@ class TestImageHashing:
             path2 = f2.name
 
         try:
-            # Order shouldn't matter (sorted internally)
+            # Order matters: image sequence affects vision embeddings/KV state
             hash_a = compute_images_hash([path1, path2])
             hash_b = compute_images_hash([path2, path1])
-            assert hash_a == hash_b
+            assert hash_a != hash_b, "Different image orders must produce different hashes"
+            # Same order is deterministic
+            hash_c = compute_images_hash([path1, path2])
+            assert hash_a == hash_c
         finally:
             os.unlink(path1)
             os.unlink(path2)
@@ -375,12 +378,8 @@ class TestMLLMCacheManager:
         # Stats should also be reset
         assert cache_manager.stats.hits == 0
 
-    def test_cache_returns_reference(self, cache_manager, temp_image):
-        """Test that fetched cache returns the stored reference.
-
-        Note: For performance, the cache returns direct references to stored
-        KV caches. In practice, MLX arrays are immutable so this is safe.
-        """
+    def test_cache_returns_deep_copy(self, cache_manager, temp_image):
+        """Test that fetched cache returns a deep copy to prevent mutation corruption."""
         original = [[1, 2, 3]]
         cache_manager.store_cache([temp_image], "prompt", original)
 
@@ -389,9 +388,9 @@ class TestMLLMCacheManager:
         assert cache is not None
         assert cache[0] == [1, 2, 3]
 
-        # Cache returns the same reference (for performance)
+        # Each fetch returns an independent deep copy
         cache2, _ = cache_manager.fetch_cache([temp_image], "prompt")
-        assert cache2 is cache  # Same reference
+        assert cache2 is not cache  # Different objects
 
     def test_repr(self, cache_manager):
         """Test string representation."""
@@ -417,13 +416,14 @@ class TestMLLMCacheManager:
             # Store
             cache_manager.store_cache(images, prompt, ["multi_cache"], num_tokens=200)
 
-            # Fetch same images in same order
+            # Fetch same images in same order — should hit
             cache, hit = cache_manager.fetch_cache(images, prompt)
             assert hit is True
 
-            # Fetch same images in different order - should still hit (sorted internally)
+            # Fetch same images in different order — must MISS
+            # (image order affects vision embeddings and KV state)
             cache, hit = cache_manager.fetch_cache([img2, img1], prompt)
-            assert hit is True
+            assert hit is False, "Different image order should produce cache miss"
         finally:
             os.unlink(img1)
             os.unlink(img2)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -649,12 +649,13 @@ class MLLMBatchGenerator:
                 # Run VLM forward pass — cache= flows through to language_model
                 logits = self._run_vision_encoding(req, cache=request_cache)
 
-                # Extract last token logits and sample
+                # Extract last token logits and sample with per-request params
                 last_logits = logits[:, -1, :]
                 logprobs = last_logits - mx.logsumexp(
                     last_logits, axis=-1, keepdims=True
                 )
-                sampled = self.sampler(logprobs)
+                req_sampler = make_sampler(temp=req.temperature, top_p=req.top_p)
+                sampled = req_sampler(logprobs)
 
                 mx.eval(sampled, logprobs)
 
@@ -707,7 +708,10 @@ class MLLMBatchGenerator:
         )
 
     def _step(
-        self, input_tokens: mx.array, cache: list[Any]
+        self,
+        input_tokens: mx.array,
+        cache: list[Any],
+        requests: list[MLLMBatchRequest] | None = None,
     ) -> tuple[mx.array, list[mx.array]]:
         """
         Run one generation step through the language model.
@@ -715,10 +719,13 @@ class MLLMBatchGenerator:
         Args:
             input_tokens: Input tokens [batch_size, 1] or [batch_size]
             cache: BatchKVCache for the language model
+            requests: Per-request data for per-request sampling params
 
         Returns:
             Tuple of (sampled tokens, logprobs list)
         """
+        from mlx_lm.sample_utils import make_sampler
+
         # Ensure correct shape
         if input_tokens.ndim == 1:
             input_tokens = input_tokens[:, None]
@@ -734,9 +741,16 @@ class MLLMBatchGenerator:
 
         logits = logits[:, -1, :]
 
-        # Sample
+        # Sample per-request with correct temperature/top_p
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        sampled = self.sampler(logprobs)
+        if requests and len(requests) == logprobs.shape[0]:
+            sampled_tokens = []
+            for i, req in enumerate(requests):
+                req_sampler = make_sampler(temp=req.temperature, top_p=req.top_p)
+                sampled_tokens.append(req_sampler(logprobs[i : i + 1]))
+            sampled = mx.concatenate(sampled_tokens, axis=0)
+        else:
+            sampled = self.sampler(logprobs)
 
         return sampled, list(logprobs)
 
@@ -776,7 +790,7 @@ class MLLMBatchGenerator:
             return []
 
         y, logprobs = batch.y, batch.logprobs
-        batch.y, batch.logprobs = self._step(y[:, None], batch.cache)
+        batch.y, batch.logprobs = self._step(y[:, None], batch.cache, batch.requests)
         mx.async_eval(batch.y, batch.logprobs)
 
         y = y.tolist()

--- a/vllm_mlx/mllm_cache.py
+++ b/vllm_mlx/mllm_cache.py
@@ -19,6 +19,7 @@ Based on research from:
 - mlx-lm cache_prompt: https://github.com/ml-explore/mlx-lm
 """
 
+import copy
 import hashlib
 import logging
 import time
@@ -173,7 +174,8 @@ def compute_images_hash(images: list[str]) -> str:
         return "no_images"
 
     hashes = [compute_image_hash(img) for img in images]
-    combined = "_".join(sorted(hashes))
+    # Preserve order: image sequence affects vision embeddings and KV state.
+    combined = "_".join(hashes)
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 
@@ -301,7 +303,8 @@ class MLLMPrefixCacheManager:
                 f"MLLM cache HIT: {cache_key[:32]}..., prefix_match={match_length}"
             )
 
-            return entry, match_length
+            # Deep copy: generation mutates kv_cache state in-place.
+            return copy.deepcopy(entry), match_length
 
         # Check for image-only match (can reuse vision embeddings)
         if images:
@@ -320,7 +323,7 @@ class MLLMPrefixCacheManager:
 
                     # Return entry for vision embeddings, but 0 prefix match
                     # (prompt is different, so KV cache can't be reused)
-                    return entry, 0
+                    return copy.deepcopy(entry), 0
 
         self.stats.misses += 1
         logger.debug(f"MLLM cache MISS: {cache_key[:32]}...")
@@ -339,7 +342,8 @@ class MLLMPrefixCacheManager:
         entry, match_len = self.fetch(images, prompt)
         # For legacy API, return hit if entry exists (don't require token match)
         if entry is not None and entry.kv_cache is not None:
-            return entry.kv_cache, True
+            # Deep copy: generation mutates cache state in-place.
+            return copy.deepcopy(entry.kv_cache), True
         return None, False
 
     def store(


### PR DESCRIPTION
## Summary

Three MLLM fixes from code review:

- **[P1] Image hash order**: `compute_images_hash()` sorted per-image hashes before combining — `[img_a, img_b]` and `[img_b, img_a]` produced identical cache keys. Image order is semantically significant (vision embeddings depend on sequence). Now preserves insertion order.

- **[P1] Per-request sampling**: `MLLMBatchGenerator` used a single shared sampler (`temp=0.7, top_p=0.9`) for all requests in the batch, ignoring per-request `temperature`/`top_p`. A request with `temperature=0` still went through stochastic sampling. Now creates per-request samplers via `make_sampler()` in both prefill and decode paths.

- **[P2] Cache deep copy**: `fetch()` and `fetch_cache()` returned live cache objects by reference. Generation mutates KV state in-place, corrupting stored entries for future lookups. Now returns `copy.deepcopy()` on all hit paths (exact, partial/vision-only).

P4 from the review (server.py cloud disconnect guard) was already fixed in PR #18.

## Files changed

- `vllm_mlx/mllm_cache.py` — remove `sorted()`, add `import copy`, deep copy on fetch paths
- `vllm_mlx/mllm_batch_generator.py` — per-request `make_sampler()` in prefill loop, `_step()` accepts `requests` param for per-row sampling
- `tests/test_mllm_cache.py` — update tests: image order now matters, cache returns deep copy

## Test plan

- [x] 1794 tests pass
- [ ] Manual: verify multi-image requests with different orders get different cache keys
- [ ] Manual: verify `temperature=0` requests produce deterministic output in batch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)