### PR TITLE
feat: MTP (Multi-Token Prediction) for SimpleEngine

### DIFF
--- a/scripts/bench_mtp.py
+++ b/scripts/bench_mtp.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Benchmark MTP (Multi-Token Prediction) for SimpleEngine.
+
+Compares decode throughput with and without MTP enabled.
+
+Usage:
+    python3.12 scripts/bench_mtp.py <model_path> [--num-tokens 200] [--warmup 1]
+"""
+
+import argparse
+import asyncio
+import logging
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("bench_mtp")
+
+
+async def run_benchmark(
+    model_path: str,
+    num_tokens: int = 200,
+    warmup: int = 1,
+    num_runs: int = 3,
+):
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    prompt = (
+        "Write a detailed explanation of how neural networks learn "
+        "through backpropagation, including the chain rule, gradient descent, "
+        "and weight updates. Cover both forward and backward passes."
+    )
+
+    results = {}
+
+    for mode_name, enable_mtp, optimistic in [
+        ("baseline (no MTP)", False, False),
+        ("MTP verified", True, False),
+        ("MTP optimistic", True, True),
+    ]:
+        print(f"\n{'='*60}")
+        print(f"  Mode: {mode_name}")
+        print(f"{'='*60}")
+
+        engine = SimpleEngine(
+            model_name=model_path,
+            enable_mtp=enable_mtp,
+            mtp_optimistic=optimistic,
+        )
+        await engine.start()
+
+        mtp_status = "N/A"
+        if enable_mtp and hasattr(engine.model, "_mtp_validated"):
+            mtp_status = "validated" if engine.model._mtp_validated else "FAILED"
+            print(f"  MTP validated: {mtp_status}")
+            if not engine.model._mtp_validated:
+                print("  SKIPPING — MTP not available")
+                await engine.stop()
+                continue
+
+        # Warmup
+        for i in range(warmup):
+            print(f"  Warmup {i+1}/{warmup}...")
+            token_count = 0
+            async for chunk in engine.stream_generate(
+                prompt=prompt,
+                max_tokens=50,
+                temperature=0.7,
+            ):
+                token_count += 1
+                if chunk.finished:
+                    break
+
+        # Benchmark runs
+        run_results = []
+        for run in range(num_runs):
+            # Use slightly different prompts to avoid cache effects
+            run_prompt = f"{prompt} (attempt {run+1})"
+            t0 = time.perf_counter()
+            token_count = 0
+            first_token_time = None
+
+            async for chunk in engine.stream_generate(
+                prompt=run_prompt,
+                max_tokens=num_tokens,
+                temperature=0.7,
+            ):
+                token_count += 1
+                if token_count == 1:
+                    first_token_time = time.perf_counter() - t0
+
+                if chunk.finished:
+                    break
+
+            elapsed = time.perf_counter() - t0
+            decode_time = elapsed - (first_token_time or 0)
+            decode_tokens = token_count - 1 if token_count > 0 else 0
+            tps = decode_tokens / decode_time if decode_time > 0 else 0
+
+            run_results.append({
+                "tokens": token_count,
+                "elapsed": elapsed,
+                "ttft": first_token_time,
+                "decode_time": decode_time,
+                "decode_tokens": decode_tokens,
+                "tps": tps,
+            })
+            print(
+                f"  Run {run+1}: {token_count} tokens, "
+                f"TTFT={first_token_time:.3f}s, "
+                f"decode={tps:.1f} tok/s"
+            )
+
+        await engine.stop()
+
+        # Average results
+        avg_tps = sum(r["tps"] for r in run_results) / len(run_results)
+        avg_ttft = sum(r["ttft"] for r in run_results) / len(run_results)
+        results[mode_name] = {
+            "avg_tps": avg_tps,
+            "avg_ttft": avg_ttft,
+            "runs": run_results,
+        }
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("  SUMMARY")
+    print(f"{'='*60}")
+    print(f"{'Mode':<25} {'Decode tok/s':>15} {'TTFT':>10} {'Speedup':>10}")
+    print("-" * 60)
+
+    baseline_tps = results.get("baseline (no MTP)", {}).get("avg_tps", 0)
+    for mode, data in results.items():
+        speedup = data["avg_tps"] / baseline_tps if baseline_tps > 0 else 0
+        print(
+            f"{mode:<25} {data['avg_tps']:>13.1f} "
+            f"{data['avg_ttft']:>9.3f}s "
+            f"{speedup:>9.2f}x"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark MTP for SimpleEngine")
+    parser.add_argument("model", type=str, help="Model path")
+    parser.add_argument(
+        "--num-tokens", type=int, default=200, help="Max tokens per run (default: 200)"
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=1, help="Warmup runs (default: 1)"
+    )
+    parser.add_argument(
+        "--num-runs", type=int, default=3, help="Benchmark runs (default: 3)"
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        run_benchmark(
+            args.model,
+            num_tokens=args.num_tokens,
+            warmup=args.warmup,
+            num_runs=args.num_runs,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_synthetic_mtp_weights.py
+++ b/scripts/gen_synthetic_mtp_weights.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Generate synthetic MTP weights for speed benchmarking.
+
+Creates random quantized MTP weights matching the model's architecture.
+The predictions will be random, but the code path and timing are valid.
+
+Usage:
+    python3.12 scripts/gen_synthetic_mtp_weights.py <model_path>
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import mlx.core as mx
+
+mx.set_default_device(mx.cpu)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_path", help="Path to MLX model directory")
+    args = parser.parse_args()
+
+    model_dir = Path(args.model_path)
+    config_path = model_dir / "config.json"
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    hidden_size = config["hidden_size"]
+    head_dim = config["head_dim"]
+    num_attention_heads = config["num_attention_heads"]
+    num_key_value_heads = config["num_key_value_heads"]
+    num_experts = config["num_experts"]
+    moe_intermediate_size = config["moe_intermediate_size"]
+    shared_expert_intermediate_size = config["shared_expert_intermediate_size"]
+    vocab_size = config["vocab_size"]
+    rms_norm_eps = config["rms_norm_eps"]
+
+    quant_config = config.get("quantization", {})
+    bits = quant_config.get("bits", 6)
+    group_size = quant_config.get("group_size", 64)
+
+    print(f"Model: {model_dir.name}")
+    print(f"hidden_size={hidden_size}, num_experts={num_experts}")
+    print(f"Quantization: {bits}-bit, group_size={group_size}")
+
+    # MTP weight shapes
+    weights = {}
+
+    # Norms (kept in FP)
+    for name in [
+        "mtp.pre_fc_norm_hidden.weight",
+        "mtp.pre_fc_norm_embedding.weight",
+        "mtp.norm.weight",
+        "mtp.layers.0.input_layernorm.weight",
+        "mtp.layers.0.post_attention_layernorm.weight",
+    ]:
+        weights[name] = mx.ones((hidden_size,))
+        print(f"  FP: {name} {weights[name].shape}")
+
+    # Q/K norm (head_dim)
+    for name in [
+        "mtp.layers.0.self_attn.q_norm.weight",
+        "mtp.layers.0.self_attn.k_norm.weight",
+    ]:
+        weights[name] = mx.ones((head_dim,))
+        print(f"  FP: {name} {weights[name].shape}")
+
+    # FC: 2*hidden_size -> hidden_size
+    fc_weight = mx.random.normal((hidden_size, hidden_size * 2)) * 0.01
+    q_w, q_s, q_b = mx.quantize(fc_weight, group_size=group_size, bits=bits)
+    mx.eval(q_w, q_s, q_b)
+    weights["mtp.fc.weight"] = q_w
+    weights["mtp.fc.scales"] = q_s
+    weights["mtp.fc.biases"] = q_b
+    print(f"  Quantized: mtp.fc.weight {q_w.shape}")
+
+    # Attention projections
+    attn_shapes = {
+        "q_proj": (num_attention_heads * head_dim * 2, hidden_size),
+        "k_proj": (num_key_value_heads * head_dim, hidden_size),
+        "v_proj": (num_key_value_heads * head_dim, hidden_size),
+        "o_proj": (hidden_size, num_attention_heads * head_dim),
+    }
+    for proj_name, (out_dim, in_dim) in attn_shapes.items():
+        key = f"mtp.layers.0.self_attn.{proj_name}.weight"
+        w = mx.random.normal((out_dim, in_dim)) * 0.01
+        q_w, q_s, q_b = mx.quantize(w, group_size=group_size, bits=bits)
+        mx.eval(q_w, q_s, q_b)
+        weights[key] = q_w
+        weights[key.replace(".weight", ".scales")] = q_s
+        weights[key.replace(".weight", ".biases")] = q_b
+        print(f"  Quantized: {key} {q_w.shape}")
+
+    # MoE gate (kept as 8-bit per quant_predicate)
+    gate_w = mx.random.normal((num_experts, hidden_size)) * 0.01
+    q_w, q_s, q_b = mx.quantize(gate_w, group_size=64, bits=8)
+    mx.eval(q_w, q_s, q_b)
+    weights["mtp.layers.0.mlp.gate.weight"] = q_w
+    weights["mtp.layers.0.mlp.gate.scales"] = q_s
+    weights["mtp.layers.0.mlp.gate.biases"] = q_b
+    print(f"  Quantized 8-bit: mtp.layers.0.mlp.gate.weight {q_w.shape}")
+
+    # Shared expert gate (8-bit)
+    se_gate_w = mx.random.normal((1, hidden_size)) * 0.01
+    weights["mtp.layers.0.mlp.shared_expert_gate.weight"] = se_gate_w
+    print(f"  FP: mtp.layers.0.mlp.shared_expert_gate.weight {se_gate_w.shape}")
+
+    # Shared expert MLP
+    for proj in ["gate_proj", "up_proj"]:
+        key = f"mtp.layers.0.mlp.shared_expert.{proj}.weight"
+        w = mx.random.normal((shared_expert_intermediate_size, hidden_size)) * 0.01
+        q_w, q_s, q_b = mx.quantize(w, group_size=group_size, bits=bits)
+        mx.eval(q_w, q_s, q_b)
+        weights[key] = q_w
+        weights[key.replace(".weight", ".scales")] = q_s
+        weights[key.replace(".weight", ".biases")] = q_b
+        print(f"  Quantized: {key} {q_w.shape}")
+
+    key = "mtp.layers.0.mlp.shared_expert.down_proj.weight"
+    w = mx.random.normal((hidden_size, shared_expert_intermediate_size)) * 0.01
+    q_w, q_s, q_b = mx.quantize(w, group_size=group_size, bits=bits)
+    mx.eval(q_w, q_s, q_b)
+    weights[key] = q_w
+    weights[key.replace(".weight", ".scales")] = q_s
+    weights[key.replace(".weight", ".biases")] = q_b
+    print(f"  Quantized: {key} {q_w.shape}")
+
+    # Expert MLP (stacked: [num_experts, intermediate_size, hidden_size])
+    for proj in ["gate_proj", "up_proj"]:
+        key = f"mtp.layers.0.mlp.switch_mlp.{proj}.weight"
+        w = mx.random.normal((num_experts, moe_intermediate_size, hidden_size)) * 0.01
+        q_w, q_s, q_b = mx.quantize(w, group_size=group_size, bits=bits)
+        mx.eval(q_w, q_s, q_b)
+        weights[key] = q_w
+        weights[key.replace(".weight", ".scales")] = q_s
+        weights[key.replace(".weight", ".biases")] = q_b
+        print(f"  Quantized: {key} {q_w.shape}")
+
+    key = "mtp.layers.0.mlp.switch_mlp.down_proj.weight"
+    w = mx.random.normal((num_experts, hidden_size, moe_intermediate_size)) * 0.01
+    q_w, q_s, q_b = mx.quantize(w, group_size=group_size, bits=bits)
+    mx.eval(q_w, q_s, q_b)
+    weights[key] = q_w
+    weights[key.replace(".weight", ".scales")] = q_s
+    weights[key.replace(".weight", ".biases")] = q_b
+    print(f"  Quantized: {key} {q_w.shape}")
+
+    # Save
+    output_file = model_dir / "model-mtp.safetensors"
+    print(f"\nSaving {len(weights)} weight tensors to {output_file}")
+    mx.save_safetensors(str(output_file), weights)
+
+    total_bytes = sum(v.nbytes for v in weights.values())
+    print(f"MTP weights size: {total_bytes / 1e6:.1f} MB")
+
+    # Update index
+    index_path = model_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        with open(index_path) as f:
+            index = json.load(f)
+        for key in weights:
+            index["weight_map"][key] = "model-mtp.safetensors"
+        with open(index_path, "w") as f:
+            json.dump(index, f, indent=2)
+        print(f"Updated index with {len(weights)} MTP entries")
+
+    # Update config
+    config["num_nextn_predict_layers"] = 1
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+    print("Updated config: num_nextn_predict_layers=1")
+
+    print("\nDone! Synthetic MTP weights added for benchmarking.")
+    print("Note: These are random weights — MTP predictions will be random.")
+    print("Use --mtp-optimistic for maximum speed benchmark.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mtp_simple.py
+++ b/tests/test_mtp_simple.py
@@ -1,0 +1,469 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MTP (Multi-Token Prediction) in SimpleEngine.
+
+Uses mock model objects — no real model loading required.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+
+
+class MockCache:
+    """Mock KVCache that supports trim and is_trimmable."""
+
+    def __init__(self, offset=0, trimmable=True):
+        self.offset = offset
+        self._trimmable = trimmable
+        self.state = [None]
+
+    def is_trimmable(self):
+        return self._trimmable
+
+    def trim(self, n):
+        self.offset = max(0, self.offset - n)
+
+    def size(self):
+        return self.offset
+
+
+class _CopyableArray:
+    """Wrapper around mx.array that supports .copy() for snapshot tests."""
+
+    def __init__(self, arr):
+        self._arr = arr
+
+    def copy(self):
+        return _CopyableArray(mx.array(self._arr))
+
+
+class MockRNNCache:
+    """Mock non-trimmable cache (like DeltaNet ArraysCache)."""
+
+    def __init__(self, offset=0):
+        self.offset = offset
+        self.state = [_CopyableArray(mx.zeros((1, 4)))]
+
+    def is_trimmable(self):
+        return False
+
+    def size(self):
+        return self.offset
+
+
+def _make_mock_model(accept=True, return_hidden=True):
+    """Create a mock model that supports MTP operations.
+
+    Args:
+        accept: If True, verify argmax matches draft token.
+        return_hidden: If True, model returns (logits, hidden) tuples.
+    """
+    model = MagicMock()
+
+    # Token ID sequences for deterministic testing
+    primary_id = 42
+    draft_id = 99
+    # If reject, verify disagrees with draft
+    verify_primary_id = draft_id if accept else 55
+
+    def mock_call(input_ids, cache=None, return_hidden=False):
+        seq_len = input_ids.shape[-1]
+        # Logits: make primary_id the argmax
+        logits = mx.zeros((1, seq_len, 100))
+        # Set primary_id position high
+        logits = logits.at[:, :, primary_id].add(10.0)
+
+        if seq_len == 2:
+            # Verify pass: set position 0 to agree/disagree with draft
+            verify_logits = mx.zeros((1, 2, 100))
+            verify_logits = verify_logits.at[:, 0, verify_primary_id].add(10.0)
+            verify_logits = verify_logits.at[:, 1, primary_id].add(10.0)
+            logits = verify_logits
+
+        if return_hidden:
+            hidden = mx.ones((1, seq_len, 64))
+            return logits, hidden
+        return logits
+
+    model.side_effect = mock_call
+    model.__call__ = mock_call
+
+    # mtp_forward: always predicts draft_id
+    def mock_mtp_forward(hidden, token_ids, mtp_cache=None):
+        draft_logits = mx.zeros((1, 1, 100))
+        draft_logits = draft_logits.at[:, :, draft_id].add(10.0)
+        return draft_logits
+
+    model.mtp_forward = mock_mtp_forward
+
+    # MTP validation attributes
+    model.mtp = MagicMock()
+    model.mtp.layers = [MagicMock()]
+    model.make_mtp_cache = MagicMock(return_value=[])
+    model.args = MagicMock()
+    model.args.num_nextn_predict_layers = 1
+
+    return model, primary_id, draft_id
+
+
+def _make_mock_tokenizer(eos_token_id=0):
+    """Create a mock tokenizer."""
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = eos_token_id
+    tokenizer.bos_token = None
+
+    # Mock encode: return list of increasing integers
+    def mock_encode(text, add_special_tokens=True):
+        # Return a simple deterministic sequence
+        return [1, 2, 3, 4, 5]
+
+    tokenizer.encode = mock_encode
+
+    # Mock decode for IncrementalDecoder
+    tokenizer.decode = MagicMock(return_value="hello")
+
+    # Mock _detokenizer_class for IncrementalDecoder
+    mock_detok = MagicMock()
+    mock_detok.return_value = mock_detok
+    mock_detok.last_segment = "x"
+    mock_detok.reset = MagicMock()
+    mock_detok.add_token = MagicMock()
+    mock_detok.finalize = MagicMock()
+    mock_detok.text = "hello world"
+    tokenizer._detokenizer_class = lambda tok: mock_detok
+
+    return tokenizer
+
+
+class TestMTPValidation(unittest.TestCase):
+    """Test _validate_and_setup_mtp."""
+
+    def test_validates_model_with_mtp(self):
+        """Model with valid MTP head should validate."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        llm.model, _, _ = _make_mock_model()
+        llm._loaded = True
+        llm.enable_mtp = True
+
+        with patch("vllm_mlx.patches.qwen3_next_mtp.validate_mtp_support", return_value=True):
+            llm._validate_and_setup_mtp()
+
+        self.assertTrue(llm._mtp_validated)
+
+    def test_fails_validation_gracefully(self):
+        """Model without MTP head should fail gracefully."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        llm.model = MagicMock()
+        llm._loaded = True
+        llm.enable_mtp = True
+
+        with patch("vllm_mlx.patches.qwen3_next_mtp.validate_mtp_support", return_value=False):
+            llm._validate_and_setup_mtp()
+
+        self.assertFalse(llm._mtp_validated)
+
+    def test_warns_when_both_draft_and_mtp(self):
+        """Should warn when both draft model and MTP are set."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model", draft_model="some-draft")
+        llm.model, _, _ = _make_mock_model()
+        llm.draft_model = MagicMock()  # Simulate loaded draft model
+        llm._loaded = True
+        llm.enable_mtp = True
+
+        with patch("vllm_mlx.patches.qwen3_next_mtp.validate_mtp_support", return_value=True):
+            with self.assertLogs("vllm_mlx.models.llm", level="WARNING") as cm:
+                llm._validate_and_setup_mtp()
+
+        self.assertTrue(llm._mtp_validated)
+        self.assertTrue(any("Both MTP and speculative" in msg for msg in cm.output))
+
+
+class TestMTPAccept(unittest.TestCase):
+    """Test MTP generation when verify accepts the draft."""
+
+    def test_yields_two_tokens_per_step(self):
+        """When draft is accepted, both primary and draft should be yielded."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = _make_mock_model(accept=True)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        # Set up cache
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        # Collect tokens (limit to avoid infinite loop)
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=4,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Should have pairs of (primary, draft)
+        self.assertEqual(len(tokens), 4)
+        self.assertEqual(tokens[0], primary_id)
+        self.assertEqual(tokens[1], draft_id)
+
+
+class TestMTPReject(unittest.TestCase):
+    """Test MTP generation when verify rejects the draft."""
+
+    def test_yields_one_token_on_reject(self):
+        """When draft is rejected, only primary should be yielded per step."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = _make_mock_model(accept=False)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=3,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Draft token (99) should NOT appear — only primaries
+        self.assertTrue(draft_id not in tokens)
+        self.assertEqual(len(tokens), 3)
+
+
+class TestMTPRejectHybrid(unittest.TestCase):
+    """Test MTP reject with hybrid cache (KV + RNN)."""
+
+    def test_rnn_restored_on_reject(self):
+        """Hybrid cache: RNN should be restored, KV trimmed by 2 on reject."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = _make_mock_model(accept=False)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        # Hybrid cache: one KV + one RNN
+        kv_cache = MockCache(offset=5, trimmable=True)
+        rnn_cache = MockRNNCache(offset=5)
+        llm._prompt_cache = [kv_cache, rnn_cache]
+        llm._main_cache_len = 2
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=2,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Draft token (99) should NOT appear — only primaries
+        self.assertTrue(draft_id not in tokens)
+
+
+class TestMTPOptimistic(unittest.TestCase):
+    """Test MTP optimistic mode (always accept)."""
+
+    def test_always_yields_two_tokens(self):
+        """Optimistic mode: always yields both primary and draft."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        # Use reject model but optimistic should still accept
+        model, primary_id, draft_id = _make_mock_model(accept=False)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = True
+
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=4,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Even with reject model, optimistic yields 2 per step
+        self.assertEqual(len(tokens), 4)
+        self.assertEqual(tokens[0], primary_id)
+        self.assertEqual(tokens[1], draft_id)
+
+
+class TestMTPEOS(unittest.TestCase):
+    """Test MTP stops on EOS from primary or draft."""
+
+    def test_stops_on_primary_eos(self):
+        """Generation stops when primary token is EOS."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = _make_mock_model(accept=True)
+        llm.model = model
+        # Set EOS to match primary token — will stop immediately
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=primary_id)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=100,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                self.assertEqual(chunk.finish_reason, "stop")
+                break
+
+        # Should stop at first primary token (EOS)
+        self.assertEqual(len(tokens), 1)
+        self.assertEqual(tokens[0], primary_id)
+
+    def test_stops_on_draft_eos(self):
+        """Generation stops when accepted draft token is EOS."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = _make_mock_model(accept=True)
+        llm.model = model
+        # Set EOS to match draft token
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=draft_id)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=100,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                self.assertEqual(chunk.finish_reason, "stop")
+                break
+
+        # Should yield primary then stop at draft (EOS)
+        self.assertEqual(len(tokens), 2)
+        self.assertEqual(tokens[0], primary_id)
+        self.assertEqual(tokens[1], draft_id)
+
+
+class TestMTPFlagPassthrough(unittest.TestCase):
+    """Test that MTP flags flow from CLI → server → engine → model."""
+
+    def test_simple_engine_passes_flags(self):
+        """SimpleEngine should pass MTP flags to MLXLanguageModel."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine(
+            model_name="test-model",
+            enable_mtp=True,
+            mtp_optimistic=True,
+        )
+
+        self.assertTrue(engine._enable_mtp)
+        self.assertTrue(engine._mtp_optimistic)
+
+    def test_server_load_model_passes_flags(self):
+        """load_model should pass MTP flags to SimpleEngine."""
+        with patch("vllm_mlx.server.SimpleEngine") as MockEngine:
+            mock_engine = MagicMock()
+            mock_engine.is_mllm = False
+            mock_engine.preserve_native_tool_format = False
+            MockEngine.return_value = mock_engine
+
+            # Mock asyncio loop
+            with patch("vllm_mlx.server.asyncio") as mock_asyncio:
+                mock_loop = MagicMock()
+                mock_asyncio.new_event_loop.return_value = mock_loop
+
+                from vllm_mlx.server import load_model
+
+                load_model(
+                    "test-model",
+                    use_batching=False,
+                    enable_mtp=True,
+                    mtp_optimistic=True,
+                )
+
+                # Check SimpleEngine was called with MTP flags
+                MockEngine.assert_called_once()
+                call_kwargs = MockEngine.call_args[1]
+                self.assertTrue(call_kwargs["enable_mtp"])
+                self.assertTrue(call_kwargs["mtp_optimistic"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mtp_simple.py
+++ b/tests/test_mtp_simple.py
@@ -2,11 +2,15 @@
 """Tests for MTP (Multi-Token Prediction) in SimpleEngine.
 
 Uses mock model objects — no real model loading required.
+Requires mlx and mlx-lm to be installed (used transitively by the code under test).
 """
 
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+mlx_lm = pytest.importorskip("mlx_lm", reason="mlx-lm required for MTP tests")
 import mlx.core as mx
 
 
@@ -418,6 +422,127 @@ class TestMTPEOS(unittest.TestCase):
         self.assertEqual(len(tokens), 2)
         self.assertEqual(tokens[0], primary_id)
         self.assertEqual(tokens[1], draft_id)
+
+
+class TestMTPErrorRecovery(unittest.TestCase):
+    """Test MTP cache rollback when draft/verify throws an exception."""
+
+    def _make_error_model(self, fail_on_verify=True):
+        """Create a model that raises on the verify pass (seq_len == 2).
+
+        First call (seq_len == 1, primary forward) works normally.
+        Second call (seq_len == 2, verify pass) raises RuntimeError.
+        """
+        model = MagicMock()
+        primary_id = 42
+        draft_id = 99
+        call_count = [0]
+
+        def mock_call(input_ids, cache=None, return_hidden=False):
+            call_count[0] += 1
+            seq_len = input_ids.shape[-1]
+
+            if fail_on_verify and seq_len == 2:
+                raise RuntimeError("Simulated verify failure")
+
+            logits = mx.zeros((1, seq_len, 100))
+            logits = logits.at[:, :, primary_id].add(10.0)
+            if return_hidden:
+                hidden = mx.ones((1, seq_len, 64))
+                return logits, hidden
+            return logits
+
+        model.side_effect = mock_call
+        model.__call__ = mock_call
+
+        def mock_mtp_forward(hidden, token_ids, mtp_cache=None):
+            draft_logits = mx.zeros((1, 1, 100))
+            draft_logits = draft_logits.at[:, :, draft_id].add(10.0)
+            return draft_logits
+
+        model.mtp_forward = mock_mtp_forward
+        model.mtp = MagicMock()
+        model.mtp.layers = [MagicMock()]
+        model.make_mtp_cache = MagicMock(return_value=[])
+        model.args = MagicMock()
+        model.args.num_nextn_predict_layers = 1
+
+        return model, primary_id, draft_id
+
+    def test_kv_cache_rolled_back_on_error(self):
+        """KV cache should be rolled back when verify throws after advancing."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = self._make_error_model(fail_on_verify=True)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        cache = [MockCache(offset=5)]
+        llm._prompt_cache = cache
+        llm._main_cache_len = 1
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=3,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Should still produce tokens (primary only, no draft) via error recovery
+        self.assertEqual(len(tokens), 3)
+        # All tokens should be primary_id (draft never accepted)
+        for t in tokens:
+            self.assertEqual(t, primary_id)
+
+    def test_hybrid_cache_rnn_restored_on_error(self):
+        """Hybrid cache: RNN state should be restored when verify throws."""
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        llm = MLXLanguageModel("test-model")
+        model, primary_id, draft_id = self._make_error_model(fail_on_verify=True)
+        llm.model = model
+        llm.tokenizer = _make_mock_tokenizer(eos_token_id=999)
+        llm._loaded = True
+        llm.enable_mtp = True
+        llm._mtp_validated = True
+        llm.mtp_optimistic = False
+
+        kv_cache = MockCache(offset=5, trimmable=True)
+        rnn_cache = MockRNNCache(offset=5)
+        # Save initial RNN state reference to verify it gets restored
+        initial_rnn_state_val = mx.array(rnn_cache.state[0]._arr)
+
+        llm._prompt_cache = [kv_cache, rnn_cache]
+        llm._main_cache_len = 2
+        llm._cached_token_ids = [1, 2, 3, 4, 5]
+
+        tokens = []
+        for chunk in llm._mtp_generate(
+            suffix_tokens=[5],
+            full_token_ids=[1, 2, 3, 4, 5],
+            max_tokens=2,
+            sampler=lambda lp: mx.argmax(lp, axis=-1),
+            stop=None,
+        ):
+            tokens.append(chunk.token)
+            if chunk.finished:
+                break
+
+        # Should still produce tokens via error recovery
+        self.assertEqual(len(tokens), 2)
+        for t in tokens:
+            self.assertEqual(t, primary_id)
 
 
 class TestMTPFlagPassthrough(unittest.TestCase):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -212,6 +212,9 @@ def serve_command(args):
             print(f"Prefix cache: max_entries={args.prefix_cache_size}")
     else:
         print("Mode: Simple (maximum throughput)")
+        if args.enable_mtp:
+            mode = "optimistic" if args.mtp_optimistic else "verified"
+            print(f"MTP: enabled ({mode} mode)")
 
     # Load model with unified server
     load_model(
@@ -231,6 +234,8 @@ def serve_command(args):
         cloud_threshold=args.cloud_threshold,
         cloud_api_base=args.cloud_api_base,
         cloud_api_key=args.cloud_api_key,
+        enable_mtp=args.enable_mtp if not args.continuous_batching else False,
+        mtp_optimistic=args.mtp_optimistic if not args.continuous_batching else False,
     )
 
     # Start server

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -47,6 +47,8 @@ class SimpleEngine(BaseEngine):
         prefill_step_size: int = 2048,
         kv_bits: int | None = None,
         kv_group_size: int = 64,
+        enable_mtp: bool = False,
+        mtp_optimistic: bool = False,
     ):
         """
         Initialize the simple engine.
@@ -71,6 +73,8 @@ class SimpleEngine(BaseEngine):
         self._prefill_step_size = prefill_step_size
         self._kv_bits = kv_bits
         self._kv_group_size = kv_group_size
+        self._enable_mtp = enable_mtp
+        self._mtp_optimistic = mtp_optimistic
         self._model = None
         self._loaded = False
 
@@ -128,6 +132,10 @@ class SimpleEngine(BaseEngine):
                 kv_bits=self._kv_bits,
                 kv_group_size=self._kv_group_size,
             )
+            # Set MTP flags before load() so validation runs during model load
+            if self._enable_mtp:
+                self._model.enable_mtp = True
+                self._model.mtp_optimistic = self._mtp_optimistic
 
         self._model.load()
         self._loaded = True
@@ -135,8 +143,13 @@ class SimpleEngine(BaseEngine):
         spec_info = ""
         if self._draft_model_name and not self._is_mllm:
             spec_info = f", speculative={self._draft_model_name}"
+        mtp_info = ""
+        if self._enable_mtp and not self._is_mllm:
+            validated = getattr(self._model, "_mtp_validated", False)
+            mode = "optimistic" if self._mtp_optimistic else "verified"
+            mtp_info = f", MTP={'active' if validated else 'failed'}({mode})"
         logger.info(
-            f"SimpleEngine loaded: {self._model_name} (MLLM={self._is_mllm}{spec_info})"
+            f"SimpleEngine loaded: {self._model_name} (MLLM={self._is_mllm}{spec_info}{mtp_info})"
         )
 
     async def stop(self) -> None:
@@ -595,6 +608,9 @@ class SimpleEngine(BaseEngine):
         self._model.model = model
         self._model.tokenizer = tokenizer
         self._model.draft_model = None
+        self._model.enable_mtp = self._enable_mtp
+        self._model.mtp_optimistic = self._mtp_optimistic
+        self._model._mtp_validated = False
         self._model._loaded = True
 
         # Load draft model separately if specified

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -98,6 +98,11 @@ class MLXLanguageModel:
         self._snapshot_prefix_ids: list[int] = []     # token IDs at snapshot time
         self._main_cache_len: int = 0  # number of main model cache layers (excl. draft)
 
+        # MTP (Multi-Token Prediction) — uses model's built-in MTP head
+        self.enable_mtp: bool = False
+        self.mtp_optimistic: bool = False
+        self._mtp_validated: bool = False
+
     def load(self) -> None:
         """Load the model and tokenizer."""
         if self._loaded:
@@ -145,6 +150,11 @@ class MLXLanguageModel:
                 )
 
             self._loaded = True
+
+            # Validate MTP support if enabled
+            if self.enable_mtp:
+                self._validate_and_setup_mtp()
+
             logger.info(f"Model loaded successfully: {self.model_name}")
 
         except ImportError:
@@ -377,6 +387,25 @@ class MLXLanguageModel:
             cache.extend(make_prompt_cache(self.draft_model))
         return cache
 
+    def _validate_and_setup_mtp(self) -> None:
+        """Validate MTP support and set up if available."""
+        from ..patches.qwen3_next_mtp import validate_mtp_support
+
+        if validate_mtp_support(self.model):
+            self._mtp_validated = True
+            if self.draft_model is not None:
+                logger.warning(
+                    "[MTP] Both MTP and speculative decoding (draft model) are enabled. "
+                    "MTP will be used; draft model will be ignored during MTP generation."
+                )
+            logger.info("[MTP] MTP validated and enabled for SimpleEngine")
+        else:
+            self._mtp_validated = False
+            logger.warning(
+                "[MTP] MTP validation failed — --enable-mtp will be ignored. "
+                "Model may not have MTP weights. Run scripts/add_mtp_weights.py."
+            )
+
     def _cache_is_trimmable(self) -> bool:
         """Check if all layers in the prompt cache support trim."""
         from mlx_lm.models.cache import can_trim_prompt_cache
@@ -503,6 +532,297 @@ class MLXLanguageModel:
         common_len = self._find_common_prefix_len(full_token_ids)
         return len(full_token_ids), len(full_token_ids) - common_len
 
+    def _mtp_generate(
+        self,
+        suffix_tokens: list[int],
+        full_token_ids: list[int],
+        max_tokens: int,
+        sampler,
+        stop: list[str] | None = None,
+    ) -> Iterator[StreamingOutput]:
+        """Custom generation loop with MTP (Multi-Token Prediction).
+
+        Uses the model's built-in MTP head for speculative generation:
+        1. Forward pass with return_hidden → (logits, hidden)
+        2. Sample primary token P
+        3. MTP draft: model.mtp_forward(hidden, P) → draft token D
+        4. Always-advance verify: model([P, D], cache) → verify logits
+        5. Accept: yield P + D; Reject: trim cache, yield P only.
+
+        Args:
+            suffix_tokens: Token IDs to prefill (non-cached portion)
+            full_token_ids: Complete prompt token IDs
+            max_tokens: Maximum tokens to generate
+            sampler: Sampling function for primary tokens
+            stop: Optional stop sequences
+        """
+        import copy
+
+        import mlx.core as mx
+        from mlx_lm.sample_utils import make_sampler
+
+        model = self.model
+        main_cache = self._prompt_cache[:self._main_cache_len]
+        is_hybrid = self._is_hybrid_cache()
+        draft_sampler = make_sampler(temp=0.0)
+        decoder = IncrementalDecoder(self.tokenizer, skip_special_tokens=False)
+
+        # Determine EOS token(s)
+        eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
+        eos_token_ids = set()
+        if isinstance(eos_token_id, int):
+            eos_token_ids.add(eos_token_id)
+        elif isinstance(eos_token_id, (list, set)):
+            eos_token_ids.update(eos_token_id)
+        # Also check eos_token_ids attribute (some tokenizers)
+        extra_eos = getattr(self.tokenizer, "eos_token_ids", None)
+        if extra_eos:
+            if isinstance(extra_eos, (list, set)):
+                eos_token_ids.update(extra_eos)
+
+        # Prefill suffix (all but last token)
+        if len(suffix_tokens) > 1:
+            self._prefill_cache(mx.array(suffix_tokens[:-1]))
+
+        # Run last suffix token with return_hidden to start generation
+        last_token = mx.array([[suffix_tokens[-1]]])
+        model_output = model(last_token, cache=main_cache, return_hidden=True)
+        if isinstance(model_output, tuple):
+            logits, hidden = model_output
+        else:
+            # Model doesn't support return_hidden — shouldn't happen if validated
+            raise RuntimeError(
+                "[MTP] model forward did not return hidden states despite validation"
+            )
+        logits = logits[:, -1, :]
+        hidden = hidden[:, -1:, :]
+
+        # Track generation
+        token_count = 0
+        accumulated_text = ""
+        skip_state = None
+        mtp_stats = {"accepted": 0, "rejected": 0, "errors": 0}
+
+        with mx.stream(mx.default_stream(mx.default_device())):
+            while token_count < max_tokens:
+                # --- 1. Get logits + hidden (from skip_state or fresh forward) ---
+                if skip_state is not None:
+                    logits = skip_state["logits"]
+                    hidden = skip_state["hidden"]
+                    skip_state = None
+
+                # --- 2. Sample primary token ---
+                logprobs = logits - mx.logsumexp(logits, keepdims=True)
+                primary = sampler(logprobs[None] if logits.ndim == 1 else logprobs)
+                mx.eval(primary)
+                primary_id = primary.item()
+
+                # Check EOS on primary
+                if primary_id in eos_token_ids:
+                    new_text = decoder.add_token(primary_id)
+                    accumulated_text += new_text
+                    token_count += 1
+                    self._cached_token_ids.append(primary_id)
+                    yield StreamingOutput(
+                        text=new_text,
+                        token=primary_id,
+                        finished=True,
+                        finish_reason="stop",
+                        prompt_tokens=len(full_token_ids),
+                    )
+                    break
+
+                # Yield primary token
+                new_text = decoder.add_token(primary_id)
+                accumulated_text += new_text
+                token_count += 1
+                self._cached_token_ids.append(primary_id)
+
+                # Check stop sequences
+                should_stop = False
+                if stop:
+                    for stop_seq in stop:
+                        if stop_seq in accumulated_text:
+                            should_stop = True
+                            break
+
+                finished = should_stop or token_count >= max_tokens
+                yield StreamingOutput(
+                    text=new_text,
+                    token=primary_id,
+                    finished=finished,
+                    finish_reason="stop" if should_stop else ("length" if token_count >= max_tokens else None),
+                    prompt_tokens=len(full_token_ids),
+                )
+                if finished:
+                    break
+
+                # --- 3. MTP draft ---
+                try:
+                    primary_arr = mx.array([[primary_id]])
+                    draft_logits = model.mtp_forward(
+                        hidden,
+                        primary_arr,
+                        mtp_cache=None,
+                    )
+                    draft_logits = draft_logits[:, -1, :]
+                    draft_logprobs = draft_logits - mx.logsumexp(
+                        draft_logits, axis=-1, keepdims=True
+                    )
+                    draft_token = draft_sampler(draft_logprobs)
+
+                    # --- 4. Snapshot RNN if hybrid ---
+                    rnn_snapshots = {}
+                    if is_hybrid:
+                        for ci, c in enumerate(main_cache):
+                            if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
+                                if hasattr(c, "state"):
+                                    rnn_snapshots[ci] = [
+                                        s.copy() if s is not None else None
+                                        for s in c.state
+                                    ]
+
+                    # --- 5. Always-advance verify [P, D] ---
+                    verify_input = mx.concatenate(
+                        [primary_arr, draft_token[:, None]], axis=1
+                    )
+                    verify_output = model(
+                        verify_input, cache=main_cache, return_hidden=True
+                    )
+                    if isinstance(verify_output, tuple):
+                        verify_logits, verify_hidden = verify_output
+                    else:
+                        verify_logits = verify_output
+                        verify_hidden = None
+
+                    if self.mtp_optimistic:
+                        # --- OPTIMISTIC: always accept ---
+                        mx.eval(draft_token)
+                        draft_id = draft_token.item()
+                        mtp_stats["accepted"] += 1
+
+                        if verify_hidden is not None:
+                            skip_state = {
+                                "logits": verify_logits[:, 1, :],
+                                "hidden": verify_hidden[:, -1:, :],
+                            }
+                            mx.async_eval(skip_state["logits"], skip_state["hidden"])
+
+                    else:
+                        # --- VERIFIED: compare argmax of verify vs draft ---
+                        verify_pred = mx.argmax(verify_logits[:, 0, :], axis=-1)
+                        mx.eval(verify_pred, draft_token)
+                        accepted = verify_pred.item() == draft_token.item()
+                        draft_id = draft_token.item()
+
+                        if accepted and verify_hidden is not None:
+                            # --- ACCEPT ---
+                            skip_state = {
+                                "logits": verify_logits[:, 1, :],
+                                "hidden": verify_hidden[:, -1:, :],
+                            }
+                            mx.async_eval(skip_state["logits"], skip_state["hidden"])
+                            mtp_stats["accepted"] += 1
+                        else:
+                            # --- REJECT ---
+                            mtp_stats["rejected"] += 1
+                            if rnn_snapshots:
+                                # Hybrid: trim KV by 2, restore RNN, re-advance with P
+                                for c in main_cache:
+                                    if hasattr(c, "is_trimmable") and c.is_trimmable():
+                                        c.trim(2)
+                                for ci, snap in rnn_snapshots.items():
+                                    main_cache[ci].state = snap
+                                # Re-advance with primary only
+                                rerun_out = model(
+                                    primary_arr, cache=main_cache, return_hidden=True
+                                )
+                                if isinstance(rerun_out, tuple):
+                                    rerun_logits, rerun_hidden = rerun_out
+                                else:
+                                    rerun_logits = rerun_out
+                                    rerun_hidden = None
+                                if rerun_hidden is not None:
+                                    skip_state = {
+                                        "logits": rerun_logits[:, -1, :],
+                                        "hidden": rerun_hidden[:, -1:, :],
+                                    }
+                                    mx.async_eval(
+                                        skip_state["logits"], skip_state["hidden"]
+                                    )
+                            else:
+                                # Pure attention: trim 1 (remove draft only)
+                                for c in main_cache:
+                                    if hasattr(c, "is_trimmable") and c.is_trimmable():
+                                        c.trim(1)
+                                if verify_hidden is not None:
+                                    skip_state = {
+                                        "logits": verify_logits[:, 0, :],
+                                        "hidden": verify_hidden[:, 0:1, :],
+                                    }
+                                    mx.async_eval(
+                                        skip_state["logits"], skip_state["hidden"]
+                                    )
+                            # Don't yield the draft on reject
+                            continue
+
+                    # --- 6. Yield accepted draft token ---
+                    if draft_id in eos_token_ids:
+                        new_text = decoder.add_token(draft_id)
+                        accumulated_text += new_text
+                        token_count += 1
+                        self._cached_token_ids.append(draft_id)
+                        yield StreamingOutput(
+                            text=new_text,
+                            token=draft_id,
+                            finished=True,
+                            finish_reason="stop",
+                            prompt_tokens=len(full_token_ids),
+                        )
+                        break
+
+                    new_text = decoder.add_token(draft_id)
+                    accumulated_text += new_text
+                    token_count += 1
+                    self._cached_token_ids.append(draft_id)
+
+                    # Check stop sequences after draft
+                    should_stop = False
+                    if stop:
+                        for stop_seq in stop:
+                            if stop_seq in accumulated_text:
+                                should_stop = True
+                                break
+
+                    finished = should_stop or token_count >= max_tokens
+                    yield StreamingOutput(
+                        text=new_text,
+                        token=draft_id,
+                        finished=finished,
+                        finish_reason="stop" if should_stop else ("length" if token_count >= max_tokens else None),
+                        prompt_tokens=len(full_token_ids),
+                    )
+                    if finished:
+                        break
+
+                except Exception as e:
+                    logger.debug(f"[MTP] draft/verify failed: {e}")
+                    mtp_stats["errors"] += 1
+                    skip_state = None
+                    # Fall through to next iteration — model forward will
+                    # be called fresh without skip_state
+
+        # Log MTP stats
+        total = mtp_stats["accepted"] + mtp_stats["rejected"]
+        if total > 0:
+            rate = mtp_stats["accepted"] / total * 100
+            logger.info(
+                f"[MTP] Stats: {mtp_stats['accepted']} accepted, "
+                f"{mtp_stats['rejected']} rejected ({rate:.1f}% accept rate), "
+                f"{mtp_stats['errors']} errors, "
+                f"{token_count} total tokens"
+            )
+
     def stream_generate(
         self,
         prompt: str,
@@ -613,6 +933,24 @@ class MLXLanguageModel:
                 prompt_to_send = full_token_ids
         else:
             prompt_to_send = suffix_tokens
+
+        # MTP path: use custom generation loop when MTP is validated
+        if self.enable_mtp and self._mtp_validated:
+            cache_saved = False
+            try:
+                for chunk in self._mtp_generate(
+                    prompt_to_send, full_token_ids, max_tokens, sampler, stop
+                ):
+                    if chunk.finished:
+                        self._save_cache_snapshot(full_token_ids)
+                        cache_saved = True
+                        yield chunk
+                        break
+                    yield chunk
+            finally:
+                if not cache_saved:
+                    self._save_cache_snapshot(full_token_ids)
+            return
 
         t_first_token = None
         cache_saved = False

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -388,23 +388,47 @@ class MLXLanguageModel:
         return cache
 
     def _validate_and_setup_mtp(self) -> None:
-        """Validate MTP support and set up if available."""
+        """Validate MTP support and set up if available.
+
+        If the model doesn't natively support MTP methods (return_hidden,
+        mtp_forward), tries to monkey-patch them onto the model class.
+        """
         from ..patches.qwen3_next_mtp import validate_mtp_support
 
-        if validate_mtp_support(self.model):
-            self._mtp_validated = True
-            if self.draft_model is not None:
-                logger.warning(
-                    "[MTP] Both MTP and speculative decoding (draft model) are enabled. "
-                    "MTP will be used; draft model will be ignored during MTP generation."
-                )
-            logger.info("[MTP] MTP validated and enabled for SimpleEngine")
-        else:
-            self._mtp_validated = False
+        if not validate_mtp_support(self.model):
+            # Try monkey-patching the model
+            try:
+                from ..patches.qwen3_next_mtp_patch import patch_model_for_mtp
+
+                if patch_model_for_mtp(self.model, model_name=self.model_name):
+                    logger.info("[MTP] Applied monkey-patch to model class")
+                    # Re-validate after patching
+                    if not validate_mtp_support(self.model):
+                        self._mtp_validated = False
+                        logger.warning(
+                            "[MTP] MTP validation failed after patching — "
+                            "--enable-mtp will be ignored."
+                        )
+                        return
+                else:
+                    self._mtp_validated = False
+                    logger.warning(
+                        "[MTP] MTP validation failed — --enable-mtp will be ignored. "
+                        "Model may not have MTP weights. Run scripts/add_mtp_weights.py."
+                    )
+                    return
+            except Exception as e:
+                self._mtp_validated = False
+                logger.warning(f"[MTP] MTP patch failed: {e}")
+                return
+
+        self._mtp_validated = True
+        if self.draft_model is not None:
             logger.warning(
-                "[MTP] MTP validation failed — --enable-mtp will be ignored. "
-                "Model may not have MTP weights. Run scripts/add_mtp_weights.py."
+                "[MTP] Both MTP and speculative decoding (draft model) are enabled. "
+                "MTP will be used; draft model will be ignored during MTP generation."
             )
+        logger.info("[MTP] MTP validated and enabled for SimpleEngine")
 
     def _cache_is_trimmable(self) -> bool:
         """Check if all layers in the prompt cache support trim."""
@@ -610,6 +634,19 @@ class MLXLanguageModel:
                     logits = skip_state["logits"]
                     hidden = skip_state["hidden"]
                     skip_state = None
+                elif token_count > 0:
+                    # No skip_state (error recovery) — need fresh model forward
+                    # Use last token from _cached_token_ids
+                    last_tok = mx.array([[self._cached_token_ids[-1]]])
+                    fresh_out = model(last_tok, cache=main_cache, return_hidden=True)
+                    if isinstance(fresh_out, tuple):
+                        logits, hidden = fresh_out
+                        logits = logits[:, -1, :]
+                        hidden = hidden[:, -1:, :]
+                    else:
+                        raise RuntimeError(
+                            "[MTP] model forward did not return hidden states"
+                        )
 
                 # --- 2. Sample primary token ---
                 logprobs = logits - mx.logsumexp(logits, keepdims=True)
@@ -678,7 +715,7 @@ class MLXLanguageModel:
                             if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
                                 if hasattr(c, "state"):
                                     rnn_snapshots[ci] = [
-                                        s.copy() if s is not None else None
+                                        mx.array(s) if s is not None else None
                                         for s in c.state
                                     ]
 

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -695,6 +695,8 @@ class MLXLanguageModel:
                     break
 
                 # --- 3. MTP draft ---
+                rnn_snapshots = {}
+                cache_advanced_by_verify = False
                 try:
                     primary_arr = mx.array([[primary_id]])
                     draft_logits = model.mtp_forward(
@@ -709,7 +711,6 @@ class MLXLanguageModel:
                     draft_token = draft_sampler(draft_logprobs)
 
                     # --- 4. Snapshot RNN if hybrid ---
-                    rnn_snapshots = {}
                     if is_hybrid:
                         for ci, c in enumerate(main_cache):
                             if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
@@ -723,6 +724,7 @@ class MLXLanguageModel:
                     verify_input = mx.concatenate(
                         [primary_arr, draft_token[:, None]], axis=1
                     )
+                    cache_advanced_by_verify = True
                     verify_output = model(
                         verify_input, cache=main_cache, return_hidden=True
                     )
@@ -846,8 +848,43 @@ class MLXLanguageModel:
                     logger.debug(f"[MTP] draft/verify failed: {e}")
                     mtp_stats["errors"] += 1
                     skip_state = None
-                    # Fall through to next iteration — model forward will
-                    # be called fresh without skip_state
+                    # Roll back cache if verify advanced it by 2 (P + D).
+                    # If error happened before verify, cache is clean.
+                    if cache_advanced_by_verify:
+                        if rnn_snapshots:
+                            # Hybrid: trim KV by 2, restore RNN snapshot
+                            for c in main_cache:
+                                if hasattr(c, "is_trimmable") and c.is_trimmable():
+                                    c.trim(2)
+                            for ci, snap in rnn_snapshots.items():
+                                main_cache[ci].state = snap
+                        else:
+                            # Pure attention: trim 2 to undo verify
+                            for c in main_cache:
+                                if hasattr(c, "is_trimmable") and c.is_trimmable():
+                                    c.trim(2)
+                        # Re-advance with primary only so cache matches
+                        # the token we already emitted
+                        try:
+                            rerun_out = model(
+                                mx.array([[primary_id]]),
+                                cache=main_cache,
+                                return_hidden=True,
+                            )
+                            if isinstance(rerun_out, tuple):
+                                rerun_logits, rerun_hidden = rerun_out
+                                skip_state = {
+                                    "logits": rerun_logits[:, -1, :],
+                                    "hidden": rerun_hidden[:, -1:, :],
+                                }
+                                mx.async_eval(
+                                    skip_state["logits"], skip_state["hidden"]
+                                )
+                        except Exception as e2:
+                            logger.warning(
+                                "[MTP] recovery forward also failed: %s", e2
+                            )
+                    # Fall through to next iteration
 
         # Log MTP stats
         total = mtp_stats["accepted"] + mtp_stats["rejected"]

--- a/vllm_mlx/patches/qwen3_next_mtp_patch.py
+++ b/vllm_mlx/patches/qwen3_next_mtp_patch.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monkey-patch qwen3_next.Model to add MTP (Multi-Token Prediction) support.
+
+Upstream mlx-lm (0.31.x) does not have return_hidden or mtp_forward.
+This module patches the loaded model instance to add these methods when
+MTP weights are present (added via scripts/add_mtp_weights.py or
+scripts/gen_synthetic_mtp_weights.py).
+
+The MTP predictor architecture (from Qwen3-Next):
+1. Norm hidden: pre_fc_norm_hidden(hidden_states)
+2. Norm embed:  pre_fc_norm_embedding(embed_tokens(token_ids))
+3. Combine:     fc(concat([hidden, embed], dim=-1))
+4. Decoder:     layers[0](x, mask, cache)  # single attention + MoE layer
+5. Final norm:  norm(x)
+6. Logits:      lm_head(x)  # shared with main model
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+class MTPPredictor(nn.Module):
+    """MTP predictor module matching Qwen3-Next architecture."""
+
+    def __init__(self, args):
+        super().__init__()
+        from mlx_lm.models.qwen3_next import (
+            Qwen3NextAttention,
+            Qwen3NextSparseMoeBlock,
+        )
+
+        hidden_size = args.hidden_size
+
+        self.pre_fc_norm_hidden = nn.RMSNorm(hidden_size, eps=args.rms_norm_eps)
+        self.pre_fc_norm_embedding = nn.RMSNorm(hidden_size, eps=args.rms_norm_eps)
+        self.fc = nn.Linear(hidden_size * 2, hidden_size, bias=False)
+        self.layers = [_MTPDecoderLayer(args)]
+        self.norm = nn.RMSNorm(hidden_size, eps=args.rms_norm_eps)
+
+
+class _MTPDecoderLayer(nn.Module):
+    """Single MTP decoder layer: attention + MoE MLP."""
+
+    def __init__(self, args):
+        super().__init__()
+        from mlx_lm.models.qwen3_next import (
+            Qwen3NextAttention,
+            Qwen3NextSparseMoeBlock,
+        )
+
+        self.self_attn = Qwen3NextAttention(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.mlp = Qwen3NextSparseMoeBlock(args)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask=mask, cache=cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+def _find_model_dir(model_name: str) -> Optional[Path]:
+    """Resolve model name to a directory path."""
+    p = Path(model_name)
+    if p.is_dir() and (p / "config.json").exists():
+        return p
+    # Try HF cache
+    hf_cache = Path.home() / ".cache" / "huggingface" / "hub"
+    slug = "models--" + model_name.replace("/", "--")
+    cache_dir = hf_cache / slug
+    if cache_dir.exists():
+        snapshots = cache_dir / "snapshots"
+        if snapshots.exists():
+            snaps = sorted(snapshots.iterdir(), key=lambda p: p.stat().st_mtime)
+            if snaps:
+                return snaps[-1]
+    return None
+
+
+def _has_mtp_weights(model_dir: Path) -> bool:
+    """Check if model directory has MTP weight files."""
+    mtp_file = model_dir / "model-mtp.safetensors"
+    if mtp_file.exists():
+        return True
+    # Check index for mtp.* entries
+    index_file = model_dir / "model.safetensors.index.json"
+    if index_file.exists():
+        try:
+            with open(index_file) as f:
+                index = json.load(f)
+            return any(k.startswith("mtp.") for k in index.get("weight_map", {}))
+        except Exception:
+            pass
+    return False
+
+
+def _load_mtp_weights(model_dir: Path) -> dict:
+    """Load MTP weights from model directory."""
+    mtp_file = model_dir / "model-mtp.safetensors"
+    if mtp_file.exists():
+        weights = mx.load(str(mtp_file))
+        return {k: v for k, v in weights.items() if k.startswith("mtp.")}
+    return {}
+
+
+def patch_model_for_mtp(model, model_name: str = None) -> bool:
+    """Monkey-patch a loaded qwen3_next.Model to support MTP.
+
+    Adds return_hidden, mtp_forward, make_mtp_cache methods.
+    Loads MTP weights from model-mtp.safetensors.
+
+    Args:
+        model: Loaded model instance
+        model_name: Model path/name for finding weight files
+
+    Returns True if patch succeeded, False otherwise.
+    """
+    from mlx_lm.models.qwen3_next import Model as Qwen3NextModel
+
+    if not isinstance(model, Qwen3NextModel):
+        logger.warning("[MTP-patch] Model is not qwen3_next.Model, cannot patch")
+        return False
+
+    # Find model directory and check for MTP weights
+    model_dir = None
+    if model_name:
+        model_dir = _find_model_dir(model_name)
+
+    if model_dir is None or not _has_mtp_weights(model_dir):
+        logger.info("[MTP-patch] No MTP weight files found")
+        return False
+
+    # Create MTP module
+    args = model.args
+    try:
+        mtp = MTPPredictor(args)
+    except Exception as e:
+        logger.warning(f"[MTP-patch] Failed to create MTP module: {e}")
+        return False
+
+    # Load MTP weights from disk
+    mtp_weights = _load_mtp_weights(model_dir)
+    if not mtp_weights:
+        logger.warning("[MTP-patch] No MTP weights found in safetensors")
+        return False
+
+    # Strip "mtp." prefix — MTPPredictor's parameters don't have it
+    stripped = {k[4:]: v for k, v in mtp_weights.items() if k.startswith("mtp.")}
+    if not stripped:
+        stripped = mtp_weights  # fallback if keys don't have prefix
+
+    # Quantize the MTP module to match model's quantization config
+    # This converts nn.Linear → nn.QuantizedLinear so weights load properly
+    try:
+        quant_config = getattr(args, "quantization", None)
+        if quant_config is None:
+            # Try reading from config.json directly
+            config_path = model_dir / "config.json"
+            if config_path.exists():
+                import json as _json
+
+                with open(config_path) as f:
+                    cfg = _json.load(f)
+                quant_config = cfg.get("quantization", {})
+
+        if quant_config:
+            bits = quant_config.get("bits", 4)
+            group_size = quant_config.get("group_size", 64)
+
+            def _quant_predicate(path, module):
+                # shared_expert_gate is tiny (1, hidden) — keep FP
+                if "shared_expert_gate" in path:
+                    return False
+                if isinstance(module, nn.Linear):
+                    # MoE gate uses 8-bit
+                    if "gate" in path and "gate_proj" not in path:
+                        return {"group_size": 64, "bits": 8}
+                    return {"group_size": group_size, "bits": bits}
+                # SwitchLinear (expert stacked weights) — also quantize
+                if hasattr(module, "to_quantized") and not isinstance(
+                    module, nn.Linear
+                ):
+                    return {"group_size": group_size, "bits": bits}
+                return False
+
+            nn.quantize(mtp, class_predicate=_quant_predicate)
+            logger.info(
+                f"[MTP-patch] Quantized MTP module: {bits}-bit, group_size={group_size}"
+            )
+    except Exception as e:
+        logger.warning(f"[MTP-patch] Failed to quantize MTP module: {e}")
+        return False
+
+    # Load weights into the MTP module
+    try:
+        mtp.load_weights(list(stripped.items()))
+        mx.eval(mtp.parameters())
+        logger.info(f"[MTP-patch] Loaded {len(stripped)} MTP weights")
+    except Exception as e:
+        logger.warning(f"[MTP-patch] Failed to load MTP weights: {e}")
+        return False
+
+    # Attach MTP module to model
+    model.mtp = mtp
+
+    # Patch __call__ to support return_hidden
+    def patched_call(self, inputs, cache=None, return_hidden=False):
+        hidden = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(hidden)
+        else:
+            out = self.lm_head(hidden)
+        if return_hidden:
+            return out, hidden
+        return out
+
+    type(model).__call__ = patched_call
+
+    # Add mtp_forward method
+    def mtp_forward(self, hidden_states, token_ids, mtp_cache=None):
+        """Predict next-next token from hidden states + current token."""
+        from mlx_lm.models.base import create_attention_mask
+
+        emb = self.model.embed_tokens(token_ids)
+        h = self.mtp.pre_fc_norm_hidden(hidden_states)
+        e = self.mtp.pre_fc_norm_embedding(emb)
+        x = self.mtp.fc(mx.concatenate([h, e], axis=-1))
+
+        mask = None
+        if mtp_cache is not None:
+            mask = create_attention_mask(x, mtp_cache)
+
+        for layer in self.mtp.layers:
+            x = layer(x, mask=mask, cache=mtp_cache)
+
+        x = self.mtp.norm(x)
+
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(x)
+        else:
+            logits = self.lm_head(x)
+
+        return logits
+
+    type(model).mtp_forward = mtp_forward
+
+    def make_mtp_cache(self):
+        from mlx_lm.models.cache import KVCache
+        return KVCache()
+
+    type(model).make_mtp_cache = make_mtp_cache
+
+    logger.info("[MTP-patch] Successfully patched model with MTP support")
+    return True

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -669,6 +669,8 @@ def load_model(
     cloud_threshold: int = 20000,
     cloud_api_base: str | None = None,
     cloud_api_key: str | None = None,
+    enable_mtp: bool = False,
+    mtp_optimistic: bool = False,
 ):
     """
     Load a model (auto-detects MLLM vs LLM).
@@ -762,6 +764,8 @@ def load_model(
             prefill_step_size=prefill_step_size,
             kv_bits=kv_bits,
             kv_group_size=kv_group_size,
+            enable_mtp=enable_mtp,
+            mtp_optimistic=mtp_optimistic,
         )
         # Start SimpleEngine synchronously (no background loop)
         # Use new_event_loop() for Python 3.10+ compatibility (get_event_loop() is deprecated)


### PR DESCRIPTION
## Summary
- Implement native MTP generation loop in `MLXLanguageModel._mtp_generate()` that uses the model's built-in MTP head for speculative generation (no separate draft model needed)
- Wire `--enable-mtp` and `--mtp-optimistic` flags through CLI → server → SimpleEngine → MLXLanguageModel
- Graceful degradation: validates MTP support at load time, falls back to standard generation if model lacks MTP weights

## Architecture
Always-advance strategy (same as BatchedEngine in scheduler.py):
1. Forward with `return_hidden=True` → (logits, hidden)
2. Sample primary token P
3. MTP draft: `model.mtp_forward(hidden, P)` → draft token D
4. Verify: `model([P, D], cache)` — cache always advances by 2
5. **Accept**: yield P + D, save skip_state for next iteration
6. **Reject (hybrid)**: trim KV by 2, restore RNN snapshot, re-advance with P only
7. **Reject (pure attn)**: trim KV by 1, yield P only

## Files Changed
- `vllm_mlx/models/llm.py` — Core: MTP fields, validation, `_mtp_generate()` loop, dispatch in `stream_generate()`
- `vllm_mlx/engine/simple.py` — Pass MTP flags, set on model before load
- `vllm_mlx/server.py` — Add `enable_mtp`/`mtp_optimistic` params to `load_model()`
- `vllm_mlx/cli.py` — Wire MTP flags for simple mode, print MTP info
- `tests/test_mtp_simple.py` — 11 unit tests (validation, accept, reject, hybrid, optimistic, EOS, passthrough)

## Test plan
- [x] `python3.12 -m pytest tests/test_mtp_simple.py -v` — 11/11 pass
- [x] Existing test suite: 384 passed (only pre-existing integration test failure)
- [x] Verified graceful degradation with real Qwen3.5-4B model (no MTP weights)
- [ ] Manual benchmark with MTP-weight-equipped model (needs `scripts/add_mtp_weights.py` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)