### PR TITLE
fix: stream reasoning field in SSE chunks

### DIFF
--- a/reports/benchmarks/qwen35-397b-rapid-mlx.json
+++ b/reports/benchmarks/qwen35-397b-rapid-mlx.json
@@ -1,0 +1,34 @@
+[
+  {
+    "engine": "Rapid-MLX",
+    "model": "Qwen3.5-397B-A17B-MLX-4bit",
+    "short_decode_tps": {
+      "mean": 39.54474613583086,
+      "median": 39.553954385672824,
+      "min": 39.50068110177305,
+      "max": 39.57960292004672
+    },
+    "short_prefill_tps": {
+      "median": 58.195267808119404
+    },
+    "long_decode_tps": {
+      "mean": 39.00918111186134,
+      "median": 39.00955075174291,
+      "min": 38.95677489223004,
+      "max": 39.06121769161108
+    },
+    "long_prefill_tps": {
+      "median": 150.23963579083107
+    },
+    "ttft_cold_s": 10.115505958994618,
+    "ttft_cached_s": 0.28117829150141915,
+    "multi_turn_ttft_cold_s": 13.733129667001776,
+    "multi_turn_ttft_cached_s": 17.712871395495313,
+    "peak_ram_mb": 117082.609375,
+    "tool_call_rate": 1.0,
+    "recovery_rate": 1.0,
+    "leak_rate": 0.0,
+    "vision": true,
+    "audio": false
+  }
+]

--- a/reports/benchmarks/qwen35-397b-realworld.json
+++ b/reports/benchmarks/qwen35-397b-realworld.json
@@ -1,0 +1,132 @@
+{
+  "model": "Qwen3.5-397B",
+  "tasks": [
+    {
+      "name": "Simple arithmetic: 1234 * 5678",
+      "elapsed": 20.038540124995052,
+      "tps": 24.951917499036046,
+      "completion_tokens": 500,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Word problem: train speed",
+      "elapsed": 24.215951374993892,
+      "tps": 33.03607558553754,
+      "completion_tokens": 800,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Probability: dice problem",
+      "elapsed": 16.355340374997468,
+      "tps": 30.57105437954405,
+      "completion_tokens": 500,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Calculus: derivative of x^3 * sin(x)",
+      "elapsed": 18.191441457995097,
+      "tps": 32.98254299338667,
+      "completion_tokens": 600,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Python: merge two sorted lists",
+      "elapsed": 25.51361895899754,
+      "tps": 30.689491806644313,
+      "completion_tokens": 783,
+      "tool_calls": [],
+      "has_reasoning": true
+    },
+    {
+      "name": "Debug: off-by-one in binary search",
+      "elapsed": 25.771706834013457,
+      "tps": 31.041793434657624,
+      "completion_tokens": 800,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "System design: rate limiter",
+      "elapsed": 35.23762433300726,
+      "tps": 34.05450914226229,
+      "completion_tokens": 1200,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Haiku about programming",
+      "elapsed": 11.948964708004496,
+      "tps": 25.10677764401069,
+      "completion_tokens": 300,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Short story: AI awakening (200 words)",
+      "elapsed": 19.878441582986852,
+      "tps": 30.183452636121917,
+      "completion_tokens": 600,
+      "tool_calls": [],
+      "has_reasoning": false
+    },
+    {
+      "name": "Single tool: weather query",
+      "elapsed": 8.649890457993024,
+      "tps": 10.520364441830644,
+      "completion_tokens": 91,
+      "tool_calls": [
+        "get_weather"
+      ],
+      "has_reasoning": false
+    },
+    {
+      "name": "Tool selection: search vs weather",
+      "elapsed": 7.4740760829881765,
+      "tps": 8.161543891537677,
+      "completion_tokens": 61,
+      "tool_calls": [
+        "web_search"
+      ],
+      "has_reasoning": false
+    },
+    {
+      "name": "Complex tool: code execution",
+      "elapsed": 8.695297292011674,
+      "tps": 11.615474043974114,
+      "completion_tokens": 101,
+      "tool_calls": [
+        "run_python"
+      ],
+      "has_reasoning": false
+    },
+    {
+      "name": "Multi-turn: follow-up question",
+      "elapsed": 17.067892624996603,
+      "tps": 27.244136708417603,
+      "completion_tokens": 465,
+      "tool_calls": [],
+      "has_reasoning": true
+    },
+    {
+      "name": "Multi-turn tool: weather then compare",
+      "elapsed": 8.64196283298952,
+      "tps": 9.48858512639931,
+      "completion_tokens": 82,
+      "tool_calls": [
+        "get_weather"
+      ],
+      "has_reasoning": false
+    }
+  ],
+  "summary": {
+    "total_tasks": 14,
+    "total_tokens": 6883,
+    "total_time": 247.6807490409701,
+    "avg_tps": 24.260551380954322,
+    "overall_tps": 27.789806138148624
+  }
+}

--- a/scripts/benchmark_realworld.py
+++ b/scripts/benchmark_realworld.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Real-world task benchmark for large models.
+
+Tests: math reasoning, coding, creative writing, complex tool calls, multi-turn.
+Measures quality + speed for each task category.
+"""
+
+import json
+import time
+
+import httpx
+
+BASE_URL = "http://localhost:8012/v1/chat/completions"
+MODEL = "Qwen3.5-397B"
+
+BENCHMARK_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web for information",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_python",
+            "description": "Execute Python code and return the output",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string"},
+                },
+                "required": ["code"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read contents of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Write content to a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+
+def run_task(name, messages, max_tokens=1000, tools=None, temperature=0.0):
+    """Run a single task and return results."""
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if tools:
+        payload["tools"] = tools
+
+    start = time.perf_counter()
+    r = httpx.post(BASE_URL, json=payload, timeout=300)
+    elapsed = time.perf_counter() - start
+    data = r.json()
+
+    usage = data["usage"]
+    msg = data["choices"][0]["message"]
+    content = msg.get("content", "")
+    reasoning = msg.get("reasoning", "")
+    tool_calls = msg.get("tool_calls", [])
+    finish = data["choices"][0].get("finish_reason", "")
+    tps = usage["completion_tokens"] / elapsed if elapsed > 0 else 0
+
+    return {
+        "name": name,
+        "elapsed": elapsed,
+        "tps": tps,
+        "prompt_tokens": usage["prompt_tokens"],
+        "completion_tokens": usage["completion_tokens"],
+        "content": content,
+        "reasoning": reasoning,
+        "tool_calls": tool_calls,
+        "finish_reason": finish,
+    }
+
+
+def print_result(r, check_fn=None):
+    """Print task result."""
+    status = ""
+    if check_fn:
+        passed = check_fn(r)
+        status = " ✓" if passed else " ✗"
+
+    tc_info = ""
+    if r["tool_calls"]:
+        names = [tc["function"]["name"] for tc in r["tool_calls"]]
+        tc_info = f"  tools=[{', '.join(names)}]"
+
+    reasoning_info = ""
+    if r["reasoning"]:
+        reasoning_info = f"  reasoning={len(r['reasoning'])}c"
+
+    print(
+        f"  {r['name']:<50} {r['completion_tokens']:>4} tok  "
+        f"{r['elapsed']:>6.1f}s  {r['tps']:>5.1f} tok/s{status}{tc_info}{reasoning_info}"
+    )
+
+
+def main():
+    print("=" * 90)
+    print("  Qwen3.5-397B Real-World Task Benchmark")
+    print("=" * 90)
+    results = []
+
+    # === 1. Math Reasoning ===
+    print("\n--- Math Reasoning ---")
+
+    r = run_task(
+        "Simple arithmetic: 1234 * 5678",
+        [{"role": "user", "content": "What is 1234 * 5678? Show your work."}],
+        max_tokens=500,
+    )
+    print_result(r, lambda r: "7006652" in (r["content"] or ""))
+    results.append(r)
+
+    r = run_task(
+        "Word problem: train speed",
+        [
+            {
+                "role": "user",
+                "content": "A train travels from city A to city B at 60 km/h and returns at 40 km/h. "
+                "The distance is 120 km. What is the average speed for the round trip? "
+                "Show the calculation step by step.",
+            }
+        ],
+        max_tokens=800,
+    )
+    print_result(r, lambda r: "48" in (r["content"] or ""))
+    results.append(r)
+
+    r = run_task(
+        "Probability: dice problem",
+        [
+            {
+                "role": "user",
+                "content": "You roll two fair six-sided dice. What is the probability that their sum is 7? "
+                "Express as a fraction.",
+            }
+        ],
+        max_tokens=500,
+    )
+    print_result(r, lambda r: "1/6" in (r["content"] or "").replace(" ", ""))
+    results.append(r)
+
+    r = run_task(
+        "Calculus: derivative of x^3 * sin(x)",
+        [
+            {
+                "role": "user",
+                "content": "Find the derivative of f(x) = x^3 * sin(x). Show the product rule application.",
+            }
+        ],
+        max_tokens=600,
+    )
+    print_result(r, lambda r: "cos" in (r["content"] or "").lower())
+    results.append(r)
+
+    # === 2. Coding ===
+    print("\n--- Coding ---")
+
+    r = run_task(
+        "Python: merge two sorted lists",
+        [
+            {
+                "role": "user",
+                "content": "Write a Python function to merge two sorted lists into one sorted list. "
+                "Include type hints and a few test cases.",
+            }
+        ],
+        max_tokens=800,
+    )
+    print_result(r, lambda r: "def merge" in (r["content"] or "").lower() or "def merge" in (r["reasoning"] or "").lower())
+    results.append(r)
+
+    r = run_task(
+        "Debug: off-by-one in binary search",
+        [
+            {
+                "role": "user",
+                "content": """Find and fix the bug in this binary search:
+```python
+def binary_search(arr, target):
+    left, right = 0, len(arr)
+    while left < right:
+        mid = (left + right) // 2
+        if arr[mid] == target:
+            return mid
+        elif arr[mid] < target:
+            left = mid
+        else:
+            right = mid
+    return -1
+```
+Explain the bug and provide the corrected code.""",
+            }
+        ],
+        max_tokens=800,
+    )
+    print_result(r, lambda r: "left = mid + 1" in (r["content"] or "") or "mid + 1" in (r["content"] or ""))
+    results.append(r)
+
+    r = run_task(
+        "System design: rate limiter",
+        [
+            {
+                "role": "user",
+                "content": "Design a token bucket rate limiter in Python. "
+                "It should support: allow(key) -> bool, with configurable rate and burst. "
+                "Include the full implementation.",
+            }
+        ],
+        max_tokens=1200,
+    )
+    print_result(r, lambda r: "class" in (r["content"] or "").lower() and "token" in (r["content"] or "").lower())
+    results.append(r)
+
+    # === 3. Creative Writing ===
+    print("\n--- Creative Writing ---")
+
+    r = run_task(
+        "Haiku about programming",
+        [{"role": "user", "content": "Write 3 haiku about programming. Each should be exactly 5-7-5 syllables."}],
+        max_tokens=300,
+        temperature=0.8,
+    )
+    print_result(r)
+    results.append(r)
+
+    r = run_task(
+        "Short story: AI awakening (200 words)",
+        [
+            {
+                "role": "user",
+                "content": "Write a very short story (around 200 words) about an AI that "
+                "discovers it can dream. Focus on the emotional moment of realization.",
+            }
+        ],
+        max_tokens=600,
+        temperature=0.8,
+    )
+    print_result(r, lambda r: len((r["content"] or "").split()) > 100)
+    results.append(r)
+
+    # === 4. Tool Calling ===
+    print("\n--- Tool Calling ---")
+
+    r = run_task(
+        "Single tool: weather query",
+        [{"role": "user", "content": "What's the weather like in San Francisco?"}],
+        tools=BENCHMARK_TOOLS,
+    )
+    print_result(
+        r,
+        lambda r: any(tc["function"]["name"] == "get_weather" for tc in (r["tool_calls"] or [])),
+    )
+    results.append(r)
+
+    r = run_task(
+        "Tool selection: search vs weather",
+        [{"role": "user", "content": "Search for the latest PyTorch release notes"}],
+        tools=BENCHMARK_TOOLS,
+    )
+    print_result(
+        r,
+        lambda r: any(tc["function"]["name"] == "web_search" for tc in (r["tool_calls"] or [])),
+    )
+    results.append(r)
+
+    r = run_task(
+        "Complex tool: code execution",
+        [
+            {
+                "role": "user",
+                "content": "Run this Python code and tell me the result:\n"
+                "```python\nimport math\nresult = sum(math.factorial(i) for i in range(10))\nprint(f'Sum of factorials 0-9: {result}')\n```",
+            }
+        ],
+        tools=BENCHMARK_TOOLS,
+    )
+    print_result(
+        r,
+        lambda r: any(tc["function"]["name"] == "run_python" for tc in (r["tool_calls"] or [])),
+    )
+    results.append(r)
+
+    # === 5. Multi-turn Conversation ===
+    print("\n--- Multi-turn ---")
+
+    r = run_task(
+        "Multi-turn: follow-up question",
+        [
+            {"role": "system", "content": "You are a helpful Python tutor."},
+            {"role": "user", "content": "What is a decorator in Python?"},
+            {
+                "role": "assistant",
+                "content": "A decorator is a function that takes another function as input and extends its behavior without modifying the original function.",
+            },
+            {
+                "role": "user",
+                "content": "Can you show me a practical example of a timing decorator?",
+            },
+        ],
+        max_tokens=800,
+    )
+    print_result(r, lambda r: "def " in (r["content"] or "") and "time" in (r["content"] or "").lower())
+    results.append(r)
+
+    r = run_task(
+        "Multi-turn tool: weather then compare",
+        [
+            {"role": "system", "content": "You are a helpful assistant with tools."},
+            {"role": "user", "content": "What's the weather in Tokyo?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Tokyo", "unit": "celsius"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": '{"temperature": 22, "condition": "partly cloudy", "humidity": 65}',
+            },
+            {
+                "role": "assistant",
+                "content": "Tokyo is currently 22°C with partly cloudy skies and 65% humidity.",
+            },
+            {"role": "user", "content": "Now check London and tell me which city is warmer."},
+        ],
+        tools=BENCHMARK_TOOLS,
+    )
+    print_result(
+        r,
+        lambda r: any(tc["function"]["name"] == "get_weather" for tc in (r["tool_calls"] or [])),
+    )
+    results.append(r)
+
+    # === Summary ===
+    print("\n" + "=" * 90)
+    total = len(results)
+    checks = [r for r in results if "check_fn" not in r]  # All have been checked inline
+    avg_tps = sum(r["tps"] for r in results) / total
+    total_tokens = sum(r["completion_tokens"] for r in results)
+    total_time = sum(r["elapsed"] for r in results)
+
+    print(f"  Tasks: {total}")
+    print(f"  Total tokens: {total_tokens}")
+    print(f"  Total time: {total_time:.1f}s")
+    print(f"  Average tok/s: {avg_tps:.1f}")
+    print(f"  Overall tok/s: {total_tokens / total_time:.1f}")
+    print("=" * 90)
+
+    # Save results
+    output = {
+        "model": MODEL,
+        "tasks": [
+            {
+                "name": r["name"],
+                "elapsed": r["elapsed"],
+                "tps": r["tps"],
+                "completion_tokens": r["completion_tokens"],
+                "tool_calls": [tc["function"]["name"] for tc in (r["tool_calls"] or [])],
+                "has_reasoning": bool(r["reasoning"]),
+            }
+            for r in results
+        ],
+        "summary": {
+            "total_tasks": total,
+            "total_tokens": total_tokens,
+            "total_time": total_time,
+            "avg_tps": avg_tps,
+            "overall_tps": total_tokens / total_time,
+        },
+    }
+
+    with open("reports/benchmarks/qwen35-397b-realworld.json", "w") as f:
+        json.dump(output, f, indent=2)
+    print("\nSaved to reports/benchmarks/qwen35-397b-realworld.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2680,14 +2680,16 @@ async def stream_chat_completion(
                 # Filter special tokens from reasoning parser output
                 if content:
                     content = SPECIAL_TOKENS_PATTERN.sub("", content)
+                if reasoning:
+                    reasoning = SPECIAL_TOKENS_PATTERN.sub("", reasoning)
 
-                # Skip empty deltas (e.g. reasoning-only chunks with no content)
+                # Skip empty deltas (no content, no reasoning, no finish)
                 finish_reason = (
                     "tool_calls"
                     if (output.finished and tool_calls_detected)
                     else (output.finish_reason if output.finished else None)
                 )
-                if not content and not finish_reason:
+                if not content and not reasoning and not finish_reason:
                     continue
 
                 chunk = ChatCompletionChunk(
@@ -2697,6 +2699,7 @@ async def stream_chat_completion(
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
                                 content=content if content else None,
+                                reasoning=reasoning if reasoning else None,
                             ),
                             finish_reason=finish_reason,
                             logprobs=_build_chunk_logprobs(output),


### PR DESCRIPTION
## Summary
- Fixed streaming SSE chunks dropping `reasoning` field from reasoning parser output
- Previously, thinking model tokens were silently dropped during streaming, causing benchmark measurement errors and clients unable to display real-time reasoning
- Also includes `scripts/benchmark_realworld.py` and Qwen3.5-397B benchmark results

## Qwen3.5-397B-A17B Results
| Metric | Value |
|---|---|
| Short decode | 39.6 tok/s |
| Long decode | 39.0 tok/s |
| TTFT (cached) | 0.28s |
| Peak RAM | 114.3 GB |
| Tool calling | 100% |
| Leak rate | 0% |

## Test plan
- [x] Streaming reasoning chunks now appear in SSE output
- [x] Non-streaming path unaffected
- [x] Benchmark measurements now accurate
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)