### PR TITLE
perf: reduce per-token SSE streaming overhead

### DIFF
--- a/vllm_mlx/api/__init__.py
+++ b/vllm_mlx/api/__init__.py
@@ -69,6 +69,7 @@ from .utils import (
     extract_multimodal_content,
     is_mllm_model,
     is_vlm_model,
+    strip_special_tokens,
 )
 
 __all__ = [
@@ -116,6 +117,7 @@ __all__ = [
     "extract_multimodal_content",
     "MLLM_PATTERNS",
     "SPECIAL_TOKENS_PATTERN",
+    "strip_special_tokens",
     # Tool calling
     "parse_tool_calls",
     "convert_tools_for_template",

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -21,6 +21,23 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"\[e~\[|\]~b\][a-z]*|\]~!b\["
 )
 
+# Fast-path characters that MUST be present for any special token to match.
+# If none of these appear in the text, regex can be skipped entirely.
+_SPECIAL_TOKEN_CHARS = frozenset("<[]")
+
+
+def strip_special_tokens(text: str) -> str:
+    """Remove special tokens from text with a fast-path bypass.
+
+    Most per-token deltas are plain text without special token markers.
+    Checking for marker characters first avoids regex overhead on ~99% of tokens.
+    """
+    # Fast path: no marker characters → no special tokens possible
+    for ch in text:
+        if ch in _SPECIAL_TOKEN_CHARS:
+            return SPECIAL_TOKENS_PATTERN.sub("", text)
+    return text
+
 
 # Regex for matching final channel marker with optional constrain token:
 #   <|channel|>final<|message|>

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -108,6 +108,7 @@ from .api.utils import (
     extract_json_from_response,
     extract_multimodal_content,
     is_mllm_model,  # noqa: F401
+    strip_special_tokens,
     strip_thinking_tags,
 )
 from .engine import (
@@ -2377,7 +2378,7 @@ async def _stream_anthropic_messages(
 
         if delta_text:
             # Filter special tokens
-            content = SPECIAL_TOKENS_PATTERN.sub("", delta_text)
+            content = strip_special_tokens(delta_text)
 
             if content:
                 accumulated_text += content
@@ -2519,6 +2520,23 @@ async def stream_chat_completion(
                 output.logprobs, token_id, engine.tokenizer, top_k_logprobs
             )
             return ChoiceLogProbs(content=[token_lp])
+
+        def _fast_sse_chunk(
+            text: str, field: str = "content", created: int | None = None
+        ) -> str:
+            """Build SSE chunk JSON directly, bypassing Pydantic serialization.
+
+            For the common case (single content/reasoning delta, no logprobs,
+            no finish_reason), this avoids constructing Pydantic objects and
+            calling model_dump_json().
+            """
+            _created = created or int(time.time())
+            escaped = json.dumps(text)  # Handles escaping
+            return (
+                f'data: {{"id":"{response_id}","object":"chat.completion.chunk",'
+                f'"created":{_created},"model":"{request.model}",'
+                f'"choices":[{{"index":0,"delta":{{"{field}":{escaped}}}}}]}}\n\n'
+            )
 
         # First chunk with role
         first_chunk = ChatCompletionChunk(
@@ -2679,9 +2697,9 @@ async def stream_chat_completion(
 
                 # Filter special tokens from reasoning parser output
                 if content:
-                    content = SPECIAL_TOKENS_PATTERN.sub("", content)
+                    content = strip_special_tokens(content)
                 if reasoning:
-                    reasoning = SPECIAL_TOKENS_PATTERN.sub("", reasoning)
+                    reasoning = strip_special_tokens(reasoning)
 
                 # Skip empty deltas (no content, no reasoning, no finish)
                 finish_reason = (
@@ -2691,6 +2709,20 @@ async def stream_chat_completion(
                 )
                 if not content and not reasoning and not finish_reason:
                     continue
+
+                # Fast path: simple content or reasoning delta without
+                # logprobs, finish_reason, or usage — skip Pydantic entirely.
+                if (
+                    not finish_reason
+                    and not want_logprobs
+                    and not output.finished
+                ):
+                    if content and not reasoning:
+                        yield _fast_sse_chunk(content, "content")
+                        continue
+                    if reasoning and not content:
+                        yield _fast_sse_chunk(reasoning, "reasoning")
+                        continue
 
                 chunk = ChatCompletionChunk(
                     id=response_id,
@@ -2708,7 +2740,8 @@ async def stream_chat_completion(
                     usage=get_usage(output) if output.finished else None,
                 )
                 sse_line = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
-                logger.info(f"[SSE] {sse_line.strip()[:300]}")
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"[SSE] {sse_line.strip()[:300]}")
                 yield sse_line
             else:
                 # Standard path without reasoning parsing
@@ -2716,7 +2749,7 @@ async def stream_chat_completion(
 
                 # Filter special tokens that may leak into streaming output
                 if content:
-                    content = SPECIAL_TOKENS_PATTERN.sub("", content)
+                    content = strip_special_tokens(content)
 
                 # Add <think> prefix on first content chunk for thinking models
                 if is_thinking_model and not think_prefix_sent and content:
@@ -2776,7 +2809,7 @@ async def stream_chat_completion(
                 # bypassed the earlier filter (e.g. via tool parser path
                 # which operates on raw delta_text).
                 if content:
-                    content = SPECIAL_TOKENS_PATTERN.sub("", content)
+                    content = strip_special_tokens(content)
 
                 # Skip empty-string content but preserve whitespace/newlines
                 # (newlines are significant for markdown formatting)
@@ -2792,6 +2825,16 @@ async def stream_chat_completion(
 
                 # Skip empty chunks (no content and no finish)
                 if not content and not finish_reason:
+                    continue
+
+                # Fast path: simple content delta — skip Pydantic.
+                if (
+                    content
+                    and not finish_reason
+                    and not want_logprobs
+                    and not output.finished
+                ):
+                    yield _fast_sse_chunk(content, "content")
                     continue
 
                 chunk = ChatCompletionChunk(


### PR DESCRIPTION
## Summary
- Add `strip_special_tokens()` fast-path: skip regex when no marker characters (`<`, `[`, `]`) are present (~99% of tokens)
- Demote per-token SSE chunk logging from INFO to DEBUG
- Add `_fast_sse_chunk()` that builds JSON directly, bypassing Pydantic `model_dump_json()` for simple content/reasoning deltas

## Benchmark Results (Qwen3.5-35B-A3B-8bit on M3 Ultra 256GB)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Decode TPS | 83.1 | 84.3 | **+1.4%** |
| Cached TTFT | 193ms | 192ms | -0.5% |
| Cold TTFT | 435ms | 458ms | (noise) |

## Key Findings
- Python overhead is <2% of total decode time at 84 tok/s
- Model forward pass (MoE routing + expert selection) is the bottleneck
- Bandwidth utilization is ~31.5% (compute-bound, not IO-bound)
- deepcopy overhead for RNN snapshots is only 0.2ms (negligible)

## Test plan
- [x] Full test suite: 1891 passed, 5 skipped
- [x] Benchmark: 3 runs, consistent improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)