### PR TITLE
feat: model alias registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/install.
 source ~/.zshrc  # or restart your terminal
 
 # 2. Start serving (first run downloads the model — ~5 GB, takes a few minutes)
-rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --port 8000
+rapid-mlx serve qwen3.5-9b --port 8000
 # Wait until you see: "Ready: http://localhost:8000/v1"
 
 # 3. Test it — open a NEW terminal and run:
@@ -177,29 +177,29 @@ Model weights must fit in unified memory. If Activity Monitor shows red memory p
 
 ### Copy-paste commands
 
-Pick the one that matches your Mac:
+Pick the one that matches your Mac. Short aliases work — run `rapid-mlx models` to see all 20.
 
 ```bash
 # 16 GB — lightweight, fast
-rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit --port 8000
+rapid-mlx serve qwen3.5-4b --port 8000
 
 # 24 GB — best small model
-rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --port 8000
+rapid-mlx serve qwen3.5-9b --port 8000
 
 # 32 GB — solid coding model
-rapid-mlx serve mlx-community/Qwen3.5-27B-4bit --port 8000
+rapid-mlx serve qwen3.5-27b --port 8000
 
 # 64 GB — sweet spot
-rapid-mlx serve mlx-community/Qwen3.5-35B-A3B-8bit --prefill-step-size 8192 --port 8000
+rapid-mlx serve qwen3.5-35b --prefill-step-size 8192 --port 8000
 
 # 96+ GB — best model
-rapid-mlx serve nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx --kv-bits 8 --prefill-step-size 8192 --port 8000
+rapid-mlx serve qwen3.5-122b --kv-bits 8 --prefill-step-size 8192 --port 8000
 
 # Coding agent — fast MoE, great for Claude Code / Cursor
-rapid-mlx serve lmstudio-community/Qwen3-Coder-Next-MLX-4bit --prefill-step-size 8192 --port 8000
+rapid-mlx serve qwen3-coder --prefill-step-size 8192 --port 8000
 
 # Vision — image understanding (see note below)
-rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit --mllm --port 8000
+rapid-mlx serve qwen3-vl-4b --mllm --port 8000
 ```
 
 > **Vision deps:** If you used `install.sh`, install into its venv: `~/.rapid-mlx/bin/pip install 'rapid-mlx[vision]'`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ vllm-mlx = "vllm_mlx.cli:main"
 vllm-mlx-chat = "vllm_mlx.gradio_app:main"
 vllm-mlx-bench = "vllm_mlx.benchmark:main"
 
+[tool.setuptools.package-data]
+vllm_mlx = ["aliases.json"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["vllm_mlx*"]

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the model alias registry."""
+
+from vllm_mlx.model_aliases import list_aliases, resolve_model
+
+
+def test_known_alias_resolves():
+    assert resolve_model("qwen3.5-9b") == "mlx-community/Qwen3.5-9B-4bit"
+    assert resolve_model("llama3-3b") == "mlx-community/Llama-3.2-3B-Instruct-4bit"
+
+
+def test_full_path_passes_through():
+    assert resolve_model("mlx-community/Foo-Bar") == "mlx-community/Foo-Bar"
+    assert resolve_model("/Users/me/local-model") == "/Users/me/local-model"
+
+
+def test_unknown_name_passes_through():
+    assert resolve_model("nonexistent-model") == "nonexistent-model"
+
+
+def test_list_aliases_nonempty():
+    aliases = list_aliases()
+    assert len(aliases) >= 15
+    assert "qwen3.5-9b" in aliases

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -2,7 +2,6 @@
 """Tests for the model alias registry."""
 
 import os
-import tempfile
 
 from vllm_mlx.model_aliases import list_aliases, resolve_model
 

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the model alias registry."""
 
+import os
+import tempfile
+
 from vllm_mlx.model_aliases import list_aliases, resolve_model
 
 
@@ -18,7 +21,26 @@ def test_unknown_name_passes_through():
     assert resolve_model("nonexistent-model") == "nonexistent-model"
 
 
+def test_local_path_takes_priority_over_alias(tmp_path):
+    """A local directory matching an alias name should win."""
+    local_dir = tmp_path / "qwen3.5-9b"
+    local_dir.mkdir()
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert resolve_model("qwen3.5-9b") == "qwen3.5-9b"
+    finally:
+        os.chdir(old_cwd)
+
+
 def test_list_aliases_nonempty():
     aliases = list_aliases()
     assert len(aliases) >= 15
     assert "qwen3.5-9b" in aliases
+
+
+def test_hermes_alias_not_llama():
+    """Hermes-3 should be under its own name, not llama3-8b."""
+    aliases = list_aliases()
+    assert "llama3-8b" not in aliases
+    assert "hermes3-8b" in aliases

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,0 +1,22 @@
+{
+  "qwen3.5-4b": "mlx-community/Qwen3.5-4B-MLX-4bit",
+  "qwen3.5-9b": "mlx-community/Qwen3.5-9B-4bit",
+  "qwen3.5-27b": "mlx-community/Qwen3.5-27B-4bit",
+  "qwen3.5-35b": "mlx-community/Qwen3.5-35B-A3B-8bit",
+  "qwen3.5-122b": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
+  "qwen3.5-122b-8bit": "mlx-community/Qwen3.5-122B-A10B-8bit",
+  "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
+  "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
+  "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+  "llama3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+  "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",
+  "phi4-14b": "mlx-community/phi-4-mini-instruct-4bit",
+  "mistral-24b": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
+  "devstral-24b": "mlx-community/Devstral-Small-2503-MLX-4bit",
+  "glm4.7-9b": "mlx-community/GLM-4.7-4bit",
+  "glm4.5-air": "mlx-community/GLM-4.5-Air-0111-4bit",
+  "gpt-oss-20b": "mlx-community/GPT-OSS-20B-4bit",
+  "minimax-m2.5": "lmstudio-community/MiniMax-M2.5-MLX-4bit",
+  "deepseek-r1-8b": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+  "kimi-48b": "mlx-community/Kimi-K2-Instruct-Q4_0-MLX"
+}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -8,7 +8,7 @@
   "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
-  "llama3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+  "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
   "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",
   "phi4-14b": "mlx-community/phi-4-mini-instruct-4bit",
   "mistral-24b": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -611,14 +611,31 @@ def bench_kv_cache_command(args):
     )
 
 
+def models_command(_args):
+    """List available model aliases."""
+    from vllm_mlx.model_aliases import list_aliases
+
+    aliases = list_aliases()
+    print()
+    print("  Available model aliases")
+    print("  " + "─" * 50)
+    for short, full in sorted(aliases.items()):
+        print(f"  {short:<20} → {full}")
+    print()
+    print(f"  {len(aliases)} aliases available")
+    print("  Usage: rapid-mlx serve <alias>")
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Rapid-MLX: AI inference for Apple Silicon",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
+  rapid-mlx serve qwen3.5-9b --port 8000
   rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --port 8000
-  rapid-mlx bench mlx-community/Qwen3.5-4B-MLX-4bit --num-prompts 10
+  rapid-mlx models
         """,
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
@@ -1095,7 +1112,19 @@ Examples:
         help="Quantization group size (default: 64)",
     )
 
+    # Models command
+    subparsers.add_parser("models", help="List available model aliases")
+
     args = parser.parse_args()
+
+    # Resolve model aliases before dispatch
+    if hasattr(args, "model") and args.model:
+        from vllm_mlx.model_aliases import resolve_model
+
+        resolved = resolve_model(args.model)
+        if resolved != args.model:
+            print(f"  Alias: {args.model} → {resolved}")
+            args.model = resolved
 
     if args.command == "serve":
         serve_command(args)
@@ -1105,6 +1134,8 @@ Examples:
         bench_detok_command(args)
     elif args.command == "bench-kv-cache":
         bench_kv_cache_command(args)
+    elif args.command == "models":
+        models_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -20,10 +20,13 @@ def resolve_model(name: str) -> str:
     """Resolve a model alias to its full HuggingFace path.
 
     If name contains '/' it's already a full path — pass through.
+    If a local file/directory with the name exists, prefer that.
     If name matches an alias, return the mapped HF path.
-    Otherwise return unchanged (could be a local path).
+    Otherwise return unchanged.
     """
     if "/" in name:
+        return name
+    if os.path.exists(name):
         return name
     aliases = _load()
     return aliases.get(name, name)

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model alias registry — maps short names to HuggingFace paths."""
+
+import json
+import os
+
+_aliases: dict[str, str] | None = None
+
+
+def _load() -> dict[str, str]:
+    global _aliases
+    if _aliases is None:
+        path = os.path.join(os.path.dirname(__file__), "aliases.json")
+        with open(path) as f:
+            _aliases = json.load(f)
+    return _aliases
+
+
+def resolve_model(name: str) -> str:
+    """Resolve a model alias to its full HuggingFace path.
+
+    If name contains '/' it's already a full path — pass through.
+    If name matches an alias, return the mapped HF path.
+    Otherwise return unchanged (could be a local path).
+    """
+    if "/" in name:
+        return name
+    aliases = _load()
+    return aliases.get(name, name)
+
+
+def list_aliases() -> dict[str, str]:
+    """Return all available aliases."""
+    return dict(_load())


### PR DESCRIPTION
## Summary
- 20 model aliases: `rapid-mlx serve qwen3.5-9b` instead of `rapid-mlx serve mlx-community/Qwen3.5-9B-4bit`
- `rapid-mlx models` command lists all available aliases
- Resolution happens before model loading — transparent to all downstream code
- README copy-paste commands updated to use short aliases
- Full HF paths and local paths still work unchanged

## Files
- `vllm_mlx/aliases.json` — alias-to-HF-path mapping (20 models)
- `vllm_mlx/model_aliases.py` — resolver module (~30 lines)
- `vllm_mlx/cli.py` — `models` subcommand + alias resolution hook
- `pyproject.toml` — package-data for aliases.json
- `tests/test_model_aliases.py` — 4 tests

## Test plan
- [x] `python3.12 -m pytest tests/test_model_aliases.py` — 4/4 pass
- [x] `rapid-mlx models` shows 20 aliases
- [ ] `rapid-mlx serve qwen3.5-9b` resolves and starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)