### PR TITLE
feat(server): add serve log-level flag

### DIFF
--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -1302,6 +1302,23 @@ class TestHarmonyCLIIntegration:
             ToolParserManager.get_tool_parser("nonexistent_parser")
 
 
+class TestServeLogLevelFlags:
+    def test_cli_serve_has_log_level_flag(self):
+        import importlib
+        import inspect
+
+        source = inspect.getsource(importlib.import_module("vllm_mlx.cli").main)
+        assert '"--log-level"' in source
+        assert 'choices=["DEBUG", "INFO", "WARNING", "ERROR"]' in source
+
+    def test_module_server_has_log_level_flag(self):
+        from pathlib import Path
+
+        source = Path("vllm_mlx/server.py").read_text()
+        assert '"--log-level"' in source
+        assert 'choices=["DEBUG", "INFO", "WARNING", "ERROR"]' in source
+
+
 # ============================================================================
 # SUPPORTS_NATIVE_TOOL_FORMAT Tests
 # ============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -102,6 +102,7 @@ def serve_command(args):
     from .server import RateLimiter, app, load_model
 
     logger = logging.getLogger(__name__)
+    uvicorn_log_level = server.configure_logging(args.log_level)
 
     # Validate tool calling arguments
     if args.enable_auto_tool_choice and not args.tool_call_parser:
@@ -365,7 +366,7 @@ def serve_command(args):
         app,
         host=args.host,
         port=args.port,
-        log_level="info",
+        log_level=uvicorn_log_level,
         timeout_keep_alive=30,
     )
 
@@ -798,6 +799,13 @@ Examples:
         "--host", type=str, default="0.0.0.0", help="Host to bind"
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    serve_parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Log level for Python logging and uvicorn",
+    )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -124,6 +124,17 @@ from .tool_parsers import ToolParserManager
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def normalize_log_level(log_level: str) -> str:
+    return log_level.upper()
+
+
+def configure_logging(log_level: str) -> str:
+    normalized = normalize_log_level(log_level)
+    logging.getLogger().setLevel(getattr(logging, normalized, logging.INFO))
+    logger.setLevel(getattr(logging, normalized, logging.INFO))
+    return normalized.lower()
+
 # Global engine instance
 _engine: BaseEngine | None = None
 _model_name: str | None = None
@@ -3256,6 +3267,13 @@ Examples:
         help="Port to bind to",
     )
     parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Log level for Python logging and uvicorn",
+    )
+    parser.add_argument(
         "--mllm",
         action="store_true",
         help="Force loading as MLLM (multimodal language model)",
@@ -3413,6 +3431,7 @@ Examples:
     )
 
     args = parser.parse_args()
+    uvicorn_log_level = configure_logging(args.log_level)
 
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter
@@ -3509,7 +3528,7 @@ Examples:
     )
 
     # Start server
-    uvicorn.run(app, host=args.host, port=args.port)
+    uvicorn.run(app, host=args.host, port=args.port, log_level=uvicorn_log_level)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #50

## Summary
- add `--log-level` to both `rapid-mlx serve` and `python -m vllm_mlx.server`
- apply the selected level to Python logging and pass the normalized value through to `uvicorn.run`
- add focused tests that verify both entrypoints expose the new flag

## Testing
- `pytest tests/test_harmony_parsers.py -k log_level`
- manual QA: invoked `serve_command()` with `--log-level WARNING` using a stubbed server and verified `uvicorn.run(..., log_level='warning')` plus root logger level `30`