### PR TITLE
fix(cli): remove duplicate --prefill-step-size argument from serve co…

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1095,12 +1095,6 @@ Examples:
         help="Number of tokens to generate speculatively per step (default: 4)",
     )
     serve_parser.add_argument(
-        "--prefill-step-size",
-        type=int,
-        default=2048,
-        help="Tokens to process per prefill chunk in simple mode (default: 2048)",
-    )
-    serve_parser.add_argument(
         "--kv-bits",
         type=int,
         default=None,


### PR DESCRIPTION
## What does this PR do?

This pull request makes a minor update to the CLI by removing a duplicated argument from the `serve` subcommand.

- Removed the duplicated `--prefill-step-size` argument from the `serve` parser in `vllm_mlx/cli.py`.


Trying to start `rapid-mlx` without this fix:
```bash
rapid-mlx serve qwen3.5-9b                                                               
Traceback (most recent call last):
  File "/Users/peter/.local/bin/rapid-mlx", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/peter/.rapid-mlx/lib/python3.13/site-packages/vllm_mlx/cli.py", line 1097, in main
    serve_parser.add_argument(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        "--prefill-step-size",
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        help="Tokens to process per prefill chunk in simple mode (default: 2048)",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1489, in add_argument
    return self._add_action(action)
           ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1878, in _add_action
    self._optionals._add_action(action)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1696, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1503, in _add_action
    self._check_conflict(action)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1645, in _check_conflict
    conflict_handler(action, confl_optionals)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/argparse.py", line 1654, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --prefill-step-size: conflicting option string: --prefill-step-size
```