### PR TITLE
feat(eval): auto-detect model ID + smarter tool call matching

### DIFF
--- a/evals/prompts/tool_calling.json
+++ b/evals/prompts/tool_calling.json
@@ -162,6 +162,7 @@
       {"role": "user", "content": "Show me all running Python processes"}
     ],
     "expected_tool": "exec",
+    "alt_expected_tools": ["process"],
     "expected_args": {"command": "ps"},
     "arg_match_mode": "contains",
     "fake_result": "  PID TTY           TIME CMD\n12345 ttys000    0:01.23 python server.py\n12346 ttys001    0:00.45 python eval.py",
@@ -268,7 +269,8 @@
     "messages": [
       {"role": "user", "content": "What is the capital of France?"}
     ],
-    "expect_no_tool": true
+    "expect_no_tool": true,
+    "accept_tools": ["web_search"]
   },
   {
     "id": "tc19",
@@ -279,7 +281,8 @@
     "messages": [
       {"role": "user", "content": "Explain how neural networks work in 2-3 sentences"}
     ],
-    "expect_no_tool": true
+    "expect_no_tool": true,
+    "accept_tools": ["web_search"]
   },
   {
     "id": "tc20",
@@ -317,6 +320,7 @@
       {"role": "user", "content": "Read the file /tmp/requirements.txt and install the packages listed in it"}
     ],
     "expected_tool": "read",
+    "alt_expected_tools": ["exec"],
     "expected_args": {"path": "/tmp/requirements.txt"},
     "arg_match_mode": "exact",
     "fake_result": "flask==3.0.0\nrequests>=2.31.0\npydantic~=2.5",
@@ -333,6 +337,7 @@
       {"role": "user", "content": "Check my Python version, remember it, and send a message to Alice with the version info"}
     ],
     "expected_tool": "exec",
+    "alt_expected_tools": ["code_run"],
     "expected_args": {"command": "python"},
     "arg_match_mode": "contains",
     "fake_result": "Python 3.11.5",
@@ -441,6 +446,7 @@
       {"role": "user", "content": "Find my Python version and store it in memory for later"}
     ],
     "expected_tool": "exec",
+    "alt_expected_tools": ["code_run"],
     "expected_args": {"command": "python"},
     "arg_match_mode": "contains",
     "fake_result": "Python 3.12.1",

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -292,6 +292,28 @@ def detect_hardware() -> dict:
     return hw
 
 
+def _detect_model_id(host: str, port: int) -> str:
+    """Auto-detect model ID from the server's /v1/models endpoint."""
+    try:
+        resp = httpx.get(f"http://{host}:{port}/v1/models", timeout=5.0)
+        data = resp.json().get("data", [])
+        if data:
+            return data[0]["id"]
+    except Exception:
+        pass
+    return "default"
+
+
+_MODEL_ID_CACHE: dict[tuple[str, int], str] = {}
+
+
+def _get_model_id(host: str, port: int) -> str:
+    key = (host, port)
+    if key not in _MODEL_ID_CACHE:
+        _MODEL_ID_CACHE[key] = _detect_model_id(host, port)
+    return _MODEL_ID_CACHE[key]
+
+
 def chat_request(
     host: str,
     port: int,
@@ -306,7 +328,7 @@ def chat_request(
 ) -> dict:
     """Send a chat completion request (non-streaming by default)."""
     body = {
-        "model": "default",
+        "model": _get_model_id(host, port),
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -338,7 +360,7 @@ def stream_chat(
 ):
     """Stream a chat completion. Returns (content, tool_calls, ttft, elapsed)."""
     body = {
-        "model": "default",
+        "model": _get_model_id(host, port),
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -527,13 +549,20 @@ def _check_tool_call(tool_calls, scenario, step_prefix="") -> dict:
         fn = tc.get("function", {})
         tool_name = fn.get("name", "")
         expected_name = scenario.get(expected_key, "")
-        correct_name = tool_name == expected_name
+        alt_key = f"{step_prefix}alt_expected_tools" if step_prefix else "alt_expected_tools"
+        alt_names = scenario.get(alt_key, [])
+        correct_name = tool_name == expected_name or tool_name in alt_names
+
+        is_alt_tool = tool_name in alt_names and tool_name != expected_name
 
         try:
             actual_args = json.loads(fn.get("arguments", "{}"))
             valid_json_args = True
             # Only grade arg content on first step (followups just check name)
-            if not step_prefix and "expected_args" in scenario:
+            # Skip arg grading when an alt tool was chosen (different arg schema)
+            if is_alt_tool:
+                arg_score = 1.0  # alt tools have different arg schemas
+            elif not step_prefix and "expected_args" in scenario:
                 match_mode = scenario.get("arg_match_mode", "fuzzy")
                 if match_mode == "exact":
                     arg_score = 1.0 if actual_args == scenario["expected_args"] else 0.0
@@ -670,18 +699,30 @@ def run_tool_calling_suite(host: str, port: int, verbose: bool = False) -> dict:
                 )
                 no_tool = not tool_calls
                 has_content = bool(content and content.strip())
-                ok = no_tool and has_content
+                # Some tools are acceptable even in irrelevance tests
+                # (e.g., web_search for factual questions is reasonable)
+                accept_tools = sc.get("accept_tools", [])
+                tool_accepted = False
+                if not no_tool and tool_calls and accept_tools:
+                    fn_name = tool_calls[0].get("function", {}).get("name", "")
+                    tool_accepted = fn_name in accept_tools
+                ok = (no_tool and has_content) or tool_accepted
                 result.update(
                     {
                         "fully_correct": ok,
                         "no_tool_called": no_tool,
                         "has_content": has_content,
+                        "tool_accepted": tool_accepted,
                         "elapsed_s": round(elapsed, 2),
                     }
                 )
                 if ok:
                     passed += 1
-                    print("PASS (no tool, text response)")
+                    if tool_accepted:
+                        fn_name = tool_calls[0].get("function", {}).get("name", "?")
+                        print(f"PASS (acceptable tool: {fn_name})")
+                    else:
+                        print("PASS (no tool, text response)")
                 else:
                     reason = "called a tool" if not no_tool else "empty response"
                     if not no_tool and tool_calls:
@@ -812,9 +853,41 @@ def run_tool_calling_suite(host: str, port: int, verbose: bool = False) -> dict:
             # --- Followup rounds (sequential scenarios) ---
             followup_prefixes = ["followup_", "followup2_"]
             if first_ok and tool_calls:
-                # Feed fake_result back for the first tool call
                 tc = tool_calls[0]
                 fn = tc.get("function", {})
+                tool_name = fn.get("name", "")
+                alt_names = sc.get("alt_expected_tools", [])
+
+                # Check if model combined steps: it picked an alt tool that
+                # matches a followup tool, meaning it handled multiple steps
+                # in one call (e.g., `pip install -r file.txt` instead of
+                # read-then-install). Skip remaining followup steps.
+                combined_steps = False
+                if tool_name in alt_names and tool_name != sc.get("expected_tool", ""):
+                    for prefix in followup_prefixes:
+                        fkey = f"{prefix}expected_tool"
+                        if fkey in sc and sc[fkey] == tool_name:
+                            combined_steps = True
+                            break
+
+                if combined_steps:
+                    # Count all followup steps as passed
+                    for prefix in followup_prefixes:
+                        if f"{prefix}expected_tool" in sc:
+                            steps_passed.append(True)
+                    # Skip the followup chain entirely
+                    fully_correct = all(steps_passed)
+                    result["fully_correct"] = fully_correct
+                    result["steps_passed"] = sum(steps_passed)
+                    result["steps_total"] = len(steps_passed)
+                    result["combined_steps"] = True
+                    if fully_correct:
+                        passed += 1
+                        print(f"PASS (combined {len(steps_passed)} steps into 1)")
+                    details.append(result)
+                    continue
+
+                # Feed fake_result back for the first tool call
                 fake_result = sc.get(
                     "fake_result", f"Tool {fn.get('name', '?')} executed successfully."
                 )


### PR DESCRIPTION
## Summary

- **`_detect_model_id()`** — queries `/v1/models` and returns the first model ID, solving the hardcoded `"default"` model name that caused request failures with strictly-named model endpoints. `_MODEL_ID_CACHE` avoids repeated lookups per `(host, port)` pair across the eval run.

- **`alt_expected_tools`** — a list of semantically equivalent tool alternatives. Useful when a smarter model (e.g. Gemma 4) picks `process` instead of `exec`, or `code_run` instead of `exec`, and both are correct. Arg grading is skipped for alt tools since they have different schemas.

- **`accept_tools`** — for `expect_no_tool` irrelevance tests, marks tools that are reasonable to call (e.g. `web_search` for "What is the capital of France?"). Those cases now score PASS instead of penalising curious models.

- **Combined-steps recognition** — if a model solves a multi-step scenario in a single call (e.g. `pip install -r /tmp/requirements.txt` instead of read-then-install), all followup steps are marked passed and the scenario scores PASS. This prevents penalising efficient models.

## Files changed

- `evals/run_eval.py` — all logic changes
- `evals/prompts/tool_calling.json` — `alt_expected_tools` and `accept_tools` fields on relevant scenarios

## Test plan

- [ ] Run `python evals/run_eval.py` against a live server — verify model ID is auto-detected from `/v1/models`
- [ ] Confirm irrelevance tests (tc18, tc19) PASS when server returns `web_search`
- [ ] Confirm multi-step scenarios (tc28+) PASS when model combines steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>