### PR TITLE
fix: add Gemma 4 aliases (gemma-4-26b, gemma-4-31b)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -9,6 +9,8 @@
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
   "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+  "gemma-4-26b": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "gemma-4-31b": "mlx-community/gemma-4-31b-it-4bit",
   "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",
   "phi4-14b": "mlx-community/phi-4-mini-instruct-4bit",
   "mistral-24b": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",


### PR DESCRIPTION
## Summary
- Adds `gemma-4-26b` → `mlx-community/gemma-4-26b-a4b-it-4bit`
- Adds `gemma-4-31b` → `mlx-community/gemma-4-31b-it-4bit`

Fixes the README Quick Start example `rapid-mlx serve gemma-4-26b` which currently errors with "Model not found".

Closes #75