### PR TITLE
feat: add Kimi K2.5 alias (closes #78)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -20,5 +20,6 @@
   "gpt-oss-20b": "mlx-community/GPT-OSS-20B-4bit",
   "minimax-m2.5": "lmstudio-community/MiniMax-M2.5-MLX-4bit",
   "deepseek-r1-8b": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+  "kimi-k2.5": "mlx-community/Kimi-K2.5",
   "kimi-48b": "mlx-community/Kimi-K2-Instruct-Q4_0-MLX"
 }


### PR DESCRIPTION
## Summary

Adds `kimi-k2.5` alias pointing to `mlx-community/Kimi-K2.5`.

Kimi K2.5 has **716K downloads** on HuggingFace — more popular than the K2 version currently aliased as `kimi-48b`.

Closes #78

## Changes

- `vllm_mlx/aliases.json`: Added `kimi-k2.5` entry

## Verify

```bash
rapid-mlx serve kimi-k2.5
```

## Notes

Kept existing `kimi-48b` alias unchanged to avoid breaking changes.