### PR TITLE
feat: add Gemma 3n E4B alias (closes #79)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -12,6 +12,7 @@
   "gemma-4-26b": "mlx-community/gemma-4-26b-a4b-it-4bit",
   "gemma-4-31b": "mlx-community/gemma-4-31b-it-4bit",
   "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",
+  "gemma-3n-e4b": "lmstudio-community/gemma-3n-E4B-it-MLX-4bit",
   "phi4-14b": "mlx-community/phi-4-mini-instruct-4bit",
   "mistral-24b": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
   "devstral-24b": "mlx-community/Devstral-Small-2503-MLX-4bit",


### PR DESCRIPTION
Adds alias for Google Gemma 3n E4B (327K downloads):

- `gemma-3n-e4b` → `lmstudio-community/gemma-3n-E4B-it-MLX-4bit`

Closes #79