### PR TITLE
feat: add Qwen3-Coder-30B alias (closes #80)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -6,6 +6,7 @@
   "qwen3.5-122b": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
   "qwen3.5-122b-8bit": "mlx-community/Qwen3.5-122B-A10B-8bit",
   "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
+  "qwen3-coder-30b": "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-4bit",
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
   "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",


### PR DESCRIPTION
Adds alias for stable Qwen3-Coder-30B-A3B (214K downloads):

- `qwen3-coder-30b` → `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-4bit`

The existing `qwen3-coder` alias points to the "Next" (beta) version; this adds the stable 30B variant.

Closes #80