### PR TITLE
feat: add Hermes 4 70B alias (closes #83)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -9,6 +9,7 @@
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
   "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+  "hermes4-70b": "lmstudio-community/Hermes-4-70B-MLX-4bit",
   "gemma-4-26b": "mlx-community/gemma-4-26b-a4b-it-4bit",
   "gemma-4-31b": "mlx-community/gemma-4-31b-it-4bit",
   "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",


### PR DESCRIPTION
Adds alias for Hermes 4 70B (65K downloads):

- `hermes4-70b` → `lmstudio-community/Hermes-4-70B-MLX-4bit`

Closes #83