### PR TITLE
feat: add Qwen3-VL 8B and 30B aliases (closes #82)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -7,6 +7,8 @@
   "qwen3.5-122b-8bit": "mlx-community/Qwen3.5-122B-A10B-8bit",
   "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
+  "qwen3-vl-8b": "lmstudio-community/Qwen3-VL-8B-Instruct-MLX-4bit",
+  "qwen3-vl-30b": "lmstudio-community/Qwen3-VL-30B-A3B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
   "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
   "gemma-4-26b": "mlx-community/gemma-4-26b-a4b-it-4bit",


### PR DESCRIPTION
## Summary

Add Qwen3-VL 8B and 30B aliases to complement the existing 4B variant.

Closes #82

## Changes

**File: `vllm_mlx/aliases.json`**

| Alias | Model | Downloads |
|-------|-------|-----------|
| `qwen3-vl-8b` | `lmstudio-community/Qwen3-VL-8B-Instruct-MLX-4bit` | 123K |
| `qwen3-vl-30b` | `lmstudio-community/Qwen3-VL-30B-A3B-Instruct-MLX-4bit` | 59K |

## Verification

```bash
rapid-mlx serve qwen3-vl-8b
rapid-mlx serve qwen3-vl-30b
```

Vision models — image input supported via the VLM pipeline.