### PR TITLE
docs: add Hermes Agent integration (57K stars)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,12 @@
+{
+  "projectName": "Rapid-MLX",
+  "projectOwner": "raullenchai",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 50,
+  "commit": false,
+  "commitConvention": "none",
+  "contributorsPerLine": 8,
+  "skipCi": true
+}

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: raullenchai

--- a/.github/ISSUE_TEMPLATE/model_support.yml
+++ b/.github/ISSUE_TEMPLATE/model_support.yml
@@ -1,0 +1,52 @@
+name: Model Support Request
+description: Request support for a new model
+labels: ["enhancement", "model-support"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting a new model! This helps us prioritize which models to add next.
+  - type: input
+    id: model_name
+    attributes:
+      label: Model name
+      placeholder: "e.g. Llama 4 Scout 17B"
+    validations:
+      required: true
+  - type: input
+    id: hf_id
+    attributes:
+      label: HuggingFace model ID (MLX version)
+      placeholder: "e.g. mlx-community/Llama-4-Scout-17B-4bit"
+    validations:
+      required: true
+  - type: dropdown
+    id: tested
+    attributes:
+      label: Have you tested it with Rapid-MLX?
+      options:
+        - "Yes — works with manual path"
+        - "Yes — but has issues"
+        - "No — haven't tried yet"
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: |
+        If tested, share:
+        - What --tool-call-parser / --reasoning-parser flags worked?
+        - Any issues (tag leaks, broken tool calls, crashes)?
+        - Benchmark numbers (tok/s, TTFT)?
+  - type: input
+    id: ram
+    attributes:
+      label: Model size (RAM needed)
+      placeholder: "e.g. 10 GB (4bit)"
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Willing to contribute?
+      options:
+        - label: I can submit a PR to add alias + parser config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ ruff check .
 ruff format --check .
 ```
 
-Most tests run without a model. Tests in `tests/test_event_loop.py` require a running server — start one first if you want to run those.
+Most tests run without a model. Tests in `tests/test_event_loop.py` require a running server.
 
 ## Pull Request Workflow
 
@@ -42,12 +42,60 @@ Most tests run without a model. Tests in `tests/test_event_loop.py` require a ru
 3. Run `ruff check` and `ruff format` before committing
 4. Open a PR against `main` with a clear description
 
-## What We Need
+## Ways to Contribute
 
-- **Hardware benchmarks** — test on your Mac and share results
-- **Model reports** — which models work well, which don't
-- **Client verifications** — test with your favorite AI tool (Cursor, Continue, Aider, etc.)
-- **Bug fixes and features** — check issues tagged `good first issue`
+### 🟢 Easy — No model download needed
+
+- **Add a model alias** — Add a short name to `vllm_mlx/aliases.json` so users can `rapid-mlx serve <alias>` instead of typing a full HuggingFace path. See [open model-support issues](https://github.com/raullenchai/Rapid-MLX/issues?q=is%3Aissue+is%3Aopen+label%3Amodel-support).
+
+- **Fix a `good first issue`** — Check the [good first issue](https://github.com/raullenchai/Rapid-MLX/labels/good%20first%20issue) label.
+
+### 🟡 Medium — Needs a model + some testing
+
+- **Test a model and report results** — Download a model, run benchmarks, report what works. Use the "Model Support Request" issue template.
+
+- **Add parser auto-detection** — Add a regex pattern to `vllm_mlx/model_auto_config.py` so a new model family gets the right tool/reasoning parser automatically.
+
+- **Verify client integrations** — Test Rapid-MLX with your favorite AI tool (Cursor, Continue, Aider, LangChain, etc.) and report results.
+
+### 🔴 Advanced
+
+- **Write a new tool call parser** — Add support for a new tool call format in `vllm_mlx/tool_parsers/`.
+- **Performance optimization** — Profiling, kernel improvements, caching strategies.
+- **BatchedEngine / continuous batching** — Multi-user serving improvements.
+
+## How to Add a Model Alias
+
+The easiest contribution — no model download needed!
+
+**File:** `vllm_mlx/aliases.json`
+
+```json
+{
+  "my-model-7b": "mlx-community/My-Model-7B-Instruct-4bit"
+}
+```
+
+That's it. Find the MLX model on [HuggingFace mlx-community](https://huggingface.co/mlx-community) and add the mapping. Convention: `<family>-<size>` in lowercase (e.g., `qwen3.5-9b`, `gemma-4-26b`).
+
+## How to Add Parser Auto-Detection
+
+When users serve a model without `--tool-call-parser`, Rapid-MLX auto-detects the right parser from the model name.
+
+**File:** `vllm_mlx/model_auto_config.py`
+
+```python
+# Add your pattern (order matters — more specific first):
+(re.compile(r"my-model", re.IGNORECASE), ModelConfig(
+    tool_call_parser="hermes",    # most common format
+    reasoning_parser=None,        # set if model has thinking tags
+)),
+```
+
+Common tool parsers: `hermes`, `llama`, `deepseek`, `gemma4`, `glm47`, `minimax`, `kimi`.
+Common reasoning parsers: `qwen3`, `deepseek_r1`, `gemma4`, `minimax`.
+
+**How to figure out the right parser:** Check the model's chat template for tool call format. Most models use Hermes-style `<tool_call>` tags. If unsure, try `hermes` first.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ print(response.choices[0].message.content)
 | [OpenCode](https://github.com/sst/opencode) | Compatible (manual) | `opencode.json` provider config; agent loop behavior is model-sensitive |
 | [Claw Code](https://github.com/ultraworkers/claw-code) | Tested | Prompt, code gen, tool calling (read_file) — both OpenAI & Anthropic endpoints |
 | [OpenClaude](https://github.com/Gitlawb/openclaude) | Tested | `CLAUDE_CODE_USE_OPENAI=1` + `OPENAI_BASE_URL`; prompt, tool calling |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Tested | `provider: custom` + `base_url`; 62 tools, tool calling, multi-turn |
 | [Goose](https://github.com/block/goose) | Tested | Ollama provider via `OLLAMA_HOST`; prompt, shell tool use |
 | [OpenClaw](https://github.com/nicepkg/openclaw) | Compatible (manual) | 14 tools, multi-round, streaming; setup wizard required |
 | [Open WebUI](https://github.com/open-webui/open-webui) | Tested | Docker E2E (register, login, model fetch, streaming chat) ([test](tests/integrations/test_openwebui.py)) |
@@ -154,6 +155,15 @@ claw --model "openai/default" prompt "summarize this repo"
 ```bash
 CLAUDE_CODE_USE_OPENAI=1 OPENAI_BASE_URL=http://localhost:8000/v1 \
 OPENAI_API_KEY=not-needed OPENAI_MODEL=default openclaude -p "hello"
+```
+
+**Hermes Agent** (`~/.hermes/config.yaml`):
+```yaml
+model:
+  provider: "custom"
+  default: "default"
+  base_url: "http://localhost:8000/v1"
+  context_length: 32768
 ```
 
 **Goose:**

--- a/README.md
+++ b/README.md
@@ -611,9 +611,16 @@ Vision, audio (STT/TTS), video understanding, and text embeddings — all throug
 
 ## Contributing
 
-Issues and PRs welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup and guidelines.
+We welcome contributions of all sizes! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
 
-We need community data — hardware benchmarks, client verifications, model reports. If you test a model on your Mac, [open an issue](https://github.com/raullenchai/Rapid-MLX/issues/new) with your hardware, model, decode speed, and what worked.
+**Easy first contributions** (no model download needed):
+- [Add a model alias](https://github.com/raullenchai/Rapid-MLX/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) — map a short name to a HuggingFace model ID
+- [Request model support](https://github.com/raullenchai/Rapid-MLX/issues/new?template=model_support.yml) — tell us which model you want
+
+**Testing contributions** (needs a Mac with Apple Silicon):
+- Benchmark a model and share results
+- Test with your favorite AI client (Cursor, Aider, LangChain, etc.)
+- [Report a bug](https://github.com/raullenchai/Rapid-MLX/issues/new?template=bug_report.yml)
 
 ### Contributors
 


### PR DESCRIPTION
## Summary
- Add Hermes Agent to Works With table (tested status)
- Add Quick Setup config for `~/.hermes/config.yaml`

Verified: chat, tool calling (62 tools), multi-turn sessions.