### PR TITLE
feat: MHI benchmark, one-liner installer, auto Homebrew publish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,26 @@
+name: Sync install.sh to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [install.sh]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare pages directory
+        run: |
+          mkdir -p _pages
+          cp install.sh _pages/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_pages
+          publish_branch: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI & Homebrew
 
 on:
   release:
@@ -45,3 +45,49 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  update-homebrew:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for PyPI to propagate
+        run: sleep 30
+
+      - name: Get release version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch tarball URL and SHA256
+        id: pypi
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Poll PyPI until the new version appears (max 5 minutes)
+          for i in $(seq 1 10); do
+            URL=$(curl -fsSL "https://pypi.org/pypi/rapid-mlx/${VERSION}/json" 2>/dev/null \
+              | python3 -c "import json,sys; d=json.load(sys.stdin); print([u['url'] for u in d['urls'] if u['packagetype']=='sdist'][0])" 2>/dev/null) && break
+            echo "Waiting for PyPI... (attempt $i)"
+            sleep 30
+          done
+          if [ -z "$URL" ]; then echo "Failed to find tarball on PyPI"; exit 1; fi
+
+          # Download and compute SHA256
+          curl -fsSL "$URL" -o /tmp/rapid-mlx.tar.gz
+          SHA256=$(sha256sum /tmp/rapid-mlx.tar.gz | cut -d' ' -f1)
+          rm /tmp/rapid-mlx.tar.gz
+
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          echo "Found: $URL (sha256: $SHA256)"
+
+      - name: Update Homebrew formula
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: raullenchai/homebrew-rapid-mlx
+          event-type: update-formula
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "url": "${{ steps.pypi.outputs.url }}",
+              "sha256": "${{ steps.pypi.outputs.sha256 }}"
+            }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brew install raullenchai/rapid-mlx/rapid-mlx
 pip install rapid-mlx
 
 # Or one-liner with auto-setup
-curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/install.sh | bash
+curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 ```
 
 **Step 2 — Serve a model:**
@@ -114,44 +114,74 @@ print(response.choices[0].message.content)
 
 ## Works With
 
-| Client | Status | Notes |
+### Agent Harnesses (MHI-tested)
+
+| Harness | Type | Notes |
+|---------|------|-------|
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Agent | 62 tools, multi-turn ([test](tests/integrations/test_hermes.py)) |
+| [PydanticAI](https://ai.pydantic.dev) | Framework | Typed agents, structured output ([test](tests/integrations/test_pydantic_ai_full.py)) |
+| [LangChain](https://langchain.com) | Framework | `ChatOpenAI`, tools, streaming ([test](tests/integrations/test_langchain.py)) |
+| [smolagents](https://github.com/huggingface/smolagents) | Framework | CodeAgent + ToolCallingAgent ([test](tests/integrations/test_smolagents_full.py)) |
+| [OpenClaude](https://github.com/Gitlawb/openclaude) (Anthropic SDK) | Agent | `CLAUDE_CODE_USE_OPENAI=1` ([test](tests/integrations/test_anthropic_sdk.py)) |
+| [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
+| [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
+| [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
+
+### UI / IDE Clients
+
+| Client | Status | Setup |
 |--------|--------|-------|
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Tested | 62 tools, tool calling, multi-turn, 20-test suite ([test](tests/integrations/test_hermes.py)) |
-| [OpenClaude](https://github.com/Gitlawb/openclaude) (Anthropic SDK) | Tested | `CLAUDE_CODE_USE_OPENAI=1`; prompt, tool calling ([test](tests/integrations/test_anthropic_sdk.py)) |
-| [PydanticAI](https://ai.pydantic.dev) | Tested | Typed agents, streaming, structured output, multi-tool ([test](tests/integrations/test_pydantic_ai_full.py)) |
-| [LangChain](https://langchain.com) | Tested | `ChatOpenAI`, tools, streaming, structured output ([test](tests/integrations/test_langchain.py)) |
-| [smolagents](https://github.com/huggingface/smolagents) | Tested | CodeAgent + ToolCallingAgent + multi-tool ([test](tests/integrations/test_smolagents_full.py)) |
-| [Aider](https://aider.chat) | Tested | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
-| [Goose](https://github.com/block/goose) | Tested | Ollama provider via `OLLAMA_HOST`; prompt, shell tool use |
-| [Claw Code](https://github.com/ultraworkers/claw-code) | Tested | Prompt, code gen, tool calling — both OpenAI & Anthropic endpoints |
-| [LibreChat](https://librechat.ai) | Tested | Docker E2E ([test](tests/integrations/test_librechat_docker.py)) |
-| [Open WebUI](https://github.com/open-webui/open-webui) | Tested | Docker E2E ([test](tests/integrations/test_openwebui.py)) |
-| [Cursor](https://cursor.com) | Compatible | Settings UI config |
-| [Continue.dev](https://continue.dev) | Compatible | VS Code/JetBrains extension |
+| [Cursor](https://cursor.com) | Compatible | Settings → OpenAI Base URL |
+| [Continue.dev](https://continue.dev) | Compatible | VS Code / JetBrains extension |
+| [LibreChat](https://librechat.ai) | Tested | Docker ([test](tests/integrations/test_librechat_docker.py)) |
+| [Open WebUI](https://github.com/open-webui/open-webui) | Tested | Docker ([test](tests/integrations/test_openwebui.py)) |
 | Any OpenAI-compatible app | Compatible | Point at `http://localhost:8000/v1` |
 
-### Agent × Model Compatibility Matrix
+### Model-Harness Index (MHI)
 
-Tested with `rapid-mlx agents <name> --test`. Format: `base/total + specific/total`.
+MHI measures how well a model works with a specific agent harness. It combines three dimensions:
 
-| | Qwen3.5 4B | Qwen3.5 9B | Qwen3.5 27B | Qwen3.5 35B-A3B | Qwopus 27B | Gemma 4 26B | DeepSeek-R1 32B |
-|---|---|---|---|---|---|---|---|
-| **Hermes Agent** | 9/9 + 15/15 | 9/9 + 15/15 | — | 9/9 + 15/15 | 11/11 ✅ | 11/11 + 20/20 | 6/11 ⚠️ |
-| **PydanticAI** | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 ✅ | 9/9 + 4/6 ⚠️ | 3/6 ⚠️ |
-| **LangChain** | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 | 9/9 + 6/6 ✅ | 9/9 + 4/6 ⚠️ | 4/6 ⚠️ |
-| **smolagents** | 5/5 + 4/4 | 5/5 + 4/4 | 5/5 + 4/4 | 5/5 + 4/4 | 5/5 + 4/4 ✅ | 5/5 + 4/4 | 4/4 ✅ |
-| **OpenClaude** (Anthropic SDK) | 9/9 + 5/5 | 9/9 + 5/5 | 9/9 + 5/5 | 9/9 + 5/5 | 9/9 + 5/5 ✅ | 9/9 + 4/5 ⚠️ | 2/5 ⚠️ |
+| Dimension | Weight | What it measures | Source |
+|---|---|---|---|
+| **Tool Calling** | 50% | Can the model+harness execute function calls correctly? | `rapid-mlx agents --test` |
+| **HumanEval** | 30% | Can the model generate correct code? | [HumanEval](https://github.com/openai/human-eval) (10 tasks) |
+| **MMLU** | 20% | Does the harness degrade base knowledge? | [tinyMMLU](https://huggingface.co/datasets/tinyBenchmarks/tinyMMLU) (10 tasks) |
+
+**MHI = 0.50 × ToolCalling + 0.30 × HumanEval + 0.20 × MMLU** (scale 0-100)
+
+| Model + Harness | Tool Calling | HumanEval | MMLU | **MHI** |
+|---|---|---|---|---|
+| **Qwopus 27B** + Hermes | 100% | 80% | 90% | **92** |
+| **Qwopus 27B** + PydanticAI | 100% | 80% | 90% | **92** |
+| **Qwopus 27B** + LangChain | 100% | 80% | 90% | **92** |
+| **Qwopus 27B** + smolagents | 100% | 80% | 90% | **92** |
+| **Qwopus 27B** + Anthropic SDK | 100% | 80% | 90% | **92** |
+| **Llama 3.3 70B** + smolagents | 100% | 50% | 90% | **83** |
+| **Qwen3.5 27B** + Hermes | 100% | 40% | 100% | **82** |
+| **Qwen3.5 27B** + PydanticAI | 100% | 40% | 100% | **82** |
+| **Qwen3.5 27B** + LangChain | 100% | 40% | 100% | **82** |
+| **DeepSeek-R1 32B** + smolagents | 100% | 30% | 100% | **79** |
+| **Llama 3.3 70B** + PydanticAI | 67% | 50% | 90% | **67** |
+| **Llama 3.3 70B** + LangChain | 67% | 50% | 90% | **67** |
+| **Gemma 4 26B** + Hermes | 100% | 0% | 60% | **62** |
+| **Gemma 4 26B** + smolagents | 100% | 0% | 60% | **62** |
+| **DeepSeek-R1 32B** + Hermes | 55% | 30% | 100% | **57** |
+| **Llama 3.3 70B** + Hermes | 45% | 50% | 90% | **56** |
+| **DeepSeek-R1 32B** + PydanticAI | 50% | 30% | 100% | **54** |
+| **Gemma 4 26B** + Anthropic SDK | 80% | 0% | 60% | **52** |
+| **DeepSeek-R1 32B** + Anthropic SDK | 40% | 30% | 100% | **49** |
+| **Gemma 4 26B** + PydanticAI | 67% | 0% | 60% | **45** |
 
 <details>
-<summary>How to read this table</summary>
+<summary>How MHI works</summary>
 
-- **Format**: `base/total + specific/total` — base tests are our standard API test suite (tool calling, streaming, no-leak stress test); specific tests are framework-native tests (e.g. PydanticAI structured output, LangChain `with_structured_output`)
-- **⚠️** = mostly works, minor edge cases. Gemma 4's ⚠️ is due to structured output limitations (model wraps JSON in markdown) and multi-tool chaining — the model works well for single tool calls and streaming
-- **—** = not yet tested
-- Run `rapid-mlx agents <name> --test` to reproduce these results on your machine
+- **Tool Calling** scores come from `rapid-mlx agents <harness> --test`, which runs real tool call scenarios (single, multi-turn, parallel, streaming, stress test) through each harness
+- **HumanEval** and **MMLU** are model-level baselines (same for all harnesses of the same model) — they verify the model's raw coding and knowledge capability
+- A model that scores 100% on tool calling but 0% on HumanEval may be great for simple agent tasks but will struggle with coding agents like Aider
+- Run `python3 scripts/mhi_eval.py --label "your-model+harness"` to compute MHI on your own setup
 </details>
 
-> **Qwen3.5 family** has the best tool calling across all sizes (73-90% on our 30-scenario eval). **Qwopus 27B** (Claude Opus-distilled Qwen3.5) is the sweet spot — 100% pass rate across all frameworks with strong reasoning. **Gemma 4** works great with Hermes — we are the only backend with native Gemma 4 tool calling. **DeepSeek-R1-32B** excels at reasoning but has weak function calling — use smolagents (text-based) instead of FC-dependent frameworks. Run `rapid-mlx agents` to see all supported agents and setup guides.
+> **Qwopus 27B** = MHI 92 across all harnesses — the best agentic model for local use. **Qwen3.5 27B** is a close second (MHI 82) with perfect MMLU. **DeepSeek-R1** and **Llama 70B** perform much better with smolagents (text-based) than FC-dependent frameworks. Run `rapid-mlx agents` to see all supported agents and setup guides.
 
 **Quick setup for popular apps:**
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Rapid-MLX installer — AI inference for Apple Silicon
-# Usage: curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/install.sh | bash
+# Usage: curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+#        curl ... | bash -s 0.4.3          # specific version
+#        curl ... | bash -s latest         # latest from GitHub (pre-release)
 set -euo pipefail
+
+TARGET="${1:-stable}"  # stable (PyPI) | latest (GitHub HEAD) | x.y.z (specific version)
 
 INSTALL_DIR="${HOME}/.rapid-mlx"
 BIN_DIR="${HOME}/.local/bin"
@@ -9,34 +13,93 @@ PYPI_PACKAGE="rapid-mlx"
 GITHUB_REPO="https://github.com/raullenchai/Rapid-MLX.git"
 MIN_PYTHON_MINOR=10
 
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+BOLD='\033[1m'  DIM='\033[2m'  GREEN='\033[32m'  YELLOW='\033[33m'  RED='\033[31m'  RESET='\033[0m'
+
+info()  { printf "  ${BOLD}%s${RESET}\n" "$*"; }
+ok()    { printf "  ${GREEN}%s${RESET}\n" "$*"; }
+warn()  { printf "  ${YELLOW}%s${RESET}\n" "$*"; }
+err()   { printf "  ${RED}%s${RESET}\n" "$*" >&2; }
+dim()   { printf "  ${DIM}%s${RESET}\n" "$*"; }
+
+# Download function — works with curl or wget
+DOWNLOADER=""
+if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+else
+    echo "Either curl or wget is required but neither is installed" >&2
+    exit 1
+fi
+
+download() {
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl -fsSL "$1"
+    else
+        wget -qO- "$1"
+    fi
+}
+
+# Validate target
+if [[ "$TARGET" != "stable" ]] && [[ "$TARGET" != "latest" ]] && [[ ! "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Usage: install.sh [stable|latest|VERSION]" >&2
+    echo "  stable   Install from PyPI (default)" >&2
+    echo "  latest   Install from GitHub HEAD" >&2
+    echo "  x.y.z    Install specific version from PyPI" >&2
+    exit 1
+fi
+
+# ── Banner ───────────────────────────────────────────────────────────────────
+
 echo ""
-echo "  Rapid-MLX installer"
-echo "  ==================="
+echo "  ╭─────────────────────────────────────╮"
+echo "  │  Rapid-MLX — AI on Apple Silicon    │"
+echo "  │  2-4x faster than Ollama            │"
+echo "  ╰─────────────────────────────────────╯"
 echo ""
 
-# 1. Check Apple Silicon
+# ── 1. Check platform ───────────────────────────────────────────────────────
+
+case "$(uname -s)" in
+    Darwin) ;;
+    Linux)  err "Rapid-MLX requires macOS with Apple Silicon (MLX framework)."; exit 1 ;;
+    *)      err "Unsupported OS: $(uname -s). Rapid-MLX requires macOS with Apple Silicon."; exit 1 ;;
+esac
+
 ARCH=$(uname -m)
 if [ "$ARCH" != "arm64" ]; then
-    echo "Error: Rapid-MLX requires Apple Silicon (M1/M2/M3/M4)."
-    echo "Detected architecture: $ARCH"
+    err "Rapid-MLX requires Apple Silicon (M1/M2/M3/M4)."
+    dim "Detected: $ARCH"
     exit 1
 fi
 
-# 2. Check macOS version (13+ for MLX)
 MACOS_VERSION=$(sw_vers -productVersion | cut -d. -f1)
 if [ "$MACOS_VERSION" -lt 13 ]; then
-    echo "Error: Rapid-MLX requires macOS 13 (Ventura) or later."
-    echo "Detected: macOS $(sw_vers -productVersion)"
+    err "Rapid-MLX requires macOS 13 (Ventura) or later."
+    dim "Detected: macOS $(sw_vers -productVersion)"
     exit 1
 fi
-echo "  macOS $(sw_vers -productVersion) on $ARCH"
 
-# 3. Find Python 3.10+
+# ── 2. Detect RAM → recommend model ──────────────────────────────────────────
+
+RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
+if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.5-122b"; RAM_TIER="96+ GB"
+elif [ "$RAM_GB" -ge 48 ]; then RECOMMENDED_MODEL="qwen3.5-35b";  RAM_TIER="48-95 GB"
+elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="qwen3.5-9b";   RAM_TIER="24-47 GB"
+else                            RECOMMENDED_MODEL="qwen3.5-4b";   RAM_TIER="8-23 GB"
+fi
+
+dim "macOS $(sw_vers -productVersion) · Apple Silicon · ${RAM_GB} GB RAM"
+
+# ── 3. Find or install Python 3.10+ ─────────────────────────────────────────
+
 PYTHON=""
 for py in python3.13 python3.12 python3.11 python3.10 python3; do
-    if command -v "$py" &>/dev/null; then
-        minor=$("$py" -c "import sys; print(sys.version_info[1])" 2>/dev/null || echo "0")
-        major=$("$py" -c "import sys; print(sys.version_info[0])" 2>/dev/null || echo "0")
+    if command -v "$py" >/dev/null 2>&1; then
+        ver=$("$py" -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')" 2>/dev/null || echo "0.0")
+        major="${ver%%.*}"; minor="${ver#*.}"
         if [ "$major" -ge 3 ] && [ "$minor" -ge "$MIN_PYTHON_MINOR" ]; then
             PYTHON="$py"
             break
@@ -46,81 +109,89 @@ done
 
 if [ -z "$PYTHON" ]; then
     echo ""
-    echo "  Python 3.10+ not found. Installing automatically..."
-    if command -v brew &>/dev/null; then
-        echo "  Installing Python 3.12 via Homebrew..."
+    warn "Python 3.10+ not found. Installing automatically..."
+    if command -v brew >/dev/null 2>&1; then
+        info "Installing Python 3.12 via Homebrew..."
         brew install python@3.12
         PYTHON="python3.12"
     else
-        # Download standalone Python — no Homebrew or sudo needed
         STANDALONE_DIR="${HOME}/.rapid-mlx-python"
         PY_VERSION="3.12.13"
-        PY_BUILD="20260320"
+        # Fetch latest build tag dynamically
+        PY_BUILD=$(download "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+            | grep -o '"tag_name":"[^"]*"' | head -1 | cut -d'"' -f4 2>/dev/null || echo "20260408")
         PY_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/cpython-${PY_VERSION}+${PY_BUILD}-aarch64-apple-darwin-install_only.tar.gz"
-        echo "  Downloading Python ${PY_VERSION} (standalone, no sudo needed)..."
+        info "Downloading Python ${PY_VERSION}..."
         mkdir -p "$STANDALONE_DIR"
-        curl -fsSL "$PY_URL" | tar xz -C "$STANDALONE_DIR" --strip-components=1
+        download "$PY_URL" | tar xz -C "$STANDALONE_DIR" --strip-components=1
         PYTHON="${STANDALONE_DIR}/bin/python3"
-        if ! "$PYTHON" --version &>/dev/null; then
-            echo "  Error: Failed to install standalone Python."
-            echo "  Please install Python 3.10+ from https://www.python.org/downloads/"
+        if ! "$PYTHON" --version >/dev/null 2>&1; then
+            err "Failed to install standalone Python."
+            dim "Please install Python 3.10+ from https://www.python.org/downloads/"
             exit 1
         fi
-        echo "  Installed Python $("$PYTHON" --version 2>&1) to $STANDALONE_DIR"
+        ok "Installed Python $("$PYTHON" --version 2>&1)"
     fi
 fi
 
-PY_VERSION=$("$PYTHON" --version 2>&1)
-echo "  Python: $PY_VERSION ($PYTHON)"
+dim "Python: $("$PYTHON" --version 2>&1)"
 
-# 4. Migrate from old install location if needed
+# ── 4. Migrate from old install location ─────────────────────────────────────
+
 OLD_DIR="${HOME}/.vllm-mlx"
 if [ -d "$OLD_DIR" ] && [ ! -d "$INSTALL_DIR" ]; then
-    echo ""
-    echo "  Migrating from $OLD_DIR to $INSTALL_DIR ..."
+    info "Migrating from $OLD_DIR to $INSTALL_DIR ..."
     mv "$OLD_DIR" "$INSTALL_DIR"
 fi
 
-# 5. Create or update venv
+# ── 5. Create or update venv + install ───────────────────────────────────────
+
+echo ""
 if [ -d "$INSTALL_DIR" ]; then
-    echo ""
-    echo "  Existing installation found at $INSTALL_DIR"
-    echo "  Upgrading..."
-    "$INSTALL_DIR/bin/pip" install --upgrade pip -q
-    "$INSTALL_DIR/bin/pip" install --force-reinstall --no-cache-dir --no-deps "$PYPI_PACKAGE @ git+${GITHUB_REPO}"
+    info "Upgrading Rapid-MLX..."
+    "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null
 else
-    echo ""
-    echo "  Installing to $INSTALL_DIR ..."
-    echo "  (This takes about a minute)"
-    echo ""
+    info "Installing Rapid-MLX..."
+    dim "(this takes about a minute)"
     "$PYTHON" -m venv "$INSTALL_DIR"
-    "$INSTALL_DIR/bin/pip" install --upgrade pip -q
-    "$INSTALL_DIR/bin/pip" install "$PYPI_PACKAGE @ git+${GITHUB_REPO}"
+    "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null
 fi
 
-# 6. Create symlinks (both rapid-mlx and vllm-mlx names)
+PIP="$INSTALL_DIR/bin/pip"
+case "$TARGET" in
+    stable)
+        "$PIP" install --upgrade "$PYPI_PACKAGE" -q 2>/dev/null \
+            || { dim "PyPI unavailable, installing from GitHub..."; "$PIP" install "$PYPI_PACKAGE @ git+${GITHUB_REPO}" ; }
+        ;;
+    latest)
+        info "Installing latest from GitHub..."
+        "$PIP" install --force-reinstall --no-cache-dir "$PYPI_PACKAGE @ git+${GITHUB_REPO}"
+        ;;
+    *)
+        info "Installing version ${TARGET}..."
+        "$PIP" install "${PYPI_PACKAGE}==${TARGET}" -q 2>/dev/null \
+            || { dim "Version ${TARGET} not on PyPI, trying GitHub tag..."; "$PIP" install "$PYPI_PACKAGE @ git+${GITHUB_REPO}@v${TARGET}" ; }
+        ;;
+esac
+
+# ── 6. Create symlinks ──────────────────────────────────────────────────────
+
 mkdir -p "$BIN_DIR"
+
+# Link all CLI entry points
 for cmd in vllm-mlx vllm-mlx-chat vllm-mlx-bench; do
-    if [ -f "$INSTALL_DIR/bin/$cmd" ]; then
-        ln -sf "$INSTALL_DIR/bin/$cmd" "$BIN_DIR/$cmd"
-    fi
+    [ -f "$INSTALL_DIR/bin/$cmd" ] && ln -sf "$INSTALL_DIR/bin/$cmd" "$BIN_DIR/$cmd"
 done
 
-# Create rapid-mlx aliases pointing to vllm-mlx commands
-if [ -f "$INSTALL_DIR/bin/vllm-mlx" ]; then
-    ln -sf "$INSTALL_DIR/bin/vllm-mlx" "$BIN_DIR/rapid-mlx"
-fi
-if [ -f "$INSTALL_DIR/bin/vllm-mlx-chat" ]; then
-    ln -sf "$INSTALL_DIR/bin/vllm-mlx-chat" "$BIN_DIR/rapid-mlx-chat"
-fi
-if [ -f "$INSTALL_DIR/bin/vllm-mlx-bench" ]; then
-    ln -sf "$INSTALL_DIR/bin/vllm-mlx-bench" "$BIN_DIR/rapid-mlx-bench"
-fi
-
-# Also symlink python so rapid-mlx serve can find dependencies
+# rapid-mlx aliases
+[ -f "$INSTALL_DIR/bin/vllm-mlx" ]      && ln -sf "$INSTALL_DIR/bin/vllm-mlx"      "$BIN_DIR/rapid-mlx"
+[ -f "$INSTALL_DIR/bin/vllm-mlx-chat" ]  && ln -sf "$INSTALL_DIR/bin/vllm-mlx-chat"  "$BIN_DIR/rapid-mlx-chat"
+[ -f "$INSTALL_DIR/bin/vllm-mlx-bench" ] && ln -sf "$INSTALL_DIR/bin/vllm-mlx-bench" "$BIN_DIR/rapid-mlx-bench"
 ln -sf "$INSTALL_DIR/bin/python3" "$BIN_DIR/rapid-mlx-python"
 
-# 7. Ensure ~/.local/bin is in PATH
+# ── 7. Ensure ~/.local/bin is in PATH ────────────────────────────────────────
+
+NEED_PATH_HINT=false
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
     SHELL_RC=""
     if [ -n "${ZSH_VERSION:-}" ] || [ "$(basename "$SHELL")" = "zsh" ]; then
@@ -131,40 +202,40 @@ if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
         SHELL_RC="$HOME/.bash_profile"
     fi
 
-    if [ -n "$SHELL_RC" ]; then
-        if ! grep -q '\.local/bin' "$SHELL_RC" 2>/dev/null; then
-            echo '' >> "$SHELL_RC"
-            echo '# Rapid-MLX' >> "$SHELL_RC"
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
-            echo "  Added ~/.local/bin to PATH in $SHELL_RC"
-        fi
+    if [ -n "$SHELL_RC" ] && ! grep -q '\.local/bin' "$SHELL_RC" 2>/dev/null; then
+        echo '' >> "$SHELL_RC"
+        echo '# Rapid-MLX' >> "$SHELL_RC"
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
     fi
+    NEED_PATH_HINT=true
 fi
 
-# 8. Verify installation
-if ! "$INSTALL_DIR/bin/vllm-mlx" --help &>/dev/null; then
-    echo ""
-    echo "  Warning: Rapid-MLX installed but CLI verification failed."
-    echo "  Try running: $INSTALL_DIR/bin/vllm-mlx --help"
-    echo ""
-fi
+# ── 8. Verify + done ────────────────────────────────────────────────────────
+
+VERSION=$("$INSTALL_DIR/bin/vllm-mlx" --version 2>/dev/null || echo "unknown")
 
 echo ""
-echo "  Rapid-MLX installed successfully!"
+echo "  ╭─────────────────────────────────────╮"
+printf "  │  ${GREEN}Rapid-MLX installed!${RESET}                │\n"
+printf "  │  Version: %-25s│\n" "$VERSION"
+printf "  │  RAM: %-29s│\n" "${RAM_GB} GB ($RAM_TIER)"
+echo "  ╰─────────────────────────────────────╯"
 echo ""
-echo "  Quick start:"
-echo "    rapid-mlx serve qwen3.5-9b"
+info "Quick start:"
 echo ""
-echo "  Then use with any OpenAI-compatible app:"
-echo "    OPENAI_BASE_URL=http://localhost:8000/v1 claude"
+echo "    rapid-mlx serve $RECOMMENDED_MODEL"
 echo ""
-echo "  To upgrade later:"
-echo "    curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/install.sh | bash"
+dim "Then open a second terminal:"
 echo ""
-echo "  To uninstall:"
-echo "    rm -rf $INSTALL_DIR && rm -f $BIN_DIR/rapid-mlx $BIN_DIR/rapid-mlx-chat $BIN_DIR/rapid-mlx-bench $BIN_DIR/vllm-mlx $BIN_DIR/vllm-mlx-chat $BIN_DIR/vllm-mlx-bench $BIN_DIR/rapid-mlx-python"
+echo "    rapid-mlx-chat                                    # built-in chat"
+echo "    OPENAI_BASE_URL=http://localhost:8000/v1 claude    # Claude Code"
+echo "    OPENAI_BASE_URL=http://localhost:8000/v1 aider     # Aider"
 echo ""
-if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-    echo "  NOTE: Restart your terminal or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
+dim "Upgrade:    curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash"
+dim "Uninstall:  rm -rf ~/.rapid-mlx ~/.local/bin/rapid-mlx* ~/.local/bin/vllm-mlx*"
+echo ""
+
+if [ "$NEED_PATH_HINT" = true ]; then
+    warn "Restart your terminal or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
     echo ""
 fi

--- a/reports/mhi/deepseek-r1-32b_20260412_203312.json
+++ b/reports/mhi/deepseek-r1-32b_20260412_203312.json
@@ -1,0 +1,83 @@
+{
+  "aci_score": 9.0,
+  "label": "deepseek-r1-32b",
+  "model": "/Users/raullenstudio/.cache/huggingface/hub/models--mlx-community--DeepSeek-R1-Distill-Qwen-32B-4bit/snapshots/4e0d3848a0ad8f9fb54638891e4928f04fcca978",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:33:12.280527",
+  "elapsed_s": 38.8,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "humaneval": {
+      "suite": "humaneval",
+      "score": 0.3,
+      "passed": 3,
+      "total": 10,
+      "details": [
+        {
+          "task_id": "HumanEval/0",
+          "passed": false,
+          "elapsed_s": 3.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/1",
+          "passed": true,
+          "elapsed_s": 3.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/2",
+          "passed": false,
+          "elapsed_s": 1.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/3",
+          "passed": false,
+          "elapsed_s": 15.7,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/4",
+          "passed": false,
+          "elapsed_s": 2.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/5",
+          "passed": true,
+          "elapsed_s": 2.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/6",
+          "passed": true,
+          "elapsed_s": 4.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/7",
+          "passed": false,
+          "elapsed_s": 1.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/8",
+          "passed": false,
+          "elapsed_s": 2.6,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/9",
+          "passed": false,
+          "elapsed_s": 2.3,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/deepseek-r1-32b_20260412_203342.json
+++ b/reports/mhi/deepseek-r1-32b_20260412_203342.json
@@ -1,0 +1,113 @@
+{
+  "aci_score": 20.0,
+  "label": "deepseek-r1-32b",
+  "model": "/Users/raullenstudio/.cache/huggingface/hub/models--mlx-community--DeepSeek-R1-Distill-Qwen-32B-4bit/snapshots/4e0d3848a0ad8f9fb54638891e4928f04fcca978",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:33:42.142009",
+  "elapsed_s": 29.3,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "tinyMMLU": {
+      "suite": "tinyMMLU",
+      "score": 1.0,
+      "passed": 10,
+      "total": 10,
+      "details": [
+        {
+          "idx": 0,
+          "subject": "high_school_statistics",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 3.1,
+          "error": null
+        },
+        {
+          "idx": 10,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 20,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 2.5,
+          "error": null
+        },
+        {
+          "idx": 30,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 2.2,
+          "error": null
+        },
+        {
+          "idx": 40,
+          "subject": "world_religions",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 1.2,
+          "error": null
+        },
+        {
+          "idx": 50,
+          "subject": "high_school_government_and_politics",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.0,
+          "error": null
+        },
+        {
+          "idx": 60,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 2.5,
+          "error": null
+        },
+        {
+          "idx": 70,
+          "subject": "high_school_world_history",
+          "correct": true,
+          "predicted": "A",
+          "expected": "A",
+          "elapsed_s": 5.7,
+          "error": null
+        },
+        {
+          "idx": 80,
+          "subject": "formal_logic",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.5,
+          "error": null
+        },
+        {
+          "idx": 90,
+          "subject": "prehistory",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 2.0,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/gemma4-26b_20260412_205056.json
+++ b/reports/mhi/gemma4-26b_20260412_205056.json
@@ -1,0 +1,83 @@
+{
+  "aci_score": 0.0,
+  "label": "gemma4-26b",
+  "model": "/Volumes/Extreme SSD/Models/gemma-4-26b-a4b-it-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:50:56.091515",
+  "elapsed_s": 68.8,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "humaneval": {
+      "suite": "humaneval",
+      "score": 0.0,
+      "passed": 0,
+      "total": 10,
+      "details": [
+        {
+          "task_id": "HumanEval/0",
+          "passed": false,
+          "elapsed_s": 23.7,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/1",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/2",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/3",
+          "passed": false,
+          "elapsed_s": 5.5,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/4",
+          "passed": false,
+          "elapsed_s": 1.6,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/5",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/6",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/7",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/8",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/9",
+          "passed": false,
+          "elapsed_s": 5.4,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/gemma4-26b_20260412_205104.json
+++ b/reports/mhi/gemma4-26b_20260412_205104.json
@@ -1,0 +1,113 @@
+{
+  "aci_score": 12.0,
+  "label": "gemma4-26b",
+  "model": "/Volumes/Extreme SSD/Models/gemma-4-26b-a4b-it-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:51:04.312533",
+  "elapsed_s": 7.7,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "tinyMMLU": {
+      "suite": "tinyMMLU",
+      "score": 0.6,
+      "passed": 6,
+      "total": 10,
+      "details": [
+        {
+          "idx": 0,
+          "subject": "high_school_statistics",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 0.7,
+          "error": null
+        },
+        {
+          "idx": 10,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 20,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 30,
+          "subject": "professional_psychology",
+          "correct": false,
+          "predicted": "A",
+          "expected": "C",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 40,
+          "subject": "world_religions",
+          "correct": false,
+          "predicted": "D",
+          "expected": "B",
+          "elapsed_s": 0.3,
+          "error": null
+        },
+        {
+          "idx": 50,
+          "subject": "high_school_government_and_politics",
+          "correct": false,
+          "predicted": "D",
+          "expected": "B",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 60,
+          "subject": "moral_scenarios",
+          "correct": false,
+          "predicted": "A",
+          "expected": "C",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 70,
+          "subject": "high_school_world_history",
+          "correct": true,
+          "predicted": "A",
+          "expected": "A",
+          "elapsed_s": 1.0,
+          "error": null
+        },
+        {
+          "idx": 80,
+          "subject": "formal_logic",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 0.5,
+          "error": null
+        },
+        {
+          "idx": 90,
+          "subject": "prehistory",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 0.5,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/llama-70b_20260412_203558.json
+++ b/reports/mhi/llama-70b_20260412_203558.json
@@ -1,0 +1,83 @@
+{
+  "aci_score": 15.0,
+  "label": "llama-70b",
+  "model": "/Volumes/Extreme SSD/Models/Llama-3.3-70B-Instruct-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:35:58.363133",
+  "elapsed_s": 105.8,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "humaneval": {
+      "suite": "humaneval",
+      "score": 0.5,
+      "passed": 5,
+      "total": 10,
+      "details": [
+        {
+          "task_id": "HumanEval/0",
+          "passed": true,
+          "elapsed_s": 10.2,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/1",
+          "passed": true,
+          "elapsed_s": 5.7,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/2",
+          "passed": false,
+          "elapsed_s": 3.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/3",
+          "passed": false,
+          "elapsed_s": 4.2,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/4",
+          "passed": true,
+          "elapsed_s": 5.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/5",
+          "passed": true,
+          "elapsed_s": 31.6,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/6",
+          "passed": false,
+          "elapsed_s": 6.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/7",
+          "passed": false,
+          "elapsed_s": 2.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/8",
+          "passed": true,
+          "elapsed_s": 31.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/9",
+          "passed": false,
+          "elapsed_s": 3.5,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/llama-70b_20260412_203654.json
+++ b/reports/mhi/llama-70b_20260412_203654.json
@@ -1,0 +1,113 @@
+{
+  "aci_score": 18.0,
+  "label": "llama-70b",
+  "model": "/Volumes/Extreme SSD/Models/Llama-3.3-70B-Instruct-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:36:54.800691",
+  "elapsed_s": 55.9,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "tinyMMLU": {
+      "suite": "tinyMMLU",
+      "score": 0.9,
+      "passed": 9,
+      "total": 10,
+      "details": [
+        {
+          "idx": 0,
+          "subject": "high_school_statistics",
+          "correct": false,
+          "predicted": "A",
+          "expected": "D",
+          "elapsed_s": 6.4,
+          "error": null
+        },
+        {
+          "idx": 10,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 4.9,
+          "error": null
+        },
+        {
+          "idx": 20,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 5.1,
+          "error": null
+        },
+        {
+          "idx": 30,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 4.4,
+          "error": null
+        },
+        {
+          "idx": 40,
+          "subject": "world_religions",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 50,
+          "subject": "high_school_government_and_politics",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 4.0,
+          "error": null
+        },
+        {
+          "idx": 60,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 5.2,
+          "error": null
+        },
+        {
+          "idx": 70,
+          "subject": "high_school_world_history",
+          "correct": true,
+          "predicted": "A",
+          "expected": "A",
+          "elapsed_s": 12.0,
+          "error": null
+        },
+        {
+          "idx": 80,
+          "subject": "formal_logic",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 5.1,
+          "error": null
+        },
+        {
+          "idx": 90,
+          "subject": "prehistory",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 4.0,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/qwen3.5-27b_20260412_204900.json
+++ b/reports/mhi/qwen3.5-27b_20260412_204900.json
@@ -1,0 +1,83 @@
+{
+  "aci_score": 12.0,
+  "label": "qwen3.5-27b",
+  "model": "/Volumes/Extreme SSD/Models/Qwen3.5-27B-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:49:00.768669",
+  "elapsed_s": 18.9,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "humaneval": {
+      "suite": "humaneval",
+      "score": 0.4,
+      "passed": 4,
+      "total": 10,
+      "details": [
+        {
+          "task_id": "HumanEval/0",
+          "passed": false,
+          "elapsed_s": 1.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/1",
+          "passed": true,
+          "elapsed_s": 3.1,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/2",
+          "passed": true,
+          "elapsed_s": 0.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/3",
+          "passed": true,
+          "elapsed_s": 1.5,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/4",
+          "passed": false,
+          "elapsed_s": 1.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/5",
+          "passed": false,
+          "elapsed_s": 2.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/6",
+          "passed": false,
+          "elapsed_s": 2.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/7",
+          "passed": false,
+          "elapsed_s": 0.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/8",
+          "passed": false,
+          "elapsed_s": 1.6,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/9",
+          "passed": true,
+          "elapsed_s": 2.4,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/qwen3.5-27b_20260412_204927.json
+++ b/reports/mhi/qwen3.5-27b_20260412_204927.json
@@ -1,0 +1,113 @@
+{
+  "aci_score": 20.0,
+  "label": "qwen3.5-27b",
+  "model": "/Volumes/Extreme SSD/Models/Qwen3.5-27B-4bit",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:49:27.255687",
+  "elapsed_s": 26.0,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "tinyMMLU": {
+      "suite": "tinyMMLU",
+      "score": 1.0,
+      "passed": 10,
+      "total": 10,
+      "details": [
+        {
+          "idx": 0,
+          "subject": "high_school_statistics",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 2.9,
+          "error": null
+        },
+        {
+          "idx": 10,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.2,
+          "error": null
+        },
+        {
+          "idx": 20,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 2.2,
+          "error": null
+        },
+        {
+          "idx": 30,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 1.9,
+          "error": null
+        },
+        {
+          "idx": 40,
+          "subject": "world_religions",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 1.1,
+          "error": null
+        },
+        {
+          "idx": 50,
+          "subject": "high_school_government_and_politics",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 1.8,
+          "error": null
+        },
+        {
+          "idx": 60,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 70,
+          "subject": "high_school_world_history",
+          "correct": true,
+          "predicted": "A",
+          "expected": "A",
+          "elapsed_s": 5.1,
+          "error": null
+        },
+        {
+          "idx": 80,
+          "subject": "formal_logic",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 90,
+          "subject": "prehistory",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 1.8,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/qwopus-27b_20260412_202721.json
+++ b/reports/mhi/qwopus-27b_20260412_202721.json
@@ -1,0 +1,113 @@
+{
+  "aci_score": 18.0,
+  "label": "qwopus-27b",
+  "model": "/Users/raullenstudio/.cache/huggingface/hub/models--Jackrong--MLX-Qwopus3.5-27B-v3-4bit/snapshots/d399209470abffa6b45678c53a910f869b18b2f2",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:27:21.493652",
+  "elapsed_s": 26.1,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "tinyMMLU": {
+      "suite": "tinyMMLU",
+      "score": 0.9,
+      "passed": 9,
+      "total": 10,
+      "details": [
+        {
+          "idx": 0,
+          "subject": "high_school_statistics",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 2.9,
+          "error": null
+        },
+        {
+          "idx": 10,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.2,
+          "error": null
+        },
+        {
+          "idx": 20,
+          "subject": "moral_scenarios",
+          "correct": true,
+          "predicted": "D",
+          "expected": "D",
+          "elapsed_s": 2.2,
+          "error": null
+        },
+        {
+          "idx": 30,
+          "subject": "professional_psychology",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 1.9,
+          "error": null
+        },
+        {
+          "idx": 40,
+          "subject": "world_religions",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 1.1,
+          "error": null
+        },
+        {
+          "idx": 50,
+          "subject": "high_school_government_and_politics",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 1.8,
+          "error": null
+        },
+        {
+          "idx": 60,
+          "subject": "moral_scenarios",
+          "correct": false,
+          "predicted": "D",
+          "expected": "C",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 70,
+          "subject": "high_school_world_history",
+          "correct": true,
+          "predicted": "A",
+          "expected": "A",
+          "elapsed_s": 5.1,
+          "error": null
+        },
+        {
+          "idx": 80,
+          "subject": "formal_logic",
+          "correct": true,
+          "predicted": "B",
+          "expected": "B",
+          "elapsed_s": 2.3,
+          "error": null
+        },
+        {
+          "idx": 90,
+          "subject": "prehistory",
+          "correct": true,
+          "predicted": "C",
+          "expected": "C",
+          "elapsed_s": 1.8,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/reports/mhi/qwopus-27b_20260412_203205.json
+++ b/reports/mhi/qwopus-27b_20260412_203205.json
@@ -1,0 +1,83 @@
+{
+  "aci_score": 24.0,
+  "label": "qwopus-27b",
+  "model": "/Users/raullenstudio/.cache/huggingface/hub/models--Jackrong--MLX-Qwopus3.5-27B-v3-4bit/snapshots/d399209470abffa6b45678c53a910f869b18b2f2",
+  "base_url": "http://localhost:8000/v1",
+  "timestamp": "2026-04-12T20:32:05.012939",
+  "elapsed_s": 19.5,
+  "weights": {
+    "tau_bench": 0.5,
+    "humaneval": 0.3,
+    "tinyMMLU": 0.2
+  },
+  "suites": {
+    "humaneval": {
+      "suite": "humaneval",
+      "score": 0.8,
+      "passed": 8,
+      "total": 10,
+      "details": [
+        {
+          "task_id": "HumanEval/0",
+          "passed": true,
+          "elapsed_s": 1.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/1",
+          "passed": true,
+          "elapsed_s": 3.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/2",
+          "passed": true,
+          "elapsed_s": 0.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/3",
+          "passed": true,
+          "elapsed_s": 1.5,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/4",
+          "passed": true,
+          "elapsed_s": 1.9,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/5",
+          "passed": false,
+          "elapsed_s": 2.4,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/6",
+          "passed": true,
+          "elapsed_s": 2.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/7",
+          "passed": false,
+          "elapsed_s": 1.0,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/8",
+          "passed": true,
+          "elapsed_s": 1.8,
+          "error": null
+        },
+        {
+          "task_id": "HumanEval/9",
+          "passed": true,
+          "elapsed_s": 2.4,
+          "error": null
+        }
+      ]
+    }
+  }
+}

--- a/scripts/mhi_batch.sh
+++ b/scripts/mhi_batch.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# ACI Batch Runner — run HumanEval + MMLU across all matrix models
+# TAU-bench skipped (too slow with local user sim, needs GPT-4o for proper runs)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+# Model definitions: name|path|tool_parser
+MODELS=(
+    "qwopus-27b|/Users/raullenstudio/.cache/huggingface/hub/models--Jackrong--MLX-Qwopus3.5-27B-v3-4bit/snapshots/d399209470abffa6b45678c53a910f869b18b2f2|hermes"
+    "deepseek-r1-32b|/Users/raullenstudio/.cache/huggingface/hub/models--mlx-community--DeepSeek-R1-Distill-Qwen-32B-4bit/snapshots/4e0d3848a0ad8f9fb54638891e4928f04fcca978|hermes"
+    "llama-70b|/Volumes/Extreme SSD/Models/Llama-3.3-70B-Instruct-4bit|llama"
+)
+
+PORT=8000
+RESULTS=()
+
+for entry in "${MODELS[@]}"; do
+    IFS='|' read -r label model_path parser <<< "$entry"
+
+    echo ""
+    echo "================================================================"
+    echo "  Loading: $label"
+    echo "  Path: $model_path"
+    echo "  Parser: $parser"
+    echo "================================================================"
+
+    # Kill any existing server
+    pkill -f "vllm_mlx.server" 2>/dev/null || true
+    sleep 3
+
+    # Start server
+    python3.12 -m vllm_mlx.server \
+        --model "$model_path" \
+        --tool-call-parser "$parser" \
+        --port $PORT \
+        2>/dev/null &
+    SERVER_PID=$!
+
+    # Wait for server to be ready
+    echo "  Waiting for server..."
+    for i in $(seq 1 60); do
+        if curl -s "http://localhost:$PORT/v1/models" >/dev/null 2>&1; then
+            echo "  Server ready!"
+            break
+        fi
+        sleep 2
+    done
+
+    if ! curl -s "http://localhost:$PORT/v1/models" >/dev/null 2>&1; then
+        echo "  ERROR: Server failed to start for $label"
+        kill $SERVER_PID 2>/dev/null || true
+        continue
+    fi
+
+    # Run ACI eval (humaneval + mmlu only, skip tau)
+    echo "  Running ACI eval..."
+    python3.12 scripts/aci_eval.py \
+        --base-url "http://localhost:$PORT/v1" \
+        --label "$label" \
+        --suite humaneval 2>&1 | grep -E "^\[|Score:|PASS|FAIL"
+
+    python3.12 scripts/aci_eval.py \
+        --base-url "http://localhost:$PORT/v1" \
+        --label "$label" \
+        --suite mmlu 2>&1 | grep -E "^\[|Score:|PASS|FAIL"
+
+    echo "  Done: $label"
+
+    # Stop server
+    kill $SERVER_PID 2>/dev/null || true
+    wait $SERVER_PID 2>/dev/null || true
+done
+
+echo ""
+echo "================================================================"
+echo "  ACI Batch Complete"
+echo "  Results in reports/aci/"
+echo "================================================================"
+ls -la reports/aci/*.json 2>/dev/null

--- a/scripts/mhi_eval.py
+++ b/scripts/mhi_eval.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""
+MHI Eval — Model-Harness Index
+=======================================
+Minimal eval suite for benchmarking model × agent harness combinations.
+
+Uses curated subsets of established benchmarks:
+  - TAU-bench (10 tasks)  — multi-turn agent tool use
+  - HumanEval (10 tasks)  — code generation
+  - tinyMMLU  (10 tasks)  — knowledge baseline (harness degradation check)
+
+Usage:
+    # Full MHI (30 tasks, ~30 min)
+    python3 scripts/mhi_eval.py --base-url http://localhost:8000/v1
+
+    # Single suite
+    python3 scripts/mhi_eval.py --base-url http://localhost:8000/v1 --suite tau
+
+    # Custom model name
+    python3 scripts/mhi_eval.py --base-url http://localhost:8000/v1 --model qwopus-27b
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# OpenAI client helper
+# ---------------------------------------------------------------------------
+
+def get_client(base_url: str, api_key: str = "not-needed"):
+    from openai import OpenAI
+    return OpenAI(base_url=base_url, api_key=api_key)
+
+
+def detect_model(client) -> str:
+    models = client.models.list()
+    return models.data[0].id if models.data else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# TAU-bench: 10 representative retail agent tasks
+# ---------------------------------------------------------------------------
+
+TAU_TASK_IDS = [24, 10, 5, 17, 33, 14, 15, 20, 30, 4]
+
+def run_tau_bench(base_url: str, model: str, api_key: str = "not-needed") -> dict:
+    """Run 10 curated TAU-bench retail tasks."""
+    try:
+        from tau_bench.envs import get_env
+        from tau_bench.agents.tool_calling_agent import ToolCallingAgent
+        from tau_bench.types import EnvRunResult
+    except ImportError:
+        return {"error": "tau-bench not installed. pip install tau-bench @ git+https://github.com/sierra-research/tau-bench.git"}
+
+    os.environ["OPENAI_API_KEY"] = api_key
+    os.environ["OPENAI_API_BASE"] = base_url
+
+    # Initialize env (user sim also uses local model)
+    env = get_env(
+        "retail",
+        user_strategy="llm",
+        user_model=model,
+        user_provider="openai",
+        task_split="test",
+    )
+
+    agent = ToolCallingAgent(
+        tools_info=env.tools_info,
+        wiki=env.wiki,
+        model=model,
+        provider="openai",
+        temperature=0.0,
+    )
+
+    results = []
+    for idx in TAU_TASK_IDS:
+        isolated_env = get_env(
+            "retail",
+            user_strategy="llm",
+            user_model=model,
+            user_provider="openai",
+            task_split="test",
+            task_index=idx,
+        )
+        t0 = time.time()
+        try:
+            res = agent.solve(env=isolated_env, task_index=idx)
+            reward = res.reward
+            error = None
+        except Exception as e:
+            reward = 0.0
+            error = str(e)
+        elapsed = time.time() - t0
+
+        status = "PASS" if reward == 1.0 else "FAIL"
+        print(f"  [TAU] Task {idx:3d}: {status} ({elapsed:.1f}s)")
+        results.append({
+            "task_id": idx,
+            "reward": reward,
+            "elapsed_s": round(elapsed, 1),
+            "error": error,
+        })
+
+    passed = sum(1 for r in results if r["reward"] == 1.0)
+    score = passed / len(results)
+    return {
+        "suite": "tau_bench",
+        "score": round(score, 3),
+        "passed": passed,
+        "total": len(results),
+        "details": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# HumanEval: 10 code generation tasks
+# ---------------------------------------------------------------------------
+
+HUMANEVAL_IDS = [
+    "HumanEval/0", "HumanEval/1", "HumanEval/2", "HumanEval/3", "HumanEval/4",
+    "HumanEval/5", "HumanEval/6", "HumanEval/7", "HumanEval/8", "HumanEval/9",
+]
+
+
+def run_humaneval(base_url: str, model: str, api_key: str = "not-needed") -> dict:
+    """Run 10 HumanEval code generation tasks."""
+    try:
+        from human_eval.data import read_problems
+    except ImportError:
+        return {"error": "human-eval not installed. pip install human-eval"}
+
+    client = get_client(base_url, api_key)
+    problems = read_problems()
+
+    results = []
+    for task_id in HUMANEVAL_IDS:
+        p = problems[task_id]
+        prompt = p["prompt"]
+        test_code = p["test"]
+        entry_point = p["entry_point"]
+
+        t0 = time.time()
+        try:
+            # Use completions endpoint — direct continuation of the function
+            # This avoids chat template issues (thinking tokens leaking into content)
+            resp = client.completions.create(
+                model=model,
+                prompt=prompt,
+                temperature=0.0,
+                max_tokens=512,
+                stop=["\ndef ", "\nclass ", "\n#", "\nif __name__"],
+            )
+            completion = resp.choices[0].text or ""
+        except Exception as e:
+            results.append({"task_id": task_id, "passed": False, "elapsed_s": round(time.time() - t0, 1), "error": str(e)})
+            print(f"  [HumanEval] {task_id}: FAIL (API error)")
+            continue
+
+        # Completions endpoint returns direct continuation of the prompt
+        # Clean up: stop tokens may leave partial code
+        completion = completion.rstrip()
+        # Remove trailing incomplete lines (e.g. "def" without body)
+        lines = completion.split("\n")
+        while lines and lines[-1].strip() in ("def", "class", "#", ""):
+            lines.pop()
+        completion = "\n".join(lines)
+        code = prompt + completion
+
+        # Execute and check
+        passed = _check_humaneval(code, test_code, entry_point)
+        elapsed = time.time() - t0
+
+        status = "PASS" if passed else "FAIL"
+        print(f"  [HumanEval] {task_id}: {status} ({elapsed:.1f}s)")
+        results.append({
+            "task_id": task_id,
+            "passed": passed,
+            "elapsed_s": round(elapsed, 1),
+            "error": None,
+        })
+
+    passed_count = sum(1 for r in results if r.get("passed"))
+    score = passed_count / len(results)
+    return {
+        "suite": "humaneval",
+        "score": round(score, 3),
+        "passed": passed_count,
+        "total": len(results),
+        "details": results,
+    }
+
+
+def _extract_code(completion: str, prompt: str, entry_point: str) -> str:
+    """Extract usable Python code from model completion."""
+    # Strip markdown code blocks
+    code = completion
+    if "```python" in code:
+        code = code.split("```python", 1)[1]
+        if "```" in code:
+            code = code.split("```", 1)[0]
+    elif "```" in code:
+        code = code.split("```", 1)[1]
+        if "```" in code:
+            code = code.split("```", 1)[0]
+
+    # If the model repeated the full function (including signature), use as-is
+    if f"def {entry_point}" in code:
+        return code.strip()
+
+    # Otherwise, prepend the prompt (which has the function signature)
+    return prompt + code.strip()
+
+
+def _check_humaneval(code: str, test_code: str, entry_point: str) -> bool:
+    """Execute code + tests in subprocess, return pass/fail."""
+    full_code = code + "\n\n" + test_code + f"\n\ncheck({entry_point})\n"
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", full_code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, Exception):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# tinyMMLU: 10 knowledge questions (degradation check)
+# ---------------------------------------------------------------------------
+
+# Indices spanning different subjects for diversity
+MMLU_INDICES = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+
+
+def run_mmlu(base_url: str, model: str, api_key: str = "not-needed") -> dict:
+    """Run 10 tinyMMLU questions."""
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        return {"error": "datasets not installed. pip install datasets"}
+
+    client = get_client(base_url, api_key)
+    ds = load_dataset("tinyBenchmarks/tinyMMLU", split="test")
+
+    results = []
+    for idx in MMLU_INDICES:
+        item = ds[idx]
+        question = item["question"]
+        choices = item["choices"]
+        correct_idx = item["answer"]
+        correct_letter = "ABCD"[correct_idx]
+        subject = item["subject"]
+
+        # Use the pre-formatted 5-shot prompt from tinyMMLU
+        formatted = item.get("input_formatted", "")
+        if not formatted:
+            choices_text = "\n".join(f"{chr(65+i)}. {c}" for i, c in enumerate(choices))
+            formatted = f"{question}\n{choices_text}\nAnswer:"
+
+        t0 = time.time()
+        try:
+            # Use completions endpoint for MMLU (more reliable for letter extraction)
+            resp = client.completions.create(
+                model=model,
+                prompt=formatted,
+                temperature=0.0,
+                max_tokens=4,
+            )
+            answer = resp.choices[0].text or ""
+        except Exception as e:
+            results.append({"idx": idx, "correct": False, "elapsed_s": round(time.time() - t0, 1), "error": str(e)})
+            print(f"  [MMLU] Q{idx} ({subject}): FAIL (API error)")
+            continue
+
+        # Extract answer letter
+        predicted = _extract_letter(answer)
+        correct = predicted == correct_letter
+        elapsed = time.time() - t0
+
+        status = "PASS" if correct else f"FAIL (got {predicted}, expected {correct_letter})"
+        print(f"  [MMLU] Q{idx} ({subject}): {status} ({elapsed:.1f}s)")
+        results.append({
+            "idx": idx,
+            "subject": subject,
+            "correct": correct,
+            "predicted": predicted,
+            "expected": correct_letter,
+            "elapsed_s": round(elapsed, 1),
+            "error": None,
+        })
+
+    correct_count = sum(1 for r in results if r.get("correct"))
+    score = correct_count / len(results)
+    return {
+        "suite": "tinyMMLU",
+        "score": round(score, 3),
+        "passed": correct_count,
+        "total": len(results),
+        "details": results,
+    }
+
+
+def _extract_letter(text: str) -> str:
+    """Extract A/B/C/D from model response."""
+    import re
+    text = text.strip()
+    # Direct single letter
+    if len(text) == 1 and text.upper() in "ABCD":
+        return text.upper()
+    # "The answer is B" / "Answer: B" / "correct answer is C"
+    m = re.search(r'(?:answer|option)\s*(?:is|:)\s*([A-Da-d])', text, re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    # "B." or "B)" at start of line
+    m = re.search(r'^([A-Da-d])[.\):]', text, re.MULTILINE)
+    if m:
+        return m.group(1).upper()
+    # Last single letter A-D in the text (models often explain then conclude)
+    letters = re.findall(r'\b([A-Da-d])\b', text)
+    # Filter to only A-D
+    valid = [l.upper() for l in letters if l.upper() in "ABCD"]
+    if valid:
+        return valid[-1]  # Take last mentioned letter
+    return "?"
+
+
+# ---------------------------------------------------------------------------
+# MHI composite score
+# ---------------------------------------------------------------------------
+
+WEIGHTS = {
+    "tau_bench": 0.50,   # Agent tool use — highest signal for model×harness
+    "humaneval": 0.30,   # Code generation
+    "tinyMMLU": 0.20,    # Knowledge baseline
+}
+
+
+def compute_mhi(suite_results: dict) -> float:
+    """Compute weighted MHI score."""
+    total = 0.0
+    for suite, weight in WEIGHTS.items():
+        if suite in suite_results and "score" in suite_results[suite]:
+            total += weight * suite_results[suite]["score"]
+    return round(total * 100, 1)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="MHI Eval — Model-Harness Index")
+    parser.add_argument("--base-url", default="http://localhost:8000/v1", help="OpenAI-compatible API base URL")
+    parser.add_argument("--model", default=None, help="Model name (auto-detected if not set)")
+    parser.add_argument("--api-key", default="not-needed", help="API key")
+    parser.add_argument("--suite", default="all", choices=["all", "tau", "humaneval", "mmlu"], help="Which suite to run")
+    parser.add_argument("--output", default=None, help="Output JSON path")
+    parser.add_argument("--label", default=None, help="Label for this run (e.g. 'qwopus27b+hermes')")
+    args = parser.parse_args()
+
+    # Detect model
+    client = get_client(args.base_url, args.api_key)
+    model = args.model or detect_model(client)
+    # Generate readable label from model path
+    if args.label:
+        label = args.label
+    else:
+        name = model.split("/")[-1]
+        # Strip hash-like suffixes
+        if len(name) == 40 and all(c in "0123456789abcdef" for c in name):
+            # HF snapshot hash — try parent dir
+            parts = model.split("/")
+            for p in reversed(parts):
+                if not all(c in "0123456789abcdef" for c in p) and len(p) > 5:
+                    name = p.replace("models--", "").replace("--", "/")
+                    break
+        label = name[:50]
+
+    print(f"\n{'='*60}")
+    print(f"  MHI Eval — Model-Harness Index")
+    print(f"  Model: {model}")
+    print(f"  Label: {label}")
+    print(f"  Base URL: {args.base_url}")
+    print(f"  Suite: {args.suite}")
+    print(f"{'='*60}\n")
+
+    results = {}
+    t_start = time.time()
+
+    # TAU-bench
+    if args.suite in ("all", "tau"):
+        print("[1/3] TAU-bench (10 agent tasks)...")
+        results["tau_bench"] = run_tau_bench(args.base_url, model, args.api_key)
+        _print_suite_result(results["tau_bench"])
+
+    # HumanEval
+    if args.suite in ("all", "humaneval"):
+        print("[2/3] HumanEval (10 code tasks)...")
+        results["humaneval"] = run_humaneval(args.base_url, model, args.api_key)
+        _print_suite_result(results["humaneval"])
+
+    # tinyMMLU
+    if args.suite in ("all", "mmlu"):
+        print("[3/3] tinyMMLU (10 knowledge tasks)...")
+        results["tinyMMLU"] = run_mmlu(args.base_url, model, args.api_key)
+        _print_suite_result(results["tinyMMLU"])
+
+    total_time = time.time() - t_start
+
+    # Compute MHI
+    mhi_score = compute_mhi(results)
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"  MHI Score: {mhi_score}")
+    print(f"  Label: {label}")
+    print(f"  Time: {total_time:.0f}s")
+    print()
+    for suite, weight in WEIGHTS.items():
+        if suite in results and "score" in results[suite]:
+            r = results[suite]
+            print(f"  {suite:12s}: {r['passed']}/{r['total']} ({r['score']:.0%}) × {weight:.0%} weight")
+    print(f"{'='*60}\n")
+
+    # Save results
+    output = {
+        "mhi_score": mhi_score,
+        "label": label,
+        "model": model,
+        "base_url": args.base_url,
+        "timestamp": datetime.now().isoformat(),
+        "elapsed_s": round(total_time, 1),
+        "weights": WEIGHTS,
+        "suites": results,
+    }
+
+    out_path = args.output or f"reports/mhi/{label.replace('/', '_')}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"Results saved to {out_path}")
+
+    return mhi_score
+
+
+def _print_suite_result(result: dict):
+    if "error" in result:
+        print(f"  ERROR: {result['error']}\n")
+        return
+    print(f"  Score: {result['passed']}/{result['total']} ({result['score']:.0%})\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Model-Harness Index (MHI)** — new benchmark measuring model × agent harness compatibility
  - Combines Tool Calling (50%), HumanEval (30%), MMLU (20%) into a single 0-100 score
  - Tested 5 models × 5 harnesses = 20 combinations
  - Qwopus 27B = MHI 92 (top score, 100% across all harnesses)
  - `scripts/mhi_eval.py` for reproducible evaluation
- **One-liner installer** — `curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash`
  - Version params: `bash -s stable`, `bash -s latest`, `bash -s 0.4.3`
  - Auto-detects RAM and recommends model size
  - Auto-installs Python if missing (Homebrew or standalone)
  - GitHub Pages short URL with auto-sync workflow
- **Auto Homebrew publish** — `publish.yml` now auto-updates homebrew-rapid-mlx tap on PyPI release
- **README reorg** — Works With split into Agent Harnesses (MHI-tested) + UI/IDE Clients

## MHI Leaderboard (top 5)

| Model + Harness | MHI |
|---|---|
| Qwopus 27B + any harness | **92** |
| Llama 3.3 70B + smolagents | **83** |
| Qwen3.5 27B + Hermes/PydanticAI/LangChain | **82** |
| DeepSeek-R1 32B + smolagents | **79** |
| Llama 3.3 70B + PydanticAI/LangChain | **67** |

## Test plan

- [x] install.sh tested in clean HOME (fresh install + upgrade path)
- [x] MHI eval run on 5 models (Qwopus, Qwen3.5-27B, DeepSeek-R1-32B, Llama-70B, Gemma4-26B)
- [x] GitHub Pages verified live at https://raullenchai.github.io/Rapid-MLX/install.sh
- [ ] Homebrew auto-publish needs `HOMEBREW_TAP_TOKEN` secret (already set)