### PR TITLE
fix: cherry-pick upstream security fixes and GLM bug fix

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -701,27 +701,25 @@ class TestToolSandboxAuditLogging:
 class TestToolSandboxHighRiskTools:
     """Tests for high-risk tool detection."""
 
-    def test_high_risk_tool_warning(self, caplog):
-        """Test that high-risk tools trigger warning."""
-        import logging
-
+    def test_high_risk_tool_blocked_by_default(self):
+        """High-risk tools should be blocked unless explicitly allowlisted."""
         sandbox = ToolSandbox()
 
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(MCPSecurityError) as exc_info:
             sandbox.validate_tool_execution(
                 tool_name="execute_command",
                 server_name="test",
                 arguments={"cmd": "ls"},
             )
 
-        assert "High-risk tool detected" in caplog.text
-        assert "execute" in caplog.text
+        assert "High-risk tool 'execute_command' is blocked" in str(exc_info.value)
+        assert "allowed_high_risk_tools" in str(exc_info.value)
 
-    def test_high_risk_shell_tool(self, caplog):
-        """Test that shell tools trigger warning."""
+    def test_high_risk_tool_allowed_by_short_name(self, caplog):
+        """Short-name allowlist entries should permit trusted high-risk tools."""
         import logging
 
-        sandbox = ToolSandbox()
+        sandbox = ToolSandbox(allowed_high_risk_tools={"run_shell"})
 
         with caplog.at_level(logging.WARNING):
             sandbox.validate_tool_execution(
@@ -730,7 +728,22 @@ class TestToolSandboxHighRiskTools:
                 arguments={},
             )
 
-        assert "High-risk tool detected" in caplog.text
+        assert "Allowing high-risk tool 'test__run_shell'" in caplog.text
+
+    def test_high_risk_tool_allowed_by_full_name(self, caplog):
+        """Full-name allowlist entries should permit trusted high-risk tools."""
+        import logging
+
+        sandbox = ToolSandbox(allowed_high_risk_tools={"trusted__execute_command"})
+
+        with caplog.at_level(logging.WARNING):
+            sandbox.validate_tool_execution(
+                tool_name="execute_command",
+                server_name="trusted",
+                arguments={"cmd": "ls"},
+            )
+
+        assert "Allowing high-risk tool 'trusted__execute_command'" in caplog.text
 
 
 class TestCustomBlockedPatterns:

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -12,6 +12,7 @@ from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
     FunctionaryToolParser,
+    Glm47ToolParser,
     GraniteToolParser,
     HarmonyToolParser,
     HermesToolParser,
@@ -39,6 +40,7 @@ class TestNativeToolFormatCapability:
             KimiToolParser,
             HermesToolParser,
             HarmonyToolParser,
+            Glm47ToolParser,
         ]
         for parser_cls in native_parsers:
             assert parser_cls.SUPPORTS_NATIVE_TOOL_FORMAT is True, (
@@ -76,6 +78,7 @@ class TestNativeToolFormatCapability:
             "kimi",
             "hermes",
             "harmony",
+            "glm47",
         ]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert parser_cls.supports_native_format() is True, (

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -13,10 +13,8 @@ from .types import MCPConfig, MCPServerConfig
 
 logger = logging.getLogger(__name__)
 
-# Default config search paths
+# Default per-user config search paths
 CONFIG_SEARCH_PATHS = [
-    "./mcp.json",
-    "./mcp.yaml",
     "~/.config/vllm-mlx/mcp.json",
     "~/.config/vllm-mlx/mcp.yaml",
 ]
@@ -32,8 +30,7 @@ def load_mcp_config(path: str | Path | None = None) -> MCPConfig:
     Search order:
     1. Explicit path argument
     2. VLLM_MLX_MCP_CONFIG environment variable
-    3. ./mcp.json or ./mcp.yaml (current directory)
-    4. ~/.config/vllm-mlx/mcp.json or mcp.yaml
+    3. ~/.config/vllm-mlx/mcp.json or mcp.yaml
 
     Args:
         path: Optional explicit path to config file
@@ -144,10 +141,20 @@ def validate_config(data: dict[str, Any]) -> MCPConfig:
     if not isinstance(default_timeout, (int, float)) or default_timeout <= 0:
         raise ValueError("'default_timeout' must be a positive number")
 
+    allowed_high_risk_tools = data.get("allowed_high_risk_tools", [])
+    if not isinstance(allowed_high_risk_tools, list) or any(
+        not isinstance(tool, str) or not tool.strip()
+        for tool in allowed_high_risk_tools
+    ):
+        raise ValueError(
+            "'allowed_high_risk_tools' must be a list of non-empty strings"
+        )
+
     return MCPConfig(
         servers=servers,
         max_tool_calls=max_tool_calls,
         default_timeout=default_timeout,
+        allowed_high_risk_tools=set(allowed_high_risk_tools),
     )
 
 
@@ -182,5 +189,6 @@ def create_example_config() -> str:
         },
         "max_tool_calls": 10,
         "default_timeout": 30.0,
+        "allowed_high_risk_tools": [],
     }
     return json.dumps(example, indent=2)

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -401,6 +401,7 @@ class ToolSandbox:
         self,
         allowed_tools: set[str] | None = None,
         blocked_tools: set[str] | None = None,
+        allowed_high_risk_tools: set[str] | None = None,
         blocked_arg_patterns: list[re.Pattern] | None = None,
         max_calls_per_minute: int = 60,
         audit_callback: Callable[[ToolExecutionAudit], None] | None = None,
@@ -412,6 +413,7 @@ class ToolSandbox:
         Args:
             allowed_tools: If set, only these tools can be executed (whitelist mode).
             blocked_tools: Tools that are always blocked (blacklist mode).
+            allowed_high_risk_tools: High-risk tools that are explicitly allowed.
             blocked_arg_patterns: Patterns to block in tool arguments.
             max_calls_per_minute: Rate limit for tool calls (0 = unlimited).
             audit_callback: Optional callback for audit events.
@@ -419,6 +421,9 @@ class ToolSandbox:
         """
         self.allowed_tools = allowed_tools
         self.blocked_tools = blocked_tools or set()
+        self.allowed_high_risk_tools = {
+            tool.lower() for tool in (allowed_high_risk_tools or set())
+        }
         self.blocked_arg_patterns = (
             blocked_arg_patterns or DANGEROUS_TOOL_ARG_PATTERNS.copy()
         )
@@ -479,7 +484,7 @@ class ToolSandbox:
                 )
 
         # Check for high-risk tool patterns
-        self._check_high_risk_tool(tool_name)
+        self._check_high_risk_tool(tool_name, full_name)
 
         # Validate arguments
         self._validate_arguments(tool_name, arguments)
@@ -497,16 +502,26 @@ class ToolSandbox:
             or tool_name.lower() in self.blocked_tools
         )
 
-    def _check_high_risk_tool(self, tool_name: str) -> None:
+    def _check_high_risk_tool(self, tool_name: str, full_name: str) -> None:
         """Check if tool matches high-risk patterns."""
         tool_lower = tool_name.lower()
+        full_lower = full_name.lower()
         for pattern in HIGH_RISK_TOOL_PATTERNS:
             if pattern in tool_lower:
-                logger.warning(
-                    f"High-risk tool detected: '{tool_name}' matches pattern '{pattern}'. "
-                    f"Ensure this tool is from a trusted MCP server."
+                if (
+                    tool_lower in self.allowed_high_risk_tools
+                    or full_lower in self.allowed_high_risk_tools
+                ):
+                    logger.warning(
+                        "Allowing high-risk tool '%s' due to explicit allowlist entry",
+                        full_name,
+                    )
+                    return
+                raise MCPSecurityError(
+                    f"High-risk tool '{tool_name}' is blocked by security policy. "
+                    f"Add '{full_name}' or '{tool_name}' to allowed_high_risk_tools "
+                    f"to allow it explicitly."
                 )
-                break
 
     def _validate_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         """Validate tool arguments for dangerous patterns."""

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -5,7 +5,7 @@ Type definitions for MCP client support.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Set
 
 
 class MCPTransport(str, Enum):
@@ -97,6 +97,7 @@ class MCPConfig:
     servers: dict[str, MCPServerConfig] = field(default_factory=dict)
     max_tool_calls: int = 10
     default_timeout: float = 30.0
+    allowed_high_risk_tools: Set[str] = field(default_factory=set)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MCPConfig":
@@ -110,6 +111,7 @@ class MCPConfig:
             servers=servers,
             max_tool_calls=data.get("max_tool_calls", 10),
             default_timeout=data.get("default_timeout", 30.0),
+            allowed_high_risk_tools=set(data.get("allowed_high_risk_tools", [])),
         )
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1947,6 +1947,21 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             messages.append(msg_dict)
         images, videos = [], []  # MLLM extracts these from messages
         logger.debug(f"MLLM: Processing {len(messages)} messages")
+        # Convert tool_call arguments from JSON string to dict so that
+        # chat templates can iterate them (e.g. GLM-4.6V calls .items()).
+        # The LLM path does this inside extract_multimodal_content(), but
+        # the MLLM path bypasses that function.
+        if engine.preserve_native_tool_format:
+            for msg_dict in messages:
+                for tc in msg_dict.get("tool_calls") or []:
+                    func = tc.get("function") or {}
+                    args = func.get("arguments")
+                    if isinstance(args, str):
+                        try:
+                            func["arguments"] = json.loads(args)
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+        messages = _normalize_messages(messages)
     else:
         # For LLM, extract text, images, and videos separately
         messages, images, videos = extract_multimodal_content(
@@ -3545,13 +3560,19 @@ async def init_mcp(config_path: str):
     global _mcp_manager, _mcp_executor
 
     try:
-        from vllm_mlx.mcp import MCPClientManager, ToolExecutor, load_mcp_config
+        from vllm_mlx.mcp import (
+            MCPClientManager,
+            ToolExecutor,
+            ToolSandbox,
+            load_mcp_config,
+        )
 
         config = load_mcp_config(config_path)
         _mcp_manager = MCPClientManager(config)
         await _mcp_manager.start()
 
-        _mcp_executor = ToolExecutor(_mcp_manager)
+        sandbox = ToolSandbox(allowed_high_risk_tools=config.allowed_high_risk_tools)
+        _mcp_executor = ToolExecutor(_mcp_manager, sandbox=sandbox)
 
         logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
 

--- a/vllm_mlx/tool_parsers/glm47_tool_parser.py
+++ b/vllm_mlx/tool_parsers/glm47_tool_parser.py
@@ -38,6 +38,8 @@ class Glm47ToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser glm47 are set.
     """
 
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Match entire tool call block
     TOOL_CALL_PATTERN = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 


### PR DESCRIPTION
## Summary
- **#347** (janhilgard): Fix MLLM tool_call arguments not converted from JSON string to dict — crashes GLM-4.6V templates that call `.items()`. Also enables `SUPPORTS_NATIVE_TOOL_FORMAT` for GLM-4.7 parser.
- **#345** (Thump604): Remove `./mcp.json` and `./mcp.yaml` from auto-discovery to prevent planted config injection from CWD.
- **#343** (Thump604): Change high-risk MCP tools from warn-only to block-by-default with `allowed_high_risk_tools` allowlist.

## Test plan
- [x] `tests/test_native_tool_format.py` — 13 passed (GLM-4.7 native format verified)
- [x] `tests/test_mcp_security.py` — 57 passed (block-by-default + allowlist tests)
- [x] Full test suite — 325 passed, 1 known failure (BatchedEngine #105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)