### PR TITLE
perf: bump mlx 0.31, expose --prefill-step-size, guard spec on non-trimmable caches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     # Core — these are all you need for `rapid-mlx serve <text-model>`
-    "mlx>=0.29.0",
+    "mlx>=0.31.0",  # 0.31+ for SDPA/qmm Metal speedups (mlx#3023, #3120, #3119)
     "mlx-lm>=0.31.0",  # 0.31+ required for ArraysCache native batching (hybrid models)
     "mlx-vlm>=0.4.4",  # 0.4.4+ required for Gemma 4 support
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -347,7 +347,9 @@ def serve_command(args):
             gpu_memory_utilization=args.gpu_memory_utilization,
             draft_model=args.draft_model,
             num_draft_tokens=args.num_draft_tokens,
-            prefill_step_size=args.prefill_step_size,
+            # SimpleEngine expects an int — substitute LLM default when unset.
+            # MLLM/Batch paths read from scheduler_config (None handled there).
+            prefill_step_size=args.prefill_step_size if args.prefill_step_size is not None else 2048,
             kv_bits=args.kv_bits,
             kv_group_size=args.kv_group_size,
             cloud_model=args.cloud_model,
@@ -1055,9 +1057,10 @@ Examples:
     serve_parser.add_argument(
         "--prefill-step-size",
         type=int,
-        default=2048,
+        default=None,
         help="Chunk size for prompt prefill processing. Larger values use more memory "
-        "but can improve prefill throughput. (default: 2048)",
+        "but can improve prefill throughput. "
+        "(default: 2048 for LLM, 1024 for MLLM/vision; lower to reduce memory)",
     )
     # SpecPrefill (attention-based sparse prefill using draft model)
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -347,9 +347,9 @@ def serve_command(args):
             gpu_memory_utilization=args.gpu_memory_utilization,
             draft_model=args.draft_model,
             num_draft_tokens=args.num_draft_tokens,
-            # SimpleEngine expects an int — substitute LLM default when unset.
-            # MLLM/Batch paths read from scheduler_config (None handled there).
-            prefill_step_size=args.prefill_step_size if args.prefill_step_size is not None else 2048,
+            # None passes through; SimpleEngine resolves to 2048 (LLM) or
+            # 1024 (MLLM/vision) based on auto-detected model type.
+            prefill_step_size=args.prefill_step_size,
             kv_bits=args.kv_bits,
             kv_group_size=args.kv_group_size,
             cloud_model=args.cloud_model,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -279,6 +279,8 @@ def serve_command(args):
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
+            # Prefill chunking
+            prefill_step_size=args.prefill_step_size,
         )
 
         print("Mode: Continuous batching (for multiple concurrent users)")

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -239,10 +239,12 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 16
         )
-        # Honor user's --prefill-step-size if set (default 1024 for MLLM safety)
-        prefill_step_size = getattr(
-            self._scheduler_config, "prefill_step_size", 1024
-        )
+        # Honor user's --prefill-step-size if explicitly set; else keep MLLM
+        # default of 1024 (safer for vision/multimodal memory profiles).
+        # SchedulerConfig.prefill_step_size is None when the CLI flag was
+        # not passed, so we leave MLLM untouched in that case.
+        user_prefill_step = getattr(self._scheduler_config, "prefill_step_size", None)
+        prefill_step_size = user_prefill_step if user_prefill_step is not None else 1024
 
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -239,11 +239,16 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 16
         )
+        # Honor user's --prefill-step-size if set (default 1024 for MLLM safety)
+        prefill_step_size = getattr(
+            self._scheduler_config, "prefill_step_size", 1024
+        )
 
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
             completion_batch_size=completion_batch_size,
+            prefill_step_size=prefill_step_size,
             enable_vision_cache=True,
             vision_cache_size=100,
         )

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -68,7 +68,7 @@ class SimpleEngine(BaseEngine):
         draft_model: str | None = None,
         num_draft_tokens: int = 4,
         mtp: bool = False,
-        prefill_step_size: int = 2048,
+        prefill_step_size: int | None = None,
         kv_bits: int | None = None,
         kv_group_size: int = 64,
         specprefill_enabled: bool = False,
@@ -87,7 +87,8 @@ class SimpleEngine(BaseEngine):
             draft_model: Optional draft model path for speculative decoding
             num_draft_tokens: Number of tokens to generate speculatively per step
             mtp: Enable native MTP speculative decoding (model must have MTP head)
-            prefill_step_size: Tokens to process per prefill chunk (default: 2048)
+            prefill_step_size: Tokens to process per prefill chunk.
+                None = engine default (2048 for LLM, 1024 for MLLM/vision).
             kv_bits: KV cache quantization bits (None=no quantization, 4 or 8)
             kv_group_size: Group size for KV cache quantization (default: 64)
             specprefill_enabled: Enable SpecPrefill (attention-based sparse prefill)
@@ -102,6 +103,10 @@ class SimpleEngine(BaseEngine):
         self._draft_model_name = draft_model
         self._num_draft_tokens = num_draft_tokens
         self._mtp = mtp
+        # Resolve None to engine-specific default: MLLM gets the safer 1024
+        # to keep vision/multimodal memory profiles in check.
+        if prefill_step_size is None:
+            prefill_step_size = 1024 if self._is_mllm else 2048
         self._prefill_step_size = prefill_step_size
         self._kv_bits = kv_bits
         self._kv_group_size = kv_group_size

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -68,7 +68,9 @@ class SchedulerConfig:
     # BatchGenerator settings
     prefill_batch_size: int = 8
     completion_batch_size: int = 32
-    prefill_step_size: int = 2048
+    # None = engine-specific default (2048 for LLM, 1024 for MLLM).
+    # Set explicitly to override both.
+    prefill_step_size: int | None = None
 
     # Prefix cache settings
     enable_prefix_cache: bool = True
@@ -1197,7 +1199,9 @@ class Scheduler:
             sampler=sampler,
             prefill_batch_size=self.config.prefill_batch_size,
             completion_batch_size=self.config.completion_batch_size,
-            prefill_step_size=self.config.prefill_step_size,
+            # Fall back to BatchGenerator's own default (2048) when caller
+            # did not pin a value via --prefill-step-size.
+            prefill_step_size=self.config.prefill_step_size or 2048,
         )
 
         # Install chunked prefill when explicitly configured OR when
@@ -1238,7 +1242,7 @@ class Scheduler:
                 "[chunked_prefill] Skipped — mlx-lm 0.31+ removed the internal "
                 "Batch API. Using native prefill_step_size=%d instead. "
                 "Memory-aware cache and mid-prefill snapshots are unavailable.",
-                self.config.prefill_step_size,
+                self.config.prefill_step_size or 2048,
             )
 
         # Install MTP if the model supports it

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -819,7 +819,7 @@ def load_model(
     gpu_memory_utilization: float = 0.90,
     draft_model: str | None = None,
     num_draft_tokens: int = 4,
-    prefill_step_size: int = 2048,
+    prefill_step_size: int | None = None,
     kv_bits: int | None = None,
     kv_group_size: int = 64,
     cloud_model: str | None = None,
@@ -847,7 +847,8 @@ def load_model(
             limit and emergency threshold (0.0-1.0, default 0.90)
         draft_model: Optional draft model for speculative decoding
         num_draft_tokens: Number of tokens to generate speculatively per step
-        prefill_step_size: Tokens to process per prefill chunk (default: 2048)
+        prefill_step_size: Tokens to process per prefill chunk.
+            None = engine default (2048 for LLM, 1024 for MLLM/vision).
         kv_bits: KV cache quantization bits (None=no quantization, 4 or 8)
         kv_group_size: Group size for KV cache quantization (default: 64)
         mtp: Enable native MTP speculative decoding (SimpleEngine only)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3768,8 +3768,9 @@ Examples:
     parser.add_argument(
         "--prefill-step-size",
         type=int,
-        default=2048,
-        help="Tokens to process per prefill chunk (default: 2048). "
+        default=None,
+        help="Tokens to process per prefill chunk "
+        "(default: 2048 for LLM, 1024 for MLLM/vision). "
         "Larger values may improve TTFT on Apple Silicon with sufficient memory.",
     )
     parser.add_argument(

--- a/vllm_mlx/speculative/prompt_lookup.py
+++ b/vllm_mlx/speculative/prompt_lookup.py
@@ -213,6 +213,17 @@ def prompt_lookup_generate_step(
     if prompt_cache is None:
         prompt_cache = cache.make_prompt_cache(model)
 
+    # Guard: speculative decoding requires a trimmable cache to roll back
+    # rejected draft tokens. Recurrent caches (ArraysCache used by
+    # GatedDeltaNet/SSM models like Qwen3.5, MiniMax) cannot be trimmed —
+    # falling through would silently corrupt state. Mirrors mlx-lm#1109.
+    can_speculate = cache.can_trim_prompt_cache(prompt_cache)
+    if not can_speculate:
+        logger.info(
+            "Prompt-lookup speculation disabled: model uses a non-trimmable "
+            "cache (e.g. GatedDeltaNet/SSM). Falling back to standard decode."
+        )
+
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
     # Initialize prompt lookup decoder
@@ -264,7 +275,8 @@ def prompt_lookup_generate_step(
         decoder.add_generated_token(current_token.item())
 
         # Try to get draft tokens via n-gram lookup
-        draft_tokens = decoder.get_draft_tokens()
+        # Skip speculation entirely on non-trimmable caches (recurrent models)
+        draft_tokens = decoder.get_draft_tokens() if can_speculate else None
 
         if draft_tokens and len(draft_tokens) > 0:
             # Speculative path: verify draft tokens


### PR DESCRIPTION
## Summary

Three upstream-driven performance/correctness improvements based on a survey of mlx, mlx-lm, mlx-vlm, and vLLM since early 2026:

1. **Bump mlx 0.30.6 → 0.31.0+** — silent SDPA/qmm Metal speedups (mlx#3023, #3120, #3119). Particularly relevant on M3U/M4M/M5.
2. **Expose `--prefill-step-size` to BatchedEngine paths** — previously only threaded through SimpleEngine. Helps 32GB Mac users avoid OOM on 20K+ prompts.
3. **Spec decoding guard for non-trimmable caches** — mirrors mlx-lm#1109. Prompt-lookup speculation would silently corrupt state on rejected drafts when used with GatedDeltaNet/SSM models (Qwen3.5, MiniMax). Now detects via `can_trim_prompt_cache()` and falls back to standard decode.

## Test plan
- [x] All 2027 unit tests pass on mlx 0.31.1 + mlx-lm 0.31.2
- [x] Spec/scheduler/batching test groups specifically green (39 + 324 tests)
- [ ] Manual smoke: `rapid-mlx serve` with a small Qwen model and a long prompt, confirm `--prefill-step-size 1024` lowers memory peak

## Deferred (separate PRs)

The original survey identified 6 items; the 3 below are larger refactors against the new mlx-lm 0.31+ API surface and warrant dedicated PRs:

- **Port mlx-lm BatchGenerator refactor (PR #1072)** — not a port; mlx-lm rewrote the API (`active_batch` removed; new `_prompt_batch`/`_generation_batch` + `SequenceStateMachine`). Our `scheduler.py` monkey-patches still reference removed internals. Closes #105.
- **mlx-vlm VisionFeatureCache (PR #913)** — model-specific; only Gemma 4 implements `encode_image()` that consumes it. Needs `mllm_scheduler.py` integration and per-model compat check. Up to 11.7x prompt TPS on multi-turn vision.
- **LRUPromptCache multi-tier (PR #1019, #911)** — refactor of `prefix_cache.py` + `memory_cache.py`. Enables prefix caching on non-trimmable DeltaNet caches. Best done after BatchedEngine API migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)