### PR TITLE
feat: rapid-mlx doctor — 4-tier regression harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ reports/*.json
 reports/*.md
 reports/*.tsv
 reports/scan_*
+
+# Doctor harness — per-run artefacts (baselines/ ARE checked in)
+harness/runs/*
+!harness/runs/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ reports/scan_*
 # Doctor harness — per-run artefacts (baselines/ ARE checked in)
 harness/runs/*
 !harness/runs/.gitkeep
+# Scorecard timestamped runs are local; only latest.md is tracked
+harness/scorecard/scorecard-*.md

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,22 @@
 .PHONY: help smoke check full benchmark update-baselines lint test clean
 
-# Pick the active interpreter, then fall back to common names.
-# Override with: make smoke PY=python3.13
-PY ?= $(shell command -v python3.12 2>/dev/null \
-              || command -v python3.13 2>/dev/null \
-              || command -v python3.11 2>/dev/null \
-              || command -v python3.10 2>/dev/null \
-              || command -v python3 2>/dev/null \
-              || echo python)
+# Pick the interpreter:
+#   1. Active venv (VIRTUAL_ENV/bin/python) — wins so contributors using
+#      a 3.10/3.11/3.13 venv get their venv's python regardless of PATH
+#   2. Versioned binaries — only if no venv is active.  Skips 'python' /
+#      'python3' here because on macOS those can be system Python 3.9,
+#      which is below our minimum (project requires-python = >=3.10).
+# Override explicitly with: make smoke PY=python3.13
+PY ?= $(shell \
+  if [ -n "$$VIRTUAL_ENV" ] && [ -x "$$VIRTUAL_ENV/bin/python" ]; then \
+    echo "$$VIRTUAL_ENV/bin/python"; \
+  else \
+    command -v python3.13 2>/dev/null \
+    || command -v python3.12 2>/dev/null \
+    || command -v python3.11 2>/dev/null \
+    || command -v python3.10 2>/dev/null \
+    || echo python3; \
+  fi)
 HF_HUB_CACHE ?= $(shell echo $$HF_HUB_CACHE)
 DOCTOR := $(PY) -m vllm_mlx.cli doctor
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+.PHONY: help smoke check full benchmark update-baselines lint test clean
+
+PY ?= python3.12
+HF_HUB_CACHE ?= $(shell echo $$HF_HUB_CACHE)
+DOCTOR := $(PY) -m vllm_mlx.cli doctor
+
+help:
+	@echo "Rapid-MLX developer targets:"
+	@echo ""
+	@echo "  Doctor (regression harness — see harness/README.md):"
+	@echo "    make smoke              ~2 min,  no model required"
+	@echo "    make check              ~10 min, qwen3.5-4b"
+	@echo "    make full               ~1-2 hr, 3 models + 11 agents"
+	@echo "    make benchmark          (not yet implemented)"
+	@echo "    make update-baselines TIER=check  re-record baseline (after review)"
+	@echo ""
+	@echo "  Quick checks:"
+	@echo "    make lint               ruff over vllm_mlx/ + tests/"
+	@echo "    make test               pytest unit suite (excludes integration)"
+	@echo ""
+	@echo "  Env: HF_HUB_CACHE=$(HF_HUB_CACHE)"
+
+# ---------- doctor tiers ----------
+smoke:
+	$(DOCTOR) smoke
+
+check:
+	$(DOCTOR) check
+
+full:
+	$(DOCTOR) full
+
+benchmark:
+	$(DOCTOR) benchmark
+
+# Usage: make update-baselines TIER=check
+# Always inspect 'git diff harness/baselines/' before committing.
+update-baselines:
+	@if [ -z "$(TIER)" ]; then \
+		echo "error: TIER is required. Example: make update-baselines TIER=check"; \
+		exit 2; \
+	fi
+	$(DOCTOR) $(TIER) --update-baselines
+
+# ---------- quick checks ----------
+lint:
+	@if $(PY) -m ruff --version >/dev/null 2>&1; then \
+		$(PY) -m ruff check vllm_mlx/ tests/; \
+	elif command -v ruff >/dev/null 2>&1; then \
+		ruff check vllm_mlx/ tests/; \
+	else \
+		echo "ruff not installed — pip install ruff"; \
+		exit 1; \
+	fi
+
+test:
+	$(PY) -m pytest tests/ -q --ignore=tests/integrations \
+	    --deselect tests/test_event_loop.py
+
+clean:
+	rm -rf harness/runs/*
+	@echo "Cleared harness/runs/ — baselines kept."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 .PHONY: help smoke check full benchmark update-baselines lint test clean
 
-PY ?= python3.12
+# Pick the active interpreter, then fall back to common names.
+# Override with: make smoke PY=python3.13
+PY ?= $(shell command -v python3.12 2>/dev/null \
+              || command -v python3.13 2>/dev/null \
+              || command -v python3.11 2>/dev/null \
+              || command -v python3.10 2>/dev/null \
+              || command -v python3 2>/dev/null \
+              || echo python)
 HF_HUB_CACHE ?= $(shell echo $$HF_HUB_CACHE)
 DOCTOR := $(PY) -m vllm_mlx.cli doctor
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 	@echo "    make smoke              ~2 min,  no model required"
 	@echo "    make check              ~10 min, qwen3.5-4b"
 	@echo "    make full               ~1-2 hr, 3 models + 11 agents"
-	@echo "    make benchmark          (not yet implemented)"
+	@echo "    make benchmark          overnight, all local models → scorecard"
 	@echo "    make update-baselines TIER=check  re-record baseline (after review)"
 	@echo ""
 	@echo "  Quick checks:"

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
 .PHONY: help smoke check full benchmark update-baselines lint test clean
 
 # Pick the interpreter:
-#   1. Active venv (VIRTUAL_ENV/bin/python) — wins so contributors using
-#      a 3.10/3.11/3.13 venv get their venv's python regardless of PATH
-#   2. Versioned binaries — only if no venv is active.  Skips 'python' /
-#      'python3' here because on macOS those can be system Python 3.9,
-#      which is below our minimum (project requires-python = >=3.10).
+#   1. Active venv ($VIRTUAL_ENV/bin/python) — wins so contributors using
+#      a 3.10/3.11/3.13 venv get their venv's python regardless of PATH.
+#   2. Versioned binaries that actually run a >=3.10 interpreter — we
+#      must run --version because pyenv shims appear on PATH for *every*
+#      version even if only one is installed, and macOS's bare 'python'
+#      is often system 3.9 (below requires-python).
+#   3. python3 last-resort fallback (lets the user see a clean error if
+#      nothing on the system meets the version requirement).
 # Override explicitly with: make smoke PY=python3.13
 PY ?= $(shell \
   if [ -n "$$VIRTUAL_ENV" ] && [ -x "$$VIRTUAL_ENV/bin/python" ]; then \
-    echo "$$VIRTUAL_ENV/bin/python"; \
-  else \
-    command -v python3.13 2>/dev/null \
-    || command -v python3.12 2>/dev/null \
-    || command -v python3.11 2>/dev/null \
-    || command -v python3.10 2>/dev/null \
-    || echo python3; \
-  fi)
+    echo "$$VIRTUAL_ENV/bin/python"; exit 0; \
+  fi; \
+  for cand in python3.13 python3.12 python3.11 python3.10 python3; do \
+    path=$$(command -v $$cand 2>/dev/null) || continue; \
+    "$$path" -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' \
+      2>/dev/null && echo "$$path" && exit 0; \
+  done; \
+  echo python3)
 HF_HUB_CACHE ?= $(shell echo $$HF_HUB_CACHE)
 DOCTOR := $(PY) -m vllm_mlx.cli doctor
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -96,7 +96,36 @@ rapid-mlx doctor full --models qwen3.5-4b,gemma-4-26b
 
 ### `benchmark` (overnight, all local models)
 
-*Not yet implemented* — see TODO at the bottom of this file.
+Sweeps every model with locally-present weights and produces a single
+scorecard markdown:
+
+```bash
+# Auto-discovers models in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+HF_HUB_CACHE=... rapid-mlx doctor benchmark
+
+# Or be explicit (forces inclusion even if cache probe misses):
+rapid-mlx doctor benchmark --models qwen3.5-4b,qwen3.5-9b,gemma-4-26b
+```
+
+Output:
+
+- `harness/scorecard/scorecard-{ts}.md` — timestamped, gitignored
+- `harness/scorecard/latest.md` — always points at the most recent run
+- `harness/runs/{ts}-benchmark/scorecard.md` — copy in the run dir for
+  self-containment alongside server logs
+
+Scorecard columns (kept narrow on purpose — wide markdown tables are
+unreadable):
+
+| Model | Decode TPS | Cold TTFT | Cached TTFT | Tool % | Score | Status |
+
+Models that fail to boot or whose autoresearch returns all-zero
+metrics get a `FAIL — <reason>` row instead of being silently dropped,
+so the scorecard always covers every model the user asked about.
+
+> v1 only sweeps the Simple engine. Cross-engine columns
+> (Simple/Batched/Hybrid) are planned for v2 once BatchedEngine
+> stabilises (see issue #105).
 
 ## Baselines
 
@@ -223,8 +252,8 @@ You're running this model for the first time. Run with
    so they get the right regression threshold (otherwise the default
    5%/10% applies).
 
-## TODO (not yet implemented)
+## TODO
 
-- `rapid-mlx doctor benchmark` — cross-model × cross-engine scorecard sweep
-- `make doctor` targets — `make smoke / check / full / benchmark`
+- `benchmark` v2: cross-engine columns (Simple / Batched / Hybrid) once
+  BatchedEngine stabilises (issue #105)
 - Pre-push git hook integration (optional, opt-in)

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,230 @@
+# Rapid-MLX Doctor — regression harness
+
+A four-tier "code health checkup" for Rapid-MLX:
+
+```
+rapid-mlx doctor smoke       # ~2 min,  no model         — pre-commit
+rapid-mlx doctor check       # ~10 min, qwen3.5-4b       — pre-PR / big change
+rapid-mlx doctor full        # ~1-2 hr, 3 models         — pre-release / refactor
+rapid-mlx doctor benchmark   # overnight, all models     — periodic / promo material
+```
+
+Pick the smallest tier that catches the kind of regression you're worried
+about. Smoke is for "did I break the build". Check is for "did I regress
+performance or break the API". Full is for "did I regress any of the
+models or agents we promise to support". Benchmark is for "what does the
+cross-model scorecard look like now".
+
+> **Where:** `vllm_mlx/doctor/` (code) + `harness/` (baselines, thresholds,
+> per-run artefacts).
+
+## Quick start
+
+From a source checkout (the doctor refuses to run from a pip install —
+it needs `tests/`, `harness/`, and `pyproject.toml`):
+
+```bash
+# Pre-commit — no model required
+rapid-mlx doctor smoke
+
+# Pre-PR — boots a server with qwen3.5-4b, runs API + perf checks,
+# diffs against the recorded baseline
+HF_HUB_CACHE="/path/to/your/hf/cache" rapid-mlx doctor check
+
+# Pre-release / after a refactor — three models + all 11 agent profiles
+HF_HUB_CACHE="/path/to/your/hf/cache" rapid-mlx doctor full
+```
+
+`HF_HUB_CACHE` is a vanilla Hugging Face env var — use it if your models
+live somewhere other than `~/.cache/huggingface`. The doctor inherits
+your environment when spawning the server.
+
+## Exit codes
+
+The doctor's exit code is a stable contract for hooks/CI:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | All checks pass |
+| 1 | At least one **performance regression** detected (vs baseline) |
+| 2 | At least one **functional failure** (a check actually broke) |
+
+A run with both a regression and a fail returns 2 (worse signal wins).
+
+## Tier reference
+
+### `smoke` (~2 min, no model)
+
+Cheap static checks. Safe to run from anywhere — no Metal, no model load.
+Designed to be invoked from a pre-commit hook or `make` target.
+
+| Check | What it does |
+| --- | --- |
+| `repo_layout` | Sanity-check `pyproject.toml`, `aliases.json`, `agents/profiles/` |
+| `imports` | Import lightweight modules — catches syntax errors fast |
+| `ruff` | Lint (binary or `python -m ruff`, gracefully skips if neither) |
+| `cli_sanity` | `rapid-mlx --help / models / agents` actually run |
+| `pytest` | Full unit suite (~45s, 2027 tests) excluding integration/server |
+
+### `check` (~10 min, qwen3.5-4b)
+
+Spins up a real server with `qwen3.5-4b`, runs API + perf checks, diffs
+against `harness/baselines/check-qwen3.5-4b.json`.
+
+| Check | What it does |
+| --- | --- |
+| `repo_layout`, `imports` | Same as smoke (cheap fail-fast) |
+| `regression_suite` | `tests/regression_suite.py` (10 API contract cases) |
+| `smoke_matrix` | `tests/test_smoke_matrix.sh` (emoji/CJK/thinking/leak) |
+| `autoresearch` | `scripts/autoresearch_bench.py --json` (13 perf metrics) |
+| `baseline_diff` | Compare metrics, flag regressions per `harness/thresholds.yaml` |
+
+Override the model with `--model qwen3.5-9b` (will need its own baseline).
+
+### `full` (~1-2 hr, 3 models × 11 agent profiles)
+
+Loops the check tier across `qwen3.5-4b`, `qwen3.5-35b`, `gemma-4-26b`
+(coverage rationale: small/medium/large × Hermes-style + Gemma's
+distinct chat template). For each model, also runs all 11 agent profiles'
+auto-generated test plans.
+
+Override the model list:
+
+```bash
+rapid-mlx doctor full --models qwen3.5-4b,gemma-4-26b
+```
+
+### `benchmark` (overnight, all local models)
+
+*Not yet implemented* — see TODO at the bottom of this file.
+
+## Baselines
+
+Baselines live at `harness/baselines/{tier}-{model}.json` and are checked
+into git. Per-model file because comparing decode-tps for a 4B and a 35B
+model is meaningless. Filename uses URL percent-encoding so model IDs
+containing `/` (e.g. `mlx-community/Qwen3.5-4B-MLX-4bit`) don't collide
+with names that happen to contain `__`.
+
+Baseline file shape:
+
+```json
+{
+  "captured_at": "2026-04-15T21:36:32",
+  "rapid_mlx_version": "0.5.1",
+  "model": "qwen3.5-4b",
+  "metrics": {
+    "decode_tps": 49.67,
+    "cold_ttft_ms": 313.63,
+    "tc_success_rate": 1.0,
+    "...": "..."
+  }
+}
+```
+
+### Recording / updating baselines
+
+```bash
+# Record a fresh baseline (after intentional perf change, or first time)
+HF_HUB_CACHE=... rapid-mlx doctor check --update-baselines
+
+# Same for full tier — writes a baseline per model in --models
+HF_HUB_CACHE=... rapid-mlx doctor full --update-baselines
+```
+
+`--update-baselines` is the only path that writes to `harness/baselines/`.
+**Always inspect the diff before committing** — this is the moment to
+catch a real regression masquerading as "just a metric change". Workflow:
+
+```bash
+# 1. Record what you see now
+rapid-mlx doctor check --update-baselines
+
+# 2. Inspect the diff
+git diff harness/baselines/
+
+# 3. If the change is justified, commit; otherwise revert + investigate
+git commit harness/baselines/check-qwen3.5-4b.json -m \
+  "chore(doctor): bump qwen3.5-4b decode_tps baseline (mlx 0.31 SDPA gains)"
+```
+
+## Thresholds
+
+`harness/thresholds.yaml` controls when a metric change becomes a
+"regression" or "improvement". Two knobs per metric:
+
+```yaml
+decode_tps:
+  regression_pct: 5     # current 5%+ slower than baseline → REGRESSION
+  improvement_pct: 10   # current 10%+ faster → IMPROVEMENT (consider --update-baselines)
+```
+
+**Sign convention:** the comparator inverts the sign for lower-is-better
+metrics (latency, memory). So a positive Δ% always means "better" in the
+report, and a negative Δ% always means "worse" — regardless of whether
+the underlying metric is throughput or latency.
+
+Defaults (used when a metric isn't listed):
+
+- Performance: `regression_pct=5`, `improvement_pct=10`
+- Accuracy: `regression_pct=0`, `improvement_pct=5` (zero tolerance)
+
+## Run artefacts
+
+Every run writes to `harness/runs/{ts}-{tier}/` (gitignored — local only):
+
+```
+harness/runs/2026-04-15-220614-check/
+├── report.md                  # human-readable summary table
+├── result.json                # machine-readable, full per-check detail
+├── diff.md                    # combined delta tables across all models
+├── diff-qwen3.5-4b.md         # per-model delta table (full tier)
+└── server-qwen3.5-4b.log      # server stdout/stderr for post-mortem
+```
+
+The directory name uses second precision plus a numeric suffix on
+collision, so concurrent invocations never overwrite each other's
+artefacts.
+
+## Common failure modes
+
+### "this command requires a source checkout"
+
+You're running from a pip-installed wheel. The doctor needs `tests/`,
+`harness/`, and `pyproject.toml` (none of which ship in the wheel).
+Clone the repo and run from there.
+
+### "all primary metrics zero — server probably rejected requests"
+
+The model name in the request body didn't match what the server
+registered. If you're hacking on `autoresearch_bench.py`, make sure the
+`"model"` field uses `"default"` or the alias the server actually knows.
+
+### "baseline model mismatch"
+
+The baseline file's recorded `model` field doesn't match the model you
+asked the doctor to test. Either you renamed a model alias, or someone
+copied a baseline file. Re-record with `--update-baselines` after
+checking what changed.
+
+### "no baseline found for model=X"
+
+You're running this model for the first time. Run with
+`--update-baselines` to record the current metrics as the new baseline.
+
+## Adding a new check
+
+1. Drop a function into `vllm_mlx/doctor/checks/` that returns a
+   `CheckResult` — see `checks/smoke.py` for the simplest examples and
+   `checks/perf.py` for one that captures metrics for baseline diff.
+2. Add a line to the relevant tier in `vllm_mlx/doctor/cli.py`
+   (`run_smoke_tier` / `_run_per_model_block`).
+3. If your check produces metrics, add them to `harness/thresholds.yaml`
+   so they get the right regression threshold (otherwise the default
+   5%/10% applies).
+
+## TODO (not yet implemented)
+
+- `rapid-mlx doctor benchmark` — cross-model × cross-engine scorecard sweep
+- `make doctor` targets — `make smoke / check / full / benchmark`
+- Pre-push git hook integration (optional, opt-in)

--- a/harness/README.md
+++ b/harness/README.md
@@ -25,19 +25,28 @@ it needs `tests/`, `harness/`, and `pyproject.toml`):
 
 ```bash
 # Pre-commit — no model required
-rapid-mlx doctor smoke
+make smoke                            # or: rapid-mlx doctor smoke
 
-# Pre-PR — boots a server with qwen3.5-4b, runs API + perf checks,
-# diffs against the recorded baseline
-HF_HUB_CACHE="/path/to/your/hf/cache" rapid-mlx doctor check
+# Pre-PR — boots qwen3.5-4b, runs API + perf checks, diffs vs baseline
+HF_HUB_CACHE=... make check           # or: rapid-mlx doctor check
 
-# Pre-release / after a refactor — three models + all 11 agent profiles
-HF_HUB_CACHE="/path/to/your/hf/cache" rapid-mlx doctor full
+# Pre-release — three models + all 11 agent profiles
+HF_HUB_CACHE=... make full
+
+# Re-record baselines (after intentional perf changes)
+HF_HUB_CACHE=... make update-baselines TIER=check
+
+# Cross-model scorecard (overnight)
+HF_HUB_CACHE=... make benchmark
 ```
 
 `HF_HUB_CACHE` is a vanilla Hugging Face env var — use it if your models
 live somewhere other than `~/.cache/huggingface`. The doctor inherits
 your environment when spawning the server.
+
+Run `make help` for the full target list. The Makefile auto-detects a
+suitable Python interpreter (active venv → python3.13/12/11/10) and
+respects `make smoke PY=python3.X` for explicit override.
 
 ## Exit codes
 
@@ -64,7 +73,7 @@ Designed to be invoked from a pre-commit hook or `make` target.
 | `imports` | Import lightweight modules — catches syntax errors fast |
 | `ruff` | Lint (binary or `python -m ruff`, gracefully skips if neither) |
 | `cli_sanity` | `rapid-mlx --help / models / agents` actually run |
-| `pytest` | Full unit suite (~45s, 2027 tests) excluding integration/server |
+| `pytest` | Full unit suite (~45s, ~2070 tests) excluding `tests/integrations/` and `test_event_loop.py` |
 
 ### `check` (~10 min, qwen3.5-4b)
 
@@ -100,7 +109,7 @@ Sweeps every model with locally-present weights and produces a single
 scorecard markdown:
 
 ```bash
-# Auto-discovers models in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+# Auto-discovers models in HF_HUB_CACHE / $HF_HOME/hub / ~/.cache/huggingface / ~/.lmstudio
 HF_HUB_CACHE=... rapid-mlx doctor benchmark
 
 # Or be explicit (forces inclusion even if cache probe misses):

--- a/harness/baselines/check-qwen3.5-4b.json
+++ b/harness/baselines/check-qwen3.5-4b.json
@@ -1,0 +1,20 @@
+{
+  "captured_at": "2026-04-15T21:36:32",
+  "rapid_mlx_version": "0.5.0",
+  "model": "qwen3.5-4b",
+  "metrics": {
+    "cold_ttft_ms": 313.62908403389156,
+    "cold_tps": 49.2736011322839,
+    "cached_ttft_ms": 393.99170805700123,
+    "decode_tps": 49.67459517661095,
+    "decode_tps_stdev": 0,
+    "mt_ttft_ms": 402.93216705322266,
+    "mt_tps": 48.32873664326039,
+    "tc_latency_ms": 2819.6406660135835,
+    "tc_success_rate": 1.0,
+    "long_ttft_ms": 1274.2738330271095,
+    "long_tps": 48.325022009001415,
+    "long_cached_ttft_ms": 1233.1054580863565,
+    "composite_score": 109.9
+  }
+}

--- a/harness/baselines/full-qwen3.5-4b.json
+++ b/harness/baselines/full-qwen3.5-4b.json
@@ -1,0 +1,20 @@
+{
+  "captured_at": "2026-04-15T22:00:44",
+  "rapid_mlx_version": "0.5.0",
+  "model": "qwen3.5-4b",
+  "metrics": {
+    "cold_ttft_ms": 312.20033299177885,
+    "cold_tps": 49.09060648629278,
+    "cached_ttft_ms": 395.03545803017914,
+    "decode_tps": 49.07147617087399,
+    "decode_tps_stdev": 0,
+    "mt_ttft_ms": 398.6949999816716,
+    "mt_tps": 48.48020296161872,
+    "tc_latency_ms": 2827.9930830467492,
+    "tc_success_rate": 1.0,
+    "long_ttft_ms": 1294.1680420190096,
+    "long_tps": 48.57615694075061,
+    "long_cached_ttft_ms": 1252.0195830147713,
+    "composite_score": 109.3
+  }
+}

--- a/harness/scorecard/latest.md
+++ b/harness/scorecard/latest.md
@@ -1,18 +1,18 @@
 # Rapid-MLX Benchmark Scorecard
 
-_Generated: 2026-04-15T23:00:26_
+_Generated: 2026-04-16T07:10:38_
 
 | Model | Decode TPS | Cold TTFT | Cached TTFT | Tool % | Score | Status |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| deepseek-r1-32b | 34.1 | 593ms | 175ms | 0% | 135.5 | OK |
-| llama3-3b | 234.9 | 122ms | 113ms | 0% | 393.4 | OK |
-| qwen3-vl-8b | 76.4 | 267ms | 182ms | 100% | 171.5 | OK |
-| qwen3.5-27b | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:53414/health with |
-| qwen3.5-35b | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:53829/health with |
-| qwen3.5-4b | 167.1 | 168ms | 217ms | 100% | 258.1 | OK |
-| qwen3.5-9b | 112.0 | 208ms | 267ms | 100% | 187.5 | OK |
-| qwopus-27b | 38.8 | 452ms | 487ms | 100% | 88.7 | OK |
-| qwopus-27b-8bit | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:54350/health with |
+| deepseek-r1-32b | 8.6 | 1111ms | 418ms | 0% | 51.8 | OK |
+| llama3-3b | 34.9 | 258ms | 189ms | 0% | 130.1 | OK |
+| qwen3-vl-8b | 12.2 | 456ms | 505ms | 100% | 59.3 | OK |
+| qwen3.5-27b | — | — | — | — | — | FAIL — server boot failed: server exited with code 1 before becoming healthy |
+| qwen3.5-35b | 10.9 | 1091ms | 1063ms | 0% | 26.5 | OK |
+| qwen3.5-4b | 25.1 | 448ms | 460ms | 100% | 78.5 | OK |
+| qwen3.5-9b | 20.7 | 539ms | 563ms | 100% | 68.1 | OK |
+| qwopus-27b | 8.8 | 1165ms | 1145ms | 100% | 41.9 | OK |
+| qwopus-27b-8bit | — | — | — | — | — | FAIL — server boot failed: server exited with code 1 before becoming healthy |
 
 ## Skipped
 

--- a/harness/scorecard/latest.md
+++ b/harness/scorecard/latest.md
@@ -1,7 +1,45 @@
 # Rapid-MLX Benchmark Scorecard
 
-_Generated: 2026-04-15T22:45:46_
+_Generated: 2026-04-15T23:00:26_
 
 | Model | Decode TPS | Cold TTFT | Cached TTFT | Tool % | Score | Status |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| qwen3.5-4b | 168.1 | 188ms | 232ms | 100% | 254.7 | OK |
+| deepseek-r1-32b | 34.1 | 593ms | 175ms | 0% | 135.5 | OK |
+| llama3-3b | 234.9 | 122ms | 113ms | 0% | 393.4 | OK |
+| qwen3-vl-8b | 76.4 | 267ms | 182ms | 100% | 171.5 | OK |
+| qwen3.5-27b | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:53414/health with |
+| qwen3.5-35b | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:53829/health with |
+| qwen3.5-4b | 167.1 | 168ms | 217ms | 100% | 258.1 | OK |
+| qwen3.5-9b | 112.0 | 208ms | 267ms | 100% | 187.5 | OK |
+| qwopus-27b | 38.8 | 452ms | 487ms | 100% | 88.7 | OK |
+| qwopus-27b-8bit | — | — | — | — | — | FAIL — server boot failed: server did not respond at http://127.0.0.1:54350/health with |
+
+## Skipped
+
+- **deepseek-r1-8b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **devstral-24b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **devstral-v2-24b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma-3n-e4b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma-4-26b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma-4-31b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma3-12b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma3-1b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gemma3-27b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **glm4.5-air** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **glm4.7-9b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **gpt-oss-20b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **hermes3-8b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **hermes4-70b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **kimi-48b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **kimi-k2.5** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **minimax-m2.5** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **ministral-3b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **mistral-24b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **phi4-14b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3-coder** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3-coder-30b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3-vl-30b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3-vl-4b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3.5-122b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwen3.5-122b-8bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
+- **qwopus-9b** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio

--- a/harness/scorecard/latest.md
+++ b/harness/scorecard/latest.md
@@ -1,0 +1,7 @@
+# Rapid-MLX Benchmark Scorecard
+
+_Generated: 2026-04-15T22:45:46_
+
+| Model | Decode TPS | Cold TTFT | Cached TTFT | Tool % | Score | Status |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| qwen3.5-4b | 168.1 | 188ms | 232ms | 100% | 254.7 | OK |

--- a/harness/thresholds.yaml
+++ b/harness/thresholds.yaml
@@ -1,0 +1,47 @@
+# Doctor regression thresholds.
+#
+# Each metric lists:
+#   regression_pct  — drop > this % triggers a Status.REGRESSION
+#   improvement_pct — gain > this % suggests --update-baselines
+#
+# We err on the strict side: catching a 5% perf regression early is
+# cheaper than chasing a 20% one after several merges have piled up.
+# Adjust per-metric, not globally — different signals tolerate different
+# noise levels.
+
+# Performance
+decode_tps:
+  regression_pct: 5
+  improvement_pct: 10
+prefill_tps:
+  regression_pct: 5
+  improvement_pct: 10
+ttft_cold_ms:
+  regression_pct: 10        # higher noise floor; cold startup is variable
+  improvement_pct: 15
+ttft_cached_ms:
+  regression_pct: 10
+  improvement_pct: 15
+multiturn_ttft_ms:
+  regression_pct: 10
+  improvement_pct: 15
+long_prompt_ttft_ms:
+  regression_pct: 10
+  improvement_pct: 15
+tool_latency_s:
+  regression_pct: 10
+  improvement_pct: 15
+peak_ram_mb:
+  regression_pct: 10        # memory growth is treated as a regression
+  improvement_pct: 10
+
+# Functional / accuracy — zero tolerance: any drop is a regression
+tool_call_accuracy:
+  regression_pct: 0
+  improvement_pct: 5
+reasoning_accuracy:
+  regression_pct: 0
+  improvement_pct: 5
+coding_accuracy:
+  regression_pct: 0
+  improvement_pct: 5

--- a/harness/thresholds.yaml
+++ b/harness/thresholds.yaml
@@ -48,16 +48,10 @@ composite_score:
   regression_pct: 5
   improvement_pct: 10
 
-# Functional / accuracy — zero tolerance: any drop is a regression
+# Functional / accuracy — zero tolerance: any drop is a regression.
+# Only metrics actually emitted by the harness are listed.  When new
+# accuracy signals are added (e.g. BFCL pass rate, eval suite scores),
+# add their threshold here so they're treated as accuracy not perf.
 tc_success_rate:
-  regression_pct: 0
-  improvement_pct: 5
-tool_call_accuracy:
-  regression_pct: 0
-  improvement_pct: 5
-reasoning_accuracy:
-  regression_pct: 0
-  improvement_pct: 5
-coding_accuracy:
   regression_pct: 0
   improvement_pct: 5

--- a/harness/thresholds.yaml
+++ b/harness/thresholds.yaml
@@ -9,33 +9,49 @@
 # Adjust per-metric, not globally — different signals tolerate different
 # noise levels.
 
-# Performance
+# Performance.  Metric names match the keys emitted by
+# scripts/autoresearch_bench.py --json (see ``run_suite()`` there).
 decode_tps:
   regression_pct: 5
   improvement_pct: 10
-prefill_tps:
+cold_tps:
   regression_pct: 5
   improvement_pct: 10
-ttft_cold_ms:
+mt_tps:
+  regression_pct: 5
+  improvement_pct: 10
+long_tps:
+  regression_pct: 5
+  improvement_pct: 10
+cold_ttft_ms:
   regression_pct: 10        # higher noise floor; cold startup is variable
   improvement_pct: 15
-ttft_cached_ms:
+cached_ttft_ms:
   regression_pct: 10
   improvement_pct: 15
-multiturn_ttft_ms:
+mt_ttft_ms:
   regression_pct: 10
   improvement_pct: 15
-long_prompt_ttft_ms:
+long_ttft_ms:
   regression_pct: 10
   improvement_pct: 15
-tool_latency_s:
+long_cached_ttft_ms:
+  regression_pct: 10
+  improvement_pct: 15
+tc_latency_ms:
   regression_pct: 10
   improvement_pct: 15
 peak_ram_mb:
   regression_pct: 10        # memory growth is treated as a regression
   improvement_pct: 10
+composite_score:
+  regression_pct: 5
+  improvement_pct: 10
 
 # Functional / accuracy — zero tolerance: any drop is a regression
+tc_success_rate:
+  regression_pct: 0
+  improvement_pct: 5
 tool_call_accuracy:
   regression_pct: 0
   improvement_pct: 5

--- a/scripts/autoresearch_bench.py
+++ b/scripts/autoresearch_bench.py
@@ -17,12 +17,16 @@ Usage:
 """
 import argparse
 import json
+import os
 import statistics
 import sys
 import time
 import urllib.request
 
-BASE_URL = "http://127.0.0.1:8000/v1/chat/completions"
+# Allow the doctor harness to point this at a non-default port.
+BASE_URL = os.environ.get(
+    "AUTORESEARCH_BASE", "http://127.0.0.1:8000/v1/chat/completions"
+)
 HEADERS = {"Content-Type": "application/json"}
 
 SYSTEM_MSG = "You are a helpful assistant. Answer concisely."
@@ -71,7 +75,7 @@ LONG_PROMPT_MESSAGES.append({"role": "user", "content": "/no_think Summarize all
 def stream_request(messages, max_tokens=300, tools=None, timeout=60):
     """Send streaming request, return metrics dict."""
     body = {
-        "model": "any",
+        "model": "default",
         "messages": messages,
         "max_tokens": max_tokens,
         "stream": True,
@@ -304,12 +308,13 @@ if __name__ == "__main__":
     parser.add_argument("--label", type=str, default="", help="Label for this run")
     args = parser.parse_args()
 
-    # Quick server health check
+    # Quick server health check — derive /v1/models from BASE_URL so the
+    # doctor harness's port override applies here too.
+    _models_url = BASE_URL.replace("/chat/completions", "/models")
     try:
-        req = urllib.request.Request("http://127.0.0.1:8000/v1/models")
-        urllib.request.urlopen(req, timeout=5)
+        urllib.request.urlopen(_models_url, timeout=5)
     except Exception as e:
-        print(f"ERROR: Server not reachable at port 8000: {e}", file=sys.stderr)
+        print(f"ERROR: Server not reachable at {_models_url}: {e}", file=sys.stderr)
         sys.exit(1)
 
     results = run_suite(n_runs=args.runs, verbose=not args.json)

--- a/scripts/autoresearch_bench.py
+++ b/scripts/autoresearch_bench.py
@@ -15,6 +15,7 @@ Metrics:
 Usage:
   python3.12 scripts/autoresearch_bench.py [--runs N] [--json]
 """
+
 import argparse
 import json
 import os
@@ -35,8 +36,14 @@ USER_MSG = "/no_think Explain how a hash table works. Cover collisions, load fac
 MULTI_TURN = [
     {"role": "system", "content": SYSTEM_MSG},
     {"role": "user", "content": "/no_think What is a binary search tree?"},
-    {"role": "assistant", "content": "A binary search tree (BST) is a data structure where each node has at most two children. The left child's value is less than the parent, and the right child's value is greater. This ordering property enables O(log n) search, insert, and delete operations in balanced trees."},
-    {"role": "user", "content": "/no_think Now implement one in Python with insert and search methods."},
+    {
+        "role": "assistant",
+        "content": "A binary search tree (BST) is a data structure where each node has at most two children. The left child's value is less than the parent, and the right child's value is greater. This ordering property enables O(log n) search, insert, and delete operations in balanced trees.",
+    },
+    {
+        "role": "user",
+        "content": "/no_think Now implement one in Python with insert and search methods.",
+    },
 ]
 
 TOOL_MESSAGES = [
@@ -67,9 +74,21 @@ LONG_PROMPT_MESSAGES = [
     {"role": "system", "content": "You are a knowledgeable assistant. " * 50},
 ]
 for i in range(20):
-    LONG_PROMPT_MESSAGES.append({"role": "user", "content": f"/no_think Question {i+1}: Explain concept number {i+1} in computer science briefly."})
-    LONG_PROMPT_MESSAGES.append({"role": "assistant", "content": f"Concept {i+1} is an important topic in computer science that involves understanding fundamental principles of computation, data organization, and algorithm design. It builds on prior concepts and enables more advanced techniques."})
-LONG_PROMPT_MESSAGES.append({"role": "user", "content": "/no_think Summarize all concepts in one paragraph."})
+    LONG_PROMPT_MESSAGES.append(
+        {
+            "role": "user",
+            "content": f"/no_think Question {i + 1}: Explain concept number {i + 1} in computer science briefly.",
+        }
+    )
+    LONG_PROMPT_MESSAGES.append(
+        {
+            "role": "assistant",
+            "content": f"Concept {i + 1} is an important topic in computer science that involves understanding fundamental principles of computation, data organization, and algorithm design. It builds on prior concepts and enables more advanced techniques.",
+        }
+    )
+LONG_PROMPT_MESSAGES.append(
+    {"role": "user", "content": "/no_think Summarize all concepts in one paragraph."}
+)
 
 
 def stream_request(messages, max_tokens=300, tools=None, timeout=60):
@@ -149,11 +168,16 @@ def run_suite(n_runs=3, verbose=True):
 
     # 1. Cold TTFT + Decode TPS (first request, no cache)
     log("\n[1/6] Cold TTFT + Decode TPS...")
-    msgs = [{"role": "system", "content": SYSTEM_MSG}, {"role": "user", "content": USER_MSG}]
+    msgs = [
+        {"role": "system", "content": SYSTEM_MSG},
+        {"role": "user", "content": USER_MSG},
+    ]
     r = stream_request(msgs, max_tokens=400)
     results["cold_ttft_ms"] = r["ttft_ms"]
     results["cold_tps"] = r["tps"]
-    log(f"  TTFT: {r['ttft_ms']:.0f}ms | Decode: {r['tps']:.1f} tok/s | Tokens: {r['tokens']}")
+    log(
+        f"  TTFT: {r['ttft_ms']:.0f}ms | Decode: {r['tps']:.1f} tok/s | Tokens: {r['tokens']}"
+    )
 
     # 2. Cached TTFT + steady-state Decode TPS
     log(f"\n[2/6] Cached TTFT + Decode TPS (x{n_runs})...")
@@ -163,10 +187,12 @@ def run_suite(n_runs=3, verbose=True):
         r = stream_request(msgs, max_tokens=400)
         cached_ttfts.append(r["ttft_ms"])
         cached_tps.append(r["tps"])
-        log(f"  Run {i+1}: TTFT={r['ttft_ms']:.0f}ms | Decode={r['tps']:.1f} tok/s")
+        log(f"  Run {i + 1}: TTFT={r['ttft_ms']:.0f}ms | Decode={r['tps']:.1f} tok/s")
     results["cached_ttft_ms"] = statistics.mean(cached_ttfts)
     results["decode_tps"] = statistics.mean(cached_tps)
-    results["decode_tps_stdev"] = statistics.stdev(cached_tps) if len(cached_tps) > 1 else 0
+    results["decode_tps_stdev"] = (
+        statistics.stdev(cached_tps) if len(cached_tps) > 1 else 0
+    )
 
     # 3. Multi-turn TTFT
     log(f"\n[3/6] Multi-turn TTFT (x{n_runs})...")
@@ -177,7 +203,7 @@ def run_suite(n_runs=3, verbose=True):
         r = stream_request(MULTI_TURN, max_tokens=150)
         mt_ttfts.append(r["ttft_ms"])
         mt_tps.append(r["tps"])
-        log(f"  Run {i+1}: TTFT={r['ttft_ms']:.0f}ms | Decode={r['tps']:.1f} tok/s")
+        log(f"  Run {i + 1}: TTFT={r['ttft_ms']:.0f}ms | Decode={r['tps']:.1f} tok/s")
     results["mt_ttft_ms"] = statistics.mean(mt_ttfts)
     results["mt_tps"] = statistics.mean(mt_tps)
 
@@ -192,7 +218,9 @@ def run_suite(n_runs=3, verbose=True):
             tc_success += 1
             if r.get("tc_latency_ms"):
                 tc_latencies.append(r["tc_latency_ms"])
-        log(f"  Run {i+1}: TC={'YES' if r.get('has_tool_calls') else 'NO'} | Latency={r.get('tc_latency_ms') or 0:.0f}ms")
+        log(
+            f"  Run {i + 1}: TC={'YES' if r.get('has_tool_calls') else 'NO'} | Latency={r.get('tc_latency_ms') or 0:.0f}ms"
+        )
     results["tc_latency_ms"] = statistics.mean(tc_latencies) if tc_latencies else 0
     results["tc_success_rate"] = tc_success / n_runs
 
@@ -201,7 +229,9 @@ def run_suite(n_runs=3, verbose=True):
     r = stream_request(LONG_PROMPT_MESSAGES, max_tokens=200)
     results["long_ttft_ms"] = r["ttft_ms"]
     results["long_tps"] = r["tps"]
-    log(f"  TTFT: {r['ttft_ms']:.0f}ms | Decode: {r['tps']:.1f} tok/s | Tokens: {r['tokens']}")
+    log(
+        f"  TTFT: {r['ttft_ms']:.0f}ms | Decode: {r['tps']:.1f} tok/s | Tokens: {r['tokens']}"
+    )
 
     # 6. Long prompt cached TTFT
     log(f"\n[6/6] Long prompt cached TTFT (x{n_runs})...")
@@ -209,16 +239,16 @@ def run_suite(n_runs=3, verbose=True):
     for i in range(n_runs):
         r = stream_request(LONG_PROMPT_MESSAGES, max_tokens=200)
         long_cached.append(r["ttft_ms"])
-        log(f"  Run {i+1}: TTFT={r['ttft_ms']:.0f}ms")
+        log(f"  Run {i + 1}: TTFT={r['ttft_ms']:.0f}ms")
     results["long_cached_ttft_ms"] = statistics.mean(long_cached)
 
     # Composite score: weighted combination (higher = better)
     # Weights reflect importance for user experience
     score = (
-        results["decode_tps"] * 1.0          # Primary: throughput
+        results["decode_tps"] * 1.0  # Primary: throughput
         + (1000 / max(results["cached_ttft_ms"], 1)) * 10  # Responsiveness
-        + (1000 / max(results["mt_ttft_ms"], 1)) * 5       # Multi-turn speed
-        + results["tc_success_rate"] * 20     # Tool reliability
+        + (1000 / max(results["mt_ttft_ms"], 1)) * 5  # Multi-turn speed
+        + results["tc_success_rate"] * 20  # Tool reliability
         + (1000 / max(results["long_cached_ttft_ms"], 1)) * 3  # Long context
     )
     results["composite_score"] = round(score, 1)
@@ -231,15 +261,19 @@ def print_summary(results, label=""):
     print("\n" + "=" * 65)
     print(f"BENCHMARK RESULTS {label}")
     print("=" * 65)
-    print(f"  Decode TPS:         {results['decode_tps']:.1f} tok/s (±{results.get('decode_tps_stdev', 0):.1f})")
+    print(
+        f"  Decode TPS:         {results['decode_tps']:.1f} tok/s (±{results.get('decode_tps_stdev', 0):.1f})"
+    )
     print(f"  Cold TTFT:          {results['cold_ttft_ms']:.0f} ms")
     print(f"  Cached TTFT:        {results['cached_ttft_ms']:.0f} ms")
     print(f"  Multi-turn TTFT:    {results['mt_ttft_ms']:.0f} ms")
     print(f"  Tool call latency:  {results['tc_latency_ms']:.0f} ms")
-    print(f"  Tool success rate:  {results['tc_success_rate']*100:.0f}%")
+    print(f"  Tool success rate:  {results['tc_success_rate'] * 100:.0f}%")
     print(f"  Long prompt TTFT:   {results['long_ttft_ms']:.0f} ms (cold)")
     print(f"  Long cached TTFT:   {results['long_cached_ttft_ms']:.0f} ms")
-    print(f"  Cache speedup:      {results['cold_ttft_ms']/max(results['cached_ttft_ms'],1):.1f}x")
+    print(
+        f"  Cache speedup:      {results['cold_ttft_ms'] / max(results['cached_ttft_ms'], 1):.1f}x"
+    )
     print(f"  Composite score:    {results['composite_score']:.1f}")
     print("=" * 65)
 
@@ -272,8 +306,8 @@ def compare_results(baseline, experiment, label=""):
             delta_pct = ((e - b) / b) * 100
 
         if key == "tc_success_rate":
-            b_str = f"{b*100:.0f}%"
-            e_str = f"{e*100:.0f}%"
+            b_str = f"{b * 100:.0f}%"
+            e_str = f"{e * 100:.0f}%"
         else:
             b_str = f"{b:.1f}{unit}"
             e_str = f"{e:.1f}{unit}"
@@ -294,9 +328,13 @@ def compare_results(baseline, experiment, label=""):
             indicator = "DN"
             regression = True
 
-        print(f"  {indicator} {name:20s}: {b_str:>10s} -> {e_str:>10s} ({delta_pct:+.1f}%)")
+        print(
+            f"  {indicator} {name:20s}: {b_str:>10s} -> {e_str:>10s} ({delta_pct:+.1f}%)"
+        )
 
-    verdict = "KEEP" if improved and not regression else "REVERT" if regression else "NEUTRAL"
+    verdict = (
+        "KEEP" if improved and not regression else "REVERT" if regression else "NEUTRAL"
+    )
     print(f"\n  Verdict: {verdict}")
     return improved, regression
 

--- a/tests/integrations/test_anthropic_sdk.py
+++ b/tests/integrations/test_anthropic_sdk.py
@@ -1,4 +1,5 @@
 """Anthropic SDK against rapid-mlx /v1/messages endpoint."""
+
 import os
 
 import httpx as _httpx
@@ -25,7 +26,9 @@ try:
     r = client.messages.create(
         model=MODEL_ID,
         max_tokens=50,
-        messages=[{"role": "user", "content": "What is 2+2? Reply with just the number."}],
+        messages=[
+            {"role": "user", "content": "What is 2+2? Reply with just the number."}
+        ],
     )
     text = r.content[0].text
     assert "4" in text, text
@@ -94,15 +97,17 @@ try:
     r = client.messages.create(
         model=MODEL_ID,
         max_tokens=200,
-        tools=[{
-            "name": "get_weather",
-            "description": "Get the weather for a city.",
-            "input_schema": {
-                "type": "object",
-                "properties": {"city": {"type": "string"}},
-                "required": ["city"],
-            },
-        }],
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Get the weather for a city.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ],
         messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
     )
     # Find tool_use blocks

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -105,9 +105,9 @@ def hermes_query(query, timeout_sec=120):
 
 def run_test(name, fn):
     """Run a test function and record the result."""
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Test: {name}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     try:
         fn()
         results[name] = "PASS"
@@ -169,7 +169,9 @@ BASIC_TOOLS = [
 
 def test_api_plain_chat():
     """Basic chat without tools."""
-    r = api_call([{"role": "user", "content": "What is 2+2? Reply with just the number."}])
+    r = api_call(
+        [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+    )
     content = r["choices"][0]["message"]["content"]
     assert "4" in content, f"Expected '4' in: {content[:100]}"
     print(f"  Response: {content[:80]}")
@@ -184,7 +186,9 @@ def test_api_single_tool_call():
     msg = r["choices"][0]["message"]
     assert msg.get("tool_calls"), f"No tool_calls in response: {msg}"
     tc = msg["tool_calls"][0]
-    assert tc["function"]["name"] == "read_file", f"Wrong tool: {tc['function']['name']}"
+    assert tc["function"]["name"] == "read_file", (
+        f"Wrong tool: {tc['function']['name']}"
+    )
     args = json.loads(tc["function"]["arguments"])
     assert "hostname" in args.get("path", "").lower(), f"Wrong path: {args}"
     print(f"  Tool: {tc['function']['name']}({args})")
@@ -232,7 +236,9 @@ def test_api_multi_turn_tool():
         tools=BASIC_TOOLS,
     )
     content2 = r2["choices"][0]["message"]["content"]
-    assert "127.0.0.1" in content2 or "localhost" in content2, f"Bad follow-up: {content2[:100]}"
+    assert "127.0.0.1" in content2 or "localhost" in content2, (
+        f"Bad follow-up: {content2[:100]}"
+    )
     print(f"  Multi-turn response: {content2[:80]}")
 
 
@@ -255,18 +261,20 @@ def test_api_many_tools():
     # Generate 20 dummy tools
     many_tools = []
     for i in range(20):
-        many_tools.append({
-            "type": "function",
-            "function": {
-                "name": f"tool_{i}",
-                "description": f"Tool number {i} that does something",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"arg": {"type": "string"}},
-                    "required": ["arg"],
+        many_tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": f"tool_{i}",
+                    "description": f"Tool number {i} that does something",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"arg": {"type": "string"}},
+                        "required": ["arg"],
+                    },
                 },
-            },
-        })
+            }
+        )
     # Add the real tools
     many_tools.extend(BASIC_TOOLS)
 
@@ -325,7 +333,9 @@ def test_api_no_tool_needed():
     )
     msg = r["choices"][0]["message"]
     content = msg.get("content", "")
-    assert "Paris" in content or "paris" in content.lower(), f"Expected Paris: {content[:100]}"
+    assert "Paris" in content or "paris" in content.lower(), (
+        f"Expected Paris: {content[:100]}"
+    )
     # Should NOT call a tool for a general knowledge question
     if msg.get("tool_calls"):
         print(f"  ⚠️ Unnecessary tool call: {msg['tool_calls'][0]['function']['name']}")
@@ -336,7 +346,12 @@ def test_api_no_tool_needed():
 def test_api_parallel_tool_calls():
     """Model can request multiple tool calls in one response."""
     r = api_call(
-        [{"role": "user", "content": "Read both /etc/hosts and /etc/resolv.conf at the same time"}],
+        [
+            {
+                "role": "user",
+                "content": "Read both /etc/hosts and /etc/resolv.conf at the same time",
+            }
+        ],
         tools=BASIC_TOOLS,
         max_tokens=500,
     )
@@ -345,7 +360,9 @@ def test_api_parallel_tool_calls():
         names = [tc["function"]["name"] for tc in msg["tool_calls"]]
         print(f"  Parallel calls: {names}")
     elif msg.get("tool_calls"):
-        print(f"  Single call (model chose sequential): {msg['tool_calls'][0]['function']['name']}")
+        print(
+            f"  Single call (model chose sequential): {msg['tool_calls'][0]['function']['name']}"
+        )
     else:
         print("  No tool calls (answered directly)")
     # Either way, no tag leaks
@@ -373,6 +390,7 @@ def test_api_stress_no_leak():
 # Hermes E2E tests (requires hermes binary)
 # =============================================================================
 
+
 def test_hermes_chat():
     """Basic Hermes chat (no tool use)."""
     out, err = hermes_query("What is 2+2? Reply with just the number.")
@@ -387,7 +405,9 @@ def test_hermes_read_file():
     out, err = hermes_query("Read the first line of pyproject.toml")
     if err:
         assert False, err
-    assert "build" in out.lower() or "project" in out.lower(), f"Unexpected: {out[:100]}"
+    assert "build" in out.lower() or "project" in out.lower(), (
+        f"Unexpected: {out[:100]}"
+    )
     print(f"  Hermes read_file: {out.strip()[:80]}")
 
 
@@ -426,6 +446,7 @@ def test_hermes_multi_step():
 # Deep agentic tests (requires hermes binary, tests real workflows)
 # =============================================================================
 
+
 def test_hermes_write_and_run():
     """Hermes writes a Python script and executes it (full agent loop)."""
     out, err = hermes_query(
@@ -437,12 +458,17 @@ def test_hermes_write_and_run():
         assert False, err
     # Verify via Hermes output or by checking the file directly
     import subprocess
+
     result = subprocess.run(
         ["python3", "/tmp/hermes_test_fib.py"],
-        capture_output=True, text=True, timeout=10,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     fib_out = result.stdout + out
-    assert any(str(n) in fib_out for n in [8, 13, 21, 34]), f"Fibonacci missing: {fib_out[:200]}"
+    assert any(str(n) in fib_out for n in [8, 13, 21, 34]), (
+        f"Fibonacci missing: {fib_out[:200]}"
+    )
     print("  Write+run: fibonacci script works")
 
 
@@ -458,11 +484,16 @@ def test_hermes_code_with_tests():
         assert False, err
     # Verify the files exist and tests pass
     import subprocess
+
     result = subprocess.run(
         ["python3", "-m", "pytest", "/tmp/hermes_test_calc.py", "-v"],
-        capture_output=True, text=True, timeout=30,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
-    assert "passed" in result.stdout.lower(), f"Tests failed: {result.stdout[:200]}{result.stderr[:200]}"
+    assert "passed" in result.stdout.lower(), (
+        f"Tests failed: {result.stdout[:200]}{result.stderr[:200]}"
+    )
     print("  Code+tests: pytest passing")
 
 
@@ -476,8 +507,9 @@ def test_hermes_code_review():
         assert False, err
     # Should mention something about the code (patterns, config, etc.)
     assert len(out) > 50, f"Response too short for a code review: {out[:100]}"
-    assert "model" in out.lower() or "pattern" in out.lower() or "config" in out.lower(), \
-        f"Doesn't look like a code review: {out[:100]}"
+    assert (
+        "model" in out.lower() or "pattern" in out.lower() or "config" in out.lower()
+    ), f"Doesn't look like a code review: {out[:100]}"
     print(f"  Code review: {out.strip()[:80]}")
 
 
@@ -489,8 +521,12 @@ def test_hermes_git_analysis():
     )
     if err:
         assert False, err
-    assert "commit" in out.lower() or "hermes" in out.lower() or "feat" in out.lower() or "fix" in out.lower(), \
-        f"No git info: {out[:200]}"
+    assert (
+        "commit" in out.lower()
+        or "hermes" in out.lower()
+        or "feat" in out.lower()
+        or "fix" in out.lower()
+    ), f"No git info: {out[:200]}"
     print("  Git analysis: OK")
 
 
@@ -510,8 +546,11 @@ def test_hermes_patch_file():
     # Verify the file was modified
     with open(test_file) as f:
         content = f.read()
-    assert "docstring" in content.lower() or "say hello" in content.lower() or '"""' in content, \
-        f"Patch not applied: {content[:200]}"
+    assert (
+        "docstring" in content.lower()
+        or "say hello" in content.lower()
+        or '"""' in content
+    ), f"Patch not applied: {content[:200]}"
     print("  Patch: file edited successfully")
 
 
@@ -524,7 +563,7 @@ if __name__ == "__main__":
     print(f"Server: {BASE_URL}")
     print(f"Model:  {MODEL_ID}")
     print(f"Hermes: {HERMES_BIN}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     t0 = time.time()
 
@@ -562,10 +601,10 @@ if __name__ == "__main__":
     passed = sum(1 for v in results.values() if v == "PASS")
     failed = sum(1 for v in results.values() if v != "PASS")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Results: {passed}/{len(results)} passed ({elapsed:.1f}s)")
     print(f"Model:   {MODEL_ID}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     for name, status in results.items():
         icon = "✅" if status == "PASS" else "❌"
         print(f"  {icon} {name}: {status}")

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import time
+
 import httpx
 
 BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://localhost:8000/v1")
@@ -94,7 +95,7 @@ def hermes_query(query, timeout_sec=120):
         output = proc.stdout + proc.stderr
         # Detect Hermes-level errors
         if "Non-retryable error" in output or "HTTP 404" in output:
-            return None, f"Hermes error: model mismatch or server down"
+            return None, "Hermes error: model mismatch or server down"
         return output, None
     except subprocess.TimeoutExpired:
         return None, "TIMEOUT"
@@ -110,7 +111,7 @@ def run_test(name, fn):
     try:
         fn()
         results[name] = "PASS"
-        print(f"  ✅ PASS")
+        print("  ✅ PASS")
     except AssertionError as e:
         results[name] = f"FAIL: {e}"
         print(f"  ❌ FAIL: {e}")
@@ -199,7 +200,7 @@ def test_api_tool_choice():
     assert msg.get("tool_calls"), f"No tool_calls: {msg.get('content', '')[:100]}"
     tc = msg["tool_calls"][0]
     assert tc["function"]["name"] == "terminal", f"Wrong tool: {tc['function']['name']}"
-    print(f"  Correctly chose: terminal")
+    print("  Correctly chose: terminal")
 
 
 def test_api_multi_turn_tool():
@@ -246,7 +247,7 @@ def test_api_no_tool_leak():
     assert "<tool_call>" not in content, f"Tag leak in content: {content[:200]}"
     assert "<function=" not in content, f"Function tag leak: {content[:200]}"
     assert "<|im_end|>" not in content, f"EOS leak: {content[:200]}"
-    print(f"  No tag leaks detected")
+    print("  No tag leaks detected")
 
 
 def test_api_many_tools():
@@ -346,7 +347,7 @@ def test_api_parallel_tool_calls():
     elif msg.get("tool_calls"):
         print(f"  Single call (model chose sequential): {msg['tool_calls'][0]['function']['name']}")
     else:
-        print(f"  No tool calls (answered directly)")
+        print("  No tool calls (answered directly)")
     # Either way, no tag leaks
     content = msg.get("content", "")
     assert "<tool_call>" not in content, f"Tag leak: {content[:100]}"
@@ -365,7 +366,7 @@ def test_api_stress_no_leak():
         if "<tool_call>" in content or "<function=" in content:
             leaked += 1
     assert leaked == 0, f"{leaked}/10 requests had tag leaks"
-    print(f"  0/10 tag leaks at temperature=0.8")
+    print("  0/10 tag leaks at temperature=0.8")
 
 
 # =============================================================================
@@ -396,7 +397,7 @@ def test_hermes_terminal():
     if err:
         assert False, err
     assert "rapid_mlx_hermes_test" in out, f"Command output missing: {out[:100]}"
-    print(f"  Hermes terminal: OK")
+    print("  Hermes terminal: OK")
 
 
 def test_hermes_search():
@@ -405,7 +406,7 @@ def test_hermes_search():
     if err:
         assert False, err
     assert "aliases" in out.lower(), f"Search failed: {out[:100]}"
-    print(f"  Hermes search: OK")
+    print("  Hermes search: OK")
 
 
 def test_hermes_multi_step():
@@ -418,7 +419,7 @@ def test_hermes_multi_step():
         assert False, err
     # Should mention a number (we have ~22 aliases)
     assert any(str(n) in out for n in range(15, 30)), f"No count found: {out[:200]}"
-    print(f"  Hermes multi-step: OK")
+    print("  Hermes multi-step: OK")
 
 
 # =============================================================================
@@ -442,7 +443,7 @@ def test_hermes_write_and_run():
     )
     fib_out = result.stdout + out
     assert any(str(n) in fib_out for n in [8, 13, 21, 34]), f"Fibonacci missing: {fib_out[:200]}"
-    print(f"  Write+run: fibonacci script works")
+    print("  Write+run: fibonacci script works")
 
 
 def test_hermes_code_with_tests():
@@ -462,7 +463,7 @@ def test_hermes_code_with_tests():
         capture_output=True, text=True, timeout=30,
     )
     assert "passed" in result.stdout.lower(), f"Tests failed: {result.stdout[:200]}{result.stderr[:200]}"
-    print(f"  Code+tests: pytest passing")
+    print("  Code+tests: pytest passing")
 
 
 def test_hermes_code_review():
@@ -490,7 +491,7 @@ def test_hermes_git_analysis():
         assert False, err
     assert "commit" in out.lower() or "hermes" in out.lower() or "feat" in out.lower() or "fix" in out.lower(), \
         f"No git info: {out[:200]}"
-    print(f"  Git analysis: OK")
+    print("  Git analysis: OK")
 
 
 def test_hermes_patch_file():
@@ -511,7 +512,7 @@ def test_hermes_patch_file():
         content = f.read()
     assert "docstring" in content.lower() or "say hello" in content.lower() or '"""' in content, \
         f"Patch not applied: {content[:200]}"
-    print(f"  Patch: file edited successfully")
+    print("  Patch: file edited successfully")
 
 
 # =============================================================================
@@ -519,7 +520,7 @@ def test_hermes_patch_file():
 # =============================================================================
 
 if __name__ == "__main__":
-    print(f"Rapid-MLX Hermes Integration Tests")
+    print("Rapid-MLX Hermes Integration Tests")
     print(f"Server: {BASE_URL}")
     print(f"Model:  {MODEL_ID}")
     print(f"Hermes: {HERMES_BIN}")

--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -1,4 +1,5 @@
 """Thorough LangChain test suite against local rapid-mlx server."""
+
 import os
 
 import httpx as _httpx
@@ -25,7 +26,9 @@ results = {}
 # === 1. Plain invoke ===
 print("=== Test 1: Plain invoke ===")
 try:
-    r = llm.invoke([HumanMessage(content="Reply with just '4' (the digit). What is 2+2?")])
+    r = llm.invoke(
+        [HumanMessage(content="Reply with just '4' (the digit). What is 2+2?")]
+    )
     assert "4" in r.content, r.content
     print(f"PASS: {r.content[:80]}")
     results["1_plain"] = "PASS"
@@ -36,10 +39,14 @@ except Exception as e:
 # === 2. System + User multi-message ===
 print("\n=== Test 2: System + User ===")
 try:
-    r = llm.invoke([
-        SystemMessage(content="You are a calculator. Output ONLY the integer result, nothing else."),
-        HumanMessage(content="7 * 8"),
-    ])
+    r = llm.invoke(
+        [
+            SystemMessage(
+                content="You are a calculator. Output ONLY the integer result, nothing else."
+            ),
+            HumanMessage(content="7 * 8"),
+        ]
+    )
     assert "56" in r.content, r.content
     print(f"PASS: {r.content[:80]}")
     results["2_system"] = "PASS"
@@ -65,6 +72,7 @@ except Exception as e:
 # === 4. Tool calling (single tool) ===
 print("\n=== Test 4: Single tool call ===")
 try:
+
     @tool
     def get_weather(city: str) -> str:
         """Get weather for a city."""
@@ -87,6 +95,7 @@ except Exception as e:
 # === 5. Multi-tool (model picks one) ===
 print("\n=== Test 5: Multi-tool selection ===")
 try:
+
     @tool
     def add(a: int, b: int) -> int:
         """Add two numbers."""
@@ -98,7 +107,9 @@ try:
         return a * b
 
     llm_multi = llm.bind_tools([add, multiply])
-    r = llm_multi.invoke([HumanMessage(content="What is 6 multiplied by 7? Use a tool.")])
+    r = llm_multi.invoke(
+        [HumanMessage(content="What is 6 multiplied by 7? Use a tool.")]
+    )
     tool_calls = r.tool_calls if hasattr(r, "tool_calls") else []
     assert len(tool_calls) > 0, f"No tool calls. content={r.content[:200]}"
     tc = tool_calls[0]
@@ -114,6 +125,7 @@ except Exception as e:
 # === 6. Structured output ===
 print("\n=== Test 6: Structured output (with_structured_output) ===")
 try:
+
     class Person(BaseModel):
         name: str = Field(description="The person's name")
         age: int = Field(description="The person's age in years")

--- a/tests/integrations/test_librechat_docker.py
+++ b/tests/integrations/test_librechat_docker.py
@@ -10,6 +10,7 @@ Pipeline:
 Pass = LibreChat successfully proxies a chat through to rapid-mlx and returns
 an answer that contains the expected substring.
 """
+
 import uuid
 
 import requests
@@ -35,7 +36,9 @@ try:
         },
         timeout=15,
     )
-    assert r.status_code in (200, 201), f"register failed: {r.status_code} {r.text[:200]}"
+    assert r.status_code in (200, 201), (
+        f"register failed: {r.status_code} {r.text[:200]}"
+    )
     print(f"PASS: status={r.status_code}")
     results["1_register"] = "PASS"
 except Exception as e:
@@ -77,7 +80,9 @@ try:
     eps = r.json()
     print(f"  raw keys: {list(eps.keys())}")
     custom = eps.get("custom") or {}
-    print(f"  custom subkeys: {list(custom.keys()) if isinstance(custom, dict) else custom}")
+    print(
+        f"  custom subkeys: {list(custom.keys()) if isinstance(custom, dict) else custom}"
+    )
     assert "Rapid-MLX" in str(eps), f"Rapid-MLX not in endpoints: {eps}"
     print("PASS: Rapid-MLX endpoint is registered")
     results["3_endpoints"] = "PASS"
@@ -94,7 +99,9 @@ try:
     print(f"  models keys: {list(models.keys())[:20]}")
     rapid_models = models.get("Rapid-MLX") or models.get("custom", {}).get("Rapid-MLX")
     assert rapid_models, f"No Rapid-MLX models in {models}"
-    assert any("gemma" in m.lower() for m in rapid_models), f"gemma not in {rapid_models}"
+    assert any("gemma" in m.lower() for m in rapid_models), (
+        f"gemma not in {rapid_models}"
+    )
     print(f"PASS: {len(rapid_models)} model(s) fetched: {rapid_models}")
     results["4_models"] = "PASS"
 except Exception as e:

--- a/tests/integrations/test_librechat_docker.py
+++ b/tests/integrations/test_librechat_docker.py
@@ -10,9 +10,8 @@ Pipeline:
 Pass = LibreChat successfully proxies a chat through to rapid-mlx and returns
 an answer that contains the expected substring.
 """
-import json
-import time
 import uuid
+
 import requests
 
 LC = "http://localhost:3081"

--- a/tests/integrations/test_openwebui.py
+++ b/tests/integrations/test_openwebui.py
@@ -6,6 +6,7 @@ Tests:
   3. GET /api/models → verify rapid-mlx models appear
   4. POST /api/chat/completions → chat through Open WebUI proxy to rapid-mlx
 """
+
 import json
 import uuid
 
@@ -20,11 +21,15 @@ results = {}
 # === 1. Register ===
 print("=== Test 1: Register ===")
 try:
-    r = requests.post(f"{OW}/api/v1/auths/signup", json={
-        "name": NAME,
-        "email": EMAIL,
-        "password": PASSWORD,
-    }, timeout=15)
+    r = requests.post(
+        f"{OW}/api/v1/auths/signup",
+        json={
+            "name": NAME,
+            "email": EMAIL,
+            "password": PASSWORD,
+        },
+        timeout=15,
+    )
     assert r.status_code in (200, 201), f"{r.status_code} {r.text[:200]}"
     data = r.json()
     token = data.get("token")
@@ -51,7 +56,11 @@ try:
     assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
     models = r.json()
     model_list = models.get("data", models) if isinstance(models, dict) else models
-    model_ids = [m.get("id", m.get("name", "?")) for m in model_list] if isinstance(model_list, list) else []
+    model_ids = (
+        [m.get("id", m.get("name", "?")) for m in model_list]
+        if isinstance(model_list, list)
+        else []
+    )
     assert len(model_ids) > 0, f"empty model list: {models}"
     print(f"PASS: {len(model_ids)} model(s): {model_ids[:3]}")
     results["2_models"] = "PASS"
@@ -70,7 +79,12 @@ if target_model:
             headers={**headers, "Content-Type": "application/json"},
             json={
                 "model": target_model,
-                "messages": [{"role": "user", "content": "What is 5+3? Reply with just the number."}],
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "What is 5+3? Reply with just the number.",
+                    }
+                ],
                 "max_tokens": 50,
                 "stream": False,
             },

--- a/tests/integrations/test_openwebui.py
+++ b/tests/integrations/test_openwebui.py
@@ -8,6 +8,7 @@ Tests:
 """
 import json
 import uuid
+
 import requests
 
 OW = "http://localhost:3000"
@@ -28,7 +29,7 @@ try:
     data = r.json()
     token = data.get("token")
     assert token, f"no token: {data}"
-    print(f"PASS: registered + got token")
+    print("PASS: registered + got token")
     results["1_register"] = "PASS"
 except Exception as e:
     print(f"FAIL: {e}")
@@ -107,11 +108,14 @@ if target_model:
         chunks = 0
         content = ""
         for line in r.iter_lines():
-            if not line: continue
+            if not line:
+                continue
             line = line.decode()
-            if not line.startswith("data: "): continue
+            if not line.startswith("data: "):
+                continue
             payload = line[6:]
-            if payload == "[DONE]": break
+            if payload == "[DONE]":
+                break
             obj = json.loads(payload)
             delta = obj.get("choices", [{}])[0].get("delta", {}).get("content", "")
             content += delta

--- a/tests/integrations/test_pydantic_ai_full.py
+++ b/tests/integrations/test_pydantic_ai_full.py
@@ -1,4 +1,5 @@
 """Thorough PydanticAI test suite against local rapid-mlx server."""
+
 import asyncio
 import os
 
@@ -39,13 +40,17 @@ except Exception as e:
 # === 2. Streaming ===
 print("\n=== Test 2: Streaming ===")
 try:
+
     async def stream_test():
         agent = Agent(model)
         chunks = []
-        async with agent.run_stream("Count from 1 to 5, separated by commas.") as result:
+        async with agent.run_stream(
+            "Count from 1 to 5, separated by commas."
+        ) as result:
             async for delta in result.stream_text(delta=True):
                 chunks.append(delta)
         return "".join(chunks)
+
     out = asyncio.run(stream_test())
     assert len(out) > 5, f"Too short: {out}"
     assert any(d in out for d in ["1", "2", "3"]), out
@@ -58,6 +63,7 @@ except Exception as e:
 # === 3. Structured output (BaseModel) ===
 print("\n=== Test 3: Structured output ===")
 try:
+
     class Person(BaseModel):
         name: str
         age: int

--- a/tests/integrations/test_smolagents_full.py
+++ b/tests/integrations/test_smolagents_full.py
@@ -1,4 +1,5 @@
 """Thorough smolagents test suite against local rapid-mlx server."""
+
 import os
 
 import httpx as _httpx
@@ -33,6 +34,7 @@ except Exception as e:
 # === 2. CodeAgent with tool ===
 print("\n=== Test 2: CodeAgent + custom tool ===")
 try:
+
     @tool
     def get_temp(city: str) -> str:
         """Returns the current temperature for a city.
@@ -54,6 +56,7 @@ except Exception as e:
 # === 3. ToolCallingAgent (uses tool_calls API instead of code) ===
 print("\n=== Test 3: ToolCallingAgent + tool ===")
 try:
+
     @tool
     def add_nums(a: int, b: int) -> int:
         """Add two integers.
@@ -76,6 +79,7 @@ except Exception as e:
 # === 4. Multi-tool ToolCallingAgent ===
 print("\n=== Test 4: ToolCallingAgent + multiple tools ===")
 try:
+
     @tool
     def square(n: int) -> int:
         """Square a number.

--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -2,10 +2,13 @@
 """Comprehensive regression and edge case test suite for Rapid-MLX."""
 
 import json
+import os
 import urllib.error
 import urllib.request
 
-BASE = "http://localhost:8777"
+# Port can be overridden by the doctor harness (which picks a free port).
+_PORT = os.environ.get("RAPID_MLX_PORT", "8777")
+BASE = f"http://localhost:{_PORT}"
 
 def api_call(path, body=None, method="GET"):
     """Make an API call, return (status_code, parsed_json_or_None)."""

--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -10,11 +10,14 @@ import urllib.request
 _PORT = os.environ.get("RAPID_MLX_PORT", "8777")
 BASE = f"http://localhost:{_PORT}"
 
+
 def api_call(path, body=None, method="GET"):
     """Make an API call, return (status_code, parsed_json_or_None)."""
     url = BASE + path
     data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     if method != "GET" and data is None:
         req.method = method
     try:
@@ -27,11 +30,14 @@ def api_call(path, body=None, method="GET"):
             body_text = ""
         return e.code, body_text
 
+
 def stream_call(path, body):
     """Make a streaming API call, return collected text and all SSE lines."""
     url = BASE + path
     data = json.dumps(body).encode()
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     text = ""
     lines = []
     with urllib.request.urlopen(req) as resp:
@@ -46,17 +52,21 @@ def stream_call(path, body):
                         text += delta["content"]
     return text, lines
 
+
 def test_1():
     """Stop at newline."""
     print("=" * 60)
     print("TEST 1: Stop sequence - newline")
-    _, r = api_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "Say hello then explain python"}],
-        "stop": ["\n"],
-        "max_tokens": 100,
-        "stream": False
-    })
+    _, r = api_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [{"role": "user", "content": "Say hello then explain python"}],
+            "stop": ["\n"],
+            "max_tokens": 100,
+            "stream": False,
+        },
+    )
     content = r["choices"][0]["message"]["content"]
     finish = r["choices"][0]["finish_reason"]
     has_newline = "\n" in content
@@ -67,17 +77,23 @@ def test_1():
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
 
+
 def test_2():
     """Multiple stop sequences (first match wins)."""
     print("=" * 60)
     print("TEST 2: Multiple stop sequences")
-    _, r = api_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "Write: Hello World! Goodbye World!"}],
-        "stop": ["World", "!"],
-        "max_tokens": 100,
-        "stream": False
-    })
+    _, r = api_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [
+                {"role": "user", "content": "Write: Hello World! Goodbye World!"}
+            ],
+            "stop": ["World", "!"],
+            "max_tokens": 100,
+            "stream": False,
+        },
+    )
     content = r["choices"][0]["message"]["content"]
     finish = r["choices"][0]["finish_reason"]
     has_world = "World" in content
@@ -90,17 +106,21 @@ def test_2():
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
 
+
 def test_3():
     """Empty stop sequence array."""
     print("=" * 60)
     print("TEST 3: Empty stop sequence array")
-    code, r = api_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "hi"}],
-        "stop": [],
-        "max_tokens": 10,
-        "stream": False
-    })
+    code, r = api_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": [],
+            "max_tokens": 10,
+            "stream": False,
+        },
+    )
     if code == 200:
         content = r["choices"][0]["message"]["content"]
         print(f"  OK: {content[:50]!r}")
@@ -111,17 +131,21 @@ def test_3():
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
 
+
 def test_4():
     """Unicode stop sequences."""
     print("=" * 60)
     print("TEST 4: Unicode stop sequences")
-    _, r = api_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "Say 你好世界 then say goodbye"}],
-        "stop": ["世界"],
-        "max_tokens": 100,
-        "stream": False
-    })
+    _, r = api_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [{"role": "user", "content": "Say 你好世界 then say goodbye"}],
+            "stop": ["世界"],
+            "max_tokens": 100,
+            "stream": False,
+        },
+    )
     content = r["choices"][0]["message"]["content"]
     has_stop = "世界" in content
     print(f"  Content: {content!r}")
@@ -131,17 +155,23 @@ def test_4():
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
 
+
 def test_5():
     """Streaming stop sequence truncation."""
     print("=" * 60)
     print("TEST 5: Streaming stop sequence truncation")
-    text, lines = stream_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "Count: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10"}],
-        "stop": [", 5"],
-        "max_tokens": 100,
-        "stream": True
-    })
+    text, lines = stream_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [
+                {"role": "user", "content": "Count: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10"}
+            ],
+            "stop": [", 5"],
+            "max_tokens": 100,
+            "stream": True,
+        },
+    )
     has_stop = ", 5" in text
     print(f"  Text: {text!r}")
     print(f"  Contains ', 5': {has_stop}")
@@ -149,17 +179,21 @@ def test_5():
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
 
+
 def test_6():
     """Completions endpoint (/v1/completions)."""
     print("=" * 60)
     print("TEST 6: Completions endpoint")
-    code, r = api_call("/v1/completions", {
-        "model": "default",
-        "prompt": "def fibonacci(n):\n    ",
-        "max_tokens": 50,
-        "stop": ["\n\n"],
-        "temperature": 0
-    })
+    code, r = api_call(
+        "/v1/completions",
+        {
+            "model": "default",
+            "prompt": "def fibonacci(n):\n    ",
+            "max_tokens": 50,
+            "stop": ["\n\n"],
+            "temperature": 0,
+        },
+    )
     print(f"  HTTP {code}")
     if code == 200:
         if isinstance(r, dict):
@@ -179,17 +213,49 @@ def test_6():
     print(f"  RESULT: {'PASS' if passed else 'FAIL (endpoint may not be implemented)'}")
     return passed
 
+
 def test_7():
     """Validation rules - all should return 400."""
     print("=" * 60)
     print("TEST 7: Validation rules")
     cases = [
-        ("max_tokens=0", {"model": "default", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 0}),
-        ("temp=-0.1", {"model": "default", "messages": [{"role": "user", "content": "hi"}], "temperature": -0.1}),
-        ("temp=2.1", {"model": "default", "messages": [{"role": "user", "content": "hi"}], "temperature": 2.1}),
-        ("n=2", {"model": "default", "messages": [{"role": "user", "content": "hi"}], "n": 2}),
+        (
+            "max_tokens=0",
+            {
+                "model": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 0,
+            },
+        ),
+        (
+            "temp=-0.1",
+            {
+                "model": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": -0.1,
+            },
+        ),
+        (
+            "temp=2.1",
+            {
+                "model": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 2.1,
+            },
+        ),
+        (
+            "n=2",
+            {
+                "model": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 2,
+            },
+        ),
         ("empty messages", {"model": "default", "messages": []}),
-        ("invalid role", {"model": "default", "messages": [{"role": "foo", "content": "hi"}]}),
+        (
+            "invalid role",
+            {"model": "default", "messages": [{"role": "foo", "content": "hi"}]},
+        ),
     ]
     all_pass = True
     for name, body in cases:
@@ -200,6 +266,7 @@ def test_7():
         print(f"  {name}: HTTP {code} ({'PASS' if ok else 'FAIL - expected 400'})")
     print(f"  RESULT: {'PASS' if all_pass else 'FAIL'}")
     return all_pass
+
 
 def test_8():
     """Health endpoint."""
@@ -215,6 +282,7 @@ def test_8():
         passed = False
     print(f"  RESULT: {'PASS' if passed else 'FAIL'}")
     return passed
+
 
 def test_9():
     """Model endpoint format validation."""
@@ -243,17 +311,21 @@ def test_9():
     print(f"  RESULT: {'PASS' if all_pass else 'FAIL'}")
     return all_pass
 
+
 def test_10():
     """Streaming usage stats (stream_options)."""
     print("=" * 60)
     print("TEST 10: Streaming usage stats")
-    text, lines = stream_call("/v1/chat/completions", {
-        "model": "default",
-        "messages": [{"role": "user", "content": "hi"}],
-        "max_tokens": 10,
-        "stream": True,
-        "stream_options": {"include_usage": True}
-    })
+    text, lines = stream_call(
+        "/v1/chat/completions",
+        {
+            "model": "default",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 10,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+    )
     print(f"  Total SSE data lines: {len(lines)}")
     print("  Last 3 lines:")
     for line in lines[-3:]:
@@ -272,9 +344,24 @@ def test_10():
     print(f"  RESULT: {'PASS' if found_usage else 'FAIL'}")
     return found_usage
 
+
 if __name__ == "__main__":
     results = {}
-    for i, test_fn in enumerate([test_1, test_2, test_3, test_4, test_5, test_6, test_7, test_8, test_9, test_10], 1):
+    for i, test_fn in enumerate(
+        [
+            test_1,
+            test_2,
+            test_3,
+            test_4,
+            test_5,
+            test_6,
+            test_7,
+            test_8,
+            test_9,
+            test_10,
+        ],
+        1,
+    ):
         try:
             results[i] = test_fn()
         except Exception as e:

--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -2,9 +2,8 @@
 """Comprehensive regression and edge case test suite for Rapid-MLX."""
 
 import json
-import urllib.request
 import urllib.error
-import sys
+import urllib.request
 
 BASE = "http://localhost:8777"
 
@@ -21,7 +20,7 @@ def api_call(path, body=None, method="GET"):
     except urllib.error.HTTPError as e:
         try:
             body_text = e.read().decode()[:500]
-        except:
+        except Exception:
             body_text = ""
         return e.code, body_text
 
@@ -169,7 +168,7 @@ def test_6():
             print(f"  Response: {r[:200]}")
             passed = False
     elif code == 404:
-        print(f"  Endpoint not implemented (404)")
+        print("  Endpoint not implemented (404)")
         passed = False
     else:
         print(f"  Response: {r[:200] if isinstance(r, str) else r}")
@@ -253,15 +252,15 @@ def test_10():
         "stream_options": {"include_usage": True}
     })
     print(f"  Total SSE data lines: {len(lines)}")
-    print(f"  Last 3 lines:")
-    for l in lines[-3:]:
-        print(f"    {l[:200]}")
+    print("  Last 3 lines:")
+    for line in lines[-3:]:
+        print(f"    {line[:200]}")
 
     found_usage = False
-    for l in reversed(lines):
-        if "[DONE]" in l:
+    for line in reversed(lines):
+        if "[DONE]" in line:
             continue
-        chunk = json.loads(l[5:].strip())
+        chunk = json.loads(line[5:].strip())
         if "usage" in chunk and chunk["usage"] is not None:
             found_usage = True
             print(f"  Usage: {chunk['usage']}")

--- a/tests/test_deltanet_cache.py
+++ b/tests/test_deltanet_cache.py
@@ -9,8 +9,6 @@ corrupting multi-turn conversations.
 """
 
 
-
-
 class FakeKVCache:
     """Simulates a trimmable KVCache."""
 
@@ -93,8 +91,7 @@ class FakeLLM:
         common_len = self._find_common_prefix_len(prompt_token_ids)
 
         has_non_trimmable = any(
-            not c.is_trimmable() and not c.empty()
-            for c in self._prompt_cache
+            not c.is_trimmable() and not c.empty() for c in self._prompt_cache
         )
 
         if common_len == 0:
@@ -175,8 +172,9 @@ class TestDeltaNetCacheReset:
         suffix = llm._prepare_cache_for_prompt([1, 2, 3, 10, 20])
 
         # Must return FULL prompt because DeltaNet can't be trimmed
-        assert suffix == [1, 2, 3, 10, 20], \
+        assert suffix == [1, 2, 3, 10, 20], (
             "Should reprocess full prompt when DeltaNet state can't be trimmed"
+        )
 
     def test_exact_same_prompt_no_reset(self):
         """When the same prompt is repeated, no reset needed."""
@@ -192,8 +190,9 @@ class TestDeltaNetCacheReset:
         # KV cache has offset = 10 (5 prompt + 5 gen), needs trim to 5
         # DeltaNet state is non-empty and KV needs_trim = True
         # So this WILL reset — which is correct because DeltaNet state includes gen tokens
-        assert suffix == [1, 2, 3, 4, 5], \
+        assert suffix == [1, 2, 3, 4, 5], (
             "Should reprocess when DeltaNet has generated token state"
+        )
 
     def test_pure_kv_cache_no_regression(self):
         """Pure KV cache models (no DeltaNet) should work as before."""
@@ -247,5 +246,6 @@ class TestDeltaNetCacheReset:
         # Turn 2: extends the prompt. KV cache offset = 10 (5 prompt + 5 gen),
         # common_len = 5, KV needs trim (10 > 5), DeltaNet is non-empty → reset
         suffix = llm._prepare_cache_for_prompt([1, 2, 3, 4, 5, 6, 7, 8])
-        assert suffix == [1, 2, 3, 4, 5, 6, 7, 8], \
+        assert suffix == [1, 2, 3, 4, 5, 6, 7, 8], (
             "DeltaNet model must reprocess full prompt when KV needs trimming"
+        )

--- a/tests/test_doctor_baseline.py
+++ b/tests/test_doctor_baseline.py
@@ -10,9 +10,9 @@ detection is wrong and we need to look at it.
 from vllm_mlx.doctor.baseline import (
     DEFAULT_THRESHOLDS,
     DeltaStatus,
-    _safe_model_slug,
     compare,
     has_regression,
+    safe_model_slug,
 )
 
 # A minimal threshold map covering the metrics we exercise below.
@@ -184,17 +184,17 @@ class TestSafeModelSlug:
             ("a/b", "a%2Fb"),
         ]
         for a, b in pairs:
-            assert _safe_model_slug(a) != _safe_model_slug(b), (
+            assert safe_model_slug(a) != safe_model_slug(b), (
                 f"slug collision: {a!r} and {b!r} both map to "
-                f"{_safe_model_slug(a)!r}"
+                f"{safe_model_slug(a)!r}"
             )
 
     def test_simple_aliases_unchanged(self):
         # Common case: an alias with no special chars stays human-readable.
-        assert _safe_model_slug("qwen3.5-4b") == "qwen3.5-4b"
+        assert safe_model_slug("qwen3.5-4b") == "qwen3.5-4b"
 
     def test_hf_path_round_trips_via_unquote(self):
         import urllib.parse
         original = "mlx-community/Qwen3.5-4B-MLX-4bit"
-        slug = _safe_model_slug(original)
+        slug = safe_model_slug(original)
         assert urllib.parse.unquote(slug) == original

--- a/tests/test_doctor_baseline.py
+++ b/tests/test_doctor_baseline.py
@@ -32,6 +32,7 @@ def _baseline(metrics: dict) -> dict:
 # Higher-is-better metrics (decode_tps)
 # ----------------------------------------------------------------------
 
+
 class TestHigherIsBetter:
     def test_within_threshold_is_ok(self):
         deltas = compare(
@@ -45,7 +46,7 @@ class TestHigherIsBetter:
 
     def test_drop_beyond_threshold_is_regression(self):
         deltas = compare(
-            current={"decode_tps": 90.0},   # 10% slower
+            current={"decode_tps": 90.0},  # 10% slower
             baseline=_baseline({"decode_tps": 100.0}),
             thresholds=TIGHT_THRESHOLDS,
         )
@@ -67,6 +68,7 @@ class TestHigherIsBetter:
 # ----------------------------------------------------------------------
 # Lower-is-better metrics (latency, memory)
 # ----------------------------------------------------------------------
+
 
 class TestLowerIsBetter:
     def test_lower_latency_is_improvement(self):
@@ -97,7 +99,7 @@ class TestLowerIsBetter:
         """Regression-test for codex round 2 finding — tc_latency_ms
         was missing from _LOWER_IS_BETTER and gave inverted signs."""
         deltas = compare(
-            current={"tc_latency_ms": 1200.0},   # 20% faster
+            current={"tc_latency_ms": 1200.0},  # 20% faster
             baseline=_baseline({"tc_latency_ms": 1500.0}),
             thresholds=TIGHT_THRESHOLDS,
         )
@@ -108,6 +110,7 @@ class TestLowerIsBetter:
 # ----------------------------------------------------------------------
 # Accuracy metrics — zero-tolerance regression
 # ----------------------------------------------------------------------
+
 
 class TestAccuracyZeroTolerance:
     def test_any_drop_is_regression(self):
@@ -123,6 +126,7 @@ class TestAccuracyZeroTolerance:
 # ----------------------------------------------------------------------
 # Edge cases
 # ----------------------------------------------------------------------
+
 
 class TestEdgeCases:
     def test_zero_baseline_no_change_is_ok(self):
@@ -174,6 +178,7 @@ class TestEdgeCases:
 # Slug injectivity — codex round 2 finding
 # ----------------------------------------------------------------------
 
+
 class TestSafeModelSlug:
     def test_distinct_inputs_produce_distinct_slugs(self):
         # Pairs that previously collided under the old replace-based
@@ -185,8 +190,7 @@ class TestSafeModelSlug:
         ]
         for a, b in pairs:
             assert safe_model_slug(a) != safe_model_slug(b), (
-                f"slug collision: {a!r} and {b!r} both map to "
-                f"{safe_model_slug(a)!r}"
+                f"slug collision: {a!r} and {b!r} both map to {safe_model_slug(a)!r}"
             )
 
     def test_simple_aliases_unchanged(self):
@@ -195,6 +199,7 @@ class TestSafeModelSlug:
 
     def test_hf_path_round_trips_via_unquote(self):
         import urllib.parse
+
         original = "mlx-community/Qwen3.5-4B-MLX-4bit"
         slug = safe_model_slug(original)
         assert urllib.parse.unquote(slug) == original

--- a/tests/test_doctor_baseline.py
+++ b/tests/test_doctor_baseline.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the doctor baseline comparator.
+
+The doctor harness lives or dies on whether ``compare()`` correctly
+classifies metrics relative to a baseline.  These are the safety net
+for that logic — if any of these fail, the doctor's regression
+detection is wrong and we need to look at it.
+"""
+
+from vllm_mlx.doctor.baseline import (
+    DEFAULT_THRESHOLDS,
+    DeltaStatus,
+    _safe_model_slug,
+    compare,
+    has_regression,
+)
+
+# A minimal threshold map covering the metrics we exercise below.
+TIGHT_THRESHOLDS = {
+    "decode_tps": {"regression_pct": 5, "improvement_pct": 10},
+    "cold_ttft_ms": {"regression_pct": 10, "improvement_pct": 15},
+    "tc_latency_ms": {"regression_pct": 10, "improvement_pct": 15},
+    "tc_success_rate": {"regression_pct": 0, "improvement_pct": 5},
+}
+
+
+def _baseline(metrics: dict) -> dict:
+    return {"model": "test-model", "metrics": metrics}
+
+
+# ----------------------------------------------------------------------
+# Higher-is-better metrics (decode_tps)
+# ----------------------------------------------------------------------
+
+class TestHigherIsBetter:
+    def test_within_threshold_is_ok(self):
+        deltas = compare(
+            current={"decode_tps": 96.0},
+            baseline=_baseline({"decode_tps": 100.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert len(deltas) == 1
+        assert deltas[0].status == DeltaStatus.OK
+        assert deltas[0].delta_pct == -4.0  # 4% slower, within 5% threshold
+
+    def test_drop_beyond_threshold_is_regression(self):
+        deltas = compare(
+            current={"decode_tps": 90.0},   # 10% slower
+            baseline=_baseline({"decode_tps": 100.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.REGRESSION
+        assert deltas[0].delta_pct == -10.0
+        assert has_regression(deltas)
+
+    def test_gain_beyond_threshold_is_improvement(self):
+        deltas = compare(
+            current={"decode_tps": 120.0},  # 20% faster
+            baseline=_baseline({"decode_tps": 100.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.IMPROVEMENT
+        assert deltas[0].delta_pct == 20.0
+        assert not has_regression(deltas)
+
+
+# ----------------------------------------------------------------------
+# Lower-is-better metrics (latency, memory)
+# ----------------------------------------------------------------------
+
+class TestLowerIsBetter:
+    def test_lower_latency_is_improvement(self):
+        # Latency dropped from 400ms to 320ms — 20% faster.
+        deltas = compare(
+            current={"cold_ttft_ms": 320.0},
+            baseline=_baseline({"cold_ttft_ms": 400.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.IMPROVEMENT
+        # Sign convention: positive delta_pct = better, even for
+        # lower-is-better metrics.  This is the contract callers rely
+        # on when rendering ↑/↓ arrows.
+        assert deltas[0].delta_pct == 20.0
+
+    def test_higher_latency_is_regression(self):
+        # Latency rose from 400ms to 500ms — 25% slower.
+        deltas = compare(
+            current={"cold_ttft_ms": 500.0},
+            baseline=_baseline({"cold_ttft_ms": 400.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.REGRESSION
+        assert deltas[0].delta_pct == -25.0
+        assert has_regression(deltas)
+
+    def test_tc_latency_ms_uses_lower_is_better(self):
+        """Regression-test for codex round 2 finding — tc_latency_ms
+        was missing from _LOWER_IS_BETTER and gave inverted signs."""
+        deltas = compare(
+            current={"tc_latency_ms": 1200.0},   # 20% faster
+            baseline=_baseline({"tc_latency_ms": 1500.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.IMPROVEMENT
+        assert deltas[0].delta_pct == 20.0
+
+
+# ----------------------------------------------------------------------
+# Accuracy metrics — zero-tolerance regression
+# ----------------------------------------------------------------------
+
+class TestAccuracyZeroTolerance:
+    def test_any_drop_is_regression(self):
+        deltas = compare(
+            current={"tc_success_rate": 0.99},
+            baseline=_baseline({"tc_success_rate": 1.0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.REGRESSION
+        assert has_regression(deltas)
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_zero_baseline_no_change_is_ok(self):
+        deltas = compare(
+            current={"composite_score": 0},
+            baseline=_baseline({"composite_score": 0}),
+            thresholds=TIGHT_THRESHOLDS,
+        )
+        assert deltas[0].status == DeltaStatus.OK
+
+    def test_new_metric_is_marked_new(self):
+        deltas = compare(
+            current={"new_thing": 42},
+            baseline=_baseline({}),
+            thresholds={},
+        )
+        assert deltas[0].status == DeltaStatus.NEW
+        assert deltas[0].baseline is None
+
+    def test_dropped_metric_is_marked_dropped(self):
+        deltas = compare(
+            current={},
+            baseline=_baseline({"old_thing": 42}),
+            thresholds={},
+        )
+        assert deltas[0].status == DeltaStatus.DROPPED
+        assert deltas[0].current is None
+
+    def test_no_baseline_returns_new_for_everything(self):
+        deltas = compare(
+            current={"a": 1, "b": 2},
+            baseline=None,
+            thresholds={},
+        )
+        assert all(d.status == DeltaStatus.NEW for d in deltas)
+
+    def test_unknown_metric_falls_back_to_default_thresholds(self):
+        # With DEFAULT_THRESHOLDS = 5%/10%, a 6% drop is regression.
+        deltas = compare(
+            current={"unknown_metric": 94.0},
+            baseline=_baseline({"unknown_metric": 100.0}),
+            thresholds={},
+        )
+        assert deltas[0].status == DeltaStatus.REGRESSION
+        assert deltas[0].threshold_pct == DEFAULT_THRESHOLDS["regression_pct"]
+
+
+# ----------------------------------------------------------------------
+# Slug injectivity — codex round 2 finding
+# ----------------------------------------------------------------------
+
+class TestSafeModelSlug:
+    def test_distinct_inputs_produce_distinct_slugs(self):
+        # Pairs that previously collided under the old replace-based
+        # scheme but must stay distinct now.
+        pairs = [
+            ("foo/bar", "foo__bar"),
+            ("foo bar", "foo_bar"),
+            ("a/b", "a%2Fb"),
+        ]
+        for a, b in pairs:
+            assert _safe_model_slug(a) != _safe_model_slug(b), (
+                f"slug collision: {a!r} and {b!r} both map to "
+                f"{_safe_model_slug(a)!r}"
+            )
+
+    def test_simple_aliases_unchanged(self):
+        # Common case: an alias with no special chars stays human-readable.
+        assert _safe_model_slug("qwen3.5-4b") == "qwen3.5-4b"
+
+    def test_hf_path_round_trips_via_unquote(self):
+        import urllib.parse
+        original = "mlx-community/Qwen3.5-4B-MLX-4bit"
+        slug = _safe_model_slug(original)
+        assert urllib.parse.unquote(slug) == original

--- a/tests/test_doctor_discovery.py
+++ b/tests/test_doctor_discovery.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for doctor's local-model discovery.
+
+The benchmark tier's "no auto-download" contract depends on discovery
+correctly distinguishing complete snapshots from partial ones.  These
+tests pin down that behavior — if any fails, the benchmark may try to
+serve a half-downloaded model and fail with a misleading runtime
+crash instead of a clean "skipped (partial download)" report.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.doctor.discovery import _check_alias, _is_complete_snapshot
+
+
+@pytest.fixture
+def tmp_cache(tmp_path: Path) -> Path:
+    """A fake HF cache root."""
+    return tmp_path / "hub"
+
+
+def _make_hf_snapshot(
+    cache_root: Path,
+    repo_id: str,
+    *,
+    with_config: bool,
+    with_weights: bool,
+    weight_resolves: bool = True,
+) -> Path:
+    """Create a synthetic HF cache snapshot under cache_root."""
+    repo_dir = cache_root / ("models--" + repo_id.replace("/", "--"))
+    snap = repo_dir / "snapshots" / "deadbeef"
+    snap.mkdir(parents=True)
+
+    if with_config:
+        (snap / "config.json").write_text("{}")
+
+    if with_weights:
+        # Mimic HF's symlink-to-blobs layout — write a real blob then
+        # symlink it from the snapshot dir so resolve(strict=True) works.
+        blobs = repo_dir / "blobs"
+        blobs.mkdir(exist_ok=True)
+        blob = blobs / "abc123"
+        blob.write_text("fake weights")
+        link = snap / "model.safetensors"
+        if weight_resolves:
+            link.symlink_to(blob)
+        else:
+            # Dangling symlink — what a half-downloaded model looks like.
+            link.symlink_to(blobs / "missing-blob")
+    return snap
+
+
+# ----------------------------------------------------------------------
+# _is_complete_snapshot
+# ----------------------------------------------------------------------
+
+class TestIsCompleteSnapshot:
+    def test_complete_snapshot_passes(self, tmp_cache):
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=True,
+        )
+        assert _is_complete_snapshot(snap) is True
+
+    def test_missing_config_fails(self, tmp_cache):
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=False, with_weights=True,
+        )
+        assert _is_complete_snapshot(snap) is False
+
+    def test_missing_weights_fails(self, tmp_cache):
+        """Regression: this was the original bug — config.json present
+        but no .safetensors file → discovery wrongly said 'available',
+        server crashed at runtime with 'No safetensors found'."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        assert _is_complete_snapshot(snap) is False
+
+    def test_dangling_symlink_fails(self, tmp_cache):
+        """Half-downloaded HF snapshot: weight file is a symlink into
+        ../blobs/ but the blob never finished downloading.  Plain
+        Path.exists() follows symlinks and returns False on these,
+        but Path.glob() still surfaces them.  resolve(strict=True)
+        is what catches the dangling case."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True,
+            with_weights=True, weight_resolves=False,
+        )
+        assert _is_complete_snapshot(snap) is False
+
+    def test_npz_weights_accepted(self, tmp_cache):
+        """Some MLX exports use .npz instead of .safetensors."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        (snap / "weights.npz").write_text("fake npz")
+        assert _is_complete_snapshot(snap) is True
+
+
+# ----------------------------------------------------------------------
+# _check_alias multi-root + multi-layout
+# ----------------------------------------------------------------------
+
+class TestCheckAlias:
+    def test_picks_complete_over_partial_at_other_root(self, tmp_path):
+        """Two cache roots: first has metadata-only snapshot, second has
+        the real weights.  Discovery must skip the partial one and
+        return the complete one — not silently use the broken path.
+
+        This was the specific shape of the bug observed on the user's
+        machine (SSD had only metadata, ~/.cache/huggingface had the
+        actual blobs).
+        """
+        partial_root = tmp_path / "ssd"
+        complete_root = tmp_path / "local"
+
+        _make_hf_snapshot(
+            partial_root, "org/repo",
+            with_config=True, with_weights=False,
+        )
+        complete_snap = _make_hf_snapshot(
+            complete_root, "org/repo",
+            with_config=True, with_weights=True,
+        )
+
+        result = _check_alias(
+            "test-alias", "org/repo", [partial_root, complete_root],
+        )
+        assert result.available is True
+        assert result.path == complete_snap
+
+    def test_partial_only_marks_unavailable_with_clear_reason(self, tmp_path):
+        cache = tmp_path / "cache"
+        _make_hf_snapshot(
+            cache, "org/repo", with_config=True, with_weights=False,
+        )
+        result = _check_alias("test-alias", "org/repo", [cache])
+        assert result.available is False
+        assert "partial download" in result.reason
+
+    def test_lm_studio_layout_recognized(self, tmp_path):
+        """LM Studio stores models as {root}/{org}/{repo}/, not the
+        HF hub layout.  Without this support the LM Studio cache was
+        invisible to discovery."""
+        lmstudio = tmp_path / "models"
+        repo_dir = lmstudio / "lmstudio-community" / "some-model"
+        repo_dir.mkdir(parents=True)
+        (repo_dir / "config.json").write_text("{}")
+        (repo_dir / "model.safetensors").write_text("fake")
+
+        result = _check_alias(
+            "test-alias",
+            "lmstudio-community/some-model",
+            [lmstudio],
+        )
+        assert result.available is True
+        assert result.path == repo_dir
+
+    def test_completely_missing_model(self, tmp_path):
+        result = _check_alias("test-alias", "org/repo", [tmp_path])
+        assert result.available is False
+        assert "not found" in result.reason.lower()

--- a/tests/test_doctor_discovery.py
+++ b/tests/test_doctor_discovery.py
@@ -99,6 +99,50 @@ class TestIsCompleteSnapshot:
         (snap / "weights.npz").write_text("fake npz")
         assert _is_complete_snapshot(snap) is True
 
+    def test_sharded_complete_passes(self, tmp_cache):
+        """All shards present + index → complete."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        # Write index + every shard it references.
+        (snap / "model.safetensors.index.json").write_text(
+            '{"weight_map": {"a": "model-1-of-2.safetensors", '
+            '"b": "model-2-of-2.safetensors"}}'
+        )
+        (snap / "model-1-of-2.safetensors").write_text("shard 1")
+        (snap / "model-2-of-2.safetensors").write_text("shard 2")
+        assert _is_complete_snapshot(snap) is True
+
+    def test_sharded_partial_fails(self, tmp_cache):
+        """Regression: index claims 2 shards, only 1 present.  Without
+        validating against the index, _is_complete_snapshot would
+        falsely pass because *one* shard glob hit resolves.  This is the
+        exact failure mode codex flagged in round 2."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        (snap / "model.safetensors.index.json").write_text(
+            '{"weight_map": {"a": "model-1-of-2.safetensors", '
+            '"b": "model-2-of-2.safetensors"}}'
+        )
+        # Only the first shard arrived before the download was killed.
+        (snap / "model-1-of-2.safetensors").write_text("shard 1")
+        assert _is_complete_snapshot(snap) is False
+
+    def test_sharded_dangling_symlink_fails(self, tmp_cache):
+        """Index references a shard that exists as a symlink, but the
+        link target is missing.  resolve(strict=True) should catch it."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        (snap / "model.safetensors.index.json").write_text(
+            '{"weight_map": {"a": "model-1-of-1.safetensors"}}'
+        )
+        (snap / "model-1-of-1.safetensors").symlink_to(
+            snap / ".." / "blobs" / "missing-blob"
+        )
+        assert _is_complete_snapshot(snap) is False
+
 
 # ----------------------------------------------------------------------
 # _check_alias multi-root + multi-layout

--- a/tests/test_doctor_discovery.py
+++ b/tests/test_doctor_discovery.py
@@ -143,6 +143,38 @@ class TestIsCompleteSnapshot:
         )
         assert _is_complete_snapshot(snap) is False
 
+    def test_corrupt_index_with_shards_fails(self, tmp_cache):
+        """Regression for codex round 3: if the index file is corrupt
+        (truncated mid-download, broken JSON), we used to fall back to
+        the single-shard glob which would falsely pass when at least
+        one shard happened to be present.  Now we treat any unreadable
+        index as a sign the snapshot can't be trusted."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        # Truncated JSON.
+        (snap / "model.safetensors.index.json").write_text(
+            '{"weight_map": {"a": "model-1-of-2'
+        )
+        (snap / "model-1-of-2.safetensors").write_text("shard 1")
+        # No model-2-of-2.safetensors.
+        assert _is_complete_snapshot(snap) is False
+
+    def test_index_with_empty_weight_map_falls_through_to_single_file(
+        self, tmp_cache
+    ):
+        """Some templates ship an index with an empty weight_map; in
+        that case treating the snapshot as a single-file layout is
+        correct (and used to work before the codex fix)."""
+        snap = _make_hf_snapshot(
+            tmp_cache, "org/repo", with_config=True, with_weights=False,
+        )
+        (snap / "model.safetensors.index.json").write_text(
+            '{"weight_map": {}}'
+        )
+        (snap / "model.safetensors").write_text("single-file weights")
+        assert _is_complete_snapshot(snap) is True
+
 
 # ----------------------------------------------------------------------
 # _check_alias multi-root + multi-layout

--- a/tests/test_doctor_discovery.py
+++ b/tests/test_doctor_discovery.py
@@ -57,16 +57,23 @@ def _make_hf_snapshot(
 # _is_complete_snapshot
 # ----------------------------------------------------------------------
 
+
 class TestIsCompleteSnapshot:
     def test_complete_snapshot_passes(self, tmp_cache):
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=True,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=True,
         )
         assert _is_complete_snapshot(snap) is True
 
     def test_missing_config_fails(self, tmp_cache):
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=False, with_weights=True,
+            tmp_cache,
+            "org/repo",
+            with_config=False,
+            with_weights=True,
         )
         assert _is_complete_snapshot(snap) is False
 
@@ -75,7 +82,10 @@ class TestIsCompleteSnapshot:
         but no .safetensors file → discovery wrongly said 'available',
         server crashed at runtime with 'No safetensors found'."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         assert _is_complete_snapshot(snap) is False
 
@@ -86,15 +96,21 @@ class TestIsCompleteSnapshot:
         but Path.glob() still surfaces them.  resolve(strict=True)
         is what catches the dangling case."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True,
-            with_weights=True, weight_resolves=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=True,
+            weight_resolves=False,
         )
         assert _is_complete_snapshot(snap) is False
 
     def test_npz_weights_accepted(self, tmp_cache):
         """Some MLX exports use .npz instead of .safetensors."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         (snap / "weights.npz").write_text("fake npz")
         assert _is_complete_snapshot(snap) is True
@@ -102,7 +118,10 @@ class TestIsCompleteSnapshot:
     def test_sharded_complete_passes(self, tmp_cache):
         """All shards present + index → complete."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         # Write index + every shard it references.
         (snap / "model.safetensors.index.json").write_text(
@@ -119,7 +138,10 @@ class TestIsCompleteSnapshot:
         falsely pass because *one* shard glob hit resolves.  This is the
         exact failure mode codex flagged in round 2."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         (snap / "model.safetensors.index.json").write_text(
             '{"weight_map": {"a": "model-1-of-2.safetensors", '
@@ -133,7 +155,10 @@ class TestIsCompleteSnapshot:
         """Index references a shard that exists as a symlink, but the
         link target is missing.  resolve(strict=True) should catch it."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         (snap / "model.safetensors.index.json").write_text(
             '{"weight_map": {"a": "model-1-of-1.safetensors"}}'
@@ -150,7 +175,10 @@ class TestIsCompleteSnapshot:
         one shard happened to be present.  Now we treat any unreadable
         index as a sign the snapshot can't be trusted."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         # Truncated JSON.
         (snap / "model.safetensors.index.json").write_text(
@@ -160,18 +188,17 @@ class TestIsCompleteSnapshot:
         # No model-2-of-2.safetensors.
         assert _is_complete_snapshot(snap) is False
 
-    def test_index_with_empty_weight_map_falls_through_to_single_file(
-        self, tmp_cache
-    ):
+    def test_index_with_empty_weight_map_falls_through_to_single_file(self, tmp_cache):
         """Some templates ship an index with an empty weight_map; in
         that case treating the snapshot as a single-file layout is
         correct (and used to work before the codex fix)."""
         snap = _make_hf_snapshot(
-            tmp_cache, "org/repo", with_config=True, with_weights=False,
+            tmp_cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
-        (snap / "model.safetensors.index.json").write_text(
-            '{"weight_map": {}}'
-        )
+        (snap / "model.safetensors.index.json").write_text('{"weight_map": {}}')
         (snap / "model.safetensors").write_text("single-file weights")
         assert _is_complete_snapshot(snap) is True
 
@@ -179,6 +206,7 @@ class TestIsCompleteSnapshot:
 # ----------------------------------------------------------------------
 # _check_alias multi-root + multi-layout
 # ----------------------------------------------------------------------
+
 
 class TestCheckAlias:
     def test_picks_complete_over_partial_at_other_root(self, tmp_path):
@@ -194,16 +222,22 @@ class TestCheckAlias:
         complete_root = tmp_path / "local"
 
         _make_hf_snapshot(
-            partial_root, "org/repo",
-            with_config=True, with_weights=False,
+            partial_root,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         complete_snap = _make_hf_snapshot(
-            complete_root, "org/repo",
-            with_config=True, with_weights=True,
+            complete_root,
+            "org/repo",
+            with_config=True,
+            with_weights=True,
         )
 
         result = _check_alias(
-            "test-alias", "org/repo", [partial_root, complete_root],
+            "test-alias",
+            "org/repo",
+            [partial_root, complete_root],
         )
         assert result.available is True
         assert result.path == complete_snap
@@ -211,7 +245,10 @@ class TestCheckAlias:
     def test_partial_only_marks_unavailable_with_clear_reason(self, tmp_path):
         cache = tmp_path / "cache"
         _make_hf_snapshot(
-            cache, "org/repo", with_config=True, with_weights=False,
+            cache,
+            "org/repo",
+            with_config=True,
+            with_weights=False,
         )
         result = _check_alias("test-alias", "org/repo", [cache])
         assert result.available is False

--- a/tests/test_doctor_runner.py
+++ b/tests/test_doctor_runner.py
@@ -199,3 +199,38 @@ class TestReportRendering:
                 break
         else:
             pytest.fail("could not find the weird-check row in report")
+
+
+# ----------------------------------------------------------------------
+# Boot-timeout heuristic
+# ----------------------------------------------------------------------
+
+class TestSuggestedBootTimeout:
+    """Picks 600s for ≥20B-shaped aliases, 180s for smaller / unknown.
+
+    Codex round 3 P2: scoping the timeout purely by tier (180s for
+    'check', 600s for 'full') broke the supported 'doctor check
+    --model qwen3.5-35b' workflow.  Per-model heuristic restores it.
+    """
+
+    def test_small_models_get_short_timeout(self):
+        from vllm_mlx.doctor.cli import _suggested_boot_timeout
+        for alias in ("qwen3.5-4b", "qwen3-0.6b", "llama3-3b", "gemma3-1b",
+                      "phi4-14b", "ministral-3b", "qwen3-vl-8b"):
+            assert _suggested_boot_timeout(alias) == 180, alias
+
+    def test_large_models_get_long_timeout(self):
+        from vllm_mlx.doctor.cli import _suggested_boot_timeout
+        for alias in ("qwen3.5-27b", "qwen3.5-35b", "qwopus-27b",
+                      "deepseek-r1-32b", "gemma-4-26b", "hermes4-70b",
+                      "qwen3.5-122b", "kimi-48b", "gpt-oss-20b"):
+            assert _suggested_boot_timeout(alias) == 600, alias
+
+    def test_unknown_alias_defaults_to_short(self):
+        """Fast-fail when the heuristic doesn't know — better to time
+        out a legitimately huge model and ask the user to retry with
+        an explicit override than to make 'doctor check' feel sluggish
+        for everyone else."""
+        from vllm_mlx.doctor.cli import _suggested_boot_timeout
+        assert _suggested_boot_timeout("some-random-model") == 180
+        assert _suggested_boot_timeout("model-1.2") == 180  # 1.2B → not matched

--- a/tests/test_doctor_runner.py
+++ b/tests/test_doctor_runner.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for doctor runner internals.
+
+These pin down the exit-code contract (which is the entire point of
+the doctor for CI integration), the markdown-cell escaping helper,
+and the run-directory atomic reservation.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.doctor.runner import (
+    CheckResult,
+    DoctorRunner,
+    Status,
+    md_cell,
+)
+
+# ----------------------------------------------------------------------
+# Exit-code contract
+# ----------------------------------------------------------------------
+
+class TestExitCodeContract:
+    """Documented contract: 0 = pass, 1 = regression, 2 = functional fail."""
+
+    def _runner(self, tmp_path: Path) -> DoctorRunner:
+        return DoctorRunner(tier="test", run_dir=tmp_path / "run")
+
+    def _result(self, name: str, status: Status) -> CheckResult:
+        return CheckResult(name=name, status=status, duration_s=0.1)
+
+    def test_all_pass_is_zero(self, tmp_path):
+        r = self._runner(tmp_path)
+        r.checks = [self._result("a", Status.PASS), self._result("b", Status.PASS)]
+        assert r._compute_exit_code() == 0
+
+    def test_skip_only_is_zero(self, tmp_path):
+        r = self._runner(tmp_path)
+        r.checks = [self._result("a", Status.SKIP)]
+        assert r._compute_exit_code() == 0
+
+    def test_pass_with_regression_is_one(self, tmp_path):
+        r = self._runner(tmp_path)
+        r.checks = [
+            self._result("a", Status.PASS),
+            self._result("b", Status.REGRESSION),
+        ]
+        assert r._compute_exit_code() == 1
+
+    def test_pass_with_fail_is_two(self, tmp_path):
+        r = self._runner(tmp_path)
+        r.checks = [
+            self._result("a", Status.PASS),
+            self._result("b", Status.FAIL),
+        ]
+        assert r._compute_exit_code() == 2
+
+    def test_fail_dominates_regression(self, tmp_path):
+        """Worse-signal-wins: a run with both regression and fail
+        reports fail (rc=2), so CI doesn't downgrade to "just perf"."""
+        r = self._runner(tmp_path)
+        r.checks = [
+            self._result("a", Status.REGRESSION),
+            self._result("b", Status.FAIL),
+        ]
+        assert r._compute_exit_code() == 2
+
+    def test_empty_runs_are_zero(self, tmp_path):
+        r = self._runner(tmp_path)
+        assert r._compute_exit_code() == 0
+
+
+# ----------------------------------------------------------------------
+# md_cell — markdown table escaping
+# ----------------------------------------------------------------------
+
+class TestMdCell:
+    def test_passes_through_safe_text(self):
+        assert md_cell("hello world") == "hello world"
+
+    def test_escapes_pipes(self):
+        """Stack-trace-like detail must not break the table layout."""
+        assert md_cell('File "x.py" | line 42') == 'File "x.py" \\| line 42'
+
+    def test_collapses_newlines(self):
+        assert md_cell("line 1\nline 2\nline 3") == "line 1 line 2 line 3"
+
+    def test_truncates_to_max_len(self):
+        long = "a" * 200
+        out = md_cell(long, max_len=50)
+        assert len(out) == 50
+        assert out.endswith("...")
+
+    def test_max_len_zero_means_uncapped(self):
+        long = "a" * 200
+        assert md_cell(long, max_len=0) == long
+
+    def test_handles_empty(self):
+        assert md_cell("") == ""
+
+    def test_handles_none_via_falsy_fallback(self):
+        # Defensive: callers occasionally pass None for missing details.
+        assert md_cell(None) == ""  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Atomic run-dir reservation
+# ----------------------------------------------------------------------
+
+class TestRunDirReservation:
+    def test_back_to_back_runs_get_distinct_dirs(self, tmp_path, monkeypatch):
+        """Concurrent invocations must never share a run dir, otherwise
+        report.md / result.json get clobbered."""
+        from vllm_mlx.doctor import runner as runner_mod
+        monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
+        r1 = DoctorRunner(tier="x")
+        r2 = DoctorRunner(tier="x")
+        r3 = DoctorRunner(tier="x")
+        assert r1.run_dir != r2.run_dir != r3.run_dir
+        assert r1.run_dir.exists()
+        assert r2.run_dir.exists()
+        assert r3.run_dir.exists()
+
+
+# ----------------------------------------------------------------------
+# Report rendering smoke test (catches structural regressions)
+# ----------------------------------------------------------------------
+
+class TestReportRendering:
+    def test_basic_report_renders_table(self, tmp_path, monkeypatch):
+        from vllm_mlx.doctor import runner as runner_mod
+        monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
+        r = DoctorRunner(tier="test")
+
+        def fake_check():
+            return CheckResult(
+                name="example",
+                status=Status.PASS,
+                duration_s=1.5,
+                detail="all good",
+            )
+        r.run_check("example", fake_check)
+        result = r.finalize()
+
+        report = (Path(result.run_dir) / "report.md").read_text()
+        assert "# Doctor Report — `test`" in report
+        assert "| example | pass | 1.5s | all good |" in report
+        assert result.exit_code == 0
+
+    def test_report_includes_diff_sections_when_stashed(self, tmp_path, monkeypatch):
+        from vllm_mlx.doctor import runner as runner_mod
+        monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
+        r = DoctorRunner(tier="test")
+        r._pending_diff_sections = [  # type: ignore[attr-defined]
+            ("model-a", "| metric | base | curr | dp | s |\n| --- | --- | --- | --- | --- |\n"),
+        ]
+
+        # Need at least one check otherwise finalize() works fine but the
+        # "Baseline diffs" section is the test point.
+        r.run_check("noop", lambda: CheckResult("noop", Status.PASS, 0.1))
+        result = r.finalize()
+
+        report = (Path(result.run_dir) / "report.md").read_text()
+        assert "## Baseline diffs" in report
+        assert "### model-a" in report
+        assert "| metric | base | curr | dp | s |" in report
+
+    def test_pipe_in_detail_does_not_break_table(self, tmp_path, monkeypatch):
+        from vllm_mlx.doctor import runner as runner_mod
+        monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
+        r = DoctorRunner(tier="test")
+
+        def crashing():
+            return CheckResult(
+                name="weird",
+                status=Status.FAIL,
+                duration_s=0.1,
+                detail='Traceback: File "x.py" | line 42 | a',
+            )
+        r.run_check("weird", crashing)
+        result = r.finalize()
+        report = (Path(result.run_dir) / "report.md").read_text()
+
+        # Find the row and confirm exactly 4 unescaped pipes (table cell
+        # boundaries: leading | + 3 separators + trailing |) means the row
+        # has exactly 5 cells like the header.
+        for line in report.splitlines():
+            if "weird" in line and line.strip().startswith("|"):
+                # Count only unescaped pipes (those NOT preceded by '\').
+                unescaped = 0
+                for i, ch in enumerate(line):
+                    if ch == "|" and (i == 0 or line[i - 1] != "\\"):
+                        unescaped += 1
+                assert unescaped == 5, (
+                    f"row should have exactly 5 unescaped pipe boundaries, "
+                    f"got {unescaped} in: {line!r}"
+                )
+                break
+        else:
+            pytest.fail("could not find the weird-check row in report")

--- a/tests/test_doctor_runner.py
+++ b/tests/test_doctor_runner.py
@@ -21,6 +21,7 @@ from vllm_mlx.doctor.runner import (
 # Exit-code contract
 # ----------------------------------------------------------------------
 
+
 class TestExitCodeContract:
     """Documented contract: 0 = pass, 1 = regression, 2 = functional fail."""
 
@@ -75,6 +76,7 @@ class TestExitCodeContract:
 # md_cell — markdown table escaping
 # ----------------------------------------------------------------------
 
+
 class TestMdCell:
     def test_passes_through_safe_text(self):
         assert md_cell("hello world") == "hello world"
@@ -108,11 +110,13 @@ class TestMdCell:
 # Atomic run-dir reservation
 # ----------------------------------------------------------------------
 
+
 class TestRunDirReservation:
     def test_back_to_back_runs_get_distinct_dirs(self, tmp_path, monkeypatch):
         """Concurrent invocations must never share a run dir, otherwise
         report.md / result.json get clobbered."""
         from vllm_mlx.doctor import runner as runner_mod
+
         monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
         r1 = DoctorRunner(tier="x")
         r2 = DoctorRunner(tier="x")
@@ -127,9 +131,11 @@ class TestRunDirReservation:
 # Report rendering smoke test (catches structural regressions)
 # ----------------------------------------------------------------------
 
+
 class TestReportRendering:
     def test_basic_report_renders_table(self, tmp_path, monkeypatch):
         from vllm_mlx.doctor import runner as runner_mod
+
         monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
         r = DoctorRunner(tier="test")
 
@@ -140,6 +146,7 @@ class TestReportRendering:
                 duration_s=1.5,
                 detail="all good",
             )
+
         r.run_check("example", fake_check)
         result = r.finalize()
 
@@ -150,10 +157,14 @@ class TestReportRendering:
 
     def test_report_includes_diff_sections_when_stashed(self, tmp_path, monkeypatch):
         from vllm_mlx.doctor import runner as runner_mod
+
         monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
         r = DoctorRunner(tier="test")
         r._pending_diff_sections = [  # type: ignore[attr-defined]
-            ("model-a", "| metric | base | curr | dp | s |\n| --- | --- | --- | --- | --- |\n"),
+            (
+                "model-a",
+                "| metric | base | curr | dp | s |\n| --- | --- | --- | --- | --- |\n",
+            ),
         ]
 
         # Need at least one check otherwise finalize() works fine but the
@@ -168,6 +179,7 @@ class TestReportRendering:
 
     def test_pipe_in_detail_does_not_break_table(self, tmp_path, monkeypatch):
         from vllm_mlx.doctor import runner as runner_mod
+
         monkeypatch.setattr(runner_mod, "RUNS_DIR", tmp_path)
         r = DoctorRunner(tier="test")
 
@@ -178,6 +190,7 @@ class TestReportRendering:
                 duration_s=0.1,
                 detail='Traceback: File "x.py" | line 42 | a',
             )
+
         r.run_check("weird", crashing)
         result = r.finalize()
         report = (Path(result.run_dir) / "report.md").read_text()
@@ -205,12 +218,14 @@ class TestReportRendering:
 # Boot-timeout default
 # ----------------------------------------------------------------------
 
+
 class TestDefaultBootTimeout:
     """Single generous default beats heuristics that miss models like
     'qwen3-coder' (80B, no param-count hint in alias)."""
 
     def test_default_is_generous(self):
         from vllm_mlx.doctor.cli import DEFAULT_BOOT_TIMEOUT_S
+
         # 600s is the floor for cold-loading 122B models from a slow SSD;
         # bumping below 300s would re-introduce the false-fail class
         # codex round 3 flagged.

--- a/tests/test_doctor_runner.py
+++ b/tests/test_doctor_runner.py
@@ -202,35 +202,16 @@ class TestReportRendering:
 
 
 # ----------------------------------------------------------------------
-# Boot-timeout heuristic
+# Boot-timeout default
 # ----------------------------------------------------------------------
 
-class TestSuggestedBootTimeout:
-    """Picks 600s for ≥20B-shaped aliases, 180s for smaller / unknown.
+class TestDefaultBootTimeout:
+    """Single generous default beats heuristics that miss models like
+    'qwen3-coder' (80B, no param-count hint in alias)."""
 
-    Codex round 3 P2: scoping the timeout purely by tier (180s for
-    'check', 600s for 'full') broke the supported 'doctor check
-    --model qwen3.5-35b' workflow.  Per-model heuristic restores it.
-    """
-
-    def test_small_models_get_short_timeout(self):
-        from vllm_mlx.doctor.cli import _suggested_boot_timeout
-        for alias in ("qwen3.5-4b", "qwen3-0.6b", "llama3-3b", "gemma3-1b",
-                      "phi4-14b", "ministral-3b", "qwen3-vl-8b"):
-            assert _suggested_boot_timeout(alias) == 180, alias
-
-    def test_large_models_get_long_timeout(self):
-        from vllm_mlx.doctor.cli import _suggested_boot_timeout
-        for alias in ("qwen3.5-27b", "qwen3.5-35b", "qwopus-27b",
-                      "deepseek-r1-32b", "gemma-4-26b", "hermes4-70b",
-                      "qwen3.5-122b", "kimi-48b", "gpt-oss-20b"):
-            assert _suggested_boot_timeout(alias) == 600, alias
-
-    def test_unknown_alias_defaults_to_short(self):
-        """Fast-fail when the heuristic doesn't know — better to time
-        out a legitimately huge model and ask the user to retry with
-        an explicit override than to make 'doctor check' feel sluggish
-        for everyone else."""
-        from vllm_mlx.doctor.cli import _suggested_boot_timeout
-        assert _suggested_boot_timeout("some-random-model") == 180
-        assert _suggested_boot_timeout("model-1.2") == 180  # 1.2B → not matched
+    def test_default_is_generous(self):
+        from vllm_mlx.doctor.cli import DEFAULT_BOOT_TIMEOUT_S
+        # 600s is the floor for cold-loading 122B models from a slow SSD;
+        # bumping below 300s would re-introduce the false-fail class
+        # codex round 3 flagged.
+        assert DEFAULT_BOOT_TIMEOUT_S >= 600

--- a/tests/test_engine_parity.py
+++ b/tests/test_engine_parity.py
@@ -131,7 +131,9 @@ class TestApplyChatTemplate:
         assert "tools" in fallback_kwargs
         assert "enable_thinking" not in fallback_kwargs
 
-    def test_fallback_strips_tools_when_both_fail(self, mock_tokenizer, simple_messages):
+    def test_fallback_strips_tools_when_both_fail(
+        self, mock_tokenizer, simple_messages
+    ):
         """Should fall back to prompt injection when template rejects both."""
         mock_tokenizer.apply_chat_template.side_effect = [
             TypeError("unsupported keyword argument 'enable_thinking'"),

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -16,13 +16,13 @@ Fix history:
   numeric args like `{a:3,b:4}` parsed as empty dict {}.
 """
 import json
+
 import pytest
 
 from vllm_mlx.tool_parsers.gemma4_tool_parser import (
     Gemma4ToolParser,
     _parse_gemma4_args,
 )
-
 
 # ---------------------------------------------------------------------------
 # _parse_gemma4_args — unit tests

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -15,6 +15,7 @@ Fix history:
 - 2026-04-07: original parser only handled `key:<|"|>value<|"|>` form;
   numeric args like `{a:3,b:4}` parsed as empty dict {}.
 """
+
 import json
 
 import pytest
@@ -44,7 +45,10 @@ from vllm_mlx.tool_parsers.gemma4_tool_parser import (
         # mixed: numeric + quoted
         ('a:3,b:<|"|>hi<|"|>', {"a": 3, "b": "hi"}),
         # multiple quoted strings
-        ('first:<|"|>Alice<|"|>,last:<|"|>Smith<|"|>', {"first": "Alice", "last": "Smith"}),
+        (
+            'first:<|"|>Alice<|"|>,last:<|"|>Smith<|"|>',
+            {"first": "Alice", "last": "Smith"},
+        ),
         # mixed: 3 fields, all types
         (
             'flag:true,n:42,name:<|"|>Bob<|"|>',

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -7,6 +7,7 @@ import pytest
 
 try:
     import mlx_lm  # noqa: F401
+
     _has_mlx_lm = True
 except ImportError:
     _has_mlx_lm = False
@@ -470,9 +471,7 @@ class TestCacheListTrimmability:
         config = MemoryCacheConfig(max_memory_mb=10, max_entries=10)
         return MemoryAwarePrefixCache(model, config)
 
-    @pytest.mark.skipif(
-        not _has_mlx_lm, reason="mlx_lm not available (Linux CI)"
-    )
+    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
     def test_supersequence_trimmable_cachelist_hits(self, cache):
         """CacheList with is_trimmable()=True must allow supersequence trim, not skip."""
         # Store a longer sequence
@@ -504,9 +503,7 @@ class TestCacheListTrimmability:
         assert result is None
         assert remaining == short_tokens
 
-    @pytest.mark.skipif(
-        not _has_mlx_lm, reason="mlx_lm not available (Linux CI)"
-    )
+    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
     def test_lcp_trimmable_cachelist_hits(self, cache):
         """CacheList with is_trimmable()=True must allow LCP trim path."""
         # Store tokens that share a prefix but diverge

--- a/tests/test_mllm_cache.py
+++ b/tests/test_mllm_cache.py
@@ -147,7 +147,9 @@ class TestImageHashing:
             # Order matters: image sequence affects vision embeddings/KV state
             hash_a = compute_images_hash([path1, path2])
             hash_b = compute_images_hash([path2, path1])
-            assert hash_a != hash_b, "Different image orders must produce different hashes"
+            assert hash_a != hash_b, (
+                "Different image orders must produce different hashes"
+            )
             # Same order is deterministic
             hash_c = compute_images_hash([path1, path2])
             assert hash_a == hash_c

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -12,20 +12,20 @@ from vllm_mlx.output_router import Channel, OutputRouter, RouterState, TokenMap
 
 # === Gemma 4 Token IDs (from tokenizer) ===
 GEMMA4_MAP = TokenMap(
-    channel_start=100,   # <|channel>
-    channel_end=101,     # <channel|>
+    channel_start=100,  # <|channel>
+    channel_end=101,  # <channel|>
     thought_word=45518,  # "thought"
-    content_word=3955,   # "content"
-    final_word=10218,    # "final"
-    turn_start=105,      # <|turn>
-    turn_end=106,        # <turn|>
+    content_word=3955,  # "content"
+    final_word=10218,  # "final"
+    turn_start=105,  # <|turn>
+    turn_end=106,  # <turn|>
     tool_call_start=48,  # <|tool_call>
-    tool_call_end=49,    # <tool_call|>
-    tool_quote=52,       # <|"|>
-    tool_start=46,       # <|tool>
-    tool_end=47,         # <tool|>
+    tool_call_end=49,  # <tool_call|>
+    tool_quote=52,  # <|"|>
+    tool_start=46,  # <|tool>
+    tool_end=47,  # <tool|>
     tool_response_start=50,  # <|tool_response>
-    tool_response_end=51,    # <tool_response|>
+    tool_response_end=51,  # <tool_response|>
     bos=2,
     eos=1,
     pad=0,
@@ -48,20 +48,39 @@ class FakeTokenizer:
 
 # Gemma 4 vocabulary (subset for testing)
 VOCAB = {
-    "<pad>": 0, "<eos>": 1, "<bos>": 2,
-    "<|tool>": 46, "<tool|>": 47,
-    "<|tool_call>": 48, "<tool_call|>": 49,
-    "<|tool_response>": 50, "<tool_response|>": 51,
+    "<pad>": 0,
+    "<eos>": 1,
+    "<bos>": 2,
+    "<|tool>": 46,
+    "<tool|>": 47,
+    "<|tool_call>": 48,
+    "<tool_call|>": 49,
+    "<|tool_response>": 50,
+    "<tool_response|>": 51,
     '<|"|>': 52,
-    "<|channel>": 100, "<channel|>": 101,
-    "<|turn>": 105, "<turn|>": 106,
+    "<|channel>": 100,
+    "<channel|>": 101,
+    "<|turn>": 105,
+    "<turn|>": 106,
     "\n": 107,
-    "thought": 45518, "content": 3955, "final": 10218,
-    "Hello": 9259, "Four": 73440, "call": 6639, ":": 236787,
-    "get": 828, "_": 236779, "weather": 19323,
-    "{": 236782, "}": 236783, "city": 13319,
-    "Tokyo": 89265, " ": 235248,
-    "The": 651, "user": 2364, "wants": 10388,
+    "thought": 45518,
+    "content": 3955,
+    "final": 10218,
+    "Hello": 9259,
+    "Four": 73440,
+    "call": 6639,
+    ":": 236787,
+    "get": 828,
+    "_": 236779,
+    "weather": 19323,
+    "{": 236782,
+    "}": 236783,
+    "city": 13319,
+    "Tokyo": 89265,
+    " ": 235248,
+    "The": 651,
+    "user": 2364,
+    "wants": 10388,
 }
 
 TOKENIZER = FakeTokenizer(VOCAB)
@@ -86,9 +105,9 @@ class TestBasicRouting:
 
     def test_bos_eos_pad_suppressed(self, router):
         """Control tokens are suppressed."""
-        assert router.feed(0) is None   # pad
-        assert router.feed(1) is None   # eos
-        assert router.feed(2) is None   # bos
+        assert router.feed(0) is None  # pad
+        assert router.feed(1) is None  # eos
+        assert router.feed(2) is None  # bos
 
     def test_turn_tokens_suppressed(self, router):
         """Turn markers are suppressed."""
@@ -101,7 +120,7 @@ class TestThinkingChannel:
 
     def test_thought_channel_detected(self, router):
         """<|channel> + thought → THINKING state, tokens go to REASONING."""
-        assert router.feed(100) is None   # <|channel> suppressed
+        assert router.feed(100) is None  # <|channel> suppressed
         assert router.feed(45518) is None  # "thought" suppressed
         assert router.state == RouterState.THINKING
 
@@ -111,9 +130,9 @@ class TestThinkingChannel:
 
     def test_thought_ends_at_channel_close(self, router):
         """<channel|> ends thinking, switches to CONTENT."""
-        router.feed(100)    # <|channel>
+        router.feed(100)  # <|channel>
         router.feed(45518)  # thought
-        router.feed(651)    # "The" (reasoning)
+        router.feed(651)  # "The" (reasoning)
 
         assert router.feed(101) is None  # <channel|> suppressed
         assert router.state == RouterState.CONTENT
@@ -125,8 +144,8 @@ class TestThinkingChannel:
     def test_thought_then_content_channel(self, router):
         """Full cycle: thought → <channel|> → content channel → answer."""
         # Thought channel
-        router.feed(100)     # <|channel>
-        router.feed(45518)   # thought
+        router.feed(100)  # <|channel>
+        router.feed(45518)  # thought
         e1 = router.feed(651)  # "The"
         assert e1.channel == Channel.REASONING
 
@@ -134,17 +153,17 @@ class TestThinkingChannel:
         router.feed(101)  # <channel|>
 
         # Content channel
-        router.feed(100)   # <|channel>
+        router.feed(100)  # <|channel>
         router.feed(3955)  # content
         e2 = router.feed(73440)  # "Four"
         assert e2.channel == Channel.CONTENT
 
     def test_implicit_content_after_thought(self, router):
         """After <channel|>, if no new <|channel>, tokens are content."""
-        router.feed(100)     # <|channel>
-        router.feed(45518)   # thought
-        router.feed(651)     # reasoning
-        router.feed(101)     # <channel|>
+        router.feed(100)  # <|channel>
+        router.feed(45518)  # thought
+        router.feed(651)  # reasoning
+        router.feed(101)  # <channel|>
 
         # No explicit content channel — should still be content
         e = router.feed(73440)  # "Four"
@@ -156,24 +175,24 @@ class TestToolCallRouting:
 
     def test_tool_call_accumulated(self, router):
         """Tokens between <|tool_call> and <tool_call|> are accumulated."""
-        assert router.feed(48) is None   # <|tool_call> → accumulate
+        assert router.feed(48) is None  # <|tool_call> → accumulate
         assert router.feed(6639) is None  # "call" → accumulate
         assert router.feed(236787) is None  # ":" → accumulate
 
     def test_tool_call_emitted_on_close(self, router):
         """Complete tool call emitted as TOOL_CALL event."""
-        router.feed(48)      # <|tool_call>
-        router.feed(6639)    # call
+        router.feed(48)  # <|tool_call>
+        router.feed(6639)  # call
         router.feed(236787)  # :
-        router.feed(828)     # get
+        router.feed(828)  # get
         router.feed(236779)  # _
-        router.feed(19323)   # weather
+        router.feed(19323)  # weather
         router.feed(236782)  # {
-        router.feed(13319)   # city
+        router.feed(13319)  # city
         router.feed(236787)  # :
-        router.feed(52)      # <|"|>
-        router.feed(89265)   # Tokyo
-        router.feed(52)      # <|"|>
+        router.feed(52)  # <|"|>
+        router.feed(89265)  # Tokyo
+        router.feed(52)  # <|"|>
         router.feed(236783)  # }
 
         event = router.feed(49)  # <tool_call|>
@@ -184,9 +203,9 @@ class TestToolCallRouting:
 
     def test_content_after_tool_call(self, router):
         """After tool call completes, back to content mode."""
-        router.feed(48)   # <|tool_call>
-        router.feed(6639) # call
-        router.feed(49)   # <tool_call|>
+        router.feed(48)  # <|tool_call>
+        router.feed(6639)  # call
+        router.feed(49)  # <tool_call|>
 
         event = router.feed(9259)  # "Hello"
         assert event.channel == Channel.CONTENT
@@ -211,8 +230,8 @@ class TestOrphanTokens:
 
     def test_content_after_orphan_tokens(self, router):
         """Content after orphan tokens routes correctly."""
-        router.feed(49)   # orphan <tool_call|>
-        router.feed(51)   # orphan <tool_response|>
+        router.feed(49)  # orphan <tool_call|>
+        router.feed(51)  # orphan <tool_response|>
         event = router.feed(9259)  # "Hello"
         assert event is not None
         assert event.channel == Channel.CONTENT
@@ -224,12 +243,17 @@ class TestFeedSequence:
     def test_thought_then_content(self, router):
         """Process a full thought→content sequence."""
         tokens = [
-            100, 45518, 107,  # <|channel> thought \n
-            651, 2364,        # "The" "user" (reasoning)
-            101,              # <channel|>
-            100, 3955, 107,   # <|channel> content \n
-            73440,            # "Four" (content)
-            101,              # <channel|>
+            100,
+            45518,
+            107,  # <|channel> thought \n
+            651,
+            2364,  # "The" "user" (reasoning)
+            101,  # <channel|>
+            100,
+            3955,
+            107,  # <|channel> content \n
+            73440,  # "Four" (content)
+            101,  # <channel|>
         ]
         result = router.feed_sequence(tokens)
         assert result["content"] == "Four"
@@ -239,14 +263,20 @@ class TestFeedSequence:
     def test_tool_call_sequence(self, router):
         """Process a tool call sequence."""
         tokens = [
-            48,               # <|tool_call>
-            6639, 236787,     # call :
-            828, 236779, 19323,  # get _ weather
-            236782,           # {
-            13319, 236787,    # city :
-            52, 89265, 52,    # <|"|> Tokyo <|"|>
-            236783,           # }
-            49,               # <tool_call|>
+            48,  # <|tool_call>
+            6639,
+            236787,  # call :
+            828,
+            236779,
+            19323,  # get _ weather
+            236782,  # {
+            13319,
+            236787,  # city :
+            52,
+            89265,
+            52,  # <|"|> Tokyo <|"|>
+            236783,  # }
+            49,  # <tool_call|>
         ]
         result = router.feed_sequence(tokens)
         assert result["tool_calls"] is not None
@@ -284,8 +314,8 @@ class TestStateReset:
 
     def test_reset_clears_state(self, router):
         """Reset returns to INIT state."""
-        router.feed(100)     # enter channel
-        router.feed(45518)   # thinking
+        router.feed(100)  # enter channel
+        router.feed(45518)  # thinking
         assert router.state == RouterState.THINKING
 
         router.reset()

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -10,7 +10,6 @@ import pytest
 
 from vllm_mlx.output_router import Channel, OutputRouter, RouterState, TokenMap
 
-
 # === Gemma 4 Token IDs (from tokenizer) ===
 GEMMA4_MAP = TokenMap(
     channel_start=100,   # <|channel>
@@ -296,7 +295,8 @@ class TestStateReset:
     def test_multiple_requests(self, router):
         """Router works correctly across multiple reset cycles."""
         # Request 1
-        router.feed(100); router.feed(45518)  # thinking
+        router.feed(100)
+        router.feed(45518)  # thinking
         e1 = router.feed(651)
         assert e1.channel == Channel.REASONING
 

--- a/tests/test_sanitize_output.py
+++ b/tests/test_sanitize_output.py
@@ -14,6 +14,7 @@ Fix history:
   tokens but left the inner `call:name{...}` body in place. Also, the
   non-streaming chat path never called sanitize_output at all.
 """
+
 import pytest
 
 from vllm_mlx.api.utils import sanitize_output
@@ -38,9 +39,7 @@ def test_strips_full_gemma4_tool_call_quoted_args():
 
 def test_strips_gemma4_markup_inside_content():
     """When markup is sandwiched between real content, leave the content."""
-    out = sanitize_output(
-        "Result: <|tool_call>call:add{a:3,b:4}<tool_call|> done"
-    )
+    out = sanitize_output("Result: <|tool_call>call:add{a:3,b:4}<tool_call|> done")
     assert out is not None
     assert "<|tool_call>" not in out
     assert "<tool_call|>" not in out

--- a/tests/test_sanitize_output.py
+++ b/tests/test_sanitize_output.py
@@ -18,7 +18,6 @@ import pytest
 
 from vllm_mlx.api.utils import sanitize_output
 
-
 # ---------------------------------------------------------------------------
 # The exact regression cases from the bug report
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_matrix.sh
+++ b/tests/test_smoke_matrix.sh
@@ -101,7 +101,7 @@ check() {
 # ---------------------------------------------------------------
 echo "[1/5] Emoji decode (streaming)"
 EMOJI_RESULT=$(stream_chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "Reply with ONLY these 3 emoji, nothing else: 🎉🚀😊"}],
     "max_tokens": 50,
     "temperature": 0,
@@ -118,7 +118,7 @@ echo ""
 # ---------------------------------------------------------------
 echo "[2/5] CJK decode (streaming)"
 CJK_RESULT=$(stream_chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "只回复四个字：你好世界"}],
     "max_tokens": 50,
     "temperature": 0,
@@ -135,7 +135,7 @@ echo ""
 # ---------------------------------------------------------------
 echo "[3/5] enable_thinking=false"
 NOTHINK_RESULT=$(chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "What is 2+2? Answer with just the number."}],
     "max_tokens": 50,
     "temperature": 0,
@@ -160,7 +160,7 @@ echo ""
 # ---------------------------------------------------------------
 echo "[4/5] enable_thinking=true vs false (streaming)"
 THINK_STREAM=$(stream_chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "What is 17 * 23?"}],
     "max_tokens": 500,
     "temperature": 0,
@@ -171,7 +171,7 @@ echo "    thinking=default (first 120): ${THINK_STREAM:0:120}"
 # contains thinking markers. The key test: default response is
 # LONGER than no-think response (thinking adds tokens).
 NOTHINK_STREAM=$(stream_chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "What is 17 * 23?"}],
     "max_tokens": 500,
     "temperature": 0,
@@ -201,7 +201,7 @@ echo ""
 # ---------------------------------------------------------------
 echo "[5/5] Special token leak (streaming)"
 CLEAN_RESULT=$(stream_chat '{
-    "model": "x",
+    "model": "default",
     "messages": [{"role": "user", "content": "Say hello in one sentence."}],
     "max_tokens": 50,
     "temperature": 0,

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -8,7 +8,7 @@ prompt_tokens tracking work together correctly.
 import json
 import unittest
 
-from vllm_mlx.api.utils import StreamingToolCallFilter, StreamingThinkRouter
+from vllm_mlx.api.utils import StreamingThinkRouter, StreamingToolCallFilter
 from vllm_mlx.server import _emit_content_pieces
 
 

--- a/tests/test_streaming_think_router.py
+++ b/tests/test_streaming_think_router.py
@@ -78,7 +78,7 @@ class TestStreamingThinkRouter(unittest.TestCase):
         p2 = r.process(" is not a tag>")
         # After p2, the held-back "<thi" + "s is not a tag>" should emit as text
         all_text = "".join(t for bt, t in p1 + p2 if bt == "text")
-        assert "Hello <this is not a tag>" == all_text
+        assert all_text == "Hello <this is not a tag>"
 
     # --- Multiple think blocks ---
 

--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -45,9 +45,9 @@ def test_build_text_model_moe():
     assert hasattr(text_model, "mtp"), "TextModel missing .mtp attribute"
     assert text_model.mtp is not None, "TextModel.mtp is None"
     assert hasattr(text_model, "mtp_forward"), "TextModel missing mtp_forward method"
-    assert hasattr(
-        text_model, "make_mtp_cache"
-    ), "TextModel missing make_mtp_cache method"
+    assert hasattr(text_model, "make_mtp_cache"), (
+        "TextModel missing make_mtp_cache method"
+    )
 
     # Verify MoE layer exists in MTP
     mtp_layer = text_model.mtp.layers[0]
@@ -77,9 +77,9 @@ def test_text_model_mtp_forward():
     next_ids = mx.array([[0]])
     logits = text_model.mtp_forward(hidden, next_ids, mtp_cache)
 
-    assert (
-        logits.shape[-1] == text_config["vocab_size"]
-    ), f"Expected vocab_size={text_config['vocab_size']}, got {logits.shape[-1]}"
+    assert logits.shape[-1] == text_config["vocab_size"], (
+        f"Expected vocab_size={text_config['vocab_size']}, got {logits.shape[-1]}"
+    )
 
 
 @pytest.mark.skipif(not VLM_MTP_MODEL.exists(), reason="VLM+MTP model not on disk")
@@ -132,9 +132,9 @@ def test_weight_sharing():
         if hasattr(layer, "self_attn"):
             vlm_weight = layer.self_attn.q_proj.weight
             tm_weight = text_model.model.layers[i].self_attn.q_proj.weight
-            assert mx.array_equal(
-                vlm_weight, tm_weight
-            ), f"Weights at layer {i} should be identical"
+            assert mx.array_equal(vlm_weight, tm_weight), (
+                f"Weights at layer {i} should be identical"
+            )
             break
     else:
         pytest.fail("No layer with self_attn found")

--- a/tests/test_tool_injection.py
+++ b/tests/test_tool_injection.py
@@ -208,9 +208,7 @@ except ImportError:
 import pytest
 
 
-@pytest.mark.skipif(
-    not _has_mistral_parser, reason="transformers not installed"
-)
+@pytest.mark.skipif(not _has_mistral_parser, reason="transformers not installed")
 class TestMistralArgsStripping:
     """Tests for [ARGS] suffix stripping in Mistral parser."""
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -34,9 +34,9 @@ class TestSmartNframes:
     def test_result_always_even(self):
         for total in [5, 7, 11, 13, 100, 999]:
             result = smart_nframes(total, 30.0)
-            assert (
-                result % FRAME_FACTOR == 0
-            ), f"Odd frame count {result} for total={total}"
+            assert result % FRAME_FACTOR == 0, (
+                f"Odd frame count {result} for total={total}"
+            )
 
 
 class TestVideoUrlParsing:

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -111,8 +111,7 @@ def get_setup_instructions(
     return "\n".join(lines)
 
 
-def apply_streaming_config(profile: AgentProfile,
-                           agent_version: str | None = None):
+def apply_streaming_config(profile: AgentProfile, agent_version: str | None = None):
     """Inject agent-specific streaming filter tags into the global registry.
 
     This is called at server startup or when an agent profile is activated,
@@ -143,9 +142,10 @@ def apply_streaming_config(profile: AgentProfile,
         )
 
 
-def get_extra_tags_for_profile(profile: AgentProfile,
-                               agent_version: str | None = None,
-                               ) -> list[tuple[str, str]]:
+def get_extra_tags_for_profile(
+    profile: AgentProfile,
+    agent_version: str | None = None,
+) -> list[tuple[str, str]]:
     """Get extra streaming tags from a profile (for per-request filter creation).
 
     Instead of mutating global state, this returns the tags so they can be

--- a/vllm_mlx/agents/base.py
+++ b/vllm_mlx/agents/base.py
@@ -101,7 +101,9 @@ class AgentProfile:
     needs_vision: bool = False
     needs_reasoning: bool = False
 
-    def get_config_for_version(self, agent_version: str | None = None) -> AgentConfigSpec:
+    def get_config_for_version(
+        self, agent_version: str | None = None
+    ) -> AgentConfigSpec:
         """Get the config spec, optionally matching an agent version."""
         if agent_version and self.versions:
             for vs in self.versions:
@@ -110,7 +112,9 @@ class AgentProfile:
                         return vs.config
         return self.config
 
-    def get_streaming_for_version(self, agent_version: str | None = None) -> AgentStreamingSpec:
+    def get_streaming_for_version(
+        self, agent_version: str | None = None
+    ) -> AgentStreamingSpec:
         """Get streaming spec, optionally matching an agent version."""
         if agent_version and self.versions:
             for vs in self.versions:
@@ -119,7 +123,9 @@ class AgentProfile:
                         return vs.streaming
         return self.streaming
 
-    def get_testing_for_version(self, agent_version: str | None = None) -> AgentTestingSpec:
+    def get_testing_for_version(
+        self, agent_version: str | None = None
+    ) -> AgentTestingSpec:
         """Get testing spec, optionally matching an agent version."""
         if agent_version and self.versions:
             for vs in self.versions:
@@ -128,8 +134,9 @@ class AgentProfile:
                         return vs.testing
         return self.testing
 
-    def render_config(self, base_url: str, model_id: str,
-                      agent_version: str | None = None) -> str | dict[str, str]:
+    def render_config(
+        self, base_url: str, model_id: str, agent_version: str | None = None
+    ) -> str | dict[str, str]:
         """Render the config file content or env vars for this agent.
 
         Returns:

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # Test result types
 # ---------------------------------------------------------------------------
 
+
 class TestStatus(Enum):
     PASS = "PASS"
     FAIL = "FAIL"
@@ -79,10 +80,10 @@ class TestReport:
             TestStatus.ERROR: "💥",
         }
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"  {self.agent_name} Integration Test Report")
         print(f"  Model: {self.model_id}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         # Group by category
         base_results = [r for r in self.results if r.category in ("api", "e2e")]
@@ -90,26 +91,34 @@ class TestReport:
 
         if base_results:
             print("\n  Base Tests (API + E2E)")
-            print(f"  {'─'*50}")
+            print(f"  {'─' * 50}")
             for r in base_results:
                 icon = icons[r.status]
                 ms = f"({r.duration_ms:.0f}ms)" if r.duration_ms else ""
-                msg = f" — {r.message}" if r.message and r.status != TestStatus.PASS else ""
+                msg = (
+                    f" — {r.message}"
+                    if r.message and r.status != TestStatus.PASS
+                    else ""
+                )
                 print(f"  {icon} {r.name:40s} {ms}{msg}")
             base_pass = sum(1 for r in base_results if r.status == TestStatus.PASS)
             print(f"  → {base_pass}/{len(base_results)} base tests passed")
 
         if specific_results:
             print("\n  Framework-Specific Tests")
-            print(f"  {'─'*50}")
+            print(f"  {'─' * 50}")
             for r in specific_results:
                 icon = icons[r.status]
-                msg = f" — {r.message}" if r.message and r.status != TestStatus.PASS else ""
+                msg = (
+                    f" — {r.message}"
+                    if r.message and r.status != TestStatus.PASS
+                    else ""
+                )
                 print(f"  {icon} {r.name:40s}{msg}")
             spec_pass = sum(1 for r in specific_results if r.status == TestStatus.PASS)
             print(f"  → {spec_pass}/{len(specific_results)} specific tests passed")
 
-        print(f"\n{'─'*60}")
+        print(f"\n{'─' * 60}")
         total = len(self.results)
         print(
             f"  Total: {self.passed}/{total} passed, "
@@ -165,9 +174,16 @@ BASIC_TOOLS = [
 ]
 
 
-def _api_call(base_url: str, model_id: str, messages: list,
-              tools=None, stream=False, max_tokens=300, temperature=0.3,
-              timeout=120) -> dict:
+def _api_call(
+    base_url: str,
+    model_id: str,
+    messages: list,
+    tools=None,
+    stream=False,
+    max_tokens=300,
+    temperature=0.3,
+    timeout=120,
+) -> dict:
     """Direct API call to Rapid-MLX server."""
     payload = {
         "model": model_id,
@@ -191,124 +207,203 @@ def _api_call(base_url: str, model_id: str, messages: list,
 # Individual test functions
 # ---------------------------------------------------------------------------
 
+
 def _test_plain_chat(base_url: str, model_id: str) -> TestResult:
     """Basic chat — model responds coherently."""
     t0 = time.time()
     try:
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "What is 2+2? Reply with just the number."}])
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "What is 2+2? Reply with just the number."}],
+        )
         content = r["choices"][0]["message"]["content"]
         if "4" in content:
-            return TestResult("plain_chat", TestStatus.PASS,
-                              duration_ms=(time.time() - t0) * 1000)
-        return TestResult("plain_chat", TestStatus.FAIL,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"Expected '4', got: {content[:80]}")
+            return TestResult(
+                "plain_chat", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
+            )
+        return TestResult(
+            "plain_chat",
+            TestStatus.FAIL,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"Expected '4', got: {content[:80]}",
+        )
     except Exception as e:
-        return TestResult("plain_chat", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "plain_chat",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_single_tool_call(base_url: str, model_id: str) -> TestResult:
     """Model produces a structured tool call."""
     t0 = time.time()
     try:
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "Read the file /etc/hostname"}],
-                       tools=BASIC_TOOLS)
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "Read the file /etc/hostname"}],
+            tools=BASIC_TOOLS,
+        )
         msg = r["choices"][0]["message"]
         if not msg.get("tool_calls"):
-            return TestResult("single_tool_call", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message="No tool_calls in response")
+            return TestResult(
+                "single_tool_call",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message="No tool_calls in response",
+            )
         tc = msg["tool_calls"][0]
         if tc["function"]["name"] != "read_file":
-            return TestResult("single_tool_call", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"Wrong tool: {tc['function']['name']}")
-        return TestResult("single_tool_call", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000)
+            return TestResult(
+                "single_tool_call",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"Wrong tool: {tc['function']['name']}",
+            )
+        return TestResult(
+            "single_tool_call", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
+        )
     except Exception as e:
-        return TestResult("single_tool_call", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "single_tool_call",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_tool_choice(base_url: str, model_id: str) -> TestResult:
     """Model picks the right tool from multiple options."""
     t0 = time.time()
     try:
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "Run the command 'echo hello'"}],
-                       tools=BASIC_TOOLS)
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "Run the command 'echo hello'"}],
+            tools=BASIC_TOOLS,
+        )
         msg = r["choices"][0]["message"]
         if not msg.get("tool_calls"):
-            return TestResult("tool_choice", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message="No tool_calls")
+            return TestResult(
+                "tool_choice",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message="No tool_calls",
+            )
         name = msg["tool_calls"][0]["function"]["name"]
         if name != "terminal":
-            return TestResult("tool_choice", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"Wrong tool: {name}, expected terminal")
-        return TestResult("tool_choice", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000)
+            return TestResult(
+                "tool_choice",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"Wrong tool: {name}, expected terminal",
+            )
+        return TestResult(
+            "tool_choice", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
+        )
     except Exception as e:
-        return TestResult("tool_choice", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "tool_choice",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_multi_turn_tool(base_url: str, model_id: str) -> TestResult:
     """Multi-turn: tool call → tool result → follow-up."""
     t0 = time.time()
     try:
-        r1 = _api_call(base_url, model_id,
-                        [{"role": "user", "content": "Read /etc/hosts"}],
-                        tools=BASIC_TOOLS)
+        r1 = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "Read /etc/hosts"}],
+            tools=BASIC_TOOLS,
+        )
         msg1 = r1["choices"][0]["message"]
         if not msg1.get("tool_calls"):
-            return TestResult("multi_turn_tool", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message="First turn should trigger tool call")
-        r2 = _api_call(base_url, model_id, [
-            {"role": "user", "content": "Read /etc/hosts"},
-            {"role": "assistant", "content": None, "tool_calls": msg1["tool_calls"]},
-            {"role": "tool", "tool_call_id": msg1["tool_calls"][0]["id"],
-             "content": "127.0.0.1 localhost\n::1 localhost"},
-            {"role": "user", "content": "What IP addresses are in that file?"},
-        ], tools=BASIC_TOOLS)
+            return TestResult(
+                "multi_turn_tool",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message="First turn should trigger tool call",
+            )
+        r2 = _api_call(
+            base_url,
+            model_id,
+            [
+                {"role": "user", "content": "Read /etc/hosts"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": msg1["tool_calls"],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": msg1["tool_calls"][0]["id"],
+                    "content": "127.0.0.1 localhost\n::1 localhost",
+                },
+                {"role": "user", "content": "What IP addresses are in that file?"},
+            ],
+            tools=BASIC_TOOLS,
+        )
         content = r2["choices"][0]["message"]["content"]
         if "127.0.0.1" in content or "localhost" in content:
-            return TestResult("multi_turn_tool", TestStatus.PASS,
-                              duration_ms=(time.time() - t0) * 1000)
-        return TestResult("multi_turn_tool", TestStatus.FAIL,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"Bad follow-up: {content[:80]}")
+            return TestResult(
+                "multi_turn_tool",
+                TestStatus.PASS,
+                duration_ms=(time.time() - t0) * 1000,
+            )
+        return TestResult(
+            "multi_turn_tool",
+            TestStatus.FAIL,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"Bad follow-up: {content[:80]}",
+        )
     except Exception as e:
-        return TestResult("multi_turn_tool", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "multi_turn_tool",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_no_tool_leak(base_url: str, model_id: str) -> TestResult:
     """No raw tool markup leaks into content."""
     t0 = time.time()
     try:
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "Use the terminal to run 'echo test'"}],
-                       tools=BASIC_TOOLS)
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "Use the terminal to run 'echo test'"}],
+            tools=BASIC_TOOLS,
+        )
         content = r["choices"][0]["message"].get("content", "")
         leaks = []
         for marker in ["<tool_call>", "<function=", "<|im_end|>", "<|tool_call|>"]:
             if marker in content:
                 leaks.append(marker)
         if leaks:
-            return TestResult("no_tool_leak", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"Leaked: {leaks}")
-        return TestResult("no_tool_leak", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000)
+            return TestResult(
+                "no_tool_leak",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"Leaked: {leaks}",
+            )
+        return TestResult(
+            "no_tool_leak", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
+        )
     except Exception as e:
-        return TestResult("no_tool_leak", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "no_tool_leak",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_many_tools(base_url: str, model_id: str, num_tools: int) -> TestResult:
@@ -317,39 +412,58 @@ def _test_many_tools(base_url: str, model_id: str, num_tools: int) -> TestResult
     try:
         many_tools = []
         for i in range(num_tools):
-            many_tools.append({
-                "type": "function",
-                "function": {
-                    "name": f"tool_{i}",
-                    "description": f"Tool number {i}",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"arg": {"type": "string"}},
-                        "required": ["arg"],
+            many_tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"tool_{i}",
+                        "description": f"Tool number {i}",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"arg": {"type": "string"}},
+                            "required": ["arg"],
+                        },
                     },
-                },
-            })
+                }
+            )
         many_tools.extend(BASIC_TOOLS)
 
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "Run the command 'echo hello'"}],
-                       tools=many_tools, max_tokens=500)
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "Run the command 'echo hello'"}],
+            tools=many_tools,
+            max_tokens=500,
+        )
         msg = r["choices"][0]["message"]
         if not msg.get("tool_calls"):
-            return TestResult("many_tools", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"No tool call with {len(many_tools)} tools")
+            return TestResult(
+                "many_tools",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"No tool call with {len(many_tools)} tools",
+            )
         name = msg["tool_calls"][0]["function"]["name"]
         if name == "terminal":
-            return TestResult("many_tools", TestStatus.PASS,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"Correct with {len(many_tools)} tools")
-        return TestResult("many_tools", TestStatus.FAIL,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"Wrong tool: {name}")
+            return TestResult(
+                "many_tools",
+                TestStatus.PASS,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"Correct with {len(many_tools)} tools",
+            )
+        return TestResult(
+            "many_tools",
+            TestStatus.FAIL,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"Wrong tool: {name}",
+        )
     except Exception as e:
-        return TestResult("many_tools", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "many_tools",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_streaming_tool_call(base_url: str, model_id: str) -> TestResult:
@@ -363,8 +477,9 @@ def _test_streaming_tool_call(base_url: str, model_id: str) -> TestResult:
             "max_tokens": 200,
             "stream": True,
         }
-        with httpx.stream("POST", f"{base_url}/chat/completions",
-                           json=payload, timeout=60) as resp:
+        with httpx.stream(
+            "POST", f"{base_url}/chat/completions", json=payload, timeout=60
+        ) as resp:
             tool_chunks = []
             finish_reason = None
             for line in resp.iter_lines():
@@ -378,38 +493,62 @@ def _test_streaming_tool_call(base_url: str, model_id: str) -> TestResult:
                     finish_reason = data["choices"][0]["finish_reason"]
 
         if not tool_chunks:
-            return TestResult("streaming_tool_call", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message="No tool_call chunks in stream")
+            return TestResult(
+                "streaming_tool_call",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message="No tool_call chunks in stream",
+            )
         if finish_reason != "tool_calls":
-            return TestResult("streaming_tool_call", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"finish_reason={finish_reason}")
-        return TestResult("streaming_tool_call", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"{len(tool_chunks)} chunks")
+            return TestResult(
+                "streaming_tool_call",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"finish_reason={finish_reason}",
+            )
+        return TestResult(
+            "streaming_tool_call",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"{len(tool_chunks)} chunks",
+        )
     except Exception as e:
-        return TestResult("streaming_tool_call", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "streaming_tool_call",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_no_tool_needed(base_url: str, model_id: str) -> TestResult:
     """Tools provided but not needed — model answers directly."""
     t0 = time.time()
     try:
-        r = _api_call(base_url, model_id,
-                       [{"role": "user", "content": "What is the capital of France?"}],
-                       tools=BASIC_TOOLS)
+        r = _api_call(
+            base_url,
+            model_id,
+            [{"role": "user", "content": "What is the capital of France?"}],
+            tools=BASIC_TOOLS,
+        )
         content = r["choices"][0]["message"].get("content", "")
         if "paris" in content.lower():
-            return TestResult("no_tool_needed", TestStatus.PASS,
-                              duration_ms=(time.time() - t0) * 1000)
-        return TestResult("no_tool_needed", TestStatus.FAIL,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"Expected Paris: {content[:80]}")
+            return TestResult(
+                "no_tool_needed", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
+            )
+        return TestResult(
+            "no_tool_needed",
+            TestStatus.FAIL,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"Expected Paris: {content[:80]}",
+        )
     except Exception as e:
-        return TestResult("no_tool_needed", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "no_tool_needed",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_stress_no_leak(base_url: str, model_id: str, rounds: int = 5) -> TestResult:
@@ -418,22 +557,36 @@ def _test_stress_no_leak(base_url: str, model_id: str, rounds: int = 5) -> TestR
     leaked = 0
     try:
         for i in range(rounds):
-            r = _api_call(base_url, model_id,
-                           [{"role": "user", "content": f"Run: echo test_{i}"}],
-                           tools=BASIC_TOOLS, temperature=0.8)
+            r = _api_call(
+                base_url,
+                model_id,
+                [{"role": "user", "content": f"Run: echo test_{i}"}],
+                tools=BASIC_TOOLS,
+                temperature=0.8,
+            )
             content = r["choices"][0]["message"].get("content", "")
             if "<tool_call>" in content or "<function=" in content:
                 leaked += 1
         if leaked:
-            return TestResult("stress_no_leak", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message=f"{leaked}/{rounds} leaked")
-        return TestResult("stress_no_leak", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"0/{rounds} leaks")
+            return TestResult(
+                "stress_no_leak",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"{leaked}/{rounds} leaked",
+            )
+        return TestResult(
+            "stress_no_leak",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"0/{rounds} leaks",
+        )
     except Exception as e:
-        return TestResult("stress_no_leak", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "stress_no_leak",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 def _test_streaming_basic(base_url: str, model_id: str) -> TestResult:
@@ -442,14 +595,17 @@ def _test_streaming_basic(base_url: str, model_id: str) -> TestResult:
     try:
         payload = {
             "model": model_id,
-            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}],
+            "messages": [
+                {"role": "user", "content": "What is 2+2? Reply with just the number."}
+            ],
             "max_tokens": 50,
             "stream": True,
         }
         chunks = 0
         content = ""
-        with httpx.stream("POST", f"{base_url}/chat/completions",
-                           json=payload, timeout=30) as resp:
+        with httpx.stream(
+            "POST", f"{base_url}/chat/completions", json=payload, timeout=30
+        ) as resp:
             for line in resp.iter_lines():
                 if not line.startswith("data: "):
                     continue
@@ -464,19 +620,30 @@ def _test_streaming_basic(base_url: str, model_id: str) -> TestResult:
                     chunks += 1
 
         if chunks == 0:
-            return TestResult("streaming_basic", TestStatus.FAIL,
-                              duration_ms=(time.time() - t0) * 1000,
-                              message="No content/reasoning chunks")
-        return TestResult("streaming_basic", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"{chunks} chunks")
+            return TestResult(
+                "streaming_basic",
+                TestStatus.FAIL,
+                duration_ms=(time.time() - t0) * 1000,
+                message="No content/reasoning chunks",
+            )
+        return TestResult(
+            "streaming_basic",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"{chunks} chunks",
+        )
     except Exception as e:
-        return TestResult("streaming_basic", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "streaming_basic",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
-def _test_tag_suppression(base_url: str, model_id: str,
-                           extra_tags: list[tuple[str, str]]) -> TestResult:
+def _test_tag_suppression(
+    base_url: str, model_id: str, extra_tags: list[tuple[str, str]]
+) -> TestResult:
     """Verify that extra streaming tags from profile are suppressed.
 
     This is a structural test — we can't force the model to produce specific
@@ -485,6 +652,7 @@ def _test_tag_suppression(base_url: str, model_id: str,
     t0 = time.time()
     try:
         from vllm_mlx.api.utils import StreamingToolCallFilter
+
         f = StreamingToolCallFilter(extra_tags=extra_tags)
         # Simulate each tag pair
         for open_tag, close_tag in extra_tags:
@@ -493,26 +661,38 @@ def _test_tag_suppression(base_url: str, model_id: str,
             remaining = f.flush()
             combined = result + remaining
             if "hidden" in combined:
-                return TestResult("tag_suppression", TestStatus.FAIL,
-                                  duration_ms=(time.time() - t0) * 1000,
-                                  message=f"Tag {open_tag!r} not suppressed")
+                return TestResult(
+                    "tag_suppression",
+                    TestStatus.FAIL,
+                    duration_ms=(time.time() - t0) * 1000,
+                    message=f"Tag {open_tag!r} not suppressed",
+                )
             # Reset for next tag
             f = StreamingToolCallFilter(extra_tags=extra_tags)
 
-        return TestResult("tag_suppression", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=f"{len(extra_tags)} tag pairs verified")
+        return TestResult(
+            "tag_suppression",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"{len(extra_tags)} tag pairs verified",
+        )
     except Exception as e:
-        return TestResult("tag_suppression", TestStatus.ERROR,
-                          duration_ms=(time.time() - t0) * 1000, message=str(e))
+        return TestResult(
+            "tag_suppression",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=str(e),
+        )
 
 
 # ---------------------------------------------------------------------------
 # E2E tests (require agent binary)
 # ---------------------------------------------------------------------------
 
-def _agent_query(binary: str, query_cmd: str, query: str,
-                 timeout: int = 120) -> tuple[str | None, str | None]:
+
+def _agent_query(
+    binary: str, query_cmd: str, query: str, timeout: int = 120
+) -> tuple[str | None, str | None]:
     """Run a single agent query. Returns (output, error)."""
     import shlex
 
@@ -532,8 +712,10 @@ def _agent_query(binary: str, query_cmd: str, query: str,
     try:
         proc = subprocess.run(
             cmd_parts,
-            capture_output=True, text=True,
-            timeout=timeout, cwd=os.getcwd(),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=os.getcwd(),
         )
         output = proc.stdout + proc.stderr
         if "error" in output.lower() and "HTTP 4" in output:
@@ -548,68 +730,114 @@ def _agent_query(binary: str, query_cmd: str, query: str,
 def _test_e2e_chat(binary: str, query_cmd: str, timeout: int) -> TestResult:
     """Agent basic chat."""
     t0 = time.time()
-    out, err = _agent_query(binary, query_cmd,
-                             "What is 2+2? Reply with just the number.", timeout)
+    out, err = _agent_query(
+        binary, query_cmd, "What is 2+2? Reply with just the number.", timeout
+    )
     if err:
         status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
-        return TestResult("e2e_chat", status,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=err, category="e2e")
+        return TestResult(
+            "e2e_chat",
+            status,
+            duration_ms=(time.time() - t0) * 1000,
+            message=err,
+            category="e2e",
+        )
     if "4" in (out or ""):
-        return TestResult("e2e_chat", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000, category="e2e")
-    return TestResult("e2e_chat", TestStatus.FAIL,
-                      duration_ms=(time.time() - t0) * 1000,
-                      message=f"Expected '4': {(out or '')[:80]}", category="e2e")
+        return TestResult(
+            "e2e_chat",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            category="e2e",
+        )
+    return TestResult(
+        "e2e_chat",
+        TestStatus.FAIL,
+        duration_ms=(time.time() - t0) * 1000,
+        message=f"Expected '4': {(out or '')[:80]}",
+        category="e2e",
+    )
 
 
 def _test_e2e_file_read(binary: str, query_cmd: str, timeout: int) -> TestResult:
     """Agent reads a file via tool call."""
     t0 = time.time()
-    out, err = _agent_query(binary, query_cmd,
-                             "Read the first line of pyproject.toml", timeout)
+    out, err = _agent_query(
+        binary, query_cmd, "Read the first line of pyproject.toml", timeout
+    )
     if err:
         status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
-        return TestResult("e2e_file_read", status,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=err, category="e2e")
+        return TestResult(
+            "e2e_file_read",
+            status,
+            duration_ms=(time.time() - t0) * 1000,
+            message=err,
+            category="e2e",
+        )
     if "build" in (out or "").lower() or "project" in (out or "").lower():
-        return TestResult("e2e_file_read", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000, category="e2e")
-    return TestResult("e2e_file_read", TestStatus.FAIL,
-                      duration_ms=(time.time() - t0) * 1000,
-                      message=f"Unexpected: {(out or '')[:80]}", category="e2e")
+        return TestResult(
+            "e2e_file_read",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            category="e2e",
+        )
+    return TestResult(
+        "e2e_file_read",
+        TestStatus.FAIL,
+        duration_ms=(time.time() - t0) * 1000,
+        message=f"Unexpected: {(out or '')[:80]}",
+        category="e2e",
+    )
 
 
-def _test_e2e_terminal(binary: str, query_cmd: str,
-                        timeout: int, agent_name: str) -> TestResult:
+def _test_e2e_terminal(
+    binary: str, query_cmd: str, timeout: int, agent_name: str
+) -> TestResult:
     """Agent runs a shell command."""
     t0 = time.time()
     marker = f"rapidmlx_{agent_name}_test"
-    out, err = _agent_query(binary, query_cmd,
-                             f"Run 'echo {marker}' and show me the output", timeout)
+    out, err = _agent_query(
+        binary, query_cmd, f"Run 'echo {marker}' and show me the output", timeout
+    )
     if err:
         status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
-        return TestResult("e2e_terminal", status,
-                          duration_ms=(time.time() - t0) * 1000,
-                          message=err, category="e2e")
+        return TestResult(
+            "e2e_terminal",
+            status,
+            duration_ms=(time.time() - t0) * 1000,
+            message=err,
+            category="e2e",
+        )
     if marker in (out or ""):
-        return TestResult("e2e_terminal", TestStatus.PASS,
-                          duration_ms=(time.time() - t0) * 1000, category="e2e")
-    return TestResult("e2e_terminal", TestStatus.FAIL,
-                      duration_ms=(time.time() - t0) * 1000,
-                      message=f"Missing marker: {(out or '')[:80]}", category="e2e")
+        return TestResult(
+            "e2e_terminal",
+            TestStatus.PASS,
+            duration_ms=(time.time() - t0) * 1000,
+            category="e2e",
+        )
+    return TestResult(
+        "e2e_terminal",
+        TestStatus.FAIL,
+        duration_ms=(time.time() - t0) * 1000,
+        message=f"Missing marker: {(out or '')[:80]}",
+        category="e2e",
+    )
 
 
 # ---------------------------------------------------------------------------
 # Test runner
 # ---------------------------------------------------------------------------
 
+
 class AgentTestRunner:
     """Dynamically builds and runs tests based on an agent profile."""
 
-    def __init__(self, profile: AgentProfile, base_url: str = "http://localhost:8000/v1",
-                 model_id: str | None = None, agent_version: str | None = None):
+    def __init__(
+        self,
+        profile: AgentProfile,
+        base_url: str = "http://localhost:8000/v1",
+        model_id: str | None = None,
+        agent_version: str | None = None,
+    ):
         self.profile = profile
         self.base_url = base_url
         self.agent_version = agent_version
@@ -627,8 +855,9 @@ class AgentTestRunner:
     def _server_available(self) -> bool:
         """Check if the Rapid-MLX server is running."""
         try:
-            r = httpx.get(f"{self.base_url.rstrip('/').rsplit('/v1', 1)[0]}/health",
-                          timeout=3)
+            r = httpx.get(
+                f"{self.base_url.rstrip('/').rsplit('/v1', 1)[0]}/health", timeout=3
+            )
             return r.status_code == 200
         except Exception:
             return False
@@ -646,14 +875,21 @@ class AgentTestRunner:
 
         if self.profile.needs_function_calling:
             tests += [
-                "single_tool_call", "tool_choice", "multi_turn_tool",
-                "no_tool_leak", "no_tool_needed",
+                "single_tool_call",
+                "tool_choice",
+                "multi_turn_tool",
+                "no_tool_leak",
+                "no_tool_needed",
             ]
             if self.profile.needs_streaming:
                 tests.append("streaming_tool_call")
 
         streaming = self.profile.get_streaming_for_version(self.agent_version)
-        if streaming.max_tools and streaming.max_tools > 10 and self.profile.needs_function_calling:
+        if (
+            streaming.max_tools
+            and streaming.max_tools > 10
+            and self.profile.needs_function_calling
+        ):
             tests.append("many_tools")
 
         if streaming.extra_tool_tags:
@@ -681,10 +917,13 @@ class AgentTestRunner:
         )
 
         if not self._server_available():
-            report.results.append(TestResult(
-                "server_check", TestStatus.ERROR,
-                message="Rapid-MLX server not running",
-            ))
+            report.results.append(
+                TestResult(
+                    "server_check",
+                    TestStatus.ERROR,
+                    message="Rapid-MLX server not running",
+                )
+            )
             return report
 
         t0 = time.time()
@@ -703,16 +942,20 @@ class AgentTestRunner:
 
             if self.profile.needs_streaming:
                 report.results.append(
-                    _test_streaming_tool_call(self.base_url, self.model_id))
+                    _test_streaming_tool_call(self.base_url, self.model_id)
+                )
 
         if streaming.max_tools and streaming.max_tools > 10:
             report.results.append(
-                _test_many_tools(self.base_url, self.model_id, streaming.max_tools))
+                _test_many_tools(self.base_url, self.model_id, streaming.max_tools)
+            )
 
         if streaming.extra_tool_tags:
             report.results.append(
-                _test_tag_suppression(self.base_url, self.model_id,
-                                      streaming.extra_tool_tags))
+                _test_tag_suppression(
+                    self.base_url, self.model_id, streaming.extra_tool_tags
+                )
+            )
 
         if self.profile.needs_streaming:
             report.results.append(_test_streaming_basic(self.base_url, self.model_id))
@@ -724,17 +967,31 @@ class AgentTestRunner:
         if self._agent_binary_available() and testing.binary and testing.query_cmd:
             binary = os.path.expanduser(testing.binary)
             report.results.append(
-                _test_e2e_chat(binary, testing.query_cmd, testing.query_timeout))
+                _test_e2e_chat(binary, testing.query_cmd, testing.query_timeout)
+            )
             if self.profile.needs_function_calling:
                 report.results.append(
-                    _test_e2e_file_read(binary, testing.query_cmd, testing.query_timeout))
+                    _test_e2e_file_read(
+                        binary, testing.query_cmd, testing.query_timeout
+                    )
+                )
                 report.results.append(
-                    _test_e2e_terminal(binary, testing.query_cmd,
-                                       testing.query_timeout, self.profile.name))
+                    _test_e2e_terminal(
+                        binary,
+                        testing.query_cmd,
+                        testing.query_timeout,
+                        self.profile.name,
+                    )
+                )
         elif testing.binary:
-            report.results.append(TestResult(
-                "e2e_tests", TestStatus.SKIP,
-                message=f"Binary not found: {testing.binary}", category="e2e"))
+            report.results.append(
+                TestResult(
+                    "e2e_tests",
+                    TestStatus.SKIP,
+                    message=f"Binary not found: {testing.binary}",
+                    category="e2e",
+                )
+            )
 
         # --- Framework-specific tests ---
         if testing.specific_tests:
@@ -765,21 +1022,27 @@ class AgentTestRunner:
         test_dir = Path(__file__).parent.parent.parent / "tests" / "integrations"
         test_path = test_dir / test_module_name
         if not test_path.exists():
-            return [TestResult(
-                f"specific:{test_module_name}", TestStatus.SKIP,
-                message=f"Test file not found: {test_path}", category="specific",
-            )]
+            return [
+                TestResult(
+                    f"specific:{test_module_name}",
+                    TestStatus.SKIP,
+                    message=f"Test file not found: {test_path}",
+                    category="specific",
+                )
+            ]
 
         t0 = time.time()
         try:
             # Load and execute the test module
             spec = importlib.util.spec_from_file_location(
-                f"specific_test_{test_module_name}", test_path,
+                f"specific_test_{test_module_name}",
+                test_path,
             )
             mod = importlib.util.module_from_spec(spec)
 
             # Set base URL env var so specific test modules use the right server
             import sys
+
             os.environ["RAPID_MLX_BASE_URL"] = self.base_url
 
             # Suppress sys.exit (test modules call exit() at the end)
@@ -797,43 +1060,68 @@ class AgentTestRunner:
 
             # If module failed to execute, report it as an error
             if exec_error is not None:
-                return [TestResult(
-                    f"specific:{test_module_name}", TestStatus.ERROR,
-                    duration_ms=(time.time() - t0) * 1000,
-                    message=f"Module execution failed: {exec_error!s:.120}",
-                    category="specific",
-                )]
+                return [
+                    TestResult(
+                        f"specific:{test_module_name}",
+                        TestStatus.ERROR,
+                        duration_ms=(time.time() - t0) * 1000,
+                        message=f"Module execution failed: {exec_error!s:.120}",
+                        category="specific",
+                    )
+                ]
 
             # Extract results dict
             results_dict = getattr(mod, "results", {})
             if not results_dict:
-                return [TestResult(
-                    f"specific:{test_module_name}", TestStatus.ERROR,
-                    duration_ms=(time.time() - t0) * 1000,
-                    message="No test results found (missing 'results' dict or all tests skipped)",
-                    category="specific",
-                )]
+                return [
+                    TestResult(
+                        f"specific:{test_module_name}",
+                        TestStatus.ERROR,
+                        duration_ms=(time.time() - t0) * 1000,
+                        message="No test results found (missing 'results' dict or all tests skipped)",
+                        category="specific",
+                    )
+                ]
 
             test_results = []
             for name, status in results_dict.items():
                 if status == "PASS":
-                    test_results.append(TestResult(
-                        name, TestStatus.PASS,
-                        duration_ms=(time.time() - t0) * 1000 / max(len(results_dict), 1),
-                        category="specific",
-                    ))
+                    test_results.append(
+                        TestResult(
+                            name,
+                            TestStatus.PASS,
+                            duration_ms=(time.time() - t0)
+                            * 1000
+                            / max(len(results_dict), 1),
+                            category="specific",
+                        )
+                    )
                 else:
-                    msg = status.replace("FAIL: ", "") if status.startswith("FAIL:") else status
-                    test_results.append(TestResult(
-                        name, TestStatus.FAIL,
-                        duration_ms=(time.time() - t0) * 1000 / max(len(results_dict), 1),
-                        message=msg[:120], category="specific",
-                    ))
+                    msg = (
+                        status.replace("FAIL: ", "")
+                        if status.startswith("FAIL:")
+                        else status
+                    )
+                    test_results.append(
+                        TestResult(
+                            name,
+                            TestStatus.FAIL,
+                            duration_ms=(time.time() - t0)
+                            * 1000
+                            / max(len(results_dict), 1),
+                            message=msg[:120],
+                            category="specific",
+                        )
+                    )
             return test_results
 
         except Exception as e:
-            return [TestResult(
-                f"specific:{test_module_name}", TestStatus.ERROR,
-                duration_ms=(time.time() - t0) * 1000,
-                message=str(e)[:120], category="specific",
-            )]
+            return [
+                TestResult(
+                    f"specific:{test_module_name}",
+                    TestStatus.ERROR,
+                    duration_ms=(time.time() - t0) * 1000,
+                    message=str(e)[:120],
+                    category="specific",
+                )
+            ]

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -261,6 +261,7 @@ def _strip_markdown_code_block(text: str) -> str:
         Text before ```json\n{...}\n``` text after
     """
     import re
+
     # Match ```json or ``` followed by content and closing ```
     pattern = re.compile(
         r"```(?:json|JSON)?\s*\n([\s\S]*?)\n\s*```",
@@ -306,7 +307,10 @@ _TOOL_CALL_TAGS: list[tuple[str, str]] = [
     ("<tool_call>", "</tool_call>"),
     ("<function=", "</function>"),
     ("[TOOL_CALL]", "[/TOOL_CALL]"),
-    ("[Calling tool", "\n"),  # Bracket-style tool calls: suppress until newline (covers both ]\n and bare \n)
+    (
+        "[Calling tool",
+        "\n",
+    ),  # Bracket-style tool calls: suppress until newline (covers both ]\n and bare \n)
 ]
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1471,6 +1471,17 @@ Examples:
         choices=["smoke", "check", "full", "benchmark"],
         help="Which tier to run (default: smoke)",
     )
+    doctor_parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Model alias for check tier (default: qwen3.5-4b)",
+    )
+    doctor_parser.add_argument(
+        "--update-baselines",
+        action="store_true",
+        help="Record current run as the new baseline (after human review)",
+    )
 
     args = parser.parse_args()
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1459,6 +1459,19 @@ Examples:
         help="Agent version for version-specific config (e.g. 0.8.5)",
     )
 
+    # Doctor command — regression harness
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Run regression harness (smoke / check / full / benchmark)",
+    )
+    doctor_parser.add_argument(
+        "tier",
+        nargs="?",
+        default="smoke",
+        choices=["smoke", "check", "full", "benchmark"],
+        help="Which tier to run (default: smoke)",
+    )
+
     args = parser.parse_args()
 
     # Resolve model aliases before dispatch
@@ -1483,6 +1496,10 @@ Examples:
         models_command(args)
     elif args.command == "agents":
         agents_command(args)
+    elif args.command == "doctor":
+        from vllm_mlx.doctor.cli import doctor_command
+
+        doctor_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1478,6 +1478,13 @@ Examples:
         help="Model alias for check tier (default: qwen3.5-4b)",
     )
     doctor_parser.add_argument(
+        "--models",
+        type=str,
+        default=None,
+        help="Comma-separated model aliases for full tier "
+             "(default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b)",
+    )
+    doctor_parser.add_argument(
         "--update-baselines",
         action="store_true",
         help="Record current run as the new baseline (after human review)",
@@ -1510,6 +1517,9 @@ Examples:
     elif args.command == "doctor":
         from vllm_mlx.doctor.cli import doctor_command
 
+        # Parse --models comma-list now so the doctor module gets a clean list.
+        if getattr(args, "models", None):
+            args.models = [m.strip() for m in args.models.split(",") if m.strip()]
         doctor_command(args)
     else:
         parser.print_help()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1481,19 +1481,32 @@ Examples:
         "--models",
         type=str,
         default=None,
-        help="Comma-separated model aliases for full tier "
-             "(default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b)",
+        help="Comma-separated model aliases for full / benchmark tiers "
+             "(full default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b; "
+             "benchmark default: auto-discovered from local cache)",
     )
     doctor_parser.add_argument(
         "--update-baselines",
         action="store_true",
-        help="Record current run as the new baseline (after human review)",
+        help="Record current run as the new baseline (check / full only). "
+             "Ignored with a warning for smoke / benchmark tiers.",
     )
 
     args = parser.parse_args()
 
-    # Resolve model aliases before dispatch
-    if hasattr(args, "model") and args.model:
+    # Resolve model aliases before dispatch.
+    #
+    # The doctor subcommand is exempt: it intentionally keeps the alias
+    # form so per-model artefacts (baseline filenames, scorecard rows,
+    # report check names) stay human-readable and stable across runs.
+    # Doctor does its own alias→path resolution inside the server-spawn
+    # path via discovery, so resolving here would write the wrong
+    # baseline filename and confuse multi-model loops.
+    if (
+        hasattr(args, "model")
+        and args.model
+        and getattr(args, "command", None) != "doctor"
+    ):
         from vllm_mlx.model_aliases import resolve_model
 
         resolved = resolve_model(args.model)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -236,7 +236,9 @@ def serve_command(args):
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
     if args.draft_model:
-        print(f"  Speculative: {args.draft_model} ({args.num_draft_tokens} draft tokens)")
+        print(
+            f"  Speculative: {args.draft_model} ({args.num_draft_tokens} draft tokens)"
+        )
     # Store MCP config path for FastAPI startup
     if args.mcp_config:
         print(f"MCP config: {args.mcp_config}")
@@ -315,7 +317,7 @@ def serve_command(args):
             print(
                 f"SpecPrefill: enabled (draft={args.specprefill_draft_model}, "
                 f"threshold={args.specprefill_threshold}, "
-                f"keep={args.specprefill_keep_pct*100:.0f}%)"
+                f"keep={args.specprefill_keep_pct * 100:.0f}%)"
             )
 
     # Check port availability before loading model (avoid wasting RAM on conflict)
@@ -327,7 +329,9 @@ def serve_command(args):
         _sock.close()
     except OSError:
         print(f"\n  Error: Port {args.port} is already in use.")
-        print(f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}")
+        print(
+            f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
+        )
         sys.exit(1)
 
     # Check disk space before downloading model
@@ -365,7 +369,9 @@ def serve_command(args):
         if "404" in error_msg or "not found" in error_msg.lower():
             print(f"\n  Error: Model '{args.model}' not found.")
             print("  Run `rapid-mlx models` to see available aliases,")
-            print("  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit")
+            print(
+                "  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit"
+            )
         else:
             print(f"\n  Error loading model: {error_msg}")
         sys.exit(1)
@@ -824,9 +830,12 @@ def agents_command(args):
         from vllm_mlx.agents.testing import AgentTestRunner
 
         model_id = args.model or None
-        runner = AgentTestRunner(profile, base_url=base_url,
-                                 model_id=model_id,
-                                 agent_version=args.agent_version)
+        runner = AgentTestRunner(
+            profile,
+            base_url=base_url,
+            model_id=model_id,
+            agent_version=args.agent_version,
+        )
         if not runner._server_available():
             print(f"\n  Server not running at {base_url}")
             print("  Start it first: rapid-mlx serve <model>")
@@ -843,23 +852,27 @@ def agents_command(args):
         if model_id == "default":
             try:
                 import httpx
+
                 resp = httpx.get(f"{base_url}/models", timeout=3)
                 model_id = resp.json()["data"][0]["id"]
             except Exception:
                 pass
 
-        summary = setup_agent_config(profile, base_url, model_id,
-                                      agent_version=args.agent_version)
+        summary = setup_agent_config(
+            profile, base_url, model_id, agent_version=args.agent_version
+        )
         print(f"\n  {profile.display_name} configured!")
         print(f"  {summary}")
         print()
         return
 
     # Default: show setup instructions
-    model_id = args.model or (profile.recommended_models[0]
-                               if profile.recommended_models else "<MODEL>")
-    instructions = get_setup_instructions(profile, base_url, model_id,
-                                          agent_version=args.agent_version)
+    model_id = args.model or (
+        profile.recommended_models[0] if profile.recommended_models else "<MODEL>"
+    )
+    instructions = get_setup_instructions(
+        profile, base_url, model_id, agent_version=args.agent_version
+    )
     print()
     print(instructions)
     print()
@@ -1102,14 +1115,14 @@ Examples:
         help="API key for authentication (if not set, no auth required)",
     )
     serve_parser.add_argument(
-    "--cors-origins",
-    type=str,
-    nargs="+",
-    default=None,
-    metavar="ORIGIN",
-    help=(
-        "Allowed CORS origins (default: * for all origins). "
-        "Example: --cors-origins http://localhost:3000 https://myapp.com"
+        "--cors-origins",
+        type=str,
+        nargs="+",
+        default=None,
+        metavar="ORIGIN",
+        help=(
+            "Allowed CORS origins (default: * for all origins). "
+            "Example: --cors-origins http://localhost:3000 https://myapp.com"
         ),
     )
     serve_parser.add_argument(
@@ -1435,27 +1448,37 @@ Examples:
         "agents", help="List, configure, and test agent integrations"
     )
     agents_parser.add_argument(
-        "agent_name", nargs="?", default=None,
+        "agent_name",
+        nargs="?",
+        default=None,
         help="Agent name (e.g. hermes, goose, aider). Omit to list all.",
     )
     agents_parser.add_argument(
-        "--setup", action="store_true",
+        "--setup",
+        action="store_true",
         help="Auto-configure the agent to point at this server",
     )
     agents_parser.add_argument(
-        "--test", action="store_true",
+        "--test",
+        action="store_true",
         help="Run integration tests for this agent",
     )
     agents_parser.add_argument(
-        "--model", type=str, default=None,
+        "--model",
+        type=str,
+        default=None,
         help="Model to use (default: auto-detect from running server)",
     )
     agents_parser.add_argument(
-        "--base-url", type=str, default="http://localhost:8000/v1",
+        "--base-url",
+        type=str,
+        default="http://localhost:8000/v1",
         help="Rapid-MLX server URL (default: http://localhost:8000/v1)",
     )
     agents_parser.add_argument(
-        "--agent-version", type=str, default=None,
+        "--agent-version",
+        type=str,
+        default=None,
         help="Agent version for version-specific config (e.g. 0.8.5)",
     )
 
@@ -1482,14 +1505,14 @@ Examples:
         type=str,
         default=None,
         help="Comma-separated model aliases for full / benchmark tiers "
-             "(full default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b; "
-             "benchmark default: auto-discovered from local cache)",
+        "(full default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b; "
+        "benchmark default: auto-discovered from local cache)",
     )
     doctor_parser.add_argument(
         "--update-baselines",
         action="store_true",
         help="Record current run as the new baseline (check / full only). "
-             "Ignored with a warning for smoke / benchmark tiers.",
+        "Ignored with a warning for smoke / benchmark tiers.",
     )
 
     args = parser.parse_args()

--- a/vllm_mlx/doctor/__init__.py
+++ b/vllm_mlx/doctor/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Rapid-MLX Doctor — comprehensive regression harness.
+
+Three tiers + a benchmark sweep:
+  - smoke      (~2 min, no model)        — pytest, ruff, CLI sanity
+  - check      (~10 min, qwen3.5-4b)      — server + perf + agents + baseline diff
+  - full       (~1-2 hr, 3 models)        — check across qwen3.5-4b/35b + gemma-4-26b
+  - benchmark  (overnight, all models)    — cross-model × cross-engine scorecard
+
+Entry point: ``rapid-mlx doctor {smoke,check,full,benchmark}``
+
+Exit codes:
+  0  all checks pass
+  1  performance regression detected (vs baseline)
+  2  functional test failure
+"""
+
+from .runner import DoctorRunner, TierResult
+
+__all__ = ["DoctorRunner", "TierResult"]

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Baseline storage + threshold-based regression comparison.
+
+Baselines live at ``harness/baselines/{tier}.json`` and are checked into
+git.  Thresholds live at ``harness/thresholds.yaml`` and are loaded once
+per run.
+
+A baseline file looks like::
+
+    {
+      "captured_at": "2026-04-15T21:00:00",
+      "rapid_mlx_version": "0.5.1",
+      "model": "qwen3.5-4b",
+      "metrics": {
+        "decode_tps": 156.2,
+        "ttft_cold_ms": 412,
+        ...
+      }
+    }
+
+The comparator returns one ``MetricDelta`` per metric so the report can
+render a complete delta table — not just the regressions.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from .runner import HARNESS_DIR
+
+# ---------------------------------------------------------------------
+# Threshold loading
+# ---------------------------------------------------------------------
+
+# Default thresholds used when a metric is not listed in thresholds.yaml.
+# Conservative on perf (5%), zero-tolerance on accuracy.
+DEFAULT_THRESHOLDS = {"regression_pct": 5, "improvement_pct": 10}
+
+
+def load_thresholds(path: Path | None = None) -> dict[str, dict[str, float]]:
+    """Load per-metric regression thresholds from YAML.
+
+    Falls back to an empty dict if PyYAML isn't installed — callers will
+    then use ``DEFAULT_THRESHOLDS`` for every metric.  We avoid making
+    PyYAML a hard dependency just for this file: if it's missing the
+    feature degrades gracefully rather than blocking the whole tier.
+    """
+    path = path or (HARNESS_DIR / "thresholds.yaml")
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        return {}
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+# ---------------------------------------------------------------------
+# Baseline read/write
+# ---------------------------------------------------------------------
+
+def baseline_path(tier: str) -> Path:
+    return HARNESS_DIR / "baselines" / f"{tier}.json"
+
+
+def load_baseline(tier: str) -> dict | None:
+    """Return the baseline dict, or None if absent."""
+    p = baseline_path(tier)
+    if not p.exists():
+        return None
+    with open(p) as f:
+        return json.load(f)
+
+
+def save_baseline(tier: str, model: str, metrics: dict[str, float]) -> Path:
+    """Write a fresh baseline file (called by --update-baselines flow)."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        ver = version("rapid-mlx")
+    except PackageNotFoundError:
+        ver = "unknown"
+
+    payload = {
+        "captured_at": _dt.datetime.now().isoformat(timespec="seconds"),
+        "rapid_mlx_version": ver,
+        "model": model,
+        "metrics": metrics,
+    }
+    p = baseline_path(tier)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload, indent=2))
+    return p
+
+
+# ---------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------
+
+class DeltaStatus(str, Enum):
+    OK = "ok"               # within thresholds
+    REGRESSION = "regression"
+    IMPROVEMENT = "improvement"
+    NEW = "new"             # metric absent in baseline
+    DROPPED = "dropped"     # metric absent in current run
+
+
+@dataclass
+class MetricDelta:
+    metric: str
+    baseline: float | None
+    current: float | None
+    delta_pct: float | None
+    status: DeltaStatus
+    threshold_pct: float | None = None
+
+
+# Metrics where SMALLER values are better (latency, memory).
+_LOWER_IS_BETTER = {
+    "ttft_cold_ms",
+    "ttft_cached_ms",
+    "multiturn_ttft_ms",
+    "long_prompt_ttft_ms",
+    "long_cached_ttft_ms",
+    "tool_latency_s",
+    "tool_latency_ms",
+    "peak_ram_mb",
+    "cold_ttft_ms",
+    "cached_ttft_ms",
+    "mt_ttft_ms",
+    "long_ttft_ms",
+}
+
+
+def _is_lower_better(metric: str) -> bool:
+    return metric in _LOWER_IS_BETTER
+
+
+def _classify(
+    metric: str,
+    baseline: float,
+    current: float,
+    thresholds: dict[str, dict[str, float]],
+) -> tuple[DeltaStatus, float, float]:
+    """Classify (status, delta_pct, regression_threshold)."""
+    cfg = thresholds.get(metric, DEFAULT_THRESHOLDS)
+    regression_pct = float(cfg.get("regression_pct", DEFAULT_THRESHOLDS["regression_pct"]))
+    improvement_pct = float(cfg.get("improvement_pct", DEFAULT_THRESHOLDS["improvement_pct"]))
+
+    if baseline == 0:
+        # Avoid div-by-zero — treat any change as a status flip.
+        if current == 0:
+            return DeltaStatus.OK, 0.0, regression_pct
+        return DeltaStatus.IMPROVEMENT if not _is_lower_better(metric) else DeltaStatus.REGRESSION, float("inf"), regression_pct
+
+    raw_delta_pct = (current - baseline) / baseline * 100
+    # For lower-is-better metrics, invert the sign so positive delta_pct
+    # always means "worse".
+    delta_pct = -raw_delta_pct if _is_lower_better(metric) else raw_delta_pct
+
+    # delta_pct > 0  means improvement
+    # delta_pct < 0  means regression (more negative = worse)
+    if delta_pct < -regression_pct:
+        return DeltaStatus.REGRESSION, delta_pct, regression_pct
+    if delta_pct > improvement_pct:
+        return DeltaStatus.IMPROVEMENT, delta_pct, regression_pct
+    return DeltaStatus.OK, delta_pct, regression_pct
+
+
+def compare(
+    current: dict[str, float],
+    baseline: dict | None,
+    thresholds: dict[str, dict[str, float]],
+) -> list[MetricDelta]:
+    """Diff current metrics against baseline, return per-metric deltas.
+
+    Caller decides what to do with regressions — typically marks the
+    enclosing CheckResult as ``Status.REGRESSION``.
+    """
+    deltas: list[MetricDelta] = []
+    base_metrics: dict[str, float] = (baseline or {}).get("metrics", {}) if baseline else {}
+
+    all_metrics = sorted(set(current) | set(base_metrics))
+    for m in all_metrics:
+        cur = current.get(m)
+        base = base_metrics.get(m)
+        if base is None:
+            deltas.append(
+                MetricDelta(metric=m, baseline=None, current=cur,
+                            delta_pct=None, status=DeltaStatus.NEW)
+            )
+            continue
+        if cur is None:
+            deltas.append(
+                MetricDelta(metric=m, baseline=base, current=None,
+                            delta_pct=None, status=DeltaStatus.DROPPED)
+            )
+            continue
+        status, delta_pct, threshold = _classify(m, base, cur, thresholds)
+        deltas.append(
+            MetricDelta(
+                metric=m, baseline=base, current=cur,
+                delta_pct=delta_pct, status=status, threshold_pct=threshold,
+            )
+        )
+    return deltas
+
+
+def render_deltas_md(deltas: list[MetricDelta]) -> str:
+    """Render a delta table as markdown.  Used in tier reports."""
+    if not deltas:
+        return "_no metrics captured_\n"
+    lines = [
+        "| Metric | Baseline | Current | Δ% | Status |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for d in deltas:
+        b = f"{d.baseline:.2f}" if isinstance(d.baseline, (int, float)) else "—"
+        c = f"{d.current:.2f}" if isinstance(d.current, (int, float)) else "—"
+        if d.delta_pct is None:
+            dp = "—"
+        else:
+            sign = "+" if d.delta_pct >= 0 else ""
+            dp = f"{sign}{d.delta_pct:.1f}%"
+        lines.append(f"| {d.metric} | {b} | {c} | {dp} | {d.status.value} |")
+    return "\n".join(lines) + "\n"
+
+
+def has_regression(deltas: list[MetricDelta]) -> bool:
+    return any(d.status == DeltaStatus.REGRESSION for d in deltas)

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -68,8 +68,18 @@ def load_thresholds(path: Path | None = None) -> dict[str, dict[str, float]]:
 # ---------------------------------------------------------------------
 
 def _safe_model_slug(model: str) -> str:
-    """File-system-safe slug for use in baseline filenames."""
-    return model.replace("/", "__").replace(" ", "_")
+    """File-system-safe, *injective* slug for baseline filenames.
+
+    Uses URL percent-encoding so the mapping is one-to-one — i.e.
+    ``foo/bar``, ``foo__bar`` and ``foo bar`` all produce distinct
+    files.  A simple ``replace('/', '__')`` would collide on names
+    that legitimately contain ``__``.
+    """
+    import urllib.parse
+
+    # safe='' so '/' (and '%') are quoted; '-' and '.' kept for
+    # readability since they appear in nearly every model id.
+    return urllib.parse.quote(model, safe="-.")
 
 
 def baseline_path(tier: str, model: str | None = None) -> Path:
@@ -138,19 +148,25 @@ class MetricDelta:
 
 
 # Metrics where SMALLER values are better (latency, memory).
+# Keep this set in sync with what scripts/autoresearch_bench.py emits.
 _LOWER_IS_BETTER = {
-    "ttft_cold_ms",
-    "ttft_cached_ms",
-    "multiturn_ttft_ms",
-    "long_prompt_ttft_ms",
-    "long_cached_ttft_ms",
-    "tool_latency_s",
-    "tool_latency_ms",
-    "peak_ram_mb",
+    # autoresearch metric names (canonical)
     "cold_ttft_ms",
     "cached_ttft_ms",
     "mt_ttft_ms",
     "long_ttft_ms",
+    "long_cached_ttft_ms",
+    "tc_latency_ms",          # tool-call latency: lower = better
+    "peak_ram_mb",
+    # legacy / alternate names retained so older baselines and
+    # external bench scripts using *ttft_cold_ms* style keys also
+    # diff with the correct sign.
+    "ttft_cold_ms",
+    "ttft_cached_ms",
+    "multiturn_ttft_ms",
+    "long_prompt_ttft_ms",
+    "tool_latency_s",
+    "tool_latency_ms",
 }
 
 

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -114,11 +114,18 @@ def load_baseline(tier: str, model: str | None = None) -> dict | None:
         with open(p) as f:
             return json.load(f)
     # Legacy fallback for models whose new slug differs from the old.
+    # Verify the loaded file's recorded model matches what we asked for —
+    # the old slug scheme was non-injective (e.g. 'foo/bar' and 'foo__bar'
+    # collided), so a hit on the legacy path could belong to a different
+    # model.  In that case we'd rather return None (clean "no baseline")
+    # than hand back another model's data and trigger a hard mismatch.
     if model is not None:
         legacy = HARNESS_DIR / "baselines" / f"{tier}-{_legacy_slug(model)}.json"
         if legacy != p and legacy.exists():
             with open(legacy) as f:
-                return json.load(f)
+                data = json.load(f)
+            if data.get("model") == model:
+                return data
     return None
 
 

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -95,13 +95,31 @@ def baseline_path(tier: str, model: str | None = None) -> Path:
     return base / f"{tier}-{_safe_model_slug(model)}.json"
 
 
+def _legacy_slug(model: str) -> str:
+    """Old slug scheme (replace-based).  Kept for migration only."""
+    return model.replace("/", "__").replace(" ", "_")
+
+
 def load_baseline(tier: str, model: str | None = None) -> dict | None:
-    """Return the baseline dict, or None if absent."""
+    """Return the baseline dict, or None if absent.
+
+    Falls back to the legacy slug scheme so baselines recorded by
+    earlier versions of the doctor are still discoverable after the
+    upgrade.  When found via the legacy path, the file is left in
+    place — ``--update-baselines`` will write the new path on next
+    run, naturally migrating it.
+    """
     p = baseline_path(tier, model)
-    if not p.exists():
-        return None
-    with open(p) as f:
-        return json.load(f)
+    if p.exists():
+        with open(p) as f:
+            return json.load(f)
+    # Legacy fallback for models whose new slug differs from the old.
+    if model is not None:
+        legacy = HARNESS_DIR / "baselines" / f"{tier}-{_legacy_slug(model)}.json"
+        if legacy != p and legacy.exists():
+            with open(legacy) as f:
+                return json.load(f)
+    return None
 
 
 def save_baseline(tier: str, model: str, metrics: dict[str, float]) -> Path:

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -67,7 +67,7 @@ def load_thresholds(path: Path | None = None) -> dict[str, dict[str, float]]:
 # Baseline read/write
 # ---------------------------------------------------------------------
 
-def _safe_model_slug(model: str) -> str:
+def safe_model_slug(model: str) -> str:
     """File-system-safe, *injective* slug for baseline filenames.
 
     Uses URL percent-encoding so the mapping is one-to-one — i.e.
@@ -92,7 +92,7 @@ def baseline_path(tier: str, model: str | None = None) -> Path:
     base = HARNESS_DIR / "baselines"
     if model is None:
         return base / f"{tier}.json"
-    return base / f"{tier}-{_safe_model_slug(model)}.json"
+    return base / f"{tier}-{safe_model_slug(model)}.json"
 
 
 def _legacy_slug(model: str) -> str:

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -67,6 +67,7 @@ def load_thresholds(path: Path | None = None) -> dict[str, dict[str, float]]:
 # Baseline read/write
 # ---------------------------------------------------------------------
 
+
 def safe_model_slug(model: str) -> str:
     """File-system-safe, *injective* slug for baseline filenames.
 
@@ -154,12 +155,13 @@ def save_baseline(tier: str, model: str, metrics: dict[str, float]) -> Path:
 # Comparison
 # ---------------------------------------------------------------------
 
+
 class DeltaStatus(str, Enum):
-    OK = "ok"               # within thresholds
+    OK = "ok"  # within thresholds
     REGRESSION = "regression"
     IMPROVEMENT = "improvement"
-    NEW = "new"             # metric absent in baseline
-    DROPPED = "dropped"     # metric absent in current run
+    NEW = "new"  # metric absent in baseline
+    DROPPED = "dropped"  # metric absent in current run
 
 
 @dataclass
@@ -181,7 +183,7 @@ _LOWER_IS_BETTER = {
     "mt_ttft_ms",
     "long_ttft_ms",
     "long_cached_ttft_ms",
-    "tc_latency_ms",          # tool-call latency: lower = better
+    "tc_latency_ms",  # tool-call latency: lower = better
     "peak_ram_mb",
     # legacy / alternate names retained so older baselines and
     # external bench scripts using *ttft_cold_ms* style keys also
@@ -207,14 +209,24 @@ def _classify(
 ) -> tuple[DeltaStatus, float, float]:
     """Classify (status, delta_pct, regression_threshold)."""
     cfg = thresholds.get(metric, DEFAULT_THRESHOLDS)
-    regression_pct = float(cfg.get("regression_pct", DEFAULT_THRESHOLDS["regression_pct"]))
-    improvement_pct = float(cfg.get("improvement_pct", DEFAULT_THRESHOLDS["improvement_pct"]))
+    regression_pct = float(
+        cfg.get("regression_pct", DEFAULT_THRESHOLDS["regression_pct"])
+    )
+    improvement_pct = float(
+        cfg.get("improvement_pct", DEFAULT_THRESHOLDS["improvement_pct"])
+    )
 
     if baseline == 0:
         # Avoid div-by-zero — treat any change as a status flip.
         if current == 0:
             return DeltaStatus.OK, 0.0, regression_pct
-        return DeltaStatus.IMPROVEMENT if not _is_lower_better(metric) else DeltaStatus.REGRESSION, float("inf"), regression_pct
+        return (
+            DeltaStatus.IMPROVEMENT
+            if not _is_lower_better(metric)
+            else DeltaStatus.REGRESSION,
+            float("inf"),
+            regression_pct,
+        )
 
     raw_delta_pct = (current - baseline) / baseline * 100
     # For lower-is-better metrics, invert the sign so positive delta_pct
@@ -241,7 +253,9 @@ def compare(
     enclosing CheckResult as ``Status.REGRESSION``.
     """
     deltas: list[MetricDelta] = []
-    base_metrics: dict[str, float] = (baseline or {}).get("metrics", {}) if baseline else {}
+    base_metrics: dict[str, float] = (
+        (baseline or {}).get("metrics", {}) if baseline else {}
+    )
 
     all_metrics = sorted(set(current) | set(base_metrics))
     for m in all_metrics:
@@ -249,21 +263,35 @@ def compare(
         base = base_metrics.get(m)
         if base is None:
             deltas.append(
-                MetricDelta(metric=m, baseline=None, current=cur,
-                            delta_pct=None, status=DeltaStatus.NEW)
+                MetricDelta(
+                    metric=m,
+                    baseline=None,
+                    current=cur,
+                    delta_pct=None,
+                    status=DeltaStatus.NEW,
+                )
             )
             continue
         if cur is None:
             deltas.append(
-                MetricDelta(metric=m, baseline=base, current=None,
-                            delta_pct=None, status=DeltaStatus.DROPPED)
+                MetricDelta(
+                    metric=m,
+                    baseline=base,
+                    current=None,
+                    delta_pct=None,
+                    status=DeltaStatus.DROPPED,
+                )
             )
             continue
         status, delta_pct, threshold = _classify(m, base, cur, thresholds)
         deltas.append(
             MetricDelta(
-                metric=m, baseline=base, current=cur,
-                delta_pct=delta_pct, status=status, threshold_pct=threshold,
+                metric=m,
+                baseline=base,
+                current=cur,
+                delta_pct=delta_pct,
+                status=status,
+                threshold_pct=threshold,
             )
         )
     return deltas

--- a/vllm_mlx/doctor/baseline.py
+++ b/vllm_mlx/doctor/baseline.py
@@ -67,13 +67,27 @@ def load_thresholds(path: Path | None = None) -> dict[str, dict[str, float]]:
 # Baseline read/write
 # ---------------------------------------------------------------------
 
-def baseline_path(tier: str) -> Path:
-    return HARNESS_DIR / "baselines" / f"{tier}.json"
+def _safe_model_slug(model: str) -> str:
+    """File-system-safe slug for use in baseline filenames."""
+    return model.replace("/", "__").replace(" ", "_")
 
 
-def load_baseline(tier: str) -> dict | None:
+def baseline_path(tier: str, model: str | None = None) -> Path:
+    """Path to the baseline JSON.
+
+    Per-model file when ``model`` is given (used by check/full tiers
+    where a baseline is only meaningful for one model).  The unsuffixed
+    path is reserved for tiers whose metrics aren't model-specific.
+    """
+    base = HARNESS_DIR / "baselines"
+    if model is None:
+        return base / f"{tier}.json"
+    return base / f"{tier}-{_safe_model_slug(model)}.json"
+
+
+def load_baseline(tier: str, model: str | None = None) -> dict | None:
     """Return the baseline dict, or None if absent."""
-    p = baseline_path(tier)
+    p = baseline_path(tier, model)
     if not p.exists():
         return None
     with open(p) as f:
@@ -95,7 +109,7 @@ def save_baseline(tier: str, model: str, metrics: dict[str, float]) -> Path:
         "model": model,
         "metrics": metrics,
     }
-    p = baseline_path(tier)
+    p = baseline_path(tier, model)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(payload, indent=2))
     return p

--- a/vllm_mlx/doctor/checks/__init__.py
+++ b/vllm_mlx/doctor/checks/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Doctor check implementations, one module per category."""

--- a/vllm_mlx/doctor/checks/agent.py
+++ b/vllm_mlx/doctor/checks/agent.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check tier — agent profile API tests against a live server."""
+
+from __future__ import annotations
+
+import time
+
+from ..runner import CheckResult, Status
+
+
+def check_agent_profile(
+    profile_name: str,
+    port: int,
+    model_id: str | None = None,
+) -> CheckResult:
+    """Run one agent profile's auto-generated test plan.
+
+    Uses ``vllm_mlx.agents.testing.AgentTestRunner`` which derives the
+    test plan from the profile's capability declarations.  E2E tests
+    that require the agent binary on disk are skipped automatically
+    when the binary isn't installed, so this works headless.
+    """
+    t0 = time.perf_counter()
+    try:
+        # Three dots: vllm_mlx/doctor/checks/ → vllm_mlx/agents/
+        from ...agents import get_profile
+        from ...agents.testing import AgentTestRunner, TestStatus
+    except ImportError as e:
+        return CheckResult(
+            name=f"agent_{profile_name}",
+            status=Status.SKIP,
+            duration_s=time.perf_counter() - t0,
+            detail=f"agent framework unavailable: {e}",
+        )
+
+    profile = get_profile(profile_name)
+    if profile is None:
+        return CheckResult(
+            name=f"agent_{profile_name}",
+            status=Status.SKIP,
+            duration_s=time.perf_counter() - t0,
+            detail=f"no profile named {profile_name!r}",
+        )
+
+    base_url = f"http://127.0.0.1:{port}/v1"
+    runner = AgentTestRunner(profile, base_url=base_url, model_id=model_id)
+    report = runner.run()
+    elapsed = time.perf_counter() - t0
+
+    n_pass = report.passed
+    n_fail = report.failed
+    n_err = report.errored
+    n_skip = report.skipped
+    detail = (
+        f"{n_pass} pass, {n_fail} fail, {n_err} error, {n_skip} skip "
+        f"({len(report.results)} total)"
+    )
+
+    # Treat ERROR same as FAIL — both indicate something the doctor
+    # would want to surface.  SKIP is fine (capability not declared).
+    if n_fail > 0 or n_err > 0:
+        # Include the failing test names so the report is actionable
+        # without needing to chase down the per-profile log.
+        bad = [
+            f"{r.name}: {r.message[:120]}"
+            for r in report.results
+            if r.status in (TestStatus.FAIL, TestStatus.ERROR)
+        ]
+        detail += "\n  failures:\n    " + "\n    ".join(bad[:5])
+        return CheckResult(
+            name=f"agent_{profile_name}",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=detail,
+        )
+
+    return CheckResult(
+        name=f"agent_{profile_name}",
+        status=Status.PASS,
+        duration_s=elapsed,
+        detail=detail,
+    )

--- a/vllm_mlx/doctor/checks/api.py
+++ b/vllm_mlx/doctor/checks/api.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check tier — API contract + smoke matrix against a live server."""
+
+from __future__ import annotations
+
+import time
+
+from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+
+
+def check_smoke_matrix(port: int) -> CheckResult:
+    """Bash smoke matrix: emoji/CJK/thinking toggle/special-token leaks."""
+    t0 = time.perf_counter()
+    script = REPO_ROOT / "tests" / "test_smoke_matrix.sh"
+    rc, stdout, stderr = run_subprocess(
+        ["bash", str(script), str(port)],
+        timeout=180,
+    )
+    elapsed = time.perf_counter() - t0
+    last_lines = "\n".join(stdout.strip().splitlines()[-12:])
+    if rc == 0:
+        return CheckResult(
+            name="smoke_matrix",
+            status=Status.PASS,
+            duration_s=elapsed,
+            detail=last_lines.split("\n")[-2] if last_lines else "",
+        )
+    return CheckResult(
+        name="smoke_matrix",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=last_lines or stderr[-500:],
+    )
+
+
+def check_regression_suite(port: int) -> CheckResult:
+    """API contract regression suite (10 cases: stop sequences, validation, etc.)."""
+    t0 = time.perf_counter()
+    script = REPO_ROOT / "tests" / "regression_suite.py"
+    py = python_executable()
+    # regression_suite.py defaults to localhost:8000; override via env if it
+    # supports it, else patch URL via PORT env.  As of writing it hardcodes
+    # the URL — we monkey-patch via a wrapper script if the port differs.
+    # For simplicity we run on the doctor's port via env override.
+    import os
+    env = os.environ.copy()
+    env["RAPID_MLX_PORT"] = str(port)
+    rc, stdout, stderr = run_subprocess(
+        [py, str(script)],
+        timeout=300,
+        env=env,
+    )
+    elapsed = time.perf_counter() - t0
+    last_lines = "\n".join(stdout.strip().splitlines()[-6:])
+    if rc == 0:
+        return CheckResult(
+            name="regression_suite",
+            status=Status.PASS,
+            duration_s=elapsed,
+            detail=last_lines,
+        )
+    return CheckResult(
+        name="regression_suite",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=last_lines or stderr[-500:],
+    )

--- a/vllm_mlx/doctor/checks/api.py
+++ b/vllm_mlx/doctor/checks/api.py
@@ -34,15 +34,18 @@ def check_smoke_matrix(port: int) -> CheckResult:
 
 
 def check_regression_suite(port: int) -> CheckResult:
-    """API contract regression suite (10 cases: stop sequences, validation, etc.)."""
+    """API contract regression suite (10 cases: stop sequences, validation, etc.).
+
+    Note: ``regression_suite.py`` always exits 0 — it only prints a
+    "N/M tests passed" summary.  We must parse that line and fail
+    whenever any case failed; otherwise regressions slip through.
+    """
+    import os
+    import re
+
     t0 = time.perf_counter()
     script = REPO_ROOT / "tests" / "regression_suite.py"
     py = python_executable()
-    # regression_suite.py defaults to localhost:8000; override via env if it
-    # supports it, else patch URL via PORT env.  As of writing it hardcodes
-    # the URL — we monkey-patch via a wrapper script if the port differs.
-    # For simplicity we run on the doctor's port via env override.
-    import os
     env = os.environ.copy()
     env["RAPID_MLX_PORT"] = str(port)
     rc, stdout, stderr = run_subprocess(
@@ -52,16 +55,44 @@ def check_regression_suite(port: int) -> CheckResult:
     )
     elapsed = time.perf_counter() - t0
     last_lines = "\n".join(stdout.strip().splitlines()[-6:])
-    if rc == 0:
+
+    # Parse "N/M tests passed" from anywhere in the output.
+    summary_re = re.compile(r"(\d+)\s*/\s*(\d+)\s+tests?\s+passed", re.IGNORECASE)
+    passed = total = None
+    for line in stdout.splitlines():
+        m = summary_re.search(line)
+        if m:
+            passed, total = int(m.group(1)), int(m.group(2))
+
+    # Subprocess crash trumps the summary parse.
+    if rc != 0:
         return CheckResult(
             name="regression_suite",
-            status=Status.PASS,
+            status=Status.FAIL,
             duration_s=elapsed,
-            detail=last_lines,
+            detail=f"script exited rc={rc}\n{last_lines or stderr[-500:]}",
         )
+
+    if passed is None or total is None:
+        # Couldn't find the summary — be conservative, treat as failure.
+        return CheckResult(
+            name="regression_suite",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=f"could not parse 'N/M tests passed' from output:\n{last_lines}",
+        )
+
+    if passed < total:
+        return CheckResult(
+            name="regression_suite",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=f"{passed}/{total} passed — see {total - passed} failure(s) above:\n{last_lines}",
+        )
+
     return CheckResult(
         name="regression_suite",
-        status=Status.FAIL,
+        status=Status.PASS,
         duration_s=elapsed,
-        detail=last_lines or stderr[-500:],
+        detail=f"{passed}/{total} tests passed",
     )

--- a/vllm_mlx/doctor/checks/benchmark.py
+++ b/vllm_mlx/doctor/checks/benchmark.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark tier — capture a small set of metrics per (model, engine) cell."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+
+
+def benchmark_one_cell(
+    model: str,
+    port: int,
+    runs: int = 1,
+) -> CheckResult:
+    """Run autoresearch_bench against a live server, return key metrics.
+
+    Captures the four metrics that fit in a scorecard cell:
+      - decode_tps      throughput (tok/s)
+      - cold_ttft_ms    time to first token, no cache
+      - cached_ttft_ms  time to first token, cache warm
+      - tc_success_rate tool calling reliability (0.0-1.0)
+
+    The result.metrics dict is the source of truth for the scorecard
+    renderer; this function does not format anything itself.
+    """
+    t0 = time.perf_counter()
+    script = REPO_ROOT / "scripts" / "autoresearch_bench.py"
+    py = python_executable()
+
+    env = os.environ.copy()
+    env["AUTORESEARCH_BASE"] = f"http://127.0.0.1:{port}/v1/chat/completions"
+
+    rc, stdout, stderr = run_subprocess(
+        [py, str(script), "--json", "--runs", str(runs)],
+        timeout=600,
+        env=env,
+    )
+    elapsed = time.perf_counter() - t0
+
+    if rc != 0:
+        return CheckResult(
+            name=f"bench[{model}]",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=f"autoresearch failed rc={rc}\n{(stderr or stdout)[-400:]}",
+        )
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        return CheckResult(
+            name=f"bench[{model}]",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=f"could not parse JSON: {e}\n{stdout[-400:]}",
+        )
+
+    # Filter to numeric metrics only.
+    metrics = {k: v for k, v in data.items() if isinstance(v, (int, float))}
+
+    # Same all-zero-primary check as the check tier perf.py — catches
+    # the silent-failure mode where every request was rejected.
+    primary_signals = ("decode_tps", "cold_tps", "cached_ttft_ms")
+    if all(metrics.get(k, 0) == 0 for k in primary_signals):
+        return CheckResult(
+            name=f"bench[{model}]",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail="all primary metrics zero — server probably rejected requests",
+            metrics=metrics,
+        )
+
+    return CheckResult(
+        name=f"bench[{model}]",
+        status=Status.PASS,
+        duration_s=elapsed,
+        detail=(
+            f"decode={metrics.get('decode_tps', 0):.1f} tok/s · "
+            f"cold_ttft={metrics.get('cold_ttft_ms', 0):.0f}ms · "
+            f"tc={metrics.get('tc_success_rate', 0):.0%}"
+        ),
+        metrics=metrics,
+    )

--- a/vllm_mlx/doctor/checks/perf.py
+++ b/vllm_mlx/doctor/checks/perf.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check tier — performance metrics via autoresearch_bench.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+
+
+def check_autoresearch(port: int, runs: int = 1) -> CheckResult:
+    """Run autoresearch_bench --json and capture metrics for baseline diff.
+
+    The script hardcodes ``http://127.0.0.1:8000`` — we override it via
+    AUTORESEARCH_BASE env var (read by our patched script).  Falls back
+    to a small in-process replacement if the script can't be retargeted.
+    """
+    t0 = time.perf_counter()
+    script = REPO_ROOT / "scripts" / "autoresearch_bench.py"
+    py = python_executable()
+
+    env = os.environ.copy()
+    env["AUTORESEARCH_BASE"] = f"http://127.0.0.1:{port}/v1/chat/completions"
+
+    rc, stdout, stderr = run_subprocess(
+        [py, str(script), "--json", "--runs", str(runs)],
+        timeout=600,
+        env=env,
+    )
+    elapsed = time.perf_counter() - t0
+
+    if rc != 0:
+        return CheckResult(
+            name="autoresearch",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=stderr[-1000:] or stdout[-500:],
+        )
+
+    # autoresearch_bench prints the JSON dict on stdout in --json mode.
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        return CheckResult(
+            name="autoresearch",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=f"could not parse JSON output: {e}\n{stdout[-500:]}",
+        )
+
+    # Lift numeric metrics to the top level for baseline comparison.
+    metrics = {k: v for k, v in data.items() if isinstance(v, (int, float))}
+
+    # Sanity: if every primary metric is zero/falsy the script almost
+    # certainly failed silently (e.g. wrong model name → all requests
+    # 404'd).  Treat that as a check failure instead of recording a
+    # garbage baseline.
+    primary_signals = ("decode_tps", "cold_tps", "cached_ttft_ms")
+    if all(metrics.get(k, 0) == 0 for k in primary_signals):
+        return CheckResult(
+            name="autoresearch",
+            status=Status.FAIL,
+            duration_s=elapsed,
+            detail=(
+                f"all primary metrics zero — server probably rejected "
+                f"requests. last 200 chars of stdout: {stdout[-200:]}"
+            ),
+            metrics=metrics,
+        )
+
+    return CheckResult(
+        name="autoresearch",
+        status=Status.PASS,
+        duration_s=elapsed,
+        detail=f"captured {len(metrics)} metrics",
+        metrics=metrics,
+    )

--- a/vllm_mlx/doctor/checks/smoke.py
+++ b/vllm_mlx/doctor/checks/smoke.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke-tier checks: static analysis + import sanity, no model required."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+
+
+def check_pytest_unit() -> CheckResult:
+    """Run the unit-test slice (excludes integration + server-required tests)."""
+    t0 = time.perf_counter()
+    py = python_executable()
+    cmd = [
+        py, "-m", "pytest",
+        "tests/",
+        "-q",
+        "--ignore=tests/integrations",
+        "--deselect", "tests/test_event_loop.py",
+    ]
+    rc, stdout, stderr = run_subprocess(cmd, timeout=300)
+    elapsed = time.perf_counter() - t0
+
+    # Pull the summary line ("=== N passed, M skipped in Ts ===") for the report.
+    summary_line = ""
+    for line in stdout.strip().splitlines()[::-1]:
+        if "passed" in line or "failed" in line or "error" in line:
+            summary_line = line.strip()
+            break
+
+    if rc == 0:
+        return CheckResult(
+            name="pytest",
+            status=Status.PASS,
+            duration_s=elapsed,
+            detail=summary_line,
+        )
+    return CheckResult(
+        name="pytest",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=summary_line or f"pytest exited {rc}\n{stderr[-1000:]}",
+    )
+
+
+def check_ruff() -> CheckResult:
+    """Run ruff lint over the package + tests.
+
+    Tries ``python -m ruff`` first (works when ruff is in the same venv),
+    falls back to a standalone ``ruff`` binary on PATH.  Skips gracefully
+    if neither is available.
+    """
+    import shutil
+
+    t0 = time.perf_counter()
+    py = python_executable()
+
+    # Try python -m ruff first
+    rc, stdout, stderr = run_subprocess(
+        [py, "-m", "ruff", "check", "vllm_mlx/", "tests/"],
+        timeout=60,
+    )
+    if rc != 0 and ("No module named" in stderr or "ModuleNotFoundError" in stderr):
+        # Fall back to standalone binary
+        ruff_bin = shutil.which("ruff")
+        if ruff_bin:
+            rc, stdout, stderr = run_subprocess(
+                [ruff_bin, "check", "vllm_mlx/", "tests/"],
+                timeout=60,
+            )
+        else:
+            elapsed = time.perf_counter() - t0
+            return CheckResult(
+                name="ruff",
+                status=Status.SKIP,
+                duration_s=elapsed,
+                detail="ruff not installed (neither module nor binary on PATH)",
+            )
+
+    elapsed = time.perf_counter() - t0
+    if rc == 0:
+        return CheckResult(name="ruff", status=Status.PASS, duration_s=elapsed)
+    return CheckResult(
+        name="ruff",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=(stdout or stderr)[-2000:],
+    )
+
+
+def check_imports() -> CheckResult:
+    """Verify critical modules import cleanly (catches syntax errors fast)."""
+    t0 = time.perf_counter()
+    py = python_executable()
+    code = (
+        "import vllm_mlx; "
+        "from vllm_mlx import cli, server, scheduler; "
+        "from vllm_mlx.engine import simple, batched, hybrid; "
+        "from vllm_mlx.agents import list_profiles; "
+        "print(f'modules: {len(list_profiles())} agent profiles')"
+    )
+    rc, stdout, stderr = run_subprocess([py, "-c", code], timeout=60)
+    elapsed = time.perf_counter() - t0
+    if rc == 0:
+        return CheckResult(
+            name="imports",
+            status=Status.PASS,
+            duration_s=elapsed,
+            detail=stdout.strip(),
+        )
+    return CheckResult(
+        name="imports",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=stderr[-1000:] or stdout[-1000:],
+    )
+
+
+def check_cli_sanity() -> CheckResult:
+    """Smoke the CLI by invoking the no-side-effect subcommands."""
+    t0 = time.perf_counter()
+    py = python_executable()
+    sub_cmds = [
+        [py, "-m", "vllm_mlx.cli", "--help"],
+        [py, "-m", "vllm_mlx.cli", "models"],
+        [py, "-m", "vllm_mlx.cli", "agents"],
+    ]
+    failures: list[str] = []
+    for sub in sub_cmds:
+        rc, stdout, stderr = run_subprocess(sub, timeout=30)
+        if rc != 0:
+            failures.append(f"{' '.join(sub[-2:])} → rc={rc}: {stderr[-200:]}")
+    elapsed = time.perf_counter() - t0
+    if not failures:
+        return CheckResult(
+            name="cli_sanity",
+            status=Status.PASS,
+            duration_s=elapsed,
+            detail=f"{len(sub_cmds)} subcommands OK",
+        )
+    return CheckResult(
+        name="cli_sanity",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail="\n".join(failures),
+    )
+
+
+def check_repo_layout() -> CheckResult:
+    """Verify expected files exist (catches accidental deletions)."""
+    t0 = time.perf_counter()
+    required: list[Path] = [
+        REPO_ROOT / "pyproject.toml",
+        REPO_ROOT / "vllm_mlx" / "aliases.json",
+        REPO_ROOT / "vllm_mlx" / "agents" / "profiles",
+    ]
+    missing = [str(p.relative_to(REPO_ROOT)) for p in required if not p.exists()]
+    elapsed = time.perf_counter() - t0
+    if not missing:
+        return CheckResult(name="repo_layout", status=Status.PASS, duration_s=elapsed)
+    return CheckResult(
+        name="repo_layout",
+        status=Status.FAIL,
+        duration_s=elapsed,
+        detail=f"missing: {', '.join(missing)}",
+    )

--- a/vllm_mlx/doctor/checks/smoke.py
+++ b/vllm_mlx/doctor/checks/smoke.py
@@ -91,14 +91,21 @@ def check_ruff() -> CheckResult:
 
 
 def check_imports() -> CheckResult:
-    """Verify critical modules import cleanly (catches syntax errors fast)."""
+    """Verify lightweight modules import cleanly (catches syntax errors fast).
+
+    We deliberately avoid importing ``vllm_mlx.server``, ``scheduler`` and
+    the engine modules here — those transitively initialize ``mlx.core``,
+    which aborts with NSRangeException on hosts without a usable Metal
+    device.  Heavy-import errors will still surface during the pytest
+    check that follows, on hosts where they actually matter.
+    """
     t0 = time.perf_counter()
     py = python_executable()
     code = (
         "import vllm_mlx; "
-        "from vllm_mlx import cli, server, scheduler; "
-        "from vllm_mlx.engine import simple, batched, hybrid; "
+        "from vllm_mlx import cli, model_aliases; "
         "from vllm_mlx.agents import list_profiles; "
+        "from vllm_mlx.doctor import DoctorRunner; "
         "print(f'modules: {len(list_profiles())} agent profiles')"
     )
     rc, stdout, stderr = run_subprocess([py, "-c", code], timeout=60)

--- a/vllm_mlx/doctor/checks/smoke.py
+++ b/vllm_mlx/doctor/checks/smoke.py
@@ -14,11 +14,14 @@ def check_pytest_unit() -> CheckResult:
     t0 = time.perf_counter()
     py = python_executable()
     cmd = [
-        py, "-m", "pytest",
+        py,
+        "-m",
+        "pytest",
         "tests/",
         "-q",
         "--ignore=tests/integrations",
-        "--deselect", "tests/test_event_loop.py",
+        "--deselect",
+        "tests/test_event_loop.py",
     ]
     rc, stdout, stderr = run_subprocess(cmd, timeout=300)
     elapsed = time.perf_counter() - t0

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 
 import sys
 
-from .runner import REPO_ROOT, DoctorRunner
+from .baseline import (
+    DeltaStatus,
+    compare,
+    has_regression,
+    load_baseline,
+    load_thresholds,
+    render_deltas_md,
+    save_baseline,
+)
+from .runner import REPO_ROOT, CheckResult, DoctorRunner, Status
+
+# Default model used by the check tier.  Tier 3 (full) loops a wider list.
+DEFAULT_CHECK_MODEL = "qwen3.5-4b"
 
 
 def _require_source_checkout() -> None:
-    """Doctor depends on tests/ + harness/ + pyproject.toml.
-
-    A pip-installed wheel does not ship those, so the command would
-    immediately produce confusing failures.  Detect that case up front
-    and exit with a clear message instead.
-    """
+    """Doctor depends on tests/ + harness/ + pyproject.toml."""
     sentinels = [
         REPO_ROOT / "pyproject.toml",
         REPO_ROOT / "tests",
@@ -37,12 +44,15 @@ def doctor_command(args) -> None:
     _require_source_checkout()
 
     tier = getattr(args, "tier", None) or "smoke"
+    update_baselines = getattr(args, "update_baselines", False)
 
     if tier == "smoke":
         result = run_smoke_tier()
     elif tier == "check":
-        print("[doctor] check tier not yet implemented", file=sys.stderr)
-        sys.exit(2)
+        result = run_check_tier(
+            model=getattr(args, "model", None) or DEFAULT_CHECK_MODEL,
+            update_baselines=update_baselines,
+        )
     elif tier == "full":
         print("[doctor] full tier not yet implemented", file=sys.stderr)
         sys.exit(2)
@@ -55,6 +65,10 @@ def doctor_command(args) -> None:
 
     sys.exit(result.exit_code)
 
+
+# ---------------------------------------------------------------------
+# Smoke tier
+# ---------------------------------------------------------------------
 
 def run_smoke_tier():
     """Static + import + CLI sanity. No model required."""
@@ -70,3 +84,122 @@ def run_smoke_tier():
     runner.run_check("cli_sanity", smoke.check_cli_sanity)
     runner.run_check("pytest", smoke.check_pytest_unit)
     return runner.finalize()
+
+
+# ---------------------------------------------------------------------
+# Check tier
+# ---------------------------------------------------------------------
+
+def run_check_tier(model: str, update_baselines: bool = False):
+    """Boot a server with ``model`` and run API + perf + agent checks."""
+    from .checks import api, perf, smoke
+    from .server import ServerStartFailed, serve
+
+    print(f"Rapid-MLX Doctor — check tier (model={model})")
+    print("=" * 60)
+
+    runner = DoctorRunner(tier="check")
+
+    # Cheap static checks first — fail fast on broken syntax / missing files.
+    runner.run_check("repo_layout", smoke.check_repo_layout)
+    runner.run_check("imports", smoke.check_imports)
+
+    server_log = runner.run_dir / "server.log"
+    try:
+        with serve(model=model, log_path=server_log) as info:
+            port = info["port"]
+            print(f"  [server] up on port {port}, log → {server_log.name}")
+            runner.run_check(
+                "regression_suite",
+                lambda: api.check_regression_suite(port),
+            )
+            runner.run_check(
+                "smoke_matrix",
+                lambda: api.check_smoke_matrix(port),
+            )
+            perf_result = runner.run_check(
+                "autoresearch",
+                lambda: perf.check_autoresearch(port, runs=1),
+            )
+    except ServerStartFailed as exc:
+        # Capture the exception locally so the closure below sees it
+        # even if Python clears `exc` at the end of the except block.
+        err_msg = f"{exc}\nlog: {server_log}"
+        runner.run_check(
+            "server_boot",
+            lambda: CheckResult(
+                name="server_boot",
+                status=Status.FAIL,
+                duration_s=0.0,
+                detail=err_msg,
+            ),
+        )
+        return runner.finalize()
+
+    # Compare perf metrics against baseline (if one exists).
+    if perf_result.metrics:
+        _apply_baseline(runner, "check", model, perf_result.metrics, update_baselines)
+
+    return runner.finalize()
+
+
+def _apply_baseline(
+    runner: DoctorRunner,
+    tier: str,
+    model: str,
+    metrics: dict,
+    update_baselines: bool,
+) -> None:
+    """Diff against baseline; flag regressions; optionally update baseline."""
+    baseline = load_baseline(tier)
+    thresholds = load_thresholds()
+
+    if update_baselines:
+        path = save_baseline(tier, model, metrics)
+        runner.run_check(
+            "baseline_update",
+            lambda: CheckResult(
+                name="baseline_update",
+                status=Status.PASS,
+                duration_s=0.0,
+                detail=f"wrote {path.relative_to(REPO_ROOT)}",
+            ),
+        )
+        return
+
+    if baseline is None:
+        # First run with no baseline — record what we saw, don't fail.
+        deltas_md = "_no baseline yet — run with --update-baselines to record one_\n"
+        (runner.run_dir / "diff.md").write_text(deltas_md)
+        runner.run_check(
+            "baseline_diff",
+            lambda: CheckResult(
+                name="baseline_diff",
+                status=Status.SKIP,
+                duration_s=0.0,
+                detail="no baseline found; run --update-baselines to create",
+            ),
+        )
+        return
+
+    deltas = compare(metrics, baseline, thresholds)
+    deltas_md = render_deltas_md(deltas)
+    (runner.run_dir / "diff.md").write_text(deltas_md)
+
+    n_regress = sum(1 for d in deltas if d.status == DeltaStatus.REGRESSION)
+    n_improve = sum(1 for d in deltas if d.status == DeltaStatus.IMPROVEMENT)
+    detail = f"{len(deltas)} metrics: {n_regress} regression(s), {n_improve} improvement(s)"
+
+    status = Status.REGRESSION if has_regression(deltas) else Status.PASS
+    runner.run_check(
+        "baseline_diff",
+        lambda: CheckResult(
+            name="baseline_diff",
+            status=status,
+            duration_s=0.0,
+            detail=detail,
+        ),
+    )
+
+    # Append delta table to the report so the summary is self-contained.
+    runner.checks[-1].detail += f"\n\n{deltas_md}"

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 
 from .baseline import (
@@ -166,9 +167,10 @@ def run_full_tier(models: list[str], update_baselines: bool = False):
             tier="full",
             update_baselines=update_baselines,
             agent_profiles=profile_names,
-            # 27B+ models in the full sweep may need >180s on a slow
-            # disk; check tier (smaller default model) keeps fast-fail.
-            boot_timeout_s=600,
+            # boot_timeout_s=None → _suggested_boot_timeout picks 600s for
+            # the 27B+ models (qwen3.5-35b, gemma-4-26b) and 180s for
+            # smaller ones, so the same logic applies regardless of which
+            # tier called us.
         )
 
     return runner.finalize()
@@ -200,13 +202,34 @@ def _resolve_agent_profiles(explicit: list[str] | None) -> list[str]:
 # Shared per-model block (used by check + full)
 # ---------------------------------------------------------------------
 
+# Boot timeout buckets keyed on the model alias's parameter-count hint.
+# The check tier defaults to qwen3.5-4b (small) which boots in <30s; bumping
+# everything to 600s would steal the tier's fast-fail property. Conversely,
+# 'doctor check --model qwen3.5-35b' is a supported workflow and 27B+ cold
+# loads on a slow disk routinely exceed 180s. Pattern-match the alias for a
+# size hint instead of asking the user to think about timeouts.
+_LARGE_MODEL_RE = re.compile(
+    r"\b(?:[2-9]\d|\d{3,})b\b", re.IGNORECASE,
+)  # matches '20b', '27b', '35b', '70b', '122b', '405b', ...
+
+
+def _suggested_boot_timeout(model: str) -> int:
+    """Pick a boot timeout based on a parameter-count hint in the alias.
+
+    Returns 600s for ≥20B-shaped aliases, 180s otherwise.  Errs on the
+    side of fast-fail: if the regex doesn't match, you get the short
+    timeout (which surfaces broken-server issues faster).
+    """
+    return 600 if _LARGE_MODEL_RE.search(model) else 180
+
+
 def _run_per_model_block(
     runner: DoctorRunner,
     model: str,
     tier: str,
     update_baselines: bool,
     agent_profiles: list[str],
-    boot_timeout_s: int = 180,
+    boot_timeout_s: int | None = None,
 ) -> None:
     """Boot a server for one model and run all model-bound checks against it.
 
@@ -214,13 +237,15 @@ def _run_per_model_block(
     records the failure and moves on, so a single broken model in the
     full sweep still yields a complete report.
 
-    ``boot_timeout_s`` is per-tier: the check tier passes 180s (small
-    qwen3.5-4b should boot in <30s; we want fast-fail when something
-    breaks), full tier overrides to 600s because it covers 27B+ models
-    whose cold load can exceed 180s when paging from a slow disk.
+    ``boot_timeout_s=None`` (default) auto-picks based on the model's
+    parameter-count hint via _suggested_boot_timeout().  Callers can
+    pass an explicit value to force a specific budget.
     """
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
+
+    if boot_timeout_s is None:
+        boot_timeout_s = _suggested_boot_timeout(model)
 
     server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
     try:

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI entry points for ``rapid-mlx doctor``."""
+
+from __future__ import annotations
+
+import sys
+
+from .runner import DoctorRunner
+
+
+def doctor_command(args) -> None:
+    """Dispatch to the requested tier."""
+    tier = getattr(args, "tier", None) or "smoke"
+
+    if tier == "smoke":
+        result = run_smoke_tier()
+    elif tier == "check":
+        print("[doctor] check tier not yet implemented", file=sys.stderr)
+        sys.exit(2)
+    elif tier == "full":
+        print("[doctor] full tier not yet implemented", file=sys.stderr)
+        sys.exit(2)
+    elif tier == "benchmark":
+        print("[doctor] benchmark tier not yet implemented", file=sys.stderr)
+        sys.exit(2)
+    else:
+        print(f"[doctor] unknown tier: {tier}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(result.exit_code)
+
+
+def run_smoke_tier():
+    """Static + import + CLI sanity. No model required."""
+    from .checks import smoke
+
+    print("Rapid-MLX Doctor — smoke tier")
+    print("=" * 60)
+
+    runner = DoctorRunner(tier="smoke")
+    runner.run_check("repo_layout", smoke.check_repo_layout)
+    runner.run_check("imports", smoke.check_imports)
+    runner.run_check("ruff", smoke.check_ruff)
+    runner.run_check("cli_sanity", smoke.check_cli_sanity)
+    runner.run_check("pytest", smoke.check_pytest_unit)
+    return runner.finalize()

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -331,8 +331,23 @@ def run_benchmark_tier(models: list[str] | None = None):
     for model in run_list:
         print(f"\n  ── model: {model} ──")
         server_log = runner.run_dir / f"server-{_safe_model_slug(model)}.log"
+        # Pass the discovered local path so LM Studio / non-HF layouts
+        # don't trigger a re-download via mlx_lm.load(alias).
+        local_path = (
+            discovery[model].path
+            if model in discovery and discovery[model].available
+            else None
+        )
         try:
-            with serve(model=model, log_path=server_log) as info:
+            # Cold load of a 27B+ model can take several minutes when
+            # the OS has to page weights from a slow disk; default
+            # 180s timeout is too tight for an overnight sweep.
+            with serve(
+                model=model,
+                model_path=local_path,
+                log_path=server_log,
+                boot_timeout_s=600,
+            ) as info:
                 port = info["port"]
                 print(f"  [server] {model} up on port {port}")
                 result = runner.run_check(

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -19,6 +19,16 @@ from .runner import REPO_ROOT, CheckResult, DoctorRunner, Status
 # Default model used by the check tier.  Tier 3 (full) loops a wider list.
 DEFAULT_CHECK_MODEL = "qwen3.5-4b"
 
+# Model list for the full tier: small/medium/large + a non-Qwen template
+# path so we cover both Hermes-style (Qwen) and Gemma's distinct chat
+# template + tool-call format.
+DEFAULT_FULL_MODELS = ["qwen3.5-4b", "qwen3.5-35b", "gemma-4-26b"]
+
+# Agent profiles to exercise per-model in the full tier.  None ⇒ all
+# loaded profiles.  Limit here if a particular profile is too slow to
+# include in the regular full sweep.
+DEFAULT_FULL_AGENT_PROFILES = None
+
 
 def _require_source_checkout() -> None:
     """Doctor depends on tests/ + harness/ + pyproject.toml."""
@@ -54,8 +64,10 @@ def doctor_command(args) -> None:
             update_baselines=update_baselines,
         )
     elif tier == "full":
-        print("[doctor] full tier not yet implemented", file=sys.stderr)
-        sys.exit(2)
+        result = run_full_tier(
+            models=getattr(args, "models", None) or DEFAULT_FULL_MODELS,
+            update_baselines=update_baselines,
+        )
     elif tier == "benchmark":
         print("[doctor] benchmark tier not yet implemented", file=sys.stderr)
         sys.exit(2)
@@ -92,8 +104,7 @@ def run_smoke_tier():
 
 def run_check_tier(model: str, update_baselines: bool = False):
     """Boot a server with ``model`` and run API + perf + agent checks."""
-    from .checks import api, perf, smoke
-    from .server import ServerStartFailed, serve
+    from .checks import smoke
 
     print(f"Rapid-MLX Doctor — check tier (model={model})")
     print("=" * 60)
@@ -104,43 +115,126 @@ def run_check_tier(model: str, update_baselines: bool = False):
     runner.run_check("repo_layout", smoke.check_repo_layout)
     runner.run_check("imports", smoke.check_imports)
 
-    server_log = runner.run_dir / "server.log"
+    _run_per_model_block(
+        runner=runner,
+        model=model,
+        tier="check",
+        update_baselines=update_baselines,
+        agent_profiles=[],  # check tier keeps it lean — agents only in full
+    )
+    return runner.finalize()
+
+
+# ---------------------------------------------------------------------
+# Full tier
+# ---------------------------------------------------------------------
+
+def run_full_tier(models: list[str], update_baselines: bool = False):
+    """Loop check-tier work across multiple models + run all agent profiles."""
+    from .checks import smoke
+
+    print(f"Rapid-MLX Doctor — full tier (models={', '.join(models)})")
+    print("=" * 60)
+
+    runner = DoctorRunner(tier="full")
+
+    runner.run_check("repo_layout", smoke.check_repo_layout)
+    runner.run_check("imports", smoke.check_imports)
+
+    # Resolve agent profile list once so a missing profile fails fast.
+    profile_names = _resolve_agent_profiles(DEFAULT_FULL_AGENT_PROFILES)
+
+    for model in models:
+        print(f"\n  ── model: {model} ──")
+        _run_per_model_block(
+            runner=runner,
+            model=model,
+            tier="full",
+            update_baselines=update_baselines,
+            agent_profiles=profile_names,
+        )
+
+    return runner.finalize()
+
+
+def _resolve_agent_profiles(explicit: list[str] | None) -> list[str]:
+    """Return the list of agent profile names to exercise."""
+    if explicit:
+        return explicit
+    try:
+        from .. import agents
+        return [p.name for p in agents.list_profiles()]
+    except Exception:
+        return ["generic"]
+
+
+# ---------------------------------------------------------------------
+# Shared per-model block (used by check + full)
+# ---------------------------------------------------------------------
+
+def _run_per_model_block(
+    runner: DoctorRunner,
+    model: str,
+    tier: str,
+    update_baselines: bool,
+    agent_profiles: list[str],
+) -> None:
+    """Boot a server for one model and run all model-bound checks against it.
+
+    Failures here do NOT abort the rest of the tier — the runner just
+    records the failure and moves on, so a single broken model in the
+    full sweep still yields a complete report.
+    """
+    from .checks import agent, api, perf
+    from .server import ServerStartFailed, serve
+
+    server_log = runner.run_dir / f"server-{_filename_safe(model)}.log"
     try:
         with serve(model=model, log_path=server_log) as info:
             port = info["port"]
-            print(f"  [server] up on port {port}, log → {server_log.name}")
+            print(f"  [server] {model} up on port {port}, log → {server_log.name}")
             runner.run_check(
-                "regression_suite",
+                f"regression_suite[{model}]",
                 lambda: api.check_regression_suite(port),
             )
             runner.run_check(
-                "smoke_matrix",
+                f"smoke_matrix[{model}]",
                 lambda: api.check_smoke_matrix(port),
             )
             perf_result = runner.run_check(
-                "autoresearch",
+                f"autoresearch[{model}]",
                 lambda: perf.check_autoresearch(port, runs=1),
             )
+            for profile_name in agent_profiles:
+                # Bind per-iteration values so the lambda doesn't close
+                # over the loop variables.
+                runner.run_check(
+                    f"agent[{profile_name}@{model}]",
+                    lambda p=profile_name, port=port: agent.check_agent_profile(
+                        p, port, model_id=model
+                    ),
+                )
     except ServerStartFailed as exc:
-        # Capture the exception locally so the closure below sees it
-        # even if Python clears `exc` at the end of the except block.
         err_msg = f"{exc}\nlog: {server_log}"
         runner.run_check(
-            "server_boot",
+            f"server_boot[{model}]",
             lambda: CheckResult(
-                name="server_boot",
+                name=f"server_boot[{model}]",
                 status=Status.FAIL,
                 duration_s=0.0,
                 detail=err_msg,
             ),
         )
-        return runner.finalize()
+        return
 
     # Compare perf metrics against baseline (if one exists).
     if perf_result.metrics:
-        _apply_baseline(runner, "check", model, perf_result.metrics, update_baselines)
+        _apply_baseline(runner, tier, model, perf_result.metrics, update_baselines)
 
-    return runner.finalize()
+
+def _filename_safe(name: str) -> str:
+    """Reduce a model name to something safe in a server log filename."""
+    return name.replace("/", "_").replace(" ", "_")
 
 
 def _apply_baseline(

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -96,6 +96,7 @@ def doctor_command(args) -> None:
 # Smoke tier
 # ---------------------------------------------------------------------
 
+
 def run_smoke_tier():
     """Static + import + CLI sanity. No model required."""
     from .checks import smoke
@@ -115,6 +116,7 @@ def run_smoke_tier():
 # ---------------------------------------------------------------------
 # Check tier
 # ---------------------------------------------------------------------
+
 
 def run_check_tier(model: str, update_baselines: bool = False):
     """Boot a server with ``model`` and run API + perf + agent checks."""
@@ -142,6 +144,7 @@ def run_check_tier(model: str, update_baselines: bool = False):
 # ---------------------------------------------------------------------
 # Full tier
 # ---------------------------------------------------------------------
+
 
 def run_full_tier(models: list[str], update_baselines: bool = False):
     """Loop check-tier work across multiple models + run all agent profiles."""
@@ -186,6 +189,7 @@ def _resolve_agent_profiles(explicit: list[str] | None) -> list[str]:
         return explicit
     try:
         from .. import agents
+
         return [p.name for p in agents.list_profiles()]
     except Exception as e:
         print(
@@ -244,7 +248,9 @@ def _run_per_model_block(
     server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
     try:
         with serve(
-            model=model, log_path=server_log, boot_timeout_s=boot_timeout_s,
+            model=model,
+            log_path=server_log,
+            boot_timeout_s=boot_timeout_s,
         ) as info:
             port = info["port"]
             print(f"  [server] {model} up on port {port}, log → {server_log.name}")
@@ -297,6 +303,7 @@ def _run_per_model_block(
 # Benchmark tier
 # ---------------------------------------------------------------------
 
+
 def run_benchmark_tier(models: list[str] | None = None):
     """Cross-model scorecard.  Auto-skips models not present locally.
 
@@ -346,11 +353,7 @@ def run_benchmark_tier(models: list[str] | None = None):
                 skipped.append((alias, f"skipped (no auto-download): {reason}"))
     else:
         run_list = [m.alias for m in discovery.values() if m.available]
-        skipped = [
-            (m.alias, m.reason)
-            for m in discovery.values()
-            if not m.available
-        ]
+        skipped = [(m.alias, m.reason) for m in discovery.values() if not m.available]
 
     if not run_list:
         if skipped:
@@ -358,13 +361,14 @@ def run_benchmark_tier(models: list[str] | None = None):
             for alias, reason in skipped:
                 print(f"    - {alias}: {reason}")
         else:
-            print("\n  no models available locally — pre-fetch with "
-                  "`huggingface-cli download`,")
+            print(
+                "\n  no models available locally — pre-fetch with "
+                "`huggingface-cli download`,"
+            )
             print("  or pass --models <alias>,<alias> to force.")
         skipped_summary = "; ".join(f"{a} ({r})" for a, r in skipped[:5])
-        detail = (
-            f"no runnable models — {len(skipped)} skipped"
-            + (f": {skipped_summary}" if skipped_summary else "")
+        detail = f"no runnable models — {len(skipped)} skipped" + (
+            f": {skipped_summary}" if skipped_summary else ""
         )
         runner.run_check(
             "discovery",
@@ -377,8 +381,10 @@ def run_benchmark_tier(models: list[str] | None = None):
         )
         return runner.finalize()
 
-    print(f"\n  Will benchmark {len(run_list)} model(s); "
-          f"{len(skipped)} skipped (not local)")
+    print(
+        f"\n  Will benchmark {len(run_list)} model(s); "
+        f"{len(skipped)} skipped (not local)"
+    )
 
     cells: list[tuple[str, CheckResult]] = []
     for model in run_list:
@@ -499,7 +505,7 @@ def _apply_baseline(
                 status=Status.SKIP,
                 duration_s=0.0,
                 detail=f"no baseline found for model={model}; "
-                       "run --update-baselines to create",
+                "run --update-baselines to create",
             ),
         )
         return
@@ -542,7 +548,9 @@ def _apply_baseline(
 
     n_regress = sum(1 for d in deltas if d.status == DeltaStatus.REGRESSION)
     n_improve = sum(1 for d in deltas if d.status == DeltaStatus.IMPROVEMENT)
-    detail = f"{len(deltas)} metrics: {n_regress} regression(s), {n_improve} improvement(s)"
+    detail = (
+        f"{len(deltas)} metrics: {n_regress} regression(s), {n_improve} improvement(s)"
+    )
 
     status = Status.REGRESSION if has_regression(deltas) else Status.PASS
     # Include model in check name so multi-model tiers don't collide.

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -256,9 +256,9 @@ def _apply_baseline(
     if update_baselines:
         path = save_baseline(tier, model, metrics)
         runner.run_check(
-            "baseline_update",
+            f"baseline_update[{model}]",
             lambda: CheckResult(
-                name="baseline_update",
+                name=f"baseline_update[{model}]",
                 status=Status.PASS,
                 duration_s=0.0,
                 detail=f"wrote {path.relative_to(REPO_ROOT)}",
@@ -268,12 +268,10 @@ def _apply_baseline(
 
     if baseline is None:
         # First run with no baseline — record what we saw, don't fail.
-        deltas_md = "_no baseline yet — run with --update-baselines to record one_\n"
-        (runner.run_dir / "diff.md").write_text(deltas_md)
         runner.run_check(
-            "baseline_diff",
+            f"baseline_diff[{model}]",
             lambda: CheckResult(
-                name="baseline_diff",
+                name=f"baseline_diff[{model}]",
                 status=Status.SKIP,
                 duration_s=0.0,
                 detail=f"no baseline found for model={model}; "
@@ -287,9 +285,9 @@ def _apply_baseline(
     baseline_model = baseline.get("model")
     if baseline_model and baseline_model != model:
         runner.run_check(
-            "baseline_diff",
+            f"baseline_diff[{model}]",
             lambda: CheckResult(
-                name="baseline_diff",
+                name=f"baseline_diff[{model}]",
                 status=Status.FAIL,
                 duration_s=0.0,
                 detail=(
@@ -302,17 +300,32 @@ def _apply_baseline(
 
     deltas = compare(metrics, baseline, thresholds)
     deltas_md = render_deltas_md(deltas)
-    (runner.run_dir / "diff.md").write_text(deltas_md)
+
+    # In multi-model tiers (full / benchmark), each call would clobber a
+    # shared diff.md and we'd lose all earlier models' delta tables.
+    # Always write per-model files; also append to a combined diff.md
+    # so single-model tiers (check) keep their existing artefact name.
+    per_model_diff = runner.run_dir / f"diff-{_filename_safe(model)}.md"
+    per_model_diff.write_text(deltas_md)
+
+    combined_diff = runner.run_dir / "diff.md"
+    section = f"## {model}\n\n{deltas_md}\n"
+    if combined_diff.exists():
+        with open(combined_diff, "a") as f:
+            f.write(section)
+    else:
+        combined_diff.write_text(section)
 
     n_regress = sum(1 for d in deltas if d.status == DeltaStatus.REGRESSION)
     n_improve = sum(1 for d in deltas if d.status == DeltaStatus.IMPROVEMENT)
     detail = f"{len(deltas)} metrics: {n_regress} regression(s), {n_improve} improvement(s)"
 
     status = Status.REGRESSION if has_regression(deltas) else Status.PASS
+    # Include model in check name so multi-model tiers don't collide.
     runner.run_check(
-        "baseline_diff",
+        f"baseline_diff[{model}]",
         lambda: CheckResult(
-            name="baseline_diff",
+            name=f"baseline_diff[{model}]",
             status=status,
             duration_s=0.0,
             detail=detail,

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -5,11 +5,37 @@ from __future__ import annotations
 
 import sys
 
-from .runner import DoctorRunner
+from .runner import REPO_ROOT, DoctorRunner
+
+
+def _require_source_checkout() -> None:
+    """Doctor depends on tests/ + harness/ + pyproject.toml.
+
+    A pip-installed wheel does not ship those, so the command would
+    immediately produce confusing failures.  Detect that case up front
+    and exit with a clear message instead.
+    """
+    sentinels = [
+        REPO_ROOT / "pyproject.toml",
+        REPO_ROOT / "tests",
+        REPO_ROOT / "harness",
+    ]
+    missing = [str(p.relative_to(REPO_ROOT)) for p in sentinels if not p.exists()]
+    if missing:
+        print(
+            "[doctor] this command requires a source checkout of Rapid-MLX.\n"
+            f"        missing: {', '.join(missing)}\n"
+            "        Clone https://github.com/raullenchai/Rapid-MLX and run "
+            "from the repo root.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def doctor_command(args) -> None:
     """Dispatch to the requested tier."""
+    _require_source_checkout()
+
     tier = getattr(args, "tier", None) or "smoke"
 
     if tier == "smoke":

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import re
 import sys
 
 from .baseline import (
@@ -202,25 +201,20 @@ def _resolve_agent_profiles(explicit: list[str] | None) -> list[str]:
 # Shared per-model block (used by check + full)
 # ---------------------------------------------------------------------
 
-# Boot timeout buckets keyed on the model alias's parameter-count hint.
-# The check tier defaults to qwen3.5-4b (small) which boots in <30s; bumping
-# everything to 600s would steal the tier's fast-fail property. Conversely,
-# 'doctor check --model qwen3.5-35b' is a supported workflow and 27B+ cold
-# loads on a slow disk routinely exceed 180s. Pattern-match the alias for a
-# size hint instead of asking the user to think about timeouts.
-_LARGE_MODEL_RE = re.compile(
-    r"\b(?:[2-9]\d|\d{3,})b\b", re.IGNORECASE,
-)  # matches '20b', '27b', '35b', '70b', '122b', '405b', ...
-
-
-def _suggested_boot_timeout(model: str) -> int:
-    """Pick a boot timeout based on a parameter-count hint in the alias.
-
-    Returns 600s for ≥20B-shaped aliases, 180s otherwise.  Errs on the
-    side of fast-fail: if the regex doesn't match, you get the short
-    timeout (which surfaces broken-server issues faster).
-    """
-    return 600 if _LARGE_MODEL_RE.search(model) else 180
+# Default boot timeout for any model.  600s is generous enough for cold
+# loads of 27B-122B models from a slow external SSD, which is the realistic
+# worst case on a developer Mac.  Server crashes (port-bind failure, missing
+# weights, import error, ...) are detected within <1s by proc.poll() in
+# server._wait_for_health regardless of this value, so the only scenario
+# where 600s actually waits 600s is a genuinely slow legitimate load — at
+# which point we want the long budget.
+#
+# Earlier iterations tried to pick a tier-/alias-aware shorter budget for
+# the small-model case, but every heuristic missed at least one supported
+# large model (Qwen3-Coder lacks a 'NNb' hint in its alias, MiniMax M2.5
+# is huge but named 'minimax-m2.5', etc.).  The optimisation isn't worth
+# the false-fail risk.
+DEFAULT_BOOT_TIMEOUT_S = 600
 
 
 def _run_per_model_block(
@@ -237,15 +231,15 @@ def _run_per_model_block(
     records the failure and moves on, so a single broken model in the
     full sweep still yields a complete report.
 
-    ``boot_timeout_s=None`` (default) auto-picks based on the model's
-    parameter-count hint via _suggested_boot_timeout().  Callers can
-    pass an explicit value to force a specific budget.
+    ``boot_timeout_s`` defaults to ``DEFAULT_BOOT_TIMEOUT_S`` (600s).
+    See the constant's docstring for why a single generous value beats
+    every per-model / per-tier heuristic we tried.
     """
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
 
     if boot_timeout_s is None:
-        boot_timeout_s = _suggested_boot_timeout(model)
+        boot_timeout_s = DEFAULT_BOOT_TIMEOUT_S
 
     server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
     try:

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -7,12 +7,12 @@ import sys
 
 from .baseline import (
     DeltaStatus,
-    _safe_model_slug,
     compare,
     has_regression,
     load_baseline,
     load_thresholds,
     render_deltas_md,
+    safe_model_slug,
     save_baseline,
 )
 from .runner import REPO_ROOT, CheckResult, DoctorRunner, Status
@@ -56,6 +56,18 @@ def doctor_command(args) -> None:
 
     tier = getattr(args, "tier", None) or "smoke"
     update_baselines = getattr(args, "update_baselines", False)
+
+    # --update-baselines only makes sense for tiers that diff against a
+    # baseline.  Warn explicitly when it's used with smoke (no perf
+    # metrics) or benchmark (scorecard, no baseline contract) so users
+    # don't think they recorded something they didn't.
+    if update_baselines and tier in ("smoke", "benchmark"):
+        print(
+            f"[doctor] --update-baselines has no effect for tier '{tier}' "
+            "(only check / full record baselines); ignoring.",
+            file=sys.stderr,
+        )
+        update_baselines = False
 
     if tier == "smoke":
         result = run_smoke_tier()
@@ -160,13 +172,24 @@ def run_full_tier(models: list[str], update_baselines: bool = False):
 
 
 def _resolve_agent_profiles(explicit: list[str] | None) -> list[str]:
-    """Return the list of agent profile names to exercise."""
+    """Return the list of agent profile names to exercise.
+
+    Loud failure on profile-loading errors: silently degrading to
+    ``["generic"]`` made full-tier reports look successful while
+    actually exercising 1/11 of the documented profile coverage.
+    """
     if explicit:
         return explicit
     try:
         from .. import agents
         return [p.name for p in agents.list_profiles()]
-    except Exception:
+    except Exception as e:
+        print(
+            f"[doctor] WARNING: agent profile loading failed "
+            f"({type(e).__name__}: {e}); falling back to 'generic' only. "
+            "Full-tier results will not reflect the documented 11-profile sweep.",
+            file=sys.stderr,
+        )
         return ["generic"]
 
 
@@ -190,9 +213,14 @@ def _run_per_model_block(
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
 
-    server_log = runner.run_dir / f"server-{_safe_model_slug(model)}.log"
+    server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
     try:
-        with serve(model=model, log_path=server_log) as info:
+        # Full tier covers 27B+ models (qwen3.5-35b, gemma-4-26b) whose
+        # cold load can exceed 180s when paging from a slow external
+        # SSD.  Use the same generous budget as the benchmark tier.
+        with serve(
+            model=model, log_path=server_log, boot_timeout_s=600,
+        ) as info:
             port = info["port"]
             print(f"  [server] {model} up on port {port}, log → {server_log.name}")
             runner.run_check(
@@ -235,7 +263,7 @@ def _run_per_model_block(
 
 
 # NOTE: per-model artefact filenames (diff-{model}.md, server-{model}.log)
-# use _safe_model_slug from baseline.py so the mapping is injective —
+# use safe_model_slug from baseline.py so the mapping is injective —
 # a non-injective scheme reintroduces the same overwrite bug per-model
 # diffs were meant to fix.
 
@@ -330,7 +358,7 @@ def run_benchmark_tier(models: list[str] | None = None):
     cells: list[tuple[str, CheckResult]] = []
     for model in run_list:
         print(f"\n  ── model: {model} ──")
-        server_log = runner.run_dir / f"server-{_safe_model_slug(model)}.log"
+        server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
         # Pass the discovered local path so LM Studio / non-HF layouts
         # don't trigger a re-download via mlx_lm.load(alias).
         local_path = (
@@ -429,7 +457,7 @@ def _apply_baseline(
             f"_no baseline yet for model={model} — "
             "run with --update-baselines to record one_\n"
         )
-        per_model_diff = runner.run_dir / f"diff-{_safe_model_slug(model)}.md"
+        per_model_diff = runner.run_dir / f"diff-{safe_model_slug(model)}.md"
         per_model_diff.write_text(notice)
         combined_diff = runner.run_dir / "diff.md"
         section = f"## {model}\n\n{notice}\n"
@@ -476,7 +504,7 @@ def _apply_baseline(
     # shared diff.md and we'd lose all earlier models' delta tables.
     # Always write per-model files; also append to a combined diff.md
     # so single-model tiers (check) keep their existing artefact name.
-    per_model_diff = runner.run_dir / f"diff-{_safe_model_slug(model)}.md"
+    per_model_diff = runner.run_dir / f"diff-{safe_model_slug(model)}.md"
     per_model_diff.write_text(deltas_md)
 
     combined_diff = runner.run_dir / "diff.md"
@@ -503,5 +531,10 @@ def _apply_baseline(
         ),
     )
 
-    # Append delta table to the report so the summary is self-contained.
-    runner.checks[-1].detail += f"\n\n{deltas_md}"
+    # Stash the full delta table on the runner so finalize() can append
+    # it to report.md as a section.  Stuffing it into CheckResult.detail
+    # would only survive in result.json — _render_markdown truncates
+    # long detail strings to 120 chars.
+    if not hasattr(runner, "_pending_diff_sections"):
+        runner._pending_diff_sections = []
+    runner._pending_diff_sections.append((model, deltas_md))

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -7,6 +7,7 @@ import sys
 
 from .baseline import (
     DeltaStatus,
+    _safe_model_slug,
     compare,
     has_regression,
     load_baseline,
@@ -188,7 +189,7 @@ def _run_per_model_block(
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
 
-    server_log = runner.run_dir / f"server-{_filename_safe(model)}.log"
+    server_log = runner.run_dir / f"server-{_safe_model_slug(model)}.log"
     try:
         with serve(model=model, log_path=server_log) as info:
             port = info["port"]
@@ -232,9 +233,10 @@ def _run_per_model_block(
         _apply_baseline(runner, tier, model, perf_result.metrics, update_baselines)
 
 
-def _filename_safe(name: str) -> str:
-    """Reduce a model name to something safe in a server log filename."""
-    return name.replace("/", "_").replace(" ", "_")
+# NOTE: per-model artefact filenames (diff-{model}.md, server-{model}.log)
+# use _safe_model_slug from baseline.py so the mapping is injective —
+# a non-injective scheme reintroduces the same overwrite bug per-model
+# diffs were meant to fix.
 
 
 def _apply_baseline(
@@ -268,6 +270,23 @@ def _apply_baseline(
 
     if baseline is None:
         # First run with no baseline — record what we saw, don't fail.
+        # Still write a diff.md (and per-model variant) so external
+        # automation that always reads run_dir/diff.md gets a stable
+        # artefact, not a missing-file error.
+        notice = (
+            f"_no baseline yet for model={model} — "
+            "run with --update-baselines to record one_\n"
+        )
+        per_model_diff = runner.run_dir / f"diff-{_safe_model_slug(model)}.md"
+        per_model_diff.write_text(notice)
+        combined_diff = runner.run_dir / "diff.md"
+        section = f"## {model}\n\n{notice}\n"
+        if combined_diff.exists():
+            with open(combined_diff, "a") as f:
+                f.write(section)
+        else:
+            combined_diff.write_text(section)
+
         runner.run_check(
             f"baseline_diff[{model}]",
             lambda: CheckResult(
@@ -305,7 +324,7 @@ def _apply_baseline(
     # shared diff.md and we'd lose all earlier models' delta tables.
     # Always write per-model files; also append to a combined diff.md
     # so single-model tiers (check) keep their existing artefact name.
-    per_model_diff = runner.run_dir / f"diff-{_filename_safe(model)}.md"
+    per_model_diff = runner.run_dir / f"diff-{_safe_model_slug(model)}.md"
     per_model_diff.write_text(deltas_md)
 
     combined_diff = runner.run_dir / "diff.md"

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -70,8 +70,9 @@ def doctor_command(args) -> None:
             update_baselines=update_baselines,
         )
     elif tier == "benchmark":
-        print("[doctor] benchmark tier not yet implemented", file=sys.stderr)
-        sys.exit(2)
+        result = run_benchmark_tier(
+            models=getattr(args, "models", None),
+        )
     else:
         print(f"[doctor] unknown tier: {tier}", file=sys.stderr)
         sys.exit(2)
@@ -237,6 +238,111 @@ def _run_per_model_block(
 # use _safe_model_slug from baseline.py so the mapping is injective —
 # a non-injective scheme reintroduces the same overwrite bug per-model
 # diffs were meant to fix.
+
+
+# ---------------------------------------------------------------------
+# Benchmark tier
+# ---------------------------------------------------------------------
+
+def run_benchmark_tier(models: list[str] | None = None):
+    """Cross-model scorecard.  Auto-skips models not present locally.
+
+    For each model:
+      1. Boot a server (Simple engine — broadest compatibility)
+      2. Run autoresearch_bench, capture decode/ttft/tool-call metrics
+      3. Tear down
+
+    Aggregates into harness/scorecard/scorecard-{ts}.md plus a
+    'latest.md' alias.  Designed to be runnable overnight — no agent
+    profile sweep, no baseline diff, just numbers for the table.
+    """
+    from .checks import benchmark, smoke
+    from .discovery import discover_local_models
+    from .scorecard import render_scorecard, write_scorecard
+    from .server import ServerStartFailed, serve
+
+    print("Rapid-MLX Doctor — benchmark tier")
+    print("=" * 60)
+
+    runner = DoctorRunner(tier="benchmark")
+    runner.run_check("repo_layout", smoke.check_repo_layout)
+    runner.run_check("imports", smoke.check_imports)
+
+    # Resolve which models to run.  Without --models, sweep every alias
+    # whose weights are already on disk.  Explicit --models overrides
+    # the auto-skip — caller takes responsibility for downloads.
+    skipped: list[tuple[str, str]] = []
+    if models:
+        run_list = models
+    else:
+        all_models = discover_local_models()
+        run_list = [m.alias for m in all_models if m.available]
+        skipped = [(m.alias, m.reason) for m in all_models if not m.available]
+
+    if not run_list:
+        print("\n  no models available locally — pre-fetch with `huggingface-cli download`,")
+        print("  or pass --models <alias>,<alias> to force.")
+        runner.run_check(
+            "discovery",
+            lambda: CheckResult(
+                name="discovery",
+                status=Status.FAIL,
+                duration_s=0.0,
+                detail="no locally-available aliases found",
+            ),
+        )
+        return runner.finalize()
+
+    print(f"\n  Will benchmark {len(run_list)} model(s); "
+          f"{len(skipped)} skipped (not local)")
+
+    cells: list[tuple[str, CheckResult]] = []
+    for model in run_list:
+        print(f"\n  ── model: {model} ──")
+        server_log = runner.run_dir / f"server-{_safe_model_slug(model)}.log"
+        try:
+            with serve(model=model, log_path=server_log) as info:
+                port = info["port"]
+                print(f"  [server] {model} up on port {port}")
+                result = runner.run_check(
+                    f"bench[{model}]",
+                    lambda port=port, model=model: benchmark.benchmark_one_cell(
+                        model, port, runs=1
+                    ),
+                )
+                cells.append((model, result))
+        except ServerStartFailed as exc:
+            err_msg = f"{exc}\nlog: {server_log}"
+            result = runner.run_check(
+                f"bench[{model}]",
+                lambda err_msg=err_msg, model=model: CheckResult(
+                    name=f"bench[{model}]",
+                    status=Status.FAIL,
+                    duration_s=0.0,
+                    detail=f"server boot failed: {err_msg.splitlines()[0]}",
+                ),
+            )
+            cells.append((model, result))
+        except Exception as exc:  # noqa: BLE001 — never abort the whole sweep
+            result = runner.run_check(
+                f"bench[{model}]",
+                lambda exc=exc, model=model: CheckResult(
+                    name=f"bench[{model}]",
+                    status=Status.FAIL,
+                    duration_s=0.0,
+                    detail=f"unexpected error: {type(exc).__name__}: {exc}",
+                ),
+            )
+            cells.append((model, result))
+
+    # Aggregate scorecard.
+    scorecard_md = render_scorecard(cells, skipped=skipped)
+    scorecard_path = write_scorecard(scorecard_md)
+    # Also drop a copy in the run_dir for self-containment.
+    (runner.run_dir / "scorecard.md").write_text(scorecard_md)
+
+    print(f"\n  Scorecard: {scorecard_path}")
+    return runner.finalize()
 
 
 def _apply_baseline(

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -150,8 +150,13 @@ def _apply_baseline(
     metrics: dict,
     update_baselines: bool,
 ) -> None:
-    """Diff against baseline; flag regressions; optionally update baseline."""
-    baseline = load_baseline(tier)
+    """Diff against baseline; flag regressions; optionally update baseline.
+
+    Baselines are per-model — comparing decode TPS for a 4B and a 35B
+    model is meaningless.  ``--update-baselines`` writes the model-
+    specific file, so each model accumulates its own history.
+    """
+    baseline = load_baseline(tier, model)
     thresholds = load_thresholds()
 
     if update_baselines:
@@ -177,7 +182,26 @@ def _apply_baseline(
                 name="baseline_diff",
                 status=Status.SKIP,
                 duration_s=0.0,
-                detail="no baseline found; run --update-baselines to create",
+                detail=f"no baseline found for model={model}; "
+                       "run --update-baselines to create",
+            ),
+        )
+        return
+
+    # Defence-in-depth: per-model file paths should already prevent this,
+    # but a manually copied/renamed file could mix model identities.
+    baseline_model = baseline.get("model")
+    if baseline_model and baseline_model != model:
+        runner.run_check(
+            "baseline_diff",
+            lambda: CheckResult(
+                name="baseline_diff",
+                status=Status.FAIL,
+                duration_s=0.0,
+                detail=(
+                    f"baseline model mismatch: file has model={baseline_model!r} "
+                    f"but current run is model={model!r}. Refusing to compare."
+                ),
             ),
         )
         return

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -166,6 +166,9 @@ def run_full_tier(models: list[str], update_baselines: bool = False):
             tier="full",
             update_baselines=update_baselines,
             agent_profiles=profile_names,
+            # 27B+ models in the full sweep may need >180s on a slow
+            # disk; check tier (smaller default model) keeps fast-fail.
+            boot_timeout_s=600,
         )
 
     return runner.finalize()
@@ -203,23 +206,26 @@ def _run_per_model_block(
     tier: str,
     update_baselines: bool,
     agent_profiles: list[str],
+    boot_timeout_s: int = 180,
 ) -> None:
     """Boot a server for one model and run all model-bound checks against it.
 
     Failures here do NOT abort the rest of the tier — the runner just
     records the failure and moves on, so a single broken model in the
     full sweep still yields a complete report.
+
+    ``boot_timeout_s`` is per-tier: the check tier passes 180s (small
+    qwen3.5-4b should boot in <30s; we want fast-fail when something
+    breaks), full tier overrides to 600s because it covers 27B+ models
+    whose cold load can exceed 180s when paging from a slow disk.
     """
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
 
     server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
     try:
-        # Full tier covers 27B+ models (qwen3.5-35b, gemma-4-26b) whose
-        # cold load can exceed 180s when paging from a slow external
-        # SSD.  Use the same generous budget as the benchmark tier.
         with serve(
-            model=model, log_path=server_log, boot_timeout_s=600,
+            model=model, log_path=server_log, boot_timeout_s=boot_timeout_s,
         ) as info:
             port = info["port"]
             print(f"  [server] {model} up on port {port}, log → {server_log.name}")

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -257,7 +257,7 @@ def run_benchmark_tier(models: list[str] | None = None):
     profile sweep, no baseline diff, just numbers for the table.
     """
     from .checks import benchmark, smoke
-    from .discovery import discover_local_models
+    from .discovery import discover_local_models, load_aliases
     from .scorecard import render_scorecard, write_scorecard
     from .server import ServerStartFailed, serve
 
@@ -269,26 +269,57 @@ def run_benchmark_tier(models: list[str] | None = None):
     runner.run_check("imports", smoke.check_imports)
 
     # Resolve which models to run.  Without --models, sweep every alias
-    # whose weights are already on disk.  Explicit --models overrides
-    # the auto-skip — caller takes responsibility for downloads.
+    # whose weights are already on disk.  Explicit --models still get
+    # an availability check so a typo doesn't trigger a multi-GB
+    # background download mid-sweep — explicit-but-missing aliases land
+    # in the skipped list with a clear reason instead.
     skipped: list[tuple[str, str]] = []
+    discovery = {m.alias: m for m in discover_local_models()}
+    aliases_set = set(load_aliases())
+
     if models:
-        run_list = models
+        run_list = []
+        for alias in models:
+            if alias not in aliases_set:
+                skipped.append((alias, "unknown alias (not in aliases.json)"))
+            elif alias in discovery and discovery[alias].available:
+                run_list.append(alias)
+            else:
+                reason = (
+                    discovery[alias].reason
+                    if alias in discovery
+                    else "weights not on disk"
+                )
+                skipped.append((alias, f"skipped (no auto-download): {reason}"))
     else:
-        all_models = discover_local_models()
-        run_list = [m.alias for m in all_models if m.available]
-        skipped = [(m.alias, m.reason) for m in all_models if not m.available]
+        run_list = [m.alias for m in discovery.values() if m.available]
+        skipped = [
+            (m.alias, m.reason)
+            for m in discovery.values()
+            if not m.available
+        ]
 
     if not run_list:
-        print("\n  no models available locally — pre-fetch with `huggingface-cli download`,")
-        print("  or pass --models <alias>,<alias> to force.")
+        if skipped:
+            print("\n  No models to benchmark.  Skipped:")
+            for alias, reason in skipped:
+                print(f"    - {alias}: {reason}")
+        else:
+            print("\n  no models available locally — pre-fetch with "
+                  "`huggingface-cli download`,")
+            print("  or pass --models <alias>,<alias> to force.")
+        skipped_summary = "; ".join(f"{a} ({r})" for a, r in skipped[:5])
+        detail = (
+            f"no runnable models — {len(skipped)} skipped"
+            + (f": {skipped_summary}" if skipped_summary else "")
+        )
         runner.run_check(
             "discovery",
             lambda: CheckResult(
                 name="discovery",
                 status=Status.FAIL,
                 duration_s=0.0,
-                detail="no locally-available aliases found",
+                detail=detail,
             ),
         )
         return runner.finalize()

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -65,6 +65,46 @@ def _repo_to_hf_dirname(repo_id: str) -> str:
     return "models--" + repo_id.replace("/", "--")
 
 
+def _is_complete_snapshot(snap: Path) -> bool:
+    """A snapshot is "complete" if it has config.json AND actual model weights.
+
+    Just probing config.json is not enough — partially-downloaded HF
+    snapshots routinely have config.json + model.safetensors.index.json
+    but no *.safetensors shards (the shards are symlinks into ../blobs/
+    that point at non-existent files when the download was aborted).
+    Loading such a snapshot crashes the server with "No safetensors
+    found", which then shows up in the scorecard as a misleading FAIL
+    even though the right diagnosis is "model never finished
+    downloading".
+
+    A weight file counts whether it's a single ``model.safetensors``,
+    sharded ``model-NNNN-of-NNNN.safetensors``, or any other
+    ``.safetensors`` file (some MLX exports use bespoke names).  We
+    additionally resolve symlinks so a dangling link does not satisfy
+    the check.
+    """
+    if not (snap / "config.json").exists():
+        return False
+    for entry in snap.glob("*.safetensors"):
+        try:
+            # resolve(strict=True) raises if the target is missing,
+            # so we can rely on it to detect dangling symlinks too.
+            entry.resolve(strict=True)
+            return True
+        except (OSError, RuntimeError):
+            continue
+    # Some loaders accept .npz or .gguf — be conservative and accept
+    # them too rather than over-report missing weights.
+    for ext in ("*.npz", "*.gguf"):
+        for entry in snap.glob(ext):
+            try:
+                entry.resolve(strict=True)
+                return True
+            except (OSError, RuntimeError):
+                continue
+    return False
+
+
 def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvailability:
     """Look for the model in the candidate cache roots.
 
@@ -75,8 +115,12 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
     The second layout is what LM Studio uses for its model store at
     ``~/.lmstudio/models``; without it, models installed via LM Studio
     were silently invisible to discovery.
+
+    A snapshot directory only counts when it has both config.json and
+    at least one resolvable weight file (see _is_complete_snapshot).
     """
     hf_dirname = _repo_to_hf_dirname(repo_id)
+    saw_partial = False
     for root in cache_roots:
         # 1. Hugging Face hub layout
         hf_candidate = root / hf_dirname
@@ -84,23 +128,31 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
             snapshots = hf_candidate / "snapshots"
             if snapshots.exists():
                 for snap in snapshots.iterdir():
-                    if (snap / "config.json").exists():
+                    if _is_complete_snapshot(snap):
                         return ModelAvailability(
                             alias=alias, repo_id=repo_id,
                             available=True, path=snap,
                         )
+                    elif (snap / "config.json").exists():
+                        saw_partial = True
 
         # 2. LM Studio / HF raw layout — repo_id maps to nested dirs.
         raw_candidate = root.joinpath(*repo_id.split("/"))
-        if (raw_candidate / "config.json").exists():
+        if _is_complete_snapshot(raw_candidate):
             return ModelAvailability(
                 alias=alias, repo_id=repo_id,
                 available=True, path=raw_candidate,
             )
+        elif (raw_candidate / "config.json").exists():
+            saw_partial = True
 
+    reason = (
+        "found config.json but no weight shards — partial download?"
+        if saw_partial
+        else "not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio"
+    )
     return ModelAvailability(
-        alias=alias, repo_id=repo_id, available=False,
-        reason="not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio",
+        alias=alias, repo_id=repo_id, available=False, reason=reason,
     )
 
 

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Detect which model aliases have weights present locally.
+
+The benchmark tier uses this to skip aliases whose weights would
+otherwise trigger a multi-GB download mid-run.  We deliberately don't
+*download* anything — the user is expected to pre-fetch what they want
+benchmarked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from .runner import REPO_ROOT
+
+
+@dataclass
+class ModelAvailability:
+    alias: str
+    repo_id: str
+    available: bool
+    path: Path | None = None
+    reason: str = ""  # only set when available=False
+
+
+def load_aliases() -> dict[str, str]:
+    """Return the alias → repo-id mapping shipped with the package."""
+    aliases_path = REPO_ROOT / "vllm_mlx" / "aliases.json"
+    with open(aliases_path) as f:
+        return json.load(f)
+
+
+def _hf_cache_roots() -> list[Path]:
+    """Return all candidate HF cache directories on this host.
+
+    HF_HUB_CACHE wins (this is what the doctor sets in the spawned
+    server's env).  ~/.cache/huggingface/hub is the standard fallback.
+    LM Studio's cache is also checked because users often have models
+    there from prior LM Studio installs.
+    """
+    roots: list[Path] = []
+    env_cache = os.environ.get("HF_HUB_CACHE")
+    if env_cache:
+        roots.append(Path(env_cache))
+    env_home = os.environ.get("HF_HOME")
+    if env_home:
+        roots.append(Path(env_home) / "hub")
+    roots.append(Path.home() / ".cache" / "huggingface" / "hub")
+    roots.append(Path.home() / ".lmstudio" / "models")
+    # Dedupe while preserving order.
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for r in roots:
+        if r and r not in seen:
+            out.append(r)
+            seen.add(r)
+    return out
+
+
+def _repo_to_hf_dirname(repo_id: str) -> str:
+    """HF cache uses 'models--{org}--{repo}' as the directory name."""
+    return "models--" + repo_id.replace("/", "--")
+
+
+def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvailability:
+    """Look for the model in the candidate cache roots."""
+    target = _repo_to_hf_dirname(repo_id)
+    for root in cache_roots:
+        candidate = root / target
+        if candidate.exists() and any(candidate.iterdir()):
+            # Sanity: at least one snapshot must contain a config.json.
+            snapshots = candidate / "snapshots"
+            if snapshots.exists():
+                for snap in snapshots.iterdir():
+                    if (snap / "config.json").exists():
+                        return ModelAvailability(
+                            alias=alias, repo_id=repo_id,
+                            available=True, path=snap,
+                        )
+            # LM Studio layout: just the model files in a subdir.
+            if (candidate / "config.json").exists():
+                return ModelAvailability(
+                    alias=alias, repo_id=repo_id,
+                    available=True, path=candidate,
+                )
+    return ModelAvailability(
+        alias=alias, repo_id=repo_id, available=False,
+        reason="not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio",
+    )
+
+
+def discover_local_models() -> list[ModelAvailability]:
+    """Return availability info for every alias in aliases.json.
+
+    Sorted: available first (alphabetical), then unavailable.
+    """
+    aliases = load_aliases()
+    cache_roots = _hf_cache_roots()
+    results = [_check_alias(a, r, cache_roots) for a, r in aliases.items()]
+    results.sort(key=lambda m: (not m.available, m.alias))
+    return results
+
+
+def available_aliases() -> list[str]:
+    """Convenience: just the aliases that are present locally."""
+    return [m.alias for m in discover_local_models() if m.available]

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -97,10 +97,15 @@ def _is_complete_snapshot(snap: Path) -> bool:
         try:
             with open(index_path) as f:
                 index = json.load(f)
-            weight_map = index.get("weight_map") or {}
-            shard_names = set(weight_map.values())
         except (OSError, json.JSONDecodeError):
-            shard_names = set()
+            # The index exists but we can't trust it — could be
+            # truncated mid-download, corrupted, or a non-standard
+            # layout we don't understand.  Either way, falling back to
+            # "any one shard counts" would re-introduce the false
+            # positive codex flagged.  Treat as incomplete instead.
+            return False
+        weight_map = index.get("weight_map") or {}
+        shard_names = set(weight_map.values())
         if shard_names:
             for shard in shard_names:
                 target = snap / shard
@@ -109,8 +114,9 @@ def _is_complete_snapshot(snap: Path) -> bool:
                 except (OSError, RuntimeError):
                     return False
             return True
-        # If the index parsed but had no weight_map, fall through and
-        # behave like a single-file model.
+        # Index parsed cleanly but has no weight_map — unusual but
+        # legitimate (some templates ship empty maps).  Fall through to
+        # the single-file glob check.
 
     # 2. Single-file or non-indexed model — at least one weight file resolves.
     for ext in ("*.safetensors", "*.npz", "*.gguf"):

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -66,36 +66,54 @@ def _repo_to_hf_dirname(repo_id: str) -> str:
 
 
 def _is_complete_snapshot(snap: Path) -> bool:
-    """A snapshot is "complete" if it has config.json AND actual model weights.
+    """A snapshot is "complete" if it has config.json AND every weight file resolves.
 
-    Just probing config.json is not enough — partially-downloaded HF
-    snapshots routinely have config.json + model.safetensors.index.json
-    but no *.safetensors shards (the shards are symlinks into ../blobs/
-    that point at non-existent files when the download was aborted).
-    Loading such a snapshot crashes the server with "No safetensors
-    found", which then shows up in the scorecard as a misleading FAIL
-    even though the right diagnosis is "model never finished
-    downloading".
+    Why "every" matters: HF interrupts mid-download can leave a snapshot
+    with config.json, the index file, and *some* shard symlinks (the
+    ones that finished) — but not all.  Loading such a snapshot crashes
+    the server with "No safetensors found" or a torch/mlx-lm error
+    halfway through deserialization, both of which surface in the
+    scorecard as misleading runtime failures rather than the correct
+    "skipped (partial download)" diagnosis.
 
-    A weight file counts whether it's a single ``model.safetensors``,
-    sharded ``model-NNNN-of-NNNN.safetensors``, or any other
-    ``.safetensors`` file (some MLX exports use bespoke names).  We
-    additionally resolve symlinks so a dangling link does not satisfy
-    the check.
+    Strategy:
+
+    1. If ``model.safetensors.index.json`` is present, parse its
+       ``weight_map`` and require every referenced shard to exist
+       (and resolve, in case it's a dangling symlink into ../blobs/).
+    2. Otherwise, require at least one resolvable ``*.safetensors`` /
+       ``*.npz`` / ``*.gguf`` file — a single-file model needs only one,
+       and we shouldn't require an index for those.
+
+    Either way: ``resolve(strict=True)`` is what catches dangling
+    symlinks, which a plain ``.exists()`` check misses on macOS.
     """
     if not (snap / "config.json").exists():
         return False
-    for entry in snap.glob("*.safetensors"):
+
+    # 1. Sharded model — the index lists every shard we need.
+    index_path = snap / "model.safetensors.index.json"
+    if index_path.exists():
         try:
-            # resolve(strict=True) raises if the target is missing,
-            # so we can rely on it to detect dangling symlinks too.
-            entry.resolve(strict=True)
+            with open(index_path) as f:
+                index = json.load(f)
+            weight_map = index.get("weight_map") or {}
+            shard_names = set(weight_map.values())
+        except (OSError, json.JSONDecodeError):
+            shard_names = set()
+        if shard_names:
+            for shard in shard_names:
+                target = snap / shard
+                try:
+                    target.resolve(strict=True)
+                except (OSError, RuntimeError):
+                    return False
             return True
-        except (OSError, RuntimeError):
-            continue
-    # Some loaders accept .npz or .gguf — be conservative and accept
-    # them too rather than over-report missing weights.
-    for ext in ("*.npz", "*.gguf"):
+        # If the index parsed but had no weight_map, fall through and
+        # behave like a single-file model.
+
+    # 2. Single-file or non-indexed model — at least one weight file resolves.
+    for ext in ("*.safetensors", "*.npz", "*.gguf"):
         for entry in snap.glob(ext):
             try:
                 entry.resolve(strict=True)

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -129,7 +129,9 @@ def _is_complete_snapshot(snap: Path) -> bool:
     return False
 
 
-def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvailability:
+def _check_alias(
+    alias: str, repo_id: str, cache_roots: list[Path]
+) -> ModelAvailability:
     """Look for the model in the candidate cache roots.
 
     Two cache layouts are checked at every root:
@@ -154,8 +156,10 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
                 for snap in snapshots.iterdir():
                     if _is_complete_snapshot(snap):
                         return ModelAvailability(
-                            alias=alias, repo_id=repo_id,
-                            available=True, path=snap,
+                            alias=alias,
+                            repo_id=repo_id,
+                            available=True,
+                            path=snap,
                         )
                     elif (snap / "config.json").exists():
                         saw_partial = True
@@ -164,8 +168,10 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
         raw_candidate = root.joinpath(*repo_id.split("/"))
         if _is_complete_snapshot(raw_candidate):
             return ModelAvailability(
-                alias=alias, repo_id=repo_id,
-                available=True, path=raw_candidate,
+                alias=alias,
+                repo_id=repo_id,
+                available=True,
+                path=raw_candidate,
             )
         elif (raw_candidate / "config.json").exists():
             saw_partial = True
@@ -176,7 +182,10 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
         else "not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio"
     )
     return ModelAvailability(
-        alias=alias, repo_id=repo_id, available=False, reason=reason,
+        alias=alias,
+        repo_id=repo_id,
+        available=False,
+        reason=reason,
     )
 
 

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -66,13 +66,22 @@ def _repo_to_hf_dirname(repo_id: str) -> str:
 
 
 def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvailability:
-    """Look for the model in the candidate cache roots."""
-    target = _repo_to_hf_dirname(repo_id)
+    """Look for the model in the candidate cache roots.
+
+    Two cache layouts are checked at every root:
+      - Hugging Face hub:  ``{root}/models--{org}--{repo}/snapshots/<sha>/``
+      - LM Studio (and HF "raw" mode):  ``{root}/{org}/{repo}/``
+
+    The second layout is what LM Studio uses for its model store at
+    ``~/.lmstudio/models``; without it, models installed via LM Studio
+    were silently invisible to discovery.
+    """
+    hf_dirname = _repo_to_hf_dirname(repo_id)
     for root in cache_roots:
-        candidate = root / target
-        if candidate.exists() and any(candidate.iterdir()):
-            # Sanity: at least one snapshot must contain a config.json.
-            snapshots = candidate / "snapshots"
+        # 1. Hugging Face hub layout
+        hf_candidate = root / hf_dirname
+        if hf_candidate.exists():
+            snapshots = hf_candidate / "snapshots"
             if snapshots.exists():
                 for snap in snapshots.iterdir():
                     if (snap / "config.json").exists():
@@ -80,12 +89,15 @@ def _check_alias(alias: str, repo_id: str, cache_roots: list[Path]) -> ModelAvai
                             alias=alias, repo_id=repo_id,
                             available=True, path=snap,
                         )
-            # LM Studio layout: just the model files in a subdir.
-            if (candidate / "config.json").exists():
-                return ModelAvailability(
-                    alias=alias, repo_id=repo_id,
-                    available=True, path=candidate,
-                )
+
+        # 2. LM Studio / HF raw layout — repo_id maps to nested dirs.
+        raw_candidate = root.joinpath(*repo_id.split("/"))
+        if (raw_candidate / "config.json").exists():
+            return ModelAvailability(
+                alias=alias, repo_id=repo_id,
+                available=True, path=raw_candidate,
+            )
+
     return ModelAvailability(
         alias=alias, repo_id=repo_id, available=False,
         reason="not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio",

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Doctor runner — orchestrates check tiers and writes per-run reports.
+
+Each check is a small callable returning ``CheckResult``.  Tiers are just
+ordered lists of checks plus optional model/server requirements.  Keeping
+the framework dumb makes it easy to add new checks: drop a function into
+``checks/`` and append it to a tier.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Repo root resolved relative to this file: vllm_mlx/doctor/runner.py → repo
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_DIR = REPO_ROOT / "harness"
+RUNS_DIR = HARNESS_DIR / "runs"
+
+
+class Status(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+    REGRESSION = "regression"
+
+
+@dataclass
+class CheckResult:
+    """Result of one named check inside a tier."""
+
+    name: str
+    status: Status
+    duration_s: float
+    detail: str = ""
+    metrics: dict = field(default_factory=dict)
+
+
+@dataclass
+class TierResult:
+    """Aggregate result of a single tier run."""
+
+    tier: str
+    started_at: str
+    duration_s: float
+    checks: list[CheckResult]
+    run_dir: str
+    exit_code: int
+
+    @property
+    def passed(self) -> bool:
+        return self.exit_code == 0
+
+
+class DoctorRunner:
+    """Run a tier of checks and persist the report."""
+
+    def __init__(self, tier: str, run_dir: Path | None = None):
+        self.tier = tier
+        self.started = _dt.datetime.now()
+        self.run_dir = run_dir or self._default_run_dir()
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.checks: list[CheckResult] = []
+
+    def _default_run_dir(self) -> Path:
+        ts = self.started.strftime("%Y-%m-%d-%H%M")
+        return RUNS_DIR / f"{ts}-{self.tier}"
+
+    # ------------------------------------------------------------------
+    # Check execution
+    # ------------------------------------------------------------------
+    def run_check(self, name: str, fn: Callable[[], CheckResult]) -> CheckResult:
+        """Execute a single check, capture timing, append to results.
+
+        ``fn`` must construct and return its own CheckResult.  Catching
+        broad ``Exception`` here is intentional: a check that crashes
+        should not abort the entire tier — we record the failure and
+        continue so the user sees the full picture in the report.
+        """
+        print(f"  [{name}]", end=" ", flush=True)
+        t0 = time.perf_counter()
+        try:
+            result = fn()
+        except Exception as e:  # noqa: BLE001 — see docstring above
+            elapsed = time.perf_counter() - t0
+            result = CheckResult(
+                name=name,
+                status=Status.FAIL,
+                duration_s=elapsed,
+                detail=f"check raised: {type(e).__name__}: {e}",
+            )
+            logger.exception("Doctor check %s crashed", name)
+
+        # Sanity: even a passing check should report a positive duration
+        if result.duration_s == 0.0:
+            result.duration_s = time.perf_counter() - t0
+
+        self.checks.append(result)
+        symbol = {
+            Status.PASS: "OK",
+            Status.FAIL: "FAIL",
+            Status.SKIP: "SKIP",
+            Status.REGRESSION: "REGRESSION",
+        }[result.status]
+        print(f"{symbol} ({result.duration_s:.1f}s)")
+        if result.detail and result.status != Status.PASS:
+            for line in result.detail.splitlines():
+                print(f"      {line}")
+        return result
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+    def finalize(self) -> TierResult:
+        """Write the report and return the tier-level aggregate."""
+        elapsed = (_dt.datetime.now() - self.started).total_seconds()
+        exit_code = self._compute_exit_code()
+
+        result = TierResult(
+            tier=self.tier,
+            started_at=self.started.isoformat(timespec="seconds"),
+            duration_s=elapsed,
+            checks=self.checks,
+            run_dir=str(self.run_dir),
+            exit_code=exit_code,
+        )
+
+        # Persist machine-readable + human-readable artefacts.
+        (self.run_dir / "result.json").write_text(
+            json.dumps(asdict(result), indent=2, default=str)
+        )
+        (self.run_dir / "report.md").write_text(self._render_markdown(result))
+
+        self._print_summary(result)
+        return result
+
+    def _compute_exit_code(self) -> int:
+        """0 = all pass, 1 = regression(s), 2 = functional failure(s)."""
+        if any(c.status == Status.FAIL for c in self.checks):
+            return 2
+        if any(c.status == Status.REGRESSION for c in self.checks):
+            return 1
+        return 0
+
+    def _render_markdown(self, result: TierResult) -> str:
+        lines = [
+            f"# Doctor Report — `{result.tier}`",
+            "",
+            f"- Started: {result.started_at}",
+            f"- Duration: {result.duration_s:.1f}s",
+            f"- Exit code: {result.exit_code}",
+            "",
+            "## Checks",
+            "",
+            "| Check | Status | Duration | Detail |",
+            "| --- | --- | --- | --- |",
+        ]
+        for c in result.checks:
+            detail = c.detail.replace("\n", " ").replace("|", "\\|")
+            if len(detail) > 120:
+                detail = detail[:117] + "..."
+            lines.append(
+                f"| {c.name} | {c.status.value} | {c.duration_s:.1f}s | {detail} |"
+            )
+        return "\n".join(lines) + "\n"
+
+    def _print_summary(self, result: TierResult) -> None:
+        n_pass = sum(1 for c in result.checks if c.status == Status.PASS)
+        n_fail = sum(1 for c in result.checks if c.status == Status.FAIL)
+        n_regress = sum(1 for c in result.checks if c.status == Status.REGRESSION)
+        n_skip = sum(1 for c in result.checks if c.status == Status.SKIP)
+
+        print()
+        print("─" * 60)
+        verdict = {0: "PASS", 1: "REGRESSION", 2: "FAIL"}[result.exit_code]
+        print(
+            f"Result: {verdict}  "
+            f"({n_pass} pass, {n_regress} regression, {n_fail} fail, {n_skip} skip)"
+        )
+        print(f"Report: {self.run_dir / 'report.md'}")
+
+
+# ----------------------------------------------------------------------
+# Helpers shared by tier implementations
+# ----------------------------------------------------------------------
+
+def run_subprocess(
+    cmd: list[str],
+    cwd: Path | None = None,
+    timeout: int = 600,
+    env: dict | None = None,
+) -> tuple[int, str, str]:
+    """Thin wrapper around subprocess.run that always captures output.
+
+    Returns ``(returncode, stdout, stderr)``.  On TimeoutExpired we return a
+    sentinel returncode of 124 so callers can treat it uniformly.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 — args are constructed by us
+            cmd,
+            cwd=cwd or REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as e:
+        return 124, e.stdout or "", f"TIMEOUT after {timeout}s\n{e.stderr or ''}"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def python_executable() -> str:
+    """Prefer the same interpreter we are running under, fall back to system python3.12."""
+    if sys.executable and Path(sys.executable).exists():
+        return sys.executable
+    py = shutil.which("python3.12") or shutil.which("python3") or "python"
+    return py

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -219,7 +219,6 @@ class DoctorRunner:
                 lines.append("")
         return "\n".join(lines) + "\n"
 
-
     def _print_summary(self, result: TierResult) -> None:
         n_pass = sum(1 for c in result.checks if c.status == Status.PASS)
         n_fail = sum(1 for c in result.checks if c.status == Status.FAIL)
@@ -255,6 +254,7 @@ def md_cell(s: str, max_len: int = 0) -> str:
 # ----------------------------------------------------------------------
 # Helpers shared by tier implementations
 # ----------------------------------------------------------------------
+
 
 def run_subprocess(
     cmd: list[str],

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -200,13 +200,25 @@ class DoctorRunner:
             "| --- | --- | --- | --- |",
         ]
         for c in result.checks:
-            detail = c.detail.replace("\n", " ").replace("|", "\\|")
-            if len(detail) > 120:
-                detail = detail[:117] + "..."
             lines.append(
-                f"| {c.name} | {c.status.value} | {c.duration_s:.1f}s | {detail} |"
+                f"| {md_cell(c.name)} | {c.status.value} | {c.duration_s:.1f}s | "
+                f"{md_cell(c.detail, max_len=120)} |"
             )
+
+        # Per-model baseline-diff tables (if any) — these are stashed by
+        # _apply_baseline because they're too long to fit in a check's
+        # detail cell.  Render as a separate section so report.md is
+        # self-contained without needing to read diff.md alongside it.
+        diff_sections = getattr(self, "_pending_diff_sections", [])
+        if diff_sections:
+            lines += ["", "## Baseline diffs", ""]
+            for model, deltas_md in diff_sections:
+                lines.append(f"### {model}")
+                lines.append("")
+                lines.append(deltas_md.rstrip())
+                lines.append("")
         return "\n".join(lines) + "\n"
+
 
     def _print_summary(self, result: TierResult) -> None:
         n_pass = sum(1 for c in result.checks if c.status == Status.PASS)
@@ -222,6 +234,22 @@ class DoctorRunner:
             f"({n_pass} pass, {n_regress} regression, {n_fail} fail, {n_skip} skip)"
         )
         print(f"Report: {self.run_dir / 'report.md'}")
+
+
+def md_cell(s: str, max_len: int = 0) -> str:
+    """Sanitise a string for safe inclusion in a markdown table cell.
+
+    Replaces newlines with spaces and escapes ``|`` so the table layout
+    is preserved.  Optionally truncates to ``max_len`` characters with
+    a "..." suffix; ``max_len=0`` (default) leaves the cell uncapped.
+
+    Used by both ``runner.py`` (per-check rows) and ``scorecard.py``
+    (per-model rows) so escaping rules stay consistent.
+    """
+    s = (s or "").replace("\n", " ").replace("|", "\\|")
+    if max_len and len(s) > max_len:
+        s = s[: max_len - 3] + "..."
+    return s
 
 
 # ----------------------------------------------------------------------

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -112,6 +112,11 @@ class DoctorRunner:
         broad ``Exception`` here is intentional: a check that crashes
         should not abort the entire tier — we record the failure and
         continue so the user sees the full picture in the report.
+
+        The caller-supplied ``name`` always wins over ``result.name``.
+        That matters for tiers that run the same check fn multiple
+        times (e.g. full tier across 3 models), where the report would
+        otherwise collapse entries.
         """
         print(f"  [{name}]", end=" ", flush=True)
         t0 = time.perf_counter()
@@ -126,6 +131,9 @@ class DoctorRunner:
                 detail=f"check raised: {type(e).__name__}: {e}",
             )
             logger.exception("Doctor check %s crashed", name)
+
+        # Caller's name wins — see docstring.
+        result.name = name
 
         # Sanity: even a passing check should report a positive duration
         if result.duration_s == 0.0:

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -70,13 +70,29 @@ class DoctorRunner:
     def __init__(self, tier: str, run_dir: Path | None = None):
         self.tier = tier
         self.started = _dt.datetime.now()
-        self.run_dir = run_dir or self._default_run_dir()
+        self.run_dir = run_dir or self._unique_run_dir()
         self.run_dir.mkdir(parents=True, exist_ok=True)
         self.checks: list[CheckResult] = []
 
-    def _default_run_dir(self) -> Path:
-        ts = self.started.strftime("%Y-%m-%d-%H%M")
-        return RUNS_DIR / f"{ts}-{self.tier}"
+    def _unique_run_dir(self) -> Path:
+        """Pick a run directory that does not collide with an existing one.
+
+        Uses second precision plus a numeric suffix on collision so back-
+        to-back invocations of the same tier never overwrite each other's
+        artefacts (which would defeat the purpose of a regression log).
+        """
+        ts = self.started.strftime("%Y-%m-%d-%H%M%S")
+        base = RUNS_DIR / f"{ts}-{self.tier}"
+        if not base.exists():
+            return base
+        # Highly unlikely (sub-second double-invocation) but cover it.
+        for i in range(1, 100):
+            candidate = RUNS_DIR / f"{ts}-{self.tier}-{i}"
+            if not candidate.exists():
+                return candidate
+        # Past 100 collisions, fall back to a microsecond-stamped dir
+        # rather than silently overwriting.
+        return RUNS_DIR / f"{ts}-{self.tier}-{self.started.microsecond}"
 
     # ------------------------------------------------------------------
     # Check execution

--- a/vllm_mlx/doctor/runner.py
+++ b/vllm_mlx/doctor/runner.py
@@ -70,29 +70,37 @@ class DoctorRunner:
     def __init__(self, tier: str, run_dir: Path | None = None):
         self.tier = tier
         self.started = _dt.datetime.now()
-        self.run_dir = run_dir or self._unique_run_dir()
-        self.run_dir.mkdir(parents=True, exist_ok=True)
+        if run_dir is None:
+            self.run_dir = self._reserve_run_dir()
+        else:
+            self.run_dir = run_dir
+            self.run_dir.mkdir(parents=True, exist_ok=True)
         self.checks: list[CheckResult] = []
 
-    def _unique_run_dir(self) -> Path:
-        """Pick a run directory that does not collide with an existing one.
+    def _reserve_run_dir(self) -> Path:
+        """Atomically create and return a unique run directory.
 
-        Uses second precision plus a numeric suffix on collision so back-
-        to-back invocations of the same tier never overwrite each other's
-        artefacts (which would defeat the purpose of a regression log).
+        Uses ``mkdir(exist_ok=False)`` so concurrent same-second invocations
+        race on the filesystem — the loser gets ``FileExistsError`` and tries
+        the next suffix.  This is the only way to be safe against multiple
+        tiers launched in parallel (CI matrix, user kicking off two tiers
+        in two terminals, etc.).
         """
+        RUNS_DIR.mkdir(parents=True, exist_ok=True)
         ts = self.started.strftime("%Y-%m-%d-%H%M%S")
-        base = RUNS_DIR / f"{ts}-{self.tier}"
-        if not base.exists():
-            return base
-        # Highly unlikely (sub-second double-invocation) but cover it.
-        for i in range(1, 100):
-            candidate = RUNS_DIR / f"{ts}-{self.tier}-{i}"
-            if not candidate.exists():
+        for i in range(0, 1000):
+            suffix = "" if i == 0 else f"-{i}"
+            candidate = RUNS_DIR / f"{ts}-{self.tier}{suffix}"
+            try:
+                candidate.mkdir(parents=False, exist_ok=False)
                 return candidate
-        # Past 100 collisions, fall back to a microsecond-stamped dir
-        # rather than silently overwriting.
-        return RUNS_DIR / f"{ts}-{self.tier}-{self.started.microsecond}"
+            except FileExistsError:
+                continue
+        # Practically unreachable — 1000 collisions in one second.
+        raise RuntimeError(
+            f"Could not reserve a unique run directory under {RUNS_DIR} "
+            f"after 1000 attempts at {ts}"
+        )
 
     # ------------------------------------------------------------------
     # Check execution

--- a/vllm_mlx/doctor/scorecard.py
+++ b/vllm_mlx/doctor/scorecard.py
@@ -61,7 +61,9 @@ def render_scorecard(
             # is still useful at a glance.
             reason = (result.detail or "fail").splitlines()[0][:80]
             status_md = f"FAIL — {md_cell(reason)}"
-        lines.append(f"| {md_cell(model)} | " + " | ".join(cells_md) + f" | {status_md} |")
+        lines.append(
+            f"| {md_cell(model)} | " + " | ".join(cells_md) + f" | {status_md} |"
+        )
 
     if skipped:
         lines += ["", "## Skipped", ""]

--- a/vllm_mlx/doctor/scorecard.py
+++ b/vllm_mlx/doctor/scorecard.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scorecard rendering for the benchmark tier.
+
+Aggregates per-cell ``CheckResult.metrics`` dicts into a single markdown
+table.  Output goes to ``harness/scorecard/scorecard-{ts}.md`` and a
+"latest" symlink so callers can always find the most recent one.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+from .runner import HARNESS_DIR, CheckResult, Status
+
+SCORECARD_DIR = HARNESS_DIR / "scorecard"
+
+# Columns rendered in the scorecard.  Keep the list short — wide tables
+# are unreadable in markdown.  Ordered by importance.
+SCORECARD_COLUMNS: list[tuple[str, str, str]] = [
+    # (metric_key, header, format)
+    ("decode_tps", "Decode TPS", "{:.1f}"),
+    ("cold_ttft_ms", "Cold TTFT", "{:.0f}ms"),
+    ("cached_ttft_ms", "Cached TTFT", "{:.0f}ms"),
+    ("tc_success_rate", "Tool %", "{:.0%}"),
+    ("composite_score", "Score", "{:.1f}"),
+]
+
+
+def render_scorecard(
+    cells: list[tuple[str, CheckResult]],
+    skipped: list[tuple[str, str]] | None = None,
+    title: str = "Rapid-MLX Benchmark Scorecard",
+) -> str:
+    """Render a markdown scorecard.
+
+    Args:
+        cells: list of (model, CheckResult) for each benchmarked combo.
+        skipped: list of (model, reason) for combos that didn't run.
+        title: H1 heading.
+    """
+    lines: list[str] = [
+        f"# {title}",
+        "",
+        f"_Generated: {_dt.datetime.now().isoformat(timespec='seconds')}_",
+        "",
+        "| Model | " + " | ".join(h for _, h, _ in SCORECARD_COLUMNS) + " | Status |",
+        "| --- | " + " | ".join("---:" for _ in SCORECARD_COLUMNS) + " | --- |",
+    ]
+
+    for model, result in cells:
+        if result.status == Status.PASS and result.metrics:
+            cells_md = []
+            for key, _h, fmt in SCORECARD_COLUMNS:
+                val = result.metrics.get(key)
+                cells_md.append(fmt.format(val) if val is not None else "—")
+            status_md = "OK"
+        else:
+            cells_md = ["—"] * len(SCORECARD_COLUMNS)
+            # Fold the failure reason into the status cell so the row
+            # is still useful at a glance.
+            reason = (result.detail or "fail").splitlines()[0][:80]
+            status_md = f"FAIL — {reason}"
+        lines.append(f"| {model} | " + " | ".join(cells_md) + f" | {status_md} |")
+
+    if skipped:
+        lines += ["", "## Skipped", ""]
+        for model, reason in skipped:
+            lines.append(f"- **{model}** — {reason}")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_scorecard(content: str) -> Path:
+    """Write the scorecard markdown to disk + update 'latest.md' alias.
+
+    Returns the timestamped path.  ``latest.md`` is a regular file
+    rather than a symlink so it stays valid on filesystems that
+    disallow symlinks (Windows by default, some shared mounts).
+    """
+    SCORECARD_DIR.mkdir(parents=True, exist_ok=True)
+    ts = _dt.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    path = SCORECARD_DIR / f"scorecard-{ts}.md"
+    path.write_text(content)
+    (SCORECARD_DIR / "latest.md").write_text(content)
+    return path

--- a/vllm_mlx/doctor/scorecard.py
+++ b/vllm_mlx/doctor/scorecard.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import datetime as _dt
 from pathlib import Path
 
-from .runner import HARNESS_DIR, CheckResult, Status
+from .runner import HARNESS_DIR, CheckResult, Status, md_cell
 
 SCORECARD_DIR = HARNESS_DIR / "scorecard"
 
@@ -60,8 +60,8 @@ def render_scorecard(
             # Fold the failure reason into the status cell so the row
             # is still useful at a glance.
             reason = (result.detail or "fail").splitlines()[0][:80]
-            status_md = f"FAIL — {reason}"
-        lines.append(f"| {model} | " + " | ".join(cells_md) + f" | {status_md} |")
+            status_md = f"FAIL — {md_cell(reason)}"
+        lines.append(f"| {md_cell(model)} | " + " | ".join(cells_md) + f" | {status_md} |")
 
     if skipped:
         lines += ["", "## Skipped", ""]

--- a/vllm_mlx/doctor/server.py
+++ b/vllm_mlx/doctor/server.py
@@ -45,8 +45,18 @@ def serve(
     log_path: Path | None = None,
     extra_args: list[str] | None = None,
     boot_timeout_s: int = 180,
+    model_path: str | Path | None = None,
 ):
     """Boot ``rapid-mlx serve <model>`` and yield the live base URL.
+
+    Args:
+        model: alias or HF repo id used for logging/display.
+        model_path: optional local path to use *instead* of resolving
+            the alias.  When provided, the server loads from this exact
+            location and never reaches Hugging Face.  This honors the
+            benchmark tier's "no auto-download" contract for models
+            installed in non-HF layouts (e.g. LM Studio's
+            ~/.lmstudio/models/{org}/{repo}/).
 
     On exit, send SIGTERM and wait up to 10s; escalate to SIGKILL if the
     process is still alive.  ``log_path`` if provided receives the
@@ -59,9 +69,13 @@ def serve(
     health_url = f"{base_url}/health"
     v1_url = f"{base_url}/v1"
 
+    # serve_target is what we pass to the CLI: the explicit local path
+    # takes precedence over the alias so the server never tries to
+    # download a model that discovery confirmed is on disk.
+    serve_target = str(model_path) if model_path else model
     cmd = [
         python_executable(),
-        "-m", "vllm_mlx.cli", "serve", model,
+        "-m", "vllm_mlx.cli", "serve", serve_target,
         "--host", "127.0.0.1",
         "--port", str(port),
     ]

--- a/vllm_mlx/doctor/server.py
+++ b/vllm_mlx/doctor/server.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subprocess lifecycle helper for ``rapid-mlx serve`` during doctor runs.
+
+Used by check / full / benchmark tiers.  Boots a server on a non-default
+port (so it doesn't collide with the user's own running server), polls
+``/health`` until ready, and guarantees teardown via context manager.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from .runner import REPO_ROOT, python_executable
+
+
+class ServerStartFailed(RuntimeError):  # noqa: N818 — domain-specific error name
+    """Server did not become healthy within the timeout."""
+
+
+def find_free_port() -> int:
+    """Pick a free TCP port on localhost.
+
+    We bind ephemeral=0 to let the OS allocate, then close immediately.
+    There is a tiny race between close and the server reusing the port,
+    but it's small enough not to matter for a single-host harness.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def serve(
+    model: str,
+    port: int | None = None,
+    log_path: Path | None = None,
+    extra_args: list[str] | None = None,
+    boot_timeout_s: int = 180,
+):
+    """Boot ``rapid-mlx serve <model>`` and yield the live base URL.
+
+    On exit, send SIGTERM and wait up to 10s; escalate to SIGKILL if the
+    process is still alive.  ``log_path`` if provided receives the
+    server's combined stdout/stderr — useful for post-mortem after a
+    failed boot.
+    """
+    if port is None:
+        port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    health_url = f"{base_url}/health"
+    v1_url = f"{base_url}/v1"
+
+    cmd = [
+        python_executable(),
+        "-m", "vllm_mlx.cli", "serve", model,
+        "--host", "127.0.0.1",
+        "--port", str(port),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    log_fh = open(log_path, "w") if log_path else subprocess.DEVNULL
+    proc = subprocess.Popen(  # noqa: S603 — args constructed by us
+        cmd,
+        cwd=REPO_ROOT,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+        # New process group so we can signal the whole tree on teardown
+        # (uvicorn + worker children).  POSIX-only; we don't run on win.
+        preexec_fn=os.setsid if sys.platform != "win32" else None,
+    )
+
+    try:
+        _wait_for_health(health_url, proc, boot_timeout_s)
+        yield {"base_url": v1_url, "health_url": health_url, "port": port}
+    finally:
+        _terminate(proc)
+        if log_fh is not subprocess.DEVNULL:
+            log_fh.close()
+
+
+def _wait_for_health(health_url: str, proc: subprocess.Popen, timeout_s: int) -> None:
+    """Poll /health until 200 or timeout.  Abort early if the process dies."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise ServerStartFailed(
+                f"server exited with code {proc.returncode} before becoming healthy"
+            )
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+            # Server still booting — keep polling.
+            time.sleep(0.5)
+    raise ServerStartFailed(
+        f"server did not respond at {health_url} within {timeout_s}s"
+    )
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Best-effort clean teardown of a server process group."""
+    if proc.poll() is not None:
+        return
+    try:
+        # Signal the whole process group (children too).
+        if sys.platform != "win32":
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        # Escalate.
+        try:
+            if sys.platform != "win32":
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+            proc.wait(timeout=5)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            pass
+    except (ProcessLookupError, PermissionError):
+        # Process already gone or can't be signalled — nothing to do.
+        pass

--- a/vllm_mlx/doctor/server.py
+++ b/vllm_mlx/doctor/server.py
@@ -75,9 +75,14 @@ def serve(
     serve_target = str(model_path) if model_path else model
     cmd = [
         python_executable(),
-        "-m", "vllm_mlx.cli", "serve", serve_target,
-        "--host", "127.0.0.1",
-        "--port", str(port),
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        serve_target,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
     ]
     if extra_args:
         cmd.extend(extra_args)

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -71,13 +71,16 @@ class BaseEngine(ABC):
     def preserve_native_tool_format(self, value: bool) -> None:
         self._preserve_native_tool_format = value
 
-    def generate_warmup(self) -> None:
+    def generate_warmup(self) -> None:  # noqa: B027 — intentional no-op default
         """Run a minimal generation to compile Metal shaders.
 
         This prevents the first real request from hanging for minutes
         while shaders compile on-demand.
+
+        The default is a no-op; engines that benefit from warmup
+        (SimpleEngine, BatchedEngine) override this.
         """
-        pass  # Subclasses may override
+        pass
 
     @abstractmethod
     async def start(self) -> None:

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -548,8 +548,11 @@ class SimpleEngine(BaseEngine):
                     finish_reason=last_chunk.finish_reason or "stop",
                 )
             return GenerationOutput(
-                text="", tokens=[], prompt_tokens=0,
-                completion_tokens=0, finish_reason="stop",
+                text="",
+                tokens=[],
+                prompt_tokens=0,
+                completion_tokens=0,
+                finish_reason="stop",
             )
 
         async with self._generation_lock:
@@ -757,7 +760,8 @@ class SimpleEngine(BaseEngine):
                             logger.warning(
                                 "MLLM stream_chat error after %d tokens "
                                 "(likely post-generation cleanup): %s",
-                                token_count, e,
+                                token_count,
+                                e,
                             )
                             break
                         raise

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -182,7 +182,9 @@ class EngineCore:
                 "max_recommended_working_set_size",
                 _device_info.get("memory_size", 0),
             )
-            _device_mem = _max_recommended if _max_recommended > 0 else 200 * 1024 * 1024 * 1024
+            _device_mem = (
+                _max_recommended if _max_recommended > 0 else 200 * 1024 * 1024 * 1024
+            )
             _memory_pressure_threshold = int(
                 _device_mem * min(_gpu_mem_util + 0.05, 0.99)
             )

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -557,7 +557,11 @@ class MemoryAwarePrefixCache:
             excess = n_cached - n_requested
 
             has_non_trimmable = any(
-                not (lc.is_trimmable() if hasattr(lc, "is_trimmable") else hasattr(lc, "trim"))
+                not (
+                    lc.is_trimmable()
+                    if hasattr(lc, "is_trimmable")
+                    else hasattr(lc, "trim")
+                )
                 for lc in best_super.cache
             )
 
@@ -638,7 +642,11 @@ class MemoryAwarePrefixCache:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
             has_non_trimmable = any(
-                not (lc.is_trimmable() if hasattr(lc, "is_trimmable") else hasattr(lc, "trim"))
+                not (
+                    lc.is_trimmable()
+                    if hasattr(lc, "is_trimmable")
+                    else hasattr(lc, "trim")
+                )
                 for lc in best_lcp_entry.cache
             )
             logger.debug(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -538,7 +538,7 @@ class MLLMScheduler:
                         prev_text = tokenizer.decode(request.output_tokens[:-1])
                         trimmed_total = decoded_so_far[:idx]
                         if len(trimmed_total) > len(prev_text):
-                            output.new_text = trimmed_total[len(prev_text):]
+                            output.new_text = trimmed_total[len(prev_text) :]
                         else:
                             output.new_text = ""
                         break

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -23,85 +23,133 @@ class ModelConfig:
 # Order matters: first match wins. More specific patterns go first.
 _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # DeepSeek V3.1 / R1-0528 — dedicated parser, before generic deepseek
-    (re.compile(r"deepseek.*(v3\.1|r1[-_]?0528)", re.IGNORECASE), ModelConfig(
-        tool_call_parser="deepseek_v31",
-        reasoning_parser="deepseek_r1",
-    )),
+    (
+        re.compile(r"deepseek.*(v3\.1|r1[-_]?0528)", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="deepseek_v31",
+            reasoning_parser="deepseek_r1",
+        ),
+    ),
     # DeepSeek R1 (non-0528) — has reasoning
-    (re.compile(r"deepseek.*r1", re.IGNORECASE), ModelConfig(
-        tool_call_parser="deepseek",
-        reasoning_parser="deepseek_r1",
-    )),
+    (
+        re.compile(r"deepseek.*r1", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="deepseek",
+            reasoning_parser="deepseek_r1",
+        ),
+    ),
     # DeepSeek (V3, V2.5, etc.) — no reasoning parser
-    (re.compile(r"deepseek", re.IGNORECASE), ModelConfig(
-        tool_call_parser="deepseek",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"deepseek", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="deepseek",
+            reasoning_parser=None,
+        ),
+    ),
     # Qwopus (Qwen3.5 distilled with Claude Opus reasoning)
-    (re.compile(r"qwopus", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser="qwen3",
-    )),
+    (
+        re.compile(r"qwopus", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+        ),
+    ),
     # Qwen3-Coder — before generic Qwen3 (non-thinking, no reasoning parser)
-    (re.compile(r"qwen3[-_]?coder", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"qwen3[-_]?coder", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
     # Qwen family (Qwen3, Qwen3.5)
-    (re.compile(r"qwen3", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser="qwen3",
-    )),
+    (
+        re.compile(r"qwen3", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+        ),
+    ),
     # GLM family (GLM-4.5, GLM-4.7)
-    (re.compile(r"glm[-_]?4", re.IGNORECASE), ModelConfig(
-        tool_call_parser="glm47",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"glm[-_]?4", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="glm47",
+            reasoning_parser=None,
+        ),
+    ),
     # MiniMax M2.5
-    (re.compile(r"minimax", re.IGNORECASE), ModelConfig(
-        tool_call_parser="minimax",
-        reasoning_parser="minimax",
-    )),
+    (
+        re.compile(r"minimax", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="minimax",
+            reasoning_parser="minimax",
+        ),
+    ),
     # GPT-OSS
-    (re.compile(r"gpt[-_]?oss", re.IGNORECASE), ModelConfig(
-        tool_call_parser="harmony",
-        reasoning_parser="harmony",
-    )),
+    (
+        re.compile(r"gpt[-_]?oss", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="harmony",
+            reasoning_parser="harmony",
+        ),
+    ),
     # Kimi
-    (re.compile(r"kimi", re.IGNORECASE), ModelConfig(
-        tool_call_parser="kimi",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"kimi", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="kimi",
+            reasoning_parser=None,
+        ),
+    ),
     # Mistral / Devstral
-    (re.compile(r"mistral|devstral", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"mistral|devstral", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
     # Gemma 4 (native tool format)
-    (re.compile(r"gemma[-_]?4", re.IGNORECASE), ModelConfig(
-        tool_call_parser="gemma4",
-        reasoning_parser="gemma4",
-    )),
+    (
+        re.compile(r"gemma[-_]?4", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="gemma4",
+            reasoning_parser="gemma4",
+        ),
+    ),
     # Gemma 2/3 (hermes format)
-    (re.compile(r"gemma", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"gemma", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
     # Hermes (fine-tuned Llama etc.)
-    (re.compile(r"hermes", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"hermes", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
     # Llama
-    (re.compile(r"llama", re.IGNORECASE), ModelConfig(
-        tool_call_parser="llama",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"llama", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="llama",
+            reasoning_parser=None,
+        ),
+    ),
     # Phi
-    (re.compile(r"phi[-_]?[34]", re.IGNORECASE), ModelConfig(
-        tool_call_parser="hermes",
-        reasoning_parser=None,
-    )),
+    (
+        re.compile(r"phi[-_]?[34]", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
 ]
 
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -33,6 +33,7 @@ def is_gemma4_model(model_path: str | Path) -> bool:
         # Try HF cache
         try:
             from huggingface_hub import snapshot_download
+
             p = Path(snapshot_download(str(model_path)))
             config_path = p / "config.json"
         except Exception:
@@ -75,13 +76,15 @@ class Gemma4TextWrapper(nn.Module):
             new_key = k
             # Strip top-level "model." wrapper
             if new_key.startswith("model."):
-                new_key = new_key[len("model."):]
+                new_key = new_key[len("model.") :]
             # Strip "language_model." to get bare model weights,
             # then re-add "language_model." for our wrapper structure
             if new_key.startswith("language_model."):
                 pass  # keep as-is — our wrapper has .language_model attribute
-            elif not any(new_key.startswith(p) for p in
-                         ["vision_tower", "audio_tower", "embed_vision", "embed_audio"]):
+            elif not any(
+                new_key.startswith(p)
+                for p in ["vision_tower", "audio_tower", "embed_vision", "embed_audio"]
+            ):
                 new_key = "language_model." + new_key
             else:
                 continue  # skip vision/audio weights
@@ -89,7 +92,10 @@ class Gemma4TextWrapper(nn.Module):
             if "rotary_emb" in new_key:
                 continue
             # Skip clipping params (vision-only)
-            if any(s in new_key for s in ["input_max", "input_min", "output_max", "output_min"]):
+            if any(
+                s in new_key
+                for s in ["input_max", "input_min", "output_max", "output_min"]
+            ):
                 continue
             sanitized[new_key] = v
         return sanitized
@@ -121,6 +127,7 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     p = Path(model_path)
     if not p.is_dir():
         from huggingface_hub import snapshot_download
+
         p = Path(snapshot_download(str(model_path)))
 
     config = json.loads((p / "config.json").read_text())
@@ -148,14 +155,16 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
         for k, v in quant_config.items():
             if isinstance(v, dict) and "bits" in v:
                 overrides[k] = {
-                    kk: vv for kk, vv in v.items()
+                    kk: vv
+                    for kk, vv in v.items()
                     if kk in ("bits", "group_size", "mode")
                 }
 
         if overrides:
             logger.info(
                 "[gemma4] Mixed quantization: %d-bit default, %d overrides (8-bit MLP)",
-                default_bits, len(overrides),
+                default_bits,
+                len(overrides),
             )
 
             def _class_predicate(path, module):
@@ -173,13 +182,16 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
 
             nn.quantize(model, class_predicate=_class_predicate)
         else:
-            logger.info("[gemma4] Applying %d-bit quantization (group_size=%d)", default_bits, default_gs)
+            logger.info(
+                "[gemma4] Applying %d-bit quantization (group_size=%d)",
+                default_bits,
+                default_gs,
+            )
             nn.quantize(model, bits=default_bits, group_size=default_gs)
 
     # Load weights
     weight_files = sorted(
-        f for f in p.glob("*.safetensors")
-        if not f.name.startswith("._")
+        f for f in p.glob("*.safetensors") if not f.name.startswith("._")
     )
     if not weight_files:
         raise FileNotFoundError(f"No .safetensors files in {p}")
@@ -194,12 +206,16 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     # Verify weights loaded
     test_param = model.language_model.model.embed_tokens
     if hasattr(test_param, "scales") and mx.all(test_param.scales == 0).item():
-        logger.warning("[gemma4] Embedding scales are zero — quantized model may have issues")
+        logger.warning(
+            "[gemma4] Embedding scales are zero — quantized model may have issues"
+        )
 
     # Load tokenizer
     tokenizer_config = tokenizer_config or {}
     eos_token_ids = config.get("eos_token_id", text_config.get("eos_token_id"))
     tokenizer = load_tokenizer(p, tokenizer_config, eos_token_ids=eos_token_ids)
 
-    logger.info("[gemma4] Loaded text-only model via LLM path (%d layers)", len(model.layers))
+    logger.info(
+        "[gemma4] Loaded text-only model via LLM path (%d layers)", len(model.layers)
+    )
     return model, tokenizer

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -35,7 +35,9 @@ class StreamingOutput:
     token: int
     finished: bool = False
     finish_reason: str | None = None
-    channel: str | None = None  # "content", "reasoning", "tool_call", or None (unrouted)
+    channel: str | None = (
+        None  # "content", "reasoning", "tool_call", or None (unrouted)
+    )
     logprobs: Any = None  # mx.array of shape [vocab_size] from mlx-lm
     prompt_tokens: int = 0
 
@@ -104,7 +106,7 @@ class MLXLanguageModel:
 
         # DeltaNet/hybrid cache snapshot for prefix reuse
         self._rnn_state_snapshot: list | None = None  # deep-copied ArraysCache states
-        self._snapshot_prefix_ids: list[int] = []     # token IDs at snapshot time
+        self._snapshot_prefix_ids: list[int] = []  # token IDs at snapshot time
         self._main_cache_len: int = 0  # number of main model cache layers (excl. draft)
 
     def load(self) -> None:
@@ -284,12 +286,16 @@ class MLXLanguageModel:
             if not c.is_trimmable():
                 snapshot.append(copy.deepcopy(c))
             else:
-                snapshot.append(None)  # placeholder — KVCache is trimmed, not snapshotted
+                snapshot.append(
+                    None
+                )  # placeholder — KVCache is trimmed, not snapshotted
         self._rnn_state_snapshot = snapshot
         self._snapshot_prefix_ids = list(prefix_ids)
         logger.info(f"Saved RNN state snapshot for {len(prefix_ids)} token prefix")
 
-    def _prefill_and_snapshot(self, prompt_token_ids: list[int], prefix_len: int) -> list[int]:
+    def _prefill_and_snapshot(
+        self, prompt_token_ids: list[int], prefix_len: int
+    ) -> list[int]:
         """Create fresh cache, prefill the common prefix, snapshot, return suffix.
 
         For hybrid caches (Qwen3.5), this enables prefix reuse across requests
@@ -692,7 +698,9 @@ class MLXLanguageModel:
                     try:
                         event = self._output_router.feed(token_id)
                     except Exception as router_err:
-                        logger.warning("OutputRouter.feed failed (%s), disabling", router_err)
+                        logger.warning(
+                            "OutputRouter.feed failed (%s), disabling", router_err
+                        )
                         self._output_router = None
                         event = None
                     if self._output_router and event is None:
@@ -729,7 +737,9 @@ class MLXLanguageModel:
                         idx = accumulated_text.find(stop_seq)
                         if idx != -1:
                             should_stop = True
-                            stop_truncate_text = new_text[: len(new_text) - (len(accumulated_text) - idx)]
+                            stop_truncate_text = new_text[
+                                : len(new_text) - (len(accumulated_text) - idx)
+                            ]
                             accumulated_text = accumulated_text[:idx]
                             break
 
@@ -749,7 +759,9 @@ class MLXLanguageModel:
                     cache_saved = True
 
                 yield StreamingOutput(
-                    text=stop_truncate_text if stop_truncate_text is not None else new_text,
+                    text=stop_truncate_text
+                    if stop_truncate_text is not None
+                    else new_text,
                     token=response.token if hasattr(response, "token") else 0,
                     finished=finished,
                     finish_reason=finish_reason,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1927,12 +1927,16 @@ class MLXMultimodalLM:
                 # Use the generation engine's prompt_tokens count which includes
                 # expanded image/video tokens. Plain text tokenization undercounts
                 # for multimodal prompts and would truncate the KV cache.
-                prompt_tokens_count = getattr(chunk, "prompt_tokens", 0) if "chunk" in dir() else 0
+                prompt_tokens_count = (
+                    getattr(chunk, "prompt_tokens", 0) if "chunk" in dir() else 0
+                )
                 if prompt_tokens_count <= 0:
                     # Zero-token streams have no reliable prompt length —
                     # skip cache storage to avoid truncating KV with a
                     # text-only token count that undercounts multimodal prompts.
-                    raise ValueError("No prompt_tokens from generation, skipping cache store")
+                    raise ValueError(
+                        "No prompt_tokens from generation, skipping cache store"
+                    )
                 token_ids = self.processor.tokenizer.encode(formatted_prompt)
 
                 cache_to_store = []

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -29,7 +29,7 @@ their token mappings in MODEL_TOKEN_MAPS.
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any
 

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 class Channel(Enum):
     """Output channel for a token."""
+
     CONTENT = auto()
     REASONING = auto()
     TOOL_CALL = auto()
@@ -47,6 +48,7 @@ class Channel(Enum):
 @dataclass
 class RouterEvent:
     """A single routed token."""
+
     channel: Channel
     token_id: int
     text: str  # decoded text for this token
@@ -55,29 +57,30 @@ class RouterEvent:
 @dataclass
 class TokenMap:
     """Special token ID mappings for a model family."""
+
     # Channel control (Gemma 4 style)
-    channel_start: int | None = None      # <|channel> = 100
-    channel_end: int | None = None        # <channel|> = 101
-    thought_word: int | None = None       # "thought" = 45518
-    content_word: int | None = None       # "content" = 3955
-    final_word: int | None = None         # "final" = 10218
+    channel_start: int | None = None  # <|channel> = 100
+    channel_end: int | None = None  # <channel|> = 101
+    thought_word: int | None = None  # "thought" = 45518
+    content_word: int | None = None  # "content" = 3955
+    final_word: int | None = None  # "final" = 10218
 
     # Turn control
-    turn_start: int | None = None         # <|turn> = 105
-    turn_end: int | None = None           # <turn|> = 106
+    turn_start: int | None = None  # <|turn> = 105
+    turn_end: int | None = None  # <turn|> = 106
 
     # Tool call (Gemma 4 style)
-    tool_call_start: int | None = None    # <|tool_call> = 48
-    tool_call_end: int | None = None      # <tool_call|> = 49
-    tool_quote: int | None = None         # <|"|> = 52
-    tool_start: int | None = None         # <|tool> = 46
-    tool_end: int | None = None           # <tool|> = 47
+    tool_call_start: int | None = None  # <|tool_call> = 48
+    tool_call_end: int | None = None  # <tool_call|> = 49
+    tool_quote: int | None = None  # <|"|> = 52
+    tool_start: int | None = None  # <|tool> = 46
+    tool_end: int | None = None  # <tool|> = 47
     tool_response_start: int | None = None  # <|tool_response> = 50
-    tool_response_end: int | None = None    # <tool_response|> = 51
+    tool_response_end: int | None = None  # <tool_response|> = 51
 
     # Think tags (Qwen/DeepSeek style) — for future migration
-    think_start: int | None = None        # <think> token ID
-    think_end: int | None = None          # </think> token ID
+    think_start: int | None = None  # <think> token ID
+    think_end: int | None = None  # </think> token ID
 
     # Standard control
     bos: int | None = None
@@ -85,13 +88,13 @@ class TokenMap:
     pad: int | None = None
 
 
-
 class RouterState(Enum):
     """State machine states."""
+
     INIT = auto()
-    THINKING = auto()           # inside thought channel
-    CONTENT = auto()            # inside content/final channel
-    TOOL_CALL = auto()          # inside tool call
+    THINKING = auto()  # inside thought channel
+    CONTENT = auto()  # inside content/final channel
+    TOOL_CALL = auto()  # inside tool call
     AWAITING_CHANNEL_TYPE = auto()  # saw <|channel>, waiting for thought/content/final
 
 
@@ -129,8 +132,12 @@ class OutputRouter:
         if token_id == m.turn_start or token_id == m.turn_end:
             return None
         # Suppress tool-related markers that may appear without proper nesting
-        if token_id in (m.tool_response_start, m.tool_response_end,
-                         m.tool_start, m.tool_end):
+        if token_id in (
+            m.tool_response_start,
+            m.tool_response_end,
+            m.tool_start,
+            m.tool_end,
+        ):
             return None
 
         # === Channel start: transition to AWAITING_CHANNEL_TYPE ===
@@ -245,10 +252,11 @@ class OutputRouter:
                 pad=vocab.get("<pad>"),
             )
             logger.info(
-                "[OutputRouter] Gemma 4 format detected: "
-                "channel=%d/%d, tool=%d/%d",
-                token_map.channel_start, token_map.channel_end,
-                token_map.tool_call_start, token_map.tool_call_end,
+                "[OutputRouter] Gemma 4 format detected: channel=%d/%d, tool=%d/%d",
+                token_map.channel_start,
+                token_map.channel_end,
+                token_map.tool_call_start,
+                token_map.tool_call_end,
             )
             return cls(token_map, tokenizer)
 

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -76,9 +76,9 @@ def list_parsers() -> list[str]:
 def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import DeepSeekR1ReasoningParser
+    from .gemma4_parser import Gemma4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
-    from .gemma4_parser import Gemma4ReasoningParser
     from .minimax_parser import MiniMaxReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
 

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -14,9 +14,7 @@ import re
 from .base import DeltaMessage, ReasoningParser
 
 # Match full thought blocks in complete text
-_THOUGHT_BLOCK = re.compile(
-    r"<\|channel>thought\n[\s\S]*?<channel\|>\s*", re.DOTALL
-)
+_THOUGHT_BLOCK = re.compile(r"<\|channel>thought\n[\s\S]*?<channel\|>\s*", re.DOTALL)
 # Match content channel markers
 _CONTENT_START = re.compile(r"<\|channel>(?:content|final)\n?")
 _CHANNEL_END = re.compile(r"<channel\|>")
@@ -55,7 +53,11 @@ class Gemma4ReasoningParser(ReasoningParser):
         # Reasoning = thought block contents (strip markers)
         reasoning = ""
         for block in thought_blocks:
-            inner = block.replace("<|channel>thought\n", "").replace("<channel|>", "").strip()
+            inner = (
+                block.replace("<|channel>thought\n", "")
+                .replace("<channel|>", "")
+                .strip()
+            )
             reasoning += inner
 
         # Content = everything after thought blocks, strip markers
@@ -91,13 +93,23 @@ class Gemma4ReasoningParser(ReasoningParser):
             if channel_ends >= thought_starts:
                 self._in_thought = False
                 # If no explicit content channel follows, switch to content mode
-                if "<|channel>content" not in current_text and "<|channel>final" not in current_text:
+                if (
+                    "<|channel>content" not in current_text
+                    and "<|channel>final" not in current_text
+                ):
                     self._in_content = True
 
         # Filter out channel markers from delta
         clean = delta_text
-        for marker in ["<|channel>", "<channel|>", "<|turn>", "<turn|>",
-                        "thought\n", "content\n", "final\n"]:
+        for marker in [
+            "<|channel>",
+            "<channel|>",
+            "<|turn>",
+            "<turn|>",
+            "thought\n",
+            "content\n",
+            "final\n",
+        ]:
             clean = clean.replace(marker, "")
 
         if not clean:

--- a/vllm_mlx/runtime/model_registry.py
+++ b/vllm_mlx/runtime/model_registry.py
@@ -156,9 +156,7 @@ class ModelRegistry:
             return
         if model_name not in self._index:
             available = ", ".join(self.list_model_names())
-            raise KeyError(
-                f"Model '{model_name}' not found. Available: {available}"
-            )
+            raise KeyError(f"Model '{model_name}' not found. Available: {available}")
 
     def list_model_names(self) -> list[str]:
         """List all canonical model names + aliases."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -160,15 +160,29 @@ def _install_chunked_prefill(
         _merge_caches,
         _right_pad_prompts,
     )
+
     # mlx-lm 0.31+ renamed Batch → GenerationBatch with different constructor
     try:
         from mlx_lm.generate import Batch as _Batch
+
         _USE_NEW_BATCH = False
     except ImportError:
         from mlx_lm.generate import GenerationBatch as _Batch
+
         _USE_NEW_BATCH = True
 
-    def _make_batch(model, uids, y, logprobs, max_tokens, num_tokens, prompt_cache, samplers, logits_processors, tokens):
+    def _make_batch(
+        model,
+        uids,
+        y,
+        logprobs,
+        max_tokens,
+        num_tokens,
+        prompt_cache,
+        samplers,
+        logits_processors,
+        tokens,
+    ):
         if _USE_NEW_BATCH:
             # GenerationBatch(model, uids, inputs, prompt_cache, tokens,
             #   samplers, fallback_sampler, logits_processors, state_machines, max_tokens)
@@ -185,7 +199,17 @@ def _install_chunked_prefill(
                 max_tokens=max_tokens,
             )
         else:
-            return _Batch(uids, y, logprobs, max_tokens, num_tokens, prompt_cache, samplers, logits_processors, tokens)
+            return _Batch(
+                uids,
+                y,
+                logprobs,
+                max_tokens,
+                num_tokens,
+                prompt_cache,
+                samplers,
+                logits_processors,
+                tokens,
+            )
 
     # Keep references to originals
     _orig_next = batch_gen._next
@@ -736,8 +760,7 @@ def _install_mtp(
                     if hasattr(_c, "state"):
                         _orig_state = _c.state
                         _copied = [
-                            s.copy() if s is not None else None
-                            for s in _orig_state
+                            s.copy() if s is not None else None for s in _orig_state
                         ]
                         # Preserve original type (tuple vs list) so downstream
                         # code that does `h, c = cache.state` doesn't break.
@@ -1209,7 +1232,7 @@ class Scheduler:
         # removed in 0.31+. Skip the monkey-patch if the old API is unavailable.
         chunked_budget = self.config.chunked_prefill_tokens
         need_chunked = chunked_budget > 0 or self.memory_aware_cache is not None
-        _has_old_batch_api = hasattr(bg, '_process_prompts')
+        _has_old_batch_api = hasattr(bg, "_process_prompts")
         if need_chunked and _has_old_batch_api:
             if chunked_budget <= 0:
                 # No explicit budget — use a very large value so normal

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -139,6 +139,7 @@ def configure_logging(log_level: str) -> str:
     logger.setLevel(getattr(logging, normalized, logging.INFO))
     return normalized.lower()
 
+
 # Multi-model registry — supports loading 2+ models simultaneously.
 # When populated, get_engine() routes by request model name.
 # Backward-compatible: single-model mode still uses _engine global as before.
@@ -205,7 +206,9 @@ _cloud_router = None  # CloudRouter instance when --cloud-model is set
 
 # GC control (Tier 0 optimization)
 _gc_control: bool = True  # Disable GC during generation to avoid latency spikes
-_no_thinking: bool = False  # --no-thinking: force enable_thinking=False in chat template
+_no_thinking: bool = (
+    False  # --no-thinking: force enable_thinking=False in chat template
+)
 
 # Pinned prefix cache (Tier 0 optimization)
 _pin_system_prompt: bool = False  # Auto-pin system prompt prefix cache blocks
@@ -374,16 +377,20 @@ async def lifespan(app: FastAPI):
             _is_hybrid = getattr(_engine, "_hybrid_throttle", False)
             if not _is_hybrid and not getattr(_engine, "_is_mllm", False):
                 # Try to find the raw model through wrapper layers
-                _model = (
-                    getattr(_engine, "_model", None)
-                    or getattr(_engine, "_shared_model", None)
+                _model = getattr(_engine, "_model", None) or getattr(
+                    _engine, "_shared_model", None
                 )
                 # Unwrap MLXLanguageModel if needed
-                if _model and hasattr(_model, "model") and not hasattr(_model, "make_cache"):
+                if (
+                    _model
+                    and hasattr(_model, "model")
+                    and not hasattr(_model, "make_cache")
+                ):
                     _model = _model.model
                 if _model and hasattr(_model, "make_cache"):
                     try:
                         from mlx_lm.models.cache import ArraysCache
+
                         _test_cache = _model.make_cache()
                         _is_hybrid = any(
                             isinstance(c, ArraysCache) for c in _test_cache
@@ -460,6 +467,7 @@ def configure_cors(origins: list[str]) -> None:
         allow_headers=["*"],
     )
 
+
 security = HTTPBearer(auto_error=False)
 
 
@@ -467,8 +475,15 @@ security = HTTPBearer(auto_error=False)
 async def _global_exception_handler(request: Request, exc: Exception):
     """Catch unhandled exceptions so they return JSON 500 instead of killing
     the connection. This keeps the server alive for subsequent requests."""
-    logger.error("Unhandled exception on %s %s: %s", request.method, request.url.path, exc, exc_info=True)
+    logger.error(
+        "Unhandled exception on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
     from starlette.responses import JSONResponse
+
     return JSONResponse(
         status_code=500,
         content={"error": {"message": str(exc), "type": type(exc).__name__}},
@@ -608,7 +623,11 @@ def _validate_model_name(request_model: str) -> None:
     if _model_path:
         accepted.add(_model_path)
     if request_model not in accepted:
-        available = ", ".join(_model_registry.list_model_names()) if _model_registry else _model_name
+        available = (
+            ", ".join(_model_registry.list_model_names())
+            if _model_registry
+            else _model_name
+        )
         raise HTTPException(
             status_code=404,
             detail=f"The model `{request_model}` does not exist. "
@@ -2160,9 +2179,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                     )
                 else:
                     result = await _wait_with_disconnect(
-                        _cloud_router.completion(
-                            cloud_messages, **cloud_kwargs
-                        ),
+                        _cloud_router.completion(cloud_messages, **cloud_kwargs),
                         raw_request,
                         timeout=request.timeout or _default_timeout,
                     )
@@ -2196,8 +2213,10 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             except Exception as e:
                 err_msg = str(e)
                 err_type = type(e).__name__
-                if "TemplateError" in err_type or "template" in err_msg.lower() or (
-                    "user" in err_msg.lower() and "found" in err_msg.lower()
+                if (
+                    "TemplateError" in err_type
+                    or "template" in err_msg.lower()
+                    or ("user" in err_msg.lower() and "found" in err_msg.lower())
                 ):
                     raise HTTPException(
                         status_code=400,
@@ -2288,10 +2307,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         # and other chat template failures, return 400 instead of 500.
         err_msg = str(e)
         err_type = type(e).__name__
-        if "TemplateError" in err_type or "template" in err_msg.lower() or (
-            "user" in err_msg.lower() and "found" in err_msg.lower()
+        if (
+            "TemplateError" in err_type
+            or "template" in err_msg.lower()
+            or ("user" in err_msg.lower() and "found" in err_msg.lower())
         ):
-            raise HTTPException(status_code=400, detail=f"Chat template error: {err_msg}")
+            raise HTTPException(
+                status_code=400, detail=f"Chat template error: {err_msg}"
+            )
         raise  # Re-raise non-template errors
     finally:
         if _gc_control and gc_was_enabled:
@@ -2520,10 +2543,14 @@ async def create_anthropic_message(
     except Exception as e:
         err_msg = str(e)
         err_type = type(e).__name__
-        if "TemplateError" in err_type or "template" in err_msg.lower() or (
-            "user" in err_msg.lower() and "found" in err_msg.lower()
+        if (
+            "TemplateError" in err_type
+            or "template" in err_msg.lower()
+            or ("user" in err_msg.lower() and "found" in err_msg.lower())
         ):
-            raise HTTPException(status_code=400, detail=f"Chat template error: {err_msg}")
+            raise HTTPException(
+                status_code=400, detail=f"Chat template error: {err_msg}"
+            )
         raise
     if output is None:
         return Response(status_code=499)  # Client closed request
@@ -3123,7 +3150,11 @@ async def stream_chat_completion(
 
                 # Tool call parsing on content
                 if tool_parser and content:
-                    if not tool_markup_possible and "<" not in content and "[" not in content:
+                    if (
+                        not tool_markup_possible
+                        and "<" not in content
+                        and "[" not in content
+                    ):
                         tool_accumulated_text += content
                     else:
                         if not tool_markup_possible:
@@ -3140,12 +3171,16 @@ async def stream_chat_completion(
                             chunk = ChatCompletionChunk(
                                 id=response_id,
                                 model=request.model or _model_name,
-                                choices=[ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        tool_calls=tool_result["tool_calls"]
-                                    ),
-                                    finish_reason="tool_calls" if output.finished else None,
-                                )],
+                                choices=[
+                                    ChatCompletionChunkChoice(
+                                        delta=ChatCompletionChunkDelta(
+                                            tool_calls=tool_result["tool_calls"]
+                                        ),
+                                        finish_reason="tool_calls"
+                                        if output.finished
+                                        else None,
+                                    )
+                                ],
                                 usage=get_usage(output) if output.finished else None,
                             )
                             yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
@@ -3157,10 +3192,12 @@ async def stream_chat_completion(
                         chunk = ChatCompletionChunk(
                             id=response_id,
                             model=request.model or _model_name,
-                            choices=[ChatCompletionChunkChoice(
-                                delta=ChatCompletionChunkDelta(),
-                                finish_reason="tool_calls",
-                            )],
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(),
+                                    finish_reason="tool_calls",
+                                )
+                            ],
                             usage=get_usage(output),
                         )
                         yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
@@ -3174,7 +3211,8 @@ async def stream_chat_completion(
 
                 # Skip empty deltas
                 finish_reason = (
-                    "tool_calls" if (output.finished and tool_calls_detected)
+                    "tool_calls"
+                    if (output.finished and tool_calls_detected)
                     else (output.finish_reason if output.finished else None)
                 )
                 if not content and not reasoning and not finish_reason:
@@ -3194,13 +3232,15 @@ async def stream_chat_completion(
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=request.model or _model_name,
-                    choices=[ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(
-                            content=sanitize_output(content) if content else None,
-                            reasoning=reasoning if reasoning else None,
-                        ),
-                        finish_reason=finish_reason,
-                    )],
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                content=sanitize_output(content) if content else None,
+                                reasoning=reasoning if reasoning else None,
+                            ),
+                            finish_reason=finish_reason,
+                        )
+                    ],
                     usage=get_usage(output) if output.finished else None,
                 )
                 sse_line = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
@@ -3244,7 +3284,11 @@ async def stream_chat_completion(
 
                 # Tool call parsing on content portion
                 if tool_parser and content:
-                    if not tool_markup_possible and "<" not in content and "[" not in content:
+                    if (
+                        not tool_markup_possible
+                        and "<" not in content
+                        and "[" not in content
+                    ):
                         tool_accumulated_text += content
                     else:
                         if not tool_markup_possible:
@@ -3324,11 +3368,7 @@ async def stream_chat_completion(
 
                 # Fast path: simple content or reasoning delta without
                 # logprobs, finish_reason, or usage — skip Pydantic entirely.
-                if (
-                    not finish_reason
-                    and not want_logprobs
-                    and not output.finished
-                ):
+                if not finish_reason and not want_logprobs and not output.finished:
                     if content and not reasoning:
                         _sse = _fast_sse_chunk(content, "content")
                         if _sse:
@@ -3375,7 +3415,11 @@ async def stream_chat_completion(
                     # Fast path: skip full parsing until '<' is seen in the stream,
                     # which could start tool markup (e.g. <tool_call>). This avoids
                     # per-token string scanning on the growing accumulated text.
-                    if not tool_markup_possible and "<" not in delta_text and "[" not in delta_text:
+                    if (
+                        not tool_markup_possible
+                        and "<" not in delta_text
+                        and "[" not in delta_text
+                    ):
                         tool_accumulated_text += delta_text
                         # No tool markup yet, fall through to normal chunk emission
                     else:

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -41,7 +41,6 @@ Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
 import math
 
 import mlx.core as mx
-
 from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.sample_utils import make_sampler
 
@@ -549,9 +548,7 @@ def _find_attention_layers(model):
     """
     results = []
     for idx, layer in enumerate(model.layers):
-        if hasattr(layer, "self_attn"):
-            results.append((idx, layer))
-        elif getattr(layer, "block_type", None) == "*":
+        if hasattr(layer, "self_attn") or getattr(layer, "block_type", None) == "*":
             results.append((idx, layer))
     return results
 

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -198,9 +198,8 @@ class DeepSeekV31ToolParser(ToolParser):
                 cur_tool_start_count == cur_tool_end_count
                 and cur_tool_end_count >= prev_tool_end_count
             ):
-                if (
-                    not self.prev_tool_call_arr
-                    or self.current_tool_id >= len(self.prev_tool_call_arr)
+                if not self.prev_tool_call_arr or self.current_tool_id >= len(
+                    self.prev_tool_call_arr
                 ):
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -175,7 +175,7 @@ class Gemma4ToolParser(ToolParser):
 
         # Text-format tool call recovery: catch [Calling tool: name({...})]
         # Models degrade to this format after multiple tool rounds at low quant
-        from .abstract_tool_parser import TEXT_TOOL_CALL_FN_PATTERN, TEXT_TOOL_CALL_ANY
+        from .abstract_tool_parser import TEXT_TOOL_CALL_ANY, TEXT_TOOL_CALL_FN_PATTERN
 
         if TEXT_TOOL_CALL_ANY.search(current_text):
             # Check if we have a complete text tool call

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -152,16 +152,14 @@ class Gemma4ToolParser(ToolParser):
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
                 # Only emit tool calls we haven't sent yet
-                new_calls = result.tool_calls[self._emitted_tool_count:]
+                new_calls = result.tool_calls[self._emitted_tool_count :]
                 self._emitted_tool_count = len(result.tool_calls)
 
                 if new_calls:
                     return {
                         "tool_calls": [
                             {
-                                "index": self._emitted_tool_count
-                                - len(new_calls)
-                                + i,
+                                "index": self._emitted_tool_count - len(new_calls) + i,
                                 "id": tc["id"],
                                 "type": "function",
                                 "function": {
@@ -180,7 +178,7 @@ class Gemma4ToolParser(ToolParser):
         if TEXT_TOOL_CALL_ANY.search(current_text):
             # Check if we have a complete text tool call
             matches = list(TEXT_TOOL_CALL_FN_PATTERN.finditer(current_text))
-            new_matches = matches[self._emitted_tool_count:]
+            new_matches = matches[self._emitted_tool_count :]
             if new_matches:
                 self._emitted_tool_count = len(matches)
                 return {

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -52,9 +52,7 @@ def _build_tool_injection_text(tools: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _inject_tools_into_messages(
-    messages: list[dict], tools: list[dict]
-) -> list[dict]:
+def _inject_tools_into_messages(messages: list[dict], tools: list[dict]) -> list[dict]:
     """Inject tool definitions into the system message.
 
     If the first message has role ``system``, append to its content.
@@ -153,8 +151,6 @@ def apply_chat_template(
                 len(tools),
             )
             injected = _inject_tools_into_messages(messages, tools)
-            return template_applicator.apply_chat_template(
-                injected, **template_kwargs
-            )
+            return template_applicator.apply_chat_template(injected, **template_kwargs)
 
         return template_applicator.apply_chat_template(messages, **template_kwargs)


### PR DESCRIPTION
## Summary

Adds **\`rapid-mlx doctor\`**, a four-tier regression harness ("code health checkup"):

| Tier | Time | What | When to run |
|---|---|---|---|
| \`smoke\` | ~45s | repo + imports + ruff + CLI sanity + pytest (2071 tests) | every commit |
| \`check\` | ~10 min | spin up qwen3.5-4b, API contract + perf + baseline diff | every PR / big change |
| \`full\` | ~1-2 hr | check across 3 models × 11 agent profiles | before release |
| \`benchmark\` | overnight | sweep all locally-cached models → markdown scorecard | periodic / promo |

Exit codes are a stable contract for hooks/CI: \`0\` = pass, \`1\` = perf regression, \`2\` = functional fail.

## Architecture

\`\`\`
vllm_mlx/doctor/                 # 13 files, ~2K LOC, lazy-imported
  runner.py     — DoctorRunner, CheckResult, atomic run-dir reservation
  cli.py        — tier dispatch + per-model orchestration
  server.py     — subprocess lifecycle (boot, /health poll, SIGTERM→SIGKILL teardown)
  baseline.py   — load/save/compare, sign-aware deltas, per-model files
  discovery.py  — locate locally-cached models (HF hub + LM Studio layouts)
  scorecard.py  — markdown table generator
  checks/
    smoke.py    — pytest, ruff, CLI sanity, imports
    api.py      — wraps regression_suite.py + smoke_matrix.sh
    perf.py     — wraps autoresearch_bench.py, captures 13 metrics
    agent.py    — wraps AgentTestRunner across all 11 profiles
    benchmark.py — single-cell metric capture for the scorecard

harness/                         # NOT shipped in wheel
  README.md     — single source of truth (tiers, baselines, thresholds, troubleshooting)
  thresholds.yaml — per-metric regression %
  baselines/    — checked-in golden numbers (qwen3.5-4b for now)
  scorecard/    — generated artefacts (latest.md tracked)
  runs/         — gitignored per-run reports
\`\`\`

## Install footprint

| Metric | Impact |
|---|---|
| Wheel size | +204 KB Python |
| Runtime deps | **0** new (stdlib + already-required PyYAML) |
| \`pip install\` time | unchanged |
| \`rapid-mlx --help\` startup | +0ms (doctor is lazy-imported) |
| \`harness/\`, \`tests/\`, \`Makefile\` | not shipped |

End users only see one new subcommand; pre-existing flows untouched.

## Reuses existing scripts (no rewrites)

- \`tests/regression_suite.py\` — API contract (10 cases)
- \`tests/test_smoke_matrix.sh\` — emoji/CJK/thinking/special-token-leak
- \`scripts/autoresearch_bench.py\` — 13 perf metrics
- \`vllm_mlx/agents/testing.py\` — auto-generated agent test plans

Small backwards-compatible tweaks to the above so they honor an
override port (\`RAPID_MLX_PORT\`, \`AUTORESEARCH_BASE\`).

## Lint debt cleanup (separate commit)

Pre-PR: 43 ruff errors. Post-PR: 0. Mostly auto-fixable (unsorted imports,
f-string placeholders); the 8 manual fixes are documented in the
\`chore: clean up ruff lint debt\` commit.

## Codex review trail

This PR went through ~16 rounds of \`codex review\` and addressed every
real issue codex flagged (12 P1/P2 fixes). 4 codex rounds hallucinated
issues in untouched files — those turned out to be real pre-existing
bugs and were filed as separate issues:

- #118 wheel missing agent profile YAMLs
- #119 \`pyproject.toml\` \`all\` extra self-reference
- #120 chat_template fallback drops \`tools\`
- #121 MTP misses nested \`text_config\`
- #122 chat_template drops \`enable_thinking\` on tool retry
- #123 Gemma 4 OOM during multimodal shard load
- #124 \`vllm-mlx-chat\` published without gradio dependency

## Test plan

- [x] All 2071 unit tests pass (was 2027 before; +14 discovery + 15 baseline + 15 ruff cleanup)
- [x] \`make smoke\` — 45s, all-pass on this machine
- [x] \`make check\` — 10 min on qwen3.5-4b, baseline recorded
- [x] \`make full\` — 8 min on qwen3.5-4b, all 11 agent profiles green
- [x] \`make benchmark\` — 7/9 local models scored; 2 correctly skipped as partial downloads
- [x] Regression detection verified end-to-end: tampered baseline → REGRESSION fired with correct sign + magnitude → restored
- [x] Concurrent invocations: atomic mkdir prevents collision

## Recorded artefacts

- \`harness/baselines/check-qwen3.5-4b.json\`
- \`harness/baselines/full-qwen3.5-4b.json\`
- \`harness/scorecard/latest.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)