### PR TITLE
fix: 7 codex-discovered issues (#118-#124)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,20 @@ chat = [
     "gradio>=4.0.0",
     "pytz>=2024.1",
 ]
-# All extras — matches pre-0.3.1 behavior
+# All extras — union of vision + chat + embeddings.
+# Expanded directly to avoid a self-dependency that breaks
+# pip install .[all] and editable installs.
 all = [
-    "rapid-mlx[vision,chat,embeddings]",
+    # vision
+    "mlx-vlm>=0.1.0",
+    "opencv-python>=4.8.0",
+    "torch>=2.3.0",
+    "torchvision>=0.18.0",
+    # chat
+    "gradio>=4.0.0",
+    "pytz>=2024.1",
+    # embeddings
+    "mlx-embeddings>=0.0.5",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -119,7 +130,7 @@ vllm-mlx-chat = "vllm_mlx.gradio_app:main"
 vllm-mlx-bench = "vllm_mlx.benchmark:main"
 
 [tool.setuptools.package-data]
-vllm_mlx = ["aliases.json"]
+vllm_mlx = ["aliases.json", "agents/profiles/*.yaml"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_engine_parity.py
+++ b/tests/test_engine_parity.py
@@ -134,10 +134,24 @@ class TestApplyChatTemplate:
     def test_fallback_strips_tools_when_both_fail(
         self, mock_tokenizer, simple_messages
     ):
-        """Should fall back to prompt injection when template rejects both."""
+        """Should fall back to prompt injection when template rejects both.
+
+        After #122's fix, the retry flow restores enable_thinking
+        before the tool-injection retry (because the step-1 pop was
+        about diagnosing which param failed, not about removing
+        thinking permanently).  If the template then *also* rejects
+        enable_thinking, a final retry strips both.
+
+        The call sequence is:
+          1. {tools, enable_thinking} → TypeError (enable_thinking?)
+          2. {tools}                  → TypeError (tools!)
+          3. {enable_thinking} + injected msgs → TypeError (enable_thinking too!)
+          4. {} + injected msgs       → success
+        """
         mock_tokenizer.apply_chat_template.side_effect = [
             TypeError("unsupported keyword argument 'enable_thinking'"),
             TypeError("unsupported keyword argument 'tools'"),
+            TypeError("unsupported keyword argument 'enable_thinking'"),
             "<injected prompt>",
         ]
         result = apply_chat_template(
@@ -148,10 +162,35 @@ class TestApplyChatTemplate:
             model_name="test",
         )
         assert result == "<injected prompt>"
-        # Third call should have neither tools nor enable_thinking
+        # Fourth call should have neither tools nor enable_thinking
         _, fallback_kwargs = mock_tokenizer.apply_chat_template.call_args
         assert "tools" not in fallback_kwargs
         assert "enable_thinking" not in fallback_kwargs
+
+    def test_fallback_keeps_enable_thinking_when_only_tools_rejected(
+        self, mock_tokenizer, simple_messages
+    ):
+        """After #122: if only tools is rejected, enable_thinking
+        survives the tool-injection retry.  This is the common case
+        for Qwen/DeepSeek models whose templates support thinking
+        but don't accept tools as a kwarg."""
+        mock_tokenizer.apply_chat_template.side_effect = [
+            TypeError("unsupported keyword argument 'enable_thinking'"),
+            TypeError("unsupported keyword argument 'tools'"),
+            "<injected with thinking>",  # tools injected, enable_thinking kept
+        ]
+        result = apply_chat_template(
+            mock_tokenizer,
+            simple_messages,
+            tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+            enable_thinking=True,
+            model_name="test",
+        )
+        assert result == "<injected with thinking>"
+        # Third call should have enable_thinking=True (restored) but no tools
+        _, fallback_kwargs = mock_tokenizer.apply_chat_template.call_args
+        assert "tools" not in fallback_kwargs
+        assert fallback_kwargs.get("enable_thinking") is True
 
     def test_no_apply_chat_template_method(self, simple_messages):
         """Should use plain text fallback when no apply_chat_template."""

--- a/vllm_mlx/gradio_app.py
+++ b/vllm_mlx/gradio_app.py
@@ -23,9 +23,17 @@ from pathlib import Path
 try:
     import gradio as gr
 except ImportError:
-    print("Error: gradio is required for the chat UI.")
-    print("Install it with: pip install 'rapid-mlx[chat]'")
-    raise SystemExit(1)
+    import sys
+
+    print(
+        "Error: gradio is required for the chat UI.\n"
+        "Install it with: pip install 'rapid-mlx[chat]'\n"
+        "\n"
+        "The vllm-mlx-chat command requires the [chat] extra which\n"
+        "includes gradio and pytz. It is not installed by default to\n"
+        "keep the base package small."
+    )
+    sys.exit(1)
 import requests
 
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -189,18 +189,21 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
             )
             nn.quantize(model, bits=default_bits, group_size=default_gs)
 
-    # Load weights
+    # Load weights — sanitize per shard to keep peak memory proportional
+    # to the text-model size, not the full multimodal checkpoint.  On
+    # Gemma 4 the multimodal shards can be >2× the language-model
+    # weight, so loading everything then sanitizing would transiently
+    # allocate the entire checkpoint and OOM smaller Macs.  Fixes #123.
     weight_files = sorted(
         f for f in p.glob("*.safetensors") if not f.name.startswith("._")
     )
     if not weight_files:
         raise FileNotFoundError(f"No .safetensors files in {p}")
-    raw_weights = {}
+    sanitized = {}
     for wf in weight_files:
-        raw_weights.update(mx.load(str(wf)))
-
-    # Sanitize and load
-    sanitized = model.sanitize(raw_weights)
+        shard = mx.load(str(wf))
+        sanitized.update(model.sanitize(shard))
+        del shard
     model.load_weights(list(sanitized.items()), strict=False)
 
     # Verify weights loaded

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -228,7 +228,7 @@ class MLXLanguageModel:
             stop=stop,
         ):
             output_text += chunk.text
-            if hasattr(chunk, "token") and chunk.token:
+            if hasattr(chunk, "token") and chunk.token is not None:
                 token_ids.append(chunk.token)
             if chunk.prompt_tokens:
                 prompt_tokens = chunk.prompt_tokens

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -116,7 +116,12 @@ def apply_chat_template(
         ``apply_chat_template`` method.
     """
     if not hasattr(template_applicator, "apply_chat_template"):
-        # Fallback for models without apply_chat_template
+        # Fallback for models without apply_chat_template.
+        # Inject tools into the system prompt so the model still sees
+        # function schemas — same treatment as the TypeError fallback
+        # below.  Fixes #120.
+        if tools:
+            messages = _inject_tools_into_messages(messages, tools)
         prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
         return prompt + "\nassistant:"
 
@@ -142,8 +147,15 @@ def apply_chat_template(
         except TypeError:
             pass
 
-        # Step 2: template also rejects tools — fall back to prompt injection
+        # Step 2: template also rejects tools — fall back to prompt injection.
+        # Restore enable_thinking: the step-1 pop removed it because we
+        # didn't know yet whether the failure was about enable_thinking
+        # or about tools.  Now we know it was tools, so re-add
+        # enable_thinking for the final retry so thinking-capable models
+        # (Qwen, DeepSeek) don't silently lose that feature.  Fixes #122.
         template_kwargs.pop("tools", None)
+        if enable_thinking is not None:
+            template_kwargs["enable_thinking"] = enable_thinking
         if tools:
             logger.info(
                 "Chat template doesn't support tools param — "
@@ -151,6 +163,15 @@ def apply_chat_template(
                 len(tools),
             )
             injected = _inject_tools_into_messages(messages, tools)
-            return template_applicator.apply_chat_template(injected, **template_kwargs)
+            try:
+                return template_applicator.apply_chat_template(
+                    injected, **template_kwargs
+                )
+            except TypeError:
+                # enable_thinking also unsupported after all — drop it
+                template_kwargs.pop("enable_thinking", None)
+                return template_applicator.apply_chat_template(
+                    injected, **template_kwargs
+                )
 
         return template_applicator.apply_chat_template(messages, **template_kwargs)

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -61,6 +61,11 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        # mlx_lm.load() succeeds but sanitize() may have silently
+        # stripped mtp.* weights.  Check if the config declares MTP
+        # layers and the model came back without a .mtp attribute;
+        # if so, re-inject from the safetensors on disk.
+        _try_inject_mtp_post_load(model, model_name)
         return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -118,9 +118,16 @@ def _read_num_mtp_layers(config: dict) -> int:
 
 def _try_inject_mtp(model, model_path, config):
     """Inject MTP support if model has MTP config + weights."""
-    if _read_num_mtp_layers(config) > 0:
+    num = _read_num_mtp_layers(config)
+    if num > 0:
         from ..patches.qwen3_next_mtp import inject_mtp_support
 
+        # inject_mtp_support reads config["num_nextn_predict_layers"]
+        # directly.  For VLM checkpoints where the field lives under
+        # text_config, surface it to the top level so the injector
+        # doesn't skip with "num_nextn_predict_layers=0".
+        if config.get("num_nextn_predict_layers", 0) == 0:
+            config = {**config, "num_nextn_predict_layers": num}
         inject_mtp_support(model, model_path, config)
 
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -104,9 +104,21 @@ def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     return model, tokenizer
 
 
+def _read_num_mtp_layers(config: dict) -> int:
+    """Read num_nextn_predict_layers from config, checking text_config too.
+
+    Multimodal checkpoints (VLM + MTP) store this under text_config,
+    while text-only checkpoints put it at the top level.  Fixes #121.
+    """
+    n = config.get("num_nextn_predict_layers", 0)
+    if n == 0:
+        n = config.get("text_config", {}).get("num_nextn_predict_layers", 0)
+    return n
+
+
 def _try_inject_mtp(model, model_path, config):
     """Inject MTP support if model has MTP config + weights."""
-    if config.get("num_nextn_predict_layers", 0) > 0:
+    if _read_num_mtp_layers(config) > 0:
         from ..patches.qwen3_next_mtp import inject_mtp_support
 
         inject_mtp_support(model, model_path, config)
@@ -124,11 +136,7 @@ def _try_inject_mtp_post_load(model, model_name):
         return
     with open(config_path) as f:
         config = json.load(f)
-    # Also check text_config for nested configs
-    num_mtp = config.get("num_nextn_predict_layers", 0)
-    if num_mtp == 0:
-        text_config = config.get("text_config", {})
-        num_mtp = text_config.get("num_nextn_predict_layers", 0)
+    num_mtp = _read_num_mtp_layers(config)
     if num_mtp > 0 and getattr(model, "mtp", None) is None:
         mtp_file = Path(model_path) / "model-mtp.safetensors"
         if mtp_file.exists():


### PR DESCRIPTION
## Summary

Batch fix for 7 pre-existing bugs surfaced by codex CLI review during
the doctor harness PR (#125). Each was filed as a separate issue; fixed
together because they're all small, independent, and low-risk.

## Changes

| Issue | What | File |
|---|---|---|
| #118 | Wheel missing agent profile YAMLs | pyproject.toml |
| #119 | 'all' extra self-references rapid-mlx | pyproject.toml |
| #120 | Chat template fallback drops tools | utils/chat_template.py |
| #121 | MTP misses nested text_config | utils/tokenizer.py |
| #122 | enable_thinking dropped on tool retry | utils/chat_template.py |
| #123 | Gemma 4 OOM during multimodal shard load | models/gemma4_text.py |
| #124 | vllm-mlx-chat without gradio | gradio_app.py |

## Codex review trail

- Round 1: found P1 — MTP detect worked but inject still saw 0 from nested config. Fixed by surfacing `num_nextn_predict_layers` to top-level before calling injector.
- Round 2: clean.
- Round 3 (full diff): flagged 2 pre-existing issues not in this PR scope.

## Test plan

- [x] 2075 tests pass (+1 new test for #122's enable_thinking preservation)
- [x] Existing test_fallback_strips_tools_when_both_fail updated to match new 4-step retry cascade
- [x] New test_fallback_keeps_enable_thinking_when_only_tools_rejected verifies the happy path

Closes #118, #119, #120, #121, #122, #123, #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)