### PR TITLE
perf: SGLang-inspired optimizations (radix cache, overlap scheduling, jump-forward decoding)

### DIFF
--- a/harness/baselines/check-batched-qwen3.5-4b.json
+++ b/harness/baselines/check-batched-qwen3.5-4b.json
@@ -1,0 +1,20 @@
+{
+  "captured_at": "2026-04-16T11:07:55",
+  "rapid_mlx_version": "0.5.0",
+  "model": "qwen3.5-4b",
+  "metrics": {
+    "cold_ttft_ms": 81.48550009354949,
+    "cold_tps": 112.42155950437478,
+    "cached_ttft_ms": 133.96895793266594,
+    "decode_tps": 112.32704081303969,
+    "decode_tps_stdev": 0,
+    "mt_ttft_ms": 161.22487490065396,
+    "mt_tps": 112.33515669498165,
+    "tc_latency_ms": 995.6307501997799,
+    "tc_success_rate": 1.0,
+    "long_ttft_ms": 862.5065411906689,
+    "long_tps": 110.30327980084134,
+    "long_cached_ttft_ms": 863.2712909020483,
+    "composite_score": 241.5
+  }
+}

--- a/harness/baselines/check-qwen3.5-4b.json
+++ b/harness/baselines/check-qwen3.5-4b.json
@@ -1,20 +1,20 @@
 {
-  "captured_at": "2026-04-15T21:36:32",
+  "captured_at": "2026-04-16T11:07:28",
   "rapid_mlx_version": "0.5.0",
   "model": "qwen3.5-4b",
   "metrics": {
-    "cold_ttft_ms": 313.62908403389156,
-    "cold_tps": 49.2736011322839,
-    "cached_ttft_ms": 393.99170805700123,
-    "decode_tps": 49.67459517661095,
+    "cold_ttft_ms": 165.5652499757707,
+    "cold_tps": 167.86137925745996,
+    "cached_ttft_ms": 217.86791691556573,
+    "decode_tps": 167.96938880336336,
     "decode_tps_stdev": 0,
-    "mt_ttft_ms": 402.93216705322266,
-    "mt_tps": 48.32873664326039,
-    "tc_latency_ms": 2819.6406660135835,
+    "mt_ttft_ms": 230.6051659397781,
+    "mt_tps": 165.71235866213658,
+    "tc_latency_ms": 1042.3383750021458,
     "tc_success_rate": 1.0,
-    "long_ttft_ms": 1274.2738330271095,
-    "long_tps": 48.325022009001415,
-    "long_cached_ttft_ms": 1233.1054580863565,
-    "composite_score": 109.9
+    "long_ttft_ms": 958.6559170857072,
+    "long_tps": 163.59455960843,
+    "long_cached_ttft_ms": 940.2715829201043,
+    "composite_score": 258.7
   }
 }

--- a/harness/thresholds-batched.yaml
+++ b/harness/thresholds-batched.yaml
@@ -1,0 +1,47 @@
+# Thresholds for BatchedEngine (--continuous-batching) tiers.
+#
+# BatchedEngine has higher run-to-run variance than SimpleEngine due to
+# scheduling overhead, background cache evaluation, and Metal command
+# buffer contention.  Wider margins prevent false-positive regressions.
+
+decode_tps:
+  regression_pct: 10
+  improvement_pct: 15
+cold_tps:
+  regression_pct: 10
+  improvement_pct: 15
+mt_tps:
+  regression_pct: 10
+  improvement_pct: 15
+long_tps:
+  regression_pct: 10
+  improvement_pct: 15
+cold_ttft_ms:
+  regression_pct: 20
+  improvement_pct: 25
+cached_ttft_ms:
+  regression_pct: 20
+  improvement_pct: 25
+mt_ttft_ms:
+  regression_pct: 20
+  improvement_pct: 25
+long_ttft_ms:
+  regression_pct: 20
+  improvement_pct: 25
+long_cached_ttft_ms:
+  regression_pct: 20
+  improvement_pct: 25
+tc_latency_ms:
+  regression_pct: 15
+  improvement_pct: 20
+peak_ram_mb:
+  regression_pct: 15
+  improvement_pct: 15
+composite_score:
+  regression_pct: 10
+  improvement_pct: 15
+
+# Accuracy — still zero tolerance
+tc_success_rate:
+  regression_pct: 0
+  improvement_pct: 5

--- a/tests/test_sglang_optimizations.py
+++ b/tests/test_sglang_optimizations.py
@@ -1,0 +1,520 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests that demonstrate measurable impact of the three SGLang-inspired
+optimizations: radix-tree prefix cache, async_eval overlap, and
+jump-forward structured decoding.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# =====================================================================
+# 1. Radix-tree prefix cache vs naive trie
+# =====================================================================
+
+
+@dataclass
+class _CacheEntry:
+    prompt_cache: list[Any]
+    count: int
+
+
+class _NaiveTrieCache:
+    """Original per-token trie implementation for comparison."""
+
+    def __init__(self, max_entries: int = 10000):
+        self._cache: dict = {}
+        self._lru: deque = deque()
+        self.max_size = max_entries
+
+    def store(self, tokens: list[int], value: Any) -> None:
+        current = self._cache
+        for tok in tokens:
+            if tok not in current:
+                current[tok] = {}
+            current = current[tok]
+        key = tuple(tokens)
+        if "cache" not in current:
+            current["cache"] = _CacheEntry(value, 1)
+            self._lru.append(key)
+        while len(self._lru) > self.max_size:
+            evict_key = self._lru.popleft()
+            self._delete(list(evict_key))
+
+    def search(self, tokens: list[int]) -> bool:
+        """Return True if exact match exists (no deepcopy — pure traversal)."""
+        current = self._cache
+        for tok in tokens:
+            if tok not in current:
+                return False
+            current = current[tok]
+        return "cache" in current
+
+    def _delete(self, tokens: list[int]) -> None:
+        path = [(self._cache, None)]
+        current = self._cache
+        for tok in tokens:
+            if tok not in current:
+                return
+            path.append((current[tok], tok))
+            current = current[tok]
+        if "cache" in current:
+            del current["cache"]
+        for i in range(len(path) - 1, 0, -1):
+            node, tok = path[i]
+            parent, _ = path[i - 1]
+            if not node:
+                del parent[tok]
+
+
+class TestRadixTreeVsTrie:
+    """Benchmark: radix tree should use fewer nodes and have faster
+    traversal for prefix-heavy workloads."""
+
+    @staticmethod
+    def _make_multi_turn_tokens(
+        system_len: int, n_turns: int, turn_len: int
+    ) -> list[list[int]]:
+        """Simulate multi-turn chat: shared system prompt + diverging turns."""
+        system = list(range(1, system_len + 1))
+        sequences = []
+        for turn in range(n_turns):
+            suffix = list(range(10000 * (turn + 1), 10000 * (turn + 1) + turn_len))
+            sequences.append(system + suffix)
+        return sequences
+
+    def test_radix_node_compression(self):
+        """Radix tree should use dramatically fewer nodes than trie.
+        This is the core value proposition of the data structure change."""
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        sequences = self._make_multi_turn_tokens(
+            system_len=2048, n_turns=50, turn_len=100
+        )
+
+        # Count trie nodes (iterative to avoid stack overflow)
+        trie = _NaiveTrieCache()
+        for seq in sequences:
+            trie.store(seq, ["dummy"])
+
+        trie_nodes = 0
+        stack = [trie._cache]
+        while stack:
+            node = stack.pop()
+            for k, v in node.items():
+                if k != "cache" and isinstance(v, dict):
+                    trie_nodes += 1
+                    stack.append(v)
+
+        # Count radix nodes
+        model = MagicMock()
+        radix = PrefixCacheManager(model, max_entries=10000)
+        for seq in sequences:
+            radix.store_cache(seq, ["dummy"])
+
+        radix_nodes = 0
+        root = radix._roots[radix.model_key]
+        rstack = [root]
+        while rstack:
+            node = rstack.pop()
+            radix_nodes += 1
+            rstack.extend(node.children.values())
+
+        compression = trie_nodes / radix_nodes if radix_nodes > 0 else 0
+        print(
+            f"\n  Trie: {trie_nodes} nodes, Radix: {radix_nodes} nodes — "
+            f"{compression:.0f}x compression"
+        )
+        # 50 sequences sharing 2048-token prefix: trie ~107,048 nodes
+        # Radix ~101 nodes (1 root + 1 compressed prefix + 50 leaves + 49 internal)
+        assert compression > 50, (
+            f"Expected >50x node compression, got {compression:.1f}x"
+        )
+
+    def test_radix_memory_efficiency(self):
+        """Radix tree uses dramatically less memory due to node compression.
+        With 200 entries sharing a 2048-token system prompt:
+        - Trie: 200*(2048+100) = ~430K dict entries
+        - Radix: 1 root + 1 compressed prefix + ~200 leaves ≈ 202 nodes
+
+        This means less GC pressure, better cache locality, and faster
+        eviction in production."""
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        sequences = self._make_multi_turn_tokens(
+            system_len=2048, n_turns=200, turn_len=100
+        )
+
+        # Trie: count total dict entries
+        trie = _NaiveTrieCache(max_entries=10000)
+        for seq in sequences:
+            trie.store(seq, ["dummy_cache"])
+
+        trie_nodes = 0
+        stack = [trie._cache]
+        while stack:
+            node = stack.pop()
+            for k, v in node.items():
+                if k != "cache" and isinstance(v, dict):
+                    trie_nodes += 1
+                    stack.append(v)
+
+        # Radix: count nodes
+        model = MagicMock()
+        radix = PrefixCacheManager(model, max_entries=10000)
+        for seq in sequences:
+            radix.store_cache(seq, ["dummy_cache"])
+
+        radix_nodes = 0
+        root = radix._roots[radix.model_key]
+        rstack = [root]
+        while rstack:
+            n = rstack.pop()
+            radix_nodes += 1
+            rstack.extend(n.children.values())
+
+        ratio = trie_nodes / radix_nodes
+        print(
+            f"\n  Trie: {trie_nodes} dict entries → Radix: {radix_nodes} nodes "
+            f"({ratio:.0f}x memory reduction)"
+        )
+        # Real-world impact: fewer allocations, less GC, faster eviction scan
+        assert ratio > 100, f"Expected >100x node reduction, got {ratio:.0f}x"
+
+    def test_radix_store_performance(self):
+        """Insertion with shared prefixes: radix should be competitive."""
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        sequences = self._make_multi_turn_tokens(
+            system_len=2048, n_turns=200, turn_len=100
+        )
+
+        trie = _NaiveTrieCache(max_entries=10000)
+        t0 = time.perf_counter()
+        for seq in sequences:
+            trie.store(seq, ["dummy_cache"])
+        trie_time = time.perf_counter() - t0
+
+        model = MagicMock()
+        radix = PrefixCacheManager(model, max_entries=10000)
+        t0 = time.perf_counter()
+        for seq in sequences:
+            radix.store_cache(seq, ["dummy_cache"])
+        radix_time = time.perf_counter() - t0
+
+        speedup = trie_time / radix_time if radix_time > 0 else float("inf")
+        print(
+            f"\n  Radix store: {radix_time*1000:.1f}ms vs "
+            f"trie store: {trie_time*1000:.1f}ms — {speedup:.1f}x"
+        )
+        # Radix should be at least as fast (fewer dict creates)
+        assert speedup > 0.8, f"Radix store unexpectedly slow: {speedup:.2f}x"
+
+
+# =====================================================================
+# 2. async_eval overlap in _cleanup_finished
+# =====================================================================
+
+
+class TestAsyncEvalOverlap:
+    """Verify that _cleanup_finished uses async_eval (non-blocking)
+    instead of sync eval (blocking) for cache tensor evaluation."""
+
+    def test_cleanup_uses_async_eval_not_sync(self):
+        """The cache tensor evaluation path must use mx.async_eval,
+        not synchronous mx.eval, to avoid GPU stalls during cleanup."""
+        import inspect
+
+        from vllm_mlx.scheduler import Scheduler
+
+        source = inspect.getsource(Scheduler._cleanup_finished)
+
+        # Must contain async_eval
+        assert "mx.async_eval" in source, (
+            "_cleanup_finished should use mx.async_eval for cache tensors"
+        )
+
+        # Must NOT contain synchronous mx.eval (except in comments)
+        for line in source.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "mx.eval(" in stripped and "async_eval" not in stripped:
+                pytest.fail(
+                    f"Found blocking mx.eval in _cleanup_finished: {stripped!r}\n"
+                    "This forces GPU sync during cleanup, killing overlap."
+                )
+
+    def test_cleanup_batches_eval_arrays(self):
+        """async_eval should be called once with all arrays, not per-layer,
+        to minimize dispatch overhead."""
+        import inspect
+
+        from vllm_mlx.scheduler import Scheduler
+
+        source = inspect.getsource(Scheduler._cleanup_finished)
+
+        # Should collect arrays first, then call async_eval once
+        assert "_eval_arrays" in source, (
+            "Should batch arrays into _eval_arrays list before async_eval"
+        )
+        assert "mx.async_eval(*_eval_arrays)" in source, (
+            "Should call async_eval with unpacked array list (single dispatch)"
+        )
+
+
+# =====================================================================
+# 3. Jump-forward structured decoding
+# =====================================================================
+
+
+class TestJumpForwardDecoding:
+    """Verify jump-forward correctly identifies deterministic tokens
+    and calculates concrete decode-step savings."""
+
+    @pytest.fixture
+    def tokenizer(self):
+        """Mock tokenizer with char-level encoding."""
+        tok = MagicMock()
+        _vocab = {}
+        _next_id = [100]
+
+        def _encode(text, add_special_tokens=False):
+            tokens = []
+            for ch in text:
+                if ch not in _vocab:
+                    _vocab[ch] = _next_id[0]
+                    _next_id[0] += 1
+                tokens.append(_vocab[ch])
+            return tokens
+
+        def _decode(ids, skip_special_tokens=False):
+            id_to_char = {v: k for k, v in _vocab.items()}
+            return "".join(id_to_char.get(i, "?") for i in ids)
+
+        tok.encode = _encode
+        tok.decode = _decode
+        return tok
+
+    def test_jump_forward_tokens_available(self, tokenizer):
+        """When a pattern is active with >= 2 remaining tokens,
+        get_jump_forward_tokens returns them."""
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+
+        pattern = ' name="'
+        pattern_tokens = proc._pattern_tokens[pattern]
+        assert len(pattern_tokens) >= 2
+
+        proc._active_pattern = pattern
+        proc._pattern_pos = 1  # First token already biased
+
+        jump = proc.get_jump_forward_tokens()
+        assert jump is not None
+        assert jump == pattern_tokens[1:]
+        print(
+            f"\n  Pattern {pattern!r}: {len(pattern_tokens)} tokens, "
+            f"jump saves {len(jump)} decode steps"
+        )
+
+    def test_no_jump_when_idle(self, tokenizer):
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+        assert proc.get_jump_forward_tokens() is None
+
+    def test_no_jump_when_single_remaining(self, tokenizer):
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+        pattern = ' name="'
+        pattern_tokens = proc._pattern_tokens[pattern]
+
+        proc._active_pattern = pattern
+        proc._pattern_pos = len(pattern_tokens) - 1
+        assert proc.get_jump_forward_tokens() is None
+
+    def test_complete_jump_forward_resets_state(self, tokenizer):
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+        proc._active_pattern = ' name="'
+        proc._pattern_pos = 2
+        proc._consecutive_bias_count = 5
+        proc._recent_text = "some text<invoke"
+
+        jumped = tokenizer.encode(' name="')
+        proc.complete_jump_forward(jumped)
+
+        assert proc._active_pattern is None
+        assert proc._pattern_pos == 0
+        assert proc._consecutive_bias_count == 0
+        assert ' name="' in proc._recent_text
+
+    def test_total_steps_saved_per_tool_call(self, tokenizer):
+        """Concrete calculation: how many forward passes does jump-forward
+        skip for one complete MiniMax tool call?
+
+        A tool call has 4 structural patterns. Each pattern's first token
+        is generated normally (biased); the rest are injected via a single
+        prefill pass. So each pattern saves (N-1) decode steps.
+        """
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+
+        total_saved = 0
+        total_structural = 0
+        details = []
+        for pattern, _trigger in proc.PATTERNS:
+            tokens = proc._pattern_tokens.get(pattern, [])
+            if len(tokens) >= 2:
+                saved = len(tokens) - 1
+                total_saved += saved
+                total_structural += len(tokens)
+                details.append(f"  {pattern!r}: {len(tokens)} tok, saves {saved}")
+
+        print("\n" + "\n".join(details))
+        print(
+            f"\n  TOTAL: {total_structural} structural tokens, "
+            f"{total_saved} decode steps saved"
+        )
+
+        # At 50 tok/s decode, each step ~20ms. 44 saved steps = ~880ms savings
+        time_saved_ms = total_saved * 20
+        print(f"  Estimated time saved: ~{time_saved_ms}ms per tool call (at 50 tok/s)")
+
+        assert total_saved >= 30, (
+            f"Expected >= 30 decode steps saved per tool call, got {total_saved}"
+        )
+
+    def test_jump_forward_wired_in_scheduler(self):
+        """The jump-forward code path must exist in scheduler.py
+        (inside the _generation_step closure)."""
+        from pathlib import Path
+
+        scheduler_src = (
+            Path(__file__).resolve().parent.parent
+            / "vllm_mlx"
+            / "scheduler.py"
+        ).read_text()
+
+        assert "get_jump_forward_tokens" in scheduler_src, (
+            "_generation_step should call get_jump_forward_tokens"
+        )
+        assert "complete_jump_forward" in scheduler_src, (
+            "_generation_step should call complete_jump_forward after injection"
+        )
+        assert "inject_logits = self.model(" in scheduler_src, (
+            "_generation_step should call model directly for jump prefill"
+        )
+
+    def test_multi_pattern_savings(self, tokenizer):
+        """Simulate two patterns firing in succession: the combined savings
+        represent a realistic tool call scenario."""
+        from vllm_mlx.api.tool_logits import MiniMaxToolLogitsProcessor
+
+        proc = MiniMaxToolLogitsProcessor(tokenizer)
+
+        patterns = [
+            (' name="', "<invoke"),
+            ("</minimax:tool_call>", "</invoke>"),
+        ]
+        total_saved = 0
+        for pattern, trigger in patterns:
+            tokens = proc._pattern_tokens.get(pattern, [])
+            if len(tokens) >= 2:
+                proc._active_pattern = pattern
+                proc._pattern_pos = 1
+                jump = proc.get_jump_forward_tokens()
+                if jump:
+                    total_saved += len(jump)
+                    proc.complete_jump_forward(jump)
+
+        print(f"\n  Two patterns: saved {total_saved} decode steps")
+        assert total_saved >= 5
+
+
+# =====================================================================
+# 4. Radix tree correctness under stress
+# =====================================================================
+
+
+class TestRadixTreeStress:
+    def test_lru_eviction(self):
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        model = MagicMock()
+        cache = PrefixCacheManager(model, max_entries=50)
+
+        for i in range(100):
+            cache.store_cache([1, 2, 3] + [i] * 10, [f"cache_{i}"])
+
+        # First 50 evicted
+        for i in range(50):
+            result, _ = cache.fetch_cache([1, 2, 3] + [i] * 10)
+            assert result is None
+
+        # Last 50 present
+        for i in range(50, 100):
+            result, _ = cache.fetch_cache([1, 2, 3] + [i] * 10)
+            assert result == [f"cache_{i}"]
+
+    def test_prefix_sharing(self):
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        model = MagicMock()
+        cache = PrefixCacheManager(model, max_entries=1000)
+
+        system = list(range(1, 2049))
+        for i in range(20):
+            cache.store_cache(system + [10000 + i, 10001 + i], [f"conv_{i}"])
+
+        for i in range(20):
+            result, remaining = cache.fetch_cache(system + [10000 + i, 10001 + i])
+            assert result == [f"conv_{i}"]
+            assert remaining == []
+
+    def test_edge_split(self):
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        model = MagicMock()
+        cache = PrefixCacheManager(model, max_entries=100)
+
+        cache.store_cache([1, 2, 3, 4, 5], ["long"])
+        cache.store_cache([1, 2, 3], ["short"])
+
+        r1, _ = cache.fetch_cache([1, 2, 3, 4, 5])
+        r2, _ = cache.fetch_cache([1, 2, 3])
+        assert r1 == ["long"]
+        assert r2 == ["short"]
+
+    def test_compaction_after_delete(self):
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        model = MagicMock()
+        cache = PrefixCacheManager(model, max_entries=100)
+
+        cache.store_cache([1, 2, 3, 4, 5], ["a"])
+        cache.store_cache([1, 2, 3, 6, 7], ["b"])
+        cache._delete_cache(cache.model_key, [1, 2, 3, 4, 5])
+
+        result, _ = cache.fetch_cache([1, 2, 3, 6, 7])
+        assert result == ["b"]
+
+        root = cache._roots[cache.model_key]
+        count = 0
+        stack = [root]
+        while stack:
+            n = stack.pop()
+            count += 1
+            stack.extend(n.children.values())
+        assert count <= 3, f"Expected <= 3 nodes after compaction, got {count}"

--- a/tests/test_sglang_optimizations.py
+++ b/tests/test_sglang_optimizations.py
@@ -442,6 +442,48 @@ class TestJumpForwardDecoding:
         print(f"\n  Two patterns: saved {total_saved} decode steps")
         assert total_saved >= 5
 
+    def test_all_parsers_have_jump_forward(self, tokenizer):
+        """Every parser with registered patterns must produce a working
+        processor with jump-forward capability."""
+        from vllm_mlx.api.tool_logits import (
+            PARSER_PATTERNS,
+            create_tool_logits_processor,
+        )
+
+        results = []
+        for parser_name, patterns in PARSER_PATTERNS.items():
+            if not patterns:
+                continue
+            proc = create_tool_logits_processor(parser_name, tokenizer)
+            assert proc is not None, f"Parser {parser_name!r} should create a processor"
+
+            # Check that at least one pattern is jumpable (>= 2 tokens)
+            jumpable = 0
+            total_saved = 0
+            for pattern_text, _trigger in patterns:
+                tokens = proc._pattern_tokens.get(pattern_text, [])
+                if len(tokens) >= 2:
+                    jumpable += 1
+                    total_saved += len(tokens) - 1
+
+            results.append((parser_name, len(patterns), jumpable, total_saved))
+
+        print("\n  Parser jump-forward coverage:")
+        print(f"  {'Parser':<20s} {'Patterns':>8s} {'Jumpable':>8s} {'Steps saved':>11s}")
+        print(f"  {'-'*20} {'-'*8} {'-'*8} {'-'*11}")
+        for name, n_pat, n_jump, saved in sorted(results):
+            print(f"  {name:<20s} {n_pat:>8d} {n_jump:>8d} {saved:>11d}")
+
+        total_parsers = len(results)
+        parsers_with_jump = sum(1 for _, _, j, _ in results if j > 0)
+        print(
+            f"\n  {parsers_with_jump}/{total_parsers} parsers have jump-forward "
+            f"patterns"
+        )
+        assert parsers_with_jump >= 10, (
+            f"Expected >= 10 parsers with jump-forward, got {parsers_with_jump}"
+        )
+
 
 # =====================================================================
 # 4. Radix tree correctness under stress

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -44,8 +44,13 @@ logger = logging.getLogger(__name__)
 
 PARSER_PATTERNS: dict[str, list[tuple[str, str | None]]] = {
     # --- Hermes / Qwen / NousResearch ---
+    # Hermes format: <tool_call>\n{"name": "FUNC", "arguments": {ARGS}}\n</tool_call>
+    # </tool_call> is a single special token in Qwen — not jumpable.
+    # The real wins are in the JSON structural prefixes:
     "hermes": [
-        ("</tool_call>", "}"),  # after JSON closing brace
+        ('\n{"name": "', "<tool_call>"),  # 6 tok, jump 5 after <tool_call>
+        ('", "arguments": ', None),  # 5 tok, jump 4 after function name closing "
+        ('}\n</tool_call>', "}"),  # 3 tok, jump 2 after args JSON closing }
     ],
     # --- MiniMax ---
     "minimax": [
@@ -63,16 +68,20 @@ PARSER_PATTERNS: dict[str, list[tuple[str, str | None]]] = {
         ("</function>", "}"),
     ],
     # --- GLM-4 ---
+    # GLM uses <tool_call>\nfunc_name\n<arg>... — </tool_call> is 1 token
     "glm47": [
-        ("</tool_call>", "}"),
+        ('}\n</tool_call>', "}"),  # 3 tok, jump 2
     ],
     # --- Qwen bracket style ---
+    # Qwen uses <tool_call>\n{"name": ...}\n</tool_call> — same as hermes
     "qwen": [
-        ("</tool_call>", "}"),
+        ('\n{"name": "', "<tool_call>"),
+        ('", "arguments": ', None),
+        ('}\n</tool_call>', "}"),
     ],
     # --- Granite ---
     "granite": [
-        ("</tool_call>", "}"),
+        ('}\n</tool_call>', "}"),  # 3 tok, jump 2
     ],
     # --- Nemotron ---
     "nemotron": [

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -191,6 +191,10 @@ class MiniMaxToolLogitsProcessor:
         self._active_pattern = None
         self._pattern_pos = 0
         self._consecutive_bias_count = 0
+        # Update _last_param_close_pos so </invoke> dedup logic stays correct
+        param_close_pos = self._recent_text.rfind("</parameter>")
+        if param_close_pos > self._last_param_close_pos:
+            self._last_param_close_pos = param_close_pos
         # Update parameter state in case jumped text contains markers
         self._update_param_state()
 

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -2,14 +2,20 @@
 """
 Logits processors for jump-forward decoding of tool call structural tokens.
 
-When models generate tool calls in XML format (e.g., MiniMax's
-<minimax:tool_call>), many tokens are predictable structural markup.
-By biasing logits toward the expected next token, we accelerate generation
-of these structural sequences without constraining the model's free choices
-for argument values.
+When models generate tool calls, many tokens are predictable structural
+markup (closing tags, delimiters).  By biasing logits toward the expected
+next token and injecting deterministic sequences via jump-forward prefill,
+we skip decode steps for these structural tokens.
+
+Supports ALL tool call parsers via a per-parser pattern registry:
+- hermes: <tool_call>, </tool_call>
+- minimax: <invoke name="...>, </parameter>, </invoke>, </minimax:tool_call>
+- llama: <function=...>, </function>
+- deepseek: <｜tool▁call▁begin｜>, <｜tool▁sep｜>, <｜tool▁call▁end｜>, ...
+- And 14 more parsers (see PARSER_PATTERNS below)
 
 Usage:
-    processor = create_tool_logits_processor("minimax", tokenizer)
+    processor = create_tool_logits_processor("hermes", tokenizer)
     if processor:
         # Pass to BatchGenerator via logits_processors
         ...
@@ -23,6 +29,130 @@ import re
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+# =====================================================================
+# Per-parser pattern registry.
+#
+# Each entry maps a parser name → list of (pattern, trigger) tuples.
+#   pattern: deterministic string that follows the trigger
+#   trigger: text suffix that activates the pattern (None = contextual)
+#
+# When the model output ends with a trigger, the processor biases
+# toward the pattern tokens.  If the pattern has >= 2 tokens, the
+# jump-forward path injects them all in a single prefill pass.
+# =====================================================================
+
+PARSER_PATTERNS: dict[str, list[tuple[str, str | None]]] = {
+    # --- Hermes / Qwen / NousResearch ---
+    "hermes": [
+        ("</tool_call>", "}"),  # after JSON closing brace
+    ],
+    # --- MiniMax ---
+    "minimax": [
+        (' name="', "<invoke"),
+        ("</parameter>", None),
+        ("</invoke>", None),
+        ("</minimax:tool_call>", "</invoke>"),
+    ],
+    # --- Llama / Meta ---
+    "llama": [
+        ("</function>", "}"),
+    ],
+    # --- Functionary / MeetKai ---
+    "functionary": [
+        ("</function>", "}"),
+    ],
+    # --- GLM-4 ---
+    "glm47": [
+        ("</tool_call>", "}"),
+    ],
+    # --- Qwen bracket style ---
+    "qwen": [
+        ("</tool_call>", "}"),
+    ],
+    # --- Granite ---
+    "granite": [
+        ("</tool_call>", "}"),
+    ],
+    # --- Nemotron ---
+    "nemotron": [
+        ("</function>", "}"),
+        ("</tool_call>", "</function>"),
+    ],
+    # --- Qwen3 Coder XML ---
+    "qwen3_coder_xml": [
+        ("</parameter>", None),
+        ("</function>", None),
+        ("</tool_call>", "</function>"),
+    ],
+    # --- Seed OSS / GPT-OSS ---
+    "seed_oss": [
+        ("</parameter>", None),
+        ("</function>", None),
+        ("</seed:tool_call>", "</function>"),
+    ],
+    # --- DeepSeek V3 ---
+    "deepseek": [
+        ("<｜tool▁call▁end｜>", "```"),
+        ("<｜tool▁calls▁end｜>", "<｜tool▁call▁end｜>"),
+    ],
+    # --- DeepSeek V3.1 ---
+    "deepseek_v31": [
+        ("<｜tool▁call▁end｜>", "}"),
+        ("<｜tool▁calls▁end｜>", "<｜tool▁call▁end｜>"),
+    ],
+    # --- Gemma 4 ---
+    "gemma4": [
+        ("}<tool_call|>", None),
+    ],
+    # --- Kimi / Moonshot ---
+    "kimi": [
+        ("<|tool_call_end|>", "}"),
+        ("<|tool_calls_section_end|>", "<|tool_call_end|>"),
+    ],
+    # --- Mistral ---
+    "mistral": [
+        # Mistral uses [TOOL_CALLS] prefix (single token) + JSON;
+        # the JSON closing is the main jump-forward opportunity
+    ],
+    # --- xLAM ---
+    "xlam": [
+        # xLAM uses code blocks or JSON arrays; closing ``` is jumpable
+    ],
+}
+
+# Alias expansion: many parser names map to the same patterns
+_PARSER_ALIASES: dict[str, str] = {
+    "nous": "hermes",
+    "qwen3_coder": "hermes",
+    "qwen3": "qwen",
+    "llama3": "llama",
+    "llama4": "llama",
+    "deepseek_v3": "deepseek",
+    "deepseek_r1": "deepseek",
+    "deepseek_r1_0528": "deepseek_v31",
+    "glm4": "glm47",
+    "granite3": "granite",
+    "nemotron3": "nemotron",
+    "gemma_4": "gemma4",
+    "kimi_k2": "kimi",
+    "moonshot": "kimi",
+    "minimax_m2": "minimax",
+    "meetkai": "functionary",
+    "harmony": "seed_oss",
+    "gpt-oss": "seed_oss",
+    "gpt_oss": "seed_oss",
+    "seed": "seed_oss",
+    "qwen3_xml": "qwen3_coder_xml",
+    "auto": "hermes",
+    "generic": "hermes",
+}
+
+
+def _get_patterns_for_parser(parser_name: str) -> list[tuple[str, str | None]]:
+    """Resolve parser name (with aliases) and return its patterns."""
+    canonical = _PARSER_ALIASES.get(parser_name, parser_name)
+    return PARSER_PATTERNS.get(canonical, [])
 
 
 def _extract_param_schemas(tools: list[dict] | None) -> dict[str, dict]:
@@ -60,59 +190,46 @@ class ToolLogitsProcessor(Protocol):
 
 class MiniMaxToolLogitsProcessor:
     """
-    Logits processor that biases structural tokens in MiniMax tool calls.
+    Logits processor that biases and jump-forwards structural tokens
+    in tool calls.
 
-    MiniMax tool call format:
-        <minimax:tool_call>
-        <invoke name="function_name">
-        <parameter name="param">value</parameter>
-        </invoke>
-        </minimax:tool_call>
+    Works with any parser's structural patterns — the PATTERNS list is
+    injected at construction time from the PARSER_PATTERNS registry.
 
-    After detecting the start of a structural sequence, biases the logits
-    toward the expected continuation tokens. Does not constrain the model
-    for free-form content (function names, parameter names, values).
-
-    State machine:
-        idle -> after_invoke (saw "<invoke")
-        after_invoke -> idle (saw ' name="')
-        idle -> after_param_value (saw '">...something not starting with <')
-        ... etc.
-
-    The processor uses a simpler approach: it pre-tokenizes known structural
-    patterns and when the recent tokens match a pattern prefix, biases toward
-    the next token in the pattern.
+    When the model output matches a trigger suffix, the processor biases
+    logits toward the pattern's deterministic tokens.  If the pattern has
+    >= 2 remaining tokens, the generation loop can skip them all via a
+    single prefill pass (jump-forward).
     """
-
-    # Structural patterns that follow predictable sequences
-    PATTERNS = [
-        # After <invoke → expect ' name="'
-        (' name="', "<invoke"),
-        # After param value closing → expect </parameter>
-        ("</parameter>", None),  # Triggered by seeing '">' after param value
-        # After </parameter> block → could be another <parameter or </invoke>
-        ("</invoke>", None),  # Triggered contextually
-        # After </invoke> → expect </minimax:tool_call>
-        ("</minimax:tool_call>", "</invoke>"),
-    ]
 
     def __init__(
         self,
         tokenizer: Any,
         bias_strength: float = 20.0,
         tool_schemas: dict[str, dict] | None = None,
+        patterns: list[tuple[str, str | None]] | None = None,
     ):
         """
-        Initialize the MiniMax tool logits processor.
+        Initialize the tool logits processor.
 
         Args:
             tokenizer: The tokenizer to use for encoding patterns.
             bias_strength: Logits bias to add to expected tokens.
             tool_schemas: Map of "tool.param" -> JSON schema for parameter value constraint.
+            patterns: List of (pattern, trigger) tuples.  If None, falls back
+                to legacy MiniMax PATTERNS for backward compat.
         """
         self.tokenizer = tokenizer
         self.bias_strength = bias_strength
         self._tool_schemas = tool_schemas or {}
+
+        # Use injected patterns or legacy MiniMax defaults
+        self.PATTERNS = patterns if patterns is not None else [
+            (' name="', "<invoke"),
+            ("</parameter>", None),
+            ("</invoke>", None),
+            ("</minimax:tool_call>", "</invoke>"),
+        ]
 
         # Pre-tokenize structural fragments
         self._pattern_tokens: dict[str, list[int]] = {}
@@ -423,26 +540,35 @@ def create_tool_logits_processor(
     tools: list[dict] | None = None,
 ) -> ToolLogitsProcessor | None:
     """
-    Factory function to create a tool logits processor for a given parser.
+    Factory function to create a tool logits processor for any parser.
+
+    Looks up deterministic structural patterns for the given parser from
+    the PARSER_PATTERNS registry.  Returns None only if the parser has
+    no registered patterns (e.g. raw-JSON-only parsers).
 
     Args:
-        parser_name: Name of the tool call parser (e.g., "minimax").
+        parser_name: Name of the tool call parser (e.g., "hermes", "minimax").
         tokenizer: The tokenizer instance.
         bias_strength: Logits bias strength.
         tools: Optional tool definitions for parameter value schema constraint.
 
     Returns:
-        A logits processor instance, or None if not supported for this parser.
+        A logits processor instance, or None if no patterns for this parser.
     """
-    tool_schemas = _extract_param_schemas(tools)
-    if parser_name == "minimax":
-        return MiniMaxToolLogitsProcessor(
-            tokenizer,
-            bias_strength=bias_strength,
-            tool_schemas=tool_schemas,
+    patterns = _get_patterns_for_parser(parser_name)
+    if not patterns:
+        logger.debug(
+            f"No jump-forward patterns registered for parser {parser_name!r}"
         )
-    # Future: add support for other parsers (hermes, llama, etc.)
-    return None
+        return None
+
+    tool_schemas = _extract_param_schemas(tools)
+    return MiniMaxToolLogitsProcessor(
+        tokenizer,
+        bias_strength=bias_strength,
+        tool_schemas=tool_schemas,
+        patterns=patterns,
+    )
 
 
 def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -156,6 +156,44 @@ class MiniMaxToolLogitsProcessor:
         self._in_parameter_value = False
         self._param_value_text = ""
 
+    def get_jump_forward_tokens(self) -> list[int] | None:
+        """Return remaining deterministic tokens in the active pattern.
+
+        Called by the generation loop to detect jump-forward opportunities.
+        When a structural pattern is active and has >= 2 remaining tokens,
+        those tokens can be injected in a single prefill pass instead of
+        N separate decode steps.
+
+        Returns:
+            List of deterministic token IDs, or None if no jump available.
+        """
+        if self._active_pattern is None:
+            return None
+        pattern_tokens = self._pattern_tokens.get(self._active_pattern, [])
+        remaining = pattern_tokens[self._pattern_pos :]
+        if len(remaining) >= 2:
+            return remaining
+        return None
+
+    def complete_jump_forward(self, jumped_tokens: list[int]) -> None:
+        """Update processor state after a jump-forward injection.
+
+        Called by the generation loop after it processes jump tokens via
+        a single prefill pass.  Updates recent text and resets pattern state.
+
+        Args:
+            jumped_tokens: The token IDs that were injected.
+        """
+        text = self.tokenizer.decode(jumped_tokens, skip_special_tokens=False)
+        self._recent_text += text
+        if len(self._recent_text) > 200:
+            self._recent_text = self._recent_text[-200:]
+        self._active_pattern = None
+        self._pattern_pos = 0
+        self._consecutive_bias_count = 0
+        # Update parameter state in case jumped text contains markers
+        self._update_param_state()
+
     # Regex patterns for detecting tool/parameter context
     _INVOKE_RE = re.compile(r'<invoke\s+name="([^"]+)"')
     _PARAM_OPEN_RE = re.compile(r'<parameter\s+name="([^"]+)">')

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -119,7 +119,11 @@ def run_smoke_tier():
 
 
 def run_check_tier(model: str, update_baselines: bool = False):
-    """Boot a server with ``model`` and run API + perf + agent checks."""
+    """Boot a server with ``model`` and run API + perf checks.
+
+    Runs twice: once in SimpleEngine mode, once in BatchedEngine
+    (``--continuous-batching``) mode, with independent baselines.
+    """
     from .checks import smoke
 
     print(f"Rapid-MLX Doctor — check tier (model={model})")
@@ -131,13 +135,26 @@ def run_check_tier(model: str, update_baselines: bool = False):
     runner.run_check("repo_layout", smoke.check_repo_layout)
     runner.run_check("imports", smoke.check_imports)
 
+    # --- SimpleEngine pass ---
     _run_per_model_block(
         runner=runner,
         model=model,
         tier="check",
         update_baselines=update_baselines,
-        agent_profiles=[],  # check tier keeps it lean — agents only in full
+        agent_profiles=[],
     )
+
+    # --- BatchedEngine pass ---
+    _run_per_model_block(
+        runner=runner,
+        model=model,
+        tier="check",
+        update_baselines=update_baselines,
+        agent_profiles=[],
+        extra_args=["--continuous-batching"],
+        engine_label="batched",
+    )
+
     return runner.finalize()
 
 
@@ -163,16 +180,23 @@ def run_full_tier(models: list[str], update_baselines: bool = False):
 
     for model in models:
         print(f"\n  ── model: {model} ──")
+        # SimpleEngine pass
         _run_per_model_block(
             runner=runner,
             model=model,
             tier="full",
             update_baselines=update_baselines,
             agent_profiles=profile_names,
-            # boot_timeout_s=None → _suggested_boot_timeout picks 600s for
-            # the 27B+ models (qwen3.5-35b, gemma-4-26b) and 180s for
-            # smaller ones, so the same logic applies regardless of which
-            # tier called us.
+        )
+        # BatchedEngine pass
+        _run_per_model_block(
+            runner=runner,
+            model=model,
+            tier="full",
+            update_baselines=update_baselines,
+            agent_profiles=[],  # agents tested in simple pass already
+            extra_args=["--continuous-batching"],
+            engine_label="batched",
         )
 
     return runner.finalize()
@@ -228,6 +252,8 @@ def _run_per_model_block(
     update_baselines: bool,
     agent_profiles: list[str],
     boot_timeout_s: int | None = None,
+    extra_args: list[str] | None = None,
+    engine_label: str | None = None,
 ) -> None:
     """Boot a server for one model and run all model-bound checks against it.
 
@@ -236,8 +262,10 @@ def _run_per_model_block(
     full sweep still yields a complete report.
 
     ``boot_timeout_s`` defaults to ``DEFAULT_BOOT_TIMEOUT_S`` (600s).
-    See the constant's docstring for why a single generous value beats
-    every per-model / per-tier heuristic we tried.
+    ``extra_args`` are appended to the ``rapid-mlx serve`` command
+    (e.g. ``["--continuous-batching"]``).
+    ``engine_label`` is used to disambiguate baselines and check names
+    (e.g. ``"batched"`` → baseline key ``check-batched-qwen3.5-4b``).
     """
     from .checks import agent, api, perf
     from .server import ServerStartFailed, serve
@@ -245,32 +273,39 @@ def _run_per_model_block(
     if boot_timeout_s is None:
         boot_timeout_s = DEFAULT_BOOT_TIMEOUT_S
 
-    server_log = runner.run_dir / f"server-{safe_model_slug(model)}.log"
+    tag = f"{model}" if not engine_label else f"{model}/{engine_label}"
+    slug_suffix = f"-{engine_label}" if engine_label else ""
+    server_log = (
+        runner.run_dir / f"server-{safe_model_slug(model)}{slug_suffix}.log"
+    )
+    # Baseline tier key includes engine label so simple/batched get
+    # independent baselines (e.g. "check" vs "check-batched").
+    baseline_tier = f"{tier}-{engine_label}" if engine_label else tier
+
     try:
         with serve(
             model=model,
             log_path=server_log,
+            extra_args=extra_args,
             boot_timeout_s=boot_timeout_s,
         ) as info:
             port = info["port"]
-            print(f"  [server] {model} up on port {port}, log → {server_log.name}")
+            print(f"  [server] {tag} up on port {port}, log → {server_log.name}")
             runner.run_check(
-                f"regression_suite[{model}]",
+                f"regression_suite[{tag}]",
                 lambda: api.check_regression_suite(port),
             )
             runner.run_check(
-                f"smoke_matrix[{model}]",
+                f"smoke_matrix[{tag}]",
                 lambda: api.check_smoke_matrix(port),
             )
             perf_result = runner.run_check(
-                f"autoresearch[{model}]",
+                f"autoresearch[{tag}]",
                 lambda: perf.check_autoresearch(port, runs=1),
             )
             for profile_name in agent_profiles:
-                # Bind per-iteration values so the lambda doesn't close
-                # over the loop variables.
                 runner.run_check(
-                    f"agent[{profile_name}@{model}]",
+                    f"agent[{profile_name}@{tag}]",
                     lambda p=profile_name, port=port: agent.check_agent_profile(
                         p, port, model_id=model
                     ),
@@ -278,9 +313,9 @@ def _run_per_model_block(
     except ServerStartFailed as exc:
         err_msg = f"{exc}\nlog: {server_log}"
         runner.run_check(
-            f"server_boot[{model}]",
+            f"server_boot[{tag}]",
             lambda: CheckResult(
-                name=f"server_boot[{model}]",
+                name=f"server_boot[{tag}]",
                 status=Status.FAIL,
                 duration_s=0.0,
                 detail=err_msg,
@@ -290,7 +325,14 @@ def _run_per_model_block(
 
     # Compare perf metrics against baseline (if one exists).
     if perf_result.metrics:
-        _apply_baseline(runner, tier, model, perf_result.metrics, update_baselines)
+        _apply_baseline(
+            runner,
+            baseline_tier,
+            model,
+            perf_result.metrics,
+            update_baselines,
+            display_label=tag,
+        )
 
 
 # NOTE: per-model artefact filenames (diff-{model}.md, server-{model}.log)
@@ -456,15 +498,25 @@ def _apply_baseline(
     model: str,
     metrics: dict,
     update_baselines: bool,
+    display_label: str | None = None,
 ) -> None:
     """Diff against baseline; flag regressions; optionally update baseline.
 
     Baselines are per-model — comparing decode TPS for a 4B and a 35B
     model is meaningless.  ``--update-baselines`` writes the model-
     specific file, so each model accumulates its own history.
+    ``display_label`` overrides the heading in diff.md (e.g.
+    ``"qwen3.5-4b (batched)"``).
     """
+    heading = display_label or model
+    diff_slug = safe_model_slug(heading)
+
     baseline = load_baseline(tier, model)
-    thresholds = load_thresholds()
+    # BatchedEngine tiers use wider thresholds (higher run-to-run variance)
+    if "batched" in tier:
+        thresholds = load_thresholds(REPO_ROOT / "harness" / "thresholds-batched.yaml")
+    else:
+        thresholds = load_thresholds()
 
     if update_baselines:
         path = save_baseline(tier, model, metrics)
@@ -480,18 +532,14 @@ def _apply_baseline(
         return
 
     if baseline is None:
-        # First run with no baseline — record what we saw, don't fail.
-        # Still write a diff.md (and per-model variant) so external
-        # automation that always reads run_dir/diff.md gets a stable
-        # artefact, not a missing-file error.
         notice = (
             f"_no baseline yet for model={model} — "
             "run with --update-baselines to record one_\n"
         )
-        per_model_diff = runner.run_dir / f"diff-{safe_model_slug(model)}.md"
+        per_model_diff = runner.run_dir / f"diff-{diff_slug}.md"
         per_model_diff.write_text(notice)
         combined_diff = runner.run_dir / "diff.md"
-        section = f"## {model}\n\n{notice}\n"
+        section = f"## {heading}\n\n{notice}\n"
         if combined_diff.exists():
             with open(combined_diff, "a") as f:
                 f.write(section)
@@ -535,11 +583,11 @@ def _apply_baseline(
     # shared diff.md and we'd lose all earlier models' delta tables.
     # Always write per-model files; also append to a combined diff.md
     # so single-model tiers (check) keep their existing artefact name.
-    per_model_diff = runner.run_dir / f"diff-{safe_model_slug(model)}.md"
+    per_model_diff = runner.run_dir / f"diff-{diff_slug}.md"
     per_model_diff.write_text(deltas_md)
 
     combined_diff = runner.run_dir / "diff.md"
-    section = f"## {model}\n\n{deltas_md}\n"
+    section = f"## {heading}\n\n{deltas_md}\n"
     if combined_diff.exists():
         with open(combined_diff, "a") as f:
             f.write(section)

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -97,10 +97,11 @@ class PrefixCacheStats:
 
 class PrefixCacheManager:
     """
-    Manages prefix caching for vllm-mlx using a trie-based LRU cache.
+    Manages prefix caching for vllm-mlx using a radix-tree LRU cache.
 
-    This implementation is inspired by mlx-lm's LRUPromptCache but adapted
-    for vllm-mlx's batching architecture.
+    Uses a radix tree (compressed trie) where single-child chains are
+    merged into nodes with token-array edges, reducing traversal from
+    O(num_tokens) to O(num_branches).
 
     The cache stores KV states keyed by token sequences, allowing:
     - Exact match: Full prompt found in cache

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -54,7 +54,7 @@ class RadixNode:
         cache_entry: CacheEntry | None = None,
     ):
         self.edge: tuple[int, ...] = edge
-        self.children: dict[int, "RadixNode"] = {}
+        self.children: dict[int, RadixNode] = {}
         self.cache_entry: CacheEntry | None = cache_entry
 
     def _compact(self) -> None:

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -37,6 +37,35 @@ class CacheEntry:
     count: int  # Reference count for sharing
 
 
+class RadixNode:
+    """Node in a radix tree for prefix caching.
+
+    Each node stores a token-array edge label and an optional cache entry.
+    Single-child chains are compressed: instead of one node per token,
+    a chain like tok1→tok2→tok3 becomes a single node with edge=(tok1,tok2,tok3).
+    This reduces traversal from O(num_tokens) to O(num_branches).
+    """
+
+    __slots__ = ("edge", "children", "cache_entry")
+
+    def __init__(
+        self,
+        edge: tuple[int, ...] = (),
+        cache_entry: CacheEntry | None = None,
+    ):
+        self.edge: tuple[int, ...] = edge
+        self.children: dict[int, "RadixNode"] = {}
+        self.cache_entry: CacheEntry | None = cache_entry
+
+    def _compact(self) -> None:
+        """Merge with single child if this node has no cache entry."""
+        if self.cache_entry is None and len(self.children) == 1:
+            child = next(iter(self.children.values()))
+            self.edge = self.edge + child.edge
+            self.cache_entry = child.cache_entry
+            self.children = child.children
+
+
 @dataclass
 class PrefixCacheStats:
     """Statistics for prefix cache performance."""
@@ -103,9 +132,8 @@ class PrefixCacheManager:
         self.model_key = id(model)
         self.max_size = max_entries
 
-        # Trie-based cache: nested dicts with token keys
-        # Structure: {model_key: {token1: {token2: {..., "cache": CacheEntry}}}}
-        self._cache: dict[Any, dict] = {}
+        # Radix tree root per model (compressed trie — token-array edges)
+        self._roots: dict[Any, RadixNode] = {}
 
         # LRU tracking: (model_key, tuple(tokens)) ordered by access time
         self._lru: deque = deque()
@@ -116,11 +144,20 @@ class PrefixCacheManager:
         # Statistics
         self.stats = PrefixCacheStats()
 
+    @staticmethod
+    def _common_prefix_len(a: tuple[int, ...], b: tuple | list) -> int:
+        """Return the length of the common prefix between two sequences."""
+        n = min(len(a), len(b))
+        for i in range(n):
+            if a[i] != b[i]:
+                return i
+        return n
+
     def _search(
         self, tokens: list[int]
     ) -> tuple[list[int] | None, list[int] | None, list[int] | None, int]:
         """
-        Search for cached prefix matching tokens.
+        Search for cached prefix matching tokens using radix tree.
 
         Returns:
             Tuple of (exact, shorter, longer, common_prefix_len)
@@ -129,41 +166,83 @@ class PrefixCacheManager:
             - longer: Tokens of longer cached prefix
             - common_prefix_len: Length of common prefix with longer match
         """
-        if self.model_key not in self._cache:
+        root = self._roots.get(self.model_key)
+        if root is None:
             return None, None, None, 0
 
-        current = self._cache[self.model_key]
-        path = []
+        node = root
+        pos = 0  # position in tokens consumed so far
+        last_cached_pos = 0 if root.cache_entry else -1
 
-        # Traverse trie following token sequence
-        for i, tok in enumerate(tokens):
-            if tok not in current:
-                # No match for this token
-                # Check if we have a shorter prefix with cache
-                if "cache" in current:
-                    return None, list(path), None, 0
+        while pos < len(tokens):
+            first_tok = tokens[pos]
+            child = node.children.get(first_tok)
+            if child is None:
+                # No matching edge — return shorter prefix if any
+                if last_cached_pos > 0:
+                    return None, tokens[:last_cached_pos], None, 0
                 return None, None, None, 0
 
-            path.append(tok)
-            current = current[tok]
+            edge = child.edge
+            cpl = self._common_prefix_len(edge, tokens[pos:])
 
-        # Reached end of tokens
-        if "cache" in current:
-            # Exact match
+            if cpl < len(edge):
+                # Partial edge match — can't go further
+                if last_cached_pos > 0:
+                    return None, tokens[:last_cached_pos], None, 0
+                return None, None, None, 0
+
+            pos += len(edge)
+            node = child
+            if node.cache_entry is not None:
+                last_cached_pos = pos
+
+        # Consumed all tokens
+        if node.cache_entry is not None:
             return list(tokens), None, None, 0
 
-        # Check for longer cached prefix
-        # DFS to find shortest extension with cache
-        stack = [(current, list(path))]
+        # Exact node reached but no cache — check for shorter
+        if last_cached_pos > 0:
+            return None, tokens[:last_cached_pos], None, 0
+
+        # Check for longer cached prefix (DFS into children)
+        stack: list[tuple[RadixNode, int]] = [(node, pos)]
         while stack:
-            node, node_path = stack.pop()
-            if "cache" in node:
-                return None, None, node_path, len(tokens)
-            for tok, child in node.items():
-                if tok != "cache":
-                    stack.append((child, node_path + [tok]))
+            n, p = stack.pop()
+            if n.cache_entry is not None:
+                return None, None, self._collect_tokens(n, p, tokens), len(tokens)
+            for child in n.children.values():
+                stack.append((child, p + len(child.edge)))
 
         return None, None, None, 0
+
+    def _collect_tokens(
+        self, target: RadixNode, target_pos: int, base_tokens: list[int]
+    ) -> list[int]:
+        """Reconstruct full token path to a node found via DFS."""
+        # Walk from root to target, collecting edge tokens
+        root = self._roots[self.model_key]
+        result = list(base_tokens)
+        # We need to find the path beyond base_tokens to target
+        # DFS again from the node at len(base_tokens) position
+        node = root
+        pos = 0
+        # First, navigate to the node at base_tokens end
+        while pos < len(base_tokens):
+            child = node.children.get(base_tokens[pos])
+            if child is None:
+                break
+            pos += len(child.edge)
+            node = child
+        # Now DFS to find target, collecting edges
+        stack: list[tuple[RadixNode, list[int]]] = [(node, [])]
+        while stack:
+            n, path = stack.pop()
+            if n is target:
+                return list(base_tokens) + path
+            for child in n.children.values():
+                stack.append((child, path + list(child.edge)))
+        return result
 
     def fetch_cache(self, tokens: list[int]) -> tuple[list[Any] | None, list[int]]:
         """
@@ -235,50 +314,109 @@ class PrefixCacheManager:
             return
 
         tokens_tuple = tuple(tokens)
-
-        # Build trie path
-        if self.model_key not in self._cache:
-            self._cache[self.model_key] = {}
-
-        current = self._cache[self.model_key]
-        for tok in tokens:
-            if tok not in current:
-                current[tok] = {}
-            current = current[tok]
-
-        # Store or update cache entry
         key = (self.model_key, tokens_tuple)
-        if "cache" in current:
-            current["cache"].count += 1
-            # Update LRU position (skip if pinned)
+
+        # Ensure root exists
+        if self.model_key not in self._roots:
+            self._roots[self.model_key] = RadixNode()
+
+        root = self._roots[self.model_key]
+        node = root
+        pos = 0
+
+        while pos < len(tokens):
+            first_tok = tokens[pos]
+            child = node.children.get(first_tok)
+
+            if child is None:
+                # No matching edge — create new leaf with remaining tokens
+                leaf = RadixNode(
+                    edge=tokens_tuple[pos:],
+                    cache_entry=CacheEntry(prompt_cache, 1),
+                )
+                node.children[first_tok] = leaf
+                self._lru_add(key)
+                self._evict_if_needed()
+                return
+
+            edge = child.edge
+            cpl = self._common_prefix_len(edge, tokens[pos:])
+
+            if cpl < len(edge):
+                # Partial match — split the edge
+                # Create intermediate node with the common prefix
+                intermediate = RadixNode(edge=edge[:cpl])
+                # Old child becomes child of intermediate with remaining edge
+                child.edge = edge[cpl:]
+                intermediate.children[child.edge[0]] = child
+                node.children[first_tok] = intermediate
+
+                remaining_pos = pos + cpl
+                if remaining_pos == len(tokens):
+                    # Tokens end at split point
+                    intermediate.cache_entry = CacheEntry(prompt_cache, 1)
+                else:
+                    # Create new leaf for diverging suffix
+                    remaining = tokens_tuple[remaining_pos:]
+                    leaf = RadixNode(
+                        edge=remaining,
+                        cache_entry=CacheEntry(prompt_cache, 1),
+                    )
+                    intermediate.children[remaining[0]] = leaf
+                self._lru_add(key)
+                self._evict_if_needed()
+                return
+
+            pos += len(edge)
+            node = child
+
+        # Exact node reached — update or set cache entry
+        if node.cache_entry is not None:
+            node.cache_entry.count += 1
             if key not in self._pinned:
                 try:
                     self._lru.remove(key)
                 except ValueError:
                     pass
         else:
-            current["cache"] = CacheEntry(prompt_cache, 1)
+            node.cache_entry = CacheEntry(prompt_cache, 1)
 
-        # Only add to LRU if not pinned
+        self._lru_add(key)
+        self._evict_if_needed()
+
+    def _lru_add(self, key: tuple) -> None:
+        """Add key to LRU if not pinned."""
         if key not in self._pinned:
             self._lru.append(key)
 
-        # Evict if over capacity (count pinned entries toward total)
+    def _evict_if_needed(self) -> None:
+        """Evict LRU entries if over capacity."""
         while len(self._lru) + len(self._pinned) > self.max_size and len(self._lru) > 0:
             self._evict_lru()
 
     def _get_cache_entry(self, tokens: list[int]) -> CacheEntry | None:
-        """Get cache entry for given tokens."""
-        if self.model_key not in self._cache:
+        """Get cache entry for given tokens via radix tree traversal."""
+        root = self._roots.get(self.model_key)
+        if root is None:
             return None
 
-        current = self._cache[self.model_key]
-        for tok in tokens:
-            if tok not in current:
+        node = root
+        pos = 0
+        while pos < len(tokens):
+            child = node.children.get(tokens[pos])
+            if child is None:
                 return None
-            current = current[tok]
+            edge = child.edge
+            remaining = tokens[pos:]
+            if len(edge) > len(remaining):
+                return None
+            for i in range(len(edge)):
+                if edge[i] != remaining[i]:
+                    return None
+            pos += len(edge)
+            node = child
 
-        return current.get("cache")
+        return node.cache_entry
 
     def _touch_lru(self, tokens_tuple: tuple) -> None:
         """Move entry to end of LRU queue (most recently used)."""
@@ -301,30 +439,46 @@ class PrefixCacheManager:
         self.stats.evictions += 1
 
     def _delete_cache(self, model_key: Any, tokens: list[int]) -> None:
-        """Delete cache entry and clean up empty trie branches."""
-        if model_key not in self._cache:
+        """Delete cache entry and compact radix tree."""
+        root = self._roots.get(model_key)
+        if root is None:
             return
 
-        # Navigate to entry
-        path = [(self._cache[model_key], None)]
-        current = self._cache[model_key]
-
-        for tok in tokens:
-            if tok not in current:
+        # Navigate to the node, tracking parent chain for cleanup
+        path: list[tuple[RadixNode, RadixNode | None, int | None]] = [
+            (root, None, None)
+        ]
+        node = root
+        pos = 0
+        while pos < len(tokens):
+            child = node.children.get(tokens[pos])
+            if child is None:
                 return
-            path.append((current[tok], tok))
-            current = current[tok]
+            edge = child.edge
+            if len(edge) > len(tokens) - pos:
+                return
+            for i in range(len(edge)):
+                if edge[i] != tokens[pos + i]:
+                    return
+            path.append((child, node, tokens[pos]))
+            pos += len(edge)
+            node = child
 
-        # Delete cache entry
-        if "cache" in current:
-            del current["cache"]
+        # Remove cache entry
+        if node.cache_entry is None:
+            return
+        node.cache_entry = None
 
-        # Clean up empty branches (bottom-up)
+        # Bottom-up cleanup: remove childless nodes, compact single-child nodes
         for i in range(len(path) - 1, 0, -1):
-            node, tok = path[i]
-            parent, _ = path[i - 1]
-            if not node:  # Empty dict
-                del parent[tok]
+            current, parent, first_tok = path[i]
+            if current.cache_entry is None and not current.children:
+                # Leaf with no cache — remove from parent
+                if parent is not None and first_tok is not None:
+                    del parent.children[first_tok]
+            elif current.cache_entry is None and len(current.children) == 1:
+                # Single child, no cache — compact
+                current._compact()
 
     def _can_trim_cache(self, prompt_cache: list[Any]) -> bool:
         """Check if all cache layers can be trimmed."""
@@ -352,7 +506,7 @@ class PrefixCacheManager:
 
     def clear(self) -> None:
         """Clear all cached entries."""
-        self._cache.clear()
+        self._roots.clear()
         self._lru.clear()
         self._pinned.clear()
         self.reset_stats()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2171,23 +2171,27 @@ class Scheduler:
                         except Exception as e:
                             logger.debug(f"Failed to store cache for {request_id}: {e}")
 
-            # Evaluate stored cache tensors incrementally (per-layer) to prevent
-            # a deferred batch evaluation spike when all lazy ops resolve at once.
-            # This spreads the VRAM cost across smaller per-layer evaluations.
+            # Kick off async evaluation of stored cache tensors so the GPU
+            # processes them in the background while Python continues with
+            # scheduling and response handling.  The periodic mx.clear_cache()
+            # in step() ensures these are fully materialized before memory
+            # pressure builds.
             if (
                 request is not None
                 and hasattr(request, "_extracted_cache")
                 and request._extracted_cache
             ):
+                _eval_arrays = []
                 for layer in request._extracted_cache:
                     if isinstance(layer, dict) and "state" in layer:
-                        keys, values = layer["state"]
-                        mx.eval(keys, values)
+                        _eval_arrays.extend(layer["state"])
                     elif hasattr(layer, "keys") and hasattr(layer, "values"):
                         keys_attr = layer.keys
                         values_attr = layer.values
                         if not callable(keys_attr) and not callable(values_attr):
-                            mx.eval(keys_attr, values_attr)
+                            _eval_arrays.extend([keys_attr, values_attr])
+                if _eval_arrays:
+                    mx.async_eval(*_eval_arrays)
 
             # Remove from running
             if request_id in self.running:
@@ -2202,10 +2206,6 @@ class Scheduler:
 
             # Track as finished
             self.finished_req_ids.add(request_id)
-
-        # Free Metal command buffers after cleanup (prevents end-of-generation spike)
-        if finished_ids:
-            mx.clear_cache()
 
     def _is_cache_corruption_error(self, error: Exception) -> bool:
         """Check if an error indicates cache corruption."""
@@ -2311,14 +2311,21 @@ class Scheduler:
 
         for attempt in range(max_retries + 1):
             try:
-                # Schedule waiting requests
+                # Schedule requests that were waiting from the previous step.
+                # On the first call this picks up requests queued via add_request().
                 scheduled = self._schedule_waiting()
                 output.scheduled_request_ids = [r.request_id for r in scheduled]
                 output.num_scheduled_tokens = sum(
                     r.num_prompt_tokens for r in scheduled
                 )
 
-                # Run generation step if we have running requests
+                # Run generation step if we have running requests.
+                # batch_generator.next() internally calls mx.async_eval() to
+                # kick off the *next* forward pass, then blocks only long
+                # enough to read *this* step's tokens.  All Python work after
+                # this call (response processing, cleanup, scheduling for the
+                # next step) runs while the GPU evaluates the next forward
+                # pass — this is the core overlap optimisation.
                 if self.batch_generator is not None and self.running:
                     raw_next = self.batch_generator.next()
                     output.has_work = True
@@ -2334,6 +2341,7 @@ class Scheduler:
                         outputs, finished_ids = self._process_batch_responses(responses)
                         output.outputs = outputs
                         output.finished_request_ids = finished_ids
+                        # Cleanup uses async_eval for cache tensors — no GPU sync
                         self._cleanup_finished(finished_ids)
 
                 # Success - break out of retry loop

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -279,43 +279,42 @@ def _install_chunked_prefill(
                 jump_tokens = _jump_proc.get_jump_forward_tokens()
 
         if jump_tokens and _jump_proc is not None:
-            # Wait for batch.y — this is the first pattern token
-            # (already biased by the processor in _step above)
-            first_tok = batch.y.tolist()[0]
-            all_inject = [first_tok] + list(jump_tokens)
+            # batch.y already contains the first pattern token (biased by
+            # the processor inside _step above) and the KV cache already
+            # has it.  jump_tokens are the REMAINING deterministic tokens.
+            # Feed them through the model in one prefill pass to update
+            # the KV cache, then sample the next free token.
 
-            # Feed all deterministic tokens through the model in one
-            # prefill pass to update the KV cache.
-            inject_arr = mx.array([all_inject])  # (1, N)
+            # Append jump_tokens (NOT first_tok — already in cache)
+            inject_arr = mx.array([jump_tokens])  # (1, N)
             inject_logits = self.model(inject_arr, cache=batch.cache)
 
-            # Append injected tokens to the sequence
+            # Extend the token sequence with the injected tokens
             batch.tokens[0] = mx.concatenate(
-                (batch.tokens[0], mx.array(all_inject))
+                (batch.tokens[0], mx.array(jump_tokens))
             )
 
-            # Sample next token from the last position's logits
-            # (this is the first non-deterministic token after the pattern)
+            # Sample the next non-deterministic token from last position
             batch.y = batch.samplers[0](inject_logits[:, -1, :])
             batch.logprobs = inject_logits[:, -1, :] - mx.logsumexp(
                 inject_logits[:, -1, :], axis=-1, keepdims=True
             )
             mx.async_eval(batch.y, batch.logprobs)
 
-            # Update processor state to reflect the completed pattern
-            _jump_proc.complete_jump_forward(all_inject)
+            # Update processor state (pattern complete)
+            _jump_proc.complete_jump_forward(jump_tokens)
 
-            # Build responses: original token y + all injected tokens
+            # Build responses: original token y[0] + all jump tokens
+            # y[0] is the previous step's token; jump_tokens are the
+            # deterministic tokens whose KV cache was just updated.
             uid = batch.uids[0]
             num_tok = batch.num_tokens[0]
             max_tok = batch.max_tokens[0]
             responses = []
-
-            # Original token from this step
-            num_tok += 1
-            batch.num_tokens[0] = num_tok
             _finished = False
-            for tok in [y[0]] + all_inject:
+
+            for tok in [y[0]] + list(jump_tokens):
+                num_tok += 1
                 finish_reason = None
                 cache_out = None
                 if tok in self.stop_tokens:
@@ -329,10 +328,10 @@ def _install_chunked_prefill(
                 responses.append(
                     self.Response(uid, tok, mx.array(0.0), finish_reason, cache_out)
                 )
-                num_tok += 1
-                batch.num_tokens[0] = num_tok
                 if _finished:
                     break
+
+            batch.num_tokens[0] = num_tok
 
             if _finished:
                 self.active_batch = None
@@ -340,8 +339,8 @@ def _install_chunked_prefill(
             self._stats.generation_time += _time.perf_counter() - tic_gen
             self._stats.generation_tokens += len(responses)
             logger.debug(
-                f"[jump-forward] injected {len(all_inject)} deterministic "
-                f"tokens (saved {len(all_inject) - 1} decode steps)"
+                f"[jump-forward] injected {len(jump_tokens)} deterministic "
+                f"tokens (saved {len(jump_tokens) - 1} decode steps)"
             )
             return responses
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -239,7 +239,7 @@ def _install_chunked_prefill(
 
         batch_gen._process_prompts = _patched_process_prompts
 
-    def _generation_step(self=batch_gen):
+    def _generation_step(self=batch_gen):  # noqa: C901
         """Run one generation step on the active batch. Returns responses."""
         batch = self.active_batch
         if batch is None or len(batch) == 0:
@@ -259,6 +259,92 @@ def _install_chunked_prefill(
         mx.async_eval(batch.y, batch.logprobs)
 
         y = y.tolist()
+
+        # ------------------------------------------------------------------
+        # Jump-forward: when the logits processor has activated a
+        # deterministic structural pattern (e.g. "</invoke>" or
+        # "</minimax:tool_call>"), inject all remaining pattern tokens
+        # in a single prefill pass instead of N separate decode steps.
+        # Only applies to single-request batches (typical agentic use).
+        # ------------------------------------------------------------------
+        jump_tokens = None
+        _jump_proc = None
+        if (
+            len(batch) == 1
+            and batch.logits_processors
+            and batch.logits_processors[0]
+        ):
+            _jump_proc = batch.logits_processors[0][0]
+            if hasattr(_jump_proc, "get_jump_forward_tokens"):
+                jump_tokens = _jump_proc.get_jump_forward_tokens()
+
+        if jump_tokens and _jump_proc is not None:
+            # Wait for batch.y — this is the first pattern token
+            # (already biased by the processor in _step above)
+            first_tok = batch.y.tolist()[0]
+            all_inject = [first_tok] + list(jump_tokens)
+
+            # Feed all deterministic tokens through the model in one
+            # prefill pass to update the KV cache.
+            inject_arr = mx.array([all_inject])  # (1, N)
+            inject_logits = self.model(inject_arr, cache=batch.cache)
+
+            # Append injected tokens to the sequence
+            batch.tokens[0] = mx.concatenate(
+                (batch.tokens[0], mx.array(all_inject))
+            )
+
+            # Sample next token from the last position's logits
+            # (this is the first non-deterministic token after the pattern)
+            batch.y = batch.samplers[0](inject_logits[:, -1, :])
+            batch.logprobs = inject_logits[:, -1, :] - mx.logsumexp(
+                inject_logits[:, -1, :], axis=-1, keepdims=True
+            )
+            mx.async_eval(batch.y, batch.logprobs)
+
+            # Update processor state to reflect the completed pattern
+            _jump_proc.complete_jump_forward(all_inject)
+
+            # Build responses: original token y + all injected tokens
+            uid = batch.uids[0]
+            num_tok = batch.num_tokens[0]
+            max_tok = batch.max_tokens[0]
+            responses = []
+
+            # Original token from this step
+            num_tok += 1
+            batch.num_tokens[0] = num_tok
+            _finished = False
+            for tok in [y[0]] + all_inject:
+                finish_reason = None
+                cache_out = None
+                if tok in self.stop_tokens:
+                    finish_reason = "stop"
+                    _finished = True
+                elif num_tok >= max_tok:
+                    finish_reason = "length"
+                    _finished = True
+                if finish_reason is not None:
+                    cache_out = batch.extract_cache(0)
+                responses.append(
+                    self.Response(uid, tok, mx.array(0.0), finish_reason, cache_out)
+                )
+                num_tok += 1
+                batch.num_tokens[0] = num_tok
+                if _finished:
+                    break
+
+            if _finished:
+                self.active_batch = None
+
+            self._stats.generation_time += _time.perf_counter() - tic_gen
+            self._stats.generation_tokens += len(responses)
+            logger.debug(
+                f"[jump-forward] injected {len(all_inject)} deterministic "
+                f"tokens (saved {len(all_inject) - 1} decode steps)"
+            )
+            return responses
+
         self._stats.generation_time += _time.perf_counter() - tic_gen
 
         keep_idx = []

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -358,6 +358,12 @@ async def lifespan(app: FastAPI):
     if _engine is not None and hasattr(_engine, "_loaded") and not _engine._loaded:
         await _engine.start()
 
+    # Retry tool logits bias setup now that the engine is fully started
+    # and the tokenizer is available.  The initial attempt in
+    # _setup_model_and_tools() may have failed because BatchedEngine's
+    # tokenizer is only populated after start().
+    _retry_tool_logits_setup()
+
     # Warmup: generate one token to trigger Metal shader compilation.
     # Runs here (not in CLI) so all engine types are fully started first.
     if _engine is not None:
@@ -976,10 +982,15 @@ def load_model(
             from .api.tool_logits import create_tool_logits_processor
 
             tokenizer = None
-            if hasattr(_engine, "_tokenizer"):
+            # Try the public property first (handles MLLM processor wrapping),
+            # then fall back to the private attribute.
+            if hasattr(_engine, "tokenizer"):
+                try:
+                    tokenizer = _engine.tokenizer
+                except Exception:
+                    pass
+            if tokenizer is None and hasattr(_engine, "_tokenizer"):
                 tokenizer = _engine._tokenizer
-            elif hasattr(_engine, "tokenizer"):
-                tokenizer = _engine.tokenizer
             if tokenizer is not None:
                 # Create factory that produces fresh processors per request
                 # Accepts optional tools for parameter value schema constraint
@@ -1002,6 +1013,52 @@ def load_model(
             logger.warning(f"Failed to set up tool logits bias: {e}")
 
     logger.info(f"Default max tokens: {_default_max_tokens}")
+
+
+def _retry_tool_logits_setup() -> None:
+    """Retry tool logits bias setup after engine.start().
+
+    BatchedEngine's tokenizer is only populated after start(), so the
+    initial attempt in _setup_model_and_tools() fails for batched mode.
+    This function is called from the lifespan handler after start().
+    """
+    global _engine
+
+    if not _enable_tool_logits_bias or not _enable_auto_tool_choice or not _tool_call_parser:
+        return
+    # Skip if already set up successfully
+    if (
+        hasattr(_engine, "_tool_logits_processor_factory")
+        and _engine._tool_logits_processor_factory is not None
+    ):
+        return
+
+    try:
+        from .api.tool_logits import create_tool_logits_processor
+
+        tokenizer = None
+        if hasattr(_engine, "tokenizer"):
+            try:
+                tokenizer = _engine.tokenizer
+            except Exception:
+                pass
+        if tokenizer is None:
+            return
+
+        def _make_factory(parser_name, tok):
+            def factory(tools=None):
+                return create_tool_logits_processor(parser_name, tok, tools=tools)
+
+            return factory
+
+        factory = _make_factory(_tool_call_parser, tokenizer)
+        _engine._tool_logits_processor_factory = factory
+        logger.info(
+            f"Tool logits bias enabled for parser: {_tool_call_parser} "
+            "(deferred setup after engine.start)"
+        )
+    except Exception as e:
+        logger.warning(f"Deferred tool logits bias setup failed: {e}")
 
     # Register in multi-model registry
     aliases = set()

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -163,23 +163,6 @@ def _try_inject_mtp_post_load(model, model_name):
             )
 
 
-def _load_non_strict(model_name: str, tokenizer_config: dict = None):
-    """Load model with strict=False to skip extra weights (e.g., vision tower)."""
-    from mlx_lm.utils import load_model, load_tokenizer
-
-    local_path = Path(model_name)
-    if local_path.is_dir():
-        model_path = local_path
-    else:
-        from huggingface_hub import snapshot_download
-
-        model_path = Path(snapshot_download(model_name))
-
-    model, _ = load_model(model_path, strict=False)
-    tokenizer = load_tokenizer(model_path, tokenizer_config or {})
-    return model, tokenizer
-
-
 def _load_with_tokenizer_fallback(model_name: str):
     """Load model with fallback tokenizer for non-standard models like Nemotron."""
     from mlx_lm.utils import load_model


### PR DESCRIPTION
## Summary

Three SGLang-inspired performance optimizations for the inference engine:

- **Radix-tree compaction for PrefixCacheManager** — Replace per-token trie with radix tree that compresses single-child chains into nodes with token-array edges. Reduces traversal from O(num_tokens) to O(num_branches). Target: 10-30% TTFT gain on multi-turn chat with shared system prompt.

- **Overlap scheduling with async_eval** — Replace synchronous `mx.eval()` in `_cleanup_finished()` with batched `mx.async_eval()` and remove redundant `mx.clear_cache()`. Cache tensor evaluation now runs on GPU in background while Python continues with scheduling. Target: 15-25% throughput gain.

- **Jump-forward structured decoding** — When the tool logits processor detects a deterministic structural pattern (e.g. `</invoke>`, `</minimax:tool_call>`), inject all remaining pattern tokens in a single prefill pass instead of N separate decode steps. Saves 3-8 decode steps per pattern occurrence. Target: 30-50% decode skip on tool calls.

## Test plan

- [x] All 27 prefix cache tests pass (radix tree is drop-in)
- [x] All 51 tool logits tests pass
- [x] 117 total tests pass
- [x] ruff lint clean
- [ ] Run `make check` with qwen3.5-4b to verify no regression
- [ ] Test tool calling with Hermes agent to validate jump-forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)