### PR TITLE
feat: support Qwen3.6-35B-A3B

### DIFF
--- a/vllm_mlx/agents/profiles/aider.yaml
+++ b/vllm_mlx/agents/profiles/aider.yaml
@@ -12,6 +12,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
     - "deepseek-r1-8b"
   parser_override: null

--- a/vllm_mlx/agents/profiles/cline.yaml
+++ b/vllm_mlx/agents/profiles/cline.yaml
@@ -14,6 +14,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "gemma-4-26b"
   parser_override: null
 

--- a/vllm_mlx/agents/profiles/codex.yaml
+++ b/vllm_mlx/agents/profiles/codex.yaml
@@ -18,6 +18,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
   parser_override: null
 

--- a/vllm_mlx/agents/profiles/generic.yaml
+++ b/vllm_mlx/agents/profiles/generic.yaml
@@ -12,6 +12,7 @@ models:
   recommended:
     - "qwen3.5-4b"
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
 
 streaming:
   extra_tool_tags: []

--- a/vllm_mlx/agents/profiles/goose.yaml
+++ b/vllm_mlx/agents/profiles/goose.yaml
@@ -12,6 +12,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
   parser_override: null
 

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -22,6 +22,7 @@ models:
     - "qwen3.5-9b"
     - "gemma-4-26b"
     - "qwen3.5-35b-a3b"
+    - "qwen3.6-35b"
   parser_override: null  # use auto-detect per model
 
 streaming:

--- a/vllm_mlx/agents/profiles/langchain.yaml
+++ b/vllm_mlx/agents/profiles/langchain.yaml
@@ -12,6 +12,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
 
 streaming:

--- a/vllm_mlx/agents/profiles/openclaude.yaml
+++ b/vllm_mlx/agents/profiles/openclaude.yaml
@@ -14,6 +14,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
     - "gemma-4-26b"
   parser_override: null

--- a/vllm_mlx/agents/profiles/openhands.yaml
+++ b/vllm_mlx/agents/profiles/openhands.yaml
@@ -13,6 +13,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
   parser_override: null
 

--- a/vllm_mlx/agents/profiles/pydanticai.yaml
+++ b/vllm_mlx/agents/profiles/pydanticai.yaml
@@ -12,6 +12,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
 
 streaming:

--- a/vllm_mlx/agents/profiles/smolagents.yaml
+++ b/vllm_mlx/agents/profiles/smolagents.yaml
@@ -12,6 +12,7 @@ config:
 models:
   recommended:
     - "qwen3.5-9b"
+    - "qwen3.6-35b"
     - "qwen3.5-4b"
 
 streaming:

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -5,6 +5,7 @@
   "qwen3.5-35b": "mlx-community/Qwen3.5-35B-A3B-8bit",
   "qwen3.5-122b": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
   "qwen3.5-122b-8bit": "mlx-community/Qwen3.5-122B-A10B-8bit",
+  "qwen3.6-35b": "mlx-community/Qwen3.6-35B-A3B-4bit",
   "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
   "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
   "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1152,6 +1152,8 @@ Examples:
             "mistral",
             "qwen",
             "qwen3_coder",
+            "qwen3_coder_xml",
+            "qwen3_xml",
             "llama",
             "hermes",
             "deepseek",
@@ -1168,7 +1170,7 @@ Examples:
         ],
         help=(
             "Select the tool call parser for the model. Options: "
-            "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
+            "auto (auto-detect), mistral, qwen, qwen3_coder, qwen3_coder_xml/qwen3_xml, llama, hermes, "
             "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, minimax, "
             "harmony/gpt-oss, gemma4. "
             "Required for --enable-auto-tool-choice."
@@ -1505,7 +1507,7 @@ Examples:
         type=str,
         default=None,
         help="Comma-separated model aliases for full / benchmark tiers "
-        "(full default: qwen3.5-4b,qwen3.5-35b,gemma-4-26b; "
+        "(full default: qwen3.5-4b,qwen3.5-35b,qwen3.6-35b,gemma-4-26b; "
         "benchmark default: auto-discovered from local cache)",
     )
     doctor_parser.add_argument(

--- a/vllm_mlx/doctor/__init__.py
+++ b/vllm_mlx/doctor/__init__.py
@@ -5,7 +5,7 @@ Rapid-MLX Doctor — comprehensive regression harness.
 Three tiers + a benchmark sweep:
   - smoke      (~2 min, no model)        — pytest, ruff, CLI sanity
   - check      (~10 min, qwen3.5-4b)      — server + perf + agents + baseline diff
-  - full       (~1-2 hr, 3 models)        — check across qwen3.5-4b/35b + gemma-4-26b
+  - full       (~1-2 hr, 4 models)        — check across qwen3.5-4b/35b + qwen3.6-35b + gemma-4-26b
   - benchmark  (overnight, all models)    — cross-model × cross-engine scorecard
 
 Entry point: ``rapid-mlx doctor {smoke,check,full,benchmark}``

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -23,7 +23,7 @@ DEFAULT_CHECK_MODEL = "qwen3.5-4b"
 # Model list for the full tier: small/medium/large + a non-Qwen template
 # path so we cover both Hermes-style (Qwen) and Gemma's distinct chat
 # template + tool-call format.
-DEFAULT_FULL_MODELS = ["qwen3.5-4b", "qwen3.5-35b", "gemma-4-26b"]
+DEFAULT_FULL_MODELS = ["qwen3.5-4b", "qwen3.5-35b", "qwen3.6-35b", "gemma-4-26b"]
 
 # Agent profiles to exercise per-model in the full tier.  None ⇒ all
 # loaded profiles.  Limit here if a particular profile is too slow to

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -54,6 +54,14 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser="qwen3",
         ),
     ),
+    # Qwen3.6 — XML tool format, before generic Qwen3
+    (
+        re.compile(r"qwen3\.6", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="qwen3_coder_xml",
+            reasoning_parser="qwen3",
+        ),
+    ),
     # Qwen3-Coder — before generic Qwen3 (non-thinking, no reasoning parser)
     (
         re.compile(r"qwen3[-_]?coder", re.IGNORECASE),


### PR DESCRIPTION
## Summary
- Day-0 support for Qwen3.6-35B-A3B (released 2026-04-16)
- Auto-config detects Qwen3.6 → `qwen3_coder_xml` parser (XML tool format, different from Qwen3.5's JSON/Hermes)
- Added alias `qwen3.6-35b`, doctor full tier, all agent profiles

## Benchmark (M3 Ultra, 4-bit)

| Metric | Qwen3.5-35B-A3B | Qwen3.6-35B-A3B |
|--------|:---:|:---:|
| Architecture | 128 experts, 3B active | 256 experts, 3B active |
| Decode TPS | 94.1 | 93.7 |
| TTFT (cold) | ~186ms | ~202ms |
| Tool calling | 100% (hermes/JSON) | 100% (XML) |
| VRAM | ~11 GB | ~20 GB |
| Context | 131K | 262K |
| Doctor score | 9/10 | 9/10 |

## Test plan
- [x] `rapid-mlx serve qwen3.6-35b` loads and serves
- [x] Tool calling works (single + parallel)
- [x] Streaming SSE works
- [x] Reasoning extraction works
- [x] `rapid-mlx doctor check --model qwen3.6-35b` passes (9/10)
- [x] `rapid-mlx doctor benchmark --models qwen3.6-35b` passes (score 173.2)
- [x] Auto-config correctly routes to `qwen3_coder_xml` parser
- [x] Qwen3.5 models unaffected (still use `hermes` parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)