### PR TITLE
feat: enable logprobs in BatchedEngine (#44)

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -604,10 +604,12 @@ class BatchedEngine(BaseEngine):
             yield GenerationOutput(
                 text=text,
                 new_text=output.new_text,
+                tokens=output.new_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,
                 finish_reason=output.finish_reason,
+                logprobs=output.logprobs,
             )
 
     async def chat(

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -148,6 +148,7 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            logprobs=new.logprobs,  # Use latest token's logprobs
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -206,6 +206,8 @@ class RequestOutput:
     # Timing
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Per-token log-probabilities (mx.array of shape [vocab_size] for current token)
+    logprobs: Any = None
 
     @property
     def usage(self) -> dict[str, int]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1999,6 +1999,7 @@ class Scheduler:
                 output_token_ids=list(request.output_token_ids),
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                logprobs=response.logprobs,
             )
 
             # Check if finished


### PR DESCRIPTION
## Summary

Propagate per-token log-probabilities through the BatchedEngine pipeline. **6 lines changed.**

The route-level logprobs code (extraction + formatting) already existed but BatchedEngine never passed logprobs data from the scheduler to GenerationOutput. This PR connects the pipeline:

```
Scheduler (computes logprobs) → RequestOutput → OutputCollector → GenerationOutput → API response
```

### Verified end-to-end

**Non-streaming:**
```json
{"logprobs": {"content": [{"token": "Hi", "logprob": 0.0, "top_logprobs": [...]}, ...]}}
```

**Streaming:**
```json
{"choices": [{"delta": {"content": "Hi"}, "logprobs": {"content": [{"token": "Hi", "logprob": 0.0, ...}]}}]}
```

## Test plan
- [x] `ruff check` — 0 errors
- [x] 2063 unit tests pass, 0 regressions
- [x] Manual e2e: non-streaming logprobs ✅
- [x] Manual e2e: streaming logprobs ✅
- [ ] Stress test with large model

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)