### PR TITLE
Fix MLX generation stream thread ownership

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -7,6 +7,10 @@ for the vLLM-style continuous batching implementation.
 """
 
 import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -433,6 +437,25 @@ class TestSchedulerIntegration:
         assert len(finished) == len(prompts), f"Only {len(finished)} requests finished"
 
 
+class TestEngineThreading:
+    """Threading tests for EngineCore."""
+
+    def test_mlx_step_thread_initializer_rebinds_generation_stream(self, monkeypatch):
+        """The executor thread must own mlx-lm's generation stream."""
+        from vllm_mlx import engine_core
+
+        fake_generate = types.SimpleNamespace(generation_stream="old-stream")
+        monkeypatch.setitem(sys.modules, "mlx_lm.generate", fake_generate)
+        monkeypatch.setattr(engine_core.mx, "default_device", lambda: "gpu")
+        monkeypatch.setattr(
+            engine_core.mx, "new_stream", lambda device: f"stream:{device}"
+        )
+
+        engine_core._init_mlx_step_thread()
+
+        assert fake_generate.generation_stream == "stream:gpu"
+
+
 @pytest.mark.asyncio
 class TestEngineAsync:
     """Async tests for the engine."""
@@ -447,6 +470,48 @@ class TestEngineAsync:
         tokenizer.eos_token_id = 0
         tokenizer.eos_token_ids = {0}
         return model, tokenizer
+
+    async def test_engine_loop_keeps_all_scheduler_steps_on_mlx_thread(
+        self, mock_model_and_tokenizer
+    ):
+        """Prefill and decode steps must run on the same MLX worker thread."""
+        from vllm_mlx.engine import EngineConfig, EngineCore
+
+        model, tokenizer = mock_model_and_tokenizer
+        engine = EngineCore(model, tokenizer, EngineConfig(step_interval=0.001))
+
+        class FakeScheduler:
+            batch_generator = None
+
+            def __init__(self):
+                self.calls = 0
+                self.thread_names = []
+
+            def has_requests(self):
+                return self.calls < 2
+
+            def step(self):
+                self.thread_names.append(threading.current_thread().name)
+                self.calls += 1
+                if self.calls >= 2:
+                    engine._running = False
+                return SimpleNamespace(outputs=[], finished_request_ids=[])
+
+            def deep_reset(self):
+                pass
+
+        fake_scheduler = FakeScheduler()
+        engine.scheduler = fake_scheduler
+        engine._running = True
+
+        try:
+            await asyncio.wait_for(engine._engine_loop(), timeout=2)
+        finally:
+            engine._running = False
+            engine.close()
+
+        assert fake_scheduler.thread_names
+        assert all(name.startswith("mlx-step") for name in fake_scheduler.thread_names)
 
     async def test_engine_lifecycle(self, mock_model_and_tokenizer):
         """Test engine start/stop lifecycle."""

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -29,6 +29,23 @@ from .scheduler import Scheduler, SchedulerConfig
 logger = logging.getLogger(__name__)
 
 
+def _init_mlx_step_thread() -> None:
+    """Create mlx-lm's generation stream inside the MLX worker thread."""
+    import sys
+
+    stream = mx.new_stream(mx.default_device())
+
+    gen_mod = sys.modules.get("mlx_lm.generate")
+    if gen_mod is not None:
+        gen_mod.generation_stream = stream
+
+    sched_mod = sys.modules.get("vllm_mlx.scheduler")
+    if sched_mod is not None and hasattr(sched_mod, "generation_stream"):
+        sched_mod.generation_stream = stream
+
+    logger.info("MLX step thread initialized: generation_stream=%s", stream)
+
+
 @dataclass
 class EngineConfig:
     """Configuration for the engine."""
@@ -153,18 +170,16 @@ class EngineCore:
         return self._running
 
     async def _engine_loop(self) -> None:
-        """Main engine loop - hybrid executor for prefill vs generation.
-
-        Prefill steps (long prompts) are run in a thread executor to keep
-        the asyncio event loop responsive.  Generation-only steps (~1-3ms)
-        are called directly to avoid ~0.5-2ms context switch overhead,
-        giving ~5-10% throughput improvement during sustained generation.
-        """
+        """Main engine loop."""
         import concurrent.futures
 
-        # Single-thread executor ensures MLX calls are never concurrent
+        # Keep every scheduler step on one thread. mlx-lm generation streams
+        # are thread-local, and Qwen3.x RotatingKVCache keeps arrays tagged
+        # with that stream across prefill and decode.
         _executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mlx-step"
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=_init_mlx_step_thread,
         )
         loop = asyncio.get_running_loop()
 
@@ -195,26 +210,7 @@ class EngineCore:
         while self._running:
             try:
                 if self.scheduler.has_requests():
-                    # Hybrid approach: use executor only when prefill is likely.
-                    # Prefill happens when there are waiting requests that need
-                    # to be inserted into the batch (may block for seconds).
-                    # Generation-only steps are fast (<3ms) and can run inline.
-                    has_waiting = self.scheduler.get_num_waiting() > 0
-                    has_partial = (
-                        self.scheduler.batch_generator is not None
-                        and getattr(self.scheduler.batch_generator, "_partial", None)
-                        is not None
-                    )
-                    needs_executor = has_waiting or has_partial
-
-                    if needs_executor:
-                        output = await loop.run_in_executor(
-                            _executor, self.scheduler.step
-                        )
-                    else:
-                        output = self.scheduler.step()
-                        # Yield to event loop after inline step
-                        await asyncio.sleep(0)
+                    output = await loop.run_in_executor(_executor, self.scheduler.step)
                     self._steps_executed += 1
 
                     # Emergency memory pressure check


### PR DESCRIPTION
## Summary

Fixes #160.

Rapid-MLX's async engine was using a hybrid scheduler execution path:

- prefill / queued-request steps ran in a single `ThreadPoolExecutor` worker
- generation-only decode steps ran inline on the asyncio event-loop thread

That is unsafe with `mlx-lm` 0.31+ for Qwen3.x / hybrid cache models. `mlx-lm` creates `generation_stream` as a thread-local MLX stream, while the batch generator and prompt/generation cache objects keep MLX arrays that are tagged with the stream used during prior work. When Rapid-MLX moved the same `BatchGenerator` from the executor thread back to the event-loop thread, MLX could no longer resolve the stream in the current thread and raised errors like:

```text
RuntimeError: There is no Stream(gpu, 3) in current thread.
```

## What changed

- Initialize `mlx_lm.generate.generation_stream` inside the MLX executor thread.
- Keep every `scheduler.step()` call on the same single `mlx-step` worker thread, including both prefill and decode.
- Preserve async HTTP/OpenAI responsiveness by still using `loop.run_in_executor(...)`; the event loop no longer runs MLX decode inline.
- Add regression coverage that verifies:
  - the executor thread initializer rebinds `mlx-lm`'s generation stream
  - prefill and decode scheduler steps stay on the `mlx-step` worker thread

This intentionally does not touch the OpenAI-compatible API routing, model aliasing, Qwen reasoning/tool parsers, or response translation code.

## Validation

Ran locally on the changed files:

```text
uvx ruff check vllm_mlx/engine_core.py tests/test_batching.py
uvx ruff format --check vllm_mlx/engine_core.py tests/test_batching.py
python -m py_compile vllm_mlx/engine_core.py tests/test_batching.py
manual regression script matching the added threading checks
```

I also applied the equivalent patch to a local `rapid-mlx 0.6.1` Homebrew install and verified `rapid-mlx serve qwen3.6-35b` with:

- server warmup
- `/v1/models`
- non-streaming `/v1/chat/completions`
- streaming SSE `/v1/chat/completions`
- a long prompt request with ~10k prompt tokens
- a `claw --model openai/default` request with a ~5.4k-token prompt

Those requests completed without the `There is no Stream(gpu, N) in current thread` scheduler failure.