### PR TITLE
Fix Qwen tool-call OpenAI translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,36 @@ Large-context requests auto-route to a cloud LLM (GPT-5, Claude, etc.) when loca
 
 Vision, audio (STT/TTS), video understanding, and text embeddings — all through the same OpenAI-compatible API.
 
+### DFlash Speculative Decoding
+
+Run a target model alongside a small **DFlash drafter** for block-based draft+verify speculative decoding (cross-attention to selected target hidden states). Works for Qwen 3.6 family with the matching DFlash drafter checkpoint. Single-request only in this mode (continuous batching disabled). Adaptive block sizing (8–22 by default) tunes itself per-request based on observed acceptance ratio.
+
+Install the drafter runtime once (uses the `dflash[mlx]` package from the upstream repo):
+
+```bash
+pip install -e /path/to/dflash[mlx]
+```
+
+Then point `--drafter` at a DFlash drafter checkpoint:
+
+```bash
+rapid-mlx serve /path/to/Qwen3.6-35B-A3B-4bit \
+  --drafter /path/to/Qwen3.6-35B-A3B-DFlash \
+  --port 8010
+```
+
+The server exposes the same `/v1/chat/completions` API as the regular path. `/v1/status` adds a `dflash` block with the lifetime acceptance ratio, current block size, and observed bounds — also surfaced live in `--tui`.
+
+Mutually exclusive with `--enable-mtp` and `--mllm`.
+
+### Live TUI Monitor
+
+`--tui` opens a full-screen dashboard alongside the server: status, model, Metal memory, prompt/output token totals, the last completed request (gen tok/s, prefill tok/s, ttft, finish reason), per-request averages, recent requests, message previews, and (when DFlash is enabled) lifetime acceptance ratio + adaptive block-size bounds. Press `q` or Ctrl-C to exit.
+
+```bash
+rapid-mlx serve <model> --tui
+```
+
 Also: logprobs API, structured JSON output (`response_format`), continuous batching, KV cache quantization (`--kv-cache-quantization`), and [2100+ tests](tests/).
 
 ---
@@ -597,6 +627,23 @@ Also: logprobs API, structured JSON output (`response_format`), continuous batch
 |------|-------------|---------|
 | `--cloud-model` | litellm model string (e.g. `openai/gpt-5`) | *(disabled)* |
 | `--cloud-threshold` | New token threshold to trigger cloud routing | `20000` |
+
+### DFlash Speculative Decoding
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--drafter` | Path or HF id of a DFlash drafter checkpoint. Triggers DFlash mode. | *(disabled)* |
+| `--dflash-block-size` | Override the drafter's default block size | *(from drafter config)* |
+| `--dflash-no-adaptive` | Disable adaptive block sizing (adaptive is on by default) | off |
+| `--dflash-block-min` | Adaptive block-size lower bound | `8` |
+| `--dflash-block-max` | Adaptive block-size upper bound | `22` |
+| `--dflash-turboquant-bits` | KV-cache TurboQuant bits for the target (requires `mlx-turboquant`) | *(off)* |
+
+### Monitor TUI
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--tui` | Run a live full-screen monitor alongside the server (q quits) | off |
 
 ### Security & Other
 

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -7,6 +7,10 @@ for the vLLM-style continuous batching implementation.
 """
 
 import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -433,6 +437,25 @@ class TestSchedulerIntegration:
         assert len(finished) == len(prompts), f"Only {len(finished)} requests finished"
 
 
+class TestEngineThreading:
+    """Threading tests for EngineCore."""
+
+    def test_mlx_step_thread_initializer_rebinds_generation_stream(self, monkeypatch):
+        """The executor thread must own mlx-lm's generation stream."""
+        from vllm_mlx import engine_core
+
+        fake_generate = types.SimpleNamespace(generation_stream="old-stream")
+        monkeypatch.setitem(sys.modules, "mlx_lm.generate", fake_generate)
+        monkeypatch.setattr(engine_core.mx, "default_device", lambda: "gpu")
+        monkeypatch.setattr(
+            engine_core.mx, "new_stream", lambda device: f"stream:{device}"
+        )
+
+        engine_core._init_mlx_step_thread()
+
+        assert fake_generate.generation_stream == "stream:gpu"
+
+
 @pytest.mark.asyncio
 class TestEngineAsync:
     """Async tests for the engine."""
@@ -447,6 +470,48 @@ class TestEngineAsync:
         tokenizer.eos_token_id = 0
         tokenizer.eos_token_ids = {0}
         return model, tokenizer
+
+    async def test_engine_loop_keeps_all_scheduler_steps_on_mlx_thread(
+        self, mock_model_and_tokenizer
+    ):
+        """Prefill and decode steps must run on the same MLX worker thread."""
+        from vllm_mlx.engine import EngineConfig, EngineCore
+
+        model, tokenizer = mock_model_and_tokenizer
+        engine = EngineCore(model, tokenizer, EngineConfig(step_interval=0.001))
+
+        class FakeScheduler:
+            batch_generator = None
+
+            def __init__(self):
+                self.calls = 0
+                self.thread_names = []
+
+            def has_requests(self):
+                return self.calls < 2
+
+            def step(self):
+                self.thread_names.append(threading.current_thread().name)
+                self.calls += 1
+                if self.calls >= 2:
+                    engine._running = False
+                return SimpleNamespace(outputs=[], finished_request_ids=[])
+
+            def deep_reset(self):
+                pass
+
+        fake_scheduler = FakeScheduler()
+        engine.scheduler = fake_scheduler
+        engine._running = True
+
+        try:
+            await asyncio.wait_for(engine._engine_loop(), timeout=2)
+        finally:
+            engine._running = False
+            engine.close()
+
+        assert fake_scheduler.thread_names
+        assert all(name.startswith("mlx-step") for name in fake_scheduler.thread_names)
 
     async def test_engine_lifecycle(self, mock_model_and_tokenizer):
         """Test engine start/stop lifecycle."""

--- a/tests/test_chat_stream_tool_continuation.py
+++ b/tests/test_chat_stream_tool_continuation.py
@@ -10,6 +10,7 @@ from vllm_mlx.domain.events import StreamEvent
 from vllm_mlx.engine import GenerationOutput
 from vllm_mlx.routes.chat import stream_chat_completion
 from vllm_mlx.service.helpers import (
+    _TOOL_CALL_JSON_RETRY_PROMPT,
     _TOOL_CALL_REQUIRED_RETRY_PROMPT,
     _TOOL_CONTINUATION_RETRY_PROMPT,
 )
@@ -94,6 +95,97 @@ class _FakeRepetitionPostProcessor(_FakeStreamingPostProcessor):
                         "id": "call_after_retry",
                         "type": "function",
                         "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+                finish_reason="tool_calls",
+                tool_calls_detected=True,
+            )
+        ]
+
+
+class _EngineThatTruncatesThenCallsTool:
+    def __init__(self):
+        self.calls = 0
+        self.messages_seen = []
+        self.tokenizer = MagicMock()
+
+    async def stream_chat(self, messages, **kwargs):
+        self.calls += 1
+        self.messages_seen.append(messages)
+        if self.calls == 1:
+            yield GenerationOutput(
+                text="<tool_call><function=write>{",
+                new_text="<tool_call><function=write>{",
+                prompt_tokens=10,
+                completion_tokens=8192,
+                finished=False,
+                finish_reason=None,
+            )
+            yield GenerationOutput(
+                text="<tool_call><function=write>{",
+                new_text="",
+                prompt_tokens=10,
+                completion_tokens=8192,
+                finished=True,
+                finish_reason="length",
+            )
+            return
+
+        yield GenerationOutput(
+            text="<tool_call><function=write>{}</function></tool_call>",
+            new_text="<tool_call><function=write>{}</function></tool_call>",
+            prompt_tokens=12,
+            completion_tokens=10,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+class _FakeTruncatedToolPostProcessor(_FakeStreamingPostProcessor):
+    def process_chunk(self, output):
+        if self.index == 0:
+            if output.finished:
+                return [
+                    StreamEvent(
+                        type="finish",
+                        finish_reason="tool_calls",
+                        tool_calls_detected=True,
+                    )
+                ]
+            return [
+                StreamEvent(
+                    type="tool_call",
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_truncated",
+                            "type": "function",
+                            "function": {"name": "write", "arguments": ""},
+                        }
+                    ],
+                    tool_calls_detected=True,
+                ),
+                StreamEvent(
+                    type="tool_call",
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "function": {"arguments": "{"},
+                        }
+                    ],
+                    tool_calls_detected=True,
+                ),
+            ]
+
+        return [
+            StreamEvent(
+                type="tool_call",
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_complete",
+                        "type": "function",
+                        "function": {"name": "write", "arguments": "{}"},
                     }
                 ],
                 finish_reason="tool_calls",
@@ -194,3 +286,48 @@ async def test_tool_request_retries_when_model_repeats_text_before_tool_call(
     assert engine.messages_seen[1][-1]["content"] == _TOOL_CALL_REQUIRED_RETRY_PROMPT
     assert not any("point point" in chunk for chunk in chunks)
     assert any('"tool_calls"' in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_tool_request_retries_when_tool_call_json_is_truncated(monkeypatch):
+    """Retry instead of streaming partial function arguments to the client."""
+    from vllm_mlx.service import postprocessor
+
+    _FakeTruncatedToolPostProcessor.instances = 0
+    monkeypatch.setattr(
+        postprocessor,
+        "StreamingPostProcessor",
+        _FakeTruncatedToolPostProcessor,
+    )
+
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "write file"}],
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "write",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    engine = _EngineThatTruncatesThenCallsTool()
+
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            engine,
+            [{"role": "user", "content": "Build app"}],
+            request,
+            tool_continuation_retry=False,
+            max_tokens=16,
+        )
+    ]
+
+    assert engine.calls == 2
+    assert engine.messages_seen[1][-1]["content"] == _TOOL_CALL_JSON_RETRY_PROMPT
+    assert not any("call_truncated" in chunk for chunk in chunks)
+    assert any("call_complete" in chunk for chunk in chunks)

--- a/tests/test_chat_stream_tool_continuation.py
+++ b/tests/test_chat_stream_tool_continuation.py
@@ -9,7 +9,10 @@ from vllm_mlx.api.models import ChatCompletionRequest
 from vllm_mlx.domain.events import StreamEvent
 from vllm_mlx.engine import GenerationOutput
 from vllm_mlx.routes.chat import stream_chat_completion
-from vllm_mlx.service.helpers import _TOOL_CONTINUATION_RETRY_PROMPT
+from vllm_mlx.service.helpers import (
+    _TOOL_CALL_REQUIRED_RETRY_PROMPT,
+    _TOOL_CONTINUATION_RETRY_PROMPT,
+)
 
 
 class _EngineThatExhaustsThenCallsTool:
@@ -78,6 +81,27 @@ class _FakeStreamingPostProcessor:
         return []
 
 
+class _FakeRepetitionPostProcessor(_FakeStreamingPostProcessor):
+    def process_chunk(self, output):
+        if self.index == 0:
+            return [StreamEvent(type="content", content="point " * 40)]
+        return [
+            StreamEvent(
+                type="tool_call",
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_after_retry",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+                finish_reason="tool_calls",
+                tool_calls_detected=True,
+            )
+        ]
+
+
 @pytest.mark.asyncio
 async def test_tool_continuation_retries_when_stream_exhausts_without_finish(
     monkeypatch,
@@ -124,3 +148,49 @@ async def test_tool_continuation_retries_when_stream_exhausts_without_finish(
     assert not any("Thinking only." in chunk for chunk in chunks)
     assert any('"tool_calls"' in chunk for chunk in chunks)
 
+
+@pytest.mark.asyncio
+async def test_tool_request_retries_when_model_repeats_text_before_tool_call(
+    monkeypatch,
+):
+    """Retry first tool turn when model enters repeated-text loop."""
+    from vllm_mlx.service import postprocessor
+
+    _FakeStreamingPostProcessor.instances = 0
+    monkeypatch.setattr(
+        postprocessor,
+        "StreamingPostProcessor",
+        _FakeRepetitionPostProcessor,
+    )
+
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "do work"}],
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    engine = _EngineThatExhaustsThenCallsTool()
+
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            engine,
+            [{"role": "user", "content": "Build app"}],
+            request,
+            tool_continuation_retry=False,
+            max_tokens=16,
+        )
+    ]
+
+    assert engine.calls == 2
+    assert engine.messages_seen[1][-1]["content"] == _TOOL_CALL_REQUIRED_RETRY_PROMPT
+    assert not any("point point" in chunk for chunk in chunks)
+    assert any('"tool_calls"' in chunk for chunk in chunks)

--- a/tests/test_chat_stream_tool_continuation.py
+++ b/tests/test_chat_stream_tool_continuation.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for chat streaming tool-continuation retry behavior."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.api.models import ChatCompletionRequest
+from vllm_mlx.domain.events import StreamEvent
+from vllm_mlx.engine import GenerationOutput
+from vllm_mlx.routes.chat import stream_chat_completion
+from vllm_mlx.service.helpers import _TOOL_CONTINUATION_RETRY_PROMPT
+
+
+class _EngineThatExhaustsThenCallsTool:
+    def __init__(self):
+        self.calls = 0
+        self.messages_seen = []
+        self.tokenizer = MagicMock()
+
+    async def stream_chat(self, messages, **kwargs):
+        self.calls += 1
+        self.messages_seen.append(messages)
+        if self.calls == 1:
+            yield GenerationOutput(
+                text="Thinking only.",
+                new_text="Thinking only.",
+                prompt_tokens=10,
+                completion_tokens=2,
+                finished=False,
+                finish_reason=None,
+            )
+            return
+
+        yield GenerationOutput(
+            text="<tool_call>",
+            new_text="<tool_call>",
+            prompt_tokens=12,
+            completion_tokens=3,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+class _FakeStreamingPostProcessor:
+    instances = 0
+
+    def __init__(self, *args, **kwargs):
+        self.index = _FakeStreamingPostProcessor.instances
+        _FakeStreamingPostProcessor.instances += 1
+
+    def set_thinking_model(self, model_name):
+        pass
+
+    def reset(self):
+        pass
+
+    def process_chunk(self, output):
+        if self.index == 0:
+            return [StreamEvent(type="content", content="Thinking only.")]
+        return [
+            StreamEvent(
+                type="tool_call",
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_test",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+                finish_reason="tool_calls",
+                tool_calls_detected=True,
+            )
+        ]
+
+    def finalize(self):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_tool_continuation_retries_when_stream_exhausts_without_finish(
+    monkeypatch,
+):
+    """Retry when engine stream ends after narration without finish event."""
+    from vllm_mlx.service import postprocessor
+
+    _FakeStreamingPostProcessor.instances = 0
+    monkeypatch.setattr(
+        postprocessor,
+        "StreamingPostProcessor",
+        _FakeStreamingPostProcessor,
+    )
+
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "do work"}],
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    engine = _EngineThatExhaustsThenCallsTool()
+
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            engine,
+            [{"role": "tool", "content": "done"}],
+            request,
+            tool_continuation_retry=True,
+            max_tokens=16,
+        )
+    ]
+
+    assert engine.calls == 2
+    assert engine.messages_seen[1][-1]["content"] == _TOOL_CONTINUATION_RETRY_PROMPT
+    assert not any("Thinking only." in chunk for chunk in chunks)
+    assert any('"tool_calls"' in chunk for chunk in chunks)
+

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for StreamingPostProcessor — the unified streaming pipeline."""
 
+import json
 from unittest.mock import MagicMock
 
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
@@ -244,6 +245,53 @@ class TestStreamingPostProcessorToolCalls:
         assert len(events) == 1
         assert events[0].type == "tool_call"
         assert events[0].finish_reason == "tool_calls"
+
+    def test_bare_calling_tool_emits_tool_call_not_content(self):
+        """Bare Qwen Calling tool syntax is translated to OpenAI tool calls."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                'Calling tool: todowrite({"todos": '
+                '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"'
+                "})"
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
 
 class TestStreamingPostProcessorNemotron:

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -294,7 +294,7 @@ class TestStreamingPostProcessorToolCalls:
         assert args["todos"][0]["content"] == "Initialize"
 
     def test_bare_calling_tool_works_without_configured_parser(self):
-        """Generic Calling tool fallback works when only request tools are present."""
+        """Generic Calling tool fallback works without a configured parser."""
         request = {
             "tools": [
                 {
@@ -313,7 +313,7 @@ class TestStreamingPostProcessorToolCalls:
         cfg = _make_cfg(enable_auto_tool_choice=False)
         pp = StreamingPostProcessor(
             cfg,
-            tools_requested=True,
+            tools_requested=False,
             request_dict=request,
         )
         pp.reset()

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -333,6 +333,56 @@ class TestStreamingPostProcessorToolCalls:
         args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
         assert args["command"].startswith("npx tsc")
 
+    def test_qwen_xml_tool_uses_schema_after_content_prefix(self):
+        """Schema conversion still works if text appears before tool markup."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        assert pp.process_chunk(_make_output("Thinking first.\n"))[0].type == "content"
+        events = pp.process_chunk(
+            _make_output(
+                "<tool_call>\n<function=todowrite>\n"
+                "<parameter=todos>\n"
+                '"[{\\"content\\": \\"Install tests\\", \\"status\\": \\"in_progress\\"}]"\n'
+                "</parameter>\n"
+                "</function>\n</tool_call>"
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Install tests"
+
 
 class TestStreamingPostProcessorNemotron:
     """Tests for Nemotron thinking prefix."""

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -293,6 +293,46 @@ class TestStreamingPostProcessorToolCalls:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_bare_calling_tool_works_without_configured_parser(self):
+        """Generic Calling tool fallback works when only request tools are present."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(enable_auto_tool_choice=False)
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                'Calling tool: bash({"command": "npx tsc --noEmit 2>&1 | '
+                'distill \\"TypeScript compilation result. Return only: PASS '
+                'or FAIL with error details.\\""})'
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        assert events[0].content is None
+        assert events[0].tool_calls[0]["function"]["name"] == "bash"
+        args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
+        assert args["command"].startswith("npx tsc")
+
 
 class TestStreamingPostProcessorNemotron:
     """Tests for Nemotron thinking prefix."""

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -333,6 +333,104 @@ class TestStreamingPostProcessorToolCalls:
         args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
         assert args["command"].startswith("npx tsc")
 
+    def test_partial_calling_tool_marker_is_buffered(self):
+        """Do not leak partial generic tool markers as assistant text."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string"},
+                                "timeout": {"type": "number"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        heading_events = pp.process_chunk(_make_output("Next step\n\n["))
+        assert len(heading_events) == 1
+        assert heading_events[0].type == "content"
+        assert heading_events[0].content == "Next step"
+        assert pp.process_chunk(_make_output("Calling tool")) == []
+        events = pp.process_chunk(
+            _make_output(
+                ': bash({"command":"npm test", "timeout": "60000"})]',
+                finished=True,
+            )
+        )
+
+        tool_events = [event for event in events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        args = json.loads(tool_events[0].tool_calls[0]["function"]["arguments"])
+        assert args["command"] == "npm test"
+        assert args["timeout"] == 60000.0
+
+    def test_generic_tool_call_drops_missing_required_duplicate(self):
+        """Malformed duplicate calls should not reach clients for schema rejection."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "edit",
+                        "parameters": {
+                            "type": "object",
+                            "required": ["filePath", "oldString", "newString"],
+                            "properties": {
+                                "filePath": {"type": "string"},
+                                "oldString": {"type": "string"},
+                                "newString": {"type": "string"},
+                                "replaceAll": {"type": "boolean"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                'Calling tool: edit({"oldString":"a","newString":"b"})\n'
+                'Calling tool: edit({"filePath":"/tmp/package.json",'
+                '"oldString":"a","newString":"b"})',
+                finished=True,
+            )
+        )
+
+        tool_events = [event for event in events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        assert len(tool_events[0].tool_calls) == 1
+        args = json.loads(tool_events[0].tool_calls[0]["function"]["arguments"])
+        assert args["filePath"] == "/tmp/package.json"
+
     def test_qwen_xml_tool_uses_schema_after_content_prefix(self):
         """Schema conversion still works if text appears before tool markup."""
         request = {

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -382,6 +382,29 @@ class TestStreamingPostProcessorToolCalls:
         assert args["command"] == "npm test"
         assert args["timeout"] == 60000.0
 
+    def test_code_brackets_are_not_treated_as_partial_tool_markers(self):
+        """Do not strip normal code brackets split at chunk boundaries."""
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict={"tools": []},
+        )
+        pp.reset()
+
+        index_events = pp.process_chunk(_make_output("const head = game.snake["))
+        array_events = pp.process_chunk(_make_output("const snake = ["))
+
+        assert len(index_events) == 1
+        assert index_events[0].type == "content"
+        assert index_events[0].content == "const head = game.snake["
+        assert len(array_events) == 1
+        assert array_events[0].type == "content"
+        assert array_events[0].content == "const snake = ["
+
     def test_generic_tool_call_drops_missing_required_duplicate(self):
         """Malformed duplicate calls should not reach clients for schema rejection."""
         request = {

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -271,6 +271,91 @@ class TestAppendToolContinuationPrompt:
         assert result[-1]["role"] == "user"
         assert "Do not stop with only reasoning" in result[-1]["content"]
 
+    def test_repeated_read_gets_anti_loop_prompt(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "arguments": '{"filePath":"app.ts","offset":10}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "lines"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "arguments": '{"offset":10,"filePath":"app.ts"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "same lines"},
+        ]
+        result, added = _append_tool_continuation_prompt(messages, True)
+
+        assert added is True
+        assert "Do not call the same read-only tool" in result[-1]["content"]
+
+    def test_repeated_read_after_mutating_tool_uses_normal_prompt(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "arguments": '{"filePath":"app.ts"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "old"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "edit",
+                            "arguments": '{"filePath":"app.ts"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "edited"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "arguments": '{"filePath":"app.ts"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_3", "content": "new"},
+        ]
+        result, added = _append_tool_continuation_prompt(messages, True)
+
+        assert added is True
+        assert "Do not stop with only reasoning" in result[-1]["content"]
+
 
 # ---------------------------------------------------------------------------
 # _extract_token_logprob

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -221,6 +221,58 @@ class TestInjectJsonInstruction:
 
 
 # ---------------------------------------------------------------------------
+# _append_tool_continuation_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestAppendToolContinuationPrompt:
+    """Tests for tool-result continuation prompt injection."""
+
+    def test_appends_after_tool_result_when_tools_requested(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [
+            {"role": "user", "content": "Build the app"},
+            {"role": "assistant", "content": "", "tool_calls": []},
+            {"role": "tool", "tool_call_id": "call_1", "content": "PASS"},
+        ]
+        result, added = _append_tool_continuation_prompt(messages, True)
+
+        assert added is True
+        assert result[-1]["role"] == "user"
+        assert "call the next tool now" in result[-1]["content"]
+        assert len(messages) == 3
+
+    def test_does_not_append_without_tools(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [{"role": "tool", "content": "PASS"}]
+        result, added = _append_tool_continuation_prompt(messages, False)
+
+        assert added is False
+        assert result is messages
+
+    def test_does_not_append_unless_last_message_is_tool(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [{"role": "user", "content": "continue"}]
+        result, added = _append_tool_continuation_prompt(messages, True)
+
+        assert added is False
+        assert result is messages
+
+    def test_appends_after_converted_tool_result_user_message(self):
+        from vllm_mlx.service.helpers import _append_tool_continuation_prompt
+
+        messages = [{"role": "user", "content": "[Tool Result (call_1)]: PASS"}]
+        result, added = _append_tool_continuation_prompt(messages, True)
+
+        assert added is True
+        assert result[-1]["role"] == "user"
+        assert "Do not stop with only reasoning" in result[-1]["content"]
+
+
+# ---------------------------------------------------------------------------
 # _extract_token_logprob
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -226,6 +226,33 @@ class TestGenericToolCallParsing:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_tool_arguments_coerce_schema_numbers(self):
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string"},
+                                "timeout": {"type": "number"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        text = 'Calling tool: bash({"command": "npm test", "timeout": "60000"})'
+
+        _, tool_calls = parse_tool_calls(text, request)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["command"] == "npm test"
+        assert args["timeout"] == 60000.0
+
 
 class TestLlamaToolParser:
     """Test the Llama tool parser."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from vllm_mlx.api.tool_calling import parse_tool_calls
 from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
@@ -191,6 +192,39 @@ class TestQwenToolParser:
         result = parser.extract_tool_calls(text)
 
         assert not result.tools_called
+
+
+class TestGenericToolCallParsing:
+    """Test generic OpenAI tool-call translation helpers."""
+
+    def test_bare_calling_tool_is_parsed_and_removed(self):
+        text = (
+            "Thinking first.\n"
+            'Calling tool: write({"filePath": "/tmp/app.tsx", "content": "ok"})'
+        )
+
+        cleaned_text, tool_calls = parse_tool_calls(text)
+
+        assert cleaned_text == "Thinking first."
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "write"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args == {"filePath": "/tmp/app.tsx", "content": "ok"}
+
+    def test_tool_arguments_decode_stringified_arrays(self):
+        text = (
+            'Calling tool: todowrite({"todos": '
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"'
+            "})"
+        )
+
+        _, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
 
 class TestLlamaToolParser:

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1069,6 +1069,42 @@ class TestQwen3CoderUpstreamNonStreaming:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args["obj_param"] == {"key": "value"}
 
+    def test_array_parameter_double_encoded_json_string(self, qwen3coder_parser):
+        """Array parameters may arrive as double-encoded JSON strings."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
     def test_fallback_no_tool_call_tags(self, qwen3coder_parser, qwen3coder_request):
         """Bare <function=...> without <tool_call> wrapper also works."""
         output = (

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1105,6 +1105,42 @@ class TestQwen3CoderUpstreamNonStreaming:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Schemas may encode nullable arrays as type lists."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
     def test_fallback_no_tool_call_tags(self, qwen3coder_parser, qwen3coder_request):
         """Bare <function=...> without <tool_call> wrapper also works."""
         output = (
@@ -1239,6 +1275,58 @@ class TestQwen3CoderUpstreamStreaming:
         assert full_args.endswith("}")
         parsed = json.loads(full_args)
         assert parsed["city"] == "Dallas"
+
+    def test_streaming_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Streaming conversion also handles nullable array schemas."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        deltas = [
+            "<tool_call>\n<function=todowrite>\n",
+            "<parameter=todos>\n",
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n",
+            "</function>\n</tool_call>",
+        ]
+        text = ""
+        collected = []
+        for delta in deltas:
+            previous = text
+            text += delta
+            result = qwen3coder_parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=text,
+                delta_text=delta,
+                request=request,
+            )
+            if result:
+                collected.append(result)
+
+        arg_parts = [
+            chunk["tool_calls"][0]["function"]["arguments"]
+            for chunk in collected
+            if "tool_calls" in chunk
+            and "arguments" in chunk["tool_calls"][0].get("function", {})
+        ]
+        args = json.loads("".join(arg_parts))
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
     def test_streaming_coarse_deltas_complete(
         self, qwen3coder_parser, qwen3coder_request

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -46,17 +46,100 @@ def _decode_json_like(value: Any) -> Any:
     return current
 
 
-def _normalize_tool_arguments(arguments: Any) -> Any:
+def _get_tool_param_config(
+    tool_name: str | None, request: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Return JSON schema properties for a requested tool."""
+    if not tool_name or not isinstance(request, dict):
+        return {}
+    tools = request.get("tools")
+    if not isinstance(tools, list):
+        return {}
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict) or function.get("name") != tool_name:
+            continue
+        parameters = function.get("parameters")
+        if not isinstance(parameters, dict):
+            return {}
+        properties = parameters.get("properties")
+        if isinstance(properties, dict):
+            return properties
+        return parameters
+    return {}
+
+
+def _schema_type(schema: Any) -> str | None:
+    if not isinstance(schema, dict):
+        return None
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    if isinstance(schema_type, str):
+        return schema_type.strip().lower()
+    for key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(key)
+        if isinstance(options, list):
+            for option in options:
+                option_type = _schema_type(option)
+                if option_type and option_type != "null":
+                    return option_type
+    return None
+
+
+def _coerce_schema_value(value: Any, schema: Any) -> Any:
+    value = _decode_json_like(value)
+    schema_type = _schema_type(schema)
+    if schema_type is None:
+        return value
+    if value is None:
+        return None
+    if schema_type in ("array", "object"):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    try:
+        if schema_type in ("integer", "int"):
+            return int(stripped)
+        if schema_type in ("number", "float"):
+            return float(stripped)
+    except (TypeError, ValueError):
+        return value
+    if schema_type in ("boolean", "bool"):
+        if stripped.lower() == "true":
+            return True
+        if stripped.lower() == "false":
+            return False
+    return value
+
+
+def _normalize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> Any:
     """Normalize parsed tool arguments before OpenAI serialization."""
     arguments = _decode_json_like(arguments)
     if isinstance(arguments, dict):
-        return {key: _decode_json_like(value) for key, value in arguments.items()}
+        param_config = _get_tool_param_config(tool_name, request)
+        return {
+            key: _coerce_schema_value(value, param_config.get(key))
+            for key, value in arguments.items()
+        }
     return arguments
 
 
-def _serialize_tool_arguments(arguments: Any) -> str:
+def _serialize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> str:
     """Serialize tool arguments as a valid OpenAI function.arguments JSON string."""
-    arguments = _normalize_tool_arguments(arguments)
+    arguments = _normalize_tool_arguments(arguments, tool_name, request)
     if isinstance(arguments, str):
         decoded = _decode_json_like(arguments)
         if decoded is not arguments:
@@ -277,7 +360,9 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
+                        ),
                     ),
                 )
             )
@@ -317,7 +402,9 @@ def parse_tool_calls(
                 type="function",
                 function=FunctionCall(
                     name=name.strip(),
-                    arguments=_serialize_tool_arguments(arguments),
+                    arguments=_serialize_tool_arguments(
+                        arguments, name.strip(), request
+                    ),
                 ),
             )
         )
@@ -353,7 +440,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name,
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(arguments, name, request),
                     ),
                 )
             )
@@ -384,7 +471,9 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
+                        ),
                     ),
                 )
             )
@@ -421,7 +510,9 @@ def parse_tool_calls(
                         type="function",
                         function=FunctionCall(
                             name=call_data["name"],
-                            arguments=_serialize_tool_arguments(call_data["arguments"]),
+                            arguments=_serialize_tool_arguments(
+                                call_data["arguments"], call_data["name"], request
+                            ),
                         ),
                     )
                 )

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -24,6 +24,121 @@ from .models import FunctionCall, ResponseFormat, ToolCall
 logger = logging.getLogger(__name__)
 
 
+def _decode_json_like(value: Any) -> Any:
+    """Decode JSON-looking strings, including one level of double encoding."""
+    if not isinstance(value, str):
+        return value
+
+    current: Any = value.strip()
+    for _ in range(3):
+        if not isinstance(current, str):
+            return current
+        stripped = current.strip()
+        if not stripped or stripped[0] not in '[{"':
+            return current
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return current
+        if parsed == current:
+            return parsed
+        current = parsed
+    return current
+
+
+def _normalize_tool_arguments(arguments: Any) -> Any:
+    """Normalize parsed tool arguments before OpenAI serialization."""
+    arguments = _decode_json_like(arguments)
+    if isinstance(arguments, dict):
+        return {key: _decode_json_like(value) for key, value in arguments.items()}
+    return arguments
+
+
+def _serialize_tool_arguments(arguments: Any) -> str:
+    """Serialize tool arguments as a valid OpenAI function.arguments JSON string."""
+    arguments = _normalize_tool_arguments(arguments)
+    if isinstance(arguments, str):
+        decoded = _decode_json_like(arguments)
+        if decoded is not arguments:
+            arguments = decoded
+    if isinstance(arguments, str):
+        return arguments
+    return json.dumps(arguments, ensure_ascii=False)
+
+
+def _iter_calling_tool_calls(text: str):
+    """Yield Qwen-style `Calling tool: name({...})` spans with balanced JSON args."""
+    marker = "Calling tool:"
+    search_from = 0
+    while True:
+        marker_idx = text.find(marker, search_from)
+        if marker_idx == -1:
+            return
+
+        i = marker_idx + len(marker)
+        while i < len(text) and text[i].isspace():
+            i += 1
+
+        name_start = i
+        while i < len(text) and (text[i].isalnum() or text[i] in "_.-"):
+            i += 1
+        name = text[name_start:i].strip()
+        if not name:
+            search_from = marker_idx + len(marker)
+            continue
+
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "(":
+            search_from = i
+            continue
+        i += 1
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "{":
+            search_from = i
+            continue
+
+        args_start = i
+        depth = 0
+        in_string = False
+        escaped = False
+        while i < len(text):
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        args_end = i + 1
+                        j = args_end
+                        while j < len(text) and text[j].isspace():
+                            j += 1
+                        if j < len(text) and text[j] == ")":
+                            j += 1
+                            if j < len(text) and text[j] == "]":
+                                j += 1
+                            start = marker_idx
+                            if marker_idx > 0 and text[marker_idx - 1] == "[":
+                                start = marker_idx - 1
+                            yield start, j, name, text[args_start:args_end]
+                            search_from = j
+                            break
+            i += 1
+        else:
+            return
+
+
 def _is_tool_call_json(obj: dict) -> bool:
     """
     Check if a JSON object looks like a tool call.
@@ -52,9 +167,9 @@ def _is_tool_call_json(obj: dict) -> bool:
     if not isinstance(obj["name"], str) or not obj["name"].strip():
         return False
 
-    # "arguments" must be a dict or string
+    # "arguments" must be JSON-like
     args = obj["arguments"]
-    if not isinstance(args, (dict, str)):
+    if not isinstance(args, (dict, list, str)):
         return False
 
     return True
@@ -132,7 +247,7 @@ def parse_tool_calls(
     Parse tool calls from model output.
 
     Supports multiple formats:
-    - Qwen3 bracket: [Calling tool: function_name({...})]
+    - Qwen3: [Calling tool: function_name({...})] or Calling tool: function_name({...})
     - Qwen:
     - Llama:
     - Nemotron:
@@ -149,11 +264,11 @@ def parse_tool_calls(
     tool_calls = []
     cleaned_text = text
 
-    # Pattern for Qwen3 bracket-style: [Calling tool: function_name({...})]
-    bracket_pattern = r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]"
-    bracket_matches = re.findall(bracket_pattern, text, re.DOTALL)
+    # Pattern for Qwen3 calling-tool style. Some models omit the outer brackets,
+    # and arguments can contain nested braces in strings, so use a balanced scan.
+    calling_tool_matches = list(_iter_calling_tool_calls(text))
 
-    for name, args_str in bracket_matches:
+    for _, _, name, args_str in calling_tool_matches:
         try:
             arguments = json.loads(args_str)
             tool_calls.append(
@@ -162,22 +277,18 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
         except json.JSONDecodeError:
             continue
 
-    # Remove bracket tool calls from cleaned text
-    if bracket_matches:
-        cleaned_text = re.sub(
-            r"\[Calling tool:\s*\w+\(\{.*?\}\)\]", "", cleaned_text, flags=re.DOTALL
-        ).strip()
+    # Remove Qwen calling-tool spans from cleaned text
+    if calling_tool_matches:
+        for start, end, _, _ in reversed(calling_tool_matches):
+            cleaned_text = cleaned_text[:start] + cleaned_text[end:]
+        cleaned_text = cleaned_text.strip()
 
     # Pattern for Nemotron-style:
     # Format 1: <tool_call><function=name><parameter=key>val</parameter></function></tool_call>
@@ -205,7 +316,8 @@ def parse_tool_calls(
                 id=f"call_{uuid.uuid4().hex[:8]}",
                 type="function",
                 function=FunctionCall(
-                    name=name.strip(), arguments=json.dumps(arguments)
+                    name=name.strip(),
+                    arguments=_serialize_tool_arguments(arguments),
                 ),
             )
         )
@@ -241,11 +353,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name,
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
@@ -276,11 +384,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
@@ -317,11 +421,7 @@ def parse_tool_calls(
                         type="function",
                         function=FunctionCall(
                             name=call_data["name"],
-                            arguments=(
-                                json.dumps(call_data["arguments"])
-                                if isinstance(call_data["arguments"], dict)
-                                else str(call_data["arguments"])
-                            ),
+                            arguments=_serialize_tool_arguments(call_data["arguments"]),
                         ),
                     )
                 )

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -72,6 +72,8 @@ def _get_tool_param_config(
 
 
 def _schema_type(schema: Any) -> str | None:
+    if isinstance(schema, str):
+        return schema.strip().lower()
     if not isinstance(schema, dict):
         return None
     schema_type = schema.get("type")
@@ -86,6 +88,12 @@ def _schema_type(schema: Any) -> str | None:
                 option_type = _schema_type(option)
                 if option_type and option_type != "null":
                     return option_type
+    if "items" in schema:
+        return "array"
+    if "properties" in schema or "additionalProperties" in schema:
+        return "object"
+    if "enum" in schema:
+        return "string"
     return None
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -117,6 +117,15 @@ def serve_command(args):
         )
         sys.exit(1)
 
+    # Validate DFlash mode incompatibilities up-front
+    if getattr(args, "drafter", None):
+        if getattr(args, "enable_mtp", False):
+            print("Error: --drafter (DFlash) and --enable-mtp are mutually exclusive.")
+            sys.exit(1)
+        if getattr(args, "mllm", False):
+            print("Error: --drafter (DFlash) is text-only; remove --mllm.")
+            sys.exit(1)
+
     # Auto-detect parser config from model name when not explicitly set
     if not args.tool_call_parser or not args.reasoning_parser:
         try:
@@ -376,6 +385,12 @@ def serve_command(args):
             cloud_api_key=args.cloud_api_key,
             served_model_name=args.served_model_name,
             mtp=args.enable_mtp,
+            drafter_path=getattr(args, "drafter", None),
+            dflash_block_size=getattr(args, "dflash_block_size", None),
+            dflash_adaptive=not getattr(args, "dflash_no_adaptive", False),
+            dflash_block_min=getattr(args, "dflash_block_min", 8),
+            dflash_block_max=getattr(args, "dflash_block_max", 22),
+            dflash_turboquant_bits=getattr(args, "dflash_turboquant_bits", None),
         )
     except Exception as e:
         # Show clean error instead of raw traceback
@@ -1426,6 +1441,51 @@ Examples:
         "--tui",
         action="store_true",
         help="Run a live full-screen monitor TUI alongside the server (q to quit).",
+    )
+    # DFlash speculative decoding (separate drafter model)
+    serve_parser.add_argument(
+        "--drafter",
+        type=str,
+        default=None,
+        help=(
+            "Path or HF id of a DFlash drafter checkpoint. Triggers DFlash "
+            "speculative decoding (block-based draft+verify with cross-attention "
+            "to selected target hidden states). Mutually exclusive with --enable-mtp "
+            "and --mllm. Single-request only (continuous batching is disabled in "
+            "DFlash mode)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--dflash-block-size",
+        type=int,
+        default=None,
+        help="Override the drafter's default block size.",
+    )
+    serve_parser.add_argument(
+        "--dflash-no-adaptive",
+        action="store_true",
+        help="Disable adaptive block sizing (adaptive is ON by default).",
+    )
+    serve_parser.add_argument(
+        "--dflash-block-min",
+        type=int,
+        default=8,
+        help="Adaptive block-size lower bound (default: 8).",
+    )
+    serve_parser.add_argument(
+        "--dflash-block-max",
+        type=int,
+        default=22,
+        help="Adaptive block-size upper bound (default: 22).",
+    )
+    serve_parser.add_argument(
+        "--dflash-turboquant-bits",
+        type=float,
+        default=None,
+        help=(
+            "Optional KV-cache TurboQuant bits for the target model under "
+            "DFlash. Requires mlx-turboquant (installed via the dflash[mlx] extra)."
+        ),
     )
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -398,13 +398,64 @@ def serve_command(args):
     print(f"  Ready: http://{host_display}:{args.port}/v1")
     print(f"  Docs:  http://{host_display}:{args.port}/docs")
     print()
-    uvicorn.run(
+
+    if getattr(args, "tui", False):
+        _run_with_tui(
+            app,
+            host=args.host,
+            port=args.port,
+            log_level=uvicorn_log_level,
+        )
+    else:
+        uvicorn.run(
+            app,
+            host=args.host,
+            port=args.port,
+            log_level=uvicorn_log_level,
+            timeout_keep_alive=30,
+        )
+
+
+def _run_with_tui(app, host: str, port: int, log_level) -> None:
+    """Run uvicorn in a background thread + the live TUI in the foreground."""
+    import os
+    import threading
+    import time
+
+    import uvicorn
+
+    config = uvicorn.Config(
         app,
-        host=args.host,
-        port=args.port,
-        log_level=uvicorn_log_level,
+        host=host,
+        port=port,
+        log_level=log_level,
         timeout_keep_alive=30,
+        access_log=False,
     )
+    server = uvicorn.Server(config)
+    # Signal handlers can only be installed from the main thread; the TUI
+    # owns the main thread, so we disable uvicorn's installer.
+    server.install_signal_handlers = lambda: None  # type: ignore[assignment]
+
+    server_thread = threading.Thread(target=server.run, daemon=True)
+    server_thread.start()
+
+    # Wait for the server to start (max ~10s) before opening the TUI.
+    for _ in range(200):
+        if server.started:
+            break
+        time.sleep(0.05)
+
+    from .tui import run_monitor
+
+    tui_host = "127.0.0.1" if host == "0.0.0.0" else host
+    base_url = f"http://{tui_host}:{port}"
+
+    try:
+        run_monitor(base_url, interval=1.0, pid=os.getpid())
+    finally:
+        server.should_exit = True
+        server_thread.join(timeout=5)
 
 
 def bench_command(args):
@@ -1370,6 +1421,11 @@ Examples:
         type=str,
         default=None,
         help="Pre-load an embedding model at startup (e.g. mlx-community/embeddinggemma-300m-6bit)",
+    )
+    serve_parser.add_argument(
+        "--tui",
+        action="store_true",
+        help="Run a live full-screen monitor TUI alongside the server (q to quit).",
     )
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")

--- a/vllm_mlx/engine/__init__.py
+++ b/vllm_mlx/engine/__init__.py
@@ -8,11 +8,13 @@ BatchedEngine is the sole engine — continuous batching for all workloads.
 from ..engine_core import AsyncEngineCore, EngineConfig, EngineCore
 from .base import BaseEngine, GenerationOutput
 from .batched import BatchedEngine
+from .dflash import DFlashEngine
 
 __all__ = [
     "BaseEngine",
     "GenerationOutput",
     "BatchedEngine",
+    "DFlashEngine",
     "EngineCore",
     "AsyncEngineCore",
     "EngineConfig",

--- a/vllm_mlx/engine/dflash.py
+++ b/vllm_mlx/engine/dflash.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+DFlash speculative-decoding engine.
+
+Wraps the dflash MLX runtime (https://github.com/dflash/dflash) so that
+`rapid-mlx serve <target> --drafter <drafter>` runs block-based draft+verify
+with a separate drafter model that conditions on hidden states from selected
+target layers.
+
+This engine is single-request: only one prompt is generated at a time; further
+requests wait on an asyncio.Lock. Continuous batching is not supported in this
+mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import sys
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..api.utils import clean_output_text
+from .base import GenerationOutput
+from .batched import BatchedEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _init_dflash_step_thread() -> None:
+    """Mirror engine_core._init_mlx_step_thread for our private executor."""
+    import mlx.core as mx
+
+    stream = mx.new_stream(mx.default_device())
+    gen_mod = sys.modules.get("mlx_lm.generate")
+    if gen_mod is not None:
+        gen_mod.generation_stream = stream
+    logger.info("DFlash step thread initialized: stream=%s", stream)
+
+
+@dataclass
+class _ActiveRequest:
+    started_at: float
+    first_token_at: float | None = None
+    prompt_tokens: int = 0
+    generated_tokens: int = 0
+    proposed_tokens: int = 0
+    accepted_tokens: int = 0
+    speculative_steps: int = 0
+    acceptance_ratio: float = 0.0
+    block_size: int = 0
+    block_history: list[int] = field(default_factory=list)
+
+
+class DFlashEngine(BatchedEngine):
+    """Speculative-decoding engine using a separate drafter model."""
+
+    def __init__(
+        self,
+        model_name: str,
+        drafter_path: str,
+        block_size: int | None = None,
+        adaptive: bool = True,
+        adaptive_min: int = 8,
+        adaptive_max: int = 22,
+        turboquant_bits: float | None = None,
+        trust_remote_code: bool = True,
+        gpu_memory_utilization: float = 0.90,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            trust_remote_code=trust_remote_code,
+            scheduler_config=None,
+            stream_interval=1,
+            force_mllm=False,
+            gpu_memory_utilization=gpu_memory_utilization,
+        )
+        if self._is_mllm:
+            raise ValueError(
+                "DFlash mode is text-only; do not pass --mllm or use a multimodal model."
+            )
+
+        self._drafter_path = drafter_path
+        self._drafter: Any = None
+        self._block_size_override = block_size
+        self._adaptive_enabled = bool(adaptive)
+        self._adaptive_min = int(adaptive_min)
+        self._adaptive_max = int(adaptive_max)
+        self._turboquant_bits = turboquant_bits
+
+        self._lock = asyncio.Lock()
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+        self._active: _ActiveRequest | None = None
+        self._inflight = 0
+
+        self._adaptive_cfg: Any = None
+        self._current_block_size = 0
+        self._observed_block_min = 0
+        self._observed_block_max = 0
+
+        self._lifetime_proposed = 0
+        self._lifetime_accepted = 0
+        self._lifetime_responses = 0
+        self._start_time = time.time()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _start_llm(self) -> None:  # noqa: D401 — overrides BatchedEngine
+        # Create the dedicated MLX worker thread BEFORE loading the model.
+        # All model + drafter operations (including the initial weight load)
+        # must run on this thread so that mlx-lm's per-thread generation
+        # stream owns the arrays used during inference (PR 161 invariant).
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="dflash-step",
+            initializer=_init_dflash_step_thread,
+        )
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, self._load_models_in_thread)
+        # mark as not-engine-started (we don't run AsyncEngineCore)
+        self._engine_started = False
+
+    def _load_models_in_thread(self) -> None:
+        """Runs on the dflash-step worker thread."""
+        try:
+            from dflash.model_mlx import (
+                AdaptiveBlockSizeConfig,
+                load_draft,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "DFlash mode requires the `dflash[mlx]` package. Install with:\n"
+                "  pip install -e /Users/samuelfajreldines/dev/dflash[mlx]\n"
+                f"Original error: {exc}"
+            ) from exc
+
+        from mlx_lm import load as mlx_load
+
+        logger.info("[DFlash] Loading target model: %s", self._model_name)
+        self._model, self._tokenizer = mlx_load(self._model_name)
+
+        logger.info("[DFlash] Loading drafter: %s", self._drafter_path)
+        self._drafter = load_draft(
+            self._drafter_path,
+            turboquant_bits=self._turboquant_bits,
+        )
+        self._drafter.bind(self._model)
+
+        self._current_block_size = (
+            int(self._block_size_override)
+            if self._block_size_override is not None
+            else int(self._drafter.config.block_size)
+        )
+
+        if self._adaptive_enabled:
+            self._adaptive_cfg = AdaptiveBlockSizeConfig(
+                enabled=True,
+                min_block_size=self._adaptive_min,
+                max_block_size=self._adaptive_max,
+                grow_threshold=0.88,
+                shrink_threshold=0.55,
+                grow_streak=2,
+                shrink_streak=2,
+            )
+        else:
+            self._adaptive_cfg = None
+
+        try:
+            import mlx.core as mx
+
+            if mx.metal.is_available():
+                info = mx.device_info()
+                max_rec = info.get(
+                    "max_recommended_working_set_size",
+                    info.get("memory_size", 0),
+                )
+                if max_rec > 0:
+                    soft = int(max_rec * self._gpu_memory_utilization)
+                    mx.set_memory_limit(soft)
+                    mx.set_cache_limit(32 * 1024 * 1024 * 1024)
+        except Exception as exc:
+            logger.warning("[DFlash] Failed to set Metal memory limits: %s", exc)
+
+    async def stop(self) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None
+        self._drafter = None
+
+    # ------------------------------------------------------------------
+    # Generation core
+    # ------------------------------------------------------------------
+
+    async def _stream_dflash(
+        self,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+    ):
+        """Run dflash.stream_generate on the dflash-step thread, yielding GenerationResponse objects."""
+        from dflash.model_mlx import stream_generate as _ds
+
+        loop = asyncio.get_running_loop()
+        executor = self._executor
+        assert executor is not None, "DFlashEngine not started"
+
+        def _make_gen():
+            return _ds(
+                self._model,
+                self._drafter,
+                self._tokenizer,
+                prompt,
+                block_size=self._block_size_override,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                adaptive_block_size=self._adaptive_cfg,
+            )
+
+        gen = await loop.run_in_executor(executor, _make_gen)
+
+        sentinel = object()
+
+        def _next():
+            try:
+                return next(gen)
+            except StopIteration:
+                return sentinel
+
+        while True:
+            resp = await loop.run_in_executor(executor, _next)
+            if resp is sentinel:
+                return
+            yield resp
+
+    async def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        stop: list[str] | None = None,
+        images: list[str] | None = None,
+        videos: list[str] | None = None,
+        **kwargs,
+    ) -> GenerationOutput:
+        if not self._loaded:
+            await self.start()
+        if images or videos:
+            raise ValueError("DFlash mode does not support images or videos.")
+
+        self._inflight += 1
+        try:
+            async with self._lock:
+                self._track_request_start()
+                last_resp = None
+                full_text_parts: list[str] = []
+                try:
+                    async for resp in self._stream_dflash(
+                        prompt, max_tokens, temperature, top_p
+                    ):
+                        last_resp = resp
+                        if resp.text:
+                            full_text_parts.append(resp.text)
+                        self._update_active(resp, new_text=resp.text or "")
+                finally:
+                    self._track_request_end()
+
+                return GenerationOutput(
+                    text=clean_output_text("".join(full_text_parts)),
+                    prompt_tokens=last_resp.prompt_tokens if last_resp else 0,
+                    completion_tokens=last_resp.generation_tokens if last_resp else 0,
+                    finished=True,
+                    finish_reason=(last_resp.finish_reason if last_resp else None) or "stop",
+                )
+        finally:
+            self._inflight -= 1
+
+    async def stream_generate(
+        self,
+        prompt: str,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        stop: list[str] | None = None,
+        images: list[str] | None = None,
+        videos: list[str] | None = None,
+        **kwargs,
+    ) -> AsyncIterator[GenerationOutput]:
+        if not self._loaded:
+            await self.start()
+        if images or videos:
+            raise ValueError("DFlash mode does not support images or videos.")
+
+        self._inflight += 1
+        try:
+            async with self._lock:
+                self._track_request_start()
+                cumulative = ""
+                last_resp = None
+                try:
+                    async for resp in self._stream_dflash(
+                        prompt, max_tokens, temperature, top_p
+                    ):
+                        last_resp = resp
+                        new_text = resp.text or ""
+                        cumulative += new_text
+                        self._update_active(resp, new_text=new_text)
+
+                        yield GenerationOutput(
+                            text=clean_output_text(cumulative),
+                            new_text=new_text,
+                            tokens=list(resp.tokens) if resp.tokens else [],
+                            prompt_tokens=resp.prompt_tokens,
+                            completion_tokens=resp.generation_tokens,
+                            finished=bool(resp.finish_reason),
+                            finish_reason=resp.finish_reason,
+                        )
+                finally:
+                    self._track_request_end()
+
+                # Some clients expect a final yield with finished=True
+                if last_resp is not None and not last_resp.finish_reason:
+                    yield GenerationOutput(
+                        text=clean_output_text(cumulative),
+                        new_text="",
+                        tokens=[],
+                        prompt_tokens=last_resp.prompt_tokens,
+                        completion_tokens=last_resp.generation_tokens,
+                        finished=True,
+                        finish_reason="stop",
+                    )
+        finally:
+            self._inflight -= 1
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def _track_request_start(self) -> None:
+        self._active = _ActiveRequest(
+            started_at=time.time(), block_size=self._current_block_size
+        )
+
+    def _track_request_end(self) -> None:
+        if self._active is not None:
+            self._lifetime_responses += 1
+            self._lifetime_proposed += self._active.proposed_tokens
+            self._lifetime_accepted += self._active.accepted_tokens
+        self._active = None
+
+    def _update_active(self, resp: Any, new_text: str = "") -> None:
+        a = self._active
+        if a is None:
+            return
+        if a.first_token_at is None and (new_text or resp.tokens):
+            a.first_token_at = time.time()
+        a.prompt_tokens = int(resp.prompt_tokens or 0)
+        a.generated_tokens = int(resp.generation_tokens or 0)
+        a.proposed_tokens = int(resp.proposed_tokens or 0)
+        a.accepted_tokens = int(resp.accepted_tokens or 0)
+        a.speculative_steps = int(resp.speculative_steps or 0)
+        a.acceptance_ratio = float(resp.avg_acceptance_ratio or 0.0)
+        history = list(resp.block_size_history or ())
+        if history:
+            a.block_history = history
+            a.block_size = int(history[-1])
+            self._current_block_size = a.block_size
+            mn = min(history)
+            mx_ = max(history)
+            self._observed_block_min = (
+                mn if self._observed_block_min == 0 else min(self._observed_block_min, mn)
+            )
+            self._observed_block_max = max(self._observed_block_max, mx_)
+
+    def get_stats(self) -> dict[str, Any]:
+        try:
+            import mlx.core as mx
+
+            active_mem_gb = mx.get_active_memory() / 1e9
+            peak_mem_gb = mx.get_peak_memory() / 1e9
+            cache_mem_gb = mx.get_cache_memory() / 1e9
+        except Exception:
+            active_mem_gb = peak_mem_gb = cache_mem_gb = 0.0
+
+        running_requests: list[dict[str, Any]] = []
+        if self._active is not None:
+            now = time.time()
+            elapsed = now - self._active.started_at
+            ttft = (
+                (self._active.first_token_at - self._active.started_at)
+                if self._active.first_token_at
+                else None
+            )
+            tps = None
+            if (
+                self._active.first_token_at
+                and self._active.generated_tokens > 0
+            ):
+                window = now - self._active.first_token_at
+                if window > 0.01:
+                    tps = self._active.generated_tokens / window
+            running_requests.append(
+                {
+                    "request_id": "dflash-active",
+                    "status": "running",
+                    "phase": (
+                        "generation" if self._active.first_token_at else "prefill"
+                    ),
+                    "elapsed_s": round(elapsed, 2),
+                    "prompt_tokens": self._active.prompt_tokens,
+                    "completion_tokens": self._active.generated_tokens,
+                    "max_tokens": 0,
+                    "tokens_per_second": tps,
+                    "ttft_s": ttft,
+                    "acceptance_ratio": self._active.acceptance_ratio,
+                    "block_size": self._active.block_size,
+                    "speculative_steps": self._active.speculative_steps,
+                    "accepted_tokens": self._active.accepted_tokens,
+                    "proposed_tokens": self._active.proposed_tokens,
+                    "cache_hit_type": None,
+                    "cached_tokens": 0,
+                    "progress": 0.0,
+                }
+            )
+
+        lifetime_ratio = (
+            (self._lifetime_accepted / self._lifetime_proposed)
+            if self._lifetime_proposed > 0
+            else 0.0
+        )
+
+        num_running = 1 if self._active is not None else 0
+        num_waiting = max(0, self._inflight - num_running)
+
+        return {
+            "engine_type": "dflash",
+            "model_name": self._model_name,
+            "is_mllm": False,
+            "loaded": self._loaded,
+            "running": self._active is not None,
+            "uptime_seconds": time.time() - self._start_time,
+            "num_running": num_running,
+            "num_waiting": num_waiting,
+            "total_requests_processed": self._lifetime_responses,
+            "metal_active_memory_gb": active_mem_gb,
+            "metal_peak_memory_gb": peak_mem_gb,
+            "metal_cache_memory_gb": cache_mem_gb,
+            "requests": running_requests,
+            "dflash": {
+                "lifetime_acceptance_ratio": lifetime_ratio,
+                "current_block_size": self._current_block_size,
+                "adaptive_enabled": self._adaptive_enabled,
+                "adaptive_min": self._adaptive_min,
+                "adaptive_max": self._adaptive_max,
+                "observed_block_min": self._observed_block_min,
+                "observed_block_max": self._observed_block_max,
+            },
+        }
+
+    def get_cache_stats(self) -> dict[str, Any] | None:
+        return None

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -29,6 +29,23 @@ from .scheduler import Scheduler, SchedulerConfig
 logger = logging.getLogger(__name__)
 
 
+def _init_mlx_step_thread() -> None:
+    """Create mlx-lm's generation stream inside the MLX worker thread."""
+    import sys
+
+    stream = mx.new_stream(mx.default_device())
+
+    gen_mod = sys.modules.get("mlx_lm.generate")
+    if gen_mod is not None:
+        gen_mod.generation_stream = stream
+
+    sched_mod = sys.modules.get("vllm_mlx.scheduler")
+    if sched_mod is not None and hasattr(sched_mod, "generation_stream"):
+        sched_mod.generation_stream = stream
+
+    logger.info("MLX step thread initialized: generation_stream=%s", stream)
+
+
 @dataclass
 class EngineConfig:
     """Configuration for the engine."""
@@ -153,18 +170,16 @@ class EngineCore:
         return self._running
 
     async def _engine_loop(self) -> None:
-        """Main engine loop - hybrid executor for prefill vs generation.
-
-        Prefill steps (long prompts) are run in a thread executor to keep
-        the asyncio event loop responsive.  Generation-only steps (~1-3ms)
-        are called directly to avoid ~0.5-2ms context switch overhead,
-        giving ~5-10% throughput improvement during sustained generation.
-        """
+        """Main engine loop."""
         import concurrent.futures
 
-        # Single-thread executor ensures MLX calls are never concurrent
+        # Keep every scheduler step on one thread. mlx-lm generation streams
+        # are thread-local, and Qwen3.x RotatingKVCache keeps arrays tagged
+        # with that stream across prefill and decode.
         _executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mlx-step"
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=_init_mlx_step_thread,
         )
         loop = asyncio.get_running_loop()
 
@@ -195,26 +210,7 @@ class EngineCore:
         while self._running:
             try:
                 if self.scheduler.has_requests():
-                    # Hybrid approach: use executor only when prefill is likely.
-                    # Prefill happens when there are waiting requests that need
-                    # to be inserted into the batch (may block for seconds).
-                    # Generation-only steps are fast (<3ms) and can run inline.
-                    has_waiting = self.scheduler.get_num_waiting() > 0
-                    has_partial = (
-                        self.scheduler.batch_generator is not None
-                        and getattr(self.scheduler.batch_generator, "_partial", None)
-                        is not None
-                    )
-                    needs_executor = has_waiting or has_partial
-
-                    if needs_executor:
-                        output = await loop.run_in_executor(
-                            _executor, self.scheduler.step
-                        )
-                    else:
-                        output = self.scheduler.step()
-                        # Yield to event loop after inline step
-                        await asyncio.sleep(0)
+                    output = await loop.run_in_executor(_executor, self.scheduler.step)
                     self._steps_executed += 1
 
                     # Emergency memory pressure check

--- a/vllm_mlx/middleware/metrics.py
+++ b/vllm_mlx/middleware/metrics.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ASGI middleware that records per-request inference metrics.
+
+Wraps responses for /v1/chat/completions and /v1/completions, parses streamed
+SSE chunks (and final non-streaming JSON) to extract usage, finish_reason,
+and incremental output text, then publishes the data to the
+RequestRecorder for the /v1/requests endpoint and the TUI monitor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from ..request_metrics import get_recorder
+
+logger = logging.getLogger(__name__)
+
+_TRACKED_PATHS = ("/v1/chat/completions", "/v1/completions")
+_MAX_BUFFER_BYTES = 4 * 1024 * 1024  # safety cap for non-stream JSON capture
+
+
+def _safe_json_loads(payload: str | bytes) -> dict | None:
+    try:
+        return json.loads(payload)
+    except Exception:
+        return None
+
+
+def _extract_chat_delta(payload: dict) -> tuple[str | None, str | None]:
+    """Returns (delta_text, finish_reason) for chat completion chunks/final."""
+    try:
+        choice = (payload.get("choices") or [None])[0]
+        if not choice:
+            return None, None
+        delta = choice.get("delta") or {}
+        text = delta.get("content")
+        if text is None:
+            message = choice.get("message") or {}
+            text = message.get("content")
+        return text, choice.get("finish_reason")
+    except Exception:
+        return None, None
+
+
+def _extract_completion_delta(payload: dict) -> tuple[str | None, str | None]:
+    """Returns (delta_text, finish_reason) for legacy completion chunks/final."""
+    try:
+        choice = (payload.get("choices") or [None])[0]
+        if not choice:
+            return None, None
+        return choice.get("text"), choice.get("finish_reason")
+    except Exception:
+        return None, None
+
+
+def _extract_usage(payload: dict) -> tuple[int | None, int | None]:
+    usage = payload.get("usage") or {}
+    if not isinstance(usage, dict):
+        return None, None
+    return (
+        usage.get("prompt_tokens"),
+        usage.get("completion_tokens"),
+    )
+
+
+class MetricsMiddleware:
+    """Pure ASGI middleware (does not buffer the entire stream)."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path not in _TRACKED_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        recorder = get_recorder()
+        req_id = recorder.start(surface=path)
+
+        is_chat = path == "/v1/chat/completions"
+        sse_carry = b""
+        json_buffer = bytearray()
+        is_sse = False
+        first_token_seen = False
+        last_finish_reason: str | None = None
+        last_prompt_tokens: int | None = None
+        last_generated_tokens: int | None = None
+        running_text_tokens = 0  # rough fallback when usage is absent
+        engine_gen_tps: float = 0.0
+        engine_ttft: float | None = None
+
+        def poll_engine_stats() -> None:
+            """Snapshot engine's per-request tps/ttft during the stream."""
+            nonlocal engine_gen_tps, engine_ttft
+            try:
+                from ..config import get_config
+
+                cfg = get_config()
+                if cfg.engine is None:
+                    return
+                stats = cfg.engine.get_stats()
+                for r in stats.get("requests") or []:
+                    tps = r.get("tokens_per_second")
+                    if tps is not None:
+                        v = float(tps)
+                        if v > engine_gen_tps:
+                            engine_gen_tps = v
+                    ttft_s = r.get("ttft_s")
+                    if ttft_s is not None and engine_ttft is None:
+                        try:
+                            engine_ttft = float(ttft_s)
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+
+        def handle_payload(payload: dict) -> None:
+            nonlocal first_token_seen, last_finish_reason
+            nonlocal last_prompt_tokens, last_generated_tokens, running_text_tokens
+            if is_chat:
+                text, finish = _extract_chat_delta(payload)
+            else:
+                text, finish = _extract_completion_delta(payload)
+            if finish:
+                last_finish_reason = finish
+            ptoks, gtoks = _extract_usage(payload)
+            if ptoks is not None:
+                last_prompt_tokens = ptoks
+            if gtoks is not None:
+                last_generated_tokens = gtoks
+            if text:
+                if not first_token_seen:
+                    recorder.mark_first_token(req_id)
+                    first_token_seen = True
+                # crude token estimate when usage events haven't arrived yet
+                running_text_tokens += max(1, len(text) // 4)
+                fallback_gtoks = (
+                    last_generated_tokens
+                    if last_generated_tokens is not None
+                    else running_text_tokens
+                )
+                recorder.update(
+                    req_id,
+                    delta_text=text,
+                    generated_tokens=fallback_gtoks,
+                    prompt_tokens=last_prompt_tokens,
+                )
+            elif ptoks is not None or gtoks is not None:
+                recorder.update(
+                    req_id,
+                    generated_tokens=last_generated_tokens,
+                    prompt_tokens=last_prompt_tokens,
+                )
+
+        def consume_sse(buf: bytes) -> bytes:
+            nonlocal sse_carry
+            data = sse_carry + buf
+            *complete, sse_carry = data.split(b"\n\n")
+            for raw_event in complete:
+                for line in raw_event.split(b"\n"):
+                    line = line.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    body = line[5:].strip()
+                    if not body or body == b"[DONE]":
+                        continue
+                    payload = _safe_json_loads(body)
+                    if isinstance(payload, dict):
+                        handle_payload(payload)
+            return sse_carry
+
+        async def send_wrapper(message):
+            nonlocal is_sse, sse_carry
+            try:
+                if message["type"] == "http.response.start":
+                    headers = message.get("headers") or []
+                    for name, value in headers:
+                        if name.decode("latin-1").lower() == "content-type":
+                            ctype = value.decode("latin-1").lower()
+                            is_sse = "text/event-stream" in ctype
+                            break
+                elif message["type"] == "http.response.body":
+                    body = message.get("body", b"") or b""
+                    more = bool(message.get("more_body", False))
+                    if is_sse:
+                        consume_sse(body)
+                        poll_engine_stats()
+                    else:
+                        if len(json_buffer) < _MAX_BUFFER_BYTES:
+                            json_buffer.extend(
+                                body[: _MAX_BUFFER_BYTES - len(json_buffer)]
+                            )
+                        poll_engine_stats()
+                    if not more:
+                        if not is_sse and json_buffer:
+                            payload = _safe_json_loads(bytes(json_buffer))
+                            if isinstance(payload, dict):
+                                handle_payload(payload)
+                        recorder.finish(
+                            req_id,
+                            finish_reason=last_finish_reason,
+                            prompt_tokens=last_prompt_tokens,
+                            generated_tokens=last_generated_tokens,
+                            non_streaming=not is_sse,
+                            engine_gen_tps=engine_gen_tps if engine_gen_tps > 0 else None,
+                            engine_ttft=engine_ttft,
+                        )
+            except Exception as exc:  # never let metrics break the response
+                logger.debug("metrics middleware error: %s", exc)
+            await send(message)
+
+        # Periodically poll engine stats so non-streaming requests still
+        # capture the engine-reported tokens_per_second / ttft while the
+        # route is generating (no SSE events arrive in that case).
+        poller_done = asyncio.Event()
+
+        async def poll_loop() -> None:
+            while not poller_done.is_set():
+                poll_engine_stats()
+                try:
+                    await asyncio.wait_for(poller_done.wait(), timeout=0.2)
+                except asyncio.TimeoutError:
+                    continue
+
+        poller_task = asyncio.create_task(poll_loop())
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception as exc:
+            recorder.finish(req_id, finish_reason="error", error=str(exc))
+            raise
+        finally:
+            poller_done.set()
+            try:
+                await poller_task
+            except Exception:
+                pass

--- a/vllm_mlx/middleware/metrics.py
+++ b/vllm_mlx/middleware/metrics.py
@@ -94,10 +94,13 @@ class MetricsMiddleware:
         running_text_tokens = 0  # rough fallback when usage is absent
         engine_gen_tps: float = 0.0
         engine_ttft: float | None = None
+        engine_acceptance: float | None = None
+        engine_block_size: int | None = None
 
         def poll_engine_stats() -> None:
-            """Snapshot engine's per-request tps/ttft during the stream."""
+            """Snapshot engine's per-request tps/ttft/acceptance during the stream."""
             nonlocal engine_gen_tps, engine_ttft
+            nonlocal engine_acceptance, engine_block_size
             try:
                 from ..config import get_config
 
@@ -115,6 +118,18 @@ class MetricsMiddleware:
                     if ttft_s is not None and engine_ttft is None:
                         try:
                             engine_ttft = float(ttft_s)
+                        except Exception:
+                            pass
+                    accept = r.get("acceptance_ratio")
+                    if accept is not None:
+                        try:
+                            engine_acceptance = float(accept)
+                        except Exception:
+                            pass
+                    block = r.get("block_size")
+                    if block is not None:
+                        try:
+                            engine_block_size = int(block)
                         except Exception:
                             pass
             except Exception:
@@ -210,6 +225,8 @@ class MetricsMiddleware:
                             non_streaming=not is_sse,
                             engine_gen_tps=engine_gen_tps if engine_gen_tps > 0 else None,
                             engine_ttft=engine_ttft,
+                            acceptance_ratio=engine_acceptance,
+                            block_size=engine_block_size,
                         )
             except Exception as exc:  # never let metrics break the response
                 logger.debug("metrics middleware error: %s", exc)

--- a/vllm_mlx/request_metrics.py
+++ b/vllm_mlx/request_metrics.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-memory recorder for completed inference requests.
+
+Used by the metrics ASGI middleware to capture per-request stats (tokens,
+finish reason, message preview, throughput) and expose them via /v1/requests
+for the TUI monitor.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from collections import deque
+from typing import Any
+
+_DEFAULT_HISTORY = 100
+_MAX_PREVIEW_CHARS = 240
+
+
+class RequestRecorder:
+    """Thread-safe ring buffer of completed request stats with a single
+    "active" snapshot for the request currently being processed."""
+
+    def __init__(self, history_limit: int = _DEFAULT_HISTORY) -> None:
+        self._lock = threading.Lock()
+        self._entries: deque[dict[str, Any]] = deque(maxlen=history_limit)
+        self._active: dict[str, dict[str, Any]] = {}
+
+    def start(self, surface: str) -> str:
+        req_id = uuid.uuid4().hex[:12]
+        now = time.time()
+        with self._lock:
+            self._active[req_id] = {
+                "request_id": req_id,
+                "surface": surface,
+                "started_at": now,
+                "updated_at": now,
+                "first_token_at": None,
+                "last_token_at": None,
+                "text_chunks": 0,
+                "phase": "prefill",
+                "generated_tokens": 0,
+                "prompt_tokens": 0,
+                "message_preview": "",
+                "message_preview_source": "output",
+            }
+        return req_id
+
+    def mark_first_token(self, req_id: str) -> None:
+        now = time.time()
+        with self._lock:
+            entry = self._active.get(req_id)
+            if entry is None:
+                return
+            if entry["first_token_at"] is None:
+                entry["first_token_at"] = now
+            entry["phase"] = "generation"
+            entry["updated_at"] = now
+
+    def update(
+        self,
+        req_id: str,
+        *,
+        delta_text: str | None = None,
+        generated_tokens: int | None = None,
+        prompt_tokens: int | None = None,
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            entry = self._active.get(req_id)
+            if entry is None:
+                return
+            entry["updated_at"] = now
+            if delta_text:
+                preview = (entry.get("message_preview") or "") + delta_text
+                if len(preview) > _MAX_PREVIEW_CHARS:
+                    preview = preview[-_MAX_PREVIEW_CHARS:]
+                entry["message_preview"] = preview
+                entry["last_token_at"] = now
+                entry["text_chunks"] = int(entry.get("text_chunks", 0)) + 1
+            if generated_tokens is not None:
+                entry["generated_tokens"] = max(
+                    entry.get("generated_tokens", 0), int(generated_tokens)
+                )
+            if prompt_tokens is not None:
+                entry["prompt_tokens"] = max(
+                    entry.get("prompt_tokens", 0), int(prompt_tokens)
+                )
+
+    def finish(
+        self,
+        req_id: str,
+        *,
+        finish_reason: str | None = None,
+        prompt_tokens: int | None = None,
+        generated_tokens: int | None = None,
+        error: str | None = None,
+        non_streaming: bool = False,
+        engine_gen_tps: float | None = None,
+        engine_ttft: float | None = None,
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            entry = self._active.pop(req_id, None)
+            if entry is None:
+                return
+
+            started_at = float(entry.get("started_at") or now)
+            first_at = entry.get("first_token_at")
+            last_at = entry.get("last_token_at")
+            text_chunks = int(entry.get("text_chunks", 0))
+            elapsed = max(0.0, now - started_at)
+            ttft = (first_at - started_at) if first_at else None
+
+            ptoks = (
+                int(prompt_tokens)
+                if prompt_tokens is not None
+                else int(entry.get("prompt_tokens") or 0)
+            )
+            gtoks = (
+                int(generated_tokens)
+                if generated_tokens is not None
+                else int(entry.get("generated_tokens") or 0)
+            )
+
+            # Generation window: use (elapsed - ttft) when ttft is known
+            # and meaningfully smaller than elapsed (real streaming with
+            # separable prefill/decode). Fall back to total elapsed for
+            # non-streaming or coalesced single-chunk streams.
+            if (
+                not non_streaming
+                and ttft is not None
+                and text_chunks > 1
+                and elapsed > ttft + 0.01
+            ):
+                generation_window = elapsed - ttft
+                prompt_tps = (ptoks / ttft) if ttft > 0.01 else 0.0
+            else:
+                generation_window = elapsed
+                ttft = None
+                prompt_tps = 0.0
+            generation_tps = (
+                (gtoks / generation_window) if generation_window > 0.01 else 0.0
+            )
+
+            # Engine-reported values (from scheduler) are more accurate
+            # than middleware timing — prefer them when available.
+            if engine_gen_tps is not None and engine_gen_tps > 0:
+                generation_tps = float(engine_gen_tps)
+            if engine_ttft is not None and engine_ttft > 0:
+                ttft = float(engine_ttft)
+                if ptoks > 0 and ttft > 0.01:
+                    prompt_tps = ptoks / ttft
+
+            record = {
+                "request_id": entry["request_id"],
+                "surface": entry.get("surface", ""),
+                "started_at": started_at,
+                "finished_at": now,
+                "elapsed": elapsed,
+                "ttft": ttft,
+                "prompt_tokens": ptoks,
+                "generated_tokens": gtoks,
+                "generation_tps": generation_tps,
+                "prompt_tps": prompt_tps,
+                "finish_reason": finish_reason or ("error" if error else "stop"),
+                "message_preview": entry.get("message_preview") or "",
+                "message_preview_source": entry.get("message_preview_source", "output"),
+                "error": error,
+            }
+            self._entries.append(record)
+
+    def entries(self, limit: int = 50) -> list[dict[str, Any]]:
+        with self._lock:
+            data = list(self._entries)
+        if limit <= 0:
+            return data
+        return data[-limit:]
+
+    def active(self) -> dict[str, Any] | None:
+        with self._lock:
+            if not self._active:
+                return None
+            req_id = next(iter(self._active))
+            return dict(self._active[req_id])
+
+    def last(self) -> dict[str, Any] | None:
+        with self._lock:
+            if not self._entries:
+                return None
+            return dict(self._entries[-1])
+
+
+_recorder: RequestRecorder | None = None
+
+
+def get_recorder() -> RequestRecorder:
+    global _recorder
+    if _recorder is None:
+        _recorder = RequestRecorder()
+    return _recorder

--- a/vllm_mlx/request_metrics.py
+++ b/vllm_mlx/request_metrics.py
@@ -99,6 +99,8 @@ class RequestRecorder:
         non_streaming: bool = False,
         engine_gen_tps: float | None = None,
         engine_ttft: float | None = None,
+        acceptance_ratio: float | None = None,
+        block_size: int | None = None,
     ) -> None:
         now = time.time()
         with self._lock:
@@ -153,6 +155,13 @@ class RequestRecorder:
                 if ptoks > 0 and ttft > 0.01:
                     prompt_tps = ptoks / ttft
 
+            record_acceptance = (
+                float(acceptance_ratio) if acceptance_ratio is not None else None
+            )
+            record_block_size = (
+                int(block_size) if block_size is not None else None
+            )
+
             record = {
                 "request_id": entry["request_id"],
                 "surface": entry.get("surface", ""),
@@ -168,6 +177,8 @@ class RequestRecorder:
                 "message_preview": entry.get("message_preview") or "",
                 "message_preview_source": entry.get("message_preview_source", "output"),
                 "error": error,
+                "acceptance_ratio": record_acceptance,
+                "block_size": record_block_size,
             }
             self._entries.append(record)
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -42,6 +42,7 @@ from ..config import get_config
 from ..engine import GenerationOutput
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
+    _TOOL_CALL_JSON_RETRY_PROMPT,
     _TOOL_CALL_REQUIRED_RETRY_PROMPT,
     _TOOL_CONTINUATION_RETRY_PROMPT,
     _TOOL_USE_SYSTEM_SUFFIX,
@@ -111,6 +112,59 @@ def _buffered_stream_text(buffered_events: list[tuple]) -> str:
         parts.append(getattr(event, "content", None) or "")
         parts.append(getattr(event, "reasoning", None) or "")
     return "".join(parts)
+
+
+def _tool_call_value(obj, key: str, default=None):
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _buffered_tool_calls_complete(buffered_events: list[tuple]) -> bool:
+    """Return True when streamed tool-call chunks assemble to valid JSON."""
+    calls: dict[int, dict[str, str | None]] = {}
+    for event, _ in buffered_events:
+        for tool_call in getattr(event, "tool_calls", None) or []:
+            index = _tool_call_value(tool_call, "index")
+            if not isinstance(index, int):
+                index = len(calls)
+            assembled = calls.setdefault(
+                index,
+                {"id": None, "name": None, "arguments": ""},
+            )
+
+            call_id = _tool_call_value(tool_call, "id")
+            if call_id:
+                assembled["id"] = str(call_id)
+
+            function = _tool_call_value(tool_call, "function", {}) or {}
+            name = _tool_call_value(function, "name")
+            if name:
+                assembled["name"] = str(name)
+
+            arguments = _tool_call_value(function, "arguments")
+            if arguments is not None:
+                assembled["arguments"] = (
+                    (assembled["arguments"] or "") + str(arguments)
+                )
+
+    if not calls:
+        return False
+
+    for assembled in calls.values():
+        if not assembled.get("name"):
+            return False
+        arguments = (assembled.get("arguments") or "").strip()
+        if not arguments:
+            return False
+        try:
+            parsed = json.loads(arguments)
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(parsed, dict):
+            return False
+
+    return True
 
 
 @router.post(
@@ -791,6 +845,7 @@ async def stream_chat_completion(
             processor.reset()
 
             buffered_events: list[tuple] = []
+            buffered_tool_call_events: list[tuple] = []
             deferred_finish: tuple | None = None
             emitted_tool_call = False
             last_output = None
@@ -831,6 +886,18 @@ async def stream_chat_completion(
                         deferred_finish = (event, output)
                         continue
 
+                    if (
+                        tool_retries_enabled
+                        and event.type == "finish"
+                        and buffered_tool_call_events
+                    ):
+                        deferred_finish = (event, output)
+                        continue
+
+                    if tool_retries_enabled and event.type == "tool_call":
+                        buffered_tool_call_events.append((event, output))
+                        continue
+
                     if event.type == "tool_call":
                         emitted_tool_call = True
                         for buffered_event, buffered_output in buffered_events:
@@ -850,6 +917,10 @@ async def stream_chat_completion(
             if not retry_reason:
                 for event in processor.finalize():
                     if event.type == "tool_call":
+                        if tool_retries_enabled:
+                            buffered_tool_call_events.append((event, last_output))
+                            continue
+
                         emitted_tool_call = True
                         for buffered_event, buffered_output in buffered_events:
                             for _sse in _format_stream_event(
@@ -876,6 +947,31 @@ async def stream_chat_completion(
                         logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
                         yield _fb_sse
 
+            if not retry_reason and buffered_tool_call_events:
+                if _buffered_tool_calls_complete(buffered_tool_call_events):
+                    emitted_tool_call = True
+                    for buffered_event, buffered_output in buffered_events:
+                        for _sse in _format_stream_event(
+                            buffered_event, buffered_output
+                        ):
+                            yield _sse
+                    buffered_events.clear()
+
+                    for tool_event, tool_output in buffered_tool_call_events:
+                        if tool_output is None:
+                            continue
+                        for _sse in _format_stream_event(tool_event, tool_output):
+                            yield _sse
+                    buffered_tool_call_events.clear()
+
+                    if deferred_finish:
+                        event, output = deferred_finish
+                        for _sse in _format_stream_event(event, output):
+                            yield _sse
+                        deferred_finish = None
+                else:
+                    retry_reason = "incomplete tool call JSON"
+
             if not retry_reason and deferred_finish and not emitted_tool_call:
                 retry_reason = "text-only stop"
             elif not retry_reason and buffered_events and not emitted_tool_call:
@@ -890,18 +986,24 @@ async def stream_chat_completion(
                     retry_attempts,
                     max_tool_continuation_retries,
                 )
+                selected_retry_prompt = (
+                    _TOOL_CALL_JSON_RETRY_PROMPT
+                    if retry_reason == "incomplete tool call JSON"
+                    else retry_prompt
+                )
                 active_messages = list(messages) + [
-                    {"role": "user", "content": retry_prompt}
+                    {"role": "user", "content": selected_retry_prompt}
                 ]
                 continue
 
-            if retry_reason and buffered_events:
+            if retry_reason and (buffered_events or buffered_tool_call_events):
                 logger.warning(
                     "[tool-continuation] suppressing buffered %s after retry "
                     "budget exhausted",
                     retry_reason,
                 )
                 buffered_events.clear()
+                buffered_tool_call_events.clear()
                 deferred_finish = None
                 finish_chunk = ChatCompletionChunk(
                     id=response_id,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4,8 +4,10 @@
 import gc
 import json
 import logging
+import re
 import time
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -40,6 +42,7 @@ from ..config import get_config
 from ..engine import GenerationOutput
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
+    _TOOL_CALL_REQUIRED_RETRY_PROMPT,
     _TOOL_CONTINUATION_RETRY_PROMPT,
     _TOOL_USE_SYSTEM_SUFFIX,
     _append_tool_continuation_prompt,
@@ -63,6 +66,51 @@ from ..service.helpers import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_REPETITION_WORD_RE = re.compile(r"[A-Za-z0-9_'-]+")
+_TOOL_TEXT_REPETITION_MIN_WORDS = 32
+_TOOL_TEXT_REPETITION_MIN_COUNT = 24
+_TOOL_TEXT_REPETITION_RATIO = 0.60
+
+
+def _tool_choice_allows_tool_calls(tool_choice) -> bool:
+    if tool_choice == "none":
+        return False
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "none":
+        return False
+    return True
+
+
+def _is_repetitive_tool_text(text: str) -> bool:
+    words = _REPETITION_WORD_RE.findall(text.lower())
+    if len(words) < _TOOL_TEXT_REPETITION_MIN_WORDS:
+        return False
+
+    tail = words[-96:]
+    most_common_count = Counter(tail).most_common(1)[0][1]
+    if (
+        most_common_count >= _TOOL_TEXT_REPETITION_MIN_COUNT
+        and most_common_count / len(tail) >= _TOOL_TEXT_REPETITION_RATIO
+    ):
+        return True
+
+    for size in (2, 3, 4):
+        if len(tail) < size * 8:
+            continue
+        ngrams = [" ".join(tail[i : i + size]) for i in range(len(tail) - size + 1)]
+        ngram_count = Counter(ngrams).most_common(1)[0][1]
+        if ngram_count >= 8 and (ngram_count * size) / len(tail) >= 0.50:
+            return True
+
+    return False
+
+
+def _buffered_stream_text(buffered_events: list[tuple]) -> str:
+    parts = []
+    for event, _ in buffered_events:
+        parts.append(getattr(event, "content", None) or "")
+        parts.append(getattr(event, "reasoning", None) or "")
+    return "".join(parts)
 
 
 @router.post(
@@ -716,7 +764,17 @@ async def stream_chat_completion(
 
         retry_attempts = 0
         active_messages = messages
-        max_tool_continuation_retries = 2 if tool_continuation_retry else 0
+        tool_retries_enabled = bool(request.tools) and _tool_choice_allows_tool_calls(
+            request.tool_choice
+        )
+        max_tool_continuation_retries = (
+            2 if (tool_continuation_retry or tool_retries_enabled) else 0
+        )
+        retry_prompt = (
+            _TOOL_CONTINUATION_RETRY_PROMPT
+            if tool_continuation_retry
+            else _TOOL_CALL_REQUIRED_RETRY_PROMPT
+        )
 
         while True:
             # Initialize post-processor
@@ -735,9 +793,12 @@ async def stream_chat_completion(
             buffered_events: list[tuple] = []
             deferred_finish: tuple | None = None
             emitted_tool_call = False
+            last_output = None
+            retry_reason = None
 
             # Stream content — PostProcessor handles reasoning/tool/sanitize
             async for output in engine.stream_chat(messages=active_messages, **kwargs):
+                last_output = output
                 if hasattr(output, "prompt_tokens") and output.prompt_tokens:
                     prompt_tokens = output.prompt_tokens
                 if hasattr(output, "completion_tokens") and output.completion_tokens:
@@ -751,6 +812,15 @@ async def stream_chat_completion(
                 for event in processor.process_chunk(output):
                     if retry_window and event.type in ("content", "reasoning"):
                         buffered_events.append((event, output))
+                        if _is_repetitive_tool_text(
+                            _buffered_stream_text(buffered_events)
+                        ):
+                            retry_reason = "repetitive text before tool call"
+                            logger.info(
+                                "[tool-continuation] detected repetitive text "
+                                "before tool call; aborting current stream"
+                            )
+                            break
                         continue
 
                     if (
@@ -773,39 +843,42 @@ async def stream_chat_completion(
                     for _sse in _format_stream_event(event, output):
                         yield _sse
 
+                if retry_reason:
+                    break
+
             # Fallback tool call detection
-            for event in processor.finalize():
-                if event.type == "tool_call":
-                    emitted_tool_call = True
-                    for buffered_event, buffered_output in buffered_events:
-                        for _sse in _format_stream_event(
-                            buffered_event, buffered_output
-                        ):
-                            yield _sse
-                    buffered_events.clear()
+            if not retry_reason:
+                for event in processor.finalize():
+                    if event.type == "tool_call":
+                        emitted_tool_call = True
+                        for buffered_event, buffered_output in buffered_events:
+                            for _sse in _format_stream_event(
+                                buffered_event, buffered_output
+                            ):
+                                yield _sse
+                        buffered_events.clear()
 
-                    tool_chunk = ChatCompletionChunk(
-                        id=response_id,
-                        model=_resolve_model_name(request.model),
-                        choices=[
-                            ChatCompletionChunkChoice(
-                                delta=ChatCompletionChunkDelta(
-                                    tool_calls=event.tool_calls,
-                                ),
-                                finish_reason="tool_calls",
-                            )
-                        ],
-                    )
-                    _fb_sse = (
-                        f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
-                    )
-                    logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
-                    yield _fb_sse
+                        tool_chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=_resolve_model_name(request.model),
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(
+                                        tool_calls=event.tool_calls,
+                                    ),
+                                    finish_reason="tool_calls",
+                                )
+                            ],
+                        )
+                        _fb_sse = (
+                            f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
+                        )
+                        logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
+                        yield _fb_sse
 
-            retry_reason = None
-            if deferred_finish and not emitted_tool_call:
+            if not retry_reason and deferred_finish and not emitted_tool_call:
                 retry_reason = "text-only stop"
-            elif buffered_events and not emitted_tool_call:
+            elif not retry_reason and buffered_events and not emitted_tool_call:
                 retry_reason = "stream exhausted without tool call"
 
             if retry_reason and retry_attempts < max_tool_continuation_retries:
@@ -818,9 +891,33 @@ async def stream_chat_completion(
                     max_tool_continuation_retries,
                 )
                 active_messages = list(messages) + [
-                    {"role": "user", "content": _TOOL_CONTINUATION_RETRY_PROMPT}
+                    {"role": "user", "content": retry_prompt}
                 ]
                 continue
+
+            if retry_reason and buffered_events:
+                logger.warning(
+                    "[tool-continuation] suppressing buffered %s after retry "
+                    "budget exhausted",
+                    retry_reason,
+                )
+                buffered_events.clear()
+                deferred_finish = None
+                finish_chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_resolve_model_name(request.model),
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(),
+                            finish_reason=(
+                                last_output.finish_reason if last_output else "stop"
+                            )
+                            or "stop",
+                        )
+                    ],
+                    usage=get_usage(last_output) if last_output else None,
+                )
+                yield f"data: {finish_chunk.model_dump_json(exclude_none=True)}\n\n"
 
             for buffered_event, buffered_output in buffered_events:
                 for _sse in _format_stream_event(buffered_event, buffered_output):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -642,6 +642,7 @@ async def stream_chat_completion(
                 request.response_format
                 and getattr(request.response_format, "type", "text") != "text"
             ),
+            request_dict=request.model_dump(),
         )
         processor.set_thinking_model(request.model)
         processor.reset()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -40,7 +40,9 @@ from ..config import get_config
 from ..engine import GenerationOutput
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
+    _TOOL_CONTINUATION_RETRY_PROMPT,
     _TOOL_USE_SYSTEM_SUFFIX,
+    _append_tool_continuation_prompt,
     _build_usage,
     _disconnect_guard,
     _extract_token_logprob,
@@ -273,6 +275,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             system_msg = {"role": "system", "content": _inject_suffix.strip()}
             messages = [system_msg] + list(messages)
 
+    messages, added_tool_continuation_prompt = _append_tool_continuation_prompt(
+        list(messages),
+        bool(request.tools),
+    )
+
     # Auto-pin system prompt prefix cache blocks
     if cfg.pin_system_prompt:
         _maybe_pin_system_prompt(messages)
@@ -315,7 +322,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Pass through enable_thinking if explicitly set by the client
     if request.enable_thinking is not None:
         chat_kwargs["enable_thinking"] = request.enable_thinking
-    elif cfg.no_thinking:
+    elif cfg.no_thinking or (
+        added_tool_continuation_prompt and cfg.tool_call_parser == "qwen3_coder_xml"
+    ):
         chat_kwargs["enable_thinking"] = False
 
     # Cloud routing: offload large-context requests to cloud LLM
@@ -407,7 +416,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 raise
         return StreamingResponse(
             _disconnect_guard(
-                stream_chat_completion(engine, messages, request, **chat_kwargs),
+                stream_chat_completion(
+                    engine,
+                    messages,
+                    request,
+                    tool_continuation_retry=added_tool_continuation_prompt,
+                    **chat_kwargs,
+                ),
                 raw_request,
             ),
             media_type="text/event-stream",
@@ -578,6 +593,7 @@ async def stream_chat_completion(
     engine,
     messages: list,
     request: ChatCompletionRequest,
+    tool_continuation_retry: bool = False,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response.
@@ -634,94 +650,34 @@ async def stream_chat_completion(
             logger.info(f"[SSE-ROLE] {_first_sse.strip()[:200]}")
         yield _first_sse
 
-        # Initialize post-processor
-        processor = StreamingPostProcessor(
-            cfg,
-            tools_requested=bool(request.tools),
-            json_mode=bool(
-                request.response_format
-                and getattr(request.response_format, "type", "text") != "text"
-            ),
-            request_dict=request.model_dump(),
-        )
-        processor.set_thinking_model(request.model)
-        processor.reset()
-
         # Track token counts for usage reporting
         prompt_tokens = 0
         completion_tokens = 0
 
-        # Stream content — PostProcessor handles reasoning/tool/sanitize
-        async for output in engine.stream_chat(messages=messages, **kwargs):
-            if hasattr(output, "prompt_tokens") and output.prompt_tokens:
-                prompt_tokens = output.prompt_tokens
-            if hasattr(output, "completion_tokens") and output.completion_tokens:
-                completion_tokens = output.completion_tokens
-
-            for event in processor.process_chunk(output):
-                if event.type == "content":
-                    if not want_logprobs:
-                        _sse = _fast_sse_chunk(event.content, "content")
-                        if _sse:
-                            yield _sse
-                    else:
-                        chunk = ChatCompletionChunk(
-                            id=response_id,
-                            model=_resolve_model_name(request.model),
-                            choices=[
-                                ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        content=event.content,
-                                    ),
-                                    logprobs=_build_chunk_logprobs(output),
-                                )
-                            ],
+        def _format_stream_event(event, output: GenerationOutput) -> list[str]:
+            if event.type == "content":
+                if not want_logprobs:
+                    _sse = _fast_sse_chunk(event.content, "content")
+                    return [_sse] if _sse else []
+                chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_resolve_model_name(request.model),
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                content=event.content,
+                            ),
+                            logprobs=_build_chunk_logprobs(output),
                         )
-                        yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+                    ],
+                )
+                return [f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"]
 
-                elif event.type == "reasoning":
-                    yield _fast_sse_chunk(event.reasoning, "reasoning_content")
+            if event.type == "reasoning":
+                return [_fast_sse_chunk(event.reasoning, "reasoning_content")]
 
-                elif event.type == "tool_call":
-                    chunk = ChatCompletionChunk(
-                        id=response_id,
-                        model=_resolve_model_name(request.model),
-                        choices=[
-                            ChatCompletionChunkChoice(
-                                delta=ChatCompletionChunkDelta(
-                                    tool_calls=event.tool_calls,
-                                ),
-                                finish_reason=event.finish_reason,
-                            )
-                        ],
-                        usage=get_usage(output) if output.finished else None,
-                    )
-                    _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
-                    logger.info(f"[SSE-TC] {_tc_sse.strip()[:300]}")
-                    yield _tc_sse
-
-                elif event.type == "finish":
-                    chunk = ChatCompletionChunk(
-                        id=response_id,
-                        model=_resolve_model_name(request.model),
-                        choices=[
-                            ChatCompletionChunkChoice(
-                                delta=ChatCompletionChunkDelta(
-                                    content=event.content,
-                                    reasoning_content=event.reasoning,
-                                ),
-                                finish_reason=event.finish_reason,
-                                logprobs=_build_chunk_logprobs(output),
-                            )
-                        ],
-                        usage=get_usage(output) if output.finished else None,
-                    )
-                    yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
-
-        # Fallback tool call detection
-        for event in processor.finalize():
             if event.type == "tool_call":
-                tool_chunk = ChatCompletionChunk(
+                chunk = ChatCompletionChunk(
                     id=response_id,
                     model=_resolve_model_name(request.model),
                     choices=[
@@ -729,13 +685,152 @@ async def stream_chat_completion(
                             delta=ChatCompletionChunkDelta(
                                 tool_calls=event.tool_calls,
                             ),
-                            finish_reason="tool_calls",
+                            finish_reason=event.finish_reason,
                         )
                     ],
+                    usage=get_usage(output) if output.finished else None,
                 )
-                _fb_sse = f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
-                logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
-                yield _fb_sse
+                _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+                logger.info(f"[SSE-TC] {_tc_sse.strip()[:300]}")
+                return [_tc_sse]
+
+            if event.type == "finish":
+                chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_resolve_model_name(request.model),
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                content=event.content,
+                                reasoning_content=event.reasoning,
+                            ),
+                            finish_reason=event.finish_reason,
+                            logprobs=_build_chunk_logprobs(output),
+                        )
+                    ],
+                    usage=get_usage(output) if output.finished else None,
+                )
+                return [f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"]
+
+            return []
+
+        retry_attempts = 0
+        active_messages = messages
+        max_tool_continuation_retries = 2 if tool_continuation_retry else 0
+
+        while True:
+            # Initialize post-processor
+            processor = StreamingPostProcessor(
+                cfg,
+                tools_requested=bool(request.tools),
+                json_mode=bool(
+                    request.response_format
+                    and getattr(request.response_format, "type", "text") != "text"
+                ),
+                request_dict=request.model_dump(),
+            )
+            processor.set_thinking_model(request.model)
+            processor.reset()
+
+            buffered_events: list[tuple] = []
+            deferred_finish: tuple | None = None
+            emitted_tool_call = False
+
+            # Stream content — PostProcessor handles reasoning/tool/sanitize
+            async for output in engine.stream_chat(messages=active_messages, **kwargs):
+                if hasattr(output, "prompt_tokens") and output.prompt_tokens:
+                    prompt_tokens = output.prompt_tokens
+                if hasattr(output, "completion_tokens") and output.completion_tokens:
+                    completion_tokens = output.completion_tokens
+
+                retry_window = (
+                    retry_attempts < max_tool_continuation_retries
+                    and not emitted_tool_call
+                )
+
+                for event in processor.process_chunk(output):
+                    if retry_window and event.type in ("content", "reasoning"):
+                        buffered_events.append((event, output))
+                        continue
+
+                    if (
+                        retry_window
+                        and event.type == "finish"
+                        and event.finish_reason == "stop"
+                    ):
+                        deferred_finish = (event, output)
+                        continue
+
+                    if event.type == "tool_call":
+                        emitted_tool_call = True
+                        for buffered_event, buffered_output in buffered_events:
+                            for _sse in _format_stream_event(
+                                buffered_event, buffered_output
+                            ):
+                                yield _sse
+                        buffered_events.clear()
+
+                    for _sse in _format_stream_event(event, output):
+                        yield _sse
+
+            # Fallback tool call detection
+            for event in processor.finalize():
+                if event.type == "tool_call":
+                    emitted_tool_call = True
+                    for buffered_event, buffered_output in buffered_events:
+                        for _sse in _format_stream_event(
+                            buffered_event, buffered_output
+                        ):
+                            yield _sse
+                    buffered_events.clear()
+
+                    tool_chunk = ChatCompletionChunk(
+                        id=response_id,
+                        model=_resolve_model_name(request.model),
+                        choices=[
+                            ChatCompletionChunkChoice(
+                                delta=ChatCompletionChunkDelta(
+                                    tool_calls=event.tool_calls,
+                                ),
+                                finish_reason="tool_calls",
+                            )
+                        ],
+                    )
+                    _fb_sse = (
+                        f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
+                    )
+                    logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
+                    yield _fb_sse
+
+            retry_reason = None
+            if deferred_finish and not emitted_tool_call:
+                retry_reason = "text-only stop"
+            elif buffered_events and not emitted_tool_call:
+                retry_reason = "stream exhausted without tool call"
+
+            if retry_reason and retry_attempts < max_tool_continuation_retries:
+                retry_attempts += 1
+                logger.info(
+                    "[tool-continuation] retrying after %s following "
+                    "tool result (attempt %d/%d)",
+                    retry_reason,
+                    retry_attempts,
+                    max_tool_continuation_retries,
+                )
+                active_messages = list(messages) + [
+                    {"role": "user", "content": _TOOL_CONTINUATION_RETRY_PROMPT}
+                ]
+                continue
+
+            for buffered_event, buffered_output in buffered_events:
+                for _sse in _format_stream_event(buffered_event, buffered_output):
+                    yield _sse
+            if deferred_finish:
+                event, output = deferred_finish
+                for _sse in _format_stream_event(event, output):
+                    yield _sse
+
+            break
 
         # Log throughput
         elapsed = time.perf_counter() - start_time

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -83,11 +83,13 @@ async def status():
     return {
         "status": "generating" if stats.get("running") else "idle",
         "model": cfg.model_name,
+        "engine_type": stats.get("engine_type"),
         "uptime_s": round(stats.get("uptime_seconds", 0), 1),
         "steps_executed": stats.get("steps_executed", 0),
         "num_running": stats.get("num_running", 0),
         "num_waiting": stats.get("num_waiting", 0),
-        "total_requests_processed": stats.get("num_requests_processed", 0),
+        "total_requests_processed": stats.get("total_requests_processed")
+        or stats.get("num_requests_processed", 0),
         "total_prompt_tokens": stats.get("total_prompt_tokens", 0),
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
         "metal": {
@@ -99,6 +101,7 @@ async def status():
         or stats.get("paged_cache")
         or stats.get("prefix_cache"),
         "requests": stats.get("requests", []),
+        "dflash": stats.get("dflash"),
     }
 
 

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -6,8 +6,22 @@ import gc
 from fastapi import APIRouter, HTTPException
 
 from ..config import get_config
+from ..request_metrics import get_recorder
 
 router = APIRouter()
+
+
+@router.get("/v1/requests")
+async def recent_requests(limit: int = 50):
+    """Return recent completed requests + active request snapshot.
+
+    Used by the `rapid-mlx serve --tui` monitor.
+    """
+    recorder = get_recorder()
+    return {
+        "active": recorder.active(),
+        "entries": recorder.entries(max(1, min(int(limit), 500))),
+    }
 
 
 @router.get("/health")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -443,6 +443,12 @@ def load_model(
     cloud_api_key: str | None = None,
     served_model_name: str | None = None,
     mtp: bool = False,
+    drafter_path: str | None = None,
+    dflash_block_size: int | None = None,
+    dflash_adaptive: bool = True,
+    dflash_block_min: int = 8,
+    dflash_block_max: int = 22,
+    dflash_turboquant_bits: float | None = None,
 ):
     """
     Load a model (auto-detects MLLM vs LLM).
@@ -489,14 +495,31 @@ def load_model(
     if force_mllm:
         logger.info("Force MLLM mode enabled via --mllm flag")
 
-    logger.info(f"Loading model with BatchedEngine: {model_name}")
-    _engine = BatchedEngine(
-        model_name=model_name,
-        scheduler_config=scheduler_config,
-        stream_interval=stream_interval,
-        force_mllm=force_mllm,
-        gpu_memory_utilization=gpu_memory_utilization,
-    )
+    if drafter_path:
+        from .engine import DFlashEngine
+
+        logger.info(
+            f"Loading model with DFlashEngine: target={model_name}, drafter={drafter_path}"
+        )
+        _engine = DFlashEngine(
+            model_name=model_name,
+            drafter_path=drafter_path,
+            block_size=dflash_block_size,
+            adaptive=dflash_adaptive,
+            adaptive_min=dflash_block_min,
+            adaptive_max=dflash_block_max,
+            turboquant_bits=dflash_turboquant_bits,
+            gpu_memory_utilization=gpu_memory_utilization,
+        )
+    else:
+        logger.info(f"Loading model with BatchedEngine: {model_name}")
+        _engine = BatchedEngine(
+            model_name=model_name,
+            scheduler_config=scheduler_config,
+            stream_interval=stream_interval,
+            force_mllm=force_mllm,
+            gpu_memory_utilization=gpu_memory_utilization,
+        )
     logger.info(f"Model loaded: {model_name}")
 
     # Set native tool format support on the engine (thread-safe via instance property)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -328,6 +328,12 @@ def configure_cors(origins: list[str]) -> None:
     )
 
 
+# Per-request metrics recorder for /v1/requests and the TUI monitor
+from .middleware.metrics import MetricsMiddleware  # noqa: E402
+
+app.add_middleware(MetricsMiddleware)
+
+
 # Auth and rate limiting — moved to middleware/auth.py
 from .middleware.auth import (  # noqa: E402
     RateLimiter,  # noqa: F401

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -369,16 +369,18 @@ def _detect_native_tool_support() -> bool:
         True if native format should be preserved
     """
     cfg = get_config()
-    if not cfg.enable_auto_tool_choice or not cfg.tool_call_parser:
+    enable_auto_tool_choice = cfg.enable_auto_tool_choice or _enable_auto_tool_choice
+    tool_call_parser = cfg.tool_call_parser or _tool_call_parser
+    if not enable_auto_tool_choice or not tool_call_parser:
         return False
 
     try:
-        parser_cls = ToolParserManager.get_tool_parser(cfg.tool_call_parser)
+        parser_cls = ToolParserManager.get_tool_parser(tool_call_parser)
         return parser_cls.supports_native_format()
     except KeyError:
         # Parser not found - this is a configuration error, log as error
         logger.error(
-            f"Tool parser '{cfg.tool_call_parser}' not found. "
+            f"Tool parser '{tool_call_parser}' not found. "
             f"Available parsers: {ToolParserManager.list_registered()}"
         )
         return False

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -54,6 +54,14 @@ _TOOL_CONTINUATION_USER_PROMPT = (
     "Only give a final answer when the task is complete."
 )
 
+_TOOL_CONTINUATION_REPEATED_READ_PROMPT = (
+    "You just repeated the same read-only tool call after receiving its result. "
+    "Use the tool result already present in the conversation. "
+    "Do not call the same read-only tool with the same arguments again. "
+    "Make a state-changing tool call, run a diagnostic command, or provide the "
+    "final answer if the task is complete."
+)
+
 _TOOL_CONTINUATION_RETRY_PROMPT = (
     "Your previous response was only narration/planning after a tool result. "
     "That is invalid for this tool-using client. "
@@ -64,6 +72,13 @@ _TOOL_CALL_REQUIRED_RETRY_PROMPT = (
     "Your previous response produced narration or repeated text instead of a tool call. "
     "That is invalid for this tool-using client. "
     "Call the first or next required tool now. Do not output explanatory text."
+)
+
+_TOOL_CALL_JSON_RETRY_PROMPT = (
+    "Your previous tool call was incomplete or had invalid JSON arguments. "
+    "That is invalid for this tool-using client. "
+    "Call the required tool again now with one complete, valid JSON object for "
+    "the function arguments. Do not output explanatory text."
 )
 
 
@@ -404,13 +419,91 @@ def _is_tool_result_message(message) -> bool:
     return stripped.startswith("[Tool Result") or stripped.startswith("<tool_response>")
 
 
+def _object_value(obj, key: str):
+    return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+
+def _normalize_tool_arguments(arguments) -> str:
+    if arguments is None:
+        return ""
+    if not isinstance(arguments, str):
+        try:
+            return json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return str(arguments)
+
+    stripped = arguments.strip()
+    try:
+        decoded = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return stripped
+    try:
+        return json.dumps(decoded, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return stripped
+
+
+def _assistant_tool_call_signature(message) -> tuple[str, str] | None:
+    if _message_role(message) != "assistant":
+        return None
+
+    tool_calls = _object_value(message, "tool_calls")
+    if not tool_calls:
+        return None
+
+    tool_call = tool_calls[0]
+    function = _object_value(tool_call, "function")
+    if not function:
+        return None
+
+    name = _object_value(function, "name")
+    if not name:
+        return None
+
+    arguments = _normalize_tool_arguments(_object_value(function, "arguments"))
+    return str(name), arguments
+
+
+def _has_repeated_recent_read_tool_call(messages: list) -> bool:
+    """Detect repeated read-only tool calls without a state-changing call between."""
+    last_signature = None
+    saw_last = False
+
+    for message in reversed(messages):
+        signature = _assistant_tool_call_signature(message)
+        if not signature:
+            continue
+
+        name, _arguments = signature
+        if name != "read":
+            if saw_last:
+                return False
+            continue
+
+        if not saw_last:
+            last_signature = signature
+            saw_last = True
+            continue
+
+        if signature == last_signature:
+            return True
+
+    return False
+
+
 def _append_tool_continuation_prompt(messages: list, tools_requested: bool) -> tuple[list, bool]:
     """Add a hidden continuation nudge after tool results for local tool models."""
     if not tools_requested or not messages:
         return messages, False
     if not _is_tool_result_message(messages[-1]):
         return messages, False
-    return messages + [{"role": "user", "content": _TOOL_CONTINUATION_USER_PROMPT}], True
+    prompt = (
+        _TOOL_CONTINUATION_REPEATED_READ_PROMPT
+        if _has_repeated_recent_read_tool_call(messages)
+        else _TOOL_CONTINUATION_USER_PROMPT
+    )
+    return messages + [{"role": "user", "content": prompt}], True
+
 
 
 def _maybe_pin_system_prompt(messages: list) -> None:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -60,6 +60,12 @@ _TOOL_CONTINUATION_RETRY_PROMPT = (
     "Call the next required tool now. Do not output any explanatory text."
 )
 
+_TOOL_CALL_REQUIRED_RETRY_PROMPT = (
+    "Your previous response produced narration or repeated text instead of a tool call. "
+    "That is invalid for this tool-using client. "
+    "Call the first or next required tool now. Do not output explanatory text."
+)
+
 
 # ── Resolution helpers ─────────────────────────────────────────────
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -47,6 +47,19 @@ _TOOL_USE_SYSTEM_SUFFIX = (
     "Give direct answers only — no preamble like 'The user asks...' or 'Let me think...'."
 )
 
+_TOOL_CONTINUATION_USER_PROMPT = (
+    "Continue the original task after the tool result above. "
+    "If any work remains and a suitable tool is available, call the next tool now. "
+    "Do not describe the next action. Do not stop with only reasoning. "
+    "Only give a final answer when the task is complete."
+)
+
+_TOOL_CONTINUATION_RETRY_PROMPT = (
+    "Your previous response was only narration/planning after a tool result. "
+    "That is invalid for this tool-using client. "
+    "Call the next required tool now. Do not output any explanatory text."
+)
+
 
 # ── Resolution helpers ─────────────────────────────────────────────
 
@@ -356,6 +369,42 @@ def _inject_json_instruction(messages: list, instruction: str) -> list:
         messages.insert(0, {"role": "system", "content": instruction})
 
     return messages
+
+
+def _message_role(message) -> str | None:
+    return (
+        message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+    )
+
+
+def _message_content(message):
+    return (
+        message.get("content")
+        if isinstance(message, dict)
+        else getattr(message, "content", None)
+    )
+
+
+def _is_tool_result_message(message) -> bool:
+    role = _message_role(message)
+    if role == "tool":
+        return True
+    if role != "user":
+        return False
+    content = _message_content(message)
+    if not isinstance(content, str):
+        return False
+    stripped = content.lstrip()
+    return stripped.startswith("[Tool Result") or stripped.startswith("<tool_response>")
+
+
+def _append_tool_continuation_prompt(messages: list, tools_requested: bool) -> tuple[list, bool]:
+    """Add a hidden continuation nudge after tool results for local tool models."""
+    if not tools_requested or not messages:
+        return messages, False
+    if not _is_tool_result_message(messages[-1]):
+        return messages, False
+    return messages + [{"role": "user", "content": _TOOL_CONTINUATION_USER_PROMPT}], True
 
 
 def _maybe_pin_system_prompt(messages: list) -> None:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ..api.tool_calling import parse_tool_calls
 from ..api.utils import sanitize_output, strip_special_tokens
 from ..domain.events import StreamEvent
 
@@ -74,10 +75,12 @@ class StreamingPostProcessor:
         tools_requested: bool = False,
         enable_thinking: bool | None = None,
         json_mode: bool = False,
+        request_dict: dict | None = None,
     ):
         self.cfg = cfg
         self.tools_requested = tools_requested
         self.json_mode = json_mode
+        self.request_dict = request_dict
 
         # Per-request parser instances — each streaming request gets its
         # own parser to avoid state corruption under concurrent
@@ -116,6 +119,36 @@ class StreamingPostProcessor:
         # the first JSON delimiter ({ or [) is seen, then emit from there.
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
+
+    @staticmethod
+    def _tool_calls_to_stream_chunks(tool_calls) -> list[dict]:
+        chunks = []
+        for i, tc in enumerate(tool_calls):
+            if hasattr(tc, "function"):
+                call_id = tc.id
+                name = tc.function.name
+                arguments = tc.function.arguments
+            elif "function" in tc:
+                call_id = tc.get("id")
+                name = tc["function"]["name"]
+                arguments = tc["function"]["arguments"]
+            else:
+                call_id = tc.get("id")
+                name = tc["name"]
+                arguments = tc["arguments"]
+
+            chunks.append(
+                {
+                    "index": i,
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    },
+                }
+            )
+        return chunks
 
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
@@ -469,7 +502,9 @@ class StreamingPostProcessor:
             and not self.tool_calls_detected
             and self.tool_parser.has_pending_tool_call(_fallback_text)
         ):
-            result = self.tool_parser.extract_tool_calls(_fallback_text)
+            result = self.tool_parser.extract_tool_calls(
+                _fallback_text, self.request_dict
+            )
             if result.tools_called:
                 tc_list = [
                     {
@@ -493,6 +528,19 @@ class StreamingPostProcessor:
                 )
                 self.tool_calls_detected = True
 
+        if "Calling tool:" in _fallback_text and not self.tool_calls_detected:
+            _, tool_calls = parse_tool_calls(_fallback_text, self.request_dict)
+            if tool_calls:
+                events.append(
+                    StreamEvent(
+                        type="tool_call",
+                        tool_calls=self._tool_calls_to_stream_chunks(tool_calls),
+                        finish_reason="tool_calls",
+                        tool_calls_detected=True,
+                    )
+                )
+                self.tool_calls_detected = True
+
         return events
 
     def _detect_tool_calls(self, content: str) -> dict | None:
@@ -502,7 +550,12 @@ class StreamingPostProcessor:
         Returns {"tool_calls": [...]} if tool calls detected.
         Returns {"content": "..."} for normal content pass-through.
         """
-        if not self.tool_markup_possible and "<" not in content and "[" not in content:
+        if (
+            not self.tool_markup_possible
+            and "<" not in content
+            and "[" not in content
+            and "Calling tool:" not in content
+        ):
             self.tool_accumulated_text += content
             return {"content": content}
 
@@ -512,15 +565,34 @@ class StreamingPostProcessor:
         tool_previous = self.tool_accumulated_text
         self.tool_accumulated_text += content
         tool_result = self.tool_parser.extract_tool_calls_streaming(
-            tool_previous, self.tool_accumulated_text, content
+            tool_previous,
+            self.tool_accumulated_text,
+            content,
+            request=self.request_dict,
         )
 
         if tool_result is None:
+            if "Calling tool:" in self.tool_accumulated_text:
+                _, tool_calls = parse_tool_calls(
+                    self.tool_accumulated_text, self.request_dict
+                )
+                if tool_calls:
+                    self.tool_calls_detected = True
+                    return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
             return None  # inside tool markup
 
         if "tool_calls" in tool_result:
             self.tool_calls_detected = True
             return tool_result
+
+        if "Calling tool:" in self.tool_accumulated_text:
+            _, tool_calls = parse_tool_calls(
+                self.tool_accumulated_text, self.request_dict
+            )
+            if tool_calls:
+                self.tool_calls_detected = True
+                return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+            return None
 
         return {"content": tool_result.get("content", "")}
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -316,7 +316,7 @@ class StreamingPostProcessor:
             return False
         if self.tool_parser:
             return True
-        return self.tools_requested and (
+        return (
             "Calling tool:" in content or "Calling tool:" in self.tool_accumulated_text
         )
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -54,16 +54,48 @@ def _has_partial_calling_tool_marker(text: str) -> bool:
     """Return True when a stream tail may become `Calling tool:`."""
     marker = "Calling tool:"
     tail = text.rstrip()
-    stripped_tail = tail
-    while stripped_tail and stripped_tail[-1] in "[ \t\r\n":
-        if stripped_tail[-1] == "[":
-            return True
-        stripped_tail = stripped_tail[:-1]
+    if tail.endswith("[") and _starts_current_line(tail, len(tail) - 1):
+        return True
     for i in range(1, len(marker)):
         partial = marker[:i]
-        if tail.endswith(partial) or tail.endswith(f"[{partial}"):
-            return True
+        if tail.endswith(partial):
+            start = len(tail) - len(partial)
+            if _starts_current_line(tail, start):
+                return True
+        if tail.endswith(f"[{partial}"):
+            start = len(tail) - len(partial) - 1
+            if _starts_current_line(tail, start):
+                return True
     return False
+
+
+def _starts_current_line(text: str, start: int) -> bool:
+    """Return True when start is preceded only by whitespace on its line."""
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    return text[line_start:start].strip() == ""
+
+
+def _find_trailing_calling_tool_prefix(text: str) -> int | None:
+    marker = "Calling tool:"
+    tail_end = len(text.rstrip())
+    tail = text[:tail_end]
+
+    if tail.endswith("["):
+        start = len(tail) - 1
+        if _starts_current_line(tail, start):
+            return start
+
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if tail.endswith(partial):
+            start = len(tail) - len(partial)
+            if _starts_current_line(tail, start):
+                return start
+        if tail.endswith(f"[{partial}"):
+            start = len(tail) - len(partial) - 1
+            if _starts_current_line(tail, start):
+                return start
+    return None
 
 
 def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
@@ -71,31 +103,9 @@ def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
     if not text:
         return None
 
-    marker = "Calling tool:"
-    tail_end = len(text.rstrip())
-    tail = text[:tail_end]
-
-    for i in range(1, len(marker)):
-        partial = marker[:i]
-        if not tail.endswith(partial):
-            continue
-        start = len(tail) - len(partial)
-        while start > 0 and tail[start - 1].isspace():
-            start -= 1
-        while start > 0 and tail[start - 1] == "[":
-            start -= 1
-            while start > 0 and tail[start - 1].isspace():
-                start -= 1
-        return text[:start]
-
-    start = len(tail)
-    saw_bracket = False
-    while start > 0 and tail[start - 1] in "[ \t\r\n":
-        if tail[start - 1] == "[":
-            saw_bracket = True
-        start -= 1
-    if saw_bracket:
-        return text[:start]
+    start = _find_trailing_calling_tool_prefix(text)
+    if start is not None:
+        return text[:start].rstrip()
     return None
 
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -251,7 +251,7 @@ class StreamingPostProcessor:
             content, reasoning = delta_text, None
 
         # Tool call detection on content
-        if self.tool_parser and content:
+        if self._should_detect_tool_calls(content):
             result = self._detect_tool_calls(content)
             if result is None:
                 return []  # suppressed (inside tool markup)
@@ -311,6 +311,15 @@ class StreamingPostProcessor:
             events.append(StreamEvent(type="reasoning", reasoning=reasoning))
         return events
 
+    def _should_detect_tool_calls(self, content: str | None) -> bool:
+        if not content:
+            return False
+        if self.tool_parser:
+            return True
+        return self.tools_requested and (
+            "Calling tool:" in content or "Calling tool:" in self.tool_accumulated_text
+        )
+
     def _process_with_reasoning(
         self, delta_text: str, output: GenerationOutput
     ) -> list[StreamEvent]:
@@ -342,7 +351,7 @@ class StreamingPostProcessor:
                 reasoning = None
 
         # Tool call detection
-        if self.tool_parser and content:
+        if self._should_detect_tool_calls(content):
             result = self._detect_tool_calls(content)
             if result is None:
                 return []
@@ -430,7 +439,7 @@ class StreamingPostProcessor:
             self._think_prefix_sent = True
 
         # Tool call detection
-        if self.tool_parser and delta_text:
+        if self._should_detect_tool_calls(delta_text):
             result = self._detect_tool_calls(delta_text)
             if result is None:
                 return []
@@ -564,12 +573,15 @@ class StreamingPostProcessor:
 
         tool_previous = self.tool_accumulated_text
         self.tool_accumulated_text += content
-        tool_result = self.tool_parser.extract_tool_calls_streaming(
-            tool_previous,
-            self.tool_accumulated_text,
-            content,
-            request=self.request_dict,
-        )
+        if self.tool_parser:
+            tool_result = self.tool_parser.extract_tool_calls_streaming(
+                tool_previous,
+                self.tool_accumulated_text,
+                content,
+                request=self.request_dict,
+            )
+        else:
+            tool_result = {"content": content}
 
         if tool_result is None:
             if "Calling tool:" in self.tool_accumulated_text:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -8,6 +8,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,55 @@ def _find_json_start(text: str) -> int:
             return i
         i += 1
     return -1
+
+
+def _has_partial_calling_tool_marker(text: str) -> bool:
+    """Return True when a stream tail may become `Calling tool:`."""
+    marker = "Calling tool:"
+    tail = text.rstrip()
+    stripped_tail = tail
+    while stripped_tail and stripped_tail[-1] in "[ \t\r\n":
+        if stripped_tail[-1] == "[":
+            return True
+        stripped_tail = stripped_tail[:-1]
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if tail.endswith(partial) or tail.endswith(f"[{partial}"):
+            return True
+    return False
+
+
+def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
+    """Remove a trailing bracket/partial marker that may start a tool call."""
+    if not text:
+        return None
+
+    marker = "Calling tool:"
+    tail_end = len(text.rstrip())
+    tail = text[:tail_end]
+
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if not tail.endswith(partial):
+            continue
+        start = len(tail) - len(partial)
+        while start > 0 and tail[start - 1].isspace():
+            start -= 1
+        while start > 0 and tail[start - 1] == "[":
+            start -= 1
+            while start > 0 and tail[start - 1].isspace():
+                start -= 1
+        return text[:start]
+
+    start = len(tail)
+    saw_bracket = False
+    while start > 0 and tail[start - 1] in "[ \t\r\n":
+        if tail[start - 1] == "[":
+            saw_bracket = True
+        start -= 1
+    if saw_bracket:
+        return text[:start]
+    return None
 
 
 class StreamingPostProcessor:
@@ -120,8 +170,37 @@ class StreamingPostProcessor:
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
 
-    @staticmethod
-    def _tool_calls_to_stream_chunks(tool_calls) -> list[dict]:
+    def _tool_call_has_required_args(self, name: str | None, arguments) -> bool:
+        if not name or not isinstance(self.request_dict, dict):
+            return True
+        tools = self.request_dict.get("tools")
+        if not isinstance(tools, list):
+            return True
+
+        required = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            if not isinstance(function, dict) or function.get("name") != name:
+                continue
+            parameters = function.get("parameters")
+            if isinstance(parameters, dict):
+                required = parameters.get("required") or []
+            break
+        if not required:
+            return True
+
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (TypeError, ValueError):
+                return False
+        if not isinstance(arguments, dict):
+            return False
+        return all(key in arguments for key in required)
+
+    def _tool_calls_to_stream_chunks(self, tool_calls) -> list[dict]:
         chunks = []
         for i, tc in enumerate(tool_calls):
             if hasattr(tc, "function"):
@@ -137,9 +216,16 @@ class StreamingPostProcessor:
                 name = tc["name"]
                 arguments = tc["arguments"]
 
+            if not self._tool_call_has_required_args(name, arguments):
+                logger.debug(
+                    "Dropping malformed tool call missing required arguments: %s",
+                    name,
+                )
+                continue
+
             chunks.append(
                 {
-                    "index": i,
+                    "index": len(chunks),
                     "id": call_id,
                     "type": "function",
                     "function": {
@@ -318,6 +404,8 @@ class StreamingPostProcessor:
             return True
         return (
             "Calling tool:" in content or "Calling tool:" in self.tool_accumulated_text
+            or _has_partial_calling_tool_marker(content)
+            or _has_partial_calling_tool_marker(self.tool_accumulated_text + content)
         )
 
     def _process_with_reasoning(
@@ -540,10 +628,13 @@ class StreamingPostProcessor:
         if "Calling tool:" in _fallback_text and not self.tool_calls_detected:
             _, tool_calls = parse_tool_calls(_fallback_text, self.request_dict)
             if tool_calls:
+                chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                if not chunks:
+                    return events
                 events.append(
                     StreamEvent(
                         type="tool_call",
-                        tool_calls=self._tool_calls_to_stream_chunks(tool_calls),
+                        tool_calls=chunks,
                         finish_reason="tool_calls",
                         tool_calls_detected=True,
                     )
@@ -589,8 +680,11 @@ class StreamingPostProcessor:
                     self.tool_accumulated_text, self.request_dict
                 )
                 if tool_calls:
+                    chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                    if not chunks:
+                        return None
                     self.tool_calls_detected = True
-                    return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+                    return {"tool_calls": chunks}
             return None  # inside tool markup
 
         if "tool_calls" in tool_result:
@@ -602,8 +696,18 @@ class StreamingPostProcessor:
                 self.tool_accumulated_text, self.request_dict
             )
             if tool_calls:
+                chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                if not chunks:
+                    return None
                 self.tool_calls_detected = True
-                return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+                return {"tool_calls": chunks}
+            return None
+
+        if _has_partial_calling_tool_marker(self.tool_accumulated_text):
+            content = tool_result.get("content", "")
+            stripped = _strip_trailing_calling_tool_prefix(content)
+            if stripped:
+                return {"content": stripped}
             return None
 
         return {"content": tool_result.get("content", "")}

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -53,6 +53,28 @@ def _get_arguments_config(func_name: str, tools: list[dict] | None) -> dict:
     return {}
 
 
+def _decode_json_like(value: Any) -> Any:
+    """Decode JSON-looking strings, including double-encoded values."""
+    if not isinstance(value, str):
+        return value
+
+    current: Any = value.strip()
+    for _ in range(3):
+        if not isinstance(current, str):
+            return current
+        stripped = current.strip()
+        if not stripped or stripped[0] not in '[{"':
+            return current
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return current
+        if parsed == current:
+            return parsed
+        current = parsed
+    return current
+
+
 def _convert_param_value(
     param_value: str, param_name: str, param_config: dict, func_name: str
 ) -> Any:
@@ -61,7 +83,7 @@ def _convert_param_value(
         return None
 
     if param_name not in param_config:
-        return param_value
+        return _decode_json_like(param_value)
 
     cfg = param_config[param_name]
     if isinstance(cfg, dict) and "type" in cfg:
@@ -87,10 +109,9 @@ def _convert_param_value(
         if param_type in ("object", "array", "arr") or param_type.startswith(
             ("dict", "list")
         ):
-            try:
-                return json.loads(param_value)
-            except (json.JSONDecodeError, TypeError, ValueError):
-                pass
+            decoded = _decode_json_like(param_value)
+            if decoded is not param_value:
+                return decoded
         try:
             return ast.literal_eval(param_value)
         except (ValueError, SyntaxError):

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -75,6 +75,37 @@ def _decode_json_like(value: Any) -> Any:
     return current
 
 
+def _schema_type(schema: Any) -> str | None:
+    """Infer a JSON schema type for tool argument conversion."""
+    if isinstance(schema, str):
+        return schema.strip().lower()
+    if not isinstance(schema, dict):
+        return None
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    if isinstance(schema_type, str):
+        return schema_type.strip().lower()
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(key)
+        if not isinstance(options, list):
+            continue
+        for option in options:
+            option_type = _schema_type(option)
+            if option_type and option_type != "null":
+                return option_type
+
+    if "items" in schema:
+        return "array"
+    if "properties" in schema or "additionalProperties" in schema:
+        return "object"
+    if "enum" in schema:
+        return "string"
+    return None
+
+
 def _convert_param_value(
     param_value: str, param_name: str, param_config: dict, func_name: str
 ) -> Any:
@@ -86,10 +117,9 @@ def _convert_param_value(
         return _decode_json_like(param_value)
 
     cfg = param_config[param_name]
-    if isinstance(cfg, dict) and "type" in cfg:
-        param_type = str(cfg["type"]).strip().lower()
-    else:
-        param_type = "string"
+    param_type = _schema_type(cfg)
+    if param_type is None:
+        return _decode_json_like(param_value)
 
     if param_type in ("string", "str", "text", "varchar", "char", "enum"):
         return param_value

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -275,6 +275,8 @@ class Qwen3CoderToolParser(ToolParser):
         if not previous_text:
             self._reset_streaming_state()
             self._streaming_request = request
+        elif request is not None and self._streaming_request is None:
+            self._streaming_request = request
 
         if not delta_text:
             return None

--- a/vllm_mlx/tui.py
+++ b/vllm_mlx/tui.py
@@ -152,6 +152,8 @@ def _build_screen(
     cache_misses = _integer(cache_info.get("misses", 0))
     cache_entries = _integer(cache_info.get("entries", 0))
 
+    dflash_info = status.get("dflash") or {}
+
     running_requests = list(status.get("requests") or [])
     entries = list((requests_data or {}).get("entries") or [])
     active_request = (requests_data or {}).get("active") or {}
@@ -235,6 +237,32 @@ def _build_screen(
             )
             + gap
             + _row("hit rate", hit_rate, right, "white", tty_on)
+        )
+    if dflash_info:
+        lifetime_ratio = _num(dflash_info.get("lifetime_acceptance_ratio", 0.0))
+        cur_block = _integer(dflash_info.get("current_block_size", 0))
+        adaptive_on = bool(dflash_info.get("adaptive_enabled"))
+        adapt_min = _integer(dflash_info.get("adaptive_min", 0))
+        adapt_max = _integer(dflash_info.get("adaptive_max", 0))
+        obs_min = _integer(dflash_info.get("observed_block_min", 0))
+        obs_max = _integer(dflash_info.get("observed_block_max", 0))
+        adaptive_label = (
+            f"{adapt_min}-{adapt_max} (obs {obs_min}-{obs_max})"
+            if adaptive_on
+            else "off"
+        )
+        rows.append(
+            _row(
+                "dflash accept",
+                f"{lifetime_ratio:.1%} lifetime {_bar(lifetime_ratio, 1.0, 12)}",
+                left,
+                "magenta",
+                tty_on,
+            )
+            + gap
+            + _row("block size", f"{cur_block} cfg", mid, "magenta", tty_on)
+            + gap
+            + _row("adaptive", adaptive_label, right, "magenta", tty_on)
         )
     rows.append(_line(width))
 
@@ -404,9 +432,17 @@ def _build_screen(
     if running_requests:
         rows.append(_line(width))
         rows.append(_c(tty_on, "bold", f"Active requests ({len(running_requests)})"))
-        header = (
-            "  id            phase       elapsed   prompt   out   tok/s   ttft   max"
+        any_dflash = any(
+            ("acceptance_ratio" in r) or ("block_size" in r) for r in running_requests
         )
+        if any_dflash:
+            header = (
+                "  id            phase       elapsed   prompt   out   tok/s   ttft   accept  block"
+            )
+        else:
+            header = (
+                "  id            phase       elapsed   prompt   out   tok/s   ttft   max"
+            )
         rows.append(_c(tty_on, "dim", _clamp(header, width)))
         for item in running_requests[:4]:
             rid = str(item.get("request_id") or "")[-12:].ljust(12)
@@ -418,11 +454,20 @@ def _build_screen(
             tps_s = "  -  " if tps is None else f"{_num(tps):>5.1f}"
             ttft = item.get("ttft_s")
             ttft_s = "  -  " if ttft is None else f"{_num(ttft):>4.2f}"
-            mx = _integer(item.get("max_tokens", 0))
-            row = (
-                f"  {rid} {phase} {elapsed:>7} "
-                f"{ptoks:>7} {otoks:>5} {tps_s} {ttft_s} {mx:>5}"
-            )
+            if any_dflash:
+                accept = _num(item.get("acceptance_ratio", 0.0))
+                bs = _integer(item.get("block_size", 0))
+                row = (
+                    f"  {rid} {phase} {elapsed:>7} "
+                    f"{ptoks:>7} {otoks:>5} {tps_s} {ttft_s} "
+                    f"{accept:>6.2f}  {bs:>4}"
+                )
+            else:
+                mx = _integer(item.get("max_tokens", 0))
+                row = (
+                    f"  {rid} {phase} {elapsed:>7} "
+                    f"{ptoks:>7} {otoks:>5} {tps_s} {ttft_s} {mx:>5}"
+                )
             rows.append(_clamp(row, width))
 
     if errors:

--- a/vllm_mlx/tui.py
+++ b/vllm_mlx/tui.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live TUI monitor for `rapid-mlx serve`.
+
+Polls /health, /v1/status, and /v1/requests of a running rapid-mlx server and
+renders a full-screen dashboard. Press `q` (or Ctrl-C) to exit.
+"""
+
+from __future__ import annotations
+
+import json
+import select
+import shutil
+import sys
+import termios
+import time
+import tty
+import urllib.error
+import urllib.request
+
+
+COLORS = {
+    "reset": "\033[0m",
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[37m",
+}
+
+
+def _c(enabled: bool, name: str, text: str) -> str:
+    if not enabled:
+        return text
+    return f"{COLORS.get(name, '')}{text}{COLORS['reset']}"
+
+
+def _fetch_json(url: str, timeout: float = 2.0) -> tuple[dict, str | None]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8")), None
+    except Exception as exc:
+        return {}, str(exc)
+
+
+def _num(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def _integer(value, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except Exception:
+        return int(default)
+
+
+def _fmt_seconds(value) -> str:
+    seconds = max(0.0, _num(value))
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    rem = int(seconds % 60)
+    if minutes < 60:
+        return f"{minutes}m{rem:02d}s"
+    hours = minutes // 60
+    minutes %= 60
+    return f"{hours}h{minutes:02d}m"
+
+
+def _fmt_gb(value) -> str:
+    return f"{_num(value):.2f} GB"
+
+
+def _clamp(text: str, width: int) -> str:
+    if width <= 0:
+        return ""
+    text = str(text)
+    if len(text) <= width:
+        return text
+    if width <= 3:
+        return text[:width]
+    return text[: width - 3] + "..."
+
+
+def _bar(value: float, limit: float, width: int = 18) -> str:
+    if width <= 0:
+        return ""
+    ratio = 0.0 if limit <= 0 else max(0.0, min(1.0, value / limit))
+    fill = int(round(ratio * width))
+    return "[" + "#" * fill + "-" * (width - fill) + "]"
+
+
+def _line(width: int, char: str = "-") -> str:
+    return char * max(0, width)
+
+
+def _row(label: str, value: str, width: int, color: str, tty_on: bool) -> str:
+    label_width = min(18, max(10, width // 4))
+    value_width = max(0, width - label_width - 1)
+    return (
+        f"{_c(tty_on, 'dim', label.ljust(label_width))} "
+        f"{_c(tty_on, color, _clamp(value, value_width))}"
+    )
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _build_screen(
+    base_url: str,
+    pid: int | str,
+    interval: float,
+    health: dict,
+    status: dict,
+    requests_data: dict,
+    errors: list[str],
+    tty_on: bool,
+) -> str:
+    width, height = shutil.get_terminal_size((110, 32))
+    width = max(80, width)
+    height = max(24, height)
+
+    model = status.get("model") or health.get("model_name") or "n/a"
+    engine_type = health.get("engine_type") or status.get("engine_type") or "n/a"
+
+    state = str(status.get("status") or "unknown")
+    loaded = bool(health.get("model_loaded"))
+
+    running = _integer(status.get("num_running", 0))
+    waiting = _integer(status.get("num_waiting", 0))
+    total_done = _integer(status.get("total_requests_processed", 0))
+    steps = _integer(status.get("steps_executed", 0))
+    uptime = _num(status.get("uptime_s", 0.0))
+
+    metal = status.get("metal") or {}
+    active_gb = _num(metal.get("active_memory_gb", 0.0))
+    cache_gb = _num(metal.get("cache_memory_gb", 0.0))
+    peak_gb = _num(metal.get("peak_memory_gb", 0.0))
+
+    prompt_toks = _integer(status.get("total_prompt_tokens", 0))
+    out_toks = _integer(status.get("total_completion_tokens", 0))
+
+    cache_info = status.get("cache") or {}
+    cache_hits = _integer(cache_info.get("hits", 0))
+    cache_misses = _integer(cache_info.get("misses", 0))
+    cache_entries = _integer(cache_info.get("entries", 0))
+
+    running_requests = list(status.get("requests") or [])
+    entries = list((requests_data or {}).get("entries") or [])
+    active_request = (requests_data or {}).get("active") or {}
+
+    # Active ticket age
+    age = 0.0
+    if active_request:
+        started = _num(active_request.get("started_at"))
+        if started:
+            age = max(0.0, time.time() - started)
+
+    if state == "generating" or running > 0:
+        status_text = "RUNNING"
+        status_color = "green"
+    elif loaded:
+        status_text = "IDLE"
+        status_color = "cyan"
+    else:
+        status_text = "LOADING"
+        status_color = "yellow"
+    if errors:
+        status_text = "DEGRADED"
+        status_color = "red"
+
+    left = 38
+    mid = 38
+    gap = "  "
+    right = max(24, width - left - mid - len(gap) * 2)
+
+    rows: list[str] = []
+    title = " Rapid-MLX Monitor "
+    subtitle = f"pid {pid} | {base_url} | refresh {interval:g}s | q quits"
+    rows.append(_c(tty_on, "bold", title) + _c(tty_on, "dim", " " + subtitle))
+    rows.append(_line(width))
+
+    rows.append(
+        _row("status", status_text, left, status_color, tty_on)
+        + gap
+        + _row(
+            "active/queued",
+            f"{running}/{waiting}  age {_fmt_seconds(age)}",
+            mid,
+            "white",
+            tty_on,
+        )
+        + gap
+        + _row("uptime", _fmt_seconds(uptime), right, "white", tty_on)
+    )
+    rows.append(
+        _row("memory active", _fmt_gb(active_gb), left, "green", tty_on)
+        + gap
+        + _row("cache", _fmt_gb(cache_gb), mid, "yellow", tty_on)
+        + gap
+        + _row("peak", _fmt_gb(peak_gb), right, "magenta", tty_on)
+    )
+    rows.append(
+        _row("model", str(model), left, "white", tty_on)
+        + gap
+        + _row("engine", str(engine_type), mid, "white", tty_on)
+        + gap
+        + _row("steps", str(steps), right, "white", tty_on)
+    )
+    rows.append(
+        _row("prompt tokens", f"{prompt_toks}", left, "cyan", tty_on)
+        + gap
+        + _row("output tokens", f"{out_toks}", mid, "cyan", tty_on)
+        + gap
+        + _row("requests done", f"{total_done}", right, "white", tty_on)
+    )
+    if cache_info:
+        hit_rate = (
+            f"{cache_hits / max(1, cache_hits + cache_misses):.1%}"
+            if (cache_hits or cache_misses)
+            else "n/a"
+        )
+        rows.append(
+            _row("prefix cache", f"{cache_entries} entries", left, "cyan", tty_on)
+            + gap
+            + _row(
+                "hit/miss", f"{cache_hits}/{cache_misses}", mid, "cyan", tty_on
+            )
+            + gap
+            + _row("hit rate", hit_rate, right, "white", tty_on)
+        )
+    rows.append(_line(width))
+
+    # Last request panel
+    last = entries[-1] if entries else {}
+    last_elapsed = _num(last.get("elapsed", 0.0))
+    last_prompt_tps = _num(last.get("prompt_tps", 0.0))
+    last_generation_tps = _num(last.get("generation_tps", 0.0))
+    last_prompt_tokens = _integer(last.get("prompt_tokens", 0))
+    last_generated_tokens = _integer(last.get("generated_tokens", 0))
+    last_finish = last.get("finish_reason", "n/a")
+    last_surface = last.get("surface", "n/a")
+    last_ttft = last.get("ttft")
+
+    rows.append(_c(tty_on, "bold", "Last request"))
+    if not last:
+        rows.append(_c(tty_on, "dim", "  no completed requests yet"))
+    else:
+        rows.append(
+            _row(
+                "tokens",
+                f"{last_generated_tokens} out / {last_prompt_tokens} prompt",
+                left,
+                "white",
+                tty_on,
+            )
+            + gap
+            + _row("elapsed", _fmt_seconds(last_elapsed), mid, "white", tty_on)
+            + gap
+            + _row("finish", str(last_finish), right, "white", tty_on)
+        )
+        rows.append(
+            _row(
+                "generation",
+                f"{last_generation_tps:.1f} tok/s {_bar(last_generation_tps, 60, 12)}",
+                left,
+                "green",
+                tty_on,
+            )
+            + gap
+            + _row(
+                "prefill",
+                f"{last_prompt_tps:.1f} tok/s {_bar(last_prompt_tps, 2500, 12)}",
+                mid,
+                "cyan",
+                tty_on,
+            )
+            + gap
+            + _row(
+                "ttft",
+                f"{_num(last_ttft):.2f}s" if last_ttft is not None else "n/a",
+                right,
+                "yellow",
+                tty_on,
+            )
+        )
+        rows.append(
+            _row("surface", str(last_surface), left, "white", tty_on)
+            + gap
+            + _row(
+                "target rate",
+                ">=20 tok/s good, >=40 fast",
+                mid,
+                "dim",
+                tty_on,
+            )
+            + gap
+            + _row("tuning", "low rate => check cache", right, "dim", tty_on)
+        )
+    rows.append(_line(width))
+
+    # Averages so far
+    rows.append(_c(tty_on, "bold", f"Averages so far ({len(entries)} requests)"))
+    if not entries:
+        rows.append(_c(tty_on, "dim", "  no completed request metrics yet"))
+    else:
+        avg_out = _mean([_num(item.get("generated_tokens", 0)) for item in entries])
+        avg_prompt = _mean([_num(item.get("prompt_tokens", 0)) for item in entries])
+        avg_gen_tps = _mean([_num(item.get("generation_tps", 0.0)) for item in entries])
+        avg_pre_tps = _mean([_num(item.get("prompt_tps", 0.0)) for item in entries])
+        avg_elapsed = _mean([_num(item.get("elapsed", 0.0)) for item in entries])
+        header = "  out  prompt  gen tok/s  prefill tok/s  elapsed"
+        row = (
+            f"  {avg_out:>5.1f} "
+            f"{avg_prompt:>7.1f} "
+            f"{avg_gen_tps:>9.1f} "
+            f"{avg_pre_tps:>13.1f} "
+            f"{avg_elapsed:>8.1f}s"
+        )
+        rows.append(_c(tty_on, "dim", _clamp(header, width)))
+        rows.append(_clamp(row, width))
+    rows.append(_line(width))
+
+    # Recent requests
+    rows.append(_c(tty_on, "bold", "Recent requests"))
+    last_message_reserved_rows = 14 + (5 if errors else 0)
+    recent_limit = max(1, min(8, height - len(rows) - last_message_reserved_rows - 1))
+    recent_entries = entries[-recent_limit:]
+    if not recent_entries:
+        rows.append(_c(tty_on, "dim", "  no completed request metrics yet"))
+    else:
+        header = (
+            "  time      surface              out  prompt  gen tok/s  prefill tok/s  finish"
+        )
+        rows.append(_c(tty_on, "dim", _clamp(header, width)))
+        for item in reversed(recent_entries):
+            ts = item.get("finished_at") or 0
+            try:
+                when = time.strftime("%H:%M:%S", time.localtime(float(ts)))
+            except Exception:
+                when = "--:--:--"
+            surface = str(item.get("surface", "n/a"))[-18:].ljust(18)
+            row = (
+                f"  {when}  "
+                f"{surface} "
+                f"{_integer(item.get('generated_tokens', 0)):>5} "
+                f"{_integer(item.get('prompt_tokens', 0)):>7} "
+                f"{_num(item.get('generation_tps', 0.0)):>9.1f} "
+                f"{_num(item.get('prompt_tps', 0.0)):>13.1f}  "
+                f"{str(item.get('finish_reason', 'n/a'))[:12]}"
+            )
+            rows.append(_clamp(row, width))
+    rows.append(_line(width))
+
+    # Last messages
+    rows.append(_c(tty_on, "bold", "Last messages"))
+    now_ts = time.time()
+    message_rows: list[str] = []
+    if active_request:
+        started_at = _num(active_request.get("started_at", 0.0))
+        updated_at = _num(active_request.get("updated_at", 0.0))
+        a_age = now_ts - started_at if started_at else 0.0
+        stale = now_ts - updated_at if updated_at else 0.0
+        message_preview = str(active_request.get("message_preview") or "")
+        text = message_preview if message_preview else "no model text yet"
+        message_rows.append(
+            "  * active "
+            f"{active_request.get('surface', 'n/a')} "
+            f"{active_request.get('phase', 'active')} "
+            f"age {_fmt_seconds(a_age)} stale {_fmt_seconds(stale)} "
+            f"{_integer(active_request.get('generated_tokens', 0))} tok | {text}"
+        )
+
+    for item in reversed(entries):
+        if len(message_rows) >= 10:
+            break
+        message_preview = str(item.get("message_preview") or "")
+        if not message_preview:
+            continue
+        finished_at = _num(item.get("finished_at", 0.0))
+        m_age = now_ts - finished_at if finished_at else 0.0
+        message_rows.append(
+            "  - "
+            f"{item.get('surface', 'n/a')} "
+            f"{_fmt_seconds(m_age)} ago "
+            f"{_integer(item.get('generated_tokens', 0))} tok "
+            f"{item.get('finish_reason', 'n/a')} | {message_preview}"
+        )
+
+    if message_rows:
+        for row in message_rows:
+            rows.append(_clamp(row, width))
+    else:
+        rows.append(_c(tty_on, "dim", "  no model messages yet"))
+
+    # Active running requests (engine view)
+    if running_requests:
+        rows.append(_line(width))
+        rows.append(_c(tty_on, "bold", f"Active requests ({len(running_requests)})"))
+        header = (
+            "  id            phase       elapsed   prompt   out   tok/s   ttft   max"
+        )
+        rows.append(_c(tty_on, "dim", _clamp(header, width)))
+        for item in running_requests[:4]:
+            rid = str(item.get("request_id") or "")[-12:].ljust(12)
+            phase = str(item.get("phase") or item.get("status") or "")[:10].ljust(10)
+            elapsed = _fmt_seconds(item.get("elapsed_s", 0.0))
+            ptoks = _integer(item.get("prompt_tokens", 0))
+            otoks = _integer(item.get("completion_tokens", 0))
+            tps = item.get("tokens_per_second")
+            tps_s = "  -  " if tps is None else f"{_num(tps):>5.1f}"
+            ttft = item.get("ttft_s")
+            ttft_s = "  -  " if ttft is None else f"{_num(ttft):>4.2f}"
+            mx = _integer(item.get("max_tokens", 0))
+            row = (
+                f"  {rid} {phase} {elapsed:>7} "
+                f"{ptoks:>7} {otoks:>5} {tps_s} {ttft_s} {mx:>5}"
+            )
+            rows.append(_clamp(row, width))
+
+    if errors:
+        rows.append(_line(width))
+        rows.append(_c(tty_on, "red", "Errors"))
+        for error in errors[-3:]:
+            rows.append(_c(tty_on, "red", "  " + _clamp(error, width - 2)))
+
+    rows.append("")
+    rows.append(
+        _c(
+            tty_on,
+            "dim",
+            "Tip: send a request to /v1/chat/completions in another terminal; metrics update here.",
+        )
+    )
+
+    return "\n".join(rows[:height])
+
+
+def _read_key() -> str | None:
+    if not sys.stdin.isatty():
+        return None
+    readable, _, _ = select.select([sys.stdin], [], [], 0)
+    if not readable:
+        return None
+    try:
+        return sys.stdin.read(1)
+    except Exception:
+        return None
+
+
+def run_monitor(base_url: str, interval: float = 1.0, pid: int | str = "?") -> int:
+    """Run the full-screen TUI loop."""
+    health_url = base_url.rstrip("/") + "/health"
+    status_url = base_url.rstrip("/") + "/v1/status"
+    requests_url = base_url.rstrip("/") + "/v1/requests?limit=50"
+    interval = max(0.1, float(interval))
+    tty_on = sys.stdout.isatty()
+
+    old_term = None
+    if tty_on and sys.stdin.isatty():
+        try:
+            old_term = termios.tcgetattr(sys.stdin)
+            tty.setcbreak(sys.stdin)
+        except Exception:
+            old_term = None
+
+    try:
+        if tty_on:
+            sys.stdout.write("\033[?1049h\033[?25l")
+            sys.stdout.flush()
+        while True:
+            health, herr = _fetch_json(health_url)
+            status, serr = _fetch_json(status_url)
+            requests_data, rerr = _fetch_json(requests_url)
+            errors = [e for e in (herr, serr, rerr) if e]
+            screen = _build_screen(
+                base_url,
+                pid,
+                interval,
+                health,
+                status,
+                requests_data,
+                errors,
+                tty_on,
+            )
+            if tty_on:
+                sys.stdout.write("\033[H\033[2J")
+            sys.stdout.write(screen + "\n")
+            sys.stdout.flush()
+            deadline = time.time() + interval
+            while time.time() < deadline:
+                key = _read_key()
+                if key in {"q", "Q", "\x03"}:
+                    return 0
+                time.sleep(0.05)
+            if not tty_on:
+                sys.stdout.write("\n")
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        if old_term is not None:
+            try:
+                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_term)
+            except Exception:
+                pass
+        if tty_on:
+            sys.stdout.write("\033[?25h\033[?1049l")
+            sys.stdout.flush()
+    return 0

--- a/vllm_mlx/tui.py
+++ b/vllm_mlx/tui.py
@@ -276,6 +276,8 @@ def _build_screen(
     last_finish = last.get("finish_reason", "n/a")
     last_surface = last.get("surface", "n/a")
     last_ttft = last.get("ttft")
+    last_accept = last.get("acceptance_ratio")
+    last_block = last.get("block_size")
 
     rows.append(_c(tty_on, "bold", "Last request"))
     if not last:
@@ -319,18 +321,18 @@ def _build_screen(
                 tty_on,
             )
         )
+        accept_text = (
+            f"{_num(last_accept):.0%} {_bar(_num(last_accept), 1.0, 12)}"
+            if last_accept is not None
+            else "n/a"
+        )
+        block_text = str(last_block) if last_block is not None else "n/a"
         rows.append(
             _row("surface", str(last_surface), left, "white", tty_on)
             + gap
-            + _row(
-                "target rate",
-                ">=20 tok/s good, >=40 fast",
-                mid,
-                "dim",
-                tty_on,
-            )
+            + _row("dflash accept", accept_text, mid, "magenta", tty_on)
             + gap
-            + _row("tuning", "low rate => check cache", right, "dim", tty_on)
+            + _row("block size", block_text, right, "magenta", tty_on)
         )
     rows.append(_line(width))
 
@@ -344,14 +346,31 @@ def _build_screen(
         avg_gen_tps = _mean([_num(item.get("generation_tps", 0.0)) for item in entries])
         avg_pre_tps = _mean([_num(item.get("prompt_tps", 0.0)) for item in entries])
         avg_elapsed = _mean([_num(item.get("elapsed", 0.0)) for item in entries])
-        header = "  out  prompt  gen tok/s  prefill tok/s  elapsed"
-        row = (
-            f"  {avg_out:>5.1f} "
-            f"{avg_prompt:>7.1f} "
-            f"{avg_gen_tps:>9.1f} "
-            f"{avg_pre_tps:>13.1f} "
-            f"{avg_elapsed:>8.1f}s"
-        )
+        accept_values = [
+            _num(item.get("acceptance_ratio"))
+            for item in entries
+            if item.get("acceptance_ratio") is not None
+        ]
+        avg_accept = _mean(accept_values) if accept_values else None
+        if avg_accept is not None:
+            header = "  out  prompt  gen tok/s  prefill tok/s  elapsed   accept"
+            row = (
+                f"  {avg_out:>5.1f} "
+                f"{avg_prompt:>7.1f} "
+                f"{avg_gen_tps:>9.1f} "
+                f"{avg_pre_tps:>13.1f} "
+                f"{avg_elapsed:>8.1f}s "
+                f"{avg_accept:>7.0%}"
+            )
+        else:
+            header = "  out  prompt  gen tok/s  prefill tok/s  elapsed"
+            row = (
+                f"  {avg_out:>5.1f} "
+                f"{avg_prompt:>7.1f} "
+                f"{avg_gen_tps:>9.1f} "
+                f"{avg_pre_tps:>13.1f} "
+                f"{avg_elapsed:>8.1f}s"
+            )
         rows.append(_c(tty_on, "dim", _clamp(header, width)))
         rows.append(_clamp(row, width))
     rows.append(_line(width))
@@ -364,9 +383,17 @@ def _build_screen(
     if not recent_entries:
         rows.append(_c(tty_on, "dim", "  no completed request metrics yet"))
     else:
-        header = (
-            "  time      surface              out  prompt  gen tok/s  prefill tok/s  finish"
+        any_accept = any(
+            item.get("acceptance_ratio") is not None for item in recent_entries
         )
+        if any_accept:
+            header = (
+                "  time      surface              out  prompt  gen tok/s  prefill tok/s  accept  block  finish"
+            )
+        else:
+            header = (
+                "  time      surface              out  prompt  gen tok/s  prefill tok/s  finish"
+            )
         rows.append(_c(tty_on, "dim", _clamp(header, width)))
         for item in reversed(recent_entries):
             ts = item.get("finished_at") or 0
@@ -375,15 +402,24 @@ def _build_screen(
             except Exception:
                 when = "--:--:--"
             surface = str(item.get("surface", "n/a"))[-18:].ljust(18)
-            row = (
+            base = (
                 f"  {when}  "
                 f"{surface} "
                 f"{_integer(item.get('generated_tokens', 0)):>5} "
                 f"{_integer(item.get('prompt_tokens', 0)):>7} "
                 f"{_num(item.get('generation_tps', 0.0)):>9.1f} "
                 f"{_num(item.get('prompt_tps', 0.0)):>13.1f}  "
-                f"{str(item.get('finish_reason', 'n/a'))[:12]}"
             )
+            if any_accept:
+                accept = item.get("acceptance_ratio")
+                accept_s = (
+                    f"{_num(accept):>5.0%}" if accept is not None else "  -  "
+                )
+                block = item.get("block_size")
+                block_s = f"{_integer(block):>4}" if block is not None else "  - "
+                row = base + f"{accept_s}  {block_s}  {str(item.get('finish_reason', 'n/a'))[:8]}"
+            else:
+                row = base + str(item.get("finish_reason", "n/a"))[:12]
             rows.append(_clamp(row, width))
     rows.append(_line(width))
 


### PR DESCRIPTION
## Summary

This PR fixes OpenCode/Hermes/Qwen 3.x tool-call translation failures reported in #160 when Rapid-MLX serves the OpenAI-compatible chat API.

The failure was not one single parser bug. It came from several OpenAI-client-visible edge cases around streamed tool calls and follow-up turns after tool results:

- Qwen sometimes emits bare `Calling tool: name({...})` text instead of the configured XML/Qwen tool-call wrapper.
- Tool arguments can arrive as JSON-looking strings, including double-encoded arrays and objects.
- Some client tool schemas use nullable/list forms such as `type: ["array", "null"]`, or omit `type` while still defining `items` / `properties`.
- Streaming chunks can split a `Calling tool` marker, causing partial text such as `[Calling tool` or `[` to leak to the client.
- The partial-marker guard must not strip normal code brackets when a chunk ends after `snake[` or `const items = [`.
- The model can emit an incomplete duplicate tool call before a valid duplicate; strict clients reject the incomplete call before they can consume the valid one.
- After a valid tool result, Qwen can stop with narration/planning instead of issuing the next tool call. OpenCode then appears to hang because the assistant turn ends without useful tool progress.
- Native tool-message preservation was detected before CLI state was synced into `ServerConfig`, so Qwen-native tool parsers could still receive converted text tool results in some startup paths.
- Qwen can enter repeated-text loops before making the next tool call, for example generating `point point point...` indefinitely.
- Qwen can also start a streamed XML tool call, emit only a partial JSON argument prefix such as `{`, then hit `max_tokens`. OpenCode receives that as an invalid tool call unless Rapid-MLX buffers and validates the stream before forwarding it.
- Qwen can repeatedly call the same read-only tool with the same arguments after already receiving that tool result, causing an agentic read loop instead of making progress.

## Changes

- Add a generic OpenAI-compatible fallback parser for bare `Calling tool: ...` calls.
- Decode JSON-like and double-encoded tool arguments before sending them to clients.
- Coerce tool arguments using JSON schema metadata, including nullable type lists, `anyOf`/`oneOf`/`allOf`, `items`, `properties`, `additionalProperties`, and enum-only schemas.
- Preserve request tool schemas across streamed content before Qwen tool markup so later arguments are coerced with the correct schema.
- Pass the original chat request into the streaming postprocessor so it can validate generic fallback calls against required tool arguments.
- Buffer partial generic tool-call markers across chunks and strip leaked marker prefixes only when they appear at the start of a line.
- Preserve normal code brackets split at chunk boundaries, such as `game.snake[` and `const items = [`.
- Drop malformed generic tool calls that are missing required schema arguments, preventing client schema validation failures from incomplete duplicate calls.
- Preserve native tool messages for parsers that support them, even when parser settings are still only present in the CLI globals during startup.
- Add a hidden continuation nudge after tool-result messages so local tool models continue the original task instead of ending with planning text.
- Add streaming retry for tool-using turns: if the model emits only content/reasoning, the stream exhausts without a tool call, or repeated text is detected before a tool call, Rapid-MLX retries with an internal instruction to call the required tool. Buffered narration/repetition is not sent to the client unless retries are exhausted.
- Suppress repeated buffered text after retry budget is exhausted so clients do not receive runaway repeated tokens.
- Disable Qwen thinking on continuation turns unless the client explicitly requested `enable_thinking`.
- Buffer streamed OpenAI tool-call chunks until their function arguments assemble into a complete valid JSON object. If generation stops with incomplete JSON, suppress the partial chunks and retry internally with a targeted tool-call JSON repair prompt.
- Detect repeated same-argument read-only tool calls after a tool result and nudge the model to use the existing result, make a state-changing/diagnostic tool call, or finish.
- Add regression coverage for OpenCode/Hermes-style tool schemas, partial stream markers, generic fallback calls, malformed duplicate calls, normal code bracket preservation, continuation prompt injection, stream-exhausted continuation retry, repeated-text retry, repeated-read nudging, and truncated streamed tool-call JSON retry.

## Validation

- `uv run ruff check vllm_mlx/routes/chat.py vllm_mlx/service/helpers.py tests/test_chat_stream_tool_continuation.py tests/test_server_utils.py` -> passed.
- `uv run pytest tests/test_chat_stream_tool_continuation.py tests/test_server_utils.py::TestAppendToolContinuationPrompt` -> 9 passed.
- Earlier focused suite: `uv run pytest tests/test_chat_stream_tool_continuation.py tests/test_server_utils.py::TestAppendToolContinuationPrompt tests/test_postprocessor.py` -> 78 passed.
- Previous broader parser/model-regression suites were run during the PR iteration and passed: 103 focused tests and 267 parser/postprocessor regression tests.
- Applied the patch locally to the Homebrew Rapid-MLX 0.6.1 install and restarted `rapid-mlx serve qwen3.6-35b`.
- Verified startup logs native tool format enabled for `qwen3_coder_xml` and reasoning parser `qwen3`.
- Re-ran OpenCode against the local OpenAI-compatible endpoint with the requested snake-game TDD prompt. OpenCode completed with exit 0 and no client-visible API translation/schema errors such as `tool: invalid`.
- During that run the new truncated-tool-call guard was exercised once: Rapid-MLX detected `incomplete tool call JSON`, suppressed the partial streamed arguments, retried internally, and OpenCode received the subsequent valid `write` tool call.
- The generated sample app still had ordinary model-quality issues after completion when checked manually; those are not API translation failures and were not addressed by this server-side PR.

Fixes #160.
