### PR TITLE
cleanup: tidy _init_mlx_step_thread (follow-up to #161)

### DIFF
--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -13,6 +13,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 
 import asyncio
 import logging
+import sys
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -31,17 +32,11 @@ logger = logging.getLogger(__name__)
 
 def _init_mlx_step_thread() -> None:
     """Create mlx-lm's generation stream inside the MLX worker thread."""
-    import sys
-
     stream = mx.new_stream(mx.default_device())
 
     gen_mod = sys.modules.get("mlx_lm.generate")
     if gen_mod is not None:
         gen_mod.generation_stream = stream
-
-    sched_mod = sys.modules.get("vllm_mlx.scheduler")
-    if sched_mod is not None and hasattr(sched_mod, "generation_stream"):
-        sched_mod.generation_stream = stream
 
     logger.info("MLX step thread initialized: generation_stream=%s", stream)
 


### PR DESCRIPTION
## Summary

Two tiny follow-ups to #161:

- Move `import sys` from inside `_init_mlx_step_thread` to the module top.
- Remove the dead `vllm_mlx.scheduler.generation_stream` rebind. `scheduler.py` has no such module-level global (only comment references), so the `hasattr` guard always falls through — defensive, but misleading.

No behaviour change. The mlx-lm `generation_stream` rebind (the part that actually fixes #160) is unchanged.

## Test plan

- [x] `pytest tests/test_batching.py::TestEngineThreading tests/test_batching.py::TestEngineAsync::test_engine_loop_keeps_all_scheduler_steps_on_mlx_thread` — both pass
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)