### PR TITLE
fix: restore prompt-boundary cache snapshot for mlx-lm 0.31+ (#163)

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -553,3 +553,89 @@ class TestGetAvailableMemory:
             # Should return 0 when psutil not available
             # Note: This test may not work as expected due to import caching
             pass
+
+
+class TestConcurrentAccess:
+    """Regression for issue #163 — fetch and store on different threads
+    used to race on the orphaned-sorted-key window during eviction."""
+
+    def _make_cache(self):
+        config = MemoryCacheConfig(max_memory_mb=64, max_entries=64)
+        return MemoryAwarePrefixCache(MagicMock(), config)
+
+    def test_lock_present(self):
+        cache = self._make_cache()
+        assert hasattr(cache, "_lock")
+
+    def test_concurrent_fetch_and_store_no_keyerror(self):
+        import threading
+
+        cache = self._make_cache()
+        # Pre-populate with overlapping prefixes to maximize eviction
+        # opportunities when stores fire.
+        for i in range(40):
+            cache.store(list(range(i, i + 16)), [MockKVCache(8, 4)])
+
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def writer():
+            i = 100
+            while not stop.is_set():
+                try:
+                    cache.store(list(range(i, i + 16)), [MockKVCache(8, 4)])
+                    i += 1
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    for i in range(0, 80, 3):
+                        cache.fetch(list(range(i, i + 16)))
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        threading.Event().wait(0.5)
+        stop.set()
+        for t in threads:
+            t.join(timeout=2)
+
+        assert errors == [], f"Concurrent access raised: {errors[:3]}"
+
+    def test_eviction_orders_remove_before_pop(self):
+        """Even without the lock, fetch should never see an orphaned key.
+
+        We simulate the eviction window by overriding ``_remove_from_sorted``
+        to capture order — entries.pop must happen *after* the sorted index
+        is cleared.
+        """
+        cache = self._make_cache()
+        cache.store([1, 2, 3], [MockKVCache(8, 4)])
+
+        order: list[str] = []
+        orig_remove = cache._remove_from_sorted
+        orig_pop = cache._entries.pop
+
+        def trace_remove(key):
+            order.append("remove_sorted")
+            orig_remove(key)
+
+        def trace_pop(key, *a, **kw):
+            order.append("pop_entries")
+            return orig_pop(key, *a, **kw)
+
+        cache._remove_from_sorted = trace_remove
+        cache._entries.pop = trace_pop
+
+        cache.remove([1, 2, 3])
+        # remove_sorted must precede pop_entries — see _evict_lru / remove
+        # docstrings.
+        assert order == ["remove_sorted", "pop_entries"], order

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -71,13 +71,17 @@ class TestPromptCacheSnapshot:
         scheduler.memory_aware_cache.store = MagicMock(return_value=True)
 
         responses = [
-            SimpleNamespace(uid=101, progress=(4, 4), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(
+                uid=101, progress=(4, 4), end_of_segment=True, end_of_prompt=True
+            ),
         ]
         scheduler._snapshot_promoted_prompts(responses)
 
         bg.extract_cache.assert_called_once_with([101])
         scheduler.memory_aware_cache.store.assert_called_once()
-        stored_tokens, stored_cache = scheduler.memory_aware_cache.store.call_args.args[:2]
+        stored_tokens, stored_cache = scheduler.memory_aware_cache.store.call_args.args[
+            :2
+        ]
         assert stored_tokens == prompt_tokens
         assert stored_cache is fake_cache_layers
 
@@ -89,7 +93,9 @@ class TestPromptCacheSnapshot:
         scheduler.memory_aware_cache.store = MagicMock()
 
         responses = [
-            SimpleNamespace(uid=101, progress=(2, 4), end_of_segment=True, end_of_prompt=False),
+            SimpleNamespace(
+                uid=101, progress=(2, 4), end_of_segment=True, end_of_prompt=False
+            ),
         ]
         scheduler._snapshot_promoted_prompts(responses)
 
@@ -105,7 +111,9 @@ class TestPromptCacheSnapshot:
         scheduler.memory_aware_cache.store = MagicMock()
 
         responses = [
-            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(
+                uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True
+            ),
         ]
         # Must not raise — snapshot is best-effort.
         scheduler._snapshot_promoted_prompts(responses)
@@ -123,7 +131,9 @@ class TestPromptCacheSnapshot:
         scheduler.memory_aware_cache.store = MagicMock()
 
         responses = [
-            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(
+                uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True
+            ),
         ]
         scheduler._snapshot_promoted_prompts(responses)
         scheduler.memory_aware_cache.store.assert_not_called()
@@ -138,7 +148,9 @@ class TestPromptCacheSnapshot:
         scheduler.batch_generator = bg
 
         responses = [
-            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(
+                uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True
+            ),
         ]
         scheduler._snapshot_promoted_prompts(responses)
         bg.extract_cache.assert_not_called()
@@ -167,9 +179,15 @@ class TestPromptCacheSnapshot:
         scheduler.memory_aware_cache.store = MagicMock(return_value=True)
 
         responses = [
-            SimpleNamespace(uid=1, progress=(2, 2), end_of_segment=True, end_of_prompt=True),
-            SimpleNamespace(uid=2, progress=(1, 2), end_of_segment=True, end_of_prompt=False),
-            SimpleNamespace(uid=3, progress=(2, 2), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(
+                uid=1, progress=(2, 2), end_of_segment=True, end_of_prompt=True
+            ),
+            SimpleNamespace(
+                uid=2, progress=(1, 2), end_of_segment=True, end_of_prompt=False
+            ),
+            SimpleNamespace(
+                uid=3, progress=(2, 2), end_of_segment=True, end_of_prompt=True
+            ),
         ]
         scheduler._snapshot_promoted_prompts(responses)
 

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the prompt-boundary cache snapshot path used by mlx-lm 0.31+.
+
+The fix for issue #163 wires Scheduler._snapshot_promoted_prompts() into the
+generation step. It reads end_of_prompt from PromptProcessingBatch.Response
+and uses BatchGenerator.extract_cache() to capture the prompt-only cache
+state, then forwards each capture to the prompt_cache_save callback so the
+MemoryAwarePrefixCache stores it under key=prompt_token_ids.
+
+These tests exercise that scheduler-level glue without needing a real
+mlx-lm runtime.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _make_scheduler_with_cache():
+    model = MagicMock()
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda x: list(range(len(x.split())))
+    config = SchedulerConfig(enable_prefix_cache=True, use_memory_aware_cache=True)
+    scheduler = Scheduler(model, tokenizer, config)
+    assert scheduler.memory_aware_cache is not None
+    assert scheduler._prompt_cache_save_cb is not None
+    return scheduler
+
+
+def _register(scheduler, request_id: str, uid: int, prompt_tokens: list[int]):
+    request = Request(
+        request_id=request_id,
+        prompt="ignored",
+        prompt_token_ids=prompt_tokens,
+        sampling_params=SamplingParams(max_tokens=4),
+    )
+    scheduler.requests[request_id] = request
+    scheduler.uid_to_request_id[uid] = request_id
+    scheduler.request_id_to_uid[request_id] = uid
+    return request
+
+
+class TestPromptCacheSnapshot:
+    def test_callback_built_when_memory_cache_enabled(self):
+        scheduler = _make_scheduler_with_cache()
+        assert callable(scheduler._prompt_cache_save_cb)
+
+    def test_no_callback_without_memory_cache(self):
+        scheduler = Scheduler(
+            MagicMock(),
+            MagicMock(),
+            SchedulerConfig(enable_prefix_cache=False),
+        )
+        assert scheduler._prompt_cache_save_cb is None
+
+    def test_snapshot_stores_promoted_prompt_only(self):
+        scheduler = _make_scheduler_with_cache()
+        prompt_tokens = [10, 20, 30, 40]
+        _register(scheduler, "req-1", uid=101, prompt_tokens=prompt_tokens)
+
+        fake_cache_layers = [object(), object()]
+        bg = MagicMock()
+        bg.extract_cache.return_value = {101: (fake_cache_layers, prompt_tokens)}
+        scheduler.batch_generator = bg
+
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        responses = [
+            SimpleNamespace(uid=101, progress=(4, 4), end_of_segment=True, end_of_prompt=True),
+        ]
+        scheduler._snapshot_promoted_prompts(responses)
+
+        bg.extract_cache.assert_called_once_with([101])
+        scheduler.memory_aware_cache.store.assert_called_once()
+        stored_tokens, stored_cache = scheduler.memory_aware_cache.store.call_args.args[:2]
+        assert stored_tokens == prompt_tokens
+        assert stored_cache is fake_cache_layers
+
+    def test_snapshot_skips_mid_prompt_chunks(self):
+        scheduler = _make_scheduler_with_cache()
+        _register(scheduler, "req-1", uid=101, prompt_tokens=[1, 2, 3])
+        bg = MagicMock()
+        scheduler.batch_generator = bg
+        scheduler.memory_aware_cache.store = MagicMock()
+
+        responses = [
+            SimpleNamespace(uid=101, progress=(2, 4), end_of_segment=True, end_of_prompt=False),
+        ]
+        scheduler._snapshot_promoted_prompts(responses)
+
+        bg.extract_cache.assert_not_called()
+        scheduler.memory_aware_cache.store.assert_not_called()
+
+    def test_snapshot_handles_extract_failure(self):
+        scheduler = _make_scheduler_with_cache()
+        _register(scheduler, "req-1", uid=101, prompt_tokens=[1, 2, 3])
+        bg = MagicMock()
+        bg.extract_cache.side_effect = RuntimeError("boom")
+        scheduler.batch_generator = bg
+        scheduler.memory_aware_cache.store = MagicMock()
+
+        responses = [
+            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+        ]
+        # Must not raise — snapshot is best-effort.
+        scheduler._snapshot_promoted_prompts(responses)
+        scheduler.memory_aware_cache.store.assert_not_called()
+
+    def test_snapshot_skips_already_removed_uid(self):
+        scheduler = _make_scheduler_with_cache()
+        _register(scheduler, "req-1", uid=101, prompt_tokens=[1, 2, 3])
+        bg = MagicMock()
+        # Stage 0 (unprocessed) returns a 2-tuple of (segments, last_input).
+        # Stage > 2 or removed uid: extract_cache may return any non-(cache,tokens)
+        # shape. Our snapshot path must skip silently.
+        bg.extract_cache.return_value = {101: ("not-a-cache-payload",)}
+        scheduler.batch_generator = bg
+        scheduler.memory_aware_cache.store = MagicMock()
+
+        responses = [
+            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+        ]
+        scheduler._snapshot_promoted_prompts(responses)
+        scheduler.memory_aware_cache.store.assert_not_called()
+
+    def test_snapshot_no_op_when_callback_disabled(self):
+        scheduler = Scheduler(
+            MagicMock(),
+            MagicMock(),
+            SchedulerConfig(enable_prefix_cache=False),
+        )
+        bg = MagicMock()
+        scheduler.batch_generator = bg
+
+        responses = [
+            SimpleNamespace(uid=101, progress=(3, 3), end_of_segment=True, end_of_prompt=True),
+        ]
+        scheduler._snapshot_promoted_prompts(responses)
+        bg.extract_cache.assert_not_called()
+
+    def test_snapshot_with_empty_responses(self):
+        scheduler = _make_scheduler_with_cache()
+        scheduler.batch_generator = MagicMock()
+        # Should not raise
+        scheduler._snapshot_promoted_prompts([])
+        scheduler.batch_generator.extract_cache.assert_not_called()
+
+    def test_snapshot_stores_only_end_of_prompt_subset(self):
+        scheduler = _make_scheduler_with_cache()
+        _register(scheduler, "req-a", uid=1, prompt_tokens=[1, 2])
+        _register(scheduler, "req-b", uid=2, prompt_tokens=[3, 4])
+        _register(scheduler, "req-c", uid=3, prompt_tokens=[5, 6])
+
+        cache_a = [object()]
+        cache_c = [object()]
+        bg = MagicMock()
+        bg.extract_cache.return_value = {
+            1: (cache_a, [1, 2]),
+            3: (cache_c, [5, 6]),
+        }
+        scheduler.batch_generator = bg
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        responses = [
+            SimpleNamespace(uid=1, progress=(2, 2), end_of_segment=True, end_of_prompt=True),
+            SimpleNamespace(uid=2, progress=(1, 2), end_of_segment=True, end_of_prompt=False),
+            SimpleNamespace(uid=3, progress=(2, 2), end_of_segment=True, end_of_prompt=True),
+        ]
+        scheduler._snapshot_promoted_prompts(responses)
+
+        bg.extract_cache.assert_called_once_with([1, 3])
+        assert scheduler.memory_aware_cache.store.call_count == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -28,6 +28,7 @@ import bisect
 import copy
 import logging
 import math
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -483,7 +484,11 @@ class MemoryAwarePrefixCache:
     - OrderedDict for O(1) LRU operations
 
     Thread Safety:
-        This class is NOT thread-safe. Use external locking if needed.
+        ``fetch``, ``store``, ``remove`` and ``clear`` hold an internal lock,
+        so it is safe to call them from different threads (e.g. the asyncio
+        event loop calling ``fetch`` while the mlx-step worker calls
+        ``store``). Read-only attribute access (``__contains__``, ``__len__``,
+        ``get_stats``) is single-op and relies on the GIL — no lock needed.
     """
 
     def __init__(
@@ -519,6 +524,10 @@ class MemoryAwarePrefixCache:
 
         # Track the match type from the last fetch() call
         self._last_match_type: str | None = None
+
+        # Guards _entries / _sorted_keys mutations against concurrent
+        # fetch/store/evict from multiple threads (asyncio loop + mlx-step).
+        self._lock = threading.Lock()
 
         logger.info(
             f"MemoryAwarePrefixCache initialized: "
@@ -560,6 +569,12 @@ class MemoryAwarePrefixCache:
 
         tokens_key = tuple(tokens)
 
+        with self._lock:
+            return self._fetch_locked(tokens, tokens_key)
+
+    def _fetch_locked(
+        self, tokens: list[int], tokens_key: tuple[int, ...]
+    ) -> tuple[list[Any] | None, list[int]]:
         # --- O(1) exact match ---
         if tokens_key in self._entries:
             entry = self._entries[tokens_key]
@@ -766,12 +781,15 @@ class MemoryAwarePrefixCache:
 
         tokens_key = tuple(tokens)
 
-        # If already cached, just update LRU order (skip expensive trim/quantize)
-        if tokens_key in self._entries:
-            self._entries.move_to_end(tokens_key)
-            return True
+        # Fast path: already cached — bump LRU and skip expensive trim/quantize.
+        # Holds the lock briefly so the bump is consistent with concurrent fetch.
+        with self._lock:
+            if tokens_key in self._entries:
+                self._entries.move_to_end(tokens_key)
+                return True
 
-        # Trim oversized KV arrays to actual used size
+        # Trim oversized KV arrays to actual used size (pure compute, no shared
+        # state — kept outside the lock so concurrent fetch isn't blocked).
         cache = _trim_to_offset(cache)
 
         # Compress cache for storage (TurboQuant or standard quantization)
@@ -792,7 +810,7 @@ class MemoryAwarePrefixCache:
                 cache, self._config.kv_bits, self._config.kv_group_size
             )
 
-        # Create entry and estimate memory
+        # Create entry and estimate memory (pure compute, no shared state).
         entry = _CacheEntry.create(tokens, cache)
 
         # Check if single entry exceeds limit
@@ -803,49 +821,63 @@ class MemoryAwarePrefixCache:
             )
             return False
 
-        # Prefix-subset eviction: remove entries whose token sequence
-        # is a strict prefix of the new entry.  Uses sorted index for
-        # O(log N + K) lookup instead of O(N) scan.
-        if evict_prefixes and self._sorted_keys:
-            to_remove = []
-            idx = bisect.bisect_left(self._sorted_keys, tokens_key)
-            # Scan backwards — prefixes of tokens_key are immediately before idx
-            for i in range(idx - 1, -1, -1):
-                key = self._sorted_keys[i]
-                klen = len(key)
-                if klen >= len(tokens_key):
-                    continue
-                if tokens_key[:klen] == key:
-                    to_remove.append(key)
-                elif key[0] != tokens_key[0]:
-                    break
-            for key in to_remove:
-                old = self._entries.pop(key)
-                self._current_memory -= old.memory_bytes
-                self._stats.evictions += 1
-                self._remove_from_sorted(key)
-                logger.debug(
-                    f"[prefix_evict] removed {len(key)} tokens, "
-                    f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
-                    f"new_entry={len(tokens_key)} tokens"
-                )
-            if to_remove:
-                self._stats.entry_count = len(self._entries)
-                self._stats.current_memory_bytes = self._current_memory
+        with self._lock:
+            # Re-check exact match: a concurrent store may have inserted
+            # the same key while we were trimming/compressing outside the
+            # lock. Just bump LRU and bail.
+            if tokens_key in self._entries:
+                self._entries.move_to_end(tokens_key)
+                return True
 
-        # Evict until we have room
-        while (
-            self._current_memory + entry.memory_bytes > self._max_memory
-            or len(self._entries) >= self._config.max_entries
-        ) and self._entries:
-            self._evict_lru()
+            # Prefix-subset eviction: remove entries whose token sequence
+            # is a strict prefix of the new entry.  Uses sorted index for
+            # O(log N + K) lookup instead of O(N) scan.
+            if evict_prefixes and self._sorted_keys:
+                to_remove = []
+                idx = bisect.bisect_left(self._sorted_keys, tokens_key)
+                # Scan backwards — prefixes of tokens_key are immediately before idx
+                for i in range(idx - 1, -1, -1):
+                    key = self._sorted_keys[i]
+                    klen = len(key)
+                    if klen >= len(tokens_key):
+                        continue
+                    if tokens_key[:klen] == key:
+                        to_remove.append(key)
+                    elif key[0] != tokens_key[0]:
+                        break
+                for key in to_remove:
+                    # Remove from sorted index FIRST so a concurrent fetch
+                    # never sees a key in the index that's missing from
+                    # _entries (was the source of issue #163's KeyError
+                    # under the higher store() rate from PR #165).
+                    self._remove_from_sorted(key)
+                    old = self._entries.pop(key)
+                    self._current_memory -= old.memory_bytes
+                    self._stats.evictions += 1
+                    logger.debug(
+                        f"[prefix_evict] removed {len(key)} tokens, "
+                        f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
+                        f"new_entry={len(tokens_key)} tokens"
+                    )
+                if to_remove:
+                    self._stats.entry_count = len(self._entries)
+                    self._stats.current_memory_bytes = self._current_memory
 
-        # Store entry
-        self._entries[tokens_key] = entry
-        self._current_memory += entry.memory_bytes
-        bisect.insort(self._sorted_keys, tokens_key)
-        self._stats.entry_count = len(self._entries)
-        self._stats.current_memory_bytes = self._current_memory
+            # Evict until we have room
+            while (
+                self._current_memory + entry.memory_bytes > self._max_memory
+                or len(self._entries) >= self._config.max_entries
+            ) and self._entries:
+                self._evict_lru()
+
+            # Store entry. Insert into _entries before _sorted_keys so
+            # that even if a future change drops the lock, fetch never
+            # observes a key in sorted_keys that's missing from entries.
+            self._entries[tokens_key] = entry
+            self._current_memory += entry.memory_bytes
+            bisect.insort(self._sorted_keys, tokens_key)
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
 
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "
@@ -862,14 +894,19 @@ class MemoryAwarePrefixCache:
             self._sorted_keys.pop(idx)
 
     def _evict_lru(self) -> None:
-        """Evict the least recently used entry."""
+        """Evict the least recently used entry.
+
+        Caller must hold ``self._lock``.
+        """
         if not self._entries:
             return
 
-        # popitem(last=False) removes oldest entry (FIFO order = LRU)
-        tokens_key, entry = self._entries.popitem(last=False)
-        self._current_memory -= entry.memory_bytes
+        # Peek the oldest key, drop sorted-index entry first so a fetch
+        # without the lock can't trip the orphaned-sorted-key KeyError.
+        tokens_key = next(iter(self._entries))
         self._remove_from_sorted(tokens_key)
+        entry = self._entries.pop(tokens_key)
+        self._current_memory -= entry.memory_bytes
         self._stats.evictions += 1
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
@@ -890,21 +927,23 @@ class MemoryAwarePrefixCache:
             True if entry was found and removed.
         """
         tokens_key = tuple(tokens)
-        entry = self._entries.pop(tokens_key, None)
-        if entry is not None:
-            self._current_memory -= entry.memory_bytes
+        with self._lock:
+            if tokens_key not in self._entries:
+                return False
             self._remove_from_sorted(tokens_key)
+            entry = self._entries.pop(tokens_key)
+            self._current_memory -= entry.memory_bytes
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory
-            return True
-        return False
+        return True
 
     def clear(self) -> None:
         """Clear all cached entries."""
-        self._entries.clear()
-        self._sorted_keys.clear()
-        self._current_memory = 0
-        self._stats = CacheStats(max_memory_bytes=self._max_memory)
+        with self._lock:
+            self._entries.clear()
+            self._sorted_keys.clear()
+            self._current_memory = 0
+            self._stats = CacheStats(max_memory_bytes=self._max_memory)
         logger.debug("Cache cleared")
 
     def get_stats(self) -> dict[str, Any]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1149,6 +1149,16 @@ class Scheduler:
         self._clear_cache_interval = 32
         self._memory_log_interval = 256
 
+        # Prompt-boundary cache snapshot callback for the new mlx-lm 0.31+ API.
+        # Built lazily once memory_aware_cache exists and reused per step.
+        # Without this hook, hybrid models can't satisfy repeated identical
+        # prompts via supersequence fallback (issue #163).
+        self._prompt_cache_save_cb = (
+            self._make_prompt_cache_save_callback()
+            if self.memory_aware_cache is not None
+            else None
+        )
+
     def _get_actual_tokenizer(self, tokenizer: Any) -> Any:
         """
         Get the actual tokenizer from a processor or tokenizer.
@@ -1265,12 +1275,18 @@ class Scheduler:
                 requests=self.requests,
             )
         elif need_chunked and not _has_old_batch_api:
-            logger.warning(
-                "[chunked_prefill] Skipped — mlx-lm 0.31+ removed the internal "
-                "Batch API. Using native prefill_step_size=%d instead. "
-                "Memory-aware cache and mid-prefill snapshots are unavailable.",
-                self.config.prefill_step_size,
-            )
+            # mlx-lm 0.31+ removed _process_prompts, so the full chunked
+            # prefill monkey-patch can't run. The prompt-boundary cache
+            # snapshot (the part that actually feeds the prefix cache)
+            # is wired into Scheduler.step() via end_of_prompt response
+            # signals — see _snapshot_promoted_prompts (issue #163).
+            if chunked_budget > 0:
+                logger.warning(
+                    "[chunked_prefill] Skipped — mlx-lm 0.31+ removed the "
+                    "internal Batch API. Using native prefill_step_size=%d "
+                    "instead. Mid-prefill snapshots are unavailable.",
+                    self.config.prefill_step_size,
+                )
 
         # Install MTP if the model supports it
         if self.config.enable_mtp:
@@ -1327,6 +1343,53 @@ class Scheduler:
                 )
 
         return _prompt_cache_save
+
+    def _snapshot_promoted_prompts(self, prompt_responses) -> None:
+        """Snapshot prompt-only cache for sequences just promoted to generation.
+
+        Reads the public ``end_of_prompt`` flag from mlx-lm 0.31+'s prompt
+        responses, then uses the public ``BatchGenerator.extract_cache`` API
+        to capture the per-uid cache state. Each capture is forwarded to the
+        prompt-cache-save callback so a future request with the identical
+        prompt finds an exact-match entry in the prefix cache.
+
+        This is the new-API equivalent of the ``_patched_process_prompts``
+        hook installed by ``_install_chunked_prefill`` for the legacy Batch
+        API. Without it, hybrid models (Mamba/DeltaNet+Transformer) MISS
+        the prefix cache forever because their non-trimmable cache layers
+        cannot satisfy the supersequence fallback path (issue #163).
+        """
+        if self._prompt_cache_save_cb is None or not prompt_responses:
+            return
+
+        promoted_uids = [
+            resp.uid
+            for resp in prompt_responses
+            if getattr(resp, "end_of_prompt", False)
+        ]
+        if not promoted_uids:
+            return
+
+        try:
+            extracted = self.batch_generator.extract_cache(promoted_uids)
+        except Exception as exc:
+            logger.debug("[prompt_cache_save] extract_cache failed: %s", exc)
+            return
+
+        for uid, payload in extracted.items():
+            # Promoted sequences (stage == 2) return (cache, tokens). Any
+            # other shape means the uid was already removed before the
+            # snapshot — skip silently.
+            if isinstance(payload, tuple) and len(payload) == 2:
+                cache, _tokens = payload
+                try:
+                    self._prompt_cache_save_cb(uid, cache)
+                except Exception as exc:
+                    logger.debug(
+                        "[prompt_cache_save] callback failed for uid=%s: %s",
+                        uid,
+                        exc,
+                    )
 
     def _make_mid_prefill_save_callback(self, save_interval: int):
         """Create a callback for saving intermediate KV cache during chunked prefill.
@@ -2346,7 +2409,8 @@ class Scheduler:
                     # mlx-lm 0.31+ returns (prompt_responses, generation_responses) tuple
                     # older versions return a flat list of responses
                     if isinstance(raw_next, tuple):
-                        _, responses = raw_next
+                        prompt_responses, responses = raw_next
+                        self._snapshot_promoted_prompts(prompt_responses)
                     else:
                         responses = raw_next
 


### PR DESCRIPTION
## Summary

Fixes #163 — hybrid models (Qwen3.5/Qwen3.6 and other Mamba/DeltaNet+Transformer) MISS the prefix cache forever even though `entries` keeps growing on every request.

Plus a thread-safety follow-up: the higher store() rate from the fix exposed a pre-existing race in `MemoryAwarePrefixCache` between the asyncio fetch and the mlx-step store/evict.

## Root cause (issue #163)

PR #105 made BatchedEngine compatible with mlx-lm 0.31+ by gating the legacy `_install_chunked_prefill` monkey-patch behind `hasattr(bg, "_process_prompts")`. mlx-lm 0.31 removed that internal API, so the gate is always False — and the gated branch was *also* the only place we registered the prompt-boundary snapshot callback.

Result, for hybrid models on rapid-mlx 0.6.1 + mlx-lm 0.31+:

1. No prompt-only entries ever stored.
2. The only `store()` that fires is at request-finish, keyed by `prompt + output_N`.
3. The next identical-prompt request looks up `prompt`, falls through to the supersequence/LCP branches in `MemoryAwarePrefixCache`.
4. Those branches **explicitly skip** when `has_non_trimmable=True` (hybrid layers can't be trimmed).
5. → MISS, plus a fresh `prompt + output_N+1` entry. `entries` grows N → N+1 forever.

Dense models (Llama, Mistral) avoid this because their KV layers are trimmable, so the supersequence branch can serve the lookup.

## Fix 1 — re-introduce the snapshot via public new-API (no monkey-patching)

- Cache `_make_prompt_cache_save_callback()` once on Scheduler init when memory_aware_cache is active.
- Add `Scheduler._snapshot_promoted_prompts(prompt_responses)` that:
  - Reads `PromptProcessingBatch.Response.end_of_prompt` (public dataclass field).
  - Calls `BatchGenerator.extract_cache(uids)` (public method) for newly-promoted uids.
  - Forwards each `(uid, cache)` to the saved callback.
- Wire it into `Scheduler.step()` right after `batch_generator.next()`.
- Drop the misleading "Memory-aware cache ... unavailable" warning; only the mid-prefill chunking is gone now, and the chunking warning only fires when `chunked_budget > 0` is explicitly requested.

The OLD-API code path (`_install_chunked_prefill` + `_patched_process_prompts`) is left untouched for users still pinned to mlx-lm < 0.31.

### Snapshot timing — verified correct

`mlx-lm/generate.py:1287-1288`: `GenerationBatch.__init__` runs `self._step()` immediately on construction, processing the last prompt token through the model. By the time `_generation_batch.extend(gen_batch)` (L1811) completes and `end_of_prompt=True` is set, cache state = full prompt processed; first sampled token is in `_next_tokens` but NOT yet fed back. Same semantic as the OLD `_patched_process_prompts` hook (which fired when `num_tokens[e] == 0`).

## Fix 2 — thread-safe MemoryAwarePrefixCache

The class docstring used to say "NOT thread-safe", but it is in fact read by the asyncio event loop (via `Scheduler.add_request → fetch`) and written by the mlx-step worker (via `Scheduler.step → store/_evict_lru`). The race was theoretical at low store() rates; this PR makes it ~10× more likely by adding the prompt-boundary snapshot path.

- Add `threading.Lock` to `MemoryAwarePrefixCache`, wrap `fetch / store / remove / clear`. Decompression and (de)quantization stay outside the lock to avoid blocking concurrent fetches on slow CPU work.
- Reorder eviction (in `_evict_lru` and the prefix-evict loop): drop the sorted-index entry first, then pop `_entries`. Belt-and-suspenders for any future code that may bypass the lock — the worst observable failure becomes a benign cache miss instead of a `KeyError`.
- Update class docstring.

## Behaviour after fix

Same prompt × N (Qwen3.6-35B-A3B-8bit, 2K tokens):

- Request 1 (cold): prefill → snapshot at prompt-end → `store(prompt_tokens, cache)` → entries[0] = prompt-only.
- Requests 2..N (warm): `fetch(prompt_tokens)` → exact match HIT, remaining=[]. TTFT collapses to cache-decompress + first-token decode.

Per `make check` autoresearch on Qwen3.5-4B (small dense, where prefix cache used to MISS less spectacularly):

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| `cached_ttft_ms` | 393.99 | 20.89 | **-94.7%** |
| `long_cached_ttft_ms` | 1233.11 | 28.71 | **-97.7%** |
| `mt_cached_ttft_ms` (multi-turn) | 402.93 | 21.17 | **-94.7%** |
| `composite_score` | 109.90 | 1001.80 | **+811%** |

## Test plan

- [x] `pytest tests/test_prompt_cache_snapshot.py` — 9 new tests, all green
- [x] `pytest tests/test_memory_cache.py::TestConcurrentAccess` — 3 new tests (lock presence, concurrent fetch/store burst, eviction order), all green
- [x] `pytest tests/test_continuous_batching.py tests/test_batching.py tests/test_memory_cache.py tests/test_prefix_cache.py tests/test_prompt_cache_snapshot.py` — 110 total, no regression
- [x] `ruff check` + `ruff format --check` clean
- [x] `make smoke` (lint + unit) — PASS
- [x] `make stress` (8 scenarios) — **8/8 PASS** (was 6/8 before lock fix; "Tool call storm" + "Mixed workload" failed via the same KeyError race)
- [x] `make benchmark` (5 local models) — all PASS, scorecard regenerated
- [x] `make check` autoresearch + baseline_diff — 11/11 metric improvements, 0 regressions
- [ ] Pre-existing failures unchanged (`make check` regression_suite Test 10 streaming usage, `smoke_matrix` empty responses) — see harness history `runs/2026-04-15-*` and `runs/2026-04-16-*`. Independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)