### PR TITLE
fix: route cache persistence to mlx-step thread (Stream(gpu,N) on shutdown)

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -475,6 +475,7 @@ class TestEngineAsync:
         self, mock_model_and_tokenizer
     ):
         """Prefill and decode steps must run on the same MLX worker thread."""
+        from vllm_mlx import engine_core
         from vllm_mlx.engine import EngineConfig, EngineCore
 
         model, tokenizer = mock_model_and_tokenizer
@@ -502,12 +503,25 @@ class TestEngineAsync:
 
         fake_scheduler = FakeScheduler()
         engine.scheduler = fake_scheduler
+
+        # Mirror what start() does — create the mlx-step worker executor so
+        # _engine_loop() picks it up. Tests can't call start() directly here
+        # because start() spawns a task and returns immediately.
+        import concurrent.futures
+
+        engine._mlx_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=engine_core._init_mlx_step_thread,
+        )
         engine._running = True
 
         try:
             await asyncio.wait_for(engine._engine_loop(), timeout=2)
         finally:
             engine._running = False
+            engine._mlx_executor.shutdown(wait=True)
+            engine._mlx_executor = None
             engine.close()
 
         assert fake_scheduler.thread_names

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for EngineCore._run_on_step_thread / _mlx_executor.
+
+Background: mlx-lm 0.31+ binds `mlx_lm.generate.generation_stream` to the
+thread that creates it. Any MLX op that touches arrays tagged with that
+stream from a different thread raises
+``RuntimeError: There is no Stream(gpu, N) in current thread.``
+
+The engine creates a single dedicated mlx-step worker thread so the
+generation hot path stays on it. Anything else that touches KV-cache
+arrays — most importantly the shutdown call to save the prefix cache —
+must be routed through the same worker via _run_on_step_thread().
+
+These tests exercise that machinery without spinning up a real model.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def engine_core(monkeypatch):
+    """Build an EngineCore with mocked model/registry/scheduler."""
+    from vllm_mlx import engine_core as ec
+
+    # Avoid the real model registry (which expects a real MLX model).
+    fake_registry = MagicMock()
+    monkeypatch.setattr(ec, "get_registry", lambda: fake_registry)
+
+    # Don't spin up a real Scheduler — patch it to a MagicMock so we can
+    # assert how save/load_cache_to_disk reaches it.
+    with patch.object(ec, "Scheduler") as scheduler_cls:
+        scheduler_instance = MagicMock()
+        scheduler_cls.return_value = scheduler_instance
+        engine = ec.EngineCore(model=MagicMock(), tokenizer=MagicMock())
+        engine.scheduler = scheduler_instance
+        yield engine
+        engine.close()
+
+
+class TestStepThread:
+    def test_executor_is_lazy(self, engine_core):
+        """Executor is None until start() runs."""
+        assert engine_core._mlx_executor is None
+
+    @pytest.mark.asyncio
+    async def test_start_creates_named_executor(self, engine_core, monkeypatch):
+        """start() creates a single-thread executor with the mlx-step name."""
+        # Stub out _init_mlx_step_thread so the test doesn't try to talk to
+        # Metal — we only care about thread-naming + executor lifecycle here.
+        from vllm_mlx import engine_core as ec
+
+        monkeypatch.setattr(ec, "_init_mlx_step_thread", lambda: None)
+
+        await engine_core.start()
+        try:
+            assert engine_core._mlx_executor is not None
+
+            captured = {}
+
+            def capture():
+                captured["thread"] = threading.current_thread().name
+                return "ok"
+
+            result = engine_core._run_on_step_thread(capture)
+            assert result == "ok"
+            assert captured["thread"].startswith("mlx-step")
+        finally:
+            await engine_core.stop()
+            assert engine_core._mlx_executor is None
+
+    def test_run_on_step_thread_falls_back_when_no_executor(self, engine_core):
+        """Without start(), _run_on_step_thread runs inline (and the caller
+        will see whatever stream error MLX would have raised)."""
+        captured = {}
+
+        def capture():
+            captured["thread"] = threading.current_thread().name
+
+        engine_core._run_on_step_thread(capture)
+        # Should have run on the *current* thread (no executor available).
+        assert captured["thread"] == threading.current_thread().name
+
+    @pytest.mark.asyncio
+    async def test_save_cache_to_disk_routes_to_worker(self, engine_core, monkeypatch):
+        """The shutdown save MUST execute on the mlx-step worker thread."""
+        from vllm_mlx import engine_core as ec
+
+        monkeypatch.setattr(ec, "_init_mlx_step_thread", lambda: None)
+
+        captured = {}
+
+        def fake_save(cache_dir):
+            captured["thread"] = threading.current_thread().name
+            captured["cache_dir"] = cache_dir
+            return True
+
+        engine_core.scheduler.save_cache_to_disk.side_effect = fake_save
+
+        await engine_core.start()
+        try:
+            assert engine_core.save_cache_to_disk("/tmp/whatever") is True
+            assert captured["cache_dir"] == "/tmp/whatever"
+            assert captured["thread"].startswith("mlx-step")
+        finally:
+            await engine_core.stop()
+
+    @pytest.mark.asyncio
+    async def test_load_cache_from_disk_routes_to_worker(
+        self, engine_core, monkeypatch
+    ):
+        """Loading also runs on the worker so loaded arrays are tagged with
+        the stream that subsequent fetches will run on."""
+        from vllm_mlx import engine_core as ec
+
+        monkeypatch.setattr(ec, "_init_mlx_step_thread", lambda: None)
+
+        captured = {}
+
+        def fake_load(cache_dir):
+            captured["thread"] = threading.current_thread().name
+            return 17
+
+        engine_core.scheduler.load_cache_from_disk.side_effect = fake_load
+
+        await engine_core.start()
+        try:
+            assert engine_core.load_cache_from_disk("/tmp/whatever") == 17
+            assert captured["thread"].startswith("mlx-step")
+        finally:
+            await engine_core.stop()
+
+    @pytest.mark.asyncio
+    async def test_run_on_step_thread_propagates_exceptions(
+        self, engine_core, monkeypatch
+    ):
+        """Worker-thread exceptions must propagate to the caller — silent
+        failure here would mean we save half the cache and never log why."""
+        from vllm_mlx import engine_core as ec
+
+        monkeypatch.setattr(ec, "_init_mlx_step_thread", lambda: None)
+
+        await engine_core.start()
+        try:
+
+            def boom():
+                raise RuntimeError("There is no Stream(gpu, 2) in current thread.")
+
+            with pytest.raises(RuntimeError, match="Stream"):
+                engine_core._run_on_step_thread(boom)
+        finally:
+            await engine_core.stop()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -118,6 +118,13 @@ class EngineCore:
         self._start_time: float | None = None
         self._steps_executed = 0
 
+        # Single MLX worker thread that owns the per-thread generation_stream
+        # (created on demand in start(); see _init_mlx_step_thread). All MLX
+        # array operations that touch cached KV state must go through this
+        # executor — the asyncio loop thread does not own a stream and will
+        # raise "There is no Stream(gpu, N) in current thread."
+        self._mlx_executor: Any = None
+
         # Detect hybrid models (GatedDeltaNet) that need request throttling
         self._hybrid_throttle = False
         self._hybrid_lock: asyncio.Lock | None = None  # lazy-init in event loop
@@ -143,6 +150,13 @@ class EngineCore:
         if self._running:
             return
 
+        import concurrent.futures
+
+        self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=_init_mlx_step_thread,
+        )
         self._running = True
         self._start_time = time.time()
         self._task = asyncio.create_task(self._engine_loop())
@@ -158,7 +172,36 @@ class EngineCore:
             except asyncio.CancelledError:
                 pass
             self._task = None
+        if self._mlx_executor is not None:
+            # Tear down BatchGenerator on the worker thread that owns its
+            # generation stream. Otherwise its __del__ runs at process exit
+            # in some other thread and calls mx.synchronize on a stream
+            # that no longer exists, raising
+            # "There is no Stream(gpu, N) in current thread."
+            try:
+                self._run_on_step_thread(self.scheduler._close_batch_generator)
+            except Exception as e:
+                logger.debug(f"Error closing BatchGenerator on worker: {e}")
+            self._mlx_executor.shutdown(wait=True)
+            self._mlx_executor = None
         logger.info("Engine stopped")
+
+    def _run_on_step_thread(self, func, *args, **kwargs):
+        """Run `func` on the MLX worker thread and return its result.
+
+        Use this for MLX operations called from the asyncio loop thread
+        (or any other thread) that touch arrays whose backing stream lives
+        on the worker — e.g. saving the prefix cache to disk on shutdown.
+
+        Falls back to a direct call if the executor isn't available
+        (engine not started or already stopped); the caller will see the
+        same Stream(gpu, N) error it would have seen pre-fix.
+        """
+        executor = self._mlx_executor
+        if executor is None:
+            return func(*args, **kwargs)
+        future = executor.submit(func, *args, **kwargs)
+        return future.result()
 
     def is_running(self) -> bool:
         """Check if engine is running."""
@@ -166,16 +209,12 @@ class EngineCore:
 
     async def _engine_loop(self) -> None:
         """Main engine loop."""
-        import concurrent.futures
-
-        # Keep every scheduler step on one thread. mlx-lm generation streams
-        # are thread-local, and Qwen3.x RotatingKVCache keeps arrays tagged
+        # The single mlx-step worker thread is created in start() so that
+        # _run_on_step_thread() can also reach it from non-loop callers
+        # (e.g. shutdown cache persistence). mlx-lm generation streams are
+        # thread-local, and Qwen3.x RotatingKVCache keeps arrays tagged
         # with that stream across prefill and decode.
-        _executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="mlx-step",
-            initializer=_init_mlx_step_thread,
-        )
+        _executor = self._mlx_executor
         loop = asyncio.get_running_loop()
 
         step_interval = self.config.step_interval
@@ -581,12 +620,23 @@ class EngineCore:
         return self.scheduler.get_cache_stats()
 
     def save_cache_to_disk(self, cache_dir: str) -> bool:
-        """Save prefix cache to disk."""
-        return self.scheduler.save_cache_to_disk(cache_dir)
+        """Save prefix cache to disk.
+
+        Routed through the mlx-step worker thread because the KV-cache
+        arrays are tagged with that thread's generation_stream; trying to
+        materialize them from the asyncio loop thread raises
+        "There is no Stream(gpu, N) in current thread."
+        """
+        return self._run_on_step_thread(self.scheduler.save_cache_to_disk, cache_dir)
 
     def load_cache_from_disk(self, cache_dir: str) -> int:
-        """Load prefix cache from disk."""
-        return self.scheduler.load_cache_from_disk(cache_dir)
+        """Load prefix cache from disk.
+
+        Loading also goes through the worker thread so the loaded arrays
+        end up tagged with the generation_stream that subsequent fetches
+        will run on.
+        """
+        return self._run_on_step_thread(self.scheduler.load_cache_from_disk, cache_dir)
 
     def _release_model(self) -> None:
         """Release model ownership."""

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -12,6 +12,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 """
 
 import asyncio
+import concurrent.futures
 import logging
 import sys
 import time
@@ -123,7 +124,7 @@ class EngineCore:
         # array operations that touch cached KV state must go through this
         # executor — the asyncio loop thread does not own a stream and will
         # raise "There is no Stream(gpu, N) in current thread."
-        self._mlx_executor: Any = None
+        self._mlx_executor: concurrent.futures.ThreadPoolExecutor | None = None
 
         # Detect hybrid models (GatedDeltaNet) that need request throttling
         self._hybrid_throttle = False
@@ -149,8 +150,6 @@ class EngineCore:
         """Start the engine loop."""
         if self._running:
             return
-
-        import concurrent.futures
 
         self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1,
@@ -199,6 +198,14 @@ class EngineCore:
         """
         executor = self._mlx_executor
         if executor is None:
+            # No worker thread: callers in test/CLI paths run sync. In
+            # production after start() this should never trigger; if it
+            # does, the call is about to hit Stream(gpu, N) again — log
+            # at debug so a future regression surfaces in diagnostics.
+            logger.debug(
+                "_run_on_step_thread: no executor, running %s inline",
+                getattr(func, "__qualname__", func),
+            )
             return func(*args, **kwargs)
         future = executor.submit(func, *args, **kwargs)
         return future.result()


### PR DESCRIPTION
## Summary

Fixes two `RuntimeError: There is no Stream(gpu, N) in current thread.` instances I uncovered while doing onboarding QA of v0.6.2. Same root cause family as #161 / #160 / #166 but in code paths #161 didn't reach.

Discovered by running the exact #166 user command against the freshly published 0.6.2 (both pip and brew):

```
WARNING: [cache_persist] failed to save entry 114: There is no Stream(gpu, 2) in current thread.
WARNING: [cache_persist] failed to save entry 115: There is no Stream(gpu, 2) in current thread.
WARNING: [cache_persist] failed to save entry 117: There is no Stream(gpu, 3) in current thread.
INFO:    [cache_persist] SAVED 114/119 entries ... in 6.1s
Exception ignored in: <function BatchGenerator.__del__ at 0x...>
  File ".../mlx_lm/generate.py", line 1557, in close
    mx.synchronize(self._stream)
RuntimeError: There is no Stream(gpu, 2) in current thread.
INFO:    Application shutdown complete.
```

## Root cause

mlx-lm 0.31+ binds `mlx_lm.generate.generation_stream` to the thread that creates it. PR #161 fixed the generation hot path by giving the mlx-step worker its own stream, but two adjacent paths still ran on the asyncio loop thread (which has no stream):

1. **Shutdown prefix-cache persistence** — `MemoryAwarePrefixCache.save_to_disk` calls `mlx_lm.models.cache.save_prompt_cache` which materializes lazy KV arrays. With Qwen3.6-27B 4-bit, ~5/119 entries silently dropped on every shutdown plus a noisy traceback in logs.
2. **`BatchGenerator.__del__`** (mlx-lm) calls `mx.synchronize(self._stream)` from whatever thread happens to GC it at process exit, after the worker thread is gone. Trailing RuntimeError on every shutdown.

## Fix

- Lift the mlx-step `ThreadPoolExecutor` onto `EngineCore._mlx_executor` so it's reachable from any thread, not just `_engine_loop`.
- Add `EngineCore._run_on_step_thread(func, *args)` — submits to the worker and blocks for the result. Falls back to inline call if executor is None (preserves test/CLI codepaths that don't go through `start()`).
- Route both `save_cache_to_disk` and `load_cache_from_disk` through it.
- In `stop()`, explicitly close `BatchGenerator` on the worker BEFORE shutting the executor down, so `__del__` sees a closed stream.

## Verification

End-to-end on `mlx-community/Qwen3.6-27B-4bit` (the model in issue #166):

| Metric | 0.6.2 baseline | This PR |
|---|---|---|
| Generation (req1 cold) | 37 tok/s | 37 tok/s (no regression) |
| Generation (req2 warm, prefix HIT) | 37 tok/s, TTFT 421→153ms | 37 tok/s, TTFT 262→159ms |
| Cache entries persisted on SIGINT | 114/119 (96%) | 117/117 (100%) |
| `Stream(gpu, N)` warnings during persist | 5 | **0** |
| Trailing `RuntimeError` from `BatchGenerator.__del__` | 1 | **0** |
| Clean `Application shutdown complete` | yes (with noise) | yes (silent) |

Tests (`make smoke` clean):
- New `tests/test_engine_step_thread.py` — 6 tests covering executor lifecycle, worker-thread routing for save/load, exception propagation, fallback when executor is unavailable.
- Existing `tests/test_batching.py::test_engine_loop_keeps_all_scheduler_steps_on_mlx_thread` updated to mirror the new `start()`-creates-executor contract.
- Full `make smoke`: 1918 passed, 17 skipped, lint clean.

## Test plan
- [x] Unit tests pass (`pytest tests/test_engine_step_thread.py -v`)
- [x] Existing batching tests pass (`pytest tests/test_batching.py -v`)
- [x] `make smoke` clean
- [x] End-to-end repro of #166 on Qwen3.6-27B 4-bit: zero Stream errors, 117/117 entries persisted, generation tok/s unchanged
- [x] Generation hot path unaffected (executor lookup is one extra attribute access vs local var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)