### PR TITLE
fix(streaming): forward request to streaming tool parsers (#171)

### DIFF
--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1212,3 +1212,139 @@ class TestJsonModePreambleStripping:
         content_events = [e for e in events3 if e.type == "content"]
         assert len(content_events) == 1
         assert '{"answer": 42}' in content_events[0].content
+
+
+class TestRequestForwardedToToolParser:
+    """#171 regression: streaming parsers (qwen3_coder) need request.tools
+    for schema-driven type conversion. Without it, raw XML leaks to delta.content."""
+
+    def test_request_forwarded_to_streaming_parser(self):
+        """request kwarg is passed to extract_tool_calls_streaming."""
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.return_value = {"content": ""}
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        request_dict = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "read", "parameters": {}},
+                }
+            ]
+        }
+        pp = StreamingPostProcessor(cfg, request=request_dict)
+        pp.reset()
+
+        pp.process_chunk(_make_output("<tool_call>"))
+        kwargs = tool_parser.extract_tool_calls_streaming.call_args.kwargs
+        assert kwargs.get("request") is request_dict
+
+    def test_request_forwarded_to_finalize_fallback(self):
+        """finalize() fallback also forwards request to extract_tool_calls."""
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.return_value = {"content": ""}
+        tool_parser.has_pending_tool_call.return_value = True
+        tool_parser.extract_tool_calls.return_value = MagicMock(tools_called=False)
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        request_dict = {"tools": [{"type": "function", "function": {"name": "x"}}]}
+        pp = StreamingPostProcessor(cfg, request=request_dict)
+        pp.reset()
+
+        pp.process_chunk(_make_output("<tool_call>incomplete"))
+        pp.finalize()
+
+        kwargs = tool_parser.extract_tool_calls.call_args.kwargs
+        assert kwargs.get("request") is request_dict
+
+    def test_request_defaults_to_none(self):
+        """No request → None is forwarded (preserves prior behavior)."""
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.return_value = {"content": ""}
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        pp.process_chunk(_make_output("<tool_call>"))
+        kwargs = tool_parser.extract_tool_calls_streaming.call_args.kwargs
+        assert kwargs.get("request") is None
+
+    def test_qwen3_coder_streaming_with_request_extracts_tool_call(self):
+        """End-to-end: real qwen3_coder parser + request → structured tool_calls,
+        not raw XML in content. Reproduces #171."""
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
+            Qwen3CoderToolParser,
+        )
+
+        parser = Qwen3CoderToolParser(tokenizer=None)
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=parser,
+        )
+        request_dict = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        }
+        pp = StreamingPostProcessor(cfg, tools_requested=True, request=request_dict)
+        pp.reset()
+
+        # Feed the canonical Qwen3-Coder XML in tokens-ish chunks.
+        full_xml = (
+            "<tool_call>\n"
+            "<function=read>\n"
+            "<parameter=path>\n"
+            "HEARTBEAT.md\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        all_events = []
+        for piece in [
+            "<tool_call>\n",
+            "<function=read>\n",
+            "<parameter=path>\n",
+            "HEARTBEAT.md\n",
+            "</parameter>\n",
+            "</function>\n",
+            "</tool_call>",
+        ]:
+            all_events.extend(pp.process_chunk(_make_output(piece)))
+        all_events.extend(pp.finalize())
+
+        # Must produce at least one tool_call event with the function name.
+        tool_events = [e for e in all_events if e.type == "tool_call"]
+        assert tool_events, (
+            f"#171 regression: no tool_call events for {full_xml!r}; "
+            f"events={[(e.type, getattr(e, 'content', None)) for e in all_events]}"
+        )
+        # Tool name should appear in at least one event.
+        names_seen = []
+        for e in tool_events:
+            for tc in e.tool_calls or []:
+                fn = tc.get("function", {}).get("name")
+                if fn:
+                    names_seen.append(fn)
+        assert "read" in names_seen, (
+            f"#171: tool_call emitted but function name 'read' missing; "
+            f"names_seen={names_seen}"
+        )

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -634,7 +634,14 @@ async def stream_chat_completion(
             logger.info(f"[SSE-ROLE] {_first_sse.strip()[:200]}")
         yield _first_sse
 
-        # Initialize post-processor
+        # Initialize post-processor.
+        # request_dict carries `tools` so streaming parsers (qwen3_coder etc.)
+        # can do schema-driven type conversion (#171).
+        request_dict = (
+            request.model_dump(exclude_none=True)
+            if hasattr(request, "model_dump")
+            else None
+        )
         processor = StreamingPostProcessor(
             cfg,
             tools_requested=bool(request.tools),
@@ -642,6 +649,7 @@ async def stream_chat_completion(
                 request.response_format
                 and getattr(request.response_format, "type", "text") != "text"
             ),
+            request=request_dict,
         )
         processor.set_thinking_model(request.model)
         processor.reset()

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -74,10 +74,15 @@ class StreamingPostProcessor:
         tools_requested: bool = False,
         enable_thinking: bool | None = None,
         json_mode: bool = False,
+        request: dict | None = None,
     ):
         self.cfg = cfg
         self.tools_requested = tools_requested
         self.json_mode = json_mode
+        # Forwarded to streaming tool parsers — qwen3_coder needs request.tools
+        # for schema-driven type conversion (#171). Without it, raw XML leaks
+        # into delta.content instead of structured tool_calls deltas.
+        self.request = request
 
         # Per-request parser instances — each streaming request gets its
         # own parser to avoid state corruption under concurrent
@@ -469,7 +474,9 @@ class StreamingPostProcessor:
             and not self.tool_calls_detected
             and self.tool_parser.has_pending_tool_call(_fallback_text)
         ):
-            result = self.tool_parser.extract_tool_calls(_fallback_text)
+            result = self.tool_parser.extract_tool_calls(
+                _fallback_text, request=self.request
+            )
             if result.tools_called:
                 tc_list = [
                     {
@@ -512,7 +519,10 @@ class StreamingPostProcessor:
         tool_previous = self.tool_accumulated_text
         self.tool_accumulated_text += content
         tool_result = self.tool_parser.extract_tool_calls_streaming(
-            tool_previous, self.tool_accumulated_text, content
+            tool_previous,
+            self.tool_accumulated_text,
+            content,
+            request=self.request,
         )
 
         if tool_result is None:


### PR DESCRIPTION
## Summary

- Closes #171.
- `qwen3_coder` streaming parser needs `request.tools` for schema-driven type conversion. The streaming SSE pipeline never passed `request` to `extract_tool_calls_streaming()`, so the parser bailed on type lookup and raw `<tool_call>` XML leaked into `delta.content` instead of structured `tool_calls` deltas.
- `StreamingPostProcessor` now stores `request` and forwards it to `extract_tool_calls_streaming()` and the `finalize()` fallback. Chat route dumps the Pydantic request to a dict before constructing the post-processor.
- Same fix unblocks any future streaming parser that needs the request body (already accepted as a kwarg by `hermes`, `gemma4`, `qwen3_coder`, `auto`).

## Why this matters

Reporter (@reidperyam) is hitting this in production: 13 user-visible failures in one 12-hour heartbeat window on the OpenClaw gateway. Affects Qwen3.5/Qwen3.6 quantized models — our flagship lineup for tool calling.

## Test plan

- [x] 4 new regression tests in `tests/test_postprocessor.py::TestRequestForwardedToToolParser`:
  - `test_request_forwarded_to_streaming_parser` — kwarg forwarded
  - `test_request_forwarded_to_finalize_fallback` — kwarg forwarded to finalize path
  - `test_request_defaults_to_none` — None preserves prior behavior
  - `test_qwen3_coder_streaming_with_request_extracts_tool_call` — end-to-end with real `Qwen3CoderToolParser` feeding canonical XML, asserts structured `tool_calls` event with function name `read`
- [x] All 70 existing `test_postprocessor.py` tests pass
- [x] Full suite (~2054 tests) passes
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)