### PR TITLE
fix(batched): route generate_warmup() through mlx-step thread (#170)

### DIFF
--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -155,5 +155,98 @@ class TestStepThread:
             await engine_core.stop()
 
 
+class TestBatchedEngineWarmup:
+    """#170 regression: BatchedEngine.generate_warmup() must run on the
+    mlx-step worker so cache arrays it touches carry the worker's stream.
+
+    Without this, models with eager cache materialization (Gemma 4
+    RotatingKVCache, sliding-window) fail every request with
+    "There is no Stream(gpu, 1) in current thread" the moment
+    BatchGenerator.prompt() evals the prompt cache state on the worker.
+    """
+
+    def test_warmup_runs_on_mlx_step_thread(self, monkeypatch):
+        """generate_warmup() routes the model forward through _run_on_step_thread."""
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        captured: dict = {}
+
+        # Stub mx.array / mx.eval so we don't touch real Metal.
+        import mlx.core as mx
+
+        monkeypatch.setattr(mx, "array", lambda x: MagicMock())
+        monkeypatch.setattr(mx, "eval", lambda *_a, **_k: None)
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.encode = MagicMock(return_value=[1, 2])
+
+        def model_call(input_ids):
+            captured["model_thread"] = threading.current_thread().name
+            return MagicMock()
+
+        engine._model = MagicMock(side_effect=model_call)
+
+        # Build a tiny EngineCore-like wrapper exposing _run_on_step_thread
+        # via a real single-thread executor named mlx-step-test.
+        import concurrent.futures
+
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mlx-step-test"
+        )
+        try:
+            inner = MagicMock()
+            inner._mlx_executor = executor
+
+            def _run_on_step_thread(func, *args, **kwargs):
+                return executor.submit(func, *args, **kwargs).result()
+
+            inner._run_on_step_thread = _run_on_step_thread
+
+            wrapper = MagicMock()
+            wrapper.engine = inner
+            engine._engine = wrapper
+
+            engine.generate_warmup()
+
+            assert captured.get("model_thread", "").startswith("mlx-step-test"), (
+                f"generate_warmup ran model on {captured.get('model_thread')!r}, "
+                f"expected mlx-step-test thread"
+            )
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_warmup_falls_back_when_executor_missing(self, monkeypatch):
+        """Without a step-thread executor, warmup runs inline (legacy path)."""
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        captured: dict = {}
+
+        import mlx.core as mx
+
+        monkeypatch.setattr(mx, "array", lambda x: MagicMock())
+        monkeypatch.setattr(mx, "eval", lambda *_a, **_k: None)
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.encode = MagicMock(return_value=[1, 2])
+
+        def model_call(input_ids):
+            captured["model_thread"] = threading.current_thread().name
+            return MagicMock()
+
+        engine._model = MagicMock(side_effect=model_call)
+        engine._engine = None  # no AsyncEngineCore yet
+
+        engine.generate_warmup()
+
+        # Should have run on caller thread.
+        assert captured.get("model_thread") == threading.current_thread().name
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -196,7 +196,16 @@ class BatchedEngine(BaseEngine):
         return self._tokenizer
 
     def generate_warmup(self) -> None:
-        """Run a minimal forward pass to compile Metal shaders."""
+        """Run a minimal forward pass to compile Metal shaders.
+
+        Routes through the MLX step thread so cache arrays touched during
+        warmup carry the step thread's generation_stream. Otherwise models
+        with eagerly-materialized caches (Gemma 4 RotatingKVCache,
+        sliding-window) raise "There is no Stream(gpu, 1) in current thread"
+        on the first request because BatchGenerator.prompt() runs on the
+        step thread but evals state tagged with the main thread's stream
+        (#170, follow-on to #161 / #167).
+        """
         if not self._loaded or self._model is None or self._is_mllm:
             return
         try:
@@ -204,8 +213,21 @@ class BatchedEngine(BaseEngine):
 
             tokens = self._tokenizer.encode("Hi")
             input_ids = mx.array([tokens])
-            self._model(input_ids)
-            mx.eval(mx.zeros(1))
+
+            def _warmup_forward() -> None:
+                out = self._model(input_ids)
+                mx.eval(out)
+
+            engine_core = (
+                getattr(self._engine, "engine", None) if self._engine else None
+            )
+            if (
+                engine_core is not None
+                and getattr(engine_core, "_mlx_executor", None) is not None
+            ):
+                engine_core._run_on_step_thread(_warmup_forward)
+            else:
+                _warmup_forward()
         except Exception:
             pass  # Non-fatal
 


### PR DESCRIPTION
## Summary

- Closes #170.
- Gemma 4 (mlx-vlm `RotatingKVCache`, sliding-window) fails every request on 0.6.4 with `RuntimeError: There is no Stream(gpu, 1) in current thread.` from `BatchGenerator.prompt()` evalling the prompt cache state.
- Root cause: `BatchedEngine.generate_warmup()` ran the model forward pass on the asyncio loop thread. Eagerly-materialized caches (RotatingKVCache) bound state to the main thread's `generation_stream`, which doesn't exist on the mlx-step worker thread that `BatchGenerator` runs on.
- This patch routes the warmup forward pass through `_run_on_step_thread()` — the missing third leg of the same invariant established by #161 (`generation_stream` bound to worker) and #167 (cache persistence routed to worker).
- Falls back to inline execution when the executor isn't available (test/CLI paths) — prior behavior preserved.

## Why Qwen wasn't affected

Qwen-style models use lazy `ArraysCache`/`KVCache` whose arrays materialize on first step-thread use, so they never trip the eager-binding path. Gemma 4's sliding-window layers materialize state immediately during the warmup forward pass.

## Test plan

- [x] 2 new regression tests in `tests/test_engine_step_thread.py::TestBatchedEngineWarmup`:
  - `test_warmup_runs_on_mlx_step_thread` — model forward executes on a thread named `mlx-step-*` when the step-thread executor is wired in
  - `test_warmup_falls_back_when_executor_missing` — falls back to caller thread when `self._engine` is None
- [x] All 6 existing `TestStepThread` tests still pass
- [x] Full suite (~2054 tests) passes
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)