### PR TITLE
fix(parsers): restore qwen3_xml to Qwen parser, fix Gemma4 streaming signature (#175)

### DIFF
--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -862,6 +862,69 @@ class TestQwen3CoderParser:
         assert result.tool_calls[1]["name"] == "list_files"
 
 
+class TestQwen3XmlAlias:
+    """Regression: qwen3_xml must resolve to QwenToolParser, not the Coder parser.
+
+    Issue #175: qwen3_xml was aliased to Qwen3CoderToolParser, which expects
+    <function=NAME> tags. Qwen3 reasoning models emit <tool_call>{json}</tool_call>
+    instead, so the Coder parser silently returned tools_called=False, causing
+    streaming chat completions to fail with finish_reason: error.
+    """
+
+    def test_qwen3_xml_resolves_to_qwen_parser(self):
+        parser_cls = ToolParserManager.get_tool_parser("qwen3_xml")
+        assert parser_cls is QwenToolParser, (
+            f"qwen3_xml must resolve to QwenToolParser (handles JSON-in-<tool_call>), "
+            f"got {parser_cls.__name__}"
+        )
+
+    def test_qwen3_xml_parses_reasoning_model_format(self):
+        parser = ToolParserManager.get_tool_parser("qwen3_xml")(tokenizer=None)
+        text = (
+            '<tool_call>{"name": "read", "arguments": {"filePath": "/etc/hostname"}}'
+            "</tool_call>"
+        )
+        result = parser.extract_tool_calls(text, request=None)
+        assert result.tools_called, (
+            "qwen3_xml must parse <tool_call>{json}</tool_call> "
+            "(Qwen3 reasoning model output)"
+        )
+        assert result.tool_calls[0]["name"] == "read"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["filePath"] == "/etc/hostname"
+
+    def test_qwen3_coder_xml_still_resolves_to_coder_parser(self):
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
+
+        parser_cls = ToolParserManager.get_tool_parser("qwen3_coder_xml")
+        assert parser_cls is Qwen3CoderToolParser, (
+            "qwen3_coder_xml must remain bound to the Coder parser"
+        )
+
+
+class TestGemma4StreamingSignature:
+    """Regression: Gemma4ToolParser.extract_tool_calls_streaming must accept request=.
+
+    Issue #175 (aside): postprocessor passes request=self.request as a kwarg, but
+    Gemma4's override was missing the parameter, raising TypeError on every Gemma 4
+    streaming tool call.
+    """
+
+    def test_gemma4_streaming_accepts_request_kwarg(self):
+        from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
+
+        parser = Gemma4ToolParser(tokenizer=None)
+        # Must not raise TypeError
+        result = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="hello",
+            delta_text="hello",
+            request={"tools": []},
+        )
+        # Plain text passes through as content
+        assert result == {"content": "hello"}
+
+
 class TestHermesStreamingFixes:
     """Test streaming fixes for Hermes parser (Issue #47)."""
 

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -901,6 +901,48 @@ class TestQwen3XmlAlias:
             "qwen3_coder_xml must remain bound to the Coder parser"
         )
 
+    def test_qwen3_xml_streaming_emits_tool_call(self):
+        """Streaming path: feed reasoning-model output token-by-token through qwen3_xml.
+
+        This is the path that was crashing in the user's bug report (raw token IDs
+        leaking into 'Internal error during streaming'). The bug surfaced because
+        the Coder parser's streaming logic doesn't recognize JSON-in-<tool_call>
+        and either raised or silently dropped emissions. With qwen3_xml routed to
+        QwenToolParser, the streaming path must successfully emit a tool_call
+        delta when the closing </tool_call> token arrives.
+        """
+        parser = ToolParserManager.get_tool_parser("qwen3_xml")(tokenizer=None)
+        # Mimic real tokenizer chunks (Qwen tokenizes <tool_call> and </tool_call>
+        # as single tokens, JSON content as several tokens).
+        chunks = [
+            "<tool_call>",
+            '{"name": ',
+            '"read", ',
+            '"arguments": ',
+            '{"filePath": ',
+            '"/etc/hostname"}}',
+            "</tool_call>",
+        ]
+        emitted_tool_calls = []
+        prev = ""
+        for chunk in chunks:
+            current = prev + chunk
+            result = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=current,
+                delta_text=chunk,
+                request={"tools": [{"type": "function", "function": {"name": "read"}}]},
+            )
+            if result and "tool_calls" in result:
+                emitted_tool_calls.extend(result["tool_calls"])
+            prev = current
+        assert len(emitted_tool_calls) >= 1, (
+            "streaming qwen3_xml must emit at least one tool_call delta"
+        )
+        assert emitted_tool_calls[-1]["function"]["name"] == "read"
+        args = json.loads(emitted_tool_calls[-1]["function"]["arguments"])
+        assert args["filePath"] == "/etc/hostname"
+
 
 class TestGemma4StreamingSignature:
     """Regression: Gemma4ToolParser.extract_tool_calls_streaming must accept request=.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1260,7 +1260,9 @@ Examples:
         ],
         help=(
             "Select the tool call parser for the model. Options: "
-            "auto (auto-detect), mistral, qwen, qwen3_coder, qwen3_coder_xml/qwen3_xml, llama, hermes, "
+            "auto (auto-detect), mistral, qwen/qwen3/qwen3_xml (reasoning models, "
+            "<tool_call>JSON</tool_call> format), qwen3_coder/qwen3_coder_xml "
+            "(Coder model, <function=NAME> XML format), llama, hermes, "
             "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, minimax, "
             "harmony/gpt-oss, gemma4. "
             "Required for --enable-auto-tool-choice."

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -21,7 +21,8 @@ Available parsers:
 - harmony/gpt-oss: GPT-OSS models (Harmony format with channels)
 - seed_oss/seed/gpt_oss: Seed-OSS / GPT-OSS models (XML format)
 - deepseek_v31/deepseek_r1_0528: DeepSeek V3.1 / R1-0528 models
-- qwen3_coder_xml/qwen3_xml: Qwen3-Coder models (XML format)
+- qwen/qwen3/qwen3_xml: Qwen models (<tool_call>JSON</tool_call> and [Calling tool:] formats)
+- qwen3_coder_xml: Qwen3-Coder models (<function=NAME> XML format)
 
 Usage:
     from vllm_mlx.tool_parsers import ToolParserManager

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -134,6 +134,7 @@ class Gemma4ToolParser(ToolParser):
         previous_token_ids: Sequence = (),
         current_token_ids: Sequence = (),
         delta_token_ids: Sequence = (),
+        request: dict[str, Any] | None = None,
     ) -> dict | None:
         # Check if we're inside a tool call
         if "<|tool_call>" in current_text:

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -97,7 +97,7 @@ def _convert_param_value(
             return param_value
 
 
-@ToolParserManager.register_module(["qwen3_coder_xml", "qwen3_xml"])
+@ToolParserManager.register_module(["qwen3_coder_xml"])
 class Qwen3CoderToolParser(ToolParser):
     """
     Tool call parser for Qwen3-Coder models using XML format.

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -25,7 +25,7 @@ def generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
-@ToolParserManager.register_module(["qwen", "qwen3"])
+@ToolParserManager.register_module(["qwen", "qwen3", "qwen3_xml"])
 class QwenToolParser(ToolParser):
     """
     Tool call parser for Qwen models.


### PR DESCRIPTION
## Summary

Fixes [#175](https://github.com/raullenchai/Rapid-MLX/issues/175). Two parser bugs reported by @stone30513 against 0.6.6.

### Bug 1: `qwen3_xml` aliased to wrong parser

`qwen3_xml` was registered as an alias of `Qwen3CoderToolParser` since the Coder parser was first added in commit `7ffce24` (March 2026). The Coder parser expects `<function=NAME><parameter=KEY>` XML tags, but Qwen3 reasoning models emit `<tool_call>{"name":..., "arguments":...}</tool_call>` JSON. Result: silent `tools_called=False`, surfacing as `finish_reason: error` in streaming chat completions.

**Note on timeline:** the user reported this as a regression vs 0.6.4, but the aliasing has been wrong since March. Most likely 0.6.5's PR #172 (qwen3_coder streaming fix) changed the streaming code path enough to make a previously silent failure into a hard error. Either way, the registration was always incorrect.

**Fix:** move `qwen3_xml` to `QwenToolParser` (which handles JSON-in-`<tool_call>`), keep `qwen3_coder_xml` as the sole alias for the Coder parser.

### Bug 2: `Gemma4ToolParser.extract_tool_calls_streaming` missing `request=` kwarg

Aside in the same issue. Postprocessor calls `extract_tool_calls_streaming(..., request=self.request)`, but Gemma4's override didn't declare the `request` parameter that the abstract base class added. Raises `TypeError` on every Gemma 4 streaming tool call.

**Fix:** add `request: dict[str, Any] | None = None` to match the base class.

## Repro (on `main` before this PR)

```python
from vllm_mlx.tool_parsers import ToolParserManager
parser = ToolParserManager.get_tool_parser("qwen3_xml")(tokenizer=None)
text = '<tool_call>{"name": "read", "arguments": {"filePath": "/etc/hostname"}}</tool_call>'
print(parser.extract_tool_calls(text).tools_called)  # False — bug
```

## Test plan

- [x] Repro confirmed on `main`: parser returns `tools_called=False` for reasoning-model XML
- [x] 4 new regression tests in `TestQwen3XmlAlias` + `TestGemma4StreamingSignature`
- [x] Tests fail on `main`, pass with the fix
- [x] Full unit suite: 2058 passed, 1 unrelated pre-existing fail (`test_reasoning_parsers.py::TestQwen3::test_only_start_tag_no_end`)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)