### PR TITLE
chore: add performance issue template + disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,70 +1,101 @@
 name: Bug Report
-description: Report a bug or unexpected behavior
+description: Report a crash, wrong output, broken tool calls, or other unexpected behavior
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for reporting! Please fill in the details below.
+      value: |
+        Thanks for reporting! Please fill in every required field — issues missing a serve command or repro steps usually can't be acted on.
+
+        For **slowdowns / low throughput**, use the **Performance Issue** template instead.
   - type: input
     id: version
     attributes:
       label: Rapid-MLX version
-      placeholder: "e.g., 0.3.12 (run: rapid-mlx --version)"
+      placeholder: "e.g. 0.6.6 (run: rapid-mlx --version)"
     validations:
       required: true
+  - type: input
+    id: prior_version
+    attributes:
+      label: Last version where it worked (if regression)
+      description: Leave blank if first install or unknown.
+      placeholder: "e.g. 0.6.4"
   - type: input
     id: hardware
     attributes:
       label: Hardware
-      placeholder: "e.g., MacBook Pro M3 Max, 64GB"
+      placeholder: "e.g. MacBook Pro M3 Max, 64 GB"
     validations:
       required: true
   - type: input
     id: macos
     attributes:
       label: macOS version
-      placeholder: "e.g., Sequoia 15.3 (Apple menu → About This Mac)"
+      placeholder: "e.g. Sequoia 15.3 (Apple menu → About This Mac)"
     validations:
       required: true
   - type: input
     id: python
     attributes:
       label: Python version
-      placeholder: "e.g., 3.12.4 (run: python3 --version)"
+      placeholder: "e.g. 3.12.4 (run: python3 --version)"
   - type: input
     id: model
     attributes:
       label: Model
-      placeholder: "e.g., qwen3.5-4b or mlx-community/Qwen3.5-4B-MLX-4bit"
+      placeholder: "e.g. qwen3.5-4b or mlx-community/Qwen3.5-4B-MLX-4bit"
     validations:
       required: true
   - type: input
     id: serve_command
     attributes:
       label: Full serve command
-      placeholder: "e.g., rapid-mlx serve qwen3.5-4b --port 8000 --no-thinking"
+      description: Every flag matters — `--tool-call-parser`, `--reasoning-parser`, `--enable-prefix-cache`, etc.
+      placeholder: "rapid-mlx serve qwen3.5-4b --enable-auto-tool-choice --tool-call-parser qwen3 ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: streaming
+    attributes:
+      label: Streaming or non-streaming?
+      options:
+        - "Streaming (`stream: true`)"
+        - "Non-streaming"
+        - "Both"
+        - "N/A — not a chat completion bug"
     validations:
       required: true
   - type: textarea
     id: description
     attributes:
-      label: What happened?
-      placeholder: Describe the bug and what you expected to happen.
+      label: What happened? What did you expect?
+      placeholder: |
+        Actual: <describe the symptom>
+        Expected: <describe what should have happened>
     validations:
       required: true
   - type: textarea
     id: reproduce
     attributes:
-      label: Steps to reproduce
+      label: Minimal reproduction
+      description: A `curl` command + the model output / error is ideal. We need to be able to reproduce locally.
       placeholder: |
         1. Start server: `rapid-mlx serve ...`
-        2. Send request: `curl ...`
-        3. See error
+        2. Send request:
+           ```
+           curl -X POST http://127.0.0.1:1234/v1/chat/completions \
+             -H 'Content-Type: application/json' \
+             -d '{...}'
+           ```
+        3. Observe: <error or wrong output>
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Error logs / output
+      label: Server logs / error output
+      description: Paste the relevant section from server stdout. Redact secrets if needed.
       render: shell
-      placeholder: Paste relevant logs or error messages here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/raullenchai/Rapid-MLX/discussions
+    about: For open-ended questions, share use cases, or general discussion. Bug reports, performance issues, and feature requests should use the forms above.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,21 +1,86 @@
 name: Feature Request
-description: Suggest a new feature or improvement
+description: Suggest a new feature, model, parser, or improvement
 labels: ["enhancement"]
 body:
-  - type: textarea
-    id: description
+  - type: markdown
     attributes:
-      label: What would you like?
-      placeholder: Describe the feature and why it would be useful.
+      value: |
+        Use this for ideas, missing features, new model support, new parser support, or any "it would be great if Rapid-MLX could …".
+
+        Best feature requests start from a real **use case** (what you're trying to do today and where you got stuck), not from a proposed implementation. We're more likely to act on something with concrete user need behind it.
+
+        For bugs / wrong output, use **Bug Report**. For slowdowns, use **Performance Issue**.
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: What are you trying to do?
+      description: Describe the user-facing goal — the workflow, integration, or capability you want. Be concrete.
+      placeholder: |
+        I'm building a Cursor-style code agent and want to use a local Qwen3.5-Coder model.
+        I need it to do parallel tool calls so the editor can apply multiple file edits in one round-trip.
     validations:
       required: true
+
+  - type: textarea
+    id: blocker
+    attributes:
+      label: What's blocking you today?
+      description: What does Rapid-MLX currently do (or not do) that prevents the workflow above? Concrete error / behavior / missing flag please.
+      placeholder: |
+        `--enable-auto-tool-choice` works for one tool per response, but when the model emits two `<tool_call>` blocks, only the first one comes through in the SSE stream. Looks like the Hermes parser stops after the first close-tag.
+    validations:
+      required: true
+
   - type: textarea
     id: workaround
     attributes:
-      label: Current workaround
-      placeholder: How do you handle this today, if at all?
+      label: Current workaround (if any)
+      description: How are you handling this today? "I can't" is a valid answer — that's useful info.
+      placeholder: |
+        Issuing two sequential requests instead of parallel — adds ~500ms per round trip and the agent doesn't get full context until both complete.
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach (optional)
+      description: |
+        If you have an idea for how to implement this, describe it. If not, leave blank — we'd rather have a clear use case than a half-baked design. Skip "use vLLM" / "use Ollama" — we know about them and have specific reasons for being on MLX.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Other tools you tried, other workarounds, similar features in adjacent projects (vLLM, llama.cpp, Ollama, mlx-lm). Saying "I tried X and it failed because Y" makes the case stronger.
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware (if relevant)
+      description: Only required if the request is hardware-specific (e.g. "support unified memory >256GB", "use M4 efficiency cores").
+      placeholder: "e.g. MacBook Pro M3 Max, 64 GB"
+
+  - type: input
+    id: model
+    attributes:
+      label: Model (if relevant)
+      description: Only required if the request is about a specific model (e.g. "support DeepSeek-V4", "Gemma 4 tool calling").
+      placeholder: "e.g. mlx-community/Qwen3.5-Coder-32B-MLX-4bit"
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to contribute this?
+      description: Helps us prioritize — feature requests with a willing implementer move much faster.
+      options:
+        - "Yes, I can open a PR with guidance"
+        - "Yes, I can help test"
+        - "No, I'm just requesting"
+    validations:
+      required: true
+
   - type: textarea
     id: context
     attributes:
       label: Additional context
-      placeholder: Links, screenshots, related issues, etc.
+      placeholder: Links to upstream issues, related projects, papers, screenshots, prior discussions.

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,116 @@
+name: Performance Issue
+description: Report a slowdown, regression, or unexpectedly low throughput
+labels: ["performance"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for issues like "slow after upgrade", "low tok/s on model X", or "TTFT too high".
+
+        **We need a baseline to act on perf reports.** Without "before" numbers we can't tell a regression from expected hardware behavior. Please complete every required field — issues missing baseline data are usually closed.
+
+        For non-perf bugs (crashes, wrong output, broken tool calls), use **Bug Report** instead.
+
+  - type: input
+    id: current_version
+    attributes:
+      label: Current Rapid-MLX version (slow)
+      placeholder: "0.6.6 (run: rapid-mlx --version)"
+    validations:
+      required: true
+
+  - type: input
+    id: prior_version
+    attributes:
+      label: Prior version where speed was acceptable
+      description: If this is your first install, write "first install" — but then we have no regression to investigate.
+      placeholder: "e.g. 0.6.4, or 'first install'"
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      placeholder: "e.g. MacBook Pro M3 Max, 64 GB"
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      placeholder: "e.g. mlx-community/Qwen3.5-4B-MLX-4bit"
+    validations:
+      required: true
+
+  - type: input
+    id: serve_command
+    attributes:
+      label: Full serve command
+      description: Include every flag — KV quantization, prefix cache, pin-system-prompt, etc. all change perf.
+      placeholder: "rapid-mlx serve <model> --enable-prefix-cache --kv-cache-quantization ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: measurement_short
+    attributes:
+      label: Short prompt measurement (~500–2000 tokens)
+      description: |
+        Run the same short prompt and report numbers. This isolates compute-bound vs bandwidth-bound issues.
+      placeholder: |
+        Prompt tokens: 1500
+        TTFT: 0.8s
+        Decode: 45 tok/s
+        Output tokens: 200
+    validations:
+      required: true
+
+  - type: textarea
+    id: measurement_long
+    attributes:
+      label: Long prompt measurement (your actual workload)
+      description: The slow case you're reporting.
+      placeholder: |
+        Prompt tokens: 60000
+        TTFT: 121s
+        Decode: 5.9 tok/s
+        Output tokens: 800
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior_measurement
+    attributes:
+      label: Same measurement on prior version
+      description: |
+        Run the same long-prompt request on the prior version (downgrade with `brew install rapid-mlx@0.6.5` or pin via pip), report tok/s and TTFT.
+        If you can't downgrade, say why — but without a "before" number we can't confirm a regression.
+      placeholder: |
+        On 0.6.4 with same model + same 60K prompt:
+        TTFT: 95s
+        Decode: 18 tok/s
+    validations:
+      required: true
+
+  - type: textarea
+    id: server_logs
+    attributes:
+      label: Server logs around the slow request
+      description: Include `[schedule]`, `[Metal memory]`, `[cache_fetch/store]`, and the final `Chat completion` lines.
+      render: shell
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: Tested with a fresh server restart (no warm-up state)
+          required: true
+        - label: Confirmed model file is the same on both versions (not re-downloaded)
+          required: true
+        - label: Other macOS apps not competing for memory bandwidth (e.g. video calls, large builds)
+          required: true


### PR DESCRIPTION
## Summary

Two recent reports bypassed our bug_report form because GitHub still offered a "blank issue" link (no `config.yml`), and the existing form didn't have a path for performance issues — leading to reports without baselines (#177) or full repro details.

- **`config.yml`** — `blank_issues_enabled: false`, route open-ended questions to Discussions
- **`performance_issue.yml`** (new) — required fields: prior version, short + long prompt measurements, **prior-version baseline numbers**. Without baseline we can't tell a regression from expected hardware behavior.
- **`bug_report.yml`** — adds "last working version" + streaming/non-streaming dropdown; tightens repro guidance; makes log output required

## Test plan

- [x] All 6 YAML files parse with `yaml.safe_load`
- [ ] After merge: open a test issue to confirm GitHub renders the new templates and that "blank issue" is no longer offered