### PR TITLE
chore(lint): drop trailing blank lines in test_cloud_router.py

### DIFF
--- a/tests/test_cloud_router.py
+++ b/tests/test_cloud_router.py
@@ -423,5 +423,3 @@ class TestCloudRouterStreamCompletion:
 
         # Should only have [DONE] since all chunks have empty choices
         assert result_chunks == ["data: [DONE]\n\n"]
-
-


### PR DESCRIPTION
Pre-existing `ruff format --check` failure on main blocking CI on every open PR. 2-line fix.