### PR TITLE
fix(engine_core): route add_request through mlx-step worker (#170)

### DIFF
--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -154,6 +154,68 @@ class TestStepThread:
         finally:
             await engine_core.stop()
 
+    @pytest.mark.asyncio
+    async def test_add_request_routes_to_worker(self, engine_core, monkeypatch):
+        """add_request() MUST run scheduler.add_request on the mlx-step worker.
+
+        scheduler.add_request walks the prefix cache (memory_aware_cache.fetch
+        does copy.deepcopy of cached KV state, paged_cache.reconstruct_cache
+        materializes block tensors). Those allocations get tagged with the
+        calling thread's default stream. If add_request runs on the asyncio
+        loop thread, the cached KV ends up on a stream the mlx-step worker
+        cannot mx.eval against, and the next batch_generator.next() raises
+        "There is no Stream(gpu, N) in current thread" inside
+        `mx.eval([c.state for c in self.prompt_cache])`.
+
+        This is the third leg of the #170 fix (after #173 warmup and #174
+        model load). Without it, every text-only model with a populated
+        prefix cache (e.g. --pin-system-prompt loaded entries from disk,
+        or a prior request's system prompt) breaks on the next request.
+        """
+        from vllm_mlx import engine_core as ec
+
+        monkeypatch.setattr(ec, "_init_mlx_step_thread", lambda: None)
+
+        captured = {}
+
+        def fake_add_request(request):
+            captured["thread"] = threading.current_thread().name
+            captured["request_id"] = request.request_id
+
+        engine_core.scheduler.add_request.side_effect = fake_add_request
+
+        await engine_core.start()
+        try:
+            request_id = await engine_core.add_request("hello")
+            assert captured["request_id"] == request_id
+            assert captured["thread"].startswith("mlx-step"), (
+                f"add_request ran on {captured['thread']!r}, expected mlx-step worker. "
+                "If add_request runs on the asyncio loop thread, prefix-cache "
+                "KV deep-copies are tagged with the wrong stream and the next "
+                "step() crashes with 'There is no Stream(gpu, N) in current thread'."
+            )
+        finally:
+            await engine_core.stop()
+
+    @pytest.mark.asyncio
+    async def test_add_request_falls_back_when_executor_missing(self, engine_core):
+        """Without start(), add_request runs scheduler.add_request inline.
+
+        Sync test/CLI paths that build an EngineCore without calling start()
+        must still work — the caller will see whatever stream error MLX would
+        have raised, but no spurious AttributeError on `_mlx_executor`."""
+        captured = {}
+
+        def fake_add_request(request):
+            captured["thread"] = threading.current_thread().name
+
+        engine_core.scheduler.add_request.side_effect = fake_add_request
+
+        # Engine never started → _mlx_executor is None.
+        assert engine_core._mlx_executor is None
+        await engine_core.add_request("hello")
+        assert captured["thread"] == threading.current_thread().name
+
 
 class TestBatchedEngineWarmup:
     """#170 regression: BatchedEngine.generate_warmup() must run on the

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -437,8 +437,21 @@ class EngineCore:
         )
         self._finished_events[request_id] = asyncio.Event()
 
-        # Add to scheduler
-        self.scheduler.add_request(request)
+        # Dispatch to the mlx-step worker so any MLX arrays allocated during
+        # prefix cache lookup (memory_aware_cache.fetch deep-copies cached KV
+        # state, paged_cache.reconstruct_cache materializes block tensors,
+        # etc.) are tagged with the worker's default stream. Otherwise those
+        # arrays carry the asyncio loop thread's stream and the next
+        # batch_generator.next() raises "There is no Stream(gpu, N) in
+        # current thread" inside `mx.eval([c.state for c in self.prompt_cache])`.
+        # Complements the warmup/model-load fix in PR #173 / #174.
+        if self._mlx_executor is not None:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                self._mlx_executor, self.scheduler.add_request, request
+            )
+        else:
+            self.scheduler.add_request(request)
 
         return request_id
 


### PR DESCRIPTION
## Summary

Closes the third leg of the `Stream(gpu, N)` bug class for #170. PR #173 (warmup) and #174 (model load) covered the engine lifecycle paths; this PR covers the per-request hot path that breaks every text-only model with a populated prefix cache.

Reproducer: `MiniMax-M2.7-8bit` on rapid-mlx 0.6.6 with `--pin-system-prompt` (which loads prefix-cache entries from disk at startup → first request is a hit). Every request fails with `RuntimeError: There is no Stream(gpu, N) in current thread.` from inside `batch_generator.next()`. Also reproduces on 0.6.7 — the v0.6.7 release (#178) only touched the `tool_parsers/` tree and didn't change this code path.

## Root cause

`EngineCore.add_request()` ran `scheduler.add_request()` inline on the asyncio loop thread. `scheduler.add_request` walks the prefix cache:

- `memory_aware_cache.fetch` does `copy.deepcopy(entry.cache)` (`memory_cache.py:587`)
- `paged_cache.reconstruct_cache` materializes block tensors

mlx-lm 0.31.3+ tags every `mx.array` with the **calling thread's** default stream. With cache hits, those arrays end up tagged with the loop thread's stream. The next `batch_generator.next()` runs on the mlx-step worker and crashes inside `mx.eval([c.state for c in self.prompt_cache])`.

Symptom pattern matches expectation:

- Cold cache → first request misses (no MLX work in `fetch`) → succeeds
- Now cache has entries → second request hits → fails
- `--pin-system-prompt` pre-loads entries from disk → first request already hits → fails immediately

## What changed

- `vllm_mlx/engine_core.py`: dispatch `self.scheduler.add_request` through `_mlx_executor` via `loop.run_in_executor` (the same single-thread executor used for `step()`). Falls back to inline when no executor is bound — matches the pattern from `_run_on_step_thread()` (cache-save path, PR #167).
- `tests/test_engine_step_thread.py`: two regression tests in `TestStepThread` covering the dispatched path and the no-executor fallback.

## Test plan

- New regression tests pass (`test_add_request_routes_to_worker`, `test_add_request_falls_back_when_executor_missing`).
- Full `TestStepThread` + `TestBatchedEngineWarmup` (10/10 pass).
- `pytest tests/ --ignore=tests/integrations`: **1675 passed**, 9 pre-existing failures (4 `test_batching_deterministic` with the same `Stream(gpu, N)` class on the concurrent-batched code path with multiple `AsyncEngineCore` instances — *not addressed by this PR*; 4 `test_platform` with `ModuleNotFoundError: torch`; 1 `test_reasoning_parsers` parser assertion). All 9 reproduce on stock main (0.6.6 and 0.6.7) without this patch — none of them touch `engine_core.py`.
- `ruff check` + `ruff format` clean on both files.
- End-to-end on `MiniMax-M2.7-8bit` (230 GB MoE) with `--pin-system-prompt --kv-cache-quantization-bits 8 --max-num-seqs 2` and 2 prefix-cache entries pre-loaded from disk (worst case for triggering the bug): three back-to-back `/v1/chat/completions` all return HTTP 200, zero stream errors in the rapid-mlx log, generation at 33.6 tok/s. Subsequent two-back-to-back test confirmed the cache-hit path is fast (request 1: 2.5 s prefill + decode, request 2: 0.22 s with cached prefix).

## Out of scope

The 4 `test_batching_deterministic` failures appear to be a related bug in the concurrent-batched code path (multiple `AsyncEngineCore` instances per process). Pre-patch they fail at `Stream(gpu, 1)`; post-patch they fail at `Stream(gpu, 4)` — same root class, different code path. Worth a separate PR.
