### PR TITLE
fix(memory): scale Metal cache_limit by device working set

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -504,6 +504,16 @@ class TestMetalCacheLimit:
         soft = 4 * 1024**3
         assert _compute_metal_cache_limit(soft) == 2 * 1024**3
 
+    def test_clamps_to_soft_limit_on_pathological_tiny_devices(self):
+        """Even with the 2 GiB floor, never exceed soft_limit (MLX implicit
+        invariant: cache_limit defaults to memory_limit, suggesting cache ≤ memory).
+        """
+        from vllm_mlx.engine.batched import _compute_metal_cache_limit
+
+        # 1 GiB soft limit (no real Apple Silicon device — paranoid edge case)
+        soft = 1 * 1024**3
+        assert _compute_metal_cache_limit(soft) == soft
+
 
 @pytest.mark.asyncio
 class TestEngineAsync:

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -463,6 +463,48 @@ class TestEngineThreading:
         assert fake_generate.generation_stream == "default-stream:gpu"
 
 
+class TestMetalCacheLimit:
+    """Verify _compute_metal_cache_limit scales by device working-set size.
+
+    Hardcoded 32 GB worked on M3 Ultra (15% of soft limit) but consumed ~50%
+    on M2 Max 96GB, contributing to memory pressure for 35B models with long
+    sessions. New formula: 25% of soft limit, capped at 32GB, floored at 2GB.
+    """
+
+    def test_caps_at_32gb_on_big_machines(self):
+        from vllm_mlx.engine.batched import _compute_metal_cache_limit
+
+        # M3 Ultra 256GB: max_rec=239GB, soft=215GB → 25% would be 54GB → cap 32GB
+        soft = 215 * 1024**3
+        assert _compute_metal_cache_limit(soft) == 32 * 1024**3
+
+    def test_scales_down_on_m2_max_96gb(self):
+        from vllm_mlx.engine.batched import _compute_metal_cache_limit
+
+        # M2 Max 96GB: max_rec=72GB, soft=65GB → 25% = 16.25GB (was 32GB hardcoded)
+        soft = 65 * 1024**3
+        cache = _compute_metal_cache_limit(soft)
+        # Allow integer-division rounding
+        assert 16 * 1024**3 <= cache <= 17 * 1024**3
+        # Critically: must be less than the old 32GB
+        assert cache < 32 * 1024**3
+
+    def test_scales_down_on_m3_max_64gb(self):
+        from vllm_mlx.engine.batched import _compute_metal_cache_limit
+
+        # M3 Max 64GB: max_rec=48GB, soft=43GB → 25% = 10.75GB
+        soft = 43 * 1024**3
+        cache = _compute_metal_cache_limit(soft)
+        assert 10 * 1024**3 <= cache <= 11 * 1024**3
+
+    def test_floors_at_2gb_on_tiny_machines(self):
+        from vllm_mlx.engine.batched import _compute_metal_cache_limit
+
+        # Hypothetical 4GB machine: 25% = 1GB, floor 2GB
+        soft = 4 * 1024**3
+        assert _compute_metal_cache_limit(soft) == 2 * 1024**3
+
+
 @pytest.mark.asyncio
 class TestEngineAsync:
     """Async tests for the engine."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -22,6 +22,29 @@ from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
 
+
+def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
+    """Pick a Metal free-cache size that scales with the device's working set.
+
+    The free cache holds memory that was freed by Python objects but not yet
+    returned to the GPU. A larger cache speeds up subsequent allocations
+    (KV cache churn, prefix cache moves) but reserves memory that inference
+    cannot use.
+
+    Old behavior (hardcoded 32 GB) was sized for big machines: comfortable on
+    M3 Ultra 256GB (15% of soft limit), but consumed ~50% of the soft limit
+    on M2 Max 96GB, leaving insufficient room for a 35B model + accumulated
+    prefix cache. Small machines hit memory pressure → catastrophic slowdown.
+
+    Scale to 25% of the soft allocation limit, capped at 32 GB (no change for
+    big machines), floored at 2 GB (avoid degenerate cache on tiny machines).
+    """
+    return max(
+        2 * 1024 * 1024 * 1024,
+        min(32 * 1024 * 1024 * 1024, soft_limit_bytes // 4),
+    )
+
+
 # Check for guided generation availability
 try:
     from ..api.guided import GuidedGenerator, is_guided_available
@@ -363,13 +386,14 @@ class BatchedEngine(BaseEngine):
             if max_recommended > 0:
                 soft_limit = int(max_recommended * self._gpu_memory_utilization)
                 mx.set_memory_limit(soft_limit)
-                mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                cache_limit = _compute_metal_cache_limit(soft_limit)
+                mx.set_cache_limit(cache_limit)
                 pct = self._gpu_memory_utilization * 100
                 logger.info(
                     f"Metal memory limits set: "
                     f"allocation_limit={soft_limit / 1e9:.1f}GB "
                     f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
-                    f"cache_limit=32GB"
+                    f"cache_limit={cache_limit / 1e9:.1f}GB"
                 )
 
         try:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -28,21 +28,25 @@ def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
 
     The free cache holds memory that was freed by Python objects but not yet
     returned to the GPU. A larger cache speeds up subsequent allocations
-    (KV cache churn, prefix cache moves) but reserves memory that inference
-    cannot use.
+    (KV cache churn, prefix cache moves) but caps the budget that inference
+    can grow into under load.
 
     Old behavior (hardcoded 32 GB) was sized for big machines: comfortable on
-    M3 Ultra 256GB (15% of soft limit), but consumed ~50% of the soft limit
-    on M2 Max 96GB, leaving insufficient room for a 35B model + accumulated
-    prefix cache. Small machines hit memory pressure → catastrophic slowdown.
+    M3 Ultra 256GB (15% of soft limit), but allowed cache to grow to ~50% of
+    the soft limit on M2 Max 96GB, leaving insufficient room for a 35B model
+    + accumulated prefix cache + transient prefill allocations. Small machines
+    hit memory pressure → macOS paging → catastrophic slowdown.
 
-    Scale to 25% of the soft allocation limit, capped at 32 GB (no change for
-    big machines), floored at 2 GB (avoid degenerate cache on tiny machines).
+    Scale to 25% of the soft allocation limit, capped at 32 GiB (no change for
+    big machines), floored at 2 GiB (avoid degenerate cache on small machines).
+    Clamp to soft_limit to preserve MLX's implicit cache ≤ memory invariant on
+    pathologically tiny devices.
     """
-    return max(
+    cache = max(
         2 * 1024 * 1024 * 1024,
         min(32 * 1024 * 1024 * 1024, soft_limit_bytes // 4),
     )
+    return min(cache, soft_limit_bytes) if soft_limit_bytes > 0 else cache
 
 
 # Check for guided generation availability


### PR DESCRIPTION
## Why

Hypothesis test for #177 (westNeighbor's 24x slowdown on M2 Max 96GB after upgrade to 0.6.6).

**Empirical bench: 0.6.5 vs 0.6.6 head-to-head on M3 Ultra 256GB shows ZERO regression** (both 92.3 tok/s on Qwen3.6-35B-A3B-4bit, identical to within 0.1 tok/s). So the slowdown is NOT a 0.6.6 code regression. But there's a real, version-independent config bug that plausibly explains the M2 Max symptom:

\`\`\`python
mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # hardcoded 32 GB
\`\`\`

The 32 GB Metal free-cache is sized for big machines. Memory math:

| Machine | max_recommended | Soft (90%) | Cache as % of soft |
|---|---|---|---|
| **M2 Max 96GB** | 72 GB | 65 GB | **49%** ⚠️ |
| M3 Max 64GB | 48 GB | 43 GB | **74%** ⚠️ |
| M3 Max 128GB | 96 GB | 86 GB | 37% |
| M2 Ultra 192GB | 144 GB | 130 GB | 25% |
| M3 Ultra 256GB | 239 GB | 215 GB | 15% |

On M2 Max 96 GB, the Metal cache reserves nearly half the working set. Combined with a 20 GB model + 10–12 GB accumulated prefix cache + active KV during decode, the system hits the memory ceiling → macOS paging/compression → catastrophic slowdown for long-running sessions. **Same behavior in 0.6.5 and 0.6.6** — westNeighbor likely just grew into the failure mode (longer chats, larger prefix cache) and blamed the upgrade due to time-correlation.

## Fix

Scale \`cache_limit\` to 25% of soft allocation limit, capped at 32 GB (no change for big machines), floored at 2 GB:

\`\`\`python
def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
    return max(
        2 * 1024 * 1024 * 1024,
        min(32 * 1024 * 1024 * 1024, soft_limit_bytes // 4),
    )
\`\`\`

| Machine | Old cache | New cache | Freed for inference |
|---|---|---|---|
| M2 Max 96GB | 32 GiB | 16 GiB | +16 GB |
| M3 Max 64GB | 32 GiB | 11 GiB | +21 GB (was over-allocated) |
| M3 Max 128GB | 32 GiB | 22 GiB | +10 GB |
| M2 Ultra 192GB | 32 GiB | 32 GiB | no change |
| M3 Ultra 256GB | 32 GiB | 32 GiB | no change |

## Validation

- 4 new unit tests (\`TestMetalCacheLimit\`): scaling formula across device sizes — pass
- Full \`tests/test_batching.py\`: 24 pass (pre-existing 2 deselected) — pass
- Bench on M3 Ultra (cap kicks in, behavior unchanged): 10 reqs @ 96.3 tok/s, 1.00x stable ratio
- Cannot validate on M2 Max (don't have one). Fix is plausible based on memory math; needs westNeighbor to confirm

## Test plan

- [x] Unit tests for scaling formula
- [x] Bench on M3 Ultra (no regression, cap kicks in)
- [ ] User #177 reports back after upgrading

🤖 Generated with [Claude Code](https://claude.com/claude-code)