### PR TITLE
fix(prefix-cache): atomic snapshot + load-time validation to stop poisoning

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -458,26 +458,37 @@ def test_save_handles_trailing_slash_in_cache_dir(tmp_path):
     assert c2.load_from_disk(str(cache_dir) + "/") == 1
 
 
-def test_load_into_non_empty_cache_is_rejected(tmp_path):
-    """Calling load_from_disk on a populated cache would double-count
-    memory and corrupt _sorted_keys (bisect.insort would create
-    duplicate entries). Refuse rather than silently break invariants.
+def test_load_into_non_empty_cache_skips_duplicates(tmp_path):
+    """If load_from_disk is called on a cache that already contains some
+    keys (e.g. populated by warmup before lifespan calls load), entries
+    whose tokens_key matches an in-memory entry must be skipped — not
+    re-inserted. Otherwise bisect.insort produces duplicate keys in
+    _sorted_keys and _current_memory double-counts.
     """
     cache_dir = tmp_path / "snap"
-    c1 = fresh_cache()
-    c1.store(list(range(11)), make_kvcache(num_tokens=11))
-    c1.save_to_disk(str(cache_dir))
+    # Persist two entries to disk: one duplicates a future in-memory
+    # entry; one is fresh.
+    persisted = fresh_cache()
+    persisted.store(list(range(11)), make_kvcache(num_tokens=11))
+    persisted.store(list(range(50, 61)), make_kvcache(num_tokens=11, fill=2.0))
+    persisted.save_to_disk(str(cache_dir))
 
-    c2 = fresh_cache()
-    c2.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
-    before_mem = c2._current_memory
-    before_keys = list(c2._sorted_keys)
+    # Simulated warmup state: the [0..10] entry is already in memory.
+    runtime = fresh_cache()
+    runtime.store(list(range(11)), make_kvcache(num_tokens=11))
+    warmup_mem = runtime._current_memory
+    warmup_keys = list(runtime._sorted_keys)
 
-    loaded = c2.load_from_disk(str(cache_dir))
-    assert loaded == 0
-    # State unchanged — no duplicate insertion
-    assert c2._current_memory == before_mem
-    assert c2._sorted_keys == before_keys
+    loaded = runtime.load_from_disk(str(cache_dir))
+    assert loaded == 1, "exactly one fresh entry should have been loaded"
+    # The duplicate did not double-insert
+    assert runtime._sorted_keys.count(tuple(range(11))) == 1
+    assert tuple(range(50, 61)) in runtime._sorted_keys
+    # Memory grew by exactly the new entry's footprint
+    new_entry_mem = runtime._current_memory - warmup_mem
+    assert new_entry_mem > 0
+    # Pre-existing entry untouched in keys list ordering wrt itself
+    assert warmup_keys[0] in runtime._sorted_keys
 
 
 def test_save_routes_writes_through_staging_dir(tmp_path, monkeypatch):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -277,25 +277,38 @@ def test_severely_truncated_safetensors_is_silently_skipped(tmp_path):
 
 
 def test_body_truncated_safetensors_should_fail_eagerly_at_load(tmp_path):
-    """BUG D — load_from_disk must eagerly materialize tensors so a body-
-    truncated safetensors raises here, not later in a worker thread.
+    """BUG D — load_from_disk must reject a body-truncated safetensors
+    even though ``mx.load`` will lazily mmap it without complaint.
     """
+    import struct
+
     cache = fresh_cache()
     cache.store(list(range(11)), make_kvcache(num_tokens=11))
     cache.save_to_disk(str(tmp_path))
 
-    # Cut just the trailing bytes (body), leaving the safetensors header valid.
     sf = tmp_path / "entry_0.safetensors"
     full = sf.read_bytes()
-    # Drop the last 100 bytes — header survives, tensor body is truncated.
-    sf.write_bytes(full[:-100])
+
+    # Compute the maximum data offset declared by the header so we can
+    # truncate strictly inside the body region — guards against future
+    # changes to padding/alignment in save_prompt_cache.
+    header_len = struct.unpack("<Q", full[:8])[0]
+    header = json.loads(full[8 : 8 + header_len])
+    max_end = max(
+        meta["data_offsets"][1]
+        for name, meta in header.items()
+        if name != "__metadata__"
+    )
+    declared_total = 8 + header_len + max_end
+    cut_to = declared_total - 100
+    assert cut_to > 8 + header_len, (
+        "test setup: cut would land in the header region, not the body — "
+        "use a larger entry"
+    )
+    sf.write_bytes(full[:cut_to])
 
     cache2 = fresh_cache()
     loaded = cache2.load_from_disk(str(tmp_path))
-
-    # CORRECT BEHAVIOR (xfail): load_from_disk should refuse a body-truncated
-    # entry. Currently it succeeds because mx.load is lazy — the corruption
-    # only surfaces later, at the first attention call.
     assert loaded == 0, (
         "Body-truncated safetensors was loaded as a usable cache entry. "
         "It will blow up later at attention time with a RuntimeError, "
@@ -392,6 +405,79 @@ def test_load_cleans_orphan_staging_dirs(tmp_path):
     assert loaded == 1
     assert not new_dir.exists()
     assert not old_dir.exists()
+
+
+def test_partial_new_index_json_is_not_promoted(tmp_path):
+    """If .new/index.json exists but is corrupt JSON (e.g. crash mid
+    json.dump), recovery must NOT promote .new — fall back to .old or
+    leave cache_dir absent rather than handing the partial snapshot
+    to subsequent json.load.
+    """
+    cache_dir = tmp_path / "snap"
+    new_dir = tmp_path / "snap.new"
+    old_dir = tmp_path / "snap.old"
+
+    # Build a valid snapshot at .old (the previous committed state)
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    c1.save_to_disk(str(cache_dir))
+    cache_dir.rename(old_dir)
+
+    # Hand-craft a .new with a *partial* index.json (simulates crash
+    # in the middle of json.dump).
+    new_dir.mkdir()
+    (new_dir / "index.json").write_text('{"versi')
+
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    # Should fall through to .old, recovering the previous snapshot
+    assert loaded == 1
+    entry = next(iter(c2._entries.values()))
+    assert entry.tokens == tuple(range(11))
+
+
+def test_save_handles_trailing_slash_in_cache_dir(tmp_path):
+    """A user-supplied cache_dir with a trailing separator must still
+    swap atomically. Without the rstrip in save_to_disk, ``cache_dir +
+    '.new'`` would become a *child* of cache_dir rather than a sibling,
+    silently breaking the swap.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.save_to_disk(str(cache_dir) + "/")
+
+    # The committed snapshot lives at cache_dir, NOT cache_dir/.new
+    assert cache_dir.exists()
+    assert (cache_dir / "index.json").exists()
+    assert not (cache_dir / ".new").exists()
+    assert not (tmp_path / "snap/.new").exists()
+
+    # Round-trips with trailing slash on load too.
+    c2 = fresh_cache()
+    assert c2.load_from_disk(str(cache_dir) + "/") == 1
+
+
+def test_load_into_non_empty_cache_is_rejected(tmp_path):
+    """Calling load_from_disk on a populated cache would double-count
+    memory and corrupt _sorted_keys (bisect.insort would create
+    duplicate entries). Refuse rather than silently break invariants.
+    """
+    cache_dir = tmp_path / "snap"
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    c1.save_to_disk(str(cache_dir))
+
+    c2 = fresh_cache()
+    c2.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
+    before_mem = c2._current_memory
+    before_keys = list(c2._sorted_keys)
+
+    loaded = c2.load_from_disk(str(cache_dir))
+    assert loaded == 0
+    # State unchanged — no duplicate insertion
+    assert c2._current_memory == before_mem
+    assert c2._sorted_keys == before_keys
 
 
 def test_save_routes_writes_through_staging_dir(tmp_path, monkeypatch):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1,0 +1,430 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reproduction tests for prefix-cache disk-persistence corruption bugs.
+
+Failure modes documented here (see analysis 2026-05-03):
+
+A. Stale ``index.json`` + freshly-overwritten ``entry_i.*`` files —
+   if a server is killed mid-shutdown after rewriting some entry files
+   but before ``index.json`` is rewritten, the next start loads using
+   the stale ``num_tokens`` field. ``arr.fromfile(f, num_tokens_old)``
+   silently truncates the new tokens.bin, producing an entry whose
+   ``tokens_key`` length disagrees with ``cache.offset``. Subsequent
+   fetches return that mismatched cache to the scheduler, which
+   appends new tokens at the wrong position → garbage attention →
+   token-id-0 collapse (``!!!!!`` in user output).
+
+B. Orphan files from a previous save are not removed when the next
+   save writes fewer entries. They sit on disk indefinitely; the next
+   crash that interrupts ``save_to_disk`` mid-rewrite turns them into
+   the inconsistency described in (A).
+
+C. ``mx.save_safetensors`` is called directly on the target path
+   (no ``.tmp`` + rename), so a SIGKILL during a single-entry write
+   leaves a half-written safetensors. ``mx.load`` will usually raise
+   on it (caught and dropped silently), but combined with (A) it can
+   amplify the inconsistency.
+
+D. ``mx.load`` is lazy — it parses the header and returns array
+   handles without materializing data. A safetensors with a valid
+   header but truncated body passes ``load_from_disk`` silently and
+   is registered as a usable cache entry. The corruption only
+   surfaces at the first attention call, often inside a worker thread
+   where the RuntimeError can be swallowed.
+
+These tests use real ``mlx_lm`` ``KVCache`` objects with very small
+tensors (1×4×N×8 fp16) so they run fast (<1s each).
+"""
+
+from __future__ import annotations
+
+import array
+import json
+import os
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+KVCache = pytest.importorskip("mlx_lm.models.cache").KVCache
+save_prompt_cache = pytest.importorskip("mlx_lm.models.cache").save_prompt_cache
+
+from vllm_mlx.memory_cache import (  # noqa: E402
+    MemoryAwarePrefixCache,
+    MemoryCacheConfig,
+)
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def make_kvcache(num_tokens: int, *, n_layers: int = 2, fill: float = 1.0) -> list:
+    """Build a populated ``mlx_lm`` KVCache list with ``num_tokens`` positions.
+
+    Tiny shape (1, 4, num_tokens, 8) fp16 keeps per-entry I/O <1 KB so
+    these tests stay fast.
+    """
+    layers = []
+    for layer_idx in range(n_layers):
+        c = KVCache()
+        keys = mx.full((1, 4, num_tokens, 8), fill + layer_idx, dtype=mx.float16)
+        values = mx.full((1, 4, num_tokens, 8), -(fill + layer_idx), dtype=mx.float16)
+        c.update_and_fetch(keys, values)
+        layers.append(c)
+    return layers
+
+
+def fresh_cache() -> MemoryAwarePrefixCache:
+    """Build a small in-memory cache for testing."""
+    return MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100),
+    )
+
+
+def write_entry_files(
+    cache_dir: str, entry_idx: int, tokens: list[int], kv_layers: list
+) -> None:
+    """Write a single (safetensors + tokens.bin) pair, mimicking save_to_disk."""
+    save_prompt_cache(
+        os.path.join(cache_dir, f"entry_{entry_idx}.safetensors"),
+        kv_layers,
+        metadata={"num_tokens": str(len(tokens))},
+    )
+    arr = array.array("i", tokens)
+    with open(os.path.join(cache_dir, f"entry_{entry_idx}_tokens.bin"), "wb") as f:
+        arr.tofile(f)
+
+
+# --------------------------------------------------------------------------
+# Sanity check — clean roundtrip works
+# --------------------------------------------------------------------------
+
+
+def test_clean_roundtrip_save_then_load(tmp_path):
+    """Sanity: clean save → load → entry preserved."""
+    cache = fresh_cache()
+    tokens = list(range(11))
+    cache.store(tokens, make_kvcache(num_tokens=11))
+    assert cache.save_to_disk(str(tmp_path)) is True
+
+    cache2 = fresh_cache()
+    loaded = cache2.load_from_disk(str(tmp_path))
+    assert loaded == 1
+
+    entry = next(iter(cache2._entries.values()))
+    assert entry.tokens == tuple(tokens)
+    # Must hold for any well-formed entry: KV state is exactly as long
+    # as the token sequence it claims to represent.
+    assert entry.cache[0].offset == len(entry.tokens)
+
+
+# --------------------------------------------------------------------------
+# BUG A — stale index.json + overwritten entry files = poisoned tokens_key
+# --------------------------------------------------------------------------
+
+
+def test_stale_index_with_overwritten_entry_loads_without_error(tmp_path):
+    """BUG A — load must reject (or normalize) entries whose tokens.bin
+    size disagrees with the index.json claim. Such entries are the
+    fingerprint of a previous interrupted save_to_disk.
+    """
+    # --- session 1: clean save with one entry of 11 tokens
+    cache_v1 = fresh_cache()
+    tokens_v1 = list(range(11))
+    cache_v1.store(tokens_v1, make_kvcache(num_tokens=11))
+    cache_v1.save_to_disk(str(tmp_path))
+
+    # Sanity: index claims num_tokens=11
+    index = json.loads((tmp_path / "index.json").read_text())
+    assert index["entries"][0]["num_tokens"] == 11
+
+    # --- session 2: simulate kill DURING save_to_disk —
+    # entry_0 files get rewritten with a longer 20-token payload,
+    # but the process dies before index.json is rewritten.
+    tokens_v2 = list(range(100, 120))  # 20 fresh tokens
+    write_entry_files(str(tmp_path), 0, tokens_v2, make_kvcache(num_tokens=20))
+
+    # index.json untouched — still says num_tokens=11
+    index_after = json.loads((tmp_path / "index.json").read_text())
+    assert index_after["entries"][0]["num_tokens"] == 11
+
+    # --- session 3: load — the size-mismatch check must reject entry_0,
+    # since tokens.bin is now 80 bytes (20 ints) but index.json claims 11.
+    cache_v3 = fresh_cache()
+    loaded = cache_v3.load_from_disk(str(tmp_path))
+    assert loaded == 0, (
+        "loader accepted an entry whose tokens.bin size disagrees with "
+        "index.json's num_tokens — that's the BUG A poisoning vector"
+    )
+    assert len(cache_v3._entries) == 0
+
+    # If any entry did slip through, its invariant must hold.
+    for entry in cache_v3._entries.values():
+        assert len(entry.tokens) == entry.cache[0].offset
+
+
+def test_poisoned_entry_returns_misaligned_cache_via_fetch(tmp_path):
+    """BUG A user-visible effect — a poisoned entry must NOT reach fetch().
+
+    If the loader rejects it (correct), fetch returns None / no match.
+    If a future regression lets one through, the returned cache.offset
+    must at least equal the matched-prefix length so the scheduler
+    appends tokens at the right position.
+    """
+    # Set up the same poisoned state as the previous test.
+    cache_v1 = fresh_cache()
+    cache_v1.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache_v1.save_to_disk(str(tmp_path))
+
+    # Overwrite entry_0 with 20-token content; leave index.json stale.
+    tokens_v2 = list(range(100, 120))
+    write_entry_files(str(tmp_path), 0, tokens_v2, make_kvcache(num_tokens=20))
+
+    cache_v3 = fresh_cache()
+    cache_v3.load_from_disk(str(tmp_path))
+
+    # User sends a prompt that begins with the (would-be-truncated) cached prefix.
+    prompt = list(range(100, 111)) + [777, 888, 999]
+    kv, remaining = cache_v3.fetch(prompt)
+
+    if kv is None:
+        # Correct path: poisoned entry was rejected at load_from_disk;
+        # fetch sees an empty cache and returns a clean miss.
+        assert remaining == prompt
+        return
+
+    # If for some reason an entry slipped through, the returned cache
+    # offset must match the matched-prefix length.
+    matched_len = len(prompt) - len(remaining)
+    returned_offset = kv[0].offset
+    assert returned_offset == matched_len, (
+        f"fetch returned cache with offset={returned_offset} for "
+        f"matched_len={matched_len} prefix. Scheduler would write next "
+        f"token at the wrong position."
+    )
+
+
+# --------------------------------------------------------------------------
+# BUG B — orphan files from a previous save are not cleaned up
+# --------------------------------------------------------------------------
+
+
+def test_save_to_disk_removes_orphans_from_previous_save(tmp_path):
+    """BUG B — directory-rename swap must leave no orphan entry files."""
+    # --- session 1: 5 entries
+    cache_v1 = fresh_cache()
+    for i in range(5):
+        cache_v1.store(
+            list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11, fill=i + 1)
+        )
+    cache_v1.save_to_disk(str(tmp_path))
+
+    # --- session 2: only 2 entries (fresh cache, simulates eviction)
+    cache_v2 = fresh_cache()
+    for i in range(2):
+        cache_v2.store(
+            list(range(500 + i * 100, 500 + i * 100 + 11)),
+            make_kvcache(num_tokens=11, fill=i + 10),
+        )
+    cache_v2.save_to_disk(str(tmp_path))
+
+    # New index.json reflects only 2 entries
+    index = json.loads((tmp_path / "index.json").read_text())
+    assert index["num_entries"] == 2
+
+    # CORRECT BEHAVIOR (xfail): orphan entry_2..entry_4 from session 1
+    # must be removed so a future crash mid-save can't resurrect them.
+    for i in range(2, 5):
+        sf = tmp_path / f"entry_{i}.safetensors"
+        tk = tmp_path / f"entry_{i}_tokens.bin"
+        assert not sf.exists(), (
+            f"orphan {sf.name} from previous save was not cleaned up — "
+            f"this is the precondition that turns a half-written next save "
+            f"into BUG A."
+        )
+        assert not tk.exists(), f"orphan {tk.name} not cleaned up"
+
+
+# --------------------------------------------------------------------------
+# Characterization tests — document current behavior (no xfail)
+# --------------------------------------------------------------------------
+
+
+def test_severely_truncated_safetensors_is_silently_skipped(tmp_path):
+    """Document current behavior: a header-corrupt .safetensors is dropped silently.
+
+    This is *acceptable* on its own (the entry just won't be used), but
+    no structured signal is propagated upward — operators have no way
+    to notice gradual cache decay. Once the diagnostic-counter fix
+    (P3 in the analysis) lands, this test should also assert that
+    ``loaded`` returns a (loaded, skipped) tuple or that a structured
+    warning was emitted.
+    """
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.save_to_disk(str(tmp_path))
+
+    # Truncate aggressively (16 bytes — far short of safetensors header)
+    sf = tmp_path / "entry_0.safetensors"
+    sf.write_bytes(sf.read_bytes()[:16])
+
+    # Load: must not raise, just skip
+    cache2 = fresh_cache()
+    loaded = cache2.load_from_disk(str(tmp_path))
+    assert loaded == 0
+    assert len(cache2._entries) == 0
+
+
+def test_body_truncated_safetensors_should_fail_eagerly_at_load(tmp_path):
+    """BUG D — load_from_disk must eagerly materialize tensors so a body-
+    truncated safetensors raises here, not later in a worker thread.
+    """
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.save_to_disk(str(tmp_path))
+
+    # Cut just the trailing bytes (body), leaving the safetensors header valid.
+    sf = tmp_path / "entry_0.safetensors"
+    full = sf.read_bytes()
+    # Drop the last 100 bytes — header survives, tensor body is truncated.
+    sf.write_bytes(full[:-100])
+
+    cache2 = fresh_cache()
+    loaded = cache2.load_from_disk(str(tmp_path))
+
+    # CORRECT BEHAVIOR (xfail): load_from_disk should refuse a body-truncated
+    # entry. Currently it succeeds because mx.load is lazy — the corruption
+    # only surfaces later, at the first attention call.
+    assert loaded == 0, (
+        "Body-truncated safetensors was loaded as a usable cache entry. "
+        "It will blow up later at attention time with a RuntimeError, "
+        "likely inside a worker thread."
+    )
+
+
+# --------------------------------------------------------------------------
+# Crash-recovery for interrupted save_to_disk swap
+# --------------------------------------------------------------------------
+
+
+def test_load_recovers_from_swap_interrupted_after_first_rename(tmp_path):
+    """If the process died after ``cache_dir → .old`` but before
+    ``.new → cache_dir``, load_from_disk must promote ``.new`` because
+    it holds the freshly-committed snapshot.
+    """
+    cache_dir = tmp_path / "snap"
+    new_dir = tmp_path / "snap.new"
+    old_dir = tmp_path / "snap.old"
+
+    # Snapshot 1 → ends up at .old (simulates the first rename of the swap)
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    c1.save_to_disk(str(cache_dir))
+    cache_dir.rename(old_dir)
+
+    # Snapshot 2 built in a side dir, then placed at .new (simulates the
+    # staging dir of an interrupted save — done writing, swap not yet
+    # finished). Using a side dir avoids triggering the next save's
+    # pre-clean of .old.
+    side_dir = tmp_path / "side"
+    c2 = fresh_cache()
+    c2.store(list(range(50, 65)), make_kvcache(num_tokens=15, fill=2.0))
+    c2.save_to_disk(str(side_dir))
+    side_dir.rename(new_dir)
+
+    assert not cache_dir.exists()
+    assert new_dir.exists()
+    assert old_dir.exists()
+
+    # Load: should promote .new to cache_dir, drop .old
+    c3 = fresh_cache()
+    loaded = c3.load_from_disk(str(cache_dir))
+    assert loaded == 1
+    assert cache_dir.exists()
+    assert not new_dir.exists()
+    assert not old_dir.exists()
+    entry = next(iter(c3._entries.values()))
+    assert entry.tokens == tuple(range(50, 65))
+
+
+def test_load_recovers_from_swap_interrupted_with_only_old(tmp_path):
+    """If only ``.old`` survives (e.g. ``.new`` was never finalized),
+    load_from_disk must restore ``.old`` to ``cache_dir``.
+    """
+    cache_dir = tmp_path / "snap"
+    c1 = fresh_cache()
+    c1.store(list(range(7)), make_kvcache(num_tokens=7))
+    c1.save_to_disk(str(cache_dir))
+
+    # Simulate crash mid-swap with no .new survivor
+    cache_dir.rename(tmp_path / "snap.old")
+    assert not cache_dir.exists()
+
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    assert loaded == 1
+    assert cache_dir.exists()
+    entry = next(iter(c2._entries.values()))
+    assert entry.tokens == tuple(range(7))
+
+
+def test_load_cleans_orphan_staging_dirs(tmp_path):
+    """If ``cache_dir`` exists alongside leftover ``.new`` / ``.old``
+    staging dirs, load_from_disk must wipe the orphans so the next
+    save starts from a clean slate.
+    """
+    cache_dir = tmp_path / "snap"
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    c1.save_to_disk(str(cache_dir))
+
+    # Sprinkle leftover staging dirs
+    new_dir = tmp_path / "snap.new"
+    old_dir = tmp_path / "snap.old"
+    new_dir.mkdir()
+    (new_dir / "leftover.txt").write_text("orphan")
+    old_dir.mkdir()
+    (old_dir / "leftover.txt").write_text("orphan")
+
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    assert loaded == 1
+    assert not new_dir.exists()
+    assert not old_dir.exists()
+
+
+def test_save_routes_writes_through_staging_dir(tmp_path, monkeypatch):
+    """Atomicity invariant: save_safetensors must be called with a path
+    inside a sibling ``<cache_dir>.new`` staging directory, not directly
+    inside ``cache_dir``. The directory-rename swap is what makes the
+    snapshot all-or-nothing.
+    """
+    seen_paths: list[str] = []
+
+    real_save = mx.save_safetensors
+
+    def spy(path, *args, **kwargs):
+        seen_paths.append(path)
+        return real_save(path, *args, **kwargs)
+
+    monkeypatch.setattr("mlx.core.save_safetensors", spy)
+
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.save_to_disk(str(cache_dir))
+
+    assert seen_paths, "save_safetensors was never called"
+    expected_staging = str(cache_dir) + ".new"
+    for p in seen_paths:
+        assert p.startswith(expected_staging + os.sep), (
+            f"save_safetensors called with {p!r}, expected to be inside "
+            f"{expected_staging!r}. Direct writes into the committed "
+            f"cache_dir defeat the atomic-snapshot guarantee."
+        )
+
+    # After save returns, the staging dir is gone (renamed into place).
+    assert not (tmp_path / "snap.new").exists()
+    assert (cache_dir / "index.json").exists()
+    assert (cache_dir / "entry_0.safetensors").exists()

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -491,6 +491,78 @@ def test_load_into_non_empty_cache_skips_duplicates(tmp_path):
     assert warmup_keys[0] in runtime._sorted_keys
 
 
+def test_recovery_rejects_new_with_index_but_no_entry_files(tmp_path):
+    """If ``.new/index.json`` references entries but the entry files are
+    missing on disk (manual deletion, fs corruption, partial restore),
+    recovery must NOT promote ``.new``. Doing so would discard ``.old``
+    in favor of an empty snapshot — net data loss.
+    """
+    cache_dir = tmp_path / "snap"
+    new_dir = tmp_path / "snap.new"
+    old_dir = tmp_path / "snap.old"
+
+    # Build a real, complete snapshot in .old
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    c1.save_to_disk(str(cache_dir))
+    cache_dir.rename(old_dir)
+
+    # Hand-craft a .new with valid-looking index.json but NO entry files
+    new_dir.mkdir()
+    (new_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "num_entries": 1,
+                "total_memory_bytes": 12345,
+                "entries": [{"index": 0, "num_tokens": 11, "memory_bytes": 12345}],
+            }
+        )
+    )
+
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    # Recovery should fall through to .old, not silently lose the snapshot
+    assert loaded == 1, "recovery promoted an empty .new and lost .old"
+    entry = next(iter(c2._entries.values()))
+    assert entry.tokens == tuple(range(11))
+
+
+def test_load_dedup_check_runs_before_safetensors_load(tmp_path, monkeypatch):
+    """Performance + memory: a tokens_key that's already in the in-memory
+    cache must skip ``load_prompt_cache`` entirely. Otherwise every
+    duplicate entry mmaps its safetensors only to discard it — wastes
+    file descriptors, memory, and time.
+    """
+    cache_dir = tmp_path / "snap"
+    persisted = fresh_cache()
+    persisted.store(list(range(11)), make_kvcache(num_tokens=11))
+    persisted.save_to_disk(str(cache_dir))
+
+    # Spy on load_prompt_cache to count calls
+    import mlx_lm.models.cache as mlx_cache_mod
+
+    real_load = mlx_cache_mod.load_prompt_cache
+    call_count = {"n": 0}
+
+    def spy(path):
+        call_count["n"] += 1
+        return real_load(path)
+
+    monkeypatch.setattr(mlx_cache_mod, "load_prompt_cache", spy)
+    monkeypatch.setattr("vllm_mlx.memory_cache.load_prompt_cache", spy, raising=False)
+
+    runtime = fresh_cache()
+    runtime.store(list(range(11)), make_kvcache(num_tokens=11))
+    loaded = runtime.load_from_disk(str(cache_dir))
+
+    assert loaded == 0, "the only persisted entry was a duplicate"
+    assert call_count["n"] == 0, (
+        f"load_prompt_cache should not be called for duplicates "
+        f"(was called {call_count['n']} time(s))"
+    )
+
+
 def test_save_routes_writes_through_staging_dir(tmp_path, monkeypatch):
     """Atomicity invariant: save_safetensors must be called with a path
     inside a sibling ``<cache_dir>.new`` staging directory, not directly

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1183,17 +1183,6 @@ class MemoryAwarePrefixCache:
         import shutil
         import time as _time
 
-        # load_from_disk is intended for a fresh, empty cache (lifespan
-        # startup). Refuse to merge into an already-populated one rather
-        # than silently double-counting memory or producing duplicate
-        # entries in _sorted_keys.
-        if self._entries:
-            logger.warning(
-                "[cache_persist] load_from_disk called on a non-empty cache — "
-                "skipping to avoid duplicate accounting"
-            )
-            return 0
-
         # Strip trailing separators (see save_to_disk for rationale).
         cache_dir = cache_dir.rstrip(os.sep)
         new_dir = cache_dir + ".new"
@@ -1261,7 +1250,8 @@ class MemoryAwarePrefixCache:
             return 0
 
         loaded = 0
-        skipped = 0
+        corrupt_skipped = 0
+        duplicate_skipped = 0
         for entry_meta in index.get("entries", []):
             i = entry_meta["index"]
             expected_num_tokens = entry_meta["num_tokens"]
@@ -1270,7 +1260,7 @@ class MemoryAwarePrefixCache:
 
             if not os.path.exists(entry_path) or not os.path.exists(tokens_path):
                 logger.warning(f"[cache_persist] missing files for entry {i}, skipping")
-                skipped += 1
+                corrupt_skipped += 1
                 continue
 
             # Cross-check tokens.bin size against index.json's claim.
@@ -1284,7 +1274,7 @@ class MemoryAwarePrefixCache:
                     f"(expected {expected_bytes} bytes for {expected_num_tokens} "
                     f"tokens, got {actual_bytes}) — corruption, skipping"
                 )
-                skipped += 1
+                corrupt_skipped += 1
                 continue
 
             # mx.load mmaps safetensors lazily and will silently return
@@ -1296,7 +1286,7 @@ class MemoryAwarePrefixCache:
                     f"[cache_persist] entry {i} safetensors body is short of "
                     f"its header's declared data range — corruption, skipping"
                 )
-                skipped += 1
+                corrupt_skipped += 1
                 continue
 
             try:
@@ -1322,8 +1312,21 @@ class MemoryAwarePrefixCache:
                             f"({head_offset}) != tokens length ({len(tokens)}) "
                             f"— corruption, skipping"
                         )
-                        skipped += 1
+                        corrupt_skipped += 1
                         continue
+
+                # Skip duplicates (e.g. an entry that warmup already
+                # populated). Without this, bisect.insort would create
+                # duplicate keys in _sorted_keys and memory would
+                # double-count. Benign — not a corruption signal.
+                tokens_key = tuple(tokens)
+                if tokens_key in self._entries:
+                    logger.debug(
+                        f"[cache_persist] entry {i} already present in cache "
+                        f"(len={len(tokens)}), skipping disk copy"
+                    )
+                    duplicate_skipped += 1
+                    continue
 
                 # Estimate memory
                 memory = estimate_kv_cache_memory(cache)
@@ -1337,7 +1340,6 @@ class MemoryAwarePrefixCache:
                     )
                     break
 
-                tokens_key = tuple(tokens)
                 entry = _CacheEntry(
                     tokens=tokens_key,
                     cache=cache,
@@ -1356,21 +1358,25 @@ class MemoryAwarePrefixCache:
 
             except Exception as e:
                 logger.warning(f"[cache_persist] failed to load entry {i}: {e}")
-                skipped += 1
+                corrupt_skipped += 1
 
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
 
         dt = _time.monotonic() - t0
-        if skipped:
+        summary = (
+            f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
+            f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
+        )
+        if duplicate_skipped:
+            summary += (
+                f", {duplicate_skipped} skipped as duplicates of in-memory entries"
+            )
+        if corrupt_skipped:
             logger.warning(
-                f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
-                f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total), "
-                f"SKIPPED {skipped} corrupt entries — disk cache may need cleanup"
+                f"{summary}, SKIPPED {corrupt_skipped} corrupt entries — "
+                f"disk cache may need cleanup"
             )
         else:
-            logger.info(
-                f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
-                f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
-            )
+            logger.info(summary)
         return loaded

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1190,8 +1190,12 @@ class MemoryAwarePrefixCache:
 
         def _has_valid_index(d: str) -> bool:
             """Cheap sanity check: index.json exists, is valid JSON, has the
-            expected version. Defends recovery against a partial index.json
-            written by a crashed save (json.dump itself isn't atomic)."""
+            expected version, AND at least one referenced entry file exists
+            on disk. The last check defends against the pathological case
+            where index.json survives but its entry files don't (manual
+            deletion, fs corruption, partial restore from backup) — without
+            it, recovery would promote a "valid index, no data" snapshot
+            and discard the previous good `.old` snapshot for nothing."""
             p = os.path.join(d, "index.json")
             if not os.path.exists(p):
                 return False
@@ -1200,7 +1204,20 @@ class MemoryAwarePrefixCache:
                     obj = json.load(f)
             except (OSError, ValueError):
                 return False
-            return isinstance(obj, dict) and obj.get("version", 0) >= 2
+            if not (isinstance(obj, dict) and obj.get("version", 0) >= 2):
+                return False
+            entries = obj.get("entries") or []
+            if not entries:
+                # An index claiming zero entries is degenerate; nothing to
+                # promote. Treat as missing so recovery can fall through
+                # to a real snapshot in the other staging dir.
+                return False
+            first_idx = entries[0].get("index")
+            if first_idx is None:
+                return False
+            sf = os.path.join(d, f"entry_{first_idx}.safetensors")
+            tk = os.path.join(d, f"entry_{first_idx}_tokens.bin")
+            return os.path.exists(sf) and os.path.exists(tk)
 
         # Crash-recovery for an interrupted save_to_disk.
         if not os.path.exists(cache_dir):
@@ -1298,6 +1315,21 @@ class MemoryAwarePrefixCache:
                     arr.fromfile(f, expected_num_tokens)
                 tokens = list(arr)
 
+                # Skip duplicates (e.g. an entry that warmup already
+                # populated). Done BEFORE load_prompt_cache so a duplicate
+                # entry doesn't pay the safetensors mmap cost only to be
+                # discarded. Without this guard, bisect.insort would also
+                # create duplicate keys in _sorted_keys and memory would
+                # double-count. Benign — not a corruption signal.
+                tokens_key = tuple(tokens)
+                if tokens_key in self._entries:
+                    logger.debug(
+                        f"[cache_persist] entry {i} already present in cache "
+                        f"(len={len(tokens)}), skipping disk copy"
+                    )
+                    duplicate_skipped += 1
+                    continue
+
                 # Load KV cache (header completeness already validated above).
                 cache = load_prompt_cache(entry_path)
 
@@ -1314,19 +1346,6 @@ class MemoryAwarePrefixCache:
                         )
                         corrupt_skipped += 1
                         continue
-
-                # Skip duplicates (e.g. an entry that warmup already
-                # populated). Without this, bisect.insort would create
-                # duplicate keys in _sorted_keys and memory would
-                # double-count. Benign — not a corruption signal.
-                tokens_key = tuple(tokens)
-                if tokens_key in self._entries:
-                    logger.debug(
-                        f"[cache_persist] entry {i} already present in cache "
-                        f"(len={len(tokens)}), skipping disk copy"
-                    )
-                    duplicate_skipped += 1
-                    continue
 
                 # Estimate memory
                 memory = estimate_kv_cache_memory(cache)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -42,6 +42,57 @@ _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 _MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
 
 
+def _safetensors_is_complete(path: str) -> bool:
+    """Validate a safetensors file is at least as long as its header claims.
+
+    Catches the body-truncated case that ``mx.load`` happily mmaps over —
+    a partial KV file that returns zeros at the missing positions and only
+    blows up much later with a wrong-output bug. Cheap: reads ≤ a few KB.
+
+    File layout (per safetensors spec):
+        [8 bytes LE uint64: header_len]
+        [header_len bytes: JSON header with data_offsets per tensor]
+        [tensor data]
+
+    Returns False on any structural problem (caller should drop the entry).
+    """
+    import json
+    import os
+    import struct
+
+    try:
+        size = os.path.getsize(path)
+        if size < 8:
+            return False
+        with open(path, "rb") as f:
+            header_len_bytes = f.read(8)
+            if len(header_len_bytes) != 8:
+                return False
+            header_len = struct.unpack("<Q", header_len_bytes)[0]
+            if header_len <= 0 or 8 + header_len > size:
+                return False
+            header_bytes = f.read(header_len)
+            if len(header_bytes) != header_len:
+                return False
+        header = json.loads(header_bytes)
+        max_end = 0
+        for name, meta in header.items():
+            if name == "__metadata__":
+                continue
+            offsets = meta.get("data_offsets") if isinstance(meta, dict) else None
+            if (
+                not isinstance(offsets, list)
+                or len(offsets) != 2
+                or not all(isinstance(x, int) for x in offsets)
+            ):
+                return False
+            if offsets[1] > max_end:
+                max_end = offsets[1]
+        return size >= 8 + header_len + max_end
+    except (OSError, ValueError, struct.error, json.JSONDecodeError):
+        return False
+
+
 def _get_available_memory() -> int:
     """
     Get available system memory in bytes.
@@ -983,18 +1034,28 @@ class MemoryAwarePrefixCache:
     def save_to_disk(self, cache_dir: str) -> bool:
         """Save all cache entries to disk using mlx_lm's safetensors format.
 
-        Directory layout::
+        The snapshot is committed via a directory-rename to make it
+        all-or-nothing: writes go to ``<cache_dir>.new/``, then a
+        three-step swap (``cache_dir → .old``, ``.new → cache_dir``,
+        ``rm .old``) atomically replaces the previous snapshot. A crash
+        anywhere during the writes leaves the previous snapshot intact;
+        :meth:`load_from_disk` recovers from a crash mid-swap.
+
+        Directory layout (committed)::
 
             cache_dir/
               index.json          # token keys + metadata per entry
               entry_0.safetensors # KV arrays for entry 0
+              entry_0_tokens.bin
               entry_1.safetensors
+              entry_1_tokens.bin
               ...
 
         Returns True if at least one entry was saved.
         """
         import json
         import os
+        import shutil
         import time as _time
 
         if not self._entries:
@@ -1002,13 +1063,23 @@ class MemoryAwarePrefixCache:
             return False
 
         t0 = _time.monotonic()
-        os.makedirs(cache_dir, exist_ok=True)
 
         try:
             from mlx_lm.models.cache import save_prompt_cache
         except ImportError:
             logger.warning("[cache_persist] mlx_lm not available, cannot save")
             return False
+
+        new_dir = cache_dir + ".new"
+        old_dir = cache_dir + ".old"
+
+        # Pre-clean stale staging dirs from a previous interrupted save.
+        for stale in (new_dir, old_dir):
+            if os.path.exists(stale):
+                logger.info(f"[cache_persist] removing stale staging dir: {stale}")
+                shutil.rmtree(stale, ignore_errors=True)
+
+        os.makedirs(new_dir, exist_ok=True)
 
         index = {
             "version": 2,
@@ -1019,15 +1090,15 @@ class MemoryAwarePrefixCache:
 
         saved = 0
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
-            entry_path = os.path.join(cache_dir, f"entry_{i}.safetensors")
+            entry_path = os.path.join(new_dir, f"entry_{i}.safetensors")
+            tokens_path = os.path.join(new_dir, f"entry_{i}_tokens.bin")
             try:
                 save_prompt_cache(
                     entry_path,
                     entry.cache,
                     metadata={"num_tokens": str(len(tokens_key))},
                 )
-                # Save tokens separately (can be 100K+ ints → binary is smaller)
-                tokens_path = os.path.join(cache_dir, f"entry_{i}_tokens.bin")
+                # Save tokens separately (can be 100K+ ints → binary is smaller).
                 import array as _array
 
                 arr = _array.array("i", tokens_key)  # 32-bit signed ints
@@ -1051,9 +1122,24 @@ class MemoryAwarePrefixCache:
             except Exception as e:
                 logger.warning(f"[cache_persist] failed to save entry {i}: {e}")
 
-        index_path = os.path.join(cache_dir, "index.json")
+        if saved == 0:
+            shutil.rmtree(new_dir, ignore_errors=True)
+            logger.warning("[cache_persist] no entries saved successfully, aborting")
+            return False
+
+        # Write index.json LAST inside the staging dir. Its presence is the
+        # signal to load_from_disk that .new contains a complete snapshot.
+        index_path = os.path.join(new_dir, "index.json")
         with open(index_path, "w") as f:
             json.dump(index, f, indent=2)
+
+        # Atomic-ish directory swap. If we crash between the two renames,
+        # load_from_disk's recovery path (see below) handles it.
+        if os.path.exists(cache_dir):
+            os.rename(cache_dir, old_dir)
+        os.rename(new_dir, cache_dir)
+        if os.path.exists(old_dir):
+            shutil.rmtree(old_dir, ignore_errors=True)
 
         dt = _time.monotonic() - t0
         logger.info(
@@ -1066,11 +1152,56 @@ class MemoryAwarePrefixCache:
     def load_from_disk(self, cache_dir: str) -> int:
         """Load cache entries from disk.
 
+        Recovers from a save interrupted between the two directory
+        renames in :meth:`save_to_disk`:
+
+        * if ``cache_dir`` is missing but ``cache_dir.new/index.json``
+          exists, the snapshot was fully written but never swapped in
+          → promote ``.new`` to ``cache_dir``;
+        * else if ``cache_dir.old`` is present and ``cache_dir`` is
+          missing, restore ``.old``.
+
+        Each entry is validated before insertion: the on-disk
+        ``tokens.bin`` size must match ``num_tokens * 4``, the
+        ``.safetensors`` file size must cover the data range declared
+        in its header (``mx.load`` mmaps lazily and returns zeros past
+        EOF, so a body-truncated KV would otherwise slip through), and
+        ``cache.offset`` must equal ``len(tokens)``. Any entry that
+        fails validation is dropped with a warning.
+
         Returns the number of entries successfully loaded.
         """
         import json
         import os
+        import shutil
         import time as _time
+
+        new_dir = cache_dir + ".new"
+        old_dir = cache_dir + ".old"
+
+        # Crash-recovery for an interrupted save_to_disk.
+        if not os.path.exists(cache_dir):
+            if os.path.exists(os.path.join(new_dir, "index.json")):
+                logger.info(
+                    f"[cache_persist] recovering interrupted save: "
+                    f"promoting {new_dir} → {cache_dir}"
+                )
+                os.rename(new_dir, cache_dir)
+                if os.path.exists(old_dir):
+                    shutil.rmtree(old_dir, ignore_errors=True)
+            elif os.path.exists(os.path.join(old_dir, "index.json")):
+                logger.info(
+                    f"[cache_persist] recovering interrupted save: "
+                    f"restoring {old_dir} → {cache_dir}"
+                )
+                os.rename(old_dir, cache_dir)
+        else:
+            # cache_dir exists — clean up any orphan staging dirs that a
+            # previous interrupted save may have left behind.
+            for stale in (new_dir, old_dir):
+                if os.path.exists(stale):
+                    logger.info(f"[cache_persist] cleaning orphan staging dir: {stale}")
+                    shutil.rmtree(stale, ignore_errors=True)
 
         index_path = os.path.join(cache_dir, "index.json")
         if not os.path.exists(index_path):
@@ -1094,13 +1225,42 @@ class MemoryAwarePrefixCache:
             return 0
 
         loaded = 0
+        skipped = 0
         for entry_meta in index.get("entries", []):
             i = entry_meta["index"]
+            expected_num_tokens = entry_meta["num_tokens"]
             entry_path = os.path.join(cache_dir, f"entry_{i}.safetensors")
             tokens_path = os.path.join(cache_dir, f"entry_{i}_tokens.bin")
 
             if not os.path.exists(entry_path) or not os.path.exists(tokens_path):
                 logger.warning(f"[cache_persist] missing files for entry {i}, skipping")
+                skipped += 1
+                continue
+
+            # Cross-check tokens.bin size against index.json's claim.
+            # Mismatch means the entry was partially rewritten by an
+            # interrupted previous save (BUG A). Drop it.
+            expected_bytes = expected_num_tokens * 4  # 32-bit signed ints
+            actual_bytes = os.path.getsize(tokens_path)
+            if actual_bytes != expected_bytes:
+                logger.warning(
+                    f"[cache_persist] entry {i} tokens.bin size mismatch "
+                    f"(expected {expected_bytes} bytes for {expected_num_tokens} "
+                    f"tokens, got {actual_bytes}) — corruption, skipping"
+                )
+                skipped += 1
+                continue
+
+            # mx.load mmaps safetensors lazily and will silently return
+            # zeros for positions past EOF. Verify the body is fully on
+            # disk via the safetensors header before trusting the entry
+            # (BUG D — body-truncated file slips through load otherwise).
+            if not _safetensors_is_complete(entry_path):
+                logger.warning(
+                    f"[cache_persist] entry {i} safetensors body is short of "
+                    f"its header's declared data range — corruption, skipping"
+                )
+                skipped += 1
                 continue
 
             try:
@@ -1109,11 +1269,25 @@ class MemoryAwarePrefixCache:
 
                 arr = _array.array("i")
                 with open(tokens_path, "rb") as f:
-                    arr.fromfile(f, entry_meta["num_tokens"])
+                    arr.fromfile(f, expected_num_tokens)
                 tokens = list(arr)
 
-                # Load KV cache
+                # Load KV cache (header completeness already validated above).
                 cache = load_prompt_cache(entry_path)
+
+                # Invariant: a well-formed entry has cache.offset == len(tokens).
+                # Any deviation means BUG A poisoning slipped through earlier
+                # checks; drop it rather than risk corrupting fetch output.
+                if cache:
+                    head_offset = getattr(cache[0], "offset", None)
+                    if head_offset is not None and head_offset != len(tokens):
+                        logger.warning(
+                            f"[cache_persist] entry {i} cache offset "
+                            f"({head_offset}) != tokens length ({len(tokens)}) "
+                            f"— corruption, skipping"
+                        )
+                        skipped += 1
+                        continue
 
                 # Estimate memory
                 memory = estimate_kv_cache_memory(cache)
@@ -1146,13 +1320,21 @@ class MemoryAwarePrefixCache:
 
             except Exception as e:
                 logger.warning(f"[cache_persist] failed to load entry {i}: {e}")
+                skipped += 1
 
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
 
         dt = _time.monotonic() - t0
-        logger.info(
-            f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
-            f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
-        )
+        if skipped:
+            logger.warning(
+                f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
+                f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total), "
+                f"SKIPPED {skipped} corrupt entries — disk cache may need cleanup"
+            )
+        else:
+            logger.info(
+                f"[cache_persist] LOADED {loaded} entries from {cache_dir} "
+                f"in {dt:.1f}s ({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
+            )
         return loaded

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -75,6 +75,8 @@ def _safetensors_is_complete(path: str) -> bool:
             if len(header_bytes) != header_len:
                 return False
         header = json.loads(header_bytes)
+        if not isinstance(header, dict):
+            return False
         max_end = 0
         for name, meta in header.items():
             if name == "__metadata__":
@@ -84,12 +86,14 @@ def _safetensors_is_complete(path: str) -> bool:
                 not isinstance(offsets, list)
                 or len(offsets) != 2
                 or not all(isinstance(x, int) for x in offsets)
+                or offsets[0] < 0
+                or offsets[1] < offsets[0]
             ):
                 return False
             if offsets[1] > max_end:
                 max_end = offsets[1]
         return size >= 8 + header_len + max_end
-    except (OSError, ValueError, struct.error, json.JSONDecodeError):
+    except (OSError, ValueError, struct.error, AttributeError, TypeError):
         return False
 
 
@@ -1070,6 +1074,9 @@ class MemoryAwarePrefixCache:
             logger.warning("[cache_persist] mlx_lm not available, cannot save")
             return False
 
+        # Strip trailing separators so ``<cache_dir>.new`` is a sibling of
+        # cache_dir, not a child. A child path silently breaks the swap.
+        cache_dir = cache_dir.rstrip(os.sep)
         new_dir = cache_dir + ".new"
         old_dir = cache_dir + ".old"
 
@@ -1176,12 +1183,39 @@ class MemoryAwarePrefixCache:
         import shutil
         import time as _time
 
+        # load_from_disk is intended for a fresh, empty cache (lifespan
+        # startup). Refuse to merge into an already-populated one rather
+        # than silently double-counting memory or producing duplicate
+        # entries in _sorted_keys.
+        if self._entries:
+            logger.warning(
+                "[cache_persist] load_from_disk called on a non-empty cache — "
+                "skipping to avoid duplicate accounting"
+            )
+            return 0
+
+        # Strip trailing separators (see save_to_disk for rationale).
+        cache_dir = cache_dir.rstrip(os.sep)
         new_dir = cache_dir + ".new"
         old_dir = cache_dir + ".old"
 
+        def _has_valid_index(d: str) -> bool:
+            """Cheap sanity check: index.json exists, is valid JSON, has the
+            expected version. Defends recovery against a partial index.json
+            written by a crashed save (json.dump itself isn't atomic)."""
+            p = os.path.join(d, "index.json")
+            if not os.path.exists(p):
+                return False
+            try:
+                with open(p) as f:
+                    obj = json.load(f)
+            except (OSError, ValueError):
+                return False
+            return isinstance(obj, dict) and obj.get("version", 0) >= 2
+
         # Crash-recovery for an interrupted save_to_disk.
         if not os.path.exists(cache_dir):
-            if os.path.exists(os.path.join(new_dir, "index.json")):
+            if _has_valid_index(new_dir):
                 logger.info(
                     f"[cache_persist] recovering interrupted save: "
                     f"promoting {new_dir} → {cache_dir}"
@@ -1189,12 +1223,14 @@ class MemoryAwarePrefixCache:
                 os.rename(new_dir, cache_dir)
                 if os.path.exists(old_dir):
                     shutil.rmtree(old_dir, ignore_errors=True)
-            elif os.path.exists(os.path.join(old_dir, "index.json")):
+            elif _has_valid_index(old_dir):
                 logger.info(
                     f"[cache_persist] recovering interrupted save: "
                     f"restoring {old_dir} → {cache_dir}"
                 )
                 os.rename(old_dir, cache_dir)
+                if os.path.exists(new_dir):
+                    shutil.rmtree(new_dir, ignore_errors=True)
         else:
             # cache_dir exists — clean up any orphan staging dirs that a
             # previous interrupted save may have left behind.


### PR DESCRIPTION
## Summary

Disk persistence in `MemoryAwarePrefixCache` had four overlapping ways to quietly corrupt a future session's KV cache, manifesting as token-id-0 collapse (`!!!!!!!!!!!`) on every request after restart. This PR closes all four with a single design: stage writes into a sibling directory and commit via rename.

Found while debugging integration tests after a crashed v0.6.6 server left poisoned files in `~/.cache/vllm-mlx/prefix_cache/<model>/` — every Anthropic request returned `!!!!`. Manually deleting the cache fixed it; the disk format gave no signal anything was wrong.

## Bugs

| Bug | Mechanism |
|---|---|
| **A** | `save_to_disk` rewrites `entry_i.*` in place. SIGKILL mid-rewrite leaves a stale `index.json` claiming `num_tokens=X_old` next to a freshly-rewritten `entry_i_tokens.bin` of size `X_new * 4`. Next load reads `arr.fromfile(f, X_old)`, silently truncating the new tokens.bin and producing an entry where `len(tokens_key) != cache.offset`. Subsequent `fetch()` returns the misaligned cache to the scheduler, which appends new tokens at the wrong KV position → garbage attention → token id 0. |
| **B** | Orphan `entry_i.*` files from a previous larger save are never removed when the next save writes fewer entries. They sit on disk indefinitely; the next interrupted save turns them into the (A) scenario. |
| **C** | `mx.save_safetensors` writes the target path directly (no `.tmp` rename), so a SIGKILL during a single-entry write leaves a half-written safetensors. |
| **D** | `mx.load` is lazy and mmaps the safetensors body — a body-truncated file passes `load_from_disk` silently and returns zeros at missing positions. The corruption only surfaces at attention time, often inside a worker thread where the `RuntimeError` gets swallowed. (Confirmed empirically: even `mx.eval(arr)` and `arr.sum().item()` don't trigger a read past the truncation.) |

## Fix

**Atomic snapshot via directory rename** (`save_to_disk`):
- Write the full snapshot into `<cache_dir>.new/`.
- `index.json` is the **last** file written inside `.new/` — its presence signals a complete snapshot.
- Three-step swap: `cache_dir → .old`, `.new → cache_dir`, `rmtree(.old)`. Any crash before the rename leaves the previous snapshot fully intact.

**Crash recovery** (`load_from_disk`):
- If `cache_dir` is missing but `cache_dir.new/index.json` exists → promote `.new` to `cache_dir`.
- Else if only `cache_dir.old` survives → restore it.
- Otherwise: clean up any orphan staging dirs.

**Per-entry validation at load** (drop with warning, don't crash):
- `tokens.bin` file size must equal `num_tokens * 4`.
- `.safetensors` body must cover the data range declared in its header — uses a small custom validator (`_safetensors_is_complete`) that parses the 8-byte header-len + JSON header and checks `data_offsets`. Catches BUG D without relying on `mx.eval` (which mmap defeats).
- `cache.offset` must equal `len(tokens)`.

**Diagnostics**: skipped count is reported in the load summary as a `WARNING` rather than buried in per-entry warnings.

## Tests

`tests/test_prefix_cache_persistence.py` — 10 new tests, ~3s total:

- `test_clean_roundtrip_save_then_load` — sanity
- `test_stale_index_with_overwritten_entry_loads_without_error` — BUG A
- `test_poisoned_entry_returns_misaligned_cache_via_fetch` — BUG A user-visible effect
- `test_save_to_disk_removes_orphans_from_previous_save` — BUG B
- `test_severely_truncated_safetensors_is_silently_skipped` — characterizes header-corrupt drop path
- `test_body_truncated_safetensors_should_fail_eagerly_at_load` — BUG D (the surprising one)
- `test_load_recovers_from_swap_interrupted_after_first_rename` — recovery: `.new` + `.old` both present
- `test_load_recovers_from_swap_interrupted_with_only_old` — recovery: only `.old` survives
- `test_load_cleans_orphan_staging_dirs` — cleanup when `cache_dir` exists alongside leftovers
- `test_save_routes_writes_through_staging_dir` — atomicity invariant (writes never go directly into `cache_dir`)

The 4 bug-repro tests were originally written as `xfail(strict=True)` to first prove the bugs were real (each one's assertion message captures the exact symptom); after the fix they pass straight.

## Test plan

- [x] `pytest tests/test_prefix_cache_persistence.py` — 10/10 pass
- [x] `pytest tests/test_memory_cache.py tests/test_prefix_cache.py tests/test_paged_cache.py tests/test_prompt_cache_snapshot.py` — 132/132 pass
- [x] Full suite: 2080 pass, 1 pre-existing fail in `test_reasoning_parsers.py::TestQwen3::test_only_start_tag_no_end` (verified pre-existing on `main`, unrelated)
- [x] `ruff check && ruff format` clean

## Notes

- Format compatible — no on-disk schema change. An old `cache_dir/` from before this PR loads fine; a `cache_dir/` written by this PR loads on older versions too (just without crash recovery). No version bump needed for the index.
- Memory: validator reads ~the JSON header per entry on load (≤ a few KB), no impact on save.
- Doesn't address: model-identity stamp (a swap of model weights under the same path still loads stale KV), `fsync` of the parent dir (power-loss durability), cross-process locking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)