### PR TITLE
docs: add Swival client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ models:
 aider --openai-api-base http://localhost:8000/v1 --openai-api-key not-needed
 ```
 
+**Swival** (`~/.swival/config.toml`):
+```toml
+[profiles.rapidmlx]
+provider = "generic"
+base_url = "http://127.0.0.1:8000"
+model = "default"
+```
+
+Run with:
+```bash
+swival --profile rapidmlx "summarize this repo"
+```
+
 **Open WebUI** (Docker one-liner):
 ```bash
 docker run -d -p 3000:8080 \


### PR DESCRIPTION
## What does this PR do?

This add setup instructions for the [Swival](https://swival.dev) harness to the README.md file.

I've been using it with Repid-MLX and `Qwen3.6-27B-UD-Q3_K_XL-mlx`, and it works perfectly.

## Checklist

- [X] Tests pass locally (`python3 -m pytest tests/ -x`)
- [X] Lint passes (`ruff check && ruff format --check`)
- [X] Updated README/docs if applicable
- [X] No breaking changes to existing API
