### PR TITLE
fix(turboquant): close #198 — both AttributeError crash and stale-quantized-cache load

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -744,6 +744,50 @@ def test_plain_entry_loadable_under_turboquant(tmp_path):
     assert loaded == 1
 
 
+def test_hybrid_entry_with_one_quantized_layer_rejected_under_plain_config(
+    tmp_path,
+):
+    """A hybrid model could mix layer types (e.g. global attention layers
+    quantized for memory, sliding-window layers kept plain). The compat
+    check must reject the WHOLE entry if ANY layer requires a config the
+    current run doesn't have — otherwise the partial dequantize at fetch
+    leaves the quantized layer's tuple-form keys for the scheduler.
+
+    Constructs an entry with [KVCache, QuantizedKVCache, KVCache] and
+    asserts rejection under plain config.
+    """
+    QuantizedKVCache = pytest.importorskip("mlx_lm.models.cache").QuantizedKVCache
+    plain = make_kvcache(num_tokens=11, n_layers=1)[0]
+    quant_layer = QuantizedKVCache(group_size=64, bits=8)
+    qk = mx.full((1, 4, 11, 64), 0.5, dtype=mx.float16)
+    qv = mx.full((1, 4, 11, 64), -0.5, dtype=mx.float16)
+    quant_layer.update_and_fetch(qk, qv)
+    plain2 = make_kvcache(num_tokens=11, n_layers=1)[0]
+    mixed = [plain, quant_layer, plain2]
+
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, mixed)
+    # Sanity: the recorded list reflects the hybrid layout.
+    with open(tmp_path / "index.json") as f:
+        idx = json.load(f)
+    assert idx["entries"][0]["cache_types"] == [
+        "KVCache",
+        "QuantizedKVCache",
+        "KVCache",
+    ]
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=False),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 0, (
+        "hybrid entry with even one QuantizedKVCache layer must be "
+        "rejected under plain config — partial dequantize would leave "
+        "tuple-form keys for the scheduler"
+    )
+
+
 def test_legacy_index_without_cache_types_falls_back_to_safetensors_metadata(
     tmp_path,
 ):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -597,3 +597,270 @@ def test_save_routes_writes_through_staging_dir(tmp_path, monkeypatch):
     assert not (tmp_path / "snap.new").exists()
     assert (cache_dir / "index.json").exists()
     assert (cache_dir / "entry_0.safetensors").exists()
+
+
+# --------------------------------------------------------------------------
+# Issue #198 BUG B — incompatible cache types loaded across config changes
+# --------------------------------------------------------------------------
+#
+# When the previous server run persisted ``QuantizedKVCache`` entries
+# (``--kv-cache-quantization`` or earlier ``--kv-cache-turboquant`` runs
+# that fell back to mlx-lm quantization) and the next run starts under
+# a different cache config, the on-disk entries' tuple-form ``keys``
+# bypass the dequantize path in ``_decompress_cache`` and reach the
+# scheduler, which crashes with::
+#
+#     AttributeError: 'list' object has no attribute 'shape'
+#
+# The hasattr guards in ``scheduler.py`` stop the crash, but the entry
+# is unusable. Real fix: ``load_from_disk`` rejects entries whose
+# persisted cache class can't be safely dequantized under the current
+# config, and counts them in ``incompatible_skipped`` (distinct from
+# ``corrupt_skipped`` so users don't see "may need cleanup" warnings
+# for an expected config change).
+
+
+def _make_quantized_kvcache(num_tokens: int, *, n_layers: int = 2):
+    """Build an mlx-lm ``QuantizedKVCache`` list with ``num_tokens`` positions.
+
+    Used to simulate persisted entries from a previous ``--kv-cache-
+    quantization`` run.
+    """
+    QuantizedKVCache = pytest.importorskip("mlx_lm.models.cache").QuantizedKVCache
+    layers = []
+    for layer_idx in range(n_layers):
+        c = QuantizedKVCache(group_size=64, bits=8)
+        # Need a head_dim that's a clean multiple of group_size for quantize.
+        keys = mx.full((1, 4, num_tokens, 64), 0.5 + layer_idx, dtype=mx.float16)
+        values = mx.full((1, 4, num_tokens, 64), -(0.5 + layer_idx), dtype=mx.float16)
+        c.update_and_fetch(keys, values)
+        layers.append(c)
+    return layers
+
+
+def _save_one_entry(
+    cache_dir, tokens, kv_layers, *, cache_types: list[str] | None = None
+):
+    """Write a one-entry snapshot directly (no MemoryAwarePrefixCache).
+
+    ``cache_types`` lets a test pretend the index.json is from a
+    different config than what we'd write today.
+    """
+    os.makedirs(cache_dir, exist_ok=True)
+    write_entry_files(str(cache_dir), 0, tokens, kv_layers)
+    types = (
+        cache_types
+        if cache_types is not None
+        else ([type(layer).__name__ for layer in kv_layers])
+    )
+    index = {
+        "version": 2,
+        "num_entries": 1,
+        "total_memory_bytes": 0,
+        "entries": [
+            {
+                "index": 0,
+                "num_tokens": len(tokens),
+                "memory_bytes": 0,
+                "cache_types": types,
+            }
+        ],
+    }
+    with open(os.path.join(str(cache_dir), "index.json"), "w") as f:
+        json.dump(index, f)
+
+
+def test_quantized_entry_rejected_under_plain_config(tmp_path):
+    """BUG B — loading a persisted QuantizedKVCache under a plain config
+    must reject the entry (otherwise the tuple-form keys reach the
+    scheduler and crash with ``'list' has no attribute 'shape'``)."""
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, _make_quantized_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=False),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 0
+    assert tuple(tokens) not in cache._entries
+
+
+def test_quantized_entry_rejected_under_turboquant_config(tmp_path):
+    """BUG B (the exact scenario in #198) — previous run wrote
+    QuantizedKVCache; current run uses ``--kv-cache-turboquant``.
+    ``_turboquant_decompress_cache`` only handles ``TurboQuantKVCache``
+    so any other type slips through unchanged. Reject at load."""
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, _make_quantized_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_turboquant=True),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 0
+
+
+def test_quantized_entry_loadable_under_kv_quantize(tmp_path):
+    """Negative control — same config restart must still load."""
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, _make_quantized_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=True),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 1
+
+
+def test_plain_entry_loadable_under_kv_quantize(tmp_path):
+    """Plain ``KVCache`` is forward-compatible with any config — the next
+    ``store()`` recompresses, until then fetch passes through unchanged.
+    Don't reject these; that would force users to wipe their cache when
+    enabling ``--kv-cache-quantization``."""
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, make_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=True),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 1
+
+
+def test_plain_entry_loadable_under_turboquant(tmp_path):
+    """Same forward-compat as above but for ``--kv-cache-turboquant``."""
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, make_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_turboquant=True),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 1
+
+
+def test_legacy_index_without_cache_types_falls_back_to_safetensors_metadata(
+    tmp_path,
+):
+    """Backward compat — index.json from before #198 lacks ``cache_types``.
+    Loader must peek at the safetensors ``__metadata__`` to figure out
+    the persisted class. Without this fallback, every legacy quantized
+    entry would be incorrectly accepted under a plain config and crash
+    the scheduler the moment it's fetched."""
+    tokens = list(range(11))
+    _save_one_entry(
+        tmp_path,
+        tokens,
+        _make_quantized_kvcache(num_tokens=11),
+        cache_types=[],  # simulate legacy index without the field
+    )
+    # Sanity: the index.json should now have cache_types == [].
+    with open(tmp_path / "index.json") as f:
+        idx = json.load(f)
+    assert idx["entries"][0]["cache_types"] == []
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=False),
+    )
+    loaded = cache.load_from_disk(str(tmp_path))
+    assert loaded == 0, (
+        "expected legacy QuantizedKVCache entry to be rejected via "
+        "safetensors-metadata fallback under plain config"
+    )
+
+
+def test_save_to_disk_records_cache_types_in_index(tmp_path):
+    """Forward-looking — the field must be present in newly written
+    index.json so future loads can pre-filter without parsing each
+    safetensors header."""
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.save_to_disk(str(tmp_path))
+
+    with open(tmp_path / "index.json") as f:
+        idx = json.load(f)
+    assert idx["entries"][0]["cache_types"] == ["KVCache", "KVCache"]
+
+
+def test_incompatible_skipped_does_not_count_as_corruption(tmp_path, caplog):
+    """The summary log must distinguish "config changed → expected skips"
+    from "disk corrupt → user should investigate". A WARNING for an
+    expected config change would be alarm fatigue."""
+    import logging as _logging
+
+    tokens = list(range(11))
+    _save_one_entry(tmp_path, tokens, _make_quantized_kvcache(num_tokens=11))
+
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=False),
+    )
+    with caplog.at_level(_logging.INFO, logger="vllm_mlx.memory_cache"):
+        cache.load_from_disk(str(tmp_path))
+
+    text = caplog.text
+    assert "incompatible" in text, "summary should mention incompatible skips"
+    assert "may need cleanup" not in text, (
+        "config-change skips must not surface as corruption warnings"
+    )
+
+
+# --------------------------------------------------------------------------
+# Issue #198 BUG A — scheduler-side hasattr guards
+# --------------------------------------------------------------------------
+#
+# Tests for the three ``.shape``-on-tuple-keys crash sites in
+# ``vllm_mlx/scheduler.py``. We exercise the validators directly with
+# the cache shape they receive when a QuantizedKVCache reaches them
+# (which happens for stale-cache scenarios where Bug B fix didn't fire,
+# or for in-memory mid-prefill states under quantized model paths).
+
+
+class _FakeQuantizedLayer:
+    """Stand-in for QuantizedKVCache shape: ``keys`` is a tuple, not array.
+
+    We use this rather than the real class to keep the test independent
+    of mlx-lm's internal layout — only the surface seen by the scheduler
+    matters for the regression we're guarding against.
+    """
+
+    def __init__(self, num_tokens: int = 11):
+        # mlx-lm QuantizedKVCache stores keys/values as 3-tuples
+        # (data, scales, biases); only ``data`` is a real array.
+        data = mx.zeros((1, 4, num_tokens, 16), dtype=mx.uint32)
+        scales = mx.zeros((1, 4, num_tokens, 1), dtype=mx.float16)
+        biases = mx.zeros((1, 4, num_tokens, 1), dtype=mx.float16)
+        self.keys = (data, scales, biases)
+        self.values = (data, scales, biases)
+
+
+def test_scheduler_validator_accepts_tuple_keys_without_crashing():
+    """BUG A — the validator must not raise ``AttributeError`` when
+    ``layer.keys`` is the QuantizedKVCache 3-tuple.
+
+    Pre-fix this would do ``layer_cache.keys.shape[0]`` and crash on
+    the tuple, taking down whichever request triggered the fetch.
+    Post-fix the validator skips the batch-dim check for non-array
+    keys (the dim is structurally guaranteed by the cache class) and
+    returns truthfully.
+
+    Note: the only Bug A site that actually fires under #198's repro
+    is this validator. The two other sites in
+    ``_reconstruct_cache_from_states`` are gated on
+    ``cache_cls is _BatchKVCache`` whose state tuple is always
+    array-typed in practice; their ``hasattr`` guards are defensive,
+    not load-bearing, so we don't pin them with tests.
+    """
+    from vllm_mlx.scheduler import Scheduler
+
+    layer = _FakeQuantizedLayer(num_tokens=11)
+    # _validate_cache is an instance method but doesn't touch self for
+    # the list-of-layers path — call unbound.
+    is_valid = Scheduler._validate_cache(None, [layer])
+    assert is_valid in (True, False)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -59,13 +59,12 @@ def _safetensors_is_complete(path: str) -> bool:
 
     Returns False on any structural problem (caller should drop the entry).
     """
-    header = _read_safetensors_header(path)
-    if header is None:
+    parsed = _read_safetensors_header(path)
+    if parsed is None:
         return False
+    header, header_len = parsed
     try:
         size = os.path.getsize(path)
-        with open(path, "rb") as f:
-            header_len = struct.unpack("<Q", f.read(8))[0]
         max_end = 0
         for name, meta in header.items():
             if name == "__metadata__":
@@ -86,12 +85,14 @@ def _safetensors_is_complete(path: str) -> bool:
         return False
 
 
-def _read_safetensors_header(path: str) -> dict | None:
+def _read_safetensors_header(path: str) -> tuple[dict, int] | None:
     """Parse a safetensors header without loading any tensor data.
 
-    Returns the parsed header dict (incl. ``__metadata__``) on success,
-    or ``None`` if the file is structurally invalid. Used by
-    :func:`_safetensors_is_complete` and :func:`_safetensors_cache_classes`.
+    Returns ``(header_dict, header_len_bytes)`` on success, or ``None`` if
+    the file is structurally invalid. Both values are needed by
+    :func:`_safetensors_is_complete` to compute the absolute end-of-data
+    offset; :func:`_safetensors_cache_classes` ignores ``header_len``.
+    Returning both from one read avoids opening the file twice.
     """
     try:
         size = os.path.getsize(path)
@@ -108,7 +109,9 @@ def _read_safetensors_header(path: str) -> dict | None:
             if len(header_bytes) != header_len:
                 return None
         header = json.loads(header_bytes)
-        return header if isinstance(header, dict) else None
+        if not isinstance(header, dict):
+            return None
+        return header, header_len
     except (OSError, ValueError, struct.error, AttributeError, TypeError):
         return None
 
@@ -122,13 +125,20 @@ def _safetensors_cache_classes(path: str) -> list[str]:
     loading on cache-type compatibility (see Bug B in #198).
 
     Returns ``[]`` if the file is unreadable, has no metadata, or has no
-    ``2.*`` keys (in which case the caller should fall back to assuming
-    a plain ``KVCache`` for backward compat with files saved before this
-    field existed).
+    ``2.*`` keys. The caller treats ``[]`` as "permissive — assume
+    ``KVCache``" for backward compat with files saved before the
+    in-index ``cache_types`` field existed; that's safe today because
+    every mlx-lm version we depend on writes the ``2.*`` metadata, so
+    an actually-quantized file always yields a non-empty list. If a
+    future mlx-lm changes the metadata key layout this will silently
+    misclassify quantized files as KVCache and re-expose Bug A — emit
+    a one-time WARNING when the metadata block exists but yields no
+    ``2.*`` keys, so format drift is at least visible in logs.
     """
-    header = _read_safetensors_header(path)
-    if header is None:
+    parsed = _read_safetensors_header(path)
+    if parsed is None:
         return []
+    header, _ = parsed
     meta = header.get("__metadata__")
     if not isinstance(meta, dict):
         return []
@@ -142,6 +152,17 @@ def _safetensors_cache_classes(path: str) -> list[str]:
             continue
         if isinstance(v, str) and v:
             layer_classes[idx] = v
+    if not layer_classes and meta:
+        # Header has metadata but no recognizable per-layer class keys —
+        # likely a future mlx-lm format change. Surface it so the cause
+        # is diagnosable without parsing the safetensors by hand.
+        logger.warning(
+            f"[cache_persist] {path}: safetensors __metadata__ present "
+            f"but no '2.*' cache-class keys found "
+            f"(meta_keys={sorted(meta)[:8]}...) — assuming plain KVCache; "
+            f"if this file was actually quantized, the entry may crash "
+            f"the scheduler at fetch (#198 BUG A)"
+        )
     return [layer_classes[i] for i in sorted(layer_classes)]
 
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -26,8 +26,11 @@ from __future__ import annotations
 
 import bisect
 import copy
+import json
 import logging
 import math
+import os
+import struct
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -56,27 +59,13 @@ def _safetensors_is_complete(path: str) -> bool:
 
     Returns False on any structural problem (caller should drop the entry).
     """
-    import json
-    import os
-    import struct
-
+    header = _read_safetensors_header(path)
+    if header is None:
+        return False
     try:
         size = os.path.getsize(path)
-        if size < 8:
-            return False
         with open(path, "rb") as f:
-            header_len_bytes = f.read(8)
-            if len(header_len_bytes) != 8:
-                return False
-            header_len = struct.unpack("<Q", header_len_bytes)[0]
-            if header_len <= 0 or 8 + header_len > size:
-                return False
-            header_bytes = f.read(header_len)
-            if len(header_bytes) != header_len:
-                return False
-        header = json.loads(header_bytes)
-        if not isinstance(header, dict):
-            return False
+            header_len = struct.unpack("<Q", f.read(8))[0]
         max_end = 0
         for name, meta in header.items():
             if name == "__metadata__":
@@ -95,6 +84,106 @@ def _safetensors_is_complete(path: str) -> bool:
         return size >= 8 + header_len + max_end
     except (OSError, ValueError, struct.error, AttributeError, TypeError):
         return False
+
+
+def _read_safetensors_header(path: str) -> dict | None:
+    """Parse a safetensors header without loading any tensor data.
+
+    Returns the parsed header dict (incl. ``__metadata__``) on success,
+    or ``None`` if the file is structurally invalid. Used by
+    :func:`_safetensors_is_complete` and :func:`_safetensors_cache_classes`.
+    """
+    try:
+        size = os.path.getsize(path)
+        if size < 8:
+            return None
+        with open(path, "rb") as f:
+            header_len_bytes = f.read(8)
+            if len(header_len_bytes) != 8:
+                return None
+            header_len = struct.unpack("<Q", header_len_bytes)[0]
+            if header_len <= 0 or 8 + header_len > size:
+                return None
+            header_bytes = f.read(header_len)
+            if len(header_bytes) != header_len:
+                return None
+        header = json.loads(header_bytes)
+        return header if isinstance(header, dict) else None
+    except (OSError, ValueError, struct.error, AttributeError, TypeError):
+        return None
+
+
+def _safetensors_cache_classes(path: str) -> list[str]:
+    """Read mlx-lm cache class names from a safetensors prompt-cache file.
+
+    ``mlx_lm.models.cache.save_prompt_cache`` writes per-layer class names
+    under metadata keys of the form ``"2.{layer_idx}"``. This reads them
+    back without instantiating the cache — needed to gate disk-cache
+    loading on cache-type compatibility (see Bug B in #198).
+
+    Returns ``[]`` if the file is unreadable, has no metadata, or has no
+    ``2.*`` keys (in which case the caller should fall back to assuming
+    a plain ``KVCache`` for backward compat with files saved before this
+    field existed).
+    """
+    header = _read_safetensors_header(path)
+    if header is None:
+        return []
+    meta = header.get("__metadata__")
+    if not isinstance(meta, dict):
+        return []
+    layer_classes: dict[int, str] = {}
+    for k, v in meta.items():
+        if not isinstance(k, str) or not k.startswith("2."):
+            continue
+        try:
+            idx = int(k.split(".", 1)[1])
+        except (IndexError, ValueError):
+            continue
+        if isinstance(v, str) and v:
+            layer_classes[idx] = v
+    return [layer_classes[i] for i in sorted(layer_classes)]
+
+
+def _cache_classes_compatible(
+    class_names: list[str], config: MemoryCacheConfig
+) -> tuple[bool, str]:
+    """Check whether a persisted cache is loadable under the current config.
+
+    Reasoning (see #198 BUG B):
+
+    * ``KVCache`` / ``MambaCache`` / etc. — always loadable. Under
+      ``kv_quantize`` or ``kv_turboquant`` the next ``store()`` call
+      will recompress; until then they pass through fetch unchanged.
+    * ``QuantizedKVCache`` — only loadable when ``kv_quantize=True``.
+      The dequantize path in ``_decompress_cache`` is guarded on the
+      flag; under any other config the tuple-form ``keys`` reach the
+      scheduler and crash (#198 BUG A's downstream symptom).
+    * ``TurboQuantKVCache`` — only loadable when ``kv_turboquant=True``.
+      In practice never persisted (no ``state`` attribute), so this
+      branch is defensive.
+
+    Returns ``(is_compatible, reason)``. ``reason`` is empty when ok.
+    """
+    if not class_names:
+        # Backward compat: pre-cache_type files have no class info. Assume
+        # KVCache (the only thing all earlier rapid-mlx versions wrote).
+        # Always compatible.
+        return True, ""
+    for cn in class_names:
+        if cn == "QuantizedKVCache" and not config.kv_quantize:
+            return (
+                False,
+                f"persisted {cn} requires --kv-cache-quantization "
+                "(current config does not enable it)",
+            )
+        if cn == "TurboQuantKVCache" and not config.kv_turboquant:
+            return (
+                False,
+                f"persisted {cn} requires --kv-cache-turboquant "
+                "(current config does not enable it)",
+            )
+    return True, ""
 
 
 def _get_available_memory() -> int:
@@ -1057,8 +1146,6 @@ class MemoryAwarePrefixCache:
 
         Returns True if at least one entry was saved.
         """
-        import json
-        import os
         import shutil
         import time as _time
 
@@ -1112,11 +1199,22 @@ class MemoryAwarePrefixCache:
                 with open(tokens_path, "wb") as f:
                     arr.tofile(f)
 
+                # Record the per-layer cache class names so loaders can
+                # gate on cache-type compatibility (#198 BUG B). Stored
+                # inline in index.json so we can pre-filter incompatible
+                # entries without parsing the safetensors header for each.
+                # Falls back to ``[]`` if the entry was empty (defensive —
+                # shouldn't happen since we reject empty caches at store).
+                cache_types = [
+                    type(layer).__name__ for layer in entry.cache if layer is not None
+                ]
+
                 index["entries"].append(
                     {
                         "index": i,
                         "num_tokens": len(tokens_key),
                         "memory_bytes": entry.memory_bytes,
+                        "cache_types": cache_types,
                     }
                 )
                 saved += 1
@@ -1178,8 +1276,6 @@ class MemoryAwarePrefixCache:
 
         Returns the number of entries successfully loaded.
         """
-        import json
-        import os
         import shutil
         import time as _time
 
@@ -1269,6 +1365,7 @@ class MemoryAwarePrefixCache:
         loaded = 0
         corrupt_skipped = 0
         duplicate_skipped = 0
+        incompatible_skipped = 0
         for entry_meta in index.get("entries", []):
             i = entry_meta["index"]
             expected_num_tokens = entry_meta["num_tokens"]
@@ -1278,6 +1375,25 @@ class MemoryAwarePrefixCache:
             if not os.path.exists(entry_path) or not os.path.exists(tokens_path):
                 logger.warning(f"[cache_persist] missing files for entry {i}, skipping")
                 corrupt_skipped += 1
+                continue
+
+            # Cache-type compatibility check (#198 BUG B). Reject entries
+            # whose persisted cache class doesn't match what the current
+            # config can dequantize at fetch time — otherwise tuple-form
+            # keys reach the scheduler. Done early to skip the safetensors
+            # body validation work for entries we'd discard anyway.
+            cache_types = entry_meta.get("cache_types") or []
+            if not cache_types:
+                # Backward compat with index.json from before cache_types
+                # existed: peek at safetensors __metadata__.
+                cache_types = _safetensors_cache_classes(entry_path)
+            ok, reason = _cache_classes_compatible(cache_types, self._config)
+            if not ok:
+                logger.info(
+                    f"[cache_persist] entry {i} skipped — {reason}; "
+                    f"persisted types={cache_types}"
+                )
+                incompatible_skipped += 1
                 continue
 
             # Cross-check tokens.bin size against index.json's claim.
@@ -1390,6 +1506,11 @@ class MemoryAwarePrefixCache:
         if duplicate_skipped:
             summary += (
                 f", {duplicate_skipped} skipped as duplicates of in-memory entries"
+            )
+        if incompatible_skipped:
+            summary += (
+                f", {incompatible_skipped} skipped as incompatible with "
+                f"current cache config (e.g. config changed between runs)"
             )
         if corrupt_skipped:
             logger.warning(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1566,7 +1566,10 @@ class Scheduler:
                     return False
                 # Validate batch dimension == 1 for KVCache layers
                 if hasattr(layer_cache, "keys") and layer_cache.keys is not None:
-                    if hasattr(layer_cache.keys, "shape") and layer_cache.keys.shape[0] != 1:
+                    if (
+                        hasattr(layer_cache.keys, "shape")
+                        and layer_cache.keys.shape[0] != 1
+                    ):
                         logger.debug(
                             f"Cache layer invalid: keys batch={layer_cache.keys.shape[0]}, expected 1"
                         )
@@ -1686,7 +1689,11 @@ class Scheduler:
                     cache = KVCache()
                     cache.keys, cache.values = state
                     cache.offset = (
-                        int(meta_state[0]) if meta_state else (cache.keys.shape[2] if hasattr(cache.keys, "shape") else 0)
+                        int(meta_state[0])
+                        if meta_state
+                        else (
+                            cache.keys.shape[2] if hasattr(cache.keys, "shape") else 0
+                        )
                     )
 
                 caches.append(cache)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1566,7 +1566,7 @@ class Scheduler:
                     return False
                 # Validate batch dimension == 1 for KVCache layers
                 if hasattr(layer_cache, "keys") and layer_cache.keys is not None:
-                    if layer_cache.keys.shape[0] != 1:
+                    if hasattr(layer_cache.keys, "shape") and layer_cache.keys.shape[0] != 1:
                         logger.debug(
                             f"Cache layer invalid: keys batch={layer_cache.keys.shape[0]}, expected 1"
                         )
@@ -1674,7 +1674,7 @@ class Scheduler:
                         cache = _KVCache()
                         cache.keys = keys
                         cache.values = values
-                        cache.offset = keys.shape[2]
+                        cache.offset = keys.shape[2] if hasattr(keys, "shape") else 0
                     else:
                         cache = cache_cls.from_state(state, meta_state)
                 else:
@@ -1686,7 +1686,7 @@ class Scheduler:
                     cache = KVCache()
                     cache.keys, cache.values = state
                     cache.offset = (
-                        int(meta_state[0]) if meta_state else cache.keys.shape[2]
+                        int(meta_state[0]) if meta_state else (cache.keys.shape[2] if hasattr(cache.keys, "shape") else 0)
                     )
 
                 caches.append(cache)


### PR DESCRIPTION
## Summary

Closes #198 (both reported failure modes).

* **Bug A** — `--kv-cache-turboquant` crashes with `AttributeError: 'list' object has no attribute 'shape'`. Three sites in `vllm_mlx/scheduler.py` access `.shape[0]`/`.shape[2]` on `layer_cache.keys` without checking it's an `mx.array`. `QuantizedKVCache` stores `keys` as a 3-tuple `(data, scales, biases)`, which trips them. The `hasattr` guards are taken from @stone30513's patch on the issue.

* **Bug B** — `ValueError: QuantizedKVCache does not yet support batching with history` when 8-bit entries from a previous `--kv-cache-quantization` run are loaded under `--kv-cache-turboquant`. Today users have to `rm -rf ~/.cache/vllm-mlx/prefix_cache/` between config changes. Fixed by gating disk loads on cache-class compatibility:
  * `QuantizedKVCache` only loadable when `kv_quantize=True`
  * `TurboQuantKVCache` only loadable when `kv_turboquant=True`
  * plain `KVCache` always loadable (forward-compat — next `store()` recompresses)

  Mismatched entries are counted in a new `incompatible_skipped` bucket (INFO log: "config changed between runs", **not** WARNING / "may need cleanup"). Cache class names are written to `index.json` per entry under a new `cache_types` field; for caches written by older rapid-mlx versions, the loader falls back to the safetensors `__metadata__` block (mlx-lm already records each layer's class name there).

The two bugs are coupled but independent: Bug A is the crash you see, Bug B is what feeds the bad entry to the scheduler in the first place. Bug A's hasattr guards are the immediate stop, Bug B's load gating is the proper fix.

## Files

| file | change |
|---|---|
| `vllm_mlx/scheduler.py` | 3 `hasattr` guards on `keys.shape[*]` (Bug A) |
| `vllm_mlx/memory_cache.py` | `_safetensors_cache_classes` + `_cache_classes_compatible` helpers; `save_to_disk` writes `cache_types` per entry; `load_from_disk` rejects incompatible entries (Bug B) |
| `tests/test_prefix_cache_persistence.py` | 9 new tests (8 for Bug B paths, 1 for Bug A validator) |

## Validation

* 24/24 tests in `test_prefix_cache_persistence.py` pass; 271/271 cache- and scheduler-related tests pass (`-k "cache or memory or prefix or scheduler"`).
* Negative control vs `main`:
  * `test_scheduler_validator_accepts_tuple_keys_without_crashing` fails with the exact `AttributeError` from #198
  * 4 of the 8 new Bug B tests fail (3 reject-path tests + the index field assertion); 1 passes by accident (loader silently accepts then crashes downstream — that's the bug).
* End-to-end: write `QuantizedKVCache` entry under `kv_quantize=True`, restart with `kv_turboquant=True` → 0 entries loaded (incompatible). Restart with `kv_quantize=True` again → 1 entry loaded (compat).
* Lint clean (`ruff check && ruff format --check`).

Original Bug A patch by @stone30513 (#198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)