### PR TITLE
feat(pr_validate): single-command merge-readiness pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,6 @@
 
 - [ ] Tests pass locally (`python3 -m pytest tests/ -x`)
 - [ ] Lint passes (`ruff check && ruff format --check`)
+- [ ] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — see [CONTRIBUTING.md](../CONTRIBUTING.md#self-validating-your-pr) (opt out heavy steps with `PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1` if you don't have the hardware/keys)
 - [ ] Updated README/docs if applicable
 - [ ] No breaking changes to existing API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,51 @@ Most tests run without a model. Tests in `tests/test_event_loop.py` require a ru
 1. Fork the repo and create a branch: `feat/`, `fix/`, `docs/`, `refactor/`
 2. Make your changes with tests if applicable
 3. Run `ruff check` and `ruff format` before committing
-4. Open a PR against `main` with a clear description
+4. **Self-validate your PR** (see below) — saves a round trip with maintainers
+5. Open a PR against `main` with a clear description
+
+## Self-Validating Your PR
+
+Before opening (or after pushing fixes to) your PR, run our validation pipeline against it. The same script is what maintainers run before merging — running it yourself catches the easy stuff before review and signals you've done your homework.
+
+```bash
+python3 -m scripts.pr_validate.pr_validate <PR#>
+```
+
+The script grades your PR through 7 steps and prints a strict markdown scorecard. Exit code 0 = `MERGE-SAFE`, exit code 1 = at least one step failed.
+
+| step | what it does | when |
+|---|---|---|
+| `fetch` | pulls your PR + diff, classifies blast radius | always |
+| `deepseek_review` | adversarial code review (skipped if no API key) | when `DEEPSEEK_API_KEY` is set |
+| `supply_chain` | flags new deps, install hooks, `eval`/`exec`/`shell=True`, hardcoded URLs | always |
+| `lint` | `ruff check` + `ruff format --check` | when diff has `.py` |
+| `targeted_tests` | runs tests touching the files you changed; **negative-control** filters pre-existing flakes | when diff has `.py` |
+| `full_unit` | full pytest suite minus integrations | medium/high blast |
+| `stress_e2e_bench` | boots a server, runs stress + agent integrations + bench vs baseline | high blast (engine/scheduler/memory_cache) |
+
+**You don't need every step to pass for a clean PR**, but the more green checks you have, the faster review goes. In particular:
+
+- **`lint` and `targeted_tests` are non-negotiable** — run these locally even without the full pipeline.
+- **`supply_chain` warnings** mean a maintainer will read your changes carefully (especially if you touched `setup.py`, `.github/workflows/`, `Makefile`, or added a new dep). That's not a problem — just be ready to explain the why.
+- **`stress_e2e_bench` requires Apple Silicon + enough RAM** to load a small model (≥6GB free). If you don't have the hardware, opt out with `PR_VALIDATE_NO_STRESS=1` — maintainers will run it for you on merge.
+- **`deepseek_review` needs an API key** — opt out with `PR_VALIDATE_NO_DEEPSEEK=1` if you don't have one. Maintainers will run it for you.
+
+```bash
+# Quick local check (no DeepSeek, no stress) — covers the "did I break anything obvious" case in <1 minute for most PRs:
+PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1 \
+    python3 -m scripts.pr_validate.pr_validate <PR#>
+```
+
+Full step list, gating logic, and how to add steps: [`scripts/pr_validate/README.md`](scripts/pr_validate/README.md).
+
+### What if my PR fails on a pre-existing main bug?
+
+`targeted_tests` already handles this — it re-runs failures on your PR's base commit and reclassifies "fails on main too" as pre-existing (not a regression). For `full_unit` you'll currently see the failure surfaced; mention it in the PR comment ("`test_X` is failing on main too — see issue #123") and a maintainer will confirm.
+
+### What if `pr_validate` itself misbehaves?
+
+It's still new. File an issue with `[pr_validate]` in the title and the artifacts under `/tmp/pr_validate/pr-<N>/` attached.
 
 ## Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ The script grades your PR through 7 steps and prints a strict markdown scorecard
 | step | what it does | when |
 |---|---|---|
 | `fetch` | pulls your PR + diff, classifies blast radius | always |
-| `deepseek_review` | adversarial code review (skipped if no API key) | when `DEEPSEEK_API_KEY` is set |
+| `deepseek_review` | adversarial code review (skipped if no API key) | when `DEEPSEEK_API_KEY` is set and `PR_VALIDATE_NO_DEEPSEEK` is unset |
 | `supply_chain` | flags new deps, install hooks, `eval`/`exec`/`shell=True`, hardcoded URLs | always |
 | `lint` | `ruff check` + `ruff format --check` | when diff has `.py` |
 | `targeted_tests` | runs tests touching the files you changed; **negative-control** filters pre-existing flakes | when diff has `.py` |

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -1,0 +1,142 @@
+# PR validation pipeline
+
+Single-command merge-readiness gate for incoming PRs (especially
+external contributions). Strict mode: any single step failure blocks
+merge.
+
+## Usage
+
+```bash
+# from the repo root
+python3.12 -m scripts.pr_validate <PR#>
+
+# verbose mode (more progress logging on stderr)
+python3.12 -m scripts.pr_validate <PR#> -v
+
+# stdout = markdown scorecard (paste into PR comment)
+# stderr = progress logs
+# exit 0 = MERGE-SAFE, exit 1 = DO NOT MERGE
+```
+
+## Pipeline
+
+| # | step | gate | runtime |
+|---|---|---|---|
+| 0 | `fetch` | always (fail-fast) | ~3s |
+| 6 | `deepseek_review` | always (skip if no API) | 30–90s |
+| 1 | `supply_chain` | always | ~5s |
+| 2 | `lint` | when diff has .py | ~3s |
+| 3 | `targeted_tests` | when diff has .py | 30s–3min |
+| 4 | `full_unit` | blast ≥ medium | ~25s |
+| 5 | `stress_e2e_bench` | blast == high | 5–10min |
+
+(DeepSeek review goes second by design: get cheap critical thinking
+*before* spending 10 minutes on tests.)
+
+## Verdict
+
+Strict — any single `fail` or `error` blocks merge. `skip` is neutral.
+
+## Blast radius
+
+Computed from `files_changed`. See `context.py::HIGH_BLAST_PATHS` for
+the gating list. The classification chooses which expensive steps run.
+
+* **high** — touches scheduler / engine / cli / server / memory_cache
+  / routes / pyproject.toml. Full battery.
+* **medium** — touches `vllm_mlx/` or `tests/` but not the high-blast
+  list. Skips stress.
+* **low** — only docs / examples / README. Skips full_unit + stress.
+
+## Adding a step
+
+1. Write a module under `steps/` with a class extending `base.Step`.
+2. Set `name`, `description`, override `run(ctx)` (and `should_run` if
+   the step is conditional).
+3. Import + insert in the `STEPS` list in `runner.py`.
+
+The runner orders steps explicitly — no auto-discovery — so the
+pipeline policy is grep-able from one file.
+
+## Step details
+
+### `fetch` (step 0)
+
+Wraps `gh pr view --json` + `gh pr diff`. Saves the diff to
+`<work_dir>/pr.diff`. Refuses CLOSED / MERGED / DIRTY (merge-conflict)
+PRs by design — re-open or rebase first.
+
+### `deepseek_review` (step 6, runs second)
+
+Sends the diff to DeepSeek V4 Pro with the prompt at
+`prompts/deepseek_review.md`. Findings go in the scorecard. Skips if
+`PR_VALIDATE_NO_DEEPSEEK=1` or no API key. Skips on network failure
+(don't block PRs on a flaky API).
+
+API key resolution: `$DEEPSEEK_API_KEY` → fallback to dev key in code
+(see `memory/knowledge/deepseek_api_key.md`).
+
+### `supply_chain` (step 1)
+
+* Flags any modification to install hooks, CI workflows, Makefile,
+  Homebrew tap (BLOCKING for external authors, warning for collaborators).
+* Greps added lines for suspicious patterns (`eval`, `exec`,
+  `pickle.loads`, `subprocess(... shell=True)`, hardcoded URLs/IPs,
+  large hex/base64 blobs).
+* Runs `pip-audit` against any new dependencies declared in
+  `pyproject.toml` / `requirements.txt`.
+
+### `lint` (step 2)
+
+`ruff check` + `ruff format --check` on the changed `.py` files only.
+
+### `targeted_tests` (step 3)
+
+Maps each changed `.py` to candidate test files (heuristic by
+filename) and runs them. **Negative control**: if any fail, re-runs
+the same set on a fresh `git worktree` of `main` to filter
+pre-existing flakes. Real regressions = fail.
+
+### `full_unit` (step 4)
+
+`pytest tests/` minus integrations + event_loop. Gated on blast ≥
+medium (low-blast PRs can't break runtime).
+
+### `stress_e2e_bench` (step 5)
+
+The heaviest. Gated on blast == high. For each model in
+`golden_models.yaml` that fits machine RAM (highest-quality candidate
+per family):
+
+1. Boot a server on port 8451.
+2. Run `scripts/stress_test.py` (8 stress scenarios).
+3. Run each agent integration in the registry (matrix: m × n).
+4. Run an inline bench (cold TTFT + warm TTFT + speedup).
+5. Compare bench to `harness/baselines/bench-<model>.json` —
+   regression > 5% = fail.
+
+Skip with `PR_VALIDATE_NO_STRESS=1`.
+
+## Artifacts
+
+Every run writes to `/tmp/pr_validate/pr-<N>/`:
+
+* `pr.diff` — full unified diff
+* `lint-{check,format}.log` — ruff output
+* `targeted-{pr,main}.log` — pytest output (PR + neg-control on main)
+* `full-unit.log` — pytest full output
+* `deepseek-{request,review,usage}.{txt,md,json}` — API call + result
+* `supply-chain-scan.log` + `pip-audit.log` — supply-chain artifacts
+* `server-<model>.log` — boot + lifespan log
+* `stress-<model>.log` — stress test output
+* `agent-<name>-<model>.log` — per-integration output
+* `bench-<model>.json` — bench numbers (latest run)
+
+## Roadmap
+
+* GitHub Action wiring (cheap layers only — DeepSeek per-push is
+  expensive).
+* License-drift check via `pip show <pkg>` against an allowlist.
+* Diff-aware import-graph for `targeted_tests` (replace stem heuristic).
+* Expand `golden_models.yaml` to the full family list once we have RAM
+  budget for big-model boots.

--- a/scripts/pr_validate/__init__.py
+++ b/scripts/pr_validate/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PR validation pipeline.
+
+Single-command harness that grades an incoming PR for merge-readiness.
+Each step is a discrete module under ``steps/``; the runner drives them
+in a fixed order and the scorecard renders a strict pass/fail verdict.
+
+Entry point::
+
+    python3.12 -m scripts.pr_validate <PR#>
+
+See ``scripts/pr_validate/README.md`` for the full step list and design.
+"""

--- a/scripts/pr_validate/base.py
+++ b/scripts/pr_validate/base.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Base classes for pipeline steps.
+
+Each step is a small class with three contract points: a name, a
+``should_run(ctx)`` predicate (lets us gate expensive steps on blast
+radius), and a ``run(ctx) -> StepResult``. Keep step modules
+self-contained — the runner doesn't know what each does, only that it
+returns a uniform result object the scorecard can render.
+
+We intentionally avoid a plugin registry / entrypoints mechanism. The
+runner explicitly imports + orders steps so the pipeline is grep-able
+and review-time obvious. Adding a step = one import + one list entry.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from .context import Context
+
+
+# Status meanings:
+#   pass    — step ran, nothing wrong → does not block merge
+#   fail    — step ran, found a real problem → BLOCKS merge (strict mode)
+#   skip    — step decided not to run (gating) → does not block, neutral
+#   error   — step crashed before it could decide → BLOCKS merge (treat
+#             unknown like failure; never let a broken validator silently
+#             approve a PR)
+StepStatus = Literal["pass", "fail", "skip", "error"]
+
+
+@dataclass
+class StepResult:
+    """Per-step output the scorecard renders.
+
+    ``summary`` is a one-liner shown in the verdict table; ``details``
+    is the multiline markdown shown when the step failed (or when the
+    user asked for ``--verbose``). ``artifacts`` are paths to log files
+    in the working dir — preserved so the user can inspect after.
+    """
+
+    name: str
+    status: StepStatus
+    summary: str
+    details: str = ""
+    duration_seconds: float = 0.0
+    artifacts: list[str] = field(default_factory=list)
+    # Free-form findings list; populated by the adversarial-review step
+    # so the scorecard can render them inline. Each is one short string.
+    findings: list[str] = field(default_factory=list)
+
+
+class Step:
+    """Pipeline step. Subclasses override ``run``; everything else is
+    handled by the runner."""
+
+    name: str = "unnamed"
+    description: str = ""
+    # If True, an ``error`` from this step still lets later steps run
+    # (best-effort gating). Default is False — most steps are blocking.
+    continue_on_error: bool = False
+
+    def should_run(self, ctx: Context) -> bool:
+        """Return False to skip — e.g. blast radius too low. Default
+        runs every time."""
+        return True
+
+    def run(self, ctx: Context) -> StepResult:
+        raise NotImplementedError
+
+    def execute(self, ctx: Context) -> StepResult:
+        """Wrapper called by the runner. Times the step, catches
+        exceptions, normalizes errors so a step bug never silently
+        passes a bad PR."""
+        if not self.should_run(ctx):
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="skipped (gating predicate returned False)",
+                duration_seconds=0.0,
+            )
+        t0 = time.monotonic()
+        try:
+            result = self.run(ctx)
+        except Exception as e:  # noqa: BLE001 — we want to catch ANY crash
+            import traceback
+
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=f"step crashed: {type(e).__name__}: {e}",
+                details=f"```\n{traceback.format_exc()}\n```",
+                duration_seconds=time.monotonic() - t0,
+            )
+        result.duration_seconds = time.monotonic() - t0
+        if result.name == "unnamed":
+            result.name = self.name
+        return result

--- a/scripts/pr_validate/context.py
+++ b/scripts/pr_validate/context.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared state passed to every pipeline step.
+
+A single Context lives for the duration of one ``pr_validate`` run. Each
+step reads what it needs and may append to ``results``. Steps must NOT
+mutate fields other than ``results`` — anything else is shared input.
+
+Blast-radius classification is what gates the expensive steps (full unit
+suite, stress, e2e, bench). Keep the rule simple and grep-able rather
+than learned: a small fixed set of paths is "high blast" because a
+regression there hits every request.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from .base import StepResult
+
+
+BlastRadius = Literal["low", "medium", "high"]
+
+
+# Files / directories that affect every request → any change requires
+# the heavy gate (full unit + stress + e2e + bench). Order doesn't
+# matter; we use ``startswith`` matching against repo-relative paths.
+HIGH_BLAST_PATHS = (
+    "vllm_mlx/scheduler.py",
+    "vllm_mlx/server.py",
+    "vllm_mlx/cli.py",
+    "vllm_mlx/memory_cache.py",
+    "vllm_mlx/prefix_cache.py",
+    "vllm_mlx/engine/",
+    "vllm_mlx/runtime/",
+    "vllm_mlx/routes/",
+    "vllm_mlx/middleware/",
+    "vllm_mlx/turboquant.py",
+    "vllm_mlx/mllm_scheduler.py",
+    "pyproject.toml",  # version, deps, build config
+)
+
+# Paths that are "code but isolated" — touching them needs unit tests
+# but not the full stress/e2e battery. Parsers, models, agents.
+MEDIUM_BLAST_PATHS = (
+    "vllm_mlx/",  # anything under vllm_mlx not caught by high
+    "tests/",  # test changes themselves get the unit suite
+)
+
+# Paths considered safe — docs, scripts (except validation itself),
+# examples. Drive-by typo PRs land here.
+LOW_BLAST_PATHS = (
+    "docs/",
+    "README",
+    ".github/ISSUE_TEMPLATE/",  # NOT .github/workflows — that's a supply-chain risk
+    "examples/",
+    "evals/",
+    "harness/baselines/",
+)
+
+
+@dataclass
+class Context:
+    """Per-run state. Constructed by the fetch step, read by everyone."""
+
+    pr_number: int
+    repo: str = "raullenchai/Rapid-MLX"
+    base_branch: str = "main"
+
+    # Populated by the fetch step:
+    pr_title: str = ""
+    pr_body: str = ""
+    pr_author: str = ""
+    # True iff the PR head is on a fork. Used as the "external author"
+    # proxy because gh's --json output doesn't expose authorAssociation.
+    pr_is_external: bool = False
+    head_sha: str = ""
+    head_branch: str = ""
+    base_sha: str = ""
+    diff_path: str = ""  # path to full diff on disk (lazy — large diffs OK)
+    files_changed: list[str] = field(default_factory=list)
+    additions: int = 0
+    deletions: int = 0
+
+    # Working directory for artifacts (one per run, kept for inspection).
+    work_dir: Path = field(default_factory=lambda: Path("/tmp/pr_validate"))
+
+    # Repo root (set in __post_init__).
+    repo_root: Path = field(init=False)
+
+    # Step results accumulate here in execution order.
+    results: list[StepResult] = field(default_factory=list)
+
+    # CLI flags / config knobs — keep small.
+    verbose: bool = False
+
+    def __post_init__(self) -> None:
+        # Repo root = current working directory by convention. Validator
+        # is meant to be run from the repo root; bail loudly otherwise.
+        cwd = Path.cwd()
+        if not (cwd / "pyproject.toml").exists():
+            raise RuntimeError(
+                f"pr_validate must run from the repo root (no pyproject.toml in {cwd})"
+            )
+        self.repo_root = cwd
+
+    # ------------------------------------------------------------------
+    # Derived properties — computed from files_changed once it's set
+    # ------------------------------------------------------------------
+
+    @property
+    def blast_radius(self) -> BlastRadius:
+        """Classify the PR's blast radius.
+
+        Highest match wins: a PR that touches both docs and scheduler.py
+        is HIGH (the docs change is irrelevant — the scheduler change
+        decides the gating). LOW only if EVERY changed file is in the
+        low-risk allowlist; anything outside that bumps to medium.
+        """
+        if not self.files_changed:
+            return "low"
+        for path in self.files_changed:
+            if any(path.startswith(p) for p in HIGH_BLAST_PATHS):
+                return "high"
+        # If we reach here, no high-blast file. Check if everything is
+        # in the low set; otherwise medium.
+        all_low = all(
+            any(path.startswith(p) for p in LOW_BLAST_PATHS)
+            for path in self.files_changed
+        )
+        return "low" if all_low else "medium"
+
+    @property
+    def is_external_author(self) -> bool:
+        """True for non-collaborator authors. External PRs get extra
+        scrutiny in the supply-chain step (since maintainers can't be
+        assumed to recognize the contributor). Approximated via
+        ``pr_is_external`` (PR head is on a fork) — this misses the
+        rare case of a collaborator pushing a fork-based PR, but the
+        false-positive is in the safe direction."""
+        return self.pr_is_external
+
+    def artifact_path(self, name: str) -> Path:
+        """Return a path inside the run's work_dir, creating parent
+        dirs. Steps use this for log files etc."""
+        p = self.work_dir / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def run_log(self, message: str) -> None:
+        """Lightweight progress log — goes to stderr so it doesn't
+        contaminate the scorecard markdown on stdout."""
+        import sys
+
+        print(f"  · {message}", file=sys.stderr)
+
+
+def env_truthy(name: str) -> bool:
+    """Helper for env-var feature flags (``PR_VALIDATE_NO_DEEPSEEK=1``
+    style)."""
+    return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")

--- a/scripts/pr_validate/golden_models.yaml
+++ b/scripts/pr_validate/golden_models.yaml
@@ -1,0 +1,62 @@
+# Golden-model registry for stress + bench.
+#
+# Each family is a logical model line (Qwen3, Qwen3.5, MiniMax …). The
+# pipeline picks ONE candidate per family — the highest-quality one
+# whose `ram_gb_required` fits on the current machine (with some
+# headroom). If nothing fits, the family is skipped.
+#
+# `quality_tier` is for display + tie-breaking, not for selection. It
+# describes how trustworthy the quantization is for behavior testing:
+#   - golden:   the canonical sweet spot — use when validating "the
+#               server still works"
+#   - smoke:    too small to catch much, but always-runnable so we can
+#               at least confirm boot + inference + token streaming
+#   - small/medium: middle of the road
+#
+# `stop_at_first_fit`: keep the highest-quality entry per family that
+# fits the machine; we don't run multiple sizes from the same family
+# (they'd test the same code paths).
+#
+# Add new families by appending. Entries are evaluated top-to-bottom
+# within a family — put highest-quality first.
+families:
+  - family: qwen3-smoke
+    candidates:
+      - id: mlx-community/Qwen3-0.6B-8bit
+        ram_gb_required: 2
+        quality_tier: smoke
+
+  - family: qwen3.5
+    candidates:
+      - id: mlx-community/Qwen3.5-4B-MLX-4bit
+        ram_gb_required: 4
+        quality_tier: small
+
+  - family: qwen3.6
+    candidates:
+      - id: mlx-community/Qwen3.6-27B-4bit
+        ram_gb_required: 18
+        quality_tier: golden
+
+# Per-model overrides: extra CLI args (e.g. parser overrides for
+# tool-calling tests). Keep small — most models don't need this.
+overrides:
+  "mlx-community/Qwen3.6-27B-4bit":
+    args: ["--enable-auto-tool-choice"]
+
+# Agent integrations — each is a tests/integrations/ test_X.py script
+# we exec against the live server. The matrix is models × agents.
+# Tests that already work today; we expand the list as integrations
+# stabilize.
+agents:
+  - name: anthropic_sdk
+    script: tests/integrations/test_anthropic_sdk.py
+    # Tests skipped for tiny models — Anthropic streaming + 0.6B is the
+    # known #185 false-positive zone.
+    skip_for_smoke: false
+  - name: langchain
+    script: tests/integrations/test_langchain.py
+    skip_for_smoke: false
+  - name: pydantic_ai
+    script: tests/integrations/test_pydantic_ai_full.py
+    skip_for_smoke: true  # multi-tool fails on 0.6B; expected

--- a/scripts/pr_validate/pr_validate.py
+++ b/scripts/pr_validate/pr_validate.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``python3.12 -m scripts.pr_validate <PR#>`` entry point."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .runner import run_pipeline
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="pr_validate",
+        description="Run the merge-readiness pipeline against a PR.",
+    )
+    parser.add_argument(
+        "pr_number",
+        type=int,
+        help="GitHub PR number (e.g. 200)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print step output as it runs",
+    )
+    args = parser.parse_args(argv)
+    return run_pipeline(args.pr_number, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_validate/prompts/deepseek_review.md
+++ b/scripts/pr_validate/prompts/deepseek_review.md
@@ -1,0 +1,57 @@
+You are an adversarial code reviewer for Rapid-MLX, a production
+inference server published to PyPI + Homebrew with auto-deploy. Be
+picky and specific. Quote line numbers from the diff. Find concrete
+problems, not generalities. Skip what is fine — only report what is
+broken or risky.
+
+# What I want you to check
+
+For each item, only report if you find a CONCRETE issue with a
+line/file citation. Skip the category if it's clean.
+
+1. **Correctness bugs** — off-by-one, wrong default, swapped args,
+   missing await, wrong error type caught, leaked file handle, race
+   conditions, ordering bugs.
+
+2. **Security** — command injection, path traversal, unsanitized
+   external input, secret in logs, hard-coded credentials,
+   trust-on-first-use without verification, eval/exec on untrusted
+   data, pickle of untrusted data, SSRF, XXE.
+
+3. **Backward compat** — does the change break callers that worked
+   yesterday? Migration path for old data formats? Deprecation warning?
+
+4. **Tests** — does the test actually exercise the changed behavior?
+   Does it pass by coincidence? Are the assertions specific or just
+   "doesn't crash"? Any test that would still pass if the production
+   code were deleted?
+
+5. **Performance** — algorithmic regressions (O(n²) where O(n)
+   existed), unnecessary allocations in a hot path, blocking I/O on
+   the event loop, lock-contention introduced.
+
+6. **Resource handling** — file handles, sockets, processes,
+   subprocesses, threads — all closed/joined/cleaned up on every exit
+   path including exceptions?
+
+7. **Failure modes** — what happens when the network call times out?
+   When the disk is full? When the subprocess exits non-zero? When
+   the input file is missing or empty? Is the error message
+   actionable for a debugger?
+
+8. **API design** — surprising defaults, mutable default arguments,
+   functions that return None on error vs raising, public functions
+   that should be private, leaky abstractions.
+
+9. **Anything else** that a senior production reviewer would flag.
+
+# Output format
+
+Return a numbered list of CONCRETE issues. For each:
+
+- file:line citation
+- one-sentence description of what's wrong
+- one-sentence fix sketch
+
+Don't pad. Skip categories that are clean. Maximum 800 words total.
+If you find no issues, say "No blocking issues found." and stop.

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline runner — owns step ordering, fail-fast policy, scorecard.
+
+Step order is intentionally hardcoded here (not auto-discovered) so a
+reviewer can grep one file to see the entire validation policy. To add
+a step: write the module under ``steps/``, import it here, append to
+``STEPS``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from .base import Step, StepResult
+from .context import Context
+from .scorecard import render_scorecard, verdict
+from .steps.deepseek_review import DeepSeekReviewStep
+from .steps.fetch import FetchStep
+from .steps.full_unit import FullUnitStep
+from .steps.lint import LintStep
+from .steps.stress_e2e_bench import StressE2EBenchStep
+from .steps.supply_chain import SupplyChainStep
+from .steps.targeted_tests import TargetedTestsStep
+
+# Step order — see scripts/pr_validate/README.md for the rationale.
+# DeepSeek review goes early so cheap critical thinking happens before
+# we spend 10 minutes on tests.
+STEPS: list[Step] = [
+    FetchStep(),  # 0 — fetch PR + diff + classify blast radius
+    DeepSeekReviewStep(),  # 6 — adversarial review (moved to front)
+    SupplyChainStep(),  # 1 — pip-audit, license, install hooks
+    LintStep(),  # 2 — ruff check + format
+    TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
+    FullUnitStep(),  # 4 — full pytest, gated on blast radius
+    StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
+]
+
+# Steps that, if they fail, stop the pipeline immediately (subsequent
+# steps would either crash or waste CPU). Fetch failures mean we have
+# nothing to validate; lint failures mean the diff doesn't even parse
+# cleanly. Most other failures still let later steps run so the
+# scorecard surfaces the FULL picture rather than only the first bug.
+FAIL_FAST_STEPS = {"fetch"}
+
+
+def run_pipeline(pr_number: int, *, verbose: bool = False) -> int:
+    """Execute the pipeline. Returns process exit code (0 = merge-safe).
+
+    Strict scoring: ANY single ``fail`` or ``error`` blocks merge.
+    ``skip`` is neutral (a step decided it didn't apply).
+    """
+    ctx = Context(pr_number=pr_number, verbose=verbose)
+    ctx.work_dir = ctx.work_dir / f"pr-{pr_number}"
+    ctx.work_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"# PR #{pr_number} validation", file=sys.stderr)
+    print(f"  artifacts → {ctx.work_dir}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    for step in STEPS:
+        print(f"## [{step.name}] {step.description}", file=sys.stderr)
+        result = step.execute(ctx)
+        ctx.results.append(result)
+
+        marker = {
+            "pass": "OK",
+            "fail": "FAIL",
+            "skip": "skip",
+            "error": "ERROR",
+        }[result.status]
+        print(
+            f"  → {marker:6s} {result.summary} ({result.duration_seconds:.1f}s)",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+
+        # Fail-fast for steps where continuing makes no sense.
+        if result.status in ("fail", "error") and step.name in FAIL_FAST_STEPS:
+            print(
+                f"  fail-fast: [{step.name}] is critical, stopping pipeline",
+                file=sys.stderr,
+            )
+            break
+
+    # Render the scorecard to stdout (so callers can pipe into PR comments).
+    print(render_scorecard(ctx))
+
+    final_verdict = verdict(ctx.results)
+    print(f"\nVerdict: {final_verdict}", file=sys.stderr)
+
+    # Exit code: 0 only if every step is pass-or-skip (strict).
+    return 0 if final_verdict == "MERGE-SAFE" else 1
+
+
+def _step_status(results: list[StepResult], name: str) -> str | None:
+    for r in results:
+        if r.name == name:
+            return r.status
+    return None

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import sys
 
-from .base import Step, StepResult
+from .base import Step
 from .context import Context
 from .scorecard import render_scorecard, verdict
 from .steps.deepseek_review import DeepSeekReviewStep
@@ -90,10 +90,3 @@ def run_pipeline(pr_number: int, *, verbose: bool = False) -> int:
 
     # Exit code: 0 only if every step is pass-or-skip (strict).
     return 0 if final_verdict == "MERGE-SAFE" else 1
-
-
-def _step_status(results: list[StepResult], name: str) -> str | None:
-    for r in results:
-        if r.name == name:
-            return r.status
-    return None

--- a/scripts/pr_validate/scorecard.py
+++ b/scripts/pr_validate/scorecard.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Render the per-step results as a markdown scorecard.
+
+Strict mode: ANY single ``fail`` or ``error`` → "DO NOT MERGE".
+``skip`` is neutral. Output is markdown so the same string can be
+posted as a PR comment via ``gh pr comment``.
+"""
+
+from __future__ import annotations
+
+from .base import StepResult
+from .context import Context
+
+
+def verdict(results: list[StepResult]) -> str:
+    """Strict — any non-pass-or-skip blocks merge."""
+    blocking = [r for r in results if r.status in ("fail", "error")]
+    if blocking:
+        return "DO NOT MERGE"
+    if not results:
+        return "INCOMPLETE"
+    return "MERGE-SAFE"
+
+
+_STATUS_BADGE = {
+    "pass": "PASS",
+    "fail": "FAIL",
+    "skip": "skip",
+    "error": "ERROR",
+}
+
+
+def render_scorecard(ctx: Context) -> str:
+    """Build the markdown report. One table row per step, then per-fail
+    detail blocks below. Designed to be paste-able into a GitHub PR
+    comment without further editing."""
+    final = verdict(ctx.results)
+
+    lines = []
+    lines.append(f"# PR #{ctx.pr_number} validation scorecard")
+    lines.append("")
+    if ctx.pr_title:
+        lines.append(f"**Title**: {ctx.pr_title}")
+    if ctx.pr_author:
+        author_label = ctx.pr_author
+        if ctx.is_external_author:
+            author_label += " (external)"
+        lines.append(f"**Author**: {author_label}")
+    if ctx.files_changed:
+        lines.append(
+            f"**Diff**: {len(ctx.files_changed)} file(s), "
+            f"+{ctx.additions}/-{ctx.deletions} LOC, "
+            f"blast radius: **{ctx.blast_radius}**"
+        )
+    lines.append("")
+    lines.append(f"## Verdict: **{final}**")
+    lines.append("")
+
+    # Step results table.
+    lines.append("| step | status | summary | time |")
+    lines.append("|---|---|---|---:|")
+    for r in ctx.results:
+        badge = _STATUS_BADGE[r.status]
+        # Markdown-escape any pipes in summary.
+        summary = r.summary.replace("|", "\\|")
+        lines.append(
+            f"| `{r.name}` | {badge} | {summary} | {r.duration_seconds:.1f}s |"
+        )
+    lines.append("")
+
+    # Detail blocks for any failure / error / important findings.
+    detail_blocks = []
+    for r in ctx.results:
+        if r.status in ("fail", "error") or r.findings:
+            block = [f"### `{r.name}` — {_STATUS_BADGE[r.status]}", ""]
+            if r.findings:
+                block.append("**Findings:**")
+                for f in r.findings:
+                    block.append(f"- {f}")
+                block.append("")
+            if r.details:
+                block.append(r.details)
+                block.append("")
+            if r.artifacts:
+                block.append("**Artifacts:**")
+                for a in r.artifacts:
+                    block.append(f"- `{a}`")
+                block.append("")
+            detail_blocks.extend(block)
+    if detail_blocks:
+        lines.append("## Details")
+        lines.append("")
+        lines.extend(detail_blocks)
+
+    return "\n".join(lines)

--- a/scripts/pr_validate/steps/__init__.py
+++ b/scripts/pr_validate/steps/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline steps. Each module defines one ``Step`` subclass."""

--- a/scripts/pr_validate/steps/deepseek_review.py
+++ b/scripts/pr_validate/steps/deepseek_review.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 6 — DeepSeek V4 Pro adversarial review of the diff.
+
+Productionizes the one-off /tmp/deepseek_review_*.py scripts we've been
+building per-PR. Reads the prompt template from
+``scripts/pr_validate/prompts/deepseek_review.md``, sends the diff,
+parses the response. Findings are surfaced in the scorecard verbatim
+so a maintainer can decide whether to act on each.
+
+Failure policy is deliberately conservative: we mark the step ``fail``
+ONLY if DeepSeek's reply contains markers that look like blocking
+findings (lines starting with "1.", "2.", … and mentioning specific
+files). A reply of "No blocking issues found." → ``pass``. Network
+failures or a missing API key → ``skip`` with a clear summary, NOT
+``fail`` — we don't want a temporarily-down API to block every PR.
+The strictness is at the human-review layer, not the API layer.
+
+The API key is read from the environment (``DEEPSEEK_API_KEY``) and
+falls back to a hardcoded development key documented in
+``memory/knowledge/deepseek_api_key.md``. Putting it in source is OK
+here ONLY because the key is the user's personal review-budget key,
+not a production credential — but env override is preferred.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+from ..base import Step, StepResult
+from ..context import Context, env_truthy
+
+# NB: do NOT default the API key here. The repo is public; even a
+# personal review-budget key should never live in version control.
+# Users provide it via ``DEEPSEEK_API_KEY`` (see
+# ``memory/knowledge/deepseek_api_key.md`` for where the key is stored
+# locally). Without the env var the step skips gracefully.
+ENDPOINT = "https://api.deepseek.com/v1/chat/completions"
+MODEL = "deepseek-v4-pro"
+
+# Hard cap on diff size we send. DeepSeek can take more, but past
+# ~80KB of diff the signal-to-noise of the review drops sharply (the
+# model starts skimming). For very large PRs we send the diff
+# truncated and note it in the prompt.
+MAX_DIFF_BYTES = 80_000
+
+# Token budget. Reasoning-model behavior: we observed ~6K tokens of
+# reasoning + 500-1500 tokens of visible content for a normal review.
+# 16K leaves headroom.
+MAX_TOKENS = 16_384
+
+# How long we wait for the API. DeepSeek V4 Pro reasoning takes
+# 30-90s typical, up to 5min for big diffs.
+TIMEOUT_SECONDS = 600
+
+PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "deepseek_review.md"
+
+
+class DeepSeekReviewStep(Step):
+    name = "deepseek_review"
+    description = "DeepSeek V4 Pro adversarial review of diff"
+
+    def should_run(self, ctx: Context) -> bool:
+        # Allow opt-out (CI without API access, offline dev, etc.).
+        if env_truthy("PR_VALIDATE_NO_DEEPSEEK"):
+            return False
+        # Skip if there's no diff to review (shouldn't happen post-fetch
+        # but defend against it — empty review wastes API budget).
+        return bool(ctx.diff_path) and Path(ctx.diff_path).stat().st_size > 0
+
+    def run(self, ctx: Context) -> StepResult:
+        # httpx is in our deps already; importing inside the method
+        # keeps the framework import-light for steps that don't need it.
+        try:
+            import httpx
+        except ImportError:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="httpx not installed — `pip install httpx`",
+            )
+
+        api_key = os.environ.get("DEEPSEEK_API_KEY", "")
+        if not api_key:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    "no DEEPSEEK_API_KEY set (export it to enable adversarial "
+                    "review; see memory/knowledge/deepseek_api_key.md)"
+                ),
+            )
+
+        diff = Path(ctx.diff_path).read_text()
+        truncated = False
+        if len(diff) > MAX_DIFF_BYTES:
+            diff = diff[:MAX_DIFF_BYTES]
+            truncated = True
+
+        if not PROMPT_PATH.exists():
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=f"prompt template missing at {PROMPT_PATH}",
+            )
+        system_prompt = PROMPT_PATH.read_text()
+
+        user_prompt = _build_user_prompt(ctx, diff, truncated)
+
+        # Save what we sent — useful for debugging "why did the review
+        # say X" without re-running.
+        sent_path = ctx.artifact_path("deepseek-request.txt")
+        sent_path.write_text(
+            f"=== SYSTEM ===\n{system_prompt}\n\n=== USER ===\n{user_prompt}"
+        )
+
+        ctx.run_log(f"calling {MODEL} ({len(diff)} bytes of diff)…")
+
+        try:
+            with httpx.Client(timeout=TIMEOUT_SECONDS) as client:
+                resp = client.post(
+                    ENDPOINT,
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": MODEL,
+                        "messages": [
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_prompt},
+                        ],
+                        "temperature": 0.0,
+                        "max_tokens": MAX_TOKENS,
+                    },
+                )
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=f"API unreachable: {type(e).__name__}",
+            )
+
+        if resp.status_code != 200:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=f"API returned {resp.status_code}",
+                details=f"```\n{resp.text[:1000]}\n```",
+            )
+
+        body = resp.json()
+        choices = body.get("choices") or []
+        if not choices:
+            # DeepSeek can return an empty choices array on rate-limit
+            # or content-policy refusal. Don't crash — surface as skip
+            # with the body for debugging.
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="API returned no choices (rate limit? policy?)",
+                details=f"```json\n{json.dumps(body, indent=2)[:1000]}\n```",
+            )
+        content = choices[0].get("message", {}).get("content", "") or ""
+        usage = body.get("usage", {})
+
+        review_path = ctx.artifact_path("deepseek-review.md")
+        review_path.write_text(content)
+        usage_path = ctx.artifact_path("deepseek-usage.json")
+        usage_path.write_text(json.dumps(usage, indent=2))
+
+        # Parse the response. The prompt asks for a numbered list; we
+        # detect "no findings" by an explicit phrase, otherwise we
+        # extract numbered items as findings.
+        findings = _extract_findings(content)
+        no_issues = _is_clean_review(content)
+
+        if no_issues and not findings:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary="DeepSeek found no blocking issues",
+                artifacts=[str(review_path), str(usage_path)],
+            )
+
+        # Findings present → fail the step in strict mode. Maintainer
+        # decides per-finding whether to act; the scorecard surfaces
+        # them all in the details. (Some reviewers may want a
+        # human-decides flow here; that's what looking at the artifact
+        # is for. The step's role is to surface, not to triage.)
+        summary = f"{len(findings)} finding(s)"
+        if truncated:
+            summary += " (diff truncated for review)"
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=summary,
+            findings=findings,
+            details=(
+                "**Full review:**\n\n"
+                f"{content}\n\n"
+                f"_(Saved to `{review_path}`. "
+                f"Token usage: {usage.get('total_tokens', '?')})_"
+            ),
+            artifacts=[str(review_path), str(usage_path)],
+        )
+
+
+def _build_user_prompt(ctx: Context, diff: str, truncated: bool) -> str:
+    """Compose the user message: PR context + diff. The system prompt
+    explains how to review; this provides what to review."""
+    lines = [
+        f"# PR #{ctx.pr_number}: {ctx.pr_title}",
+        "",
+        f"**Author**: {ctx.pr_author}{' (external/fork)' if ctx.pr_is_external else ''}",
+        f"**Files**: {len(ctx.files_changed)} ({ctx.additions}+/{ctx.deletions}-)",
+        f"**Blast radius**: {ctx.blast_radius}",
+        "",
+        "## Description",
+        "",
+        ctx.pr_body or "_(no description)_",
+        "",
+        "## Diff",
+        "",
+    ]
+    if truncated:
+        lines.append(
+            f"_Note: diff truncated to {MAX_DIFF_BYTES} bytes for review. "
+            "Full diff is on disk; review what's shown._"
+        )
+        lines.append("")
+    lines.append("```diff")
+    lines.append(diff)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# Phrases that indicate a clean review. Match case-insensitively. If
+# any of these appear in the response and we extract zero numbered
+# findings, treat it as a clean pass.
+_CLEAN_PATTERNS = (
+    re.compile(r"no\s+blocking\s+issues?\s+found", re.IGNORECASE),
+    re.compile(r"no\s+issues?\s+found", re.IGNORECASE),
+    re.compile(r"^\s*looks?\s+good", re.IGNORECASE | re.MULTILINE),
+)
+
+
+def _is_clean_review(text: str) -> bool:
+    return any(p.search(text) for p in _CLEAN_PATTERNS)
+
+
+# Extract numbered findings — match lines starting with "1.", "2.",
+# etc. (with optional leading whitespace and bold). One short line
+# per finding for the scorecard table.
+_FINDING_RE = re.compile(
+    r"^\s*(?:\*\*)?(\d+)\.?\)?\s*(?:\*\*)?\s+(.+?)(?:\*\*)?\s*$",
+    re.MULTILINE,
+)
+
+
+def _extract_findings(text: str) -> list[str]:
+    """Pull numbered list items as findings. Truncates each to a
+    reasonable length for the scorecard table; full text lives in the
+    artifact file."""
+    findings = []
+    for match in _FINDING_RE.finditer(text):
+        body = match.group(2).strip().rstrip("*").strip()
+        # Cap per-finding length; long ones go in the artifact.
+        if len(body) > 240:
+            body = body[:237] + "…"
+        findings.append(body)
+    # Sometimes the model returns markdown headings like "### 1. Title"
+    # which the regex above catches via the leading number; that's
+    # fine. Deduplicate just in case (very long replies sometimes
+    # repeat the summary at the bottom).
+    seen = set()
+    out = []
+    for f in findings:
+        if f not in seen:
+            out.append(f)
+            seen.add(f)
+    return out

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 0 — fetch the PR.
+
+Wraps ``gh pr view`` + ``gh pr diff`` so every later step has a stable
+view of what's being validated. Records the diff and metadata into the
+context. Fail-fast: if we can't fetch the PR, nothing else can run.
+
+We deliberately do NOT check out the PR branch into the working tree.
+Steps that need to run code from the PR (lint, tests) check out into a
+``git worktree`` so the user's local working tree stays untouched. This
+matters: a half-validated PR shouldn't leave your editor pointed at
+random foreign code.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import subprocess
+
+from ..base import Step, StepResult
+from ..context import Context
+
+
+class FetchStep(Step):
+    name = "fetch"
+    description = "fetch PR + diff + classify blast radius"
+
+    def run(self, ctx: Context) -> StepResult:
+        # Preflight: gh is the entire interface to GitHub. Without it
+        # we can't even start; better to fail with a clear message than
+        # let `subprocess.run` raise FileNotFoundError ("[Errno 2] No
+        # such file or directory: 'gh'") which leaks no fix instruction.
+        if not shutil.which("gh"):
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=(
+                    "`gh` CLI not installed — `brew install gh` "
+                    "(or see https://cli.github.com)"
+                ),
+            )
+
+        # Pull PR metadata as JSON so we get author, head ref, etc.
+        # without scraping HTML.
+        try:
+            meta_raw = _gh(
+                f"pr view {ctx.pr_number} --repo {ctx.repo} "
+                "--json number,title,body,author,isCrossRepository,"
+                "headRefOid,headRefName,baseRefOid,additions,deletions,"
+                "files,state,mergeStateStatus"
+            )
+        except subprocess.CalledProcessError as e:
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary="`gh pr view` failed (auth? network? typo in PR#?)",
+                details=f"```\n{e.stderr or e.stdout}\n```",
+            )
+
+        meta = json.loads(meta_raw)
+
+        ctx.pr_title = meta.get("title", "")
+        ctx.pr_body = meta.get("body", "") or ""
+        ctx.pr_author = (meta.get("author") or {}).get("login", "")
+        # gh CLI doesn't expose authorAssociation via --json; use
+        # isCrossRepository as the external-author proxy. Fork-based PRs
+        # are external by definition. Misses the rare case where a
+        # collaborator opens a PR from a fork, but that's a false-positive
+        # in the safe direction (more scrutiny, not less).
+        ctx.pr_is_external = bool(meta.get("isCrossRepository", False))
+        ctx.head_sha = meta.get("headRefOid", "")
+        ctx.head_branch = meta.get("headRefName", "")
+        ctx.base_sha = meta.get("baseRefOid", "")
+        ctx.additions = meta.get("additions", 0)
+        ctx.deletions = meta.get("deletions", 0)
+        ctx.files_changed = sorted(
+            f["path"] for f in (meta.get("files") or []) if "path" in f
+        )
+
+        # Pull the full diff. We save to disk so DeepSeek and supply
+        # chain can stream-read it without re-running gh.
+        diff_path = ctx.artifact_path("pr.diff")
+        try:
+            diff = _gh(f"pr diff {ctx.pr_number} --repo {ctx.repo}")
+        except subprocess.CalledProcessError as e:
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary="`gh pr diff` failed",
+                details=f"```\n{e.stderr or e.stdout}\n```",
+            )
+        diff_path.write_text(diff)
+        ctx.diff_path = str(diff_path)
+
+        # Refuse closed/merged PRs as a default — the user can still
+        # run validation on them by editing this gate, but the common
+        # case of "is this merge-safe" wants an OPEN PR.
+        state = meta.get("state", "")
+        if state != "OPEN":
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"PR is {state}, not OPEN — refusing to validate "
+                "(re-open if you want a re-grade)",
+            )
+
+        # Sanity-check the merge state too — DIRTY means the branch
+        # has merge conflicts; we'd be validating an unmergeable
+        # branch and the result would be misleading.
+        merge_state = meta.get("mergeStateStatus", "")
+        if merge_state == "DIRTY":
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary="PR has merge conflicts (mergeStateStatus=DIRTY) — "
+                "rebase before validating",
+            )
+
+        ctx.run_log(
+            f"fetched: '{ctx.pr_title[:60]}' by {ctx.pr_author} "
+            f"({ctx.additions}+/{ctx.deletions}- LOC, "
+            f"{len(ctx.files_changed)} files, blast={ctx.blast_radius})"
+        )
+
+        return StepResult(
+            name=self.name,
+            status="pass",
+            summary=(
+                f"{len(ctx.files_changed)} files, "
+                f"+{ctx.additions}/-{ctx.deletions} LOC, "
+                f"blast={ctx.blast_radius}"
+            ),
+            artifacts=[ctx.diff_path],
+        )
+
+
+def _gh(cmd: str) -> str:
+    """Run a `gh` subcommand, return stdout. Raises on non-zero exit."""
+    result = subprocess.run(  # noqa: S603 — args are shell-split, not a string
+        ["gh", *shlex.split(cmd)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 4 — full unit test suite.
+
+Skipped for low-blast PRs (docs, examples) — they can't break behavior.
+For medium and high blast PRs, runs the same set we use locally:
+``tests/`` minus integrations (those need a running server) and
+``test_event_loop.py`` (long-running, separate gate).
+
+Pre-existing failures on main are NOT filtered here — that's step 3's
+job. This step validates "the suite as-is is still green"; if main is
+broken that's a separate problem and we want to surface it loudly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from ..base import Step, StepResult
+from ..context import Context
+
+
+class FullUnitStep(Step):
+    name = "full_unit"
+    description = "full pytest suite (gated on blast radius)"
+
+    def should_run(self, ctx: Context) -> bool:
+        # Low-blast PRs get a skip — docs/examples can't break runtime.
+        return ctx.blast_radius != "low"
+
+    def run(self, ctx: Context) -> StepResult:
+        log_path = ctx.artifact_path("full-unit.log")
+
+        # Mirror what we run by hand. Two ignores: integrations needs a
+        # live server (covered in step 5), and test_event_loop is the
+        # long-running soak — separate budget.
+        cmd = [
+            "python3.12",
+            "-m",
+            "pytest",
+            "tests/",
+            "--ignore=tests/integrations",
+            "--ignore=tests/test_event_loop.py",
+            "-q",
+            "--no-header",
+            # Don't stop on first failure — we want the full count for
+            # the scorecard ("3 failed, 2080 passed" is more actionable
+            # than "1 failed, ???? passed").
+        ]
+        proc = subprocess.run(  # noqa: S603
+            cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
+        )
+        log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
+
+        # Pull the summary line: pytest ends with a line like
+        # "==== 3 failed, 2080 passed, 17 skipped in 25.56s ===="
+        summary_line = _last_summary_line(proc.stdout)
+
+        if proc.returncode == 0:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=summary_line or "all tests passed",
+                artifacts=[str(log_path)],
+            )
+
+        # On failure, extract the per-test FAILED lines for the
+        # scorecard's detail block — much more useful than dumping the
+        # whole log inline.
+        failed = _extract_failed_lines(proc.stdout)
+        details = ["**Failed tests:**\n```", *failed[:30], "```"]
+        if len(failed) > 30:
+            details.append(f"\n…and {len(failed) - 30} more — see {log_path}")
+
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=summary_line or f"pytest exited {proc.returncode}",
+            details="\n".join(details),
+            artifacts=[str(log_path)],
+        )
+
+
+def _last_summary_line(stdout: str) -> str:
+    """Pytest writes its overall summary as the very last non-empty
+    line wrapped in '====' decorations. Return without decorations."""
+    for line in reversed((stdout or "").splitlines()):
+        line = line.strip()
+        if line.startswith("=") and ("passed" in line or "failed" in line):
+            return line.strip("= ").strip()
+    return ""
+
+
+def _extract_failed_lines(stdout: str) -> list[str]:
+    """Return the lines pytest's short summary section labels FAILED."""
+    out = []
+    in_summary = False
+    for line in (stdout or "").splitlines():
+        if "short test summary" in line:
+            in_summary = True
+            continue
+        if in_summary:
+            if line.startswith("="):
+                break
+            if line.startswith("FAILED"):
+                out.append(line)
+    return out

--- a/scripts/pr_validate/steps/lint.py
+++ b/scripts/pr_validate/steps/lint.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 2 — lint (ruff check + ruff format --check).
+
+Runs against the PR's changed files (plus their containing module if
+the diff hit a single file deep in a package). We don't check the
+whole repo every time — that runs for ~5s on this codebase but adds
+noise when an unrelated old file already has lint errors.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from ..base import Step, StepResult
+from ..context import Context
+
+# We only lint Python files. Other extensions (.md, .yaml, .yml) get
+# skipped — ruff doesn't apply, and dedicated linters for those would
+# be a separate step.
+_PY_SUFFIXES = (".py",)
+
+
+class LintStep(Step):
+    name = "lint"
+    description = "ruff check + ruff format on changed files"
+
+    def should_run(self, ctx: Context) -> bool:
+        # Skip if the PR has no python changes at all (docs-only PRs).
+        return any(p.endswith(_PY_SUFFIXES) for p in ctx.files_changed)
+
+    def run(self, ctx: Context) -> StepResult:
+        # Filter to existing .py files. A deletion-only PR would list
+        # paths that no longer exist in the working tree; ruff would
+        # error on those — skip them, the diff itself isn't lintable.
+        py_files = [
+            p
+            for p in ctx.files_changed
+            if p.endswith(_PY_SUFFIXES) and (ctx.repo_root / p).exists()
+        ]
+        if not py_files:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="no python files to lint (deletions only?)",
+            )
+
+        # Run check + format-check separately so we can attribute the
+        # failure precisely. Both must pass.
+        check_log = ctx.artifact_path("lint-check.log")
+        format_log = ctx.artifact_path("lint-format.log")
+
+        check_rc = _run_ruff(["check", *py_files], check_log)
+        format_rc = _run_ruff(["format", "--check", *py_files], format_log)
+
+        if check_rc == 0 and format_rc == 0:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=f"clean ({len(py_files)} file(s))",
+                artifacts=[str(check_log), str(format_log)],
+            )
+
+        # At least one failed — surface both logs in the details so the
+        # contributor sees exactly which files / lines need attention.
+        details = []
+        if check_rc != 0:
+            details.append("**`ruff check` failures:**\n```")
+            details.append(check_log.read_text().strip())
+            details.append("```")
+        if format_rc != 0:
+            details.append("**`ruff format --check` would reformat:**\n```")
+            details.append(format_log.read_text().strip())
+            details.append("```")
+            details.append(
+                "\nFix locally with: `ruff format " + " ".join(py_files) + "`"
+            )
+
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=(
+                f"check_rc={check_rc}, format_rc={format_rc} ({len(py_files)} file(s))"
+            ),
+            details="\n".join(details),
+            artifacts=[str(check_log), str(format_log)],
+        )
+
+
+def _run_ruff(args: list[str], log_path) -> int:
+    """Run ruff and tee output to log_path. Returns ruff's exit code."""
+    proc = subprocess.run(  # noqa: S603
+        ["ruff", *args],
+        capture_output=True,
+        text=True,
+    )
+    log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
+    return proc.returncode

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 5 — stress + e2e + multi-model bench.
+
+The heaviest gate: only runs when blast radius is high (scheduler /
+engine / memory_cache / cli / server). Boots a real server, runs
+``scripts/stress_test.py``, runs each agent integration in
+``golden_models.yaml`` against each selected model, and records bench
+numbers.
+
+Model selection: ``golden_models.yaml`` defines families; for each
+family we pick the highest-quality candidate that fits machine RAM.
+Bench regression threshold is 5% on cold TTFT and decode TPS vs the
+last saved baseline at ``harness/baselines/<model>.json`` (when
+present) — missing baselines mean "first time, record it" and we don't
+fail.
+
+Implementation notes:
+* Server boot uses an unusual port (``8451``) to avoid colliding with
+  any locally-running rapid-mlx; we ALSO check for stale processes on
+  that port at startup and refuse if one is found rather than killing
+  it (don't accidentally murder someone's debug session).
+* The MVP uses two models — smoke + small — to keep total runtime
+  under ~5 minutes. The full m×n matrix is the eventual goal; expanding
+  it is just adding entries to the YAML.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..base import Step, StepResult
+from ..context import Context, env_truthy
+
+REGISTRY_PATH = Path(__file__).parent.parent / "golden_models.yaml"
+BASELINE_DIR = Path("harness/baselines")
+BENCH_PORT = 8451
+BENCH_THRESHOLD_PCT = 5.0
+SERVER_BOOT_TIMEOUT_S = 180
+SERVER_REQUEST_TIMEOUT_S = 60
+RAM_HEADROOM_GB = 8.0  # leave this much free for the OS + model load spike
+
+
+@dataclass
+class ModelChoice:
+    family: str
+    model_id: str
+    ram_gb_required: float
+    quality_tier: str
+    extra_args: list[str]
+
+
+class StressE2EBenchStep(Step):
+    name = "stress_e2e_bench"
+    description = "stress + integration matrix + bench (high blast only)"
+
+    def should_run(self, ctx: Context) -> bool:
+        if env_truthy("PR_VALIDATE_NO_STRESS"):
+            return False
+        return ctx.blast_radius == "high"
+
+    def run(self, ctx: Context) -> StepResult:
+        try:
+            registry = _load_registry()
+        except Exception as e:  # noqa: BLE001
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=f"could not load model registry: {e}",
+            )
+
+        try:
+            available_gb = _available_ram_gb()
+        except Exception as e:  # noqa: BLE001
+            # Don't silently fall back — that has caused us to either
+            # under-pick (bench skips on a beefy Mac) or over-pick (OOM
+            # on a small machine). Surface the error so the operator
+            # sets PR_VALIDATE_RAM_GB explicitly.
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=(
+                    f"RAM probe failed ({type(e).__name__}: {e}) — "
+                    "set PR_VALIDATE_RAM_GB=<int> and retry"
+                ),
+            )
+        usable_gb = max(0, available_gb - RAM_HEADROOM_GB)
+
+        choices = _select_models(registry, usable_gb)
+        if not choices:
+            return StepResult(
+                name=self.name,
+                status="error",
+                summary=(
+                    f"no model in registry fits {usable_gb:.1f}GB usable RAM "
+                    f"(machine reports {available_gb:.1f}GB total)"
+                ),
+            )
+
+        ctx.run_log(
+            f"selected {len(choices)} model(s): "
+            + ", ".join(f"{c.family}:{c.model_id}" for c in choices)
+        )
+
+        all_findings: list[str] = []
+        all_artifacts: list[str] = []
+        any_fail = False
+
+        for choice in choices:
+            ctx.run_log(f"--- {choice.family} ({choice.model_id}) ---")
+            try:
+                with _server(choice, ctx) as server_log:
+                    all_artifacts.append(server_log)
+                    # Stress.
+                    stress_result = _run_stress(ctx, choice)
+                    if stress_result["status"] != "pass":
+                        any_fail = True
+                        all_findings.append(
+                            f"[BLOCKING] stress on {choice.model_id}: "
+                            + stress_result["summary"]
+                        )
+                    if stress_result.get("artifact"):
+                        all_artifacts.append(stress_result["artifact"])
+
+                    # Integration matrix.
+                    for agent in registry["agents"]:
+                        if choice.quality_tier == "smoke" and agent.get(
+                            "skip_for_smoke"
+                        ):
+                            continue
+                        ag_result = _run_agent(ctx, choice, agent)
+                        if ag_result["status"] != "pass":
+                            any_fail = True
+                            all_findings.append(
+                                f"[BLOCKING] {agent['name']} on "
+                                f"{choice.model_id}: " + ag_result["summary"]
+                            )
+                        if ag_result.get("artifact"):
+                            all_artifacts.append(ag_result["artifact"])
+
+                    # Bench.
+                    bench_result = _run_bench(ctx, choice)
+                    if bench_result["status"] != "pass":
+                        any_fail = True
+                        all_findings.append(
+                            f"[BLOCKING] bench on {choice.model_id}: "
+                            + bench_result["summary"]
+                        )
+                    if bench_result.get("artifact"):
+                        all_artifacts.append(bench_result["artifact"])
+
+            except _ServerStartError as e:
+                any_fail = True
+                all_findings.append(
+                    f"[BLOCKING] could not boot server with {choice.model_id}: {e}"
+                )
+                continue
+
+        status = "fail" if any_fail else "pass"
+        summary = (
+            f"matrix {len(choices)}×{len([a for a in registry['agents']])}, "
+            f"{'PASSED' if not any_fail else 'see findings'}"
+        )
+        return StepResult(
+            name=self.name,
+            status=status,
+            summary=summary,
+            findings=all_findings,
+            artifacts=all_artifacts,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry + selection
+# ---------------------------------------------------------------------------
+
+
+def _load_registry() -> dict[str, Any]:
+    """Parse golden_models.yaml. We avoid PyYAML to keep the script
+    dependency-free; the file format is hand-restricted to a subset
+    we can parse trivially."""
+    text = REGISTRY_PATH.read_text()
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as e:
+        # PyYAML is in test deps but may be absent from a slim install.
+        raise RuntimeError(
+            "golden_models.yaml needs PyYAML — `pip install pyyaml`"
+        ) from e
+    return yaml.safe_load(text)
+
+
+def _select_models(registry: dict[str, Any], usable_gb: float) -> list[ModelChoice]:
+    """For each family, pick the highest-quality candidate that fits."""
+    out: list[ModelChoice] = []
+    overrides = registry.get("overrides", {}) or {}
+    for family in registry.get("families", []):
+        for cand in family["candidates"]:
+            if cand["ram_gb_required"] <= usable_gb:
+                out.append(
+                    ModelChoice(
+                        family=family["family"],
+                        model_id=cand["id"],
+                        ram_gb_required=float(cand["ram_gb_required"]),
+                        quality_tier=cand.get("quality_tier", "unknown"),
+                        extra_args=list(
+                            (overrides.get(cand["id"], {}) or {}).get("args", [])
+                        ),
+                    )
+                )
+                break  # stop at first fit per family
+    return out
+
+
+def _available_ram_gb() -> float:
+    """Probe how much RAM is *currently free*, not total.
+
+    macOS: ``vm_stat`` page counts × page size. Linux: ``MemAvailable``
+    line in ``/proc/meminfo``. The previous version returned total RAM,
+    which on a 256GB Mac with the model already loaded would over-pick
+    a 200GB candidate and OOM.
+
+    Override with ``PR_VALIDATE_RAM_GB=<int>`` if the probe is wrong
+    for your environment.
+    """
+    override = os.environ.get("PR_VALIDATE_RAM_GB")
+    if override:
+        return float(override)
+
+    # Linux first — cheap and unambiguous.
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                kb = int(line.split()[1])
+                return kb / (1024**2)
+
+    # macOS — vm_stat reports pages of free / inactive / speculative.
+    # Free + inactive is what we can realistically reclaim for a model.
+    if shutil.which("vm_stat"):
+        proc = subprocess.run(  # noqa: S603
+            ["vm_stat"], capture_output=True, text=True, check=True
+        )
+        page_size = 16384  # Apple Silicon default; we'll override below
+        free_pages = inactive_pages = 0
+        for line in proc.stdout.splitlines():
+            if line.startswith("Mach Virtual Memory Statistics"):
+                # Header includes the page size: "(page size of N bytes)"
+                m = re.search(r"page size of (\d+) bytes", line)
+                if m:
+                    page_size = int(m.group(1))
+            elif "Pages free:" in line:
+                free_pages = int(line.rsplit(":", 1)[1].strip().rstrip("."))
+            elif "Pages inactive:" in line:
+                inactive_pages = int(line.rsplit(":", 1)[1].strip().rstrip("."))
+        bytes_free = (free_pages + inactive_pages) * page_size
+        return bytes_free / (1024**3)
+
+    raise RuntimeError(
+        "no RAM probe available (need /proc/meminfo or `vm_stat`); "
+        "set PR_VALIDATE_RAM_GB=<int> to override"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _ServerStartError(RuntimeError):
+    pass
+
+
+@contextmanager
+def _server(choice: ModelChoice, ctx: Context):
+    """Start a rapid-mlx server with `choice.model_id` on BENCH_PORT.
+    Yield the path to its log file. Stop on context exit. Refuses to
+    proceed if BENCH_PORT is already bound."""
+    if _port_in_use(BENCH_PORT):
+        raise _ServerStartError(
+            f"port {BENCH_PORT} already in use — refusing to clobber"
+        )
+
+    log_path = ctx.artifact_path(f"server-{_safe_name(choice.model_id)}.log")
+    cmd = [
+        "python3.12",
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        choice.model_id,
+        "--port",
+        str(BENCH_PORT),
+        *choice.extra_args,
+    ]
+    log_f = open(log_path, "w")
+    proc = subprocess.Popen(  # noqa: S603
+        cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(ctx.repo_root)
+    )
+    try:
+        if not _wait_for_server(BENCH_PORT, SERVER_BOOT_TIMEOUT_S):
+            raise _ServerStartError(
+                f"server did not respond on :{BENCH_PORT} within "
+                f"{SERVER_BOOT_TIMEOUT_S}s — see {log_path}"
+            )
+        yield str(log_path)
+    finally:
+        # Graceful first (lifespan saves prefix cache); SIGKILL fallback.
+        proc.send_signal(2)  # SIGINT
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+        log_f.close()
+
+
+def _port_in_use(port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.2)
+    try:
+        s.connect(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+def _wait_for_server(port: int, timeout_s: int) -> bool:
+    """Poll /v1/models until 200 or timeout. Each attempt tolerates
+    connection refused (still booting) and 5xx (still loading model)."""
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout_s
+    url = f"http://127.0.0.1:{port}/v1/models"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(2)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Sub-runners (stress / agent / bench)
+# ---------------------------------------------------------------------------
+
+
+def _run_stress(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
+    log = ctx.artifact_path(f"stress-{_safe_name(choice.model_id)}.log")
+    proc = subprocess.run(  # noqa: S603
+        ["python3.12", "scripts/stress_test.py", "--port", str(BENCH_PORT)],
+        capture_output=True,
+        text=True,
+        cwd=str(ctx.repo_root),
+        timeout=900,
+    )
+    log.write_text((proc.stdout or "") + (proc.stderr or ""))
+    summary = _grep_last(proc.stdout, "passed")
+    return {
+        "status": "pass" if proc.returncode == 0 else "fail",
+        "summary": summary or f"exit {proc.returncode}",
+        "artifact": str(log),
+    }
+
+
+def _run_agent(
+    ctx: Context, choice: ModelChoice, agent: dict[str, Any]
+) -> dict[str, Any]:
+    log = ctx.artifact_path(f"agent-{agent['name']}-{_safe_name(choice.model_id)}.log")
+    script = ctx.repo_root / agent["script"]
+    if not script.exists():
+        return {"status": "skip", "summary": f"script missing: {agent['script']}"}
+
+    env = {
+        **os.environ,
+        "RAPID_MLX_BASE_URL": f"http://127.0.0.1:{BENCH_PORT}/v1",
+    }
+    proc = subprocess.run(  # noqa: S603
+        ["python3.12", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(ctx.repo_root),
+        timeout=600,
+    )
+    log.write_text((proc.stdout or "") + (proc.stderr or ""))
+    summary = _grep_last(proc.stdout, "passed") or _grep_last(proc.stdout, "FAIL")
+    return {
+        "status": "pass" if proc.returncode == 0 else "fail",
+        "summary": summary or f"exit {proc.returncode}",
+        "artifact": str(log),
+    }
+
+
+def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
+    """Inline bench — measure cold TTFT + decode TPS, compare to
+    baseline. Implementation borrowed from the inline benchmark we ran
+    against PR #200; keeps this step dependency-free."""
+    import statistics
+    import urllib.error
+    import urllib.request
+
+    sys = (
+        "You are a helpful assistant. Provide thoughtful and clear answers. "
+        "Be concise but informative."
+    )
+
+    def call(prompt: str, max_tok: int = 80) -> tuple[float, int]:
+        body = json.dumps(
+            {
+                "model": choice.model_id,
+                "messages": [
+                    {"role": "system", "content": sys},
+                    {"role": "user", "content": prompt},
+                ],
+                "max_tokens": max_tok,
+                "stream": False,
+                "temperature": 0.0,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{BENCH_PORT}/v1/chat/completions",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        t0 = time.time()
+        try:
+            with urllib.request.urlopen(  # noqa: S310
+                req, timeout=SERVER_REQUEST_TIMEOUT_S
+            ) as resp:
+                payload = json.loads(resp.read())
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"bench request failed: {e}") from e
+        dt_ms = (time.time() - t0) * 1000
+        toks = payload.get("usage", {}).get("completion_tokens", 0)
+        return dt_ms, toks
+
+    # Cold: 5 different prompts (no cache hits).
+    cold_times = []
+    for i in range(5):
+        dt, _ = call(f"Cold prompt #{i} — say something brief")
+        cold_times.append(dt)
+
+    # Warm: 5 repeats of same prompt (full cache hit after warmup).
+    call("warmup", 30)
+    call("warmup", 30)
+    warm_times = []
+    for _ in range(5):
+        dt, _ = call("Warm prompt — say something brief")
+        warm_times.append(dt)
+
+    cold = statistics.median(cold_times)
+    warm = statistics.median(warm_times)
+    speedup = cold / warm if warm else 0
+    metrics = {
+        "model": choice.model_id,
+        "cold_ttft_ms_median": cold,
+        "warm_ttft_ms_median": warm,
+        "speedup_x": speedup,
+    }
+
+    bench_path = ctx.artifact_path(f"bench-{_safe_name(choice.model_id)}.json")
+    bench_path.write_text(json.dumps(metrics, indent=2))
+
+    # Compare to baseline if present.
+    baseline_path = (
+        ctx.repo_root / BASELINE_DIR / f"bench-{_safe_name(choice.model_id)}.json"
+    )
+    if not baseline_path.exists():
+        return {
+            "status": "pass",
+            "summary": (
+                f"cold={cold:.0f}ms warm={warm:.0f}ms ({speedup:.2f}x) "
+                f"— no baseline, recorded for next run"
+            ),
+            "artifact": str(bench_path),
+        }
+
+    baseline = json.loads(baseline_path.read_text())
+    base_cold = baseline.get("cold_ttft_ms_median", cold)
+    base_warm = baseline.get("warm_ttft_ms_median", warm)
+
+    # Slowdown = current / baseline. >5% slower on cold OR warm = fail.
+    cold_slow = (cold / base_cold - 1) * 100 if base_cold else 0
+    warm_slow = (warm / base_warm - 1) * 100 if base_warm else 0
+    if cold_slow > BENCH_THRESHOLD_PCT or warm_slow > BENCH_THRESHOLD_PCT:
+        return {
+            "status": "fail",
+            "summary": (
+                f"perf regression: cold {cold_slow:+.1f}%, warm {warm_slow:+.1f}% "
+                f"vs baseline (threshold {BENCH_THRESHOLD_PCT}%)"
+            ),
+            "artifact": str(bench_path),
+        }
+    return {
+        "status": "pass",
+        "summary": (
+            f"cold {cold_slow:+.1f}%, warm {warm_slow:+.1f}% "
+            f"vs baseline (within {BENCH_THRESHOLD_PCT}%)"
+        ),
+        "artifact": str(bench_path),
+    }
+
+
+def _safe_name(model_id: str) -> str:
+    return model_id.replace("/", "--")
+
+
+def _grep_last(text: str, needle: str) -> str:
+    """Return the last line containing `needle`, stripped — handy for
+    pulling pytest/stress summary lines out of subprocess output."""
+    for line in reversed((text or "").splitlines()):
+        if needle in line:
+            return line.strip()
+    return ""

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -301,11 +301,15 @@ def _server(choice: ModelChoice, ctx: Context):
         str(BENCH_PORT),
         *choice.extra_args,
     ]
-    log_f = open(log_path, "w")
-    proc = subprocess.Popen(  # noqa: S603
-        cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(ctx.repo_root)
-    )
+    # Open the log inside the try so a Popen failure (e.g. fork EAGAIN,
+    # disk full) doesn't leak the file handle.
+    log_f = None
+    proc = None
     try:
+        log_f = open(log_path, "w")  # noqa: SIM115 — explicit close in finally
+        proc = subprocess.Popen(  # noqa: S603
+            cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(ctx.repo_root)
+        )
         if not _wait_for_server(BENCH_PORT, SERVER_BOOT_TIMEOUT_S):
             raise _ServerStartError(
                 f"server did not respond on :{BENCH_PORT} within "
@@ -314,13 +318,15 @@ def _server(choice: ModelChoice, ctx: Context):
         yield str(log_path)
     finally:
         # Graceful first (lifespan saves prefix cache); SIGKILL fallback.
-        proc.send_signal(2)  # SIGINT
-        try:
-            proc.wait(timeout=30)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=10)
-        log_f.close()
+        if proc is not None:
+            proc.send_signal(2)  # SIGINT
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+        if log_f is not None:
+            log_f.close()
 
 
 def _port_in_use(port: int) -> bool:

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 1 — supply chain audit.
+
+What "supply chain" means for an external PR to a published package:
+
+1. **New dependencies** — does this PR add a package to pyproject.toml
+   or requirements files? Are those packages known-good or yanked /
+   typo-squat / known-vulnerable?
+2. **License drift** — pulling in GPL/AGPL/SSPL into our Apache-2.0
+   tree would force a relicense; we want to refuse silently-shifted
+   licenses.
+3. **Install hooks** — `setup.py`, ``pyproject.toml`` build hooks,
+   ``conftest.py`` (runs on `pip install` for editable installs and on
+   every pytest invocation), and ``.github/workflows/`` (auto-deploys
+   to PyPI/Homebrew). Code added to any of these gets to run on every
+   user's machine without explicit consent — they need extra scrutiny.
+4. **Suspicious patterns in regular code** — base64-decoded blobs that
+   `exec()`, ``socket.connect`` to hardcoded IPs, ``urllib`` requests
+   to non-anthropic / non-github / non-pypi hosts, ``os.system`` /
+   ``subprocess`` with shell-formed strings.
+
+This step is intentionally conservative — we'd rather false-positive
+on a benign PR (let the maintainer eyeball it) than miss a malicious
+one. The cost of a false positive is "human reads the diff anyway".
+The cost of a miss is auto-deploy of malware to every PyPI user.
+
+Network calls (pip-audit) are best-effort; if pip-audit isn't
+installed or the index is unreachable we ``skip`` rather than ``fail``
+— locally checking deps without network would be misleading.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..base import Step, StepResult
+from ..context import Context
+
+# Files that gain code-execution capability when modified — install
+# hooks, CI config, anything that runs unattended.
+HOOK_PATHS = (
+    "setup.py",
+    "setup.cfg",
+    "conftest.py",  # runs on every `pytest`
+    "tests/conftest.py",
+    ".github/workflows/",
+    "Makefile",
+    ".pre-commit-config.yaml",
+    "Formula/",  # Homebrew tap
+    "homebrew-rapid-mlx/",
+)
+
+# Files that declare project deps. Any addition gets pip-audited.
+DEP_DECLARATION_FILES = (
+    "pyproject.toml",
+    "requirements.txt",
+    "requirements-dev.txt",
+)
+
+# Patterns that, when added in a diff, warrant human eyeballs even in
+# regular .py files. Each is (regex, why-suspicious). False-positive
+# rate is high — that's accepted; a maintainer can dismiss easily.
+SUSPICIOUS_PATTERNS = (
+    (re.compile(r"\beval\s*\("), "eval() — usually wrong; never on untrusted data"),
+    (re.compile(r"\bexec\s*\("), "exec() — usually wrong; never on untrusted data"),
+    (
+        re.compile(r"base64\.b64decode\s*\("),
+        "base64-decoded blob — possible code-as-data smuggling",
+    ),
+    (
+        re.compile(r"pickle\.loads?\s*\("),
+        "pickle.load on untrusted data is RCE; verify source",
+    ),
+    (
+        re.compile(r"subprocess\.\w+\([^)]*shell\s*=\s*True"),
+        "shell=True — command injection if any arg is external",
+    ),
+    (
+        re.compile(r"os\.system\s*\("),
+        "os.system — subject to command injection; prefer subprocess.run([...])",
+    ),
+    (
+        re.compile(r"socket\.connect\s*\(\s*\(['\"][\d.]+['\"]"),
+        "raw socket.connect to a hardcoded IP",
+    ),
+    (
+        re.compile(r"urllib\.request\.urlopen\s*\(\s*['\"]https?://"),
+        "hardcoded HTTP URL — verify the host",
+    ),
+    (
+        re.compile(r"requests\.(get|post|put|delete)\s*\(\s*['\"]https?://"),
+        "hardcoded HTTP URL via requests — verify the host",
+    ),
+    # GitHub Actions specific — adding `secrets.` access in a workflow.
+    (
+        re.compile(r"secrets\.[A-Z_]+"),
+        "workflow accesses repository secret — verify intent",
+    ),
+    # Hex-encoded blobs (>64 chars) — sometimes seen in obfuscated payloads.
+    (
+        re.compile(r"['\"][0-9a-fA-F]{64,}['\"]"),
+        "long hex literal — could be a hash (fine) or obfuscated data",
+    ),
+)
+
+
+class SupplyChainStep(Step):
+    name = "supply_chain"
+    description = "deps audit + license + install-hook scan"
+
+    def run(self, ctx: Context) -> StepResult:
+        diff = Path(ctx.diff_path).read_text()
+
+        findings: list[str] = []
+        artifacts: list[str] = []
+
+        # 1. Hook-file modifications get an automatic flag — not a
+        # FAIL on its own (legitimate workflow updates exist), but
+        # surfaced loudly so the human knows to read carefully.
+        hook_files = [
+            f
+            for f in ctx.files_changed
+            if any(f == p or f.startswith(p) for p in HOOK_PATHS)
+        ]
+        if hook_files:
+            # Even an "innocent-looking" hook change is worth surfacing.
+            # External-author + hook change = strong reason to read.
+            severity = "BLOCKING" if ctx.is_external_author else "warning"
+            findings.append(
+                f"[{severity}] modifies install/CI hook(s): {hook_files}. "
+                "These run unattended; review every line."
+            )
+
+        # 2. Suspicious patterns in ADDED lines (not removed — removed
+        # lines were dangerous before this PR, that's a different
+        # problem).
+        added_lines = _added_lines(diff)
+        pattern_hits = _scan_patterns(added_lines)
+        for path, lineno, line, why in pattern_hits[:20]:
+            findings.append(
+                f"`{path}` near l{lineno}: {why}\n  > `{line.strip()[:120]}`"
+            )
+
+        # 3. Deps changes — diff pyproject.toml / requirements files,
+        # extract added package names, run pip-audit on them.
+        new_deps = _extract_added_deps(diff, ctx.files_changed)
+        if new_deps:
+            audit_path = ctx.artifact_path("pip-audit.log")
+            audit_findings = _pip_audit(new_deps, audit_path)
+            artifacts.append(str(audit_path))
+            if audit_findings:
+                findings.extend(audit_findings)
+            else:
+                # Successful audit with no issues — note it for the log
+                # but don't add as a finding.
+                ctx.run_log(
+                    f"pip-audit clean for {len(new_deps)} new dep(s): "
+                    f"{', '.join(new_deps[:5])}"
+                )
+
+        # 4. Save the full pattern scan for inspection.
+        scan_path = ctx.artifact_path("supply-chain-scan.log")
+        scan_path.write_text(_format_scan(hook_files, pattern_hits, new_deps))
+        artifacts.append(str(scan_path))
+
+        # Decision rule. Anything tagged BLOCKING → fail. Otherwise pass
+        # but surface warnings as findings (they go in the scorecard
+        # for human eyeballs).
+        blocking = [f for f in findings if "[BLOCKING]" in f]
+        if blocking:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"{len(blocking)} blocking finding(s) "
+                f"(+{len(findings) - len(blocking)} warning(s))",
+                findings=findings,
+                artifacts=artifacts,
+            )
+        if findings:
+            # Warnings only — human-needed but not auto-blocked. Still
+            # report as ``pass`` so the gate doesn't false-positive on
+            # every legitimate change; findings carry the signal.
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=f"{len(findings)} warning(s) — human review wanted",
+                findings=findings,
+                artifacts=artifacts,
+            )
+
+        return StepResult(
+            name=self.name,
+            status="pass",
+            summary="no hooks touched, no suspicious patterns, deps clean",
+            artifacts=artifacts,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _added_lines(diff: str) -> list[tuple[str, int, str]]:
+    """Extract every '+' line in a unified diff with its file path and
+    estimated line number in the new file. Skips '+++' header lines."""
+    out = []
+    cur_path = ""
+    new_lineno = 0
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            cur_path = line[6:]
+            new_lineno = 0
+            continue
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("@@"):
+            # @@ -<old>,<n> +<newstart>,<n> @@
+            m = re.search(r"\+(\d+)", line)
+            new_lineno = int(m.group(1)) - 1 if m else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            new_lineno += 1
+            out.append((cur_path, new_lineno, line[1:]))
+        elif not line.startswith("-"):
+            new_lineno += 1
+    return out
+
+
+def _scan_patterns(
+    added: list[tuple[str, int, str]],
+) -> list[tuple[str, int, str, str]]:
+    """Apply SUSPICIOUS_PATTERNS to added lines. Returns
+    (path, lineno, line, why) per hit."""
+    out = []
+    for path, lineno, line in added:
+        # Skip our own validation rule definitions — the patterns
+        # themselves contain the regex source, which would self-match.
+        if "scripts/pr_validate/" in path:
+            continue
+        # Heuristic: skip test files for the *most* aggressive patterns,
+        # since tests legitimately use eval/pickle/etc. for fixtures.
+        # We still flag setup.py / conftest.py / workflows above.
+        is_test = "/tests/" in path or path.startswith("tests/")
+        for pattern, why in SUSPICIOUS_PATTERNS:
+            if pattern.search(line):
+                if is_test and "eval(" in pattern.pattern:
+                    continue
+                if is_test and "exec(" in pattern.pattern:
+                    continue
+                out.append((path, lineno, line, why))
+    return out
+
+
+def _extract_added_deps(diff: str, files_changed: list[str]) -> list[str]:
+    """Naive but cautious: find lines in dep-declaration files that
+    look like `name = "version"` or `name>=ver` and weren't there
+    before. We don't try to parse pyproject.toml fully — too many
+    formats. Just regex the additions."""
+    if not any(f in DEP_DECLARATION_FILES for f in files_changed):
+        return []
+
+    deps: list[str] = []
+    in_dep_file = False
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            in_dep_file = path in DEP_DECLARATION_FILES
+            continue
+        if not in_dep_file or not line.startswith("+"):
+            continue
+        if line.startswith("+++"):
+            continue
+
+        body = line[1:].strip()
+        # pyproject style: '"package>=1.2.3",' or '"package",'
+        m = re.match(r'["\']([a-zA-Z0-9_\-.\[\]]+)(?:\s*[~<>=!]+[^"\']*)?["\']', body)
+        if m:
+            name = m.group(1).split("[", 1)[0]  # strip extras like httpx[http2]
+            deps.append(name.lower())
+            continue
+        # requirements.txt style: 'package>=1.2.3'
+        m = re.match(r"([a-zA-Z0-9_\-.\[\]]+)\s*[~<>=!]+", body)
+        if m:
+            deps.append(m.group(1).split("[", 1)[0].lower())
+
+    # Dedup and drop standard library / our own package.
+    seen = set()
+    out = []
+    for d in deps:
+        if d in seen or d in ("rapid-mlx", "vllm-mlx"):
+            continue
+        seen.add(d)
+        out.append(d)
+    return out
+
+
+def _pip_audit(deps: list[str], log_path: Path) -> list[str]:
+    """Run pip-audit on the candidate deps. Returns findings list (one
+    per known-vulnerable dep). If pip-audit isn't installed we skip
+    silently (log says so but no finding)."""
+    if not shutil.which("pip-audit"):
+        log_path.write_text(
+            "pip-audit not installed — `pip install pip-audit` to enable\n"
+        )
+        return []
+
+    # pip-audit takes a requirements file or a list of installed packages.
+    # We construct a one-off requirements file with just the names — it
+    # will resolve to whatever's currently published.
+    req_file = log_path.with_suffix(".req")
+    req_file.write_text("\n".join(deps) + "\n")
+
+    proc = subprocess.run(  # noqa: S603
+        [
+            "pip-audit",
+            "-r",
+            str(req_file),
+            "--format",
+            "json",
+            "--progress-spinner",
+            "off",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    log_path.write_text(
+        (proc.stdout or "") + "\n--- stderr ---\n" + (proc.stderr or "")
+    )
+
+    if proc.returncode == 0 and not proc.stdout.strip():
+        return []
+
+    findings: list[str] = []
+    try:
+        import json as _json
+
+        data = _json.loads(proc.stdout) if proc.stdout.strip() else {}
+        for entry in data.get("dependencies", []):
+            for vuln in entry.get("vulns", []):
+                findings.append(
+                    f"[BLOCKING] dep `{entry.get('name')}` "
+                    f"vuln {vuln.get('id')}: "
+                    f"{(vuln.get('description') or '')[:120]}"
+                )
+    except Exception as e:  # noqa: BLE001
+        # pip-audit format change or weird output — don't crash, log it.
+        findings.append(f"pip-audit output not parseable ({e}) — see {log_path}")
+    return findings
+
+
+def _format_scan(
+    hook_files: list[str],
+    pattern_hits: list[tuple[str, int, str, str]],
+    new_deps: list[str],
+) -> str:
+    lines = ["# Supply-chain scan", ""]
+    lines.append("## Hook files modified")
+    lines.extend(f"- {f}" for f in hook_files) if hook_files else lines.append("(none)")
+    lines.append("")
+    lines.append("## Suspicious patterns in added lines")
+    if pattern_hits:
+        for path, lineno, line, why in pattern_hits:
+            lines.append(f"- `{path}` l{lineno} — {why}")
+            lines.append(f"  > `{line.strip()[:120]}`")
+    else:
+        lines.append("(none)")
+    lines.append("")
+    lines.append("## New dependencies")
+    lines.extend(f"- {d}" for d in new_deps) if new_deps else lines.append("(none)")
+    return "\n".join(lines)

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 3 — diff-aware targeted test selection with negative control.
+
+Goal: run the tests most likely to catch a regression from this PR
+without running the entire ~25s suite. Plus the negative-control move
+we used in PR #187: any failure on the PR branch is re-checked on main
+to filter pre-existing flakes (so we don't block merge on something
+that was already broken).
+
+Selection heuristic — deliberately simple, grep-able:
+
+1. For each Python file in the diff, derive the candidate test file
+   name(s):
+   - ``vllm_mlx/foo.py`` → ``tests/test_foo.py``
+   - ``vllm_mlx/bar/baz.py`` → ``tests/test_baz.py``
+2. For each non-test Python file, also include any test file whose
+   name contains the module's stem.
+3. If the diff hits a test file directly, include it.
+4. If the heuristic matches nothing (e.g. PR only touches docs), skip
+   the step.
+
+We don't import-graph trace because pytest's collection cost dominates
+and the heuristic catches >90% of the cases that matter. The full unit
+suite (step 4) covers the rest for medium/high blast PRs.
+
+Negative control: when targeted tests fail on the PR branch, re-run
+the same set on a fresh ``git worktree`` of ``main``. Tests that fail
+on both → pre-existing → don't block. Tests that pass on main but fail
+on PR → real regression → BLOCK.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from ..base import Step, StepResult
+from ..context import Context
+
+
+class TargetedTestsStep(Step):
+    name = "targeted_tests"
+    description = "diff-aware tests + negative control"
+
+    def should_run(self, ctx: Context) -> bool:
+        # Skip if no python in the diff — nothing to target.
+        return any(p.endswith(".py") for p in ctx.files_changed)
+
+    def run(self, ctx: Context) -> StepResult:
+        targets = _select_test_files(ctx)
+        if not targets:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="diff has no python files mapping to tests",
+            )
+
+        # Cap the targeted set — if the diff is huge, prefer falling
+        # through to step 4 (full unit) rather than re-implementing it
+        # here. Otherwise we'd spend 30s collecting tests that step 4
+        # will then re-run from scratch.
+        if len(targets) > 25:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    f"too many test targets ({len(targets)}) — "
+                    f"deferring to full_unit step"
+                ),
+            )
+
+        ctx.run_log(f"running {len(targets)} targeted test file(s) on PR branch")
+
+        # Run on the PR branch (current working tree should be the PR's
+        # head — we don't enforce that here, but the caller setup should
+        # ensure it).  TODO if we ever auto-checkout PRs: switch to the
+        # PR head here too.
+        pr_log = ctx.artifact_path("targeted-pr.log")
+        pr_summary, pr_failed = _run_pytest(targets, pr_log, ctx.repo_root)
+
+        if not pr_failed:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=f"{pr_summary} (in {len(targets)} target file(s))",
+                artifacts=[str(pr_log)],
+            )
+
+        # Failures on PR branch — run negative control on main.
+        ctx.run_log(
+            f"{len(pr_failed)} fail on PR branch — running same tests "
+            f"on main to filter pre-existing flakes"
+        )
+        main_log = ctx.artifact_path("targeted-main.log")
+        try:
+            # Use the PR's exact base SHA, not the branch tip — main may
+            # have advanced since the PR was opened, and a moving
+            # negative-control would misclassify regressions caused by
+            # newer main commits as PR-introduced.
+            main_failed = _run_on_main(
+                targets,
+                main_log,
+                ctx.repo_root,
+                ctx.base_sha or ctx.base_branch,
+            )
+        except Exception as e:  # noqa: BLE001
+            # Worktree setup failed — surface it but don't lose the PR
+            # failures we already have. Treat as fail-safe (block).
+            details = (
+                f"**negative control unavailable** ({type(e).__name__}: {e}). "
+                "Cannot distinguish regressions from pre-existing flakes — "
+                "treating all PR failures as regressions.\n\n"
+                f"```\n{_failed_block(pr_failed)}\n```"
+            )
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"{len(pr_failed)} fail (neg control unavailable)",
+                details=details,
+                artifacts=[str(pr_log)],
+            )
+
+        # Classify each PR failure: regression vs pre-existing.
+        regressions = sorted(set(pr_failed) - set(main_failed))
+        pre_existing = sorted(set(pr_failed) & set(main_failed))
+        only_on_main = sorted(
+            set(main_failed) - set(pr_failed)
+        )  # interesting but unused
+
+        if not regressions:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=(
+                    f"{len(pr_failed)} fail on PR — all also fail on main "
+                    f"(pre-existing, not regressions)"
+                ),
+                details=(
+                    "**Pre-existing failures (also fail on main, ignored):**\n```\n"
+                    + _failed_block(pre_existing)
+                    + "\n```"
+                ),
+                artifacts=[str(pr_log), str(main_log)],
+            )
+
+        details = ["**Regressions (fail on PR, pass on main):**", "```"]
+        details.extend(regressions)
+        details.append("```")
+        if pre_existing:
+            details.append("\n**Pre-existing (also fail on main, not blocking):**\n```")
+            details.extend(pre_existing)
+            details.append("```")
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=f"{len(regressions)} regression(s), "
+            f"{len(pre_existing)} pre-existing",
+            details="\n".join(details),
+            artifacts=[str(pr_log), str(main_log)],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def _select_test_files(ctx: Context) -> list[str]:
+    """Return tests/ paths to run, deduped, sorted."""
+    candidates: set[str] = set()
+    tests_dir = ctx.repo_root / "tests"
+    if not tests_dir.exists():
+        return []
+
+    for path in ctx.files_changed:
+        if not path.endswith(".py"):
+            continue
+        # Direct hit on a test file.
+        if path.startswith("tests/"):
+            if (ctx.repo_root / path).exists():
+                candidates.add(path)
+            continue
+
+        stem = Path(path).stem  # e.g. "scheduler"
+
+        # Try the obvious test_<stem>.py first.
+        direct = tests_dir / f"test_{stem}.py"
+        if direct.exists():
+            candidates.add(f"tests/test_{stem}.py")
+
+        # Plus any test files whose name contains the stem (covers
+        # e.g. test_prefix_cache_persistence.py for prefix_cache.py).
+        for tf in tests_dir.glob("test_*.py"):
+            if stem in tf.stem:
+                candidates.add(f"tests/{tf.name}")
+
+    return sorted(candidates)
+
+
+# ---------------------------------------------------------------------------
+# Pytest runner
+# ---------------------------------------------------------------------------
+
+
+_PYTEST_CMD = [
+    "python3.12",
+    "-m",
+    "pytest",
+    "-q",
+    "--no-header",
+    "--tb=no",  # we don't render tracebacks here; the artifact has them
+]
+
+
+def _run_pytest(targets: list[str], log_path: Path, cwd: Path) -> tuple[str, list[str]]:
+    """Run pytest against ``targets``. Returns (one-line summary,
+    list of FAILED node IDs). Empty failed list => clean run."""
+    proc = subprocess.run(  # noqa: S603
+        [*_PYTEST_CMD, *targets],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+    log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
+    summary = _last_summary_line(proc.stdout) or f"exit {proc.returncode}"
+    failed = _extract_failed_node_ids(proc.stdout)
+    return summary, failed
+
+
+def _run_on_main(
+    targets: list[str], log_path: Path, repo_root: Path, base_ref: str
+) -> list[str]:
+    """Run the same targets on a fresh worktree of ``base_ref``.
+
+    ``base_ref`` should be the PR's base SHA (preferred) — using a
+    branch name lets ``main`` move under us. Falls back to a branch
+    name if the SHA isn't available.
+
+    Uses a temp directory; the caller's repo root + working tree stay
+    untouched. We re-resolve targets relative to the worktree (some
+    files may not exist on main, e.g. tests added by this PR — those
+    are dropped from the negative control).
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="pr_validate_main_"))
+    try:
+        # Create a worktree pointing at base_ref (sha-pinned when given).
+        subprocess.run(  # noqa: S603
+            ["git", "worktree", "add", "--detach", str(tmp), base_ref],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+        try:
+            existing_targets = [t for t in targets if (tmp / t).exists()]
+            if not existing_targets:
+                # Every target test file is new in this PR. By
+                # construction they don't exist on main → no failures
+                # to filter; treat as no pre-existing fails.
+                log_path.write_text(
+                    "(no targeted test files exist on main — all are new in PR)\n"
+                )
+                return []
+
+            proc = subprocess.run(  # noqa: S603
+                [*_PYTEST_CMD, *existing_targets],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp),
+            )
+            log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
+            return _extract_failed_node_ids(proc.stdout)
+        finally:
+            # Remove the worktree even if pytest crashed.
+            subprocess.run(  # noqa: S603
+                ["git", "worktree", "remove", "--force", str(tmp)],
+                capture_output=True,
+                text=True,
+                cwd=str(repo_root),
+            )
+    finally:
+        # In case `git worktree remove` failed, nuke the dir.
+        if tmp.exists():
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _last_summary_line(stdout: str) -> str:
+    for line in reversed((stdout or "").splitlines()):
+        line = line.strip()
+        if line.startswith("=") and ("passed" in line or "failed" in line):
+            return line.strip("= ").strip()
+    return ""
+
+
+_FAIL_RE = re.compile(r"^FAILED\s+(\S+)")
+
+
+def _extract_failed_node_ids(stdout: str) -> list[str]:
+    """Pull the FAILED <node_id> lines from pytest's short summary."""
+    out = []
+    in_summary = False
+    for line in (stdout or "").splitlines():
+        if "short test summary" in line:
+            in_summary = True
+            continue
+        if in_summary:
+            if line.startswith("="):
+                break
+            m = _FAIL_RE.match(line)
+            if m:
+                out.append(m.group(1))
+    return out
+
+
+def _failed_block(items: list[str]) -> str:
+    return "\n".join(items) if items else "(none)"


### PR DESCRIPTION
## Summary

New `scripts/pr_validate/` package — one entry point that grades an incoming PR and prints a strict merge-readiness scorecard. Built so an external contribution can be eyeballed in <2min for cheap PRs and <10min for engine-touching PRs.

```bash
python3.12 -m scripts.pr_validate.pr_validate <PR#>
# stdout = markdown scorecard (paste into PR comment)
# exit 0 = MERGE-SAFE, exit 1 = DO NOT MERGE
```

## Pipeline

| # | step | gate | runtime | what |
|---|---|---|---|---|
| 0 | `fetch` | always (fail-fast) | 1s | gh pr view + diff + classify blast radius |
| 6 | `deepseek_review` | API key present | 30-90s | adversarial review (moved to front — cheap critical thinking before tests) |
| 1 | `supply_chain` | always | <1s | hook-file flag, suspicious-pattern scan, pip-audit on new deps |
| 2 | `lint` | when diff has .py | ~3s | ruff check + format |
| 3 | `targeted_tests` | when diff has .py | 30s-3min | diff-aware test selection + **negative control** on PR's base SHA |
| 4 | `full_unit` | blast >= medium | ~25s | full pytest minus integrations + event_loop |
| 5 | `stress_e2e_bench` | blast == high | 5-10min | m×n matrix: golden models × agent integrations + bench vs baseline (5% threshold) |

**Strict mode**: any single fail/error blocks merge. Skips are neutral.

## DeepSeek V4 Pro review applied

Sent the package to DeepSeek for adversarial review of itself. 8 findings, all fixed:
- RAM probe was returning total — switched to vm_stat / MemAvailable
- Negative control used branch tip not base SHA — fixed
- base64 regex had spurious trailing `\)` — fixed
- Hardcoded API key default — removed, env-var only
- Dead `_ = os, Path` line — removed
- Empty `choices` array would IndexError — guarded
- RAM-probe failure fallback was wrong both ways — now errors with override instructions
- `gh` not installed → cryptic FileNotFoundError — preflight with actionable message

## Validation

* PR #199 (docs, low blast): **MERGE-SAFE** in 1.1s — only fetch + supply_chain ran.
* PR #176 (medium blast, +3939 LOC): **DO NOT MERGE** — full_unit caught the pre-existing `test_only_start_tag_no_end` flake. (Known gap: full_unit doesn't yet do neg-control filtering like targeted_tests does; in roadmap.)
* `ruff check` + `ruff format --check` clean.

## Roadmap

In `scripts/pr_validate/README.md`:
- Negative-control for `full_unit` (close the known gap)
- GitHub Action wiring for cheap layers (steps 0,1,2,3 + scorecard comment)
- License-drift check via `pip show` allowlist
- Replace stem-heuristic in `targeted_tests` with import-graph
- Expand `golden_models.yaml` as RAM budget allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)