### PR TITLE
Fix Qwen tool-call OpenAI translation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,18 +126,15 @@ jobs:
         run: |
           pytest \
             tests/test_platform.py \
-            tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \
             tests/test_paged_cache.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
             tests/test_optimizations.py \
-            tests/test_simple_engine.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \
             tests/test_streaming_simulator.py \
-            tests/test_deltanet_snapshot.py \
             tests/test_streaming_detokenizer.py \
             tests/test_tool_logits.py \
             -v --tb=short \

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for StreamingPostProcessor — the unified streaming pipeline."""
 
+import json
 from unittest.mock import MagicMock
 
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
@@ -244,6 +245,53 @@ class TestStreamingPostProcessorToolCalls:
         assert len(events) == 1
         assert events[0].type == "tool_call"
         assert events[0].finish_reason == "tool_calls"
+
+    def test_bare_calling_tool_emits_tool_call_not_content(self):
+        """Bare Qwen Calling tool syntax is translated to OpenAI tool calls."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request_dict=request,
+        )
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                'Calling tool: todowrite({"todos": '
+                '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"'
+                "})"
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
 
 class TestStreamingPostProcessorNemotron:

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -275,7 +275,7 @@ class TestStreamingPostProcessorToolCalls:
         pp = StreamingPostProcessor(
             cfg,
             tools_requested=True,
-            request_dict=request,
+            request=request,
         )
         pp.reset()
 
@@ -293,6 +293,55 @@ class TestStreamingPostProcessorToolCalls:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_qwen_xml_tool_uses_schema_after_content_prefix(self):
+        """Schema conversion still works if text appears before tool markup."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request=request,
+        )
+        pp.reset()
+
+        assert pp.process_chunk(_make_output("Thinking first.\n"))[0].type == "content"
+        events = pp.process_chunk(
+            _make_output(
+                "<tool_call>\n<function=todowrite>\n"
+                "<parameter=todos>\n"
+                '"[{\\"content\\": \\"Install tests\\", \\"status\\": \\"in_progress\\"}]"\n'
+                "</parameter>\n"
+                "</function>\n</tool_call>"
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Install tests"
 
 class TestStreamingPostProcessorNemotron:
     """Tests for Nemotron thinking prefix."""

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -413,6 +413,7 @@ class TestStreamingPostProcessorToolCalls:
         assert len(tool_events[0].tool_calls) == 1
         args = json.loads(tool_events[0].tool_calls[0]["function"]["arguments"])
         assert args["filePath"] == "/tmp/package.json"
+
     def test_qwen_xml_tool_uses_schema_after_content_prefix(self):
         """Schema conversion still works if text appears before tool markup."""
         request = {
@@ -462,6 +463,7 @@ class TestStreamingPostProcessorToolCalls:
         args = json.loads(events[0].tool_calls[0]["function"]["arguments"])
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Install tests"
+
 
 class TestStreamingPostProcessorNemotron:
     """Tests for Nemotron thinking prefix."""

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -342,6 +342,29 @@ class TestStreamingPostProcessorToolCalls:
         assert args["command"] == "npm test"
         assert args["timeout"] == 60000.0
 
+    def test_code_brackets_are_not_treated_as_partial_tool_markers(self):
+        """Do not strip normal code brackets split at chunk boundaries."""
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request={"tools": []},
+        )
+        pp.reset()
+
+        index_events = pp.process_chunk(_make_output("const head = game.snake["))
+        array_events = pp.process_chunk(_make_output("const snake = ["))
+
+        assert len(index_events) == 1
+        assert index_events[0].type == "content"
+        assert index_events[0].content == "const head = game.snake["
+        assert len(array_events) == 1
+        assert array_events[0].type == "content"
+        assert array_events[0].content == "const snake = ["
+
     def test_generic_tool_call_drops_missing_required_duplicate(self):
         """Malformed duplicate calls should not reach clients for schema rejection."""
         request = {

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -324,11 +324,11 @@ class TestStreamingPostProcessorToolCalls:
         )
         pp.reset()
 
-        heading_events = pp.process_chunk(_make_output("Next step\n\n["))
+        heading_events = pp.process_chunk(_make_output("Next step\n\n[C"))
         assert len(heading_events) == 1
         assert heading_events[0].type == "content"
         assert heading_events[0].content == "Next step"
-        assert pp.process_chunk(_make_output("Calling tool")) == []
+        assert pp.process_chunk(_make_output("alling tool")) == []
         events = pp.process_chunk(
             _make_output(
                 ': bash({"command":"npm test", "timeout": "60000"})]',
@@ -364,6 +364,25 @@ class TestStreamingPostProcessorToolCalls:
         assert len(array_events) == 1
         assert array_events[0].type == "content"
         assert array_events[0].content == "const snake = ["
+
+    def test_line_start_bare_bracket_is_not_stripped(self):
+        """A bare array bracket on its own line is normal content."""
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request={"tools": []},
+        )
+        pp.reset()
+
+        events = pp.process_chunk(_make_output("Here is an array:\n["))
+
+        assert len(events) == 1
+        assert events[0].type == "content"
+        assert events[0].content == "Here is an array:\n["
 
     def test_generic_tool_call_drops_missing_required_duplicate(self):
         """Malformed duplicate calls should not reach clients for schema rejection."""

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -293,6 +293,103 @@ class TestStreamingPostProcessorToolCalls:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_partial_calling_tool_marker_is_buffered(self):
+        """Do not leak partial generic tool markers as assistant text."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string"},
+                                "timeout": {"type": "number"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request=request,
+        )
+        pp.reset()
+
+        heading_events = pp.process_chunk(_make_output("Next step\n\n["))
+        assert len(heading_events) == 1
+        assert heading_events[0].type == "content"
+        assert heading_events[0].content == "Next step"
+        assert pp.process_chunk(_make_output("Calling tool")) == []
+        events = pp.process_chunk(
+            _make_output(
+                ': bash({"command":"npm test", "timeout": "60000"})]',
+                finished=True,
+            )
+        )
+
+        tool_events = [event for event in events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        args = json.loads(tool_events[0].tool_calls[0]["function"]["arguments"])
+        assert args["command"] == "npm test"
+        assert args["timeout"] == 60000.0
+
+    def test_generic_tool_call_drops_missing_required_duplicate(self):
+        """Malformed duplicate calls should not reach clients for schema rejection."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "edit",
+                        "parameters": {
+                            "type": "object",
+                            "required": ["filePath", "oldString", "newString"],
+                            "properties": {
+                                "filePath": {"type": "string"},
+                                "oldString": {"type": "string"},
+                                "newString": {"type": "string"},
+                                "replaceAll": {"type": "boolean"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="qwen3_coder_xml",
+        )
+        pp = StreamingPostProcessor(
+            cfg,
+            tools_requested=True,
+            request=request,
+        )
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                'Calling tool: edit({"oldString":"a","newString":"b"})\n'
+                'Calling tool: edit({"filePath":"/tmp/package.json",'
+                '"oldString":"a","newString":"b"})',
+                finished=True,
+            )
+        )
+
+        tool_events = [event for event in events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        assert len(tool_events[0].tool_calls) == 1
+        args = json.loads(tool_events[0].tool_calls[0]["function"]["arguments"])
+        assert args["filePath"] == "/tmp/package.json"
     def test_qwen_xml_tool_uses_schema_after_content_prefix(self):
         """Schema conversion still works if text appears before tool markup."""
         request = {

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 from vllm_mlx.api.tool_calling import (
     _is_tool_call_json,
     _parse_raw_json_tool_calls,
+    _serialize_tool_arguments,
     convert_tools_for_template,
     format_tool_call_for_message,
     parse_tool_calls,
@@ -258,6 +259,54 @@ class TestParseToolCalls:
         cleaned, tool_calls = parse_tool_calls(text, request=request)
 
         assert tool_calls is not None
+
+    def test_schema_without_properties_does_not_coerce_schema_keys(self):
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "foo",
+                        "parameters": {"type": "object", "required": ["x"]},
+                    },
+                }
+            ]
+        }
+
+        result = _serialize_tool_arguments(
+            {"type": "1", "required": "false"},
+            tool_name="foo",
+            request=request,
+        )
+
+        assert result == '{"type": "1", "required": "false"}'
+
+    def test_boolean_schema_coerces_common_aliases(self):
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "foo",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {"type": "boolean"},
+                                "disabled": {"type": "boolean"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        result = _serialize_tool_arguments(
+            {"enabled": "yes", "disabled": "0"},
+            tool_name="foo",
+            request=request,
+        )
+
+        assert result == '{"enabled": true, "disabled": false}'
 
 
 class TestConvertToolsForTemplate:

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -226,6 +226,33 @@ class TestGenericToolCallParsing:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_tool_arguments_coerce_schema_numbers(self):
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string"},
+                                "timeout": {"type": "number"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        text = 'Calling tool: bash({"command": "npm test", "timeout": "60000"})'
+
+        _, tool_calls = parse_tool_calls(text, request)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["command"] == "npm test"
+        assert args["timeout"] == 60000.0
+
 
 class TestLlamaToolParser:
     """Test the Llama tool parser."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from vllm_mlx.api.tool_calling import parse_tool_calls
 from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
@@ -191,6 +192,39 @@ class TestQwenToolParser:
         result = parser.extract_tool_calls(text)
 
         assert not result.tools_called
+
+
+class TestGenericToolCallParsing:
+    """Test generic OpenAI tool-call translation helpers."""
+
+    def test_bare_calling_tool_is_parsed_and_removed(self):
+        text = (
+            "Thinking first.\n"
+            'Calling tool: write({"filePath": "/tmp/app.tsx", "content": "ok"})'
+        )
+
+        cleaned_text, tool_calls = parse_tool_calls(text)
+
+        assert cleaned_text == "Thinking first."
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "write"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args == {"filePath": "/tmp/app.tsx", "content": "ok"}
+
+    def test_tool_arguments_decode_stringified_arrays(self):
+        text = (
+            'Calling tool: todowrite({"todos": '
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"'
+            "})"
+        )
+
+        _, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
 
 class TestLlamaToolParser:

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1069,6 +1069,42 @@ class TestQwen3CoderUpstreamNonStreaming:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args["obj_param"] == {"key": "value"}
 
+    def test_array_parameter_double_encoded_json_string(self, qwen3coder_parser):
+        """Array parameters may arrive as double-encoded JSON strings."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
     def test_fallback_no_tool_call_tags(self, qwen3coder_parser, qwen3coder_request):
         """Bare <function=...> without <tool_call> wrapper also works."""
         output = (

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1105,6 +1105,42 @@ class TestQwen3CoderUpstreamNonStreaming:
         assert isinstance(args["todos"], list)
         assert args["todos"][0]["content"] == "Initialize"
 
+    def test_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Schemas may encode nullable arrays as type lists."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
     def test_fallback_no_tool_call_tags(self, qwen3coder_parser, qwen3coder_request):
         """Bare <function=...> without <tool_call> wrapper also works."""
         output = (
@@ -1239,6 +1275,58 @@ class TestQwen3CoderUpstreamStreaming:
         assert full_args.endswith("}")
         parsed = json.loads(full_args)
         assert parsed["city"] == "Dallas"
+
+    def test_streaming_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Streaming conversion also handles nullable array schemas."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        deltas = [
+            "<tool_call>\n<function=todowrite>\n",
+            "<parameter=todos>\n",
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n",
+            "</function>\n</tool_call>",
+        ]
+        text = ""
+        collected = []
+        for delta in deltas:
+            previous = text
+            text += delta
+            result = qwen3coder_parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=text,
+                delta_text=delta,
+                request=request,
+            )
+            if result:
+                collected.append(result)
+
+        arg_parts = [
+            chunk["tool_calls"][0]["function"]["arguments"]
+            for chunk in collected
+            if "tool_calls" in chunk
+            and "arguments" in chunk["tool_calls"][0].get("function", {})
+        ]
+        args = json.loads("".join(arg_parts))
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
     def test_streaming_coarse_deltas_complete(
         self, qwen3coder_parser, qwen3coder_request

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -46,17 +46,100 @@ def _decode_json_like(value: Any) -> Any:
     return current
 
 
-def _normalize_tool_arguments(arguments: Any) -> Any:
+def _get_tool_param_config(
+    tool_name: str | None, request: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Return JSON schema properties for a requested tool."""
+    if not tool_name or not isinstance(request, dict):
+        return {}
+    tools = request.get("tools")
+    if not isinstance(tools, list):
+        return {}
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict) or function.get("name") != tool_name:
+            continue
+        parameters = function.get("parameters")
+        if not isinstance(parameters, dict):
+            return {}
+        properties = parameters.get("properties")
+        if isinstance(properties, dict):
+            return properties
+        return parameters
+    return {}
+
+
+def _schema_type(schema: Any) -> str | None:
+    if not isinstance(schema, dict):
+        return None
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    if isinstance(schema_type, str):
+        return schema_type.strip().lower()
+    for key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(key)
+        if isinstance(options, list):
+            for option in options:
+                option_type = _schema_type(option)
+                if option_type and option_type != "null":
+                    return option_type
+    return None
+
+
+def _coerce_schema_value(value: Any, schema: Any) -> Any:
+    value = _decode_json_like(value)
+    schema_type = _schema_type(schema)
+    if schema_type is None:
+        return value
+    if value is None:
+        return None
+    if schema_type in ("array", "object"):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    try:
+        if schema_type in ("integer", "int"):
+            return int(stripped)
+        if schema_type in ("number", "float"):
+            return float(stripped)
+    except (TypeError, ValueError):
+        return value
+    if schema_type in ("boolean", "bool"):
+        if stripped.lower() == "true":
+            return True
+        if stripped.lower() == "false":
+            return False
+    return value
+
+
+def _normalize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> Any:
     """Normalize parsed tool arguments before OpenAI serialization."""
     arguments = _decode_json_like(arguments)
     if isinstance(arguments, dict):
-        return {key: _decode_json_like(value) for key, value in arguments.items()}
+        param_config = _get_tool_param_config(tool_name, request)
+        return {
+            key: _coerce_schema_value(value, param_config.get(key))
+            for key, value in arguments.items()
+        }
     return arguments
 
 
-def _serialize_tool_arguments(arguments: Any) -> str:
+def _serialize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> str:
     """Serialize tool arguments as a valid OpenAI function.arguments JSON string."""
-    arguments = _normalize_tool_arguments(arguments)
+    arguments = _normalize_tool_arguments(arguments, tool_name, request)
     if isinstance(arguments, str):
         decoded = _decode_json_like(arguments)
         if decoded is not arguments:
@@ -277,7 +360,9 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
+                        ),
                     ),
                 )
             )
@@ -317,7 +402,9 @@ def parse_tool_calls(
                 type="function",
                 function=FunctionCall(
                     name=name.strip(),
-                    arguments=_serialize_tool_arguments(arguments),
+                    arguments=_serialize_tool_arguments(
+                        arguments, name.strip(), request
+                    ),
                 ),
             )
         )
@@ -353,7 +440,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name,
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(arguments, name, request),
                     ),
                 )
             )
@@ -384,7 +471,9 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=_serialize_tool_arguments(arguments),
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
+                        ),
                     ),
                 )
             )
@@ -421,7 +510,9 @@ def parse_tool_calls(
                         type="function",
                         function=FunctionCall(
                             name=call_data["name"],
-                            arguments=_serialize_tool_arguments(call_data["arguments"]),
+                            arguments=_serialize_tool_arguments(
+                                call_data["arguments"], call_data["name"], request
+                            ),
                         ),
                     )
                 )

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -24,6 +24,121 @@ from .models import FunctionCall, ResponseFormat, ToolCall
 logger = logging.getLogger(__name__)
 
 
+def _decode_json_like(value: Any) -> Any:
+    """Decode JSON-looking strings, including one level of double encoding."""
+    if not isinstance(value, str):
+        return value
+
+    current: Any = value.strip()
+    for _ in range(3):
+        if not isinstance(current, str):
+            return current
+        stripped = current.strip()
+        if not stripped or stripped[0] not in '[{"':
+            return current
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return current
+        if parsed == current:
+            return parsed
+        current = parsed
+    return current
+
+
+def _normalize_tool_arguments(arguments: Any) -> Any:
+    """Normalize parsed tool arguments before OpenAI serialization."""
+    arguments = _decode_json_like(arguments)
+    if isinstance(arguments, dict):
+        return {key: _decode_json_like(value) for key, value in arguments.items()}
+    return arguments
+
+
+def _serialize_tool_arguments(arguments: Any) -> str:
+    """Serialize tool arguments as a valid OpenAI function.arguments JSON string."""
+    arguments = _normalize_tool_arguments(arguments)
+    if isinstance(arguments, str):
+        decoded = _decode_json_like(arguments)
+        if decoded is not arguments:
+            arguments = decoded
+    if isinstance(arguments, str):
+        return arguments
+    return json.dumps(arguments, ensure_ascii=False)
+
+
+def _iter_calling_tool_calls(text: str):
+    """Yield Qwen-style `Calling tool: name({...})` spans with balanced JSON args."""
+    marker = "Calling tool:"
+    search_from = 0
+    while True:
+        marker_idx = text.find(marker, search_from)
+        if marker_idx == -1:
+            return
+
+        i = marker_idx + len(marker)
+        while i < len(text) and text[i].isspace():
+            i += 1
+
+        name_start = i
+        while i < len(text) and (text[i].isalnum() or text[i] in "_.-"):
+            i += 1
+        name = text[name_start:i].strip()
+        if not name:
+            search_from = marker_idx + len(marker)
+            continue
+
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "(":
+            search_from = i
+            continue
+        i += 1
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "{":
+            search_from = i
+            continue
+
+        args_start = i
+        depth = 0
+        in_string = False
+        escaped = False
+        while i < len(text):
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        args_end = i + 1
+                        j = args_end
+                        while j < len(text) and text[j].isspace():
+                            j += 1
+                        if j < len(text) and text[j] == ")":
+                            j += 1
+                            if j < len(text) and text[j] == "]":
+                                j += 1
+                            start = marker_idx
+                            if marker_idx > 0 and text[marker_idx - 1] == "[":
+                                start = marker_idx - 1
+                            yield start, j, name, text[args_start:args_end]
+                            search_from = j
+                            break
+            i += 1
+        else:
+            return
+
+
 def _is_tool_call_json(obj: dict) -> bool:
     """
     Check if a JSON object looks like a tool call.
@@ -52,9 +167,9 @@ def _is_tool_call_json(obj: dict) -> bool:
     if not isinstance(obj["name"], str) or not obj["name"].strip():
         return False
 
-    # "arguments" must be a dict or string
+    # "arguments" must be JSON-like
     args = obj["arguments"]
-    if not isinstance(args, (dict, str)):
+    if not isinstance(args, (dict, list, str)):
         return False
 
     return True
@@ -132,7 +247,7 @@ def parse_tool_calls(
     Parse tool calls from model output.
 
     Supports multiple formats:
-    - Qwen3 bracket: [Calling tool: function_name({...})]
+    - Qwen3: [Calling tool: function_name({...})] or Calling tool: function_name({...})
     - Qwen:
     - Llama:
     - Nemotron:
@@ -149,11 +264,11 @@ def parse_tool_calls(
     tool_calls = []
     cleaned_text = text
 
-    # Pattern for Qwen3 bracket-style: [Calling tool: function_name({...})]
-    bracket_pattern = r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]"
-    bracket_matches = re.findall(bracket_pattern, text, re.DOTALL)
+    # Pattern for Qwen3 calling-tool style. Some models omit the outer brackets,
+    # and arguments can contain nested braces in strings, so use a balanced scan.
+    calling_tool_matches = list(_iter_calling_tool_calls(text))
 
-    for name, args_str in bracket_matches:
+    for _, _, name, args_str in calling_tool_matches:
         try:
             arguments = json.loads(args_str)
             tool_calls.append(
@@ -162,22 +277,18 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
         except json.JSONDecodeError:
             continue
 
-    # Remove bracket tool calls from cleaned text
-    if bracket_matches:
-        cleaned_text = re.sub(
-            r"\[Calling tool:\s*\w+\(\{.*?\}\)\]", "", cleaned_text, flags=re.DOTALL
-        ).strip()
+    # Remove Qwen calling-tool spans from cleaned text
+    if calling_tool_matches:
+        for start, end, _, _ in reversed(calling_tool_matches):
+            cleaned_text = cleaned_text[:start] + cleaned_text[end:]
+        cleaned_text = cleaned_text.strip()
 
     # Pattern for Nemotron-style:
     # Format 1: <tool_call><function=name><parameter=key>val</parameter></function></tool_call>
@@ -205,7 +316,8 @@ def parse_tool_calls(
                 id=f"call_{uuid.uuid4().hex[:8]}",
                 type="function",
                 function=FunctionCall(
-                    name=name.strip(), arguments=json.dumps(arguments)
+                    name=name.strip(),
+                    arguments=_serialize_tool_arguments(arguments),
                 ),
             )
         )
@@ -241,11 +353,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name,
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
@@ -276,11 +384,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments),
                     ),
                 )
             )
@@ -317,11 +421,7 @@ def parse_tool_calls(
                         type="function",
                         function=FunctionCall(
                             name=call_data["name"],
-                            arguments=(
-                                json.dumps(call_data["arguments"])
-                                if isinstance(call_data["arguments"], dict)
-                                else str(call_data["arguments"])
-                            ),
+                            arguments=_serialize_tool_arguments(call_data["arguments"]),
                         ),
                     )
                 )

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -260,7 +260,7 @@ def _is_tool_call_json(obj: dict) -> bool:
 
     # "arguments" must be JSON-like
     args = obj["arguments"]
-    if not isinstance(args, (dict, list, str)):
+    if not isinstance(args, (dict, str)):
         return False
 
     return True

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -72,6 +72,8 @@ def _get_tool_param_config(
 
 
 def _schema_type(schema: Any) -> str | None:
+    if isinstance(schema, str):
+        return schema.strip().lower()
     if not isinstance(schema, dict):
         return None
     schema_type = schema.get("type")
@@ -86,6 +88,12 @@ def _schema_type(schema: Any) -> str | None:
                 option_type = _schema_type(option)
                 if option_type and option_type != "null":
                     return option_type
+    if "items" in schema:
+        return "array"
+    if "properties" in schema or "additionalProperties" in schema:
+        return "object"
+    if "enum" in schema:
+        return "string"
     return None
 
 

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -67,7 +67,7 @@ def _get_tool_param_config(
         properties = parameters.get("properties")
         if isinstance(properties, dict):
             return properties
-        return parameters
+        return {}
     return {}
 
 
@@ -118,9 +118,10 @@ def _coerce_schema_value(value: Any, schema: Any) -> Any:
     except (TypeError, ValueError):
         return value
     if schema_type in ("boolean", "bool"):
-        if stripped.lower() == "true":
+        normalized = stripped.lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
             return True
-        if stripped.lower() == "false":
+        if normalized in {"false", "0", "no", "n", "off"}:
             return False
     return value
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -275,10 +275,14 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
     for layer_cache in cache:
         if layer_cache is None:
             continue
-        # TurboQuantKVCache: has values_compressed instead of values
-        from .turboquant import TurboQuantKVCache
+        # TurboQuantKVCache imports MLX at module import time. Keep this optional
+        # so memory-cache unit tests can run on non-MLX Linux CI with mock caches.
+        try:
+            from .turboquant import TurboQuantKVCache
+        except ImportError:
+            TurboQuantKVCache = None  # noqa: N806
 
-        if isinstance(layer_cache, TurboQuantKVCache):
+        if TurboQuantKVCache is not None and isinstance(layer_cache, TurboQuantKVCache):
             total_bytes += layer_cache.memory_bytes
             continue
         # Handle different cache object types

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ..api.tool_calling import parse_tool_calls
 from ..api.utils import sanitize_output, strip_special_tokens
 from ..domain.events import StreamEvent
 
@@ -121,6 +122,36 @@ class StreamingPostProcessor:
         # the first JSON delimiter ({ or [) is seen, then emit from there.
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
+
+    @staticmethod
+    def _tool_calls_to_stream_chunks(tool_calls) -> list[dict]:
+        chunks = []
+        for i, tc in enumerate(tool_calls):
+            if hasattr(tc, "function"):
+                call_id = tc.id
+                name = tc.function.name
+                arguments = tc.function.arguments
+            elif "function" in tc:
+                call_id = tc.get("id")
+                name = tc["function"]["name"]
+                arguments = tc["function"]["arguments"]
+            else:
+                call_id = tc.get("id")
+                name = tc["name"]
+                arguments = tc["arguments"]
+
+            chunks.append(
+                {
+                    "index": i,
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    },
+                }
+            )
+        return chunks
 
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
@@ -500,6 +531,19 @@ class StreamingPostProcessor:
                 )
                 self.tool_calls_detected = True
 
+        if "Calling tool:" in _fallback_text and not self.tool_calls_detected:
+            _, tool_calls = parse_tool_calls(_fallback_text, self.request)
+            if tool_calls:
+                events.append(
+                    StreamEvent(
+                        type="tool_call",
+                        tool_calls=self._tool_calls_to_stream_chunks(tool_calls),
+                        finish_reason="tool_calls",
+                        tool_calls_detected=True,
+                    )
+                )
+                self.tool_calls_detected = True
+
         return events
 
     def _detect_tool_calls(self, content: str) -> dict | None:
@@ -509,7 +553,12 @@ class StreamingPostProcessor:
         Returns {"tool_calls": [...]} if tool calls detected.
         Returns {"content": "..."} for normal content pass-through.
         """
-        if not self.tool_markup_possible and "<" not in content and "[" not in content:
+        if (
+            not self.tool_markup_possible
+            and "<" not in content
+            and "[" not in content
+            and "Calling tool:" not in content
+        ):
             self.tool_accumulated_text += content
             return {"content": content}
 
@@ -526,11 +575,27 @@ class StreamingPostProcessor:
         )
 
         if tool_result is None:
+            if "Calling tool:" in self.tool_accumulated_text:
+                _, tool_calls = parse_tool_calls(
+                    self.tool_accumulated_text, self.request
+                )
+                if tool_calls:
+                    self.tool_calls_detected = True
+                    return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
             return None  # inside tool markup
 
         if "tool_calls" in tool_result:
             self.tool_calls_detected = True
             return tool_result
+
+        if "Calling tool:" in self.tool_accumulated_text:
+            _, tool_calls = parse_tool_calls(
+                self.tool_accumulated_text, self.request
+            )
+            if tool_calls:
+                self.tool_calls_detected = True
+                return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+            return None
 
         return {"content": tool_result.get("content", "")}
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -691,9 +691,7 @@ class StreamingPostProcessor:
             return tool_result
 
         if "Calling tool:" in self.tool_accumulated_text:
-            _, tool_calls = parse_tool_calls(
-                self.tool_accumulated_text, self.request
-            )
+            _, tool_calls = parse_tool_calls(self.tool_accumulated_text, self.request)
             if tool_calls:
                 chunks = self._tool_calls_to_stream_chunks(tool_calls)
                 if not chunks:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -54,8 +54,6 @@ def _has_partial_calling_tool_marker(text: str) -> bool:
     """Return True when a stream tail may become `Calling tool:`."""
     marker = "Calling tool:"
     tail = text.rstrip()
-    if tail.endswith("[") and _starts_current_line(tail, len(tail) - 1):
-        return True
     for i in range(1, len(marker)):
         partial = marker[:i]
         if tail.endswith(partial):
@@ -79,11 +77,6 @@ def _find_trailing_calling_tool_prefix(text: str) -> int | None:
     marker = "Calling tool:"
     tail_end = len(text.rstrip())
     tail = text[:tail_end]
-
-    if tail.endswith("["):
-        start = len(tail) - 1
-        if _starts_current_line(tail, start):
-            return start
 
     for i in range(1, len(marker)):
         partial = marker[:i]

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -54,16 +54,48 @@ def _has_partial_calling_tool_marker(text: str) -> bool:
     """Return True when a stream tail may become `Calling tool:`."""
     marker = "Calling tool:"
     tail = text.rstrip()
-    stripped_tail = tail
-    while stripped_tail and stripped_tail[-1] in "[ \t\r\n":
-        if stripped_tail[-1] == "[":
-            return True
-        stripped_tail = stripped_tail[:-1]
+    if tail.endswith("[") and _starts_current_line(tail, len(tail) - 1):
+        return True
     for i in range(1, len(marker)):
         partial = marker[:i]
-        if tail.endswith(partial) or tail.endswith(f"[{partial}"):
-            return True
+        if tail.endswith(partial):
+            start = len(tail) - len(partial)
+            if _starts_current_line(tail, start):
+                return True
+        if tail.endswith(f"[{partial}"):
+            start = len(tail) - len(partial) - 1
+            if _starts_current_line(tail, start):
+                return True
     return False
+
+
+def _starts_current_line(text: str, start: int) -> bool:
+    """Return True when start is preceded only by whitespace on its line."""
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    return text[line_start:start].strip() == ""
+
+
+def _find_trailing_calling_tool_prefix(text: str) -> int | None:
+    marker = "Calling tool:"
+    tail_end = len(text.rstrip())
+    tail = text[:tail_end]
+
+    if tail.endswith("["):
+        start = len(tail) - 1
+        if _starts_current_line(tail, start):
+            return start
+
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if tail.endswith(partial):
+            start = len(tail) - len(partial)
+            if _starts_current_line(tail, start):
+                return start
+        if tail.endswith(f"[{partial}"):
+            start = len(tail) - len(partial) - 1
+            if _starts_current_line(tail, start):
+                return start
+    return None
 
 
 def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
@@ -71,31 +103,9 @@ def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
     if not text:
         return None
 
-    marker = "Calling tool:"
-    tail_end = len(text.rstrip())
-    tail = text[:tail_end]
-
-    for i in range(1, len(marker)):
-        partial = marker[:i]
-        if not tail.endswith(partial):
-            continue
-        start = len(tail) - len(partial)
-        while start > 0 and tail[start - 1].isspace():
-            start -= 1
-        while start > 0 and tail[start - 1] == "[":
-            start -= 1
-            while start > 0 and tail[start - 1].isspace():
-                start -= 1
-        return text[:start]
-
-    start = len(tail)
-    saw_bracket = False
-    while start > 0 and tail[start - 1] in "[ \t\r\n":
-        if tail[start - 1] == "[":
-            saw_bracket = True
-        start -= 1
-    if saw_bracket:
-        return text[:start]
+    start = _find_trailing_calling_tool_prefix(text)
+    if start is not None:
+        return text[:start].rstrip()
     return None
 
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -8,6 +8,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,55 @@ def _find_json_start(text: str) -> int:
             return i
         i += 1
     return -1
+
+
+def _has_partial_calling_tool_marker(text: str) -> bool:
+    """Return True when a stream tail may become `Calling tool:`."""
+    marker = "Calling tool:"
+    tail = text.rstrip()
+    stripped_tail = tail
+    while stripped_tail and stripped_tail[-1] in "[ \t\r\n":
+        if stripped_tail[-1] == "[":
+            return True
+        stripped_tail = stripped_tail[:-1]
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if tail.endswith(partial) or tail.endswith(f"[{partial}"):
+            return True
+    return False
+
+
+def _strip_trailing_calling_tool_prefix(text: str) -> str | None:
+    """Remove a trailing bracket/partial marker that may start a tool call."""
+    if not text:
+        return None
+
+    marker = "Calling tool:"
+    tail_end = len(text.rstrip())
+    tail = text[:tail_end]
+
+    for i in range(1, len(marker)):
+        partial = marker[:i]
+        if not tail.endswith(partial):
+            continue
+        start = len(tail) - len(partial)
+        while start > 0 and tail[start - 1].isspace():
+            start -= 1
+        while start > 0 and tail[start - 1] == "[":
+            start -= 1
+            while start > 0 and tail[start - 1].isspace():
+                start -= 1
+        return text[:start]
+
+    start = len(tail)
+    saw_bracket = False
+    while start > 0 and tail[start - 1] in "[ \t\r\n":
+        if tail[start - 1] == "[":
+            saw_bracket = True
+        start -= 1
+    if saw_bracket:
+        return text[:start]
+    return None
 
 
 class StreamingPostProcessor:
@@ -123,8 +173,37 @@ class StreamingPostProcessor:
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
 
-    @staticmethod
-    def _tool_calls_to_stream_chunks(tool_calls) -> list[dict]:
+    def _tool_call_has_required_args(self, name: str | None, arguments) -> bool:
+        if not name or not isinstance(self.request, dict):
+            return True
+        tools = self.request.get("tools")
+        if not isinstance(tools, list):
+            return True
+
+        required = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            if not isinstance(function, dict) or function.get("name") != name:
+                continue
+            parameters = function.get("parameters")
+            if isinstance(parameters, dict):
+                required = parameters.get("required") or []
+            break
+        if not required:
+            return True
+
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (TypeError, ValueError):
+                return False
+        if not isinstance(arguments, dict):
+            return False
+        return all(key in arguments for key in required)
+
+    def _tool_calls_to_stream_chunks(self, tool_calls) -> list[dict]:
         chunks = []
         for i, tc in enumerate(tool_calls):
             if hasattr(tc, "function"):
@@ -140,9 +219,16 @@ class StreamingPostProcessor:
                 name = tc["name"]
                 arguments = tc["arguments"]
 
+            if not self._tool_call_has_required_args(name, arguments):
+                logger.debug(
+                    "Dropping malformed tool call missing required arguments: %s",
+                    name,
+                )
+                continue
+
             chunks.append(
                 {
-                    "index": i,
+                    "index": len(chunks),
                     "id": call_id,
                     "type": "function",
                     "function": {
@@ -534,10 +620,13 @@ class StreamingPostProcessor:
         if "Calling tool:" in _fallback_text and not self.tool_calls_detected:
             _, tool_calls = parse_tool_calls(_fallback_text, self.request)
             if tool_calls:
+                chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                if not chunks:
+                    return events
                 events.append(
                     StreamEvent(
                         type="tool_call",
-                        tool_calls=self._tool_calls_to_stream_chunks(tool_calls),
+                        tool_calls=chunks,
                         finish_reason="tool_calls",
                         tool_calls_detected=True,
                     )
@@ -580,8 +669,11 @@ class StreamingPostProcessor:
                     self.tool_accumulated_text, self.request
                 )
                 if tool_calls:
+                    chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                    if not chunks:
+                        return None
                     self.tool_calls_detected = True
-                    return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+                    return {"tool_calls": chunks}
             return None  # inside tool markup
 
         if "tool_calls" in tool_result:
@@ -593,8 +685,18 @@ class StreamingPostProcessor:
                 self.tool_accumulated_text, self.request
             )
             if tool_calls:
+                chunks = self._tool_calls_to_stream_chunks(tool_calls)
+                if not chunks:
+                    return None
                 self.tool_calls_detected = True
-                return {"tool_calls": self._tool_calls_to_stream_chunks(tool_calls)}
+                return {"tool_calls": chunks}
+            return None
+
+        if _has_partial_calling_tool_marker(self.tool_accumulated_text):
+            content = tool_result.get("content", "")
+            stripped = _strip_trailing_calling_tool_prefix(content)
+            if stripped:
+                return {"content": stripped}
             return None
 
         return {"content": tool_result.get("content", "")}

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -53,6 +53,28 @@ def _get_arguments_config(func_name: str, tools: list[dict] | None) -> dict:
     return {}
 
 
+def _decode_json_like(value: Any) -> Any:
+    """Decode JSON-looking strings, including double-encoded values."""
+    if not isinstance(value, str):
+        return value
+
+    current: Any = value.strip()
+    for _ in range(3):
+        if not isinstance(current, str):
+            return current
+        stripped = current.strip()
+        if not stripped or stripped[0] not in '[{"':
+            return current
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return current
+        if parsed == current:
+            return parsed
+        current = parsed
+    return current
+
+
 def _convert_param_value(
     param_value: str, param_name: str, param_config: dict, func_name: str
 ) -> Any:
@@ -61,7 +83,7 @@ def _convert_param_value(
         return None
 
     if param_name not in param_config:
-        return param_value
+        return _decode_json_like(param_value)
 
     cfg = param_config[param_name]
     if isinstance(cfg, dict) and "type" in cfg:
@@ -87,10 +109,9 @@ def _convert_param_value(
         if param_type in ("object", "array", "arr") or param_type.startswith(
             ("dict", "list")
         ):
-            try:
-                return json.loads(param_value)
-            except (json.JSONDecodeError, TypeError, ValueError):
-                pass
+            decoded = _decode_json_like(param_value)
+            if decoded is not param_value:
+                return decoded
         try:
             return ast.literal_eval(param_value)
         except (ValueError, SyntaxError):

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -75,6 +75,37 @@ def _decode_json_like(value: Any) -> Any:
     return current
 
 
+def _schema_type(schema: Any) -> str | None:
+    """Infer a JSON schema type for tool argument conversion."""
+    if isinstance(schema, str):
+        return schema.strip().lower()
+    if not isinstance(schema, dict):
+        return None
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    if isinstance(schema_type, str):
+        return schema_type.strip().lower()
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(key)
+        if not isinstance(options, list):
+            continue
+        for option in options:
+            option_type = _schema_type(option)
+            if option_type and option_type != "null":
+                return option_type
+
+    if "items" in schema:
+        return "array"
+    if "properties" in schema or "additionalProperties" in schema:
+        return "object"
+    if "enum" in schema:
+        return "string"
+    return None
+
+
 def _convert_param_value(
     param_value: str, param_name: str, param_config: dict, func_name: str
 ) -> Any:
@@ -86,10 +117,9 @@ def _convert_param_value(
         return _decode_json_like(param_value)
 
     cfg = param_config[param_name]
-    if isinstance(cfg, dict) and "type" in cfg:
-        param_type = str(cfg["type"]).strip().lower()
-    else:
-        param_type = "string"
+    param_type = _schema_type(cfg)
+    if param_type is None:
+        return _decode_json_like(param_value)
 
     if param_type in ("string", "str", "text", "varchar", "char", "enum"):
         return param_value

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -22,6 +22,7 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
+from ..api.tool_calling import _decode_json_like, _schema_type
 from .abstract_tool_parser import (
     ExtractedToolCallInformation,
     ToolParser,
@@ -47,63 +48,8 @@ def _get_arguments_config(func_name: str, tools: list[dict] | None) -> dict:
             params = func.get("parameters", {})
             if isinstance(params, dict) and "properties" in params:
                 return params["properties"]
-            elif isinstance(params, dict):
-                return params
             return {}
     return {}
-
-
-def _decode_json_like(value: Any) -> Any:
-    """Decode JSON-looking strings, including double-encoded values."""
-    if not isinstance(value, str):
-        return value
-
-    current: Any = value.strip()
-    for _ in range(3):
-        if not isinstance(current, str):
-            return current
-        stripped = current.strip()
-        if not stripped or stripped[0] not in '[{"':
-            return current
-        try:
-            parsed = json.loads(stripped)
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return current
-        if parsed == current:
-            return parsed
-        current = parsed
-    return current
-
-
-def _schema_type(schema: Any) -> str | None:
-    """Infer a JSON schema type for tool argument conversion."""
-    if isinstance(schema, str):
-        return schema.strip().lower()
-    if not isinstance(schema, dict):
-        return None
-
-    schema_type = schema.get("type")
-    if isinstance(schema_type, list):
-        schema_type = next((item for item in schema_type if item != "null"), None)
-    if isinstance(schema_type, str):
-        return schema_type.strip().lower()
-
-    for key in ("anyOf", "oneOf", "allOf"):
-        options = schema.get(key)
-        if not isinstance(options, list):
-            continue
-        for option in options:
-            option_type = _schema_type(option)
-            if option_type and option_type != "null":
-                return option_type
-
-    if "items" in schema:
-        return "array"
-    if "properties" in schema or "additionalProperties" in schema:
-        return "object"
-    if "enum" in schema:
-        return "string"
-    return None
 
 
 def _convert_param_value(

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -275,6 +275,8 @@ class Qwen3CoderToolParser(ToolParser):
         if not previous_text:
             self._reset_streaming_state()
             self._streaming_request = request
+        elif request is not None and self._streaming_request is None:
+            self._streaming_request = request
 
         if not delta_text:
             return None


### PR DESCRIPTION
## Summary

This is the focused split-out from #162 for the Qwen/OpenAI tool-call translation fixes requested in the owner review.

It keeps only the parser/postprocessor pieces needed for #160:

- parse bare Qwen `Calling tool: name({...})` output into OpenAI `tool_calls`
- decode JSON-looking and double-encoded tool arguments before OpenAI serialization
- coerce Qwen tool arguments with request JSON schema metadata, including nullable type lists and nested array/object forms
- keep request tool schemas available after streamed content prefixes so Qwen streaming conversion still has schema context
- buffer split `Calling tool` / `[` marker tails without stripping normal code brackets such as `game.snake[` or `const items = [`
- drop malformed duplicate generic tool calls that are missing required schema args before emitting the valid duplicate

Out of scope on purpose, per #162 review:

- no DFlash changes
- no TUI or metrics middleware changes
- no hidden continuation-prompt injection
- no buffered stream retry/repeated-text retry machinery
- no generic fallback when tool parsing is not configured

Fixes #160.

## Tests

- `uv run --extra dev ruff check vllm_mlx/api/tool_calling.py vllm_mlx/service/postprocessor.py vllm_mlx/tool_parsers/qwen3coder_tool_parser.py tests/test_postprocessor.py tests/test_tool_parsers.py tests/test_upstream_regression.py`
- `uv run --extra dev pytest tests/test_postprocessor.py tests/test_tool_parsers.py tests/test_upstream_regression.py` -> 275 passed
