### PR TITLE
fix(streaming): accumulate new_text across skipped steps for stream_interval > 1

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -586,6 +586,191 @@ class TestEngineAsync:
         assert fake_scheduler.thread_names
         assert all(name.startswith("mlx-step") for name in fake_scheduler.thread_names)
 
+    async def test_stream_interval_buffer_merges_skipped_step_deltas(
+        self, mock_model_and_tokenizer
+    ):
+        """Regression: stream_interval > 1 must not drop step deltas.
+
+        Pre-fix, when ``RequestStreamState.should_send()`` returned False the
+        engine skipped ``collector.put()`` and that step's ``new_text`` /
+        ``new_token_ids`` / ``logprobs`` were silently lost. After PR #210 the
+        engine accumulates per-step deltas in ``_stream_buffers`` and flushes
+        the merged delta on the next ``should_send() == True`` step. This
+        test feeds 6 step outputs through the loop with stream_interval=4
+        and asserts the buffer + flush invariants on all three delta fields.
+        A finished=True step must always trigger a flush.
+        """
+        from vllm_mlx import engine_core
+        from vllm_mlx.engine import EngineConfig, EngineCore
+        from vllm_mlx.output_collector import RequestStreamState
+
+        model, tokenizer = mock_model_and_tokenizer
+        engine = EngineCore(
+            model,
+            tokenizer,
+            EngineConfig(step_interval=0.001, stream_interval=4),
+        )
+
+        rid = "stream-interval-buffer-test"
+        # Per-step deltas. completion_tokens climbs by 1 each step (matches
+        # scheduler's one-token-per-step contract). logprobs values are
+        # sentinels — the test asserts the *list* is preserved, the type
+        # of the entries is irrelevant.
+        steps = [
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[10],
+                new_text="he",
+                output_token_ids=[10],
+                output_text="he",
+                finished=False,
+                completion_tokens=1,
+                logprobs="lp1",
+            ),
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[20],
+                new_text="llo",
+                output_token_ids=[10, 20],
+                output_text="hello",
+                finished=False,
+                completion_tokens=2,
+                logprobs="lp2",
+            ),
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[30],
+                new_text=" wo",
+                output_token_ids=[10, 20, 30],
+                output_text="hello wo",
+                finished=False,
+                completion_tokens=3,
+                logprobs="lp3",
+            ),
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[40],
+                new_text="rld",
+                output_token_ids=[10, 20, 30, 40],
+                output_text="hello world",
+                finished=False,
+                completion_tokens=4,
+                logprobs="lp4",
+            ),
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[50],
+                new_text="!",
+                output_token_ids=[10, 20, 30, 40, 50],
+                output_text="hello world!",
+                finished=False,
+                completion_tokens=5,
+                logprobs="lp5",
+            ),
+            RequestOutput(
+                request_id=rid,
+                new_token_ids=[60],
+                new_text=".",
+                output_token_ids=[10, 20, 30, 40, 50, 60],
+                output_text="hello world!.",
+                finished=True,
+                finish_reason="stop",
+                completion_tokens=6,
+                logprobs="lp6",
+            ),
+        ]
+
+        class FakeScheduler:
+            batch_generator = None
+
+            def __init__(self):
+                self.calls = 0
+
+            def has_requests(self):
+                return self.calls < len(steps)
+
+            def step(self):
+                output = steps[self.calls]
+                self.calls += 1
+                if self.calls >= len(steps):
+                    engine._running = False
+                return SimpleNamespace(
+                    outputs=[output],
+                    finished_request_ids=[rid] if output.finished else [],
+                )
+
+            def deep_reset(self):
+                pass
+
+        engine.scheduler = FakeScheduler()
+
+        # Capture every collector.put rather than aggregating, so we can
+        # see exactly which deltas reached the consumer.
+        puts: list[RequestOutput] = []
+
+        class RecordingCollector:
+            def put(self, output):
+                puts.append(output)
+
+            def clear(self):
+                pass
+
+        engine._output_collectors[rid] = RecordingCollector()
+        engine._stream_states[rid] = RequestStreamState(stream_interval=4)
+        engine._finished_events[rid] = asyncio.Event()
+
+        import concurrent.futures
+
+        engine._mlx_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=engine_core._init_mlx_step_thread,
+        )
+        engine._running = True
+
+        try:
+            await asyncio.wait_for(engine._engine_loop(), timeout=2)
+        finally:
+            engine._running = False
+            engine._mlx_executor.shutdown(wait=True)
+            engine._mlx_executor = None
+            engine.close()
+
+        # should_send() with stream_interval=4 fires at:
+        #   step 1 (sent_tokens==0 first-token rule)
+        #   step 5 (5 - 1 == 4 >= stream_interval)
+        #   step 6 (finished=True always flushes)
+        # → 3 puts, with steps 2-5 merged into the second.
+        assert len(puts) == 3, f"expected 3 puts, got {len(puts)}: {puts!r}"
+
+        # Concatenated new_text across all puts must equal sum of step deltas.
+        assert "".join(p.new_text for p in puts) == "hello world!.", (
+            f"new_text mismatch: {[p.new_text for p in puts]!r}"
+        )
+
+        # Concatenated new_token_ids across all puts must equal full token
+        # order. Pre-fix, 3 of 6 token ids were dropped.
+        flat_token_ids: list[int] = []
+        for p in puts:
+            flat_token_ids.extend(p.new_token_ids)
+        assert flat_token_ids == [10, 20, 30, 40, 50, 60]
+
+        # Concatenated logprobs across all puts must equal the full per-step
+        # list. Each put.logprobs is itself a list (the buffer normalizes
+        # mx.array → [mx.array] so subsequent merges concat). Pre-fix this
+        # field was overwritten on every merge: only 3 of 6 entries survived.
+        flat_lp: list = []
+        for p in puts:
+            flat_lp.extend(p.logprobs or [])
+        assert flat_lp == ["lp1", "lp2", "lp3", "lp4", "lp5", "lp6"], (
+            f"logprobs not preserved across stream_interval merges: {flat_lp!r}"
+        )
+
+        # finished=True must always flush, even if the buffer is otherwise
+        # empty (it is here — step 5 already drained it).
+        assert puts[-1].finished is True
+        assert puts[-1].new_token_ids == [60]
+
     async def test_engine_lifecycle(self, mock_model_and_tokenizer):
         """Test engine start/stop lifecycle."""
         from vllm_mlx.engine import AsyncEngineCore, EngineConfig

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -152,6 +152,11 @@ class EngineCore:
         self._output_collectors: dict[str, RequestOutputCollector] = {}
         self._stream_states: dict[str, RequestStreamState] = {}
         self._finished_events: dict[str, asyncio.Event] = {}
+        # Per-request accumulator for stream_interval > 1: each step's
+        # new_text/new_token_ids delta is merged here regardless of
+        # should_send(); the buffer is flushed in one shot when should_send()
+        # triggers, so no token deltas are dropped between sends.
+        self._stream_buffers: dict[str, RequestOutput] = {}
 
         # Engine state
         self._running = False
@@ -340,11 +345,34 @@ class EngineCore:
                                     collector.put(req_output)
                                 else:
                                     state = states.get(rid)
+                                    # Merge this step's delta into the buffer so
+                                    # tokens that fall between should_send() hits
+                                    # are not silently discarded. new_text /
+                                    # new_token_ids accumulate; cumulative status
+                                    # fields take the latest value.
+                                    buf = self._stream_buffers.get(rid)
+                                    if buf is None:
+                                        self._stream_buffers[rid] = req_output
+                                    else:
+                                        self._stream_buffers[rid] = RequestOutput(
+                                            request_id=rid,
+                                            new_token_ids=buf.new_token_ids
+                                            + req_output.new_token_ids,
+                                            new_text=buf.new_text + req_output.new_text,
+                                            output_token_ids=req_output.output_token_ids,
+                                            output_text=req_output.output_text,
+                                            finished=req_output.finished,
+                                            finish_reason=req_output.finish_reason,
+                                            prompt_tokens=req_output.prompt_tokens,
+                                            completion_tokens=req_output.completion_tokens,
+                                            logprobs=req_output.logprobs,
+                                        )
                                     if state and state.should_send(
                                         req_output.completion_tokens,
                                         req_output.finished,
                                     ):
-                                        collector.put(req_output)
+                                        flushed = self._stream_buffers.pop(rid)
+                                        collector.put(flushed)
                                         state.mark_sent(req_output.completion_tokens)
 
                             if req_output.finished:
@@ -467,6 +495,7 @@ class EngineCore:
         if collector:
             collector.clear()
         self._stream_states.pop(request_id, None)
+        self._stream_buffers.pop(request_id, None)
         self._finished_events.pop(request_id, None)
         self.scheduler.remove_finished_request(request_id)
 
@@ -749,6 +778,7 @@ class EngineCore:
             collector.clear()
         self._output_collectors.clear()
         self._stream_states.clear()
+        self._stream_buffers.clear()
         self._finished_events.clear()
 
         logger.debug(f"Engine {self._engine_id} closed")

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -347,26 +347,39 @@ class EngineCore:
                                     state = states.get(rid)
                                     # Merge this step's delta into the buffer so
                                     # tokens that fall between should_send() hits
-                                    # are not silently discarded. new_text /
-                                    # new_token_ids accumulate; cumulative status
-                                    # fields take the latest value.
+                                    # are not silently discarded. new_text,
+                                    # new_token_ids, and logprobs are all
+                                    # per-step deltas (scheduler emits one
+                                    # token's worth per step) and must
+                                    # accumulate; cumulative status fields take
+                                    # the latest value.
                                     buf = self._stream_buffers.get(rid)
-                                    if buf is None:
-                                        self._stream_buffers[rid] = req_output
-                                    else:
-                                        self._stream_buffers[rid] = RequestOutput(
-                                            request_id=rid,
-                                            new_token_ids=buf.new_token_ids
-                                            + req_output.new_token_ids,
-                                            new_text=buf.new_text + req_output.new_text,
-                                            output_token_ids=req_output.output_token_ids,
-                                            output_text=req_output.output_text,
-                                            finished=req_output.finished,
-                                            finish_reason=req_output.finish_reason,
-                                            prompt_tokens=req_output.prompt_tokens,
-                                            completion_tokens=req_output.completion_tokens,
-                                            logprobs=req_output.logprobs,
-                                        )
+                                    # Wrap per-step logprobs (mx.array or None)
+                                    # into a list so subsequent merges concat
+                                    # instead of overwriting. The flushed
+                                    # RequestOutput's logprobs is therefore a
+                                    # list[mx.array] when stream_interval > 1.
+                                    new_lp = (
+                                        [req_output.logprobs]
+                                        if req_output.logprobs is not None
+                                        else []
+                                    )
+                                    prev_text = buf.new_text if buf else ""
+                                    prev_tokens = buf.new_token_ids if buf else []
+                                    prev_lp = (buf.logprobs if buf else None) or []
+                                    self._stream_buffers[rid] = RequestOutput(
+                                        request_id=rid,
+                                        new_token_ids=prev_tokens
+                                        + req_output.new_token_ids,
+                                        new_text=prev_text + req_output.new_text,
+                                        output_token_ids=req_output.output_token_ids,
+                                        output_text=req_output.output_text,
+                                        finished=req_output.finished,
+                                        finish_reason=req_output.finish_reason,
+                                        prompt_tokens=req_output.prompt_tokens,
+                                        completion_tokens=req_output.completion_tokens,
+                                        logprobs=(prev_lp + new_lp) or None,
+                                    )
                                     if state and state.should_send(
                                         req_output.completion_tokens,
                                         req_output.finished,


### PR DESCRIPTION
Issue #209

## What does this PR do?

The producer-side should_send() gate in _engine_loop dropped N-1 of every N token deltas at stream_interval=N, garbling streaming responses (and occasionally corrupting SSE JSON via stranded BPE control bytes). Buffer each step's delta per-request and flush the merged RequestOutput when should_send() hits. stream_interval=1 fast path is untouched.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — see [CONTRIBUTING.md](../CONTRIBUTING.md#self-validating-your-pr) (opt out heavy steps with `PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1` if you don't have the hardware/keys)
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API
