### PR TITLE
Fix no-thinking Anthropic streams for Claude Code

### DIFF
--- a/tests/test_anthropic_route_streaming.py
+++ b/tests/test_anthropic_route_streaming.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Route-level Anthropic streaming regressions."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.routes.anthropic import router
+
+
+class _ThinkingTemplateTokenizer:
+    chat_template = "{% if add_generation_prompt %}<think>{% endif %}"
+
+
+class _StreamingEngine:
+    preserve_native_tool_format = False
+    tokenizer = _ThinkingTemplateTokenizer()
+
+    def __init__(self, deltas: list[str]):
+        self._deltas = deltas
+        self.calls = []
+
+    async def stream_chat(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        for i, text in enumerate(self._deltas, start=1):
+            yield SimpleNamespace(
+                new_text=text,
+                prompt_tokens=5,
+                completion_tokens=i,
+            )
+
+
+def _make_client(engine: _StreamingEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _parse_sse_data(response_text: str) -> list[dict]:
+    events = []
+    for raw_event in response_text.split("\n\n"):
+        data_line = next(
+            (line for line in raw_event.splitlines() if line.startswith("data: ")),
+            None,
+        )
+        if not data_line:
+            continue
+        data = data_line.removeprefix("data: ")
+        if data == "[DONE]":
+            continue
+        events.append(json.loads(data))
+    return events
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_anthropic_stream_route_no_thinking_template_answers_as_text():
+    """Server no-thinking mode should keep direct answers as text blocks."""
+    engine = _StreamingEngine(["Direct ", "answer"])
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert engine.calls[0]["kwargs"]["enable_thinking"] is False
+
+    events = _parse_sse_data(response.text)
+    block_starts = [e for e in events if e.get("type") == "content_block_start"]
+    assert [e["content_block"]["type"] for e in block_starts] == ["text"]
+
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    thinking_deltas = [
+        e
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "thinking_delta"
+    ]
+
+    assert "".join(text_deltas) == "Direct answer"
+    assert thinking_deltas == []
+    assert any(
+        e.get("type") == "message_delta"
+        and e.get("delta", {}).get("stop_reason") == "end_turn"
+        for e in events
+    )

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -9,6 +9,7 @@ import json
 import unittest
 
 from vllm_mlx.api.utils import StreamingThinkRouter, StreamingToolCallFilter
+from vllm_mlx.routes.anthropic import _should_start_in_thinking
 from vllm_mlx.server import _emit_content_pieces
 
 
@@ -58,6 +59,28 @@ class TestEmitContentPieces(unittest.TestCase):
         assert events == []
         assert block_type is None
         assert index == 0
+
+
+class TestAnthropicThinkingStartDecision(unittest.TestCase):
+    """Test when Anthropic streaming should start inside a thinking block."""
+
+    THINKING_TEMPLATE = "{% if add_generation_prompt %}<think>{% endif %}"
+
+    def test_thinking_template_starts_in_thinking_by_default(self):
+        """Thinking-capable templates keep implicit thinking support by default."""
+        assert _should_start_in_thinking(self.THINKING_TEMPLATE, None) is True
+
+    def test_thinking_template_starts_in_thinking_when_explicitly_enabled(self):
+        """Explicit thinking preserves the implicit-template routing behavior."""
+        assert _should_start_in_thinking(self.THINKING_TEMPLATE, True) is True
+
+    def test_thinking_template_does_not_start_in_thinking_when_disabled(self):
+        """No-thinking mode must emit direct answer tokens as text, not thinking."""
+        assert _should_start_in_thinking(self.THINKING_TEMPLATE, False) is False
+
+    def test_plain_template_never_starts_in_thinking(self):
+        """Templates without an implicit think marker should start as text."""
+        assert _should_start_in_thinking("{{ add_generation_prompt }}", None) is False
 
 
 class TestStreamingPipelineIntegration(unittest.TestCase):
@@ -154,6 +177,31 @@ class TestStreamingPipelineIntegration(unittest.TestCase):
         assert len(block_starts) == 2
         assert block_starts[0]["content_block"]["type"] == "thinking"
         assert block_starts[1]["content_block"]["type"] == "text"
+
+    def test_no_thinking_template_plain_answer_streams_as_text(self):
+        """Disabled thinking should not turn direct answer tokens into thinking."""
+        start_in_thinking = _should_start_in_thinking(
+            TestAnthropicThinkingStartDecision.THINKING_TEMPLATE,
+            enable_thinking=False,
+        )
+        events, _, block_index = self._run_pipeline(
+            ["Direct ", "answer"],
+            start_in_thinking=start_in_thinking,
+        )
+        parsed = self._parse_events(events)
+
+        block_starts = [p for p in parsed if p["type"] == "content_block_start"]
+        text_deltas = [
+            p["delta"]["text"]
+            for p in parsed
+            if p["type"] == "content_block_delta"
+            and p["delta"].get("type") == "text_delta"
+        ]
+
+        assert len(block_starts) == 1
+        assert block_starts[0]["content_block"]["type"] == "text"
+        assert "".join(text_deltas) == "Direct answer"
+        assert block_index == 1
 
     def test_text_then_tool_call(self):
         """Text followed by tool call - tool markup suppressed from text."""

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -44,6 +44,26 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _should_start_in_thinking(
+    chat_template: str, enable_thinking: bool | None
+) -> bool:
+    """Return whether streaming should begin in an implicit thinking block.
+
+    Some thinking-capable chat templates include ``<think>`` in the generated
+    assistant prefix instead of emitting it as a normal output token.  In that
+    case the stream router needs to start in thinking mode so tokens before
+    ``</think>`` are emitted as Anthropic thinking deltas.
+
+    When thinking is explicitly disabled, however, the template marker is only
+    stale capability metadata for routing purposes: direct answer tokens should
+    be emitted as text.  Otherwise Claude Code receives a message with only a
+    thinking block and no text result.
+    """
+    if enable_thinking is False:
+        return False
+    return "<think>" in chat_template and "add_generation_prompt" in chat_template
+
+
 @router.post("/v1/messages")
 async def create_anthropic_message(
     request: Request,
@@ -340,8 +360,8 @@ async def _stream_anthropic_messages(
     _chat_template = ""
     if _tokenizer and hasattr(_tokenizer, "chat_template"):
         _chat_template = _tokenizer.chat_template or ""
-    _starts_thinking = (
-        "<think>" in _chat_template and "add_generation_prompt" in _chat_template
+    _starts_thinking = _should_start_in_thinking(
+        _chat_template, chat_kwargs.get("enable_thinking")
     )
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
     prompt_tokens = 0


### PR DESCRIPTION
## Summary
- Fix Anthropic streaming with `--no-thinking` so template-level `<think>` capability metadata does not force direct answer tokens into a thinking block.
- Preserve default / thinking-enabled implicit thinking routing for thinking-capable templates.
- Add regression coverage at both the stream-pipeline level and `/v1/messages` route level for the no-thinking plain-answer path.

## Verification
- `git diff --check`
- `uv run --python /opt/homebrew/bin/python3.11 --with pytest --with pytest-cov python -m pytest tests/test_anthropic_route_streaming.py tests/test_streaming_pipeline_integration.py -q` — 18 passed
- `uv run --python /opt/homebrew/bin/python3.11 --with pytest --with pytest-cov python -m pytest tests/test_anthropic_route_streaming.py tests/test_streaming_pipeline_integration.py tests/test_anthropic_adapter.py tests/test_anthropic_models.py tests/test_api_utils.py -q` — 175 passed
- `uv run --python /opt/homebrew/bin/python3.11 --extra dev --extra vision python scripts/dev_test.py smoke` — ruff PASS; unit PASS; 1975 passed, 17 skipped, 146 deselected
- `uv run --python /opt/homebrew/bin/python3.11 --extra dev --extra vision rapid-mlx doctor` — PASS (3 pass, 0 regression, 0 fail, 1 skip; model_load skipped because test model download required)
- Live Claude Code smoke against a temporary local `rapid-mlx serve --no-thinking --disable-prefix-cache` server — Anthropic stream started as text and Claude Code returned non-empty result; server was shut down afterward.

## Notes
- Local/user model setup was not changed; only repo code/tests were modified.
