### PR TITLE
fix(reasoning): split delta at channel marker in Gemma4 streaming parser

### DIFF
--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -5,6 +5,7 @@ import pytest
 
 from vllm_mlx.reasoning.base import DeltaMessage, ReasoningParser
 from vllm_mlx.reasoning.deepseek_r1_parser import DeepSeekR1ReasoningParser
+from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
 from vllm_mlx.reasoning.gpt_oss_parser import (
     _CHANNEL_RE,
     _STRUCTURAL_TOKENS,
@@ -982,3 +983,120 @@ class TestHarmonyStreaming:
 
         assert "thinking" in "".join(reasoning_parts)
         assert "answer" in "".join(content_parts)
+
+
+# ---------------------------------------------------------------------------
+# Gemma4ReasoningParser
+# ---------------------------------------------------------------------------
+
+
+class TestGemma4Streaming:
+    """Streaming behavior for Gemma4's <|channel>thought / <channel|> /
+    <|channel>content channel format.
+
+    The pre-#219 implementation classified the entire delta_text into one
+    channel based on the channel state at the *end* of current_text. That
+    worked when each delta was a single token (stream_interval=1) but
+    misrouted bytes when stream_interval > 1 produced a buffered delta
+    that straddled a channel marker.
+    """
+
+    def setup_method(self):
+        self.parser = Gemma4ReasoningParser()
+        self.parser.reset_state()
+
+    def test_empty_delta_returns_none(self):
+        result = self.parser.extract_reasoning_streaming("", "", "")
+        assert result is None
+
+    def test_no_channel_seen_defaults_to_content(self):
+        delta = "hello world"
+        result = self.parser.extract_reasoning_streaming("", delta, delta)
+        assert result.content == "hello world"
+        assert result.reasoning is None
+
+    def test_thought_open_then_text_routes_to_reasoning(self):
+        d1 = "<|channel>thought\n"
+        m1 = self.parser.extract_reasoning_streaming("", d1, d1)
+        # Marker-only delta: nothing to emit after stripping.
+        assert m1 is None or (m1.reasoning is None and m1.content is None)
+
+        d2 = "thinking step 1"
+        prev = d1
+        curr = prev + d2
+        m2 = self.parser.extract_reasoning_streaming(prev, curr, d2)
+        assert m2.reasoning == "thinking step 1"
+        assert m2.content is None
+
+    def test_delta_straddles_thought_close_then_content_open(self):
+        """Regression for issue #219.
+
+        At stream_interval > 1 a single buffered delta can contain the tail of
+        the thought channel, the channel-close marker, the content-open marker,
+        and the start of the actual content. The pre-fix parser classified the
+        entire delta as content (because state at end of current_text was
+        in_content), so bytes before the close marker leaked from reasoning
+        into content. This test asserts the split.
+        """
+        prev = "<|channel>thought\nworking through it"
+        self.parser.extract_reasoning_streaming("", prev, prev)
+        assert self.parser._in_thought is True
+
+        delta = " final guess<channel|><|channel>content\nThe answer is 42."
+        curr = prev + delta
+        result = self.parser.extract_reasoning_streaming(prev, curr, delta)
+        assert result.reasoning == " final guess", (
+            f"reasoning bytes from before the close marker should stay in "
+            f"reasoning, got {result.reasoning!r}"
+        )
+        assert result.content == "The answer is 42.", (
+            f"content bytes from after the content-open marker should land in "
+            f"content, got {result.content!r}"
+        )
+        assert self.parser._in_content is True
+        assert self.parser._in_thought is False
+
+    def test_delta_straddles_implicit_close_only(self):
+        """Thought-close with no explicit content marker must still split,
+        with the post-close bytes going to content (matches the original
+        parser's implicit-content semantic)."""
+        prev = "<|channel>thought\nreasoning"
+        self.parser.extract_reasoning_streaming("", prev, prev)
+        assert self.parser._in_thought is True
+
+        delta = " done<channel|>plain answer"
+        curr = prev + delta
+        result = self.parser.extract_reasoning_streaming(prev, curr, delta)
+        assert result.reasoning == " done"
+        assert result.content == "plain answer"
+        assert self.parser._in_content is True
+
+    def test_delta_with_no_marker_routes_whole_to_current_channel(self):
+        """No marker in delta = original whole-delta dispatch (regression
+        guard so the new split branch doesn't break the common case)."""
+        prev = "<|channel>thought\nstart"
+        self.parser.extract_reasoning_streaming("", prev, prev)
+        delta = " more thinking text"
+        curr = prev + delta
+        result = self.parser.extract_reasoning_streaming(prev, curr, delta)
+        assert result.reasoning == " more thinking text"
+        assert result.content is None
+
+    def test_finished_content_phase_routes_to_content(self):
+        """Once in content phase, deltas without markers route to content."""
+        prev = "<|channel>thought\nx<channel|><|channel>content\nA"
+        self.parser.extract_reasoning_streaming("", prev, prev)
+        assert self.parser._in_content is True
+        delta = "BC"
+        result = self.parser.extract_reasoning_streaming(prev, prev + delta, delta)
+        assert result.content == "BC"
+        assert result.reasoning is None
+
+    def test_reset_state(self):
+        self.parser._in_thought = True
+        self.parser._in_content = True
+        self.parser._saw_any_channel = True
+        self.parser.reset_state()
+        assert self.parser._in_thought is False
+        assert self.parser._in_content is False
+        assert self.parser._saw_any_channel is False

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -75,6 +75,10 @@ class Gemma4ReasoningParser(ReasoningParser):
         if not delta_text:
             return None
 
+        # Snapshot pre-update state so we can detect a thought-to-content
+        # flip that happened DURING this delta (issue #219).
+        was_in_thought = self._in_thought
+
         # Track channel state based on accumulated text
         # Check if we just entered thought channel
         if "<|channel>thought" in current_text and not self._in_content:
@@ -98,6 +102,39 @@ class Gemma4ReasoningParser(ReasoningParser):
                     and "<|channel>final" not in current_text
                 ):
                     self._in_content = True
+
+        # If a thought-to-content flip happened DURING this delta and a
+        # state-flipping marker is fully visible in delta_text, split the
+        # delta so reasoning bytes that arrived before the marker stay in
+        # delta.reasoning instead of being misrouted into delta.content.
+        # Pre-fix (#219), the whole-delta classifier below tagged the entire
+        # delta as content whenever should_send() flushed a buffered delta
+        # straddling the channel transition.
+        if was_in_thought and not self._in_thought:
+            flip_pos = -1
+            for marker in ("<channel|>", "<|channel>content", "<|channel>final"):
+                idx = delta_text.find(marker)
+                if idx >= 0 and (flip_pos < 0 or idx < flip_pos):
+                    flip_pos = idx
+            if flip_pos >= 0:
+                pre = delta_text[:flip_pos]
+                post = delta_text[flip_pos:]
+                for m in (
+                    "<|channel>",
+                    "<channel|>",
+                    "<|turn>",
+                    "<turn|>",
+                    "thought\n",
+                    "content\n",
+                    "final\n",
+                ):
+                    pre = pre.replace(m, "")
+                    post = post.replace(m, "")
+                if pre or post:
+                    return DeltaMessage(
+                        reasoning=pre if pre else None,
+                        content=post if post else None,
+                    )
 
         # Filter out channel markers from delta
         clean = delta_text


### PR DESCRIPTION
Closes #219.

## What this changes

`Gemma4ReasoningParser.extract_reasoning_streaming` previously classified the entire `delta_text` into a single channel based on the channel state at the end of `current_text`. That worked at `stream_interval=1` (every delta one token wide) but misrouted bytes when PR #210 buffering produced a delta that straddled the thought-to-content transition: the bytes generated before the close-of-thought marker were tagged as content along with the bytes after.

This adds a guarded split. After the existing state-update block runs, if `_in_thought` was True before this delta and False after, the new branch finds the earliest of `<channel|>`, `<|channel>content`, or `<|channel>final` fully present in `delta_text` and splits the delta at that position. Pre-marker bytes go to `delta.reasoning`, post-marker bytes (after the same marker-stripping the original classifier applies) go to `delta.content`.

If no full marker is in `delta_text` (the rare split-across-deltas case), the function falls through to the original whole-delta classifier with the original behavior unchanged.

## Diff size

`vllm_mlx/reasoning/gemma4_parser.py`: +37 / -0 (purely additive). The original whole-delta classifier is untouched.

`tests/test_reasoning_parsers.py`: +118 (new `TestGemma4Streaming` class with 8 cases).

## Why

End-to-end on `gemma-4-31b-it-mxfp8` with `--stream-interval 100`, the pre-fix parser produced a 14-byte leak: the tail of the model's CoT scratchpad (e.g. `". Wyoming (WY)"`) prepended to `delta.content` in the chunk that contained the channel transition. Issue #219 has the per-chunk SSE evidence and the diff signature.

After this fix, on the same model and prompt, the streaming reassembly is byte-identical to the non-streamed response (912 chars, 0-byte diff verified live).

## Test plan

`tests/test_reasoning_parsers.py::TestGemma4Streaming` adds 8 unit tests:

- `test_empty_delta_returns_none`: sanity.
- `test_no_channel_seen_defaults_to_content`: sanity, no channel markers means plain content.
- `test_thought_open_then_text_routes_to_reasoning`: marker-only delta then a text-only delta; both end up in the right channel.
- `test_delta_straddles_thought_close_then_content_open`: **the regression** itself. One delta containing trailing thought text plus close-of-thought plus content-open plus start-of-content; asserts the split.
- `test_delta_straddles_implicit_close_only`: thought-close with no explicit content marker still splits, with post-close bytes going to content (matches the original parser's implicit-content semantic).
- `test_delta_with_no_marker_routes_whole_to_current_channel`: regression guard so the new branch doesn't break the no-marker common case.
- `test_finished_content_phase_routes_to_content`: once in content phase, plain text routes to content.
- `test_reset_state`: `reset_state` clears all three flags.

Local results: 8 new tests pass; full reasoning-parser suite passes 204/204 with no regressions (`tests/test_reasoning_parsers.py` plus `tests/test_reasoning_parser.py`).

End-to-end verified on the live `gemma-4-31b-it-mxfp8` server with `--stream-interval 100` against the issue's repro prompt: streaming-vs-non-streaming `diff` of the 50-states response is now empty (912 chars, byte-identical). Pre-fix, the streamed reassembly had a 14-byte `". Wyoming (WY)"` prefix.

## Scope

Gemma4 only. Three other parsers (Qwen3 / DeepSeekR1 / MiniMax) already split deltas at markers correctly. `HarmonyReasoningParser` has a related but distinct issue: its `extract_reasoning_streaming` returns `None` on a delta containing `<|channel|>`, which would discard surrounding bytes if the delta straddles a channel switch. Different symptom (drop, not misroute), out of scope here. Worth filing as its own issue if the Harmony format ever runs at `stream_interval > 1`.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — see [CONTRIBUTING.md](../CONTRIBUTING.md#self-validating-your-pr) (opt out heavy steps with `PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1` if you don't have the hardware/keys)
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API
