### PR TITLE
fix(anthropic): bypass reasoning parser on enable_thinking=False (#223)

### DIFF
--- a/tests/test_anthropic_route_streaming.py
+++ b/tests/test_anthropic_route_streaming.py
@@ -113,3 +113,130 @@ def test_anthropic_stream_route_no_thinking_template_answers_as_text():
         and e.get("delta", {}).get("stop_reason") == "end_turn"
         for e in events
     )
+
+
+def test_anthropic_stream_route_reasoning_parser_with_no_thinking_answers_as_text():
+    """Closes #223. Server has --reasoning-parser qwen3 active AND the
+    request opts out of thinking. The qwen3 parser's implicit-think
+    heuristic routes any text without a <think> tag to ``reasoning``;
+    pre-fix that meant every direct-answer token landed in
+    ``thinking_delta`` blocks and ``text_delta`` was empty. The fix
+    bypasses the reasoning parser whenever enable_thinking=False so the
+    answer flows through the same think_router path as the
+    no-parser-configured case.
+
+    This test is the regression guard PR #213 missed: that PR added the
+    bypass for the parser-less path but left the parser-configured path
+    unchanged — surfaced by post-merge audit on 2026-05-05.
+    """
+    engine = _StreamingEngine(["Direct ", "answer"])
+
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    # The exact scenario #223 catches: reasoning parser configured at
+    # server start, then a per-request enable_thinking=False arrives.
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert engine.calls[0]["kwargs"]["enable_thinking"] is False
+
+    events = _parse_sse_data(response.text)
+
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    thinking_deltas = [
+        e
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "thinking_delta"
+    ]
+
+    # Pre-fix this assertion failed: thinking_deltas would have ALL the
+    # text and text_deltas would be []. Post-fix the answer streams as
+    # text and the thinking channel stays empty.
+    assert "".join(text_deltas) == "Direct answer", (
+        f"answer should stream as text_delta, got {text_deltas!r}; "
+        f"thinking_deltas={thinking_deltas!r}"
+    )
+    assert thinking_deltas == []
+
+
+def test_anthropic_stream_route_reasoning_parser_with_thinking_default_still_works():
+    """Inverse guard: when enable_thinking is NOT explicitly False (i.e.
+    default thinking-on for a reasoning model), the reasoning parser
+    must still be exercised so the existing #185 fix isn't regressed.
+    The model emits a <think>…</think> block followed by the answer;
+    the parser splits them, and the route emits thinking_delta then
+    text_delta.
+    """
+    # Model output: a thinking block + a real answer.
+    engine = _StreamingEngine(["<think>scratch</think>", "real answer"])
+
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    # Server is NOT in no_thinking mode; client doesn't override.
+    cfg.no_thinking = False
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "what is 6*7"}],
+        },
+    )
+
+    assert response.status_code == 200
+    # No enable_thinking override on the request → kwargs absent or None.
+    assert engine.calls[0]["kwargs"].get("enable_thinking") is not False
+
+    events = _parse_sse_data(response.text)
+
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    thinking_deltas = [
+        e["delta"]["thinking"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "thinking_delta"
+    ]
+
+    # The reasoning parser path is engaged. The qwen3 parser splits
+    # <think>…</think> from the rest, so thinking and text both carry
+    # content. Asserting non-empty on each side guards the parser path
+    # without binding to specific token boundaries the parser chooses.
+    assert "real answer" in "".join(text_deltas), text_deltas
+    assert "scratch" in "".join(thinking_deltas), thinking_deltas

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -378,6 +378,16 @@ async def _stream_anthropic_messages(
             reasoning_parser = get_parser(cfg.reasoning_parser_name)()
         except Exception:
             pass
+    # Closes #223: when the client explicitly opts out of thinking, bypass
+    # the reasoning parser. Parsers like qwen3 use an implicit-think
+    # heuristic (no <think> tag → all tokens treated as reasoning), so a
+    # direct answer would otherwise be misrouted to thinking_delta blocks
+    # and the text_delta block would stay empty. Mirrors the chat-route
+    # bypass at postprocessor.py:217. The think_router branch below picks
+    # up the work, and `_should_start_in_thinking` already returns False
+    # for enable_thinking=False, so the answer streams as text.
+    if chat_kwargs.get("enable_thinking") is False:
+        reasoning_parser = None
     if reasoning_parser:
         reasoning_parser.reset_state()
 


### PR DESCRIPTION
Closes #223.

## Bug

PR #213 (today) fixed #185 for the StreamingThinkRouter path, but the parallel `reasoning_parser` path was missed. When a server is started with `--reasoning-parser <name>` and a request explicitly opts out of thinking:

- The qwen3 / deepseek_r1 / minimax parsers use an implicit-think heuristic — text without a `<think>` tag is classified as reasoning.
- `enable_thinking=False` is exactly the case where the model produces no `<think>` tag.
- Result: every output token is routed to `thinking_delta` blocks; `text_delta` stays empty.
- Anthropic clients (Claude Code, etc.) see only thinking content, no answer.

This is the same failure mode as #185, just on the parser-active sub-path that #213 didn't touch.

## Fix

Mirror the chat-route bypass at `postprocessor.py:217`. One added gate at `routes/anthropic.py:389`:

```python
if chat_kwargs.get("enable_thinking") is False:
    reasoning_parser = None
```

When the parser is dropped, the streaming loop's existing `if reasoning_parser:` branch falls through to the `think_router` path. `_should_start_in_thinking` already returns False for `enable_thinking=False` (since the chat template won't emit a leading `<think>`), so the answer streams as `text_delta`.

## Tests

Two regressions added to `tests/test_anthropic_route_streaming.py`:

1. **`test_anthropic_stream_route_reasoning_parser_with_no_thinking_answers_as_text`** — reproduces #223. Sets `cfg.reasoning_parser_name = "qwen3"`, sends a no-thinking request, asserts the answer streams as `text_delta` and `thinking_delta` is empty.
2. **`test_anthropic_stream_route_reasoning_parser_with_thinking_default_still_works`** — inverse guard. Default thinking-on with reasoning parser; `<think>scratch</think>real answer` must split correctly across `thinking_delta` and `text_delta`. Prevents the fix from regressing #185.

**Verified the test catches the bug**: with the fix reverted, `test_…_no_thinking_answers_as_text` fails with all output in `thinking_delta` (proven locally via temporary revert).

## Origin

Surfaced by post-merge audit on 2026-05-05 — DeepSeek V4 Pro adversarial review on the cumulative `e6687da..HEAD` diff covering today's 6 merges (#208, #213, #216, #217, #210, #222).

## Risk

Low. New behavior only diverges from old when:
1. Server has `--reasoning-parser <name>` configured, AND
2. Request sends `enable_thinking=False` or server runs with `--no-thinking`

In that combination, the old behavior was the buggy "all output → thinking" path. The new behavior matches the chat route. Other code paths (no reasoning parser; or thinking enabled) are byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)