### PR TITLE
fix(cli): drop stale gemma-4-26b from doctor --models help

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1579,7 +1579,7 @@ Examples:
         type=str,
         default=None,
         help="Comma-separated model aliases for full / benchmark tiers "
-        "(full default: qwen3.5-35b,qwen3.6-35b,gemma-4-26b; "
+        "(full default: qwen3.5-35b,qwen3.6-35b; "
         "benchmark default: auto-discovered from local cache)",
     )
     doctor_parser.add_argument(


### PR DESCRIPTION
## Summary

The `--models` help string for `rapid-mlx doctor` advertised three default models for the `full` tier — `qwen3.5-35b,qwen3.6-35b,gemma-4-26b` — but the runner only ever instantiates two:

```python
# vllm_mlx/doctor/cli.py:32
DEFAULT_FULL_MODELS = ["qwen3.5-35b", "qwen3.6-35b"]
```

`gemma-4-26b` was dropped from the actual default during the agentic-runtime migration but the help text was not updated. Anyone reading `--help` and expecting gemma to run sees a 2-model run and wonders why.

One-character fix: drop `gemma-4-26b` from the help literal so it matches the runner.

## Origin

Surfaced by the post-merge DeepSeek V4 Pro audit on 2026-05-05 (the cumulative diff covering today's six merges).

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)