### PR TITLE
feat: migrate DeepSeek R1 reasoning to OutputRouter

### DIFF
--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -97,6 +97,20 @@ QWEN3_VOCAB = {
 
 QWEN3_TOKENIZER = FakeTokenizer(QWEN3_VOCAB)
 
+# DeepSeek R1 vocabulary subset from deepseek-ai/DeepSeek-R1-Distill-Qwen-7B.
+DEEPSEEK_R1_VOCAB = {
+    "<｜end▁of▁sentence｜>": 151643,
+    "<｜begin▁of▁sentence｜>": 151646,
+    "<think>": 151648,
+    "</think>": 151649,
+    "Step": 1,
+    " one": 2,
+    "Answer": 3,
+    "Plain": 4,
+}
+
+DEEPSEEK_R1_TOKENIZER = FakeTokenizer(DEEPSEEK_R1_VOCAB)
+
 
 @pytest.fixture
 def router():
@@ -327,6 +341,15 @@ class TestFromTokenizer:
         assert router.map.think_start == 248068
         assert router.map.think_end == 248069
 
+    def test_deepseek_r1_think_tags_detected(self):
+        """DeepSeek R1 tokenizer think tags and unicode controls are detected."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+        assert router.map.think_start == 151648
+        assert router.map.think_end == 151649
+        assert router.map.bos == 151646
+        assert router.map.eos == 151643
+
 
 class TestQwen3ThinkRouting:
     """Test Qwen3 <think> routing."""
@@ -381,6 +404,71 @@ class TestQwen3ThinkRouting:
 
         result = router.feed_sequence([248068, 1, 2, 248069, 3])
         assert result["reasoning"] == "Reasoning"
+        assert result["content"] == "Answer"
+        assert result["tool_calls"] is None
+
+
+class TestDeepSeekR1ThinkRouting:
+    """Test DeepSeek R1 <think> routing."""
+
+    def test_unicode_bos_eos_are_suppressed(self):
+        """DeepSeek's unicode BOS/EOS special tokens do not leak."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(151646) is None
+        assert router.feed(151643) is None
+
+    def test_think_block_routes_to_reasoning_then_content(self):
+        """<think> payload routes to reasoning until </think>."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(151648) is None  # <think>
+        assert router.state == RouterState.THINKING
+
+        reasoning = router.feed(1)  # Step
+        assert reasoning is not None
+        assert reasoning.channel == Channel.REASONING
+        assert reasoning.text == "Step"
+
+        assert router.feed(151649) is None  # </think>
+        assert router.state == RouterState.CONTENT
+
+        content = router.feed(3)  # Answer
+        assert content is not None
+        assert content.channel == Channel.CONTENT
+        assert content.text == "Answer"
+
+    def test_orphan_think_end_switches_to_content(self):
+        """A lone </think> is suppressed and following tokens are content."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(151649) is None
+        assert router.state == RouterState.CONTENT
+
+        event = router.feed(3)
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+
+    def test_no_tag_output_routes_as_content(self):
+        """Plain DeepSeek output with no think tags passes through as content."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+
+        event = router.feed(4)
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+        assert event.text == "Plain"
+
+    def test_feed_sequence_separates_reasoning_and_content(self):
+        """Batch routing separates DeepSeek reasoning and answer text."""
+        router = OutputRouter.from_tokenizer(DEEPSEEK_R1_TOKENIZER)
+        assert router is not None
+
+        result = router.feed_sequence([151648, 1, 2, 151649, 3])
+        assert result["reasoning"] == "Step one"
         assert result["content"] == "Answer"
         assert result["tool_calls"] is None
 

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -24,8 +24,8 @@ Usage:
 Designed to replace the fragile regex-based strip_special_tokens +
 reasoning_parser + tool_call_parser chain with a single unified router.
 
-Currently implements Gemma 4 and Qwen-style think tag formats. Other models
-can be added by defining their token mappings in MODEL_TOKEN_MAPS.
+Currently implements Gemma 4 plus Qwen3 / DeepSeek R1 `<think>`-tag formats.
+Other models can be added by defining their token mappings in MODEL_TOKEN_MAPS.
 """
 
 import logging
@@ -185,7 +185,7 @@ class OutputRouter:
                 return RouterEvent(Channel.TOOL_CALL, token_id, full_text)
             return None
 
-        # === Think tags (Qwen-style) ===
+        # === Think tags (Qwen / DeepSeek style) ===
         if token_id == m.think_start:
             self.state = RouterState.THINKING
             return None
@@ -269,13 +269,15 @@ class OutputRouter:
             )
             return cls(token_map, tokenizer)
 
-        # Qwen detection: <think>...</think> reasoning tags.
+        # Qwen3 / DeepSeek R1 detection: <think>...</think> reasoning tags.
+        # DeepSeek's BOS/EOS use unicode brackets; fall back to plain <bos>/<eos>
+        # for Qwen3 (which has neither in its vocab).
         if "<think>" in vocab and "</think>" in vocab:
             token_map = TokenMap(
                 think_start=vocab.get("<think>"),
                 think_end=vocab.get("</think>"),
-                bos=vocab.get("<bos>"),
-                eos=vocab.get("<eos>"),
+                bos=vocab.get("<｜begin▁of▁sentence｜>") or vocab.get("<bos>"),
+                eos=vocab.get("<｜end▁of▁sentence｜>") or vocab.get("<eos>"),
                 pad=vocab.get("<pad>"),
             )
             logger.info(


### PR DESCRIPTION
## Summary
- add token-level routing for DeepSeek R1 `<think>` / `</think>` tokens
- detect DeepSeek R1 tokenizer vocab through `OutputRouter.from_tokenizer()` using the real `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` token IDs
- suppress DeepSeek's unicode BOS/EOS tokens and add focused routing coverage

Resolves #65.

## Validation
- `python3.12 -m pytest tests/test_output_router.py tests/test_streaming_newlines.py -v`
