### PR TITLE
feat: migrate GPT-OSS Harmony routing to OutputRouter

### DIFF
--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -111,6 +111,26 @@ DEEPSEEK_R1_VOCAB = {
 
 DEEPSEEK_R1_TOKENIZER = FakeTokenizer(DEEPSEEK_R1_VOCAB)
 
+# GPT-OSS/Harmony vocabulary subset from openai/gpt-oss-20b.
+HARMONY_VOCAB = {
+    "<|return|>": 200002,
+    "<|constrain|>": 200003,
+    "<|channel|>": 200005,
+    "<|start|>": 200006,
+    "<|end|>": 200007,
+    "<|message|>": 200008,
+    "<|call|>": 200012,
+    "analysis": 35644,
+    "final": 17196,
+    " json": 1,
+    "Reason": 2,
+    "ing": 3,
+    "Answer": 4,
+    "Plain": 5,
+}
+
+HARMONY_TOKENIZER = FakeTokenizer(HARMONY_VOCAB)
+
 
 @pytest.fixture
 def router():
@@ -350,6 +370,15 @@ class TestFromTokenizer:
         assert router.map.bos == 151646
         assert router.map.eos == 151643
 
+    def test_harmony_detected(self):
+        """GPT-OSS/Harmony tokenizer auto-detected."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+        assert router.map.harmony_channel == 200005
+        assert router.map.harmony_message == 200008
+        assert router.map.harmony_return == 200002
+        assert router.map.harmony_call == 200012
+
 
 class TestQwen3ThinkRouting:
     """Test Qwen3 <think> routing."""
@@ -473,6 +502,101 @@ class TestDeepSeekR1ThinkRouting:
         assert result["tool_calls"] is None
 
 
+class TestHarmonyRouting:
+    """Test GPT-OSS/Harmony channel routing."""
+
+    def test_analysis_channel_routes_message_to_reasoning(self):
+        """Harmony analysis payload routes to REASONING."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200005) is None  # <|channel|>
+        assert router.state == RouterState.AWAITING_CHANNEL_TYPE
+        assert router.feed(35644) is None  # analysis
+        assert router.state == RouterState.AWAITING_MESSAGE
+        assert router.feed(200008) is None  # <|message|>
+        assert router.state == RouterState.THINKING
+
+        event = router.feed(2)  # Reason
+        assert event is not None
+        assert event.channel == Channel.REASONING
+        assert event.text == "Reason"
+
+        assert router.feed(200007) is None  # <|end|>
+        assert router.state == RouterState.CONTENT
+
+    def test_final_channel_routes_message_to_content(self):
+        """Harmony final payload routes to CONTENT."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200005) is None  # <|channel|>
+        assert router.feed(17196) is None  # final
+        assert router.feed(200008) is None  # <|message|>
+
+        event = router.feed(4)  # Answer
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+        assert event.text == "Answer"
+
+        assert router.feed(200002) is None  # <|return|>
+        assert router.state == RouterState.CONTENT
+
+    def test_premessage_metadata_is_suppressed(self):
+        """Tokens before <|message|> in a Harmony channel do not leak."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        router.feed(200005)  # <|channel|>
+        router.feed(17196)  # final
+        assert router.feed(200003) is None  # <|constrain|>
+        assert router.feed(1) is None  # " json"
+        assert router.feed(200008) is None  # <|message|>
+
+        event = router.feed(4)
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+
+    def test_orphan_harmony_controls_are_suppressed(self):
+        """Harmony structural tokens do not leak outside a channel."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200006) is None  # <|start|>
+        assert router.feed(200007) is None  # <|end|>
+        assert router.feed(200002) is None  # <|return|>
+        assert router.feed(200012) is None  # <|call|>
+        assert router.feed(200008) is None  # <|message|>
+
+        event = router.feed(5)
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+
+    def test_feed_sequence_separates_analysis_and_final(self):
+        """Batch routing separates Harmony analysis and final channels."""
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        result = router.feed_sequence(
+            [
+                200005,
+                35644,
+                200008,
+                2,
+                3,
+                200007,
+                200005,
+                17196,
+                200008,
+                4,
+                200002,
+            ]
+        )
+        assert result["reasoning"] == "Reasoning"
+        assert result["content"] == "Answer"
+        assert result["tool_calls"] is None
+
+
 class TestStateReset:
     """Test state management."""
 
@@ -485,6 +609,8 @@ class TestStateReset:
         router.reset()
         assert router.state == RouterState.INIT
         assert router._tool_tokens == []
+        assert router._pending_channel_style is None
+        assert router._pending_message_channel is None
 
     def test_multiple_requests(self, router):
         """Router works correctly across multiple reset cycles."""

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -24,8 +24,9 @@ Usage:
 Designed to replace the fragile regex-based strip_special_tokens +
 reasoning_parser + tool_call_parser chain with a single unified router.
 
-Currently implements Gemma 4 plus Qwen3 / DeepSeek R1 `<think>`-tag formats.
-Other models can be added by defining their token mappings in MODEL_TOKEN_MAPS.
+Currently implements Gemma 4, Qwen3 / DeepSeek R1 `<think>`-tag, and
+GPT-OSS Harmony `<|channel|>` formats. Other models can be added by
+defining their token mappings in MODEL_TOKEN_MAPS.
 """
 
 import logging
@@ -82,6 +83,17 @@ class TokenMap:
     think_start: int | None = None  # <think> token ID
     think_end: int | None = None  # </think> token ID
 
+    # Channel control (GPT-OSS/Harmony style)
+    harmony_channel: int | None = None  # <|channel|>
+    harmony_message: int | None = None  # <|message|>
+    harmony_start: int | None = None  # <|start|>
+    harmony_end: int | None = None  # <|end|>
+    harmony_return: int | None = None  # <|return|>
+    harmony_call: int | None = None  # <|call|>
+    harmony_constrain: int | None = None  # <|constrain|>
+    harmony_analysis_word: int | None = None  # "analysis"
+    harmony_final_word: int | None = None  # "final"
+
     # Standard control
     bos: int | None = None
     eos: int | None = None
@@ -96,6 +108,7 @@ class RouterState(Enum):
     CONTENT = auto()  # inside content/final channel
     TOOL_CALL = auto()  # inside tool call
     AWAITING_CHANNEL_TYPE = auto()  # saw <|channel>, waiting for thought/content/final
+    AWAITING_MESSAGE = auto()  # saw Harmony channel name, waiting for <|message|>
 
 
 class OutputRouter:
@@ -111,11 +124,15 @@ class OutputRouter:
         self.tokenizer = tokenizer
         self.state = RouterState.INIT
         self._tool_tokens: list[int] = []  # accumulated tool call token IDs
+        self._pending_channel_style: str | None = None
+        self._pending_message_channel: Channel | None = None
 
     def reset(self):
         """Reset state for a new request."""
         self.state = RouterState.INIT
         self._tool_tokens = []
+        self._pending_channel_style = None
+        self._pending_message_channel = None
 
     def feed(self, token_id: int) -> RouterEvent | None:
         """
@@ -131,6 +148,22 @@ class OutputRouter:
             return None
         if token_id == m.turn_start or token_id == m.turn_end:
             return None
+
+        if token_id == m.harmony_channel:
+            self.state = RouterState.AWAITING_CHANNEL_TYPE
+            self._pending_channel_style = "harmony"
+            self._pending_message_channel = None
+            return None
+
+        if token_id == m.harmony_end or token_id == m.harmony_return:
+            self.state = RouterState.CONTENT
+            self._pending_channel_style = None
+            self._pending_message_channel = None
+            return None
+
+        if token_id in (m.harmony_start, m.harmony_call, m.harmony_constrain):
+            return None
+
         # Suppress tool-related markers that may appear without proper nesting
         if token_id in (
             m.tool_response_start,
@@ -147,6 +180,21 @@ class OutputRouter:
 
         # === Channel type word: set state based on which channel ===
         if self.state == RouterState.AWAITING_CHANNEL_TYPE:
+            if self._pending_channel_style == "harmony":
+                if token_id == m.harmony_analysis_word:
+                    self._pending_message_channel = Channel.REASONING
+                    self.state = RouterState.AWAITING_MESSAGE
+                    return None
+                if token_id == m.harmony_final_word:
+                    self._pending_message_channel = Channel.CONTENT
+                    self.state = RouterState.AWAITING_MESSAGE
+                    return None
+
+                self.state = RouterState.CONTENT
+                self._pending_channel_style = None
+                text = self.tokenizer.decode([token_id])
+                return RouterEvent(Channel.CONTENT, token_id, text)
+
             if token_id == m.thought_word:
                 self.state = RouterState.THINKING
                 return None  # suppress "thought"
@@ -158,6 +206,21 @@ class OutputRouter:
                 self.state = RouterState.CONTENT
                 text = self.tokenizer.decode([token_id])
                 return RouterEvent(Channel.CONTENT, token_id, text)
+
+        # === Harmony message boundary: suppress metadata before payload ===
+        if self.state == RouterState.AWAITING_MESSAGE:
+            if token_id == m.harmony_message:
+                self.state = (
+                    RouterState.THINKING
+                    if self._pending_message_channel == Channel.REASONING
+                    else RouterState.CONTENT
+                )
+                self._pending_channel_style = None
+                self._pending_message_channel = None
+            return None
+
+        if token_id == m.harmony_message:
+            return None
 
         # === Channel end: transition back ===
         if token_id == m.channel_end:
@@ -266,6 +329,29 @@ class OutputRouter:
                 token_map.channel_end,
                 token_map.tool_call_start,
                 token_map.tool_call_end,
+            )
+            return cls(token_map, tokenizer)
+
+        # GPT-OSS/Harmony detection: channel/message special tokens.
+        if "<|channel|>" in vocab and "<|message|>" in vocab:
+            token_map = TokenMap(
+                harmony_channel=vocab.get("<|channel|>"),
+                harmony_message=vocab.get("<|message|>"),
+                harmony_start=vocab.get("<|start|>"),
+                harmony_end=vocab.get("<|end|>"),
+                harmony_return=vocab.get("<|return|>"),
+                harmony_call=vocab.get("<|call|>"),
+                harmony_constrain=vocab.get("<|constrain|>"),
+                harmony_analysis_word=vocab.get("analysis"),
+                harmony_final_word=vocab.get("final"),
+                bos=vocab.get("<|endoftext|>"),
+                eos=vocab.get("<|endoftext|>"),
+                pad=vocab.get("<|endoftext|>"),
+            )
+            logger.info(
+                "[OutputRouter] Harmony format detected: channel=%d, message=%d",
+                token_map.harmony_channel,
+                token_map.harmony_message,
             )
             return cls(token_map, tokenizer)
 


### PR DESCRIPTION
## Summary
- add GPT-OSS/Harmony token-map detection for channel/message structural tokens
- route `analysis` channel message payloads to reasoning and `final` channel message payloads to content
- suppress Harmony structural tokens and pre-message metadata, with focused OutputRouter coverage using `openai/gpt-oss-20b` tokenizer IDs

Resolves #66.

## Validation
- `python3.12 -m pytest tests/test_output_router.py tests/test_streaming_newlines.py -v`
