### PR TITLE
fix(server): sync ServerConfig before native-tool-format detection (#225)

### DIFF
--- a/tests/test_anthropic_stream_reasoning.py
+++ b/tests/test_anthropic_stream_reasoning.py
@@ -101,6 +101,12 @@ def patched_cfg():
     cfg.engine = None
     cfg.model_name = "qwen3.5-test"
     cfg.cloud_router = None
+    # MagicMock attributes default to truthy MagicMock instances. The route at
+    # anthropic.py:332 reads `cfg.no_thinking`; left unset, that path forces
+    # chat_kwargs["enable_thinking"]=False, which the #223 fix at line 389
+    # then uses to null out the reasoning parser. The #185 regression below
+    # depends on the parser running, so pin no_thinking to a real False.
+    cfg.no_thinking = False
     with patch.object(anthropic_route, "get_config", return_value=cfg):
         yield cfg
 

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -20,15 +20,43 @@ bug.
 
 from __future__ import annotations
 
+import pytest
+
 
 class _StubEngine:
+    """Minimal stand-in for `BatchedEngine` — only the surface `load_model`
+    actually accesses between construction and the model-registry add.
+
+    This is intentionally explicit (not `MagicMock`) so that any future
+    `load_model` change touching a new attribute fails LOUDLY with
+    `AttributeError`, not silently with a fabricated MagicMock value.
+    """
+
     is_mllm = False
     preserve_native_tool_format = False
     _tokenizer = None
     _tool_logits_processor_factory = None
 
-    def __init__(self, **kwargs):  # noqa: D401 — match BatchedEngine signature loosely
+    def __init__(self, *args, **kwargs):
+        # Accept positional too in case `BatchedEngine.__init__` ever takes any.
+        self.args = args
         self.kwargs = kwargs
+
+
+@pytest.fixture(autouse=True)
+def _reset_cfg_around_each_test():
+    """Reset the ServerConfig singleton before AND after every test.
+
+    `monkeypatch.setattr` on module globals is restored automatically, but
+    the cfg singleton is a separate process-level object that must be
+    explicitly reset on both sides — otherwise a mid-test failure leaks
+    cfg state into the next test.
+    """
+    from vllm_mlx.config import reset_config
+
+    reset_config()
+    yield
+    reset_config()
 
 
 def test_load_model_enables_native_tool_format_when_parser_supports_it(monkeypatch):
@@ -37,9 +65,6 @@ def test_load_model_enables_native_tool_format_when_parser_supports_it(monkeypat
     unsynced when detection ran.
     """
     from vllm_mlx import server
-    from vllm_mlx.config import reset_config
-
-    reset_config()
 
     monkeypatch.setattr(server, "BatchedEngine", _StubEngine)
     monkeypatch.setattr(server, "_engine", None, raising=False)
@@ -67,9 +92,8 @@ def test_detect_native_tool_support_requires_synced_config(monkeypatch):
     `_sync_config()` first.
     """
     from vllm_mlx import server
-    from vllm_mlx.config import get_config, reset_config
+    from vllm_mlx.config import get_config
 
-    reset_config()
     monkeypatch.setattr(server, "_enable_auto_tool_choice", True, raising=False)
     monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
     monkeypatch.setattr(server, "_reasoning_parser", None, raising=False)
@@ -90,3 +114,46 @@ def test_detect_native_tool_support_requires_synced_config(monkeypatch):
     assert cfg.enable_auto_tool_choice is True
     assert cfg.tool_call_parser == "hermes"
     assert server._detect_native_tool_support() is True
+
+
+def test_sync_config_is_idempotent(monkeypatch):
+    """`_sync_config()` is called twice in `load_model` (early before native
+    tool detection, late after the model registry add). Both calls must
+    leave cfg in the same state — if the function ever grows non-idempotent
+    side effects (counter increments, callback fires, cache invalidations),
+    the late re-sync becomes a latent bug.
+    """
+    from vllm_mlx import server
+    from vllm_mlx.config import get_config
+
+    monkeypatch.setattr(server, "_enable_auto_tool_choice", True, raising=False)
+    monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser", None, raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser_name", None, raising=False)
+    monkeypatch.setattr(server, "_tool_parser_instance", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
+    monkeypatch.setattr(server, "_engine", None, raising=False)
+
+    server._sync_config()
+    cfg = get_config()
+    snapshot = {
+        "engine": cfg.engine,
+        "model_name": cfg.model_name,
+        "model_alias": cfg.model_alias,
+        "model_path": cfg.model_path,
+        "enable_auto_tool_choice": cfg.enable_auto_tool_choice,
+        "tool_call_parser": cfg.tool_call_parser,
+        "tool_parser_instance": cfg.tool_parser_instance,
+        "enable_tool_logits_bias": cfg.enable_tool_logits_bias,
+        "reasoning_parser": cfg.reasoning_parser,
+        "reasoning_parser_name": cfg.reasoning_parser_name,
+        "mcp_manager": cfg.mcp_manager,
+        "model_registry": cfg.model_registry,
+    }
+
+    server._sync_config()
+    cfg2 = get_config()
+
+    for k, v in snapshot.items():
+        assert getattr(cfg2, k) == v, f"_sync_config() not idempotent on cfg.{k}"

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression for #225 — startup ordering.
+
+`_detect_native_tool_support()` reads `cfg.enable_auto_tool_choice` and
+`cfg.tool_call_parser` via `get_config()`. If `_sync_config()` runs
+*after* the detection call (the pre-fix layout), those fields are still
+at their dataclass defaults (False, None), the guard short-circuits to
+False, and `_engine.preserve_native_tool_format` is silently set to
+False even though the configured parser supports native format.
+
+Downstream symptom (per the bug report on Qwen3.5-9B-4bit and
+Qwen3.6-35B-A3B-4bit-DWQ): assistant tool history gets serialised by
+`api/utils.py::process_messages` as
+`[Calling tool: name({json})]` text. The model sees prose-format
+examples in context and mimics that pattern on subsequent turns —
+streaming chunks emit the literal string instead of structured
+`tool_calls`. Looks like a model failure but is a startup ordering
+bug.
+"""
+
+from __future__ import annotations
+
+
+class _StubEngine:
+    is_mllm = False
+    preserve_native_tool_format = False
+    _tokenizer = None
+    _tool_logits_processor_factory = None
+
+    def __init__(self, **kwargs):  # noqa: D401 — match BatchedEngine signature loosely
+        self.kwargs = kwargs
+
+
+def test_load_model_enables_native_tool_format_when_parser_supports_it(monkeypatch):
+    """After load_model() returns, the engine MUST reflect the parser's
+    native-format support. Pre-fix this asserted False because cfg was
+    unsynced when detection ran.
+    """
+    from vllm_mlx import server
+    from vllm_mlx.config import reset_config
+
+    reset_config()
+
+    monkeypatch.setattr(server, "BatchedEngine", _StubEngine)
+    monkeypatch.setattr(server, "_engine", None, raising=False)
+    monkeypatch.setattr(server, "_enable_auto_tool_choice", True, raising=False)
+    monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser_name", None, raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser", None, raising=False)
+    monkeypatch.setattr(server, "_tool_parser_instance", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
+    monkeypatch.setattr(server, "_model_alias", None, raising=False)
+
+    server.load_model("mlx-community/Qwen3.5-9B-4bit")
+
+    assert server._engine is not None
+    # hermes parser sets SUPPORTS_NATIVE_TOOL_FORMAT = True; with the
+    # ordering fix, detection sees the synced cfg and propagates that
+    # to the engine.
+    assert server._engine.preserve_native_tool_format is True
+
+
+def test_detect_native_tool_support_requires_synced_config(monkeypatch):
+    """Contract test for the ordering invariant: detection short-circuits
+    to False when cfg has not been synced yet, so callers MUST run
+    `_sync_config()` first.
+    """
+    from vllm_mlx import server
+    from vllm_mlx.config import get_config, reset_config
+
+    reset_config()
+    monkeypatch.setattr(server, "_enable_auto_tool_choice", True, raising=False)
+    monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser", None, raising=False)
+    monkeypatch.setattr(server, "_reasoning_parser_name", None, raising=False)
+    monkeypatch.setattr(server, "_tool_parser_instance", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
+    monkeypatch.setattr(server, "_engine", None, raising=False)
+
+    cfg = get_config()
+    assert cfg.enable_auto_tool_choice is False
+    assert cfg.tool_call_parser is None
+    assert server._detect_native_tool_support() is False
+
+    server._sync_config()
+
+    cfg = get_config()
+    assert cfg.enable_auto_tool_choice is True
+    assert cfg.tool_call_parser == "hermes"
+    assert server._detect_native_tool_support() is True

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -516,6 +516,14 @@ def load_model(
     )
     logger.info(f"Model loaded: {model_name}")
 
+    # Sync globals into ServerConfig BEFORE _detect_native_tool_support reads
+    # them via get_config(). Detection short-circuits when cfg.tool_call_parser
+    # is None or cfg.enable_auto_tool_choice is False, so an unsynced cfg
+    # silently disables native tool format and forces api/utils.py into the
+    # prose-conversion fallback ([Calling tool: ...]) — the model then mimics
+    # that format on subsequent turns. See #225.
+    _sync_config()
+
     # Set native tool format support on the engine (thread-safe via instance property)
     _engine.preserve_native_tool_format = _detect_native_tool_support()
     if _engine.preserve_native_tool_format:
@@ -569,9 +577,19 @@ def load_model(
         max_tokens=_default_max_tokens,
     )
     _model_registry.add(entry, is_default=True)
-
-    # Sync globals into ServerConfig so route modules can use get_config()
-    _sync_config()
+    # `_sync_config()` already ran earlier — before `_detect_native_tool_support()`.
+    # No re-sync is needed here, but only because of these invariants. If a
+    # future change violates any of them, add a second `_sync_config()` call:
+    #   1. `cfg.model_registry = _model_registry` (in `_sync_config`) is a
+    #      reference assignment, not a copy — registry mutations after sync
+    #      are visible through `get_config().model_registry` immediately.
+    #   2. Every global that `_sync_config()` mirrors is set BEFORE the
+    #      engine is constructed at line 510 (which is also before the early
+    #      sync). New mutable globals must follow the same rule.
+    #   3. State set on `_engine` between the early sync and here
+    #      (`preserve_native_tool_format`, `_tool_logits_processor_factory`)
+    #      is mutation on the same object `cfg.engine` references — route
+    #      modules see the updates without a re-sync.
 
 
 def _sync_config() -> None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -592,8 +592,15 @@ def load_model(
 def _sync_config() -> None:
     """Copy server globals into the ServerConfig singleton.
 
-    Called after load_model() and whenever globals change.
-    Bridges the old global-variable pattern with the new config object.
+    Called after load_model() and whenever globals change. Bridges the old
+    global-variable pattern with the new config object.
+
+    **Must remain idempotent.** load_model() calls this twice (once early
+    before _detect_native_tool_support() reads cfg, once again after the
+    model registry add as a safety net for future call-site drift). All
+    assignments below MUST be straight overwrites — no counters, no
+    callback fires, no cache invalidations that depend on prior state.
+    See test_sync_config_is_idempotent in tests/test_server_load_model_order.py.
     """
     cfg = get_config()
     cfg.engine = _engine

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -577,19 +577,16 @@ def load_model(
         max_tokens=_default_max_tokens,
     )
     _model_registry.add(entry, is_default=True)
-    # `_sync_config()` already ran earlier — before `_detect_native_tool_support()`.
-    # No re-sync is needed here, but only because of these invariants. If a
-    # future change violates any of them, add a second `_sync_config()` call:
-    #   1. `cfg.model_registry = _model_registry` (in `_sync_config`) is a
-    #      reference assignment, not a copy — registry mutations after sync
-    #      are visible through `get_config().model_registry` immediately.
-    #   2. Every global that `_sync_config()` mirrors is set BEFORE the
-    #      engine is constructed at line 510 (which is also before the early
-    #      sync). New mutable globals must follow the same rule.
-    #   3. State set on `_engine` between the early sync and here
-    #      (`preserve_native_tool_format`, `_tool_logits_processor_factory`)
-    #      is mutation on the same object `cfg.engine` references — route
-    #      modules see the updates without a re-sync.
+
+    # Defensive re-sync. `_sync_config()` already ran earlier (before
+    # `_detect_native_tool_support()`); under current invariants this call is
+    # redundant — `cfg.model_registry` holds a reference to `_model_registry`,
+    # every global synced is set before engine construction, and `_engine`
+    # mutations propagate via `cfg.engine`. Kept anyway because the bug this
+    # PR fixes (#225) was a silent call-ordering failure, and the cost of an
+    # idempotent re-sync is trivial against the cost of re-introducing the
+    # same failure mode if a future change violates the invariants.
+    _sync_config()
 
 
 def _sync_config() -> None:


### PR DESCRIPTION
Closes #225 (h/t @reidperyam for the precise root-cause analysis and reproduction).

## Bug

`_detect_native_tool_support()` reads `cfg.enable_auto_tool_choice` and `cfg.tool_call_parser` via `get_config()`. In `load_model()`, the pre-fix call order was:

```text
1. _engine.preserve_native_tool_format = _detect_native_tool_support()  # line 520
2. … register model entry …
3. _sync_config()                                                        # line 574
```

so detection ran while cfg still held its dataclass defaults (`False`, `None`). The guard `if not cfg.enable_auto_tool_choice or not cfg.tool_call_parser: return False` short-circuited, and `_engine.preserve_native_tool_format` was silently set to `False` regardless of which parser was configured.

This affects every parser that advertises `SUPPORTS_NATIVE_TOOL_FORMAT = True`: `deepseek`, `deepseekv31`, `functionary`, `granite`, `harmony`, `hermes` (and its `qwen3_coder` alias), `kimi`, `llama`, `mistral`, `qwen3coder_xml`, `seed_oss`.

## Symptom

With native format silently disabled, `api/utils.py::process_messages` serialised assistant tool history as prose:

```text
[Calling tool: read({"path":"/tmp/foo"})]
[Tool Result (call_a)]: file contents...
```

Models saw prose-format examples in context and mimicked the pattern on subsequent turns — per @reidperyam's measurement, ~40% of streaming responses on Qwen3.5-9B-4bit and Qwen3.6-35B-A3B-4bit-DWQ emitted the literal `[Calling tool: ...]` string instead of structured `tool_calls`. Looked like model failure, was actually a startup ordering bug.

The visible tell was missing in the startup log:

```text
INFO:vllm_mlx.server:Native tool format enabled for parser: <name>
```

This line is conditional on `_engine.preserve_native_tool_format` being True. If you don't see it for a parser that should support native format, this bug is firing.

## Fix

Move the existing `_sync_config()` call to immediately after engine construction, before native-tool-format detection runs. Per V4 Pro round-2 review, the second `_sync_config()` at end of `load_model` is **kept** as a defensive safety net — the cost of an idempotent re-sync is trivial against the cost of re-introducing the same silent-ordering failure mode if a future change violates the invariants. Three invariants documented above the call.

## Test plan

`tests/test_server_load_model_order.py` adds three regressions:

* **contract test** — `_detect_native_tool_support()` returns False when cfg is unsynced, True after `_sync_config()`
* **integration test** — after `load_model()` returns with a stub engine + hermes parser configured, `_engine.preserve_native_tool_format` is True
* **idempotency test** — `_sync_config()` called twice leaves cfg in identical state across all 12 mirrored fields (per V4 Pro round-3 #4)

Plus an autouse fixture (`_reset_cfg_around_each_test`) that resets the cfg singleton before AND after each test, so mid-test failures can't leak state (per V4 Pro round-3 #5).

Verification:
- [x] Integration test FAILS on the pre-fix tree (`assert False is True`) and PASSES post-fix
- [x] `tests/test_server.py` + `test_server_utils.py` + new file: 67 passed, 0 failed
- [x] Broader tool-call/server tests: 183 passed, 6 skipped
- [x] pr_validate full pipeline (round 3): targeted_tests **68 passed**, full_unit **2148 passed, 0 failed**, lint clean, supply_chain clean, deepseek_review re-run with this PR's deltas
- [x] `ruff check` + `ruff format --check` clean

## Bundled test fix (also in this PR)

`tests/test_anthropic_stream_reasoning.py::test_reasoning_parser_stream_emits_text_chunks` (the #185 regression test) was failing on `raullenchai/main` HEAD before this PR. Root cause was in the test fixture, not the production code: the fixture built cfg with `MagicMock()` and didn't set `no_thinking`, so on the mock that attribute returned another MagicMock (truthy). After PR #224 (the #223 fix) the route reads `cfg.no_thinking` to force `enable_thinking=False`, which then nulls out the reasoning parser. One-line fix on the fixture (`cfg.no_thinking = False`); not splitting into a separate PR because it would either merge this PR with a failing test step or block on follow-up. Verified pre-existing on main HEAD before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)