### PR TITLE
chore: bump version to 0.6.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.13"
+version = "0.6.14"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Brew-only release. Pairs with [homebrew-rapid-mlx#3](https://github.com/raullenchai/homebrew-rapid-mlx/pull/3), which extends the v0.6.13 source-rebuild treatment from pydantic_core to also include rpds-py.

v0.6.13 brew upgrade onboarding still printed `Error: Failed changing dylib ID` for `rpds.cpython-312-darwin.so` (transitive dep via jsonschema). Same root cause as the pydantic_core issue — the PyPI wheel ships without headerpad space, so install_name_tool fails during keg relocation.

No Python code changes.

## Verification (already done locally)

- Bug reproduced on PyPI wheel: `install_name_tool -id <long-Cellar-path>` exits 1 with `larger updated load commands do not fit (...use -headerpad_max_install_names)`.
- Fix validated: `RUSTFLAGS=-headerpad_max_install_names` + `--no-binary rpds-py` source build → install_name_tool exits 0.
- End-to-end: `brew reinstall --build-from-source rapid-mlx` against patched formula → 0 dylib errors (was 1 on v0.6.13). CLI smoke test passes.
- Codex review: clean, no concerns.

## Test plan

- [x] Local source rebuild + install_name_tool validates fix
- [x] Brew reinstall produces 0 `Failed changing dylib` errors
- [x] CLI works post-reinstall
- [ ] After merge + tag: publish.yml uploads to PyPI, repository-dispatch triggers brew tap update; verify Homebrew formula auto-updates to 0.6.14 keeping the `pydantic-core,rpds-py` install block
- [ ] Re-run brew onboarding test on fresh upgrade