### PR TITLE
fix(chat): iterate merged per-step logprobs under stream_interval > 1 (#220)

### DIFF
--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -301,6 +301,139 @@ class TestExtractTokenLogprob:
 
 
 # ---------------------------------------------------------------------------
+# _extract_streaming_token_logprobs (regression for #220)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractStreamingTokenLogprobs:
+    """Regression for #220 — under stream_interval > 1 a single chunk
+    carries a list[mx.array] of merged per-step distributions, one per
+    token in the merged window. The downstream SSE consumer must see
+    one TokenLogProb entry per generated token, not one per flush.
+
+    Pre-#220, the chat-route handler passed the entire list to
+    ``_extract_token_logprob`` as one flattened array, producing
+    misaligned top-k indices and a single under-counted entry.
+    """
+
+    def _make_chunk(
+        self, logprobs, new_text="hi", new_token_ids=None, tokens=None
+    ):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            logprobs=logprobs,
+            new_text=new_text,
+            new_token_ids=new_token_ids,
+            tokens=tokens or [],
+        )
+
+    def _make_logprob_array(self, vocab_size=64):
+        arr = np.full(vocab_size, -10.0)
+        arr[0] = -0.1
+        mock = MagicMock()
+        mock.astype.return_value = mock
+        return mock, arr
+
+    def test_single_array_yields_one_entry(self):
+        """Backward-compat — stream_interval=1 still gives one entry."""
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        mock, arr = self._make_logprob_array()
+        tok = MagicMock()
+        tok.decode.return_value = "x"
+        chunk = self._make_chunk(
+            logprobs=mock, new_token_ids=[7], tokens=[7]
+        )
+
+        with patch("numpy.array", return_value=arr):
+            result = _extract_streaming_token_logprobs(chunk, tok, top_k=3)
+
+        assert len(result) == 1
+
+    def test_list_of_three_yields_three_entries(self):
+        """The bug — under stream_interval=4, a 3-token flush carries a
+        3-element list and must produce 3 separate TokenLogProb entries.
+        """
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        mock_a, arr_a = self._make_logprob_array()
+        mock_b, arr_b = self._make_logprob_array()
+        mock_c, arr_c = self._make_logprob_array()
+        tok = MagicMock()
+        tok.decode.return_value = "x"
+        chunk = self._make_chunk(
+            logprobs=[mock_a, mock_b, mock_c],
+            new_token_ids=[10, 11, 12],
+            tokens=[10, 11, 12],
+        )
+
+        with patch("numpy.array", side_effect=[arr_a, arr_b, arr_c]):
+            result = _extract_streaming_token_logprobs(chunk, tok, top_k=3)
+
+        assert len(result) == 3, (
+            "Expected one TokenLogProb per merged step; pre-fix this "
+            "returned a single entry per flush"
+        )
+
+    def test_list_pairs_with_new_token_ids(self):
+        """Each per-step distribution must be paired with the matching
+        ``new_token_ids[i]``, not always the last token in ``tokens``."""
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        mock_a, arr_a = self._make_logprob_array()
+        mock_b, arr_b = self._make_logprob_array()
+        mock_a.astype.return_value = mock_a
+        mock_b.astype.return_value = mock_b
+
+        observed_token_ids = []
+        tok = MagicMock()
+
+        def fake_decode(ids):
+            observed_token_ids.append(ids[0])
+            return f"t{ids[0]}"
+
+        tok.decode.side_effect = fake_decode
+
+        chunk = self._make_chunk(
+            logprobs=[mock_a, mock_b],
+            new_token_ids=[20, 21],
+            tokens=[10, 11, 20, 21],
+        )
+
+        with patch("numpy.array", side_effect=[arr_a, arr_b]):
+            _extract_streaming_token_logprobs(chunk, tok, top_k=1)
+
+        # The sampled token decoded for each entry must come from
+        # new_token_ids, not from chunk.tokens[-1] (= 21 for both).
+        sampled = [tid for tid in observed_token_ids if tid in (20, 21)]
+        assert sampled == [20, 21], (
+            f"Per-step token IDs must come from new_token_ids; got {sampled}"
+        )
+
+    def test_empty_chunk_returns_empty(self):
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        chunk = self._make_chunk(logprobs=None)
+        assert _extract_streaming_token_logprobs(chunk, MagicMock(), top_k=3) == []
+
+    def test_no_new_text_returns_empty(self):
+        """A chunk without new_text (e.g. empty tool-call passthrough)
+        produces no logprobs entries even if logprobs is set."""
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        mock, _ = self._make_logprob_array()
+        chunk = self._make_chunk(logprobs=mock, new_text="")
+        assert _extract_streaming_token_logprobs(chunk, MagicMock(), top_k=3) == []
+
+    def test_empty_list_returns_empty(self):
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        chunk = self._make_chunk(logprobs=[], new_text="hi", new_token_ids=[])
+        assert _extract_streaming_token_logprobs(chunk, MagicMock(), top_k=3) == []
+
+
+# ---------------------------------------------------------------------------
 # _validate_tool_call_params
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -316,9 +316,7 @@ class TestExtractStreamingTokenLogprobs:
     misaligned top-k indices and a single under-counted entry.
     """
 
-    def _make_chunk(
-        self, logprobs, new_text="hi", new_token_ids=None, tokens=None
-    ):
+    def _make_chunk(self, logprobs, new_text="hi", new_token_ids=None, tokens=None):
         from types import SimpleNamespace
 
         return SimpleNamespace(
@@ -342,9 +340,7 @@ class TestExtractStreamingTokenLogprobs:
         mock, arr = self._make_logprob_array()
         tok = MagicMock()
         tok.decode.return_value = "x"
-        chunk = self._make_chunk(
-            logprobs=mock, new_token_ids=[7], tokens=[7]
-        )
+        chunk = self._make_chunk(logprobs=mock, new_token_ids=[7], tokens=[7])
 
         with patch("numpy.array", return_value=arr):
             result = _extract_streaming_token_logprobs(chunk, tok, top_k=3)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -44,7 +44,6 @@ from ..service.helpers import (
     _build_usage,
     _disconnect_guard,
     _extract_streaming_token_logprobs,
-    _extract_token_logprob,
     _inject_json_instruction,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -43,6 +43,7 @@ from ..service.helpers import (
     _TOOL_USE_SYSTEM_SUFFIX,
     _build_usage,
     _disconnect_guard,
+    _extract_streaming_token_logprobs,
     _extract_token_logprob,
     _inject_json_instruction,
     _maybe_pin_system_prompt,
@@ -478,13 +479,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             output = None
             async for chunk in engine.stream_chat(messages=messages, **chat_kwargs):
                 output = chunk
-                if chunk.logprobs is not None and chunk.new_text:
-                    token_id = chunk.tokens[-1] if chunk.tokens else 0
-                    token_logprobs_list.append(
-                        _extract_token_logprob(
-                            chunk.logprobs, token_id, engine.tokenizer, top_k_logprobs
-                        )
+                token_logprobs_list.extend(
+                    _extract_streaming_token_logprobs(
+                        chunk, engine.tokenizer, top_k_logprobs
                     )
+                )
             if output is None:
                 return Response(status_code=499)
         elif use_guided and json_schema:
@@ -643,13 +642,12 @@ async def stream_chat_completion(
 
         def _build_chunk_logprobs(output: GenerationOutput) -> ChoiceLogProbs | None:
             """Build ChoiceLogProbs for a streaming chunk if logprobs requested."""
-            if not want_logprobs or output.logprobs is None:
+            if not want_logprobs:
                 return None
-            token_id = output.tokens[-1] if output.tokens else 0
-            token_lp = _extract_token_logprob(
-                output.logprobs, token_id, engine.tokenizer, top_k_logprobs
+            entries = _extract_streaming_token_logprobs(
+                output, engine.tokenizer, top_k_logprobs
             )
-            return ChoiceLogProbs(content=[token_lp])
+            return ChoiceLogProbs(content=entries) if entries else None
 
         # Pre-compute SSE template parts that don't change per-token.
         _sse_created = int(time.time())

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -151,12 +151,9 @@ def _extract_streaming_token_logprobs(
     if chunk.logprobs is None or not getattr(chunk, "new_text", None):
         return []
     lps = chunk.logprobs if isinstance(chunk.logprobs, list) else [chunk.logprobs]
-    tids = chunk.new_token_ids or (
-        [chunk.tokens[-1]] if chunk.tokens else [0]
-    )
+    tids = chunk.new_token_ids or ([chunk.tokens[-1]] if chunk.tokens else [0])
     return [
-        _extract_token_logprob(lp, tid, tokenizer, top_k)
-        for lp, tid in zip(lps, tids)
+        _extract_token_logprob(lp, tid, tokenizer, top_k) for lp, tid in zip(lps, tids)
     ]
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -132,6 +132,34 @@ def get_usage(output: GenerationOutput) -> Usage:
     )
 
 
+def _extract_streaming_token_logprobs(
+    chunk, tokenizer, top_k: int
+) -> list[TokenLogProb]:
+    """Yield one TokenLogProb per generated token in a streaming chunk.
+
+    ``chunk.logprobs`` may be either a single per-step ``mx.array``
+    (under ``stream_interval=1``) or a ``list[mx.array]`` of merged
+    per-step distributions accumulated across skipped ``should_send()``
+    steps (under ``stream_interval > 1``, after PR #210). The downstream
+    SSE consumer expects one entry per *generated token*, not per flush
+    — so we must iterate, pairing each per-step distribution with the
+    corresponding ``new_token_ids`` entry. Without this iteration the
+    list-form gets passed to ``_extract_token_logprob`` as one giant
+    flattened array, and ``argmax`` reads from concatenated unrelated
+    vocab dims (#220).
+    """
+    if chunk.logprobs is None or not getattr(chunk, "new_text", None):
+        return []
+    lps = chunk.logprobs if isinstance(chunk.logprobs, list) else [chunk.logprobs]
+    tids = chunk.new_token_ids or (
+        [chunk.tokens[-1]] if chunk.tokens else [0]
+    )
+    return [
+        _extract_token_logprob(lp, tid, tokenizer, top_k)
+        for lp, tid in zip(lps, tids)
+    ]
+
+
 def _extract_token_logprob(
     logprobs_array, token_id: int, tokenizer, top_k: int
 ) -> TokenLogProb:


### PR DESCRIPTION
## Summary

Closes #220. PR #210 made streaming **text** correct under `stream_interval > 1` by buffering per-step deltas and flushing the merged result. The logprobs consumer at `routes/chat.py` was written when each chunk's `logprobs` was a single `mx.array` per step and didn't get the corresponding update — under `stream_interval > 1` it produced wrong output:

1. **Under-counted**: emitted ONE `TokenLogProb` per flush instead of per generated token.
2. **Misaligned**: passed the entire `list[mx.array]` to `_extract_token_logprob`, which `flatten()`-ed N vocab-size distributions into one 1D array of length `N*vocab_size`. Top-k argmax then picked across concatenated unrelated vocab dims; `probs[token_id]` read from the wrong distribution.
3. **Wrong sampled token**: used `chunk.tokens[-1]` as the sampled token, ignoring the other N-1 tokens whose logprobs were merged.

## Fix

- New shared helper `_extract_streaming_token_logprobs(chunk, tokenizer, top_k)` in `service/helpers.py`. Pairs each per-step distribution with the matching `new_token_ids[i]`, falling back to `[chunk.tokens[-1]]` for the single-array path so default behavior is unchanged.
- Wired into both `routes/chat.py` callsites:
  - Line 481-487 — non-streaming-with-logprobs path
  - Line 644-652 — streaming `_build_chunk_logprobs` closure

## Tests

6 new regression tests under `TestExtractStreamingTokenLogprobs`:

| Test | Asserts |
|---|---|
| `test_single_array_yields_one_entry` | Backward-compat — `stream_interval=1` unchanged |
| `test_list_of_three_yields_three_entries` | List of N produces N entries (the bug) |
| `test_list_pairs_with_new_token_ids` | Per-step token IDs come from `new_token_ids`, not `chunk.tokens[-1]` |
| `test_empty_chunk_returns_empty` | Guard for `logprobs is None` |
| `test_no_new_text_returns_empty` | Guard for empty `new_text` (e.g. tool-call passthrough) |
| `test_empty_list_returns_empty` | Guard for empty list |

## Test plan
- [x] `python3.12 -m pytest tests/test_server_utils.py -v` → 46 passed (40 existing + 6 new)
- [x] `python3.12 -m pytest tests/test_chat_route_tool_tag_leak.py -v` → 4 passed (no regression in adjacent route logic)
- [ ] `python3.12 -c 'from scripts.pr_validate.pr_validate import main; main()' <PR#> -v` → pending
- [ ] `make full` → pending

## Severity

Low. Defaults work correctly. Only trips when both `--stream-interval > 1` AND per-token `logprobs` are explicitly requested. Filed as #220 for tracking, not a release blocker.

Closes #220