### PR TITLE
feat(aliases): add Bonsai unpacked aliases (refs #215)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -44,5 +44,8 @@
   "gemma3-1b": "mlx-community/gemma-3-1b-it-4bit",
   "gemma3-27b": "mlx-community/gemma-3-27b-it-4bit",
   "nemotron-30b": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
-  "nemotron-nano": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit"
+  "nemotron-nano": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
+  "bonsai-1.7b": "prism-ml/Bonsai-1.7B-unpacked",
+  "bonsai-4b": "prism-ml/Bonsai-4B-unpacked",
+  "bonsai-8b": "prism-ml/Bonsai-8B-unpacked"
 }


### PR DESCRIPTION
## Summary

Refs #215. Adds short aliases for Prism ML's Bonsai **unpacked** (FP16) variants — the only Bonsai weights that load with stock mlx-lm today.

```
rapid-mlx serve bonsai-1.7b   →  prism-ml/Bonsai-1.7B-unpacked
rapid-mlx serve bonsai-4b     →  prism-ml/Bonsai-4B-unpacked
rapid-mlx serve bonsai-8b     →  prism-ml/Bonsai-8B-unpacked
```

## Verification

```python
from mlx_lm import load, generate
model, tokenizer = load("prism-ml/Bonsai-1.7B-unpacked")
print(generate(model, tokenizer, prompt="Hello, my name is", max_tokens=20))
# → "Alice, and I'm a student at a university. I'm interested in studying computer sc"
```

Backbone: Qwen3-1.7B (28 decoder blocks, GQA 16/8, SwiGLU + RoPE + RMSNorm, 32K context, 152K vocab). Stock mlx-lm 0.31.3 path — no custom code needed.

## Not aliased — needs upstream work

`prism-ml/Bonsai-{1.7B,4B,8B}-mlx-1bit` are the headline 1.25 bpw variants (288 tok/s on M4 Pro per their card). Stock mlx-lm rejects them:

```
ValueError: [quantize] The requested number of bits 1 is not supported.
The supported bits are 2, 3, 4, 5, 6 and 8.
```

Loading requires the [PrismML mlx fork](https://github.com/PrismML-Eng/mlx) (`mlx @ git+https://github.com/PrismML-Eng/mlx.git@prism`). Vendoring or upstreaming that into mlx is much larger scope — out of this PR.

## Test plan
- [x] `python3.12 -c "from huggingface_hub import HfApi; ..."` — all 3 unpacked repos exist (last_modified 2026-04-16)
- [x] mlx-lm load + generate succeeds on Bonsai-1.7B-unpacked
- [ ] `pr_validate <PR#>` — pending
- [ ] `make full` — pending

Refs #215