### PR TITLE
chore: cherry-pick top 10 upstream fixes (waybarrios/vllm-mlx)

### DIFF
--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -9,6 +9,7 @@ Handles translation of:
 """
 
 import json
+import re
 import uuid
 
 from .anthropic_models import (
@@ -60,6 +61,10 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
             system_text = "\n".join(parts)
         else:
             system_text = str(request.system)
+        # Strip per-request billing/tracking headers injected by some
+        # clients (e.g. Claude Code).  These contain a per-request hash
+        # that prevents prefix-cache reuse across turn boundaries.
+        system_text = re.sub(r"x-anthropic-billing-header:[^\n]*\n?", "", system_text)
         messages.append(Message(role="system", content=system_text))
 
     # Convert each message

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -611,6 +611,7 @@ class BatchedEngine(BaseEngine):
 
             return GenerationOutput(
                 text=clean_output_text(output.output_text),
+                tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -600,7 +600,7 @@ class ToolSandbox:
             logger.info(
                 f"AUDIT: Tool executed - {server_name}__{tool_name} "
                 f"(took {execution_time_ms:.1f}ms)"
-                if execution_time_ms
+                if execution_time_ms is not None
                 else f"AUDIT: Tool executed - {server_name}__{tool_name}"
             )
         else:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1217,13 +1217,15 @@ class MemoryAwarePrefixCache:
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
             entry_path, tokens_path = _entry_paths(i)
             try:
-                # Dequantize _QuantizedCacheWrapper layers before saving.
+                # Dequantize QuantizedKVCache layers before saving.
                 # save_prompt_cache requires .state and .meta_state which
                 # the wrapper does not provide; dequantizing restores the
                 # original cache types that do.
+                from mlx_lm.models.cache import QuantizedKVCache
+
                 persist_cache = (
                     _dequantize_cache(entry.cache)
-                    if any(isinstance(c, _QuantizedCacheWrapper) for c in entry.cache)
+                    if any(isinstance(c, QuantizedKVCache) for c in entry.cache)
                     else entry.cache
                 )
                 save_prompt_cache(

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1217,9 +1217,18 @@ class MemoryAwarePrefixCache:
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
             entry_path, tokens_path = _entry_paths(i)
             try:
+                # Dequantize _QuantizedCacheWrapper layers before saving.
+                # save_prompt_cache requires .state and .meta_state which
+                # the wrapper does not provide; dequantizing restores the
+                # original cache types that do.
+                persist_cache = (
+                    _dequantize_cache(entry.cache)
+                    if any(isinstance(c, _QuantizedCacheWrapper) for c in entry.cache)
+                    else entry.cache
+                )
                 save_prompt_cache(
                     entry_path,
-                    entry.cache,
+                    persist_cache,
                     metadata={"num_tokens": str(len(tokens_key))},
                 )
                 # Save tokens separately (can be 100K+ ints → binary is smaller).

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -678,7 +678,7 @@ class MLLMBatchGenerator:
         # KVCache.merge() creates a BatchKVCache with proper left-padding
         # alignment, so all requests share a single batched cache for
         # subsequent generation steps.
-        from mlx_lm.models.cache import KVCache
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
 
         sample_cache = per_request_caches[0][0]
         if not isinstance(sample_cache, (KVCache, RotatingKVCache)):

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -681,11 +681,12 @@ class MLLMBatchGenerator:
         from mlx_lm.models.cache import KVCache
 
         sample_cache = per_request_caches[0][0]
-        if not isinstance(sample_cache, KVCache):
+        if not isinstance(sample_cache, (KVCache, RotatingKVCache)):
             raise ValueError(
-                f"MLLM continuous batching requires standard KVCache but got "
-                f"{type(sample_cache).__name__}. Disable --kv-cache-quantization "
-                f"when using multimodal models with --continuous-batching."
+                f"MLLM continuous batching requires KVCache or RotatingKVCache "
+                f"but got {type(sample_cache).__name__}. Disable "
+                f"--kv-cache-quantization when using multimodal models with "
+                f"--continuous-batching."
             )
 
         try:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -394,6 +394,12 @@ class MLLMScheduler:
         if request_id in self.running:
             del self.running[request_id]
 
+        # Credit in-flight tokens so dashboard metrics stay accurate
+        # (without this, aborted requests' tokens vanish from /v1/status).
+        if request.num_output_tokens > 0:
+            self.total_completion_tokens += request.num_output_tokens
+            self.total_prompt_tokens += request.num_prompt_tokens
+
         # Mark as aborted
         if request is not None:
             request.status = RequestStatus.FINISHED_ABORTED

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -952,7 +952,7 @@ class PagedCacheManager:
     @staticmethod
     def compute_block_hash(tokens: list[int]) -> str:
         """Compute legacy string hash for a sequence of tokens."""
-        token_bytes = bytes(t & 0xFF for t in tokens)
+        token_bytes = b"".join(t.to_bytes(4, "big") for t in tokens)
         return hashlib.sha256(token_bytes).hexdigest()[:16]
 
     def find_cached_block(self, tokens: list[int]) -> CacheBlock | None:

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -13,7 +13,7 @@ This module provides two implementations:
 import copy
 import logging
 import time
-from collections import deque
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
@@ -107,8 +107,9 @@ class PrefixCacheManager:
         # Structure: {model_key: {token1: {token2: {..., "cache": CacheEntry}}}}
         self._cache: dict[Any, dict] = {}
 
-        # LRU tracking: (model_key, tuple(tokens)) ordered by access time
-        self._lru: deque = deque()
+        # LRU tracking: OrderedDict keyed by (model_key, tuple(tokens)), insertion
+        # order = least-recently-used first. move_to_end() and popitem() are O(1).
+        self._lru: OrderedDict = OrderedDict()
 
         # Pinned entries: keys excluded from LRU eviction
         self._pinned: set = set()
@@ -250,18 +251,15 @@ class PrefixCacheManager:
         key = (self.model_key, tokens_tuple)
         if "cache" in current:
             current["cache"].count += 1
-            # Update LRU position (skip if pinned)
-            if key not in self._pinned:
-                try:
-                    self._lru.remove(key)
-                except ValueError:
-                    pass
         else:
             current["cache"] = CacheEntry(prompt_cache, 1)
 
-        # Only add to LRU if not pinned
+        # Only track in LRU if not pinned (move_to_end is O(1) for OrderedDict)
         if key not in self._pinned:
-            self._lru.append(key)
+            if key in self._lru:
+                self._lru.move_to_end(key)
+            else:
+                self._lru[key] = None
 
         # Evict if over capacity (count pinned entries toward total)
         while len(self._lru) + len(self._pinned) > self.max_size and len(self._lru) > 0:
@@ -281,22 +279,21 @@ class PrefixCacheManager:
         return current.get("cache")
 
     def _touch_lru(self, tokens_tuple: tuple) -> None:
-        """Move entry to end of LRU queue (most recently used)."""
+        """Move entry to most-recently-used position — O(1) with OrderedDict."""
         key = (self.model_key, tokens_tuple)
         if key in self._pinned:
             return  # Pinned entries stay out of LRU
-        try:
-            self._lru.remove(key)
-        except ValueError:
-            pass
-        self._lru.append(key)
+        if key in self._lru:
+            self._lru.move_to_end(key)
+        else:
+            self._lru[key] = None
 
     def _evict_lru(self) -> None:
-        """Evict least recently used entry."""
+        """Evict least recently used entry — O(1) popitem from OrderedDict."""
         if not self._lru:
             return
 
-        model_key, tokens_tuple = self._lru.popleft()
+        (model_key, tokens_tuple), _ = self._lru.popitem(last=False)
         self._delete_cache(model_key, list(tokens_tuple))
         self.stats.evictions += 1
 
@@ -389,10 +386,7 @@ class PrefixCacheManager:
                 f"already at capacity ({self.max_size})"
             )
             return False
-        try:
-            self._lru.remove(key)
-        except ValueError:
-            pass  # May already be removed from LRU
+        self._lru.pop(key, None)
         self._pinned.add(key)
         logger.info(f"Pinned prefix ({len(tokens)} tokens)")
         return True
@@ -414,7 +408,7 @@ class PrefixCacheManager:
         self._pinned.discard(key)
         # Re-add to LRU (at MRU end)
         if key not in self._lru:
-            self._lru.append(key)
+            self._lru[key] = None
         logger.info(f"Unpinned prefix ({len(tokens)} tokens) - added back to LRU")
         return True
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1900,6 +1900,12 @@ class Scheduler:
         if request_id in self.running:
             del self.running[request_id]
 
+        # Credit in-flight tokens so dashboard metrics stay accurate
+        # (without this, aborted requests' tokens vanish from /v1/status).
+        if request is not None and request.num_output_tokens > 0:
+            self.total_completion_tokens += request.num_output_tokens
+            self.total_prompt_tokens += request.num_prompt_tokens
+
         if request is not None:
             request.set_finished(RequestStatus.FINISHED_ABORTED)
         self.finished_req_ids.add(request_id)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1908,6 +1908,9 @@ class Scheduler:
 
         if request is not None:
             request.set_finished(RequestStatus.FINISHED_ABORTED)
+            # Release cache references so Metal buffers can be freed
+            request.prompt_cache = None
+            request._extracted_cache = None
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
 
@@ -2039,6 +2042,12 @@ class Scheduler:
                 request.status = RequestStatus.RUNNING
                 # Attach incremental decoder for multi-byte safe streaming
                 request._decoder = IncrementalDecoder(self._actual_tokenizer)
+                # Release the prompt cache reference now that BatchGenerator
+                # has its own copy.  Holding this reference prevents MLX from
+                # freeing the Metal buffers until the request object is GC'd,
+                # which under sustained traffic can accumulate hundreds of GB
+                # of wired memory (issue #442).
+                request.prompt_cache = None
                 self.running[request.request_id] = request
                 scheduled.append(request)
 
@@ -2301,6 +2310,14 @@ class Scheduler:
                         values_attr = layer.values
                         if not callable(keys_attr) and not callable(values_attr):
                             mx.eval(keys_attr, values_attr)
+
+            # Release all cache references on the request so Metal buffers
+            # can be freed.  The prefix cache (if any) holds its own copy;
+            # keeping a second reference here pins the buffers in wired memory
+            # until the request object is GC'd (issue #442).
+            if request is not None:
+                request.prompt_cache = None
+                request._extracted_cache = None
 
             # Remove from running
             if request_id in self.running:

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -166,6 +166,8 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
         else:
             raise
 
+    return model, tokenizer
+
 
 def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     """Load model with strict=False to discard extra weights (e.g., vision tower, MTP)."""


### PR DESCRIPTION
## Summary

Cherry-picks 9 actionable fixes/perf improvements from upstream `waybarrios/vllm-mlx` plus 1 in-tree compatibility fix (10 commits total). Selected for: applies cleanly or with minor merge work, no dependency on upstream-only refactors, observable bug or perf impact.

## Cherry-picks

| # | SHA | Subject |
|---|---|---|
| 1 | 970b699 | fix: 4-byte encoding in compute_block_hash to prevent false KV cache hits (#444) |
| 2 | 1a07ab3 | fix: credit in-flight tokens on request abort for accurate metrics (#456) |
| 3 | d925954 | fix: dequantize _QuantizedCacheWrapper before disk persistence (#451) |
| 4 | 494981f | perf: replace deque with OrderedDict for O(1) LRU in PrefixCacheManager (#448) |
| 5 | 77dc62a | fix: release stale cache/buffer references to prevent Metal memory growth (#453) |
| 6 | 919c417 | fix: 'is not None' check for execution_time_ms in MCP audit log (#447) |
| 7 | 864b81e | fix: include tokens in GenerationOutput for BatchedEngine when model is mllm |
| 8 | 15b47d7 | fix: RotatingKVCache support in MLLM batching + missing return in tokenizer |
| 9 | 1d87e46 | strip billing header from Anthropic system prompt for prefix cache (#277) |
| 10 | aefa27a | **(local fixup)** use QuantizedKVCache class name in dequant guard (the #451 cherry-pick referenced upstream's `_QuantizedCacheWrapper` symbol; our fork exposes it as `mlx_lm.models.cache.QuantizedKVCache`) |

## Skipped (and why)

- **9c37f76 / d5d6010 / 9630c5d / 42d1842 / 6f0efc2 / 588d206 / dc2279d / af632ad / 3c00c44 / d35c949 / 4392e92 / 09cc64e / b61f57c / 01261c1 / d38b978 / c516a7d / 503c226 / fe2a172 / a0b6392 / eeea534 / 380b12d / 2cce3da / 7c64416** — upstream depends on refactors/files we don't have (e.g. expanded MLLMSchedulerConfig, full `_extract_token_logprob` rewrite, qwen3_5_mtp.py removed, larger `qwen_tool_parser`, server.py decomposition divergence, removed `repetition_penalty` not in our fork, etc.). Conflicts large enough that resolving them would mean rewriting the upstream change.
- **e65f0e0** — already imported in our fork (no-op).

## Test plan

- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations -m "not slow" -k "not Integration"` — **2115 passed, 12 skipped**
- [x] `tests/test_prefix_cache.py` — 27/27 (validates OrderedDict LRU + pinned-prefix interaction)
- [x] `tests/test_prefix_cache_persistence.py` — 28/28 (validates the QuantizedKVCache fixup)
- [x] `tests/test_anthropic_adapter.py` — 45/45 (validates billing-header strip)
- [ ] `pr_validate` MERGE-SAFE
- [ ] `make full` doctor harness regression-only baseline diff (to catch tps regressions, especially around the OrderedDict swap and the Metal-cache release point)

## Notes for review

- All 9 upstream commits are individually documented and well-scoped. No churn beyond the listed files.
- The `aefa27a` fixup is the only original change; without it, `test_prefix_cache_persistence.py` regresses with `NameError: _QuantizedCacheWrapper`.
- Branch is clean (no merge commits). Each cherry-pick keeps the original author and DCO line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)