### PR TITLE
docs(bench): document find_free_port TOCTOU + retry contract

### DIFF
--- a/scripts/bench_vs_ollama.py
+++ b/scripts/bench_vs_ollama.py
@@ -187,6 +187,14 @@ def require_executable(name: str) -> str:
 
 
 def find_free_port() -> int:
+    """Return an ephemeral local port.
+
+    The socket is closed before this returns, so the port is technically
+    racy — another process on the same host could grab it before our
+    subprocess binds. Callers must therefore wrap the port handoff in a
+    bind-retry loop (see ``PORT_BIND_ATTEMPTS``); we surface ``EADDRINUSE``
+    as a ``ManagedProcessExitError`` and retry with a fresh port.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])


### PR DESCRIPTION
## Summary

Follow-up to #176 ([review thread](https://github.com/raullenchai/Rapid-MLX/pull/176#pullrequestreview)). Adds an 8-line docstring to `scripts/bench_vs_ollama.py::find_free_port` so future readers see why the bind-then-close pattern is expected and that callers MUST pair it with the existing `PORT_BIND_ATTEMPTS` retry.

The retry itself is already in place (`benchmark_rapid_mlx` line ~1328, `benchmark_ollama` line ~1395); this PR is doc-only.

## Why doc-only

Considered alternatives:
- `SO_REUSEADDR` — doesn't actually close the TOCTOU window on macOS/Linux for fresh binds
- Pass bound socket via `Popen(pass_fds=...)` — would require teaching `rapid-mlx serve` and `ollama serve` to inherit FDs, well outside this script's scope
- Retry loop — already implemented

## Test plan

- [x] `ruff check scripts/bench_vs_ollama.py` — clean
- [x] `ruff format --check scripts/bench_vs_ollama.py` — already formatted
- [x] `python3.12 -m pytest tests/test_bench_vs_ollama.py -q` — 63/63 passed in 0.17s

🤖 Generated with [Claude Code](https://claude.com/claude-code)