### PR TITLE
fix: post-v0.6.14 codex review findings (cache_types + mllm abort)

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -848,6 +848,30 @@ class TestDeferredAbortWaitingDeque:
         assert "test-abort" in scheduler.finished_req_ids
 
 
+@_skip_no_mlx_lm
+class TestMLLMAbortMissingRequest:
+    """Regression: late/duplicate abort for an id no longer in self.requests
+    must not raise on the new token-credit dereference (codex post-v0.6.14)."""
+
+    def test_do_abort_request_when_request_missing(self):
+        from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+        mock_model = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor.tokenizer = MagicMock()
+
+        scheduler = MLLMScheduler(mock_model, mock_processor, MLLMSchedulerConfig())
+
+        # No add_request call — simulate cleanup having already popped it.
+        scheduler._do_abort_request("orphan-id")
+
+        assert "orphan-id" in scheduler.finished_req_ids
+        assert "orphan-id" in scheduler._aborted_queue_ids
+        # Token counters must not move when there's no request to credit.
+        assert scheduler.total_completion_tokens == 0
+        assert scheduler.total_prompt_tokens == 0
+
+
 # Integration tests (require model loading)
 @pytest.mark.slow
 @pytest.mark.skipif(not os.environ.get("RUN_SLOW_TESTS"), reason="Slow tests disabled")

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -832,6 +832,60 @@ def test_save_to_disk_records_cache_types_in_index(tmp_path):
     assert idx["entries"][0]["cache_types"] == ["KVCache", "KVCache"]
 
 
+def test_save_to_disk_records_post_dequant_cache_types(tmp_path):
+    """Regression — when ``store`` quantized the entry but ``save_to_disk``
+    must dequantize before persisting (save_prompt_cache requires .state /
+    .meta_state which QuantizedKVCache doesn't expose), the index must
+    record the *post-dequant* class names. Recording ``QuantizedKVCache``
+    here would cause a subsequent unquantized startup to reject the entry
+    as "config changed", silently losing a perfectly loadable cache.
+    Caught by codex post-v0.6.14 review."""
+    n_tokens = 300  # > kv_min_quantize_tokens default of 256
+    # Build a real KVCache with head_dim=64 so quantize(group_size=64) works.
+    kv_layers = []
+    for layer_idx in range(2):
+        c = KVCache()
+        keys = mx.full((1, 4, n_tokens, 64), 0.5 + layer_idx, dtype=mx.float16)
+        values = mx.full((1, 4, n_tokens, 64), -(0.5 + layer_idx), dtype=mx.float16)
+        c.update_and_fetch(keys, values)
+        kv_layers.append(c)
+    cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(
+            max_memory_mb=64,
+            max_entries=100,
+            kv_quantize=True,
+        ),
+    )
+    cache.store(list(range(n_tokens)), kv_layers)
+
+    # Sanity — entry.cache should now be QuantizedKVCache layers.
+    QuantizedKVCache = pytest.importorskip("mlx_lm.models.cache").QuantizedKVCache
+    entry = next(iter(cache._entries.values()))
+    assert all(isinstance(c, QuantizedKVCache) for c in entry.cache)
+
+    cache.save_to_disk(str(tmp_path))
+
+    with open(tmp_path / "index.json") as f:
+        idx = json.load(f)
+    assert idx["entries"][0]["cache_types"] == ["KVCache", "KVCache"], (
+        "cache_types must reflect what's on disk (post-dequant), not what "
+        "lived in entry.cache before save"
+    )
+
+    # End-to-end: a future unquantized startup must accept this entry.
+    plain = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=64, max_entries=100, kv_quantize=False),
+    )
+    loaded = plain.load_from_disk(str(tmp_path))
+    assert loaded == 1, (
+        "previously-quantized-but-now-dequantized entry must load under "
+        "unquantized config (otherwise users lose their cache after toggling "
+        "--kv-cache-quantization off)"
+    )
+
+
 def test_incompatible_skipped_does_not_count_as_corruption(tmp_path, caplog):
     """The summary log must distinguish "config changed → expected skips"
     from "disk corrupt → user should investigate". A WARNING for an

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1241,13 +1241,13 @@ class MemoryAwarePrefixCache:
                     arr.tofile(f)
 
                 # Record the per-layer cache class names so loaders can
-                # gate on cache-type compatibility (#198 BUG B). Stored
-                # inline in index.json so we can pre-filter incompatible
-                # entries without parsing the safetensors header for each.
-                # Falls back to ``[]`` if the entry was empty (defensive —
-                # shouldn't happen since we reject empty caches at store).
+                # gate on cache-type compatibility (#198 BUG B). Read from
+                # ``persist_cache`` (post-dequantize), not ``entry.cache``,
+                # so the index reflects what's actually on disk — otherwise
+                # a saved-while-quantized entry would be rejected on a
+                # subsequent unquantized startup despite being loadable.
                 cache_types = [
-                    type(layer).__name__ for layer in entry.cache if layer is not None
+                    type(layer).__name__ for layer in persist_cache if layer is not None
                 ]
 
                 index["entries"].append(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -396,7 +396,10 @@ class MLLMScheduler:
 
         # Credit in-flight tokens so dashboard metrics stay accurate
         # (without this, aborted requests' tokens vanish from /v1/status).
-        if request.num_output_tokens > 0:
+        # Same ``request is not None`` guard as below — late/duplicate
+        # aborts arrive after self.requests.pop() and would otherwise
+        # raise AttributeError on the dereference.
+        if request is not None and request.num_output_tokens > 0:
             self.total_completion_tokens += request.num_output_tokens
             self.total_prompt_tokens += request.num_prompt_tokens
 


### PR DESCRIPTION
## Summary

Two latent P2 bugs found by `codex review --base v0.6.14` over today's batch (10 PRs since v0.6.14). Both reproduce; both have negative-control tests.

### 1. `memory_cache.save_to_disk` records pre-dequantize class names — `vllm_mlx/memory_cache.py:1249`

When a quantized entry is dequantized for `save_prompt_cache` (it needs `.state/.meta_state` that `QuantizedKVCache` doesn't expose), the on-disk file holds plain `KVCache` layers, but `cache_types` in `index.json` was being built from `entry.cache` — recording `QuantizedKVCache`. A subsequent restart **without** `--kv-cache-quantization` rejects the entry as "config changed" via `_cache_classes_compatible`, silently losing a perfectly loadable persisted cache.

Pre-dates v0.6.14 (introduced in #200, but only triggers when users actually enable `--kv-cache-quantization`).

**Fix**: read `cache_types` from `persist_cache` (post-dequantize).

### 2. `MLLMScheduler._do_abort_request` AttributeError on missing request — `vllm_mlx/mllm_scheduler.py:399`

PR #249 added a token-credit dereference to keep dashboard metrics accurate after abort, but skipped the `request is not None` guard the rest of the function uses. Late or duplicate aborts for an id that's already been popped now raise `AttributeError` before cleanup, breaking pending-abort processing.

The text scheduler at `vllm_mlx/scheduler.py:_do_abort_request` keeps the guard correctly.

**Fix**: same guard `if request is not None and request.num_output_tokens > 0`.

## Test plan

- [x] `tests/test_prefix_cache_persistence.py::test_save_to_disk_records_post_dequant_cache_types` — **fails on main**, asserts `cache_types == ['KVCache', 'KVCache']` (post-dequant), end-to-end load under unquantized config succeeds
- [x] `tests/test_mllm_continuous_batching.py::TestMLLMAbortMissingRequest` — **fails on main** with `AttributeError: 'NoneType' object has no attribute 'num_output_tokens'`
- [x] Negative control: with new tests in place but production hunks reverted, both fail with the exact error modes codex described
- [x] Broader: 66/66 in `test_prefix_cache_persistence.py` + `test_mllm_continuous_batching.py`
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)