### PR TITLE
docs: fix stale repo URLs and outdated tooling references in docs/

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -60,4 +60,4 @@ If you have a different Apple Silicon chip, please share your results:
 rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
 ```
 
-Open an issue with your results at [GitHub Issues](https://github.com/waybarrios/vllm-mlx/issues).
+Open an issue with your results at [GitHub Issues](https://github.com/raullenchai/Rapid-MLX/issues).

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -6,8 +6,8 @@ We welcome contributions to rapid-mlx!
 
 ```bash
 # Clone the repository
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
+git clone https://github.com/raullenchai/Rapid-MLX.git
+cd Rapid-MLX
 
 # Install with dev dependencies
 pip install -e ".[dev]"
@@ -31,12 +31,9 @@ pytest --cov=vllm_mlx tests/
 ### Code Style
 
 ```bash
-# Format code
-black vllm_mlx/
-isort vllm_mlx/
-
-# Type checking
-mypy vllm_mlx/
+# Lint and format
+ruff check .
+ruff format --check .
 ```
 
 ### Running Benchmarks
@@ -83,4 +80,4 @@ rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results_m4.json
 
 ## Questions?
 
-Open an issue at [GitHub Issues](https://github.com/waybarrios/vllm-mlx/issues).
+Open an issue at [GitHub Issues](https://github.com/raullenchai/Rapid-MLX/issues).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,8 +8,8 @@
 ## Install with uv (Recommended)
 
 ```bash
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
+git clone https://github.com/raullenchai/Rapid-MLX.git
+cd Rapid-MLX
 
 uv pip install -e .
 ```
@@ -17,8 +17,8 @@ uv pip install -e .
 ## Install with pip
 
 ```bash
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
+git clone https://github.com/raullenchai/Rapid-MLX.git
+cd Rapid-MLX
 
 pip install -e .
 ```


### PR DESCRIPTION
## Summary

This PR fixes **5 stale repository URLs** and **outdated tooling references** left over from the original repo name (`waybarrios/vllm-mlx` → `raullenchai/Rapid-MLX`).

### Changes

**Stale repo URLs** (3 files, 5 occurrences):
- `docs/getting-started/installation.md` — 2 clone URLs updated
- `docs/development/contributing.md` — 1 clone URL + 1 issues link updated
- `docs/benchmarks/README.md` — 1 issues link updated

**Outdated tooling** (1 file):
- `docs/development/contributing.md` — replaced `black`/`isort`/`mypy` recommendations with `ruff` (which is what the project actually uses, as configured in `pyproject.toml` and the Makefile)

### Why

New contributors following the docs would clone from the wrong repository and use the wrong formatting tools. These are clearly leftover references from before the repo was renamed/transferred.