### PR TITLE
Require auth for health management routes

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -179,6 +179,63 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/health"),
+            ("get", "/health/ready"),
+            ("post", "/v1/cache/clear"),
+            ("get", "/v1/status"),
+            ("get", "/v1/cache/stats"),
+            ("delete", "/v1/cache"),
+        ],
+    )
+    def test_health_router_requires_api_key_when_configured(self, method, path):
+        """Health, status, and cache management routes honor API auth."""
+        orig = self._patch_config(api_key="test-secret", ready=True)
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+
+            r = getattr(client, method)(path)
+
+            assert r.status_code == 401
+            assert r.json()["detail"] == "API key required"
+        finally:
+            self._restore_config(orig)
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/health"),
+            ("get", "/health/ready"),
+            ("post", "/v1/cache/clear"),
+            ("get", "/v1/status"),
+            ("get", "/v1/cache/stats"),
+            ("delete", "/v1/cache"),
+        ],
+    )
+    def test_health_router_accepts_valid_api_key(self, method, path, mock_engine):
+        """Valid Bearer token preserves access to protected management routes."""
+        orig = self._patch_config(
+            api_key="test-secret",
+            engine=mock_engine,
+            mcp_manager=None,
+            model_name="test-model",
+            ready=True,
+        )
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+
+            r = getattr(client, method)(
+                path, headers={"Authorization": "Bearer test-secret"}
+            )
+
+            assert r.status_code != 401
+        finally:
+            self._restore_config(orig)
+
     def test_status_no_engine(self):
         """Status returns not_loaded when no engine."""
         orig = self._patch_config(engine=None, model_name=None)

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -3,11 +3,12 @@
 
 import gc
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from ..config import get_config
+from ..middleware.auth import verify_api_key
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
 @router.get("/health")


### PR DESCRIPTION
## Summary
- require `verify_api_key` for the health/status/cache router when an API key is configured
- cover `/health`, `/health/ready`, `/v1/cache/clear`, `/v1/status`, `/v1/cache/stats`, and `DELETE /v1/cache` with auth regression tests
- preserve current unauthenticated behavior when no API key is configured

## Root cause
`vllm_mlx/routes/health.py` mounted its router without the authentication dependency used by the other API route modules, leaving status and cache-management endpoints callable without credentials.

## Tests
- `uv run pytest tests/test_routes.py tests/test_config_and_middleware.py`
- `uv run ruff check vllm_mlx/routes/health.py tests/test_routes.py`
- `uv run ruff format --check vllm_mlx/routes/health.py tests/test_routes.py`

Closes #189.