### PR TITLE
Fix Anthropic route authentication + support SDK x-api-key

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -104,7 +104,11 @@ rapid-mlx serve mlx-community/Qwen3-4B-4bit \
 
 ### Security
 
-When `--api-key` is set, all API requests require the `Authorization: Bearer <api-key>` header:
+When `--api-key` is set, protected API routes require the
+`Authorization: Bearer <api-key>` header. Anthropic-compatible routes
+(`/v1/messages` and `/v1/messages/count_tokens`) also accept
+`x-api-key: <api-key>` for SDK compatibility; if both headers are sent, both
+must match.
 
 ```python
 from openai import OpenAI

--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -496,6 +496,68 @@ def test_shared_rate_limit_ignores_x_api_key_for_non_anthropic_routes(
     assert second.json()["detail"].startswith("Rate limit exceeded.")
 
 
+def test_shared_rate_limit_uses_same_bearer_identity_for_anthropic_and_standard_routes(
+    anthropic_client,
+):
+    from vllm_mlx.middleware.auth import (
+        check_rate_limit,
+        check_rate_limit_or_x_api_key,
+        verify_api_key,
+        verify_api_key_or_x_api_key,
+    )
+
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    app = FastAPI()
+
+    @app.get(
+        "/standard",
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def standard_endpoint():
+        return {"ok": True}
+
+    @app.get(
+        "/anthropic",
+        dependencies=[
+            Depends(verify_api_key_or_x_api_key),
+            Depends(check_rate_limit_or_x_api_key),
+        ],
+    )
+    async def anthropic_endpoint():
+        return {"ok": True}
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer test-secret"}
+    first = client.get("/standard", headers=headers)
+    second = client.get("/anthropic", headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_shared_auth_rejects_x_api_key_for_non_anthropic_routes(
+    anthropic_client,
+):
+    from vllm_mlx.middleware.auth import verify_api_key
+
+    app = FastAPI()
+
+    @app.get("/test", dependencies=[Depends(verify_api_key)])
+    async def test_endpoint():
+        return {"ok": True}
+
+    client = TestClient(app)
+    x_api_key_only = client.get("/test", headers={"x-api-key": "test-secret"})
+    bearer = client.get("/test", headers={"Authorization": "Bearer test-secret"})
+
+    assert x_api_key_only.status_code == 401
+    assert x_api_key_only.json()["detail"] == "API key required"
+    assert bearer.status_code == 200
+
+
 def test_configure_rate_limiter_updates_shared_anthropic_dependency(
     anthropic_client,
 ):

--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Auth regressions for Anthropic-compatible HTTP routes."""
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, text: str) -> list[int]:
+        self.calls.append(text)
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+
+
+class _Engine:
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.calls = []
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        return _GenerationOutput(
+            text="hello",
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+
+def _install_lightweight_engine_modules(monkeypatch):
+    """Avoid importing MLX-backed engine package in route-level HTTP tests."""
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.anthropic",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "anthropic"),
+)
+_MISSING = object()
+
+
+@pytest.fixture
+def anthropic_client(monkeypatch):
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.routes.anthropic import router
+
+    cfg = reset_config()
+    cfg.api_key = "test-secret"
+    cfg.engine = _Engine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    app.include_router(router)
+    yield SimpleNamespace(
+        client=TestClient(app),
+        engine=cfg.engine,
+        rate_limiter=rate_limiter,
+        reset_config=reset_config,
+    )
+
+    reset_config()
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    for name, previous in previous_modules.items():
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+    for (module_name, attr), previous in previous_attrs.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if previous is _MISSING:
+            if hasattr(module, attr):
+                delattr(module, attr)
+        else:
+            setattr(module, attr, previous)
+
+
+def _messages_payload() -> dict:
+    return {
+        "model": "test-model",
+        "max_tokens": 4,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+
+def test_anthropic_messages_requires_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post("/v1/messages", json=_messages_payload())
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "API key required"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_rejects_invalid_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_rejects_invalid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"x-api-key": "wrong-secret"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_accepts_valid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"x-api-key": "test-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content"] == [{"type": "text", "text": "hello"}]
+    assert len(engine.calls) == 1
+
+
+def test_anthropic_messages_accepts_valid_bearer_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content"] == [{"type": "text", "text": "hello"}]
+    assert len(engine.calls) == 1
+
+
+def test_anthropic_messages_rejects_mixed_invalid_credentials(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={
+            "Authorization": "Bearer wrong-secret",
+            "x-api-key": "test-secret",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_rejects_mixed_invalid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={
+            "Authorization": "Bearer test-secret",
+            "x-api-key": "wrong-secret",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_respects_rate_limit(anthropic_client):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    headers = {"x-api-key": "test-secret"}
+    first = client.post("/v1/messages", json=_messages_payload(), headers=headers)
+    second = client.post("/v1/messages", json=_messages_payload(), headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_anthropic_messages_rate_limit_uses_same_identity_for_valid_headers(
+    anthropic_client,
+):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    first = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"x-api-key": "test-secret"},
+    )
+    second = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={
+            "Authorization": "Bearer test-secret",
+            "x-api-key": "test-secret",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_anthropic_messages_rate_limit_treats_x_api_key_and_bearer_as_same_key(
+    anthropic_client,
+):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    first = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"x-api-key": "test-secret"},
+    )
+    second = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_anthropic_messages_rate_limit_treats_bearer_and_x_api_key_as_same_key(
+    anthropic_client,
+):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    first = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    second = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={"x-api-key": "test-secret"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_anthropic_count_tokens_requires_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "API key required"
+    assert engine.tokenizer.calls == []
+
+
+def test_anthropic_count_tokens_rejects_invalid_bearer_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.tokenizer.calls == []
+
+
+def test_anthropic_count_tokens_rejects_invalid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={"x-api-key": "wrong-secret"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.tokenizer.calls == []
+
+
+def test_anthropic_count_tokens_rejects_mixed_invalid_bearer(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={
+            "Authorization": "Bearer wrong-secret",
+            "x-api-key": "test-secret",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.tokenizer.calls == []
+
+
+def test_anthropic_count_tokens_rejects_mixed_invalid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={
+            "Authorization": "Bearer test-secret",
+            "x-api-key": "wrong-secret",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.tokenizer.calls == []
+
+
+def test_anthropic_count_tokens_respects_rate_limit(anthropic_client):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    payload = {"messages": [{"role": "user", "content": "hello"}]}
+    headers = {"x-api-key": "test-secret"}
+    first = client.post("/v1/messages/count_tokens", json=payload, headers=headers)
+    second = client.post("/v1/messages/count_tokens", json=payload, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_anthropic_count_tokens_rate_limit_treats_header_forms_as_same_key(
+    anthropic_client,
+):
+    client = anthropic_client.client
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    payload = {"messages": [{"role": "user", "content": "hello"}]}
+    first = client.post(
+        "/v1/messages/count_tokens",
+        json=payload,
+        headers={"x-api-key": "test-secret"},
+    )
+    second = client.post(
+        "/v1/messages/count_tokens",
+        json=payload,
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_shared_rate_limit_ignores_x_api_key_for_non_anthropic_routes(
+    anthropic_client,
+):
+    from vllm_mlx.middleware.auth import check_rate_limit
+
+    anthropic_client.rate_limiter.enabled = True
+    anthropic_client.rate_limiter.requests_per_minute = 1
+
+    app = FastAPI()
+
+    @app.get("/test", dependencies=[Depends(check_rate_limit)])
+    async def test_endpoint():
+        return {"ok": True}
+
+    client = TestClient(app)
+    first = client.get("/test", headers={"x-api-key": "one"})
+    second = client.get("/test", headers={"x-api-key": "two"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_configure_rate_limiter_updates_shared_anthropic_dependency(
+    anthropic_client,
+):
+    from vllm_mlx.middleware.auth import configure_rate_limiter
+
+    configured = configure_rate_limiter(requests_per_minute=1, enabled=True)
+
+    assert configured is anthropic_client.rate_limiter
+
+    payload = {"messages": [{"role": "user", "content": "hello"}]}
+    headers = {"x-api-key": "test-secret"}
+    first = anthropic_client.client.post(
+        "/v1/messages/count_tokens", json=payload, headers=headers
+    )
+    second = anthropic_client.client.post(
+        "/v1/messages/count_tokens", json=payload, headers=headers
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"].startswith("Rate limit exceeded.")
+
+
+def test_server_startup_configures_shared_rate_limiter():
+    server_source = Path("vllm_mlx/server.py").read_text()
+    cli_source = Path("vllm_mlx/cli.py").read_text()
+
+    assert "configure_rate_limiter(args.rate_limit" in server_source
+    assert "configure_rate_limiter(args.rate_limit" in cli_source
+    assert "_rate_limiter = RateLimiter(requests_per_minute=args.rate_limit" not in (
+        server_source + cli_source
+    )
+
+
+def test_anthropic_count_tokens_accepts_valid_bearer_api_key(anthropic_client):
+    client = anthropic_client.client
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"input_tokens": 5}
+
+
+def test_anthropic_count_tokens_accepts_valid_x_api_key(anthropic_client):
+    client = anthropic_client.client
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers={"x-api-key": "test-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"input_tokens": 5}

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -98,8 +98,9 @@ def serve_command(args):
 
     # Import unified server
     from . import server
+    from .middleware.auth import configure_rate_limiter
     from .scheduler import SchedulerConfig
-    from .server import RateLimiter, app, load_model
+    from .server import app, load_model
 
     logger = logging.getLogger(__name__)
     uvicorn_log_level = server.configure_logging(args.log_level)
@@ -152,9 +153,7 @@ def serve_command(args):
     cors_origins = args.cors_origins if args.cors_origins else ["*"]
     server.configure_cors(cors_origins)
     if args.rate_limit > 0:
-        server._rate_limiter = RateLimiter(
-            requests_per_minute=args.rate_limit, enabled=True
-        )
+        server._rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
 
     # Configure GC control
     gc_control = args.gc_control and not args.no_gc_control

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -89,9 +89,12 @@ def _extract_bearer_token(authorization: str | None) -> str | None:
 
 def _rate_limit_client_id(request: Request) -> str:
     """Resolve the default client id for rate limiting."""
-    return request.headers.get(
-        "Authorization", request.client.host if request.client else "unknown"
-    )
+    authorization = request.headers.get("Authorization")
+    if authorization:
+        bearer_key = _extract_bearer_token(authorization)
+        return bearer_key or authorization
+
+    return request.client.host if request.client else "unknown"
 
 
 def _anthropic_rate_limit_client_id(request: Request) -> str:

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -64,11 +64,52 @@ class RateLimiter:
 rate_limiter = RateLimiter(requests_per_minute=60, enabled=False)
 
 
-async def check_rate_limit(request: Request):
-    """Rate limiting dependency for FastAPI."""
-    client_id = request.headers.get(
+def configure_rate_limiter(
+    requests_per_minute: int,
+    *,
+    enabled: bool = True,
+) -> RateLimiter:
+    """Configure the shared rate limiter object used by FastAPI dependencies."""
+    with rate_limiter._lock:
+        rate_limiter.requests_per_minute = requests_per_minute
+        rate_limiter.enabled = enabled
+        rate_limiter._requests.clear()
+    return rate_limiter
+
+
+def _extract_bearer_token(authorization: str | None) -> str | None:
+    """Return the raw Bearer token from an Authorization header."""
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return None
+    return token
+
+
+def _rate_limit_client_id(request: Request) -> str:
+    """Resolve the default client id for rate limiting."""
+    return request.headers.get(
         "Authorization", request.client.host if request.client else "unknown"
     )
+
+
+def _anthropic_rate_limit_client_id(request: Request) -> str:
+    """Resolve a stable client id for Anthropic-compatible API-key headers."""
+    bearer_key = _extract_bearer_token(request.headers.get("Authorization"))
+    if bearer_key:
+        return bearer_key
+
+    x_api_key = request.headers.get("x-api-key")
+    if x_api_key:
+        return x_api_key
+
+    return request.client.host if request.client else "unknown"
+
+
+async def check_rate_limit(request: Request):
+    """Rate limiting dependency for FastAPI."""
+    client_id = _rate_limit_client_id(request)
 
     allowed, retry_after = rate_limiter.is_allowed(client_id)
     if not allowed:
@@ -79,8 +120,21 @@ async def check_rate_limit(request: Request):
         )
 
 
-async def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    """Verify API key if authentication is enabled."""
+async def check_rate_limit_or_x_api_key(request: Request):
+    """Rate limiting dependency for Anthropic-compatible API-key headers."""
+    client_id = _anthropic_rate_limit_client_id(request)
+
+    allowed, retry_after = rate_limiter.is_allowed(client_id)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Rate limit exceeded. Retry after {retry_after} seconds.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+
+def _verify_api_key_values(*api_keys: str | None) -> bool:
+    """Verify one or more API key values against the configured key."""
     global _auth_warning_logged
 
     cfg = get_config()
@@ -93,8 +147,26 @@ async def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(sec
             _auth_warning_logged = True
         return True
 
-    if credentials is None:
+    provided_keys = [api_key for api_key in api_keys if api_key]
+    if not provided_keys:
         raise HTTPException(status_code=401, detail="API key required")
-    if not secrets.compare_digest(credentials.credentials, cfg.api_key):
+    if not all(
+        secrets.compare_digest(api_key, cfg.api_key) for api_key in provided_keys
+    ):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
+
+
+async def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Verify API key if authentication is enabled."""
+    bearer_key = credentials.credentials if credentials is not None else None
+    return _verify_api_key_values(bearer_key)
+
+
+async def verify_api_key_or_x_api_key(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
+    """Verify OpenAI Bearer auth or Anthropic x-api-key auth."""
+    bearer_key = credentials.credentials if credentials is not None else None
+    return _verify_api_key_values(bearer_key, request.headers.get("x-api-key"))

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
 from ..api.anthropic_adapter import anthropic_to_openai, openai_to_anthropic
@@ -29,6 +29,7 @@ from ..api.utils import (
 )
 from ..config import get_config
 from ..engine import BaseEngine
+from ..middleware.auth import check_rate_limit_or_x_api_key, verify_api_key_or_x_api_key
 from ..service.helpers import (
     _build_usage,
     _disconnect_guard,
@@ -62,7 +63,13 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 
-@router.post("/v1/messages")
+@router.post(
+    "/v1/messages",
+    dependencies=[
+        Depends(verify_api_key_or_x_api_key),
+        Depends(check_rate_limit_or_x_api_key),
+    ],
+)
 async def create_anthropic_message(
     request: Request,
 ):
@@ -202,7 +209,13 @@ async def create_anthropic_message(
     )
 
 
-@router.post("/v1/messages/count_tokens")
+@router.post(
+    "/v1/messages/count_tokens",
+    dependencies=[
+        Depends(verify_api_key_or_x_api_key),
+        Depends(check_rate_limit_or_x_api_key),
+    ],
+)
 async def count_anthropic_tokens(request: Request):
     """Count tokens for an Anthropic Messages API request."""
     body = await request.json()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -351,6 +351,7 @@ def configure_cors(origins: list[str]) -> None:
 from .middleware.auth import (  # noqa: E402
     RateLimiter,  # noqa: F401
     check_rate_limit,  # noqa: F401
+    configure_rate_limiter,  # noqa: F401
     verify_api_key,  # noqa: F401
 )
 from .middleware.auth import (
@@ -901,7 +902,7 @@ Examples:
 
     # Configure rate limiter
     if args.rate_limit > 0:
-        _rate_limiter = RateLimiter(requests_per_minute=args.rate_limit, enabled=True)
+        _rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
         logger.info(
             f"Rate limiting enabled: {args.rate_limit} requests/minute per client"
         )


### PR DESCRIPTION
## Summary

Fixes #188 by adding authentication and rate limiting to the Anthropic-compatible endpoints:

- `POST /v1/messages`
- `POST /v1/messages/count_tokens`

Both endpoints now enforce the configured `--api-key` before reaching model or tokenizer work.

## Why this shape

The original issue was that the Anthropic routes were registered without the auth dependencies used by the rest of the API surface. Adding the normal `verify_api_key` dependency would close the Bearer-token bypass, but it would also break standard Anthropic SDK clients.

The Anthropic SDK sends the configured client `api_key` as:

```text
x-api-key: <key>
```

So this PR adds an Anthropic-specific auth dependency that accepts both supported forms:

- `Authorization: Bearer <key>` for curl/OpenAI-style callers already using Rapid-MLX auth
- `x-api-key: <key>` for Anthropic SDK compatibility

The `x-api-key` behavior is intentionally scoped to the Anthropic routes. Existing OpenAI-compatible routes continue to use Bearer-only auth.

## Rate-limit behavior

The Anthropic routes use a separate rate-limit dependency so `x-api-key` can participate in rate-limit identity only on Anthropic-compatible routes. That dependency still uses the same global limiter configured by `--rate-limit`.

Bearer credentials are normalized to the raw token before rate-limit bucketing for both standard and Anthropic routes. That avoids giving the same API key separate buckets when a client alternates between OpenAI-compatible endpoints and Anthropic-compatible endpoints.

Anthropic `x-api-key` requests use the same token value as their rate-limit identity, so an Anthropic SDK caller and a Bearer caller using the same configured API key share the same bucket on Anthropic routes.

## Startup wiring

CLI and direct server startup were previously replacing a server-local `_rate_limiter` alias. FastAPI dependencies call the limiter in `vllm_mlx.middleware.auth`, so replacing only the alias would leave the dependency path on the disabled default limiter.

This PR adds `configure_rate_limiter(...)`, which mutates the shared middleware limiter in place and returns it for the existing server alias. That keeps startup behavior connected for both the existing OpenAI-compatible dependencies and the new Anthropic-specific dependency.

## Security details

- Missing credentials still return `401 API key required`.
- Wrong credentials still return `401 Invalid API key`.
- If both Bearer and `x-api-key` are present, both must match the configured key. A valid header cannot mask an invalid supported credential.
- `x-api-key` remains Anthropic-only; standard protected routes still require Bearer auth.
- Documentation now calls out the Anthropic SDK `x-api-key` compatibility explicitly.

## Tests

Added route-level regression coverage for:

- original unauthenticated `/v1/messages` bypass
- original unauthenticated `/v1/messages/count_tokens` bypass
- valid Bearer and valid `x-api-key` on both Anthropic routes
- wrong Bearer, wrong `x-api-key`, and mixed invalid credentials
- auth failures not reaching `engine.chat` or tokenizer `encode`
- rate limiting on both Anthropic routes
- rate-limit identity staying stable when Anthropic callers switch between Bearer and `x-api-key`
- Bearer rate-limit identity shared across standard and Anthropic dependencies
- standard protected routes rejecting `x-api-key` when used without Bearer auth
- shared non-Anthropic rate limiting ignoring `x-api-key`
- startup configuration mutating the shared middleware limiter used by dependencies

## Review follow-up

After the first review pass, the PR was updated to:

- accept Anthropic SDK `x-api-key` credentials in addition to Bearer auth on Anthropic routes
- configure the shared middleware rate limiter from both startup paths
- align Bearer rate-limit identity across route families
- document the route-specific `x-api-key` behavior

A read-only multi-agent review rerun found no actionable findings after the latest rate-limit identity fix.

## Validation

```text
/private/tmp/rapid-mlx-pytest-188/bin/python -m pytest tests/test_anthropic_route_auth.py -q
# 25 passed

/private/tmp/rapid-mlx-pytest-188/bin/python -m pytest tests/test_config_and_middleware.py::TestVerifyApiKey tests/test_config_and_middleware.py::TestCheckRateLimit tests/test_anthropic_route_streaming.py -q
# 9 passed

/private/tmp/rapid-mlx-pytest-188/bin/python -m pytest tests/test_server.py::TestRateLimiter tests/test_server.py::TestRateLimiterHTTPResponse -q
# 7 passed

/private/tmp/rapid-mlx-pytest-188/bin/python -m ruff check vllm_mlx/middleware/auth.py vllm_mlx/routes/anthropic.py vllm_mlx/cli.py vllm_mlx/server.py tests/test_anthropic_route_auth.py
# All checks passed

/private/tmp/rapid-mlx-pytest-188/bin/python -m ruff format --check vllm_mlx/middleware/auth.py vllm_mlx/routes/anthropic.py vllm_mlx/cli.py vllm_mlx/server.py tests/test_anthropic_route_auth.py
# 5 files already formatted

git diff --check vllm_mlx/middleware/auth.py vllm_mlx/routes/anthropic.py vllm_mlx/cli.py vllm_mlx/server.py tests/test_anthropic_route_auth.py docs/reference/cli.md
# passed
```
