### PR TITLE
install.sh: use uv when available, faster repeat installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,20 +157,34 @@ else
     "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null
 fi
 
+# Use uv for resolution + parallel downloads when available — typically 3-10x
+# faster than pip on a fresh install. Falls back to the venv's pip.
 PIP="$INSTALL_DIR/bin/pip"
+INSTALLER=("$PIP" install --prefer-binary)
+UPGRADE_INSTALLER=("$PIP" install --upgrade --prefer-binary)
+FORCE_INSTALLER=("$PIP" install --force-reinstall --prefer-binary)
+
+if command -v uv >/dev/null 2>&1; then
+    UV_PY="$INSTALL_DIR/bin/python"
+    INSTALLER=(uv pip install --python "$UV_PY")
+    UPGRADE_INSTALLER=(uv pip install --python "$UV_PY" --upgrade)
+    FORCE_INSTALLER=(uv pip install --python "$UV_PY" --reinstall)
+    dim "Using uv for fast install"
+fi
+
 case "$TARGET" in
     stable)
-        "$PIP" install --upgrade "$PYPI_PACKAGE" -q 2>/dev/null \
-            || { dim "PyPI unavailable, installing from GitHub..."; "$PIP" install "$PYPI_PACKAGE @ git+${GITHUB_REPO}" ; }
+        "${UPGRADE_INSTALLER[@]}" "$PYPI_PACKAGE" -q 2>/dev/null \
+            || { dim "PyPI unavailable, installing from GitHub..."; "${INSTALLER[@]}" "$PYPI_PACKAGE @ git+${GITHUB_REPO}" ; }
         ;;
     latest)
         info "Installing latest from GitHub..."
-        "$PIP" install --force-reinstall --no-cache-dir "$PYPI_PACKAGE @ git+${GITHUB_REPO}"
+        "${FORCE_INSTALLER[@]}" "$PYPI_PACKAGE @ git+${GITHUB_REPO}"
         ;;
     *)
         info "Installing version ${TARGET}..."
-        "$PIP" install "${PYPI_PACKAGE}==${TARGET}" -q 2>/dev/null \
-            || { dim "Version ${TARGET} not on PyPI, trying GitHub tag..."; "$PIP" install "$PYPI_PACKAGE @ git+${GITHUB_REPO}@v${TARGET}" ; }
+        "${INSTALLER[@]}" "${PYPI_PACKAGE}==${TARGET}" -q 2>/dev/null \
+            || { dim "Version ${TARGET} not on PyPI, trying GitHub tag..."; "${INSTALLER[@]}" "$PYPI_PACKAGE @ git+${GITHUB_REPO}@v${TARGET}" ; }
         ;;
 esac
 


### PR DESCRIPTION
## Summary

- Use `uv` if it's on `$PATH` for resolution + parallel downloads — typically 3-10x faster than pip on a fresh install. Falls back to the venv's pip if uv is not present, so behavior is unchanged for users without it.
- Drop `--no-cache-dir` from the `latest` target so repeat installs / version bumps reuse pip's wheel cache instead of re-downloading every dep.
- Add `--prefer-binary` defensively to avoid surprise source builds.

## Why

`curl … | install.sh | bash` currently re-downloads everything on every `bash -s latest`. uv parallelizes wheel fetches and the cache lets the second run reuse what's already on disk.

## Test plan

- [ ] `bash install.sh stable` on a fresh machine without uv (pip path)
- [ ] `bash install.sh stable` with uv on `$PATH`
- [ ] `bash install.sh latest` twice in a row — second run should be visibly faster
- [ ] `bash install.sh 0.6.15` falls back to GitHub tag if PyPI version missing

## Companion PR

The Homebrew formula in `raullenchai/homebrew-rapid-mlx` is the slower install path. Companion PR there cleans up the post-install caveats and drops `--no-cache-dir`: https://github.com/raullenchai/homebrew-rapid-mlx/pull/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)