### PR TITLE
chore(logging): silence httpx/hf_hub chatter at startup

### DIFF
--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -565,3 +565,54 @@ class TestExtractJsonFromResponse:
 
         text = "Hello, world!"
         assert extract_json_from_response(text) == text
+
+
+# ---------------------------------------------------------------------------
+# configure_logging — quiet chatty third-party loggers
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    """Verify chatty transport-layer loggers are silenced at INFO/WARNING but
+    not at DEBUG, so HF Hub / httpx noise doesn't drown out startup."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_loggers(self):
+        import logging as _logging
+
+        names = ("httpx", "httpcore", "urllib3", "huggingface_hub")
+        saved = {n: _logging.getLogger(n).level for n in names}
+        yield
+        for n, lvl in saved.items():
+            _logging.getLogger(n).setLevel(lvl)
+
+    def test_info_silences_chatty_loggers(self):
+        import logging as _logging
+
+        from vllm_mlx import server
+
+        server.configure_logging("INFO")
+        for name in ("httpx", "httpcore", "urllib3", "huggingface_hub"):
+            assert _logging.getLogger(name).level == _logging.WARNING
+
+    def test_debug_lets_chatty_loggers_through(self):
+        import logging as _logging
+
+        from vllm_mlx import server
+
+        server.configure_logging("DEBUG")
+        for name in ("httpx", "httpcore", "urllib3", "huggingface_hub"):
+            assert _logging.getLogger(name).level == _logging.NOTSET
+
+    def test_idempotent_across_level_toggles(self):
+        """INFO → DEBUG → INFO must reset chatty loggers each time."""
+        import logging as _logging
+
+        from vllm_mlx import server
+
+        server.configure_logging("INFO")
+        assert _logging.getLogger("httpx").level == _logging.WARNING
+        server.configure_logging("DEBUG")
+        assert _logging.getLogger("httpx").level == _logging.NOTSET
+        server.configure_logging("INFO")
+        assert _logging.getLogger("httpx").level == _logging.WARNING

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -137,6 +137,22 @@ def configure_logging(log_level: str) -> str:
     normalized = normalize_log_level(log_level)
     logging.getLogger().setLevel(getattr(logging, normalized, logging.INFO))
     logger.setLevel(getattr(logging, normalized, logging.INFO))
+
+    # Silence chatty transport-layer loggers unless the user explicitly asked
+    # for DEBUG. At INFO level, ``httpx`` emits one line per HF Hub request
+    # (config.json, README, every model shard), which floods startup with a
+    # screenful of pure noise before the model even loads. ``huggingface_hub``
+    # also doubles up on transfer chatter. Pinning them to WARNING leaves
+    # genuine errors visible without the per-request play-by-play.
+    #
+    # On DEBUG we explicitly reset to NOTSET so they inherit the root level,
+    # making this idempotent across repeated configure_logging() calls in the
+    # same process (test fixtures, in-process restarts).
+    chatty_loggers = ("httpx", "httpcore", "urllib3", "huggingface_hub")
+    target = logging.NOTSET if normalized == "DEBUG" else logging.WARNING
+    for name in chatty_loggers:
+        logging.getLogger(name).setLevel(target)
+
     return normalized.lower()
 
 


### PR DESCRIPTION
## Summary

At INFO log level, `httpx` emits one line per HF Hub request during model download (config.json, README, every shard's HEAD, xet-read-token GETs). On a first-time download of a 30-shard model that's a screenful of pure noise before the user can even see "Model loaded". `huggingface_hub` doubles up on transfer status.

Pin `httpx`, `httpcore`, `urllib3`, and `huggingface_hub` to WARNING in `configure_logging` whenever the requested level is anything other than DEBUG. Genuine errors (4xx/5xx) still surface; the per-request play-by-play does not.

## Why

User report (verbatim): pasting their `rapid-mlx serve deepseek-v4-flash-4bit` startup output and saying *"这个有点丑"* (this is a bit ugly). The biggest single noise source was ~30 `INFO:httpx:HTTP Request: ...` lines interleaved with the rich-style banner.

## Idempotency

On DEBUG we explicitly reset chatty loggers to `NOTSET` so they inherit the root level again. Without this, an INFO→DEBUG→INFO cycle in-process leaves the loggers stuck at WARNING. Test `test_idempotent_across_level_toggles` guards this.

## Before / after (subset of startup output)

**Before** (~30 lines like this during model load):
\`\`\`
INFO:httpx:HTTP Request: HEAD https://huggingface.co/.../resolve/.../model-00003-of-00033.safetensors "HTTP/1.1 302 Found"
INFO:httpx:HTTP Request: HEAD https://huggingface.co/.../resolve/.../model-00002-of-00033.safetensors "HTTP/1.1 302 Found"
INFO:httpx:HTTP Request: HEAD https://huggingface.co/.../resolve/.../chat_template.jinja "HTTP/1.1 307 Temporary Redirect"
... (x27 more) ...
\`\`\`

**After**: those lines are gone. Real progress (download tqdm, model-loaded banner) still renders.

## Verification

- \`pytest tests/test_server_utils.py::TestConfigureLogging -v\` — 3/3 pass
- \`ruff check && ruff format --check\` — clean

## What's NOT in this PR

- Demoting \`INFO:vllm_mlx.engine_core:MLX step thread initialized: ...\` and similar internal-state logs to DEBUG. Each is a judgment call — keeping the scope narrow to one focused change.
- Unifying the \`INFO:logger:msg\` format with the rich-style banner. Larger refactor; would not bundle.
- Suppressing HF Hub's tqdm progress bars. Genuine progress, not pure noise — leave alone.

## Versioning

\`server.py\` is not in \`version-check.yml\`'s watched paths (only \`aliases.json\`, \`model_auto_config.py\`, \`cli.py\`, \`pyproject.toml\`), so no \`pyproject.toml\` bump is needed. Will ride the next release that bumps for another reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)