### PR TITLE
fix(cli): hard-fail on insufficient disk space before downloading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.18"
+version = "0.6.19"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the pre-flight disk-space check in cli._check_disk_space.
+
+The check must: hard-fail when disk is provably insufficient, return
+silently when it can't determine size or the model is already cached,
+and respect HF_HOME via huggingface_hub.constants.HF_HUB_CACHE.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx.cli import _check_disk_space
+
+
+def _make_info(file_sizes_bytes: list[int]) -> SimpleNamespace:
+    """Build a fake huggingface_hub.ModelInfo with sibling file sizes."""
+    siblings = [SimpleNamespace(size=sz) for sz in file_sizes_bytes]
+    return SimpleNamespace(siblings=siblings, safetensors=None)
+
+
+def _fake_statvfs(free_bytes: int):
+    """Build a fake os.statvfs result with the requested free space."""
+    return SimpleNamespace(f_bavail=free_bytes // 4096, f_frsize=4096)
+
+
+class TestDiskSpaceCheck:
+    def test_aborts_when_model_too_large(self):
+        """141 GB model on 8.8 GB disk — the bug we're fixing."""
+        info = _make_info([int(141 * 1024**3)])
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch("os.statvfs", return_value=_fake_statvfs(int(8.8 * 1024**3))),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _check_disk_space("mlx-community/DeepSeek-V4-Flash-4bit")
+            assert exc.value.code == 1
+
+    def test_passes_when_disk_has_room(self):
+        info = _make_info([int(2 * 1024**3)])  # 2 GB model
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch("os.statvfs", return_value=_fake_statvfs(int(50 * 1024**3))),
+        ):
+            # Should not raise.
+            _check_disk_space("mlx-community/Qwen3-0.6B-8bit")
+
+    def test_force_skips_abort(self):
+        """With --force-disk-check (force=True), insufficient disk warns
+        but does not abort."""
+        info = _make_info([int(141 * 1024**3)])
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch("os.statvfs", return_value=_fake_statvfs(int(8.8 * 1024**3))),
+        ):
+            # Should not raise.
+            _check_disk_space("mlx-community/DeepSeek-V4-Flash-4bit", force=True)
+
+    def test_returns_silently_when_model_size_unknown(self):
+        """If HF doesn't return file sizes (gated repo, weird config),
+        we can't math the disk requirement — skip rather than guess."""
+        info = _make_info([])  # no siblings
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.model_info", return_value=info),
+        ):
+            _check_disk_space("mlx-community/Some-Model")  # no raise
+
+    def test_returns_silently_when_hf_api_fails(self):
+        """Network errors / 404s during the size query must not block
+        startup — the loader has its own 404 handler."""
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch(
+                "huggingface_hub.model_info",
+                side_effect=ConnectionError("offline"),
+            ),
+        ):
+            _check_disk_space("mlx-community/Some-Model")  # no raise
+
+    def test_skips_local_path(self, tmp_path):
+        """Local model directories don't need disk checking."""
+        local = tmp_path / "my-model"
+        local.mkdir()
+        # Should not raise even without mocking model_info — must short-circuit.
+        _check_disk_space(str(local))
+
+    def test_skips_already_cached(self):
+        """If config.json is in the cache, skip the size check entirely."""
+        with (
+            patch(
+                "huggingface_hub.try_to_load_from_cache",
+                return_value="/fake/path/config.json",
+            ),
+            patch("os.path.exists", return_value=True),
+        ):
+            # Should not raise even without mocking model_info.
+            _check_disk_space("mlx-community/Some-Model")
+
+    def test_uses_hf_hub_cache_for_statvfs(self):
+        """The probe must use HF_HUB_CACHE (respects HF_HOME), not the
+        hard-coded ~/.cache/huggingface."""
+        info = _make_info([int(2 * 1024**3)])
+        seen_paths = []
+
+        def capture_statvfs(path):
+            seen_paths.append(path)
+            return _fake_statvfs(int(50 * 1024**3))
+
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "huggingface_hub.constants.HF_HUB_CACHE",
+                "/Volumes/external/hf",
+            ),
+            patch("os.statvfs", side_effect=capture_statvfs),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: p == "/Volumes/external" or p.startswith("/"),
+            ),
+        ):
+            _check_disk_space("mlx-community/Qwen3-0.6B-8bit")
+
+        assert seen_paths, "statvfs was never called"
+        assert any(
+            "external" in p or p == "/Volumes/external" or p.startswith("/Volumes")
+            for p in seen_paths
+        ) or any(p.startswith(os.path.expanduser("~")) for p in seen_paths), (
+            f"statvfs probe path {seen_paths!r} didn't include HF_HUB_CACHE ancestor"
+        )

--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -8,7 +8,6 @@ and respect HF_HOME via huggingface_hub.constants.HF_HUB_CACHE.
 
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -106,7 +105,12 @@ class TestDiskSpaceCheck:
 
     def test_uses_hf_hub_cache_for_statvfs(self):
         """The probe must use HF_HUB_CACHE (respects HF_HOME), not the
-        hard-coded ~/.cache/huggingface."""
+        hard-coded ~/.cache/huggingface.
+
+        Asserts strictly on /Volumes — the HOME fallback only kicks in when
+        the walk-up loop runs out of ancestors, which would mask a
+        regression that drops the HF_HUB_CACHE pivot entirely.
+        """
         info = _make_info([int(2 * 1024**3)])
         seen_paths = []
 
@@ -130,9 +134,7 @@ class TestDiskSpaceCheck:
             _check_disk_space("mlx-community/Qwen3-0.6B-8bit")
 
         assert seen_paths, "statvfs was never called"
-        assert any(
-            "external" in p or p == "/Volumes/external" or p.startswith("/Volumes")
-            for p in seen_paths
-        ) or any(p.startswith(os.path.expanduser("~")) for p in seen_paths), (
-            f"statvfs probe path {seen_paths!r} didn't include HF_HUB_CACHE ancestor"
+        assert any("/Volumes" in p for p in seen_paths), (
+            f"statvfs probe path {seen_paths!r} didn't include HF_HUB_CACHE; "
+            "the HF_HOME pivot regressed and the probe fell back to $HOME."
         )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -17,76 +17,103 @@ import os
 import sys
 
 
-def _check_disk_space(model_name: str) -> None:
-    """Check if there's enough disk space to download the model.
+def _check_disk_space(model_name: str, force: bool = False) -> None:
+    """Verify there's enough disk space to download the model.
 
-    Queries HuggingFace for model repo size and compares with available space.
-    Warns (but does not block) if disk space is insufficient.
-    Skips silently if the model is already local or if the check fails.
+    Queries HuggingFace for the repo size and compares with available space
+    on the resolved HF cache filesystem (respects ``HF_HOME`` /
+    ``HF_HUB_CACHE`` rather than the hard-coded ``~/.cache/huggingface``).
+
+    Behaviour:
+
+    - Model is already a local path → return.
+    - ``config.json`` is in the cache → assume already downloaded → return.
+    - HF API call fails (offline, gated repo, etc.) → return silently. The
+      loader's 404/auth handlers will surface the real error if there is one.
+    - Determined size and disk is insufficient → print actionable error
+      and ``sys.exit(1)``. ``force=True`` warns instead of aborting.
+
+    The previous behaviour was to print a soft warning then continue. Users
+    burned 30+ minutes downloading a 141 GB model on an 8.8 GB disk before
+    HF Hub crashed with ``OSError: No space left on device``.
     """
-    import os
-    from pathlib import Path
-
-    # Skip if model is a local path that already exists
+    # Skip if model is a local path that already exists.
     if os.path.exists(model_name):
         return
 
-    # Check if model is already cached by huggingface_hub
+    # Skip if model is already in the HF cache.
     try:
         from huggingface_hub import try_to_load_from_cache
 
-        # Quick check: see if config.json is cached (implies model is downloaded)
         cached = try_to_load_from_cache(model_name, "config.json")
         if isinstance(cached, str) and os.path.exists(cached):
             return
     except Exception:
         pass
 
-    # Query HuggingFace API for model size
+    # Query HF for repo size + free space on the actual HF cache filesystem.
     try:
         from huggingface_hub import model_info
+        from huggingface_hub.constants import HF_HUB_CACHE
 
         info = model_info(model_name, files_metadata=True)
-        # safetensors_total or siblings file sizes
-        model_size_bytes = 0
-        if hasattr(info, "safetensors") and info.safetensors:
-            # Total size from safetensors metadata
-            params = info.safetensors
-            if hasattr(params, "total"):
-                # This is parameter count, not file size — use siblings instead
-                pass
-        # Sum file sizes from siblings
-        if hasattr(info, "siblings") and info.siblings:
-            for sibling in info.siblings:
-                if hasattr(sibling, "size") and sibling.size:
-                    model_size_bytes += sibling.size
-
+        model_size_bytes = sum(
+            (s.size or 0)
+            for s in (getattr(info, "siblings", None) or [])
+            if hasattr(s, "size")
+        )
         if model_size_bytes == 0:
-            return  # Can't determine size, skip check
+            return  # Can't determine size — skip rather than guess.
 
-        # Get available disk space
-        cache_dir = Path.home() / ".cache" / "huggingface"
-        stat = os.statvfs(str(cache_dir) if cache_dir.exists() else str(Path.home()))
+        # statvfs needs an existing path; HF_HUB_CACHE may not exist yet on
+        # a fresh install. Walk up to the first ancestor that does.
+        probe = HF_HUB_CACHE
+        while probe and not os.path.exists(probe):
+            parent = os.path.dirname(probe)
+            if parent == probe:
+                break
+            probe = parent
+        if not probe or not os.path.exists(probe):
+            probe = os.path.expanduser("~")
+
+        stat = os.statvfs(probe)
         available_bytes = stat.f_bavail * stat.f_frsize
+
+        # ~10% headroom for temp files during xet_get / move-into-place.
+        required_bytes = int(model_size_bytes * 1.1)
+        if available_bytes >= required_bytes:
+            return
 
         model_size_gb = model_size_bytes / (1024**3)
         available_gb = available_bytes / (1024**3)
+        need_to_free_gb = (required_bytes - available_bytes) / (1024**3)
 
-        # Need ~10% extra for temp files during download
-        required_bytes = int(model_size_bytes * 1.1)
-
-        if available_bytes < required_bytes:
-            print()
+        print()
+        print("  Error: Insufficient disk space for download.")
+        print(f"    Model size:    {model_size_gb:>7.1f} GB")
+        print(f"    Free space:    {available_gb:>7.1f} GB  ({probe})")
+        print(f"    Need to free:  {need_to_free_gb:>7.1f} GB")
+        print()
+        print("  Suggestions:")
+        print("    - Free disk space, or set HF_HOME to a drive with more room")
+        print("    - Pick a smaller variant: rapid-mlx models")
+        if not force:
             print(
-                f"  Warning: Model requires ~{model_size_gb:.1f} GB "
-                f"but only {available_gb:.1f} GB available on disk."
-            )
-            print(
-                "  The download may fail. Free up disk space or choose a smaller model."
+                "    - Bypass this check (download will likely fail mid-way): "
+                "--force-disk-check"
             )
             print()
+            sys.exit(1)
+        # ``force=True``: warn loudly, let the user proceed at their own risk.
+        print("  --force-disk-check set — proceeding anyway.")
+        print()
+    except SystemExit:
+        raise
     except Exception:
-        pass  # Non-critical — don't block startup on check failure
+        # Network / auth / etc. failures are non-critical — fall through to
+        # the loader's own error handling rather than blocking startup on a
+        # flaky HF metadata query.
+        pass
 
 
 def serve_command(args):
@@ -386,7 +413,7 @@ def serve_command(args):
         sys.exit(1)
 
     # Check disk space before downloading model
-    _check_disk_space(args.model)
+    _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
 
     # Load model with unified server
     try:
@@ -763,6 +790,15 @@ Examples:
         type=str,
         default=None,
         help="The model name used in the API. If not specified, the model argument is used.",
+    )
+    serve_parser.add_argument(
+        "--force-disk-check",
+        action="store_true",
+        help=(
+            "Skip the pre-flight disk-space check that aborts when the model "
+            "is larger than free disk. Use only if you know the HF cache lives "
+            "on a different filesystem (e.g. external drive via HF_HOME)."
+        ),
     )
     serve_parser.add_argument(
         "--host", type=str, default="0.0.0.0", help="Host to bind"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -67,7 +67,9 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
 
         # statvfs needs an existing path; HF_HUB_CACHE may not exist yet on
         # a fresh install. Walk up to the first ancestor that does.
-        probe = HF_HUB_CACHE
+        # Resolve to absolute up front so a relative HF_HUB_CACHE doesn't
+        # short-circuit to CWD when an ancestor walk hits ".".
+        probe = os.path.abspath(HF_HUB_CACHE) if HF_HUB_CACHE else ""
         while probe and not os.path.exists(probe):
             parent = os.path.dirname(probe)
             if parent == probe:
@@ -485,6 +487,8 @@ def bench_command(args):
     from .engine_core import AsyncEngineCore, EngineConfig
     from .request import SamplingParams
     from .scheduler import SchedulerConfig
+
+    _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
 
     # Handle prefix cache flags
     enable_prefix_cache = args.enable_prefix_cache and not args.disable_prefix_cache
@@ -1266,6 +1270,15 @@ Examples:
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")
     bench_parser.add_argument("model", type=str, help="Model to benchmark")
+    bench_parser.add_argument(
+        "--force-disk-check",
+        action="store_true",
+        help=(
+            "Skip the pre-flight disk-space check that aborts when the model "
+            "is larger than free disk. Use only if you know the HF cache lives "
+            "on a different filesystem (e.g. external drive via HF_HOME)."
+        ),
+    )
     bench_parser.add_argument(
         "--num-prompts", type=int, default=10, help="Number of prompts"
     )


### PR DESCRIPTION
## Repro

\`\`\`
\$ rapid-mlx serve deepseek-v4-flash-4bit
  ...
  Warning: Model requires ~141.1 GB but only 8.8 GB available on disk.
  The download may fail. Free up disk space or choose a smaller model.

INFO:vllm_mlx.server:Loading model with BatchedEngine: ...
[30 minutes of progress bars]
OSError: I/O error: IO Error: No space left on device (os error 28)
\`\`\`

The pre-flight check had the math right but was just a soft warning. Users lose 30+ min of bandwidth + partial download to a clearly preventable failure.

## Fix

Three changes to \`_check_disk_space\`:

1. **Hard-fail by default** when disk is provably insufficient. Replaces the soft warning with an actionable error block (model size, free space, exact GB to free, the cache path) + \`sys.exit(1)\`.
2. **Respect \`HF_HOME\`** via \`huggingface_hub.constants.HF_HUB_CACHE\` instead of the hard-coded \`~/.cache/huggingface\`. Users with HF cache on an external drive now get the right free-space number. \`statvfs\` walks up to the first existing ancestor (HF_HUB_CACHE may not exist on a fresh install).
3. **\`--force-disk-check\`** escape hatch on \`serve\` for the rare case where the user knows the cache lives on a filesystem we can't introspect (network mount, etc).

Silent paths preserved: local model paths, already-cached models, HF API failures, unknown model sizes — all still return without aborting.

## After

\`\`\`
\$ rapid-mlx serve deepseek-v4-flash-4bit
  Alias: deepseek-v4-flash-4bit → mlx-community/DeepSeek-V4-Flash-4bit
  ...

  Error: Insufficient disk space for download.
    Model size:      141.0 GB
    Free space:        8.8 GB  (/Users/.../.cache/huggingface/hub)
    Need to free:    146.3 GB

  Suggestions:
    - Free disk space, or set HF_HOME to a drive with more room
    - Pick a smaller variant: rapid-mlx models
    - Bypass this check (download will likely fail mid-way): --force-disk-check

[exit 1]
\`\`\`

## Tests

\`tests/test_disk_space_check.py\` — 8 tests:
- Aborts on the user's exact 141 GB / 8.8 GB scenario.
- Passes when disk has room.
- \`force=True\` warns instead of aborting.
- Silent on unknown size, HF API failure, local path, already-cached.
- Verifies \`HF_HUB_CACHE\` is the path probed (not the legacy hardcoded one).

## Versioning

Bump 0.6.18 → 0.6.19. Touches \`cli.py\` (watched path), and changes user-visible behaviour (errors instead of warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)