### PR TITLE
fix(cli): bench leaks 30-line HF stack trace on bad model

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -464,7 +464,31 @@ def bench_command(args):
 
     async def run_benchmark():
         print(f"Loading model: {args.model}")
-        model, tokenizer = load(args.model)
+        try:
+            model, tokenizer = load(args.model)
+        except Exception as e:
+            # Mirror serve_command: clean message instead of a 30-line
+            # traceback when the user typed a missing repo / bad alias.
+            from huggingface_hub.utils import RepositoryNotFoundError
+
+            is_404 = isinstance(e, RepositoryNotFoundError) or (
+                "404" in str(e) or "not found" in str(e).lower()
+            )
+            if is_404:
+                from vllm_mlx.model_aliases import suggest_similar
+
+                shown = getattr(args, "_original_alias", args.model)
+                print(f"\n  Error: Model '{shown}' not found on HuggingFace.")
+                suggestions = suggest_similar(shown)
+                if suggestions:
+                    print(f"  Did you mean: {', '.join(suggestions)}?")
+                print("  Run `rapid-mlx models` to see available aliases,")
+                print(
+                    "  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit"
+                )
+            else:
+                print(f"\n  Error loading model: {e}")
+            sys.exit(1)
 
         scheduler_config = SchedulerConfig(
             max_num_seqs=args.max_num_seqs,


### PR DESCRIPTION
## Reproduction

```
$ rapid-mlx bench totally-fake-org/Nonexistent-Model
Loading model: totally-fake-org/Nonexistent-Model
… ~30 lines of internal frames …
huggingface_hub.errors.RepositoryNotFoundError: 404 Client Error.
Repository Not Found for url: https://huggingface.co/api/models/totally-fake-org/Nonexistent-Model/revision/main
```

Same shape as the typo bug `#272` fixed for `serve`. The `bench` command had no analogous protection — `mlx_lm.load(args.model)` raises straight through to the user's terminal.

## Audit

I went through the rest of the CLI's subcommand handlers looking for the same pattern:

| Subcommand | Pattern | Status |
|------------|---------|--------|
| `serve`    | wraps `load_model` in try/except with HF 404 handler | already fixed (on main) |
| `bench`    | naked `load(args.model)` | **this PR** |
| `info`     | regex-only, never hits HF | safe |
| `models`   | lists local aliases | safe |
| `agents`   | own paths, no model load on the front edge | safe |
| `doctor`   | runs through its own driver with separate error handling | safe |

So this PR is the focused fix.

## Fix

Mirror `serve_command`'s handler verbatim — typed `RepositoryNotFoundError` check, fallback substring match for older `huggingface_hub`, alias-suggestion via `suggest_similar`, and `_original_alias` for what the user typed.

## After

```
$ rapid-mlx bench totally-fake-org/Nonexistent-Model
Loading model: totally-fake-org/Nonexistent-Model

  Error: Model 'totally-fake-org/Nonexistent-Model' not found on HuggingFace.
  Run `rapid-mlx models` to see available aliases,
  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit
```

```
$ rapid-mlx bench deepseek-v4-27b   # caught earlier by the typo guard in main()

  Error: 'deepseek-v4-27b' is not a known alias or HuggingFace path.
  Did you mean: deepseek-v4-flash-2bit, deepseek-v4-flash, deepseek-v4-flash-8bit?
  …
```

Exit 1 in both cases, no traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)