### PR TITLE
feat(cli): version + help subcommands

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1376,6 +1376,14 @@ Examples:
     # Models command
     subparsers.add_parser("models", help="List available model aliases")
 
+    # Version + help — utility commands that mirror the existing flags but
+    # are scriptable as plain subcommands.
+    subparsers.add_parser("version", help="Show version number")
+    help_parser = subparsers.add_parser("help", help="Show help for a subcommand")
+    help_parser.add_argument(
+        "subcommand", nargs="?", help="Subcommand to show help for (omit for top-level)"
+    )
+
     # Info command — show the per-model profile (parsers + capability gates)
     info_parser = subparsers.add_parser(
         "info",
@@ -1500,6 +1508,18 @@ Examples:
         bench_command(args)
     elif args.command == "models":
         models_command(args)
+    elif args.command == "version":
+        print(f"rapid-mlx {_version}")
+    elif args.command == "help":
+        target = getattr(args, "subcommand", None)
+        if not target:
+            parser.print_help()
+        elif target in subparsers.choices:
+            subparsers.choices[target].print_help()
+        else:
+            print(f"Unknown subcommand: {target}")
+            print("Run `rapid-mlx help` for the list of subcommands.")
+            sys.exit(1)
     elif args.command == "info":
         info_command(args)
     elif args.command == "agents":


### PR DESCRIPTION
## Summary

Two utility subcommands dropped from #272:

- `rapid-mlx version` — prints version number (same output as `--version`)
- `rapid-mlx help [subcommand]` — git/docker/brew-style help dispatcher

## Behavior

```
$ rapid-mlx version
rapid-mlx 0.6.19

$ rapid-mlx help                     # = --help
usage: rapid-mlx [-h] [--version]
                {serve,bench,models,version,help,info,agents,doctor} ...
…

$ rapid-mlx help serve               # = serve --help
usage: rapid-mlx serve [-h] …

$ rapid-mlx help nonsense
Unknown subcommand: nonsense
Run `rapid-mlx help` for the list of subcommands.
$ echo \$?
1
```

## Why

`version` is useful when scripting — some shells make `--`-prefixed flags awkward to interpolate, and most modern CLIs (git, docker, ollama, brew) expose both forms.

`help <cmd>` is the conventional way to discover subcommand options without remembering to add `--help` after the command name.

## Implementation note

The `help` dispatch uses `subparsers.choices` (public API since Python 3.7) to look up subparser objects by name and call their `print_help()`.

## Companion

`feat(cli): pull/rm/ps subcommands` in #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)