### PR TITLE
ci: use RELEASE_PAT for auto-release (closes #271)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -100,7 +100,13 @@ jobs:
       - name: Create tag and release
         if: steps.parse.outputs.should_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a user PAT (RELEASE_PAT) so the resulting ``release: published``
+          # event fires downstream workflows. Releases created with the default
+          # ``GITHUB_TOKEN`` are suppressed by GitHub's anti-loop guard, leaving
+          # ``publish.yml`` un-triggered and the version stranded between tag
+          # and PyPI/Homebrew. Falls back to ``GITHUB_TOKEN`` if the secret is
+          # absent so forks don't break — the release just won't auto-publish.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           # Pass untrusted strings (commit subjects from git log) via env, never
           # via ``${{ }}`` interpolation into a ``run:`` block — otherwise a
           # commit subject containing ``$(...)`` would execute on the runner


### PR DESCRIPTION
## Summary

- Switch ``auto-release.yml`` to use ``secrets.RELEASE_PAT`` (with ``GITHUB_TOKEN`` fallback) when creating the release. Fine-grained PAT scoped to ``Contents: write`` on this repo.
- Releases created by ``GITHUB_TOKEN`` don't fire downstream ``release: published`` events (GitHub's anti-loop guard), so ``publish.yml`` stays un-triggered and the new version never makes it to PyPI / Homebrew.
- Manually re-recreating the release under a user identity unblocked v0.6.16, v0.6.18, and just now v0.6.19. This PR makes that automatic.

## What this changes

```diff
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
```

Only the "Create tag and release" step. The other ``gh`` calls in the workflow (tag-existence + changelog) only use ``git`` commands locally, no API token needed.

## Why ``||`` fallback to ``GITHUB_TOKEN``

So forks of this repo don't fail when ``RELEASE_PAT`` isn't set — they'll still tag/release, just without downstream publish (which is the correct behaviour for a fork that doesn't own ``rapid-mlx`` on PyPI anyway).

## Test plan

- [x] PAT is configured as ``RELEASE_PAT`` repository secret (fine-grained, ``Contents: write`` only)
- [ ] Merge this PR and bump version to 0.6.20 → confirm release auto-publishes to PyPI + Homebrew tap with no manual delete-and-recreate

Closes #271.