### PR TITLE
feat(model): SuffixDecoding tier classification framework (#269)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,8 @@ It's still new. File an issue with `[pr_validate]` in the title and the artifact
 
 - **Add parser auto-detection** — Add a regex pattern to `vllm_mlx/model_auto_config.py` so a new model family gets the right tool/reasoning parser automatically.
 
+- **Classify a model into a SuffixDecoding tier** — After adding a `ModelConfig` entry, run `python3.12 scripts/bench_suffix_decoding_integrated.py --model <id>` (10-20 min). Paste the resulting `suffix_decoding_tier=` and `suffix_bench_speedup=` into the entry. Reference the bench output in your PR. See [docs/suffix_decoding_eligibility.md](docs/suffix_decoding_eligibility.md).
+
 - **Verify client integrations** — Test Rapid-MLX with your favorite AI tool (Cursor, Continue, Aider, LangChain, etc.) and report results.
 
 ### 🔴 Advanced

--- a/docs/suffix_decoding_eligibility.md
+++ b/docs/suffix_decoding_eligibility.md
@@ -1,0 +1,111 @@
+# SuffixDecoding eligibility — per-model classification
+
+> **Default**: `--suffix-decoding` is **OFF**. The flag is opt-in because
+> the win is workload-dependent and some models regress on plain chat.
+>
+> This page tells you whether flipping it on for *your* model is a good
+> idea.
+
+## Tier definitions
+
+| Tier | Trigger | Startup hint | What you should do |
+|---|---|---|---|
+| **AGENT** | `tool_loop ≥ 1.8x` AND `min(其余) ≥ 0.95x` | `💡 SuffixDecoding recommended for this model (tool ~Nx) — try --suffix-decoding` | Enable `--suffix-decoding` for agentic / tool-heavy traffic. |
+| **STRUCTURED** | `max ≥ 1.5x` AND `min ≥ 0.90x` | `💡 SuffixDecoding may help on structured output (~Nx peak) — try --suffix-decoding` | Worth trying if you do JSON / code generation; benchmark your own traffic. |
+| **NEUTRAL** | `min ≥ 0.95x` AND `max ≥ 1.0x` | (silent) | Leave OFF; it neither helps nor hurts. |
+| **AVOID** | any workload `< 0.85x` | `⚠️ SuffixDecoding is known to regress this model — avoid --suffix-decoding` | Leave OFF. It will measurably slow chat/tool/etc. |
+| **UNKNOWN** | not benched | (silent) | Leave OFF, or run the bench (below) and update the profile. |
+
+The hint is informational only — there is no auto-enable. The actual
+workload mix at *your* startup is unknown, so the user owns the flag.
+
+## Why this matters
+
+`--suffix-decoding` exploits repetition in the *output* token stream. It
+wins big when output is structured (JSON), agentic (tool-call loops), or
+code-edit-like (lots of token reuse from the prompt). It loses on
+free-form chat where repetition is incidental — every wasted draft is a
+small but real overhead.
+
+The same model size can land in opposite tiers depending on training
+mix:
+
+| Model | Tier | tool_loop speedup | Why |
+|---|---|---|---|
+| Qwen3-0.6B-8bit | **AGENT** | 4.6x | RLHF tuned for tool calling — output token vocabulary tightly clusters around the tool-format tokens, so the suffix tree hits often. |
+| Llama-3.2-1B-Instruct-4bit | **NEUTRAL/STRUCTURED** | 1.27x | Same size, but no tool-RLHF. Outputs more diverse, fewer suffix hits. |
+
+In other words: **size doesn't predict tier**. Bench the model you ship.
+
+## How to bench a new model
+
+```bash
+python3.12 scripts/bench_suffix_decoding_integrated.py \
+    --model mlx-community/Qwen3-0.6B-8bit \
+    --runs 3 \
+    --max-tokens 256
+```
+
+This runs four workloads (chat, json_array, tool_loop, code_edit) at
+N=3 runs each, in vanilla and `--suffix-decoding ON` modes, takes the
+median, and computes the tier. Wall-clock ~10–20 min per model on M3
+Ultra; longer on slower hardware.
+
+The result file (`evals/results/suffix_<model>.json`) shows raw TPS,
+speedup ratios, and the resulting tier:
+
+```json
+{
+  "model": "mlx-community/Qwen3-0.6B-8bit",
+  "vanilla_tps": {"chat": 280.0, "json_array": 290.0, "tool_loop": 305.0, "code_edit": 240.0},
+  "suffix_tps":  {"chat": 295.0, "json_array": 410.0, "tool_loop": 1402.0, "code_edit": 380.0},
+  "speedup":     {"chat": 1.05,  "json_array": 1.41,  "tool_loop": 4.60,    "code_edit": 1.58},
+  "tier": "agent"
+}
+```
+
+Pass `--update-profile` to also print the patch for the corresponding
+`ModelConfig` entry in `vllm_mlx/model_auto_config.py`. Paste it
+manually — the script never auto-edits source.
+
+## Currently classified models
+
+> **Status**: framework just landed; classifications are still being
+> filled in. All models default to `unknown` until benched.
+
+The first sweep (issue #269 acceptance criteria) covers:
+
+- mlx-community/Qwen3-0.6B-8bit
+- mlx-community/Qwen3-4B-4bit
+- mlx-community/Qwen3-8B-4bit
+- mlx-community/Qwen3-14B-4bit
+- mlx-community/Llama-3.2-1B-Instruct-4bit
+- mlx-community/Llama-3.1-8B-Instruct-4bit
+- mlx-community/SmolLM3-3B-4bit
+
+Hybrid arches (Qwen3.5/3.6, Granite4, Qwopus) are gated upstream by
+`supports_spec_decode=False` and stay `n/a (hybrid arch)`.
+
+## FAQ
+
+**Why not auto-enable AGENT-tier models?**
+Because the *traffic mix* at your startup is unknown. A model classified
+AGENT may still see chat-only requests in your deployment, where the
+tier-defining `tool_loop` win never applies. Default-OFF is conservative
+and predictable.
+
+**Why does model size not determine the tier?**
+See the Qwen3-0.6B vs Llama-3.2-1B example above. Tier is determined by
+output-token *predictability*, which is a function of training data and
+RLHF — not parameter count.
+
+**When do tiers re-bench?**
+On meaningful upstream version bumps (`mlx`, `mlx-lm`, the model
+release itself). There's no automatic schedule; CI doesn't gate on
+tier values changing. Track via the result JSON timestamps under
+`evals/results/`.
+
+**Will the boundaries (`1.8x`, `1.5x`, `0.85x`, ...) change?**
+They're tunable in `vllm_mlx/model_auto_config.py::classify_suffix_decoding_tier`.
+If you adjust them, also re-classify every model — the boundaries are
+fixed across the registry by design (fairness + stability).

--- a/evals/results/suffix_bonsai-1.7b.json
+++ b/evals/results/suffix_bonsai-1.7b.json
@@ -1,0 +1,24 @@
+{
+  "model": "bonsai-1.7b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 92.3,
+    "json_array": 93.8,
+    "tool_loop": 87.0,
+    "code_edit": 88.7
+  },
+  "suffix_tps": {
+    "chat": 91.6,
+    "json_array": 93.3,
+    "tool_loop": 96.1,
+    "code_edit": 90.8
+  },
+  "speedup": {
+    "chat": 0.992,
+    "json_array": 0.995,
+    "tool_loop": 1.105,
+    "code_edit": 1.023
+  },
+  "tier": "neutral"
+}

--- a/evals/results/suffix_hermes3-8b.json
+++ b/evals/results/suffix_hermes3-8b.json
@@ -1,0 +1,24 @@
+{
+  "model": "hermes3-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 96.4,
+    "json_array": 98.2,
+    "tool_loop": 96.0,
+    "code_edit": 93.7
+  },
+  "suffix_tps": {
+    "chat": 94.7,
+    "json_array": 96.5,
+    "tool_loop": 97.2,
+    "code_edit": 95.3
+  },
+  "speedup": {
+    "chat": 0.983,
+    "json_array": 0.982,
+    "tool_loop": 1.012,
+    "code_edit": 1.018
+  },
+  "tier": "neutral"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.21"
+version = "0.6.22"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/bench_suffix_decoding_integrated.py
+++ b/scripts/bench_suffix_decoding_integrated.py
@@ -254,6 +254,12 @@ def start_server(model: str, port: int, suffix_decoding: bool) -> ServerHandle:
         str(port),
         "--log-level",
         "WARNING",
+        # Determinism: disable prefix cache so the second/third run of the
+        # same workload doesn't replay cached generation. Without this,
+        # disk-persisted entries from prior sessions can pin TPS to bogus
+        # 1000+ tok/s outliers (decode_time goes to ~0). The bench is
+        # measuring the suffix-decoding optimization, not cache reuse.
+        "--disable-prefix-cache",
     ]
     if suffix_decoding:
         cmd.append("--suffix-decoding")
@@ -351,6 +357,12 @@ def run_workload(
 
     total = time.perf_counter() - t0
     if completion_tokens is None or completion_tokens <= 0:
+        return 0.0
+    # Discard runs where the model bailed in fewer than 32 tokens — decode
+    # time is dominated by per-request overhead, not generation, and TPS
+    # becomes meaningless. Returning 0 makes the median() filter these out
+    # naturally if at least one of the 3 runs is healthy.
+    if completion_tokens < 32:
         return 0.0
     decode_time = max(total - (ttft or 0.0), 1e-6)
     return completion_tokens / decode_time

--- a/scripts/bench_suffix_decoding_integrated.py
+++ b/scripts/bench_suffix_decoding_integrated.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Integrated SuffixDecoding eligibility bench (issue #269).
+
+Purpose: classify a model into a SuffixDecoding *tier* by measuring the
+speedup (or regression) it gets from ``--suffix-decoding`` on four
+representative workloads:
+
+    chat        — open-ended assistant turn (low repetition)
+    json_array  — structured output (medium repetition)
+    tool_loop   — agentic tool-call loop (high repetition)
+    code_edit   — code editing diff (high repetition)
+
+The classifier in ``vllm_mlx.model_auto_config.classify_suffix_decoding_tier``
+turns the resulting ``{workload: speedup}`` dict into one of:
+
+    agent / structured / neutral / avoid / unknown
+
+Workflow:
+    1. Start a server with the model and ``--suffix-decoding`` OFF.
+    2. Run all four workloads × N=3 runs × ``--max-tokens`` tokens.
+    3. Stop the server; restart with ``--suffix-decoding`` ON.
+    4. Repeat workload runs.
+    5. Compute median TPS per (workload, mode); ratio = ON / OFF.
+    6. Classify; print summary; optionally write tier + speedup_dict
+       into the corresponding ``ModelConfig`` entry in
+       ``vllm_mlx/model_auto_config.py`` via ``--update-profile``.
+
+Sequential server lifecycles avoid GPU contention; total wall-clock is
+~10-20 min per model on M3 Ultra.
+
+Usage:
+    python3.12 scripts/bench_suffix_decoding_integrated.py \\
+        --model mlx-community/Qwen3-0.6B-8bit \\
+        --max-tokens 256 --runs 3
+
+    # Update the model_auto_config.py entry in-place after a run:
+    python3.12 scripts/bench_suffix_decoding_integrated.py \\
+        --model mlx-community/Qwen3-0.6B-8bit \\
+        --update-profile
+
+This script is intentionally *opinionated* about the four workloads: the
+tier table in #269 was tuned for these exact prompts. Editing them
+silently shifts every model's classification. If you want to extend with
+a fifth workload, update ``WORKLOADS`` here AND the boundaries in
+``classify_suffix_decoding_tier``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from vllm_mlx.model_auto_config import (  # noqa: E402
+    classify_suffix_decoding_tier,
+)
+
+logger = logging.getLogger("bench_suffix")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+# ---- Workload definitions -------------------------------------------------
+#
+# Each workload is a chat-completions request body sans the model field.
+# Token budget per workload is bounded by ``--max-tokens``; the *prompt*
+# size below is fixed so changing budget doesn't shift acceptance rates.
+
+CHAT_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Write a short, friendly explanation of why the sky appears "
+                "blue. Two paragraphs, no bullet points."
+            ),
+        }
+    ],
+}
+
+JSON_ARRAY_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Return a JSON array of exactly 12 objects, each with the "
+                "fields ``id`` (integer 1..12), ``name`` (a short fruit "
+                "name) and ``color`` (a CSS color name). Output JSON only, "
+                "no commentary."
+            ),
+        }
+    ],
+}
+
+TOOL_LOOP_WORKLOAD = {
+    "messages": [
+        {
+            "role": "system",
+            "content": (
+                "You are a data-pipeline assistant. Use the tools "
+                "exactly when needed. Always end with a tool call to "
+                "``submit_summary`` once data has been fetched, parsed, "
+                "validated and written."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Build a fresh export of the ``invoices`` table for "
+                "Q1 2026. Read the latest snapshot, parse it, validate "
+                "row counts, write the result to S3, and finalize."
+            ),
+        },
+    ],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_snapshot",
+                "description": "Read latest data snapshot",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"table": {"type": "string"}},
+                    "required": ["table"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "parse_rows",
+                "description": "Parse rows",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"format": {"type": "string"}},
+                    "required": ["format"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "validate_counts",
+                "description": "Validate row counts vs expected",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"expected": {"type": "integer"}},
+                    "required": ["expected"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "write_s3",
+                "description": "Write export to S3",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                    "required": ["key"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "submit_summary",
+                "description": "Final summary, terminates the loop",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"status": {"type": "string"}},
+                    "required": ["status"],
+                },
+            },
+        },
+    ],
+    "tool_choice": "auto",
+}
+
+CODE_EDIT_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Below is a Python function. Replace the bare ``except:`` "
+                "with ``except Exception as e:`` and log the error using "
+                "``logger.exception``. Return the entire updated function "
+                "as a fenced code block.\n\n"
+                "```python\n"
+                "def fetch(url):\n"
+                "    try:\n"
+                "        return httpx.get(url, timeout=5).json()\n"
+                "    except:\n"
+                "        return None\n"
+                "```"
+            ),
+        }
+    ],
+}
+
+WORKLOADS: dict[str, dict] = {
+    "chat": CHAT_WORKLOAD,
+    "json_array": JSON_ARRAY_WORKLOAD,
+    "tool_loop": TOOL_LOOP_WORKLOAD,
+    "code_edit": CODE_EDIT_WORKLOAD,
+}
+
+
+# ---- Server lifecycle -----------------------------------------------------
+
+
+@dataclass
+class ServerHandle:
+    proc: subprocess.Popen
+    base_url: str
+    model: str
+
+    def stop(self) -> None:
+        try:
+            self.proc.send_signal(signal.SIGINT)
+            self.proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+
+
+def start_server(model: str, port: int, suffix_decoding: bool) -> ServerHandle:
+    """Spin up ``rapid-mlx serve`` and wait for /v1/models to answer.
+
+    ``suffix_decoding=True`` adds the ``--suffix-decoding`` flag. Logs go
+    to a temp file so the parent process isn't drowned in startup noise.
+    """
+    log_path = f"/tmp/bench_suffix_{port}.log"
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        model,
+        "--port",
+        str(port),
+        "--log-level",
+        "WARNING",
+    ]
+    if suffix_decoding:
+        cmd.append("--suffix-decoding")
+
+    logger.info("  starting server: port=%d suffix_decoding=%s", port, suffix_decoding)
+    logf = open(log_path, "w")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=logf,
+        stderr=subprocess.STDOUT,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    base_url = f"http://127.0.0.1:{port}/v1"
+    deadline = time.time() + 600  # 10 min for cold cache + Metal compile
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            logf.close()
+            logger.error("  server exited; tail of %s:", log_path)
+            # Read the last ~30 lines directly instead of os.system("tail …")
+            # — no shell, no injection surface, and the server-died code path
+            # benefits from being silent on Windows where ``tail`` is absent.
+            try:
+                with open(log_path) as f:
+                    tail_lines = f.readlines()[-30:]
+                for line in tail_lines:
+                    logger.error("    %s", line.rstrip())
+            except OSError as e:
+                logger.error("    (could not read log: %s)", e)
+            raise RuntimeError("server died during startup")
+        try:
+            r = httpx.get(f"{base_url}/models", timeout=2.0)
+            if r.status_code == 200:
+                logger.info("  server up at %s", base_url)
+                return ServerHandle(proc=proc, base_url=base_url, model=model)
+        except Exception:
+            pass
+        time.sleep(2)
+
+    proc.kill()
+    raise RuntimeError(f"server did not become ready within deadline (port={port})")
+
+
+# ---- Workload execution ---------------------------------------------------
+
+
+def run_workload(
+    handle: ServerHandle,
+    workload_body: dict,
+    max_tokens: int,
+) -> float:
+    """Run one request and return decode TPS (completion tokens / decode time).
+
+    Streams to capture TTFT, then derives decode time from
+    ``usage.completion_tokens`` divided by (total_time - ttft).
+    """
+    payload = {
+        "model": handle.model,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        **workload_body,
+    }
+    t0 = time.perf_counter()
+    ttft: float | None = None
+    completion_tokens: int | None = None
+
+    with httpx.stream(
+        "POST",
+        f"{handle.base_url}/chat/completions",
+        json=payload,
+        timeout=300.0,
+    ) as r:
+        for line in r.iter_lines():
+            if not line or not line.startswith("data: "):
+                continue
+            blob = line[len("data: ") :]
+            if blob.strip() == "[DONE]":
+                break
+            try:
+                obj = json.loads(blob)
+            except json.JSONDecodeError:
+                continue
+            # First content delta sets TTFT.
+            if ttft is None:
+                choices = obj.get("choices") or []
+                if choices and (
+                    choices[0].get("delta", {}).get("content")
+                    or choices[0].get("delta", {}).get("tool_calls")
+                ):
+                    ttft = time.perf_counter() - t0
+            usage = obj.get("usage")
+            if usage and usage.get("completion_tokens") is not None:
+                completion_tokens = int(usage["completion_tokens"])
+
+    total = time.perf_counter() - t0
+    if completion_tokens is None or completion_tokens <= 0:
+        return 0.0
+    decode_time = max(total - (ttft or 0.0), 1e-6)
+    return completion_tokens / decode_time
+
+
+# ---- Driver ---------------------------------------------------------------
+
+
+def bench_one_mode(
+    model: str,
+    port: int,
+    suffix_decoding: bool,
+    runs: int,
+    max_tokens: int,
+) -> dict[str, float]:
+    """Median decode TPS per workload, for one (vanilla|suffix) mode."""
+    handle = start_server(model, port, suffix_decoding)
+    try:
+        # 1 warmup run that we discard — covers Metal kernel JIT, cache
+        # population, and tokenizer load.
+        run_workload(handle, WORKLOADS["chat"], max_tokens=32)
+        results: dict[str, float] = {}
+        for name, body in WORKLOADS.items():
+            samples: list[float] = []
+            for i in range(runs):
+                tps = run_workload(handle, body, max_tokens=max_tokens)
+                logger.info(
+                    "  [%s] %s run %d/%d: %.1f tok/s",
+                    "ON " if suffix_decoding else "OFF",
+                    name,
+                    i + 1,
+                    runs,
+                    tps,
+                )
+                samples.append(tps)
+            results[name] = median(samples)
+        return results
+    finally:
+        handle.stop()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bench SuffixDecoding eligibility for one model."
+    )
+    parser.add_argument("--model", required=True, help="HF repo or alias")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--runs", type=int, default=3, help="runs per workload")
+    parser.add_argument("--port", type=int, default=8765, help="ephemeral port")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON result file (defaults to evals/results/suffix_<model>.json)",
+    )
+    parser.add_argument(
+        "--update-profile",
+        action="store_true",
+        help=(
+            "After classifying, print the patch that would update the "
+            "model_auto_config.py entry. Does NOT auto-edit the source — "
+            "shows the tier + dict so the user can paste it in."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    logger.info("Bench: %s", args.model)
+
+    logger.info("--- vanilla (suffix_decoding=OFF) ---")
+    vanilla = bench_one_mode(
+        args.model,
+        args.port,
+        suffix_decoding=False,
+        runs=args.runs,
+        max_tokens=args.max_tokens,
+    )
+
+    logger.info("--- suffix decoding ON ---")
+    suffix = bench_one_mode(
+        args.model,
+        args.port,
+        suffix_decoding=True,
+        runs=args.runs,
+        max_tokens=args.max_tokens,
+    )
+
+    speedup = {
+        name: round(suffix[name] / vanilla[name], 3) if vanilla[name] > 0 else 0.0
+        for name in WORKLOADS
+    }
+    tier = classify_suffix_decoding_tier(speedup)
+
+    summary = {
+        "model": args.model,
+        "max_tokens": args.max_tokens,
+        "runs": args.runs,
+        "vanilla_tps": {k: round(v, 1) for k, v in vanilla.items()},
+        "suffix_tps": {k: round(v, 1) for k, v in suffix.items()},
+        "speedup": speedup,
+        "tier": tier,
+    }
+
+    output = args.output or REPO_ROOT / "evals/results" / (
+        f"suffix_{args.model.replace('/', '_').lower()}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2) + "\n")
+    logger.info("--- summary ---")
+    for k, v in speedup.items():
+        marker = "↑" if v >= 1.05 else ("↓" if v <= 0.95 else "·")
+        logger.info("  %-12s %5.2fx %s", k, v, marker)
+    logger.info("  tier: %s", tier)
+    logger.info("  written: %s", output)
+
+    if args.update_profile:
+        sd_keys = ", ".join(f'"{k}": {v}' for k, v in speedup.items())
+        logger.info("\nPatch for ModelConfig in vllm_mlx/model_auto_config.py:")
+        logger.info('    suffix_decoding_tier="%s",', tier)
+        logger.info("    suffix_bench_speedup={%s},", sd_keys)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SuffixDecoding tier classification (#269)."""
+
+from __future__ import annotations
+
+from vllm_mlx.model_auto_config import (
+    ModelConfig,
+    classify_suffix_decoding_tier,
+    format_profile_table,
+    suffix_decoding_hint,
+)
+
+
+class TestClassifyTier:
+    """Pure-function tests for the tier boundary logic."""
+
+    def test_empty_input_is_unknown(self):
+        assert classify_suffix_decoding_tier({}) == "unknown"
+
+    def test_qwen3_06b_is_agent(self):
+        # Real numbers from evals/results/SUFFIX_POC_REPORT.md
+        speedup = {
+            "chat": 1.05,
+            "json_array": 1.41,
+            "tool_loop": 4.60,
+            "code_edit": 1.58,
+        }
+        assert classify_suffix_decoding_tier(speedup) == "agent"
+
+    def test_qwen3_14b_is_agent(self):
+        # tool_loop 1.99x (>=1.8) AND others all >= 0.95
+        speedup = {
+            "chat": 0.98,
+            "json_array": 1.20,
+            "tool_loop": 1.99,
+            "code_edit": 1.30,
+        }
+        assert classify_suffix_decoding_tier(speedup) == "agent"
+
+    def test_llama_no_tool_rlhf_is_structured_when_some_workload_wins(self):
+        speedup = {
+            "chat": 0.97,
+            "json_array": 1.55,
+            "tool_loop": 1.27,
+            "code_edit": 1.40,
+        }
+        # tool_loop < 1.8 → not AGENT.  max=1.55 >= 1.5 AND min=0.97 >= 0.90 → STRUCTURED.
+        assert classify_suffix_decoding_tier(speedup) == "structured"
+
+    def test_no_workload_wins_but_no_regression_is_neutral(self):
+        speedup = {"chat": 0.99, "tool_loop": 1.02, "json_array": 1.00}
+        assert classify_suffix_decoding_tier(speedup) == "neutral"
+
+    def test_any_regression_is_avoid(self):
+        # tool_loop wins big but chat regresses → AVOID. The regression
+        # dominates because we don't know the user's traffic mix.
+        speedup = {"chat": 0.78, "tool_loop": 3.0, "json_array": 1.5}
+        assert classify_suffix_decoding_tier(speedup) == "avoid"
+
+    def test_avoid_threshold_is_strict_lt_0_85(self):
+        # <0.85 → AVOID (regression dominates).
+        assert classify_suffix_decoding_tier({"chat": 0.84}) == "avoid"
+        # 0.85 escapes the AVOID-from-low-lo trip but doesn't clear
+        # STRUCTURED's 0.90 floor either, so it falls through into the
+        # mixed-signal AVOID at the end. That's the intended behavior:
+        # being "just above the regression threshold" is not enough to
+        # recommend the flag.
+        assert classify_suffix_decoding_tier({"chat": 0.85, "x": 1.6}) == "avoid"
+        # Clearing the STRUCTURED floor (0.90) flips to STRUCTURED.
+        assert classify_suffix_decoding_tier({"chat": 0.90, "x": 1.6}) == "structured"
+
+    def test_agent_requires_others_dont_regress(self):
+        # tool_loop=2x but code_edit dropped to 0.92 → fails AGENT's
+        # ``min(others) >= 0.95`` gate. Falls through positive buckets
+        # and lands on AVOID rather than silently shipping a regression.
+        speedup = {"tool_loop": 2.0, "chat": 1.0, "code_edit": 0.92, "json_array": 1.1}
+        # 0.92 >= 0.85 so not AVOID-from-regression… but 0.92 < 0.95 so
+        # not AGENT… max=2.0 >= 1.5 AND min=0.92 >= 0.90 → STRUCTURED.
+        assert classify_suffix_decoding_tier(speedup) == "structured"
+
+    def test_agent_requires_tool_loop_specifically(self):
+        # max workload is "json_array" 2x; tool_loop is 1.0. Even though
+        # max > 1.8 globally, AGENT specifically needs *tool_loop* to win
+        # (otherwise the agent label is misleading).
+        speedup = {"tool_loop": 1.0, "chat": 1.0, "json_array": 2.0, "code_edit": 1.0}
+        assert classify_suffix_decoding_tier(speedup) == "structured"
+
+    def test_single_workload_dict(self):
+        # A degenerate single-workload bench shouldn't crash; if the only
+        # workload is tool_loop ≥ 1.8x, return AGENT regardless of
+        # ``min(others)`` (which is empty).
+        assert classify_suffix_decoding_tier({"tool_loop": 2.5}) == "agent"
+
+
+class TestSuffixDecodingHint:
+    """The startup hint surfaces only AGENT/STRUCTURED/AVOID — not
+    UNKNOWN or NEUTRAL — to keep ``rapid-mlx serve`` startup quiet."""
+
+    def test_no_cfg_no_hint(self):
+        assert suffix_decoding_hint(None) is None
+
+    def test_unknown_is_silent(self):
+        cfg = ModelConfig(suffix_decoding_tier="unknown")
+        assert suffix_decoding_hint(cfg) is None
+
+    def test_neutral_is_silent(self):
+        cfg = ModelConfig(suffix_decoding_tier="neutral")
+        assert suffix_decoding_hint(cfg) is None
+
+    def test_agent_recommends(self):
+        cfg = ModelConfig(
+            suffix_decoding_tier="agent",
+            suffix_bench_speedup={"chat": 1.05, "tool_loop": 4.6},
+        )
+        hint = suffix_decoding_hint(cfg)
+        assert hint is not None
+        assert "recommended" in hint.lower()
+        assert "4.6" in hint  # surfaces the actual tool win
+
+    def test_structured_recommends(self):
+        cfg = ModelConfig(
+            suffix_decoding_tier="structured",
+            suffix_bench_speedup={"chat": 0.97, "json_array": 1.55},
+        )
+        hint = suffix_decoding_hint(cfg)
+        assert hint is not None
+        assert "structured" in hint.lower() or "may help" in hint.lower()
+
+    def test_avoid_warns(self):
+        cfg = ModelConfig(
+            suffix_decoding_tier="avoid",
+            suffix_bench_speedup={"chat": 0.78},
+        )
+        hint = suffix_decoding_hint(cfg)
+        assert hint is not None
+        assert "regress" in hint.lower() or "avoid" in hint.lower()
+
+    def test_hybrid_no_hint_even_if_tier_is_agent(self):
+        """If the safety gate ``supports_spec_decode=False`` is set, we
+        must not nudge the user toward a flag that's silently ignored."""
+        cfg = ModelConfig(
+            supports_spec_decode=False,
+            suffix_decoding_tier="agent",
+            suffix_bench_speedup={"tool_loop": 2.5},
+        )
+        assert suffix_decoding_hint(cfg) is None
+
+
+class TestProfileTableCell:
+    """The Level 2 ``rapid-mlx info`` table must surface the tier without
+    crashing on edge cases (no bench data, hybrid models, missing fields)."""
+
+    def test_unknown_mentions_bench_script(self):
+        cfg = ModelConfig()  # default unknown, empty dict
+        table = format_profile_table("test/Model", cfg)
+        assert "Suffix tier" in table
+        assert "unknown" in table.lower()
+        assert "bench_suffix_decoding_integrated" in table
+
+    def test_hybrid_says_n_a(self):
+        cfg = ModelConfig(supports_spec_decode=False, is_hybrid=True)
+        table = format_profile_table("test/HybridModel", cfg)
+        assert "n/a" in table.lower()
+        assert "hybrid" in table.lower()
+
+    def test_agent_shows_tool_loop_speedup(self):
+        cfg = ModelConfig(
+            suffix_decoding_tier="agent",
+            suffix_bench_speedup={"chat": 1.05, "tool_loop": 4.6, "json_array": 1.41},
+        )
+        table = format_profile_table("test/AgentModel", cfg)
+        # Should pick the peak workload (tool_loop here).
+        assert "tool_loop" in table
+        assert "4.6" in table
+
+    def test_avoid_shows_worst_workload(self):
+        cfg = ModelConfig(
+            suffix_decoding_tier="avoid",
+            suffix_bench_speedup={"chat": 0.78, "tool_loop": 1.5},
+        )
+        table = format_profile_table("test/AvoidModel", cfg)
+        # AVOID surfaces the regression, not the peak.
+        assert "chat" in table
+        assert "0.78" in table
+
+
+class TestModelConfigDefaults:
+    """Backward compatibility: existing ``ModelConfig`` constructions
+    must not regress when the new fields default in."""
+
+    def test_default_tier_is_unknown(self):
+        assert ModelConfig().suffix_decoding_tier == "unknown"
+
+    def test_default_speedup_dict_is_empty_not_none(self):
+        # ``None`` would crash hint/table code that does ``or {}``;
+        # default-empty-dict avoids the conditional and keeps semantics
+        # ("we have no data" reads cleanly as ``not cfg.suffix_bench_speedup``).
+        cfg = ModelConfig()
+        assert cfg.suffix_bench_speedup == {}
+
+    def test_each_modelconfig_gets_its_own_dict(self):
+        """``field(default_factory=dict)`` regression test — using a
+        bare ``dict()`` literal as the default would share the same
+        dict across all ModelConfig instances."""
+        a = ModelConfig()
+        b = ModelConfig()
+        a.suffix_bench_speedup["chat"] = 1.0
+        assert b.suffix_bench_speedup == {}, (
+            "ModelConfig instances must not share dict state"
+        )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -123,7 +123,14 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "neutral",
+    "suffix_bench_speedup": {
+      "chat": 0.983,
+      "json_array": 0.982,
+      "tool_loop": 1.012,
+      "code_edit": 1.018
+    }
   },
   "gemma-4-26b": {
     "hf_path": "mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -326,7 +333,14 @@
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "neutral",
+    "suffix_bench_speedup": {
+      "chat": 0.992,
+      "json_array": 0.995,
+      "tool_loop": 1.105,
+      "code_edit": 1.023
+    }
   },
   "bonsai-4b": {
     "hf_path": "prism-ml/Bonsai-4B-unpacked",

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -191,6 +191,7 @@ class EngineCore:
             enrich_model_config,
             format_profile_summary,
             format_profile_table,
+            suffix_decoding_hint,
         )
 
         model_path = (
@@ -223,6 +224,12 @@ class EngineCore:
                 display_path, self.model_config
             ).splitlines():
                 logger.info(line)
+
+        # SuffixDecoding eligibility hint — silent for unknown/neutral tiers
+        # so this only fires when the bench has data worth surfacing.
+        hint = suffix_decoding_hint(self.model_config)
+        if hint:
+            logger.info(hint)
 
         logger.debug(f"Engine {self._engine_id} initialized")
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -43,6 +43,13 @@ class AliasProfile:
     is_hybrid: bool = False
     supports_spec_decode: bool = True
     default_max_tokens: int | None = None
+    # SuffixDecoding eligibility — populated from cross-model bench (issue #269).
+    # ``None`` for ``suffix_bench_speedup`` means "not benched yet"; the tier
+    # then defaults to ``"unknown"`` and the startup hint stays silent.
+    # When populated, ``suffix_bench_speedup`` is a tuple of ``(workload, speedup)``
+    # pairs (tuple, not dict, so frozen dataclass instances stay safely shareable).
+    suffix_decoding_tier: str = "unknown"
+    suffix_bench_speedup: tuple[tuple[str, float], ...] | None = None
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -72,6 +79,25 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: 'hf_path' must be a non-empty string, "
             f"got {type(hf_path).__name__}={hf_path!r}"
         )
+    raw_speedup = value.get("suffix_bench_speedup")
+    speedup: tuple[tuple[str, float], ...] | None
+    if raw_speedup is None:
+        speedup = None
+    elif isinstance(raw_speedup, dict):
+        try:
+            speedup = tuple(sorted((k, float(v)) for k, v in raw_speedup.items()))
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"alias {alias!r}: suffix_bench_speedup values must be numbers"
+            ) from e
+    else:
+        raise ValueError(
+            f"alias {alias!r}: suffix_bench_speedup must be an object, "
+            f"got {type(raw_speedup).__name__}"
+        )
+    tier = value.get("suffix_decoding_tier", "unknown")
+    if not isinstance(tier, str):
+        raise ValueError(f"alias {alias!r}: suffix_decoding_tier must be a string")
     return AliasProfile(
         hf_path=hf_path,
         tool_call_parser=value.get("tool_call_parser"),
@@ -79,6 +105,8 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         is_hybrid=bool(value.get("is_hybrid", False)),
         supports_spec_decode=bool(value.get("supports_spec_decode", True)),
         default_max_tokens=value.get("default_max_tokens"),
+        suffix_decoding_tier=tier,
+        suffix_bench_speedup=speedup,
     )
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -24,7 +24,7 @@ specific first.
 
 import logging
 import re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from .model_aliases import resolve_profile
@@ -62,6 +62,18 @@ class ModelConfig:
     # Pure-attention models (llama, qwen3, mistral, gemma3, gpt-oss,
     # phi, ...) are safe.
     supports_spec_decode: bool = True
+
+    # SuffixDecoding eligibility tier (#269). One of:
+    #   "unknown"    — not benched (silent default)
+    #   "agent"      — tool_loop ≥ 1.8x, no regression — recommend the flag
+    #   "structured" — peak workload ≥ 1.5x, no regression — may help
+    #   "neutral"    — no workload wins, no regression — silent
+    #   "avoid"      — at least one workload regresses — warn
+    suffix_decoding_tier: str = "unknown"
+    # Per-workload speedup measured by ``scripts/bench_suffix_decoding_integrated.py``.
+    # ``field(default_factory=dict)`` so each ``ModelConfig`` instance gets
+    # its own fresh dict (a literal ``{}`` would silently share state).
+    suffix_bench_speedup: dict[str, float] = field(default_factory=dict)
 
 
 # Model family patterns → optimal config.
@@ -327,7 +339,14 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             f"tool_call_parser={profile.tool_call_parser}, "
             f"reasoning_parser={profile.reasoning_parser}, "
             f"is_hybrid={profile.is_hybrid}, "
-            f"supports_spec_decode={profile.supports_spec_decode}"
+            f"supports_spec_decode={profile.supports_spec_decode}, "
+            f"suffix_tier={profile.suffix_decoding_tier}"
+        )
+        # AliasProfile stores the bench dict as a sorted tuple (frozen
+        # dataclasses must avoid mutable shared state). Materialize a
+        # fresh dict here so each ModelConfig instance owns its copy.
+        speedup = (
+            dict(profile.suffix_bench_speedup) if profile.suffix_bench_speedup else {}
         )
         return ModelConfig(
             tool_call_parser=profile.tool_call_parser,
@@ -335,6 +354,8 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             default_max_tokens=profile.default_max_tokens,
             is_hybrid=profile.is_hybrid,
             supports_spec_decode=profile.supports_spec_decode,
+            suffix_decoding_tier=profile.suffix_decoding_tier,
+            suffix_bench_speedup=speedup,
         )
 
     for pattern, config in _MODEL_PATTERNS:
@@ -408,11 +429,147 @@ def enrich_model_config(cfg: ModelConfig | None, model: Any) -> ModelConfig:
 #             can see capabilities without launching a server.
 
 
+# --- SuffixDecoding tier classification (#269) ----------------------------
+#
+# Pure function so the boundary logic is unit-testable in isolation. Bench
+# numbers come from ``scripts/bench_suffix_decoding_integrated.py``;
+# thresholds are tuned to match the qualitative recommendation we'd give
+# a user looking at the same table by eye:
+#
+#   - AGENT     — tool calling specifically wins big AND nothing regresses
+#                 (we'd tell the user "turn it on").
+#   - STRUCTURED — some workload wins meaningfully AND nothing meaningfully
+#                  regresses (we'd say "try it for that workload").
+#   - NEUTRAL   — within noise across the board (silent — no point
+#                 suggesting either direction).
+#   - AVOID     — anything regresses past 0.85x, or signal is too mixed
+#                 to recommend (warn at startup).
+
+
+def classify_suffix_decoding_tier(speedup: dict[str, float]) -> str:
+    """Map a per-workload speedup dict to a tier string.
+
+    Empty dict → "unknown". Single-workload dicts use the special-case
+    rule that an empty ``min(others)`` is treated as +∞ (the AGENT gate
+    is satisfied vacuously). See ``tests/test_suffix_decoding_tier.py``
+    for boundary cases including the real Qwen3-0.6B / Qwen3-14B numbers.
+    """
+    if not speedup:
+        return "unknown"
+
+    lo = min(speedup.values())
+    hi = max(speedup.values())
+
+    # AVOID first: any individual workload regressing past 0.85x means
+    # we don't know the user's traffic mix well enough to recommend.
+    if lo < 0.85:
+        return "avoid"
+
+    # AGENT — tool_loop must be the workload winning big, AND no other
+    # workload regresses past 0.95x. Tool_loop missing from the dict
+    # means the bench didn't measure it; we can't claim agent then.
+    tool_loop = speedup.get("tool_loop")
+    if tool_loop is not None and tool_loop >= 1.8:
+        others = [v for k, v in speedup.items() if k != "tool_loop"]
+        if not others or min(others) >= 0.95:
+            return "agent"
+
+    # STRUCTURED — some workload wins meaningfully (≥1.5x) AND the
+    # weakest workload still clears 0.90x (small regression tolerated
+    # because the user is opting in for the structured win).
+    if hi >= 1.5 and lo >= 0.90:
+        return "structured"
+
+    # NEUTRAL — flat across the board. Tighter than STRUCTURED's 0.90
+    # floor: we want true noise here, not a near-miss STRUCTURED.
+    if lo >= 0.95 and hi >= 1.0 and hi < 1.5:
+        return "neutral"
+
+    # Mixed signal that didn't fit any positive bucket — recommend AVOID
+    # rather than silently shipping ambiguous data.
+    return "avoid"
+
+
+def suffix_decoding_hint(cfg: "ModelConfig | None") -> str | None:
+    """Startup hint for the SuffixDecoding flag, or ``None`` for silent tiers.
+
+    The hint surfaces only AGENT / STRUCTURED / AVOID tiers. UNKNOWN and
+    NEUTRAL stay silent — no user-visible nudge until bench data exists
+    or there's a real regression to warn about.
+
+    Hybrid arches (``supports_spec_decode=False``) always return ``None``
+    even if the tier was somehow set: spec decoding is gated off at the
+    engine level, and a "recommended" hint there would just confuse.
+    """
+    if cfg is None:
+        return None
+    if not cfg.supports_spec_decode:
+        return None
+    tier = cfg.suffix_decoding_tier
+    speedup = cfg.suffix_bench_speedup or {}
+    if tier == "agent":
+        peak = speedup.get("tool_loop") or (max(speedup.values()) if speedup else 0)
+        return (
+            f"SuffixDecoding: recommended for tool/agent traffic "
+            f"(tool_loop {peak:.1f}x). Pass --suffix-decoding to enable."
+        )
+    if tier == "structured":
+        peak_key = max(speedup, key=speedup.get) if speedup else "structured"
+        peak_val = speedup.get(peak_key, 0)
+        return (
+            f"SuffixDecoding: may help on {peak_key} ({peak_val:.2f}x). "
+            "Pass --suffix-decoding if your traffic matches."
+        )
+    if tier == "avoid":
+        worst_key = min(speedup, key=speedup.get) if speedup else "some workloads"
+        worst_val = speedup.get(worst_key, 0)
+        return (
+            f"SuffixDecoding: NOT recommended for this model — {worst_key} "
+            f"regresses to {worst_val:.2f}x. Leave --suffix-decoding off."
+        )
+    return None
+
+
 def _arch_label(cfg: "ModelConfig") -> str:
     """One-word architecture label for human display."""
     if cfg.is_hybrid:
         return "hybrid (linear-attention/Mamba)"
     return "pure attention"
+
+
+def _suffix_tier_cell(cfg: "ModelConfig") -> str:
+    """Format the ``Suffix tier`` row for ``rapid-mlx info``.
+
+    AGENT/STRUCTURED — surface the peak workload speedup (the reason the
+    tier was assigned). AVOID — surface the worst-regressing workload so
+    the user understands the warning. UNKNOWN — point them at the bench
+    script. Hybrid arches always render ``n/a`` regardless of tier
+    because ``supports_spec_decode=False`` gates the flag off anyway.
+    """
+    if not cfg.supports_spec_decode:
+        return "n/a (hybrid arch — spec decode off)"
+    tier = cfg.suffix_decoding_tier
+    speedup = cfg.suffix_bench_speedup or {}
+    if tier == "unknown":
+        return "unknown — run scripts/bench_suffix_decoding_integrated"
+    if tier == "agent" and speedup:
+        peak_key = (
+            "tool_loop" if "tool_loop" in speedup else max(speedup, key=speedup.get)
+        )
+        return (
+            f"agent ({peak_key} {speedup[peak_key]:.2f}x — recommend --suffix-decoding)"
+        )
+    if tier == "structured" and speedup:
+        peak_key = max(speedup, key=speedup.get)
+        return (
+            f"structured ({peak_key} {speedup[peak_key]:.2f}x — try if traffic matches)"
+        )
+    if tier == "neutral":
+        return "neutral (within noise — leave off)"
+    if tier == "avoid" and speedup:
+        worst_key = min(speedup, key=speedup.get)
+        return f"avoid ({worst_key} {speedup[worst_key]:.2f}x regression — leave off)"
+    return tier
 
 
 def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:
@@ -459,6 +616,7 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Architecture", "unknown"),
             ("Spec decode", "✓ default-on"),
             ("Throttle", "✗ default-off"),
+            ("Suffix tier", "unknown — run scripts/bench_suffix_decoding_integrated"),
         ]
     else:
         spec = "✓ supported" if cfg.supports_spec_decode else "✗ disabled (hybrid arch)"
@@ -469,6 +627,7 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Architecture", _arch_label(cfg)),
             ("Spec decode", spec),
             ("Throttle", throttle),
+            ("Suffix tier", _suffix_tier_cell(cfg)),
         ]
 
     body = [_row(header), _row(sep)]


### PR DESCRIPTION
## Summary

Closes #269. Adds **SuffixDecoding eligibility classification** on top of the per-alias profile SSOT (PR #283), so each alias can publish its own benched tier — `agent` / `structured` / `neutral` / `avoid` / `unknown` — and the engine emits a startup hint accordingly.

| Tier | Trigger | Hint | Action |
|---|---|---|---|
| **agent** | `tool_loop ≥ 1.8x` AND `min(others) ≥ 0.95x` | recommended | enable for tool traffic |
| **structured** | `max ≥ 1.5x` AND `min ≥ 0.90x` | may help | try if traffic matches |
| **neutral** | `min ≥ 0.95x` AND `1.0x ≤ max < 1.5x` | (silent) | leave OFF |
| **avoid** | any `< 0.85x` OR mixed signal | warn | leave OFF |
| **unknown** | not benched | (silent) | bench it |

## Rebased on SSOT (PR #283)

Originally targeted `ModelConfig` directly. Now lands the new fields on **`AliasProfile`** (the SSOT) and propagates to `ModelConfig` via `detect_model_config`. Per-alias granularity is automatic — `qwen3.5-4b` and `qwen3.5-122b` can carry different tiers if measured separately.

## What lands

| Surface | Change |
|---|---|
| `AliasProfile` | + `suffix_decoding_tier`, + `suffix_bench_speedup` (sorted tuple form for frozen-dataclass safety) |
| `ModelConfig` | + same two fields (mirror); resolved from profile when alias hits |
| `_coerce()` | parses + validates new JSON keys |
| `classify_suffix_decoding_tier(speedup)` | pure boundary fn, single source of truth |
| `suffix_decoding_hint(cfg)` | engine-init hint, silent for `unknown`/`neutral` |
| `format_profile_table` | new `Suffix tier` row in `rapid-mlx info` |
| `engine_core.py` | emits hint after profile summary |
| `scripts/bench_suffix_decoding_integrated.py` | server-driver bench |
| `docs/suffix_decoding_eligibility.md` | tier table + how-to |
| `tests/test_suffix_decoding_tier.py` | 24 contract tests |
| `CONTRIBUTING.md` | new-model checklist points at the bench |

## Bench script reliability fixes (commit `138bd9a`)

Found while running the cross-model sweep:

1. **`--disable-prefix-cache`** added to spawned servers. Without it, disk-persisted prefix cache entries from prior sessions replay cached generation → bogus 1000-2000+ tok/s outliers (decode time → ~0). v1 `bonsai-1.7b` classified as `avoid` (0.72-0.80x); v2 (cache-clean) shows the real behaviour: `neutral` (0.99-1.10x).
2. **Reject runs where `completion_tokens < 32`**. Decode time becomes meaningless when the model bails early; `median()` over the healthy runs filters the bogus zero naturally.

## Bench data populated

| Alias | Tier | Speedups | Notes |
|---|---|---|---|
| `bonsai-1.7b` | **neutral** | chat 0.99, json 1.00, tool 1.10, code 1.02 | small dense model, suffix overhead = wins |
| `hermes3-8b`  | **neutral** | 0.98–1.02 across all four | tightest data — clear noise band |

All other dense aliases stay `unknown` (silent default — no user-visible change). Hybrid aliases auto-render `n/a (hybrid arch — spec decode off)` regardless of tier.

## Broken aliases discovered (out of scope)

These three popular candidates were in the original sweep plan but are broken upstream and need separate alias-fix PRs:

| Alias | Failure |
|---|---|
| `gpt-oss-20b` (`mlx-community/GPT-OSS-20B-4bit`) | HF returns 401 — repo gated/removed |
| `gemma3-12b` (`mlx-community/gemma-3-12b-it-qat-4bit`) | tokenizer ships no chat template |
| `mistral-24b` (`mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit`) | same — no chat template |

## Test plan

- [x] **24 new contract tests** in `tests/test_suffix_decoding_tier.py` — boundary cases for `classify_suffix_decoding_tier` (incl. real Qwen3-0.6B / Qwen3-14B numbers from #269), hint visibility (silent for unknown/neutral, warns for avoid, suppressed for hybrid), `rapid-mlx info` table cells, `ModelConfig` defaults regression check.
- [x] **2289 unit tests pass** (1 pre-existing flake in `test_batching_deterministic` unrelated — confirmed on clean main).
- [x] `ruff check` + `ruff format --check` clean.
- [x] **Bench-driver smoke**: 2 aliases benched end-to-end on M3 Ultra, results written to `evals/results/suffix_*.json`, merged into `aliases.json` via the new schema fields.

## Out of scope (follow-ups)

- Cross-model bench sweep for the remaining 32 dense aliases (each ~10-20 min on M3 Ultra; manual or CI nightly).
- Alias fixes for the 3 broken candidates above.
- Bench methodology hardening: TPS measurement is fragile when the model returns very short responses (early EOS → tiny decode time). The current `< 32 tokens → 0.0` guard catches the worst cases but `smollm3-3b` and `llama3-3b` v2 runs still produced unreliable data we discarded — see commit message for details. A follow-up should consider longer minimum gen, decode-time floors, or a separate fixture set tuned per workload.
- Auto-enable AGENT-tier models (intentional left manual — traffic mix unknown at startup).
