### PR TITLE
refactor: per-alias model profiles SSOT (P0+P1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.20"
+version = "0.6.21"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SSOT contract tests for the per-alias model profile registry.
+
+Pre-PR architecture had two sources: ``aliases.json`` (51 alias→hf_path
+mappings) and ``_MODEL_PATTERNS`` (25 regex-keyed ``ModelConfig`` rows).
+A new alias would silently inherit whichever pattern's regex happened to
+match its HF path, with no per-alias granularity for capability flags.
+
+These tests pin down the new contract:
+
+- every alias has an explicit profile in ``aliases.json``
+- ``detect_model_config`` prefers the alias profile over the regex
+  fallback
+- the regex fallback still works for unaliased HF paths (so users
+  serving a brand-new model from HuggingFace still get sensible
+  parser/capability inference)
+- the legacy bare-string form is still accepted at load time, with
+  default capability flags
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from vllm_mlx.model_aliases import (
+    AliasProfile,
+    list_aliases,
+    list_profiles,
+    resolve_model,
+    resolve_profile,
+)
+from vllm_mlx.model_auto_config import detect_model_config
+
+ALIASES_PATH = Path(__file__).parent.parent / "vllm_mlx" / "aliases.json"
+
+
+# ---- Schema sanity --------------------------------------------------------
+
+
+def test_aliases_json_is_rich_schema() -> None:
+    """Every entry must be the new dict form (string form was the old
+    schema; if it appears in ``aliases.json`` going forward the migration
+    has regressed)."""
+    with open(ALIASES_PATH) as f:
+        raw = json.load(f)
+    assert raw, "aliases.json must not be empty"
+    for alias, value in raw.items():
+        assert isinstance(value, dict), f"{alias!r}: rich schema required"
+        assert "hf_path" in value, f"{alias!r}: missing hf_path"
+        assert isinstance(value["hf_path"], str)
+
+
+def test_every_alias_has_explicit_profile_fields() -> None:
+    """No alias should rely on default capability flags — the whole
+    point of the SSOT is to be explicit. ``tool_call_parser`` and
+    ``reasoning_parser`` are allowed to be null (some families have no
+    native tool format), but the bool gates must be present."""
+    with open(ALIASES_PATH) as f:
+        raw = json.load(f)
+    for alias, value in raw.items():
+        assert "is_hybrid" in value, f"{alias!r}: missing is_hybrid"
+        assert "supports_spec_decode" in value, (
+            f"{alias!r}: missing supports_spec_decode"
+        )
+        assert isinstance(value["is_hybrid"], bool)
+        assert isinstance(value["supports_spec_decode"], bool)
+
+
+def test_no_orphan_aliases() -> None:
+    """The pre-SSOT audit found 6 orphans with no profile (bonsai×3,
+    ministral, nemotron×2). After P1 every alias must resolve."""
+    aliases = list_aliases()
+    for alias in aliases:
+        cfg = detect_model_config(alias)
+        assert cfg is not None, f"orphan alias: {alias}"
+
+
+def test_orphan_aliases_now_covered() -> None:
+    """Pin the 6 specific aliases that were orphans before this PR to
+    catch a regression where someone deletes their profile."""
+    for orphan in (
+        "bonsai-1.7b",
+        "bonsai-4b",
+        "bonsai-8b",
+        "ministral-3b",
+        "nemotron-30b",
+        "nemotron-nano",
+    ):
+        profile = resolve_profile(orphan)
+        assert profile is not None, f"{orphan} regressed to orphan"
+
+
+# ---- Loader behaviour -----------------------------------------------------
+
+
+def test_list_aliases_returns_legacy_string_view() -> None:
+    """Old callers (doctor harness, tests) expect ``{alias: hf_path}``."""
+    aliases = list_aliases()
+    assert len(aliases) == 51
+    assert all(isinstance(p, str) for p in aliases.values())
+    assert aliases["qwen3.5-4b"] == "mlx-community/Qwen3.5-4B-MLX-4bit"
+
+
+def test_list_profiles_returns_rich_dataclass_view() -> None:
+    profiles = list_profiles()
+    assert len(profiles) == 51
+    p = profiles["qwen3.5-4b"]
+    assert isinstance(p, AliasProfile)
+    assert p.hf_path == "mlx-community/Qwen3.5-4B-MLX-4bit"
+    assert p.tool_call_parser == "hermes"
+    assert p.reasoning_parser == "qwen3"
+    assert p.is_hybrid is True
+    assert p.supports_spec_decode is False
+
+
+def test_resolve_model_unchanged_for_callers() -> None:
+    """Existing callers of ``resolve_model`` must keep getting a string."""
+    assert resolve_model("qwen3.5-4b") == "mlx-community/Qwen3.5-4B-MLX-4bit"
+    assert (
+        resolve_model("mlx-community/Qwen3.5-4B-MLX-4bit")
+        == "mlx-community/Qwen3.5-4B-MLX-4bit"
+    )
+    assert resolve_model("totally-unknown") == "totally-unknown"
+
+
+# ---- Lookup paths ---------------------------------------------------------
+
+
+def test_resolve_profile_by_alias_name() -> None:
+    p = resolve_profile("qwen3.5-4b")
+    assert p is not None
+    assert p.tool_call_parser == "hermes"
+
+
+def test_resolve_profile_by_hf_path_reverse_lookup() -> None:
+    """The reverse lookup is what makes per-alias profiles win when the
+    user passes the full HF path on the command line."""
+    p = resolve_profile("mlx-community/Qwen3.5-4B-MLX-4bit")
+    assert p is not None
+    assert p.tool_call_parser == "hermes"
+    assert p.is_hybrid is True
+
+
+def test_resolve_profile_returns_none_for_unknown() -> None:
+    assert resolve_profile("totally-unknown") is None
+    assert resolve_profile("unaffiliated/Random-Model-2099-99B") is None
+
+
+# ---- detect_model_config integration -------------------------------------
+
+
+def test_detect_model_config_prefers_alias_profile_over_regex() -> None:
+    """``qwen3.5-4b`` (alias) and the matching qwen3.5 regex pattern
+    happen to agree today, but the alias path is the one we contract on
+    — pin a known field that exists on the alias profile so a future
+    regex change can't silently take over."""
+    cfg = detect_model_config("qwen3.5-4b")
+    assert cfg is not None
+    assert cfg.tool_call_parser == "hermes"
+    assert cfg.is_hybrid is True
+    assert cfg.supports_spec_decode is False
+
+
+def test_detect_model_config_falls_back_to_regex_for_unaliased_path() -> None:
+    """A user serves a brand-new HF model that isn't aliased — regex
+    fallback must still infer a sensible parser."""
+    cfg = detect_model_config("custom-org/Qwen3-99B-Instruct-4bit")
+    assert cfg is not None
+    assert cfg.tool_call_parser == "hermes"  # generic /qwen3/ pattern
+
+
+def test_detect_model_config_returns_none_when_neither_matches() -> None:
+    cfg = detect_model_config("no-prefix-no-pattern-2099")
+    assert cfg is None
+
+
+# ---- Backward compat with legacy bare-string form ------------------------
+
+
+def test_legacy_string_value_still_loads(tmp_path) -> None:
+    """An external tool that hand-edited ``aliases.json`` to the old
+    ``{alias: hf_path_string}`` form should still load — defaults fill in
+    the new capability fields."""
+    legacy = tmp_path / "aliases.json"
+    legacy.write_text(json.dumps({"foo": "org/Foo-Model-7B"}))
+
+    import vllm_mlx.model_aliases as ma
+
+    # Reset module cache and point loader at the legacy file
+    with (
+        patch.object(ma, "_aliases", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(legacy)),
+    ):
+        profiles = ma.list_profiles()
+
+    assert "foo" in profiles
+    assert profiles["foo"].hf_path == "org/Foo-Model-7B"
+    # Defaults for fields not present in legacy form
+    assert profiles["foo"].tool_call_parser is None
+    assert profiles["foo"].is_hybrid is False
+    assert profiles["foo"].supports_spec_decode is True
+
+
+def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
+    """A typo in the JSON should fail loud and point at the bad alias,
+    not crash deep in some downstream caller."""
+    bad = tmp_path / "aliases.json"
+    bad.write_text(json.dumps({"foo": 42}))
+
+    import vllm_mlx.model_aliases as ma
+
+    with (
+        patch.object(ma, "_aliases", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+    ):
+        try:
+            ma.list_profiles()
+        except ValueError as e:
+            assert "foo" in str(e)
+            return
+    raise AssertionError("expected ValueError for bad alias value")
+
+
+# ---- Cross-family granularity (the whole point of the refactor) ----------
+
+
+def test_qwen35_family_aliases_share_hybrid_flag() -> None:
+    """All qwen3.5-* aliases currently share the same regex profile —
+    they should also share it after migration. This is the regression
+    guard: if someone bumps just one variant's tier without bumping the
+    others, this test will catch the inconsistency that a per-alias
+    schema enables."""
+    profiles = list_profiles()
+    family = {a: p for a, p in profiles.items() if a.startswith("qwen3.5-")}
+    assert len(family) == 6
+    flags = {(p.is_hybrid, p.supports_spec_decode) for p in family.values()}
+    assert flags == {(True, False)}, (
+        f"qwen3.5-* family disagrees on capability flags: {flags}"
+    )
+
+
+def test_per_alias_schema_allows_independent_overrides() -> None:
+    """Schema check: two aliases can carry different capability flags
+    even if they map to the same family. This is what we couldn't do
+    before, and it's the architectural reason for the refactor."""
+    profiles = list_profiles()
+    p1 = profiles["qwen3.5-4b"]
+    # Object identity check would be wrong; equality on a value-typed
+    # dataclass is what we actually want — separate AliasProfile
+    # instances per alias means we can mutate one without touching the
+    # other. (Mutation isn't supported because the dataclass is frozen,
+    # but a re-load with edited JSON would work.)
+    assert p1 is not profiles["qwen3.5-9b"]

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -24,6 +24,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from vllm_mlx.model_aliases import (
     AliasProfile,
     list_aliases,
@@ -176,6 +178,37 @@ def test_detect_model_config_returns_none_when_neither_matches() -> None:
     assert cfg is None
 
 
+def test_detect_model_config_alias_wins_over_regex_when_they_disagree() -> None:
+    """The whole architectural point: when an alias profile and a regex
+    pattern both could match, the alias profile must win. Today the
+    derivations agree by construction (alias profiles were generated
+    from the regex matches), but the day someone bumps a single
+    alias's tier in aliases.json, the regex is going to keep returning
+    the family-wide value — and we need the alias to override it.
+
+    Simulate this by monkeypatching the alias profile's
+    tool_call_parser to something the qwen3.5 regex would never
+    return, and assert the alias's value reaches the caller.
+    """
+    import vllm_mlx.model_aliases as ma
+    from vllm_mlx.model_aliases import AliasProfile
+
+    real = ma._aliases["qwen3.5-4b"]
+    forged = AliasProfile(
+        hf_path=real.hf_path,
+        tool_call_parser="ALIAS_WINS",  # the regex would say "hermes"
+        reasoning_parser=real.reasoning_parser,
+        is_hybrid=real.is_hybrid,
+        supports_spec_decode=real.supports_spec_decode,
+    )
+    with patch.dict(ma._aliases, {"qwen3.5-4b": forged}):
+        cfg = detect_model_config("qwen3.5-4b")
+    assert cfg is not None
+    assert cfg.tool_call_parser == "ALIAS_WINS", (
+        "regex shadowed the alias profile — alias-first lookup is broken"
+    )
+
+
 # ---- Backward compat with legacy bare-string form ------------------------
 
 
@@ -191,6 +224,7 @@ def test_legacy_string_value_still_loads(tmp_path) -> None:
     # Reset module cache and point loader at the legacy file
     with (
         patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
         patch("vllm_mlx.model_aliases.os.path.join", return_value=str(legacy)),
     ):
         profiles = ma.list_profiles()
@@ -203,6 +237,39 @@ def test_legacy_string_value_still_loads(tmp_path) -> None:
     assert profiles["foo"].supports_spec_decode is True
 
 
+def test_empty_hf_path_string_form_raises(tmp_path) -> None:
+    """Empty hf_path slips through downstream as a ``""`` and surfaces
+    as a confusing 404 — catch it at load time."""
+    bad = tmp_path / "aliases.json"
+    bad.write_text(json.dumps({"foo": ""}))
+
+    import vllm_mlx.model_aliases as ma
+
+    with (
+        patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+        pytest.raises(ValueError, match="empty"),
+    ):
+        ma.list_profiles()
+
+
+def test_empty_hf_path_dict_form_raises(tmp_path) -> None:
+    """Same empty-path check for the rich-schema form."""
+    bad = tmp_path / "aliases.json"
+    bad.write_text(json.dumps({"foo": {"hf_path": ""}}))
+
+    import vllm_mlx.model_aliases as ma
+
+    with (
+        patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+        pytest.raises(ValueError, match="non-empty string"),
+    ):
+        ma.list_profiles()
+
+
 def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
     """A typo in the JSON should fail loud and point at the bad alias,
     not crash deep in some downstream caller."""
@@ -213,14 +280,11 @@ def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
 
     with (
         patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
         patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+        pytest.raises(ValueError, match="foo"),
     ):
-        try:
-            ma.list_profiles()
-        except ValueError as e:
-            assert "foo" in str(e)
-            return
-    raise AssertionError("expected ValueError for bad alias value")
+        ma.list_profiles()
 
 
 # ---- Cross-family granularity (the whole point of the refactor) ----------
@@ -253,3 +317,58 @@ def test_per_alias_schema_allows_independent_overrides() -> None:
     # other. (Mutation isn't supported because the dataclass is frozen,
     # but a re-load with edited JSON would work.)
     assert p1 is not profiles["qwen3.5-9b"]
+
+
+# ---- Reverse-lookup behaviour with shared hf_paths -----------------------
+
+
+def test_reverse_lookup_for_shared_hf_path_is_deterministic() -> None:
+    """Two aliases (``nemotron-30b`` and ``nemotron-nano``) point at the
+    same MLX repo. Reverse lookup by HF path should return the
+    JSON-insertion-order-first alias's profile, deterministically.
+
+    The contract is "any profile valid for this path", but we lock in
+    the order so a future re-shuffle of aliases.json is forced to
+    explicitly update this test (which is the right place to think
+    about who's the canonical alias).
+    """
+    profiles = list_profiles()
+    nemotron_30b = profiles["nemotron-30b"]
+    nemotron_nano = profiles["nemotron-nano"]
+    assert nemotron_30b.hf_path == nemotron_nano.hf_path
+
+    # nemotron-30b appears first in aliases.json, so reverse lookup
+    # by the shared HF path returns nemotron-30b's profile object.
+    via_path = resolve_profile(nemotron_30b.hf_path)
+    assert via_path is not None
+    assert via_path is nemotron_30b
+
+
+def test_reverse_lookup_handles_deepseek_v4_flash_duplicate() -> None:
+    """``deepseek-v4-flash`` and ``deepseek-v4-flash-8bit`` share
+    ``mlx-community/DeepSeek-V4-Flash-8bit`` — same regression guard
+    pattern as the nemotron pair, different family."""
+    profiles = list_profiles()
+    flash = profiles["deepseek-v4-flash"]
+    flash_8bit = profiles["deepseek-v4-flash-8bit"]
+    assert flash.hf_path == flash_8bit.hf_path
+    via_path = resolve_profile(flash.hf_path)
+    assert via_path is not None
+    # Both profiles agree on capability flags (same model), so either
+    # would be correct semantically. Pin the JSON order winner.
+    assert via_path is flash
+
+
+def test_reverse_lookup_index_built_once_after_first_load() -> None:
+    """Cheap behavioural check that the reverse index is built once and
+    reused — exercises the cache path. Not a perf benchmark; just
+    asserts ``_hf_to_alias`` is populated."""
+    import vllm_mlx.model_aliases as ma
+
+    # Trigger load
+    ma.list_profiles()
+    assert ma._hf_to_alias is not None
+    assert len(ma._hf_to_alias) <= len(ma._aliases)  # dedup possible
+    # Every hf_path in aliases must be reachable via reverse lookup
+    for profile in ma._aliases.values():
+        assert profile.hf_path in ma._hf_to_alias

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,53 +1,359 @@
 {
-  "qwen3.5-4b": "mlx-community/Qwen3.5-4B-MLX-4bit",
-  "qwen3.5-9b": "mlx-community/Qwen3.5-9B-4bit",
-  "qwen3.5-27b": "mlx-community/Qwen3.5-27B-4bit",
-  "qwen3.5-35b": "mlx-community/Qwen3.5-35B-A3B-8bit",
-  "qwen3.5-122b": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
-  "qwen3.5-122b-8bit": "mlx-community/Qwen3.5-122B-A10B-8bit",
-  "qwen3.6-27b": "mlx-community/Qwen3.6-27B-4bit",
-  "qwen3.6-27b-8bit": "unsloth/Qwen3.6-27B-MLX-8bit",
-  "qwen3.6-35b": "mlx-community/Qwen3.6-35B-A3B-4bit",
-  "qwen3.6-35b-6bit": "mlx-community/Qwen3.6-35B-A3B-6bit",
-  "deepseek-v4-flash": "mlx-community/DeepSeek-V4-Flash-8bit",
-  "deepseek-v4-flash-2bit": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
-  "deepseek-v4-flash-8bit": "mlx-community/DeepSeek-V4-Flash-8bit",
-  "deepseek-v4-flash-4bit": "mlx-community/DeepSeek-V4-Flash-4bit",
-  "qwen3-coder": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
-  "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
-  "llama3-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
-  "hermes3-8b": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
-  "gemma-4-26b": "mlx-community/gemma-4-26b-a4b-it-4bit",
-  "gemma-4-31b": "mlx-community/gemma-4-31b-it-4bit",
-  "gemma3-12b": "mlx-community/gemma-3-12b-it-qat-4bit",
-  "phi4-14b": "mlx-community/phi-4-mini-instruct-4bit",
-  "mistral-24b": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
-  "devstral-24b": "mlx-community/Devstral-Small-2503-MLX-4bit",
-  "glm4.7-9b": "mlx-community/GLM-4.7-4bit",
-  "glm4.5-air": "mlx-community/GLM-4.5-Air-0111-4bit",
-  "gpt-oss-20b": "mlx-community/GPT-OSS-20B-4bit",
-  "minimax-m2.5": "lmstudio-community/MiniMax-M2.5-MLX-4bit",
-  "deepseek-r1-8b": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
-  "deepseek-r1-32b": "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
-  "qwopus-9b": "Jackrong/MLX-Qwopus3.5-9B-v3-4bit",
-  "qwopus-27b": "Jackrong/MLX-Qwopus3.5-27B-v3-4bit",
-  "qwopus-27b-8bit": "Jackrong/MLX-Qwopus3.5-27B-v3-8bit",
-  "kimi-48b": "mlx-community/Kimi-K2-Instruct-Q4_0-MLX",
-  "kimi-k2.5": "mlx-community/Kimi-K2.5-3bit",
-  "ministral-3b": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
-  "hermes4-70b": "lmstudio-community/Hermes-4-70B-MLX-4bit",
-  "qwen3-vl-8b": "mlx-community/Qwen3-VL-8B-Instruct-4bit",
-  "qwen3-vl-30b": "mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit",
-  "devstral-v2-24b": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
-  "qwen3-coder-30b": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
-  "gemma-3n-e4b": "mlx-community/gemma-3n-E4B-it-4bit",
-  "gemma3-1b": "mlx-community/gemma-3-1b-it-4bit",
-  "gemma3-27b": "mlx-community/gemma-3-27b-it-4bit",
-  "nemotron-30b": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
-  "nemotron-nano": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
-  "bonsai-1.7b": "prism-ml/Bonsai-1.7B-unpacked",
-  "bonsai-4b": "prism-ml/Bonsai-4B-unpacked",
-  "bonsai-8b": "prism-ml/Bonsai-8B-unpacked",
-  "smollm3-3b": "mlx-community/SmolLM3-3B-4bit",
-  "granite4-tiny": "mlx-community/granite-4.0-h-tiny-4bit"
+  "qwen3.5-4b": {
+    "hf_path": "mlx-community/Qwen3.5-4B-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-9b": {
+    "hf_path": "mlx-community/Qwen3.5-9B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-27b": {
+    "hf_path": "mlx-community/Qwen3.5-27B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-35b": {
+    "hf_path": "mlx-community/Qwen3.5-35B-A3B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-122b": {
+    "hf_path": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-122b-8bit": {
+    "hf_path": "mlx-community/Qwen3.5-122B-A10B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.6-27b": {
+    "hf_path": "mlx-community/Qwen3.6-27B-4bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.6-27b-8bit": {
+    "hf_path": "unsloth/Qwen3.6-27B-MLX-8bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.6-35b": {
+    "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.6-35b-6bit": {
+    "hf_path": "mlx-community/Qwen3.6-35B-A3B-6bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "deepseek-v4-flash": {
+    "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
+    "tool_call_parser": "deepseek",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "deepseek-v4-flash-2bit": {
+    "hf_path": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
+    "tool_call_parser": "deepseek",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "deepseek-v4-flash-8bit": {
+    "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
+    "tool_call_parser": "deepseek",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "deepseek-v4-flash-4bit": {
+    "hf_path": "mlx-community/DeepSeek-V4-Flash-4bit",
+    "tool_call_parser": "deepseek",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "qwen3-coder": {
+    "hf_path": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3-vl-4b": {
+    "hf_path": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "llama3-3b": {
+    "hf_path": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "tool_call_parser": "llama",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "hermes3-8b": {
+    "hf_path": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma-4-26b": {
+    "hf_path": "mlx-community/gemma-4-26b-a4b-it-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma-4-31b": {
+    "hf_path": "mlx-community/gemma-4-31b-it-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma3-12b": {
+    "hf_path": "mlx-community/gemma-3-12b-it-qat-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "phi4-14b": {
+    "hf_path": "mlx-community/phi-4-mini-instruct-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "mistral-24b": {
+    "hf_path": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "devstral-24b": {
+    "hf_path": "mlx-community/Devstral-Small-2503-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "glm4.7-9b": {
+    "hf_path": "mlx-community/GLM-4.7-4bit",
+    "tool_call_parser": "glm47",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "glm4.5-air": {
+    "hf_path": "mlx-community/GLM-4.5-Air-0111-4bit",
+    "tool_call_parser": "glm47",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gpt-oss-20b": {
+    "hf_path": "mlx-community/GPT-OSS-20B-4bit",
+    "tool_call_parser": "harmony",
+    "reasoning_parser": "harmony",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "minimax-m2.5": {
+    "hf_path": "lmstudio-community/MiniMax-M2.5-MLX-4bit",
+    "tool_call_parser": "minimax",
+    "reasoning_parser": "minimax",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "deepseek-r1-8b": {
+    "hf_path": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+    "tool_call_parser": "deepseek_v31",
+    "reasoning_parser": "deepseek_r1",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "deepseek-r1-32b": {
+    "hf_path": "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
+    "tool_call_parser": "deepseek",
+    "reasoning_parser": "deepseek_r1",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "qwopus-9b": {
+    "hf_path": "Jackrong/MLX-Qwopus3.5-9B-v3-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwopus-27b": {
+    "hf_path": "Jackrong/MLX-Qwopus3.5-27B-v3-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwopus-27b-8bit": {
+    "hf_path": "Jackrong/MLX-Qwopus3.5-27B-v3-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "kimi-48b": {
+    "hf_path": "mlx-community/Kimi-K2-Instruct-Q4_0-MLX",
+    "tool_call_parser": "kimi",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "kimi-k2.5": {
+    "hf_path": "mlx-community/Kimi-K2.5-3bit",
+    "tool_call_parser": "kimi",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "ministral-3b": {
+    "hf_path": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "hermes4-70b": {
+    "hf_path": "lmstudio-community/Hermes-4-70B-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "qwen3-vl-8b": {
+    "hf_path": "mlx-community/Qwen3-VL-8B-Instruct-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "qwen3-vl-30b": {
+    "hf_path": "mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "devstral-v2-24b": {
+    "hf_path": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "qwen3-coder-30b": {
+    "hf_path": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma-3n-e4b": {
+    "hf_path": "mlx-community/gemma-3n-E4B-it-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma3-1b": {
+    "hf_path": "mlx-community/gemma-3-1b-it-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "gemma3-27b": {
+    "hf_path": "mlx-community/gemma-3-27b-it-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "nemotron-30b": {
+    "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "nemotron-nano": {
+    "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "bonsai-1.7b": {
+    "hf_path": "prism-ml/Bonsai-1.7B-unpacked",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "bonsai-4b": {
+    "hf_path": "prism-ml/Bonsai-4B-unpacked",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "bonsai-8b": {
+    "hf_path": "prism-ml/Bonsai-8B-unpacked",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "smollm3-3b": {
+    "hf_path": "mlx-community/SmolLM3-3B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "granite4-tiny": {
+    "hf_path": "mlx-community/granite-4.0-h-tiny-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  }
 }

--- a/vllm_mlx/doctor/discovery.py
+++ b/vllm_mlx/doctor/discovery.py
@@ -14,8 +14,6 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from .runner import REPO_ROOT
-
 
 @dataclass
 class ModelAvailability:
@@ -27,10 +25,16 @@ class ModelAvailability:
 
 
 def load_aliases() -> dict[str, str]:
-    """Return the alias → repo-id mapping shipped with the package."""
-    aliases_path = REPO_ROOT / "vllm_mlx" / "aliases.json"
-    with open(aliases_path) as f:
-        return json.load(f)
+    """Return the alias → repo-id mapping shipped with the package.
+
+    Thin wrapper over ``vllm_mlx.model_aliases.list_aliases`` so the
+    doctor harness sees the same view regardless of whether the entry
+    in ``aliases.json`` is the legacy bare-string form or the rich
+    profile form (this module pre-dates the schema bump).
+    """
+    from ..model_aliases import list_aliases as _list
+
+    return _list()
 
 
 def _hf_cache_roots() -> list[Path]:

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -17,14 +17,24 @@ import os
 from dataclasses import dataclass
 
 _aliases: dict[str, "AliasProfile"] | None = None
+# Reverse index: hf_path → first alias that references it. Built once
+# alongside ``_aliases`` so reverse lookups in ``resolve_profile`` are
+# O(1) instead of scanning all 50+ profiles on every cache-miss.
+# When two aliases share the same hf_path (e.g. ``nemotron-30b`` and
+# ``nemotron-nano`` both pointing at the same MLX repo), the first one
+# in JSON order wins. The contract is "any profile valid for this
+# path" rather than "the canonical alias", so this is fine.
+_hf_to_alias: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
 class AliasProfile:
     """Per-alias profile — resolved from ``aliases.json``.
 
-    Mirrors the fields of ``ModelConfig`` (kept separate to avoid an
-    import cycle between ``model_aliases`` and ``model_auto_config``).
+    Mirrors a subset of ``ModelConfig``'s fields. Kept separate so this
+    module stays import-light (``model_auto_config`` pulls in regex,
+    typing, etc. that aren't needed when callers only want the alias →
+    hf_path map).
     """
 
     hf_path: str
@@ -40,16 +50,30 @@ def _coerce(alias: str, value: object) -> AliasProfile:
 
     Accepts both the rich dict form and the legacy bare-string form so a
     file edited by hand or carried over from an old release still loads.
+
+    Validates that ``hf_path`` is a non-empty string regardless of the
+    schema flavor — an empty path slips silently through every
+    downstream check (``resolve_model`` returns ``""``, downloads fail
+    with confusing 404s) and the loader is the only honest place to
+    catch it.
     """
     if isinstance(value, str):
+        if not value:
+            raise ValueError(f"alias {alias!r}: hf_path string is empty")
         return AliasProfile(hf_path=value)
     if not isinstance(value, dict) or "hf_path" not in value:
         raise ValueError(
             f"alias {alias!r}: value must be a string or an object with "
             f"'hf_path', got {type(value).__name__}"
         )
+    hf_path = value["hf_path"]
+    if not isinstance(hf_path, str) or not hf_path:
+        raise ValueError(
+            f"alias {alias!r}: 'hf_path' must be a non-empty string, "
+            f"got {type(hf_path).__name__}={hf_path!r}"
+        )
     return AliasProfile(
-        hf_path=value["hf_path"],
+        hf_path=hf_path,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),
         is_hybrid=bool(value.get("is_hybrid", False)),
@@ -59,12 +83,17 @@ def _coerce(alias: str, value: object) -> AliasProfile:
 
 
 def _load() -> dict[str, AliasProfile]:
-    global _aliases
+    global _aliases, _hf_to_alias
     if _aliases is None:
         path = os.path.join(os.path.dirname(__file__), "aliases.json")
         with open(path) as f:
             raw = json.load(f)
         _aliases = {alias: _coerce(alias, v) for alias, v in raw.items()}
+        # Build reverse index in JSON-insertion order so the "first alias
+        # wins" rule is deterministic.
+        _hf_to_alias = {}
+        for alias, profile in _aliases.items():
+            _hf_to_alias.setdefault(profile.hf_path, alias)
     return _aliases
 
 
@@ -100,19 +129,20 @@ def resolve_profile(name: str) -> AliasProfile | None:
 
     Two lookups in order:
     1. Direct alias name match (``qwen3.5-4b``).
-    2. Reverse HF-path match (``mlx-community/Qwen3.5-4B-MLX-4bit``).
+    2. Reverse HF-path match (``mlx-community/Qwen3.5-4B-MLX-4bit``)
+       via the pre-built ``_hf_to_alias`` index — O(1).
 
     Returns ``None`` if no alias covers this name/path — caller should
     then fall back to the regex-based ``detect_model_config``.
     """
-    profiles = _load()
+    profiles = _load()  # also populates _hf_to_alias on first call
     direct = profiles.get(name)
     if direct is not None:
         return direct
-    if "/" in name:
-        for profile in profiles.values():
-            if profile.hf_path == name:
-                return profile
+    if "/" in name and _hf_to_alias is not None:
+        canonical = _hf_to_alias.get(name)
+        if canonical is not None:
+            return profiles[canonical]
     return None
 
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -1,19 +1,70 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Model alias registry — maps short names to HuggingFace paths."""
+"""Model alias registry — single source of truth for known models.
+
+Each entry in ``aliases.json`` is a per-alias profile: HF path + parser +
+capability gates. Code that just needs ``alias → hf_path`` calls
+``resolve_model``; code that needs the full profile (parser, hybrid
+flag, spec-decode gate, …) calls ``resolve_profile``.
+
+The legacy short form (``"alias": "hf_path"``) is still accepted for
+backward compatibility with any external tool that hand-edits the file —
+that entry just gets default capability flags.
+"""
 
 import difflib
 import json
 import os
+from dataclasses import dataclass
 
-_aliases: dict[str, str] | None = None
+_aliases: dict[str, "AliasProfile"] | None = None
 
 
-def _load() -> dict[str, str]:
+@dataclass(frozen=True)
+class AliasProfile:
+    """Per-alias profile — resolved from ``aliases.json``.
+
+    Mirrors the fields of ``ModelConfig`` (kept separate to avoid an
+    import cycle between ``model_aliases`` and ``model_auto_config``).
+    """
+
+    hf_path: str
+    tool_call_parser: str | None = None
+    reasoning_parser: str | None = None
+    is_hybrid: bool = False
+    supports_spec_decode: bool = True
+    default_max_tokens: int | None = None
+
+
+def _coerce(alias: str, value: object) -> AliasProfile:
+    """Build an ``AliasProfile`` from a raw JSON value.
+
+    Accepts both the rich dict form and the legacy bare-string form so a
+    file edited by hand or carried over from an old release still loads.
+    """
+    if isinstance(value, str):
+        return AliasProfile(hf_path=value)
+    if not isinstance(value, dict) or "hf_path" not in value:
+        raise ValueError(
+            f"alias {alias!r}: value must be a string or an object with "
+            f"'hf_path', got {type(value).__name__}"
+        )
+    return AliasProfile(
+        hf_path=value["hf_path"],
+        tool_call_parser=value.get("tool_call_parser"),
+        reasoning_parser=value.get("reasoning_parser"),
+        is_hybrid=bool(value.get("is_hybrid", False)),
+        supports_spec_decode=bool(value.get("supports_spec_decode", True)),
+        default_max_tokens=value.get("default_max_tokens"),
+    )
+
+
+def _load() -> dict[str, AliasProfile]:
     global _aliases
     if _aliases is None:
         path = os.path.join(os.path.dirname(__file__), "aliases.json")
         with open(path) as f:
-            _aliases = json.load(f)
+            raw = json.load(f)
+        _aliases = {alias: _coerce(alias, v) for alias, v in raw.items()}
     return _aliases
 
 
@@ -29,13 +80,40 @@ def resolve_model(name: str) -> str:
         return name
     if os.path.exists(name):
         return name
-    aliases = _load()
-    return aliases.get(name, name)
+    profile = _load().get(name)
+    return profile.hf_path if profile is not None else name
 
 
 def list_aliases() -> dict[str, str]:
-    """Return all available aliases."""
+    """Return all aliases as ``{alias: hf_path}`` (legacy view)."""
+    return {alias: profile.hf_path for alias, profile in _load().items()}
+
+
+def list_profiles() -> dict[str, AliasProfile]:
+    """Return all alias profiles. Use this when you need parser/capability
+    info, not just the HF path."""
     return dict(_load())
+
+
+def resolve_profile(name: str) -> AliasProfile | None:
+    """Return the profile for an alias name or full HF path.
+
+    Two lookups in order:
+    1. Direct alias name match (``qwen3.5-4b``).
+    2. Reverse HF-path match (``mlx-community/Qwen3.5-4B-MLX-4bit``).
+
+    Returns ``None`` if no alias covers this name/path — caller should
+    then fall back to the regex-based ``detect_model_config``.
+    """
+    profiles = _load()
+    direct = profiles.get(name)
+    if direct is not None:
+        return direct
+    if "/" in name:
+        for profile in profiles.values():
+            if profile.hf_path == name:
+                return profile
+    return None
 
 
 def _family_prefix(name: str) -> str:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -301,12 +301,45 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
 def detect_model_config(model_path: str) -> ModelConfig | None:
     """Detect optimal parser config from model name/path.
 
+    Two-stage lookup:
+    1. **Alias profile** (single source of truth) — if ``model_path`` is a
+       known alias name (``qwen3.5-4b``) or maps to one's HF path
+       (``mlx-community/Qwen3.5-4B-MLX-4bit``), return that profile's
+       config directly. This guarantees per-alias granularity for any
+       optimization that varies by size/quant within a family.
+    2. **Regex fallback** (``_MODEL_PATTERNS``) — for non-aliased HF
+       paths the user serves directly. Coarser-grained: one pattern
+       covers a whole family.
+
     Args:
         model_path: Model name or path (e.g. "mlx-community/Qwen3.5-9B-4bit")
 
     Returns:
-        ModelConfig if a pattern matches, None otherwise.
+        ModelConfig if an alias profile or regex pattern matches, None
+        otherwise.
     """
+    # Local import to break a circular dependency: model_aliases needs
+    # the dataclass shape from this module via duck-typing only, so the
+    # late import is the cheaper side of the cycle to defer.
+    from .model_aliases import resolve_profile
+
+    profile = resolve_profile(model_path)
+    if profile is not None:
+        logger.info(
+            f"Resolved alias profile for '{model_path}' → "
+            f"tool_call_parser={profile.tool_call_parser}, "
+            f"reasoning_parser={profile.reasoning_parser}, "
+            f"is_hybrid={profile.is_hybrid}, "
+            f"supports_spec_decode={profile.supports_spec_decode}"
+        )
+        return ModelConfig(
+            tool_call_parser=profile.tool_call_parser,
+            reasoning_parser=profile.reasoning_parser,
+            default_max_tokens=profile.default_max_tokens,
+            is_hybrid=profile.is_hybrid,
+            supports_spec_decode=profile.supports_spec_decode,
+        )
+
     for pattern, config in _MODEL_PATTERNS:
         if pattern.search(model_path):
             logger.info(

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -27,6 +27,8 @@ import re
 from dataclasses import dataclass, replace
 from typing import Any
 
+from .model_aliases import resolve_profile
+
 logger = logging.getLogger(__name__)
 
 
@@ -318,11 +320,6 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
         ModelConfig if an alias profile or regex pattern matches, None
         otherwise.
     """
-    # Local import to break a circular dependency: model_aliases needs
-    # the dataclass shape from this module via duck-typing only, so the
-    # late import is the cheaper side of the cycle to defer.
-    from .model_aliases import resolve_profile
-
     profile = resolve_profile(model_path)
     if profile is not None:
         logger.info(


### PR DESCRIPTION
## Summary

Replaces the dual-source design (``aliases.json`` + ``_MODEL_PATTERNS`` regex table) with **explicit per-alias profiles** in ``aliases.json``. Every alias now carries its own ``tool_call_parser`` / ``reasoning_parser`` / ``is_hybrid`` / ``supports_spec_decode``, so capability flags can vary independently within a family (``qwen3.5-4b`` vs ``qwen3.5-122b``).

This is the architectural prerequisite for PR #281 — without per-alias granularity the SuffixDecoding tier was forced to be per-regex (one tier covers all 6 ``qwen3.5-*`` aliases), which can't reflect actual bench results.

## Pre-PR audit

| | Count | Detail |
|---|---|---|
| Total aliases in ``aliases.json`` | 51 | |
| Covered by a ``_MODEL_PATTERNS`` regex | 45 | shared across ~25 patterns |
| **Orphan aliases** (no profile, fell through to defaults) | **6** | bonsai×3, ministral-3b, nemotron×2 |
| Patterns covering ≥4 aliases | 4 | ``/qwen3\.5/`` (6), ``/qwen3\.6/`` (4), ``/deepseek.*v4/`` (4), ``/gemma/`` (4) |

## P0 — SSOT

| Surface | Change |
|---|---|
| ``aliases.json`` | rich-schema bump: ``{alias: {hf_path, tool_call_parser, reasoning_parser, is_hybrid, supports_spec_decode}}``. Legacy bare-string form still loads (defaults fill missing fields). |
| ``model_aliases.py`` | + ``AliasProfile`` (frozen dataclass), + ``list_profiles``, + ``resolve_profile`` (alias name OR reverse hf_path lookup, O(1) via cached reverse index). ``resolve_model``/``list_aliases`` keep old signatures. |
| ``model_auto_config.detect_model_config`` | now consults the alias profile first; regex stays as the fallback for un-aliased HF paths. |
| ``doctor/discovery.load_aliases`` | thin wrapper over ``list_aliases`` so the harness sees a consistent string view regardless of schema flavor. |

## P1 — orphan coverage

The 6 aliases that fell through to ``ModelConfig()`` defaults now have explicit profiles:

| alias | tool_call_parser | reasoning_parser | is_hybrid | supports_spec_decode |
|---|---|---|---|---|
| bonsai-1.7b/4b/8b | ``null`` | ``null`` | false | true |
| ministral-3b | ``hermes`` | ``null`` | false | true |
| nemotron-30b/nano | ``hermes`` | ``null`` | **true** (Mamba hybrid) | **false** |

Note: nemotron's hybrid flag was previously wrong (defaulted to ``false`` because no pattern matched), so spec decoding would have produced corrupted output. P1 fixes that.

## Test plan

- [x] **23 new contract tests** in ``tests/test_model_profiles_ssot.py``:
  - schema validity (every entry is rich form, every alias has the bool gates)
  - no-orphan invariant (51/51 aliases now resolve)
  - alias-vs-regex preference (alias profile wins over the matching regex; verified via monkeypatch)
  - reverse hf_path lookup (full HF path also resolves to its alias profile, including shared-path determinism for nemotron-30b/-nano and deepseek-v4-flash pairs)
  - regex fallback still works for un-aliased HF paths
  - legacy bare-string form loads with default capability flags
  - empty hf_path rejection (both schemas)
  - family flag consistency (``qwen3.5-*`` must all agree on hybrid/spec_decode)
- [x] **Full unit suite: 2255 passed, 17 skipped, 7 deselected** (excluded 4 heavy MLLM/video files that need real Qwen3-VL weights — not relevant to this refactor; covered by GitHub matrix CI)
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] **GitHub matrix CI: all green** (lint, type-check, version bump check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests)
- [x] ``make check --model qwen3.5-4b``: **0 regression vs baseline** (4 pass, 0 regression, 2 pre-existing fail, 1 skip — Test 10 streaming-usage and thinking-toggle are documented as known pre-existing issues, see harness baseline notes)
- [ ] ``pr_validate`` end-to-end — local run hangs on MLLM tests requiring real Qwen3-VL weights; **superseded by the GitHub Actions matrix above**, which runs the same suite with the right environment

## Out of scope (follow-ups)

- **PR #281** (``suffix_decoding_tier``) — will rebase on top of this; the new field lands in ``AliasProfile`` rather than ``ModelConfig``, giving per-alias granularity.
- **Cross-model bench sweep** populating the new tier field per alias.
- **Eventually retiring ``_MODEL_PATTERNS``** once every served model is an alias (still useful today as a fallback for users who serve a brand-new HF model directly).
