### PR TITLE
fix(bench): suffix-decoding TPS reliability gates

### DIFF
--- a/evals/results/suffix_bonsai-1.7b.json
+++ b/evals/results/suffix_bonsai-1.7b.json
@@ -3,22 +3,213 @@
   "max_tokens": 256,
   "runs": 3,
   "vanilla_tps": {
-    "chat": 92.3,
-    "json_array": 93.8,
-    "tool_loop": 87.0,
-    "code_edit": 88.7
+    "chat": 142.0,
+    "json_array": 141.5,
+    "tool_loop": 137.1,
+    "code_edit": 141.0
   },
   "suffix_tps": {
-    "chat": 91.6,
-    "json_array": 93.3,
-    "tool_loop": 96.1,
-    "code_edit": 90.8
+    "chat": 141.9,
+    "json_array": 141.3,
+    "tool_loop": 136.8,
+    "code_edit": 141.3
   },
   "speedup": {
-    "chat": 0.992,
-    "json_array": 0.995,
-    "tool_loop": 1.105,
-    "code_edit": 1.023
+    "chat": 0.999,
+    "json_array": 0.999,
+    "tool_loop": 0.998,
+    "code_edit": 1.002
   },
-  "tier": "neutral"
+  "skipped": {},
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 142.0,
+          "completion_tokens": 198,
+          "decode_time": 1.394,
+          "total_time": 1.504,
+          "rejected_reason": null
+        },
+        {
+          "tps": 142.0,
+          "completion_tokens": 256,
+          "decode_time": 1.803,
+          "total_time": 1.906,
+          "rejected_reason": null
+        },
+        {
+          "tps": 142.0,
+          "completion_tokens": 227,
+          "decode_time": 1.598,
+          "total_time": 1.7,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 141.5,
+          "completion_tokens": 249,
+          "decode_time": 1.759,
+          "total_time": 1.867,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.4,
+          "completion_tokens": 256,
+          "decode_time": 1.811,
+          "total_time": 1.918,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.5,
+          "completion_tokens": 256,
+          "decode_time": 1.809,
+          "total_time": 1.914,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 137.2,
+          "completion_tokens": 113,
+          "decode_time": 0.824,
+          "total_time": 1.014,
+          "rejected_reason": null
+        },
+        {
+          "tps": 137.0,
+          "completion_tokens": 111,
+          "decode_time": 0.81,
+          "total_time": 0.998,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.152,
+          "total_time": 0.341,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 62,
+          "decode_time": 0.442,
+          "total_time": 0.557,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 141.0,
+          "completion_tokens": 94,
+          "decode_time": 0.666,
+          "total_time": 0.781,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 61,
+          "decode_time": 0.434,
+          "total_time": 0.549,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 141.9,
+          "completion_tokens": 198,
+          "decode_time": 1.395,
+          "total_time": 1.507,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.9,
+          "completion_tokens": 177,
+          "decode_time": 1.247,
+          "total_time": 1.349,
+          "rejected_reason": null
+        },
+        {
+          "tps": 142.0,
+          "completion_tokens": 216,
+          "decode_time": 1.521,
+          "total_time": 1.624,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 141.3,
+          "completion_tokens": 247,
+          "decode_time": 1.749,
+          "total_time": 1.856,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.3,
+          "completion_tokens": 243,
+          "decode_time": 1.719,
+          "total_time": 1.826,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.3,
+          "completion_tokens": 247,
+          "decode_time": 1.748,
+          "total_time": 1.855,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 136.9,
+          "completion_tokens": 112,
+          "decode_time": 0.818,
+          "total_time": 1.007,
+          "rejected_reason": null
+        },
+        {
+          "tps": 136.8,
+          "completion_tokens": 114,
+          "decode_time": 0.833,
+          "total_time": 1.023,
+          "rejected_reason": null
+        },
+        {
+          "tps": 136.8,
+          "completion_tokens": 115,
+          "decode_time": 0.841,
+          "total_time": 1.03,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 141.1,
+          "completion_tokens": 108,
+          "decode_time": 0.765,
+          "total_time": 0.88,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.4,
+          "completion_tokens": 168,
+          "decode_time": 1.188,
+          "total_time": 1.302,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 53,
+          "decode_time": 0.379,
+          "total_time": 0.493,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
 }

--- a/scripts/bench_suffix_decoding_integrated.py
+++ b/scripts/bench_suffix_decoding_integrated.py
@@ -306,15 +306,56 @@ def start_server(model: str, port: int, suffix_decoding: bool) -> ServerHandle:
 # ---- Workload execution ---------------------------------------------------
 
 
+# Reliability thresholds — see `tests/test_suffix_bench_methodology.py`.
+#
+# MIN_DECODE_TIME — runs whose decode-time slice is shorter than this can't
+# be measured reliably. Per-request overhead (TLS handshake, framework JSON
+# round-trip, last-chunk flush) dominates; TPS becomes 1000-2700 tok/s
+# nonsense for short responses. 0.5s gives at least ~50-150 generated
+# tokens at typical M-series rates, enough that wall-clock noise is small.
+MIN_DECODE_TIME = 0.5
+
+# TPS_CEILING — physical sanity check. No single-request mlx-lm decode on
+# any M-series Mac (M2 → M3 Ultra) has been observed above this for any
+# model size we ship as an alias (largest sustained: SmolLM3-3B-4bit ~280
+# tok/s, Llama-3.2-1B-4bit ~330 tok/s). A reading above the ceiling means
+# the timing window collapsed (cache hit, prefill-counted-as-decode, etc.)
+# rather than the model genuinely going that fast.
+TPS_CEILING = 500.0
+
+
+@dataclass
+class WorkloadRun:
+    """One end-to-end stream measurement.
+
+    ``tps`` is ``None`` when the run was rejected (too short, ceiling
+    breach, or zero-token response). The raw fields stay populated so a
+    later post-mortem can see *why* it was rejected without re-running.
+    """
+
+    tps: float | None
+    completion_tokens: int
+    decode_time: float
+    total_time: float
+    rejected_reason: str | None = None
+
+
 def run_workload(
     handle: ServerHandle,
     workload_body: dict,
     max_tokens: int,
-) -> float:
-    """Run one request and return decode TPS (completion tokens / decode time).
+) -> WorkloadRun:
+    """Run one request and return a ``WorkloadRun`` with TPS + raw timing.
 
-    Streams to capture TTFT, then derives decode time from
-    ``usage.completion_tokens`` divided by (total_time - ttft).
+    Reliability rules (set ``tps=None`` and a ``rejected_reason``):
+
+    * Zero/missing ``completion_tokens`` — server didn't report usage.
+    * ``decode_time < MIN_DECODE_TIME`` — gen too short to measure.
+    * ``tps > TPS_CEILING`` — implausibly fast, indicates cache leak or
+      collapsed timing window. Don't poison median() with the outlier.
+
+    Returning a structured value (instead of just a float) lets the
+    caller persist raw data for forensic debugging without re-running.
     """
     payload = {
         "model": handle.model,
@@ -325,7 +366,7 @@ def run_workload(
     }
     t0 = time.perf_counter()
     ttft: float | None = None
-    completion_tokens: int | None = None
+    completion_tokens: int = 0
 
     with httpx.stream(
         "POST",
@@ -356,19 +397,54 @@ def run_workload(
                 completion_tokens = int(usage["completion_tokens"])
 
     total = time.perf_counter() - t0
-    if completion_tokens is None or completion_tokens <= 0:
-        return 0.0
-    # Discard runs where the model bailed in fewer than 32 tokens — decode
-    # time is dominated by per-request overhead, not generation, and TPS
-    # becomes meaningless. Returning 0 makes the median() filter these out
-    # naturally if at least one of the 3 runs is healthy.
-    if completion_tokens < 32:
-        return 0.0
-    decode_time = max(total - (ttft or 0.0), 1e-6)
-    return completion_tokens / decode_time
+    decode_time = max(total - (ttft or 0.0), 0.0)
+
+    return _classify_run(completion_tokens, decode_time, total)
+
+
+def _classify_run(
+    completion_tokens: int, decode_time: float, total_time: float
+) -> WorkloadRun:
+    """Apply the reliability gates. Pulled out so it's unit-testable
+    without spinning up an actual server."""
+    if completion_tokens <= 0:
+        return WorkloadRun(
+            None, completion_tokens, decode_time, total_time, "zero_completion_tokens"
+        )
+    if decode_time < MIN_DECODE_TIME:
+        return WorkloadRun(
+            None,
+            completion_tokens,
+            decode_time,
+            total_time,
+            f"decode_time<{MIN_DECODE_TIME}s",
+        )
+    tps = completion_tokens / decode_time
+    if tps > TPS_CEILING:
+        return WorkloadRun(
+            None,
+            completion_tokens,
+            decode_time,
+            total_time,
+            f"tps>{TPS_CEILING}_ceiling",
+        )
+    return WorkloadRun(tps, completion_tokens, decode_time, total_time, None)
 
 
 # ---- Driver ---------------------------------------------------------------
+
+
+@dataclass
+class ModeResult:
+    """Outcome of one (vanilla|suffix) bench pass.
+
+    ``median_tps[name]`` is ``None`` when *every* run for that workload
+    was rejected (so the caller can mark it 'skipped' rather than treat
+    the missing data as 0.0 → false 'avoid' classification).
+    """
+
+    median_tps: dict[str, float | None]
+    raw_runs: dict[str, list[WorkloadRun]]
 
 
 def bench_one_mode(
@@ -377,29 +453,42 @@ def bench_one_mode(
     suffix_decoding: bool,
     runs: int,
     max_tokens: int,
-) -> dict[str, float]:
-    """Median decode TPS per workload, for one (vanilla|suffix) mode."""
+) -> ModeResult:
+    """Run every workload ``runs`` times in a single server lifetime.
+
+    Returns a ``ModeResult`` with both the per-workload median (over
+    valid runs only) and the full raw run list for downstream
+    persistence.
+    """
     handle = start_server(model, port, suffix_decoding)
     try:
         # 1 warmup run that we discard — covers Metal kernel JIT, cache
         # population, and tokenizer load.
         run_workload(handle, WORKLOADS["chat"], max_tokens=32)
-        results: dict[str, float] = {}
+        median_tps: dict[str, float | None] = {}
+        raw: dict[str, list[WorkloadRun]] = {}
         for name, body in WORKLOADS.items():
-            samples: list[float] = []
+            workload_runs: list[WorkloadRun] = []
             for i in range(runs):
-                tps = run_workload(handle, body, max_tokens=max_tokens)
+                wr = run_workload(handle, body, max_tokens=max_tokens)
+                tag = (
+                    f"{wr.tps:.1f} tok/s"
+                    if wr.tps is not None
+                    else f"REJECTED ({wr.rejected_reason}, {wr.completion_tokens}t/{wr.decode_time:.2f}s decode)"
+                )
                 logger.info(
-                    "  [%s] %s run %d/%d: %.1f tok/s",
+                    "  [%s] %s run %d/%d: %s",
                     "ON " if suffix_decoding else "OFF",
                     name,
                     i + 1,
                     runs,
-                    tps,
+                    tag,
                 )
-                samples.append(tps)
-            results[name] = median(samples)
-        return results
+                workload_runs.append(wr)
+            valid = [r.tps for r in workload_runs if r.tps is not None]
+            median_tps[name] = median(valid) if valid else None
+            raw[name] = workload_runs
+        return ModeResult(median_tps=median_tps, raw_runs=raw)
     finally:
         handle.stop()
 
@@ -449,20 +538,61 @@ def main(argv: list[str] | None = None) -> int:
         max_tokens=args.max_tokens,
     )
 
-    speedup = {
-        name: round(suffix[name] / vanilla[name], 3) if vanilla[name] > 0 else 0.0
-        for name in WORKLOADS
-    }
-    tier = classify_suffix_decoding_tier(speedup)
+    # Compute per-workload speedup, skipping workloads where either mode
+    # failed to produce *any* valid run. A workload with no valid data in
+    # either pass shouldn't poison the tier — we drop it from the dict
+    # the classifier sees and report it as 'skipped' in the JSON output.
+    speedup: dict[str, float] = {}
+    skipped: dict[str, str] = {}
+    for name in WORKLOADS:
+        v = vanilla.median_tps.get(name)
+        s = suffix.median_tps.get(name)
+        if v is None or s is None or v <= 0:
+            reason = (
+                "vanilla all runs rejected"
+                if v is None or v <= 0
+                else "suffix all runs rejected"
+            )
+            skipped[name] = reason
+            continue
+        speedup[name] = round(s / v, 3)
+
+    tier = classify_suffix_decoding_tier(speedup) if speedup else "unknown"
+
+    def _serialize_runs(raw: dict[str, list[WorkloadRun]]) -> dict[str, list[dict]]:
+        return {
+            name: [
+                {
+                    "tps": round(r.tps, 1) if r.tps is not None else None,
+                    "completion_tokens": r.completion_tokens,
+                    "decode_time": round(r.decode_time, 3),
+                    "total_time": round(r.total_time, 3),
+                    "rejected_reason": r.rejected_reason,
+                }
+                for r in runs
+            ]
+            for name, runs in raw.items()
+        }
 
     summary = {
         "model": args.model,
         "max_tokens": args.max_tokens,
         "runs": args.runs,
-        "vanilla_tps": {k: round(v, 1) for k, v in vanilla.items()},
-        "suffix_tps": {k: round(v, 1) for k, v in suffix.items()},
+        "vanilla_tps": {
+            k: (round(v, 1) if v is not None else None)
+            for k, v in vanilla.median_tps.items()
+        },
+        "suffix_tps": {
+            k: (round(v, 1) if v is not None else None)
+            for k, v in suffix.median_tps.items()
+        },
         "speedup": speedup,
+        "skipped": skipped,
         "tier": tier,
+        "raw_runs": {
+            "vanilla": _serialize_runs(vanilla.raw_runs),
+            "suffix": _serialize_runs(suffix.raw_runs),
+        },
     }
 
     output = args.output or REPO_ROOT / "evals/results" / (
@@ -471,17 +601,26 @@ def main(argv: list[str] | None = None) -> int:
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(summary, indent=2) + "\n")
     logger.info("--- summary ---")
-    for k, v in speedup.items():
-        marker = "↑" if v >= 1.05 else ("↓" if v <= 0.95 else "·")
-        logger.info("  %-12s %5.2fx %s", k, v, marker)
+    for k in WORKLOADS:
+        if k in skipped:
+            logger.info("  %-12s SKIPPED (%s)", k, skipped[k])
+        else:
+            v = speedup[k]
+            marker = "↑" if v >= 1.05 else ("↓" if v <= 0.95 else "·")
+            logger.info("  %-12s %5.2fx %s", k, v, marker)
     logger.info("  tier: %s", tier)
     logger.info("  written: %s", output)
 
     if args.update_profile:
-        sd_keys = ", ".join(f'"{k}": {v}' for k, v in speedup.items())
-        logger.info("\nPatch for ModelConfig in vllm_mlx/model_auto_config.py:")
-        logger.info('    suffix_decoding_tier="%s",', tier)
-        logger.info("    suffix_bench_speedup={%s},", sd_keys)
+        # The SSOT lives in aliases.json (PR #283 / #281). Print a JSON
+        # snippet the contributor can paste into the alias entry.
+        snippet = json.dumps(
+            {"suffix_decoding_tier": tier, "suffix_bench_speedup": speedup},
+            indent=2,
+        )
+        logger.info("\nPatch for vllm_mlx/aliases.json (alias %s):", args.model)
+        for line in snippet.splitlines():
+            logger.info("  %s", line)
 
     return 0
 

--- a/tests/test_suffix_bench_methodology.py
+++ b/tests/test_suffix_bench_methodology.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SuffixDecoding bench reliability gates (#269 follow-up).
+
+The bench script's previous methodology produced bogus 1000-2700 tok/s
+TPS readings when the model returned short responses (early EOS,
+refusal, or single-chunk streaming). The fix adds three gates — zero
+tokens, decode-time floor, TPS ceiling — implemented in
+``_classify_run`` so they're testable without a live server.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the bench script as a module without invoking its CLI.
+_BENCH_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "bench_suffix_decoding_integrated.py"
+)
+_spec = importlib.util.spec_from_file_location("bench_suffix_decoding", _BENCH_PATH)
+assert _spec and _spec.loader
+bench = importlib.util.module_from_spec(_spec)
+sys.modules["bench_suffix_decoding"] = bench
+_spec.loader.exec_module(bench)
+
+
+class TestClassifyRun:
+    """``_classify_run`` is the boundary that decides whether a single
+    request's measurement is trustworthy."""
+
+    def test_normal_run_passes(self):
+        # 100 tokens in 1.0s decode = 100 tok/s — comfortably realistic.
+        wr = bench._classify_run(completion_tokens=100, decode_time=1.0, total_time=1.5)
+        assert wr.tps == pytest.approx(100.0)
+        assert wr.rejected_reason is None
+
+    def test_zero_tokens_rejected(self):
+        # Server didn't report usage / model returned nothing — caller can't
+        # tell decode rate from one missing data point.
+        wr = bench._classify_run(0, 0.5, 1.0)
+        assert wr.tps is None
+        assert wr.rejected_reason == "zero_completion_tokens"
+
+    def test_negative_tokens_rejected(self):
+        wr = bench._classify_run(-1, 1.0, 1.0)
+        assert wr.tps is None
+        assert wr.rejected_reason == "zero_completion_tokens"
+
+    def test_decode_time_floor_rejects_short_window(self):
+        # 80 tokens generated in 0.04s → 2000 tok/s. This is the exact
+        # failure mode that burned smollm3-3b's code_edit run in v2 —
+        # technically >32 tokens (the old guard) but still meaningless.
+        wr = bench._classify_run(completion_tokens=80, decode_time=0.04, total_time=0.6)
+        assert wr.tps is None
+        assert wr.rejected_reason and "decode_time" in wr.rejected_reason
+
+    def test_decode_time_at_floor_passes(self):
+        # Exactly at the boundary should be accepted (closed lower bound).
+        wr = bench._classify_run(
+            completion_tokens=50,
+            decode_time=bench.MIN_DECODE_TIME,
+            total_time=1.0,
+        )
+        assert wr.tps is not None
+        assert wr.rejected_reason is None
+
+    def test_tps_ceiling_rejects_implausible_speed(self):
+        # 1000 tokens in 1.0s decode = 1000 tok/s. Past the floor but no
+        # mlx-lm decode on M-series we ship runs that fast.
+        wr = bench._classify_run(
+            completion_tokens=1000, decode_time=1.0, total_time=1.5
+        )
+        assert wr.tps is None
+        assert wr.rejected_reason and "ceiling" in wr.rejected_reason
+
+    def test_tps_ceiling_at_boundary(self):
+        # Just under the ceiling passes; at-or-above gets rejected. Models
+        # that genuinely run this fast on M3 Ultra would be a surprise but
+        # we keep the gate strict to catch measurement errors.
+        wr_under = bench._classify_run(
+            completion_tokens=int(bench.TPS_CEILING * 0.99),
+            decode_time=1.0,
+            total_time=1.5,
+        )
+        assert wr_under.tps is not None
+
+        wr_over = bench._classify_run(
+            completion_tokens=int(bench.TPS_CEILING * 1.5),
+            decode_time=1.0,
+            total_time=1.5,
+        )
+        assert wr_over.tps is None
+
+    def test_raw_fields_preserved_on_reject(self):
+        """Even rejected runs must carry the raw timing so post-mortem
+        debugging doesn't need a re-run — that's the whole reason
+        ``WorkloadRun`` is a dataclass instead of a float."""
+        wr = bench._classify_run(completion_tokens=10, decode_time=0.05, total_time=0.4)
+        assert wr.tps is None
+        assert wr.completion_tokens == 10
+        assert wr.decode_time == 0.05
+        assert wr.total_time == 0.4
+        assert wr.rejected_reason  # non-empty
+
+
+class TestThresholds:
+    """Thresholds are constants, not magic numbers — tests pin the
+    intent so a future tweak that 'happens to make a test pass' has to
+    update this assertion too."""
+
+    def test_min_decode_time_is_half_second(self):
+        # 0.5s is enough that the per-request HTTP overhead (~10-50ms on
+        # localhost) is <10% of the measurement.
+        assert pytest.approx(0.5) == bench.MIN_DECODE_TIME
+
+    def test_tps_ceiling_above_observed_peak(self):
+        # 500 sits comfortably above the fastest mlx-lm decode we ship
+        # (~330 tok/s for Llama-3.2-1B-4bit). If a future model goes past
+        # this for real we re-tune; until then it's a reliable sanity gate.
+        assert pytest.approx(500.0) == bench.TPS_CEILING


### PR DESCRIPTION
## Summary

Follow-up #1 to PR #281: fix the methodology bugs that caused us to discard the smollm3-3b and llama3-3b bench data during the cross-model sweep.

## Bugs in the v1/v2 bench

The original script computed TPS as ``completion_tokens / decode_time`` with a single ``< 32 tokens → 0`` guard. Two failure modes still slipped through:

1. **Short decode windows produce nonsense TPS.** A run that generates 80 tokens in 0.04s clears the 32-token floor but reports 2000 tok/s — completely fictional. We saw this on smollm3-3b's `code_edit` workload (vanilla median 2746 tok/s for a 3B model).
2. **Workloads with all runs rejected silently became "avoid".** The old code returned 0.0 speedup, which trips the `< 0.85x → avoid` regression check. A model that *can't be measured* on a workload was being told to disable suffix decoding because of it.

## Fix: three explicit gates

Pulled into ``_classify_run`` (pure function, no server needed) so the boundaries are unit-testable:

| Gate | Threshold | Reject reason |
|---|---|---|
| zero tokens | `completion_tokens <= 0` | `zero_completion_tokens` |
| decode floor | `decode_time < 0.5s` | `decode_time<0.5s` |
| TPS ceiling | `tps > 500` | `tps>500.0_ceiling` |

The 0.5s decode floor is set so per-request overhead (TLS, JSON round-trip, last-chunk flush — typically 10-50ms on localhost) is <10% of the measurement. The 500 tok/s ceiling sits comfortably above the fastest single-request mlx-lm decode we ship (~330 tok/s for Llama-3.2-1B-4bit).

## Skipped workloads

When *every* run for a workload is rejected, it now lands in `skipped[name] = "<reason>"` in the JSON output and gets dropped from the classifier input. Previously: silent → false `avoid` tier.

## Raw-data persistence

The summary JSON gains a `raw_runs` block with every individual run's `completion_tokens`, `decode_time`, `total_time`, and `rejected_reason`. So when a future bench produces a surprising tier, the post-mortem reads the existing JSON instead of re-running.

## Sanity

Bonsai-1.7b re-bench under the new methodology:

```
chat        0.999x  ·
json_array  0.999x  ·
tool_loop   0.998x  ·
code_edit   1.002x  ·
tier: neutral
```

Tight numbers, same classification as PR #281 (`neutral`). Result file updated.

## Test plan

- [x] **10 new contract tests** in `tests/test_suffix_bench_methodology.py` — every gate, threshold pinning, raw-fields-on-reject.
- [x] All 34 suffix-related tests pass (10 new + 24 from #281).
- [x] 142 total alias/profile/tier tests pass.
- [x] `ruff check` + `ruff format` clean.
- [x] End-to-end sanity bench on bonsai-1.7b confirms `neutral` classification stable.

## Out of scope (next follow-ups, the original plan)

- batch 1 bench: 5 popular dense models with the fixed methodology
- alias path fixes for `gpt-oss-20b` (HF 401), `gemma3-12b`, `mistral-24b` (no chat template)