### PR TITLE
data(suffix-tier): batch-1 — 4 popular dense aliases

### DIFF
--- a/evals/results/suffix_llama3-3b.json
+++ b/evals/results/suffix_llama3-3b.json
@@ -1,0 +1,216 @@
+{
+  "model": "llama3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 223.0,
+    "json_array": 222.0,
+    "tool_loop": null,
+    "code_edit": 223.3
+  },
+  "suffix_tps": {
+    "chat": 222.8,
+    "json_array": 221.6,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.999,
+    "json_array": 0.998
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "suffix all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 223.8,
+          "completion_tokens": 192,
+          "decode_time": 0.858,
+          "total_time": 1.004,
+          "rejected_reason": null
+        },
+        {
+          "tps": 222.9,
+          "completion_tokens": 238,
+          "decode_time": 1.068,
+          "total_time": 1.185,
+          "rejected_reason": null
+        },
+        {
+          "tps": 223.0,
+          "completion_tokens": 227,
+          "decode_time": 1.018,
+          "total_time": 1.131,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 222.0,
+          "completion_tokens": 181,
+          "decode_time": 0.815,
+          "total_time": 0.939,
+          "rejected_reason": null
+        },
+        {
+          "tps": 221.5,
+          "completion_tokens": 183,
+          "decode_time": 0.826,
+          "total_time": 0.95,
+          "rejected_reason": null
+        },
+        {
+          "tps": 222.1,
+          "completion_tokens": 182,
+          "decode_time": 0.82,
+          "total_time": 0.941,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.094,
+          "total_time": 0.404,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.093,
+          "total_time": 0.405,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.093,
+          "total_time": 0.404,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 223.3,
+          "completion_tokens": 147,
+          "decode_time": 0.658,
+          "total_time": 0.791,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.254,
+          "total_time": 0.388,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 77,
+          "decode_time": 0.352,
+          "total_time": 0.485,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 222.8,
+          "completion_tokens": 176,
+          "decode_time": 0.79,
+          "total_time": 0.935,
+          "rejected_reason": null
+        },
+        {
+          "tps": 222.5,
+          "completion_tokens": 226,
+          "decode_time": 1.016,
+          "total_time": 1.128,
+          "rejected_reason": null
+        },
+        {
+          "tps": 223.1,
+          "completion_tokens": 190,
+          "decode_time": 0.852,
+          "total_time": 0.964,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 221.6,
+          "completion_tokens": 256,
+          "decode_time": 1.155,
+          "total_time": 1.278,
+          "rejected_reason": null
+        },
+        {
+          "tps": 221.6,
+          "completion_tokens": 181,
+          "decode_time": 0.817,
+          "total_time": 0.94,
+          "rejected_reason": null
+        },
+        {
+          "tps": 221.8,
+          "completion_tokens": 184,
+          "decode_time": 0.83,
+          "total_time": 0.953,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.093,
+          "total_time": 0.405,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.093,
+          "total_time": 0.404,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.093,
+          "total_time": 0.404,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 107,
+          "decode_time": 0.486,
+          "total_time": 0.62,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 61,
+          "decode_time": 0.281,
+          "total_time": 0.414,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 57,
+          "decode_time": 0.263,
+          "total_time": 0.397,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_ministral-3b.json
+++ b/evals/results/suffix_ministral-3b.json
@@ -1,0 +1,216 @@
+{
+  "model": "ministral-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 201.7,
+    "json_array": 200.8,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 201.2,
+    "json_array": 200.4,
+    "tool_loop": null,
+    "code_edit": 200.4
+  },
+  "speedup": {
+    "chat": 0.998,
+    "json_array": 0.998
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 201.7,
+          "completion_tokens": 204,
+          "decode_time": 1.011,
+          "total_time": 1.322,
+          "rejected_reason": null
+        },
+        {
+          "tps": 201.7,
+          "completion_tokens": 180,
+          "decode_time": 0.892,
+          "total_time": 1.197,
+          "rejected_reason": null
+        },
+        {
+          "tps": 201.5,
+          "completion_tokens": 184,
+          "decode_time": 0.913,
+          "total_time": 1.217,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 200.8,
+          "completion_tokens": 256,
+          "decode_time": 1.275,
+          "total_time": 1.589,
+          "rejected_reason": null
+        },
+        {
+          "tps": 200.5,
+          "completion_tokens": 256,
+          "decode_time": 1.277,
+          "total_time": 1.591,
+          "rejected_reason": null
+        },
+        {
+          "tps": 200.8,
+          "completion_tokens": 256,
+          "decode_time": 1.275,
+          "total_time": 1.588,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.073,
+          "total_time": 0.343,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 25,
+          "decode_time": 0.13,
+          "total_time": 0.399,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.073,
+          "total_time": 0.342,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.325,
+          "total_time": 0.653,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 82,
+          "decode_time": 0.413,
+          "total_time": 0.741,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 78,
+          "decode_time": 0.394,
+          "total_time": 0.723,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 201.2,
+          "completion_tokens": 172,
+          "decode_time": 0.855,
+          "total_time": 1.166,
+          "rejected_reason": null
+        },
+        {
+          "tps": 201.6,
+          "completion_tokens": 211,
+          "decode_time": 1.046,
+          "total_time": 1.351,
+          "rejected_reason": null
+        },
+        {
+          "tps": 201.0,
+          "completion_tokens": 162,
+          "decode_time": 0.806,
+          "total_time": 1.11,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 200.4,
+          "completion_tokens": 256,
+          "decode_time": 1.277,
+          "total_time": 1.592,
+          "rejected_reason": null
+        },
+        {
+          "tps": 200.5,
+          "completion_tokens": 256,
+          "decode_time": 1.277,
+          "total_time": 1.591,
+          "rejected_reason": null
+        },
+        {
+          "tps": 200.3,
+          "completion_tokens": 256,
+          "decode_time": 1.278,
+          "total_time": 1.593,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.073,
+          "total_time": 0.342,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.075,
+          "total_time": 0.343,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.073,
+          "total_time": 0.342,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 86,
+          "decode_time": 0.433,
+          "total_time": 0.762,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 200.4,
+          "completion_tokens": 196,
+          "decode_time": 0.978,
+          "total_time": 1.306,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 75,
+          "decode_time": 0.378,
+          "total_time": 0.705,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_phi4-14b.json
+++ b/evals/results/suffix_phi4-14b.json
@@ -1,0 +1,216 @@
+{
+  "model": "phi4-14b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 174.5,
+    "json_array": 173.9,
+    "tool_loop": 171.4,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 173.2,
+    "json_array": 172.7,
+    "tool_loop": 170.3,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.993,
+    "json_array": 0.993,
+    "tool_loop": 0.994
+  },
+  "skipped": {
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 174.4,
+          "completion_tokens": 256,
+          "decode_time": 1.468,
+          "total_time": 1.583,
+          "rejected_reason": null
+        },
+        {
+          "tps": 174.5,
+          "completion_tokens": 256,
+          "decode_time": 1.467,
+          "total_time": 1.577,
+          "rejected_reason": null
+        },
+        {
+          "tps": 174.5,
+          "completion_tokens": 256,
+          "decode_time": 1.467,
+          "total_time": 1.578,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 174.1,
+          "completion_tokens": 181,
+          "decode_time": 1.039,
+          "total_time": 1.16,
+          "rejected_reason": null
+        },
+        {
+          "tps": 173.8,
+          "completion_tokens": 184,
+          "decode_time": 1.059,
+          "total_time": 1.179,
+          "rejected_reason": null
+        },
+        {
+          "tps": 173.9,
+          "completion_tokens": 179,
+          "decode_time": 1.029,
+          "total_time": 1.146,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 171.4,
+          "completion_tokens": 256,
+          "decode_time": 1.494,
+          "total_time": 1.662,
+          "rejected_reason": null
+        },
+        {
+          "tps": 171.4,
+          "completion_tokens": 256,
+          "decode_time": 1.494,
+          "total_time": 1.66,
+          "rejected_reason": null
+        },
+        {
+          "tps": 171.3,
+          "completion_tokens": 256,
+          "decode_time": 1.494,
+          "total_time": 1.663,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.374,
+          "total_time": 0.506,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.374,
+          "total_time": 0.506,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 62,
+          "decode_time": 0.362,
+          "total_time": 0.493,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 173.2,
+          "completion_tokens": 256,
+          "decode_time": 1.478,
+          "total_time": 1.592,
+          "rejected_reason": null
+        },
+        {
+          "tps": 173.3,
+          "completion_tokens": 256,
+          "decode_time": 1.477,
+          "total_time": 1.585,
+          "rejected_reason": null
+        },
+        {
+          "tps": 173.1,
+          "completion_tokens": 256,
+          "decode_time": 1.479,
+          "total_time": 1.586,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 172.8,
+          "completion_tokens": 158,
+          "decode_time": 0.914,
+          "total_time": 1.032,
+          "rejected_reason": null
+        },
+        {
+          "tps": 172.7,
+          "completion_tokens": 162,
+          "decode_time": 0.938,
+          "total_time": 1.057,
+          "rejected_reason": null
+        },
+        {
+          "tps": 172.6,
+          "completion_tokens": 164,
+          "decode_time": 0.95,
+          "total_time": 1.068,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 170.1,
+          "completion_tokens": 134,
+          "decode_time": 0.788,
+          "total_time": 0.952,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.138,
+          "total_time": 0.303,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 170.4,
+          "completion_tokens": 161,
+          "decode_time": 0.945,
+          "total_time": 1.11,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 62,
+          "decode_time": 0.365,
+          "total_time": 0.495,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 63,
+          "decode_time": 0.37,
+          "total_time": 0.501,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 61,
+          "decode_time": 0.359,
+          "total_time": 0.489,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_smollm3-3b.json
+++ b/evals/results/suffix_smollm3-3b.json
@@ -1,0 +1,216 @@
+{
+  "model": "smollm3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 403.4,
+    "json_array": 174.0,
+    "tool_loop": 175.2,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 375.6,
+    "json_array": null,
+    "tool_loop": 175.1,
+    "code_edit": 173.7
+  },
+  "speedup": {
+    "chat": 0.931,
+    "tool_loop": 0.999
+  },
+  "skipped": {
+    "json_array": "suffix all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 444.5,
+          "completion_tokens": 607,
+          "decode_time": 1.366,
+          "total_time": 3.502,
+          "rejected_reason": null
+        },
+        {
+          "tps": 362.2,
+          "completion_tokens": 664,
+          "decode_time": 1.833,
+          "total_time": 3.815,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 907,
+          "decode_time": 1.674,
+          "total_time": 5.184,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 174.0,
+          "completion_tokens": 2304,
+          "decode_time": 13.238,
+          "total_time": 13.238,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1255,
+          "decode_time": 1.838,
+          "total_time": 7.175,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1594,
+          "decode_time": 1.497,
+          "total_time": 9.105,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 175.2,
+          "completion_tokens": 2304,
+          "decode_time": 13.149,
+          "total_time": 13.149,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 966,
+          "decode_time": 0.404,
+          "total_time": 5.479,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 0.724,
+          "total_time": 13.161,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 1388,
+          "decode_time": 0.315,
+          "total_time": 7.949,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1845,
+          "decode_time": 0.836,
+          "total_time": 10.581,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1338,
+          "decode_time": 0.719,
+          "total_time": 7.665,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 334.9,
+          "completion_tokens": 794,
+          "decode_time": 2.371,
+          "total_time": 4.571,
+          "rejected_reason": null
+        },
+        {
+          "tps": 389.7,
+          "completion_tokens": 683,
+          "decode_time": 1.753,
+          "total_time": 3.938,
+          "rejected_reason": null
+        },
+        {
+          "tps": 375.6,
+          "completion_tokens": 763,
+          "decode_time": 2.032,
+          "total_time": 4.395,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 0.385,
+          "total_time": 13.248,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 1.656,
+          "total_time": 13.25,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1615,
+          "decode_time": 1.89,
+          "total_time": 9.234,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 175.1,
+          "completion_tokens": 2304,
+          "decode_time": 13.157,
+          "total_time": 13.157,
+          "rejected_reason": null
+        },
+        {
+          "tps": 175.1,
+          "completion_tokens": 2304,
+          "decode_time": 13.156,
+          "total_time": 13.156,
+          "rejected_reason": null
+        },
+        {
+          "tps": 175.1,
+          "completion_tokens": 2304,
+          "decode_time": 13.157,
+          "total_time": 13.157,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 1184,
+          "decode_time": 0.396,
+          "total_time": 6.788,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 173.7,
+          "completion_tokens": 2304,
+          "decode_time": 13.263,
+          "total_time": 13.263,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1628,
+          "decode_time": 1.072,
+          "total_time": 9.325,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    }
+  }
+}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -116,7 +116,12 @@
     "tool_call_parser": "llama",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.999,
+      "json_array": 0.998
+    }
   },
   "hermes3-8b": {
     "hf_path": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
@@ -158,7 +163,13 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.993,
+      "json_array": 0.993,
+      "tool_loop": 0.994
+    }
   },
   "mistral-24b": {
     "hf_path": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
@@ -256,7 +267,12 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.998,
+      "json_array": 0.998
+    }
   },
   "hermes4-70b": {
     "hf_path": "lmstudio-community/Hermes-4-70B-MLX-4bit",
@@ -361,7 +377,12 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.931,
+      "tool_loop": 0.999
+    }
   },
   "granite4-tiny": {
     "hf_path": "mlx-community/granite-4.0-h-tiny-4bit",


### PR DESCRIPTION
## Summary

Bench the first batch of popular dense aliases under the new methodology gates (PR #284) and populate `suffix_decoding_tier` + `suffix_bench_speedup` in `aliases.json`. All four classify as `avoid` — useful guidance for users on small dense models where SuffixDecoding overhead exceeds savings.

## Tier results

| Alias | Tier | Speedup |
|---|---|---|
| smollm3-3b | `avoid` | chat 0.931, tool_loop 0.999 |
| llama3-3b | `avoid` | chat 0.999, json_array 0.998 |
| phi4-14b | `avoid` | chat 0.993, json_array 0.993, tool_loop 0.994 |
| ministral-3b | `avoid` | chat 0.998, json_array 0.998 |

`phi4-14b` alias maps to `phi-4-mini-instruct-4bit` (3.8B dense).

Honest signal: small dense (1-4B) models don't benefit — drafter overhead dominates memory-bound decode. With this PR, users running `rapid-mlx serve <alias> --suffix-decoding` will see the AVOID hint at startup.

## Out of scope (documented for follow-up)

- **gemma3-1b** — 5th candidate failed: `mlx_vlm` doesn't support `gemma3_text` model_type, server can't load. Pre-existing alias breakage, not a SuffixDecoding methodology issue.
- **hermes3-8b** — already tier=`neutral` in `aliases.json`, but the data was generated under old (pre-#284) methodology without raw_runs. Re-bench under new gates in a follow-up data PR.

## Methodology

All runs used the post-PR-#284 bench script with:
- `--disable-prefix-cache` (avoid replay-cached fake high TPS)
- decode-time floor of 0.5s (reject sub-window timing noise)
- TPS ceiling of 500 tok/s (catch measurement errors)
- 3 runs × 4 workloads × 2 modes per alias

Workloads where all runs in either mode hit the gates are dropped from the classifier input (recorded in `skipped`) so the tier doesn't get poisoned by partial data.

## Test plan

- [x] `python3.12 -m pytest tests/test_suffix_decoding_tier.py tests/test_model_aliases.py tests/test_model_auto_config.py tests/test_suffix_bench_methodology.py -q` — 119 pass
- [x] Broader unit: 2299 pass + 1 pre-existing flake (`test_batching_deterministic::test_concurrent_same_prompt`, documented in CLAUDE.md)
- [x] `ruff check vllm_mlx/` + `ruff format --check vllm_mlx/` — clean
- [x] `python3.12 -c "import json; json.load(open('vllm_mlx/aliases.json'))"` — valid JSON
- [x] `make check` skipped — data-only PR, no inference-path code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)