### PR TITLE
fix(engine): plumb prefill_step_size to MLLMSchedulerConfig

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -324,11 +324,13 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 16
         )
+        prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", 1024)
 
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
             completion_batch_size=completion_batch_size,
+            prefill_step_size=prefill_step_size,
             enable_vision_cache=True,
             vision_cache_size=100,
         )


### PR DESCRIPTION
## What does this PR do?

Fixes a silent no-op of `--prefill-step-size` for vision/multimodal serving.

`BatchedEngine._start_mllm` (`vllm_mlx/engine/batched.py:328`) constructs `MLLMSchedulerConfig` without forwarding `prefill_step_size` from the engine's scheduler config, so the value always falls back to the dataclass default of `1024`. The MLLM batch generator's safe-limit check at `mllm_batch_generator.py:638` (`max_batch_tokens = prefill_step_size * len(requests)`) then rejects any single-request prompt longer than 1024 tokens.

In practice this makes the documented `--prefill-step-size` CLI flag silently a no-op for VLM serving and breaks image upload entirely — Qwen3-VL emits ~8000+ tokens for a typical photograph, which trips the guard and returns:

```
ERROR:vllm_mlx.mllm_scheduler:Batch generation failed: Total prompt tokens (8815) exceeds safe limit (1024) for 1 requests. Reduce prompt length or batch size.
```

The fix forwards `self._scheduler_config.prefill_step_size` (default `1024`, matching the existing dataclass default — so behavior is unchanged when the flag is not set) into the constructor, alongside the existing `prefill_batch_size` / `completion_batch_size` plumbing already present a few lines above.

### Repro

```bash
rapid-mlx serve mlx-community/Qwen3-VL-8B-Instruct-4bit --port 8000 --prefill-step-size 16384
# upload any photo via OpenAI-compatible chat completions → safe limit still 1024 (bug)
# with this fix → safe limit becomes 16384 as requested
```

## Checklist

- [x] Tests pass locally — `python3 -m pytest tests/test_mllm_continuous_batching.py -x -q` → 37 passed
- [x] Lint passes — `ruff check` + `ruff format --check` on the modified file
- [ ] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — happy to run once a PR# is assigned
- [x] Updated README/docs if applicable — N/A (existing `--help` text becomes accurate again)
- [x] No breaking changes to existing API — pure plumbing fix; dataclass default preserved at `1024`

I didn't add a regression test because exercising `BatchedEngine._start_mllm` requires a real VLM load (the path constructs `MLXMultimodalLM` and submits to a thread executor). Happy to add a unit test that mocks the scheduler-config plumbing if you'd prefer — just let me know the level of mocking you're comfortable with.