### PR TITLE
fix(engine): plumb prefill_step_size to MLLMSchedulerConfig

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -324,11 +324,13 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 16
         )
+        prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", 1024)
 
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
             completion_batch_size=completion_batch_size,
+            prefill_step_size=prefill_step_size,
             enable_vision_cache=True,
             vision_cache_size=100,
         )


### PR DESCRIPTION
Rebased version of #286 (by @young310) for SOP validation.

**Bug:** `BatchedEngine._start_mllm` builds `MLLMSchedulerConfig` without forwarding `prefill_step_size` from the engine's scheduler config, so the value always falls back to the dataclass default of 1024. For VLM serving (images emit ~8000+ tokens), this trips the safe-limit check and returns:

```
ERROR: Total prompt tokens (8815) exceeds safe limit (1024) for 1 requests.
```

**Fix:** Forward `prefill_step_size` via `getattr(self._scheduler_config, "prefill_step_size", 1024)`, consistent with the existing pattern for `prefill_batch_size` and `completion_batch_size` on the lines above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)