### PR TITLE
chore: bump version to 0.6.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.22"
+version = "0.6.23"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cuts release **v0.6.23**, shipping the past 48h of merged work to PyPI + Homebrew via `auto-release.yml`.

This is the first release since **v0.6.20** (last shipped tag). 0.6.21 and 0.6.22 were inline `pyproject.toml` bumps whose commit subjects did not match the auto-release regex (`^chore: bump version to`), so neither shipped — this PR ships everything accumulated since then as 0.6.23.

## Notable changes since v0.6.20

- **#301** codex review fixes: per-uid drafter cleanup (memory-leak fix), Qwen3 streaming `finalize_streaming` empty-delta correctness, fallback `BatchedEngine` defaults aligned with canonical `SchedulerConfig`, stat key rename `drafts_proposed` → `draft_tokens_proposed`
- **#290** plumb `prefill_step_size` to `MLLMSchedulerConfig`
- **#289** split delta at channel marker in Gemma4 streaming parser
- **#288** bypass `StreamingThinkRouter` when `reasoning_parser` is active (Anthropic-compat regression fix)
- **#285** batch-1 SuffixDecoding tier data (4 popular dense aliases)
- **#284** suffix-decoding TPS reliability gates + raw-data persistence

## Pre-release SOP — followed (per `CLAUDE.md` Release SOP)

| Step | Result |
|---|---|
| 1. Pre-flight inventory | inference-touching; full gates |
| 2. Full PR Merge SOP on #301 | merged 2026-05-07 21:45Z (squash) |
| 3. Binary / install size audit | 447 MB site-packages, **0% growth** vs 0.6.20 |
| 4. Fresh-install user simulation (subagent) | 6/6 happy paths complete; 2 minor friction items pre-existing |
| 5. Perf regression check | clean `make check` baseline; qwen3.6-35b uncontended runs showed 0 regressions |
| 6. Agent integration smoke | covered by step 4 (Anthropic-compat round-trip ✅) + qwen3.6-35b agent runs |
| 7. Supply-chain re-audit | `pip-audit`: 0 vulns; `auto-release.yml` / `install.sh` / `publish.yml` integrity verified clean since v0.6.20 (only `2baf796 ci: use RELEASE_PAT for auto-release` — benign) |
| 8. Signature / artifact integrity | Trusted Publisher OIDC only (sigstore TBD) |

## Test plan

- [x] `ruff check && ruff format --check` clean (per #301 + the version-only diff)
- [x] full unit suite — 2419 passed (3 pre-existing flakes confirmed on clean main)
- [x] `pip install dist/*.whl` round-trip in clean venv — `rapid-mlx --version` → 0.6.23
- [ ] CI green on this PR (lint / type-check / version-check / test-matrix / test-apple-silicon)
- [ ] Squash-merge → `auto-release.yml` triggers on `chore: bump version to 0.6.23` subject regex
- [ ] PyPI v0.6.23 visible at https://pypi.org/project/rapid-mlx/0.6.23/
- [ ] Homebrew tap auto-updates to 0.6.23

## Out of scope (follow-ups)

- Cooldown state shared across requests (closure-scoped, not per-uid) — tracked from #301 review
- Drafter cleanup on abort path (currently only fires on natural finish) — tracked from #301 review
- batch-2 SuffixDecoding bench data (#176) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)