### PR TITLE
feat(cli): add rapid-mlx chat (interactive REPL)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.23"
+version = "0.6.24"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `rapid-mlx chat` (interactive REPL command)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import cli
+
+
+def _sse(events: list[dict]) -> bytes:
+    """Build an SSE byte stream from a list of OpenAI-format chunks."""
+    out = []
+    for ev in events:
+        out.append(f"data: {json.dumps(ev)}\n\n")
+    out.append("data: [DONE]\n\n")
+    return "".join(out).encode("utf-8")
+
+
+def _delta(content: str | None) -> dict:
+    return {"choices": [{"delta": {"content": content} if content else {}}]}
+
+
+class _FakeChatHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP server that pretends to be /v1/chat/completions."""
+
+    canned_response: list[dict] = []
+    received_payloads: list[dict] = []
+
+    def log_message(self, *_args, **_kwargs):  # silence stderr
+        pass
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        self.received_payloads.append(json.loads(body))
+        if self.path != "/v1/chat/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        self.wfile.write(_sse(self.canned_response))
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/health/ready":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@contextmanager
+def _fake_server(canned: list[dict]):
+    _FakeChatHandler.canned_response = canned
+    _FakeChatHandler.received_payloads = []
+    server = HTTPServer(("127.0.0.1", 0), _FakeChatHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield port, _FakeChatHandler.received_payloads
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_chat_subcommand_registered_in_cli():
+    """`rapid-mlx chat --help` exits 0 (subparser is wired)."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--help"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 0
+
+
+def test_chat_subcommand_requires_model():
+    """`rapid-mlx chat` (no model) exits non-zero."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code != 0
+
+
+def test_stream_chat_response_concatenates_deltas():
+    """`_stream_chat_response` streams chunks and returns concatenated content."""
+    canned = [_delta("Hello"), _delta(", "), _delta("world!")]
+    with _fake_server(canned) as (port, _payloads):
+        buf = io.StringIO()
+        with patch.object(sys, "stdout", buf):
+            full = cli._stream_chat_response(
+                f"http://127.0.0.1:{port}",
+                {"model": "x", "messages": [], "stream": True},
+                timeout_s=10,
+            )
+    assert full == "Hello, world!"
+    assert buf.getvalue() == "Hello, world!"
+
+
+def test_stream_chat_response_skips_empty_deltas():
+    """Tool-only / role-only deltas (no content) are ignored."""
+    canned = [
+        {"choices": [{"delta": {"role": "assistant"}}]},
+        _delta("hi"),
+        {"choices": [{"delta": {}}]},
+    ]
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()),
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+    assert full == "hi"
+
+
+def test_stream_chat_response_raises_on_http_error():
+    """A non-200 response raises RuntimeError carrying the body."""
+
+    class _ErrHandler(BaseHTTPRequestHandler):
+        def log_message(self, *_a, **_kw):
+            pass
+
+        def do_POST(self):  # noqa: N802
+            self.send_response(500)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"boom")
+
+    server = HTTPServer(("127.0.0.1", 0), _ErrHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        with pytest.raises(RuntimeError, match=r"HTTP 500"):
+            cli._stream_chat_response(
+                f"http://127.0.0.1:{port}",
+                {"model": "x", "messages": [], "stream": True},
+                timeout_s=5,
+            )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_chat_command_repl_multi_turn(monkeypatch, capsys):
+    """End-to-end: `chat --base-url ...` accumulates multi-turn history."""
+    canned = [_delta("Hi there!")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["hello", "/reset", "again", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+
+        ns = type("Args", (), {})()
+        ns.base_url = f"http://127.0.0.1:{port}"
+        ns.port = None
+        ns.system = None
+        ns.no_think = False
+        ns.max_tokens = 50
+        ns.temperature = 0.0
+        ns.ready_timeout = 5
+        ns.response_timeout = 5
+        ns.model = "qwen3.5-4b"
+
+        cli.chat_command(ns)
+
+    # Two POSTs — one before /reset, one after — both should ask for the
+    # latest user turn only on second request because /reset clears history.
+    assert len(payloads) == 2
+    # First request: history = [{"role":"user","content":"hello"}]
+    assert payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
+    # After /reset and "again", history should NOT contain "hello".
+    assert payloads[1]["messages"] == [{"role": "user", "content": "again"}]
+
+
+def test_chat_command_system_prompt_prepended(monkeypatch):
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q1", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = type("Args", (), {})()
+        ns.base_url = f"http://127.0.0.1:{port}"
+        ns.port = None
+        ns.system = "be terse"
+        ns.no_think = False
+        ns.max_tokens = 50
+        ns.temperature = 0.0
+        ns.ready_timeout = 5
+        ns.response_timeout = 5
+        ns.model = "qwen3.5-4b"
+        cli.chat_command(ns)
+    assert payloads[0]["messages"][0] == {"role": "system", "content": "be terse"}
+    assert payloads[0]["messages"][1] == {"role": "user", "content": "q1"}
+
+
+def test_chat_command_no_think_passes_chat_template_kwargs(monkeypatch):
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = type("Args", (), {})()
+        ns.base_url = f"http://127.0.0.1:{port}"
+        ns.port = None
+        ns.system = None
+        ns.no_think = True
+        ns.max_tokens = 50
+        ns.temperature = 0.0
+        ns.ready_timeout = 5
+        ns.response_timeout = 5
+        ns.model = "qwen3.5-4b"
+        cli.chat_command(ns)
+    assert payloads[0].get("chat_template_kwargs") == {"enable_thinking": False}
+
+
+def test_chat_command_history_unchanged_on_http_error(monkeypatch):
+    """A failed turn must not leave a user message in history (would corrupt
+    the next turn). The user-side rollback is a contract we test explicitly."""
+
+    class _ErrHandler(BaseHTTPRequestHandler):
+        def log_message(self, *_a, **_kw):
+            pass
+
+        def do_POST(self):  # noqa: N802
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"boom")
+
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+
+    server = HTTPServer(("127.0.0.1", 0), _ErrHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        # We can't easily inspect `messages` post-hoc since chat_command
+        # holds it locally — but we can confirm the second turn is sent
+        # WITHOUT the failed first turn in the history.
+        # Wire two failing POSTs but check the second request body.
+        recorded = []
+        orig = _ErrHandler.do_POST
+
+        def _capture(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length).decode("utf-8")
+            recorded.append(json.loads(body))
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"boom")
+
+        _ErrHandler.do_POST = _capture  # type: ignore[assignment]
+
+        inputs = iter(["bad1", "bad2", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = type("Args", (), {})()
+        ns.base_url = f"http://127.0.0.1:{port}"
+        ns.port = None
+        ns.system = None
+        ns.no_think = False
+        ns.max_tokens = 50
+        ns.temperature = 0.0
+        ns.ready_timeout = 5
+        ns.response_timeout = 5
+        ns.model = "qwen3.5-4b"
+        cli.chat_command(ns)
+
+        _ErrHandler.do_POST = orig  # type: ignore[assignment]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    # Both turns were sent — and the second turn must NOT carry the failed
+    # first turn (rollback contract).
+    assert len(recorded) == 2
+    assert recorded[1]["messages"] == [{"role": "user", "content": "bad2"}]

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -208,7 +208,10 @@ def test_chat_command_system_prompt_prepended(monkeypatch):
     assert payloads[0]["messages"][1] == {"role": "user", "content": "q1"}
 
 
-def test_chat_command_no_think_passes_chat_template_kwargs(monkeypatch):
+def test_chat_command_no_think_sets_top_level_enable_thinking(monkeypatch):
+    """`--no-think` must set the top-level ``enable_thinking`` request field
+    that the rapid-mlx server actually honors. Sending nested
+    ``chat_template_kwargs`` would be silently dropped."""
     canned = [_delta("ok")]
     with _fake_server(canned) as (port, payloads):
         inputs = iter(["q", "exit"])
@@ -224,7 +227,39 @@ def test_chat_command_no_think_passes_chat_template_kwargs(monkeypatch):
         ns.response_timeout = 5
         ns.model = "qwen3.5-4b"
         cli.chat_command(ns)
-    assert payloads[0].get("chat_template_kwargs") == {"enable_thinking": False}
+    assert payloads[0].get("enable_thinking") is False
+    # The unsupported nested form must NOT be present.
+    assert "chat_template_kwargs" not in payloads[0]
+
+
+def test_chat_command_survives_connection_failure(monkeypatch, capsys):
+    """If the server is unreachable, the REPL must keep running (not crash)
+    and roll back the failed user turn so the next request is clean."""
+    # Bind a port and immediately release it so connect() will fail.
+    import socket
+
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+
+    inputs = iter(["hello", "exit"])
+    monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+
+    ns = type("Args", (), {})()
+    ns.base_url = f"http://127.0.0.1:{dead_port}"
+    ns.port = None
+    ns.system = None
+    ns.no_think = False
+    ns.max_tokens = 50
+    ns.temperature = 0.0
+    ns.ready_timeout = 1
+    ns.response_timeout = 2
+    ns.model = "qwen3.5-4b"
+    # Should not raise — REPL prints "Request failed" and continues to "exit".
+    cli.chat_command(ns)
+    captured = capsys.readouterr()
+    assert "Request failed" in captured.out
 
 
 def test_chat_command_history_unchanged_on_http_error(monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -803,6 +803,255 @@ def ps_command(_args):
     print()
 
 
+def _spawn_chat_server(
+    model: str, log_path: str, served_name: str | None = None
+) -> tuple[object, str]:
+    """Spawn a `serve` subprocess on an ephemeral port for chat REPL use.
+
+    Returns (Popen handle, base_url). The caller must register cleanup —
+    `chat_command` does so via atexit + signal handlers.
+
+    If ``served_name`` is given, it is passed via ``--served-model-name`` so
+    the spawned server exposes the alias as the API model name (e.g. user
+    typed ``qwen3.5-4b`` → API requests use ``qwen3.5-4b`` rather than the
+    expanded HF path).
+    """
+    import socket
+    import subprocess
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}"
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        model,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--log-level",
+        "WARNING",
+    ]
+    if served_name and served_name != model:
+        cmd.extend(["--served-model-name", served_name])
+    log = open(log_path, "w")  # noqa: SIM115 — kept open for proc lifetime
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    return proc, base_url
+
+
+def _wait_for_chat_server(base_url: str, proc, timeout_s: int = 600) -> None:
+    """Block until /health/ready returns 200, the proc exits, or timeout."""
+    import time
+
+    import requests
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"server exited early (code {proc.returncode}); "
+                "see chat-server.log for details"
+            )
+        try:
+            r = requests.get(f"{base_url}/health/ready", timeout=2)
+            if r.status_code == 200:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(1)
+    raise TimeoutError(
+        f"server did not become ready within {timeout_s}s "
+        "(large models can take longer — pass --ready-timeout)"
+    )
+
+
+def _stream_chat_response(base_url: str, payload: dict, timeout_s: int) -> str:
+    """POST /v1/chat/completions with stream=True and print tokens as they
+    arrive. Returns the full assistant content (concatenated content deltas).
+
+    Reasoning-content deltas (Qwen3, DeepSeek-R1, etc.) are streamed to stdout
+    in dim ANSI so the user sees thinking, but excluded from the returned
+    string — chat history stores only the final answer, matching the
+    OpenAI-compat split between ``content`` and ``reasoning_content``.
+    """
+    import json
+
+    import requests
+
+    DIM = "\x1b[2m"
+    RESET = "\x1b[0m"
+    is_tty = sys.stdout.isatty()
+    in_reasoning = False
+    full = ""
+
+    with requests.post(
+        f"{base_url}/v1/chat/completions",
+        json=payload,
+        stream=True,
+        timeout=timeout_s,
+    ) as resp:
+        if resp.status_code != 200:
+            # With stream=True the body may still be partial / mid-chunk when
+            # the server closed the socket; read defensively so we surface a
+            # useful HTTP code instead of a ChunkedEncodingError.
+            try:
+                body = resp.text[:500]
+            except Exception:
+                body = "(no body)"
+            raise RuntimeError(f"HTTP {resp.status_code}: {body}")
+        for line in resp.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[6:]
+            if data == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            delta = chunk.get("choices", [{}])[0].get("delta", {}) or {}
+            reasoning = delta.get("reasoning_content")
+            piece = delta.get("content")
+            if reasoning:
+                if not in_reasoning:
+                    sys.stdout.write(f"{DIM}[thinking] " if is_tty else "[thinking] ")
+                    in_reasoning = True
+                sys.stdout.write(reasoning)
+                sys.stdout.flush()
+            if piece:
+                if in_reasoning:
+                    sys.stdout.write(f"{RESET}\n" if is_tty else "\n")
+                    in_reasoning = False
+                sys.stdout.write(piece)
+                sys.stdout.flush()
+                full += piece
+    if in_reasoning and is_tty:
+        sys.stdout.write(RESET)
+        sys.stdout.flush()
+    return full
+
+
+def chat_command(args):
+    """Interactive REPL chat with a model.
+
+    Spawns a local `serve` on an ephemeral port (or connects to an existing
+    server via --base-url / --port), then loops stdin → /v1/chat/completions
+    (streaming) → stdout. Maintains multi-turn history; `/reset` clears it.
+    Exits cleanly on Ctrl-D, Ctrl-C, or `exit` / `quit`.
+    """
+    import atexit
+    import signal
+    import subprocess
+    import tempfile
+
+    base_url: str
+    proc = None
+    log_path: str | None = None
+
+    if args.base_url:
+        base_url = args.base_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+    elif args.port is not None:
+        base_url = f"http://127.0.0.1:{args.port}"
+    else:
+        log_path = tempfile.NamedTemporaryFile(
+            prefix="rapid-mlx-chat-", suffix=".log", delete=False
+        ).name
+        print(f"\n  Starting server (log: {log_path}) ...")
+        # If main() resolved an alias, expose the alias as the API model name
+        # so the chat request body matches what the user typed.
+        original = getattr(args, "_original_alias", None)
+        proc, base_url = _spawn_chat_server(args.model, log_path, served_name=original)
+
+        def _cleanup():
+            if proc and proc.poll() is None:
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+        atexit.register(_cleanup)
+        # Ensure SIGINT/SIGTERM also kill the server before we exit.
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                signal.signal(sig, lambda *_: (_cleanup(), sys.exit(130)))
+            except (ValueError, OSError):
+                pass
+
+        try:
+            _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
+        except (RuntimeError, TimeoutError) as e:
+            print(f"\n  Failed to start server: {e}")
+            sys.exit(1)
+        print("  Ready.\n")
+
+    print("  Chat — Ctrl-D / Ctrl-C / 'exit' to quit, '/reset' to clear history.\n")
+
+    served_name = getattr(args, "_original_alias", args.model)
+    messages: list[dict] = []
+    if args.system:
+        messages.append({"role": "system", "content": args.system})
+
+    extra: dict = {}
+    if args.no_think:
+        extra["chat_template_kwargs"] = {"enable_thinking": False}
+
+    while True:
+        try:
+            line = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line:
+            continue
+        if line in ("exit", "quit", "/exit", "/quit"):
+            break
+        if line in ("/reset", "/clear"):
+            messages = (
+                [{"role": "system", "content": args.system}] if args.system else []
+            )
+            print("  (history cleared)\n")
+            continue
+
+        messages.append({"role": "user", "content": line})
+        payload = {
+            "model": served_name,
+            "messages": messages,
+            "max_tokens": args.max_tokens,
+            "temperature": args.temperature,
+            "stream": True,
+            **extra,
+        }
+        try:
+            assistant = _stream_chat_response(
+                base_url, payload, timeout_s=args.response_timeout
+            )
+        except KeyboardInterrupt:
+            print("\n  (response interrupted)\n")
+            messages.pop()
+            continue
+        except RuntimeError as e:
+            print(f"\n  {e}\n")
+            messages.pop()
+            continue
+        print("\n")
+        if assistant:
+            messages.append({"role": "assistant", "content": assistant})
+        else:
+            messages.pop()
+
+
 def info_command(args):
     """Print the per-model profile for a model name or alias.
 
@@ -1558,6 +1807,62 @@ Examples:
     )
     subparsers.add_parser("ps", help="List running rapid-mlx servers")
 
+    # Chat — interactive REPL backed by a (spawned or existing) server
+    chat_parser = subparsers.add_parser(
+        "chat", help="Interactive chat REPL with a model"
+    )
+    chat_parser.add_argument(
+        "model", help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name)"
+    )
+    chat_parser.add_argument(
+        "--system",
+        type=str,
+        default=None,
+        help="System prompt prepended to the conversation",
+    )
+    chat_parser.add_argument(
+        "--no-think",
+        action="store_true",
+        help="Disable thinking mode for reasoning models (Qwen3 enable_thinking=False)",
+    )
+    chat_parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=2048,
+        help="Max tokens per assistant response (default: 2048)",
+    )
+    chat_parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.7,
+        help="Sampling temperature (default: 0.7)",
+    )
+    chat_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Connect to existing server on 127.0.0.1:<port> instead of spawning",
+    )
+    chat_parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        help="Connect to existing server URL (e.g. http://host:8000) "
+        "instead of spawning. Overrides --port.",
+    )
+    chat_parser.add_argument(
+        "--ready-timeout",
+        type=int,
+        default=600,
+        help="Seconds to wait for the spawned server to become ready (default: 600)",
+    )
+    chat_parser.add_argument(
+        "--response-timeout",
+        type=int,
+        default=600,
+        help="Seconds to wait for a single assistant response (default: 600)",
+    )
+
     # Info command — show the per-model profile (parsers + capability gates)
     info_parser = subparsers.add_parser(
         "info",
@@ -1700,6 +2005,8 @@ Examples:
         rm_command(args)
     elif args.command == "ps":
         ps_command(args)
+    elif args.command == "chat":
+        chat_command(args)
     elif args.command == "info":
         info_command(args)
     elif args.command == "agents":

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1003,9 +1003,14 @@ def chat_command(args):
     if args.system:
         messages.append({"role": "system", "content": args.system})
 
+    # The rapid-mlx server's ChatCompletionRequest exposes a top-level
+    # ``enable_thinking`` field — ``chat_template_kwargs`` is not a recognized
+    # request field and would be silently dropped.
     extra: dict = {}
     if args.no_think:
-        extra["chat_template_kwargs"] = {"enable_thinking": False}
+        extra["enable_thinking"] = False
+
+    import requests
 
     while True:
         try:
@@ -1043,6 +1048,13 @@ def chat_command(args):
             continue
         except RuntimeError as e:
             print(f"\n  {e}\n")
+            messages.pop()
+            continue
+        except requests.RequestException as e:
+            # Connection refused, timeout, dropped midstream — keep the REPL
+            # alive and roll back the failed user turn so the next request
+            # doesn't carry a dangling user role with no assistant reply.
+            print(f"\n  Request failed: {e}\n")
             messages.pop()
             continue
         print("\n")


### PR DESCRIPTION
## Summary

Adds the missing one-terminal flow that today forces users to run \`serve\` in one terminal and \`curl\` in another. Closes the biggest UX gap from the per-model profile audit.

\`\`\`bash
\$ rapid-mlx chat qwen3.5-9b
  Alias: qwen3.5-9b → mlx-community/Qwen3.5-9B-MLX-4bit
  Starting server (log: /tmp/rapid-mlx-chat-xxx.log) ...
  Ready.

  Chat — Ctrl-D / Ctrl-C / 'exit' to quit, '/reset' to clear history.

> hi
Hi! How can I help you today?

> /reset
  (history cleared)

> exit
\`\`\`

## What it does

- Spawns \`serve\` on an ephemeral port, waits for \`/health/ready\`, then loops stdin → \`/v1/chat/completions\` (streaming) → stdout.
- Multi-turn history maintained; \`/reset\` clears, \`exit\`/\`Ctrl-D\`/\`Ctrl-C\` exits cleanly.
- atexit + SIGINT/SIGTERM handlers ensure the spawned server is terminated — no orphans.
- Reasoning-content (Qwen3, DeepSeek-R1) streams in dim ANSI with a \`[thinking]\` prefix on tty, but is **not** added to chat history (only final \`content\` is fed back into subsequent turns).
- Failed turn rolls back the user message so the next request doesn't carry a dangling user role.
- Defensive \`resp.text\` read on HTTP-error path (the test fake exposed a real ChunkedEncodingError on partial-stream-then-close).
- When given an alias, spawns serve with \`--served-model-name <alias>\` so the chat request body uses the alias the user typed, not the expanded HF path.

## Flags

| flag | default | purpose |
|---|---|---|
| \`--system\` | none | prepend a system prompt |
| \`--no-think\` | off | \`enable_thinking=False\` for Qwen3 reasoning |
| \`--max-tokens\` | 2048 | per-response cap |
| \`--temperature\` | 0.7 | sampling |
| \`--port\` | none | connect to existing server on 127.0.0.1:port |
| \`--base-url\` | none | connect to existing server URL (overrides --port) |
| \`--ready-timeout\` | 600 | wait for spawned server to become ready |
| \`--response-timeout\` | 600 | per-response timeout |

## Test plan

- [x] 9 new hermetic tests in \`tests/test_cli_chat.py\` (stdlib HTTPServer fake, ~3.6s):
  - subparser wiring + required model arg
  - SSE delta concatenation, empty-delta skip
  - HTTP-error → \`RuntimeError(\"HTTP NNN: ...\")\`
  - multi-turn history accumulation + \`/reset\`
  - \`--system\` prepends, \`--no-think\` → \`chat_template_kwargs\`
  - failed-turn history rollback
- [x] Lint + format clean (\`ruff check\` + \`ruff format --check\`)
- [x] End-to-end smoke: \`echo -e 'hi\\nexit' | rapid-mlx chat qwen3.5-4b --no-think\` — server boots, response streams, REPL exits, no leftover \`vllm_mlx.cli serve\` processes.
- [x] Broader unit suite: 2319 pass / 17 skip / 7 deselect / **3 pre-existing flakes** (test_concurrent_same_prompt, TestAPIKeyVerification×2 — confirmed on clean main during PR #301 work, also documented in CLAUDE.md MEMORY.md).
- [ ] CI green on this PR

## Out of scope

- Auto-detect existing local \`serve\` (via \`rapid-mlx ps\`) and reuse instead of always spawning. Today the user can pass \`--port\` to reuse explicitly.
- Tab completion / readline editing in the REPL — Python's stdlib \`input()\` is intentionally minimal here.
- Tool-call display in the REPL (\`delta.tool_calls\`) — surfaces as empty content today; out of scope for the first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)