### PR TITLE
feat(cli): rapid-mlx models surfaces AliasProfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.24"
+version = "0.6.25"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `rapid-mlx models` — pins the per-alias profile rendering."""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+from vllm_mlx import cli
+from vllm_mlx.model_aliases import list_profiles
+
+
+def _capture_models_output() -> str:
+    """Run `models_command` with stdout captured. Patches the version-check
+    helper so the test stays hermetic (no PyPI lookup at test time)."""
+    buf = io.StringIO()
+    with (
+        patch.object(sys, "stdout", buf),
+        patch("vllm_mlx._version_check.print_staleness_warning_if_any"),
+    ):
+        cli.models_command(None)
+    return buf.getvalue()
+
+
+def test_models_command_lists_all_aliases():
+    """Every alias in aliases.json must appear in the table."""
+    out = _capture_models_output()
+    profiles = list_profiles()
+    assert len(profiles) >= 20, "expected 20+ aliases (per project goal)"
+    for alias in profiles:
+        assert alias in out, f"alias {alias!r} missing from `rapid-mlx models` output"
+    assert f"({len(profiles)} aliases)" in out
+
+
+def test_models_command_shows_capability_columns():
+    """Capability columns (Tools, Reasoning, Spec-Decode, Suffix Tier) appear."""
+    out = _capture_models_output()
+    for header in ("Tools", "Reasoning", "Spec-Decode", "Suffix Tier"):
+        assert header in out, f"column header {header!r} missing"
+
+
+def test_models_command_renders_hybrid_marker_for_qwen35():
+    """Hybrid models (e.g. qwen3.5-4b) must show '✗ hybrid' + tier 'n/a'.
+
+    The point of the column is to spare users an `info` round-trip when
+    deciding whether spec-decode/suffix-decode will help. Trust the gate.
+    """
+    out = _capture_models_output()
+    profiles = list_profiles()
+    qwen35_4b = profiles.get("qwen3.5-4b")
+    assert qwen35_4b is not None, "qwen3.5-4b alias missing — fixture drift"
+    assert qwen35_4b.is_hybrid, "qwen3.5-4b should still be is_hybrid=True"
+
+    # Find the qwen3.5-4b row and confirm the hybrid markers.
+    matches = [line for line in out.splitlines() if "qwen3.5-4b " in line]
+    assert matches, "no row found for qwen3.5-4b"
+    row = matches[0]
+    assert "✗ hybrid" in row, f"expected '✗ hybrid' marker in row: {row!r}"
+    assert "n/a" in row, f"expected suffix tier 'n/a' in row: {row!r}"
+
+
+def test_models_command_renders_parser_for_hermes3_8b():
+    """Non-hybrid model with both parsers populated should show them.
+
+    hermes3-8b has tool_call_parser='hermes' and a benched suffix tier
+    ('neutral'). Pin this so a tier/data regression on hermes3-8b is
+    caught at CI time rather than first user report.
+    """
+    out = _capture_models_output()
+    matches = [line for line in out.splitlines() if "hermes3-8b " in line]
+    assert matches, "no row found for hermes3-8b"
+    row = matches[0]
+    assert "hermes" in row, f"expected 'hermes' tool parser in row: {row!r}"
+    assert "neutral" in row, f"expected 'neutral' tier in row: {row!r}"
+
+
+def test_models_command_renders_em_dash_for_unset_parsers():
+    """An alias without tool_call_parser / reasoning_parser should show '—'."""
+    out = _capture_models_output()
+    profiles = list_profiles()
+    # Find any alias that has neither parser populated.
+    candidates = [
+        a
+        for a, p in profiles.items()
+        if not p.tool_call_parser and not p.reasoning_parser
+    ]
+    if not candidates:
+        # Schema may have tightened — skip cleanly.
+        import pytest
+
+        pytest.skip("no aliases without parsers (schema may have tightened)")
+    alias = candidates[0]
+    matches = [line for line in out.splitlines() if f"{alias} " in line]
+    assert matches, f"no row found for {alias}"
+    row = matches[0]
+    # Both placeholders should appear.
+    assert row.count("—") >= 2, f"expected two em-dashes in row: {row!r}"
+
+
+def test_models_command_mentions_chat_pull_serve_in_tip():
+    """The footer should advertise the four canonical actions."""
+    out = _capture_models_output()
+    for cmd in ("info", "pull", "chat", "serve"):
+        assert f"rapid-mlx {cmd}" in out, (
+            f"footer tip missing 'rapid-mlx {cmd}' suggestion"
+        )
+
+
+def test_models_command_subparser_smoke():
+    """`rapid-mlx models --help` exits 0 (subparser still wired)."""
+    import pytest
+
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "models", "--help"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 0

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -625,46 +625,60 @@ def bench_command(args):
 
 
 def models_command(_args):
-    """List available model aliases."""
-    from vllm_mlx._version_check import print_staleness_warning_if_any
-    from vllm_mlx.model_aliases import list_aliases
+    """List available model aliases with their per-model profile capabilities.
 
-    # Best-effort: warn if the user is on a stale brew/pip install. The
-    # call is fail-silent and gated to interactive TTYs, so it'll never
-    # break this command — see ``_version_check.py``.
+    Pulls from ``list_profiles()`` so every alias's ``tool_call_parser`` /
+    ``reasoning_parser`` / ``is_hybrid`` / ``supports_spec_decode`` /
+    ``suffix_decoding_tier`` shows up in the table — letting users pick a
+    model on capabilities, not just on name.
+    """
+    from vllm_mlx._version_check import print_staleness_warning_if_any
+    from vllm_mlx.model_aliases import list_profiles
+
     print_staleness_warning_if_any()
 
-    # Hardcoded benchmark data: (size, speed, recommended Mac tier)
-    MODEL_INFO = {
-        "qwen3.5-4b": ("2.4 GB", "168 tok/s", "16GB+ Mac"),
-        "qwen3.5-9b": ("5.1 GB", "108 tok/s", "24GB+ Mac"),
-        "qwen3.5-27b": ("15.3 GB", "39 tok/s", "32GB+ Mac"),
-        "qwen3.5-35b": ("37 GB", "83 tok/s", "48GB+ Mac"),
-        "qwen3.5-122b": ("65 GB", "57 tok/s", "96GB+ Mac"),
-        "qwen3.6-35b": ("20 GB", "94 tok/s", "32GB+ Mac"),
-        "qwen3-coder": ("45 GB", "74 tok/s", "64GB+ Mac"),
-        "gemma-4-26b": ("14.4 GB", "85 tok/s", "24GB+ Mac"),
-        "gemma-4-31b": ("17 GB", "31 tok/s", "32GB+ Mac"),
-        "qwopus-27b": ("14.8 GB", "39 tok/s", "32GB+ Mac"),
-        "kimi-48b": ("~28 GB", "94 tok/s", "48GB+ Mac"),
-    }
+    profiles = list_profiles()
+    print()
+    print(f"  Available models ({len(profiles)} aliases)")
 
-    aliases = list_aliases()
-    print()
-    print("  Available model aliases")
-    print("  " + "─" * 70)
-    print(f"  {'Alias':<20} {'Size':<10} {'Speed':<12} {'Recommended'}")
-    print("  " + "─" * 70)
-    for short, full in sorted(aliases.items()):
-        info = MODEL_INFO.get(short)
-        if info:
-            size, speed, rec = info
-            print(f"  {short:<20} {size:<10} {speed:<12} {rec}")
+    # Widths sized to fit the longest values currently in aliases.json:
+    # alias 22 (qwen3.5-122b-mxfp4 etc.), tool 16 (qwen3_coder_xml + 1 pad),
+    # reasoning 12 (deepseek_r1 + 1 pad), spec 10 ("✗ hybrid"), tier 11.
+    cols = (
+        ("Alias", 22),
+        ("Tools", 16),
+        ("Reasoning", 12),
+        ("Spec-Decode", 10),
+        ("Suffix Tier", 11),
+    )
+    width = sum(w for _, w in cols) + len(cols) - 1
+    sep = "  " + "─" * width
+    header = "  " + " ".join(f"{name:<{w}}" for name, w in cols)
+    print(sep)
+    print(header)
+    print(sep)
+
+    for alias in sorted(profiles.keys()):
+        p = profiles[alias]
+        tools = p.tool_call_parser or "—"
+        reasoning = p.reasoning_parser or "—"
+        if p.is_hybrid:
+            # Hybrid models cannot use spec-decode or suffix-decode regardless
+            # of the supports_spec_decode flag (mlx-lm BatchGenerator gate).
+            spec = "✗ hybrid"
+            tier = "n/a"
         else:
-            print(f"  {short:<20} → {full}")
+            spec = "✓" if p.supports_spec_decode else "✗"
+            tier = p.suffix_decoding_tier
+        row = f"  {alias:<22} {tools:<16} {reasoning:<12} {spec:<10} {tier:<11}"
+        print(row)
+
+    print(sep)
     print()
-    print(f"  {len(aliases)} aliases available")
-    print("  Usage: rapid-mlx serve <alias>")
+    print("  Tip: `rapid-mlx info <alias>` for the full per-model profile")
+    print("       `rapid-mlx pull <alias>` to download")
+    print("       `rapid-mlx chat <alias>` for an interactive REPL")
+    print("       `rapid-mlx serve <alias>` for an OpenAI-compatible server")
     print()
 
 


### PR DESCRIPTION
## Summary

Reshapes \`rapid-mlx models\` so every alias's per-profile capabilities (parser, hybrid status, suffix-decoding tier) show in the table. Closes part 2 of the per-model profile audit gap list (#178 was part 1: \`chat\` REPL).

## Before / After

**Before** — hardcoded MODEL_INFO with size/speed for 11/51 aliases; the other 40 fell back to \`alias → mlx-community/...\` with no capability info anywhere:

\`\`\`
  Alias               Size       Speed       Recommended
  ──────────────────────────────────────────────────────
  qwen3.5-4b          2.4 GB     168 tok/s   16GB+ Mac
  qwen3.5-9b          5.1 GB     108 tok/s   24GB+ Mac
  ...
  deepseek-r1-8b      → mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit
  [40 more shown as raw HF paths]
\`\`\`

**After** — pulls from \`list_profiles()\` so every row shows capability columns:

\`\`\`
  Available models (51 aliases)
  ──────────────────────────────────────────────────────────────────────────────
  Alias                  Tools            Reasoning    Spec-Decode  Suffix Tier
  ──────────────────────────────────────────────────────────────────────────────
  hermes3-8b             hermes           —            ✓            neutral
  llama3-3b              llama            —            ✓            avoid
  qwen3.5-4b             hermes           qwen3        ✗ hybrid     n/a
  qwen3.6-35b            qwen3_coder_xml  qwen3        ✗ hybrid     n/a
  smollm3-3b             hermes           qwen3        ✓            avoid
  ...
\`\`\`

## Why this matters

A user picking a model can now see at a glance:
- Does it support tool-calling? (\`Tools\` column)
- Does it have reasoning content? (\`Reasoning\`)
- Will SuffixDecoding help my workload? (\`Suffix Tier\` — agent / structured / neutral / avoid / unknown / n/a)
- Is it hybrid (so spec-decode/suffix-decode are unavailable)? (\`Spec-Decode\` shows \`✗ hybrid\`)

Hybrid models (\`is_hybrid=True\`) display \`✗ hybrid\` for spec-decode and \`n/a\` for tier — consistent with the framework's existing hard gate (mlx-lm BatchGenerator rejects spec/suffix on hybrid). Trust the gate; no point teasing users with a tier they can't enable.

## Footer

Advertises the four canonical actions (now that \`chat\` shipped in #303):

\`\`\`
  Tip: \`rapid-mlx info <alias>\`  for the full per-model profile
       \`rapid-mlx pull <alias>\`  to download
       \`rapid-mlx chat <alias>\`  for an interactive REPL
       \`rapid-mlx serve <alias>\` for an OpenAI-compatible server
\`\`\`

## Test plan

- [x] 7 new tests in \`tests/test_cli_models.py\`:
  - All 51 aliases appear in output (catches rendering regression)
  - Capability column headers present
  - qwen3.5-4b row → \`✗ hybrid\` + \`n/a\` (pins hybrid contract)
  - hermes3-8b row → \`hermes\` + \`neutral\` (pins data contract)
  - Aliases without parsers show \`—\` placeholder
  - Footer mentions chat / pull / serve / info
  - \`rapid-mlx models --help\` exits 0 (subparser still wired)
- [x] Lint + format clean (\`ruff check\` + \`ruff format --check\`)
- [x] 52 targeted tests pass (chat + models + aliases + SSOT)
- [ ] Codex review (multi-round) until convergence
- [ ] pr_validate (per CLAUDE.md SOP)
- [ ] CI green

## Out of scope

- Adding size / speed columns back as data-driven (would need a new bench script + JSON store; better to surface that in \`info\`).
- Per-tier filtering (\`rapid-mlx models --tier=agent\`) — leave for a follow-up if users ask.
- Width auto-fit if more parsers are added — current widths are sized to fit all 15 known parser names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)