### PR TITLE
feat(cli): auto-apply suffix_decoding_tier in serve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.25"
+version = "0.6.26"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_serve_auto_suffix_decoding.py
+++ b/tests/test_serve_auto_suffix_decoding.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `_apply_alias_profile_to_args` — the helper that bridges
+``AliasProfile`` (and the regex fallback ``ModelConfig``) into the serve
+command's argparse Namespace.
+
+Pins the contract:
+- tier ``agent`` or ``structured`` + non-hybrid + user didn't override
+  → ``args.suffix_decoding`` becomes True
+- tier ``neutral`` / ``avoid`` / ``unknown`` → no change
+- ``supports_spec_decode=False`` (hybrid) → no change even if tier=agent
+- ``--no-suffix-decoding`` opt-out → no change even on agent tier
+- ``--suffix-decoding`` already set → no change (already enabled)
+- ``auto_config=None`` (unknown alias) → no-op, no crash
+
+Plus the existing parser auto-detect contract (tool_call + reasoning).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import cli
+from vllm_mlx.model_auto_config import ModelConfig
+
+
+def _args(**overrides) -> SimpleNamespace:
+    """Minimal Namespace covering only the fields the helper reads."""
+    base = SimpleNamespace(
+        tool_call_parser=None,
+        reasoning_parser=None,
+        enable_auto_tool_choice=False,
+        no_thinking=False,
+        suffix_decoding=False,
+        no_suffix_decoding=False,
+    )
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+def _cfg(**overrides) -> ModelConfig:
+    base = dict(
+        tool_call_parser="hermes",
+        reasoning_parser=None,
+        is_hybrid=False,
+        supports_spec_decode=True,
+        suffix_decoding_tier="unknown",
+    )
+    base.update(overrides)
+    return ModelConfig(**base)
+
+
+_logger = logging.getLogger("test")
+
+
+# ---------------------------------------------------------------------- happy path
+
+
+def test_agent_tier_auto_enables_suffix_decoding():
+    args = _args()
+    cli._apply_alias_profile_to_args(args, _cfg(suffix_decoding_tier="agent"), _logger)
+    assert args.suffix_decoding is True
+
+
+def test_structured_tier_auto_enables_suffix_decoding():
+    args = _args()
+    cli._apply_alias_profile_to_args(
+        args, _cfg(suffix_decoding_tier="structured"), _logger
+    )
+    assert args.suffix_decoding is True
+
+
+# ---------------------------------------------------------------------- silent tiers
+
+
+@pytest.mark.parametrize("tier", ["neutral", "avoid", "unknown"])
+def test_quiet_tiers_do_not_auto_enable(tier):
+    args = _args()
+    cli._apply_alias_profile_to_args(args, _cfg(suffix_decoding_tier=tier), _logger)
+    assert args.suffix_decoding is False
+
+
+# ---------------------------------------------------------------------- hybrid gate
+
+
+def test_hybrid_arch_blocks_auto_enable_even_at_agent_tier():
+    """Belt + suspenders: a hybrid model (supports_spec_decode=False) must
+    keep the flag off even if tier somehow became ``agent``. The framework
+    gate is the floor; the CLI must not fight it."""
+    args = _args()
+    cfg = _cfg(
+        suffix_decoding_tier="agent",
+        is_hybrid=True,
+        supports_spec_decode=False,
+    )
+    cli._apply_alias_profile_to_args(args, cfg, _logger)
+    assert args.suffix_decoding is False
+
+
+# ---------------------------------------------------------------------- explicit overrides
+
+
+def test_no_suffix_decoding_opts_out_of_auto_enable():
+    args = _args(no_suffix_decoding=True)
+    cli._apply_alias_profile_to_args(args, _cfg(suffix_decoding_tier="agent"), _logger)
+    assert args.suffix_decoding is False
+
+
+def test_already_enabled_remains_enabled_for_any_tier():
+    """If user passed --suffix-decoding, the auto-apply must NOT toggle it
+    off for any tier value (it would override explicit user intent)."""
+    for tier in ["agent", "structured", "neutral", "avoid", "unknown"]:
+        args = _args(suffix_decoding=True)
+        cli._apply_alias_profile_to_args(args, _cfg(suffix_decoding_tier=tier), _logger)
+        assert args.suffix_decoding is True, f"tier={tier} flipped suffix_decoding off"
+
+
+# ---------------------------------------------------------------------- robustness
+
+
+def test_none_config_is_noop():
+    """If detect_model_config returned None (unknown alias / non-string),
+    helper must not crash and must leave args untouched."""
+    args = _args()
+    cli._apply_alias_profile_to_args(args, None, _logger)
+    assert args.suffix_decoding is False
+    assert args.tool_call_parser is None
+    assert args.reasoning_parser is None
+    assert args.enable_auto_tool_choice is False
+
+
+# ---------------------------------------------------------------------- parser auto-detect (regression)
+
+
+def test_parser_autodetect_sets_tool_call_and_reasoning():
+    args = _args()
+    cli._apply_alias_profile_to_args(
+        args, _cfg(tool_call_parser="hermes", reasoning_parser="qwen3"), _logger
+    )
+    assert args.tool_call_parser == "hermes"
+    assert args.reasoning_parser == "qwen3"
+    assert args.enable_auto_tool_choice is True
+
+
+def test_parser_autodetect_respects_existing_tool_call():
+    """If user explicitly passed --tool-call-parser, helper must not
+    override it."""
+    args = _args(tool_call_parser="custom")
+    cli._apply_alias_profile_to_args(args, _cfg(tool_call_parser="hermes"), _logger)
+    assert args.tool_call_parser == "custom"
+    # enable_auto_tool_choice must NOT be flipped on by the helper when the
+    # parser was user-set; the existing serve flow handles that.
+    assert args.enable_auto_tool_choice is False
+
+
+def test_parser_autodetect_respects_no_thinking():
+    """--no-thinking must suppress the reasoning_parser auto-set."""
+    args = _args(no_thinking=True)
+    cli._apply_alias_profile_to_args(args, _cfg(reasoning_parser="qwen3"), _logger)
+    assert args.reasoning_parser is None
+
+
+# ---------------------------------------------------------------------- argparse smoke
+
+
+def test_help_advertises_no_suffix_decoding_flag():
+    """The CLI exposes --no-suffix-decoding as a registered flag."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "--help"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 0
+
+
+def test_no_suffix_decoding_argparse_stores_true():
+    """`rapid-mlx serve <model> --no-suffix-decoding` parses to
+    args.no_suffix_decoding=True (argparse hyphen→underscore)."""
+    parser_args = [
+        "rapid-mlx",
+        "serve",
+        "qwen3.5-4b",
+        "--no-suffix-decoding",
+    ]
+
+    captured: dict = {}
+
+    def fake_serve(args):
+        captured["ns"] = args
+
+    with (
+        patch.object(sys, "argv", parser_args),
+        patch.object(cli, "serve_command", side_effect=fake_serve),
+    ):
+        # main() resolves the alias and dispatches; we capture the args.
+        cli.main()
+
+    assert captured["ns"].no_suffix_decoding is True
+    assert captured["ns"].suffix_decoding is False

--- a/tests/test_serve_auto_suffix_decoding.py
+++ b/tests/test_serve_auto_suffix_decoding.py
@@ -111,6 +111,20 @@ def test_no_suffix_decoding_opts_out_of_auto_enable():
     assert args.suffix_decoding is False
 
 
+def test_enable_mtp_blocks_auto_suffix_decoding():
+    """If user explicitly chose MTP, the auto-apply must NOT flip on
+    suffix-decoding (the two are mutually exclusive — both monkey-patch
+    BatchGenerator step). Otherwise the mutual-exclusion check fires and
+    `serve` exits with an error after the user already declared intent.
+
+    Codex review #305 round 1 P2.
+    """
+    args = _args(enable_mtp=True)
+    cli._apply_alias_profile_to_args(args, _cfg(suffix_decoding_tier="agent"), _logger)
+    assert args.suffix_decoding is False
+    assert args.enable_mtp is True
+
+
 def test_already_enabled_remains_enabled_for_any_tier():
     """If user passed --suffix-decoding, the auto-apply must NOT toggle it
     off for any tier value (it would override explicit user intent)."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -118,6 +118,53 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
         pass
 
 
+def _apply_alias_profile_to_args(args, auto_config, logger) -> None:
+    """Bridge from the resolved per-alias ``ModelConfig`` to ``serve``'s
+    argparse Namespace. Mutates ``args`` in place.
+
+    Wires three auto-decisions:
+    - ``tool_call_parser`` → enables auto tool choice (parser auto-detect)
+    - ``reasoning_parser`` → enabled unless ``--no-thinking`` already set
+    - ``suffix_decoding_tier`` ∈ {``agent``, ``structured``} on a non-hybrid
+      arch → flips ``args.suffix_decoding=True`` unless the user already
+      passed either ``--suffix-decoding`` or ``--no-suffix-decoding``
+
+    Hybrid arches (``supports_spec_decode=False``) skip the suffix-decoding
+    auto-enable even if the tier is somehow set; the framework gate
+    (mlx-lm BatchGenerator) refuses spec-decode on hybrids so the flag
+    would be a no-op at best, confusing at worst. Trust the gate.
+    """
+    if auto_config is None:
+        return
+    if not args.tool_call_parser and auto_config.tool_call_parser:
+        args.tool_call_parser = auto_config.tool_call_parser
+        args.enable_auto_tool_choice = True
+        logger.info(
+            f"Auto-configured --tool-call-parser {auto_config.tool_call_parser}"
+        )
+    if (
+        not args.reasoning_parser
+        and not args.no_thinking
+        and auto_config.reasoning_parser
+    ):
+        args.reasoning_parser = auto_config.reasoning_parser
+        logger.info(
+            f"Auto-configured --reasoning-parser {auto_config.reasoning_parser}"
+        )
+    if (
+        not args.suffix_decoding
+        and not args.no_suffix_decoding
+        and auto_config.supports_spec_decode
+        and auto_config.suffix_decoding_tier in ("agent", "structured")
+    ):
+        args.suffix_decoding = True
+        logger.info(
+            f"Auto-enabled --suffix-decoding "
+            f"(profile tier: {auto_config.suffix_decoding_tier}; "
+            "pass --no-suffix-decoding to disable)"
+        )
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -147,30 +194,18 @@ def serve_command(args):
         )
         sys.exit(1)
 
-    # Auto-detect parser config from model name when not explicitly set
-    if not args.tool_call_parser or not args.reasoning_parser:
-        try:
-            from .model_auto_config import detect_model_config
+    # Auto-detect parser + suffix-decoding tier from the alias profile.
+    # ``detect_model_config`` is the single source of truth — it consults
+    # ``aliases.json`` first (rich profile), then regex fallback.
+    try:
+        from .model_auto_config import detect_model_config
 
-            auto_config = detect_model_config(args.model)
-            if auto_config:
-                if not args.tool_call_parser and auto_config.tool_call_parser:
-                    args.tool_call_parser = auto_config.tool_call_parser
-                    args.enable_auto_tool_choice = True
-                    logger.info(
-                        f"Auto-configured --tool-call-parser {auto_config.tool_call_parser}"
-                    )
-                if (
-                    not args.reasoning_parser
-                    and not args.no_thinking
-                    and auto_config.reasoning_parser
-                ):
-                    args.reasoning_parser = auto_config.reasoning_parser
-                    logger.info(
-                        f"Auto-configured --reasoning-parser {auto_config.reasoning_parser}"
-                    )
-        except Exception as e:
-            logger.debug(f"Auto-detection failed (non-fatal): {e}")
+        auto_config = detect_model_config(args.model)
+    except Exception as e:
+        logger.debug(f"Auto-detection failed (non-fatal): {e}")
+        auto_config = None
+
+    _apply_alias_profile_to_args(args, auto_config, logger)
 
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)
@@ -1478,8 +1513,18 @@ Examples:
         default=False,
         help="Enable SuffixDecoding spec-decode (drafter-free, statistical). "
         "Speedup is workload-dependent: 3-5x on tool-call/JSON/code-edit, "
-        "~1x on free-form chat. Auto-disabled on hybrid models "
+        "~1x on free-form chat. Auto-enabled when the alias profile's "
+        "suffix_decoding_tier is 'agent' or 'structured'; pass "
+        "--no-suffix-decoding to opt out. Auto-disabled on hybrid models "
         "(Qwen3.5/3.6, Granite4, Mamba/Jamba/RWKV).",
+    )
+    serve_parser.add_argument(
+        "--no-suffix-decoding",
+        action="store_true",
+        default=False,
+        help="Opt out of the auto-enable triggered by an 'agent' or "
+        "'structured' alias profile tier. Useful for benchmarking the "
+        "non-spec-decode baseline.",
     )
     serve_parser.add_argument(
         "--suffix-max-draft",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -151,9 +151,15 @@ def _apply_alias_profile_to_args(args, auto_config, logger) -> None:
         logger.info(
             f"Auto-configured --reasoning-parser {auto_config.reasoning_parser}"
         )
+    # Auto-enable suffix-decoding only when no other spec-decode method
+    # was explicitly chosen. ``--enable-mtp`` is mutually exclusive with
+    # ``--suffix-decoding`` (both monkey-patch BatchGenerator step), so
+    # auto-flipping suffix on top of an explicit --enable-mtp would
+    # exit-with-error after the user already declared their intent.
     if (
         not args.suffix_decoding
         and not args.no_suffix_decoding
+        and not getattr(args, "enable_mtp", False)
         and auto_config.supports_spec_decode
         and auto_config.suffix_decoding_tier in ("agent", "structured")
     ):


### PR DESCRIPTION
## Summary

Closes the loop on the per-alias SSOT: ``rapid-mlx serve <alias>`` now flips ``--suffix-decoding`` on automatically when the alias profile's tier is ``agent`` or ``structured`` and the framework gate would let the flag take effect.

Today users see "recommended" in ``info`` output but have to remember to add the flag — the information was there, just unactionable. Closes part 3 of the per-model profile audit gap list.

## Behavior

| condition | action |
|---|---|
| tier ``agent`` or ``structured`` + non-hybrid + user untouched | auto-enable, INFO log |
| ``--no-suffix-decoding`` flag (new) | opt out on any tier |
| ``--suffix-decoding`` already passed | no change for any tier |
| ``supports_spec_decode=False`` (hybrid arch) | no change even at agent tier |
| tier ``neutral`` / ``avoid`` / ``unknown`` | no change |

The hybrid skip is belt-and-suspenders: the framework gate (mlx-lm BatchGenerator) refuses spec-decode on hybrid arches, so the flag would be a no-op at best. Trust the gate.

## Refactor

Extracted the auto-detect block (parser + reasoning + suffix tier) from ``serve_command`` into ``_apply_alias_profile_to_args(args, auto_config, logger)``. Lets us pin the contract with hermetic unit tests rather than mocking out uvicorn / model loading.

## Test plan

- [x] 14 new tests in \`tests/test_serve_auto_suffix_decoding.py\`:
  - agent / structured → auto-enable
  - neutral / avoid / unknown → no auto-enable
  - hybrid arch blocks auto-enable even at agent tier
  - \`--no-suffix-decoding\` opt-out works
  - \`--suffix-decoding\` already-set is preserved across all tiers
  - \`None\` config (unknown alias) is a no-op
  - parser auto-detect regression (tool_call + reasoning)
  - \`--tool-call-parser\` user override respected
  - \`--no-thinking\` suppresses reasoning_parser
  - argparse smoke for the new flag (\`store_true\`, hyphen→underscore)
- [x] Lint + format clean
- [x] Existing tests for parser auto-detect still pass (refactor didn't change that contract)
- [ ] Codex review (multi-round) until convergence
- [ ] pr_validate (per CLAUDE.md SOP)
- [ ] CI green

## Out of scope

- Per-tier custom auto-tuning of \`--suffix-max-draft\` / \`--suffix-min-confidence\` based on the bench's measured peak workload. Today the auto-enable uses the framework defaults; refining is a follow-up after batch-2/3 tier benches land (#181) so we have data to tune on.
- ``--no-thinking`` ↔ ``--reasoning-parser`` interaction — left unchanged here; existing behavior preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)