### PR TITLE
test(reasoning): cover <|channel>final straddle case in Gemma4 parser

### DIFF
--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -1028,21 +1028,28 @@ class TestGemma4Streaming:
         assert m2.reasoning == "thinking step 1"
         assert m2.content is None
 
-    def test_delta_straddles_thought_close_then_content_open(self):
+    @pytest.mark.parametrize(
+        "content_marker",
+        ["<|channel>content", "<|channel>final"],
+        ids=["content", "final"],
+    )
+    def test_delta_straddles_thought_close_then_content_open(self, content_marker):
         """Regression for issue #219.
 
         At stream_interval > 1 a single buffered delta can contain the tail of
-        the thought channel, the channel-close marker, the content-open marker,
-        and the start of the actual content. The pre-fix parser classified the
-        entire delta as content (because state at end of current_text was
-        in_content), so bytes before the close marker leaked from reasoning
-        into content. This test asserts the split.
+        the thought channel, the channel-close marker, the content-channel-open
+        marker (either <|channel>content or <|channel>final, since the parser
+        treats final as a content-channel variant), and the start of the actual
+        content. The pre-fix parser classified the entire delta as content
+        (because state at end of current_text was in_content), so bytes before
+        the close marker leaked from reasoning into content. This test asserts
+        the split for both content and final markers.
         """
         prev = "<|channel>thought\nworking through it"
         self.parser.extract_reasoning_streaming("", prev, prev)
         assert self.parser._in_thought is True
 
-        delta = " final guess<channel|><|channel>content\nThe answer is 42."
+        delta = f" final guess<channel|>{content_marker}\nThe answer is 42."
         curr = prev + delta
         result = self.parser.extract_reasoning_streaming(prev, curr, delta)
         assert result.reasoning == " final guess", (
@@ -1050,8 +1057,8 @@ class TestGemma4Streaming:
             f"reasoning, got {result.reasoning!r}"
         )
         assert result.content == "The answer is 42.", (
-            f"content bytes from after the content-open marker should land in "
-            f"content, got {result.content!r}"
+            f"content bytes from after the {content_marker} marker should land "
+            f"in content, got {result.content!r}"
         )
         assert self.parser._in_content is True
         assert self.parser._in_thought is False


### PR DESCRIPTION
Follow-up to #289 (issue #219), addressing the test-gap note from the review.

## Why

When #289 merged, the regression test covered the `<|channel>content` straddle case but not the `<|channel>final` branch. Both markers are listed in the parser's `flip_pos` detection block (`vllm_mlx/reasoning/gemma4_parser.py`) and both trigger the same split logic, but only one had a dedicated regression guard. From the review on #221:

> Missing test: `<|channel>final` straddle. `test_delta_straddles_thought_close_then_content_open` covers `<|channel>content`; the `<|channel>final` branch in the flip detection code (`<|channel>final` in the marker list) has no dedicated straddle test. Low risk since the stripping is symmetric, but a 5-line parametrize would close the gap.

## What this changes

`tests/test_reasoning_parsers.py::TestGemma4Streaming::test_delta_straddles_thought_close_then_content_open` is now `@pytest.mark.parametrize`d over the two content-channel-opener variants. The body of the test is unchanged; only the literal `<|channel>content` is replaced with the parametrized `content_marker`.

After the change, pytest reports the cases separately:

```
test_delta_straddles_thought_close_then_content_open[content] PASSED
test_delta_straddles_thought_close_then_content_open[final]   PASSED
```

## Diff size

`tests/test_reasoning_parsers.py`: +16 / -9 (single function, signature + decorator + one literal turned into an f-string interpolation).

No production code change. Parser logic untouched. This is purely a test-coverage addition.

## Test plan

- `python3 -m pytest tests/test_reasoning_parsers.py::TestGemma4Streaming -v` reports 9 cases (was 8), both parametrized variants pass.
- Full reasoning-parser suite (`tests/test_reasoning_parsers.py` + `tests/test_reasoning_parser.py`): 205 passing (was 204 pre-parametrize), no regressions.
- `ruff check` and `ruff format --check` clean on the changed file.


## Checklist

- [ ] Tests pass locally (`python3 -m pytest tests/ -x`)
- [ ] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — see [CONTRIBUTING.md](../CONTRIBUTING.md#self-validating-your-pr) (opt out heavy steps with `PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1` if you don't have the hardware/keys)
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API
