### PR TITLE
data(suffix-tier): cross-validation v2 vs v3 sweep

### DIFF
--- a/evals/results/suffix_bonsai-1.7b_v2.json
+++ b/evals/results/suffix_bonsai-1.7b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "bonsai-1.7b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 123.4,
+    "json_array": 120.1,
+    "tool_loop": 122.7,
+    "code_edit": 119.0
+  },
+  "suffix_tps": {
+    "chat": 88.1,
+    "json_array": 156.6,
+    "tool_loop": 108.6,
+    "code_edit": 125.0
+  },
+  "speedup": {
+    "chat": 0.713,
+    "json_array": 1.304,
+    "tool_loop": 0.884,
+    "code_edit": 1.051
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 130.3,
+          "completion_tokens": 226,
+          "decode_time": 1.735,
+          "total_time": 1.865,
+          "rejected_reason": null
+        },
+        {
+          "tps": 123.4,
+          "completion_tokens": 226,
+          "decode_time": 1.831,
+          "total_time": 1.955,
+          "rejected_reason": null
+        },
+        {
+          "tps": 121.0,
+          "completion_tokens": 226,
+          "decode_time": 1.868,
+          "total_time": 1.992,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 129.1,
+          "completion_tokens": 245,
+          "decode_time": 1.898,
+          "total_time": 2.028,
+          "rejected_reason": null
+        },
+        {
+          "tps": 120.1,
+          "completion_tokens": 245,
+          "decode_time": 2.04,
+          "total_time": 2.167,
+          "rejected_reason": null
+        },
+        {
+          "tps": 116.7,
+          "completion_tokens": 245,
+          "decode_time": 2.099,
+          "total_time": 2.233,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 118.4,
+          "completion_tokens": 112,
+          "decode_time": 0.946,
+          "total_time": 1.237,
+          "rejected_reason": null
+        },
+        {
+          "tps": 124.6,
+          "completion_tokens": 112,
+          "decode_time": 0.899,
+          "total_time": 1.115,
+          "rejected_reason": null
+        },
+        {
+          "tps": 122.7,
+          "completion_tokens": 112,
+          "decode_time": 0.913,
+          "total_time": 1.136,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 119.0,
+          "completion_tokens": 91,
+          "decode_time": 0.765,
+          "total_time": 0.903,
+          "rejected_reason": null
+        },
+        {
+          "tps": 115.2,
+          "completion_tokens": 91,
+          "decode_time": 0.79,
+          "total_time": 0.931,
+          "rejected_reason": null
+        },
+        {
+          "tps": 134.7,
+          "completion_tokens": 91,
+          "decode_time": 0.676,
+          "total_time": 0.944,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 87.6,
+          "completion_tokens": 223,
+          "decode_time": 2.546,
+          "total_time": 2.698,
+          "rejected_reason": null
+        },
+        {
+          "tps": 91.2,
+          "completion_tokens": 223,
+          "decode_time": 2.446,
+          "total_time": 2.573,
+          "rejected_reason": null
+        },
+        {
+          "tps": 88.1,
+          "completion_tokens": 223,
+          "decode_time": 2.532,
+          "total_time": 2.729,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 145.8,
+          "completion_tokens": 245,
+          "decode_time": 1.681,
+          "total_time": 1.807,
+          "rejected_reason": null
+        },
+        {
+          "tps": 156.6,
+          "completion_tokens": 245,
+          "decode_time": 1.565,
+          "total_time": 1.695,
+          "rejected_reason": null
+        },
+        {
+          "tps": 159.7,
+          "completion_tokens": 245,
+          "decode_time": 1.534,
+          "total_time": 1.668,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 97.5,
+          "completion_tokens": 112,
+          "decode_time": 1.148,
+          "total_time": 1.377,
+          "rejected_reason": null
+        },
+        {
+          "tps": 108.6,
+          "completion_tokens": 112,
+          "decode_time": 1.032,
+          "total_time": 1.3,
+          "rejected_reason": null
+        },
+        {
+          "tps": 131.5,
+          "completion_tokens": 112,
+          "decode_time": 0.852,
+          "total_time": 1.058,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 123.0,
+          "completion_tokens": 91,
+          "decode_time": 0.74,
+          "total_time": 0.856,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.6,
+          "completion_tokens": 91,
+          "decode_time": 0.725,
+          "total_time": 0.84,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.0,
+          "completion_tokens": 91,
+          "decode_time": 0.728,
+          "total_time": 0.844,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_bonsai-1.7b_v3.json
+++ b/evals/results/suffix_bonsai-1.7b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "bonsai-1.7b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 146.1,
+    "json_array": 145.6,
+    "tool_loop": 141.0,
+    "code_edit": 145.5
+  },
+  "suffix_tps": {
+    "chat": 113.9,
+    "json_array": 203.4,
+    "tool_loop": 132.2,
+    "code_edit": 125.5
+  },
+  "speedup": {
+    "chat": 0.78,
+    "json_array": 1.397,
+    "tool_loop": 0.938,
+    "code_edit": 0.863
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 146.0,
+          "completion_tokens": 226,
+          "decode_time": 1.547,
+          "total_time": 1.658,
+          "rejected_reason": null
+        },
+        {
+          "tps": 146.1,
+          "completion_tokens": 226,
+          "decode_time": 1.547,
+          "total_time": 1.65,
+          "rejected_reason": null
+        },
+        {
+          "tps": 146.1,
+          "completion_tokens": 226,
+          "decode_time": 1.546,
+          "total_time": 1.649,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 145.6,
+          "completion_tokens": 245,
+          "decode_time": 1.683,
+          "total_time": 1.792,
+          "rejected_reason": null
+        },
+        {
+          "tps": 145.3,
+          "completion_tokens": 245,
+          "decode_time": 1.687,
+          "total_time": 1.794,
+          "rejected_reason": null
+        },
+        {
+          "tps": 145.7,
+          "completion_tokens": 245,
+          "decode_time": 1.682,
+          "total_time": 1.786,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 141.1,
+          "completion_tokens": 112,
+          "decode_time": 0.794,
+          "total_time": 0.983,
+          "rejected_reason": null
+        },
+        {
+          "tps": 140.9,
+          "completion_tokens": 112,
+          "decode_time": 0.795,
+          "total_time": 0.983,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.0,
+          "completion_tokens": 112,
+          "decode_time": 0.794,
+          "total_time": 0.983,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 145.3,
+          "completion_tokens": 91,
+          "decode_time": 0.626,
+          "total_time": 0.739,
+          "rejected_reason": null
+        },
+        {
+          "tps": 145.5,
+          "completion_tokens": 91,
+          "decode_time": 0.625,
+          "total_time": 0.74,
+          "rejected_reason": null
+        },
+        {
+          "tps": 145.7,
+          "completion_tokens": 91,
+          "decode_time": 0.625,
+          "total_time": 0.74,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 113.1,
+          "completion_tokens": 223,
+          "decode_time": 1.972,
+          "total_time": 2.081,
+          "rejected_reason": null
+        },
+        {
+          "tps": 114.0,
+          "completion_tokens": 223,
+          "decode_time": 1.957,
+          "total_time": 2.059,
+          "rejected_reason": null
+        },
+        {
+          "tps": 113.9,
+          "completion_tokens": 223,
+          "decode_time": 1.958,
+          "total_time": 2.061,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 205.7,
+          "completion_tokens": 245,
+          "decode_time": 1.191,
+          "total_time": 1.299,
+          "rejected_reason": null
+        },
+        {
+          "tps": 202.4,
+          "completion_tokens": 245,
+          "decode_time": 1.211,
+          "total_time": 1.318,
+          "rejected_reason": null
+        },
+        {
+          "tps": 203.4,
+          "completion_tokens": 245,
+          "decode_time": 1.205,
+          "total_time": 1.313,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 128.7,
+          "completion_tokens": 112,
+          "decode_time": 0.87,
+          "total_time": 1.075,
+          "rejected_reason": null
+        },
+        {
+          "tps": 132.6,
+          "completion_tokens": 112,
+          "decode_time": 0.845,
+          "total_time": 1.049,
+          "rejected_reason": null
+        },
+        {
+          "tps": 132.2,
+          "completion_tokens": 112,
+          "decode_time": 0.847,
+          "total_time": 1.058,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 123.6,
+          "completion_tokens": 91,
+          "decode_time": 0.736,
+          "total_time": 0.852,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.7,
+          "completion_tokens": 91,
+          "decode_time": 0.724,
+          "total_time": 0.838,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.5,
+          "completion_tokens": 91,
+          "decode_time": 0.725,
+          "total_time": 0.841,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_bonsai-4b_v2.json
+++ b/evals/results/suffix_bonsai-4b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "bonsai-4b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 65.1,
+    "json_array": 63.7,
+    "tool_loop": null,
+    "code_edit": 65.3
+  },
+  "suffix_tps": {
+    "chat": 47.6,
+    "json_array": 50.9,
+    "tool_loop": null,
+    "code_edit": 66.1
+  },
+  "speedup": {
+    "chat": 0.732,
+    "json_array": 0.799,
+    "code_edit": 1.012
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 59.7,
+          "completion_tokens": 195,
+          "decode_time": 3.266,
+          "total_time": 3.502,
+          "rejected_reason": null
+        },
+        {
+          "tps": 67.0,
+          "completion_tokens": 195,
+          "decode_time": 2.912,
+          "total_time": 3.141,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.1,
+          "completion_tokens": 195,
+          "decode_time": 2.997,
+          "total_time": 3.236,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 67.5,
+          "completion_tokens": 46,
+          "decode_time": 0.681,
+          "total_time": 0.924,
+          "rejected_reason": null
+        },
+        {
+          "tps": 63.7,
+          "completion_tokens": 46,
+          "decode_time": 0.722,
+          "total_time": 0.899,
+          "rejected_reason": null
+        },
+        {
+          "tps": 62.1,
+          "completion_tokens": 46,
+          "decode_time": 0.741,
+          "total_time": 0.912,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.325,
+          "total_time": 0.72,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.262,
+          "total_time": 0.661,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.278,
+          "total_time": 0.698,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 66.8,
+          "completion_tokens": 43,
+          "decode_time": 0.644,
+          "total_time": 0.834,
+          "rejected_reason": null
+        },
+        {
+          "tps": 61.2,
+          "completion_tokens": 43,
+          "decode_time": 0.703,
+          "total_time": 0.894,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.3,
+          "completion_tokens": 43,
+          "decode_time": 0.658,
+          "total_time": 0.843,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 49.9,
+          "completion_tokens": 195,
+          "decode_time": 3.911,
+          "total_time": 4.078,
+          "rejected_reason": null
+        },
+        {
+          "tps": 47.6,
+          "completion_tokens": 195,
+          "decode_time": 4.096,
+          "total_time": 4.262,
+          "rejected_reason": null
+        },
+        {
+          "tps": 47.2,
+          "completion_tokens": 195,
+          "decode_time": 4.132,
+          "total_time": 4.29,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 55.4,
+          "completion_tokens": 46,
+          "decode_time": 0.831,
+          "total_time": 1.068,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.9,
+          "completion_tokens": 46,
+          "decode_time": 0.903,
+          "total_time": 1.083,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.4,
+          "completion_tokens": 46,
+          "decode_time": 0.912,
+          "total_time": 1.095,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.439,
+          "total_time": 0.88,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.4,
+          "total_time": 0.796,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.398,
+          "total_time": 0.878,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 66.1,
+          "completion_tokens": 43,
+          "decode_time": 0.651,
+          "total_time": 0.84,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 43,
+          "decode_time": 0.477,
+          "total_time": 0.699,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 43,
+          "decode_time": 0.491,
+          "total_time": 0.708,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_bonsai-4b_v3.json
+++ b/evals/results/suffix_bonsai-4b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "bonsai-4b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 72.8,
+    "json_array": 72.7,
+    "tool_loop": null,
+    "code_edit": 72.5
+  },
+  "suffix_tps": {
+    "chat": 57.3,
+    "json_array": 63.9,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.788,
+    "json_array": 0.88
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "suffix all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 72.8,
+          "completion_tokens": 195,
+          "decode_time": 2.678,
+          "total_time": 2.822,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.7,
+          "completion_tokens": 195,
+          "decode_time": 2.681,
+          "total_time": 2.818,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.8,
+          "completion_tokens": 195,
+          "decode_time": 2.68,
+          "total_time": 2.817,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 72.7,
+          "completion_tokens": 46,
+          "decode_time": 0.633,
+          "total_time": 0.778,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.4,
+          "completion_tokens": 46,
+          "decode_time": 0.635,
+          "total_time": 0.781,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.7,
+          "completion_tokens": 46,
+          "decode_time": 0.633,
+          "total_time": 0.777,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.257,
+          "total_time": 0.624,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.256,
+          "total_time": 0.621,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.257,
+          "total_time": 0.625,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 72.6,
+          "completion_tokens": 43,
+          "decode_time": 0.593,
+          "total_time": 0.759,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.5,
+          "completion_tokens": 43,
+          "decode_time": 0.593,
+          "total_time": 0.758,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.5,
+          "completion_tokens": 43,
+          "decode_time": 0.593,
+          "total_time": 0.76,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 57.2,
+          "completion_tokens": 195,
+          "decode_time": 3.41,
+          "total_time": 3.557,
+          "rejected_reason": null
+        },
+        {
+          "tps": 57.4,
+          "completion_tokens": 195,
+          "decode_time": 3.395,
+          "total_time": 3.534,
+          "rejected_reason": null
+        },
+        {
+          "tps": 57.3,
+          "completion_tokens": 195,
+          "decode_time": 3.401,
+          "total_time": 3.539,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 65.1,
+          "completion_tokens": 46,
+          "decode_time": 0.707,
+          "total_time": 0.852,
+          "rejected_reason": null
+        },
+        {
+          "tps": 63.9,
+          "completion_tokens": 46,
+          "decode_time": 0.72,
+          "total_time": 0.865,
+          "rejected_reason": null
+        },
+        {
+          "tps": 63.7,
+          "completion_tokens": 46,
+          "decode_time": 0.722,
+          "total_time": 0.868,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.376,
+          "total_time": 0.769,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.362,
+          "total_time": 0.728,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 18,
+          "decode_time": 0.363,
+          "total_time": 0.729,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 43,
+          "decode_time": 0.487,
+          "total_time": 0.653,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 43,
+          "decode_time": 0.422,
+          "total_time": 0.613,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 43,
+          "decode_time": 0.422,
+          "total_time": 0.612,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_bonsai-8b_v2.json
+++ b/evals/results/suffix_bonsai-8b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "bonsai-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 39.7,
+    "json_array": 42.0,
+    "tool_loop": null,
+    "code_edit": 38.8
+  },
+  "suffix_tps": {
+    "chat": 30.9,
+    "json_array": 53.3,
+    "tool_loop": 25.8,
+    "code_edit": 45.8
+  },
+  "speedup": {
+    "chat": 0.78,
+    "json_array": 1.268,
+    "code_edit": 1.181
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 39.4,
+          "completion_tokens": 248,
+          "decode_time": 6.287,
+          "total_time": 6.559,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.5,
+          "completion_tokens": 248,
+          "decode_time": 6.13,
+          "total_time": 6.342,
+          "rejected_reason": null
+        },
+        {
+          "tps": 39.7,
+          "completion_tokens": 248,
+          "decode_time": 6.252,
+          "total_time": 6.473,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 41.9,
+          "completion_tokens": 245,
+          "decode_time": 5.849,
+          "total_time": 6.06,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.0,
+          "completion_tokens": 245,
+          "decode_time": 5.83,
+          "total_time": 6.025,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.0,
+          "completion_tokens": 245,
+          "decode_time": 5.831,
+          "total_time": 6.025,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.476,
+          "total_time": 1.061,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.475,
+          "total_time": 1.059,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.49,
+          "total_time": 1.072,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 19.5,
+          "completion_tokens": 47,
+          "decode_time": 2.41,
+          "total_time": 2.84,
+          "rejected_reason": null
+        },
+        {
+          "tps": 39.7,
+          "completion_tokens": 47,
+          "decode_time": 1.183,
+          "total_time": 1.449,
+          "rejected_reason": null
+        },
+        {
+          "tps": 38.8,
+          "completion_tokens": 47,
+          "decode_time": 1.211,
+          "total_time": 1.473,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 31.1,
+          "completion_tokens": 248,
+          "decode_time": 7.976,
+          "total_time": 8.193,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.6,
+          "completion_tokens": 248,
+          "decode_time": 8.107,
+          "total_time": 8.358,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.9,
+          "completion_tokens": 248,
+          "decode_time": 8.014,
+          "total_time": 8.289,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 53.3,
+          "completion_tokens": 245,
+          "decode_time": 4.597,
+          "total_time": 4.906,
+          "rejected_reason": null
+        },
+        {
+          "tps": 52.9,
+          "completion_tokens": 245,
+          "decode_time": 4.634,
+          "total_time": 4.87,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.4,
+          "completion_tokens": 245,
+          "decode_time": 4.507,
+          "total_time": 4.739,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 27.7,
+          "completion_tokens": 20,
+          "decode_time": 0.722,
+          "total_time": 1.374,
+          "rejected_reason": null
+        },
+        {
+          "tps": 23.7,
+          "completion_tokens": 20,
+          "decode_time": 0.844,
+          "total_time": 1.506,
+          "rejected_reason": null
+        },
+        {
+          "tps": 25.8,
+          "completion_tokens": 20,
+          "decode_time": 0.775,
+          "total_time": 1.434,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 44.7,
+          "completion_tokens": 47,
+          "decode_time": 1.05,
+          "total_time": 1.309,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.8,
+          "completion_tokens": 47,
+          "decode_time": 1.025,
+          "total_time": 1.32,
+          "rejected_reason": null
+        },
+        {
+          "tps": 48.4,
+          "completion_tokens": 47,
+          "decode_time": 0.972,
+          "total_time": 1.239,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_bonsai-8b_v3.json
+++ b/evals/results/suffix_bonsai-8b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "bonsai-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 42.2,
+    "json_array": 42.1,
+    "tool_loop": null,
+    "code_edit": 42.4
+  },
+  "suffix_tps": {
+    "chat": 34.6,
+    "json_array": 61.8,
+    "tool_loop": 29.6,
+    "code_edit": 54.1
+  },
+  "speedup": {
+    "chat": 0.822,
+    "json_array": 1.466,
+    "code_edit": 1.277
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 42.2,
+          "completion_tokens": 248,
+          "decode_time": 5.88,
+          "total_time": 6.066,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.2,
+          "completion_tokens": 248,
+          "decode_time": 5.882,
+          "total_time": 6.063,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.2,
+          "completion_tokens": 248,
+          "decode_time": 5.883,
+          "total_time": 6.063,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 42.1,
+          "completion_tokens": 245,
+          "decode_time": 5.818,
+          "total_time": 6.015,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.1,
+          "completion_tokens": 245,
+          "decode_time": 5.817,
+          "total_time": 6.013,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.1,
+          "completion_tokens": 245,
+          "decode_time": 5.817,
+          "total_time": 6.012,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.476,
+          "total_time": 1.064,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.475,
+          "total_time": 1.057,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.476,
+          "total_time": 1.061,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 42.4,
+          "completion_tokens": 47,
+          "decode_time": 1.109,
+          "total_time": 1.343,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.4,
+          "completion_tokens": 47,
+          "decode_time": 1.109,
+          "total_time": 1.342,
+          "rejected_reason": null
+        },
+        {
+          "tps": 42.4,
+          "completion_tokens": 47,
+          "decode_time": 1.108,
+          "total_time": 1.343,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 35.3,
+          "completion_tokens": 248,
+          "decode_time": 7.025,
+          "total_time": 7.215,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.6,
+          "completion_tokens": 248,
+          "decode_time": 7.158,
+          "total_time": 7.339,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.6,
+          "completion_tokens": 248,
+          "decode_time": 7.161,
+          "total_time": 7.342,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 62.0,
+          "completion_tokens": 245,
+          "decode_time": 3.951,
+          "total_time": 4.146,
+          "rejected_reason": null
+        },
+        {
+          "tps": 61.7,
+          "completion_tokens": 245,
+          "decode_time": 3.972,
+          "total_time": 4.167,
+          "rejected_reason": null
+        },
+        {
+          "tps": 61.8,
+          "completion_tokens": 245,
+          "decode_time": 3.967,
+          "total_time": 4.162,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 31.3,
+          "completion_tokens": 20,
+          "decode_time": 0.639,
+          "total_time": 1.26,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.6,
+          "completion_tokens": 20,
+          "decode_time": 0.677,
+          "total_time": 1.264,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.6,
+          "completion_tokens": 20,
+          "decode_time": 0.676,
+          "total_time": 1.262,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 47.6,
+          "completion_tokens": 47,
+          "decode_time": 0.987,
+          "total_time": 1.221,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.1,
+          "completion_tokens": 47,
+          "decode_time": 0.869,
+          "total_time": 1.102,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.2,
+          "completion_tokens": 47,
+          "decode_time": 0.867,
+          "total_time": 1.101,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_cross_validation.md
+++ b/evals/results/suffix_cross_validation.md
@@ -1,0 +1,25 @@
+# SuffixDecoding cross-validation: v2 vs v3 sweep
+
+Total: 18 aliases · stable 14 · unstable 2 · fragile 2
+
+| Alias | v2 tier | v3 tier | status | v2 speedup (chat/json/tool/code) | v3 speedup |
+|---|---|---|---|---|---|
+| `bonsai-1.7b` | avoid | avoid | ✅ stable | 0.71/1.30/0.88/1.05 | 0.78/1.40/0.94/0.86 |
+| `bonsai-4b` | avoid | avoid | ✅ stable | 0.73/0.80/—/1.01 | 0.79/0.88/—/— |
+| `bonsai-8b` | avoid | avoid | ✅ stable | 0.78/1.27/—/1.18 | 0.82/1.47/—/1.28 |
+| `deepseek-r1-32b` | neutral | avoid | ⚠ unstable | 1.03/0.99/0.98/1.00 | 0.67/0.84/0.71/0.70 |
+| `deepseek-r1-8b` | avoid | avoid | ✅ stable | 1.03/0.96/—/0.29 | 0.84/0.83/—/— |
+| `devstral-v2-24b` | neutral | avoid | ⚠ unstable | 0.99/1.01/—/1.03 | 0.71/0.99/—/0.75 |
+| `gemma-4-26b` | avoid | unknown | ❓ fragile | —/0.20/—/— | — |
+| `gemma-4-31b` | avoid | avoid | ✅ stable | 1.47/0.67/—/1.00 | 1.61/0.72/—/1.07 |
+| `gemma3-27b` | unknown | unknown | ❓ fragile | — | — |
+| `hermes3-8b` | avoid | avoid | ✅ stable | 0.61/0.98/0.59/0.58 | 0.68/1.10/0.62/0.69 |
+| `hermes4-70b` | avoid | avoid | ✅ stable | 0.69/1.08/0.75/0.68 | 0.70/1.12/0.79/0.70 |
+| `llama3-3b` | avoid | avoid | ✅ stable | 0.59/0.88/—/— | 0.64/0.95/—/— |
+| `ministral-3b` | avoid | avoid | ✅ stable | 0.84/1.08/—/— | 0.67/0.92/—/— |
+| `phi4-14b` | avoid | avoid | ✅ stable | 0.66/0.94/0.67/0.87 | 0.65/0.90/0.64/— |
+| `qwen3-coder-30b` | avoid | avoid | ✅ stable | 0.87/0.99/1.04/0.93 | 0.45/0.89/—/1.80 |
+| `qwen3-vl-30b` | neutral | neutral | ✅ stable | 1.05/1.03/—/0.99 | 1.00/1.00/—/1.01 |
+| `qwen3-vl-8b` | neutral | neutral | ✅ stable | 0.99/1.03/—/1.02 | 1.00/1.00/—/1.00 |
+| `smollm3-3b` | avoid | avoid | ✅ stable | 0.51/—/0.78/— | —/2.76/0.63/— |
+

--- a/evals/results/suffix_deepseek-r1-32b_v2.json
+++ b/evals/results/suffix_deepseek-r1-32b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "deepseek-r1-32b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 32.3,
+    "json_array": 33.6,
+    "tool_loop": 34.3,
+    "code_edit": 33.8
+  },
+  "suffix_tps": {
+    "chat": 33.4,
+    "json_array": 33.2,
+    "tool_loop": 33.7,
+    "code_edit": 33.9
+  },
+  "speedup": {
+    "chat": 1.032,
+    "json_array": 0.986,
+    "tool_loop": 0.984,
+    "code_edit": 1.002
+  },
+  "skipped": {},
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 30.1,
+          "completion_tokens": 646,
+          "decode_time": 21.433,
+          "total_time": 22.373,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.3,
+          "completion_tokens": 495,
+          "decode_time": 15.312,
+          "total_time": 16.234,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.4,
+          "completion_tokens": 627,
+          "decode_time": 19.381,
+          "total_time": 20.256,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 34.3,
+          "completion_tokens": 570,
+          "decode_time": 16.614,
+          "total_time": 17.557,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.7,
+          "completion_tokens": 1906,
+          "decode_time": 58.214,
+          "total_time": 59.072,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.6,
+          "completion_tokens": 969,
+          "decode_time": 28.819,
+          "total_time": 29.739,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 34.4,
+          "completion_tokens": 471,
+          "decode_time": 13.688,
+          "total_time": 15.0,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.4,
+          "completion_tokens": 950,
+          "decode_time": 28.403,
+          "total_time": 29.737,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.3,
+          "completion_tokens": 480,
+          "decode_time": 14.013,
+          "total_time": 15.319,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 32.2,
+          "completion_tokens": 2149,
+          "decode_time": 66.654,
+          "total_time": 67.608,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.5,
+          "completion_tokens": 411,
+          "decode_time": 11.907,
+          "total_time": 12.857,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.8,
+          "completion_tokens": 655,
+          "decode_time": 19.363,
+          "total_time": 20.315,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 33.4,
+          "completion_tokens": 671,
+          "decode_time": 20.105,
+          "total_time": 20.921,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.3,
+          "completion_tokens": 703,
+          "decode_time": 21.112,
+          "total_time": 21.92,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.4,
+          "completion_tokens": 682,
+          "decode_time": 20.409,
+          "total_time": 21.25,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 33.1,
+          "completion_tokens": 833,
+          "decode_time": 25.181,
+          "total_time": 26.153,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.2,
+          "completion_tokens": 782,
+          "decode_time": 23.589,
+          "total_time": 24.561,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.2,
+          "completion_tokens": 724,
+          "decode_time": 21.8,
+          "total_time": 22.741,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 34.4,
+          "completion_tokens": 293,
+          "decode_time": 8.518,
+          "total_time": 9.849,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.7,
+          "completion_tokens": 421,
+          "decode_time": 12.494,
+          "total_time": 13.825,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.6,
+          "completion_tokens": 474,
+          "decode_time": 14.087,
+          "total_time": 15.448,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 33.6,
+          "completion_tokens": 522,
+          "decode_time": 15.526,
+          "total_time": 16.498,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.0,
+          "completion_tokens": 468,
+          "decode_time": 13.782,
+          "total_time": 14.743,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.9,
+          "completion_tokens": 623,
+          "decode_time": 18.374,
+          "total_time": 19.308,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_deepseek-r1-32b_v3.json
+++ b/evals/results/suffix_deepseek-r1-32b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "deepseek-r1-32b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 29.6,
+    "json_array": 29.5,
+    "tool_loop": 28.8,
+    "code_edit": 29.4
+  },
+  "suffix_tps": {
+    "chat": 19.7,
+    "json_array": 24.9,
+    "tool_loop": 20.4,
+    "code_edit": 20.5
+  },
+  "speedup": {
+    "chat": 0.668,
+    "json_array": 0.844,
+    "tool_loop": 0.709,
+    "code_edit": 0.698
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 29.7,
+          "completion_tokens": 586,
+          "decode_time": 19.76,
+          "total_time": 20.731,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.6,
+          "completion_tokens": 586,
+          "decode_time": 19.825,
+          "total_time": 20.797,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.5,
+          "completion_tokens": 586,
+          "decode_time": 19.848,
+          "total_time": 20.803,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 29.4,
+          "completion_tokens": 622,
+          "decode_time": 21.189,
+          "total_time": 22.304,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.6,
+          "completion_tokens": 622,
+          "decode_time": 21.047,
+          "total_time": 22.139,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.5,
+          "completion_tokens": 622,
+          "decode_time": 21.116,
+          "total_time": 22.181,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 28.9,
+          "completion_tokens": 774,
+          "decode_time": 26.76,
+          "total_time": 28.196,
+          "rejected_reason": null
+        },
+        {
+          "tps": 28.8,
+          "completion_tokens": 774,
+          "decode_time": 26.888,
+          "total_time": 28.339,
+          "rejected_reason": null
+        },
+        {
+          "tps": 28.8,
+          "completion_tokens": 774,
+          "decode_time": 26.866,
+          "total_time": 28.316,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 29.5,
+          "completion_tokens": 499,
+          "decode_time": 16.891,
+          "total_time": 17.969,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.4,
+          "completion_tokens": 499,
+          "decode_time": 16.956,
+          "total_time": 18.008,
+          "rejected_reason": null
+        },
+        {
+          "tps": 29.4,
+          "completion_tokens": 499,
+          "decode_time": 16.957,
+          "total_time": 18.049,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 19.7,
+          "completion_tokens": 586,
+          "decode_time": 29.683,
+          "total_time": 30.697,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.9,
+          "completion_tokens": 526,
+          "decode_time": 26.419,
+          "total_time": 27.806,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.7,
+          "completion_tokens": 586,
+          "decode_time": 29.793,
+          "total_time": 30.813,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 24.7,
+          "completion_tokens": 622,
+          "decode_time": 25.191,
+          "total_time": 26.619,
+          "rejected_reason": null
+        },
+        {
+          "tps": 24.9,
+          "completion_tokens": 622,
+          "decode_time": 25.022,
+          "total_time": 26.46,
+          "rejected_reason": null
+        },
+        {
+          "tps": 25.0,
+          "completion_tokens": 622,
+          "decode_time": 24.923,
+          "total_time": 26.347,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 20.4,
+          "completion_tokens": 774,
+          "decode_time": 37.85,
+          "total_time": 39.558,
+          "rejected_reason": null
+        },
+        {
+          "tps": 20.4,
+          "completion_tokens": 774,
+          "decode_time": 37.92,
+          "total_time": 39.727,
+          "rejected_reason": null
+        },
+        {
+          "tps": 20.4,
+          "completion_tokens": 774,
+          "decode_time": 37.907,
+          "total_time": 39.736,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 20.5,
+          "completion_tokens": 474,
+          "decode_time": 23.075,
+          "total_time": 24.427,
+          "rejected_reason": null
+        },
+        {
+          "tps": 20.5,
+          "completion_tokens": 487,
+          "decode_time": 23.718,
+          "total_time": 24.925,
+          "rejected_reason": null
+        },
+        {
+          "tps": 20.5,
+          "completion_tokens": 474,
+          "decode_time": 23.147,
+          "total_time": 24.5,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_deepseek-r1-8b_v2.json
+++ b/evals/results/suffix_deepseek-r1-8b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "deepseek-r1-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 197.3,
+    "json_array": 420.3,
+    "tool_loop": null,
+    "code_edit": 489.3
+  },
+  "suffix_tps": {
+    "chat": 203.2,
+    "json_array": 405.4,
+    "tool_loop": 419.3,
+    "code_edit": 141.5
+  },
+  "speedup": {
+    "chat": 1.03,
+    "json_array": 0.964,
+    "code_edit": 0.289
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 193.8,
+          "completion_tokens": 373,
+          "decode_time": 1.925,
+          "total_time": 4.087,
+          "rejected_reason": null
+        },
+        {
+          "tps": 204.1,
+          "completion_tokens": 373,
+          "decode_time": 1.827,
+          "total_time": 3.961,
+          "rejected_reason": null
+        },
+        {
+          "tps": 197.3,
+          "completion_tokens": 373,
+          "decode_time": 1.89,
+          "total_time": 4.048,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 421.3,
+          "completion_tokens": 1484,
+          "decode_time": 3.522,
+          "total_time": 15.693,
+          "rejected_reason": null
+        },
+        {
+          "tps": 410.0,
+          "completion_tokens": 1484,
+          "decode_time": 3.62,
+          "total_time": 15.993,
+          "rejected_reason": null
+        },
+        {
+          "tps": 420.3,
+          "completion_tokens": 1484,
+          "decode_time": 3.531,
+          "total_time": 15.755,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.732,
+          "total_time": 6.171,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.63,
+          "total_time": 5.35,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.632,
+          "total_time": 5.178,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 481.7,
+          "completion_tokens": 2299,
+          "decode_time": 4.773,
+          "total_time": 25.79,
+          "rejected_reason": null
+        },
+        {
+          "tps": 497.0,
+          "completion_tokens": 2299,
+          "decode_time": 4.626,
+          "total_time": 24.883,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2299,
+          "decode_time": 4.562,
+          "total_time": 24.981,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 172.4,
+          "completion_tokens": 544,
+          "decode_time": 3.155,
+          "total_time": 7.874,
+          "rejected_reason": null
+        },
+        {
+          "tps": 234.6,
+          "completion_tokens": 658,
+          "decode_time": 2.804,
+          "total_time": 8.803,
+          "rejected_reason": null
+        },
+        {
+          "tps": 203.2,
+          "completion_tokens": 514,
+          "decode_time": 2.529,
+          "total_time": 6.55,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 375.7,
+          "completion_tokens": 1475,
+          "decode_time": 3.926,
+          "total_time": 21.217,
+          "rejected_reason": null
+        },
+        {
+          "tps": 405.4,
+          "completion_tokens": 1526,
+          "decode_time": 3.764,
+          "total_time": 22.7,
+          "rejected_reason": null
+        },
+        {
+          "tps": 413.5,
+          "completion_tokens": 1526,
+          "decode_time": 3.691,
+          "total_time": 22.862,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 235.0,
+          "completion_tokens": 600,
+          "decode_time": 2.553,
+          "total_time": 8.265,
+          "rejected_reason": null
+        },
+        {
+          "tps": 423.4,
+          "completion_tokens": 820,
+          "decode_time": 1.937,
+          "total_time": 12.026,
+          "rejected_reason": null
+        },
+        {
+          "tps": 419.3,
+          "completion_tokens": 820,
+          "decode_time": 1.956,
+          "total_time": 12.241,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 231.7,
+          "completion_tokens": 1477,
+          "decode_time": 6.375,
+          "total_time": 27.807,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 4.243,
+          "total_time": 41.879,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": 51.3,
+          "completion_tokens": 2304,
+          "decode_time": 44.916,
+          "total_time": 44.916,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_deepseek-r1-8b_v3.json
+++ b/evals/results/suffix_deepseek-r1-8b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "deepseek-r1-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 240.2,
+    "json_array": 484.8,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 202.2,
+    "json_array": 401.2,
+    "tool_loop": 424.3,
+    "code_edit": 174.9
+  },
+  "speedup": {
+    "chat": 0.842,
+    "json_array": 0.828
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 240.4,
+          "completion_tokens": 373,
+          "decode_time": 1.552,
+          "total_time": 3.439,
+          "rejected_reason": null
+        },
+        {
+          "tps": 240.2,
+          "completion_tokens": 373,
+          "decode_time": 1.553,
+          "total_time": 3.455,
+          "rejected_reason": null
+        },
+        {
+          "tps": 240.2,
+          "completion_tokens": 373,
+          "decode_time": 1.553,
+          "total_time": 3.436,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 484.8,
+          "completion_tokens": 1484,
+          "decode_time": 3.061,
+          "total_time": 13.821,
+          "rejected_reason": null
+        },
+        {
+          "tps": 482.6,
+          "completion_tokens": 1484,
+          "decode_time": 3.075,
+          "total_time": 13.853,
+          "rejected_reason": null
+        },
+        {
+          "tps": 486.0,
+          "completion_tokens": 1484,
+          "decode_time": 3.053,
+          "total_time": 13.85,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.629,
+          "total_time": 5.164,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.63,
+          "total_time": 5.172,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 546,
+          "decode_time": 0.63,
+          "total_time": 5.166,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 2299,
+          "decode_time": 3.989,
+          "total_time": 21.758,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2299,
+          "decode_time": 3.988,
+          "total_time": 21.757,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2299,
+          "decode_time": 3.992,
+          "total_time": 21.768,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 172.4,
+          "completion_tokens": 544,
+          "decode_time": 3.156,
+          "total_time": 7.032,
+          "rejected_reason": null
+        },
+        {
+          "tps": 233.7,
+          "completion_tokens": 658,
+          "decode_time": 2.815,
+          "total_time": 8.838,
+          "rejected_reason": null
+        },
+        {
+          "tps": 202.2,
+          "completion_tokens": 514,
+          "decode_time": 2.542,
+          "total_time": 6.585,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 370.8,
+          "completion_tokens": 1475,
+          "decode_time": 3.978,
+          "total_time": 21.069,
+          "rejected_reason": null
+        },
+        {
+          "tps": 418.6,
+          "completion_tokens": 1526,
+          "decode_time": 3.645,
+          "total_time": 22.542,
+          "rejected_reason": null
+        },
+        {
+          "tps": 401.2,
+          "completion_tokens": 1526,
+          "decode_time": 3.804,
+          "total_time": 22.675,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 247.5,
+          "completion_tokens": 600,
+          "decode_time": 2.424,
+          "total_time": 8.22,
+          "rejected_reason": null
+        },
+        {
+          "tps": 424.3,
+          "completion_tokens": 820,
+          "decode_time": 1.932,
+          "total_time": 12.032,
+          "rejected_reason": null
+        },
+        {
+          "tps": 425.2,
+          "completion_tokens": 820,
+          "decode_time": 1.928,
+          "total_time": 11.936,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 287.4,
+          "completion_tokens": 1477,
+          "decode_time": 5.139,
+          "total_time": 22.711,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 3.494,
+          "total_time": 34.232,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": 62.4,
+          "completion_tokens": 2304,
+          "decode_time": 36.914,
+          "total_time": 36.914,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_devstral-v2-24b_v2.json
+++ b/evals/results/suffix_devstral-v2-24b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "devstral-v2-24b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 46.1,
+    "json_array": 45.4,
+    "tool_loop": null,
+    "code_edit": 45.4
+  },
+  "suffix_tps": {
+    "chat": 45.8,
+    "json_array": 46.1,
+    "tool_loop": null,
+    "code_edit": 46.7
+  },
+  "speedup": {
+    "chat": 0.992,
+    "json_array": 1.015,
+    "code_edit": 1.029
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 44.8,
+          "completion_tokens": 202,
+          "decode_time": 4.509,
+          "total_time": 4.824,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.4,
+          "completion_tokens": 178,
+          "decode_time": 3.834,
+          "total_time": 4.205,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.1,
+          "completion_tokens": 171,
+          "decode_time": 3.706,
+          "total_time": 3.998,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 45.1,
+          "completion_tokens": 252,
+          "decode_time": 5.588,
+          "total_time": 5.941,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.6,
+          "completion_tokens": 254,
+          "decode_time": 5.574,
+          "total_time": 5.938,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.4,
+          "completion_tokens": 256,
+          "decode_time": 5.64,
+          "total_time": 5.987,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.278,
+          "total_time": 1.733,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.286,
+          "total_time": 1.73,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.283,
+          "total_time": 1.717,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 45.3,
+          "completion_tokens": 66,
+          "decode_time": 1.455,
+          "total_time": 1.897,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.1,
+          "completion_tokens": 76,
+          "decode_time": 1.648,
+          "total_time": 2.178,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.4,
+          "completion_tokens": 77,
+          "decode_time": 1.696,
+          "total_time": 2.143,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 46.8,
+          "completion_tokens": 216,
+          "decode_time": 4.614,
+          "total_time": 4.888,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.8,
+          "completion_tokens": 193,
+          "decode_time": 4.216,
+          "total_time": 4.528,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.1,
+          "completion_tokens": 191,
+          "decode_time": 4.233,
+          "total_time": 4.573,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 46.1,
+          "completion_tokens": 255,
+          "decode_time": 5.532,
+          "total_time": 5.87,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.5,
+          "completion_tokens": 256,
+          "decode_time": 5.628,
+          "total_time": 5.976,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.4,
+          "completion_tokens": 256,
+          "decode_time": 5.522,
+          "total_time": 5.904,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.315,
+          "total_time": 1.765,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.318,
+          "total_time": 1.784,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.3,
+          "total_time": 1.831,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 46.7,
+          "completion_tokens": 65,
+          "decode_time": 1.392,
+          "total_time": 1.827,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.6,
+          "completion_tokens": 49,
+          "decode_time": 1.052,
+          "total_time": 1.572,
+          "rejected_reason": null
+        },
+        {
+          "tps": 47.5,
+          "completion_tokens": 74,
+          "decode_time": 1.558,
+          "total_time": 1.986,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_devstral-v2-24b_v3.json
+++ b/evals/results/suffix_devstral-v2-24b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "devstral-v2-24b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 43.7,
+    "json_array": 43.4,
+    "tool_loop": null,
+    "code_edit": 43.7
+  },
+  "suffix_tps": {
+    "chat": 31.0,
+    "json_array": 43.1,
+    "tool_loop": 23.9,
+    "code_edit": 32.7
+  },
+  "speedup": {
+    "chat": 0.708,
+    "json_array": 0.993,
+    "code_edit": 0.749
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 43.7,
+          "completion_tokens": 189,
+          "decode_time": 4.323,
+          "total_time": 4.612,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.6,
+          "completion_tokens": 189,
+          "decode_time": 4.331,
+          "total_time": 4.613,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.7,
+          "completion_tokens": 189,
+          "decode_time": 4.325,
+          "total_time": 4.599,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 43.3,
+          "completion_tokens": 256,
+          "decode_time": 5.908,
+          "total_time": 6.281,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.4,
+          "completion_tokens": 256,
+          "decode_time": 5.896,
+          "total_time": 6.267,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.7,
+          "completion_tokens": 256,
+          "decode_time": 5.861,
+          "total_time": 6.239,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.312,
+          "total_time": 1.765,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.306,
+          "total_time": 1.758,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.31,
+          "total_time": 1.761,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 44.0,
+          "completion_tokens": 77,
+          "decode_time": 1.75,
+          "total_time": 2.208,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.7,
+          "completion_tokens": 77,
+          "decode_time": 1.764,
+          "total_time": 2.225,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.6,
+          "completion_tokens": 77,
+          "decode_time": 1.767,
+          "total_time": 2.222,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 31.3,
+          "completion_tokens": 184,
+          "decode_time": 5.883,
+          "total_time": 6.171,
+          "rejected_reason": null
+        },
+        {
+          "tps": 31.0,
+          "completion_tokens": 184,
+          "decode_time": 5.944,
+          "total_time": 6.219,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.9,
+          "completion_tokens": 184,
+          "decode_time": 5.948,
+          "total_time": 6.228,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 42.9,
+          "completion_tokens": 256,
+          "decode_time": 5.966,
+          "total_time": 6.337,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.6,
+          "completion_tokens": 256,
+          "decode_time": 5.608,
+          "total_time": 5.979,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.1,
+          "completion_tokens": 256,
+          "decode_time": 5.935,
+          "total_time": 6.309,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 24.0,
+          "completion_tokens": 13,
+          "decode_time": 0.542,
+          "total_time": 1.996,
+          "rejected_reason": null
+        },
+        {
+          "tps": 23.9,
+          "completion_tokens": 13,
+          "decode_time": 0.544,
+          "total_time": 1.997,
+          "rejected_reason": null
+        },
+        {
+          "tps": 23.9,
+          "completion_tokens": 13,
+          "decode_time": 0.543,
+          "total_time": 1.995,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 32.8,
+          "completion_tokens": 77,
+          "decode_time": 2.345,
+          "total_time": 2.81,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.7,
+          "completion_tokens": 77,
+          "decode_time": 2.355,
+          "total_time": 2.811,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.6,
+          "completion_tokens": 77,
+          "decode_time": 2.361,
+          "total_time": 2.825,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma-4-26b_v2.json
+++ b/evals/results/suffix_gemma-4-26b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "gemma-4-26b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": 353.0,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 497.3,
+    "json_array": 71.6,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {
+    "json_array": 0.203
+  },
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 1.662,
+          "total_time": 18.682,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 1.667,
+          "total_time": 18.61,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 2.82,
+          "total_time": 28.302,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 339.4,
+          "completion_tokens": 2176,
+          "decode_time": 6.412,
+          "total_time": 35.152,
+          "rejected_reason": null
+        },
+        {
+          "tps": 367.9,
+          "completion_tokens": 2176,
+          "decode_time": 5.915,
+          "total_time": 34.33,
+          "rejected_reason": null
+        },
+        {
+          "tps": 353.0,
+          "completion_tokens": 2176,
+          "decode_time": 6.164,
+          "total_time": 33.282,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.029,
+          "total_time": 0.634,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.028,
+          "total_time": 0.631,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.034,
+          "total_time": 0.662,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.924,
+          "total_time": 7.714,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.712,
+          "total_time": 7.415,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.866,
+          "total_time": 7.6,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 805,
+          "decode_time": 1.532,
+          "total_time": 13.357,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": 497.3,
+          "completion_tokens": 805,
+          "decode_time": 1.619,
+          "total_time": 13.209,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 805,
+          "decode_time": 1.551,
+          "total_time": 13.489,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 71.2,
+          "completion_tokens": 954,
+          "decode_time": 13.405,
+          "total_time": 13.405,
+          "rejected_reason": null
+        },
+        {
+          "tps": 73.9,
+          "completion_tokens": 954,
+          "decode_time": 12.917,
+          "total_time": 12.917,
+          "rejected_reason": null
+        },
+        {
+          "tps": 71.6,
+          "completion_tokens": 954,
+          "decode_time": 13.322,
+          "total_time": 13.322,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.031,
+          "total_time": 0.774,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.032,
+          "total_time": 0.755,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.667,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.627,
+          "total_time": 10.615,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.562,
+          "total_time": 10.382,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.508,
+          "total_time": 10.507,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma-4-26b_v3.json
+++ b/evals/results/suffix_gemma-4-26b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "gemma-4-26b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": null,
+    "json_array": 97.3,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {},
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "json_array": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "unknown",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 1.644,
+          "total_time": 18.407,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 1.639,
+          "total_time": 18.423,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1853,
+          "decode_time": 1.652,
+          "total_time": 18.443,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 2176,
+          "decode_time": 3.886,
+          "total_time": 21.687,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2176,
+          "decode_time": 3.888,
+          "total_time": 21.715,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2176,
+          "decode_time": 3.961,
+          "total_time": 21.871,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.022,
+          "total_time": 0.524,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.022,
+          "total_time": 0.521,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.021,
+          "total_time": 0.518,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.558,
+          "total_time": 5.186,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.565,
+          "total_time": 5.212,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 530,
+          "decode_time": 0.56,
+          "total_time": 5.222,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 805,
+          "decode_time": 1.172,
+          "total_time": 9.801,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 805,
+          "decode_time": 1.171,
+          "total_time": 9.766,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 805,
+          "decode_time": 1.174,
+          "total_time": 9.784,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 97.2,
+          "completion_tokens": 954,
+          "decode_time": 9.818,
+          "total_time": 9.818,
+          "rejected_reason": null
+        },
+        {
+          "tps": 97.3,
+          "completion_tokens": 954,
+          "decode_time": 9.808,
+          "total_time": 9.808,
+          "rejected_reason": null
+        },
+        {
+          "tps": 97.4,
+          "completion_tokens": 954,
+          "decode_time": 9.797,
+          "total_time": 9.797,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.628,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.022,
+          "total_time": 0.625,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.626,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.444,
+          "total_time": 7.956,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.442,
+          "total_time": 7.968,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 660,
+          "decode_time": 0.44,
+          "total_time": 7.95,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma-4-31b_v2.json
+++ b/evals/results/suffix_gemma-4-31b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "gemma-4-31b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 143.3,
+    "json_array": 101.1,
+    "tool_loop": null,
+    "code_edit": 216.0
+  },
+  "suffix_tps": {
+    "chat": 210.4,
+    "json_array": 67.7,
+    "tool_loop": null,
+    "code_edit": 215.2
+  },
+  "speedup": {
+    "chat": 1.468,
+    "json_array": 0.67,
+    "code_edit": 0.996
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 143.3,
+          "completion_tokens": 460,
+          "decode_time": 3.209,
+          "total_time": 14.899,
+          "rejected_reason": null
+        },
+        {
+          "tps": 143.3,
+          "completion_tokens": 460,
+          "decode_time": 3.209,
+          "total_time": 14.898,
+          "rejected_reason": null
+        },
+        {
+          "tps": 143.3,
+          "completion_tokens": 460,
+          "decode_time": 3.21,
+          "total_time": 14.895,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 101.1,
+          "completion_tokens": 975,
+          "decode_time": 9.643,
+          "total_time": 32.236,
+          "rejected_reason": null
+        },
+        {
+          "tps": 101.1,
+          "completion_tokens": 975,
+          "decode_time": 9.645,
+          "total_time": 32.237,
+          "rejected_reason": null
+        },
+        {
+          "tps": 101.0,
+          "completion_tokens": 975,
+          "decode_time": 9.654,
+          "total_time": 32.286,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.061,
+          "total_time": 5.253,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.062,
+          "total_time": 5.251,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.063,
+          "total_time": 5.253,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 219.5,
+          "completion_tokens": 352,
+          "decode_time": 1.603,
+          "total_time": 11.647,
+          "rejected_reason": null
+        },
+        {
+          "tps": 216.0,
+          "completion_tokens": 352,
+          "decode_time": 1.629,
+          "total_time": 11.788,
+          "rejected_reason": null
+        },
+        {
+          "tps": 215.0,
+          "completion_tokens": 352,
+          "decode_time": 1.638,
+          "total_time": 11.89,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 210.4,
+          "completion_tokens": 519,
+          "decode_time": 2.466,
+          "total_time": 21.249,
+          "rejected_reason": null
+        },
+        {
+          "tps": 210.6,
+          "completion_tokens": 519,
+          "decode_time": 2.464,
+          "total_time": 21.22,
+          "rejected_reason": null
+        },
+        {
+          "tps": 209.8,
+          "completion_tokens": 519,
+          "decode_time": 2.473,
+          "total_time": 21.212,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 67.7,
+          "completion_tokens": 801,
+          "decode_time": 11.832,
+          "total_time": 34.937,
+          "rejected_reason": null
+        },
+        {
+          "tps": 123.2,
+          "completion_tokens": 934,
+          "decode_time": 7.58,
+          "total_time": 38.675,
+          "rejected_reason": null
+        },
+        {
+          "tps": 67.4,
+          "completion_tokens": 792,
+          "decode_time": 11.748,
+          "total_time": 33.701,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.066,
+          "total_time": 6.831,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.067,
+          "total_time": 7.115,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.068,
+          "total_time": 7.107,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 216.3,
+          "completion_tokens": 339,
+          "decode_time": 1.567,
+          "total_time": 15.764,
+          "rejected_reason": null
+        },
+        {
+          "tps": 214.9,
+          "completion_tokens": 335,
+          "decode_time": 1.559,
+          "total_time": 16.103,
+          "rejected_reason": null
+        },
+        {
+          "tps": 215.2,
+          "completion_tokens": 335,
+          "decode_time": 1.556,
+          "total_time": 16.103,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma-4-31b_v3.json
+++ b/evals/results/suffix_gemma-4-31b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "gemma-4-31b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 122.7,
+    "json_array": 87.7,
+    "tool_loop": null,
+    "code_edit": 189.0
+  },
+  "suffix_tps": {
+    "chat": 197.4,
+    "json_array": 63.0,
+    "tool_loop": null,
+    "code_edit": 202.0
+  },
+  "speedup": {
+    "chat": 1.608,
+    "json_array": 0.718,
+    "code_edit": 1.069
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 122.7,
+          "completion_tokens": 460,
+          "decode_time": 3.748,
+          "total_time": 17.426,
+          "rejected_reason": null
+        },
+        {
+          "tps": 123.1,
+          "completion_tokens": 460,
+          "decode_time": 3.738,
+          "total_time": 17.281,
+          "rejected_reason": null
+        },
+        {
+          "tps": 122.0,
+          "completion_tokens": 460,
+          "decode_time": 3.77,
+          "total_time": 17.364,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 88.3,
+          "completion_tokens": 975,
+          "decode_time": 11.042,
+          "total_time": 37.402,
+          "rejected_reason": null
+        },
+        {
+          "tps": 87.4,
+          "completion_tokens": 975,
+          "decode_time": 11.154,
+          "total_time": 37.361,
+          "rejected_reason": null
+        },
+        {
+          "tps": 87.7,
+          "completion_tokens": 975,
+          "decode_time": 11.121,
+          "total_time": 37.214,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.092,
+          "total_time": 5.857,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.089,
+          "total_time": 5.898,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.094,
+          "total_time": 5.877,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 189.0,
+          "completion_tokens": 352,
+          "decode_time": 1.862,
+          "total_time": 13.505,
+          "rejected_reason": null
+        },
+        {
+          "tps": 188.6,
+          "completion_tokens": 352,
+          "decode_time": 1.866,
+          "total_time": 13.378,
+          "rejected_reason": null
+        },
+        {
+          "tps": 189.2,
+          "completion_tokens": 352,
+          "decode_time": 1.86,
+          "total_time": 13.436,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 197.4,
+          "completion_tokens": 519,
+          "decode_time": 2.629,
+          "total_time": 23.72,
+          "rejected_reason": null
+        },
+        {
+          "tps": 197.5,
+          "completion_tokens": 519,
+          "decode_time": 2.627,
+          "total_time": 23.685,
+          "rejected_reason": null
+        },
+        {
+          "tps": 195.8,
+          "completion_tokens": 519,
+          "decode_time": 2.651,
+          "total_time": 23.635,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 63.0,
+          "completion_tokens": 801,
+          "decode_time": 12.724,
+          "total_time": 37.94,
+          "rejected_reason": null
+        },
+        {
+          "tps": 114.2,
+          "completion_tokens": 934,
+          "decode_time": 8.178,
+          "total_time": 42.399,
+          "rejected_reason": null
+        },
+        {
+          "tps": 62.5,
+          "completion_tokens": 792,
+          "decode_time": 12.667,
+          "total_time": 36.737,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.101,
+          "total_time": 7.756,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.105,
+          "total_time": 7.929,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 111,
+          "decode_time": 0.1,
+          "total_time": 7.967,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 202.0,
+          "completion_tokens": 339,
+          "decode_time": 1.678,
+          "total_time": 17.149,
+          "rejected_reason": null
+        },
+        {
+          "tps": 202.1,
+          "completion_tokens": 335,
+          "decode_time": 1.657,
+          "total_time": 17.566,
+          "rejected_reason": null
+        },
+        {
+          "tps": 201.0,
+          "completion_tokens": 335,
+          "decode_time": 1.667,
+          "total_time": 17.619,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma3-27b_v2.json
+++ b/evals/results/suffix_gemma3-27b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "gemma3-27b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {},
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "json_array": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "unknown",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.097,
+          "total_time": 0.097,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.096,
+          "total_time": 0.096,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.097,
+          "total_time": 0.097,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.097,
+          "total_time": 0.097,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.093,
+          "total_time": 0.093,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.094,
+          "total_time": 0.094,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.094,
+          "total_time": 0.094,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.095,
+          "total_time": 0.095,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.095,
+          "total_time": 0.095,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.093,
+          "total_time": 0.093,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.09,
+          "total_time": 0.09,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.099,
+          "total_time": 0.099,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.093,
+          "total_time": 0.093,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.092,
+          "total_time": 0.092,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.095,
+          "total_time": 0.095,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.094,
+          "total_time": 0.094,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.094,
+          "total_time": 0.094,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.095,
+          "total_time": 0.095,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.097,
+          "total_time": 0.097,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.099,
+          "total_time": 0.099,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.1,
+          "total_time": 0.1,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.095,
+          "total_time": 0.095,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.096,
+          "total_time": 0.096,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.096,
+          "total_time": 0.096,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma3-27b_v3.json
+++ b/evals/results/suffix_gemma3-27b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "gemma3-27b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {},
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "json_array": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "unknown",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.083,
+          "total_time": 0.083,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.084,
+          "total_time": 0.084,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.081,
+          "total_time": 0.081,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.082,
+          "total_time": 0.082,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.087,
+          "total_time": 0.087,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.085,
+          "total_time": 0.085,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.085,
+          "total_time": 0.085,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.084,
+          "total_time": 0.084,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.083,
+          "total_time": 0.083,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.084,
+          "total_time": 0.084,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.087,
+          "total_time": 0.087,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.082,
+          "total_time": 0.082,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.082,
+          "total_time": 0.082,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.081,
+          "total_time": 0.081,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.079,
+          "total_time": 0.079,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.081,
+          "total_time": 0.081,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.081,
+          "total_time": 0.081,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.082,
+          "total_time": 0.082,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.083,
+          "total_time": 0.083,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_hermes3-8b_v2.json
+++ b/evals/results/suffix_hermes3-8b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "hermes3-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 109.4,
+    "json_array": 114.6,
+    "tool_loop": 108.4,
+    "code_edit": 113.2
+  },
+  "suffix_tps": {
+    "chat": 67.2,
+    "json_array": 111.8,
+    "tool_loop": 64.3,
+    "code_edit": 66.1
+  },
+  "speedup": {
+    "chat": 0.615,
+    "json_array": 0.976,
+    "tool_loop": 0.594,
+    "code_edit": 0.584
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 112.8,
+          "completion_tokens": 152,
+          "decode_time": 1.348,
+          "total_time": 1.516,
+          "rejected_reason": null
+        },
+        {
+          "tps": 109.4,
+          "completion_tokens": 152,
+          "decode_time": 1.39,
+          "total_time": 1.568,
+          "rejected_reason": null
+        },
+        {
+          "tps": 101.7,
+          "completion_tokens": 152,
+          "decode_time": 1.494,
+          "total_time": 1.64,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 116.8,
+          "completion_tokens": 256,
+          "decode_time": 2.192,
+          "total_time": 2.367,
+          "rejected_reason": null
+        },
+        {
+          "tps": 114.6,
+          "completion_tokens": 256,
+          "decode_time": 2.234,
+          "total_time": 2.408,
+          "rejected_reason": null
+        },
+        {
+          "tps": 109.1,
+          "completion_tokens": 256,
+          "decode_time": 2.346,
+          "total_time": 2.544,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 108.2,
+          "completion_tokens": 157,
+          "decode_time": 1.451,
+          "total_time": 1.787,
+          "rejected_reason": null
+        },
+        {
+          "tps": 122.6,
+          "completion_tokens": 157,
+          "decode_time": 1.28,
+          "total_time": 1.617,
+          "rejected_reason": null
+        },
+        {
+          "tps": 108.4,
+          "completion_tokens": 157,
+          "decode_time": 1.449,
+          "total_time": 1.803,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 114.3,
+          "completion_tokens": 116,
+          "decode_time": 1.015,
+          "total_time": 1.281,
+          "rejected_reason": null
+        },
+        {
+          "tps": 103.4,
+          "completion_tokens": 116,
+          "decode_time": 1.121,
+          "total_time": 1.389,
+          "rejected_reason": null
+        },
+        {
+          "tps": 113.2,
+          "completion_tokens": 116,
+          "decode_time": 1.025,
+          "total_time": 1.334,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 67.2,
+          "completion_tokens": 152,
+          "decode_time": 2.261,
+          "total_time": 2.509,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.0,
+          "completion_tokens": 152,
+          "decode_time": 2.34,
+          "total_time": 2.495,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.7,
+          "completion_tokens": 152,
+          "decode_time": 2.179,
+          "total_time": 2.418,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 111.8,
+          "completion_tokens": 256,
+          "decode_time": 2.291,
+          "total_time": 2.465,
+          "rejected_reason": null
+        },
+        {
+          "tps": 109.0,
+          "completion_tokens": 256,
+          "decode_time": 2.349,
+          "total_time": 2.61,
+          "rejected_reason": null
+        },
+        {
+          "tps": 115.6,
+          "completion_tokens": 256,
+          "decode_time": 2.214,
+          "total_time": 2.452,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 62.1,
+          "completion_tokens": 197,
+          "decode_time": 3.172,
+          "total_time": 3.453,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.9,
+          "completion_tokens": 197,
+          "decode_time": 3.034,
+          "total_time": 3.376,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.3,
+          "completion_tokens": 197,
+          "decode_time": 3.062,
+          "total_time": 3.347,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 66.1,
+          "completion_tokens": 116,
+          "decode_time": 1.756,
+          "total_time": 2.024,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.9,
+          "completion_tokens": 116,
+          "decode_time": 1.761,
+          "total_time": 2.016,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.4,
+          "completion_tokens": 116,
+          "decode_time": 1.672,
+          "total_time": 1.879,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_hermes3-8b_v3.json
+++ b/evals/results/suffix_hermes3-8b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "hermes3-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 126.3,
+    "json_array": 125.8,
+    "tool_loop": 125.0,
+    "code_edit": 125.7
+  },
+  "suffix_tps": {
+    "chat": 85.4,
+    "json_array": 138.8,
+    "tool_loop": 78.0,
+    "code_edit": 87.3
+  },
+  "speedup": {
+    "chat": 0.676,
+    "json_array": 1.103,
+    "tool_loop": 0.624,
+    "code_edit": 0.694
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 126.4,
+          "completion_tokens": 152,
+          "decode_time": 1.203,
+          "total_time": 1.347,
+          "rejected_reason": null
+        },
+        {
+          "tps": 126.3,
+          "completion_tokens": 152,
+          "decode_time": 1.203,
+          "total_time": 1.337,
+          "rejected_reason": null
+        },
+        {
+          "tps": 126.2,
+          "completion_tokens": 152,
+          "decode_time": 1.204,
+          "total_time": 1.338,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 125.9,
+          "completion_tokens": 256,
+          "decode_time": 2.033,
+          "total_time": 2.189,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.8,
+          "completion_tokens": 256,
+          "decode_time": 2.036,
+          "total_time": 2.19,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.8,
+          "completion_tokens": 256,
+          "decode_time": 2.034,
+          "total_time": 2.189,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 124.9,
+          "completion_tokens": 157,
+          "decode_time": 1.257,
+          "total_time": 1.513,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.0,
+          "completion_tokens": 157,
+          "decode_time": 1.256,
+          "total_time": 1.511,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.0,
+          "completion_tokens": 157,
+          "decode_time": 1.256,
+          "total_time": 1.511,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 125.7,
+          "completion_tokens": 116,
+          "decode_time": 0.923,
+          "total_time": 1.101,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.7,
+          "completion_tokens": 116,
+          "decode_time": 0.923,
+          "total_time": 1.101,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.7,
+          "completion_tokens": 116,
+          "decode_time": 0.923,
+          "total_time": 1.102,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 84.8,
+          "completion_tokens": 152,
+          "decode_time": 1.793,
+          "total_time": 1.938,
+          "rejected_reason": null
+        },
+        {
+          "tps": 85.4,
+          "completion_tokens": 152,
+          "decode_time": 1.779,
+          "total_time": 1.914,
+          "rejected_reason": null
+        },
+        {
+          "tps": 86.1,
+          "completion_tokens": 152,
+          "decode_time": 1.764,
+          "total_time": 1.898,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 138.8,
+          "completion_tokens": 256,
+          "decode_time": 1.844,
+          "total_time": 2.001,
+          "rejected_reason": null
+        },
+        {
+          "tps": 138.7,
+          "completion_tokens": 256,
+          "decode_time": 1.846,
+          "total_time": 2.002,
+          "rejected_reason": null
+        },
+        {
+          "tps": 139.0,
+          "completion_tokens": 256,
+          "decode_time": 1.842,
+          "total_time": 1.998,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 78.0,
+          "completion_tokens": 197,
+          "decode_time": 2.525,
+          "total_time": 2.779,
+          "rejected_reason": null
+        },
+        {
+          "tps": 78.1,
+          "completion_tokens": 197,
+          "decode_time": 2.523,
+          "total_time": 2.778,
+          "rejected_reason": null
+        },
+        {
+          "tps": 78.0,
+          "completion_tokens": 197,
+          "decode_time": 2.524,
+          "total_time": 2.779,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 83.4,
+          "completion_tokens": 116,
+          "decode_time": 1.391,
+          "total_time": 1.571,
+          "rejected_reason": null
+        },
+        {
+          "tps": 87.3,
+          "completion_tokens": 116,
+          "decode_time": 1.329,
+          "total_time": 1.508,
+          "rejected_reason": null
+        },
+        {
+          "tps": 87.4,
+          "completion_tokens": 116,
+          "decode_time": 1.328,
+          "total_time": 1.506,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_hermes4-70b_v2.json
+++ b/evals/results/suffix_hermes4-70b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "hermes4-70b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 16.4,
+    "json_array": 16.3,
+    "tool_loop": 19.3,
+    "code_edit": 16.7
+  },
+  "suffix_tps": {
+    "chat": 11.4,
+    "json_array": 17.6,
+    "tool_loop": 14.5,
+    "code_edit": 11.4
+  },
+  "speedup": {
+    "chat": 0.695,
+    "json_array": 1.08,
+    "tool_loop": 0.751,
+    "code_edit": 0.679
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 16.4,
+          "completion_tokens": 245,
+          "decode_time": 14.942,
+          "total_time": 15.804,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.4,
+          "completion_tokens": 245,
+          "decode_time": 14.955,
+          "total_time": 15.785,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.4,
+          "completion_tokens": 245,
+          "decode_time": 14.958,
+          "total_time": 15.787,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 16.3,
+          "completion_tokens": 256,
+          "decode_time": 15.675,
+          "total_time": 16.755,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.3,
+          "completion_tokens": 256,
+          "decode_time": 15.671,
+          "total_time": 16.752,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.3,
+          "completion_tokens": 256,
+          "decode_time": 15.707,
+          "total_time": 16.788,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 19.3,
+          "completion_tokens": 114,
+          "decode_time": 5.9,
+          "total_time": 11.689,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.3,
+          "completion_tokens": 114,
+          "decode_time": 5.902,
+          "total_time": 11.696,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 114,
+          "decode_time": 5.821,
+          "total_time": 11.589,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 16.7,
+          "completion_tokens": 256,
+          "decode_time": 15.353,
+          "total_time": 16.683,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.7,
+          "completion_tokens": 256,
+          "decode_time": 15.308,
+          "total_time": 16.64,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.7,
+          "completion_tokens": 256,
+          "decode_time": 15.303,
+          "total_time": 16.633,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 10.9,
+          "completion_tokens": 256,
+          "decode_time": 23.393,
+          "total_time": 24.24,
+          "rejected_reason": null
+        },
+        {
+          "tps": 11.4,
+          "completion_tokens": 231,
+          "decode_time": 20.3,
+          "total_time": 21.115,
+          "rejected_reason": null
+        },
+        {
+          "tps": 11.5,
+          "completion_tokens": 134,
+          "decode_time": 11.685,
+          "total_time": 12.499,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 18.0,
+          "completion_tokens": 256,
+          "decode_time": 14.23,
+          "total_time": 15.296,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.6,
+          "completion_tokens": 256,
+          "decode_time": 14.509,
+          "total_time": 15.577,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.6,
+          "completion_tokens": 256,
+          "decode_time": 14.511,
+          "total_time": 15.578,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 14.5,
+          "completion_tokens": 114,
+          "decode_time": 7.859,
+          "total_time": 14.933,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.5,
+          "completion_tokens": 114,
+          "decode_time": 7.859,
+          "total_time": 14.932,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.5,
+          "completion_tokens": 114,
+          "decode_time": 7.855,
+          "total_time": 14.928,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 11.4,
+          "completion_tokens": 256,
+          "decode_time": 22.519,
+          "total_time": 23.852,
+          "rejected_reason": null
+        },
+        {
+          "tps": 11.1,
+          "completion_tokens": 256,
+          "decode_time": 23.034,
+          "total_time": 24.366,
+          "rejected_reason": null
+        },
+        {
+          "tps": 11.4,
+          "completion_tokens": 256,
+          "decode_time": 22.533,
+          "total_time": 23.865,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_hermes4-70b_v3.json
+++ b/evals/results/suffix_hermes4-70b_v3.json
@@ -1,0 +1,215 @@
+{
+  "model": "hermes4-70b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 14.8,
+    "json_array": 14.8,
+    "tool_loop": 17.5,
+    "code_edit": 14.9
+  },
+  "suffix_tps": {
+    "chat": 10.4,
+    "json_array": 16.7,
+    "tool_loop": 13.8,
+    "code_edit": 10.4
+  },
+  "speedup": {
+    "chat": 0.701,
+    "json_array": 1.123,
+    "tool_loop": 0.786,
+    "code_edit": 0.696
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 14.8,
+          "completion_tokens": 245,
+          "decode_time": 16.528,
+          "total_time": 17.481,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.8,
+          "completion_tokens": 245,
+          "decode_time": 16.556,
+          "total_time": 17.489,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.9,
+          "completion_tokens": 245,
+          "decode_time": 16.496,
+          "total_time": 17.396,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 14.8,
+          "completion_tokens": 256,
+          "decode_time": 17.293,
+          "total_time": 18.445,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.8,
+          "completion_tokens": 256,
+          "decode_time": 17.259,
+          "total_time": 18.42,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.9,
+          "completion_tokens": 256,
+          "decode_time": 17.21,
+          "total_time": 18.364,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 17.5,
+          "completion_tokens": 114,
+          "decode_time": 6.515,
+          "total_time": 12.478,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.4,
+          "completion_tokens": 114,
+          "decode_time": 6.562,
+          "total_time": 12.539,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.6,
+          "completion_tokens": 114,
+          "decode_time": 6.495,
+          "total_time": 12.46,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 14.9,
+          "completion_tokens": 256,
+          "decode_time": 17.17,
+          "total_time": 18.589,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.9,
+          "completion_tokens": 256,
+          "decode_time": 17.215,
+          "total_time": 18.634,
+          "rejected_reason": null
+        },
+        {
+          "tps": 14.9,
+          "completion_tokens": 256,
+          "decode_time": 17.204,
+          "total_time": 18.616,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 10.0,
+          "completion_tokens": 256,
+          "decode_time": 25.544,
+          "total_time": 26.498,
+          "rejected_reason": null
+        },
+        {
+          "tps": 10.4,
+          "completion_tokens": 231,
+          "decode_time": 22.227,
+          "total_time": 23.136,
+          "rejected_reason": null
+        },
+        {
+          "tps": 10.4,
+          "completion_tokens": 134,
+          "decode_time": 12.838,
+          "total_time": 13.752,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 17.0,
+          "completion_tokens": 256,
+          "decode_time": 15.093,
+          "total_time": 16.243,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.6,
+          "completion_tokens": 256,
+          "decode_time": 15.387,
+          "total_time": 16.538,
+          "rejected_reason": null
+        },
+        {
+          "tps": 16.7,
+          "completion_tokens": 256,
+          "decode_time": 15.362,
+          "total_time": 16.521,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 13.8,
+          "completion_tokens": 114,
+          "decode_time": 8.272,
+          "total_time": 15.505,
+          "rejected_reason": null
+        },
+        {
+          "tps": 13.7,
+          "completion_tokens": 114,
+          "decode_time": 8.326,
+          "total_time": 15.552,
+          "rejected_reason": null
+        },
+        {
+          "tps": 13.8,
+          "completion_tokens": 114,
+          "decode_time": 8.285,
+          "total_time": 15.53,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 10.4,
+          "completion_tokens": 256,
+          "decode_time": 24.633,
+          "total_time": 26.049,
+          "rejected_reason": null
+        },
+        {
+          "tps": 10.2,
+          "completion_tokens": 256,
+          "decode_time": 25.157,
+          "total_time": 26.566,
+          "rejected_reason": null
+        },
+        {
+          "tps": 10.4,
+          "completion_tokens": 256,
+          "decode_time": 24.723,
+          "total_time": 26.161,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_llama3-3b_v2.json
+++ b/evals/results/suffix_llama3-3b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "llama3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 168.4,
+    "json_array": 186.4,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 99.0,
+    "json_array": 163.1,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.588,
+    "json_array": 0.875
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 158.8,
+          "completion_tokens": 227,
+          "decode_time": 1.43,
+          "total_time": 1.596,
+          "rejected_reason": null
+        },
+        {
+          "tps": 168.4,
+          "completion_tokens": 227,
+          "decode_time": 1.348,
+          "total_time": 1.558,
+          "rejected_reason": null
+        },
+        {
+          "tps": 191.9,
+          "completion_tokens": 227,
+          "decode_time": 1.183,
+          "total_time": 1.33,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 182.7,
+          "completion_tokens": 183,
+          "decode_time": 1.002,
+          "total_time": 1.211,
+          "rejected_reason": null
+        },
+        {
+          "tps": 188.8,
+          "completion_tokens": 183,
+          "decode_time": 0.969,
+          "total_time": 1.119,
+          "rejected_reason": null
+        },
+        {
+          "tps": 186.4,
+          "completion_tokens": 183,
+          "decode_time": 0.982,
+          "total_time": 1.187,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.097,
+          "total_time": 0.452,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.1,
+          "total_time": 0.492,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.122,
+          "total_time": 0.515,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.293,
+          "total_time": 0.512,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.301,
+          "total_time": 0.526,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.285,
+          "total_time": 0.445,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 109.5,
+          "completion_tokens": 227,
+          "decode_time": 2.072,
+          "total_time": 2.236,
+          "rejected_reason": null
+        },
+        {
+          "tps": 99.0,
+          "completion_tokens": 227,
+          "decode_time": 2.293,
+          "total_time": 2.428,
+          "rejected_reason": null
+        },
+        {
+          "tps": 98.5,
+          "completion_tokens": 227,
+          "decode_time": 2.305,
+          "total_time": 2.436,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 139.6,
+          "completion_tokens": 183,
+          "decode_time": 1.311,
+          "total_time": 1.475,
+          "rejected_reason": null
+        },
+        {
+          "tps": 174.7,
+          "completion_tokens": 183,
+          "decode_time": 1.048,
+          "total_time": 1.218,
+          "rejected_reason": null
+        },
+        {
+          "tps": 163.1,
+          "completion_tokens": 183,
+          "decode_time": 1.122,
+          "total_time": 1.283,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.246,
+          "total_time": 0.633,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.324,
+          "total_time": 0.701,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.211,
+          "total_time": 0.622,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.351,
+          "total_time": 0.524,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.361,
+          "total_time": 0.519,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.384,
+          "total_time": 0.54,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_llama3-3b_v3.json
+++ b/evals/results/suffix_llama3-3b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "llama3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 233.2,
+    "json_array": 232.0,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 149.2,
+    "json_array": 221.0,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.64,
+    "json_array": 0.953
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 232.0,
+          "completion_tokens": 227,
+          "decode_time": 0.978,
+          "total_time": 1.123,
+          "rejected_reason": null
+        },
+        {
+          "tps": 233.2,
+          "completion_tokens": 227,
+          "decode_time": 0.973,
+          "total_time": 1.087,
+          "rejected_reason": null
+        },
+        {
+          "tps": 233.2,
+          "completion_tokens": 227,
+          "decode_time": 0.973,
+          "total_time": 1.086,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 232.0,
+          "completion_tokens": 183,
+          "decode_time": 0.789,
+          "total_time": 0.912,
+          "rejected_reason": null
+        },
+        {
+          "tps": 231.4,
+          "completion_tokens": 183,
+          "decode_time": 0.791,
+          "total_time": 0.914,
+          "rejected_reason": null
+        },
+        {
+          "tps": 232.1,
+          "completion_tokens": 183,
+          "decode_time": 0.788,
+          "total_time": 0.91,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.09,
+          "total_time": 0.408,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.09,
+          "total_time": 0.401,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.09,
+          "total_time": 0.405,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.244,
+          "total_time": 0.378,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.244,
+          "total_time": 0.377,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.244,
+          "total_time": 0.378,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 149.2,
+          "completion_tokens": 227,
+          "decode_time": 1.522,
+          "total_time": 1.669,
+          "rejected_reason": null
+        },
+        {
+          "tps": 148.8,
+          "completion_tokens": 227,
+          "decode_time": 1.525,
+          "total_time": 1.642,
+          "rejected_reason": null
+        },
+        {
+          "tps": 150.0,
+          "completion_tokens": 227,
+          "decode_time": 1.513,
+          "total_time": 1.628,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 220.7,
+          "completion_tokens": 183,
+          "decode_time": 0.829,
+          "total_time": 0.968,
+          "rejected_reason": null
+        },
+        {
+          "tps": 221.0,
+          "completion_tokens": 183,
+          "decode_time": 0.828,
+          "total_time": 0.968,
+          "rejected_reason": null
+        },
+        {
+          "tps": 221.3,
+          "completion_tokens": 183,
+          "decode_time": 0.827,
+          "total_time": 0.967,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.156,
+          "total_time": 0.468,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.155,
+          "total_time": 0.474,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 17,
+          "decode_time": 0.158,
+          "total_time": 0.469,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.269,
+          "total_time": 0.42,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.274,
+          "total_time": 0.408,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 55,
+          "decode_time": 0.278,
+          "total_time": 0.412,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_ministral-3b_v2.json
+++ b/evals/results/suffix_ministral-3b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "ministral-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 171.9,
+    "json_array": 178.9,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 144.1,
+    "json_array": 193.1,
+    "tool_loop": null,
+    "code_edit": 96.2
+  },
+  "speedup": {
+    "chat": 0.838,
+    "json_array": 1.08
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 147.5,
+          "completion_tokens": 207,
+          "decode_time": 1.403,
+          "total_time": 1.816,
+          "rejected_reason": null
+        },
+        {
+          "tps": 171.9,
+          "completion_tokens": 207,
+          "decode_time": 1.204,
+          "total_time": 1.587,
+          "rejected_reason": null
+        },
+        {
+          "tps": 188.0,
+          "completion_tokens": 207,
+          "decode_time": 1.101,
+          "total_time": 1.505,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 178.9,
+          "completion_tokens": 256,
+          "decode_time": 1.431,
+          "total_time": 1.848,
+          "rejected_reason": null
+        },
+        {
+          "tps": 172.9,
+          "completion_tokens": 256,
+          "decode_time": 1.481,
+          "total_time": 1.821,
+          "rejected_reason": null
+        },
+        {
+          "tps": 180.3,
+          "completion_tokens": 256,
+          "decode_time": 1.42,
+          "total_time": 1.813,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.071,
+          "total_time": 0.343,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.071,
+          "total_time": 0.343,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.071,
+          "total_time": 0.343,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.699,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.7,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.699,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 139.3,
+          "completion_tokens": 202,
+          "decode_time": 1.45,
+          "total_time": 1.762,
+          "rejected_reason": null
+        },
+        {
+          "tps": 144.1,
+          "completion_tokens": 215,
+          "decode_time": 1.492,
+          "total_time": 1.799,
+          "rejected_reason": null
+        },
+        {
+          "tps": 147.5,
+          "completion_tokens": 204,
+          "decode_time": 1.383,
+          "total_time": 1.69,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 195.4,
+          "completion_tokens": 256,
+          "decode_time": 1.31,
+          "total_time": 1.628,
+          "rejected_reason": null
+        },
+        {
+          "tps": 192.9,
+          "completion_tokens": 256,
+          "decode_time": 1.327,
+          "total_time": 1.645,
+          "rejected_reason": null
+        },
+        {
+          "tps": 193.1,
+          "completion_tokens": 256,
+          "decode_time": 1.325,
+          "total_time": 1.642,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.083,
+          "total_time": 0.354,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.117,
+          "total_time": 0.387,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.279,
+          "total_time": 0.55,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 45.4,
+          "completion_tokens": 76,
+          "decode_time": 1.675,
+          "total_time": 2.213,
+          "rejected_reason": null
+        },
+        {
+          "tps": 123.5,
+          "completion_tokens": 76,
+          "decode_time": 0.615,
+          "total_time": 0.964,
+          "rejected_reason": null
+        },
+        {
+          "tps": 96.2,
+          "completion_tokens": 76,
+          "decode_time": 0.79,
+          "total_time": 1.147,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_ministral-3b_v3.json
+++ b/evals/results/suffix_ministral-3b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "ministral-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 210.2,
+    "json_array": 209.2,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 141.1,
+    "json_array": 191.9,
+    "tool_loop": null,
+    "code_edit": 148.3
+  },
+  "speedup": {
+    "chat": 0.671,
+    "json_array": 0.917
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 210.3,
+          "completion_tokens": 207,
+          "decode_time": 0.984,
+          "total_time": 1.295,
+          "rejected_reason": null
+        },
+        {
+          "tps": 210.2,
+          "completion_tokens": 207,
+          "decode_time": 0.985,
+          "total_time": 1.289,
+          "rejected_reason": null
+        },
+        {
+          "tps": 207.3,
+          "completion_tokens": 207,
+          "decode_time": 0.999,
+          "total_time": 1.309,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 209.2,
+          "completion_tokens": 256,
+          "decode_time": 1.223,
+          "total_time": 1.539,
+          "rejected_reason": null
+        },
+        {
+          "tps": 208.9,
+          "completion_tokens": 256,
+          "decode_time": 1.225,
+          "total_time": 1.54,
+          "rejected_reason": null
+        },
+        {
+          "tps": 209.2,
+          "completion_tokens": 256,
+          "decode_time": 1.224,
+          "total_time": 1.537,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.071,
+          "total_time": 0.341,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.072,
+          "total_time": 0.34,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.072,
+          "total_time": 0.34,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.697,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.7,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.369,
+          "total_time": 0.698,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 136.3,
+          "completion_tokens": 202,
+          "decode_time": 1.482,
+          "total_time": 1.793,
+          "rejected_reason": null
+        },
+        {
+          "tps": 141.1,
+          "completion_tokens": 215,
+          "decode_time": 1.524,
+          "total_time": 1.831,
+          "rejected_reason": null
+        },
+        {
+          "tps": 147.3,
+          "completion_tokens": 204,
+          "decode_time": 1.385,
+          "total_time": 1.691,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 194.3,
+          "completion_tokens": 256,
+          "decode_time": 1.318,
+          "total_time": 1.635,
+          "rejected_reason": null
+        },
+        {
+          "tps": 191.0,
+          "completion_tokens": 256,
+          "decode_time": 1.341,
+          "total_time": 1.658,
+          "rejected_reason": null
+        },
+        {
+          "tps": 191.9,
+          "completion_tokens": 256,
+          "decode_time": 1.334,
+          "total_time": 1.65,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.083,
+          "total_time": 0.353,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.118,
+          "total_time": 0.387,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 13,
+          "decode_time": 0.118,
+          "total_time": 0.388,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 76,
+          "decode_time": 0.487,
+          "total_time": 0.816,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 148.1,
+          "completion_tokens": 76,
+          "decode_time": 0.513,
+          "total_time": 0.844,
+          "rejected_reason": null
+        },
+        {
+          "tps": 148.6,
+          "completion_tokens": 76,
+          "decode_time": 0.512,
+          "total_time": 0.841,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_phi4-14b_v2.json
+++ b/evals/results/suffix_phi4-14b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "phi4-14b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 128.6,
+    "json_array": 129.5,
+    "tool_loop": 128.9,
+    "code_edit": 122.4
+  },
+  "suffix_tps": {
+    "chat": 84.8,
+    "json_array": 122.3,
+    "tool_loop": 86.5,
+    "code_edit": 107.1
+  },
+  "speedup": {
+    "chat": 0.66,
+    "json_array": 0.944,
+    "tool_loop": 0.671,
+    "code_edit": 0.874
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 126.1,
+          "completion_tokens": 250,
+          "decode_time": 1.983,
+          "total_time": 2.13,
+          "rejected_reason": null
+        },
+        {
+          "tps": 128.6,
+          "completion_tokens": 250,
+          "decode_time": 1.945,
+          "total_time": 2.089,
+          "rejected_reason": null
+        },
+        {
+          "tps": 130.2,
+          "completion_tokens": 250,
+          "decode_time": 1.92,
+          "total_time": 2.06,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 131.0,
+          "completion_tokens": 163,
+          "decode_time": 1.244,
+          "total_time": 1.399,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.5,
+          "completion_tokens": 163,
+          "decode_time": 1.299,
+          "total_time": 1.454,
+          "rejected_reason": null
+        },
+        {
+          "tps": 129.5,
+          "completion_tokens": 163,
+          "decode_time": 1.259,
+          "total_time": 1.412,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 128.9,
+          "completion_tokens": 171,
+          "decode_time": 1.327,
+          "total_time": 1.52,
+          "rejected_reason": null
+        },
+        {
+          "tps": 128.9,
+          "completion_tokens": 171,
+          "decode_time": 1.326,
+          "total_time": 1.533,
+          "rejected_reason": null
+        },
+        {
+          "tps": 130.7,
+          "completion_tokens": 171,
+          "decode_time": 1.309,
+          "total_time": 1.531,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 124.0,
+          "completion_tokens": 64,
+          "decode_time": 0.516,
+          "total_time": 0.681,
+          "rejected_reason": null
+        },
+        {
+          "tps": 120.9,
+          "completion_tokens": 64,
+          "decode_time": 0.529,
+          "total_time": 0.697,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.478,
+          "total_time": 0.639,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 83.6,
+          "completion_tokens": 250,
+          "decode_time": 2.992,
+          "total_time": 3.137,
+          "rejected_reason": null
+        },
+        {
+          "tps": 84.8,
+          "completion_tokens": 256,
+          "decode_time": 3.019,
+          "total_time": 3.16,
+          "rejected_reason": null
+        },
+        {
+          "tps": 89.4,
+          "completion_tokens": 256,
+          "decode_time": 2.863,
+          "total_time": 3.011,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 115.5,
+          "completion_tokens": 163,
+          "decode_time": 1.411,
+          "total_time": 1.579,
+          "rejected_reason": null
+        },
+        {
+          "tps": 122.3,
+          "completion_tokens": 163,
+          "decode_time": 1.333,
+          "total_time": 1.494,
+          "rejected_reason": null
+        },
+        {
+          "tps": 125.4,
+          "completion_tokens": 163,
+          "decode_time": 1.3,
+          "total_time": 1.457,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 90.5,
+          "completion_tokens": 171,
+          "decode_time": 1.89,
+          "total_time": 2.091,
+          "rejected_reason": null
+        },
+        {
+          "tps": 86.5,
+          "completion_tokens": 171,
+          "decode_time": 1.976,
+          "total_time": 2.18,
+          "rejected_reason": null
+        },
+        {
+          "tps": 84.4,
+          "completion_tokens": 171,
+          "decode_time": 2.027,
+          "total_time": 2.228,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 107.1,
+          "completion_tokens": 64,
+          "decode_time": 0.598,
+          "total_time": 0.787,
+          "rejected_reason": null
+        },
+        {
+          "tps": 109.9,
+          "completion_tokens": 64,
+          "decode_time": 0.582,
+          "total_time": 0.76,
+          "rejected_reason": null
+        },
+        {
+          "tps": 106.8,
+          "completion_tokens": 64,
+          "decode_time": 0.599,
+          "total_time": 0.779,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_phi4-14b_v3.json
+++ b/evals/results/suffix_phi4-14b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "phi4-14b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 180.4,
+    "json_array": 179.9,
+    "tool_loop": 177.8,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 117.2,
+    "json_array": 161.4,
+    "tool_loop": 113.1,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.65,
+    "json_array": 0.897,
+    "tool_loop": 0.636
+  },
+  "skipped": {
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 180.5,
+          "completion_tokens": 250,
+          "decode_time": 1.385,
+          "total_time": 1.499,
+          "rejected_reason": null
+        },
+        {
+          "tps": 180.4,
+          "completion_tokens": 250,
+          "decode_time": 1.386,
+          "total_time": 1.494,
+          "rejected_reason": null
+        },
+        {
+          "tps": 180.3,
+          "completion_tokens": 250,
+          "decode_time": 1.387,
+          "total_time": 1.494,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 180.0,
+          "completion_tokens": 163,
+          "decode_time": 0.905,
+          "total_time": 1.025,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.6,
+          "completion_tokens": 163,
+          "decode_time": 0.908,
+          "total_time": 1.026,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.9,
+          "completion_tokens": 163,
+          "decode_time": 0.906,
+          "total_time": 1.023,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 177.7,
+          "completion_tokens": 171,
+          "decode_time": 0.962,
+          "total_time": 1.129,
+          "rejected_reason": null
+        },
+        {
+          "tps": 177.8,
+          "completion_tokens": 171,
+          "decode_time": 0.962,
+          "total_time": 1.128,
+          "rejected_reason": null
+        },
+        {
+          "tps": 178.0,
+          "completion_tokens": 171,
+          "decode_time": 0.961,
+          "total_time": 1.127,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.361,
+          "total_time": 0.491,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.361,
+          "total_time": 0.494,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.361,
+          "total_time": 0.492,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 117.2,
+          "completion_tokens": 250,
+          "decode_time": 2.133,
+          "total_time": 2.248,
+          "rejected_reason": null
+        },
+        {
+          "tps": 116.6,
+          "completion_tokens": 256,
+          "decode_time": 2.195,
+          "total_time": 2.305,
+          "rejected_reason": null
+        },
+        {
+          "tps": 119.5,
+          "completion_tokens": 256,
+          "decode_time": 2.143,
+          "total_time": 2.252,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 158.4,
+          "completion_tokens": 163,
+          "decode_time": 1.029,
+          "total_time": 1.148,
+          "rejected_reason": null
+        },
+        {
+          "tps": 161.4,
+          "completion_tokens": 163,
+          "decode_time": 1.01,
+          "total_time": 1.13,
+          "rejected_reason": null
+        },
+        {
+          "tps": 161.4,
+          "completion_tokens": 163,
+          "decode_time": 1.01,
+          "total_time": 1.13,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 115.5,
+          "completion_tokens": 171,
+          "decode_time": 1.48,
+          "total_time": 1.651,
+          "rejected_reason": null
+        },
+        {
+          "tps": 113.1,
+          "completion_tokens": 171,
+          "decode_time": 1.513,
+          "total_time": 1.68,
+          "rejected_reason": null
+        },
+        {
+          "tps": 112.0,
+          "completion_tokens": 171,
+          "decode_time": 1.526,
+          "total_time": 1.693,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.446,
+          "total_time": 0.596,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.449,
+          "total_time": 0.598,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.448,
+          "total_time": 0.597,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-coder-30b_v2.json
+++ b/evals/results/suffix_qwen3-coder-30b_v2.json
@@ -1,0 +1,215 @@
+{
+  "model": "qwen3-coder-30b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 87.9,
+    "json_array": 86.6,
+    "tool_loop": 74.6,
+    "code_edit": 64.4
+  },
+  "suffix_tps": {
+    "chat": 76.9,
+    "json_array": 85.6,
+    "tool_loop": 77.5,
+    "code_edit": 59.8
+  },
+  "speedup": {
+    "chat": 0.874,
+    "json_array": 0.988,
+    "tool_loop": 1.039,
+    "code_edit": 0.929
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 87.9,
+          "completion_tokens": 183,
+          "decode_time": 2.081,
+          "total_time": 2.245,
+          "rejected_reason": null
+        },
+        {
+          "tps": 86.0,
+          "completion_tokens": 178,
+          "decode_time": 2.07,
+          "total_time": 2.237,
+          "rejected_reason": null
+        },
+        {
+          "tps": 88.5,
+          "completion_tokens": 156,
+          "decode_time": 1.764,
+          "total_time": 1.954,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 87.7,
+          "completion_tokens": 256,
+          "decode_time": 2.921,
+          "total_time": 3.193,
+          "rejected_reason": null
+        },
+        {
+          "tps": 83.5,
+          "completion_tokens": 256,
+          "decode_time": 3.067,
+          "total_time": 3.306,
+          "rejected_reason": null
+        },
+        {
+          "tps": 86.6,
+          "completion_tokens": 223,
+          "decode_time": 2.575,
+          "total_time": 2.767,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.042,
+          "total_time": 0.8,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": 74.6,
+          "completion_tokens": 70,
+          "decode_time": 0.938,
+          "total_time": 1.774,
+          "rejected_reason": null
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.036,
+          "total_time": 0.797,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 66.0,
+          "completion_tokens": 47,
+          "decode_time": 0.712,
+          "total_time": 0.989,
+          "rejected_reason": null
+        },
+        {
+          "tps": 53.7,
+          "completion_tokens": 47,
+          "decode_time": 0.876,
+          "total_time": 1.12,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.4,
+          "completion_tokens": 47,
+          "decode_time": 0.73,
+          "total_time": 1.03,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 76.9,
+          "completion_tokens": 174,
+          "decode_time": 2.264,
+          "total_time": 2.454,
+          "rejected_reason": null
+        },
+        {
+          "tps": 88.2,
+          "completion_tokens": 187,
+          "decode_time": 2.119,
+          "total_time": 2.277,
+          "rejected_reason": null
+        },
+        {
+          "tps": 66.6,
+          "completion_tokens": 202,
+          "decode_time": 3.032,
+          "total_time": 3.199,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 77.7,
+          "completion_tokens": 256,
+          "decode_time": 3.296,
+          "total_time": 3.493,
+          "rejected_reason": null
+        },
+        {
+          "tps": 90.1,
+          "completion_tokens": 223,
+          "decode_time": 2.474,
+          "total_time": 2.734,
+          "rejected_reason": null
+        },
+        {
+          "tps": 85.6,
+          "completion_tokens": 256,
+          "decode_time": 2.992,
+          "total_time": 3.214,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 77.5,
+          "completion_tokens": 123,
+          "decode_time": 1.587,
+          "total_time": 2.441,
+          "rejected_reason": null
+        },
+        {
+          "tps": 80.1,
+          "completion_tokens": 124,
+          "decode_time": 1.549,
+          "total_time": 2.223,
+          "rejected_reason": null
+        },
+        {
+          "tps": 68.2,
+          "completion_tokens": 256,
+          "decode_time": 3.752,
+          "total_time": 4.541,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 56.2,
+          "completion_tokens": 47,
+          "decode_time": 0.836,
+          "total_time": 1.08,
+          "rejected_reason": null
+        },
+        {
+          "tps": 59.8,
+          "completion_tokens": 47,
+          "decode_time": 0.786,
+          "total_time": 1.067,
+          "rejected_reason": null
+        },
+        {
+          "tps": 84.4,
+          "completion_tokens": 47,
+          "decode_time": 0.557,
+          "total_time": 0.889,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-coder-30b_v3.json
+++ b/evals/results/suffix_qwen3-coder-30b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "qwen3-coder-30b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 101.6,
+    "json_array": 102.0,
+    "tool_loop": null,
+    "code_edit": 50.5
+  },
+  "suffix_tps": {
+    "chat": 45.2,
+    "json_array": 90.5,
+    "tool_loop": null,
+    "code_edit": 91.0
+  },
+  "speedup": {
+    "chat": 0.445,
+    "json_array": 0.887,
+    "code_edit": 1.802
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 71.0,
+          "completion_tokens": 172,
+          "decode_time": 2.423,
+          "total_time": 2.665,
+          "rejected_reason": null
+        },
+        {
+          "tps": 101.7,
+          "completion_tokens": 172,
+          "decode_time": 1.691,
+          "total_time": 1.84,
+          "rejected_reason": null
+        },
+        {
+          "tps": 101.6,
+          "completion_tokens": 172,
+          "decode_time": 1.694,
+          "total_time": 1.842,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 101.7,
+          "completion_tokens": 256,
+          "decode_time": 2.518,
+          "total_time": 2.704,
+          "rejected_reason": null
+        },
+        {
+          "tps": 102.3,
+          "completion_tokens": 256,
+          "decode_time": 2.503,
+          "total_time": 2.687,
+          "rejected_reason": null
+        },
+        {
+          "tps": 102.0,
+          "completion_tokens": 256,
+          "decode_time": 2.509,
+          "total_time": 2.695,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.031,
+          "total_time": 0.677,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.047,
+          "total_time": 0.897,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.046,
+          "total_time": 0.935,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 50.2,
+          "completion_tokens": 47,
+          "decode_time": 0.937,
+          "total_time": 1.203,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.5,
+          "completion_tokens": 47,
+          "decode_time": 0.93,
+          "total_time": 1.197,
+          "rejected_reason": null
+        },
+        {
+          "tps": 51.5,
+          "completion_tokens": 47,
+          "decode_time": 0.913,
+          "total_time": 1.181,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 44.9,
+          "completion_tokens": 170,
+          "decode_time": 3.789,
+          "total_time": 4.023,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.4,
+          "completion_tokens": 170,
+          "decode_time": 3.747,
+          "total_time": 3.957,
+          "rejected_reason": null
+        },
+        {
+          "tps": 45.2,
+          "completion_tokens": 170,
+          "decode_time": 3.763,
+          "total_time": 3.969,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 89.8,
+          "completion_tokens": 256,
+          "decode_time": 2.849,
+          "total_time": 3.084,
+          "rejected_reason": null
+        },
+        {
+          "tps": 90.5,
+          "completion_tokens": 256,
+          "decode_time": 2.83,
+          "total_time": 3.069,
+          "rejected_reason": null
+        },
+        {
+          "tps": 91.0,
+          "completion_tokens": 256,
+          "decode_time": 2.814,
+          "total_time": 3.071,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.074,
+          "total_time": 0.976,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.057,
+          "total_time": 0.981,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 22,
+          "decode_time": 0.062,
+          "total_time": 0.987,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 91.0,
+          "completion_tokens": 47,
+          "decode_time": 0.516,
+          "total_time": 0.799,
+          "rejected_reason": null
+        },
+        {
+          "tps": 88.5,
+          "completion_tokens": 47,
+          "decode_time": 0.531,
+          "total_time": 0.807,
+          "rejected_reason": null
+        },
+        {
+          "tps": 92.7,
+          "completion_tokens": 47,
+          "decode_time": 0.507,
+          "total_time": 0.789,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-vl-30b_v2.json
+++ b/evals/results/suffix_qwen3-vl-30b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "qwen3-vl-30b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 37.7,
+    "json_array": 39.1,
+    "tool_loop": null,
+    "code_edit": 36.7
+  },
+  "suffix_tps": {
+    "chat": 39.5,
+    "json_array": 40.3,
+    "tool_loop": null,
+    "code_edit": 36.4
+  },
+  "speedup": {
+    "chat": 1.046,
+    "json_array": 1.031,
+    "code_edit": 0.993
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 37.7,
+          "completion_tokens": 204,
+          "decode_time": 5.407,
+          "total_time": 5.407,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.0,
+          "completion_tokens": 204,
+          "decode_time": 5.512,
+          "total_time": 5.512,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.8,
+          "completion_tokens": 204,
+          "decode_time": 5.401,
+          "total_time": 5.401,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 39.1,
+          "completion_tokens": 241,
+          "decode_time": 6.168,
+          "total_time": 6.168,
+          "rejected_reason": null
+        },
+        {
+          "tps": 39.2,
+          "completion_tokens": 241,
+          "decode_time": 6.148,
+          "total_time": 6.148,
+          "rejected_reason": null
+        },
+        {
+          "tps": 38.6,
+          "completion_tokens": 241,
+          "decode_time": 6.246,
+          "total_time": 6.246,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.033,
+          "total_time": 0.986,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.965,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.041,
+          "total_time": 0.962,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 34.3,
+          "completion_tokens": 50,
+          "decode_time": 1.457,
+          "total_time": 1.457,
+          "rejected_reason": null
+        },
+        {
+          "tps": 36.7,
+          "completion_tokens": 50,
+          "decode_time": 1.363,
+          "total_time": 1.363,
+          "rejected_reason": null
+        },
+        {
+          "tps": 38.5,
+          "completion_tokens": 50,
+          "decode_time": 1.297,
+          "total_time": 1.297,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 39.5,
+          "completion_tokens": 204,
+          "decode_time": 5.17,
+          "total_time": 5.17,
+          "rejected_reason": null
+        },
+        {
+          "tps": 39.9,
+          "completion_tokens": 204,
+          "decode_time": 5.113,
+          "total_time": 5.113,
+          "rejected_reason": null
+        },
+        {
+          "tps": 38.8,
+          "completion_tokens": 204,
+          "decode_time": 5.254,
+          "total_time": 5.254,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 40.3,
+          "completion_tokens": 241,
+          "decode_time": 5.98,
+          "total_time": 5.98,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.4,
+          "completion_tokens": 241,
+          "decode_time": 5.971,
+          "total_time": 5.971,
+          "rejected_reason": null
+        },
+        {
+          "tps": 39.1,
+          "completion_tokens": 241,
+          "decode_time": 6.166,
+          "total_time": 6.166,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.041,
+          "total_time": 0.989,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.037,
+          "total_time": 0.853,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.038,
+          "total_time": 0.878,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 36.6,
+          "completion_tokens": 50,
+          "decode_time": 1.364,
+          "total_time": 1.364,
+          "rejected_reason": null
+        },
+        {
+          "tps": 36.4,
+          "completion_tokens": 50,
+          "decode_time": 1.372,
+          "total_time": 1.372,
+          "rejected_reason": null
+        },
+        {
+          "tps": 36.0,
+          "completion_tokens": 50,
+          "decode_time": 1.39,
+          "total_time": 1.39,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-vl-30b_v3.json
+++ b/evals/results/suffix_qwen3-vl-30b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "qwen3-vl-30b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 70.8,
+    "json_array": 70.3,
+    "tool_loop": null,
+    "code_edit": 57.5
+  },
+  "suffix_tps": {
+    "chat": 71.2,
+    "json_array": 70.7,
+    "tool_loop": null,
+    "code_edit": 57.8
+  },
+  "speedup": {
+    "chat": 1.005,
+    "json_array": 1.005,
+    "code_edit": 1.006
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 70.6,
+          "completion_tokens": 204,
+          "decode_time": 2.889,
+          "total_time": 2.889,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.9,
+          "completion_tokens": 204,
+          "decode_time": 2.877,
+          "total_time": 2.877,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.8,
+          "completion_tokens": 204,
+          "decode_time": 2.88,
+          "total_time": 2.88,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 70.1,
+          "completion_tokens": 241,
+          "decode_time": 3.437,
+          "total_time": 3.437,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.5,
+          "completion_tokens": 241,
+          "decode_time": 3.42,
+          "total_time": 3.42,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.3,
+          "completion_tokens": 241,
+          "decode_time": 3.428,
+          "total_time": 3.428,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.027,
+          "total_time": 0.69,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.682,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.027,
+          "total_time": 0.686,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 57.3,
+          "completion_tokens": 50,
+          "decode_time": 0.872,
+          "total_time": 0.872,
+          "rejected_reason": null
+        },
+        {
+          "tps": 57.5,
+          "completion_tokens": 50,
+          "decode_time": 0.87,
+          "total_time": 0.87,
+          "rejected_reason": null
+        },
+        {
+          "tps": 57.6,
+          "completion_tokens": 50,
+          "decode_time": 0.868,
+          "total_time": 0.868,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 71.2,
+          "completion_tokens": 204,
+          "decode_time": 2.866,
+          "total_time": 2.866,
+          "rejected_reason": null
+        },
+        {
+          "tps": 71.2,
+          "completion_tokens": 204,
+          "decode_time": 2.865,
+          "total_time": 2.865,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.9,
+          "completion_tokens": 204,
+          "decode_time": 2.878,
+          "total_time": 2.878,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 70.8,
+          "completion_tokens": 241,
+          "decode_time": 3.406,
+          "total_time": 3.406,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.5,
+          "completion_tokens": 241,
+          "decode_time": 3.418,
+          "total_time": 3.418,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.7,
+          "completion_tokens": 241,
+          "decode_time": 3.41,
+          "total_time": 3.41,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.026,
+          "total_time": 0.688,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.679,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.026,
+          "total_time": 0.682,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 57.8,
+          "completion_tokens": 50,
+          "decode_time": 0.865,
+          "total_time": 0.865,
+          "rejected_reason": null
+        },
+        {
+          "tps": 57.9,
+          "completion_tokens": 50,
+          "decode_time": 0.863,
+          "total_time": 0.863,
+          "rejected_reason": null
+        },
+        {
+          "tps": 56.9,
+          "completion_tokens": 50,
+          "decode_time": 0.879,
+          "total_time": 0.879,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-vl-8b_v2.json
+++ b/evals/results/suffix_qwen3-vl-8b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "qwen3-vl-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 54.7,
+    "json_array": 53.6,
+    "tool_loop": null,
+    "code_edit": 49.7
+  },
+  "suffix_tps": {
+    "chat": 54.4,
+    "json_array": 55.4,
+    "tool_loop": null,
+    "code_edit": 50.9
+  },
+  "speedup": {
+    "chat": 0.995,
+    "json_array": 1.034,
+    "code_edit": 1.024
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 57.2,
+          "completion_tokens": 167,
+          "decode_time": 2.92,
+          "total_time": 2.92,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.7,
+          "completion_tokens": 167,
+          "decode_time": 3.052,
+          "total_time": 3.052,
+          "rejected_reason": null
+        },
+        {
+          "tps": 52.9,
+          "completion_tokens": 167,
+          "decode_time": 3.155,
+          "total_time": 3.155,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 53.6,
+          "completion_tokens": 160,
+          "decode_time": 2.988,
+          "total_time": 2.988,
+          "rejected_reason": null
+        },
+        {
+          "tps": 58.1,
+          "completion_tokens": 160,
+          "decode_time": 2.756,
+          "total_time": 2.756,
+          "rejected_reason": null
+        },
+        {
+          "tps": 53.6,
+          "completion_tokens": 160,
+          "decode_time": 2.986,
+          "total_time": 2.986,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.026,
+          "total_time": 1.023,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.024,
+          "total_time": 1.03,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.024,
+          "total_time": 0.975,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 46.5,
+          "completion_tokens": 55,
+          "decode_time": 1.183,
+          "total_time": 1.183,
+          "rejected_reason": null
+        },
+        {
+          "tps": 49.7,
+          "completion_tokens": 55,
+          "decode_time": 1.107,
+          "total_time": 1.107,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.7,
+          "completion_tokens": 55,
+          "decode_time": 1.086,
+          "total_time": 1.086,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 53.5,
+          "completion_tokens": 167,
+          "decode_time": 3.119,
+          "total_time": 3.119,
+          "rejected_reason": null
+        },
+        {
+          "tps": 60.7,
+          "completion_tokens": 167,
+          "decode_time": 2.753,
+          "total_time": 2.753,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.4,
+          "completion_tokens": 167,
+          "decode_time": 3.068,
+          "total_time": 3.068,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 55.4,
+          "completion_tokens": 160,
+          "decode_time": 2.887,
+          "total_time": 2.887,
+          "rejected_reason": null
+        },
+        {
+          "tps": 56.6,
+          "completion_tokens": 160,
+          "decode_time": 2.825,
+          "total_time": 2.825,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.5,
+          "completion_tokens": 160,
+          "decode_time": 2.934,
+          "total_time": 2.934,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.102,
+          "total_time": 1.082,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.03,
+          "total_time": 0.983,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.038,
+          "total_time": 0.986,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 48.0,
+          "completion_tokens": 55,
+          "decode_time": 1.145,
+          "total_time": 1.145,
+          "rejected_reason": null
+        },
+        {
+          "tps": 55.9,
+          "completion_tokens": 55,
+          "decode_time": 0.984,
+          "total_time": 0.984,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.9,
+          "completion_tokens": 55,
+          "decode_time": 1.081,
+          "total_time": 1.081,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-vl-8b_v3.json
+++ b/evals/results/suffix_qwen3-vl-8b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "qwen3-vl-8b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 80.4,
+    "json_array": 79.1,
+    "tool_loop": null,
+    "code_edit": 65.5
+  },
+  "suffix_tps": {
+    "chat": 80.6,
+    "json_array": 79.1,
+    "tool_loop": null,
+    "code_edit": 65.4
+  },
+  "speedup": {
+    "chat": 1.003,
+    "json_array": 1.0,
+    "code_edit": 0.999
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 80.3,
+          "completion_tokens": 167,
+          "decode_time": 2.08,
+          "total_time": 2.08,
+          "rejected_reason": null
+        },
+        {
+          "tps": 80.5,
+          "completion_tokens": 167,
+          "decode_time": 2.074,
+          "total_time": 2.074,
+          "rejected_reason": null
+        },
+        {
+          "tps": 80.4,
+          "completion_tokens": 167,
+          "decode_time": 2.077,
+          "total_time": 2.077,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 79.1,
+          "completion_tokens": 160,
+          "decode_time": 2.022,
+          "total_time": 2.022,
+          "rejected_reason": null
+        },
+        {
+          "tps": 79.1,
+          "completion_tokens": 160,
+          "decode_time": 2.023,
+          "total_time": 2.023,
+          "rejected_reason": null
+        },
+        {
+          "tps": 79.3,
+          "completion_tokens": 160,
+          "decode_time": 2.017,
+          "total_time": 2.017,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.861,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.864,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.863,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 65.2,
+          "completion_tokens": 55,
+          "decode_time": 0.843,
+          "total_time": 0.843,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.5,
+          "completion_tokens": 55,
+          "decode_time": 0.839,
+          "total_time": 0.839,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.6,
+          "completion_tokens": 55,
+          "decode_time": 0.838,
+          "total_time": 0.838,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 80.1,
+          "completion_tokens": 167,
+          "decode_time": 2.086,
+          "total_time": 2.086,
+          "rejected_reason": null
+        },
+        {
+          "tps": 80.6,
+          "completion_tokens": 167,
+          "decode_time": 2.071,
+          "total_time": 2.071,
+          "rejected_reason": null
+        },
+        {
+          "tps": 80.8,
+          "completion_tokens": 167,
+          "decode_time": 2.067,
+          "total_time": 2.067,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 79.3,
+          "completion_tokens": 160,
+          "decode_time": 2.018,
+          "total_time": 2.018,
+          "rejected_reason": null
+        },
+        {
+          "tps": 79.1,
+          "completion_tokens": 160,
+          "decode_time": 2.022,
+          "total_time": 2.022,
+          "rejected_reason": null
+        },
+        {
+          "tps": 79.1,
+          "completion_tokens": 160,
+          "decode_time": 2.022,
+          "total_time": 2.022,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.863,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.023,
+          "total_time": 0.86,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.025,
+          "total_time": 0.867,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 65.4,
+          "completion_tokens": 55,
+          "decode_time": 0.841,
+          "total_time": 0.841,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.4,
+          "completion_tokens": 55,
+          "decode_time": 0.841,
+          "total_time": 0.841,
+          "rejected_reason": null
+        },
+        {
+          "tps": 65.5,
+          "completion_tokens": 55,
+          "decode_time": 0.839,
+          "total_time": 0.839,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_smollm3-3b_v2.json
+++ b/evals/results/suffix_smollm3-3b_v2.json
@@ -1,0 +1,216 @@
+{
+  "model": "smollm3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 350.4,
+    "json_array": null,
+    "tool_loop": 144.9,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 177.3,
+    "json_array": 453.5,
+    "tool_loop": 112.5,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.506,
+    "tool_loop": 0.776
+  },
+  "skipped": {
+    "json_array": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 350.4,
+          "completion_tokens": 535,
+          "decode_time": 1.527,
+          "total_time": 3.753,
+          "rejected_reason": null
+        },
+        {
+          "tps": 360.4,
+          "completion_tokens": 535,
+          "decode_time": 1.485,
+          "total_time": 3.734,
+          "rejected_reason": null
+        },
+        {
+          "tps": 338.6,
+          "completion_tokens": 535,
+          "decode_time": 1.58,
+          "total_time": 3.843,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 1629,
+          "decode_time": 1.979,
+          "total_time": 11.922,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1629,
+          "decode_time": 2.164,
+          "total_time": 11.885,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1629,
+          "decode_time": 1.953,
+          "total_time": 11.63,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 144.9,
+          "completion_tokens": 2304,
+          "decode_time": 15.898,
+          "total_time": 15.898,
+          "rejected_reason": null
+        },
+        {
+          "tps": 180.3,
+          "completion_tokens": 2304,
+          "decode_time": 12.777,
+          "total_time": 12.777,
+          "rejected_reason": null
+        },
+        {
+          "tps": 139.0,
+          "completion_tokens": 2304,
+          "decode_time": 16.576,
+          "total_time": 16.576,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 936,
+          "decode_time": 0.403,
+          "total_time": 6.733,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 936,
+          "decode_time": 0.418,
+          "total_time": 6.316,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 936,
+          "decode_time": 0.425,
+          "total_time": 6.507,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 179.3,
+          "completion_tokens": 528,
+          "decode_time": 2.945,
+          "total_time": 6.301,
+          "rejected_reason": null
+        },
+        {
+          "tps": 174.4,
+          "completion_tokens": 528,
+          "decode_time": 3.027,
+          "total_time": 6.04,
+          "rejected_reason": null
+        },
+        {
+          "tps": 177.3,
+          "completion_tokens": 528,
+          "decode_time": 2.978,
+          "total_time": 6.009,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 416.6,
+          "completion_tokens": 1004,
+          "decode_time": 2.41,
+          "total_time": 10.135,
+          "rejected_reason": null
+        },
+        {
+          "tps": 453.5,
+          "completion_tokens": 1004,
+          "decode_time": 2.214,
+          "total_time": 10.126,
+          "rejected_reason": null
+        },
+        {
+          "tps": 470.4,
+          "completion_tokens": 1004,
+          "decode_time": 2.134,
+          "total_time": 9.981,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 109.7,
+          "completion_tokens": 2304,
+          "decode_time": 21.009,
+          "total_time": 21.009,
+          "rejected_reason": null
+        },
+        {
+          "tps": 114.3,
+          "completion_tokens": 2304,
+          "decode_time": 20.162,
+          "total_time": 20.162,
+          "rejected_reason": null
+        },
+        {
+          "tps": 112.5,
+          "completion_tokens": 2304,
+          "decode_time": 20.481,
+          "total_time": 20.481,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 1548,
+          "decode_time": 0.353,
+          "total_time": 14.569,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1548,
+          "decode_time": 0.363,
+          "total_time": 14.542,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1548,
+          "decode_time": 0.339,
+          "total_time": 14.357,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_smollm3-3b_v3.json
+++ b/evals/results/suffix_smollm3-3b_v3.json
@@ -1,0 +1,216 @@
+{
+  "model": "smollm3-3b",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": 179.8,
+    "tool_loop": 180.5,
+    "code_edit": 179.5
+  },
+  "suffix_tps": {
+    "chat": 215.9,
+    "json_array": 496.1,
+    "tool_loop": 113.1,
+    "code_edit": null
+  },
+  "speedup": {
+    "json_array": 2.759,
+    "tool_loop": 0.626
+  },
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "code_edit": "suffix all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 757,
+          "decode_time": 1.289,
+          "total_time": 4.222,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 757,
+          "decode_time": 1.29,
+          "total_time": 4.217,
+          "rejected_reason": "tps>500.0_ceiling"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 757,
+          "decode_time": 1.29,
+          "total_time": 4.22,
+          "rejected_reason": "tps>500.0_ceiling"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 179.7,
+          "completion_tokens": 2304,
+          "decode_time": 12.819,
+          "total_time": 12.819,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.8,
+          "completion_tokens": 2304,
+          "decode_time": 12.811,
+          "total_time": 12.811,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.8,
+          "completion_tokens": 2304,
+          "decode_time": 12.815,
+          "total_time": 12.815,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 180.7,
+          "completion_tokens": 2304,
+          "decode_time": 12.753,
+          "total_time": 12.753,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.7,
+          "completion_tokens": 2304,
+          "decode_time": 12.822,
+          "total_time": 12.822,
+          "rejected_reason": null
+        },
+        {
+          "tps": 180.5,
+          "completion_tokens": 2304,
+          "decode_time": 12.762,
+          "total_time": 12.762,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 179.4,
+          "completion_tokens": 2304,
+          "decode_time": 12.842,
+          "total_time": 12.842,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.5,
+          "completion_tokens": 2304,
+          "decode_time": 12.838,
+          "total_time": 12.838,
+          "rejected_reason": null
+        },
+        {
+          "tps": 179.5,
+          "completion_tokens": 2304,
+          "decode_time": 12.834,
+          "total_time": 12.834,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 215.7,
+          "completion_tokens": 622,
+          "decode_time": 2.884,
+          "total_time": 5.348,
+          "rejected_reason": null
+        },
+        {
+          "tps": 215.9,
+          "completion_tokens": 622,
+          "decode_time": 2.88,
+          "total_time": 5.331,
+          "rejected_reason": null
+        },
+        {
+          "tps": 216.1,
+          "completion_tokens": 622,
+          "decode_time": 2.878,
+          "total_time": 5.324,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 496.1,
+          "completion_tokens": 962,
+          "decode_time": 1.939,
+          "total_time": 7.107,
+          "rejected_reason": null
+        },
+        {
+          "tps": 496.1,
+          "completion_tokens": 962,
+          "decode_time": 1.939,
+          "total_time": 7.11,
+          "rejected_reason": null
+        },
+        {
+          "tps": 496.1,
+          "completion_tokens": 962,
+          "decode_time": 1.939,
+          "total_time": 7.129,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 113.1,
+          "completion_tokens": 2304,
+          "decode_time": 20.379,
+          "total_time": 20.379,
+          "rejected_reason": null
+        },
+        {
+          "tps": 113.1,
+          "completion_tokens": 2304,
+          "decode_time": 20.373,
+          "total_time": 20.373,
+          "rejected_reason": null
+        },
+        {
+          "tps": 113.8,
+          "completion_tokens": 2304,
+          "decode_time": 20.251,
+          "total_time": 20.251,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 1476,
+          "decode_time": 0.326,
+          "total_time": 11.193,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1476,
+          "decode_time": 0.324,
+          "total_time": 11.182,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 1476,
+          "decode_time": 0.325,
+          "total_time": 11.198,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second sweep against the same 17 v2-tier'd dense aliases plus retry of the 4 deepseek-v4-flash variants now that disk is free. Goal: cross-check the single-shot v2 tier classifications committed in #308 to surface run-to-run instability.

This is **data-only** — `vllm_mlx/aliases.json` is NOT modified. The v2 tiers committed in #308 stand. This PR commits the raw v2 + v3 bench files and a comparison table for future use.

## Outcome

| Status | Count | Aliases |
|---|---:|---|
| ✅ stable (v2==v3) | 14 | bonsai-{1.7b,4b,8b}, llama3-3b, ministral-3b, smollm3-3b, deepseek-r1-8b, hermes3-8b, qwen3-vl-{8b,30b}, phi4-14b, qwen3-coder-30b, gemma-4-31b, hermes4-70b |
| ⚠ unstable (tier flipped across runs) | 2 | `deepseek-r1-32b`: neutral → avoid · `devstral-v2-24b`: neutral → avoid |
| ❓ fragile (no usable v3 data) | 2 | `gemma-4-26b`: avoid → unknown · `gemma3-27b`: unknown → unknown |
| ❌ hard-fail | 4 | `deepseek-v4-flash{,-2bit,-4bit,-8bit}` — server load timeout (vendored DeepSeek-V4 arch issue, distinct from v2's disk-pre-flight failure) |

Full per-alias comparison: [`evals/results/suffix_cross_validation.md`](https://github.com/raullenchai/Rapid-MLX/blob/data/suffix-tier-resweep/evals/results/suffix_cross_validation.md)

## Pattern: every v2 `neutral` flipped to `avoid` in v3

Speedups in the [0.95, 1.05] band (the neutral zone) are inherently more noise-sensitive than speedups firmly above or below — small fluctuations push them past the 0.85x avoid threshold. This is exactly the failure mode #320 S4 (CV-based stability gate) is designed to catch.

Concrete: until S4 lands, **#305 (auto-apply suffix tier in serve) should stay held**. Auto-applying neutral tiers to user-facing serve defaults would mean their `--enable-suffix-decoding` toggles on/off across releases. Documented in #320 / #305.

## Methodology delta from v2 sweep

Re-sweep script (`/tmp/run_suffix_resweep.sh`) deletes each model's HF cache after bench → disk stays near-constant (peaked at ~260 GB free during the sweep, never dropped below the pre-flight floor that broke v2). This is #320 S3 in spirit; productionizing the wrapper into `scripts/` belongs in the broader S3 PR.

## What this PR adds

- `evals/results/suffix_<alias>_v2.json` × 18 — preserves the raw v2 bench data (was previously only summarized in aliases.json)
- `evals/results/suffix_<alias>_v3.json` × 18 — fresh post-#308 cross-validation runs
- `evals/results/suffix_cross_validation.md` — comparison table

## What this PR does NOT change

- `vllm_mlx/aliases.json` — left alone deliberately. The 2 unstable aliases (`deepseek-r1-32b`, `devstral-v2-24b`) currently carry tier=`neutral` from v2; the v3 read says they should be `avoid` (more conservative). Promoting that change requires deciding whether v3 is "more correct" than v2 or just "another data point." That decision belongs to the upcoming #320 S4 work, not to a single follow-up PR.

## Test plan

- [x] No production code changes — passes existing tests trivially
- [x] No version bump needed — pure data; `evals/results/` doesn't trigger `version-check`
- [ ] Reviewer: spot-check 1-2 of the v3 JSON files against the cross-validation table to confirm the tier+speedup parses correctly
- [ ] Reviewer: confirm the recommended hold on #305 until S4 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)