### PR TITLE
feat(cli): rapid-mlx chat defaults model to qwen3.5-4b

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -86,14 +86,45 @@ def test_chat_subcommand_registered_in_cli():
     assert exc.value.code == 0
 
 
-def test_chat_subcommand_requires_model():
-    """`rapid-mlx chat` (no model) exits non-zero."""
+def test_chat_no_model_defaults_to_qwen35_4b():
+    """`rapid-mlx chat` (no model) routes chat_command with qwen3.5-4b.
+
+    Goes through the real ``cli.main()`` so a parser-wiring regression
+    (e.g. dropping ``nargs='?'`` or changing the default alias) fails the
+    test. ``chat_command`` is patched to capture args before the REPL
+    runs.
+    """
+    captured: list = []
     with (
         patch.object(sys, "argv", ["rapid-mlx", "chat"]),
-        pytest.raises(SystemExit) as exc,
+        patch.object(cli, "chat_command", side_effect=captured.append),
     ):
         cli.main()
-    assert exc.value.code != 0
+    assert len(captured) == 1
+    args = captured[0]
+    # Either the alias name itself or the resolved HF repo path — either
+    # signals the default plumbed through. The canonical alias is the one
+    # we documented as the default; confirm via the round-trip name.
+    assert (
+        args.model == "qwen3.5-4b"
+        or getattr(args, "_original_alias", None) == "qwen3.5-4b"
+    )
+
+
+def test_chat_with_alias_overrides_default():
+    """`rapid-mlx chat <alias>` uses the user-supplied alias, not the default."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "smollm3-3b"]),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    args = captured[0]
+    assert (
+        args.model == "smollm3-3b"
+        or getattr(args, "_original_alias", None) == "smollm3-3b"
+    )
 
 
 def test_stream_chat_response_concatenates_deltas():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1838,7 +1838,11 @@ Examples:
         "chat", help="Interactive chat REPL with a model"
     )
     chat_parser.add_argument(
-        "model", help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name)"
+        "model",
+        nargs="?",
+        default="qwen3.5-4b",
+        help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name). "
+        "Defaults to qwen3.5-4b when omitted.",
     )
     chat_parser.add_argument(
         "--system",


### PR DESCRIPTION
## Summary

Make ``rapid-mlx chat`` (no positional arg) work as a zero-config entry point — new users get a working REPL without first having to look up which alias to pass. ``rapid-mlx chat <alias>`` continues to override the default.

Motivation came out of a UX dry-run: a brand-new user trying ``rapid-mlx chat`` first hits a ``the following arguments are required: model`` error and bounces. Closing that gap is the cheapest possible "out-of-the-box" win.

## Behavior

| invocation | model used |
|---|---|
| ``rapid-mlx chat`` | ``qwen3.5-4b`` (default) |
| ``rapid-mlx chat smollm3-3b`` | ``smollm3-3b`` |
| ``rapid-mlx chat mlx-community/Foo-4bit`` | the HF repo |
| ``rapid-mlx chat --port 8000`` | ``qwen3.5-4b`` (connects to existing server, sends the alias as the API model name) |

## Implementation

The positional ``model`` argument switched to ``nargs='?'`` with ``default="qwen3.5-4b"``. Alias resolution in ``main()`` (cli.py:1988-2012) already handles arbitrary alias strings, so the default flows through ``resolve_model`` → ``_original_alias`` → API ``served_name`` exactly like a user-supplied alias would. No changes to ``chat_command`` itself.

## Test plan

- [x] Replaced ``test_chat_subcommand_requires_model`` with two new tests:
  - ``test_chat_no_model_defaults_to_qwen35_4b`` — ``chat`` (no arg) routes ``chat_command`` with the default alias. Goes through real ``cli.main()`` so a parser-wiring regression (e.g. dropping ``nargs='?'``) fails the test.
  - ``test_chat_with_alias_overrides_default`` — ``chat <alias>`` is honored, default is not applied.
- [x] 11 tests in ``tests/test_cli_chat.py`` pass
- [x] Lint + format clean (``ruff check && ruff format --check``)
- [x] ``rapid-mlx chat --help`` shows ``[model]`` + the new default in help text

## Out of scope

- Cold-download progress indicator (separate issue from chat UX dry-run — when ``qwen3.5-4b`` isn't cached the user sees a static "Starting server..." line with no feedback).
- ``--port``/``--base-url`` preflight check (HEAD ``/v1/models`` to confirm the target server is up before printing "Ready.").
- ``BatchGenerator.__del__`` ``AttributeError: '_old_wired_limit'`` at clean shutdown.

These are separate UX bugs surfaced in the same dry-run; tracking as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)