### PR TITLE
chore: bump version to 0.6.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.25"
+version = "0.6.26"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bundle release for 7 commits since v0.6.23. Skips 0.6.24 and 0.6.25 — those bumps were inlined inside feature PRs (#303, #304) so their squash subjects didn't match the auto-release regex and the workflow never fired. 0.6.26 is the next clean tag.

The squash subject of this PR is the canonical ``chore: bump version to 0.6.26`` so ``Auto-release on version bump`` will fire on merge.

## What ships

| PR | Type | Headline |
|---|---|---|
| #325 | Surface | ``rapid-mlx chat`` defaults to ``qwen3.5-4b`` (zero-config REPL) |
| #323 | Data | v3 cross-validation suffix-decoding sweep — refined tier classifications across the alias registry |
| #326 | Test fix | Test data drift fix on hermes3-8b tier (gated this bump PR's CI) |
| #318 | Dev | Spam-issue auto-close GitHub workflow |
| #308 | Bench | Force greedy sampling in suffix-decoding bench (TPS reliability gates) |
| #306 | Test | asyncio loop flake fix + xfail batched determinism |
| #304 | Surface | ``rapid-mlx models`` surfaces AliasProfile capabilities |
| #303 | Surface | New ``rapid-mlx chat`` interactive REPL |

**Zero inference-touching changes** since v0.6.23 (no model loading / KV cache / scheduler / engine / parser / MLLM modifications). ``make full`` and per-model perf regression check skipped per CLAUDE.md SOP.

## SOP gates run

- [x] **Step 1 inventory**: ``git log v0.6.23..raullenchai/main --oneline`` → 7 commits, classified above
- [x] **Step 3 install size audit**: 447 MB in fresh venv — within noise of v0.6.23 baseline (445 MB after mlx-vlm split, recorded in ``knowledge/install_size_audit.md``). No regression.
- [x] **Step 4 fresh-install user simulation**: subagent installed wheel into clean venv, walked through ``rapid-mlx version`` → ``models`` → ``info qwen3-coder-30b`` → ``chat`` (default qwen3.5-4b cold) → ``chat bonsai-1.7b`` (warm) → exit. Verdict: ship — all surfaces work, no user-facing tracebacks, no leaked servers post-exit.
- [x] **Step 5 perf regression**: skipped (no inference changes — see classification above)
- [x] **Step 6 agent integration smoke**: skipped (no parser / route / Anthropic-compat changes since v0.6.23 — Aider/OpenCode/Cline/Claude Code agent surfaces all unchanged at the API layer)
- [x] **Step 7 supply-chain re-audit**: ``pyproject.toml`` diff vs v0.6.23 = version line only; no new deps; ``install.sh`` and ``publish.yml``/``auto-release.yml`` untouched; ``pip-audit`` on bundle = no known vulnerabilities
- [x] **Step 9 land bump**: this PR

## Post-merge verification (runs in step 10)

- [ ] ``v0.6.26`` tag created by ``auto-release.yml``
- [ ] PyPI shows 0.6.26 (``pip index versions rapid-mlx``)
- [ ] Homebrew tap formula updated (``brew info raullenchai/tap/rapid-mlx``)
- [ ] Re-run subagent fresh-install against real PyPI (not local wheel) once propagated

## Out of scope (tracked as follow-ups)

- Cold-download progress indicator for ``rapid-mlx chat`` (subagent noted "static 'Starting server...' line, no progress")
- ``BatchGenerator.__del__ AttributeError`` at clean shutdown (cosmetic but every-exit-100%-repro)
- ``--port``/``--base-url`` preflight in chat (HEAD ``/v1/models`` before "Ready.")
- ``_suffix_stats`` Prometheus metrics exporter (deferred — task #196)

🤖 Generated with [Claude Code](https://claude.com/claude-code)