### PR TITLE
fix(cli): default chat thinking OFF (regression in 0.6.26)

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -201,7 +201,9 @@ def test_chat_command_repl_multi_turn(monkeypatch, capsys):
         ns.base_url = f"http://127.0.0.1:{port}"
         ns.port = None
         ns.system = None
-        ns.no_think = False
+        ns.think = (
+            True  # request the server-default behavior — no enable_thinking field sent
+        )
         ns.max_tokens = 50
         ns.temperature = 0.0
         ns.ready_timeout = 5
@@ -228,7 +230,7 @@ def test_chat_command_system_prompt_prepended(monkeypatch):
         ns.base_url = f"http://127.0.0.1:{port}"
         ns.port = None
         ns.system = "be terse"
-        ns.no_think = False
+        ns.think = True  # server-default thinking behavior
         ns.max_tokens = 50
         ns.temperature = 0.0
         ns.ready_timeout = 5
@@ -239,10 +241,15 @@ def test_chat_command_system_prompt_prepended(monkeypatch):
     assert payloads[0]["messages"][1] == {"role": "user", "content": "q1"}
 
 
-def test_chat_command_no_think_sets_top_level_enable_thinking(monkeypatch):
-    """`--no-think` must set the top-level ``enable_thinking`` request field
-    that the rapid-mlx server actually honors. Sending nested
-    ``chat_template_kwargs`` would be silently dropped."""
+def test_chat_command_default_thinking_off_sends_enable_thinking_false(monkeypatch):
+    """Chat REPL defaults to thinking OFF.
+
+    Reasoning models like Qwen3.5 otherwise leak raw chain-of-thought into
+    the user-visible REPL output, and on the default qwen3.5-4b model
+    degenerate into infinite repetition until max-tokens — producing zero
+    usable output for a brand-new user. Pinning the default here so a
+    refactor doesn't silently restore the broken behavior shipped in 0.6.26.
+    """
     canned = [_delta("ok")]
     with _fake_server(canned) as (port, payloads):
         inputs = iter(["q", "exit"])
@@ -251,7 +258,7 @@ def test_chat_command_no_think_sets_top_level_enable_thinking(monkeypatch):
         ns.base_url = f"http://127.0.0.1:{port}"
         ns.port = None
         ns.system = None
-        ns.no_think = True
+        ns.think = False  # default
         ns.max_tokens = 50
         ns.temperature = 0.0
         ns.ready_timeout = 5
@@ -261,6 +268,42 @@ def test_chat_command_no_think_sets_top_level_enable_thinking(monkeypatch):
     assert payloads[0].get("enable_thinking") is False
     # The unsupported nested form must NOT be present.
     assert "chat_template_kwargs" not in payloads[0]
+
+
+def test_chat_command_explicit_think_omits_enable_thinking_field(monkeypatch):
+    """``--think`` opts back into reasoning mode. We omit the
+    ``enable_thinking`` field entirely so the server falls back to its
+    own default (which is True on Qwen3-family templates)."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = type("Args", (), {})()
+        ns.base_url = f"http://127.0.0.1:{port}"
+        ns.port = None
+        ns.system = None
+        ns.think = True
+        ns.max_tokens = 50
+        ns.temperature = 0.0
+        ns.ready_timeout = 5
+        ns.response_timeout = 5
+        ns.model = "qwen3.5-4b"
+        cli.chat_command(ns)
+    assert "enable_thinking" not in payloads[0]
+
+
+def test_chat_subcommand_accepts_legacy_no_think_flag():
+    """``--no-think`` is preserved via argparse BooleanOptionalAction so
+    users with prior shell history don't break on upgrade. Behavior matches
+    the new default (thinking off)."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--no-think"]),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    assert captured[0].think is False
 
 
 def test_chat_command_survives_connection_failure(monkeypatch, capsys):
@@ -281,7 +324,7 @@ def test_chat_command_survives_connection_failure(monkeypatch, capsys):
     ns.base_url = f"http://127.0.0.1:{dead_port}"
     ns.port = None
     ns.system = None
-    ns.no_think = False
+    ns.think = False
     ns.max_tokens = 50
     ns.temperature = 0.0
     ns.ready_timeout = 1
@@ -338,7 +381,7 @@ def test_chat_command_history_unchanged_on_http_error(monkeypatch):
         ns.base_url = f"http://127.0.0.1:{port}"
         ns.port = None
         ns.system = None
-        ns.no_think = False
+        ns.think = False
         ns.max_tokens = 50
         ns.temperature = 0.0
         ns.ready_timeout = 5

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1020,8 +1020,15 @@ def chat_command(args):
     # The rapid-mlx server's ChatCompletionRequest exposes a top-level
     # ``enable_thinking`` field — ``chat_template_kwargs`` is not a recognized
     # request field and would be silently dropped.
+    #
+    # Default thinking OFF in the REPL. Reasoning models (Qwen3.5/3.6, etc.)
+    # otherwise emit raw chain-of-thought to stdout AND, on the default
+    # qwen3.5-4b model, degenerate into infinite repetition until max-tokens
+    # truncates the response — producing zero usable output for a brand-new
+    # user. ``--think`` opts back in for users who explicitly want to see
+    # reasoning traces; ``--no-think`` is preserved as the legacy form.
     extra: dict = {}
-    if args.no_think:
+    if not args.think:
         extra["enable_thinking"] = False
 
     import requests
@@ -1851,9 +1858,13 @@ Examples:
         help="System prompt prepended to the conversation",
     )
     chat_parser.add_argument(
-        "--no-think",
-        action="store_true",
-        help="Disable thinking mode for reasoning models (Qwen3 enable_thinking=False)",
+        "--think",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable thinking/reasoning mode (default: off in chat REPL — "
+        "reasoning models like Qwen3.5 otherwise leak raw chain-of-thought "
+        "and can loop until max-tokens). Use --think to surface reasoning, "
+        "--no-think is also accepted for back-compat.",
     )
     chat_parser.add_argument(
         "--max-tokens",


### PR DESCRIPTION
## Summary

**Hotfix for 0.6.26 release-blocking regression.** ``rapid-mlx chat`` (no args) defaults to qwen3.5-4b — but on that exact model with thinking ON, the model degenerates into infinite repetition until ``max_tokens`` (2048) truncates the response. **Every brand-new user installing 0.6.26 sees zero usable output on their first invocation.**

This PR flips the chat REPL's thinking default to OFF. We're shipping 0.6.27 immediately — 0.6.26 is not being yanked (the failure mode is visible, not silent corruption — users can ``pip install -U`` and recover) but every new ``pip install rapid-mlx`` should land on 0.6.27.

## Reproduction (0.6.26 from PyPI)

```
$ pip install rapid-mlx==0.6.26
$ rapid-mlx chat <<< $'Tell me a 3-sentence story about a robot.\nexit'

> [thinking trace ...]
*Wait, I need to check the sentence count.*
*Okay, I will write the final version.*
*Wait, I need to check the sentence count.*
*Okay, I will write the final version.*
... [100x repetition, hits 2048-token cap] ...
```

## Verification (this PR's wheel)

```
> Unit 734 began its routine by meticulously arranging soil into perfect
geometric patterns, its sensors humming with precision.
However, when a tiny, clumsy error caused a seed to sprout into a vibrant,
chaotic weed, the robot froze, its logic processors overwhelmed by the
unpredictable beauty of nature.
Realizing that its code could never replicate the messy joy of a blooming
garden, Unit 734 finally chose to simply watch the flowers grow, content
to be a silent observer rather than a master gardener.
```

## Fix

- Default ``--think`` to ``False`` in chat REPL
- ``argparse.BooleanOptionalAction`` so both ``--think`` and ``--no-think`` are accepted (back-compat)
- ``--no-think`` is now a no-op (thinking already off by default) but doesn't error — preserves user shell history

## Test plan

- [x] Replaced ``test_chat_command_no_think_sets_top_level_enable_thinking`` with two tests pinning the new contract:
  - ``test_chat_command_default_thinking_off_sends_enable_thinking_false``
  - ``test_chat_command_explicit_think_omits_enable_thinking_field``
- [x] Added ``test_chat_subcommand_accepts_legacy_no_think_flag`` for back-compat lock-in
- [x] All 13 tests in ``tests/test_cli_chat.py`` pass
- [x] Lint + format clean
- [x] **End-to-end repro on built wheel** against real qwen3.5-4b model: default chat now produces a coherent 3-sentence story (paste above)

## Out of scope (follow-ups)

- Strip ``<think>...</think>`` blocks from streamed output when ``--think`` is opted in (users who *do* want to see reasoning should get it formatted, not raw)
- Investigate why qwen3.5-4b's thinking mode degenerates into infinite repetition on certain prompts in the MLX-4bit quant — likely a stop-token / template issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)