### PR TITLE
chore: bump version to 0.6.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.26"
+version = "0.6.27"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

**Hotfix release.** 0.6.26 shipped a release-blocking regression on the headline ``rapid-mlx chat`` feature: thinking ON by default + qwen3.5-4b default model = degenerate output (infinite repetition until max-tokens) on first user invocation. 0.6.27 ships #328 which flips chat thinking default to OFF.

**0.6.26 NOT being yanked** — the failure mode is visible (users see clearly broken output, not silent corruption) and a PyPI yank would only block new installs without helping users already on 0.6.26 (who recover via ``pip install -U``). Shipping 0.6.27 immediately so every fresh ``pip install rapid-mlx`` lands here.

## What ships (since v0.6.26 — 1 commit)

- #328 ``fix(cli): default chat thinking OFF`` — flips thinking default in the chat REPL; ``--think`` opts in; ``--no-think`` preserved as legacy back-compat (no-op now)

## SOP gates run

- [x] **Step 1 inventory**: 1 commit since v0.6.26 (#328) — surface change, no inference-touching
- [x] **Step 4 fresh-install verification (compressed)**: end-to-end repro on the merged hotfix wheel against real qwen3.5-4b — coherent 3-sentence story output (was 100x repetition cap-hit on 0.6.26)
- [x] **Step 5 perf**: skipped (no inference changes)
- [x] **Step 6 agent integration**: skipped (no parser/route/Anthropic-compat changes)
- [x] **Step 7 supply-chain**: ``pyproject.toml`` diff vs v0.6.26 = version line only; no new deps
- [x] **Step 9 land bump**: this PR

## Post-merge verification

- [ ] ``v0.6.27`` tag created by ``auto-release.yml``
- [ ] PyPI shows 0.6.27
- [ ] Homebrew tap formula updated
- [ ] ``rapid-mlx chat`` (no args) on a fresh ``pip install rapid-mlx==0.6.27`` produces coherent default output

🤖 Generated with [Claude Code](https://claude.com/claude-code)