### PR TITLE
feat(chat): TUI polish — slash commands, multi-line, speed counter, OpenCode profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ curl http://localhost:8000/v1/chat/completions \
 
 That's it — you now have an OpenAI-compatible AI server on `localhost:8000`. Point any app at `http://localhost:8000/v1` and it just works.
 
+> **Want a Claude Code-like TUI?** Rapid-MLX is the *backend* — pair it with an open-source agent CLI like [OpenCode](https://github.com/sst/opencode) or [codex](https://github.com/openai/codex) for the full slash-commands / tool-use / multi-turn experience. Run `rapid-mlx agents opencode --setup` (or `codex --setup`) to wire it up automatically.
+
 > **Tip:** Run `rapid-mlx models` to see all available model aliases. For a smaller/faster model, try `rapid-mlx serve qwen3.5-9b` (~5 GB).
 
 <details>
@@ -135,6 +137,7 @@ print(response.choices[0].message.content)
 | [OpenClaude](https://github.com/Gitlawb/openclaude) (Anthropic SDK) | Agent | `CLAUDE_CODE_USE_OPENAI=1` ([test](tests/integrations/test_anthropic_sdk.py)) |
 | [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
 | [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
+| [OpenCode](https://github.com/sst/opencode) | TUI Agent | Claude Code-like terminal UX, OpenAI-compat provider |
 | [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
 
 ### UI / IDE Clients

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.27"
+version = "0.6.28"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -926,6 +926,26 @@ def test_chat_command_slash_command_dispatch_uses_exact_match(
     )
 
 
+def test_chat_command_slash_command_accepts_tab_separator(
+    monkeypatch, tmp_path, capsys
+):
+    """``/save\\tpath.md`` (tab as separator) must work like
+    ``/save path.md``. Splitting on a literal space character would treat
+    the whole tab-separated form as an unknown command — split() with no
+    separator handles all whitespace."""
+    canned = [_delta("ok")]
+    target = tmp_path / "tabbed.md"
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["hi", f"/save\t{target}", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert target.exists(), (
+        f"/save with tab separator should write the file, "
+        f"got: {capsys.readouterr().out!r}"
+    )
+    assert "## User" in target.read_text(encoding="utf-8")
+
+
 def test_stream_chat_response_repetition_truncates_at_cutoff_in_one_chunk(
     monkeypatch,
 ):

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -694,3 +694,198 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
 
     cli._ensure_model_downloaded("mlx-community/Fake-Model-1B")
     assert called == ["mlx-community/Fake-Model-1B"]
+
+
+def test_chat_command_heredoc_preserves_indentation_and_blank_lines(monkeypatch):
+    """Heredoc must preserve leading whitespace (Python indentation) and
+    trailing blank lines verbatim — calling ``.strip()`` corrupts exactly
+    the code-paste workflow the heredoc exists for."""
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(
+            [
+                '"""',
+                "    def f():",
+                "        return 1",
+                "",  # blank line in the middle
+                "    g()",
+                "",  # trailing blank
+                '"""',
+                "exit",
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert len(payloads) == 1
+    msg = payloads[0]["messages"][0]
+    expected = "    def f():\n        return 1\n\n    g()\n"
+    assert msg["content"] == expected, (
+        f"heredoc must preserve leading spaces + trailing blank, "
+        f"got: {msg['content']!r}"
+    )
+
+
+def test_chat_command_save_uses_exclusive_mode_no_toctou(monkeypatch, tmp_path):
+    """``/save`` must call ``open(path, 'x')`` so the existence check is
+    atomic. An ``exists()``-then-``open('w')`` pair is TOCTOU-racy and a
+    symlink to an arbitrary path can defeat ``os.path.exists`` on the
+    first probe but still get clobbered on the open."""
+    canned = [_delta("ok")]
+    target = tmp_path / "x.md"
+    seen_modes: list[str] = []
+    real_open = open
+
+    def _spy_open(path, mode="r", *args, **kwargs):
+        if str(path) == str(target):
+            seen_modes.append(mode)
+        return real_open(path, mode, *args, **kwargs)
+
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch("builtins.open", side_effect=_spy_open),
+    ):
+        inputs = iter(["hi", f"/save {target}", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert "x" in seen_modes, (
+        f"expected /save to open with exclusive mode 'x' (got modes={seen_modes})"
+    )
+
+
+def test_chat_command_sigterm_handler_installed_before_spawn(monkeypatch):
+    """SIGTERM handler MUST be installed before any ``_spawn_chat_server``
+    call. A SIGTERM landing in the window between Popen() and
+    signal.signal() uses Python's default handler (skips atexit) and
+    orphans the spawned server."""
+    import signal as _signal
+
+    call_order: list[str] = []
+
+    real_signal = _signal.signal
+
+    def _spy_signal(signum, handler):
+        if signum == _signal.SIGTERM:
+            call_order.append("signal.SIGTERM")
+        return real_signal(signum, handler)
+
+    def _fake_spawn(*_a, **_kw):
+        call_order.append("spawn")
+
+        # Return a no-op proc plus a base_url that points at the fake
+        # server so the rest of the REPL flow is unaffected.
+        class _NoopProc:
+            _rapid_mlx_log = None
+            _rapid_mlx_log_path = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                pass
+
+            def kill(self):
+                pass
+
+        return _NoopProc(), f"http://127.0.0.1:{port}"
+
+    monkeypatch.setattr("signal.signal", _spy_signal)
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: None)
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (fake_port, _payloads):
+        port = fake_port
+        inputs = iter(["hi", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        # Take the spawn path: clear base_url and port so chat_command
+        # falls into the "spawn our own" branch.
+        ns = _ns_for_chat(fake_port)
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+    assert "signal.SIGTERM" in call_order, "SIGTERM handler was never installed"
+    assert "spawn" in call_order, "spawn never happened"
+    assert call_order.index("signal.SIGTERM") < call_order.index("spawn"), (
+        f"SIGTERM handler installed AFTER spawn — orphan window. "
+        f"call_order={call_order}"
+    )
+
+
+def test_chat_command_switch_model_rollback_on_wait_failure(monkeypatch, capsys):
+    """When the candidate server fails the readiness wait, ``_switch_model``
+    must (1) tear down the candidate proc, (2) keep the old proc as the
+    active one, and (3) NOT clear chat history. Round-1 P0 regression test."""
+
+    spawned: list[object] = []
+    teardowns: list[object] = []
+
+    class _FakeProc:
+        def __init__(self, name):
+            self.name = name
+            self._rapid_mlx_log = None
+            self._rapid_mlx_log_path = None
+            self._terminated = False
+
+        def poll(self):
+            return None if not self._terminated else 0
+
+        def terminate(self):
+            self._terminated = True
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self._terminated = True
+
+    def _fake_spawn(model, log_path, served_name=None):
+        proc = _FakeProc(model)
+        spawned.append(proc)
+        return proc, f"http://127.0.0.1:{port}"
+
+    wait_calls = {"n": 0}
+
+    def _fake_wait(base_url, proc, timeout_s):
+        wait_calls["n"] += 1
+        # First call (initial spawn) succeeds; second call (the /model
+        # candidate) fails.
+        if wait_calls["n"] >= 2:
+            raise RuntimeError("simulated load failure")
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", _fake_wait)
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda alias: f"mlx-community/{alias}-resolved",
+    )
+
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (fake_port, payloads):
+        port = fake_port
+        inputs = iter(["first turn", "/model bogus", "second turn", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(fake_port, model="qwen3.5-4b")
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    out = capsys.readouterr().out
+    assert "Failed to start new server" in out, (
+        "expected explicit rollback message on candidate failure"
+    )
+    assert "previous server still running" in out
+    # Two user turns: history must NOT be cleared by a failed switch.
+    assert len(payloads) == 2, (
+        f"expected both turns to land on the original server "
+        f"(history preserved); saw {len(payloads)}"
+    )
+    # Both turns sent the SAME conversation list; the second turn carries
+    # the first as history.
+    assert any(m["content"] == "first turn" for m in payloads[1]["messages"]), (
+        "second-turn payload lost the first turn after the failed /model swap"
+    )

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -398,3 +398,234 @@ def test_chat_command_history_unchanged_on_http_error(monkeypatch):
     # first turn (rollback contract).
     assert len(recorded) == 2
     assert recorded[1]["messages"] == [{"role": "user", "content": "bad2"}]
+
+
+def _ns_for_chat(port: int, **overrides) -> object:
+    """Build a chat_command argparse namespace pointing at a fake server."""
+    ns = type("Args", (), {})()
+    ns.base_url = f"http://127.0.0.1:{port}"
+    ns.port = None
+    ns.system = None
+    ns.think = False
+    ns.max_tokens = 50
+    ns.temperature = 0.0
+    ns.ready_timeout = 5
+    ns.response_timeout = 5
+    ns.model = "qwen3.5-4b"
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_stream_chat_response_captures_usage_into_metrics():
+    """When the server emits a usage chunk (stream_options.include_usage),
+    `_stream_chat_response` populates the metrics dict so the chat REPL
+    can print the token-speed line."""
+    canned = [
+        _delta("Hello"),
+        _delta(", world!"),
+        # Final usage-only chunk: empty choices, populated usage block.
+        {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 4}},
+    ]
+    metrics: dict = {}
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()),
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+            metrics=metrics,
+        )
+    assert full == "Hello, world!"
+    assert metrics["completion_tokens"] == 4
+    assert metrics["prompt_tokens"] == 7
+
+
+def test_chat_command_help_command_prints_help(monkeypatch, capsys):
+    """`/help` lists the slash commands and exits to the prompt without
+    sending anything to the server."""
+    canned = [_delta("ok")]  # never sent — REPL exits before any POST
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["/help", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    for needle in ("/help", "/reset", "/model", "/save", "/exit"):
+        assert needle in out, f"help output missing {needle!r}"
+    assert payloads == [], "help must not send any chat completion request"
+
+
+def test_chat_command_unknown_slash_command_warns(monkeypatch, capsys):
+    """`/foo` produces a friendly hint and does NOT POST to the server."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["/madeup", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "Unknown command" in out
+    assert "/help" in out
+    assert payloads == []
+
+
+def test_chat_command_save_writes_markdown_file(monkeypatch, tmp_path, capsys):
+    """`/save <path>` serialises history (sans system prompt) to markdown."""
+    canned = [_delta("Hi there!")]
+    out_path = tmp_path / "convo.md"
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["hello", f"/save {out_path}", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    body = out_path.read_text(encoding="utf-8")
+    assert "# rapid-mlx chat" in body
+    assert "## User" in body and "hello" in body
+    assert "## Assistant" in body and "Hi there!" in body
+    assert "Saved" in capsys.readouterr().out
+
+
+def test_chat_command_save_without_arg_prints_usage(monkeypatch, capsys):
+    """Bare `/save` should not crash — prints a Usage hint."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["/save", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert "Usage: /save" in capsys.readouterr().out
+
+
+def test_chat_command_multiline_heredoc_collected_into_one_message(monkeypatch):
+    """Triple-quote heredoc collects multiple input lines into a single
+    user message. Critical for pasting code blocks."""
+    canned = [_delta("noted")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(['"""', "line one", "line two", '"""', "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert len(payloads) == 1
+    msg = payloads[0]["messages"][0]
+    assert msg["role"] == "user"
+    assert msg["content"] == "line one\nline two"
+
+
+def test_chat_command_sends_stream_options_include_usage(monkeypatch):
+    """Chat payload must request usage in the stream so the speed line
+    can show real (not estimated) token counts."""
+    canned = [_delta("hi"), {"choices": [], "usage": {"completion_tokens": 1}}]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert payloads[0].get("stream_options") == {"include_usage": True}
+
+
+def test_chat_command_speed_line_uses_server_token_count(monkeypatch, capsys):
+    """When the server reports usage, the speed line shows the real count
+    (not an estimate prefixed with `~`)."""
+    canned = [
+        _delta("hello world"),
+        {"choices": [], "usage": {"completion_tokens": 17}},
+    ]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "17 tok" in out
+    assert "tok/s" in out
+    assert "~17" not in out
+
+
+def test_stream_chat_response_renders_atx_headings(monkeypatch):
+    """ATX headings (`# h1`..`###### h6`) at line start get a colored
+    style applied across the heading line. We simulate a TTY so the
+    state machine path runs."""
+
+    class _Tty(io.StringIO):
+        def isatty(self):
+            return True
+
+    canned = [
+        _delta("# Big\n"),
+        _delta("## Sub\n"),
+        _delta("Body line with `code`.\n"),
+        _delta("### Smaller\n"),
+        _delta("Tail.\n"),
+    ]
+    out_buf = _Tty()
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", out_buf),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        # Make sure NO_COLOR isn't set in the test env.
+        os = __import__("os")
+        os.environ.pop("NO_COLOR", None)
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+    rendered = out_buf.getvalue()
+    # Plain text content survived intact.
+    assert full == "# Big\n## Sub\nBody line with `code`.\n### Smaller\nTail.\n"
+    # Heading lines are wrapped in ANSI escapes.
+    assert "\x1b[" in rendered, "expected ANSI escapes on a TTY render"
+    assert "# Big" in rendered and "## Sub" in rendered
+    # Plain body line did not pick up a heading style — only inline `code`
+    # got the cyan single-backtick wrap.
+    assert "Body line with " in rendered
+
+
+def test_stream_chat_response_aborts_on_repetition(monkeypatch):
+    """The repetition guard must cut the stream when the model degenerates
+    into the same token repeated 30+ times — otherwise the screen fills
+    with garbage and the REPL feels broken. We model the real-world
+    scenario by feeding the same word as 80 separate chunks (matching how
+    a token-streaming server actually delivers degenerate output).
+    """
+    canned = [_delta("Barley ") for _ in range(80)]
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()) as buf,
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+    # Guard kicked in well before the 80th chunk.
+    assert full.count("Barley") < 80
+    assert "repeating" in buf.getvalue() or "repetition" in buf.getvalue()
+
+
+def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
+    """`_ensure_model_downloaded` must gate on `_check_disk_space` so a
+    user without room for a 20 GB model fails fast with a clear error
+    instead of a 90 % partial download."""
+    # Force the cache-miss path so we reach the download branch.
+    monkeypatch.setattr(
+        "huggingface_hub.try_to_load_from_cache", lambda *_a, **_kw: None
+    )
+    # Force a non-existent model_name path.
+    monkeypatch.setattr("os.path.exists", lambda _p: False)
+
+    called: list = []
+
+    def _fake_check(name, force=False):
+        called.append(name)
+
+    monkeypatch.setattr(cli, "_check_disk_space", _fake_check)
+    # Make snapshot_download a no-op so we don't hit the network.
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", lambda *_a, **_kw: "/tmp/fake"
+    )
+    # Stub model_info too so we don't query the API.
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda *_a, **_kw: type("I", (), {"siblings": []})(),
+    )
+
+    cli._ensure_model_downloaded("mlx-community/Fake-Model-1B")
+    assert called == ["mlx-community/Fake-Model-1B"]

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -578,6 +578,71 @@ def test_stream_chat_response_renders_atx_headings(monkeypatch):
     assert "Body line with " in rendered
 
 
+def test_chat_command_heredoc_does_not_trigger_slash_dispatch(monkeypatch):
+    """A heredoc body whose first line starts with `/save` (or any
+    slash) must reach the model as a regular user message, not get
+    silently swallowed by the slash-command dispatcher. Pasted markdown
+    docs whose first line is a path (`/path/to/file.py`) was a real
+    regression in round-1 review."""
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (port, payloads):
+        # Heredoc body opens with `/save`-looking text — must NOT be
+        # dispatched as the /save slash command.
+        inputs = iter(['"""', "/save broken.txt", "second line", '"""', "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert len(payloads) == 1, "heredoc body must reach the server as a chat turn"
+    msg = payloads[0]["messages"][0]
+    assert msg["role"] == "user"
+    assert msg["content"] == "/save broken.txt\nsecond line"
+
+
+def test_chat_command_save_refuses_to_overwrite(monkeypatch, tmp_path, capsys):
+    """`/save` must NOT silently clobber an existing file — destructive
+    and easily triggered by typing the same path twice."""
+    canned = [_delta("ok")]
+    target = tmp_path / "convo.md"
+    target.write_text("PRE-EXISTING CONTENT")
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["hi", f"/save {target}", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert target.read_text() == "PRE-EXISTING CONTENT", "must not overwrite"
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_chat_command_save_creates_parent_directories(monkeypatch, tmp_path):
+    """`/save logs/2026/convo.md` should auto-create the parent dirs
+    instead of failing with a confusing ENOENT."""
+    canned = [_delta("ok")]
+    nested = tmp_path / "logs" / "subdir" / "convo.md"
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["hi", f"/save {nested}", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert nested.exists()
+    assert "## User" in nested.read_text(encoding="utf-8")
+
+
+def test_stream_chat_response_no_false_positive_on_repeated_lists(monkeypatch):
+    """Legitimate repetitive content (a list of zeros, a markdown table
+    separator) used to trip the round-1 guard's `≤2 unique tokens in 30`
+    rule. The new guard requires the SAME single token to repeat
+    consecutively, so these must stream through cleanly."""
+    canned = [_delta("[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]")]
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()) as buf,
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+    assert full == "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+    assert "repeating" not in buf.getvalue()
+
+
 def test_stream_chat_response_aborts_on_repetition(monkeypatch):
     """The repetition guard must cut the stream when the model degenerates
     into the same token repeated 30+ times — otherwise the screen fills

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -842,9 +842,11 @@ def test_chat_command_switch_model_rollback_on_wait_failure(monkeypatch, capsys)
         def kill(self):
             self._terminated = True
 
-    def _fake_spawn(model, log_path, served_name=None):
+    def _fake_spawn(model, log_path, served_name=None, *, register_in=None):
         proc = _FakeProc(model)
         spawned.append(proc)
+        if register_in is not None:
+            register_in.append(proc)
         return proc, f"http://127.0.0.1:{port}"
 
     wait_calls = {"n": 0}
@@ -888,4 +890,70 @@ def test_chat_command_switch_model_rollback_on_wait_failure(monkeypatch, capsys)
     # the first as history.
     assert any(m["content"] == "first turn" for m in payloads[1]["messages"]), (
         "second-turn payload lost the first turn after the failed /model swap"
+    )
+
+
+def test_chat_command_slash_command_dispatch_uses_exact_match(
+    monkeypatch, tmp_path, capsys
+):
+    """``/savefoo bar`` (typo) must NOT match ``/save``. ``startswith``
+    matched the prefix and silently wrote a file from a typo. Exact-token
+    parsing now treats the unknown command like any other slash typo and
+    surfaces the help."""
+    canned = [_delta("ack")]
+    target = tmp_path / "should_not_appear.md"
+    with _fake_server(canned) as (port, payloads):
+        # Three inputs: a typo of /save, a typo of /model, then exit. None
+        # of the typos must trigger the corresponding command.
+        inputs = iter(
+            [
+                f"/savefoo {target}",
+                "/modelfoo qwen3.5-4b",
+                "exit",
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert not target.exists(), "/savefoo must NOT trigger /save"
+    assert "Unknown command: /savefoo" in out
+    assert "Unknown command: /modelfoo" in out
+    # Neither typo should have reached the server as a chat turn either —
+    # they're slash-prefixed, so the /-handler swallows them with a hint.
+    assert payloads == [], (
+        f"slash typos must be swallowed by the dispatcher, "
+        f"not forwarded to the server. payloads={payloads}"
+    )
+
+
+def test_stream_chat_response_repetition_truncates_at_cutoff_in_one_chunk(
+    monkeypatch,
+):
+    """If a single SSE delta coalesces many repeated tokens (servers do
+    batch under load), the abort message must land before the user sees
+    the full 50-token wall — emit the prefix up to the cutoff, abort,
+    then explain. Round-3 codex finding: previously the entire chunk
+    was emitted before the rolling counter detected the run."""
+    # 60 copies of the same single token in ONE delta — well past the
+    # REPEAT_LIMIT=25 threshold.
+    big_chunk = (" Barley" * 60).strip() + " "
+    canned = [_delta(big_chunk)]
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()) as buf,
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+    rendered = buf.getvalue()
+    # Only the prefix up to the cutoff should land; not all 60 copies.
+    barley_count = full.count("Barley")
+    assert barley_count < 60, (
+        f"emitted full degenerate chunk before abort detected ({barley_count}/60)"
+    )
+    # And the abort hint did print.
+    assert "repeating" in rendered or "repetition" in rendered, (
+        "expected the repetition-abort hint to be visible"
     )

--- a/vllm_mlx/agents/profiles/opencode.yaml
+++ b/vllm_mlx/agents/profiles/opencode.yaml
@@ -1,0 +1,62 @@
+name: opencode
+display_name: "OpenCode"
+repo: "sst/opencode"
+stars: 16000
+
+# OpenCode (opencode.ai) is a Claude-Code-like terminal coding agent.
+# It speaks the OpenAI-compatible chat completions API via the
+# ``@ai-sdk/openai-compatible`` provider; we point that at rapid-mlx.
+#
+# Config lives at ~/.config/opencode/opencode.json (or ./opencode.json in
+# a project root). The ``$schema`` URL is canonical from opencode.ai.
+config:
+  type: json
+  path: "~/.config/opencode/opencode.json"
+  template: |
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "provider": {
+        "rapid-mlx": {
+          "npm": "@ai-sdk/openai-compatible",
+          "name": "Rapid-MLX",
+          "options": {
+            "baseURL": "{base_url}",
+            "apiKey": "not-needed"
+          },
+          "models": {
+            "{model_id}": {}
+          }
+        }
+      },
+      "model": "rapid-mlx/{model_id}"
+    }
+
+models:
+  recommended:
+    - "qwen3-coder-30b"
+    - "qwen3.5-9b"
+    - "qwen3.6-35b"
+    - "qwen3.5-4b"
+  parser_override: null
+
+streaming:
+  extra_tool_tags: []
+  suppress_patterns: []
+  max_tools: 25  # mirrors Claude Code tool count
+
+testing:
+  binary: opencode
+  query_cmd: null  # opencode is interactive — no single-query mode
+  query_timeout: 120
+  install_cmd: "brew install sst/tap/opencode  # or: npm install -g opencode-ai"
+
+capabilities:
+  function_calling: true
+  streaming: true
+  vision: false
+  reasoning: true
+
+known_issues:
+  - "Config schema may need updating across OpenCode versions — if this template doesn't load, run `opencode --help` and check `~/.config/opencode/opencode.json` against the docs at opencode.ai."
+  - "OpenCode is interactive-only (no headless query mode); --test in rapid-mlx agents will skip the query check."
+  - "First run of OpenCode may prompt for an Anthropic API key — choose 'skip' since rapid-mlx is providing the model via the openai-compat provider."

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -898,12 +898,23 @@ def ps_command(_args):
 
 
 def _spawn_chat_server(
-    model: str, log_path: str, served_name: str | None = None
+    model: str,
+    log_path: str,
+    served_name: str | None = None,
+    *,
+    register_in: list | None = None,
 ) -> tuple[object, str]:
     """Spawn a `serve` subprocess on an ephemeral port for chat REPL use.
 
-    Returns (Popen handle, base_url). The caller must register cleanup —
-    `chat_command` does so via atexit + signal handlers.
+    Returns (Popen handle, base_url).
+
+    ``register_in`` is an optional list (typically the chat REPL's
+    ``_active_procs``). When provided, the new ``Popen`` is appended to it
+    *immediately* after construction — narrowing the SIGTERM-orphan race
+    that exists between ``Popen()`` returning and the caller registering
+    the handle. Caller-side ``register_in.append(proc)`` would still leave
+    one Python statement of unprotected window; doing it inside this
+    function closes that window for the caller.
 
     If ``served_name`` is given, it is passed via ``--served-model-name`` so
     the spawned server exposes the alias as the API model name (e.g. user
@@ -939,6 +950,10 @@ def _spawn_chat_server(
         stderr=subprocess.STDOUT,
         start_new_session=True,
     )
+    # Register first so a SIGTERM landing between here and the caller's
+    # next statement still tears the child down.
+    if register_in is not None:
+        register_in.append(proc)
     # Stash the log handle and path on the proc object so the chat REPL
     # can close+unlink them when the proc is torn down (fixes the file
     # descriptor + tempfile leak across `/model` swaps).
@@ -1247,15 +1262,22 @@ def _stream_chat_response(
                 if in_reasoning:
                     sys.stdout.write(f"{RESET}\n  " if is_tty else "\n")
                     in_reasoning = False
-                _emit_with_inline_md(piece)
-                full += piece
+                # Detect repetition BEFORE emitting. If a single coalesced
+                # delta contains the cutoff inside it (server batched many
+                # repeated tokens into one chunk), find the position and
+                # only emit the prefix up to that token — otherwise the
+                # user sees the full degenerate dump before the abort
+                # message lands.
+                #
                 # Rolling counter: each new whitespace-separated token in
                 # this delta either extends the current consecutive run
                 # or resets it. Aborts only on a single token repeated
                 # ``REPEAT_LIMIT`` times in a row, not on diverse-but-
                 # repetitive content like ``[0, 0, 0, ...]`` or markdown
                 # tables.
-                for tok in piece.split():
+                cutoff_idx: int | None = None
+                tokens = piece.split()
+                for i, tok in enumerate(tokens):
                     if tok == repeat_last:
                         repeat_run += 1
                     else:
@@ -1263,7 +1285,31 @@ def _stream_chat_response(
                         repeat_run = 1
                     if repeat_run >= REPEAT_LIMIT:
                         repetition_aborted = True
+                        cutoff_idx = i
                         break
+                if cutoff_idx is not None:
+                    # Find the byte position in ``piece`` corresponding to
+                    # the start of the cutoff token, so we can emit only
+                    # the prefix. ``str.split()`` collapses runs of
+                    # whitespace, so we walk the original text token-by-
+                    # token to recover the offset.
+                    pos = 0
+                    seen = 0
+                    while seen < cutoff_idx and pos < len(piece):
+                        # Skip leading whitespace.
+                        while pos < len(piece) and piece[pos].isspace():
+                            pos += 1
+                        # Skip the token itself.
+                        while pos < len(piece) and not piece[pos].isspace():
+                            pos += 1
+                        seen += 1
+                    prefix = piece[:pos]
+                    if prefix:
+                        _emit_with_inline_md(prefix)
+                        full += prefix
+                else:
+                    _emit_with_inline_md(piece)
+                    full += piece
                 if repetition_aborted:
                     break
     _close_open_md_spans()
@@ -1408,8 +1454,12 @@ def chat_command(args):
         # If main() resolved an alias, expose the alias as the API model name
         # so the chat request body matches what the user typed.
         original = getattr(args, "_original_alias", None)
-        proc, base_url = _spawn_chat_server(args.model, log_path, served_name=original)
-        _active_procs.append(proc)
+        proc, base_url = _spawn_chat_server(
+            args.model,
+            log_path,
+            served_name=original,
+            register_in=_active_procs,
+        )
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
@@ -1607,15 +1657,17 @@ def chat_command(args):
             prefix="rapid-mlx-chat-", suffix=".log", delete=False
         ).name
         print(f"  Starting server {DIM}(log: {new_log_path}){RESET} ...")
+        # ``register_in=_active_procs`` makes the candidate visible to
+        # ``_cleanup`` *inside* ``_spawn_chat_server`` — before the
+        # readiness wait, before any further Python statement runs in
+        # this scope. A SIGTERM/Ctrl-C during the (possibly multi-second)
+        # load tears the child down via the cleanup walk.
         new_proc, new_base_url = _spawn_chat_server(
-            resolved, new_log_path, served_name=new_alias
+            resolved,
+            new_log_path,
+            served_name=new_alias,
+            register_in=_active_procs,
         )
-        # Register the candidate in the cleanup set IMMEDIATELY — before
-        # the readiness wait. A SIGTERM/Ctrl-C during the (possibly
-        # multi-second) load otherwise orphans this process: it isn't
-        # bound to the outer ``proc`` yet and was previously invisible
-        # to ``_cleanup``.
-        _active_procs.append(new_proc)
         try:
             _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as exc:
@@ -1663,37 +1715,41 @@ def chat_command(args):
                 continue
             is_heredoc = True
         if not is_heredoc:
-            if line in ("exit", "quit", "/exit", "/quit"):
+            # Parse the leading word as the command and dispatch on
+            # *exact* match. ``startswith("/save")`` would otherwise treat
+            # ``/savefoo`` as ``/save`` (with arg ``foo``), silently
+            # writing a file from a typo. Same for ``/modelfoo``.
+            cmd, _, rest = line.partition(" ")
+            rest = rest.strip()
+            if cmd in ("exit", "quit", "/exit", "/quit"):
                 break
-            if line in ("/help", "/?"):
+            if cmd in ("/help", "/?"):
                 _print_help()
                 continue
-            if line in ("/reset", "/clear"):
+            if cmd in ("/reset", "/clear"):
                 messages = (
                     [{"role": "system", "content": args.system}] if args.system else []
                 )
                 print(f"  {DIM}(history cleared){RESET}\n")
                 continue
-            if line.startswith("/save"):
-                parts = line.split(maxsplit=1)
-                if len(parts) < 2:
+            if cmd == "/save":
+                if not rest:
                     print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
                 else:
-                    _save_conversation(parts[1])
+                    _save_conversation(rest)
                 continue
-            if line.startswith("/model"):
-                parts = line.split(maxsplit=1)
-                if len(parts) < 2:
+            if cmd == "/model":
+                if not rest:
                     print(
                         f"  {YELLOW}Usage: /model <alias>{RESET}  "
                         f"{DIM}(see `rapid-mlx models`){RESET}\n"
                     )
                 else:
-                    _switch_model(parts[1].strip())
+                    _switch_model(rest)
                 continue
-            if line.startswith("/"):
+            if cmd.startswith("/"):
                 print(
-                    f"  {YELLOW}Unknown command: {line.split()[0]}{RESET}  "
+                    f"  {YELLOW}Unknown command: {cmd}{RESET}  "
                     f"{DIM}(type /help){RESET}\n"
                 )
                 continue

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -118,6 +118,77 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
         pass
 
 
+def _ensure_model_downloaded(model_name: str) -> None:
+    """Pre-fetch a model in the foreground so HF's tqdm progress is visible.
+
+    Used by ``rapid-mlx chat``: the chat REPL spawns ``serve`` as a
+    subprocess with stdout/stderr redirected to a log file. If the model
+    isn't cached, the user sees a silent multi-minute hang while several
+    GB downloads behind the log. Calling ``snapshot_download`` here first
+    surfaces the standard HF progress bars on the user's terminal, then
+    the spawned server starts as a cache hit.
+
+    No-op when the model is already cached, when ``model_name`` is a local
+    path, or when the HF lookup fails (let the loader's own error paths
+    handle it).
+    """
+    if os.path.exists(model_name):
+        return
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(model_name, "config.json")
+        if isinstance(cached, str) and os.path.exists(cached):
+            return
+    except Exception:
+        return
+
+    # Disk-space gate: a 20 GB partial download that fails on the last
+    # shard wastes the user's time. ``_check_disk_space`` queries HF for
+    # the repo size and aborts with a clear message + exit(1) if there
+    # isn't enough room on the resolved HF cache filesystem.
+    _check_disk_space(model_name)
+
+    try:
+        from huggingface_hub import model_info, snapshot_download
+
+        size_gb = 0.0
+        try:
+            info = model_info(model_name, files_metadata=True)
+            size_bytes = sum(
+                (s.size or 0)
+                for s in (getattr(info, "siblings", None) or [])
+                if hasattr(s, "size")
+            )
+            size_gb = size_bytes / (1024**3)
+        except Exception:
+            pass
+
+        is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+        BOLD = "\x1b[1m" if is_tty else ""
+        DIM = "\x1b[2m" if is_tty else ""
+        RESET = "\x1b[0m" if is_tty else ""
+        if size_gb > 0:
+            print(
+                f"\n  {BOLD}First-time download{RESET} — "
+                f"fetching {model_name} {DIM}(~{size_gb:.1f} GB){RESET} "
+                "from HuggingFace ..."
+            )
+        else:
+            print(
+                f"\n  {BOLD}First-time download{RESET} — "
+                f"fetching {model_name} from HuggingFace ..."
+            )
+
+        snapshot_download(model_name)
+        print()
+    except Exception as e:
+        # Don't block startup on flaky pre-fetch — the spawned serve
+        # will retry the download (just without a foreground progress
+        # bar) and surface the real error.
+        print(f"\n  Pre-download skipped ({type(e).__name__}); server will retry.")
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -863,32 +934,76 @@ def _spawn_chat_server(
 
 
 def _wait_for_chat_server(base_url: str, proc, timeout_s: int = 600) -> None:
-    """Block until /health/ready returns 200, the proc exits, or timeout."""
+    """Block until /health/ready returns 200, the proc exits, or timeout.
+
+    On a TTY, draws a spinner + elapsed-seconds counter to stderr so the
+    user can see the chat REPL is alive while the spawned server loads
+    weights (typically 20-90 s for 4-30 B models on Apple Silicon). The
+    line is erased before this function returns so the caller's next
+    print lands on a clean line.
+    """
     import time
 
     import requests
 
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            raise RuntimeError(
-                f"server exited early (code {proc.returncode}); "
-                "see chat-server.log for details"
-            )
-        try:
-            r = requests.get(f"{base_url}/health/ready", timeout=2)
-            if r.status_code == 200:
-                return
-        except requests.RequestException:
-            pass
-        time.sleep(1)
+    is_tty = sys.stderr.isatty()
+    spinner = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    cyan = "\x1b[36m" if is_tty else ""
+    dim = "\x1b[2m" if is_tty else ""
+    reset = "\x1b[0m" if is_tty else ""
+    start = time.monotonic()
+    deadline = start + timeout_s
+    tick = 0
+
+    def _draw():
+        if not is_tty:
+            return
+        elapsed = int(time.monotonic() - start)
+        ch = spinner[tick % len(spinner)]
+        sys.stderr.write(
+            f"\r  {cyan}{ch}{reset} loading model ... {dim}{elapsed}s{reset}"
+        )
+        sys.stderr.flush()
+
+    def _clear():
+        if not is_tty:
+            return
+        sys.stderr.write("\r" + " " * 40 + "\r")
+        sys.stderr.flush()
+
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"server exited early (code {proc.returncode}); "
+                    "see chat-server.log for details"
+                )
+            # Animate the spinner at 10 fps; only poll /health once a
+            # second to keep the spinner smooth and the network polite.
+            if tick % 10 == 0:
+                try:
+                    r = requests.get(f"{base_url}/health/ready", timeout=2)
+                    if r.status_code == 200:
+                        return
+                except requests.RequestException:
+                    pass
+            _draw()
+            time.sleep(0.1)
+            tick += 1
+    finally:
+        _clear()
     raise TimeoutError(
         f"server did not become ready within {timeout_s}s "
         "(large models can take longer — pass --ready-timeout)"
     )
 
 
-def _stream_chat_response(base_url: str, payload: dict, timeout_s: int) -> str:
+def _stream_chat_response(
+    base_url: str,
+    payload: dict,
+    timeout_s: int,
+    metrics: dict | None = None,
+) -> str:
     """POST /v1/chat/completions with stream=True and print tokens as they
     arrive. Returns the full assistant content (concatenated content deltas).
 
@@ -896,16 +1011,168 @@ def _stream_chat_response(base_url: str, payload: dict, timeout_s: int) -> str:
     in dim ANSI so the user sees thinking, but excluded from the returned
     string — chat history stores only the final answer, matching the
     OpenAI-compat split between ``content`` and ``reasoning_content``.
+
+    Plain streaming: tokens land directly in the user's terminal as they
+    arrive. We deliberately do NOT use ``rich.Live`` + ``Markdown`` here:
+    Live re-renders the panel on every refresh and, when the console's
+    cursor-overwrite path is unreliable (recordings, some terminal
+    multiplexers), each refresh appends rather than overwrites — turning
+    a 200-token response into a wall of repeated text. Live markdown
+    rendering deserves a separate, more careful effort with explicit
+    fallback detection; for now correctness wins over formatting.
     """
     import json
 
     import requests
 
     DIM = "\x1b[2m"
+    BOLD = "\x1b[1m"
     RESET = "\x1b[0m"
-    is_tty = sys.stdout.isatty()
+    MAGENTA = "\x1b[35m"
+    CYAN = "\x1b[36m"
+    is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
     in_reasoning = False
     full = ""
+
+    # ----- Streaming markdown colorer ------------------------------------
+    # Body text streams in the terminal's default color (Claude-Code-style
+    # — accents only on chrome). Inline coloring handles the markers users
+    # see most often: ``\`code\``` (cyan), ``\`\`\`fence\`\`\``` (dim cyan
+    # block), ``**bold**`` (ANSI bold), and ATX headers (``#`` … ``####``)
+    # at line start. Lists / italic stay raw so the parser stays small.
+    HEADING_STYLE = {
+        1: BOLD + CYAN,  # `# h1`     — most prominent
+        2: BOLD + MAGENTA,  # `## h2`    — secondary
+        3: BOLD,  # `### h3`   — bold only
+        4: CYAN,  # `#### h4`  — cyan
+        5: MAGENTA,  # `##### h5` — magenta
+        6: DIM,  # `###### h6`— dim
+    }
+    _state = {
+        "in_fence": False,  # inside a ``` block
+        "in_inline_code": False,  # inside a `code` span
+        "in_bold": False,  # inside **bold**
+        "in_heading": False,  # inside an ATX heading line
+        "at_line_start": True,  # cursor is at start of a logical line
+        "pending": "",  # buffered chars awaiting lookahead
+    }
+
+    def _emit_with_inline_md(piece: str) -> None:
+        if not is_tty:
+            sys.stdout.write(piece)
+            sys.stdout.flush()
+            return
+        text = _state["pending"] + piece
+        _state["pending"] = ""
+        out: list[str] = []
+        i, n = 0, len(text)
+        while i < n:
+            c = text[i]
+            # Newline closes any line-scoped span (heading) and resets the
+            # line-start anchor so the next `#`/`*`/etc. is interpreted in
+            # the right context.
+            if c == "\n":
+                if _state["in_heading"]:
+                    out.append(RESET)
+                    _state["in_heading"] = False
+                out.append("\n")
+                _state["at_line_start"] = True
+                i += 1
+                continue
+            # ATX heading: `#`..`######` followed by space at line start.
+            # We skip this inside fences (a `#` at line start there is
+            # almost always a comment, not a heading).
+            if _state["at_line_start"] and c == "#" and not _state["in_fence"]:
+                # Count consecutive `#` (1..6).
+                j = i
+                while j < n and j - i < 6 and text[j] == "#":
+                    j += 1
+                # Need to see one more char after the hashes to decide
+                # heading vs literal "###foo" — buffer if we don't have it.
+                if j == n:
+                    _state["pending"] = text[i:]
+                    break
+                hashes = j - i
+                if 1 <= hashes <= 6 and text[j] == " ":
+                    style = HEADING_STYLE.get(hashes, BOLD)
+                    out.append(style)
+                    out.append(text[i : j + 1])  # emit "## "
+                    _state["in_heading"] = True
+                    _state["at_line_start"] = False
+                    i = j + 1
+                    continue
+                # Not a heading — fall through to literal emission below.
+            if c == "`":
+                # Need 2 chars of lookahead to disambiguate ``` vs `.
+                if i + 2 >= n:
+                    _state["pending"] = text[i:]
+                    break
+                if text[i : i + 3] == "```":
+                    if _state["in_fence"]:
+                        out.append("```" + RESET)
+                        _state["in_fence"] = False
+                    else:
+                        out.append(DIM + CYAN + "```")
+                        _state["in_fence"] = True
+                    _state["at_line_start"] = False
+                    i += 3
+                    continue
+                # Single backtick.
+                if _state["in_fence"]:
+                    out.append("`")
+                elif _state["in_inline_code"]:
+                    out.append("`" + RESET)
+                    _state["in_inline_code"] = False
+                else:
+                    out.append(CYAN + "`")
+                    _state["in_inline_code"] = True
+                _state["at_line_start"] = False
+                i += 1
+                continue
+            if c == "*" and not _state["in_fence"] and not _state["in_inline_code"]:
+                if i + 1 >= n:
+                    _state["pending"] = text[i:]
+                    break
+                if text[i : i + 2] == "**":
+                    if _state["in_bold"]:
+                        out.append("**" + RESET)
+                        _state["in_bold"] = False
+                    else:
+                        out.append(BOLD + "**")
+                        _state["in_bold"] = True
+                    _state["at_line_start"] = False
+                    i += 2
+                    continue
+            out.append(c)
+            # Whitespace (other than newline, handled above) keeps the
+            # line-start anchor true so leading-indent headings still
+            # parse — e.g., a list item's child paragraph is rare here.
+            if c not in " \t":
+                _state["at_line_start"] = False
+            i += 1
+        sys.stdout.write("".join(out))
+        sys.stdout.flush()
+
+    def _close_open_md_spans() -> None:
+        if is_tty and (
+            _state["in_fence"]
+            or _state["in_inline_code"]
+            or _state["in_bold"]
+            or _state["in_heading"]
+        ):
+            sys.stdout.write(RESET)
+            sys.stdout.flush()
+        if _state["pending"]:
+            sys.stdout.write(_state["pending"])
+            sys.stdout.flush()
+            _state["pending"] = ""
+
+    # ----- Repetition guard ----------------------------------------------
+    # Smaller models (qwen3.5-4b on multi-turn, etc.) sometimes degenerate
+    # into the same token repeated until max_tokens — filling the screen
+    # with a wall of "Barley Barley Barley...". We can't fix the model,
+    # but we can stop the stream so the REPL stays usable.
+    repetition_aborted = False
 
     with requests.post(
         f"{base_url}/v1/chat/completions",
@@ -932,24 +1199,53 @@ def _stream_chat_response(base_url: str, payload: dict, timeout_s: int) -> str:
                 chunk = json.loads(data)
             except json.JSONDecodeError:
                 continue
-            delta = chunk.get("choices", [{}])[0].get("delta", {}) or {}
+            # When the caller passes ``stream_options.include_usage``,
+            # the server emits a final chunk with empty choices and a
+            # populated ``usage`` block. Capture it for the speed line.
+            usage = chunk.get("usage")
+            if usage and metrics is not None:
+                metrics["completion_tokens"] = usage.get("completion_tokens")
+                metrics["prompt_tokens"] = usage.get("prompt_tokens")
+            # The usage-only final chunk has ``choices=[]``; guard
+            # against an IndexError there.
+            choices = chunk.get("choices") or []
+            delta = choices[0].get("delta", {}) if choices else {}
             reasoning = delta.get("reasoning_content")
             piece = delta.get("content")
             if reasoning:
                 if not in_reasoning:
-                    sys.stdout.write(f"{DIM}[thinking] " if is_tty else "[thinking] ")
+                    if is_tty:
+                        sys.stdout.write(f"{MAGENTA}[thinking]{RESET} {DIM}")
+                    else:
+                        sys.stdout.write("[thinking] ")
                     in_reasoning = True
                 sys.stdout.write(reasoning)
                 sys.stdout.flush()
             if piece:
                 if in_reasoning:
-                    sys.stdout.write(f"{RESET}\n" if is_tty else "\n")
+                    sys.stdout.write(f"{RESET}\n  " if is_tty else "\n")
                     in_reasoning = False
-                sys.stdout.write(piece)
-                sys.stdout.flush()
+                _emit_with_inline_md(piece)
                 full += piece
+                # Repetition guard: if the last 30 whitespace-separated
+                # tokens collapse to ≤2 unique values, the model has
+                # almost certainly degenerated — abort the stream.
+                words = full.split()
+                if len(words) >= 30 and len(set(words[-30:])) <= 2:
+                    repetition_aborted = True
+                    break
+    _close_open_md_spans()
     if in_reasoning and is_tty:
         sys.stdout.write(RESET)
+        sys.stdout.flush()
+    if repetition_aborted:
+        msg = (
+            f"\n\n  {DIM}(response cut: model began repeating itself — "
+            f"try /reset or a larger model){RESET}"
+            if is_tty
+            else "\n\n(response cut: repetition detected)"
+        )
+        sys.stdout.write(msg)
         sys.stdout.flush()
     return full
 
@@ -971,6 +1267,16 @@ def chat_command(args):
     proc = None
     log_path: str | None = None
 
+    # TTY-gated ANSI palette for the chat UI. NO_COLOR is honoured.
+    _is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    BOLD = "\x1b[1m" if _is_tty else ""
+    DIM = "\x1b[2m" if _is_tty else ""
+    GREEN = "\x1b[32m" if _is_tty else ""
+    CYAN = "\x1b[36m" if _is_tty else ""
+    YELLOW = "\x1b[33m" if _is_tty else ""
+    RED = "\x1b[31m" if _is_tty else ""
+    RESET = "\x1b[0m" if _is_tty else ""
+
     if args.base_url:
         base_url = args.base_url.rstrip("/")
         if base_url.endswith("/v1"):
@@ -978,39 +1284,69 @@ def chat_command(args):
     elif args.port is not None:
         base_url = f"http://127.0.0.1:{args.port}"
     else:
+        # Pre-download in the foreground so the HF tqdm progress bar lands
+        # in the user's terminal. Otherwise the serve subprocess swallows
+        # the bar into the log file and `rapid-mlx chat` looks frozen for
+        # several minutes on first run with a fresh model.
+        _ensure_model_downloaded(args.model)
+
         log_path = tempfile.NamedTemporaryFile(
             prefix="rapid-mlx-chat-", suffix=".log", delete=False
         ).name
-        print(f"\n  Starting server (log: {log_path}) ...")
+        print(f"\n  Starting server {DIM}(log: {log_path}){RESET} ...")
         # If main() resolved an alias, expose the alias as the API model name
         # so the chat request body matches what the user typed.
         original = getattr(args, "_original_alias", None)
         proc, base_url = _spawn_chat_server(args.model, log_path, served_name=original)
 
         def _cleanup():
+            # Exit fast on REPL teardown. Give SIGTERM 1 s to flush
+            # uvicorn's lifespan, then SIGKILL — there's nothing critical
+            # to write back, the model is in-memory only, and a 10 s
+            # graceful shutdown made `exit` feel like 5 s of frozen
+            # terminal.
             if proc and proc.poll() is None:
                 try:
                     proc.terminate()
-                    proc.wait(timeout=10)
+                    proc.wait(timeout=1)
                 except subprocess.TimeoutExpired:
-                    proc.kill()
+                    try:
+                        proc.kill()
+                    except (ProcessLookupError, OSError):
+                        pass
+                except (ProcessLookupError, OSError):
+                    pass
 
         atexit.register(_cleanup)
-        # Ensure SIGINT/SIGTERM also kill the server before we exit.
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            try:
-                signal.signal(sig, lambda *_: (_cleanup(), sys.exit(130)))
-            except (ValueError, OSError):
-                pass
+        # SIGTERM gets a custom handler that runs cleanup before exiting.
+        # SIGINT is *deliberately* left on the default handler: that way
+        # Ctrl-C unblocks ``input()`` via the natural KeyboardInterrupt
+        # path, the REPL loop's ``except KeyboardInterrupt: break`` fires,
+        # and ``atexit`` runs ``_cleanup``. A custom SIGINT handler that
+        # calls ``proc.terminate(); proc.wait(timeout=10)`` makes the
+        # whole REPL feel frozen for up to 10 s after Ctrl-C and also
+        # suppresses the KeyboardInterrupt that ``input()`` relies on.
+        try:
+            signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
+        except (ValueError, OSError):
+            pass
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as e:
-            print(f"\n  Failed to start server: {e}")
+            print(f"\n  {RED}Failed to start server:{RESET} {e}")
             sys.exit(1)
-        print("  Ready.\n")
+        print(f"  {GREEN}✓ Ready.{RESET}\n")
 
-    print("  Chat — Ctrl-D / Ctrl-C / 'exit' to quit, '/reset' to clear history.\n")
+    print(
+        f"  {BOLD}Chat{RESET} — "
+        f"{DIM}type {RESET}{BOLD}/help{RESET}{DIM} for commands, "
+        f"Ctrl-D to exit.{RESET}"
+    )
+    print(
+        f"  {DIM}For a Claude Code-like TUI: `rapid-mlx agents codex --setup`, "
+        f"then run `codex` in any project.{RESET}\n"
+    )
 
     served_name = getattr(args, "_original_alias", args.model)
     messages: list[dict] = []
@@ -1031,23 +1367,155 @@ def chat_command(args):
     if not args.think:
         extra["enable_thinking"] = False
 
+    import time
+
     import requests
+
+    # Importing ``readline`` upgrades the built-in ``input()`` so that the
+    # arrow keys recall earlier prompts (and Ctrl-A/E/U work). The module
+    # is stdlib on macOS/Linux; on Windows it doesn't exist and we just
+    # fall back to plain input().
+    try:
+        import readline  # noqa: F401 — side-effect import
+    except ImportError:
+        pass
+
+    prompt = f"{BOLD}{CYAN}>{RESET} " if _is_tty else "> "
+    cont_prompt = f"{DIM}…{RESET} " if _is_tty else "… "
+
+    def _print_help():
+        print(
+            f"\n  {BOLD}Slash commands{RESET}\n"
+            f"    {BOLD}/help{RESET}              show this help\n"
+            f"    {BOLD}/reset{RESET}, {BOLD}/clear{RESET}     clear conversation history\n"
+            f"    {BOLD}/model <alias>{RESET}     switch model "
+            f"{DIM}(restarts the server, resets history){RESET}\n"
+            f"    {BOLD}/save <path>{RESET}       save conversation to a markdown file\n"
+            f"    {BOLD}/exit{RESET}, {BOLD}/quit{RESET}       exit chat\n"
+            f"\n  {BOLD}Multi-line input{RESET}\n"
+            f'    type {BOLD}"""{RESET} on its own line to start, again to end '
+            f"{DIM}(paste code blocks){RESET}\n"
+            f"\n  {BOLD}Keys{RESET}\n"
+            f"    {BOLD}Ctrl-C{RESET}             cancel the current response, "
+            f"or exit at empty prompt\n"
+            f"    {BOLD}Ctrl-D{RESET}             exit\n"
+        )
+
+    def _save_conversation(path_arg: str):
+        path = os.path.expanduser(path_arg)
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(f"# rapid-mlx chat — {served_name}\n\n")
+                for m in messages:
+                    if m["role"] == "system":
+                        continue
+                    f.write(f"## {m['role'].capitalize()}\n\n{m['content']}\n\n")
+            print(f"  {GREEN}✓{RESET} Saved {len(messages)} messages to {path}\n")
+        except OSError as exc:
+            print(f"  {RED}Save failed:{RESET} {exc}\n")
+
+    def _read_multiline() -> str:
+        lines: list[str] = []
+        while True:
+            try:
+                more = input(cont_prompt)
+            except (EOFError, KeyboardInterrupt):
+                print(f"\n  {YELLOW}(multi-line cancelled){RESET}\n")
+                return ""
+            if more.rstrip() == '"""':
+                return "\n".join(lines).strip()
+            lines.append(more)
+
+    def _switch_model(new_alias: str) -> None:
+        nonlocal proc, base_url, log_path, served_name, messages
+        if proc is None:
+            print(
+                f"  {YELLOW}/model is only available when chat spawns its "
+                f"own server (not with --base-url / --port).{RESET}\n"
+            )
+            return
+        from vllm_mlx.model_aliases import resolve_model
+
+        resolved = resolve_model(new_alias) or new_alias
+        print(f"  {DIM}Switching to {new_alias} → {resolved} ...{RESET}")
+        # Tear down the current server.
+        try:
+            proc.terminate()
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            _ensure_model_downloaded(resolved)
+        except SystemExit:
+            print(f"  {RED}Model switch aborted.{RESET}\n")
+            return
+        log_path = tempfile.NamedTemporaryFile(
+            prefix="rapid-mlx-chat-", suffix=".log", delete=False
+        ).name
+        print(f"  Starting server {DIM}(log: {log_path}){RESET} ...")
+        proc, base_url = _spawn_chat_server(resolved, log_path, served_name=new_alias)
+        try:
+            _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
+        except (RuntimeError, TimeoutError) as exc:
+            print(f"  {RED}Failed to start new server:{RESET} {exc}\n")
+            return
+        served_name = new_alias
+        messages = [{"role": "system", "content": args.system}] if args.system else []
+        print(
+            f"  {GREEN}✓ Switched to {new_alias}.{RESET} "
+            f"{DIM}(history cleared){RESET}\n"
+        )
 
     while True:
         try:
-            line = input("> ").strip()
+            line = input(prompt).rstrip()
         except (EOFError, KeyboardInterrupt):
             print()
             break
         if not line:
             continue
+        if line == '"""':
+            line = _read_multiline()
+            if not line:
+                continue
         if line in ("exit", "quit", "/exit", "/quit"):
             break
+        if line in ("/help", "/?"):
+            _print_help()
+            continue
         if line in ("/reset", "/clear"):
             messages = (
                 [{"role": "system", "content": args.system}] if args.system else []
             )
-            print("  (history cleared)\n")
+            print(f"  {DIM}(history cleared){RESET}\n")
+            continue
+        if line.startswith("/save"):
+            parts = line.split(maxsplit=1)
+            if len(parts) < 2:
+                print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
+            else:
+                _save_conversation(parts[1])
+            continue
+        if line.startswith("/model"):
+            parts = line.split(maxsplit=1)
+            if len(parts) < 2:
+                print(
+                    f"  {YELLOW}Usage: /model <alias>{RESET}  "
+                    f"{DIM}(see `rapid-mlx models`){RESET}\n"
+                )
+            else:
+                _switch_model(parts[1].strip())
+            continue
+        if line.startswith("/"):
+            print(
+                f"  {YELLOW}Unknown command: {line.split()[0]}{RESET}  "
+                f"{DIM}(type /help){RESET}\n"
+            )
             continue
 
         messages.append({"role": "user", "content": line})
@@ -1057,28 +1525,56 @@ def chat_command(args):
             "max_tokens": args.max_tokens,
             "temperature": args.temperature,
             "stream": True,
+            "stream_options": {"include_usage": True},
             **extra,
         }
+        # Claude-Code-style turn marker: a colored bullet introduces the
+        # assistant's response so the user can visually scan turn
+        # boundaries when scrolling back through long conversations.
+        sys.stdout.write(f"\n  {CYAN}●{RESET} ")
+        sys.stdout.flush()
+        metrics: dict = {}
+        start_t = time.monotonic()
         try:
             assistant = _stream_chat_response(
-                base_url, payload, timeout_s=args.response_timeout
+                base_url,
+                payload,
+                timeout_s=args.response_timeout,
+                metrics=metrics,
             )
         except KeyboardInterrupt:
-            print("\n  (response interrupted)\n")
+            print(f"\n  {YELLOW}(response interrupted){RESET}\n")
             messages.pop()
             continue
         except RuntimeError as e:
-            print(f"\n  {e}\n")
+            print(f"\n  {RED}{e}{RESET}\n")
             messages.pop()
             continue
         except requests.RequestException as e:
             # Connection refused, timeout, dropped midstream — keep the REPL
             # alive and roll back the failed user turn so the next request
             # doesn't carry a dangling user role with no assistant reply.
-            print(f"\n  Request failed: {e}\n")
+            print(f"\n  {RED}Request failed:{RESET} {e}\n")
             messages.pop()
             continue
-        print("\n")
+        elapsed = time.monotonic() - start_t
+        # Speed line: prefer server-reported usage, fall back to a rough
+        # 4-chars-per-token estimate when the server doesn't ship usage
+        # in the stream.
+        tokens = metrics.get("completion_tokens")
+        if not tokens:
+            tokens = max(1, len(assistant) // 4)
+            tokens_label = f"~{tokens}"
+        else:
+            tokens_label = str(tokens)
+        if assistant and elapsed > 0:
+            tps = tokens / elapsed
+            print(
+                f"\n  {DIM}{tokens_label} tok · {elapsed:.1f}s · "
+                f"{tps:.0f} tok/s{RESET}\n"
+            )
+        else:
+            print()
         if assistant:
             messages.append({"role": "assistant", "content": assistant})
         else:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1298,6 +1298,11 @@ def chat_command(args):
     base_url: str
     proc = None
     log_path: str | None = None
+    # Tracks every spawned server (initial + every /model candidate) so
+    # the SIGTERM/atexit cleanup tears down in-flight candidates too —
+    # not just the bound ``proc``. A SIGTERM landing while a /model
+    # swap is mid-spawn would otherwise orphan the candidate server.
+    _active_procs: list[subprocess.Popen] = []
 
     # TTY-gated ANSI palette for the chat UI. NO_COLOR is honoured.
     _is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
@@ -1308,6 +1313,80 @@ def chat_command(args):
     YELLOW = "\x1b[33m" if _is_tty else ""
     RED = "\x1b[31m" if _is_tty else ""
     RESET = "\x1b[0m" if _is_tty else ""
+
+    def _teardown_proc(p) -> None:
+        """Terminate a spawned chat server and free its log file.
+
+        Used by `_cleanup` (process exit) and `_switch_model` (mid-
+        session swap). Idempotent — safe to call when the proc has
+        already exited or never existed. Also reaps the killed child
+        with wait(timeout=1) so repeated /model swaps don't leave
+        zombies until the parent exits.
+        """
+        if p is None:
+            return
+        try:
+            if p.poll() is None:
+                try:
+                    p.terminate()
+                    p.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    try:
+                        p.kill()
+                        # Reap the SIGKILL'd child — without this,
+                        # repeated /model swaps stack zombie entries.
+                        try:
+                            p.wait(timeout=1)
+                        except subprocess.TimeoutExpired:
+                            pass
+                    except (ProcessLookupError, OSError):
+                        pass
+                except (ProcessLookupError, OSError):
+                    pass
+        finally:
+            # Drop from the tracked set so a subsequent _cleanup walk
+            # doesn't double-tear it down.
+            try:
+                _active_procs.remove(p)
+            except ValueError:
+                pass
+            # Close the log handle and unlink the tempfile so /model
+            # swaps don't leak FDs and tempfiles. Both attributes set
+            # by _spawn_chat_server.
+            fh = getattr(p, "_rapid_mlx_log", None)
+            if fh is not None:
+                try:
+                    fh.close()
+                except OSError:
+                    pass
+            lp = getattr(p, "_rapid_mlx_log_path", None)
+            if lp:
+                try:
+                    os.unlink(lp)
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    pass
+
+    def _cleanup():
+        # Walk every tracked proc — covers the active server and any
+        # in-flight /model candidate. Iterate over a snapshot since
+        # _teardown_proc mutates _active_procs.
+        for p in list(_active_procs):
+            _teardown_proc(p)
+
+    # Install SIGTERM handler + atexit BEFORE any spawn. Otherwise a
+    # SIGTERM landing in the window between `Popen()` and `signal.signal`
+    # uses Python's default handler (calls `_exit`, skips atexit) and
+    # orphans the spawned server. SIGINT is *deliberately* left on the
+    # default handler so Ctrl-C unblocks ``input()`` via the natural
+    # KeyboardInterrupt path, the REPL loop's ``except
+    # KeyboardInterrupt: break`` fires, and atexit runs ``_cleanup``.
+    try:
+        signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
+    except (ValueError, OSError):
+        pass
+    atexit.register(_cleanup)
 
     if args.base_url:
         base_url = args.base_url.rstrip("/")
@@ -1330,69 +1409,7 @@ def chat_command(args):
         # so the chat request body matches what the user typed.
         original = getattr(args, "_original_alias", None)
         proc, base_url = _spawn_chat_server(args.model, log_path, served_name=original)
-
-        def _teardown_proc(p) -> None:
-            """Terminate a spawned chat server and free its log file.
-
-            Used by `_cleanup` (process exit) and `_switch_model` (mid-
-            session swap). Idempotent — safe to call when the proc has
-            already exited or never existed.
-            """
-            if p is None:
-                return
-            try:
-                if p.poll() is None:
-                    try:
-                        p.terminate()
-                        p.wait(timeout=1)
-                    except subprocess.TimeoutExpired:
-                        try:
-                            p.kill()
-                        except (ProcessLookupError, OSError):
-                            pass
-                    except (ProcessLookupError, OSError):
-                        pass
-            finally:
-                # Close the log handle and unlink the tempfile so /model
-                # swaps don't leak FDs and tempfiles. Both attributes set
-                # by _spawn_chat_server.
-                fh = getattr(p, "_rapid_mlx_log", None)
-                if fh is not None:
-                    try:
-                        fh.close()
-                    except OSError:
-                        pass
-                lp = getattr(p, "_rapid_mlx_log_path", None)
-                if lp:
-                    try:
-                        os.unlink(lp)
-                    except FileNotFoundError:
-                        pass
-                    except OSError:
-                        pass
-
-        def _cleanup():
-            # Exit fast on REPL teardown — drives _teardown_proc on the
-            # current ``proc``. SIGTERM gives uvicorn 1 s to flush its
-            # lifespan; then SIGKILL.
-            _teardown_proc(proc)
-
-        # Install the SIGTERM handler BEFORE atexit registration. A
-        # SIGTERM in the microsecond window between `atexit.register` and
-        # `signal.signal` would otherwise hit Python's default handler
-        # (calls `_exit`, skips atexit) and orphan the spawned server.
-        try:
-            signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
-        except (ValueError, OSError):
-            pass
-        atexit.register(_cleanup)
-        # SIGINT is *deliberately* left on the default handler: that way
-        # Ctrl-C unblocks ``input()`` via the natural KeyboardInterrupt
-        # path, the REPL loop's ``except KeyboardInterrupt: break`` fires,
-        # and ``atexit`` runs ``_cleanup``. A custom SIGINT handler that
-        # calls ``proc.terminate(); proc.wait(timeout=10)`` makes the
-        # whole REPL feel frozen for up to 10 s after Ctrl-C and also
-        # suppresses the KeyboardInterrupt that ``input()`` relies on.
+        _active_procs.append(proc)
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
@@ -1484,14 +1501,6 @@ def chat_command(args):
 
     def _save_conversation(path_arg: str):
         path = os.path.expanduser(path_arg)
-        # Refuse silently overwriting an existing file — destructive and
-        # easily triggered by a stray `/save out.md` over a working file.
-        if os.path.exists(path):
-            print(
-                f"  {YELLOW}{path} already exists.{RESET} "
-                f"{DIM}(/save won't overwrite — pick a different path){RESET}\n"
-            )
-            return
         # Auto-create parent directories; otherwise users see a confusing
         # "No such file or directory" for /save logs/2026-05/convo.md.
         parent = os.path.dirname(os.path.abspath(path))
@@ -1502,13 +1511,27 @@ def chat_command(args):
                 print(f"  {RED}Save failed:{RESET} cannot create {parent}: {exc}\n")
                 return
         try:
-            with open(path, "w", encoding="utf-8") as f:
+            # Mode "x" (O_CREAT | O_EXCL) is atomic — refuses if the path
+            # already exists, with no TOCTOU window between exists() and
+            # open() that an exists()-then-open("w") check has. Also
+            # naturally rejects existing symlinks pointing elsewhere.
+            with open(path, "x", encoding="utf-8") as f:
                 f.write(f"# rapid-mlx chat — {served_name}\n\n")
                 for m in messages:
                     if m["role"] == "system":
                         continue
                     f.write(f"## {m['role'].capitalize()}\n\n{m['content']}\n\n")
             print(f"  {GREEN}✓{RESET} Saved {len(messages)} messages to {path}\n")
+        except FileExistsError:
+            print(
+                f"  {YELLOW}{path} already exists.{RESET} "
+                f"{DIM}(/save won't overwrite — pick a different path){RESET}\n"
+            )
+        except IsADirectoryError:
+            print(
+                f"  {RED}Save failed:{RESET} {path} is a directory — "
+                f"{DIM}give a file path, not a directory{RESET}\n"
+            )
         except OSError as exc:
             print(f"  {RED}Save failed:{RESET} {exc}\n")
 
@@ -1518,10 +1541,22 @@ def chat_command(args):
             try:
                 more = input(cont_prompt)
             except (EOFError, KeyboardInterrupt):
-                print(f"\n  {YELLOW}(multi-line cancelled){RESET}\n")
+                # Tell the user how many lines they're losing — silent
+                # discard on Ctrl-C/Ctrl-D mid-paste is hostile.
+                if lines:
+                    print(
+                        f"\n  {YELLOW}(multi-line cancelled — "
+                        f"{len(lines)} line{'' if len(lines) == 1 else 's'} "
+                        f"discarded){RESET}\n"
+                    )
+                else:
+                    print(f"\n  {YELLOW}(multi-line cancelled){RESET}\n")
                 return ""
             if more.rstrip() == '"""':
-                return "\n".join(lines).strip()
+                # Preserve leading/trailing whitespace verbatim — the
+                # heredoc is meant for code paste, where stripping
+                # indentation actively corrupts the input.
+                return "\n".join(lines)
             lines.append(more)
 
     def _switch_model(new_alias: str) -> None:
@@ -1575,6 +1610,12 @@ def chat_command(args):
         new_proc, new_base_url = _spawn_chat_server(
             resolved, new_log_path, served_name=new_alias
         )
+        # Register the candidate in the cleanup set IMMEDIATELY — before
+        # the readiness wait. A SIGTERM/Ctrl-C during the (possibly
+        # multi-second) load otherwise orphans this process: it isn't
+        # bound to the outer ``proc`` yet and was previously invisible
+        # to ``_cleanup``.
+        _active_procs.append(new_proc)
         try:
             _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as exc:
@@ -1587,13 +1628,17 @@ def chat_command(args):
             _teardown_proc(new_proc)
             return
 
-        # 3. New server is healthy — commit by tearing down the old one.
-        _teardown_proc(proc)
+        # 3. New server is healthy — commit. Rebind ``proc`` BEFORE
+        #    tearing down the old one so a SIGTERM during teardown
+        #    walks the new (still-running) proc, not just a freshly
+        #    killed corpse.
+        old_proc = proc
         proc = new_proc
         base_url = new_base_url
         log_path = new_log_path
         served_name = new_alias
         messages = [{"role": "system", "content": args.system}] if args.system else []
+        _teardown_proc(old_proc)
         print(
             f"  {GREEN}✓ Switched to {new_alias}.{RESET} "
             f"{DIM}(history cleared){RESET}\n"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -944,12 +944,18 @@ def _spawn_chat_server(
     if served_name and served_name != model:
         cmd.extend(["--served-model-name", served_name])
     log = open(log_path, "w")  # noqa: SIM115 — kept open for proc lifetime
-    proc = subprocess.Popen(  # noqa: S603
-        cmd,
-        stdout=log,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(  # noqa: S603
+            cmd,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    except (OSError, ValueError):
+        # Popen raised before constructing the child — the log handle
+        # would otherwise leak. Re-raise after closing.
+        log.close()
+        raise
     # Register first so a SIGTERM landing between here and the caller's
     # next statement still tears the child down.
     if register_in is not None:
@@ -1719,8 +1725,12 @@ def chat_command(args):
             # *exact* match. ``startswith("/save")`` would otherwise treat
             # ``/savefoo`` as ``/save`` (with arg ``foo``), silently
             # writing a file from a typo. Same for ``/modelfoo``.
-            cmd, _, rest = line.partition(" ")
-            rest = rest.strip()
+            # ``str.split(maxsplit=1)`` (no separator arg) splits on any
+            # whitespace, so ``/save\tpath.md`` works the same as
+            # ``/save path.md``.
+            parts = line.split(maxsplit=1)
+            cmd = parts[0] if parts else ""
+            rest = parts[1].strip() if len(parts) > 1 else ""
             if cmd in ("exit", "quit", "/exit", "/quit"):
                 break
             if cmd in ("/help", "/?"):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -182,10 +182,19 @@ def _ensure_model_downloaded(model_name: str) -> None:
 
         snapshot_download(model_name)
         print()
+    except SystemExit:
+        # _check_disk_space aborts via sys.exit(1) — let it through.
+        raise
     except Exception as e:
-        # Don't block startup on flaky pre-fetch — the spawned serve
-        # will retry the download (just without a foreground progress
-        # bar) and surface the real error.
+        # Definitive 404s are surfaced so callers (e.g. ``/model bogus``)
+        # can refuse fast instead of spawning a doomed serve subprocess
+        # that fails after ``--ready-timeout``. Other transient errors
+        # (network, auth) fall through silently — the spawned server's
+        # own loader will retry and surface a real error if needed.
+        from huggingface_hub.utils import RepositoryNotFoundError
+
+        if isinstance(e, RepositoryNotFoundError) or "404" in str(e):
+            raise RuntimeError(f"Model {model_name!r} not found on HuggingFace") from e
         print(f"\n  Pre-download skipped ({type(e).__name__}); server will retry.")
 
 
@@ -930,6 +939,11 @@ def _spawn_chat_server(
         stderr=subprocess.STDOUT,
         start_new_session=True,
     )
+    # Stash the log handle and path on the proc object so the chat REPL
+    # can close+unlink them when the proc is torn down (fixes the file
+    # descriptor + tempfile leak across `/model` swaps).
+    proc._rapid_mlx_log = log
+    proc._rapid_mlx_log_path = log_path
     return proc, base_url
 
 
@@ -1168,10 +1182,18 @@ def _stream_chat_response(
             _state["pending"] = ""
 
     # ----- Repetition guard ----------------------------------------------
-    # Smaller models (qwen3.5-4b on multi-turn, etc.) sometimes degenerate
-    # into the same token repeated until max_tokens — filling the screen
-    # with a wall of "Barley Barley Barley...". We can't fix the model,
-    # but we can stop the stream so the REPL stays usable.
+    # Models occasionally degenerate into the same token repeated until
+    # max_tokens — filling the screen with "Barley Barley Barley...".
+    # The earlier guard ("≤2 unique tokens in the last 30") fired on
+    # legitimate content like ``[0, 0, 0, 0, 0]``, markdown table
+    # separators ``| --- | --- |``, and any list of identical short
+    # numbers. The current criterion is stricter: the SAME token must
+    # repeat ≥``REPEAT_LIMIT`` times *consecutively*. Tracked in a
+    # rolling counter so cost is O(1) per chunk regardless of response
+    # length (the previous ``full.split()`` was O(n²)).
+    REPEAT_LIMIT = 25
+    repeat_last: str | None = None
+    repeat_run = 0
     repetition_aborted = False
 
     with requests.post(
@@ -1227,12 +1249,22 @@ def _stream_chat_response(
                     in_reasoning = False
                 _emit_with_inline_md(piece)
                 full += piece
-                # Repetition guard: if the last 30 whitespace-separated
-                # tokens collapse to ≤2 unique values, the model has
-                # almost certainly degenerated — abort the stream.
-                words = full.split()
-                if len(words) >= 30 and len(set(words[-30:])) <= 2:
-                    repetition_aborted = True
+                # Rolling counter: each new whitespace-separated token in
+                # this delta either extends the current consecutive run
+                # or resets it. Aborts only on a single token repeated
+                # ``REPEAT_LIMIT`` times in a row, not on diverse-but-
+                # repetitive content like ``[0, 0, 0, ...]`` or markdown
+                # tables.
+                for tok in piece.split():
+                    if tok == repeat_last:
+                        repeat_run += 1
+                    else:
+                        repeat_last = tok
+                        repeat_run = 1
+                    if repeat_run >= REPEAT_LIMIT:
+                        repetition_aborted = True
+                        break
+                if repetition_aborted:
                     break
     _close_open_md_spans()
     if in_reasoning and is_tty:
@@ -1299,26 +1331,61 @@ def chat_command(args):
         original = getattr(args, "_original_alias", None)
         proc, base_url = _spawn_chat_server(args.model, log_path, served_name=original)
 
-        def _cleanup():
-            # Exit fast on REPL teardown. Give SIGTERM 1 s to flush
-            # uvicorn's lifespan, then SIGKILL — there's nothing critical
-            # to write back, the model is in-memory only, and a 10 s
-            # graceful shutdown made `exit` feel like 5 s of frozen
-            # terminal.
-            if proc and proc.poll() is None:
-                try:
-                    proc.terminate()
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
+        def _teardown_proc(p) -> None:
+            """Terminate a spawned chat server and free its log file.
+
+            Used by `_cleanup` (process exit) and `_switch_model` (mid-
+            session swap). Idempotent — safe to call when the proc has
+            already exited or never existed.
+            """
+            if p is None:
+                return
+            try:
+                if p.poll() is None:
                     try:
-                        proc.kill()
+                        p.terminate()
+                        p.wait(timeout=1)
+                    except subprocess.TimeoutExpired:
+                        try:
+                            p.kill()
+                        except (ProcessLookupError, OSError):
+                            pass
                     except (ProcessLookupError, OSError):
                         pass
-                except (ProcessLookupError, OSError):
-                    pass
+            finally:
+                # Close the log handle and unlink the tempfile so /model
+                # swaps don't leak FDs and tempfiles. Both attributes set
+                # by _spawn_chat_server.
+                fh = getattr(p, "_rapid_mlx_log", None)
+                if fh is not None:
+                    try:
+                        fh.close()
+                    except OSError:
+                        pass
+                lp = getattr(p, "_rapid_mlx_log_path", None)
+                if lp:
+                    try:
+                        os.unlink(lp)
+                    except FileNotFoundError:
+                        pass
+                    except OSError:
+                        pass
 
+        def _cleanup():
+            # Exit fast on REPL teardown — drives _teardown_proc on the
+            # current ``proc``. SIGTERM gives uvicorn 1 s to flush its
+            # lifespan; then SIGKILL.
+            _teardown_proc(proc)
+
+        # Install the SIGTERM handler BEFORE atexit registration. A
+        # SIGTERM in the microsecond window between `atexit.register` and
+        # `signal.signal` would otherwise hit Python's default handler
+        # (calls `_exit`, skips atexit) and orphan the spawned server.
+        try:
+            signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
+        except (ValueError, OSError):
+            pass
         atexit.register(_cleanup)
-        # SIGTERM gets a custom handler that runs cleanup before exiting.
         # SIGINT is *deliberately* left on the default handler: that way
         # Ctrl-C unblocks ``input()`` via the natural KeyboardInterrupt
         # path, the REPL loop's ``except KeyboardInterrupt: break`` fires,
@@ -1326,10 +1393,6 @@ def chat_command(args):
         # calls ``proc.terminate(); proc.wait(timeout=10)`` makes the
         # whole REPL feel frozen for up to 10 s after Ctrl-C and also
         # suppresses the KeyboardInterrupt that ``input()`` relies on.
-        try:
-            signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
-        except (ValueError, OSError):
-            pass
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
@@ -1371,17 +1434,35 @@ def chat_command(args):
 
     import requests
 
-    # Importing ``readline`` upgrades the built-in ``input()`` so that the
-    # arrow keys recall earlier prompts (and Ctrl-A/E/U work). The module
-    # is stdlib on macOS/Linux; on Windows it doesn't exist and we just
-    # fall back to plain input().
+    # Importing ``readline`` upgrades the built-in ``input()`` so that
+    # the arrow keys recall earlier prompts (and Ctrl-A/E/U/R work).
+    # The module is stdlib on macOS/Linux; on Windows it doesn't exist
+    # and we fall back to plain input(). When readline IS available we
+    # need to wrap the colored prompt's ANSI escapes in \001/\002 so
+    # readline's column counter doesn't include the invisible bytes —
+    # otherwise long history entries wrap incorrectly and Ctrl-A jumps
+    # to the wrong column (especially on libedit-backed Apple system
+    # python). The wrappers are no-op on a terminal, so it's safe to
+    # always emit them when readline is loaded.
+    have_readline = False
     try:
         import readline  # noqa: F401 — side-effect import
+
+        have_readline = True
     except ImportError:
         pass
 
-    prompt = f"{BOLD}{CYAN}>{RESET} " if _is_tty else "> "
-    cont_prompt = f"{DIM}…{RESET} " if _is_tty else "… "
+    def _wrap_invisible(esc: str) -> str:
+        if have_readline and esc:
+            return "\001" + esc + "\002"
+        return esc
+
+    if _is_tty:
+        prompt = _wrap_invisible(BOLD + CYAN) + ">" + _wrap_invisible(RESET) + " "
+        cont_prompt = _wrap_invisible(DIM) + "…" + _wrap_invisible(RESET) + " "
+    else:
+        prompt = "> "
+        cont_prompt = "… "
 
     def _print_help():
         print(
@@ -1403,6 +1484,23 @@ def chat_command(args):
 
     def _save_conversation(path_arg: str):
         path = os.path.expanduser(path_arg)
+        # Refuse silently overwriting an existing file — destructive and
+        # easily triggered by a stray `/save out.md` over a working file.
+        if os.path.exists(path):
+            print(
+                f"  {YELLOW}{path} already exists.{RESET} "
+                f"{DIM}(/save won't overwrite — pick a different path){RESET}\n"
+            )
+            return
+        # Auto-create parent directories; otherwise users see a confusing
+        # "No such file or directory" for /save logs/2026-05/convo.md.
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            try:
+                os.makedirs(parent, exist_ok=True)
+            except OSError as exc:
+                print(f"  {RED}Save failed:{RESET} cannot create {parent}: {exc}\n")
+                return
         try:
             with open(path, "w", encoding="utf-8") as f:
                 f.write(f"# rapid-mlx chat — {served_name}\n\n")
@@ -1427,6 +1525,14 @@ def chat_command(args):
             lines.append(more)
 
     def _switch_model(new_alias: str) -> None:
+        """Hot-swap the spawned chat server to a new model alias.
+
+        Order matters: validate + pre-download the new model BEFORE
+        terminating the old one. If anything fails (bogus alias, disk
+        gate, network), the old server stays running and the REPL is
+        usable. Only when the new model is on-disk and the new server is
+        spawn-ready do we tear down the old proc and rebind.
+        """
         nonlocal proc, base_url, log_path, served_name, messages
         if proc is None:
             print(
@@ -1437,33 +1543,55 @@ def chat_command(args):
         from vllm_mlx.model_aliases import resolve_model
 
         resolved = resolve_model(new_alias) or new_alias
-        print(f"  {DIM}Switching to {new_alias} → {resolved} ...{RESET}")
-        # Tear down the current server.
-        try:
-            proc.terminate()
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            try:
-                proc.kill()
-            except (ProcessLookupError, OSError):
-                pass
-        except (ProcessLookupError, OSError):
-            pass
+        print(f"  {DIM}Preparing {new_alias} → {resolved} ...{RESET}")
+
+        # 1. Pre-download the new model (this also runs the disk-space
+        #    gate). The current server keeps running while we do this so
+        #    a download failure leaves the user where they were.
         try:
             _ensure_model_downloaded(resolved)
         except SystemExit:
-            print(f"  {RED}Model switch aborted.{RESET}\n")
+            # Disk gate aborted via sys.exit(1); old server is untouched.
+            print(
+                f"  {RED}Model switch aborted{RESET} "
+                f"{DIM}(disk gate); previous server still running.{RESET}\n"
+            )
             return
-        log_path = tempfile.NamedTemporaryFile(
+        except RuntimeError as exc:
+            # Definitive 404 from HF; old server stays.
+            print(
+                f"  {RED}Model switch aborted:{RESET} {exc}  "
+                f"{DIM}(previous server still running){RESET}\n"
+            )
+            return
+
+        # 2. Allocate a new log file and spawn the new server. We don't
+        #    tear down the old one yet; we want a working candidate
+        #    before we commit.
+        new_log_path = tempfile.NamedTemporaryFile(
             prefix="rapid-mlx-chat-", suffix=".log", delete=False
         ).name
-        print(f"  Starting server {DIM}(log: {log_path}){RESET} ...")
-        proc, base_url = _spawn_chat_server(resolved, log_path, served_name=new_alias)
+        print(f"  Starting server {DIM}(log: {new_log_path}){RESET} ...")
+        new_proc, new_base_url = _spawn_chat_server(
+            resolved, new_log_path, served_name=new_alias
+        )
         try:
-            _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
+            _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as exc:
-            print(f"  {RED}Failed to start new server:{RESET} {exc}\n")
+            print(
+                f"  {RED}Failed to start new server:{RESET} {exc}  "
+                f"{DIM}(previous server still running){RESET}\n"
+            )
+            # Roll back: tear down the half-spawned new proc + free its
+            # log file. The old proc/base_url/log_path stay bound.
+            _teardown_proc(new_proc)
             return
+
+        # 3. New server is healthy — commit by tearing down the old one.
+        _teardown_proc(proc)
+        proc = new_proc
+        base_url = new_base_url
+        log_path = new_log_path
         served_name = new_alias
         messages = [{"role": "system", "content": args.system}] if args.system else []
         print(
@@ -1479,44 +1607,51 @@ def chat_command(args):
             break
         if not line:
             continue
+        # Heredoc-pasted content must NEVER be dispatched as a slash
+        # command — a markdown doc whose first line starts with `/path`
+        # or whose content includes `/save` would otherwise be silently
+        # eaten by the slash dispatcher. Track the source so we know.
+        is_heredoc = False
         if line == '"""':
             line = _read_multiline()
             if not line:
                 continue
-        if line in ("exit", "quit", "/exit", "/quit"):
-            break
-        if line in ("/help", "/?"):
-            _print_help()
-            continue
-        if line in ("/reset", "/clear"):
-            messages = (
-                [{"role": "system", "content": args.system}] if args.system else []
-            )
-            print(f"  {DIM}(history cleared){RESET}\n")
-            continue
-        if line.startswith("/save"):
-            parts = line.split(maxsplit=1)
-            if len(parts) < 2:
-                print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
-            else:
-                _save_conversation(parts[1])
-            continue
-        if line.startswith("/model"):
-            parts = line.split(maxsplit=1)
-            if len(parts) < 2:
-                print(
-                    f"  {YELLOW}Usage: /model <alias>{RESET}  "
-                    f"{DIM}(see `rapid-mlx models`){RESET}\n"
+            is_heredoc = True
+        if not is_heredoc:
+            if line in ("exit", "quit", "/exit", "/quit"):
+                break
+            if line in ("/help", "/?"):
+                _print_help()
+                continue
+            if line in ("/reset", "/clear"):
+                messages = (
+                    [{"role": "system", "content": args.system}] if args.system else []
                 )
-            else:
-                _switch_model(parts[1].strip())
-            continue
-        if line.startswith("/"):
-            print(
-                f"  {YELLOW}Unknown command: {line.split()[0]}{RESET}  "
-                f"{DIM}(type /help){RESET}\n"
-            )
-            continue
+                print(f"  {DIM}(history cleared){RESET}\n")
+                continue
+            if line.startswith("/save"):
+                parts = line.split(maxsplit=1)
+                if len(parts) < 2:
+                    print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
+                else:
+                    _save_conversation(parts[1])
+                continue
+            if line.startswith("/model"):
+                parts = line.split(maxsplit=1)
+                if len(parts) < 2:
+                    print(
+                        f"  {YELLOW}Usage: /model <alias>{RESET}  "
+                        f"{DIM}(see `rapid-mlx models`){RESET}\n"
+                    )
+                else:
+                    _switch_model(parts[1].strip())
+                continue
+            if line.startswith("/"):
+                print(
+                    f"  {YELLOW}Unknown command: {line.split()[0]}{RESET}  "
+                    f"{DIM}(type /help){RESET}\n"
+                )
+                continue
 
         messages.append({"role": "user", "content": line})
         payload = {


### PR DESCRIPTION
## Summary

Polish `rapid-mlx chat` (interactive REPL) so it feels like a real TUI, and add an OpenCode agent profile so users who want a full Claude-Code-like agent experience can `rapid-mlx agents opencode --setup` against rapid-mlx as the OpenAI-compat backend.

**What changed in the chat REPL** (`vllm_mlx/cli.py`):
- Slash commands: `/help`, `/reset` (`/clear`), `/save <path>`, `/model <alias>`, `/exit`
- Multi-line heredoc input via `"""` open/close (paste code blocks without newline-on-Enter quirks)
- Token/speed counter at end of each turn (server `usage` chunk preferred, char-fallback prefixed with `~`)
- Streaming inline markdown rendering: ATX headings (`#`–`######`), `**bold**`, ` `inline code` `, ` ```fence``` `
- ANSI color palette gated on TTY + `NO_COLOR`
- Repetition guard: cuts the stream when a single token repeats ≥25 consecutively (rolling counter, O(1)/chunk)
- Disk-space pre-flight before HF download; `_ensure_model_downloaded` shows the tqdm bar in the user's terminal
- Hot model swap via `/model <alias>` — validates + downloads new model BEFORE killing the old one; rolls back on any failure

**OpenCode agent profile** (`vllm_mlx/agents/profiles/opencode.yaml`): writes `~/.config/opencode/opencode.json` pointing at rapid-mlx via `@ai-sdk/openai-compatible`.

## Multi-round codex review (gold-standard convergence)

Per the PR Merge SOP, this branch went through 4 adversarial review rounds:

| Round | Commit | Verdict |
|---|---|---|
| Initial | 9cfdb9c | feature land |
| Round 1 | 357c620 | P0/P1 fixes — file-descriptor + tempfile leak, /model rollback semantics, repetition false-positives + O(n²) cost, heredoc slash-injection, /save overwrite + mkdir, libedit prompt corruption, SIGTERM/atexit ordering |
| Round 2 | 8b735f2 | P0 fixes — `_active_procs` tracks every spawned proc; SIGTERM handler installed BEFORE any spawn; /switch_model rebinds proc before tearing down old; reap SIGKILL'd children; /save uses `open(path, \"x\")` (atomic O_CREAT\\|O_EXCL); heredoc preserves whitespace |
| Round 3 | 127377b | codex **CONVERGED on P0** (zero new findings); landed P1s — slash exact-match (`/savefoo` no longer triggers `/save`), repetition prefix-emit, spawn race closed by passing `register_in=` into `_spawn_chat_server` |
| Round 4 | 2520671 | codex **CONVERGED on P0 AND P1** (zero new findings); landed 2 P2 nits — tab-separator slash parsing, log handle leak on Popen failure |

Two consecutive zero-P0 rounds = gold standard per SOP.

## Test plan

- [x] `ruff check && ruff format --check` clean on `vllm_mlx/cli.py` + `tests/test_cli_chat.py`
- [x] `python3.12 -m pytest tests/test_cli_chat.py -q` — **35 chat tests pass** (28 existing + 7 new contract tests)
- [x] Broader unit suite — **2356 pass, 17 skip, 1 xfailed** (matches baseline)
- [x] Preview wheel built + reinstalled at `/tmp/rapid-mlx-preview/bin/rapid-mlx` and end-to-end exercised against qwen3.5-4b and qwen3.6-35b
- [x] `make check` skipped — **no inference-path changes** (REPL only invokes `/v1/chat/completions` over HTTP; doesn't touch model loading, KV cache, schedulers, parsers, or BatchedEngine)
- [ ] CI matrix (lint, type-check, version-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests) — pending on this PR

## New tests

- `_stream_chat_response` — usage capture, ATX headings, repetition false-positives on legit lists, repetition prefix-emit on coalesced chunks
- `chat_command` — /help, unknown slash, /save (write, no-overwrite, parent-dir creation, exclusive-mode TOCTOU, tab separator), heredoc (multi-line, slash bypass, whitespace preservation), /model (rollback on candidate-load failure)
- `_ensure_model_downloaded` — disk-space gate
- SIGTERM handler installed before first spawn (orphan-window regression test)
- `/savefoo`/`/modelfoo` typos rejected as unknown commands

## Out of scope (intentional)

- True async-safe SIGTERM handler — current `_active_procs` set + register-before-Popen-returns design narrows the orphan window to a 1-2 statement gap inside `_spawn_chat_server`, which is acceptable for an interactive REPL. A `pthread_sigmask` block is overkill here.
- Markdown nested-style restoration after closing inline spans — `**outer \`inner\` outer**` resets to plain after the inner closes. Cosmetic; flagged as round-3 P2 codex nit.
- `/save` escaping of assistant content containing `## ` or fences — fuses into saved markdown structure. Flagged as round-3 P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)