### PR TITLE
test(reasoning): cover flip_pos branch for <|channel>final marker (follow-up to #307)

### DIFF
--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -1063,6 +1063,48 @@ class TestGemma4Streaming:
         assert self.parser._in_content is True
         assert self.parser._in_thought is False
 
+    @pytest.mark.parametrize(
+        "content_marker",
+        ["<|channel>content", "<|channel>final"],
+        ids=["content", "final"],
+    )
+    def test_delta_flip_pos_lands_on_content_marker_when_no_channel_close(
+        self, content_marker
+    ):
+        """Coverage follow-up to PR #307.
+
+        #307's parametrize covers the case where the delta also contains
+        ``<channel|>``, which always wins flip_pos as the earliest marker.
+        That meant flip_pos's ``<|channel>content`` and ``<|channel>final``
+        entries (gemma4_parser.py L115) had no test that picked them as the
+        winning marker. This test forces flip_pos to land on the content
+        marker by omitting ``<channel|>`` from the delta.
+
+        Mutation guard: removing either entry from the flip_pos tuple makes
+        the corresponding parametrize case fail because the post-marker bytes
+        leak into the same DeltaMessage as the pre-marker bytes via the
+        fallback whole-delta cleanup at the bottom of
+        ``extract_reasoning_streaming``.
+        """
+        prev = "<|channel>thought\nworking through it"
+        self.parser.extract_reasoning_streaming("", prev, prev)
+        assert self.parser._in_thought is True
+
+        delta = f" final guess{content_marker}\nThe answer is 42."
+        curr = prev + delta
+        result = self.parser.extract_reasoning_streaming(prev, curr, delta)
+        assert result.reasoning == " final guess", (
+            f"with no <channel|> in delta, flip_pos must land on "
+            f"{content_marker} and route pre-marker bytes to reasoning, got "
+            f"reasoning={result.reasoning!r}"
+        )
+        assert result.content == "The answer is 42.", (
+            f"post-{content_marker} bytes must land in content, got "
+            f"content={result.content!r}"
+        )
+        assert self.parser._in_content is True
+        assert self.parser._in_thought is False
+
     def test_delta_straddles_implicit_close_only(self):
         """Thought-close with no explicit content marker must still split,
         with the post-close bytes going to content (matches the original


### PR DESCRIPTION
## Why

Follow-up to #307 (just merged). #307 parametrized `test_delta_straddles_thought_close_then_content_open` over `<|channel>content` and `<|channel>final`, closing the gap noted in #221's review where the L89 OR branch (`if "<|channel>content" in current_text or "<|channel>final" in current_text`) had no `<|channel>final` guard.

But the test input was `" final guess<channel|>{marker}\nThe answer is 42."` — `<channel|>` (thought-close) always appears at the earliest position, so `flip_pos` resolves to it for **both** parametrize variants. That means the **`flip_pos` loop's `<|channel>content` and `<|channel>final` entries** at `gemma4_parser.py:115` still had no test that picked either as the winning marker.

Pre-existing review note from #307 (codex round 1, P2):
> The new `[final]` case is useful, but only for part of the branch surface. Because the delta is `...<channel|><|channel>final\n...`, `flip_pos` is found at the earlier `<channel|>` marker for both params. So the param does **not** exercise the `<|channel>final` entry in the `flip_pos` marker loop differently from `<|channel>content`.

## What this changes

Adds a sibling parametrized test `test_delta_flip_pos_lands_on_content_marker_when_no_channel_close[content|final]` that omits `<channel|>` from the delta. The state still flips out of thought (because `<|channel>{content,final}` in `current_text` triggers L89 OR), so the `flip_pos` loop runs — and now lands on the content marker itself.

```python
delta = f" final guess{content_marker}\nThe answer is 42."
# flip_pos loop:
#   <channel|>            → idx=-1
#   <|channel>content/final → idx=12  ← winner
```

After the change, `TestGemma4Streaming` reports 11 cases (was 9 after #307):

```
test_delta_straddles_thought_close_then_content_open[content]                    PASSED
test_delta_straddles_thought_close_then_content_open[final]                      PASSED
test_delta_flip_pos_lands_on_content_marker_when_no_channel_close[content]       PASSED
test_delta_flip_pos_lands_on_content_marker_when_no_channel_close[final]         PASSED
```

## Mutation guard verified

Removing `"<|channel>final"` from the `flip_pos` tuple at `gemma4_parser.py:115`:

| Test                                                       | Before mutation | After mutation |
|------------------------------------------------------------|-----------------|----------------|
| `..._straddles_thought_close_then_content_open[final]`    | PASS            | PASS (covered by `<channel|>` winning anyway) |
| `..._flip_pos_lands_on_content_marker..._[final]`         | PASS            | **FAIL** — `reasoning=None`, bytes leak: `content=' final guessThe answer is 42.'` |
| `..._flip_pos_lands_on_content_marker..._[content]`       | PASS            | PASS (only `<|channel>final` was removed) |

Symmetric guard exists for `<|channel>content` via the `[content]` case (verified by removing `"<|channel>content"` instead).

## Diff size

`tests/test_reasoning_parsers.py`: +42 / -0. No production code change. Parser logic untouched.

## Test plan

- [x] `python3.12 -m pytest tests/test_reasoning_parsers.py::TestGemma4Streaming -v` — 11/11 pass
- [x] Full reasoning-parser suites (`tests/test_reasoning_parsers.py` + `tests/test_reasoning_parser.py`): 207 passing (was 205 after #307)
- [x] `ruff check && ruff format --check` clean on the changed file
- [x] Mutation: removing `"<|channel>final"` from flip_pos tuple → `[final]` case fails, `[content]` case passes (mutation precise)
- [x] Mutation: removing `"<|channel>content"` from flip_pos tuple → `[content]` case fails, `[final]` case passes (symmetric guard verified)

## Out of scope

- The L89 OR branch coverage for `<|channel>final` is what #307 already shipped — not duplicated here.
- The flip_pos's `<channel|>` entry has its own dedicated coverage via `test_delta_straddles_implicit_close_only` (delta with only `<channel|>`, no content marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)