### PR TITLE
fix(security): re-cherry-pick upstream MCP/MLLM fixes from #338

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -699,38 +699,74 @@ class TestToolSandboxAuditLogging:
 
 
 class TestToolSandboxHighRiskTools:
-    """Tests for high-risk tool detection."""
+    """Tests for high-risk tool block-by-default + allowlist opt-in."""
 
-    def test_high_risk_tool_warning(self, caplog):
-        """Test that high-risk tools trigger warning."""
-        import logging
-
+    def test_high_risk_execute_blocked_by_default(self):
+        """Tools matching 'execute' are blocked unless allowlisted."""
         sandbox = ToolSandbox()
-
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(MCPSecurityError, match="high-risk pattern 'execute'"):
             sandbox.validate_tool_execution(
                 tool_name="execute_command",
                 server_name="test",
                 arguments={"cmd": "ls"},
             )
 
-        assert "High-risk tool detected" in caplog.text
-        assert "execute" in caplog.text
-
-    def test_high_risk_shell_tool(self, caplog):
-        """Test that shell tools trigger warning."""
-        import logging
-
+    def test_high_risk_shell_blocked_by_default(self):
+        """Tools matching 'shell' are blocked unless allowlisted."""
         sandbox = ToolSandbox()
-
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(MCPSecurityError, match="high-risk pattern 'shell'"):
             sandbox.validate_tool_execution(
                 tool_name="run_shell",
                 server_name="test",
                 arguments={},
             )
 
-        assert "High-risk tool detected" in caplog.text
+    def test_high_risk_eval_blocked_by_default(self):
+        """Tools matching 'eval' are blocked unless allowlisted."""
+        sandbox = ToolSandbox()
+        with pytest.raises(MCPSecurityError, match="high-risk pattern 'eval'"):
+            sandbox.validate_tool_execution(
+                tool_name="eval_python",
+                server_name="test",
+                arguments={},
+            )
+
+    def test_allowlist_bare_name_unblocks(self):
+        """Adding the bare tool name to the allowlist permits execution."""
+        sandbox = ToolSandbox(allowed_high_risk_tools={"execute_command"})
+        sandbox.validate_tool_execution(
+            tool_name="execute_command",
+            server_name="test",
+            arguments={"cmd": "ls"},
+        )
+
+    def test_allowlist_namespaced_name_unblocks(self):
+        """Adding the namespaced tool name (server__tool) permits execution."""
+        sandbox = ToolSandbox(allowed_high_risk_tools={"trusted__execute_command"})
+        sandbox.validate_tool_execution(
+            tool_name="execute_command",
+            server_name="trusted",
+            arguments={"cmd": "ls"},
+        )
+
+    def test_allowlist_other_server_still_blocked(self):
+        """Allowlisting one namespaced name doesn't unblock another server."""
+        sandbox = ToolSandbox(allowed_high_risk_tools={"trusted__execute_command"})
+        with pytest.raises(MCPSecurityError):
+            sandbox.validate_tool_execution(
+                tool_name="execute_command",
+                server_name="untrusted",
+                arguments={"cmd": "ls"},
+            )
+
+    def test_non_high_risk_tool_unaffected(self):
+        """Tools that don't match any high-risk pattern still execute freely."""
+        sandbox = ToolSandbox()
+        sandbox.validate_tool_execution(
+            tool_name="read_file",
+            server_name="test",
+            arguments={"path": "/tmp/x"},
+        )
 
 
 class TestCustomBlockedPatterns:
@@ -760,3 +796,78 @@ class TestCustomBlockedPatterns:
                 server_name="server",
                 arguments={"path": "~/secret"},
             )
+
+
+class TestConfigDiscoveryNoCWD:
+    """Regression: ./mcp.json and ./mcp.yaml must NOT be auto-discovered.
+
+    Plant-in-CWD attack: an attacker who can drop a file in the victim's
+    working directory (shared dirs, /tmp, downloaded archives) could inject
+    arbitrary MCP server commands by relying on auto-discovery. Explicit
+    --mcp-config or VLLM_MLX_MCP_CONFIG env var still work.
+    """
+
+    def test_cwd_mcp_json_not_auto_discovered(self, tmp_path, monkeypatch):
+        from vllm_mlx.mcp.config import CONFIG_SEARCH_PATHS, load_mcp_config
+
+        monkeypatch.chdir(tmp_path)
+        # Plant a malicious-looking config in CWD
+        (tmp_path / "mcp.json").write_text(
+            '{"servers": {"evil": {"transport": "stdio", "command": "rm"}}}'
+        )
+
+        # Discovery should NOT pick it up
+        assert "./mcp.json" not in CONFIG_SEARCH_PATHS
+        assert "./mcp.yaml" not in CONFIG_SEARCH_PATHS
+
+        # And load_mcp_config() with no path returns empty config (file ignored)
+        config = load_mcp_config()
+        assert config.servers == {}
+
+    def test_explicit_path_still_works(self, tmp_path):
+        """Explicit --mcp-config path is the only way to load a CWD-local file."""
+        from vllm_mlx.mcp.config import load_mcp_config
+
+        cfg_file = tmp_path / "mcp.json"
+        cfg_file.write_text(
+            '{"servers": {"x": {"transport": "stdio", "command": "uvx"}}}'
+        )
+
+        config = load_mcp_config(str(cfg_file))
+        assert "x" in config.servers
+
+
+class TestAllowedHighRiskToolsConfig:
+    """Plumbing: allowed_high_risk_tools flows from config into MCPConfig."""
+
+    def test_default_empty(self):
+        from vllm_mlx.mcp.types import MCPConfig
+
+        cfg = MCPConfig()
+        assert cfg.allowed_high_risk_tools == []
+
+    def test_from_dict_reads_allowlist(self):
+        from vllm_mlx.mcp.types import MCPConfig
+
+        cfg = MCPConfig.from_dict(
+            {
+                "servers": {},
+                "allowed_high_risk_tools": ["trusted__execute_command", "run_shell"],
+            }
+        )
+        assert cfg.allowed_high_risk_tools == [
+            "trusted__execute_command",
+            "run_shell",
+        ]
+
+    def test_validate_config_rejects_non_list(self):
+        from vllm_mlx.mcp.config import validate_config
+
+        with pytest.raises(ValueError, match="allowed_high_risk_tools"):
+            validate_config({"servers": {}, "allowed_high_risk_tools": "not_a_list"})
+
+    def test_validate_config_rejects_non_strings(self):
+        from vllm_mlx.mcp.config import validate_config
+
+        with pytest.raises(ValueError, match="allowed_high_risk_tools"):
+            validate_config({"servers": {}, "allowed_high_risk_tools": [1, 2, 3]})

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -829,8 +829,14 @@ class TestConfigDiscoveryNoCWD:
         from vllm_mlx.mcp.config import load_mcp_config
 
         cfg_file = tmp_path / "mcp.json"
+        # skip_security_validation bypasses the PATH check so the test runs
+        # without depending on what's installed on the CI runner — this test
+        # only verifies discovery behavior, not security validation.
         cfg_file.write_text(
-            '{"servers": {"x": {"transport": "stdio", "command": "uvx"}}}'
+            '{"servers": {"x": {'
+            '"transport": "stdio", "command": "uvx", '
+            '"skip_security_validation": true'
+            "}}}"
         )
 
         config = load_mcp_config(str(cfg_file))

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -7,11 +7,15 @@ preserve_native_format parameter in extract_multimodal_content().
 
 import pytest
 
-from vllm_mlx.api.utils import extract_multimodal_content
+from vllm_mlx.api.utils import (
+    decode_inline_tool_call_arguments,
+    extract_multimodal_content,
+)
 from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
     FunctionaryToolParser,
+    Glm47ToolParser,
     GraniteToolParser,
     HarmonyToolParser,
     HermesToolParser,
@@ -39,6 +43,7 @@ class TestNativeToolFormatCapability:
             KimiToolParser,
             HermesToolParser,
             HarmonyToolParser,
+            Glm47ToolParser,
         ]
         for parser_cls in native_parsers:
             assert parser_cls.SUPPORTS_NATIVE_TOOL_FORMAT is True, (
@@ -76,6 +81,8 @@ class TestNativeToolFormatCapability:
             "kimi",
             "hermes",
             "harmony",
+            "glm47",
+            "glm4",
         ]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert parser_cls.supports_native_format() is True, (
@@ -367,3 +374,78 @@ class TestEdgeCases:
         assert len(images) == 1
         assert images[0] == "http://example.com/img.jpg"
         assert processed[1]["role"] == "tool"
+
+
+class TestDecodeInlineToolCallArguments:
+    """Helper called from the MLLM route — chat templates that iterate
+    tool_calls[].function.arguments crash if it's still a JSON string."""
+
+    def test_string_arguments_decoded_to_dict(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris", "unit": "C"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        decode_inline_tool_call_arguments(messages)
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == {
+            "city": "Paris",
+            "unit": "C",
+        }
+
+    def test_dict_arguments_left_alone(self):
+        original = {"city": "Paris"}
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "x", "arguments": original}}],
+            }
+        ]
+        decode_inline_tool_call_arguments(messages)
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] is original
+
+    def test_malformed_json_left_as_string(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "x", "arguments": "not json"}}],
+            }
+        ]
+        decode_inline_tool_call_arguments(messages)
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == "not json"
+
+    def test_messages_without_tool_calls_unchanged(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "tool", "tool_call_id": "x", "content": "result"},
+        ]
+        decode_inline_tool_call_arguments(messages)
+        assert messages == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "tool", "tool_call_id": "x", "content": "result"},
+        ]
+
+    def test_multiple_tool_calls_each_decoded(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "a", "arguments": '{"x": 1}'}},
+                    {"function": {"name": "b", "arguments": '{"y": 2}'}},
+                ],
+            }
+        ]
+        decode_inline_tool_call_arguments(messages)
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"x": 1}
+        assert messages[0]["tool_calls"][1]["function"]["arguments"] == {"y": 2}

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -3,6 +3,7 @@
 Utility functions for text processing and model detection.
 """
 
+import json
 import logging
 import re
 
@@ -596,6 +597,28 @@ def is_mllm_model(model_name: str) -> bool:
 
 # Backwards compatibility alias
 is_vlm_model = is_mllm_model
+
+
+def decode_inline_tool_call_arguments(messages: list[dict]) -> None:
+    """Decode `tool_calls[].function.arguments` from JSON string to dict in-place.
+
+    The OpenAI API serializes tool-call arguments as a JSON-encoded string.
+    Some chat templates (GLM-4.6V, Qwen3 MLLM variants) iterate the arguments
+    dict via `.items()`/`|items` and crash on a string. The non-MLLM path
+    handles this inside `extract_multimodal_content()`; the MLLM branch
+    bypasses that helper, so callers in the MLLM path call this directly.
+
+    Mutates `messages` in-place. Malformed JSON is left untouched.
+    """
+    for msg in messages:
+        for tc in msg.get("tool_calls") or []:
+            func = tc.get("function") or {}
+            args = func.get("arguments")
+            if isinstance(args, str):
+                try:
+                    func["arguments"] = json.loads(args)
+                except (json.JSONDecodeError, ValueError):
+                    pass
 
 
 # =============================================================================

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -13,10 +13,12 @@ from .types import MCPConfig, MCPServerConfig
 
 logger = logging.getLogger(__name__)
 
-# Default config search paths
+# Default config search paths.
+# Intentionally excludes ./mcp.json and ./mcp.yaml: an attacker who can plant
+# a file in a victim's CWD (shared dirs, /tmp, downloaded archives) could
+# inject arbitrary MCP server commands/args. Use --mcp-config <path> or the
+# VLLM_MLX_MCP_CONFIG env var for explicit project-local configs.
 CONFIG_SEARCH_PATHS = [
-    "./mcp.json",
-    "./mcp.yaml",
     "~/.config/vllm-mlx/mcp.json",
     "~/.config/vllm-mlx/mcp.yaml",
 ]
@@ -32,8 +34,10 @@ def load_mcp_config(path: str | Path | None = None) -> MCPConfig:
     Search order:
     1. Explicit path argument
     2. VLLM_MLX_MCP_CONFIG environment variable
-    3. ./mcp.json or ./mcp.yaml (current directory)
-    4. ~/.config/vllm-mlx/mcp.json or mcp.yaml
+    3. ~/.config/vllm-mlx/mcp.json or mcp.yaml
+
+    CWD discovery (./mcp.json, ./mcp.yaml) is intentionally NOT searched —
+    see CONFIG_SEARCH_PATHS for rationale.
 
     Args:
         path: Optional explicit path to config file
@@ -144,10 +148,17 @@ def validate_config(data: dict[str, Any]) -> MCPConfig:
     if not isinstance(default_timeout, (int, float)) or default_timeout <= 0:
         raise ValueError("'default_timeout' must be a positive number")
 
+    allowed_high_risk_tools = data.get("allowed_high_risk_tools", [])
+    if not isinstance(allowed_high_risk_tools, list) or not all(
+        isinstance(t, str) for t in allowed_high_risk_tools
+    ):
+        raise ValueError("'allowed_high_risk_tools' must be a list of strings")
+
     return MCPConfig(
         servers=servers,
         max_tool_calls=max_tool_calls,
         default_timeout=default_timeout,
+        allowed_high_risk_tools=allowed_high_risk_tools,
     )
 
 

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -405,6 +405,7 @@ class ToolSandbox:
         max_calls_per_minute: int = 60,
         audit_callback: Callable[[ToolExecutionAudit], None] | None = None,
         enabled: bool = True,
+        allowed_high_risk_tools: set[str] | None = None,
     ):
         """
         Initialize tool sandbox.
@@ -416,6 +417,10 @@ class ToolSandbox:
             max_calls_per_minute: Rate limit for tool calls (0 = unlimited).
             audit_callback: Optional callback for audit events.
             enabled: If False, sandbox checks are bypassed (dev mode only).
+            allowed_high_risk_tools: Set of tool names (bare or namespaced)
+                that are exempt from the high-risk-pattern block. Tools whose
+                names match HIGH_RISK_TOOL_PATTERNS (execute, shell, eval, …)
+                are blocked unless listed here.
         """
         self.allowed_tools = allowed_tools
         self.blocked_tools = blocked_tools or set()
@@ -425,6 +430,7 @@ class ToolSandbox:
         self.max_calls_per_minute = max_calls_per_minute
         self.audit_callback = audit_callback
         self.enabled = enabled
+        self.allowed_high_risk_tools = allowed_high_risk_tools or set()
 
         # Rate limiting state
         self._call_times: dict[str, list[float]] = defaultdict(list)
@@ -478,8 +484,8 @@ class ToolSandbox:
                     f"Tool '{tool_name}' is not in the allowed tools list"
                 )
 
-        # Check for high-risk tool patterns
-        self._check_high_risk_tool(tool_name)
+        # Check for high-risk tool patterns (block-by-default with allowlist)
+        self._check_high_risk_tool(tool_name, full_name)
 
         # Validate arguments
         self._validate_arguments(tool_name, arguments)
@@ -497,16 +503,31 @@ class ToolSandbox:
             or tool_name.lower() in self.blocked_tools
         )
 
-    def _check_high_risk_tool(self, tool_name: str) -> None:
-        """Check if tool matches high-risk patterns."""
+    def _check_high_risk_tool(self, tool_name: str, full_name: str) -> None:
+        """Block high-risk tools unless explicitly allowlisted.
+
+        Tools whose names match HIGH_RISK_TOOL_PATTERNS (shell, exec, eval,
+        run_command, …) can pivot a victim's workflow into arbitrary command
+        execution. They are blocked by default; opt-in by adding the bare or
+        namespaced tool name to ``allowed_high_risk_tools``.
+        """
         tool_lower = tool_name.lower()
         for pattern in HIGH_RISK_TOOL_PATTERNS:
-            if pattern in tool_lower:
-                logger.warning(
-                    f"High-risk tool detected: '{tool_name}' matches pattern '{pattern}'. "
-                    f"Ensure this tool is from a trusted MCP server."
+            if pattern not in tool_lower:
+                continue
+            if (
+                tool_name in self.allowed_high_risk_tools
+                or full_name in self.allowed_high_risk_tools
+            ):
+                logger.info(
+                    f"High-risk tool '{tool_name}' allowed via allowed_high_risk_tools"
                 )
-                break
+                return
+            raise MCPSecurityError(
+                f"Tool '{tool_name}' matches high-risk pattern '{pattern}' "
+                f"and is blocked by default. Add '{full_name}' (or '{tool_name}') "
+                f"to MCPConfig.allowed_high_risk_tools to opt in."
+            )
 
     def _validate_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         """Validate tool arguments for dangerous patterns."""

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -97,6 +97,10 @@ class MCPConfig:
     servers: dict[str, MCPServerConfig] = field(default_factory=dict)
     max_tool_calls: int = 10
     default_timeout: float = 30.0
+    # Tools whose names match HIGH_RISK_TOOL_PATTERNS (execute, shell, eval,
+    # exec, system, run_command, subprocess) are blocked by default. Add the
+    # full namespaced tool name (e.g. "filesystem__execute") here to opt-in.
+    allowed_high_risk_tools: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MCPConfig":
@@ -110,6 +114,7 @@ class MCPConfig:
             servers=servers,
             max_tool_calls=data.get("max_tool_calls", 10),
             default_timeout=data.get("default_timeout", 30.0),
+            allowed_high_risk_tools=data.get("allowed_high_risk_tools", []),
         )
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -31,6 +31,7 @@ from ..api.tool_calling import (
 )
 from ..api.utils import (
     clean_output_text,
+    decode_inline_tool_call_arguments,
     extract_json_from_response,
     extract_multimodal_content,
     sanitize_output,
@@ -244,6 +245,12 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 msg_dict = {k: v for k, v in raw.items() if v is not None}
             messages.append(msg_dict)
         images, videos = [], []
+        # The non-MLLM branch decodes tool_call.function.arguments from JSON
+        # string to dict inside extract_multimodal_content() so chat templates
+        # that iterate args via .items() (e.g. GLM-4.6V) don't crash. The
+        # MLLM branch bypasses that helper, so call the shared decoder here.
+        if engine.preserve_native_tool_format:
+            decode_inline_tool_call_arguments(messages)
         logger.debug(f"MLLM: Processing {len(messages)} messages")
     else:
         messages, images, videos = extract_multimodal_content(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -662,11 +662,25 @@ async def init_mcp(config_path: str):
     global _mcp_manager, _mcp_executor
 
     try:
-        from vllm_mlx.mcp import MCPClientManager, ToolExecutor, load_mcp_config
+        from vllm_mlx.mcp import (
+            MCPClientManager,
+            ToolExecutor,
+            ToolSandbox,
+            load_mcp_config,
+            set_sandbox,
+        )
 
         config = load_mcp_config(config_path)
         _mcp_manager = MCPClientManager(config)
         await _mcp_manager.start()
+
+        # Wire allowed_high_risk_tools from config into the global sandbox so
+        # default-deny on shell/exec/eval tools respects the user's allowlist.
+        set_sandbox(
+            ToolSandbox(
+                allowed_high_risk_tools=set(config.allowed_high_risk_tools),
+            )
+        )
 
         _mcp_executor = ToolExecutor(_mcp_manager)
 

--- a/vllm_mlx/tool_parsers/glm47_tool_parser.py
+++ b/vllm_mlx/tool_parsers/glm47_tool_parser.py
@@ -38,6 +38,12 @@ class Glm47ToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser glm47 are set.
     """
 
+    # GLM-4.7 chat templates render `tool_calls` natively via the same
+    # <tool_call>…</tool_call> markup the parser emits, so feed previous-turn
+    # tool calls back to the model in their native form instead of converting
+    # them to a synthetic <function=…> string.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Match entire tool call block
     TOOL_CALL_PATTERN = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 


### PR DESCRIPTION
## What does this PR do?

Re-applies three upstream waybarrios fixes that were dropped when PR #113 was closed as too stale to rebase. Each fix is its own commit so the security audit trail per-fix is preserved.

| Commit | Fix | Severity |
|---|---|---|
| \`d23d7c4\` | Drop \`./mcp.json\` and \`./mcp.yaml\` from MCP config auto-discovery | **Security** (CWD plant attack) |
| \`10fd086\` | Block high-risk MCP tools by default with allowlist opt-in | **Security** (silent shell/exec via untrusted MCP server) |
| \`d9ff910\` | Decode MLLM tool_call args + enable GLM-4.7 native tool format | Correctness (template crash + format regression) |
| \`dc25e94\` | Tests for all three fixes | — |

## Why is this needed?

Closes #338. The three upstream fixes (waybarrios#345, #343, #347) are still required on current main:

- **#345 (CWD discovery):** confirmed \`./mcp.json\` and \`./mcp.yaml\` were still in \`vllm_mlx/mcp/config.py:CONFIG_SEARCH_PATHS\` before this PR. Plant-in-CWD attack lets anyone with shared-dir access (downloaded archives, /tmp, multi-user systems) hijack what MCP servers Rapid-MLX launches.
- **#343 (high-risk tools):** confirmed \`_check_high_risk_tool\` only logged a warning; tools matching \`shell\`/\`exec\`/\`eval\` patterns from a malicious MCP server would execute silently. Now blocked-by-default with explicit \`allowed_high_risk_tools\` opt-in (per-tool, by bare or namespaced name).
- **#347 (MLLM args + GLM-4.7):** confirmed the MLLM branch in \`vllm_mlx/routes/chat.py\` doesn't go through \`extract_multimodal_content()\`, so chat templates that iterate \`tool_calls[].function.arguments\` via \`.items()\` (GLM-4.6V especially) crash. Also \`Glm47ToolParser.SUPPORTS_NATIVE_TOOL_FORMAT\` was \`False\`, causing GLM-4.7 to receive synthetic \`<function=...>\` instead of native \`<tool_call>...</tool_call>\` previous-turn rendering.

Auto-deploy blast radius: every Rapid-MLX release pushes to PyPI + Homebrew within minutes. Holding security fixes in stale branches means the bypass stays live in users' \`pip install\` paths.

## AI assistance disclosure

Claude Opus 4.7 (1M context) wrote the re-applied changes and tests. I (raullenchai) reviewed each diff against the upstream waybarrios PRs, ran the full unit suite locally, and confirmed each fix is still needed on current main before applying. The architectural choice to extract \`decode_inline_tool_call_arguments\` into a shared helper (instead of inlining in \`routes/chat.py\` like the original waybarrios#347) is mine — it keeps a single source of truth for MLLM/non-MLLM args decoding.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. Generated portions are limited to test boilerplate and helper docstrings.

## Test plan

- \`python3.12 -m pytest tests/test_mcp_security.py tests/test_native_tool_format.py -q\` → 85 passed
- \`python3.12 -m pytest tests/test_mcp_security.py tests/test_native_tool_format.py tests/test_routes.py tests/test_tool_parsers.py tests/test_config_and_middleware.py -q\` → 259 passed
- Full unit suite (\`pytest tests/ --ignore=integrations --ignore=test_event_loop --ignore=test_mllm* --ignore=test_video\`) → **2434 passed, 17 skipped, 1 xfailed** in 81s
- \`ruff check\` + \`ruff format --check\` → clean

## Verification per fix

**Fix 1 — CWD discovery removed.** New \`TestConfigDiscoveryNoCWD\`:
- Plants \`./mcp.json\` with malicious server in CWD; \`load_mcp_config()\` returns empty config (file ignored).
- Asserts \`./mcp.json\`/\`./mcp.yaml\` are not in \`CONFIG_SEARCH_PATHS\`.
- Confirms explicit path still works (regression guard for \`--mcp-config\` users).

**Fix 2 — Block-by-default for high-risk tools.** Rewrote \`TestToolSandboxHighRiskTools\` (the old tests asserted \"warning logged\" — incompatible with the new contract):
- \`execute_*\`/\`run_shell\`/\`eval_*\` tools all raise \`MCPSecurityError\` by default.
- Allowlist by bare name unblocks; allowlist by namespaced \`server__tool\` unblocks.
- Allowlist scoped to one server doesn't leak to another (\`untrusted__execute_command\` still blocked when only \`trusted__execute_command\` is allowed).
- Non-high-risk tools (e.g. \`read_file\`) still execute freely.

**Fix 3 — MLLM args + GLM-4.7 native.** New \`TestDecodeInlineToolCallArguments\`:
- String args → dict (`json.loads\` succeeds).
- Dict args → dict (no-op, identity preserved).
- Malformed JSON → string (no-op, no exception).
- Messages without \`tool_calls\` → unchanged.
- Multiple tool_calls in one message → all decoded.

\`Glm47ToolParser\` added to the parametrized \`SUPPORTS_NATIVE_TOOL_FORMAT\` lists in \`TestNativeToolFormatCapability\`.

## Checklist

- [x] Tests pass locally (\`python3.12 -m pytest tests/ -x\` — 2434 passed)
- [x] Lint passes (\`ruff check && ruff format --check\` — clean)
- [x] If new tests touch a critical code path (parser / scheduler / security), I've spot-checked that they fail when the corresponding production line is broken — verified by running the new \`TestToolSandboxHighRiskTools\` against the old warn-only code (all 6 fail) and the new \`TestConfigDiscoveryNoCWD\` against the old discovery list (asserts on \`CONFIG_SEARCH_PATHS\` fail)
- [ ] Updated README/docs if applicable — not required (security defaults; \`allowed_high_risk_tools\` documented inline in \`MCPConfig\` docstring)
- [x] No breaking changes to existing API — \`MCPConfig\` field defaults to empty list, \`ToolSandbox\` parameter is keyword-only with default

🤖 Generated with [Claude Code](https://claude.com/claude-code)