### PR TITLE
fix(parser): dedup Qwen multi-tool streaming deltas (#181)

### DIFF
--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -192,6 +192,87 @@ class TestQwenToolParser:
 
         assert not result.tools_called
 
+    def test_streaming_dedups_multi_tool_xml(self, parser):
+        """Regression for #181: streaming multi-tool XML emits each call once.
+
+        Pre-fix: every closing </tool_call> re-emitted ALL tool calls found
+        so far, with index recounted from 0. OpenAI client merge-by-index
+        then concatenated names ('readread') and args ('{}{}').
+        """
+        chunks = [
+            "<tool_call>",
+            '{"name":"read","arguments":{}}',
+            "</tool_call>",
+            "<tool_call>",
+            '{"name":"write","arguments":{}}',
+            "</tool_call>",
+        ]
+        emitted = []
+        prev = ""
+        for c in chunks:
+            cur = prev + c
+            r = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=c,
+                request={"tools": []},
+            )
+            if r and "tool_calls" in r:
+                emitted.extend(r["tool_calls"])
+            prev = cur
+
+        assert len(emitted) == 2, f"expected 2 deltas, got {len(emitted)}"
+        assert [tc["function"]["name"] for tc in emitted] == ["read", "write"]
+        assert [tc["index"] for tc in emitted] == [0, 1]
+
+    def test_streaming_dedups_multi_tool_bracket(self, parser):
+        """Regression for #181: bracket format also dedups."""
+        chunks = [
+            '[Calling tool: read({"x":1})]',
+            '[Calling tool: write({"y":2})]',
+        ]
+        emitted = []
+        prev = ""
+        for c in chunks:
+            cur = prev + c
+            r = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=c,
+                request={"tools": []},
+            )
+            if r and "tool_calls" in r:
+                emitted.extend(r["tool_calls"])
+            prev = cur
+
+        assert [tc["function"]["name"] for tc in emitted] == ["read", "write"]
+        assert [tc["index"] for tc in emitted] == [0, 1]
+
+    def test_streaming_single_tool_unchanged(self, parser):
+        """Regression guard: single tool case (the common path) still works."""
+        chunks = [
+            "<tool_call>",
+            '{"name":"only","arguments":{"k":"v"}}',
+            "</tool_call>",
+        ]
+        emitted = []
+        prev = ""
+        for c in chunks:
+            cur = prev + c
+            r = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=c,
+                request={"tools": []},
+            )
+            if r and "tool_calls" in r:
+                emitted.extend(r["tool_calls"])
+            prev = cur
+
+        assert len(emitted) == 1
+        assert emitted[0]["function"]["name"] == "only"
+        assert emitted[0]["index"] == 0
+
 
 class TestLlamaToolParser:
     """Test the Llama tool parser."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -273,6 +273,48 @@ class TestQwenToolParser:
         assert emitted[0]["function"]["name"] == "only"
         assert emitted[0]["index"] == 0
 
+    def test_streaming_malformed_first_tool_does_not_desync_indices(self, parser):
+        """Codex-flagged: a malformed JSON tool body must not shift indices.
+
+        Pre-fix code used raw close-marker counts as the dedup offset. If a
+        close marker appeared but the JSON inside failed to parse, the count
+        incremented but the emitted-call list didn't, so the next valid tool
+        would receive a wrong index (or be sliced away). We now base the
+        offset on len(prev_parsed.tool_calls) so malformed entries don't
+        desynchronise valid ones.
+        """
+        # NOT_JSON is an unquoted bareword: regex still isolates the {...}
+        # block but json.loads rejects it. Avoids the unrelated regex-fusion
+        # case where a stray '{' in body 1 swallows body 2.
+        chunks = [
+            "<tool_call>",
+            '{"name":"broken","arguments":NOT_JSON}',
+            "</tool_call>",
+            "<tool_call>",
+            '{"name":"valid","arguments":{}}',
+            "</tool_call>",
+        ]
+        emitted = []
+        prev = ""
+        for c in chunks:
+            cur = prev + c
+            r = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=c,
+                request={"tools": []},
+            )
+            if r and "tool_calls" in r:
+                emitted.extend(r["tool_calls"])
+            prev = cur
+
+        # Malformed first tool is silently dropped; the valid second tool
+        # must still emit at index 0 (not 1, which would break OpenAI clients
+        # that expect contiguous indexing from 0).
+        assert len(emitted) == 1
+        assert emitted[0]["function"]["name"] == "valid"
+        assert emitted[0]["index"] == 0
+
 
 class TestLlamaToolParser:
     """Test the Llama tool parser."""

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -139,33 +139,42 @@ class QwenToolParser(ToolParser):
         if not has_tool_marker:
             return {"content": delta_text}
 
-        # Count closes seen in current vs previous text. A "close" is either
-        # </tool_call> (XML form) or )] (bracket form). Both styles consume
-        # exactly one close per tool call, so a single counter works for the
-        # mixed case too.
-        prev_closes = previous_text.count("</tool_call>") + previous_text.count(")]")
-        cur_closes = current_text.count("</tool_call>") + current_text.count(")]")
+        # Use the count of *successfully parsed* tool calls in previous_text
+        # as the dedup offset, not raw close-marker count. If a malformed
+        # tool call slips past the close-marker counter but fails JSON parse,
+        # raw counts desync from emitted-call indices and later valid calls
+        # get wrong indices or get dropped. Re-parsing previous_text costs
+        # one extra extract per delta but stays correct under malformed input.
+        prev_close_count = previous_text.count("</tool_call>") + previous_text.count(
+            ")]"
+        )
+        cur_close_count = current_text.count("</tool_call>") + current_text.count(")]")
 
-        if cur_closes > prev_closes:
-            # New tool call(s) completed in this delta — parse and emit only
-            # the newly-completed ones, indexed past what we've already sent.
-            result = self.extract_tool_calls(current_text, request)
-            if result.tools_called:
-                new_calls = result.tool_calls[prev_closes:]
-                if new_calls:
-                    return {
-                        "tool_calls": [
-                            {
-                                "index": prev_closes + i,
-                                "id": tc["id"],
-                                "type": "function",
-                                "function": {
-                                    "name": tc["name"],
-                                    "arguments": tc["arguments"],
-                                },
-                            }
-                            for i, tc in enumerate(new_calls)
-                        ]
-                    }
+        if cur_close_count <= prev_close_count:
+            return None
 
-        return None
+        result = self.extract_tool_calls(current_text, request)
+        if not result.tools_called:
+            return None
+
+        prev_result = self.extract_tool_calls(previous_text, request)
+        prev_emitted = len(prev_result.tool_calls) if prev_result.tools_called else 0
+
+        new_calls = result.tool_calls[prev_emitted:]
+        if not new_calls:
+            return None
+
+        return {
+            "tool_calls": [
+                {
+                    "index": prev_emitted + i,
+                    "id": tc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["arguments"],
+                    },
+                }
+                for i, tc in enumerate(new_calls)
+            ]
+        }

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -124,6 +124,12 @@ class QwenToolParser(ToolParser):
     ) -> dict[str, Any] | None:
         """
         Extract tool calls from streaming Qwen model output.
+
+        Counts closing markers in current vs previous text to dedup already-
+        emitted tool calls (same pattern as HermesToolParser). Without this
+        dedup, every closing marker re-emitted ALL tool calls found so far,
+        which the OpenAI streaming protocol then merges by `index` →
+        `name="readread"` and `arguments="{}{}"` for two-tool turns.
         """
         # Check for tool call markers
         has_tool_marker = (
@@ -133,25 +139,33 @@ class QwenToolParser(ToolParser):
         if not has_tool_marker:
             return {"content": delta_text}
 
-        # If we're in a tool call, accumulate and parse at the end
-        # For simplicity, return None during accumulation
-        if "</tool_call>" in delta_text or ")]" in delta_text:
-            # Tool call complete, parse the whole thing
-            result = self.extract_tool_calls(current_text)
+        # Count closes seen in current vs previous text. A "close" is either
+        # </tool_call> (XML form) or )] (bracket form). Both styles consume
+        # exactly one close per tool call, so a single counter works for the
+        # mixed case too.
+        prev_closes = previous_text.count("</tool_call>") + previous_text.count(")]")
+        cur_closes = current_text.count("</tool_call>") + current_text.count(")]")
+
+        if cur_closes > prev_closes:
+            # New tool call(s) completed in this delta — parse and emit only
+            # the newly-completed ones, indexed past what we've already sent.
+            result = self.extract_tool_calls(current_text, request)
             if result.tools_called:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(result.tool_calls)
-                    ]
-                }
+                new_calls = result.tool_calls[prev_closes:]
+                if new_calls:
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": prev_closes + i,
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"],
+                                },
+                            }
+                            for i, tc in enumerate(new_calls)
+                        ]
+                    }
 
         return None


### PR DESCRIPTION
## Summary

Fix #181: `QwenToolParser.extract_tool_calls_streaming` re-emitted ALL tool calls on every closing marker, with `index` recounted from 0. The OpenAI streaming protocol then merge-by-index produced corrupt results on multi-tool turns:

- two-tool output → `name="readread"`, `arguments="{}{}"`

## Fix

Adopt Hermes-style stateless dedup: count closing markers in `previous_text` vs `current_text`. Only emit the new slice (`result.tool_calls[prev_closes:]`) and offset indices accordingly.

A "close" is `</tool_call>` (XML form) or `)]` (bracket form). Both styles consume exactly one close per tool call, so a single counter handles the mixed case too.

## Tests

`tests/test_tool_parsers.py::TestQwenToolParser` adds three regression tests:
- `test_streaming_dedups_multi_tool_xml` — pinned 2 tools, 2 distinct deltas with names `["read","write"]` and indices `[0,1]`
- `test_streaming_dedups_multi_tool_bracket` — same for bracket form
- `test_streaming_single_tool_unchanged` — guard the common path

## Validation

- Lint clean
- Unit suite: 2543 pass, 0 regression
- Doctor harness on qwen3.5-35b vs fresh baseline: **0 regressions, 11 improvements**, `stress[qwen3.5-35b]` 8/8 PASS, `tc_success_rate=1.0`
- All 7 GitHub CI checks SUCCESS

## Out of scope

- **#197 (OutputRouter partial-tool-call drop)**: original branch added a `finalize()` method to `OutputRouter`, but fresh-eyes review found that `OutputRouter` has zero production callers. Dropping that commit and tracking the broader question separately in #343 (wire OutputRouter into a live model path or remove as dead code).

## Test plan

- [x] `python3.12 -m pytest tests/test_tool_parsers.py::TestQwenToolParser -q` — all pass
- [x] Full unit suite (2543 pass, 0 regression)
- [x] `make check --model qwen3.5-35b` against fresh baseline (0 regressions, 11 improvements)
- [x] CI green CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)