### PR TITLE
fix(harness): repair smoke_matrix + regression_suite Test 10 pre-existing fails

### DIFF
--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -43,16 +43,21 @@ def stream_call(path, body):
     with urllib.request.urlopen(req) as resp:
         for line in resp:
             line = line.decode().strip()
-            if line.startswith("data:"):
-                lines.append(line)
-                if "[DONE]" not in line:
-                    d = json.loads(line[5:].strip())
-                    # Trailing usage chunk (stream_options.include_usage) has
-                    # choices=[]; skip it for delta extraction.
-                    if d.get("choices"):
-                        delta = d["choices"][0].get("delta", {})
-                        if "content" in delta:
-                            text += delta["content"]
+            if not line.startswith("data:"):
+                continue
+            lines.append(line)
+            if "[DONE]" in line:
+                continue
+            try:
+                d = json.loads(line[5:].strip())
+            except json.JSONDecodeError:
+                continue
+            # Trailing usage chunk (stream_options.include_usage) has
+            # choices=[]; skip it for delta extraction.
+            if d.get("choices"):
+                delta = d["choices"][0].get("delta", {})
+                if "content" in delta:
+                    text += delta["content"]
     return text, lines
 
 

--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -47,9 +47,12 @@ def stream_call(path, body):
                 lines.append(line)
                 if "[DONE]" not in line:
                     d = json.loads(line[5:].strip())
-                    delta = d["choices"][0].get("delta", {})
-                    if "content" in delta:
-                        text += delta["content"]
+                    # Trailing usage chunk (stream_options.include_usage) has
+                    # choices=[]; skip it for delta extraction.
+                    if d.get("choices"):
+                        delta = d["choices"][0].get("delta", {})
+                        if "content" in delta:
+                            text += delta["content"]
     return text, lines
 
 

--- a/tests/test_smoke_matrix.sh
+++ b/tests/test_smoke_matrix.sh
@@ -37,7 +37,9 @@ chat() {
         -d "${body}" 2>/dev/null
 }
 
-# Helper: streaming request, collect all content deltas
+# Helper: streaming request, collect all content + reasoning_content deltas.
+# reasoning_content is included so length-based comparisons (e.g. test 4)
+# correctly measure thinking output that the reasoning parser routes there.
 stream_chat() {
     local body="$1"
     curl -sfN "${BASE}" \
@@ -53,10 +55,12 @@ for line in sys.stdin:
         continue
     try:
         d = json.loads(line)
-        delta = d.get('choices', [{}])[0].get('delta', {})
-        c = delta.get('content', '')
-        if c:
-            text += c
+        choices = d.get('choices') or []
+        if not choices:
+            continue
+        delta = choices[0].get('delta', {})
+        text += delta.get('content', '') or ''
+        text += delta.get('reasoning_content', '') or ''
     except: pass
 print(text)
 " 2>/dev/null

--- a/tests/test_smoke_matrix.sh
+++ b/tests/test_smoke_matrix.sh
@@ -55,13 +55,14 @@ for line in sys.stdin:
         continue
     try:
         d = json.loads(line)
-        choices = d.get('choices') or []
-        if not choices:
-            continue
-        delta = choices[0].get('delta', {})
-        text += delta.get('content', '') or ''
-        text += delta.get('reasoning_content', '') or ''
-    except: pass
+    except json.JSONDecodeError:
+        continue
+    choices = d.get('choices') or []
+    if not choices:
+        continue
+    delta = choices[0].get('delta', {}) if isinstance(choices[0], dict) else {}
+    text += delta.get('content', '') or ''
+    text += delta.get('reasoning_content', '') or ''
 print(text)
 " 2>/dev/null
 }


### PR DESCRIPTION
## Summary

Two long-standing pre-existing fails in the doctor harness — both stale test helpers, **not product bugs**. Confirmed via manual probe of a live qwen3.5-4b server.

### 1. `regression_suite.py` Test 10 — IndexError on trailing usage chunk

`stream_call()` indexed `d[\"choices\"][0]` without guarding for the trailing chunk that `stream_options.include_usage` emits with `choices=[]`. The IndexError killed the parse loop before Test 10 could inspect the `usage` field. Guard with `if d.get(\"choices\")`.

### 2. `test_smoke_matrix.sh` Test 4 — `THINKING_LONGER` not found

`stream_chat()` collected only `delta.content`. Our reasoning parser correctly routes thinking output to `delta.reasoning_content` per the OpenAI extension (`vllm_mlx/routes/chat.py:740`). So `THINK_STREAM` only captured the post-`</think>` final answer — same length as the no-thinking response, ratio test fails. Collect both fields.

## Why these have lingered

Documented as \"known pre-existing\" in the project CLAUDE.md but never tracked or fixed. Both are shell/python scripts not under pytest collection, so CI never caught them — only `make check` exercises them.

## Verification

Synthetic SSE replay against representative chunk shapes (real captures from a 4B server probe):
- `regression_suite.py` — Test 10 now finds `usage` in the trailing chunk and PASSes.
- `test_smoke_matrix.sh` — Test 4 length ratio returns `THINKING_LONGER` when thinking content is present.

Lint clean, bash syntax check clean.

## Test plan

- [x] `ruff check tests/regression_suite.py` clean
- [x] `ruff format --check tests/regression_suite.py` clean
- [x] `bash -n tests/test_smoke_matrix.sh` clean
- [x] Synthetic SSE replay shows both fixes resolve their respective failures
- [ ] Full validation via `make check --model qwen3.5-4b` after merge (the harness is itself the test surface)

## Out of scope

- Adding a missing 35B \"check\" baseline (separate concern; can ship in a follow-up)
- Migrating these scripts under pytest collection so CI catches future regressions (issue worth filing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)