### PR TITLE
chore: port upstream observability fix + AutoToolParser false-positive guards

### DIFF
--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -310,6 +310,54 @@ class TestBatchedEngineWarmup:
         assert captured.get("model_thread") == threading.current_thread().name
 
 
+class TestBatchedEngineGetStats:
+    """get_stats() must promote MLLMScheduler keys (Metal memory + the
+    batch_generator throughput dict) to the top level. /v1/status reads
+    from the top level — without this forwarding, generation_tps stays
+    invisible to monitoring even though the underlying counters tick.
+    """
+
+    def _make_engine(self, mllm_stats):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._model_name = "test-model"
+        engine._is_mllm = False
+        engine._loaded = True
+        engine._stream_interval = 1
+        engine._engine = None
+        engine._mllm_scheduler = MagicMock()
+        engine._mllm_scheduler.get_stats = MagicMock(return_value=mllm_stats)
+        return engine
+
+    def test_get_stats_forwards_batch_generator(self):
+        bg = {"generation_tps": 42.0, "prompt_tps": 100.0}
+        engine = self._make_engine(
+            {
+                "metal_active_memory_gb": 1.0,
+                "batch_generator": bg,
+                "other_key": "ignored",
+            }
+        )
+
+        stats = engine.get_stats()
+
+        assert stats["batch_generator"] == bg
+        assert stats["metal_active_memory_gb"] == 1.0
+        # Non-promoted keys must not appear at top level.
+        assert "other_key" not in stats
+        # Full mllm_stats remains nested for debugging.
+        assert stats["mllm_scheduler"]["other_key"] == "ignored"
+
+    def test_get_stats_omits_missing_batch_generator(self):
+        engine = self._make_engine({"metal_active_memory_gb": 2.5})
+
+        stats = engine.get_stats()
+
+        assert "batch_generator" not in stats
+        assert stats["metal_active_memory_gb"] == 2.5
+
+
 class TestGuidedGenerationStepThread:
     """#170 regression: BatchedEngine.generate_with_schema must run
     _run_guided_generation on the mlx-step worker (the same thread that

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -324,6 +324,28 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_status_preserves_zero_float_throughput(self, mock_engine):
+        """A genuine 0.0 idle reading must stay a float. `or 0` would
+        collapse it to int 0; downstream schemas that require number-as-
+        float would reject the response."""
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "batch_generator": {"prompt_tps": 0.0, "generation_tps": 0.0},
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            # JSON round-trip preserves int vs float: 0.0 → 0.0, 0 → 0.
+            # The stricter assertion is that the raw text contains "0.0".
+            r = TestClient(self._make_app()).get("/v1/status")
+            assert '"generation_tps":0.0' in r.text.replace(" ", "")
+            assert '"prompt_tps":0.0' in r.text.replace(" ", "")
+            # Sanity: numeric comparison still holds.
+            assert data["generation_tps"] == 0
+            assert data["prompt_tps"] == 0
+        finally:
+            self._restore_config(orig)
+
     def test_cache_clear_no_engine(self):
         """Cache clear returns 503 when no engine."""
         orig = self._patch_config(engine=None)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -291,6 +291,39 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_status_handles_non_dict_batch_generator(self, mock_engine):
+        """Defensive: malformed batch_generator (not a dict) must not 500.
+
+        Codex flagged that `stats.get(...) or {}` only guards the falsy case;
+        a string/list/int would crash on `.get(...)`. Confirm we coerce safely.
+        """
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "batch_generator": "unexpected-string",
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            assert data["generation_tps"] == 0
+            assert data["prompt_tps"] == 0
+        finally:
+            self._restore_config(orig)
+
+    def test_status_coerces_none_throughput_to_zero(self, mock_engine):
+        """Defensive: explicit-None throughput values must serialize as 0,
+        not null. Monitoring dashboards expect a number."""
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "batch_generator": {"prompt_tps": None, "generation_tps": None},
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            assert data["generation_tps"] == 0
+            assert data["prompt_tps"] == 0
+        finally:
+            self._restore_config(orig)
+
     def test_cache_clear_no_engine(self):
         """Cache clear returns 503 when no engine."""
         orig = self._patch_config(engine=None)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -260,6 +260,34 @@ class TestHealthRoutes:
             assert data["model"] == "test-model"
             assert data["steps_executed"] == 500
             assert data["metal"]["active_memory_gb"] == 8.5
+            # generation_tps/prompt_tps default to 0 when batch_generator
+            # stats are absent (text-only batched engine path).
+            assert data["generation_tps"] == 0
+            assert data["prompt_tps"] == 0
+        finally:
+            self._restore_config(orig)
+
+    def test_status_exposes_batch_generator_throughput(self, mock_engine):
+        """Status surfaces generation_tps/prompt_tps from batch_generator stats.
+
+        Regression for the upstream bug where these counters existed in the
+        batch generator but never reached /v1/status because the engine
+        layer didn't forward the 'batch_generator' key.
+        """
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "batch_generator": {
+                "prompt_tps": 142.7,
+                "generation_tps": 38.4,
+            },
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+            data = client.get("/v1/status").json()
+            assert data["generation_tps"] == 38.4
+            assert data["prompt_tps"] == 142.7
         finally:
             self._restore_config(orig)
 

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -706,6 +706,44 @@ class TestAutoToolParser:
 
         assert not result.tools_called
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Read [the docs](https://example.test) before changing this.",
+            "The output array was [1, 2, 3], not a tool call.",
+            'Here is JSON: [{"label": "alpha", "score": 0.7}]',
+            "Use [square brackets] for optional text.",
+            "This prose mentions [read(file_path)] without JSON arguments.",
+        ],
+    )
+    def test_no_false_positive_for_ordinary_bracket_text(self, parser, text):
+        """Ordinary bracket text must remain content, not be auto-classified
+        as a tool call (port from upstream #485)."""
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.content == text
+
+    @pytest.mark.parametrize(
+        "delta",
+        [
+            "See [the docs](https://example.test)",
+            "Values: [1, 2, 3]",
+            'JSON data: [{"label": "alpha"}]',
+            "Literal [square brackets] in text",
+        ],
+    )
+    def test_streaming_ordinary_brackets_emit_content(self, parser, delta):
+        """Streaming must not suppress ordinary bracket text as
+        in-progress markup (port from upstream #485)."""
+        result = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=delta,
+            delta_text=delta,
+        )
+
+        assert result == {"content": delta}
+
 
 class TestEdgeCases:
     """Test edge cases and error handling."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -930,11 +930,15 @@ class BatchedEngine(BaseEngine):
         if self._mllm_scheduler:
             mllm_stats = self._mllm_scheduler.get_stats()
             stats["mllm_scheduler"] = mllm_stats
-            # Promote Metal memory stats to top-level for /v1/status
+            # Promote Metal memory stats + batch_generator throughput to
+            # top-level for /v1/status. Without "batch_generator" forwarded,
+            # generation_tps/prompt_tps stay invisible to monitoring even
+            # though the underlying counters are populated.
             for key in (
                 "metal_active_memory_gb",
                 "metal_peak_memory_gb",
                 "metal_cache_memory_gb",
+                "batch_generator",
             ):
                 if key in mllm_stats:
                     stats[key] = mllm_stats[key]

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -92,7 +92,9 @@ async def status():
         return {"status": "not_loaded", "model": None, "requests": []}
 
     stats = cfg.engine.get_stats()
-    bg = stats.get("batch_generator") or {}
+    bg = stats.get("batch_generator")
+    if not isinstance(bg, dict):
+        bg = {}
 
     return {
         "status": "generating" if stats.get("running") else "idle",
@@ -104,8 +106,10 @@ async def status():
         "total_requests_processed": stats.get("num_requests_processed", 0),
         "total_prompt_tokens": stats.get("total_prompt_tokens", 0),
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
-        "generation_tps": bg.get("generation_tps", 0),
-        "prompt_tps": bg.get("prompt_tps", 0),
+        # `or 0` collapses both missing and explicit-None to 0; dashboards
+        # that parse this expect a number, never null.
+        "generation_tps": bg.get("generation_tps") or 0,
+        "prompt_tps": bg.get("prompt_tps") or 0,
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -92,6 +92,7 @@ async def status():
         return {"status": "not_loaded", "model": None, "requests": []}
 
     stats = cfg.engine.get_stats()
+    bg = stats.get("batch_generator") or {}
 
     return {
         "status": "generating" if stats.get("running") else "idle",
@@ -103,6 +104,8 @@ async def status():
         "total_requests_processed": stats.get("num_requests_processed", 0),
         "total_prompt_tokens": stats.get("total_prompt_tokens", 0),
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
+        "generation_tps": bg.get("generation_tps", 0),
+        "prompt_tps": bg.get("prompt_tps", 0),
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -96,6 +96,13 @@ async def status():
     if not isinstance(bg, dict):
         bg = {}
 
+    # Coerce missing-or-None to a float zero. `or 0` would collapse a
+    # legitimate 0.0 value to int 0; dashboards with strict number-type
+    # schemas care about the difference.
+    def _tps(key: str) -> float:
+        v = bg.get(key)
+        return 0.0 if v is None else v
+
     return {
         "status": "generating" if stats.get("running") else "idle",
         "model": cfg.model_name,
@@ -106,10 +113,8 @@ async def status():
         "total_requests_processed": stats.get("num_requests_processed", 0),
         "total_prompt_tokens": stats.get("total_prompt_tokens", 0),
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
-        # `or 0` collapses both missing and explicit-None to 0; dashboards
-        # that parse this expect a number, never null.
-        "generation_tps": bg.get("generation_tps") or 0,
-        "prompt_tps": bg.get("prompt_tps") or 0,
+        "generation_tps": _tps("generation_tps"),
+        "prompt_tps": _tps("prompt_tps"),
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),


### PR DESCRIPTION
## Summary

Two upstream improvements ported to our refactored layout, plus triage of the broader Tier A/B candidate list (issue #344 spawned for the one item that needed deeper porting).

## Changes

### 1. Expose generation_tps / prompt_tps in /v1/status (waybarrios#460)

\`MLLMScheduler.get_stats()\` already includes a \`batch_generator\` sub-dict with \`prompt_tps\` and \`generation_tps\` (populated by \`MLLMBatchGenerator._stats\`), but \`BatchedEngine.get_stats()\` was only forwarding the \`metal_*\` keys to the top level. Result: monitoring dashboards saw zero throughput regardless of actual load.

Fix: add \`\"batch_generator\"\` to the forward list in \`BatchedEngine.get_stats()\` and surface \`generation_tps\` / \`prompt_tps\` in \`routes/health.py\` \`/v1/status\` payload.

### 2. AutoToolParser false-positive guards (waybarrios#485 test port)

Upstream added regression coverage for ordinary bracket text that AutoToolParser must NOT classify as a tool call:
- markdown links: \`[the docs](https://example.test)\`
- JSON arrays: \`[1, 2, 3]\`, \`[{\"label\": \"alpha\"}]\`
- prose with \`[square brackets]\`
- \`[func(file_path)]\` without JSON args

Our parser already handles all 5 cases correctly (verified live); the tests pin the contract so a future refactor can't regress. 9 new parametrized cases (5 non-streaming, 4 streaming).

## Triage of related upstream commits (skipped + why)

| SHA | What | Why skipped |
|---|---|---|
| waybarrios#456 | credit in-flight tokens on abort | Already in our fork with extra \`request is not None\` guards |
| waybarrios#469 | MLLM prefix cache disable wiring | N/A — relies on config fields (\`enable_prefix_cache\`, \`use_memory_aware_cache\`, etc.) that don't exist in our \`MLLMSchedulerConfig\` |
| waybarrios#432 | don't suppress whitespace deltas | N/A — the suppression block being removed doesn't exist in our refactored \`PostProcessor\` |
| waybarrios#509 | qwen3 xml chunk boundaries | N/A — fixes \`qwen3_xml_tool_parser.py\` which we don't have (we use a different XML parser) |
| waybarrios#433 | tool_call promotion in \`<think>\` | Structural conflict with our refactored \`think_parser.py\`; tracked as #344 |

## Test plan

- [x] \`ruff check\` + \`ruff format\` clean
- [x] Targeted: \`tests/test_routes.py::TestHealthRoutes\` (25 pass) + \`tests/test_tool_parsers.py::TestAutoToolParser\` (16 pass — was 7, +9 new)
- [x] Full unit suite gating below

🤖 Generated with [Claude Code](https://claude.com/claude-code)