### PR TITLE
feat(cli): better unknown-model UX — separator-tolerant suggestions + popular fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.31"
+version = "0.6.32"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -91,3 +91,51 @@ def test_suggest_similar_matches_partial_family_token():
     no exact ``hermes-foo`` separator pattern."""
     suggestions = suggest_similar("hermes")
     assert "hermes3-8b" in suggestions, suggestions
+
+
+# --- Letter-only fallback (separator-mismatched names) ----------------
+
+
+def test_suggest_similar_letter_fallback_handles_separator_mismatch():
+    """Real bug from the field: ``rapid-mlx chat gemma4-27b`` returned
+    zero suggestions because the strict family parser sees ``gemma4`` and
+    no alias starts with ``gemma4`` (we have ``gemma-4-26b`` and
+    ``gemma3-27b``). The letter-only fallback must catch this — extract
+    ``gemma`` and match the whole gemma family."""
+    suggestions = suggest_similar("gemma4-27b")
+    assert suggestions, "letter-only fallback must produce gemma family suggestions"
+    # All suggestions must be in the gemma family — no llama / qwen leakage.
+    for s in suggestions:
+        assert s.startswith("gemma"), s
+
+
+def test_suggest_similar_letter_fallback_collapsed_separator():
+    """User collapses our hyphen — ``mistral24b`` should still suggest
+    ``mistral-24b``, not return []."""
+    assert "mistral-24b" in suggest_similar("mistral24b")
+
+
+def test_suggest_similar_letter_fallback_skips_legit_looking_names():
+    """When the input has no size/quant suffix tokens (i.e., looks
+    structurally like a legit single-segment HF repo ID), suggest_similar
+    must return [] — not bait-and-switch ``gpt2`` to ``gpt-oss-20b`` or
+    ``qwen-coder`` to ``qwen3-coder``. The CLI layer's POPULAR_ALIASES
+    fallback handles those cases at presentation time."""
+    # ``gpt2`` has been pinned by test_suggest_similar_lets_legitimate_hf_ids_through;
+    # this case adds the partial-family equivalent.
+    assert suggest_similar("qwen-coder") == []
+
+
+def test_popular_aliases_curated_list_resolves():
+    """Every entry in POPULAR_ALIASES (used as the user-facing
+    'try one of these' fallback when zero fuzzy matches) must be a real
+    alias in aliases.json — otherwise the error message is a lie."""
+    from vllm_mlx.model_aliases import POPULAR_ALIASES
+
+    aliases = list_aliases()
+    missing = [a for a in POPULAR_ALIASES if a not in aliases]
+    assert not missing, (
+        f"POPULAR_ALIASES references non-existent aliases: {missing}. "
+        f"Update vllm_mlx/model_aliases.py POPULAR_ALIASES tuple after "
+        f"removing or renaming aliases."
+    )

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -3,6 +3,8 @@
 
 import os
 
+import pytest
+
 from vllm_mlx.model_aliases import list_aliases, resolve_model, suggest_similar
 
 
@@ -124,6 +126,27 @@ def test_suggest_similar_letter_fallback_skips_legit_looking_names():
     # ``gpt2`` has been pinned by test_suggest_similar_lets_legitimate_hf_ids_through;
     # this case adds the partial-family equivalent.
     assert suggest_similar("qwen-coder") == []
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("gemma4-27b", "gemma"),
+        ("Gemma4-27b", "gemma"),  # lowercased
+        ("gemma_4-27b", "gemma"),  # stops at non-letter
+        ("mistral24b", "mistral"),
+        ("qwen3.5-4b", "qwen"),  # stops at first digit
+        ("123abc", ""),  # leading non-letter → empty
+        ("", ""),  # empty input
+        ("ab", "ab"),  # short prefix (caller enforces ≥3 minimum)
+    ],
+)
+def test_letters_only_prefix(raw, expected):
+    """Direct coverage for the letter-only family extraction. Caller
+    (suggest_similar) enforces the 3-char minimum, so we don't here."""
+    from vllm_mlx.model_aliases import _letters_only_prefix
+
+    assert _letters_only_prefix(raw) == expected
 
 
 def test_popular_aliases_curated_list_resolves():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -17,6 +17,27 @@ import os
 import sys
 
 
+def _print_unknown_model_help(name: str, *, full_path_example: str) -> None:
+    """Print fuzzy suggestions + a curated popular-models hint.
+
+    Replaces the older "Did you mean: X?" + "Run `rapid-mlx models`" pattern
+    that left users empty-handed when no close fuzzy match existed
+    (e.g. ``rapid-mlx chat gemma4-27b`` returned zero suggestions, told the
+    user to run another command, and gave no hint of what was actually
+    supported). Now: always show *something* — fuzzy matches when we have
+    them, curated popular aliases when we don't.
+    """
+    from vllm_mlx.model_aliases import POPULAR_ALIASES, list_aliases, suggest_similar
+
+    suggestions = suggest_similar(name)
+    if suggestions:
+        print(f"  Did you mean: {', '.join(suggestions)}?")
+    else:
+        print(f"  Try one of: {', '.join(POPULAR_ALIASES)}")
+    print(f"  Run `rapid-mlx models` to see all {len(list_aliases())} aliases,")
+    print(f"  or pass a full path like: {full_path_example}")
+
+
 def _check_disk_space(model_name: str, force: bool = False) -> None:
     """Verify there's enough disk space to download the model.
 
@@ -676,16 +697,10 @@ def serve_command(args):
             "404" in str(e) or "not found" in str(e).lower()
         )
         if is_404:
-            from vllm_mlx.model_aliases import suggest_similar
-
             shown = getattr(args, "_original_alias", args.model)
             print(f"\n  Error: Model '{shown}' not found on HuggingFace.")
-            suggestions = suggest_similar(shown)
-            if suggestions:
-                print(f"  Did you mean: {', '.join(suggestions)}?")
-            print("  Run `rapid-mlx models` to see available aliases,")
-            print(
-                "  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit"
+            _print_unknown_model_help(
+                shown, full_path_example="mlx-community/Qwen3.5-9B-4bit"
             )
         else:
             print(f"\n  Error loading model: {e}")
@@ -741,16 +756,10 @@ def bench_command(args):
                 "404" in str(e) or "not found" in str(e).lower()
             )
             if is_404:
-                from vllm_mlx.model_aliases import suggest_similar
-
                 shown = getattr(args, "_original_alias", args.model)
                 print(f"\n  Error: Model '{shown}' not found on HuggingFace.")
-                suggestions = suggest_similar(shown)
-                if suggestions:
-                    print(f"  Did you mean: {', '.join(suggestions)}?")
-                print("  Run `rapid-mlx models` to see available aliases,")
-                print(
-                    "  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit"
+                _print_unknown_model_help(
+                    shown, full_path_example="mlx-community/Qwen3.5-9B-4bit"
                 )
             else:
                 print(f"\n  Error loading model: {e}")
@@ -932,16 +941,10 @@ def pull_command(args):
             "404" in str(e) or "not found" in str(e).lower()
         )
         if is_404:
-            from vllm_mlx.model_aliases import suggest_similar
-
             shown = getattr(args, "_original_alias", repo_id)
             print(f"\n  Error: Model '{shown}' not found on HuggingFace.")
-            suggestions = suggest_similar(shown)
-            if suggestions:
-                print(f"  Did you mean: {', '.join(suggestions)}?")
-            print("  Run `rapid-mlx models` to see available aliases,")
-            print(
-                "  or use a full HuggingFace path like: mlx-community/Qwen3.5-9B-4bit"
+            _print_unknown_model_help(
+                shown, full_path_example="mlx-community/Qwen3.5-9B-4bit"
             )
             sys.exit(1)
         raise
@@ -3085,7 +3088,7 @@ Examples:
         and args.model
         and getattr(args, "command", None) != "doctor"
     ):
-        from vllm_mlx.model_aliases import resolve_model, suggest_similar
+        from vllm_mlx.model_aliases import resolve_model
 
         resolved = resolve_model(args.model)
         if resolved != args.model:
@@ -3099,11 +3102,9 @@ Examples:
             print(
                 f"\n  Error: '{args.model}' is not a known alias or HuggingFace path."
             )
-            suggestions = suggest_similar(args.model)
-            if suggestions:
-                print(f"  Did you mean: {', '.join(suggestions)}?")
-            print("  Run `rapid-mlx models` to see all aliases,")
-            print("  or pass a full path like: mlx-community/Qwen3.5-9B-4bit")
+            _print_unknown_model_help(
+                args.model, full_path_example="mlx-community/Qwen3.5-9B-4bit"
+            )
             sys.exit(1)
 
     if args.command == "serve":

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -198,33 +198,98 @@ def _family_prefix(name: str) -> str:
     return "-".join(parts)
 
 
+def _letters_only_prefix(name: str) -> str:
+    """Extract the leading ``[a-z]+`` run from ``name`` (lowercased).
+
+    Used as a fallback family hint when the dash-aware ``_family_prefix``
+    returns nothing useful — handles cases where the user collapses or
+    inserts separators we don't use (``gemma4-27b`` → ``gemma``, matches
+    our ``gemma-4-*`` and ``gemma3-*`` aliases; ``mistral24b`` →
+    ``mistral``, matches ``mistral-24b``).
+    """
+    out = []
+    for ch in name.lower():
+        if ch.isalpha():
+            out.append(ch)
+        else:
+            break
+    return "".join(out)
+
+
 def suggest_similar(name: str, n: int = 3, cutoff: float = 0.5) -> list[str]:
     """Return up to ``n`` aliases similar to ``name`` for typo suggestions.
 
-    Family-aware: only suggests aliases that share a family prefix with the
-    input. This keeps the wrong-family bait-and-switch (typing
-    ``deepseek-v4-27b`` and being told ``deepseek-r1-32b``) from happening,
-    and also prevents legitimate single-segment HuggingFace IDs like
-    ``gpt2`` or ``bert-base-uncased`` from spuriously matching.
+    Family-aware in two passes:
+    1. **Strict family match** — uses ``_family_prefix`` (drops trailing
+       size/quant tokens). Keeps the wrong-family bait-and-switch (typing
+       ``deepseek-v4-27b`` and being told ``deepseek-r1-32b``) from
+       happening, and prevents legitimate single-segment HuggingFace IDs
+       like ``gpt2`` or ``bert-base-uncased`` from spuriously matching.
+    2. **Letter-only prefix fallback** — if step 1 finds nothing, retry
+       using the ``[a-z]+`` prefix (e.g. ``gemma4-27b`` → ``gemma``). The
+       cutoff is dropped here because we already filtered by family
+       overlap; difflib just orders by closeness within the family.
 
-    Behaviour:
-    - Multi-segment family (``fam`` contains ``-``): match aliases that
-      start with ``fam-`` or are exactly ``fam``.
-    - Single-segment family (``hermes``, ``qwen3.5``, ``gpt2``): match
-      aliases whose name starts with ``fam``. Requires ``fam`` to be at
-      least 3 chars to avoid one- or two-letter false positives.
-    - No same-family match: return ``[]`` (let the loader's 404 handle it).
+    Returns ``[]`` only when neither pass finds anything in the same
+    letter family — at which point the caller should show a curated
+    "popular models" fallback rather than leave the user empty-handed.
     """
-    fam = _family_prefix(name)
-    if not fam:
-        return []
     aliases = list(_load().keys())
-    if "-" in fam:
-        same_fam = [a for a in aliases if a.startswith(fam + "-") or a == fam]
-    else:
-        if len(fam) < 3:
-            return []
-        same_fam = [a for a in aliases if a.startswith(fam)]
-    if not same_fam:
+
+    # Pass 1: strict family prefix.
+    fam = _family_prefix(name)
+    same_fam: list[str] = []
+    if fam:
+        if "-" in fam:
+            same_fam = [a for a in aliases if a.startswith(fam + "-") or a == fam]
+        elif len(fam) >= 3:
+            same_fam = [a for a in aliases if a.startswith(fam)]
+        if same_fam:
+            # If we found candidates in the same strict family, trust the
+            # cutoff — even if it filters everything out. The cutoff
+            # rejecting ``gpt2`` against ``gpt-oss-20b`` is the
+            # legitimate-HF-ID guarantee at work; the letter-only
+            # fallback below would override that and is wrong here.
+            return difflib.get_close_matches(name, same_fam, n=n, cutoff=cutoff)
+
+    # Pass 2: letter-only prefix fallback. Gated to inputs where the
+    # strict family parser *had to strip something* (signal that the user
+    # typed a name following our size/quant naming convention) — handles
+    # ``gemma4-27b`` (fam stripped to ``gemma4``, no exact match) and
+    # ``mistral24b`` (fam stripped to empty by the trailing ``-b``-ish
+    # token). Untouched inputs like ``gpt2``, ``bert-base-uncased`` or
+    # ``qwen-coder`` skip this fallback so legit single-segment HF repo
+    # IDs aren't bait-and-switched.
+    if fam == name:
         return []
-    return difflib.get_close_matches(name, same_fam, n=n, cutoff=cutoff)
+    letter_fam = _letters_only_prefix(name)
+    if len(letter_fam) < 3:
+        return []
+    same_letter_fam = [a for a in aliases if _letters_only_prefix(a) == letter_fam]
+    if not same_letter_fam:
+        return []
+    # Within a family, order by similarity to the typed name. No cutoff —
+    # any same-letter-family alias is a sane suggestion.
+    ranked = sorted(
+        same_letter_fam,
+        key=lambda a: difflib.SequenceMatcher(None, name, a).ratio(),
+        reverse=True,
+    )
+    return ranked[:n]
+
+
+# Curated "what should a brand-new user try" list. Surfaced when the user
+# typed a name we couldn't match to anything (or even fuzzy-match within a
+# family). Hand-picked rather than auto-generated so it always leads with
+# the small/fast tier and one well-known representative per category —
+# auto-generation would spit out alphabetic noise like ``bonsai-*`` first.
+POPULAR_ALIASES: tuple[str, ...] = (
+    "qwen3.5-4b",  # default smoke / small
+    "qwen3.5-9b",  # mid-size general
+    "qwen3.6-27b",  # latest hybrid family
+    "qwen3-coder-30b",  # coding
+    "gemma3-12b",  # gemma family rep
+    "llama3-3b",  # tiny llama
+    "mistral-24b",  # mistral
+    "deepseek-r1-32b",  # reasoning
+)


### PR DESCRIPTION
## Summary

Real bug from the field: typing `rapid-mlx chat gemma4-27b` returned **zero suggestions** and just told the user to run another command. Users have no idea what we ship.

Two fixes:

### 1. Separator-tolerant fuzzy match
`suggest_similar` gains a letter-only-prefix fallback (gated to inputs where the strict family parser stripped size/quant tokens — preserves the legit-HF-ID guarantee for `gpt2`, `bert-base-uncased`, etc.).

| Input | Before | After |
|---|---|---|
| `gemma4-27b` | `[]` (nothing) | `gemma3-27b, gemma-4-26b, gemma3-12b` |
| `mistral24b` | `[]` | `mistral-24b` |
| `qwen3.6-30b` | already worked | `qwen3.6-35b, qwen3.6-27b, qwen3.6-35b-ud` |
| `gpt2` | `[]` (legit HF) | `[]` (legit HF, preserved) |
| `bert-base-uncased` | `[]` (legit HF) | `[]` (preserved) |

### 2. Popular-models inline fallback
When no fuzzy suggestion fires (`foobar`, or legit-shaped `qwen-coder`), the CLI now prints a curated 8-alias list inline instead of pointing the user at another command:

```
$ rapid-mlx chat foobar
  Error: 'foobar' is not a known alias or HuggingFace path.
  Try one of: qwen3.5-4b, qwen3.5-9b, qwen3.6-27b, qwen3-coder-30b, gemma3-12b, llama3-3b, mistral-24b, deepseek-r1-32b
  Run `rapid-mlx models` to see all 57 aliases,
  or pass a full path like: mlx-community/Qwen3.5-9B-4bit
```

`POPULAR_ALIASES` is hand-curated (not auto-generated) so it always leads with the right defaults — auto-generation would alphabetize and surface `bonsai-*` first.

### 3. Single error helper across 4 sites
Centralised the duplicated "Did you mean..." formatting from 4 CLI sites (`serve` HF 404, `bench` HF 404, `pull` HF 404, pre-flight unknown alias) into one `_print_unknown_model_help` helper.

## Behavior matrix (verified end-to-end via `python3.12 -m vllm_mlx.cli chat <name>`)

| Input | Path | Output |
|---|---|---|
| `gemma4-27b` | letter-fallback | `Did you mean: gemma3-27b, gemma-4-26b, gemma3-12b?` |
| `mistral24b` | letter-fallback | `Did you mean: mistral-24b?` |
| `qwen3.6-30b` | strict family | `Did you mean: qwen3.6-35b, qwen3.6-27b, qwen3.6-35b-ud?` |
| `qwen-coder` | popular fallback | `Try one of: ... qwen3-coder-30b ...` |
| `foobar` | popular fallback | `Try one of: ...` |
| `gpt2` | left alone (HF passthrough) | unchanged |

## Tests

- New: `test_suggest_similar_letter_fallback_handles_separator_mismatch` — pins the gemma4 case
- New: `test_suggest_similar_letter_fallback_collapsed_separator` — pins mistral24b
- New: `test_suggest_similar_letter_fallback_skips_legit_looking_names` — pins the gpt2/qwen-coder boundary
- New: `test_popular_aliases_curated_list_resolves` — every POPULAR_ALIASES entry must exist in aliases.json (SSOT guard)
- Pre-existing: `test_suggest_similar_lets_legitimate_hf_ids_through` still passes

## Test plan

- [x] `pytest tests/test_model_aliases.py -q` — **16 passed**
- [x] `pytest tests/ --ignore=...` — **2464 passed**
- [x] `ruff check && ruff format --check` — clean
- [x] Smoke each failure mode via real CLI invocation (above table)

## Out of scope

- `qwen-coder`-style typos still fall through to the popular list rather than getting family-targeted suggestions. Distinguishing `qwen-coder` (typo for `qwen3-coder`) from a hypothetical legit HF repo `qwen-coder` is structurally impossible from the alias name alone — the popular-models fallback covers it adequately.

## Version

Bumped 0.6.31 → 0.6.32 — user-visible CLI presentation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)