### PR TITLE
feat(telemetry): Phase 1 — opt-in consent + CLI surface (Issue #236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,14 +704,14 @@ Rapid-MLX **can** send anonymous usage data to help us prioritise the right mode
 - Subcommand names (`serve` / `chat` / `agents` / `bench` / `doctor`)
 - Model alias names (`qwen3.5-9b`) or canonical HF repo IDs (`mlx-community/...`) — local paths are redacted to `<local>`
 - Bucketed counts: prompt/completion tokens, TTFT, tokens/sec — never exact values
-- Error categories + a hash fingerprint of the failure site (module:function:lineno only — never the message text)
+- Error categories + a hash fingerprint of the failure site (exception class name + per-frame `file:function:lineno` only — never the message text or absolute paths)
 - OS, arch, Apple chip name, RAM (rounded to GB), Python major.minor
 
 ### What we never collect
 
 - Prompts, completions, tool-call arguments, file contents, or any user-generated text
 - Local file paths, working directory, or model paths beyond their HF repo ID
-- IPs (a Cloudflare Worker strips them before forwarding) or hostnames
+- IPs or hostnames (Phase 2 will route through a Cloudflare Worker that strips IPs before forwarding to the aggregator; Phase 1 ships no transport at all)
 - API keys, environment variable values, auth headers
 - Stack trace messages or argument values
 

--- a/README.md
+++ b/README.md
@@ -695,6 +695,53 @@ Result: PASS
 
 ---
 
+## Telemetry
+
+Rapid-MLX **can** send anonymous usage data to help us prioritise the right models and catch regressions. **It is off by default and never starts collecting without your explicit opt-in.**
+
+### What we collect (only if you opt in)
+
+- Subcommand names (`serve` / `chat` / `agents` / `bench` / `doctor`)
+- Model alias names (`qwen3.5-9b`) or canonical HF repo IDs (`mlx-community/...`) — local paths are redacted to `<local>`
+- Bucketed counts: prompt/completion tokens, TTFT, tokens/sec — never exact values
+- Error categories + a hash fingerprint of the failure site (module:function:lineno only — never the message text)
+- OS, arch, Apple chip name, RAM (rounded to GB), Python major.minor
+
+### What we never collect
+
+- Prompts, completions, tool-call arguments, file contents, or any user-generated text
+- Local file paths, working directory, or model paths beyond their HF repo ID
+- IPs (a Cloudflare Worker strips them before forwarding) or hostnames
+- API keys, environment variable values, auth headers
+- Stack trace messages or argument values
+
+### Manage it
+
+```bash
+rapid-mlx telemetry status     # show current state and why
+rapid-mlx telemetry preview    # print the exact JSON payload that would be sent
+rapid-mlx telemetry enable     # opt in
+rapid-mlx telemetry disable    # opt out
+rapid-mlx telemetry reset      # delete consent + client-id files (re-prompts on next run)
+```
+
+### Force-disable in scripts / CI
+
+Either of these always wins, regardless of stored consent:
+
+```bash
+RAPID_MLX_TELEMETRY=0 rapid-mlx serve qwen3.5-9b
+rapid-mlx --no-telemetry serve qwen3.5-9b
+```
+
+There is intentionally **no env-var equivalent for force-on** — opting in must be an explicit one-time `rapid-mlx telemetry enable`. CI agents will never silently contribute.
+
+### Where the code lives
+
+Everything is in [`vllm_mlx/telemetry/`](vllm_mlx/telemetry/) — read it. Phase 1 (this release) ships the consent mechanism and CLI surface; **no network code is in the codebase yet**. Phase 2 will add the transport behind the same opt-in gate; the schema is documented in [`vllm_mlx/telemetry/schema.py`](vllm_mlx/telemetry/schema.py). Tracking issue: [#236](https://github.com/raullenchai/Rapid-MLX/issues/236).
+
+---
+
 ## Development
 
 ### Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.32"
+version = "0.6.33"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -86,10 +86,27 @@ def test_preview_emits_valid_json_payload(fake_home):
     r = _run_cli("telemetry", "preview", home=fake_home)
     assert r.returncode == 0, r.stderr
 
-    # Pull out the JSON object — output has framing text around it.
-    start = r.stdout.find("{")
-    end = r.stdout.rfind("}") + 1
-    payload = json.loads(r.stdout[start:end])
+    # Anchor on the first line containing ``"schema_version"`` so we
+    # don't get confused by stray ``{`` in framing text (e.g. a path
+    # like ``/some/{template}/dir`` would break naive parsing).
+    lines = r.stdout.splitlines()
+    schema_idx = next(
+        (i for i, line in enumerate(lines) if '"schema_version"' in line),
+        None,
+    )
+    assert schema_idx is not None, f"no schema_version line in:\n{r.stdout}"
+    open_idx = next(i for i in range(schema_idx, -1, -1) if lines[i].strip() == "{")
+    # Track brace depth so the nested platform/session sub-objects'
+    # ``}`` don't fool us into closing the envelope early.
+    depth = 0
+    close_idx = None
+    for i in range(open_idx, len(lines)):
+        depth += lines[i].count("{") - lines[i].count("}")
+        if depth == 0:
+            close_idx = i
+            break
+    assert close_idx is not None, "could not find matching close brace"
+    payload = json.loads("\n".join(lines[open_idx : close_idx + 1]))
     assert payload["schema_version"] == 1
     assert "client_id" in payload
     assert payload["session_id"].startswith("preview-")

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the user-facing ``rapid-mlx telemetry ...`` subcommand surface.
+
+Smoke-level: every action returns 0, prints something resembling its
+purpose. The deep behaviour (precedence, redaction, prompt skips) is
+covered in ``test_telemetry_state.py`` / ``test_telemetry_consent.py``
+/ ``test_telemetry_redact.py``. This file only guards the CLI wiring
+itself — argparse exposes all 5 actions, dispatch reaches the right
+handler, the global ``--no-telemetry`` flag is plumbed through.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    return tmp_path
+
+
+def _run_cli(*args, env_overrides=None, home=None):
+    """Spawn the CLI as a subprocess so argparse + dispatch run end-to-end.
+
+    In-process invocation would short-circuit ``sys.exit`` and miss
+    real-world failure modes (broken imports, missing dispatch case).
+    """
+    import os
+
+    env = os.environ.copy()
+    if home is not None:
+        env["HOME"] = str(home)
+    env.pop("RAPID_MLX_TELEMETRY", None)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_status_default_off(fake_home):
+    r = _run_cli("telemetry", "status", home=fake_home)
+    assert r.returncode == 0, r.stderr
+    assert "disabled" in r.stdout.lower()
+    assert "default" in r.stdout.lower()
+
+
+def test_status_after_enable(fake_home):
+    enable = _run_cli("telemetry", "enable", home=fake_home)
+    assert enable.returncode == 0, enable.stderr
+    status = _run_cli("telemetry", "status", home=fake_home)
+    assert status.returncode == 0
+    assert "enabled" in status.stdout.lower()
+    assert "consent-file" in status.stdout.lower()
+
+
+def test_disable_records_false(fake_home):
+    _run_cli("telemetry", "enable", home=fake_home)
+    _run_cli("telemetry", "disable", home=fake_home)
+    status = _run_cli("telemetry", "status", home=fake_home)
+    assert "disabled" in status.stdout.lower()
+    # Must say it WAS prompted — disable=record consent=False, not "never".
+    assert "false" in status.stdout.lower() or "consent: false" in status.stdout.lower()
+
+
+def test_preview_emits_valid_json_payload(fake_home):
+    """The preview must be parseable JSON with the documented schema
+    fields. If the structure drifts silently, the README docs lie and
+    Phase 2's transport will send a payload that doesn't match the
+    Cloudflare Worker's validator."""
+    r = _run_cli("telemetry", "preview", home=fake_home)
+    assert r.returncode == 0, r.stderr
+
+    # Pull out the JSON object — output has framing text around it.
+    start = r.stdout.find("{")
+    end = r.stdout.rfind("}") + 1
+    payload = json.loads(r.stdout[start:end])
+    assert payload["schema_version"] == 1
+    assert "client_id" in payload
+    assert payload["session_id"].startswith("preview-")
+    assert "platform" in payload
+    for key in ("os", "arch", "chip", "memory_gb", "python_version"):
+        assert key in payload["platform"]
+    assert payload["event"] == "session_start"
+
+
+def test_reset_removes_consent(fake_home):
+    _run_cli("telemetry", "enable", home=fake_home)
+    r = _run_cli("telemetry", "reset", home=fake_home)
+    assert r.returncode == 0
+    status = _run_cli("telemetry", "status", home=fake_home)
+    assert "never prompted" in status.stdout.lower()
+
+
+def test_status_with_no_action_defaults_to_status(fake_home):
+    """``rapid-mlx telemetry`` (no action) should be a friendly status,
+    not an argparse error — users will type the bare command first."""
+    r = _run_cli("telemetry", home=fake_home)
+    assert r.returncode == 0, r.stderr
+    assert "telemetry" in r.stdout.lower()
+
+
+def test_global_no_telemetry_flag(fake_home):
+    """``--no-telemetry`` must be reachable on the root parser."""
+    _run_cli("telemetry", "enable", home=fake_home)
+    r = _run_cli("--no-telemetry", "telemetry", "status", home=fake_home)
+    assert r.returncode == 0, r.stderr
+    assert "cli-flag" in r.stdout.lower()
+    assert "disabled" in r.stdout.lower()
+
+
+def test_env_kill_switch_via_subprocess(fake_home):
+    _run_cli("telemetry", "enable", home=fake_home)
+    r = _run_cli(
+        "telemetry",
+        "status",
+        home=fake_home,
+        env_overrides={"RAPID_MLX_TELEMETRY": "0"},
+    )
+    assert r.returncode == 0
+    assert "env-var" in r.stdout.lower()
+    assert "disabled" in r.stdout.lower()
+
+
+def test_help_lists_telemetry_subcommand():
+    """Bare ``rapid-mlx --help`` must surface the telemetry subcommand
+    so users discover it. Regression target: someone refactors the
+    subparsers and accidentally drops the registration."""
+    r = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "telemetry" in r.stdout
+
+
+def test_telemetry_help_lists_all_five_actions():
+    r = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "telemetry", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert r.returncode == 0, r.stderr
+    for action in ("status", "enable", "disable", "preview", "reset"):
+        assert action in r.stdout, f"missing action {action!r} in --help"

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the first-run consent prompt's skip rules.
+
+If any of these guards regresses, we either nag users (prompting on
+non-interactive subcommands or re-prompting after they answered) OR
+silently never ask (skipping when we shouldn't, leaving telemetry
+permanently off without disclosure). Both are bugs the original issue
+explicitly calls out as deal-breakers.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    return tmp_path
+
+
+def _stub_tty(monkeypatch, *, in_=True, out=True):
+    """Force ``sys.stdin.isatty()`` / ``sys.stdout.isatty()`` regardless
+    of the actual test runner environment (CI, tmux, etc.)."""
+    import sys
+
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: in_)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: out)
+
+
+def test_skips_when_consent_already_recorded(fake_home, monkeypatch, capsys):
+    """User already answered — never re-prompt, even on later interactive runs."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import record_consent
+
+    record_consent(False, rapid_mlx_version="0.6.33")
+    _stub_tty(monkeypatch)
+    maybe_prompt_for_consent("serve")
+    assert capsys.readouterr().out == ""
+
+
+def test_skips_when_env_var_set(fake_home, monkeypatch, capsys):
+    """Env var already governs state — no need to ask."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    _stub_tty(monkeypatch)
+    maybe_prompt_for_consent("serve")
+    assert capsys.readouterr().out == ""
+
+
+def test_skips_when_cli_no_telemetry(fake_home, monkeypatch, capsys):
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    _stub_tty(monkeypatch)
+    maybe_prompt_for_consent("serve", cli_no_telemetry=True)
+    assert capsys.readouterr().out == ""
+
+
+def test_skips_when_stdin_not_tty(fake_home, monkeypatch, capsys):
+    """Pipes / CI / daemons must NOT see a prompt that hangs the process."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    _stub_tty(monkeypatch, in_=False)
+    maybe_prompt_for_consent("serve")
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    ["version", "help", "models", "ps", "info", "telemetry"],
+)
+def test_skips_for_non_interactive_subcommands(
+    fake_home, monkeypatch, capsys, subcommand
+):
+    """One-shot info commands must stay quiet (and grep-friendly)."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    _stub_tty(monkeypatch)
+    maybe_prompt_for_consent(subcommand)
+    assert capsys.readouterr().out == ""
+
+
+def test_skips_when_subcommand_none(fake_home, monkeypatch, capsys):
+    """`rapid-mlx` with no subcommand prints help — no prompt."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    _stub_tty(monkeypatch)
+    maybe_prompt_for_consent(None)
+    assert capsys.readouterr().out == ""
+
+
+def test_yes_records_consent_true(fake_home, monkeypatch, capsys):
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+    maybe_prompt_for_consent("serve")
+
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is True
+    out = capsys.readouterr().out
+    assert "telemetry enabled" in out.lower()
+
+
+def test_no_records_consent_false(fake_home, monkeypatch, capsys):
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "n")
+    maybe_prompt_for_consent("serve")
+
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is False
+    out = capsys.readouterr().out
+    assert "stays off" in out.lower()
+
+
+def test_empty_answer_defaults_to_no(fake_home, monkeypatch):
+    """Pressing enter at the y/N prompt defaults to N — same as Ollama,
+    same as Homebrew's modern prompt. The disclosure says ``y/N`` so the
+    default has to be N or it's a lie."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "")
+    maybe_prompt_for_consent("serve")
+
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is False
+
+
+def test_eof_during_prompt_does_not_record(fake_home, monkeypatch, capsys):
+    """Ctrl-D mid-prompt is "I changed my mind" — must NOT record a
+    silent No that prevents future prompting."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+
+    def boom():
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", boom)
+    maybe_prompt_for_consent("serve")
+    # No consent recorded → next interactive run will re-prompt.
+    assert get_consent_state() is None
+
+
+def test_records_prompted_version_correctly(fake_home, monkeypatch):
+    """``status`` shows users when they were prompted and on which
+    version. If we record the wrong version, future schema-version
+    bumps can't reliably re-prompt only stale users."""
+    from vllm_mlx import __version__ as actual_version
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+    maybe_prompt_for_consent("serve")
+
+    state = get_consent_state()
+    assert state is not None
+    assert state.prompted_version == actual_version
+
+
+def test_unwritable_home_does_not_crash_cli(fake_home, monkeypatch, capsys):
+    """If recording consent fails (read-only home, disk full, etc.), the
+    CLI must NOT crash — telemetry consent is never a reason for the
+    user's actual subcommand to fail."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    def boom(*a, **kw):
+        raise OSError("read-only filesystem")
+
+    # Make every path operation in record_consent fail.
+    monkeypatch.setattr(
+        "vllm_mlx.telemetry.consent.record_consent",
+        lambda *a, **kw: (_ for _ in ()).throw(boom()),
+    )
+    # Should swallow the error and return cleanly.
+    maybe_prompt_for_consent("serve")

--- a/tests/test_telemetry_redact.py
+++ b/tests/test_telemetry_redact.py
@@ -156,6 +156,18 @@ def test_hash_flag_names_handles_equals_form():
     assert all("8000" not in name for name in result)
 
 
+def test_hash_flag_names_value_with_equals():
+    """``--filter=key=value`` — value contains ``=``. The flag name is
+    everything before the FIRST ``=``; the rest (incl. inner ``=``) is
+    the value and must be dropped wholesale."""
+    argv = ["--filter=key=value", "--header=X-Trace=abc123"]
+    result = hash_flag_names(argv)
+    assert result == ["filter", "header"]
+    # No part of either value survives.
+    for needle in ("key", "value", "X-Trace", "abc123"):
+        assert needle not in result
+
+
 def test_hash_flag_names_short_flags():
     argv = ["-V", "-y", "--verbose"]
     assert hash_flag_names(argv) == ["V", "verbose", "y"]
@@ -214,6 +226,31 @@ def test_fingerprint_traceback_omits_message_text():
     # The hex-only check is the strongest guarantee — the function
     # returns a sha256 prefix, so anything non-hex is a bug.
     assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_traceback_excludes_exception_module_path():
+    """A custom exception from ``foo.bar.baz.MyError`` must not have
+    its full module path become part of the hash input — that would
+    leak which third-party packages the user has installed.
+
+    We test indirectly: two exception classes with the same NAME but
+    different MODULE paths must produce the same fingerprint when
+    raised from the same site. If the implementation included
+    ``__module__``, the hashes would diverge.
+    """
+    # Build two distinct classes both named ``CustomError`` in different
+    # synthetic modules. Real-world analogue: two third-party packages
+    # both shipping a ``ConnectionError``.
+    err1 = type("CustomError", (Exception,), {"__module__": "pkg_a.sub"})
+    err2 = type("CustomError", (Exception,), {"__module__": "pkg_b.deep.nested"})
+
+    def trigger(cls) -> str:
+        try:
+            raise cls("x")
+        except Exception as e:
+            return fingerprint_traceback(e)
+
+    assert trigger(err1) == trigger(err2)
 
 
 def test_fingerprint_traceback_omits_local_paths():

--- a/tests/test_telemetry_redact.py
+++ b/tests/test_telemetry_redact.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin redaction primitives — every "could this leak PII?" decision lives here.
+
+If any of these tests starts failing, telemetry payloads are about to
+contain user data they shouldn't. Be very suspicious before "fixing" a
+red test by relaxing the assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.telemetry.redact import (
+    bucket_memory_gb,
+    bucket_tokens,
+    bucket_tps,
+    bucket_ttft_ms,
+    fingerprint_traceback,
+    hash_flag_names,
+    normalize_model_path,
+    platform_info,
+)
+
+# ----------------------------------------------------------- token buckets
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (-1, "0-256"),  # negative clamps
+        (0, "0-256"),
+        (255, "0-256"),
+        (256, "256-1k"),  # boundary goes UP
+        (1023, "256-1k"),
+        (1024, "1k-4k"),
+        (4095, "1k-4k"),
+        (4096, "4k-16k"),
+        (16384, "16k-64k"),
+        (65535, "16k-64k"),
+        (65536, "64k+"),
+        (1_000_000, "64k+"),
+    ],
+)
+def test_bucket_tokens_boundaries(n, expected):
+    assert bucket_tokens(n) == expected
+
+
+@pytest.mark.parametrize(
+    "ms,expected",
+    [
+        (-1, "<100ms"),
+        (0, "<100ms"),
+        (99, "<100ms"),
+        (100, "100-500ms"),
+        (499, "100-500ms"),
+        (500, "500-1500ms"),
+        (1500, "1.5-5s"),
+        (4999, "1.5-5s"),
+        (5000, ">5s"),
+    ],
+)
+def test_bucket_ttft_boundaries(ms, expected):
+    assert bucket_ttft_ms(ms) == expected
+
+
+@pytest.mark.parametrize(
+    "tps,expected",
+    [
+        (-1, "<10"),
+        (0, "<10"),
+        (9.999, "<10"),
+        (10, "10-30"),
+        (29.99, "10-30"),
+        (30, "30-50"),
+        (50, "50-100"),
+        (99.99, "50-100"),
+        (100, ">100"),
+        (1000, ">100"),
+    ],
+)
+def test_bucket_tps_boundaries(tps, expected):
+    assert bucket_tps(tps) == expected
+
+
+def test_bucket_memory_rounds_and_clamps():
+    assert bucket_memory_gb(0) == 0
+    assert bucket_memory_gb(-1) == 0
+    assert bucket_memory_gb(1024**3) == 1
+    assert bucket_memory_gb(int(1.4 * 1024**3)) == 1
+    assert bucket_memory_gb(int(1.6 * 1024**3)) == 2
+    assert bucket_memory_gb(256 * 1024**3) == 256
+
+
+# ----------------------------------------------------------- model paths
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "mlx-community/Qwen3.5-9B-4bit",
+        "huggingface/transformers",
+        "user_name/model.v2",
+        "a/b",
+    ],
+)
+def test_normalize_model_path_passes_hf_repo_ids(raw):
+    assert normalize_model_path(raw) == raw
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/Users/alice/models/foo",
+        "./local-checkout",
+        "../sibling",
+        "~/models/foo",
+        "C:\\Users\\bob\\model",
+        "file:///tmp/model",
+        "org/path/with/extra/slashes",  # invalid HF shape — redact don't pass through
+        "weird name with spaces/x",
+    ],
+)
+def test_normalize_model_path_redacts_local(raw):
+    assert normalize_model_path(raw) == "<local>"
+
+
+def test_normalize_model_path_bare_alias_passes():
+    """Bare alias names (no slash) are public + harmless."""
+    assert normalize_model_path("qwen3.5-9b") == "qwen3.5-9b"
+    assert normalize_model_path("hermes3-8b") == "hermes3-8b"
+
+
+def test_normalize_model_path_empty():
+    assert normalize_model_path("") == "<empty>"
+
+
+# ----------------------------------------------------------- argv flags
+
+
+def test_hash_flag_names_extracts_only_names():
+    """The whole point of this function is that flag *values* never come
+    out the other side. ``--api-key sk-real-secret`` must yield
+    ``["api-key"]`` with no trace of the secret."""
+    argv = ["--api-key", "sk-real-secret", "--port", "8000", "model-name"]
+    assert hash_flag_names(argv) == ["api-key", "port"]
+
+
+def test_hash_flag_names_handles_equals_form():
+    """``--key=value`` is one token — must still drop the value."""
+    argv = ["--api-key=sk-secret", "--port=8000"]
+    result = hash_flag_names(argv)
+    assert "api-key" in result
+    assert "port" in result
+    # No secret material survives anywhere
+    assert all("sk-secret" not in name for name in result)
+    assert all("8000" not in name for name in result)
+
+
+def test_hash_flag_names_short_flags():
+    argv = ["-V", "-y", "--verbose"]
+    assert hash_flag_names(argv) == ["V", "verbose", "y"]
+
+
+def test_hash_flag_names_returns_sorted_unique():
+    argv = ["--zebra", "--alpha", "--zebra", "--mike"]
+    assert hash_flag_names(argv) == ["alpha", "mike", "zebra"]
+
+
+def test_hash_flag_names_empty_and_non_strings():
+    """Defence: argv from sys.argv is always strings, but a caller might
+    pass garbage. Don't crash — just skip non-strings."""
+    assert hash_flag_names([]) == []
+    assert hash_flag_names(["not-a-flag", "another-positional"]) == []
+    assert hash_flag_names([None, 42, "--real"]) == ["real"]
+
+
+# ----------------------------------------------------------- traceback
+
+
+def test_fingerprint_traceback_is_deterministic():
+    """Same exception site → same fingerprint across calls. This is the
+    contract that makes error counting in aggregate possible.
+
+    Both ``raise`` and ``catch`` must be at the same source line in
+    every iteration, otherwise the lineno differs and fingerprints
+    rightly differ.
+    """
+
+    def trigger_and_fingerprint() -> str:
+        try:
+            raise ValueError("user secret leaked here")
+        except ValueError as e:
+            return fingerprint_traceback(e)
+
+    fp1 = trigger_and_fingerprint()
+    fp2 = trigger_and_fingerprint()
+
+    assert fp1 == fp2
+    assert len(fp1) == 16
+
+
+def test_fingerprint_traceback_omits_message_text():
+    """The raised exception's message contains ``"user secret leaked"``.
+    The fingerprint must NOT contain those words. Critical PII guard."""
+
+    try:
+        raise RuntimeError("user secret leaked here in the message")
+    except RuntimeError as e:
+        fp = fingerprint_traceback(e)
+
+    assert "user" not in fp
+    assert "secret" not in fp
+    assert "leaked" not in fp
+    # The hex-only check is the strongest guarantee — the function
+    # returns a sha256 prefix, so anything non-hex is a bug.
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_traceback_omits_local_paths():
+    """Frame filenames are absolute paths revealing user's home. Only
+    the basename should survive into the hash input."""
+    try:
+        raise RuntimeError("x")
+    except RuntimeError as e:
+        fp = fingerprint_traceback(e)
+
+    # The fingerprint is just hex — but a stronger signal: changing the
+    # *directory* of the test file shouldn't change the fingerprint
+    # (because we strip directories). We can prove this indirectly by
+    # showing two different exception sites give different fingerprints.
+    def site_a():
+        raise ValueError("a")
+
+    def site_b():
+        raise ValueError("b")
+
+    try:
+        site_a()
+    except ValueError as e:
+        fp_a = fingerprint_traceback(e)
+    try:
+        site_b()
+    except ValueError as e:
+        fp_b = fingerprint_traceback(e)
+
+    # Different lineno → different fingerprint
+    assert fp_a != fp_b
+    # All fingerprints are 16 hex chars
+    for f in (fp, fp_a, fp_b):
+        assert len(f) == 16
+
+
+# ----------------------------------------------------------- platform
+
+
+def test_platform_info_no_full_kernel_string():
+    """Darwin's ``platform.release()`` is something like ``25.3.0`` —
+    we keep ``25.3`` only. The patch number changes weekly and is a
+    soft fingerprint."""
+    info = platform_info()
+    assert isinstance(info["os_version"], str)
+    # At most two dots (major.minor or just major); never four-segment.
+    assert info["os_version"].count(".") <= 1
+
+
+def test_platform_info_python_version_short():
+    info = platform_info()
+    # "3.12" not "3.12.13"
+    assert info["python_version"].count(".") == 1
+
+
+def test_platform_info_memory_is_rounded_int():
+    info = platform_info()
+    assert isinstance(info["memory_gb"], int)
+    assert info["memory_gb"] >= 0
+
+
+def test_platform_info_no_unbounded_strings():
+    """Sanity: every string field has a sane upper bound. Catches
+    accidental inclusion of multi-line stack traces or huge env dumps."""
+    info = platform_info()
+    for key in ("os", "os_version", "arch", "chip", "python_version"):
+        assert isinstance(info[key], str)
+        assert len(info[key]) < 200, f"{key} suspiciously long: {info[key]!r}"

--- a/tests/test_telemetry_state.py
+++ b/tests/test_telemetry_state.py
@@ -188,3 +188,54 @@ def test_consent_file_atomic_write(fake_home):
     record_consent(True, rapid_mlx_version="0.6.33")
     leftover = consent_path().with_suffix(consent_path().suffix + ".tmp")
     assert not leftover.exists()
+
+
+def test_record_consent_cleans_up_stale_tmp(fake_home):
+    """Simulate an interrupted previous write by pre-planting a .tmp.
+    record_consent must overwrite it cleanly and leave nothing behind."""
+    import yaml
+
+    from vllm_mlx.telemetry.state import (
+        consent_path,
+        get_consent_state,
+        record_consent,
+    )
+
+    cpath = consent_path()
+    cpath.parent.mkdir(parents=True, exist_ok=True)
+    stale = cpath.with_suffix(cpath.suffix + ".tmp")
+    stale.write_text("partial: junk\nthis is not valid")
+    assert stale.exists()
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    assert not stale.exists(), "stale .tmp should be cleaned up"
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is True
+    # And the real consent file is well-formed YAML.
+    parsed = yaml.safe_load(cpath.read_text())
+    assert parsed["consent"] is True
+
+
+def test_schema_version_mismatch_treated_as_unprompted(fake_home):
+    """A consent file with a schema_version we don't recognize must
+    be treated as 'never prompted' so the user gets re-asked under
+    whatever the current disclosure copy is. Forward-compat for
+    Phase 2+."""
+    import yaml
+
+    from vllm_mlx.telemetry.state import consent_path, get_consent_state
+
+    cpath = consent_path()
+    cpath.parent.mkdir(parents=True, exist_ok=True)
+    cpath.write_text(
+        yaml.safe_dump(
+            {
+                "consent": True,
+                "prompted_at": "2026-05-10T00:00:00Z",
+                "prompted_version": "0.6.33",
+                "schema_version": 99,  # future-version we don't know
+            }
+        )
+    )
+    assert get_consent_state() is None

--- a/tests/test_telemetry_state.py
+++ b/tests/test_telemetry_state.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the consent precedence contract.
+
+The four-layer precedence (CLI flag > env-var kill switch > stored
+consent > default off) is the *single decision* every event-emit site
+in Phase 2+ will rely on. Breaking it silently re-enables (or
+silently disables) telemetry for the whole user base, which is the
+exact failure mode this issue exists to avoid. Test it directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Reroute ``Path.home()`` so consent files land under tmp.
+
+    The telemetry state module reads ``Path.home()`` at call time on
+    purpose (so tests can do exactly this). Setting ``HOME`` is the
+    documented way to override on POSIX.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+    # Force-reload the state module so any cached path objects (there
+    # shouldn't be any, but defence in depth) get rebuilt under the new
+    # HOME.
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    return tmp_path
+
+
+def test_default_is_off(fake_home):
+    from vllm_mlx.telemetry.state import is_enabled
+
+    assert is_enabled() is False
+
+
+def test_consent_round_trip(fake_home):
+    from vllm_mlx.telemetry.state import (
+        get_consent_state,
+        is_enabled,
+        record_consent,
+    )
+
+    assert get_consent_state() is None
+    record_consent(True, rapid_mlx_version="0.6.33")
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is True
+    assert state.prompted_version == "0.6.33"
+    assert state.schema_version == 1
+    assert state.prompted_at.endswith("Z")
+    assert is_enabled() is True
+
+
+def test_env_kill_switch_wins_over_consent(fake_home, monkeypatch):
+    """Stored consent=True must NOT override RAPID_MLX_TELEMETRY=0.
+
+    Critical contract: the env var is the documented "scripts can force
+    off without touching the file" escape hatch. If consent could
+    override it, CI runs would silently leak data the user thought they
+    had disabled.
+    """
+    from vllm_mlx.telemetry.state import is_enabled, record_consent
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    assert is_enabled() is True
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    assert is_enabled() is False
+
+
+def test_cli_flag_wins_over_consent(fake_home):
+    """Even with consent=True and no env var, --no-telemetry forces off."""
+    from vllm_mlx.telemetry.state import is_enabled, record_consent
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    assert is_enabled() is True
+    assert is_enabled(cli_no_telemetry=True) is False
+
+
+def test_env_force_on_is_ignored(fake_home, monkeypatch):
+    """RAPID_MLX_TELEMETRY=1 must NOT silently opt the user in.
+
+    Documented as kill-switch only — anything else means a CI agent or
+    mistyped env var could enable telemetry without the user ever
+    consenting. Default-off when no consent file exists is the contract.
+    """
+    from vllm_mlx.telemetry.state import is_enabled
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "1")
+    assert is_enabled() is False  # still off — no stored consent
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "true")
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("falsy", ["0", "false", "FALSE", "no", "off", "  0  ", ""])
+def test_env_falsy_values_all_disable(fake_home, monkeypatch, falsy):
+    from vllm_mlx.telemetry.state import is_enabled, record_consent
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", falsy)
+    assert is_enabled() is False, f"falsy value {falsy!r} should kill-switch"
+
+
+def test_client_id_idempotent(fake_home):
+    from vllm_mlx.telemetry.state import get_or_create_client_id
+
+    first = get_or_create_client_id()
+    assert first
+    assert len(first) == 36  # uuid4 string form
+    assert get_or_create_client_id() == first
+
+
+def test_client_id_user_zeroed_uuid_preserved(fake_home):
+    """User can replace client_id with all-zeros to anonymize.
+
+    Documented escape hatch: ``echo 00000000-... > telemetry-client-id``
+    keeps the file present (so we don't regenerate) but contributes
+    only to anonymous aggregate counts. If we silently overwrote, we'd
+    break the documented user contract.
+    """
+    from vllm_mlx.telemetry.state import client_id_path, get_or_create_client_id
+
+    zero = "00000000-0000-0000-0000-000000000000"
+    path = client_id_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(zero + "\n")
+    assert get_or_create_client_id() == zero
+
+
+def test_reset_state_removes_both_files(fake_home):
+    from vllm_mlx.telemetry.state import (
+        client_id_path,
+        consent_path,
+        get_or_create_client_id,
+        record_consent,
+        reset_state,
+    )
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    get_or_create_client_id()
+    assert consent_path().exists()
+    assert client_id_path().exists()
+    reset_state()
+    assert not consent_path().exists()
+    assert not client_id_path().exists()
+    # Idempotent — second reset_state on missing files must not raise.
+    reset_state()
+
+
+def test_consent_source_reports_origin(fake_home, monkeypatch):
+    """The status command shows users *why* telemetry is in its current
+    state — verify each source string is correctly reported."""
+    from vllm_mlx.telemetry.state import consent_source, record_consent
+
+    assert "default" in consent_source()
+    record_consent(True, rapid_mlx_version="0.6.33")
+    assert "consent-file" in consent_source()
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    assert "env-var" in consent_source()
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY")
+    assert "cli-flag" in consent_source(cli_no_telemetry=True)
+
+
+def test_corrupt_consent_file_treated_as_unprompted(fake_home):
+    """A garbage consent file must NOT crash the CLI — we treat it as
+    'never prompted' so the next interactive run re-asks the user.
+    Crashing here would block every serve invocation."""
+    from vllm_mlx.telemetry.state import consent_path, get_consent_state
+
+    path = consent_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(":\n  not valid yaml :: at all")
+    assert get_consent_state() is None
+
+
+def test_consent_file_atomic_write(fake_home):
+    """``record_consent`` writes via temp + rename so a SIGINT mid-write
+    can't leave a half-file. The .tmp file should NOT be present after
+    a successful write."""
+    from vllm_mlx.telemetry.state import consent_path, record_consent
+
+    record_consent(True, rapid_mlx_version="0.6.33")
+    leftover = consent_path().with_suffix(consent_path().suffix + ".tmp")
+    assert not leftover.exists()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2279,6 +2279,102 @@ def upgrade_command(args):
     sys.exit(result.returncode)
 
 
+def telemetry_command(args) -> None:
+    """Manage anonymous usage telemetry — see Issue #236.
+
+    Five actions: ``status`` / ``enable`` / ``disable`` / ``preview`` /
+    ``reset``. Defaults to ``status`` when no action given so users can
+    type ``rapid-mlx telemetry`` and immediately see what's set up.
+    """
+    # Imports kept inside the function so the telemetry package is only
+    # loaded when actually needed — keeps `--help` and unrelated
+    # subcommands cheap.
+    import json
+
+    from vllm_mlx import __version__ as rapid_mlx_version
+    from vllm_mlx.telemetry import (
+        consent_source,
+        get_consent_state,
+        get_or_create_client_id,
+        is_enabled,
+        record_consent,
+        reset_state,
+    )
+    from vllm_mlx.telemetry.schema import sample_preview_payload
+    from vllm_mlx.telemetry.state import client_id_path, consent_path
+
+    action = getattr(args, "telemetry_action", None) or "status"
+    cli_no = getattr(args, "no_telemetry", False)
+
+    if action == "status":
+        state = get_consent_state()
+        print()
+        print(
+            f"  Telemetry: {'ENABLED' if is_enabled(cli_no_telemetry=cli_no) else 'disabled'}"
+        )
+        print(f"  Source:    {consent_source(cli_no_telemetry=cli_no)}")
+        if state is not None:
+            print(
+                f"  Consent:   {state.consent} (recorded {state.prompted_at}, "
+                f"by rapid-mlx {state.prompted_version})"
+            )
+        else:
+            print("  Consent:   never prompted")
+        print(f"  Files:     {consent_path()}")
+        print(f"             {client_id_path()}")
+        print()
+        print("  Subcommands:  enable | disable | preview | reset")
+        print()
+        return
+
+    if action == "enable":
+        record_consent(True, rapid_mlx_version=rapid_mlx_version)
+        # Generate the client_id eagerly so `preview` immediately after
+        # has a real id to show.
+        get_or_create_client_id()
+        print()
+        print("  Telemetry: ENABLED. Thanks for helping us prioritise.")
+        print("  Disable anytime with `rapid-mlx telemetry disable`.")
+        print("  Preview what we'd send: `rapid-mlx telemetry preview`.")
+        print()
+        return
+
+    if action == "disable":
+        record_consent(False, rapid_mlx_version=rapid_mlx_version)
+        print()
+        print("  Telemetry: disabled. No data will be sent.")
+        print("  Re-enable anytime with `rapid-mlx telemetry enable`.")
+        print()
+        return
+
+    if action == "preview":
+        cid = get_or_create_client_id()
+        payload = sample_preview_payload(
+            client_id=cid, rapid_mlx_version=rapid_mlx_version
+        )
+        print()
+        print("  Sample payload (this is exactly the shape we send):")
+        print()
+        print(json.dumps(payload.to_dict(), indent=2))
+        print()
+        if not is_enabled(cli_no_telemetry=cli_no):
+            print("  Telemetry is currently disabled — nothing is actually sent.")
+            print()
+        return
+
+    if action == "reset":
+        reset_state()
+        print()
+        print("  Removed consent + client-id files. Next interactive run re-prompts.")
+        print()
+        return
+
+    # Unknown action — argparse choices=[] would have caught this earlier
+    # in normal flow; defensive guard for future maintainers.
+    print(f"  Unknown telemetry action: {action!r}")
+    sys.exit(1)
+
+
 def main():
     from importlib.metadata import version as pkg_version
 
@@ -2299,6 +2395,12 @@ Examples:
     )
     parser.add_argument(
         "--version", "-V", action="version", version=f"rapid-mlx {_version}"
+    )
+    parser.add_argument(
+        "--no-telemetry",
+        action="store_true",
+        help="Disable anonymous usage telemetry for this run "
+        "(equivalent to RAPID_MLX_TELEMETRY=0).",
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
@@ -3073,7 +3175,48 @@ Examples:
         "Ignored with a warning for smoke / benchmark tiers.",
     )
 
+    # Telemetry subcommand — opt-in anonymous usage data (Issue #236).
+    # See vllm_mlx/telemetry/ for what we collect / don't collect, and
+    # the README "Telemetry" section for the user-facing summary.
+    telemetry_parser = subparsers.add_parser(
+        "telemetry",
+        help="Manage anonymous usage telemetry (opt-in)",
+    )
+    telemetry_subparsers = telemetry_parser.add_subparsers(
+        dest="telemetry_action",
+        help="Telemetry actions",
+    )
+    telemetry_subparsers.add_parser(
+        "status", help="Show whether telemetry is enabled and why"
+    )
+    telemetry_subparsers.add_parser(
+        "enable", help="Opt in to anonymous usage telemetry"
+    )
+    telemetry_subparsers.add_parser(
+        "disable", help="Opt out of anonymous usage telemetry"
+    )
+    telemetry_subparsers.add_parser(
+        "preview",
+        help="Print a sample payload showing exactly what telemetry would send",
+    )
+    telemetry_subparsers.add_parser(
+        "reset",
+        help="Delete the consent + client-id files (next run re-prompts)",
+    )
+
     args = parser.parse_args()
+
+    # First-run consent prompt — fires at most once per machine, only on
+    # interactive subcommands when stdin is a tty. Safe no-op otherwise.
+    # Must run *before* heavy subcommand work so the user sees the
+    # disclosure before any model load logs scroll past.
+    if getattr(args, "command", None) is not None:
+        from vllm_mlx.telemetry import maybe_prompt_for_consent
+
+        maybe_prompt_for_consent(
+            args.command,
+            cli_no_telemetry=getattr(args, "no_telemetry", False),
+        )
 
     # Resolve model aliases before dispatch.
     #
@@ -3146,6 +3289,8 @@ Examples:
         if getattr(args, "models", None):
             args.models = [m.strip() for m in args.models.split(",") if m.strip()]
         doctor_command(args)
+    elif args.command == "telemetry":
+        telemetry_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/vllm_mlx/telemetry/__init__.py
+++ b/vllm_mlx/telemetry/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Anonymous opt-in usage telemetry — Phase 1 (consent + plumbing only).
+
+This package owns the consent state, redaction primitives, and event
+schema. **No network code lives here in Phase 1** — the transport,
+collector, and Cloudflare Worker arrive in a follow-up PR. This split
+exists so the privacy mechanism (kill switch, consent file, redaction
+contracts, CLI subcommand) can land and be reviewed in isolation,
+before any byte ever leaves the machine.
+
+See ``docs/telemetry.md`` (or the README "Telemetry" section) for the
+full schema, what we do/do not collect, and how to disable.
+
+Public API:
+
+- ``is_enabled`` — the single decision point. Returns False unless the
+  user opted in AND no kill switch is active.
+- ``get_consent_state`` — full record (consent bool, when prompted,
+  which version prompted them) for ``rapid-mlx telemetry status``.
+- ``record_consent`` — persist a yes/no answer.
+- ``reset_state`` — wipe both consent + client-id files.
+- ``maybe_prompt_for_consent`` — first-run interactive prompt; safe to
+  call from every subcommand (it skips itself when not appropriate).
+"""
+
+from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+from vllm_mlx.telemetry.state import (
+    ConsentState,
+    consent_source,
+    get_consent_state,
+    get_or_create_client_id,
+    is_enabled,
+    record_consent,
+    reset_state,
+)
+
+__all__ = [
+    "ConsentState",
+    "consent_source",
+    "get_consent_state",
+    "get_or_create_client_id",
+    "is_enabled",
+    "maybe_prompt_for_consent",
+    "record_consent",
+    "reset_state",
+]

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -114,8 +114,10 @@ def maybe_prompt_for_consent(
                 "to be re-prompted)."
             )
         print()
-    except Exception:
-        # Belt-and-braces: telemetry consent is *never* a reason for the
-        # CLI to fail. Catch everything (including SystemExit-via-input),
-        # swallow it, and let the actual subcommand run.
+    except (OSError, EOFError, KeyboardInterrupt):
+        # Telemetry consent is *never* a reason for the CLI to fail —
+        # but only swallow the failure modes we actually expect: I/O on
+        # an unwritable home, terminal weirdness, or user Ctrl-C during
+        # input. Programming errors (AttributeError, TypeError, ...)
+        # propagate so they get noticed in development.
         return

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""First-run consent prompt.
+
+Fires at most once per machine, only when:
+
+- The user has never been prompted (``get_consent_state`` returns None).
+- ``RAPID_MLX_TELEMETRY`` is not set (env var already determines state,
+  no need to ask).
+- ``--no-telemetry`` is not set on this run.
+- ``stdin`` is a tty (we are not in a pipe / CI / daemon-spawn).
+- The current subcommand is interactive (``serve``, ``chat``, etc.) —
+  not ``version``, ``help``, ``models``, ``ps``, ``info``, or any
+  read-only / one-shot command where a prompt would be intrusive.
+
+The disclosure copy is intentionally short: 6 lines, links to README,
+defaults to NO. We never nag — declining writes ``consent=False`` so
+this prompt does not fire again.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from vllm_mlx import __version__ as _rapid_mlx_version  # noqa: N811
+from vllm_mlx.telemetry.state import (
+    ENV_VAR,
+    consent_path,
+    get_consent_state,
+    record_consent,
+)
+
+# Subcommands where prompting would be intrusive (one-shot info commands,
+# pipe-friendly outputs, or commands explicitly about telemetry config).
+# Everything else (serve, chat, agents, bench, doctor, pull, rm, upgrade)
+# is interactive enough that a one-time disclosure is OK.
+_NON_INTERACTIVE_SUBCOMMANDS = frozenset(
+    {
+        "version",
+        "help",
+        "models",
+        "ps",
+        "info",
+        "telemetry",
+    }
+)
+
+_DISCLOSURE = """\
+Rapid-MLX can send anonymous usage data so we can prioritise the right
+models and catch regressions across the user base.
+
+We collect (only if you say yes): subcommand names, model alias names,
+bucketed token/latency counts, error categories, OS + chip + RAM.
+
+We never collect: prompts, completions, file paths, IPs, env-var values,
+or any user-generated text. Source: vllm_mlx/telemetry/.
+
+Type 'y' to opt in, anything else to decline. You can change this anytime
+with `rapid-mlx telemetry {{enable,disable,reset}}`. To force-disable in
+scripts: set {env}=0.
+"""
+
+
+def maybe_prompt_for_consent(
+    subcommand: str | None, *, cli_no_telemetry: bool = False
+) -> None:
+    """Show the first-run prompt if (and only if) all guards pass.
+
+    Returns silently when any guard skips. Never raises — a broken stdin
+    or unwritable home directory must not crash the user's serve / chat
+    invocation just because we couldn't ask about telemetry.
+    """
+    try:
+        if cli_no_telemetry:
+            return
+        # Env var already decides — no need to prompt.
+        import os
+
+        if os.environ.get(ENV_VAR) is not None:
+            return
+        if subcommand in _NON_INTERACTIVE_SUBCOMMANDS:
+            return
+        if subcommand is None:
+            return
+        if get_consent_state() is not None:
+            return
+        if not sys.stdin.isatty():
+            return
+        if not sys.stdout.isatty():
+            return
+
+        version = _rapid_mlx_version
+        print()
+        print(_DISCLOSURE.format(env=ENV_VAR))
+        print("  [opt-in to anonymous telemetry?  y/N]  ", end="", flush=True)
+        try:
+            answer = input().strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            # Treat interruption as decline. Don't record — let the user
+            # be re-prompted next interactive run, since they didn't
+            # actually answer.
+            print()
+            return
+        consent = answer in ("y", "yes")
+        record_consent(consent, rapid_mlx_version=version)
+        if consent:
+            print(
+                "Thanks — telemetry enabled. Disable anytime with "
+                "`rapid-mlx telemetry disable`."
+            )
+        else:
+            print(
+                "Got it — telemetry stays off. Enable later with "
+                f"`rapid-mlx telemetry enable` (or delete {consent_path()} "
+                "to be re-prompted)."
+            )
+        print()
+    except Exception:
+        # Belt-and-braces: telemetry consent is *never* a reason for the
+        # CLI to fail. Catch everything (including SystemExit-via-input),
+        # swallow it, and let the actual subcommand run.
+        return

--- a/vllm_mlx/telemetry/redact.py
+++ b/vllm_mlx/telemetry/redact.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Redaction primitives — every "could this leak PII?" decision lives here.
+
+Phase 1 ships these as pure functions with thorough unit tests. Phase 2
+event sites call them; the contract is "if it didn't go through redact,
+it doesn't leave the machine".
+
+Bucketing rationale: exact counts (token totals, TTFT in ms) are a soft
+fingerprint when joined with other fields. Bucketing into a small fixed
+set of strings collapses the join surface to something an aggregation
+pipeline can actually count without re-identifying a session.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+import re
+import traceback
+from pathlib import Path
+
+# ---------------------------------------------------------------- bucketing
+
+
+_TOKEN_BUCKETS: tuple[tuple[int, str], ...] = (
+    (256, "0-256"),
+    (1024, "256-1k"),
+    (4096, "1k-4k"),
+    (16384, "4k-16k"),
+    (65536, "16k-64k"),
+)
+_TOKEN_OVERFLOW = "64k+"
+
+
+def bucket_tokens(n: int) -> str:
+    """Map a token count to one of 6 fixed buckets.
+
+    Edges go to the *upper* bucket — exactly 256 tokens lands in
+    ``"256-1k"``, not ``"0-256"`` — because the buckets read as
+    half-open intervals ``[lower, upper)``.
+    """
+    if n < 0:
+        return "0-256"
+    for upper, label in _TOKEN_BUCKETS:
+        if n < upper:
+            return label
+    return _TOKEN_OVERFLOW
+
+
+_TTFT_BUCKETS: tuple[tuple[float, str], ...] = (
+    (100, "<100ms"),
+    (500, "100-500ms"),
+    (1500, "500-1500ms"),
+    (5000, "1.5-5s"),
+)
+_TTFT_OVERFLOW = ">5s"
+
+
+def bucket_ttft_ms(ms: float) -> str:
+    if ms < 0:
+        return "<100ms"
+    for upper, label in _TTFT_BUCKETS:
+        if ms < upper:
+            return label
+    return _TTFT_OVERFLOW
+
+
+_TPS_BUCKETS: tuple[tuple[float, str], ...] = (
+    (10, "<10"),
+    (30, "10-30"),
+    (50, "30-50"),
+    (100, "50-100"),
+)
+_TPS_OVERFLOW = ">100"
+
+
+def bucket_tps(tps: float) -> str:
+    if tps < 0:
+        return "<10"
+    for upper, label in _TPS_BUCKETS:
+        if tps < upper:
+            return label
+    return _TPS_OVERFLOW
+
+
+def bucket_memory_gb(bytes_: int) -> int:
+    """Round a byte count to the nearest GB. Negatives clamp to 0."""
+    if bytes_ <= 0:
+        return 0
+    return round(bytes_ / (1024**3))
+
+
+# ---------------------------------------------------------------- model paths
+
+# A HuggingFace repo ID is roughly ``org/name`` with letters, digits,
+# dot, dash, and underscore. We deliberately keep this strict — anything
+# else gets redacted, even at the cost of losing the model identity for
+# users who downloaded directly via git clone or symlinked HF cache.
+_HF_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+def normalize_model_path(path: str) -> str:
+    """Pass through ``org/name`` repo IDs; redact local paths to ``"<local>"``.
+
+    A local ``./qwen3.5-9b`` checkout that resolve_model() prefers over
+    the alias would otherwise leak the user's home-directory layout via
+    the model name.
+    """
+    if not path:
+        return "<empty>"
+    # Local-path heuristics: anything that looks like a filesystem path.
+    if path.startswith(("/", "./", "../", "~/")) or "\\" in path:
+        return "<local>"
+    if path.startswith("file://"):
+        return "<local>"
+    # Any ``/`` that survives must be the org/name separator and the
+    # whole string must match the repo-ID pattern.
+    if "/" in path:
+        if _HF_REPO_RE.match(path):
+            return path
+        return "<local>"
+    # Bare alias names (``qwen3.5-9b``) are public + harmless.
+    return path
+
+
+# ---------------------------------------------------------------- argv flags
+
+# Captures ``--flag``, ``--flag-name``, and short ``-x`` (single letter
+# only — multi-char short opts like ``-xy`` are uncommon enough we don't
+# bother). Dashes inside the name are kept; everything after ``=`` is
+# dropped before we ever see it because we only return names.
+_LONG_FLAG_RE = re.compile(r"^--([A-Za-z][A-Za-z0-9-]*)(?:=.*)?$")
+_SHORT_FLAG_RE = re.compile(r"^-([A-Za-z])$")
+
+
+def hash_flag_names(argv: list[str]) -> list[str]:
+    """Extract flag names from argv. Values are NEVER returned.
+
+    Only the name of each flag survives. ``--api-key sk-xxx`` becomes
+    ``["api-key"]`` (note: ``sk-xxx`` is never even read by this
+    function — we simply skip non-flag tokens). Returns sorted unique
+    list so the output is order-independent.
+    """
+    names: set[str] = set()
+    for token in argv:
+        if not isinstance(token, str):
+            continue
+        m = _LONG_FLAG_RE.match(token)
+        if m:
+            names.add(m.group(1))
+            continue
+        m = _SHORT_FLAG_RE.match(token)
+        if m:
+            names.add(m.group(1))
+    return sorted(names)
+
+
+# ---------------------------------------------------------------- traceback
+
+
+def fingerprint_traceback(exc: BaseException) -> str:
+    """Hash a traceback's *module paths only* — never message text.
+
+    We use the qualified frame paths (filename + function name + line
+    number) joined with the exception's class name. Crucially, we do NOT
+    include ``str(exc)`` — exception messages routinely contain user
+    input ("could not open /Users/alice/secret.txt").
+
+    Returns a 16-hex-char prefix of sha256 — enough to distinguish ~10^9
+    distinct sites with negligible collision risk, short enough to
+    eyeball in a dashboard.
+    """
+    tb = traceback.TracebackException.from_exception(exc)
+    parts: list[str] = [exc.__class__.__module__ + ":" + exc.__class__.__name__]
+    for frame in tb.stack:
+        # frame.filename is an absolute path — strip the directory part
+        # to avoid leaking the user's home. We keep the basename + the
+        # function name + line number, which is enough to identify the
+        # site without revealing where rapid-mlx is installed.
+        basename = Path(frame.filename).name
+        parts.append(f"{basename}:{frame.name}:{frame.lineno}")
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+# ---------------------------------------------------------------- platform
+
+
+def _read_chip_brand() -> str:
+    """Best-effort Apple Silicon chip name (e.g. ``"Apple M3 Ultra"``).
+
+    Falls back to ``platform.processor()`` on non-Darwin or when sysctl
+    is unavailable. Never raises.
+    """
+    if platform.system() != "Darwin":
+        return platform.processor() or "unknown"
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+        brand = result.stdout.strip()
+        return brand or platform.processor() or "unknown"
+    except (OSError, subprocess.TimeoutExpired):
+        return platform.processor() or "unknown"
+
+
+def _read_total_memory_bytes() -> int:
+    """Best-effort total RAM in bytes. Returns 0 if unknown."""
+    try:
+        import psutil
+
+        return int(psutil.virtual_memory().total)
+    except Exception:
+        return 0
+
+
+def platform_info() -> dict:
+    """Coarse platform fingerprint — schema-stable, no full kernel string.
+
+    Notes:
+    - ``os_version`` is major.minor only (Darwin 25.3.0 → "25.3"). The
+      patch number changes weekly and is a soft fingerprint.
+    - ``python_version`` is also major.minor only.
+    - ``memory_gb`` is rounded — exact byte counts can identify
+      individual machines.
+    """
+    os_release = platform.release() or ""
+    os_version = ".".join(os_release.split(".")[:2]) or os_release
+    py_version = "{}.{}".format(*platform.python_version_tuple()[:2])
+    return {
+        "os": platform.system().lower(),
+        "os_version": os_version,
+        "arch": platform.machine(),
+        "chip": _read_chip_brand(),
+        "memory_gb": bucket_memory_gb(_read_total_memory_bytes()),
+        "python_version": py_version,
+    }

--- a/vllm_mlx/telemetry/redact.py
+++ b/vllm_mlx/telemetry/redact.py
@@ -17,6 +17,7 @@ import hashlib
 import platform
 import re
 import traceback
+from functools import lru_cache
 from pathlib import Path
 
 # ---------------------------------------------------------------- bucketing
@@ -108,10 +109,18 @@ def normalize_model_path(path: str) -> str:
     """
     if not path:
         return "<empty>"
-    # Local-path heuristics: anything that looks like a filesystem path.
+    # Local-path heuristics, layered from cheap-string to robust-Path:
+    # the early returns keep the common HF-ID case fast.
     if path.startswith(("/", "./", "../", "~/")) or "\\" in path:
         return "<local>"
     if path.startswith("file://"):
+        return "<local>"
+    # Catch Windows drive-letter forms (``C:Users\...``, ``C:\\...``)
+    # and UNC paths that the cheap prefix check above misses.
+    try:
+        if Path(path).is_absolute():
+            return "<local>"
+    except (TypeError, ValueError, OSError):
         return "<local>"
     # Any ``/`` that survives must be the org/name separator and the
     # whole string must match the repo-ID pattern.
@@ -159,19 +168,24 @@ def hash_flag_names(argv: list[str]) -> list[str]:
 
 
 def fingerprint_traceback(exc: BaseException) -> str:
-    """Hash a traceback's *module paths only* — never message text.
+    """Hash a traceback's *frame paths only* — never message text, never
+    the exception's full module path.
 
-    We use the qualified frame paths (filename + function name + line
-    number) joined with the exception's class name. Crucially, we do NOT
-    include ``str(exc)`` — exception messages routinely contain user
-    input ("could not open /Users/alice/secret.txt").
+    We include only the bare exception class name (``ValueError``, not
+    ``transformers.models.llama.ModelError``) plus per-frame
+    ``basename:function:lineno``. Crucially we do NOT include ``str(exc)``
+    — exception messages routinely contain user input ("could not open
+    /Users/alice/secret.txt").
 
     Returns a 16-hex-char prefix of sha256 — enough to distinguish ~10^9
     distinct sites with negligible collision risk, short enough to
     eyeball in a dashboard.
     """
     tb = traceback.TracebackException.from_exception(exc)
-    parts: list[str] = [exc.__class__.__module__ + ":" + exc.__class__.__name__]
+    # Bare class name only — not ``__module__`` — so the fingerprint
+    # input does not reveal which third-party packages the user has
+    # installed (a soft fingerprint we don't need).
+    parts: list[str] = [exc.__class__.__name__]
     for frame in tb.stack:
         # frame.filename is an absolute path — strip the directory part
         # to avoid leaking the user's home. We keep the basename + the
@@ -186,11 +200,14 @@ def fingerprint_traceback(exc: BaseException) -> str:
 # ---------------------------------------------------------------- platform
 
 
+@lru_cache(maxsize=1)
 def _read_chip_brand() -> str:
     """Best-effort Apple Silicon chip name (e.g. ``"Apple M3 Ultra"``).
 
     Falls back to ``platform.processor()`` on non-Darwin or when sysctl
-    is unavailable. Never raises.
+    is unavailable. Never raises. Cached because chip identity does not
+    change at runtime and Phase 2 will call ``platform_info()`` per
+    event — without the cache that's a subprocess fork per request.
     """
     if platform.system() != "Darwin":
         return platform.processor() or "unknown"

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Telemetry payload schema v1 — wire shape only.
+
+Phase 1 ships the dataclasses + a sample-payload builder used by
+``rapid-mlx telemetry preview``. **No event sites populate these in
+Phase 1** — they exist so reviewers can audit exactly what could ever
+go on the wire, and so Phase 2 can wire events without re-debating the
+shape.
+
+Bump ``SCHEMA_VERSION`` whenever a backwards-incompatible field changes
+(rename / drop / type-change). Adding optional fields does not require
+a bump.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from vllm_mlx.telemetry.redact import (
+    bucket_memory_gb,
+    platform_info,
+)
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class PlatformInfo:
+    os: str
+    os_version: str
+    arch: str
+    chip: str
+    memory_gb: int
+    python_version: str
+
+
+@dataclass(frozen=True)
+class SessionPayload:
+    subcommand: str  # "serve" | "agents" | "bench" | "chat" | "doctor" | "models"
+    duration_seconds: int | None = None  # session_end only; None on session_start
+    models_loaded: tuple[str, ...] = ()  # HF repo IDs only (normalized)
+    engine: str = ""  # "batched" / future variants
+    flag_names: tuple[str, ...] = ()  # names only, sorted, no values
+
+
+@dataclass(frozen=True)
+class RequestPayload:
+    endpoint: str  # "/v1/chat/completions" etc.
+    model_alias: str
+    stream: bool
+    tool_call_used: bool
+    prompt_tokens_bucket: str
+    completion_tokens_bucket: str
+    ttft_ms_bucket: str
+    tps_bucket: str
+    status: int
+
+
+@dataclass(frozen=True)
+class ErrorPayload:
+    category: str  # "model_load_failure" | "oom" | "tool_parse" | "shutdown_traceback"
+    fingerprint: str  # 16-hex from redact.fingerprint_traceback()
+    phase: str  # "startup" | "request" | "shutdown"
+
+
+@dataclass(frozen=True)
+class TelemetryPayload:
+    """The complete on-the-wire envelope.
+
+    Exactly one of ``session`` / ``request`` / ``error`` is populated
+    per payload — the discriminator is the ``event`` field.
+    """
+
+    schema_version: int
+    client_id: str
+    session_id: str
+    rapid_mlx_version: str
+    platform: PlatformInfo
+    event: str  # "session_start" | "session_end" | "request" | "error"
+    timestamp: str  # ISO-8601 UTC, "Z" suffix
+    session: SessionPayload | None = None
+    request: RequestPayload | None = None
+    error: ErrorPayload | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Render the envelope as a JSON-ready dict.
+
+        ``None`` event-payload fields are dropped so the payload doesn't
+        carry empty placeholders for the two events it isn't.
+        """
+        d = asdict(self)
+        for key in ("session", "request", "error"):
+            if d.get(key) is None:
+                d.pop(key, None)
+        return d
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sample_preview_payload(
+    *,
+    client_id: str,
+    rapid_mlx_version: str,
+) -> TelemetryPayload:
+    """A representative payload for ``rapid-mlx telemetry preview``.
+
+    Built from real platform info + made-up session fields so users can
+    see exactly what would leave their machine without having to start
+    a server. The session_id is a fixed dummy because previews shouldn't
+    burn a real per-process id.
+    """
+    info = platform_info()
+    return TelemetryPayload(
+        schema_version=SCHEMA_VERSION,
+        client_id=client_id,
+        session_id="preview-0000000000000000",
+        rapid_mlx_version=rapid_mlx_version,
+        platform=PlatformInfo(
+            os=info["os"],
+            os_version=info["os_version"],
+            arch=info["arch"],
+            chip=info["chip"],
+            memory_gb=info["memory_gb"],
+            python_version=info["python_version"],
+        ),
+        event="session_start",
+        timestamp=_utc_now_iso(),
+        session=SessionPayload(
+            subcommand="serve",
+            models_loaded=("mlx-community/Qwen3.5-9B-4bit",),
+            engine="batched",
+            flag_names=("port", "host"),
+        ),
+    )
+
+
+__all__ = [
+    "ErrorPayload",
+    "PlatformInfo",
+    "RequestPayload",
+    "SCHEMA_VERSION",
+    "SessionPayload",
+    "TelemetryPayload",
+    "bucket_memory_gb",
+    "sample_preview_payload",
+]

--- a/vllm_mlx/telemetry/state.py
+++ b/vllm_mlx/telemetry/state.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Consent + client-id state for opt-in telemetry.
+
+Two files live under ``~/.rapid-mlx/``:
+
+- ``telemetry-client-id`` — a UUID4 string. Stable across runs so we can
+  count distinct opted-in machines without identifying them. The user
+  can ``rm`` it to reset, or replace its contents with the all-zero UUID
+  to anonymize their machine while still contributing aggregate counts.
+
+- ``telemetry-consent.yaml`` — records the user's yes/no answer plus
+  metadata (when prompted, which version asked) so we never re-prompt
+  the same user and can later detect schema-version bumps that should
+  re-prompt.
+
+Two files rather than one because: ``rm telemetry-consent.yaml``
+re-triggers the first-run prompt without losing the client_id; ``rm
+telemetry-client-id`` rotates identity without re-prompting. Bundling
+them would force the user into all-or-nothing.
+
+The ``is_enabled`` decision precedence (highest first):
+
+1. ``--no-telemetry`` CLI flag → forced OFF for this run.
+2. ``RAPID_MLX_TELEMETRY=0`` env → forced OFF.
+3. Stored consent file → whatever the user answered.
+4. Default → OFF. (Anonymous data collection without explicit opt-in is
+   a non-starter.)
+
+There is intentionally no env-var equivalent for forcing ON. CI agents
+silently opting in via ``RAPID_MLX_TELEMETRY=1`` would skew the data
+toward synthetic workloads. Users who want to opt in run
+``rapid-mlx telemetry enable`` once.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+ENV_VAR = "RAPID_MLX_TELEMETRY"
+
+
+def _default_telemetry_dir() -> Path:
+    """Resolved at call time so ``HOME`` overrides in tests take effect."""
+    return Path.home() / ".rapid-mlx"
+
+
+def client_id_path() -> Path:
+    return _default_telemetry_dir() / "telemetry-client-id"
+
+
+def consent_path() -> Path:
+    return _default_telemetry_dir() / "telemetry-consent.yaml"
+
+
+@dataclass(frozen=True)
+class ConsentState:
+    """The on-disk record of the user's opt-in answer.
+
+    ``consent=False`` is meaningfully different from "no file exists":
+    the former means the user was prompted and said no (don't re-prompt),
+    the latter means we still owe them the first-run disclosure.
+    """
+
+    consent: bool
+    prompted_at: str  # ISO-8601 UTC, "Z" suffix
+    prompted_version: str  # rapid-mlx version that showed the prompt
+    schema_version: int = 1
+
+
+def get_consent_state() -> ConsentState | None:
+    """Return the stored consent record, or ``None`` if never prompted.
+
+    ``None`` is a signal to the caller that the first-run prompt should
+    fire (subject to the other guards in ``consent.maybe_prompt_for_consent``).
+    Malformed files also return ``None`` rather than raising — a corrupt
+    consent record should re-prompt, not crash the CLI.
+    """
+    path = consent_path()
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    consent = data.get("consent")
+    prompted_at = data.get("prompted_at")
+    prompted_version = data.get("prompted_version")
+    if not isinstance(consent, bool) or not isinstance(prompted_at, str):
+        return None
+    if not isinstance(prompted_version, str):
+        return None
+    schema_version = data.get("schema_version", 1)
+    if not isinstance(schema_version, int):
+        schema_version = 1
+    return ConsentState(
+        consent=consent,
+        prompted_at=prompted_at,
+        prompted_version=prompted_version,
+        schema_version=schema_version,
+    )
+
+
+def record_consent(consent: bool, *, rapid_mlx_version: str) -> ConsentState:
+    """Persist the user's answer.
+
+    Writes the file with mode 0600 — the directory itself stays at the
+    user's umask default, which is fine because the only sensitive bytes
+    are inside this file (the client_id UUID is random and the consent
+    answer is binary).
+    """
+    state = ConsentState(
+        consent=consent,
+        prompted_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        prompted_version=rapid_mlx_version,
+    )
+    path = consent_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "consent": state.consent,
+        "prompted_at": state.prompted_at,
+        "prompted_version": state.prompted_version,
+        "schema_version": state.schema_version,
+    }
+    # write-then-rename so a SIGINT mid-write can't leave a half-file
+    # that get_consent_state() would silently treat as "never prompted"
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(yaml.safe_dump(payload, sort_keys=True))
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+    return state
+
+
+def get_or_create_client_id() -> str:
+    """Return the persistent UUID, creating it on first call.
+
+    Idempotent: subsequent calls read the existing file. A user-edited
+    file containing the all-zero UUID is preserved as-is (documented
+    way to anonymize while still contributing aggregate counts).
+    """
+    path = client_id_path()
+    if path.exists():
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    new_id = str(uuid.uuid4())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(new_id + "\n")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+    return new_id
+
+
+def reset_state() -> None:
+    """Remove both consent + client-id files. Next run re-prompts."""
+    for path in (consent_path(), client_id_path()):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _env_kill_switch_active() -> bool:
+    """``RAPID_MLX_TELEMETRY=0`` (or any falsy value) wins.
+
+    Truthy values are intentionally ignored — see module docstring for
+    why there's no env-var force-on.
+    """
+    raw = os.environ.get(ENV_VAR)
+    if raw is None:
+        return False
+    return raw.strip().lower() in ("0", "false", "no", "off", "")
+
+
+def is_enabled(*, cli_no_telemetry: bool = False) -> bool:
+    """Single decision point used by every event-emit site.
+
+    Phase 1 has no event sites — the function exists so Phase 2 can call
+    it with no further design work, and so tests can pin the precedence
+    contract today.
+    """
+    if cli_no_telemetry:
+        return False
+    if _env_kill_switch_active():
+        return False
+    state = get_consent_state()
+    if state is None:
+        return False
+    return state.consent
+
+
+def consent_source(*, cli_no_telemetry: bool = False) -> str:
+    """Human-readable source of the current is_enabled() answer.
+
+    Used by ``rapid-mlx telemetry status`` so users can debug why
+    telemetry is (or isn't) enabled without reading our code.
+    """
+    if cli_no_telemetry:
+        return "cli-flag (--no-telemetry)"
+    if _env_kill_switch_active():
+        return f"env-var ({ENV_VAR}={os.environ.get(ENV_VAR, '')!r})"
+    state = get_consent_state()
+    if state is None:
+        return "default (no consent recorded)"
+    return f"consent-file ({consent_path()})"

--- a/vllm_mlx/telemetry/state.py
+++ b/vllm_mlx/telemetry/state.py
@@ -44,6 +44,11 @@ import yaml
 
 ENV_VAR = "RAPID_MLX_TELEMETRY"
 
+# Bump when the on-disk consent file format changes incompatibly. A
+# stored record with a smaller schema_version is treated as "never
+# prompted" so the user gets re-asked under the new disclosure copy.
+CURRENT_CONSENT_SCHEMA_VERSION = 1
+
 
 def _default_telemetry_dir() -> Path:
     """Resolved at call time so ``HOME`` overrides in tests take effect."""
@@ -98,6 +103,13 @@ def get_consent_state() -> ConsentState | None:
     schema_version = data.get("schema_version", 1)
     if not isinstance(schema_version, int):
         schema_version = 1
+    # Treat unknown / older schema versions as "never prompted" so a
+    # disclosure-copy bump in a future release re-asks every user under
+    # the new wording. Forward-compat (newer file from a downgraded
+    # rapid-mlx) hits the same path — safer to re-prompt than to honor
+    # a record we don't fully understand.
+    if schema_version != CURRENT_CONSENT_SCHEMA_VERSION:
+        return None
     return ConsentState(
         consent=consent,
         prompted_at=prompted_at,
@@ -130,6 +142,12 @@ def record_consent(consent: bool, *, rapid_mlx_version: str) -> ConsentState:
     # write-then-rename so a SIGINT mid-write can't leave a half-file
     # that get_consent_state() would silently treat as "never prompted"
     tmp = path.with_suffix(path.suffix + ".tmp")
+    # Clean up any leftover .tmp from a previous interrupted write so
+    # we never start out with a partial file under our chosen name.
+    try:
+        tmp.unlink()
+    except FileNotFoundError:
+        pass
     tmp.write_text(yaml.safe_dump(payload, sort_keys=True))
     try:
         os.chmod(tmp, 0o600)


### PR DESCRIPTION
## Summary

Phase 1 of opt-in anonymous usage telemetry per Issue #236. Ships the **privacy mechanism** (consent file, kill switch, redaction primitives, CLI surface) **without any network code**. The collector / Cloudflare Worker / aggregation pipeline are explicitly Phase 2 — this PR exists so the consent contract and PII guardrails can be reviewed in isolation before any byte ever leaves the machine.

## What ships

- **`vllm_mlx/telemetry/`** — new package, no network deps
  - `state.py` — consent file + client_id + precedence: \`--no-telemetry\` > \`RAPID_MLX_TELEMETRY=0\` > stored consent > **default OFF**. Force-on env var intentionally NOT supported (no silent CI opt-in).
  - `consent.py` — first-run prompt, gated on tty + interactive subcommand + no env var + no prior answer. Defaults to N. Never raises (telemetry consent is never a reason for the CLI to crash).
  - `redact.py` — token / TTFT / TPS bucketing, model-path normalization (HF repo IDs pass through, local paths → \`<local>\`), flag-name extraction (values never returned), traceback fingerprinting (module:function:lineno only — never message text or absolute paths).
  - \`schema.py\` — v1 dataclasses + \`sample_preview_payload()\` for the \`preview\` subcommand. **No event sites populate these in Phase 1.**

- **\`rapid-mlx telemetry\`** — five actions: \`status\` (default) / \`enable\` / \`disable\` / \`preview\` / \`reset\`.

- **\`--no-telemetry\`** global flag.

- **README \"Telemetry\" section** — what we collect / what we never collect / how to disable.

## Out of scope (Phase 2)

- httpx transport, batched flush, Cloudflare Worker
- Any actual event-emit site (request / session / error)
- Backend selection (PostHog vs Plausible vs D1 — Issue #236 open Q1)
- Sampling rate, EU endpoint, public transparency report

## Test plan

- [x] 103 new tests, all pass:
  - **state** (18): default off; consent round-trip; env-kill-switch wins over stored consent; CLI flag wins over consent; env=1 does NOT silently opt-in; falsy env values (0/false/no/off/empty) all kill-switch; client_id idempotent; user-zeroed UUID preserved; reset removes both files; consent_source reports correct origin; corrupt consent file → re-prompt (don't crash); atomic write leaves no .tmp behind.
  - **redact** (40): token / TTFT / TPS / memory bucket boundaries; HF repo ID passthrough; local-path / Windows / file:// / spaces all redacted; bare alias passthrough; flag values NEVER returned (sk-secret / 8000 stripped); short flags; sorted unique; non-string argv handled; traceback determinism; message text never in fingerprint; only hex chars; different sites different fingerprints; platform info has no full kernel string / no exact memory bytes.
  - **consent** (17): skips on non-tty / env-var / cli-flag / already-answered / each non-interactive subcommand / no subcommand; y/n records correctly; empty defaults to N; EOF does NOT record (lets next run re-prompt); records correct prompted_version; unwritable home does not crash CLI.
  - **cli** (10): subprocess-level smoke for every action + global flag + env kill switch + \`--help\` lists all actions.

- [x] Full unit suite (\`tests/ --ignore=mllm,video\`) — **2575 pass, 17 skipped, 7 deselected, 1 xfailed** (no regressions; the 17/7/1 are pre-existing).

- [x] Lint + format clean (\`ruff check && ruff format --check\` on changed paths).

- [ ] CI gate green
- [ ] DeepSeek adversarial review (run after CI green)

## Privacy contract — read these before merging

1. **Default OFF** — no consent file = no data, no exceptions.
2. **No env-var force-on** — \`RAPID_MLX_TELEMETRY=1\` is ignored. Opting in requires explicit \`rapid-mlx telemetry enable\` (or interactive 'y' at the first-run prompt).
3. **\`RAPID_MLX_TELEMETRY=0\` always wins** — even with \`consent=true\` recorded. Documented escape hatch for scripts / CI / paranoid operators.
4. **Bucketed everything** — exact token counts / TTFT / RAM / OS patch numbers can re-identify a session when joined; bucketing collapses the join surface.
5. **No prompts, no completions, no file paths, no IPs, no env values** — all four redact tests for these are P0 if they break.
6. **Phase 1 has zero \`httpx\` or \`requests\` calls in \`telemetry/\`** — \`grep\` it.

## Version

0.6.32 → 0.6.33

🤖 Generated with [Claude Code](https://claude.com/claude-code)