### PR TITLE
fix(mllm/engine): block hybrid+--mllm at startup; recover in-flight requests on Metal errors

### DIFF
--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for engine-loop recovery when scheduler.step raises (#353).
+
+The user-visible behaviour we pin:
+- A RuntimeError out of ``scheduler.step`` does not leave HTTP handlers
+  awaiting forever — every in-flight request gets a final RequestOutput
+  with ``error=<...>`` and its ``finished_event`` set.
+- ``engine.generate`` surfaces that error as ``InferenceAbortedError`` so
+  the chat handler can map to 503.
+- The detection branch for Metal-shaped messages does not require a real
+  GPU — we just check that error messages containing 'Metal' / 'MTL' /
+  'command buffer' / 'gpu::check_error' are recognised.
+
+These are unit tests; the actual Metal async-abort path (mlx-lm#1015)
+can't be reproduced without a real GPU OOM, but the recovery wiring it
+relies on is what we exercise here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.engine_core import EngineConfig, EngineCore
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.request import InferenceAbortedError, RequestOutput
+
+
+def _make_engine() -> EngineCore:
+    """Construct an EngineCore against mock model + tokenizer.
+
+    Bails the test if the construction path needs more wiring than we can
+    fake — the same guard pattern as test_idle_event_wakeup.
+    """
+    fake_model = MagicMock()
+    fake_tokenizer = MagicMock()
+    cfg = EngineConfig(model_name="test-fake-model")
+    try:
+        return EngineCore(fake_model, fake_tokenizer, cfg)
+    except Exception as e:
+        pytest.skip(f"EngineCore construction needs more mock setup: {e}")
+
+
+def test_request_output_carries_error_field():
+    """RequestOutput must declare ``error`` so the engine loop can flag
+    an aborted request without piggy-backing on finish_reason."""
+    out = RequestOutput(request_id="r1", error="boom")
+    assert out.error == "boom"
+    assert out.finished is False  # default — engine loop sets True explicitly
+
+
+def test_inference_aborted_error_is_runtime_error():
+    """HTTP handlers catch via isinstance(..., InferenceAbortedError); the
+    class must remain a RuntimeError subclass so generic ``except
+    RuntimeError`` paths still see it."""
+    err = InferenceAbortedError("metal hung")
+    assert isinstance(err, RuntimeError)
+    assert "metal" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_engine_loop_fails_in_flight_requests_on_step_exception():
+    """When scheduler.step raises, every awaiting request must receive a
+    final RequestOutput with ``error`` set and have its finished_event set
+    so HTTP handlers unblock instead of timing out."""
+    engine = _make_engine()
+
+    # Replace scheduler with a stub that always raises a Metal-shaped error.
+    class _BoomScheduler:
+        def has_requests(self):
+            return True
+
+        def step(self):
+            raise RuntimeError(
+                "Metal command buffer error: kIOGPUCommandBufferCallbackErrorOutOfMemory"
+            )
+
+        def add_request(self, *_a, **_kw):
+            pass
+
+        def abort_request(self, *_a, **_kw):
+            return True
+
+        def remove_finished_request(self, *_a, **_kw):
+            pass
+
+    engine.scheduler = _BoomScheduler()
+
+    # Pre-seed the in-flight tracking that add_request would normally set.
+    rid = "test-req-1"
+    engine._output_collectors[rid] = RequestOutputCollector(aggregate=True)
+    engine._finished_events[rid] = asyncio.Event()
+
+    # Drive the engine loop briefly — long enough for one step to raise.
+    engine._running = True
+    loop_task = asyncio.create_task(engine._engine_loop())
+    try:
+        await asyncio.wait_for(engine._finished_events[rid].wait(), timeout=1.0)
+    finally:
+        engine._running = False
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+    collector = engine._output_collectors[rid]
+    final = collector.get_nowait()
+    assert final is not None, "collector must receive an error RequestOutput"
+    assert final.finished is True
+    assert final.error and ("Metal" in final.error or "metal" in final.error.lower())
+
+
+def test_metal_message_detection_patterns():
+    """Pin the substring matchers used to flag Metal errors — if these
+    drift, the recovery path silently downgrades to the generic branch
+    (still works, just logs more noisily)."""
+    samples = [
+        "Metal command buffer error: kIOGPUCommandBufferCallbackErrorOutOfMemory",
+        "RuntimeError from mlx::core::gpu::check_error",
+        "MTL exception in completion handler",
+        "command buffer failed",
+    ]
+    for s in samples:
+        assert any(
+            n in s for n in ("Metal", "MTL", "command buffer", "gpu::check_error")
+        ), f"{s!r} no longer matches any Metal heuristic"

--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -113,6 +113,102 @@ async def test_engine_loop_fails_in_flight_requests_on_step_exception():
     assert final.error and ("Metal" in final.error or "metal" in final.error.lower())
 
 
+@pytest.mark.asyncio
+async def test_stream_outputs_raises_on_error_field():
+    """Streaming path: when the engine loop puts a final RequestOutput with
+    ``error`` into the collector, ``stream_outputs`` must surface it as
+    InferenceAbortedError instead of silently yielding a terminal chunk —
+    otherwise streaming HTTP handlers would emit an empty SSE close instead
+    of a 503 (#353 DeepSeek round 1 P0)."""
+    engine = _make_engine()
+
+    rid = "stream-test-1"
+    engine._output_collectors[rid] = RequestOutputCollector(aggregate=True)
+
+    # Push the error output the engine loop would have produced.
+    engine._output_collectors[rid].put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="error",
+            error="Inference aborted: RuntimeError: Metal command buffer error",
+        )
+    )
+
+    raised = None
+    yields = []
+    try:
+        async for chunk in engine.stream_outputs(rid):
+            yields.append(chunk)
+    except InferenceAbortedError as exc:
+        raised = exc
+
+    assert raised is not None, "stream_outputs must raise InferenceAbortedError"
+    assert "Metal" in str(raised)
+    assert yields == [], (
+        "stream_outputs must not yield the error chunk before raising — "
+        "otherwise streaming clients receive a malformed terminal frame"
+    )
+
+
+@pytest.mark.asyncio
+async def test_engine_loop_backs_off_on_persistent_failures():
+    """When step() fails repeatedly the loop must back off — otherwise the
+    retry cadence floods logs at ~10 Hz and burns CPU spinning on a stuck
+    Metal state (#353 DeepSeek round 1 P0). We exercise this by measuring
+    how long the loop takes to complete N failures past the burst cap."""
+    engine = _make_engine()
+
+    fail_count = {"n": 0}
+
+    class _AlwaysFailScheduler:
+        def has_requests(self):
+            return True
+
+        def step(self):
+            fail_count["n"] += 1
+            raise RuntimeError("Metal command buffer error: persistent")
+
+        def add_request(self, *_a, **_kw):
+            pass
+
+        def abort_request(self, *_a, **_kw):
+            return True
+
+        def remove_finished_request(self, *_a, **_kw):
+            pass
+
+    engine.scheduler = _AlwaysFailScheduler()
+    engine._running = True
+
+    import time as _time
+
+    loop_task = asyncio.create_task(engine._engine_loop())
+    try:
+        # Run for 0.6 s. With the 0.1 s fast retry cadence, that would let
+        # ~6 step() calls through; with the 1 s slow cadence after the
+        # 10-failure burst, we'd be at most ~11. Verifying we don't exceed
+        # ~20 ensures backoff is actually engaged (no-backoff would yield
+        # 60+ failures over the same window).
+        start = _time.perf_counter()
+        await asyncio.sleep(0.6)
+        elapsed = _time.perf_counter() - start
+    finally:
+        engine._running = False
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+    # The exact count is timing-sensitive but a generous ceiling pins the
+    # contract: backoff must keep the retry rate well below "every 100 ms".
+    assert fail_count["n"] <= 20, (
+        f"engine loop attempted step() {fail_count['n']} times in "
+        f"{elapsed:.2f}s — backoff is not engaging on persistent failures"
+    )
+
+
 def test_metal_message_detection_patterns():
     """Pin the substring matchers used to flag Metal errors — if these
     drift, the recovery path silently downgrades to the generic branch

--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the startup probe that blocks hybrid models from --mllm mode (#352).
+
+The user-facing contract:
+- MLLM continuous batching cannot merge ArraysCache / MambaCache (only
+  KVCache / RotatingKVCache).
+- We must fail at startup with a message naming the actual incompatibility
+  (hybrid backbone), not the misleading "disable --kv-cache-quantization"
+  the user saw in #352 with Qwen3.6-35B-A3B-UD --mllm.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+from vllm_mlx.engine.batched import _probe_mllm_cache_type
+
+
+class _FakeArraysCache:
+    """Stand-in for mlx-lm's ArraysCache that doesn't import the real one
+    (which requires building a layer). Type name is what the probe uses
+    for the error message, so a class with the right __name__ is enough."""
+
+    pass
+
+
+_FakeArraysCache.__name__ = "ArraysCache"
+
+
+def _model_with_cache(cache_obj):
+    """Build a fake language_model whose make_prompt_cache hook returns
+    a single-layer cache containing ``cache_obj``."""
+    m = MagicMock()
+    # mlx-lm's make_prompt_cache calls model.make_cache() when present;
+    # both that and a direct prompt-cache list need to return the layers.
+    m.make_cache = MagicMock(return_value=[cache_obj])
+    # mlx-lm 0.31's make_prompt_cache also walks layers/n_kv_heads etc.
+    # for fallback construction — we only need the make_cache path here,
+    # which short-circuits the fallback.
+    return m
+
+
+def test_probe_returns_none_for_kvcache():
+    """Standard text models produce KVCache → probe returns None and
+    startup proceeds normally."""
+    model = _model_with_cache(KVCache())
+    assert _probe_mllm_cache_type(model) is None
+
+
+def test_probe_returns_none_for_rotating_kvcache():
+    """Sliding-window models (e.g. Gemma 4 with RotatingKVCache) are
+    also MLLM-compatible."""
+    model = _model_with_cache(RotatingKVCache(max_size=256))
+    assert _probe_mllm_cache_type(model) is None
+
+
+def test_probe_returns_class_name_for_arrayscache():
+    """Hybrid models (Qwen3.5/3.6/Nemotron) produce ArraysCache; probe
+    must return the offending type name so the caller can quote it in
+    the startup error."""
+    model = _model_with_cache(_FakeArraysCache())
+    assert _probe_mllm_cache_type(model) == "ArraysCache"
+
+
+def test_probe_returns_none_when_make_prompt_cache_raises():
+    """A model that crashes on cache construction (e.g. mid-load,
+    incompatible mlx-lm version) is best-effort skipped — runtime path
+    surfaces the real error rather than us masking it with #352's text."""
+    broken = MagicMock()
+    broken.make_cache = MagicMock(side_effect=RuntimeError("not loaded"))
+    # mlx-lm's make_prompt_cache will try fallbacks; we expect *some* path
+    # to raise inside it. The probe swallows that and returns None.
+    result = _probe_mllm_cache_type(broken)
+    assert result is None
+
+
+def test_probe_returns_none_for_empty_cache():
+    """Defensive: zero-layer model returns an empty list. Probe must not
+    IndexError into sample = cache[0]."""
+    model = MagicMock()
+    model.make_cache = MagicMock(return_value=[])
+    assert _probe_mllm_cache_type(model) is None

--- a/tests/test_stop_string_enforcement.py
+++ b/tests/test_stop_string_enforcement.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for server-side stop-string truncation in the text Scheduler.
+
+The OpenAI-API contract says ``stop`` (list of strings) is honoured by the
+server: if any string in the list appears in the generated output, the
+server must truncate at that point and report ``finish_reason="stop"``.
+mlx-lm's BatchGenerator only honours integer ``stop_tokens`` — so the
+scheduler has to scan the decoded output itself.
+
+This was missing on the text path (MLLMScheduler had it, Scheduler did
+not), which surfaced as 4 failing regression-suite tests on qwen3.5-4b:
+tests 1 (newline), 2 (literal word), 4 (Unicode), 5 (streaming).
+
+These unit tests exercise ``Scheduler._process_batch_responses`` directly with
+a mocked tokenizer so the truncation contract is pinned without needing
+a real model.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _make_scheduler() -> Scheduler:
+    model = MagicMock()
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda s: list(range(len(s.split())))
+    config = SchedulerConfig(max_num_seqs=4)
+    return Scheduler(model, tokenizer, config)
+
+
+def _make_request(
+    rid: str,
+    stop_strings: list[str] | None,
+    prefilled_tokens: list[int] | None = None,
+) -> Request:
+    """Build a Request already in the ``running`` state with the given
+    output token ids — _process_batch_responses appends one more token from the
+    incoming Response, so prefilled_tokens is the prefix and the test
+    drives the final token via the Response."""
+    sp = SamplingParams(max_tokens=100, stop=stop_strings or [])
+    req = Request(request_id=rid, prompt="ignored", sampling_params=sp)
+    req.num_prompt_tokens = 4
+    req.status = RequestStatus.RUNNING
+    if prefilled_tokens:
+        for t in prefilled_tokens:
+            req.append_output_token(t)
+    return req
+
+
+def _run_step(
+    scheduler: Scheduler,
+    request: Request,
+    *,
+    last_token: int,
+    decoded_full: str,
+    finish_reason: str | None = None,
+):
+    """Drive ``_process_batch_responses`` once for a single request and return
+    the resulting RequestOutput.
+
+    ``decoded_full`` is what the tokenizer will return when asked to
+    decode the full output_token_ids list AFTER the new token is appended.
+    We stub _decode_tokens to return ``decoded_full`` so the test fully
+    controls the surface the stop-string check scans.
+    """
+    rid = request.request_id
+    uid = 0
+    scheduler.running[rid] = request
+    scheduler.uid_to_request_id[uid] = rid
+
+    # Stub _decode_tokens to return controllable strings. The scheduler
+    # calls it both for the stop check (full output) and for the
+    # ``prev_text`` computation (output minus last token); we approximate
+    # both by stripping the last char of decoded_full for the prev case.
+    def _decode(tokens):
+        if tokens == request.output_token_ids:
+            return decoded_full
+        if len(tokens) == len(request.output_token_ids) - 1:
+            # The "previously streamed" surface — anything shorter than
+            # the full text is fine for the test invariants we're pinning.
+            return decoded_full[:-1] if decoded_full else ""
+        return decoded_full
+
+    scheduler._decode_tokens = _decode  # type: ignore[method-assign]
+
+    # Build a minimal Response stub matching BatchGenerator's contract.
+    response = MagicMock()
+    response.uid = uid
+    response.token = last_token
+    response.finish_reason = finish_reason
+    response.logprobs = None
+    # No prompt_cache attr — _process_batch_responses checks hasattr.
+    del response.prompt_cache
+
+    outputs, finished = scheduler._process_batch_responses([response])
+    assert len(outputs) == 1
+    return outputs[0], finished
+
+
+def test_stop_string_truncates_output_at_match():
+    """Output contains the stop string → finish_reason becomes "stop"
+    and output_text is the prefix BEFORE the stop marker."""
+    scheduler = _make_scheduler()
+    req = _make_request("r1", stop_strings=["World"], prefilled_tokens=[10, 11])
+
+    output, finished = _run_step(
+        scheduler,
+        req,
+        last_token=12,
+        decoded_full="Hello World!",
+        finish_reason=None,
+    )
+
+    assert output.finished is True
+    assert output.finish_reason == "stop"
+    assert "World" not in output.output_text
+    assert output.output_text == "Hello "
+    assert "r1" in finished
+
+
+def test_stop_string_first_match_wins():
+    """With multiple stop strings, the one that matches earliest in the
+    output wins. The user's ["World", "!"] case should stop at "World"
+    not at "!"."""
+    scheduler = _make_scheduler()
+    req = _make_request("r2", stop_strings=["World", "!"], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="Hello World! Goodbye World!",
+    )
+
+    assert output.finished is True
+    assert output.finish_reason == "stop"
+    # Both stop strings should be absent; truncated at first ("World")
+    assert "World" not in output.output_text
+    assert "!" not in output.output_text
+    assert output.output_text == "Hello "
+
+
+def test_stop_string_unicode_match():
+    """Stop string with non-ASCII chars must match the same way ASCII does."""
+    scheduler = _make_scheduler()
+    req = _make_request("r3", stop_strings=["世界"], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="你好世界 goodbye",
+    )
+
+    assert output.finished is True
+    assert output.finish_reason == "stop"
+    assert "世界" not in output.output_text
+    assert output.output_text == "你好"
+
+
+def test_stop_string_no_match_does_not_truncate():
+    """If no stop string matches, generation continues — finish_reason
+    stays None and output_text contains the full decoded surface."""
+    scheduler = _make_scheduler()
+    req = _make_request("r4", stop_strings=["XYZ"], prefilled_tokens=[10])
+
+    output, finished = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="Hello there",
+    )
+
+    assert output.finished is False
+    assert output.finish_reason is None
+    assert finished == set()
+
+
+def test_empty_stop_list_skips_check():
+    """Empty stop list → no truncation, even when the output happens
+    to contain content matching empty string semantics."""
+    scheduler = _make_scheduler()
+    req = _make_request("r5", stop_strings=[], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="anything goes",
+    )
+
+    assert output.finished is False
+    assert output.finish_reason is None
+
+
+def test_empty_string_in_stop_list_is_ignored():
+    """A stop string of "" would otherwise match anywhere; the guard in
+    the scheduler must skip empty strings to avoid truncating at offset
+    0 on every step."""
+    scheduler = _make_scheduler()
+    req = _make_request("r6", stop_strings=[""], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="Hello",
+    )
+
+    assert output.finished is False
+    assert output.finish_reason is None
+
+
+def test_stop_string_finishes_with_already_set_finish_reason():
+    """When BatchGenerator already flagged finish_reason="length", the
+    stop-string check must not override it (length wins)."""
+    scheduler = _make_scheduler()
+    req = _make_request("r7", stop_strings=["World"], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="Hello World",
+        finish_reason="length",
+    )
+
+    assert output.finished is True
+    # length sticks — the new check only runs when finish_reason is None
+    assert output.finish_reason == "length"
+
+
+def test_stop_string_at_position_zero():
+    """Stop marker appears at the very start of the decoded output —
+    trimmed_total is "" and new_text must be "" (not the un-trimmed
+    surface). Pinned because DeepSeek flagged this edge case as
+    untested in round 1."""
+    scheduler = _make_scheduler()
+    req = _make_request("r0", stop_strings=["Hello"], prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full="Hello World",
+    )
+
+    assert output.finished is True
+    assert output.finish_reason == "stop"
+    assert output.output_text == ""
+    # new_text must not echo the stop marker
+    assert "Hello" not in output.new_text
+
+
+def test_stop_string_truncates_new_text_for_streaming():
+    """The streaming new_text on the truncating step must NEVER contain
+    the stop marker, regardless of how prev_text was estimated. This is
+    the contract streaming HTTP handlers depend on (test_5 in the
+    regression suite)."""
+    scheduler = _make_scheduler()
+    req = _make_request("rs", stop_strings=[", 5"], prefilled_tokens=[10, 11])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=12,
+        decoded_full="1, 2, 3, 4, 5, 6",
+    )
+
+    assert output.finish_reason == "stop"
+    assert "5" not in output.output_text
+    # The new_text emitted on the truncating step must also not leak the
+    # stop marker — that's the bug streaming clients hit if the slice
+    # logic is wrong.
+    assert ", 5" not in output.new_text
+
+
+@pytest.mark.parametrize(
+    "decoded_full,stop_strings,expected_prefix",
+    [
+        ("foo\nbar", ["\n"], "foo"),
+        ("Hello, World!", ["World"], "Hello, "),
+        ("a, b, c, 5, 6", [", 5"], "a, b, c"),
+    ],
+)
+def test_stop_string_truncation_parametrized(
+    decoded_full, stop_strings, expected_prefix
+):
+    """Parametrised across the patterns exercised by regression_suite
+    tests 1, 2, 5 — each pins that the trimmed output is the prefix
+    immediately before the first stop-marker occurrence."""
+    scheduler = _make_scheduler()
+    req = _make_request("rp", stop_strings=stop_strings, prefilled_tokens=[10])
+
+    output, _ = _run_step(
+        scheduler,
+        req,
+        last_token=11,
+        decoded_full=decoded_full,
+    )
+
+    assert output.finish_reason == "stop"
+    assert output.output_text == expected_prefix

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -24,6 +24,34 @@ from .base import BaseEngine, GenerationOutput
 logger = logging.getLogger(__name__)
 
 
+def _probe_mllm_cache_type(language_model: Any) -> str | None:
+    """Return the offending cache type name when ``language_model`` is
+    incompatible with MLLM continuous batching, or None if it's fine.
+
+    "Incompatible" means ``make_prompt_cache`` returns something other than
+    a list of ``KVCache`` / ``RotatingKVCache`` — currently ArraysCache (hybrid
+    Qwen3.5/3.6, etc.) or MambaCache (Nemotron, Granite4). Returning a name
+    instead of a bool lets the caller put the actual class in the error
+    message (#352).
+
+    The probe is best-effort; if mlx-lm raises before producing a cache list
+    we return None and let the runtime path surface the real error instead
+    of masking it with a misleading hybrid-incompat message.
+    """
+    from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+
+    try:
+        test_cache = make_prompt_cache(language_model)
+    except Exception:
+        return None
+    if not test_cache:
+        return None
+    sample = test_cache[0]
+    if isinstance(sample, (KVCache, RotatingKVCache)):
+        return None
+    return type(sample).__name__
+
+
 def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
     """Pick a Metal free-cache size that scales with the device's working set.
 
@@ -312,6 +340,27 @@ class BatchedEngine(BaseEngine):
 
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor
+
+        # Fail fast at startup if the language backbone is a hybrid model
+        # (linear-attention or recurrent layers, producing ArraysCache /
+        # MambaCache). MLLM continuous batching builds a BatchKVCache via
+        # KVCache.merge(), which requires standard KVCache or RotatingKVCache;
+        # otherwise the first request raises ValueError mid-prefill.
+        # Catching it now means a clear startup error instead of the user
+        # seeing "Batch generation failed" on their very first image request
+        # (GitHub #352, Qwen3.6-35B-A3B + --mllm).
+        language_model = getattr(self._model, "language_model", self._model)
+        cache_type = self._model_load_executor.submit(
+            _probe_mllm_cache_type, language_model
+        ).result()
+        if cache_type is not None:
+            raise RuntimeError(
+                f"Model '{self._model_name}' uses a hybrid/linear-attention "
+                f"language backbone ({cache_type}), which is incompatible "
+                f"with --mllm continuous batching (requires standard KVCache "
+                f"or RotatingKVCache). Drop --mllm for text-only use, or pick "
+                f"a non-hybrid VLM (Qwen3-VL, Gemma-3, etc.). See #352."
+            )
 
         # Create MLLM scheduler config with batch generator support
         if self._scheduler_config and hasattr(self._scheduler_config, "max_num_seqs"):

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -353,7 +353,12 @@ class EngineCore:
             )
         except Exception:
             _memory_pressure_threshold = 200 * 1024 * 1024 * 1024
-        _memory_check_interval = 64
+        # Check every 16 steps (was 64). Sustained-load Metal errors
+        # correlate with creeping memory pressure; catching it 4× sooner
+        # gives mx.clear_cache() a chance to defuse before the next
+        # large allocation pushes us into a Metal-side OOM, which currently
+        # propagates as an uncatchable abort (see GitHub #353 / mlx-lm#1015).
+        _memory_check_interval = 16
 
         while self._running:
             try:
@@ -469,7 +474,70 @@ class EngineCore:
             except Exception as e:
                 import traceback
 
-                logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
+                # If step() raises (e.g. Metal RuntimeError that did propagate
+                # synchronously to Python, an unexpected scheduler bug, etc.),
+                # the in-flight requests would otherwise hang forever waiting
+                # on finished_events that never get set. Surface the error to
+                # every waiting client as a structured RequestOutput and
+                # release their events so HTTP handlers can return 503 instead
+                # of timing out.
+                #
+                # NOTE: this does NOT recover from the async Metal abort path
+                # described in #353. When mlx::core::gpu::check_error throws
+                # from inside Metal's addCompletedHandler block, the C++
+                # exception propagates straight to std::terminate -> abort()
+                # without ever passing through a Python frame, and the whole
+                # process dies. Tracking that path against mlx-lm#1015 /
+                # ml-explore/mlx#... — once mlx defers the throw to the next
+                # eval, this handler will start catching it.
+                msg = str(e)
+                is_metal = any(
+                    needle in msg
+                    for needle in ("Metal", "MTL", "command buffer", "gpu::check_error")
+                )
+                if is_metal:
+                    logger.error(
+                        "Metal runtime error caught in engine loop — failing "
+                        f"in-flight requests and clearing buffers: {e}"
+                    )
+                    try:
+                        mx.clear_cache()
+                    except Exception:
+                        pass
+                else:
+                    logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
+
+                # Fail all in-flight requests with a structured error output so
+                # awaiting HTTP handlers unblock (#353).
+                err_text = (
+                    f"Inference aborted: {type(e).__name__}: {e}"
+                    if is_metal
+                    else f"Engine loop error: {type(e).__name__}: {e}"
+                )
+                for rid in list(self._finished_events.keys()):
+                    collector = self._output_collectors.get(rid)
+                    if collector is not None:
+                        try:
+                            collector.put(
+                                RequestOutput(
+                                    request_id=rid,
+                                    new_token_ids=[],
+                                    new_text="",
+                                    output_token_ids=[],
+                                    output_text="",
+                                    finished=True,
+                                    finish_reason="error",
+                                    prompt_tokens=0,
+                                    completion_tokens=0,
+                                    error=err_text,
+                                )
+                            )
+                        except Exception:
+                            pass
+                    ev = self._finished_events.get(rid)
+                    if ev is not None:
+                        ev.set()
+
                 await asyncio.sleep(0.1)
 
     async def add_request(
@@ -717,6 +785,14 @@ class EngineCore:
 
             if final_output is None:
                 raise RuntimeError(f"No output for request {request_id}")
+
+            # Engine loop sets error= when it aborts the request (e.g. Metal
+            # runtime error). Surface as InferenceAbortedError so the HTTP
+            # layer maps to 503 (#353).
+            if final_output.error:
+                from .request import InferenceAbortedError
+
+                raise InferenceAbortedError(final_output.error)
 
             return final_output
 

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -359,12 +359,19 @@ class EngineCore:
         # large allocation pushes us into a Metal-side OOM, which currently
         # propagates as an uncatchable abort (see GitHub #353 / mlx-lm#1015).
         _memory_check_interval = 16
+        # Consecutive step() failures — once we hit the cap we sleep longer
+        # between retries so a permanently-broken Metal state (e.g. real OOM
+        # we can't recover from) stops flooding the log at 10 Hz. Resets
+        # on the first successful step. See #353.
+        _consecutive_step_failures = 0
+        _STEP_FAILURE_BURST = 10
 
         while self._running:
             try:
                 if self.scheduler.has_requests():
                     output = await loop.run_in_executor(_executor, self.scheduler.step)
                     self._steps_executed += 1
+                    _consecutive_step_failures = 0
 
                     # Emergency memory pressure check
                     if self._steps_executed % _memory_check_interval == 0:
@@ -538,7 +545,20 @@ class EngineCore:
                     if ev is not None:
                         ev.set()
 
-                await asyncio.sleep(0.1)
+                # Slow the retry loop when failures persist — a stuck Metal
+                # state would otherwise burn CPU + flood logs at ~10 Hz. After
+                # a burst of failures, back off to 1 s between attempts.
+                _consecutive_step_failures += 1
+                backoff = (
+                    1.0 if _consecutive_step_failures >= _STEP_FAILURE_BURST else 0.1
+                )
+                if _consecutive_step_failures == _STEP_FAILURE_BURST:
+                    logger.warning(
+                        f"Engine step has failed {_STEP_FAILURE_BURST} times in a row — "
+                        "backing off retry cadence to 1 s. Investigate the underlying "
+                        "Metal/scheduler error."
+                    )
+                await asyncio.sleep(backoff)
 
     async def add_request(
         self,
@@ -695,6 +715,18 @@ class EngineCore:
                             f"[stream_outputs] {request_id[:12]} first token after "
                             f"{_time.monotonic() - _t0:.1f}s"
                         )
+
+                    # Engine loop sets ``error`` when it aborts a request mid-
+                    # flight (e.g. Metal RuntimeError that propagated to Python).
+                    # Raise so streaming HTTP handlers can map to 503 instead of
+                    # silently yielding an empty terminal chunk (#353).
+                    if output.error:
+                        from .request import InferenceAbortedError
+
+                        logger.warning(
+                            f"[stream_outputs] {request_id[:12]} engine aborted: {output.error}"
+                        )
+                        raise InferenceAbortedError(output.error)
 
                     yield output
 

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -682,11 +682,20 @@ class MLLMBatchGenerator:
 
         sample_cache = per_request_caches[0][0]
         if not isinstance(sample_cache, (KVCache, RotatingKVCache)):
+            # Two distinct causes land here:
+            #   1. Hybrid/linear-attention backbone (ArraysCache /
+            #      MambaCache) — see GitHub #352. Should be caught at
+            #      startup by the probe in BatchedEngine._start_mllm.
+            #   2. --kv-cache-quantization explicitly enabled on a
+            #      non-hybrid MLLM.
+            # Name both so the runtime message isn't misleading when
+            # quantization is NOT the cause.
             raise ValueError(
                 f"MLLM continuous batching requires KVCache or RotatingKVCache "
-                f"but got {type(sample_cache).__name__}. Disable "
-                f"--kv-cache-quantization when using multimodal models with "
-                f"--continuous-batching."
+                f"but got {type(sample_cache).__name__}. Either the language "
+                f"backbone is hybrid/linear-attention (drop --mllm or pick a "
+                f"non-hybrid VLM), or --kv-cache-quantization was enabled "
+                f"(disable it for multimodal models with continuous batching)."
             )
 
         try:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -185,6 +185,16 @@ class Request:
         return self.request_id == other.request_id
 
 
+class InferenceAbortedError(RuntimeError):
+    """Raised when the engine aborts an in-flight request due to a runtime
+    failure (e.g. a Metal command-buffer error caught in the engine loop).
+
+    Distinguished from generic ``RuntimeError`` so HTTP handlers can map it
+    to a 503 instead of a 500 — the server may still be healthy enough to
+    handle a retry against a smaller request.
+    """
+
+
 @dataclass
 class RequestOutput:
     """
@@ -208,6 +218,10 @@ class RequestOutput:
     completion_tokens: int = 0
     # Per-token log-probabilities (mx.array of shape [vocab_size] for current token)
     logprobs: Any = None
+    # Set when the engine aborts the request before completion (e.g. Metal
+    # runtime error caught in the engine loop). HTTP layer converts this to
+    # 503. Plain finish reasons (stop / length / etc.) leave this as None.
+    error: str | None = None
 
     @property
     def usage(self) -> dict[str, int]:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -522,8 +522,15 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     except HTTPException:
         raise
     except Exception as e:
+        from ..request import InferenceAbortedError
+
         err_msg = str(e)
         err_type = type(e).__name__
+        if isinstance(e, InferenceAbortedError):
+            # Engine aborted the request (e.g. Metal runtime error caught
+            # in the engine loop). 503 — the server is still up and a
+            # smaller request may succeed (#353).
+            raise HTTPException(status_code=503, detail=err_msg)
         if (
             "TemplateError" in err_type
             or "template" in err_msg.lower()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2670,8 +2670,44 @@ class Scheduler:
                 logprobs=response.logprobs,
             )
 
+            # Check text-based stop sequences. ``SamplingParams.stop`` is a
+            # list of user-supplied strings (OpenAI-API contract); mlx-lm's
+            # BatchGenerator only honours ``stop_token_ids``, so we have to
+            # match-and-truncate on the decoded output here. MLLMScheduler
+            # has had the equivalent check since launch; the text scheduler
+            # was silently dropping ``request.stop`` until #354 / regression
+            # tests 1, 2, 4, 5 surfaced the gap.
+            #
+            # Known limitations (carried over from MLLMScheduler; proper
+            # fix needs a streaming lookahead buffer — out of scope here):
+            # if the stop marker straddles the previous-token boundary,
+            # the prefix that landed in the streamed surface has already
+            # been sent to the client. ``output_text`` is correctly
+            # truncated; streaming clients see the prefix.
+            finish_reason = response.finish_reason
+            stop_trimmed = False
+            stop_params = request.sampling_params.stop or []
+            if finish_reason is None and stop_params:
+                decoded_so_far = self._decode_tokens(request.output_token_ids)
+                for stop_str in stop_params:
+                    if stop_str and stop_str in decoded_so_far:
+                        finish_reason = "stop"
+                        idx = decoded_so_far.index(stop_str)
+                        trimmed_total = decoded_so_far[:idx]
+                        request.output_text = trimmed_total
+                        stop_trimmed = True
+                        # Adjust new_text so streaming clients only see the
+                        # valid prefix, never the stop marker itself.
+                        prev_text = self._decode_tokens(request.output_token_ids[:-1])
+                        if len(trimmed_total) > len(prev_text):
+                            output.new_text = trimmed_total[len(prev_text) :]
+                        else:
+                            output.new_text = ""
+                        break
+
             # Check if finished
-            if response.finish_reason is not None:
+            if finish_reason is not None:
+                response.finish_reason = finish_reason
                 if response.finish_reason == "stop":
                     request.set_finished(RequestStatus.FINISHED_STOPPED)
                 elif response.finish_reason == "length":
@@ -2681,15 +2717,25 @@ class Scheduler:
                 output.finish_reason = response.finish_reason
                 finished_ids.add(request_id)
 
-                # Decode full output using decoder if available (ensures
-                # any held-back multi-byte chars are flushed)
-                decoder = getattr(request, "_decoder", None)
-                if decoder is not None:
-                    output.output_text = decoder.get_full_text()
+                if stop_trimmed:
+                    # request.output_text was already truncated to the prefix
+                    # before the stop string — using that as the final output
+                    # preserves the truncation; re-decoding here would put the
+                    # stop marker back in.
+                    output.output_text = request.output_text
+                    self._cleanup_detokenizer(request_id)
                 else:
-                    output.output_text = self._decode_tokens(request.output_token_ids)
-                request.output_text = output.output_text
-                self._cleanup_detokenizer(request_id)
+                    # Decode full output using decoder if available (ensures
+                    # any held-back multi-byte chars are flushed)
+                    decoder = getattr(request, "_decoder", None)
+                    if decoder is not None:
+                        output.output_text = decoder.get_full_text()
+                    else:
+                        output.output_text = self._decode_tokens(
+                            request.output_token_ids
+                        )
+                    request.output_text = output.output_text
+                    self._cleanup_detokenizer(request_id)
 
                 # Extract cache for future reuse (critical for agentic multi-turn)
                 if hasattr(response, "prompt_cache"):


### PR DESCRIPTION
## Summary

Three sustained-use breakages reported back-to-back, all rooted in scheduler/engine error-handling gaps:

**Closes #352** — `rapid-mlx serve <qwen3.6-A3B-UD> --mllm` accepted at startup but failed every image request with a misleading `Disable --kv-cache-quantization` message (the user hadn't passed that flag). Root cause: Qwen3.6 hybrid backbone produces `ArraysCache`, which `MLLMBatchGenerator` can't merge into a `BatchKVCache`.

- Add a startup probe (`_probe_mllm_cache_type`) that fails fast with a clear message naming the actual incompatibility (hybrid/linear-attention backbone) and recommends compatible VLMs (Qwen3-VL, Gemma-3).
- Rewrite the runtime fallback message to name both possible causes (hybrid backbone OR `--kv-cache-quantization`) instead of misleadingly blaming a flag the user may not have passed.

**Closes #353** — Metal command-buffer `RuntimeError` during sustained load left in-flight HTTP requests awaiting `finished_event` forever (engine loop's generic `except Exception` logged and continued without signalling collectors).

- Wire `RequestOutput.error` + new `InferenceAbortedError(RuntimeError)`. When `scheduler.step` raises, every in-flight request gets a final `RequestOutput` with `error=...`, its event is set, `engine.generate` re-raises as `InferenceAbortedError`, and the chat handler maps to **503**.
- Tighten memory-pressure check interval from 64 → 16 steps so creeping allocations get a `mx.clear_cache()` shot before the next prefill pushes Metal into OOM.
- Add a Metal-substring heuristic so Metal errors get a tighter log line vs unrelated engine-loop exceptions.

**Residual risk for #353 (documented inline):** when `mlx::core::gpu::check_error` throws from inside Metal's `addCompletedHandler` block, the C++ exception propagates directly to `std::terminate` → `abort()` without ever passing through a Python frame. That path still kills the process and needs an mlx-core upstream fix — tracked under [mlx-lm#1015](https://github.com/ml-explore/mlx-lm/issues/1015). The recovery wiring in this PR is what mlx-core will eventually feed into once the throw is deferred to the next eval.

**Bundled: stop-string truncation on the text path** — `regression_suite[qwen3.5-4b]` was hitting 6/10 consistently (not flaky — confirmed across bb332a5 and 4cedbf4 back-to-back, 2026-05-10). Root cause: `vllm_mlx/scheduler.Scheduler._process_batch_responses` never read `SamplingParams.stop`. `MLLMScheduler` had the check; the text scheduler did not. mlx-lm's `BatchGenerator` only honours integer `stop_tokens`, so the OpenAI-API contract (`stop: list[str]`) requires server-side scanning of the decoded surface.

- Port the stop-string check from `MLLMScheduler`. On each step, decode the cumulative output, scan for any stop string, and if matched: truncate `request.output_text` at the first occurrence, set `finish_reason="stop"`, and slice `output.new_text` so the streaming surface never leaks the marker.
- Length-finish reasons still win — the check only runs when `finish_reason is None`.
- Empty strings in the stop list are explicitly skipped (would otherwise match at offset 0 on every step).

## Test plan

- [x] 5 new unit tests for `_probe_mllm_cache_type` (KVCache/RotatingKVCache pass through, ArraysCache → name returned, broken-model → `None`, empty-cache → `None`)
- [x] 6 new unit tests for engine-loop recovery (`RequestOutput.error` field, `InferenceAbortedError` ⊂ `RuntimeError`, in-flight requests get error output + event when `step()` raises, stream-side raises on error, persistent-failure backoff, Metal heuristic patterns)
- [x] 12 new unit tests for stop-string enforcement (basic truncation, first-match-wins, Unicode, no-match, empty-list, empty-string-ignored, length-wins, position-zero edge, streaming new_text never leaks marker, parametrised across regression_suite #1/#2/#5 patterns)
- [x] Full unit suite: **2600 passed, 17 skipped, 1 xfailed** — no regressions
- [x] `ruff check` + `ruff format --check` clean on modified files
- [x] `make check --model qwen3.5-4b` — `regression_suite` now **10/10** (was 6/10 before this PR); `stress` 8/8; `autoresearch` 14/14. Only failure is the documented `smoke_matrix` thinking-toggle flake (passed on 4cedbf4, failed on bb332a5 — pre-existing, not introduced by this PR).
- [ ] Live MLLM smoke against a Qwen3.6-A3B-UD model (needs ~30 GB weights; will run before merge if user wants)

## Out of scope / follow-ups

- True end-to-end fix for the async Metal abort (#353) requires mlx-core changes — not actionable from Python.
- Pre-request memory gate (reject 503 before accepting if `active_memory > 95% of threshold`) considered but deferred — would need careful sizing to avoid throwing spurious 503s under bursty but recoverable load.
- `smoke_matrix` thinking-toggle flake is unrelated to scheduler/engine paths touched here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
