### PR TITLE
chore: bump version to 0.6.35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.34"
+version = "0.6.35"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Single-commit hotfix release bundling PR #357 (#355 fix).

The #355 fix wires `top_k`, `min_p`, `repetition_penalty`,
`presence_penalty`, and `frequency_penalty` through to the mlx-lm
sampler + logits processors. Qwen3.6's recommended `top_k=20` for
coding (and other OpenAI-compatible sampling params) is now reachable
from any client.

## Bundle inventory

```
16797b9 fix(api): pass top_k/min_p/penalties through to mlx-lm sampler (#355) (#357)
```

## Release SOP status

- [x] **Pre-flight inventory** — 1-commit inference-touching bundle
- [x] **Bundle audit** — already validated via PR #357's 4-round adversarial review (DeepSeek-R1) with zero new P0 findings on round 4 convergence
- [x] **Targeted tests** — 12 new contract tests pass (`tests/test_sampling_params_passthrough.py`)
- [x] **Full unit suite** — 2615 pass, 17 skip, 1 xfail
- [x] **Lint + format** — `ruff check` and `ruff format --check` clean
- [x] **Install size audit** — 447 MB (vs 445 MB on 0.6.34, +0.5%, well under 5% soft threshold)
- [x] **Supply-chain re-audit** — zero changes to `install.sh`, `publish.yml`, `auto-release.yml`, or `pyproject.toml` deps since 0.6.34
- [x] **Post-merge doctor check on qwen3.5-4b** — 0 new regressions
  - `regression_suite[qwen3.5-4b]` 10/10 ✓ (PR #354's stop-string fix holding)
  - `stress[qwen3.5-4b]` 8/8 ✓
  - `autoresearch[qwen3.5-4b]` 14 metrics OK ✓
  - `smoke_matrix[qwen3.5-4b]` 9/10 — the 1 fail is `thinking-toggle`, the documented pre-existing flake from MEMORY.md (same fail on clean main `bb332a5`)
- [ ] **`make full` perf regression check** — SKIPPED — pure API plumbing layer (Pydantic field declarations + kwarg forwarding + sampler arg wiring) doesn't alter generation throughput characteristics. `autoresearch` step of doctor check confirmed 4b metrics nominal.
- [ ] **Agent integration smoke / fresh-install subagent simulation** — SKIPPED for this single-commit hotfix. Deferred-followup from 0.6.34 release stays open; will run on next multi-commit release.

## Test plan

- [x] Local CI parity: `ruff check` + `ruff format --check` clean
- [x] Local full unit suite: 2615 passed (excluding MLLM/video)
- [ ] CI matrix green (test-matrix 3.10 / 3.11 / 3.12 / test-apple-silicon)
- [ ] `Auto-release on version bump` workflow fires post-merge
- [ ] PyPI propagation: `pip index versions rapid-mlx` shows 0.6.35 within ~5 min
- [ ] Homebrew tap formula auto-updated by `Publish to PyPI & Homebrew`

🤖 Generated with [Claude Code](https://claude.com/claude-code)