### PR TITLE
chore(deps): bump mlx-vlm 0.4.4 → 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 # Vision/multimodal models (Gemma 4, Qwen-VL, etc.) — adds ~322 MB
 # Required for any model with vision input. Text-only models work without this.
 vision = [
-    "mlx-vlm>=0.4.4",  # 0.4.4+ required for Gemma 4 support
+    "mlx-vlm>=0.5.0",  # 0.5.0: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix (relevant to our [vision] users), and a new continuous-batching guard. No breaking VL changes.
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -71,7 +71,7 @@ chat = [
 # pip install .[all] and editable installs.
 all = [
     # vision
-    "mlx-vlm>=0.4.4",
+    "mlx-vlm>=0.5.0",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",


### PR DESCRIPTION
## Summary

Bumps the `[vision]` and `[all]` extras' `mlx-vlm` floor from `>=0.4.4` to `>=0.5.0` — picks up upstream's 2026-05-06 release with **Gemma 4 stability fixes** and a **TurboQuant race-condition fix** that's directly relevant to our `--kv-cache-turboquant` users.

Kept **deliberately isolated** so a potential VL regression doesn't get entangled with the in-flight DFlash spec-decode feature (which lands in a follow-up PR after this ships and settles).

## What's in mlx-vlm 0.5.0 vs 0.4.4

Across `0.4.4 → 0.5.0` (per upstream release notes):

- Fix gemma4 multi-image processing for different-sized images
- Fix race condition in TurboQuant fused fast-quantize kernels — **touches our `[vision]` users; net upgrade, not breakage**
- Fix Gemma 4 tool parser (hyphenated function names)
- Fix `gemma4 cache.offset` snapshot under batched caches
- Fix Gemma 4 quantized per-layer projection loading
- (`0.4.0 → 0.4.4` history: Qwen3.5 continuous-batching guards, SAM 3.1, Falcon-OCR, RF-DETR, granite vision additions)

No breaking VL API changes observed.

## Transitive bump

mlx-vlm 0.5.0 hard-pins `mlx-lm>=0.31.3`, which transitively bumps our installed mlx-lm from `0.31.2 → 0.31.3`. Still in range of our existing `mlx-lm>=0.31.0` pin — no pyproject change needed.

## Validation

| Check | Result |
|---|---|
| Full unit suite (excl. weight-dependent MLLM/video) under mlx-vlm 0.5.0 + mlx-lm 0.31.3 | **3019 pass + 1 xpassed**, 17 skipped |
| `test_text_model_from_vlm.py` + `test_mllm_hybrid_probe.py` | **7 pass**, 4 skipped (weights) |
| All VL-touching imports (`benchmark`, `multimodal_processor`, `plugin`, `text_model_from_vlm`, `mllm_batch_generator`, `gemma4_text`, `mllm`, `routes.health`) | clean |
| `ruff check` + `ruff format --check` | clean |

### Pre-existing failures (confirmed independent of this bump)

4 tests in `test_batching_deterministic.py` (`test_batched_faster_than_sequential`, `test_engine_stats`, `test_very_short_max_tokens`, `test_multiple_start_stop`) fail with `RuntimeError: There is no Stream(gpu, N) in current thread`. **Confirmed pre-existing**: same 4 fail identically on the `mlx-vlm 0.4.4 + mlx-lm 0.31.2` baseline. Root cause is the thread-local Stream behavior in mlx-lm 0.31+ documented in memory/gotchas.md — not caused by this bump.

### MLLM / video tests

`test_mllm.py`, `test_mllm_cache.py`, `test_mllm_continuous_batching.py`, `test_video.py` need real Qwen3-VL weights and hang locally — **deferred to the CI test-apple-silicon matrix per SOP**.

## Test plan

- [x] Lint clean (ruff check + format)
- [x] Unit suite green minus pre-existing flake (3019/3019 modulo `test_batching_deterministic.py`)
- [x] All VL module imports clean under 0.5.0
- [x] Release notes reviewed — no breaking changes
- [x] Transitive mlx-lm bump (`0.31.2 → 0.31.3`) verified in range of existing pin
- [ ] CI matrix green (test-apple-silicon covers MLLM/video)

## Follow-up

After this lands and ships as the next release: rebase `feat/dflash-spec-decode` on top of main, drop the now-redundant pyproject bump, and open the DFlash feature PR (`--enable-dflash` flag, dedicated DFlash server, eligibility gates, `info` command DFlash status, 11 new tests + README section — already prepared on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)