### PR TITLE
chore: bump version to 0.6.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.35"
+version = "0.6.36"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release v0.6.36 — bundles two surface-touching changes since v0.6.35:

- **PR #360**: mlx-vlm 0.4.4 → 0.5.0 (vision/dflash extras only). Text-only users unaffected (mlx-vlm not in core deps).
- **PR #359**: under-spec'd alias guard + info CLI tests (test-only).

No inference-path code changed since v0.6.35. Classification: **surface-touching release** per Release SOP step 1.

## Pre-flight (Release SOP)

- [x] Inventory: 2 commits, no inference-touching changes.
- [x] PR Merge SOP gates green on the two component PRs (#360 codex×N, make check qwen3.5-4b 0-regressions, CI matrix green).
- [x] DFlash review wave (17 rounds DeepSeek V4 Pro) converged on the sibling branch; not in this bundle.
- [ ] CI green on this bump PR (auto)
- [ ] Post-release: PyPI propagation + Homebrew tap refresh
- [ ] Post-release: subagent fresh-install smoke (PyPI + install.sh)

## Test plan

- [ ] All CI checks pass (lint, type-check, version-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests)
- [ ] After merge: \`auto-release.yml\` workflow fires and creates tag v0.6.36 + GitHub Release
- [ ] After release: \`publish.yml\` uploads to PyPI; Homebrew formula updates
- [ ] \`pip index versions rapid-mlx\` shows 0.6.36 within ~15 min of merge
- [ ] \`brew info raullenchai/tap/rapid-mlx\` shows 0.6.36

🤖 Generated with [Claude Code](https://claude.com/claude-code)