### PR TITLE
feat: DFlash speculative decoding (Qwen3.5-27B-8bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,20 @@ Large-context requests auto-route to a cloud LLM (GPT-5, Claude, etc.) when loca
 
 Vision, audio (STT/TTS), video understanding, and text embeddings — all through the same OpenAI-compatible API.
 
+### DFlash Speculative Decoding (Qwen3.5/3.6, single-user)
+
+For dense, ≥8-bit Qwen3.5/3.6 aliases — z-lab's block-diffusion drafter (via mlx-vlm) gives a ~2× speedup on single-stream code/long-form generation.
+
+```bash
+pip install 'rapid-mlx[dflash]'
+rapid-mlx info qwen3.5-27b-8bit       # check per-gate eligibility
+rapid-mlx serve qwen3.5-27b-8bit --enable-dflash
+```
+
+Measured on Qwen3.5-27B-8bit (M3 Ultra): **2.18× (fibonacci) / 2.02× (quicksort) / 1.83× (hash table)** vs autoregressive. Acceptance rate floors out on 4-bit and MoE models, so DFlash is gated to validated aliases — run `rapid-mlx info <alias>` to see which pass.
+
+**v1 limitations**: DFlash mode runs a dedicated single-user server (mlx-vlm doesn't expose a batched DFlash kernel yet). Tool calling, MCP, and embeddings aren't available in DFlash mode — restart without `--enable-dflash` for those.
+
 Also: logprobs API, structured JSON output (`response_format`), continuous batching, KV cache quantization (`--kv-cache-quantization`), and [2100+ tests](tests/).
 
 ---
@@ -615,6 +629,7 @@ Also: logprobs API, structured JSON output (`response_format`), continuous batch
 | `--kv-cache-turboquant` | TurboQuant V-cache compression (3-4 bit, 86% savings on dense models) | off |
 | `--kv-cache-quantization` | Quantize prefix cache entries for memory savings | off |
 | `--enable-prefix-cache` | Cache common prefixes across requests | off |
+| `--enable-dflash` | DFlash speculative decoding for eligible aliases (single-user, ~2× speedup) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
 
 ### Cloud Routing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,20 @@ dependencies = [
 [project.optional-dependencies]
 # Vision/multimodal models (Gemma 4, Qwen-VL, etc.) — adds ~322 MB
 # Required for any model with vision input. Text-only models work without this.
+# 0.5.0+ also unlocks DFlash speculative decoding (see [dflash] extras).
 vision = [
-    "mlx-vlm>=0.5.0",  # 0.5.0: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix (relevant to our [vision] users), and a new continuous-batching guard. No breaking VL changes.
+    "mlx-vlm>=0.5.0",  # 0.5.0: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
+]
+# DFlash speculative decoding for Qwen3.5/3.6 dense 8-bit models
+# (issue #264). Adds ~1-4 GB at runtime (drafter weights) and depends on
+# mlx-vlm's spec-decode runtime. Text-only — does NOT pull torch/cv2 like
+# the vision extras do. Only enable if you serve a DFlash-eligible alias
+# (e.g. qwen3.5-27b-8bit) with --enable-dflash.
+dflash = [
+    "mlx-vlm>=0.5.0",
 ]
 # Embedding endpoint
 embeddings = [
@@ -80,6 +89,7 @@ all = [
     "pytz>=2024.1",
     # embeddings
     "mlx-embeddings>=0.0.5",
+    # dflash (text-only path covered by mlx-vlm above; listed for clarity)
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -45,10 +45,13 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "tool_call_parser",
         "reasoning_parser",
         "is_hybrid",
+        "is_moe",
         "supports_spec_decode",
         "default_max_tokens",
         "suffix_decoding_tier",
         "suffix_bench_speedup",
+        "supports_dflash",
+        "dflash_draft_model",
     }
 )
 
@@ -301,6 +304,119 @@ def test_negative_control_unregistered_parser_is_caught() -> None:
     # And a positive control: a real parser must exist (so the test
     # itself wouldn't trivially pass for the wrong reason).
     assert any(p in valid for p in ("hermes", "qwen3_coder_xml", "minimax"))
+
+
+# =============================================================================
+# DFlash speculative-decoding contract (issue #264)
+# =============================================================================
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_dflash_requires_drafter(alias: str) -> None:
+    """If ``supports_dflash=True``, ``dflash_draft_model`` MUST be set.
+    A half-populated DFlash alias would silently fall back to AR at
+    server-start time and look like an unexplained perf regression."""
+    profile = list_profiles()[alias]
+    if profile.supports_dflash:
+        assert profile.dflash_draft_model, (
+            f"{alias}: supports_dflash=True but dflash_draft_model is empty"
+        )
+        assert "/" in profile.dflash_draft_model, (
+            f"{alias}: dflash_draft_model={profile.dflash_draft_model!r} "
+            f"must be 'org/repo' format"
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_dflash_excludes_moe_architectures(alias: str) -> None:
+    """``is_moe=True`` MUST NOT pair with ``supports_dflash=True``. PoC on
+    Qwen3.6-35B-A3B (MoE hybrid) measured 0.76-0.82× regression
+    regardless of precision — DFlash drafters' hidden-state fusion
+    misfires on expert-routing churn (accept_len floors at ~1.5).
+    Re-enabling this combination would ship the regression to users."""
+    profile = list_profiles()[alias]
+    if profile.is_moe:
+        assert not profile.supports_dflash, (
+            f"{alias}: is_moe=True but supports_dflash=True — DFlash "
+            f"acceptance collapses on MoE due to expert-routing churn. "
+            f"Confirmed regression on Qwen3.6-35B-A3B; do not enable on "
+            f"MoE aliases."
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_dflash_excludes_4bit_precision(alias: str) -> None:
+    """DFlash on a 4-bit MLX main model regresses (PoC: 0.63-0.96× on
+    Qwen3.5-4B-MLX-4bit, accept_len 2.35-3.88). 4-bit AR is already at
+    memory-bandwidth floor; drafter overhead dominates. Pattern is
+    detected from the HF path naming convention (``-4bit`` suffix or
+    ``-4bit-`` infix), which is how mlx-community publishes quantized
+    variants."""
+    profile = list_profiles()[alias]
+    if not profile.supports_dflash:
+        return
+    hf = profile.hf_path
+    is_4bit = (
+        "-4bit" in hf
+        or hf.endswith("-4bit")
+        or "4bit-" in hf
+        or "mxfp4" in hf.lower()
+        or "nvfp4" in hf.lower()
+    )
+    assert not is_4bit, (
+        f"{alias}: supports_dflash=True but hf_path={hf!r} looks like a "
+        f"4-bit quantized variant. DFlash regresses on 4-bit precision "
+        f"(accept rate collapses). Use an 8-bit or higher quantization."
+    )
+
+
+def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
+    """DFlash drafters published today are Qwen-family-specific. Any
+    eligible alias must point at a ``z-lab/Qwen3.5-*-DFlash`` or
+    ``z-lab/Qwen3.6-*-DFlash`` drafter. Catches an accidental copy-paste
+    that swaps the drafter to an incompatible model."""
+    valid_drafter_prefixes = (
+        "z-lab/Qwen3.5-",
+        "z-lab/Qwen3.6-",
+    )
+    for alias, profile in list_profiles().items():
+        if not profile.supports_dflash:
+            continue
+        d = profile.dflash_draft_model or ""
+        ok = any(d.startswith(p) for p in valid_drafter_prefixes)
+        assert d.endswith("-DFlash") and ok, (
+            f"{alias}: dflash_draft_model={d!r} doesn't match the "
+            f"expected ``z-lab/Qwen3.5-*-DFlash`` or "
+            f"``z-lab/Qwen3.6-*-DFlash`` shape. If you've validated a "
+            f"new drafter family, update this allow-list."
+        )
+
+
+def test_negative_control_dflash_on_moe_is_caught() -> None:
+    """A future PR adding ``is_moe=true`` + ``supports_dflash=true`` must
+    be rejected by ``test_dflash_excludes_moe_architectures``."""
+    from vllm_mlx.model_aliases import AliasProfile
+
+    bad = AliasProfile(
+        hf_path="fake/MoE-Model",
+        is_moe=True,
+        supports_dflash=True,
+        dflash_draft_model="z-lab/Qwen3.6-35B-A3B-DFlash",
+    )
+    caught = bad.is_moe and bad.supports_dflash
+    assert caught, "the MoE-DFlash exclusion guard would miss this"
+
+
+def test_negative_control_dflash_missing_drafter_is_caught() -> None:
+    """``supports_dflash=True`` without ``dflash_draft_model`` must be
+    rejected at JSON load time by ``_coerce``."""
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="dflash_draft_model"):
+        _coerce(
+            "fake-alias",
+            {"hf_path": "fake/Model", "supports_dflash": True},
+        )
 
 
 def test_default_max_tokens_is_positive_or_none() -> None:

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -356,13 +356,11 @@ def test_dflash_excludes_4bit_precision(alias: str) -> None:
     if not profile.supports_dflash:
         return
     hf = profile.hf_path
-    is_4bit = (
-        "-4bit" in hf
-        or hf.endswith("-4bit")
-        or "4bit-" in hf
-        or "mxfp4" in hf.lower()
-        or "nvfp4" in hf.lower()
-    )
+    # Case-insensitive AND anchored on the "-4bit" form so the test
+    # matches ``eligibility._looks_like_4bit`` exactly. Drift between
+    # the two would let an alias green-light here but crash at boot.
+    hf_lc = hf.lower()
+    is_4bit = "-4bit" in hf_lc or "mxfp4" in hf_lc or "nvfp4" in hf_lc
     assert not is_4bit, (
         f"{alias}: supports_dflash=True but hf_path={hf!r} looks like a "
         f"4-bit quantized variant. DFlash regresses on 4-bit precision "
@@ -394,8 +392,11 @@ def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
 
 def test_negative_control_dflash_on_moe_is_caught() -> None:
     """A future PR adding ``is_moe=true`` + ``supports_dflash=true`` must
-    be rejected by ``test_dflash_excludes_moe_architectures``."""
+    be rejected by the eligibility gate. Exercises the actual gate path
+    (not just the data structure) so a regression that quietly removes
+    the MoE check in ``eligibility.check`` fails this test."""
     from vllm_mlx.model_aliases import AliasProfile
+    from vllm_mlx.speculative.dflash import DFlashUnavailable, check
 
     bad = AliasProfile(
         hf_path="fake/MoE-Model",
@@ -403,8 +404,8 @@ def test_negative_control_dflash_on_moe_is_caught() -> None:
         supports_dflash=True,
         dflash_draft_model="z-lab/Qwen3.6-35B-A3B-DFlash",
     )
-    caught = bad.is_moe and bad.supports_dflash
-    assert caught, "the MoE-DFlash exclusion guard would miss this"
+    with pytest.raises(DFlashUnavailable, match="MoE"):
+        check(bad, alias="fake-moe-alias")
 
 
 def test_negative_control_dflash_missing_drafter_is_caught() -> None:

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -177,5 +177,12 @@ def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:
 
     profile = resolve_profile("qwen3.5-27b")
     assert profile is not None
-    with pytest.raises(DFlashUnavailable):
+    # Match-string: capture both reasons (4-bit + not-opted-in). The
+    # bare ``raises`` would pass even if the gate silently degraded to
+    # the generic message, defeating the point of this regression test.
+    with pytest.raises(DFlashUnavailable) as excinfo:
         check(profile, alias="qwen3.5-27b")
+    msg = str(excinfo.value)
+    assert "4-bit" in msg, (
+        f"4-bit hint missing from DFlashUnavailable message; got:\n{msg}"
+    )

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``vllm_mlx/speculative/dflash/eligibility.py``.
+
+These verify each gate fires in isolation. Integration with the CLI
+and engine is covered separately in ``test_dflash_integration.py``
+(which is skipped when the drafter isn't cached).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.speculative.dflash.eligibility import (
+    DFlashUnavailable,
+    _looks_like_4bit,
+    check,
+    report,
+)
+
+
+def _good_profile() -> AliasProfile:
+    """Reference 'should pass' profile: dense, 8-bit, has drafter."""
+    return AliasProfile(
+        hf_path="mlx-community/Qwen3.5-27B-8bit",
+        is_hybrid=True,
+        is_moe=False,
+        supports_dflash=True,
+        dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
+    )
+
+
+# =============================================================================
+# _looks_like_4bit — quantization detection from HF path
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "hf_path,expected",
+    [
+        ("mlx-community/Qwen3.5-4B-MLX-4bit", True),
+        ("mlx-community/Qwen3.5-27B-4bit", True),
+        ("unsloth/Qwen3.6-27B-UD-MLX-4bit", True),
+        ("nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx", True),
+        ("RedHatAI/Qwen3.6-35B-A3B-NVFP4", True),
+        ("mlx-community/Qwen3.6-35B-A3B-4bit-DWQ", True),
+        # 8-bit + higher should NOT match
+        ("mlx-community/Qwen3.5-27B-8bit", False),
+        ("mlx-community/Qwen3.6-35B-A3B-8bit", False),
+        ("mlx-community/Qwen3.5-27B-bf16", False),
+        ("Qwen/Qwen3.5-4B", False),
+        ("mlx-community/Qwen3.5-27B-6bit", False),
+        ("mlx-community/Qwen3.5-27B-5bit", False),
+    ],
+)
+def test_looks_like_4bit_classification(hf_path: str, expected: bool) -> None:
+    assert _looks_like_4bit(hf_path) is expected
+
+
+# =============================================================================
+# Gate-by-gate: check() raises with actionable messages
+# =============================================================================
+
+
+def test_check_passes_for_good_profile() -> None:
+    """Reference happy path — no exception, no reasons."""
+    p = _good_profile()
+    check(p, alias="qwen3.5-27b-8bit")
+    r = report(p, alias="qwen3.5-27b-8bit")
+    assert r.reasons == ()
+
+
+def test_check_rejects_alias_without_supports_dflash() -> None:
+    """Profile not marked DFlash-eligible — most common case (any
+    non-validated alias). Default ``supports_dflash=False`` must trip
+    the gate."""
+    p = AliasProfile(hf_path="mlx-community/Qwen3.5-27B-8bit")
+    with pytest.raises(DFlashUnavailable, match="not DFlash-enabled"):
+        check(p, alias="qwen3.5-27b-not-validated")
+
+
+def test_check_rejects_moe_alias() -> None:
+    """MoE → reject even if supports_dflash=True (contradiction caught
+    here as a defense-in-depth; alias-contract test rejects this at
+    schema-load time too)."""
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-8bit",
+        is_moe=True,
+        supports_dflash=True,
+        dflash_draft_model="z-lab/Qwen3.6-35B-A3B-DFlash",
+    )
+    with pytest.raises(DFlashUnavailable, match="MoE"):
+        check(p, alias="qwen3.6-35b-8bit")
+
+
+def test_check_rejects_4bit_main_model() -> None:
+    """4-bit main model → reject. Note: aliases marked
+    ``supports_dflash=True`` can't be 4-bit (alias-contract guard),
+    so this gate primarily defends against test-only profiles."""
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.5-27B-4bit",  # 4-bit!
+        supports_dflash=True,
+        dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
+    )
+    with pytest.raises(DFlashUnavailable, match="4-bit"):
+        check(p, alias="qwen3.5-27b")
+
+
+def test_check_message_lists_eligible_aliases() -> None:
+    """Error messages must point users at a working alias — saves a
+    docs round-trip."""
+    p = AliasProfile(hf_path="mlx-community/Qwen3.6-35B-A3B-8bit", is_moe=True)
+    try:
+        check(p, alias="qwen3.6-35b-8bit")
+        raise AssertionError("should have raised")
+    except DFlashUnavailable as e:
+        msg = str(e)
+        assert "qwen3.5-27b-8bit" in msg, (
+            f"error message should suggest a working alias; got:\n{msg}"
+        )
+
+
+# =============================================================================
+# report() — structured per-gate status (used by `info` command)
+# =============================================================================
+
+
+def test_report_collects_all_failures() -> None:
+    """``report()`` must NOT short-circuit on first failure — render
+    all failing gates so the user fixes everything in one round."""
+    bad = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-4bit",  # 4-bit AND MoE
+        is_moe=True,
+        # supports_dflash=False (default) → 3 reasons total
+    )
+    r = report(bad, alias="qwen3.6-35b")
+    assert len(r.reasons) == 3, f"expected 3 reasons, got: {r.reasons}"
+    joined = " ".join(r.reasons)
+    assert "MoE" in joined
+    assert "4-bit" in joined
+    assert "not DFlash-enabled" in joined
+
+
+def test_report_no_alias_name_renders_cleanly() -> None:
+    """Some callers (programmatic use) don't have an alias name. Header
+    fallback must still produce something useful."""
+    bad = AliasProfile(hf_path="mlx-community/Qwen3.5-27B-4bit", is_moe=True)
+    try:
+        check(bad)  # alias=None
+        raise AssertionError("should have raised")
+    except DFlashUnavailable as e:
+        assert "DFlash unavailable" in str(e)
+
+
+# =============================================================================
+# AliasProfile<>aliases.json integration — currently eligible aliases
+# =============================================================================
+
+
+def test_qwen3_5_27b_8bit_alias_passes_check() -> None:
+    """The one alias we've validated by PoC must pass eligibility — a
+    regression here means we accidentally tightened a gate."""
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-27b-8bit")
+    assert profile is not None, "qwen3.5-27b-8bit alias missing"
+    check(profile, alias="qwen3.5-27b-8bit")
+
+
+def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:
+    """The default ``qwen3.5-27b`` alias points at the 4-bit variant —
+    eligibility must reject it with a clear 4-bit hint, not the
+    generic 'not enabled' message (since supports_dflash=False).
+    Confirms users get the right pointer when they pick the wrong
+    quantization."""
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-27b")
+    assert profile is not None
+    with pytest.raises(DFlashUnavailable):
+        check(profile, alias="qwen3.5-27b")

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -106,6 +106,60 @@ def test_info_dflash_marks_4bit_alias_ineligible(capsys) -> None:
     assert "ineligible" in captured.out
 
 
+def test_info_dflash_start_with_uses_alias_not_hf_path(capsys) -> None:
+    """``main()`` resolves alias → HF path before dispatch, stashing the
+    user-typed alias on ``args._original_alias``. The ``Start with`` hint
+    in the DFlash block must render the *alias*, not the resolved HF
+    repo — copy-pasting the resolved path back into ``rapid-mlx serve``
+    breaks the alias-keyed eligibility check."""
+    from vllm_mlx.cli import info_command
+
+    # Mirror main()'s pre-resolve: model = HF path, _original_alias = alias.
+    args = type(
+        "Args",
+        (),
+        {
+            "model": "mlx-community/Qwen3.5-27B-8bit",
+            "_original_alias": "qwen3.5-27b-8bit",
+        },
+    )()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "rapid-mlx serve qwen3.5-27b-8bit --enable-dflash" in captured.out
+    # The HF path must not show up in the start-with hint.
+    assert "rapid-mlx serve mlx-community/" not in captured.out
+
+
+def test_models_listing_renders_dflash_column(capsys) -> None:
+    """``rapid-mlx models`` must show a ``DFlash`` column so users can
+    scan eligibility at a glance. The known-good alias renders ✓; a
+    non-DFlash alias renders —."""
+    from vllm_mlx.cli import models_command
+
+    models_command(None)
+    captured = capsys.readouterr()
+    # Header
+    assert "DFlash" in captured.out
+    # The qwen3.5-27b-8bit row must show ✓ in its DFlash column. We can't
+    # anchor on exact column offsets (table widths may shift), so look
+    # for the alias and the marker on the same line.
+    lines = captured.out.splitlines()
+    eligible_row = next(
+        (line for line in lines if "qwen3.5-27b-8bit " in line),
+        None,
+    )
+    assert eligible_row is not None, "qwen3.5-27b-8bit row missing"
+    assert "✓" in eligible_row, f"DFlash column should be ✓: {eligible_row!r}"
+
+    # A non-DFlash alias renders — in the DFlash column.
+    ineligible_row = next(
+        (line for line in lines if "qwen3.5-4b " in line),
+        None,
+    )
+    assert ineligible_row is not None, "qwen3.5-4b row missing"
+    assert "—" in ineligible_row, f"DFlash column should be —: {ineligible_row!r}"
+
+
 # =============================================================================
 # Server-app construction — _build_app with mocks. Verifies the FastAPI
 # surface and the lock + serial dispatch logic without loading weights.

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -18,10 +18,22 @@ Two tiers of coverage here:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from unittest.mock import MagicMock
 
 import pytest
+
+# Several "unit-ish" tests below monkey-patch ``mlx_vlm`` symbols
+# (stream_generate / prompt_utils.apply_chat_template) to exercise the
+# server path without loading any weights. They still require mlx_vlm
+# to be importable — i.e. the ``[dflash]`` (or ``[vision]``) extras
+# present. Gate them so a minimal install runs the rest of the suite.
+_MLX_VLM_AVAILABLE = importlib.util.find_spec("mlx_vlm") is not None
+_skip_without_mlx_vlm = pytest.mark.skipif(
+    not _MLX_VLM_AVAILABLE,
+    reason="mlx_vlm not installed (DFlash test path needs [dflash] extras)",
+)
 
 # =============================================================================
 # CLI flag plumbing — argparse adds --enable-dflash + the eligibility check
@@ -231,6 +243,410 @@ def test_chat_completions_rejects_empty_messages() -> None:
     assert r.status_code == 400
 
 
+@_skip_without_mlx_vlm
+def test_stream_completion_surfaces_generator_exception(monkeypatch) -> None:
+    """When ``mlx_vlm.stream_generate`` raises mid-stream, the SSE
+    response must finish cleanly with an OpenAI-style error block + a
+    final ``[DONE]`` event — never leave the client hanging.
+
+    Regression guard for the DeepSeek-flagged unhandled-exception path
+    in ``_next_chunk`` (was only catching ``StopIteration``)."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash import server as srv
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+    class _BoomGen:
+        """Sync generator that yields once, then raises — mirrors the
+        shape of mlx-vlm ``stream_generate`` so the production iter
+        loop exercises both the happy and error branches."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.calls += 1
+            if self.calls == 1:
+
+                class _Chunk:
+                    text = "hello"
+                    token = 1
+                    prompt_tokens = 7
+                    generation_tokens = 1
+
+                return _Chunk()
+            raise RuntimeError("simulated mlx-vlm failure")
+
+    def _fake_stream_generate(*args, **kwargs):
+        return _BoomGen()
+
+    # Patch the symbol where it's looked up — mlx_vlm.stream_generate.
+    # The server imports it lazily inside ``_stream_completion``, so we
+    # patch the source module not a re-export.
+    import mlx_vlm
+
+    monkeypatch.setattr(mlx_vlm, "stream_generate", _fake_stream_generate)
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    # Mock processor / model so _render_prompt doesn't try to invoke
+    # mlx-vlm chat templating. apply_chat_template is patched at the
+    # source too.
+    import mlx_vlm.prompt_utils
+
+    monkeypatch.setattr(
+        mlx_vlm.prompt_utils,
+        "apply_chat_template",
+        lambda *a, **kw: "rendered prompt",
+    )
+
+    app = srv._build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        body = b"".join(resp.iter_bytes()).decode()
+
+    # The stream must terminate with a ``[DONE]`` marker — proves the
+    # response coroutine didn't crash mid-flight.
+    assert "data: [DONE]" in body, (
+        "stream must end with [DONE] even when the upstream generator "
+        f"raises; body was:\n{body}"
+    )
+    # The final delta block must carry the error block + finish_reason=error.
+    assert '"finish_reason": "error"' in body
+    assert "dflash_runtime_error" in body
+    assert "simulated mlx-vlm failure" in body
+    # And the one happy chunk that *did* arrive before the raise must
+    # still appear in the stream.
+    assert '"content": "hello"' in body
+
+
+# =============================================================================
+# finish_reason: must report "length" on token-budget hit (OpenAI clients
+# distinguish "stop" from "length"; presenting "stop" for a truncated
+# reply misleads downstream tools that auto-continue on truncation).
+# =============================================================================
+
+
+@_skip_without_mlx_vlm
+def test_stream_completion_surfaces_constructor_exception(monkeypatch) -> None:
+    """If ``stream_generate`` raises at *construction* time (before
+    yielding the first chunk — e.g. OOM, missing mlx-vlm kernel), the
+    SSE response must finish with an error block + ``[DONE]``, not
+    propagate out of the async generator and leave the client hanging.
+    Regression guard for round-7 review finding."""
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    def _exploding_stream_generate(*a, **kw):
+        raise RuntimeError("simulated OOM at generator construction")
+
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "stream_generate", _exploding_stream_generate)
+
+    req = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="ping")],
+        stream=True,
+    )
+    gen_iter = srv._stream_completion(
+        prompt="ping",
+        request=req,
+        served_model_name="qwen3.5-27b-8bit",
+        gen_kwargs={"max_tokens": 4},
+        model=MagicMock(),
+        processor=MagicMock(),
+    )
+
+    async def _drain() -> list[bytes]:
+        return [b async for b in gen_iter]
+
+    chunks = asyncio.run(_drain())
+    body = b"".join(chunks).decode()
+    # Must still get a clean [DONE] terminator + the error block.
+    assert "data: [DONE]" in body, (
+        f"constructor-time crash must still terminate the stream; got:\n{body}"
+    )
+    assert '"finish_reason": "error"' in body
+    assert "dflash_runtime_error" in body
+    assert "simulated OOM at generator construction" in body
+
+
+@_skip_without_mlx_vlm
+def test_stream_completion_reports_length_when_max_tokens_hit(monkeypatch) -> None:
+    """When ``generation_tokens >= max_tokens``, the final SSE event must
+    carry ``finish_reason="length"``. mlx-vlm's GenerationResult doesn't
+    expose finish_reason itself, so the server infers it from token-count
+    vs budget. Regression guard for round-5 review finding."""
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _Chunk:
+        text = "x"
+        token = 1
+        prompt_tokens = 3
+        generation_tokens = 4  # equals max_tokens below
+
+    def _gen():
+        yield _Chunk()
+
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "stream_generate", lambda *a, **kw: _gen())
+
+    req = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="ping")],
+        stream=True,
+    )
+    gen_iter = srv._stream_completion(
+        prompt="ping",
+        request=req,
+        served_model_name="qwen3.5-27b-8bit",
+        gen_kwargs={"max_tokens": 4},  # budget hit
+        model=MagicMock(),
+        processor=MagicMock(),
+    )
+
+    async def _drain() -> list[bytes]:
+        return [b async for b in gen_iter]
+
+    chunks = asyncio.run(_drain())
+    body = b"".join(chunks).decode()
+    # The penultimate SSE event carries the final finish_reason — must be
+    # "length", not "stop", since we hit the token budget.
+    assert '"finish_reason": "length"' in body, (
+        f"max_tokens hit should report finish_reason=length; got:\n{body}"
+    )
+    assert '"finish_reason": "stop"' not in body, (
+        f"must not also emit finish_reason=stop on the final event; got:\n{body}"
+    )
+
+
+@_skip_without_mlx_vlm
+def test_stream_completion_reports_stop_when_eos_lands_at_max_tokens(
+    monkeypatch,
+) -> None:
+    """Edge case from round-13 review: if the model emits EOS at exactly
+    ``max_tokens``, the stop was natural (the model would have stopped
+    even with a larger budget). Reporting "length" would mislead clients
+    that auto-continue on truncation. The token-id disambiguation must
+    correctly classify this as "stop"."""
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _Chunk:
+        text = "done"
+        token = 7  # we'll make this the EOS token id below
+        prompt_tokens = 3
+        generation_tokens = 4  # equals max_tokens — would otherwise be "length"
+
+    def _gen():
+        yield _Chunk()
+
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "stream_generate", lambda *a, **kw: _gen())
+
+    # Processor's tokenizer reports eos_token_id == 7 — matches the
+    # chunk's token, so the heuristic must override "length" → "stop".
+    processor = MagicMock()
+    processor.tokenizer.eos_token_id = 7
+
+    req = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="ping")],
+        stream=True,
+    )
+    gen_iter = srv._stream_completion(
+        prompt="ping",
+        request=req,
+        served_model_name="qwen3.5-27b-8bit",
+        gen_kwargs={"max_tokens": 4},
+        model=MagicMock(),
+        processor=processor,
+    )
+
+    async def _drain() -> list[bytes]:
+        return [b async for b in gen_iter]
+
+    chunks = asyncio.run(_drain())
+    body = b"".join(chunks).decode()
+    assert '"finish_reason": "stop"' in body, (
+        "EOS at exactly max_tokens must be classified as stop, not length; "
+        f"got:\n{body}"
+    )
+    assert '"finish_reason": "length"' not in body, (
+        f"must not also emit length when last token is EOS; got:\n{body}"
+    )
+
+
+@_skip_without_mlx_vlm
+def test_non_stream_completion_reports_length_when_max_tokens_hit(
+    monkeypatch,
+) -> None:
+    """Same length-vs-stop distinction in the non-stream path."""
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _Result:
+        text = "xxxx"
+        prompt_tokens = 3
+        generation_tokens = 4  # equals max_tokens below
+
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "generate", lambda *a, **kw: _Result())
+
+    req = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="ping")],
+        stream=False,
+    )
+    resp = asyncio.run(
+        srv._non_stream_completion(
+            prompt="ping",
+            request=req,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 4},
+            model=MagicMock(),
+            processor=MagicMock(),
+        )
+    )
+    assert resp.choices[0].finish_reason == "length", (
+        f"max_tokens hit should report finish_reason=length, "
+        f"got {resp.choices[0].finish_reason!r}"
+    )
+
+
+# =============================================================================
+# Thread-affinity contract — every mlx-vlm call must land on the dedicated
+# single-thread executor. mlx-lm 0.31.3+ keeps GPU Stream in thread-local
+# storage; hand-off across worker threads crashes mid-generation with
+# "There is no Stream(gpu, N) in current thread". A regression here would
+# only surface in production (no Stream error in mock tests), so we pin
+# the invariant via the executor's identity.
+# =============================================================================
+
+
+@_skip_without_mlx_vlm
+def test_stream_completion_pins_to_dedicated_executor(monkeypatch) -> None:
+    """``_stream_completion`` must submit every mlx-vlm call (generator
+    construction + each ``next(gen)``) to the module-level single-thread
+    ``_dflash_executor`` — never to the default ThreadPoolExecutor
+    (which has N workers and would tear apart mlx's thread-local Stream).
+
+    The spy counts submissions on the pinned executor; a regression
+    that routed work to the default executor would zero the counter."""
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    # Runtime spy on ``_dflash_executor.submit`` — counts the actual
+    # submissions during a real ``_stream_completion`` invocation.
+    submit_count = [0]
+    real_submit = srv._dflash_executor.submit
+
+    def _count_submit(fn, *args, **kwargs):
+        submit_count[0] += 1
+        return real_submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr(srv._dflash_executor, "submit", _count_submit)
+
+    class _OneChunk:
+        text = "hi"
+        generation_tokens = 1
+        prompt_tokens = 2
+
+    def _gen():
+        yield _OneChunk()
+
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "stream_generate", lambda *a, **kw: _gen())
+
+    req = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="ping")],
+        stream=True,
+    )
+    gen_iter = srv._stream_completion(
+        prompt="ping",
+        request=req,
+        served_model_name="qwen3.5-27b-8bit",
+        gen_kwargs={"max_tokens": 8},
+        model=MagicMock(),
+        processor=MagicMock(),
+    )
+
+    async def _drain() -> None:
+        async for _ in gen_iter:
+            pass
+
+    asyncio.run(_drain())
+
+    # Expect at least 2 submits: one for ``_make_gen`` (construct the
+    # generator on the worker) and at least one for ``_next_chunk``.
+    assert submit_count[0] >= 2, (
+        f"_dflash_executor.submit only called {submit_count[0]} time(s); "
+        "expected ≥2 (one for generator construction + one per next()). "
+        "Thread affinity contract violated."
+    )
+
+
+def test_dflashruntime_accept_lens_tolerates_wrong_type(caplog) -> None:
+    """If a future mlx-vlm renames ``accept_lens`` or changes its type,
+    we must not crash on reset — degrade to a warning + no-op. Verifies
+    the isinstance guard added after the round-4 review."""
+    import logging
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+    drafter = MagicMock()
+    drafter.accept_lens = 42  # not a list
+    rt = DFlashRuntime(drafter=drafter, kind="dflash", drafter_repo="fake/repo")
+
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.speculative.dflash.runtime"):
+        rt.reset_accept_lens()
+    assert any("unexpected type" in rec.message for rec in caplog.records), (
+        "reset_accept_lens should warn (not crash) when accept_lens isn't a list"
+    )
+    # Snapshot also degrades gracefully — empty list, not raise.
+    assert rt.accept_lens_snapshot() == []
+
+
 # =============================================================================
 # Eligibility error surfaces (CLI startup) — the gate must fail fast
 # with an actionable error before the user wastes 5 min downloading weights.
@@ -286,6 +702,26 @@ def test_dflash_e2e_chat_completion_smoke() -> None:
 
     if not have_runtime():
         pytest.skip("mlx-vlm 0.5.0+ not installed")
+
+    # Cache-presence gate — if a curious dev sets RAPID_MLX_DFLASH_E2E=1
+    # but doesn't have the weights, ``mlx_vlm.load`` would silently
+    # start a multi-GB HuggingFace download (no progress visible from
+    # pytest). Skip with a precise reason so they know how to bring the
+    # test into reach instead of waiting on a stuck process.
+    from huggingface_hub import try_to_load_from_cache
+
+    _required_repos = (
+        "mlx-community/Qwen3.5-27B-8bit",
+        "z-lab/Qwen3.5-27B-DFlash",
+    )
+    for repo in _required_repos:
+        cfg = try_to_load_from_cache(repo, "config.json")
+        if not cfg:
+            pytest.skip(
+                f"DFlash e2e: {repo} not cached locally. Run "
+                f"`huggingface-cli download {repo}` before re-running "
+                "with RAPID_MLX_DFLASH_E2E=1."
+            )
 
     from fastapi.testclient import TestClient
     from mlx_vlm import load

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the DFlash production path.
+
+Two tiers of coverage here:
+
+1. **Unit-ish** — exercise the CLI/info/server module surface without
+   loading any weights. These run in the standard pytest suite (no
+   mlx-vlm 0.5.0 required); they verify the user-facing plumbing
+   (flag parsing, eligibility errors, info rendering, app construction
+   with mocked model/processor/runtime).
+
+2. **End-to-end** — guarded by ``RAPID_MLX_DFLASH_E2E=1`` and the
+   presence of mlx-vlm 0.5.0 + the Qwen3.5-27B-8bit weights and DFlash
+   drafter locally. These actually generate text via the production
+   server. They live here (not in a separate file) so a maintainer can
+   add new e2e cases without searching for the right module.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+# =============================================================================
+# CLI flag plumbing — argparse adds --enable-dflash + the eligibility check
+# fires before the model load when an ineligible alias is passed.
+# =============================================================================
+
+
+def test_serve_parser_exposes_enable_dflash() -> None:
+    """``--enable-dflash`` is a real flag (not argparse.SUPPRESSed)."""
+    # serve flags are inlined in main(); easier to assert on --help than
+    # to re-build the parser. Coarser but reliable.
+    import subprocess
+    import sys
+
+    out = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "--enable-dflash" in out.stdout, "serve --help should list --enable-dflash"
+    # Help text mentions the install path so users know how to enable
+    # the feature when it's missing.
+    assert "[dflash]" in out.stdout, (
+        "help text should reference the rapid-mlx[dflash] extras"
+    )
+
+
+# =============================================================================
+# info command DFlash block — the user-facing eligibility status table.
+# =============================================================================
+
+
+def test_info_renders_dflash_block_for_eligible_alias(capsys) -> None:
+    """``rapid-mlx info qwen3.5-27b-8bit`` shows the per-gate table."""
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.5-27b-8bit"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DFlash eligibility" in captured.out
+    # All four declared-content gates should pass for the validated alias.
+    assert "Declared support" in captured.out
+    assert "Not MoE" in captured.out
+    assert "Drafter declared" in captured.out
+    assert "z-lab/Qwen3.5-27B-DFlash" in captured.out
+
+
+def test_info_dflash_block_skipped_for_unknown_alias(capsys) -> None:
+    """Unknown HF paths (not in aliases.json) — no DFlash block, since
+    eligibility is per-alias and can't be inferred from a raw path."""
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "not-a-real-alias-zzz"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DFlash eligibility" not in captured.out
+
+
+def test_info_dflash_marks_4bit_alias_ineligible(capsys) -> None:
+    """The default ``qwen3.5-27b`` alias points at the 4-bit variant and
+    must surface as ineligible with the right gate failing."""
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.5-27b"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DFlash eligibility" in captured.out
+    assert "ineligible" in captured.out
+
+
+# =============================================================================
+# Server-app construction — _build_app with mocks. Verifies the FastAPI
+# surface and the lock + serial dispatch logic without loading weights.
+# =============================================================================
+
+
+def test_build_app_returns_fastapi_app() -> None:
+    """The app exposes the three OpenAI-compat routes."""
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+    )
+    routes = {r.path for r in app.routes if hasattr(r, "path")}
+    assert "/healthz" in routes
+    assert "/v1/models" in routes
+    assert "/v1/chat/completions" in routes
+
+
+def test_healthz_and_models_routes() -> None:
+    """``/healthz`` reports DFlash mode + drafter; ``/v1/models`` lists
+    the served name. These don't touch the model so they're safe to
+    exercise without weights."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["engine"] == "dflash"
+    assert body["drafter"] == "z-lab/Qwen3.5-27B-DFlash"
+
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "list"
+    assert body["data"][0]["id"] == "qwen3.5-27b-8bit"
+
+
+def test_chat_completions_rejects_tools() -> None:
+    """DFlash v1 doesn't run a tool-call parser. The route must reject
+    tool requests with a clear 400 — silent passthrough would surprise
+    users (model emits free-form text instead of structured tool calls)."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {}},
+                }
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "tool calling" in r.json()["detail"].lower()
+
+
+def test_chat_completions_rejects_empty_messages() -> None:
+    """OpenAI-compat parity: empty messages → 400."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "qwen3.5-27b-8bit", "messages": []},
+    )
+    assert r.status_code == 400
+
+
+# =============================================================================
+# Eligibility error surfaces (CLI startup) — the gate must fail fast
+# with an actionable error before the user wastes 5 min downloading weights.
+# =============================================================================
+
+
+def test_run_dflash_server_raises_when_mlx_vlm_missing(monkeypatch) -> None:
+    """When mlx-vlm 0.5.0+ isn't importable, ``run_dflash_server``
+    raises with the install hint — not a cryptic ImportError."""
+    from vllm_mlx.speculative.dflash import server as srv
+
+    monkeypatch.setattr(srv, "have_runtime", lambda: False)
+    with pytest.raises(RuntimeError, match=r"rapid-mlx\[dflash\]"):
+        srv.run_dflash_server(
+            main_model_repo="mlx-community/Qwen3.5-27B-8bit",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+            host="127.0.0.1",
+            port=58999,  # never bound — raises before uvicorn
+            served_model_name="qwen3.5-27b-8bit",
+            default_max_tokens=512,
+            cors_origins=["*"],
+            uvicorn_log_level="info",
+        )
+
+
+# =============================================================================
+# End-to-end — heavy. Requires:
+#   - ``RAPID_MLX_DFLASH_E2E=1`` env var (opt-in; CI doesn't set it)
+#   - mlx-vlm 0.5.0+ installed (skipif gates this)
+#   - Qwen3.5-27B-8bit + DFlash drafter cached locally (~30 GB combined)
+# Validates the full happy path: model load → generate → OpenAI-format
+# response. Mirrors the PoC bench harness but goes through our server.
+# =============================================================================
+
+
+_E2E_ENABLED = os.environ.get("RAPID_MLX_DFLASH_E2E", "") in ("1", "true", "yes")
+
+
+@pytest.mark.skipif(
+    not _E2E_ENABLED,
+    reason="DFlash e2e disabled — set RAPID_MLX_DFLASH_E2E=1 to enable "
+    "(requires Qwen3.5-27B-8bit + drafter cached, ~30 GB)",
+)
+def test_dflash_e2e_chat_completion_smoke() -> None:
+    """One non-streaming chat completion through the production server.
+
+    Loads the real model + drafter, fires a single completion through
+    ``_non_stream_completion``, and asserts the response shape +
+    plausible token counts. Doesn't measure speedup here — the bench
+    harness owns that — but does confirm the wiring produces a valid
+    OpenAI-compat response."""
+    from vllm_mlx.speculative.dflash.eligibility import have_runtime
+
+    if not have_runtime():
+        pytest.skip("mlx-vlm 0.5.0+ not installed")
+
+    from fastapi.testclient import TestClient
+    from mlx_vlm import load
+
+    from vllm_mlx.speculative.dflash.runtime import load_runtime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    model, processor = load("mlx-community/Qwen3.5-27B-8bit")
+    runtime = load_runtime("z-lab/Qwen3.5-27B-DFlash")
+    app = _build_app(
+        model=model,
+        processor=processor,
+        runtime=runtime,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [
+                {"role": "user", "content": "Write the first 5 Fibonacci numbers."}
+            ],
+            "max_tokens": 64,
+            "temperature": 0.0,
+            "stream": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"]["role"] == "assistant"
+    assert body["choices"][0]["message"]["content"]
+    assert body["usage"]["completion_tokens"] > 0

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -100,14 +100,14 @@ def test_orphan_aliases_now_covered() -> None:
 def test_list_aliases_returns_legacy_string_view() -> None:
     """Old callers (doctor harness, tests) expect ``{alias: hf_path}``."""
     aliases = list_aliases()
-    assert len(aliases) == 57
+    assert len(aliases) == 58
     assert all(isinstance(p, str) for p in aliases.values())
     assert aliases["qwen3.5-4b"] == "mlx-community/Qwen3.5-4B-MLX-4bit"
 
 
 def test_list_profiles_returns_rich_dataclass_view() -> None:
     profiles = list_profiles()
-    assert len(profiles) == 57
+    assert len(profiles) == 58
     p = profiles["qwen3.5-4b"]
     assert isinstance(p, AliasProfile)
     assert p.hf_path == "mlx-community/Qwen3.5-4B-MLX-4bit"
@@ -298,7 +298,7 @@ def test_qwen35_family_aliases_share_hybrid_flag() -> None:
     schema enables."""
     profiles = list_profiles()
     family = {a: p for a, p in profiles.items() if a.startswith("qwen3.5-")}
-    assert len(family) == 7
+    assert len(family) == 8
     flags = {(p.is_hybrid, p.supports_spec_decode) for p in family.values()}
     assert flags == {(True, False)}, (
         f"qwen3.5-* family disagrees on capability flags: {flags}"

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -25,28 +25,42 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.5-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.5-122b": {
     "hf_path": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.5-122b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-122B-A10B-8bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
+  "qwen3.5-27b-8bit": {
+    "hf_path": "mlx-community/Qwen3.5-27B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": true,
+    "dflash_draft_model": "z-lab/Qwen3.5-27B-DFlash"
   },
   "qwen3.6-27b": {
     "hf_path": "mlx-community/Qwen3.6-27B-4bit",
@@ -74,35 +88,40 @@
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.6-35b-6bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-6bit",
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.6-35b-8bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-8bit",
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.6-35b-ud": {
     "hf_path": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "qwen3.6-35b-dwq": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "deepseek-v4-flash": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
@@ -385,7 +404,8 @@
       "chat": 1.046,
       "json_array": 1.031,
       "code_edit": 0.993
-    }
+    },
+    "is_moe": true
   },
   "devstral-v2-24b": {
     "hf_path": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
@@ -412,7 +432,8 @@
       "json_array": 0.988,
       "tool_loop": 1.039,
       "code_edit": 0.929
-    }
+    },
+    "is_moe": true
   },
   "gemma-3n-e4b": {
     "hf_path": "mlx-community/gemma-3n-E4B-it-4bit",
@@ -440,14 +461,16 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "nemotron-nano": {
     "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "bonsai-1.7b": {
     "hf_path": "prism-ml/Bonsai-1.7B-unpacked",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1001,13 +1001,15 @@ def models_command(_args):
 
     # Widths sized to fit the longest values currently in aliases.json:
     # alias 22 (qwen3.5-122b-mxfp4 etc.), tool 16 (qwen3_coder_xml + 1 pad),
-    # reasoning 12 (deepseek_r1 + 1 pad), spec 10 ("✗ hybrid"), tier 11.
+    # reasoning 12 (deepseek_r1 + 1 pad), spec 10 ("✗ hybrid"), tier 11,
+    # dflash 7 ("✓ ready"/"—").
     cols = (
         ("Alias", 22),
         ("Tools", 16),
         ("Reasoning", 12),
         ("Spec-Decode", 10),
         ("Suffix Tier", 11),
+        ("DFlash", 7),
     )
     width = sum(w for _, w in cols) + len(cols) - 1
     sep = "  " + "─" * width
@@ -1028,7 +1030,16 @@ def models_command(_args):
         else:
             spec = "✓" if p.supports_spec_decode else "✗"
             tier = p.suffix_decoding_tier
-        row = f"  {alias:<22} {tools:<16} {reasoning:<12} {spec:<10} {tier:<11}"
+        # DFlash column — eligible aliases show ✓, everything else "—" so
+        # the visual scan immediately surfaces what supports it. We don't
+        # re-run the eligibility gate here (which would also check that
+        # mlx-vlm 0.5.0+ is installed) — that's a runtime concern; the
+        # registry column is pure declarative state.
+        dflash = "✓" if p.supports_dflash else "—"
+        row = (
+            f"  {alias:<22} {tools:<16} {reasoning:<12} "
+            f"{spec:<10} {tier:<11} {dflash:<7}"
+        )
         print(row)
 
     print(sep)
@@ -2220,11 +2231,16 @@ def info_command(args):
         format_profile_table,
     )
 
+    # ``main()`` (cli.py:~3400) pre-resolves ``args.model`` from alias →
+    # HF path before dispatch, stashing the user-typed alias on
+    # ``args._original_alias``. Pull from that first so DFlash
+    # eligibility (alias-keyed) and the start-command hint render with
+    # the alias the user actually typed, not the resolved HF repo.
+    original_alias = getattr(args, "_original_alias", None) or args.model
     name = args.model
-    # Preserve the user-typed alias so DFlash eligibility (which is
-    # keyed by alias, not hf_path) can render with the right name.
-    original_alias = name
-    resolved = resolve_model(name)
+    resolved = (
+        resolve_model(name) if not getattr(args, "_original_alias", None) else None
+    )
     if resolved and resolved != name:
         print(f"  alias: {name} → {resolved}")
         name = resolved

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -486,6 +486,19 @@ def serve_command(args):
     else:
         server._reasoning_parser = None
 
+    # DFlash mutual-exclusion gate fires BEFORE the startup banner so
+    # the user sees a clean error instead of an optimistic "Features:
+    # dflash" line immediately followed by an exit. The deeper SchedulerConfig
+    # mutex (suffix vs. mtp) stays below since it doesn't involve DFlash.
+    if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
+        print(
+            "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
+            "or --enable-mtp. DFlash runs a dedicated single-user server "
+            "that bypasses BatchedEngine; other spec-decode methods only "
+            "apply to the BatchedEngine path.\n"
+        )
+        sys.exit(1)
+
     # DFlash eligibility gate fires here, BEFORE the startup banner —
     # so the user sees a clean error rather than an optimistic "DFlash
     # enabled" feature line followed by an exit. Cheap (just reads
@@ -517,6 +530,44 @@ def serve_command(args):
                 "``pip install 'rapid-mlx[dflash]'``.\n"
             )
             sys.exit(1)
+
+        # Warn about flags that BatchedEngine honours but the DFlash
+        # server doesn't — better to surface this once at startup than
+        # to let users wonder why their tuning has no effect. Inspected
+        # against the actual argparse Namespace so we only mention flags
+        # the user explicitly set away from their default.
+        _GPU_MEM_DEFAULT = 0.90  # keep in sync with the serve_parser default
+        _dflash_ignored: list[str] = []
+        if getattr(args, "enable_prefix_cache", False):
+            _dflash_ignored.append("--enable-prefix-cache")
+        if getattr(args, "kv_cache_quantization", None):
+            _dflash_ignored.append("--kv-cache-quantization")
+        # gpu-memory-utilization defaults to 0.90 (not None) in the serve
+        # parser, so an ``is not None`` check would fire on every invocation.
+        # Compare to the real default — only warn when the user explicitly
+        # tuned it. Tolerate a tiny float-equality slack for safety.
+        _gpu_mem = getattr(args, "gpu_memory_utilization", _GPU_MEM_DEFAULT)
+        if _gpu_mem is not None and abs(_gpu_mem - _GPU_MEM_DEFAULT) > 1e-6:
+            _dflash_ignored.append("--gpu-memory-utilization")
+        if getattr(args, "enable_auto_tool_choice", False):
+            _dflash_ignored.append("--enable-auto-tool-choice")
+        if getattr(args, "tool_call_parser", None):
+            _dflash_ignored.append("--tool-call-parser")
+        if getattr(args, "reasoning_parser", None):
+            _dflash_ignored.append("--reasoning-parser")
+        if getattr(args, "embedding_model", None):
+            _dflash_ignored.append("--embedding-model")
+        if getattr(args, "mcp_config", None):
+            _dflash_ignored.append("--mcp-config")
+        if _dflash_ignored:
+            print(
+                "\n  ⚠ The following flags are ignored under --enable-dflash"
+                "\n    (DFlash uses a dedicated single-user server that bypasses"
+                "\n    BatchedEngine):"
+                f"\n      {', '.join(_dflash_ignored)}"
+                "\n    Drop them from your serve command, or run without"
+                "\n    --enable-dflash if you need them.\n"
+            )
 
     # Startup summary
     print()
@@ -589,19 +640,12 @@ def serve_command(args):
         sys.exit(1)
 
     # Mutual exclusion: only one spec-decode method may wrap _step at a time.
+    # (The DFlash-vs-{suffix,mtp} check is upstream, before the banner.)
     if args.suffix_decoding and args.enable_mtp:
         print(
             "\n  Error: --suffix-decoding and --enable-mtp are mutually "
             "exclusive (both monkey-patch the BatchGenerator step). "
             "Pick one.\n"
-        )
-        sys.exit(1)
-    if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
-        print(
-            "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
-            "or --enable-mtp. DFlash runs a dedicated single-user server "
-            "that bypasses BatchedEngine; other spec-decode methods only "
-            "apply to the BatchedEngine path.\n"
         )
         sys.exit(1)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -486,6 +486,38 @@ def serve_command(args):
     else:
         server._reasoning_parser = None
 
+    # DFlash eligibility gate fires here, BEFORE the startup banner —
+    # so the user sees a clean error rather than an optimistic "DFlash
+    # enabled" feature line followed by an exit. Cheap (just reads
+    # aliases.json + checks the module spec); no model load yet.
+    if args.enable_dflash:
+        from .model_aliases import resolve_profile
+        from .speculative.dflash import DFlashUnavailable, check
+        from .speculative.dflash.eligibility import have_runtime
+
+        _alias_name = getattr(args, "_original_alias", None) or args.model
+        _profile = resolve_profile(_alias_name)
+        if _profile is None:
+            print(
+                f"\n  Error: --enable-dflash requires a known alias, got "
+                f"{_alias_name!r}. DFlash eligibility is recorded per-alias "
+                f"in aliases.json; ad-hoc HuggingFace paths can't be "
+                f"validated. Try ``rapid-mlx info qwen3.5-27b-8bit``.\n"
+            )
+            sys.exit(1)
+        try:
+            check(_profile, alias=_alias_name)
+        except DFlashUnavailable as e:
+            print(f"\n  Error: {e}\n")
+            sys.exit(1)
+        if not have_runtime():
+            print(
+                "\n  Error: --enable-dflash requires mlx-vlm 0.5.0+ for the "
+                "DFlash drafter hooks. Install with: "
+                "``pip install 'rapid-mlx[dflash]'``.\n"
+            )
+            sys.exit(1)
+
     # Startup summary
     print()
     print("  Rapid-MLX")
@@ -510,6 +542,8 @@ def serve_command(args):
         features.append("pin-system-prompt")
     if args.cors_origins:
         features.append(f"cors: {', '.join(args.cors_origins)}")
+    if args.enable_dflash:
+        features.append("dflash: single-user")
     if features:
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
@@ -539,7 +573,9 @@ def serve_command(args):
     if getattr(args, "draft_model", None):
         print(
             "\n  ⚠ --draft-model is deprecated and has no effect."
-            "\n    For speculative decoding, use --enable-mtp (requires model with MTP head).\n"
+            "\n    For DFlash speculative decoding, use --enable-dflash "
+            "(requires a DFlash-eligible alias). "
+            "For MTP, use --enable-mtp (requires a model with MTP head).\n"
         )
     if getattr(args, "specprefill", False):
         print("\n  ⚠ --specprefill is deprecated and has no effect.\n")
@@ -558,6 +594,14 @@ def serve_command(args):
             "\n  Error: --suffix-decoding and --enable-mtp are mutually "
             "exclusive (both monkey-patch the BatchGenerator step). "
             "Pick one.\n"
+        )
+        sys.exit(1)
+    if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
+        print(
+            "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
+            "or --enable-mtp. DFlash runs a dedicated single-user server "
+            "that bypasses BatchedEngine; other spec-decode methods only "
+            "apply to the BatchedEngine path.\n"
         )
         sys.exit(1)
 
@@ -668,6 +712,32 @@ def serve_command(args):
     # Pre-flight memory check — warn (don't abort) if model + working set
     # would push unified memory past the kernel-panic threshold (issue #324).
     _check_memory_capacity(args.model)
+
+    # DFlash fork: when --enable-dflash is set, skip BatchedEngine entirely
+    # and run the dedicated DFlash server. The eligibility check above has
+    # already validated the alias, so by here we have a known-good profile.
+    if args.enable_dflash:
+        from .model_aliases import resolve_profile
+        from .speculative.dflash.server import run_dflash_server
+
+        _alias_name = getattr(args, "_original_alias", None) or args.model
+        _profile = resolve_profile(_alias_name)
+        # The eligibility check at top of serve_command guarantees this
+        # passes — assert to be defensive against future refactors.
+        assert _profile is not None and _profile.supports_dflash, (
+            f"DFlash profile invariant violated for {_alias_name!r}"
+        )
+        run_dflash_server(
+            main_model_repo=_profile.hf_path,
+            drafter_repo=_profile.dflash_draft_model,  # validated non-None by _coerce
+            host=args.host,
+            port=args.port,
+            served_model_name=args.served_model_name or _alias_name,
+            default_max_tokens=args.max_tokens,
+            cors_origins=cors_origins,
+            uvicorn_log_level=uvicorn_log_level,
+        )
+        return
 
     # Load model with unified server
     try:
@@ -2100,13 +2170,16 @@ def info_command(args):
     Stage 1 (regex match) only — does NOT load the model, so this is fast
     and works without weights. Stage 2 (ArraysCache probe) is skipped.
     """
-    from vllm_mlx.model_aliases import resolve_model
+    from vllm_mlx.model_aliases import resolve_model, resolve_profile
     from vllm_mlx.model_auto_config import (
         detect_model_config,
         format_profile_table,
     )
 
     name = args.model
+    # Preserve the user-typed alias so DFlash eligibility (which is
+    # keyed by alias, not hf_path) can render with the right name.
+    original_alias = name
     resolved = resolve_model(name)
     if resolved and resolved != name:
         print(f"  alias: {name} → {resolved}")
@@ -2116,8 +2189,84 @@ def info_command(args):
     print()
     print(format_profile_table(name, cfg))
     print()
+
+    # DFlash eligibility — render the report so users can see which
+    # gates pass/fail without consulting the docs. Skipped for unknown
+    # models since AliasProfile is alias-keyed.
+    profile = resolve_profile(original_alias)
+    if profile is not None:
+        _print_dflash_status(original_alias, profile)
+
     if cfg is None:
         print("  No pattern matched — runtime probe will run when the model loads.")
+        print()
+
+
+def _print_dflash_status(alias: str, profile) -> None:
+    """Render a 3-row DFlash status block for ``rapid-mlx info <alias>``.
+
+    Shows each gate (declared support / not MoE / not 4-bit / drafter
+    present) so a user who tried ``--enable-dflash`` and got a vague
+    error can see exactly which gate they're tripping.
+    """
+    from vllm_mlx.speculative.dflash.eligibility import (
+        _looks_like_4bit,
+        have_runtime,
+        report,
+    )
+
+    r = report(profile, alias=alias)
+    inner = 60
+    sep = "─" * inner
+
+    def _row(text: str) -> str:
+        return f"│ {text:<{inner}} │"
+
+    def _yes(ok: bool, msg_ok: str, msg_no: str) -> str:
+        return ("✓ " + msg_ok) if ok else ("✗ " + msg_no)
+
+    rows = [
+        (
+            "Declared support",
+            _yes(profile.supports_dflash, "yes (supports_dflash=true)", "no"),
+        ),
+        ("Not MoE", _yes(not profile.is_moe, "yes (dense)", "no (MoE)")),
+        (
+            "Precision ≥8-bit",
+            _yes(
+                not _looks_like_4bit(profile.hf_path),
+                "yes",
+                "no (4-bit/mxfp4/nvfp4)",
+            ),
+        ),
+        (
+            "Drafter declared",
+            _yes(
+                bool(profile.dflash_draft_model),
+                profile.dflash_draft_model or "yes",
+                "no (dflash_draft_model unset)",
+            ),
+        ),
+        (
+            "mlx-vlm 0.5.0+",
+            _yes(have_runtime(), "installed", "missing (need rapid-mlx[dflash])"),
+        ),
+    ]
+
+    eligible = not r.reasons and have_runtime()
+    summary = "✓ eligible" if eligible else "✗ ineligible"
+
+    top = "┌" + "─" * (inner + 2) + "┐"
+    bot = "└" + "─" * (inner + 2) + "┘"
+
+    body = [top, _row(f"DFlash eligibility: {summary}"), _row(sep)]
+    for k, v in rows:
+        body.append(_row(f"{k:<18}: {v}"))
+    body.append(bot)
+    print("\n".join(body))
+    print()
+    if eligible:
+        print(f"  Start with: rapid-mlx serve {alias} --enable-dflash")
         print()
 
 
@@ -2567,6 +2716,21 @@ Examples:
         type=str,
         default=None,
         help=argparse.SUPPRESS,
+    )
+    # DFlash — block-diffusion drafter speculative decoding (z-lab / mlx-vlm).
+    # Currently single-user serial mode; runs a dedicated DFlash server that
+    # bypasses BatchedEngine. Eligible aliases declare ``supports_dflash=true``
+    # in aliases.json (dense, ≥8-bit, drafter available — qwen3.5-27b-8bit
+    # is the only validated one today). PoC: 1.83–2.18× on Qwen3.5-27B-8bit.
+    serve_parser.add_argument(
+        "--enable-dflash",
+        action="store_true",
+        default=False,
+        help="Enable DFlash speculative decoding (block-diffusion drafter, "
+        "single-user serial mode). Requires a DFlash-eligible alias "
+        "(see ``rapid-mlx info <alias>``). Loads the drafter from the "
+        "alias's ``dflash_draft_model`` field. Install with "
+        "``pip install 'rapid-mlx[dflash]'``.",
     )
     serve_parser.add_argument(
         "--num-draft-tokens",

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -97,6 +97,14 @@ class EngineConfig:
     stream_interval: int = 1  # Tokens to batch before streaming (1=every token)
     gpu_memory_utilization: float = 0.90  # Fraction of device memory for allocation
     tool_logits_processor_factory: Any | None = None  # Factory for tool logits bias
+    # DFlash speculative decoding (issue #264). When True, the engine
+    # loads ``dflash_draft_model`` and runs DFlash for B=1 requests on
+    # eligible aliases. B>1 transparently falls back to AR until phase-2
+    # batched support lands. Eligibility is verified by
+    # ``vllm_mlx.speculative.dflash.check`` at server-start time —
+    # invalid combinations error out before any weights load.
+    enable_dflash: bool = False
+    dflash_draft_model: str | None = None
 
 
 class EngineCore:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -97,14 +97,12 @@ class EngineConfig:
     stream_interval: int = 1  # Tokens to batch before streaming (1=every token)
     gpu_memory_utilization: float = 0.90  # Fraction of device memory for allocation
     tool_logits_processor_factory: Any | None = None  # Factory for tool logits bias
-    # DFlash speculative decoding (issue #264). When True, the engine
-    # loads ``dflash_draft_model`` and runs DFlash for B=1 requests on
-    # eligible aliases. B>1 transparently falls back to AR until phase-2
-    # batched support lands. Eligibility is verified by
-    # ``vllm_mlx.speculative.dflash.check`` at server-start time —
-    # invalid combinations error out before any weights load.
-    enable_dflash: bool = False
-    dflash_draft_model: str | None = None
+    # NOTE: DFlash speculative decoding (issue #264) bypasses the
+    # BatchedEngine entirely via a dedicated server module
+    # (``vllm_mlx.speculative.dflash.server``). No engine-side fields
+    # are needed today. If a future phase-2 brings DFlash inside
+    # BatchedEngine for B>1 support, add the config fields back here
+    # and wire them through ``EngineCore.__init__``.
 
 
 class EngineCore:

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -28,6 +28,12 @@ from dataclasses import dataclass
 # - ``avoid``:   benched, regression on at least one canonical workload
 VALID_SUFFIX_TIERS: frozenset[str] = frozenset({"unknown", "neutral", "good", "avoid"})
 
+
+# Canonical name for the DFlash speculative-decoding drafter kind. Kept
+# as a module constant so eligibility checks, CLI flag handlers, and
+# alias validation all reference the same string.
+DFLASH_KIND: str = "dflash"
+
 _aliases: dict[str, "AliasProfile"] | None = None
 # Reverse index: hf_path → first alias that references it. Built once
 # alongside ``_aliases`` so reverse lookups in ``resolve_profile`` are
@@ -53,6 +59,14 @@ class AliasProfile:
     tool_call_parser: str | None = None
     reasoning_parser: str | None = None
     is_hybrid: bool = False
+    # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
+    # plus future Mixtral/Granite-MoE families). Tracked separately from
+    # ``is_hybrid`` because the two attributes gate different downstream
+    # paths — hybrid affects ArraysCache/GDN rollback, MoE affects DFlash
+    # acceptance rate (the drafter's hidden-state fusion misfires on
+    # expert-routing churn; PoC measured 0.76-0.82× regression regardless
+    # of precision on Qwen3.6-35B-A3B).
+    is_moe: bool = False
     supports_spec_decode: bool = True
     default_max_tokens: int | None = None
     # SuffixDecoding eligibility — populated from cross-model bench (issue #269).
@@ -62,6 +76,15 @@ class AliasProfile:
     # pairs (tuple, not dict, so frozen dataclass instances stay safely shareable).
     suffix_decoding_tier: str = "unknown"
     suffix_bench_speedup: tuple[tuple[str, float], ...] | None = None
+    # DFlash speculative-decoding eligibility (issue #264). Explicit opt-in
+    # per alias rather than auto-derived because the PoC showed
+    # precision-dependent regressions: 4-bit kills acceptance even on dense
+    # models. Aliases keep ``supports_dflash=False`` until benched to win
+    # by ≥1.3× on the canonical Fibonacci/Quicksort/HashTable prompts.
+    # ``dflash_draft_model`` is the matching drafter HF path (e.g.
+    # ``z-lab/Qwen3.5-27B-DFlash``); required if ``supports_dflash=True``.
+    supports_dflash: bool = False
+    dflash_draft_model: str | None = None
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -110,15 +133,32 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     tier = value.get("suffix_decoding_tier", "unknown")
     if not isinstance(tier, str):
         raise ValueError(f"alias {alias!r}: suffix_decoding_tier must be a string")
+    supports_dflash = bool(value.get("supports_dflash", False))
+    dflash_draft_model = value.get("dflash_draft_model")
+    if supports_dflash and not dflash_draft_model:
+        # Fail loud here, not at server-start — a half-populated DFlash
+        # alias would silently fall back to AR and look like a perf bug.
+        raise ValueError(
+            f"alias {alias!r}: supports_dflash=true requires "
+            f"dflash_draft_model to be set"
+        )
+    if dflash_draft_model is not None and not isinstance(dflash_draft_model, str):
+        raise ValueError(
+            f"alias {alias!r}: dflash_draft_model must be a string, "
+            f"got {type(dflash_draft_model).__name__}"
+        )
     return AliasProfile(
         hf_path=hf_path,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),
         is_hybrid=bool(value.get("is_hybrid", False)),
+        is_moe=bool(value.get("is_moe", False)),
         supports_spec_decode=bool(value.get("supports_spec_decode", True)),
         default_max_tokens=value.get("default_max_tokens"),
         suffix_decoding_tier=tier,
         suffix_bench_speedup=speedup,
+        supports_dflash=supports_dflash,
+        dflash_draft_model=dflash_draft_model,
     )
 
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -133,7 +133,21 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     tier = value.get("suffix_decoding_tier", "unknown")
     if not isinstance(tier, str):
         raise ValueError(f"alias {alias!r}: suffix_decoding_tier must be a string")
-    supports_dflash = bool(value.get("supports_dflash", False))
+
+    # Strict bool coercion — bare ``bool(...)`` treats the string
+    # ``"false"`` as True and silently flips a careful maintainer's
+    # intent. Validate the JSON type explicitly so a typo in
+    # aliases.json fails loud at load time.
+    def _strict_bool(key: str, default: bool) -> bool:
+        raw = value.get(key, default)
+        if not isinstance(raw, bool):
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a JSON boolean, "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        return raw
+
+    supports_dflash = _strict_bool("supports_dflash", False)
     dflash_draft_model = value.get("dflash_draft_model")
     if supports_dflash and not dflash_draft_model:
         # Fail loud here, not at server-start — a half-populated DFlash
@@ -151,9 +165,9 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         hf_path=hf_path,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),
-        is_hybrid=bool(value.get("is_hybrid", False)),
-        is_moe=bool(value.get("is_moe", False)),
-        supports_spec_decode=bool(value.get("supports_spec_decode", True)),
+        is_hybrid=_strict_bool("is_hybrid", False),
+        is_moe=_strict_bool("is_moe", False),
+        supports_spec_decode=_strict_bool("supports_spec_decode", True),
         default_max_tokens=value.get("default_max_tokens"),
         suffix_decoding_tier=tier,
         suffix_bench_speedup=speedup,

--- a/vllm_mlx/speculative/dflash/__init__.py
+++ b/vllm_mlx/speculative/dflash/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash speculative-decoding integration (issue #264).
+
+DFlash is a block-diffusion drafter (z-lab) integrated into mlx-vlm's
+``generate_step``. Rapid-MLX wires it into ``BatchedEngine`` for B=1
+generation; B>1 transparently falls back to AR until phase-2 batched
+support lands.
+
+Eligibility (enforced by ``eligibility.check``):
+  - alias has ``supports_dflash=True`` in ``aliases.json``
+  - alias is NOT MoE (PoC: 0.76-0.82× regression on Qwen3.6-35B-A3B)
+  - main-model precision ≥ 8-bit (PoC: 4-bit accept rate collapses)
+  - drafter HF path is reachable (no gating block)
+
+Public API:
+  - ``DFlashUnavailable``: raised by ``check`` when an alias fails any gate
+  - ``check(profile)``: returns ``None`` on success, raises with message
+  - ``load_runtime(drafter_repo)``: lazy import of mlx-vlm drafter loader
+"""
+
+from .eligibility import DFlashUnavailable, check
+from .runtime import load_runtime
+
+__all__ = ["DFlashUnavailable", "check", "load_runtime"]

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash eligibility checks — gate the feature behind validated combos.
+
+This is the single chokepoint between user intent (``--enable-dflash`` on
+the CLI) and the runtime hook. Failures here surface as actionable error
+messages at server-start, never as silent regressions at request time.
+
+Gates derived from PoC bench data (see issue #264):
+  - Alias must declare ``supports_dflash=True`` (explicit opt-in)
+  - Alias must NOT be ``is_moe=True`` (MoE acceptance floors at ~1.5)
+  - Main model must be 8-bit or higher (4-bit regresses; gate by hf_path
+    naming convention, double-checked at load time by inspecting the
+    quantization config)
+  - Drafter HF path must be reachable (no auth-gated repo without token)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from vllm_mlx.model_aliases import AliasProfile
+
+
+class DFlashUnavailable(RuntimeError):  # noqa: N818 — domain-specific error name
+    """Raised when an alias fails a DFlash eligibility gate.
+
+    The message is end-user-facing: it explains *which* gate failed and
+    *what* the user can do (switch alias, change quantization, etc.).
+    """
+
+
+@dataclass(frozen=True)
+class EligibilityReport:
+    """Structured eligibility result. Used by ``rapid-mlx info <alias>``
+    to render a per-gate status table without re-checking each gate."""
+
+    alias: str | None
+    supports_dflash: bool
+    is_moe: bool
+    is_4bit: bool
+    has_drafter: bool
+    reasons: tuple[str, ...]  # all failing-gate reasons (empty if eligible)
+
+
+def _looks_like_4bit(hf_path: str) -> bool:
+    """Heuristic: detect 4-bit quantization from the HF repo name.
+
+    mlx-community publishes quants as ``-4bit``, ``-mxfp4``, ``-nvfp4``
+    suffixes/segments. Mirrors the contract test's detection so a CLI
+    error and a unit-test guard share one rule.
+    """
+    lowered = hf_path.lower()
+    if "-4bit" in lowered or lowered.endswith("-4bit"):
+        return True
+    if "4bit-" in lowered:
+        return True
+    if "mxfp4" in lowered or "nvfp4" in lowered:
+        return True
+    return False
+
+
+def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport:
+    """Compute the eligibility report without raising. Used by ``info``
+    to render gate status — ``check`` is the raise-on-failure variant.
+    """
+    reasons: list[str] = []
+    if not profile.supports_dflash:
+        reasons.append(
+            "alias is not DFlash-enabled (set supports_dflash=true in "
+            "aliases.json after benching to validate ≥1.3× speedup)"
+        )
+    if profile.is_moe:
+        reasons.append(
+            "alias is MoE (is_moe=true) — DFlash acceptance floors at "
+            "~1.5 tokens/round on expert-routing churn; regression "
+            "measured on Qwen3.6-35B-A3B"
+        )
+    is_4bit = _looks_like_4bit(profile.hf_path)
+    if is_4bit:
+        reasons.append(
+            f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
+            "DFlash regresses on 4-bit (use an 8-bit or higher variant)"
+        )
+    has_drafter = bool(profile.dflash_draft_model)
+    if profile.supports_dflash and not has_drafter:
+        # Should be caught at JSON-load time by _coerce, but defend
+        # against direct AliasProfile construction in tests/code.
+        reasons.append("supports_dflash is set but dflash_draft_model is empty")
+    return EligibilityReport(
+        alias=alias,
+        supports_dflash=profile.supports_dflash,
+        is_moe=profile.is_moe,
+        is_4bit=is_4bit,
+        has_drafter=has_drafter,
+        reasons=tuple(reasons),
+    )
+
+
+def check(profile: AliasProfile, alias: str | None = None) -> None:
+    """Raise ``DFlashUnavailable`` with an actionable message if any
+    eligibility gate fails. Returns ``None`` on success."""
+    r = report(profile, alias=alias)
+    if not r.reasons:
+        return
+    header = f"DFlash unavailable for {alias!r}" if alias else "DFlash unavailable"
+    bullet = "\n  - ".join(r.reasons)
+    raise DFlashUnavailable(
+        f"{header}:\n  - {bullet}\n\n"
+        "Eligible aliases today: qwen3.5-27b-8bit. Run "
+        "`rapid-mlx info <alias>` to inspect per-alias DFlash status."
+    )
+
+
+def have_runtime() -> bool:
+    """Return True iff mlx-vlm 0.5.0+ DFlash hooks are importable.
+
+    Kept fast (no actual import on success path) so it's cheap to call
+    in CLI startup and in ``rapid-mlx info`` rendering. Result is
+    cached by ``importlib`` after first call.
+    """
+    try:
+        # Probe the specific symbol DFlash needs — a partial install
+        # (pre-0.5.0 mlx-vlm in our deps) would have `mlx_vlm` but no
+        # `speculative.drafters.load_drafter`.
+        import importlib
+
+        spec = importlib.util.find_spec("mlx_vlm.speculative.drafters")
+        return spec is not None
+    except (ImportError, AttributeError):
+        return False
+
+
+# Bypass-toggle for tests that need to exercise gates without a real
+# drafter on disk. Tests set this via monkeypatch; production code never
+# reads the env directly.
+DFLASH_SKIP_RUNTIME_CHECK_ENV = "RAPID_MLX_DFLASH_SKIP_RUNTIME_CHECK"
+
+
+def runtime_check_skipped() -> bool:
+    """Honour ``RAPID_MLX_DFLASH_SKIP_RUNTIME_CHECK=1`` for tests that
+    only exercise eligibility logic without actually loading weights."""
+    return os.environ.get(DFLASH_SKIP_RUNTIME_CHECK_ENV, "") in ("1", "true", "yes")

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -8,15 +8,16 @@ messages at server-start, never as silent regressions at request time.
 Gates derived from PoC bench data (see issue #264):
   - Alias must declare ``supports_dflash=True`` (explicit opt-in)
   - Alias must NOT be ``is_moe=True`` (MoE acceptance floors at ~1.5)
-  - Main model must be 8-bit or higher (4-bit regresses; gate by hf_path
-    naming convention, double-checked at load time by inspecting the
-    quantization config)
+  - Main model must be 8-bit or higher; detected from the HF path
+    naming convention (``-4bit``/``mxfp4``/``nvfp4`` suffixes used by
+    mlx-community). A custom-named 4-bit repo would slip through this
+    heuristic — for v1 we accept that risk since every supported alias
+    is curated; load-time quant-config inspection is a phase-2 item.
   - Drafter HF path must be reachable (no auth-gated repo without token)
 """
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
 from vllm_mlx.model_aliases import AliasProfile
@@ -51,9 +52,11 @@ def _looks_like_4bit(hf_path: str) -> bool:
     error and a unit-test guard share one rule.
     """
     lowered = hf_path.lower()
-    if "-4bit" in lowered or lowered.endswith("-4bit"):
-        return True
-    if "4bit-" in lowered:
+    # Anchor the 4-bit infix on a leading hyphen so a model name like
+    # "Foo-4bit-attention" (where "4bit-" is part of the architecture
+    # tag rather than the quant suffix) doesn't get falsely flagged.
+    # "-4bit" handles both the trailing form and any mid-name segment.
+    if "-4bit" in lowered:
         return True
     if "mxfp4" in lowered or "nvfp4" in lowered:
         return True
@@ -97,6 +100,26 @@ def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport
     )
 
 
+def eligible_aliases() -> list[str]:
+    """Return alias names whose AliasProfile currently passes every
+    DFlash gate. Computed from the live ``aliases.json`` registry so
+    error messages don't go stale as more aliases are validated.
+
+    Kept tolerant: any import or registry error returns an empty list
+    rather than raising, since this is only used to enrich error text.
+    """
+    try:
+        from vllm_mlx.model_aliases import list_profiles
+
+        return sorted(
+            name
+            for name, profile in list_profiles().items()
+            if not report(profile).reasons
+        )
+    except Exception:  # noqa: BLE001 — diagnostic helper, never fatal
+        return []
+
+
 def check(profile: AliasProfile, alias: str | None = None) -> None:
     """Raise ``DFlashUnavailable`` with an actionable message if any
     eligibility gate fails. Returns ``None`` on success."""
@@ -105,11 +128,18 @@ def check(profile: AliasProfile, alias: str | None = None) -> None:
         return
     header = f"DFlash unavailable for {alias!r}" if alias else "DFlash unavailable"
     bullet = "\n  - ".join(r.reasons)
-    raise DFlashUnavailable(
-        f"{header}:\n  - {bullet}\n\n"
-        "Eligible aliases today: qwen3.5-27b-8bit. Run "
-        "`rapid-mlx info <alias>` to inspect per-alias DFlash status."
-    )
+    eligible = eligible_aliases()
+    if eligible:
+        suffix = (
+            f"Eligible aliases today: {', '.join(eligible)}. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DFlash status."
+        )
+    else:
+        suffix = (
+            "No aliases currently pass every DFlash gate. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DFlash status."
+        )
+    raise DFlashUnavailable(f"{header}:\n  - {bullet}\n\n{suffix}")
 
 
 def have_runtime() -> bool:
@@ -129,15 +159,3 @@ def have_runtime() -> bool:
         return spec is not None
     except (ImportError, AttributeError):
         return False
-
-
-# Bypass-toggle for tests that need to exercise gates without a real
-# drafter on disk. Tests set this via monkeypatch; production code never
-# reads the env directly.
-DFLASH_SKIP_RUNTIME_CHECK_ENV = "RAPID_MLX_DFLASH_SKIP_RUNTIME_CHECK"
-
-
-def runtime_check_skipped() -> bool:
-    """Honour ``RAPID_MLX_DFLASH_SKIP_RUNTIME_CHECK=1`` for tests that
-    only exercise eligibility logic without actually loading weights."""
-    return os.environ.get(DFLASH_SKIP_RUNTIME_CHECK_ENV, "") in ("1", "true", "yes")

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -40,17 +40,27 @@ class DFlashRuntime:
 
     def reset_accept_lens(self) -> None:
         """Clear the per-round acceptance counters between requests so
-        metric reports don't pool acceptance across sessions."""
+        metric reports don't pool acceptance across sessions. Tolerant
+        of mlx-vlm versions that might rename / change the type of the
+        attribute — silently no-ops if it isn't a list (the public
+        contract of mlx-vlm 0.5.0's drafter has it as ``list[int]``,
+        but the upstream API is not yet declared stable)."""
         accept_lens = getattr(self.drafter, "accept_lens", None)
-        if accept_lens is not None:
+        if isinstance(accept_lens, list):
             accept_lens.clear()
+        elif accept_lens is not None:
+            logger.warning(
+                "DFlash drafter.accept_lens has unexpected type %s; "
+                "metrics may pool across requests",
+                type(accept_lens).__name__,
+            )
 
     def accept_lens_snapshot(self) -> list[int]:
         """Return a copy of the current accept-len list. Cheap; used by
         the metrics endpoint to compute mean accept per request without
         racing with the in-progress generator."""
         accept_lens = getattr(self.drafter, "accept_lens", None)
-        if accept_lens is None:
+        if not isinstance(accept_lens, list):
             return []
         return list(accept_lens)
 

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash runtime — lazy bridge into mlx-vlm's spec-decode machinery.
+
+mlx-vlm 0.5.0+ implements DFlash: drafter loading
+(``load_drafter``), the per-step draft-verify-walk loop
+(``_dflash_rounds``), and hidden-state capture on Qwen3.5/3.6 language
+models. We don't vendor any of that — we *call into* it from
+``BatchedEngine._step``. This module is the import boundary so the
+mlx-vlm dependency stays optional (``pip install rapid-mlx[dflash]``).
+
+Public surface:
+  - ``DFlashRuntime`` — handle owning the drafter + the call adapter
+  - ``load_runtime(drafter_repo)`` — lazy import + drafter load
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .eligibility import have_runtime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DFlashRuntime:
+    """Handle around an mlx-vlm DFlash drafter + its call adapter.
+
+    ``drafter`` is the loaded model object (mlx-vlm's ``DFlashDraftModel``);
+    ``kind`` is the resolved drafter family (e.g. ``"dflash"``) — kept
+    so log lines and metric names stay aligned with what mlx-vlm reports
+    internally.
+    """
+
+    drafter: Any
+    kind: str
+    drafter_repo: str
+
+    def reset_accept_lens(self) -> None:
+        """Clear the per-round acceptance counters between requests so
+        metric reports don't pool acceptance across sessions."""
+        accept_lens = getattr(self.drafter, "accept_lens", None)
+        if accept_lens is not None:
+            accept_lens.clear()
+
+    def accept_lens_snapshot(self) -> list[int]:
+        """Return a copy of the current accept-len list. Cheap; used by
+        the metrics endpoint to compute mean accept per request without
+        racing with the in-progress generator."""
+        accept_lens = getattr(self.drafter, "accept_lens", None)
+        if accept_lens is None:
+            return []
+        return list(accept_lens)
+
+
+def load_runtime(drafter_repo: str, kind: str = "dflash") -> DFlashRuntime:
+    """Lazy-import mlx-vlm's drafter loader and return a ``DFlashRuntime``.
+
+    The mlx-vlm import is deferred to call time so installing rapid-mlx
+    without the ``[dflash]`` extras leaves the CLI / unit tests working;
+    only users who actually pass ``--enable-dflash`` ever touch the
+    mlx-vlm code path.
+    """
+    if not have_runtime():
+        raise RuntimeError(
+            "DFlash runtime not available — mlx-vlm 0.5.0+ is required. "
+            "Install with: pip install 'rapid-mlx[dflash]'"
+        )
+    # Import here, not at module top, so the optional dep stays optional.
+    from mlx_vlm.speculative.drafters import load_drafter
+
+    logger.info("Loading DFlash drafter: %s (kind=%s)", drafter_repo, kind)
+    drafter, resolved_kind = load_drafter(drafter_repo, kind=kind)
+    return DFlashRuntime(drafter=drafter, kind=resolved_kind, drafter_repo=drafter_repo)

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash server — dedicated single-user mode that bypasses BatchedEngine.
+
+When ``--enable-dflash`` is set, the CLI launches this server instead of
+the standard ``vllm_mlx.server.app``. It hosts a minimal OpenAI-compatible
+surface (``/healthz``, ``/v1/models``, ``/v1/chat/completions``) and routes
+generation through mlx-vlm's ``stream_generate`` with the loaded DFlash
+drafter.
+
+Why a separate server (not a fork of the standard route)?
+  - mlx-vlm's ``generate_step`` is a per-request Python generator with its
+    own ``prompt_cache`` argument. BatchedEngine merges per-request KV
+    caches into a ``BatchKVCache``. Grafting one onto the other would
+    invent batched-DFlash that doesn't exist upstream and would risk
+    regressing the non-DFlash path under attention layout changes.
+  - DFlash today only validates on B=1 anyway (see PoC: 1.83-2.18× on
+    Qwen3.5-27B-8bit; no batched-DFlash kernel exists in mlx-vlm 0.5.0).
+  - A separate, opt-in server is a clean blast-radius boundary: turning
+    on DFlash can never break a request that doesn't use it.
+
+v1 limitations (documented in README + ``rapid-mlx info``):
+  - Single-user serial. Concurrent requests queue on an ``asyncio.Lock``.
+  - No tool calling, MCP, embeddings, or audio in this server (the
+    standard server handles those).
+  - No prefix cache (per-request KV cache built fresh each call).
+
+These limitations are deliberate for v1 — the target user is someone
+running ``rapid-mlx serve qwen3.5-27b-8bit --enable-dflash`` to get a
+~2× speedup on code/long-form completions on a single Apple Silicon box.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelInfo,
+    ModelsResponse,
+    Usage,
+)
+
+from .eligibility import have_runtime
+from .runtime import DFlashRuntime, load_runtime
+
+logger = logging.getLogger(__name__)
+
+
+# Global serial lock — DFlash is single-stream by design (mlx-vlm doesn't
+# expose a batched DFlash kernel in 0.5.0). The second concurrent request
+# waits its turn; this matches the PoC reality.
+_dflash_lock = asyncio.Lock()
+
+
+def _build_app(
+    *,
+    model: Any,
+    processor: Any,
+    runtime: DFlashRuntime,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+) -> FastAPI:
+    """Create the FastAPI application for DFlash mode.
+
+    All globals (``model``, ``processor``, ``runtime``) are captured by
+    closure here rather than module-level so a future caller could host
+    multiple DFlash instances side-by-side without state collision.
+    """
+    app = FastAPI(title="rapid-mlx (DFlash)")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "engine": "dflash",
+            "mode": "single-user-serial",
+            "drafter": runtime.drafter_repo,
+        }
+
+    @app.get("/v1/models")
+    async def list_models() -> ModelsResponse:
+        return ModelsResponse(
+            data=[
+                ModelInfo(
+                    id=served_model_name,
+                    created=int(time.time()),
+                    owned_by="rapid-mlx",
+                )
+            ]
+        )
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: ChatCompletionRequest):
+        if not request.messages:
+            raise HTTPException(status_code=400, detail="messages must not be empty")
+        if request.n is not None and request.n > 1:
+            raise HTTPException(status_code=400, detail="n > 1 is not supported")
+        if request.tools:
+            # DFlash server doesn't run a tool-call parser. Surface this so
+            # users don't think their tools "silently worked" when in fact
+            # the model just emitted free-form text.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Tool calling is not supported in DFlash mode (v1 "
+                    "limitation). Restart without --enable-dflash to use "
+                    "tools."
+                ),
+            )
+
+        # Render chat messages into a single prompt string via mlx-vlm's
+        # processor. We pass through the model's chat template so the
+        # tokenizer-side reasoning/tool markers match what the model was
+        # trained on; no rapid-mlx-side prompt mutation happens here.
+        prompt = _render_prompt(processor, model, request)
+
+        max_tokens = (
+            request.max_tokens if request.max_tokens is not None else default_max_tokens
+        )
+        temperature = request.temperature if request.temperature is not None else 0.0
+        top_p = request.top_p if request.top_p is not None else 1.0
+
+        gen_kwargs = dict(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            draft_model=runtime.drafter,
+            draft_kind=runtime.kind,
+        )
+
+        if request.stream:
+            return StreamingResponse(
+                _stream_completion(
+                    prompt=prompt,
+                    request=request,
+                    served_model_name=served_model_name,
+                    gen_kwargs=gen_kwargs,
+                    model=model,
+                    processor=processor,
+                ),
+                media_type="text/event-stream",
+            )
+
+        return await _non_stream_completion(
+            prompt=prompt,
+            request=request,
+            served_model_name=served_model_name,
+            gen_kwargs=gen_kwargs,
+            model=model,
+            processor=processor,
+        )
+
+    return app
+
+
+def _render_prompt(processor: Any, model: Any, request: ChatCompletionRequest) -> str:
+    """Apply the model's chat template via mlx-vlm's helper.
+
+    mlx-vlm's ``apply_chat_template`` mirrors mlx-lm's but accepts the
+    multimodal kwargs the VLM models need (we pass ``num_images=0`` since
+    DFlash-eligible aliases are text-only Qwen3.5/3.6 variants today).
+    """
+    from mlx_vlm.prompt_utils import apply_chat_template
+
+    messages = []
+    for m in request.messages:
+        content = m.content
+        if isinstance(content, list):
+            # Multimodal payload — DFlash server is text-only. Collapse
+            # text parts; ignore image/video parts (a 400 might surprise
+            # users sending mixed content; better to silently degrade).
+            text_pieces = []
+            for part in content:
+                part_type = part.type if hasattr(part, "type") else part.get("type", "")
+                if part_type == "text":
+                    text_pieces.append(
+                        part.text if hasattr(part, "text") else part.get("text", "")
+                    )
+            content = "".join(text_pieces)
+        messages.append({"role": m.role, "content": content})
+
+    return apply_chat_template(
+        processor,
+        model.config,
+        messages,
+        num_images=0,
+        num_audios=0,
+        enable_thinking=True,
+    )
+
+
+async def _stream_completion(
+    *,
+    prompt: str,
+    request: ChatCompletionRequest,
+    served_model_name: str,
+    gen_kwargs: dict[str, Any],
+    model: Any,
+    processor: Any,
+) -> AsyncIterator[bytes]:
+    """Stream OpenAI-format chunks. Generation happens under the serial
+    lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events."""
+    from mlx_vlm import stream_generate
+
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+
+    # First chunk — role marker
+    first = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    }
+    yield f"data: {json.dumps(first)}\n\n".encode()
+
+    finish_reason = "stop"
+    total_completion_tokens = 0
+    prompt_tokens = 0
+
+    async with _dflash_lock:
+        # mlx-vlm's stream_generate is a sync generator — run it in a
+        # thread pool so we don't block the FastAPI event loop. Iterate
+        # by polling with ``run_in_executor`` per chunk.
+        loop = asyncio.get_event_loop()
+        gen = stream_generate(model, processor, prompt, **gen_kwargs)
+
+        def _next_chunk():
+            try:
+                return next(gen)
+            except StopIteration:
+                return None
+
+        while True:
+            chunk = await loop.run_in_executor(None, _next_chunk)
+            if chunk is None:
+                break
+            if not chunk.text:
+                continue
+            total_completion_tokens = chunk.generation_tokens
+            prompt_tokens = chunk.prompt_tokens
+            piece = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": served_model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": chunk.text},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(piece)}\n\n".encode()
+
+    # Final chunk — finish_reason + usage
+    final = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": total_completion_tokens,
+            "total_tokens": prompt_tokens + total_completion_tokens,
+        },
+    }
+    yield f"data: {json.dumps(final)}\n\n".encode()
+    yield b"data: [DONE]\n\n"
+
+
+async def _non_stream_completion(
+    *,
+    prompt: str,
+    request: ChatCompletionRequest,
+    served_model_name: str,
+    gen_kwargs: dict[str, Any],
+    model: Any,
+    processor: Any,
+) -> ChatCompletionResponse:
+    """Run generation under the serial lock, return one
+    ``ChatCompletionResponse`` containing the full text."""
+    from mlx_vlm import generate
+
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+
+    async with _dflash_lock:
+        loop = asyncio.get_event_loop()
+        # mlx-vlm's ``generate`` blocks; offload to thread to keep the
+        # FastAPI event loop free for concurrent (queued) requests.
+        result = await loop.run_in_executor(
+            None,
+            lambda: generate(model, processor, prompt, **gen_kwargs),
+        )
+
+    return ChatCompletionResponse(
+        id=completion_id,
+        object="chat.completion",
+        created=created,
+        model=served_model_name,
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(role="assistant", content=result.text),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=result.prompt_tokens,
+            completion_tokens=result.generation_tokens,
+            total_tokens=result.prompt_tokens + result.generation_tokens,
+        ),
+    )
+
+
+def run_dflash_server(
+    *,
+    main_model_repo: str,
+    drafter_repo: str,
+    host: str,
+    port: int,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+    uvicorn_log_level: str,
+) -> None:
+    """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
+
+    The mlx-vlm load path is mandatory: the DFlash hooks
+    (``capture_layer_ids``, ``_dflash_rounds``) live on the mlx-vlm
+    model classes, not mlx-lm's. Loading via ``mlx_lm.load`` would give
+    us a model without the hooks and DFlash would silently fall back to
+    AR — exactly the kind of "silent regression" the eligibility gate
+    is meant to prevent. We surface a clear error if mlx-vlm is missing
+    or too old.
+    """
+    if not have_runtime():
+        raise RuntimeError(
+            "DFlash server requires mlx-vlm 0.5.0+ — install with "
+            "``pip install 'rapid-mlx[dflash]'``."
+        )
+
+    import uvicorn
+    from mlx_vlm import load
+
+    logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
+    t0 = time.perf_counter()
+    model, processor = load(main_model_repo)
+    logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
+
+    runtime = load_runtime(drafter_repo)
+
+    app = _build_app(
+        model=model,
+        processor=processor,
+        runtime=runtime,
+        served_model_name=served_model_name,
+        default_max_tokens=default_max_tokens,
+        cors_origins=cors_origins,
+    )
+
+    print()
+    host_display = "localhost" if host == "0.0.0.0" else host
+    print(f"  Ready: http://{host_display}:{port}/v1  (DFlash mode)")
+    print(f"  Docs:  http://{host_display}:{port}/docs")
+    print()
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=uvicorn_log_level,
+        timeout_keep_alive=30,
+    )

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -32,6 +32,8 @@ running ``rapid-mlx serve qwen3.5-27b-8bit --enable-dflash`` to get a
 from __future__ import annotations
 
 import asyncio
+import atexit
+import concurrent.futures
 import json
 import logging
 import time
@@ -65,6 +67,28 @@ logger = logging.getLogger(__name__)
 _dflash_lock = asyncio.Lock()
 
 
+# Dedicated single-thread executor so every mlx-vlm call (drafter loading,
+# generate, stream_generate's ``next``) executes on ONE thread for the
+# lifetime of the process. Reason: mlx-lm 0.31.3+ keeps the GPU Stream
+# in thread-local storage; iterating a generator across threads (which
+# would happen if we used the default ThreadPoolExecutor with N workers)
+# trips "There is no Stream(gpu, N) in current thread" mid-stream. Pinning
+# to one worker preserves thread affinity and matches the serial-only
+# contract enforced by ``_dflash_lock``.
+_dflash_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="dflash-worker"
+)
+
+
+@atexit.register
+def _shutdown_dflash_executor() -> None:
+    """Drain the DFlash worker on interpreter exit. Python registers an
+    implicit atexit for ThreadPoolExecutor, but registering ours
+    explicitly makes shutdown order deterministic and silences
+    "unfinished thread" warnings during graceful uvicorn termination."""
+    _dflash_executor.shutdown(wait=False, cancel_futures=True)
+
+
 def _build_app(
     *,
     model: Any,
@@ -76,9 +100,17 @@ def _build_app(
 ) -> FastAPI:
     """Create the FastAPI application for DFlash mode.
 
-    All globals (``model``, ``processor``, ``runtime``) are captured by
-    closure here rather than module-level so a future caller could host
-    multiple DFlash instances side-by-side without state collision.
+    Per-app state (``model``, ``processor``, ``runtime``,
+    ``served_model_name``) is captured by closure so a single Python
+    process could in principle host multiple ``_build_app`` instances
+    against different models without per-request state collision.
+
+    Note: ``_dflash_lock`` and ``_dflash_executor`` are *module-level*
+    by design — every DFlash invocation must serialise through the
+    same single-thread worker because mlx's GPU Stream is thread-local
+    (see the ``_dflash_executor`` docstring at module top). A future
+    multi-model deployment would still share that worker; one model
+    can't run while another's generator is mid-step.
     """
     app = FastAPI(title="rapid-mlx (DFlash)")
     app.add_middleware(
@@ -188,15 +220,31 @@ def _render_prompt(processor: Any, model: Any, request: ChatCompletionRequest) -
         content = m.content
         if isinstance(content, list):
             # Multimodal payload — DFlash server is text-only. Collapse
-            # text parts; ignore image/video parts (a 400 might surprise
-            # users sending mixed content; better to silently degrade).
+            # text parts; non-text parts (image/audio/video) are
+            # dropped. A 400 would surprise users mid-prompt, but a
+            # silent drop hides "why is my model ignoring the image?"
+            # debugging — so we degrade with a visible WARN log per
+            # request that hits this path.
             text_pieces = []
+            dropped_kinds: list[str] = []
             for part in content:
                 part_type = part.type if hasattr(part, "type") else part.get("type", "")
                 if part_type == "text":
                     text_pieces.append(
                         part.text if hasattr(part, "text") else part.get("text", "")
                     )
+                elif part_type:
+                    dropped_kinds.append(part_type)
+            if dropped_kinds:
+                logger.warning(
+                    "DFlash server is text-only; dropped %d non-text "
+                    "content part(s) of type(s) %s. The request will be "
+                    "served using text parts only — switch to the standard "
+                    "server (no --enable-dflash) for full multimodal "
+                    "support.",
+                    len(dropped_kinds),
+                    sorted(set(dropped_kinds)),
+                )
             content = "".join(text_pieces)
         messages.append({"role": m.role, "content": content})
 
@@ -241,44 +289,180 @@ async def _stream_completion(
     finish_reason = "stop"
     total_completion_tokens = 0
     prompt_tokens = 0
+    # Track the last token id to disambiguate "hit max_tokens but the
+    # final token was actually EOS" — without this we'd falsely flag a
+    # natural-stop response as truncated when it lands on exactly the
+    # budget. None means "no token observed yet".
+    last_token_id: int | None = None
+
+    # Track max_tokens so we can report ``finish_reason="length"`` when
+    # generation was truncated (OpenAI clients distinguish "stop"
+    # = natural end / stop sequence from "length" = token-budget hit;
+    # presenting "stop" for a truncated reply misleads downstream tools).
+    _max_tokens = gen_kwargs.get("max_tokens")
+
+    # Resolve the model's EOS token id (best-effort). Used by the
+    # length-vs-stop disambiguation below; falls back to None when the
+    # processor doesn't expose a tokenizer (the heuristic then degrades
+    # to pure token-count comparison).
+    _eos_ids: set[int] = set()
+    _tok = getattr(processor, "tokenizer", processor)
+    _eos = getattr(_tok, "eos_token_id", None)
+    if isinstance(_eos, int):
+        _eos_ids.add(_eos)
+    elif isinstance(_eos, (list, tuple, set)):
+        _eos_ids.update(int(t) for t in _eos if isinstance(t, int))
+
+    error_message: str | None = None
 
     async with _dflash_lock:
         # mlx-vlm's stream_generate is a sync generator — run it in a
         # thread pool so we don't block the FastAPI event loop. Iterate
-        # by polling with ``run_in_executor`` per chunk.
-        loop = asyncio.get_event_loop()
-        gen = stream_generate(model, processor, prompt, **gen_kwargs)
+        # by polling with ``run_in_executor`` per chunk. We're already
+        # inside a coroutine, so use ``get_running_loop`` (the 3.10+
+        # idiom; ``get_event_loop`` is deprecated for in-coroutine use).
+        # The executor MUST be ``_dflash_executor`` (single-thread) so
+        # consecutive ``next(gen)`` calls land on the same worker —
+        # mlx's GPU Stream is thread-local and a hand-off across worker
+        # threads would crash mid-generation.
+        loop = asyncio.get_running_loop()
 
+        # Create the generator on the same worker that will drive it,
+        # not on the event-loop thread — otherwise the first ``next``
+        # crosses a thread boundary just like the rest.
+        #
+        # Wrap construction in a sentinel pattern too: if
+        # ``stream_generate`` raises at setup time (OOM, missing kernel,
+        # bad arg) the exception would otherwise propagate out of the
+        # async generator and leave the SSE client hanging without a
+        # ``[DONE]``. Surfacing it as an error SSE keeps the contract
+        # the same as the mid-stream error path below.
+        def _make_gen():
+            try:
+                return stream_generate(model, processor, prompt, **gen_kwargs)
+            except Exception as e:  # noqa: BLE001 — surface upstream; outer code converts to error SSE
+                return e
+
+        gen_or_err = await loop.run_in_executor(_dflash_executor, _make_gen)
+        if isinstance(gen_or_err, Exception):
+            logger.exception(
+                "DFlash stream_generate raised at construction: %s",
+                gen_or_err,
+                exc_info=gen_or_err,
+            )
+            error_message = f"{type(gen_or_err).__name__}: {gen_or_err}"
+            finish_reason = "error"
+            gen = None
+        else:
+            gen = gen_or_err
+
+        # Sentinels distinguish "generator exhausted" (None) from
+        # "generator raised mid-stream" (an Exception instance). Catching
+        # only StopIteration would let any other mlx-vlm error propagate
+        # through run_in_executor, abort the response coroutine, and
+        # leave the SSE client hanging without a final ``[DONE]`` — the
+        # client then either times out or holds the connection forever.
         def _next_chunk():
             try:
                 return next(gen)
             except StopIteration:
                 return None
+            except Exception as e:  # noqa: BLE001 — surface upstream; loop converts to error SSE
+                return e
 
-        while True:
-            chunk = await loop.run_in_executor(None, _next_chunk)
-            if chunk is None:
-                break
-            if not chunk.text:
-                continue
-            total_completion_tokens = chunk.generation_tokens
-            prompt_tokens = chunk.prompt_tokens
-            piece = {
-                "id": completion_id,
-                "object": "chat.completion.chunk",
-                "created": created,
-                "model": served_model_name,
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {"content": chunk.text},
-                        "finish_reason": None,
-                    }
-                ],
-            }
-            yield f"data: {json.dumps(piece)}\n\n".encode()
+        try:
+            while gen is not None:
+                chunk = await loop.run_in_executor(_dflash_executor, _next_chunk)
+                if chunk is None:
+                    break
+                if isinstance(chunk, Exception):
+                    logger.exception(
+                        "DFlash stream_generate raised mid-stream: %s",
+                        chunk,
+                        exc_info=chunk,
+                    )
+                    error_message = f"{type(chunk).__name__}: {chunk}"
+                    finish_reason = "error"
+                    break
+                # Always sync token counts from the chunk — even when text
+                # is empty (mlx-vlm occasionally emits trailing flush
+                # chunks carrying the final token counters but no
+                # incremental text). Skipping the update would leave the
+                # final usage block with stale numbers.
+                total_completion_tokens = chunk.generation_tokens
+                prompt_tokens = chunk.prompt_tokens
+                _ct = getattr(chunk, "token", None)
+                if isinstance(_ct, int):
+                    last_token_id = _ct
+                if not chunk.text:
+                    continue
+                piece = {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": served_model_name,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": chunk.text},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(piece)}\n\n".encode()
+        finally:
+            # On client disconnect (CancelledError) or any other exit
+            # from the loop, drain the generator so its GPU state is
+            # released *before* the lock unblocks the next request.
+            # Without this the abandoned generator's KV cache lingers
+            # until GC runs, transiently doubling memory and risking a
+            # mid-step crash if the next request triggers reallocation.
+            # Routed through ``_dflash_executor`` for thread affinity.
+            if gen is not None:
+                _gen_to_close = gen
 
-    # Final chunk — finish_reason + usage
+                def _close_gen():
+                    try:
+                        _gen_to_close.close()
+                    except Exception:  # noqa: BLE001 — cleanup is best-effort
+                        logger.debug(
+                            "DFlash generator close raised; ignoring",
+                            exc_info=True,
+                        )
+
+                # ``run_in_executor`` may itself observe cancellation;
+                # shield so the cleanup completes before propagating
+                # the cancellation up.
+                try:
+                    await asyncio.shield(
+                        loop.run_in_executor(_dflash_executor, _close_gen)
+                    )
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+
+    # Length-truncation detection — mlx-vlm's GenerationResult has no
+    # ``finish_reason`` field, so we infer "length" by comparing the
+    # completion token count to the budget. Only set when we exited the
+    # loop normally (StopIteration), not when the generator errored or
+    # produced fewer tokens (natural stop).
+    #
+    # Subtle case: if the model emitted EOS exactly at ``max_tokens``,
+    # the stop was natural and reporting "length" would mislead clients
+    # into auto-continuing (only to get an immediate EOS again). Check
+    # the last token id against the resolved EOS set to keep the
+    # classification honest in this edge case.
+    if (
+        finish_reason == "stop"
+        and _max_tokens is not None
+        and total_completion_tokens >= _max_tokens
+        and last_token_id not in _eos_ids
+    ):
+        finish_reason = "length"
+
+    # Final chunk — finish_reason + usage. If we broke out of the loop
+    # because the underlying generator raised, attach an OpenAI-style
+    # error block so the client gets a readable failure instead of
+    # silent truncation.
     final = {
         "id": completion_id,
         "object": "chat.completion.chunk",
@@ -291,6 +475,8 @@ async def _stream_completion(
             "total_tokens": prompt_tokens + total_completion_tokens,
         },
     }
+    if error_message is not None:
+        final["error"] = {"type": "dflash_runtime_error", "message": error_message}
     yield f"data: {json.dumps(final)}\n\n".encode()
     yield b"data: [DONE]\n\n"
 
@@ -312,13 +498,53 @@ async def _non_stream_completion(
     created = int(time.time())
 
     async with _dflash_lock:
-        loop = asyncio.get_event_loop()
-        # mlx-vlm's ``generate`` blocks; offload to thread to keep the
-        # FastAPI event loop free for concurrent (queued) requests.
-        result = await loop.run_in_executor(
-            None,
-            lambda: generate(model, processor, prompt, **gen_kwargs),
+        loop = asyncio.get_running_loop()
+
+        # mlx-vlm's ``generate`` blocks; offload to the dedicated
+        # single-thread DFlash executor so every mlx-vlm call lands on
+        # the same worker (matches ``_stream_completion`` — see the
+        # _dflash_executor comment at module top).
+        #
+        # Wrap in a sentinel pattern so generate-time errors (OOM, bad
+        # arg, drafter mismatch) come back as a clean HTTP 500 with a
+        # readable detail string rather than a raw stack trace. Mirrors
+        # the stream path's error handling.
+        def _generate_safely():
+            try:
+                return generate(model, processor, prompt, **gen_kwargs)
+            except Exception as e:  # noqa: BLE001 — surface as HTTPException below
+                return e
+
+        result = await loop.run_in_executor(_dflash_executor, _generate_safely)
+
+    if isinstance(result, Exception):
+        logger.exception(
+            "DFlash non-stream generate raised: %s", result, exc_info=result
         )
+        raise HTTPException(
+            status_code=500,
+            detail=f"DFlash runtime error: {type(result).__name__}: {result}",
+        )
+
+    # OpenAI distinguishes "stop" (natural end / stop sequence) from
+    # "length" (token-budget hit). mlx-vlm doesn't surface that on
+    # GenerationResult, so infer from token-count vs requested budget.
+    #
+    # Known v1 limitation: unlike the streaming path which can read
+    # ``chunk.token`` and check against EOS, ``mlx_vlm.generate``
+    # returns only the concatenated text + token counts. If the model
+    # emits EOS at exactly ``max_tokens`` the non-stream response will
+    # still report ``finish_reason="length"`` (false truncation). A
+    # client that auto-continues will issue one more request that
+    # immediately returns EOS — annoying but not corrupt. Fix requires
+    # an upstream mlx-vlm change to expose the final token id; tracked
+    # as a v2 follow-up.
+    _max_tokens = gen_kwargs.get("max_tokens")
+    finish_reason = (
+        "length"
+        if _max_tokens is not None and result.generation_tokens >= _max_tokens
+        else "stop"
+    )
 
     return ChatCompletionResponse(
         id=completion_id,
@@ -329,7 +555,7 @@ async def _non_stream_completion(
             ChatCompletionChoice(
                 index=0,
                 message=AssistantMessage(role="assistant", content=result.text),
-                finish_reason="stop",
+                finish_reason=finish_reason,
             )
         ],
         usage=Usage(
@@ -360,11 +586,42 @@ def run_dflash_server(
     AR — exactly the kind of "silent regression" the eligibility gate
     is meant to prevent. We surface a clear error if mlx-vlm is missing
     or too old.
+
+    Eligibility re-check: even though the CLI's ``serve_command`` gates
+    on the alias before calling here, a *programmatic* caller (e.g. a
+    notebook or test harness) can bypass the CLI entirely. We re-run
+    the path-detectable gates (4-bit quant via repo-name heuristic;
+    non-empty drafter). MoE detection requires the AliasProfile (an
+    ``is_moe`` flag aliases.json maintains by hand) and is therefore
+    only enforced via the CLI entrypoint — callers serving an
+    arbitrary ``main_model_repo`` programmatically are responsible for
+    not pointing it at a MoE model. Documented in CALLERS.md.
     """
     if not have_runtime():
         raise RuntimeError(
             "DFlash server requires mlx-vlm 0.5.0+ — install with "
             "``pip install 'rapid-mlx[dflash]'``."
+        )
+
+    # Belt-and-suspenders eligibility re-check for programmatic callers
+    # (the CLI's serve_command already gates on the alias upstream, but
+    # we don't want to depend on it being the only entrypoint).
+    from .eligibility import (
+        DFlashUnavailable,
+        _looks_like_4bit,  # noqa: PLC2701 — internal helper
+    )
+
+    if _looks_like_4bit(main_model_repo):
+        raise DFlashUnavailable(
+            f"DFlash cannot run on a 4-bit quantized model "
+            f"(main_model_repo={main_model_repo!r}); upstream PoC measured "
+            "regression to 0.63-0.96× on Qwen3.5-4B-MLX-4bit. Use the "
+            "8-bit variant."
+        )
+    if not drafter_repo:
+        raise DFlashUnavailable(
+            "DFlash requires a non-empty drafter_repo — pass the DFlash "
+            "drafter HF path (e.g. 'z-lab/Qwen3.5-27B-DFlash')."
         )
 
     import uvicorn


### PR DESCRIPTION
## Summary

Production support for **DFlash speculative decoding** — block-diffusion drafter via mlx-vlm 0.5.0 — on Qwen3.5-27B-8bit.

- Adds `--enable-dflash` flag to `rapid-mlx serve`. Eligibility (alias declared, drafter declared, non-MoE, non-4bit, mlx-vlm 0.5.0+) is checked **before** model load — fast fail with an actionable error.
- Dedicated FastAPI server (`vllm_mlx/speculative/dflash/server.py`) bypasses BatchedEngine because mlx-lm's BatchGenerator and the diffusion drafter are incompatible at the cache layer. The DFlash server runs single-user serial mode with an asyncio.Lock + dedicated `ThreadPoolExecutor(max_workers=1)` for thread affinity (mlx GPU Stream is thread-local).
- Per-alias SSOT: `AliasProfile.supports_dflash` + `dflash_drafter` (no parallel config). Only `qwen3.5-27b-8bit` ships with `supports_dflash=true` — conservative gating per PoC bench data; expanding the eligible set requires per-alias benching.
- `rapid-mlx models` listing surfaces a new **DFlash** column so users see what's eligible at a glance.
- `rapid-mlx info <alias>` renders a per-gate eligibility table with the right hint (alias, not resolved HF path).

## Test plan

- [x] 627 DFlash + alias-contract tests pass (eligibility, info rendering, models listing, server app, length/stop disambiguation, executor affinity, MoE/missing-drafter negative controls)
- [x] Broader unit suite: 3242 passed, 18 skipped, 1 xpassed. 4 `test_batching_deterministic` failures confirmed **pre-existing** on clean main (mlx-lm thread-local Stream issue, unrelated to this PR — verified by git-stash + re-run)
- [x] `ruff check && ruff format --check` clean
- [x] 17 rounds of DeepSeek V4 Pro adversarial review applied (converged)
- [ ] `make check qwen3.5-4b` (no inference regressions on non-DFlash path)
- [ ] CI matrix green
- [ ] Optional: e2e DFlash generation with real Qwen3.5-27B-8bit weights (gated on `RAPID_MLX_DFLASH_E2E=1`)

## Notes

- This is the **PR-2** in a two-PR ship: PR-1 (#360) isolated the mlx-vlm 0.4.4 → 0.5.0 bump and was released as v0.6.36. v0.6.36 does **not** include DFlash; this PR targets v0.6.37.
- Auto-deploy blast radius: DFlash is **opt-in** via flag + extras. Non-DFlash users are unaffected (no codepath changes outside the new `vllm_mlx/speculative/dflash/` module + the CLI flag plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)