### PR TITLE
fix(dflash)+feat: hotfix thread-affinity + qwen3.6-27b-8bit + bump 0.6.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.36"
+version = "0.6.37"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -726,6 +726,72 @@ def test_run_dflash_server_raises_when_mlx_vlm_missing(monkeypatch) -> None:
         )
 
 
+@_skip_without_mlx_vlm
+def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
+    """Model + drafter MUST load on the ``_dflash_executor`` worker
+    thread, never on the main thread.
+
+    Regression guard for the v0.6.36 hotfix: mlx-lm 0.31.3+ keeps the GPU
+    Stream in thread-local storage. If ``load()`` runs on the main thread
+    but ``generate()`` runs on the executor, mlx-vlm raises ``RuntimeError:
+    There is no Stream(gpu, N) in current thread`` on the first request.
+    Pinning load to the same executor that owns generate keeps streams
+    reachable for the process lifetime.
+
+    Mocks ``load`` / ``load_runtime`` to record which thread they run on,
+    and patches ``uvicorn.run`` to a no-op so the test doesn't bind a port.
+    """
+    import threading
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    load_thread: dict[str, str | None] = {"load": None, "load_runtime": None}
+
+    def _fake_load(_repo):
+        load_thread["load"] = threading.current_thread().name
+        return MagicMock(), MagicMock()
+
+    def _fake_load_runtime(_repo):
+        load_thread["load_runtime"] = threading.current_thread().name
+        return MagicMock()
+
+    # Patch the imports at the point of use inside ``run_dflash_server``.
+    import mlx_vlm as _mlx_vlm
+
+    monkeypatch.setattr(_mlx_vlm, "load", _fake_load)
+    monkeypatch.setattr(srv, "load_runtime", _fake_load_runtime)
+
+    # No-op uvicorn so we don't bind a port; return immediately after load.
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
+
+    srv.run_dflash_server(
+        main_model_repo="mlx-community/Qwen3.5-27B-8bit",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        host="127.0.0.1",
+        port=58998,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+        uvicorn_log_level="info",
+    )
+
+    # Both must have run on the dflash worker thread (prefix set when the
+    # ThreadPoolExecutor was constructed at module load).
+    assert load_thread["load"] is not None, "load() was not called"
+    assert load_thread["load_runtime"] is not None, "load_runtime() was not called"
+    assert load_thread["load"].startswith("dflash-worker"), (
+        f"model load must run on dflash-worker thread, ran on "
+        f"{load_thread['load']!r} — Stream(gpu, N) would not be visible "
+        f"to generate() on the executor."
+    )
+    assert load_thread["load_runtime"].startswith("dflash-worker"), (
+        f"drafter load must run on dflash-worker thread, ran on "
+        f"{load_thread['load_runtime']!r}."
+    )
+
+
 # =============================================================================
 # End-to-end — heavy. Requires:
 #   - ``RAPID_MLX_DFLASH_E2E=1`` env var (opt-in; CI doesn't set it)

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -74,7 +74,9 @@
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "supports_dflash": true,
+    "dflash_draft_model": "z-lab/Qwen3.6-27B-DFlash"
   },
   "qwen3.6-27b-ud": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-4bit",

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -627,12 +627,22 @@ def run_dflash_server(
     import uvicorn
     from mlx_vlm import load
 
-    logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
-    t0 = time.perf_counter()
-    model, processor = load(main_model_repo)
-    logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
+    # CRITICAL: load model + drafter on the dedicated DFlash executor
+    # thread (not the main thread). mlx-lm 0.31.3+ keeps GPU streams in
+    # thread-local storage, so weights loaded on thread A cannot be
+    # evaluated on thread B — generate() raises ``RuntimeError: There
+    # is no Stream(gpu, N) in current thread``. By pinning load AND all
+    # subsequent generate() calls to the same single-worker executor,
+    # streams stay reachable for the lifetime of the process.
+    def _load_all():
+        t0 = time.perf_counter()
+        m, p = load(main_model_repo)
+        logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
+        rt = load_runtime(drafter_repo)
+        return m, p, rt
 
-    runtime = load_runtime(drafter_repo)
+    logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
+    model, processor, runtime = _dflash_executor.submit(_load_all).result()
 
     app = _build_app(
         model=model,


### PR DESCRIPTION
## Summary

**P0 hotfix**: v0.6.36 ships DFlash with a thread-affinity bug — every chat-completion request fails with HTTP 500: ``RuntimeError: There is no Stream(gpu, N) in current thread``. The 17-round DeepSeek review didn't catch it because the e2e test was gated and never ran locally; only mocked unit tests exercised the code path.

**Root cause**: ``run_dflash_server`` loaded the main model + drafter on the main thread, then handed them to ``_dflash_executor`` (single-worker pool that owns generate()). mlx-lm 0.31.3+ keeps the GPU Stream in thread-local storage — weights loaded on thread A aren't evaluatable on thread B.

**Fix**: load both the main model and the drafter on the same executor that owns generation. One-call change to ``run_dflash_server``.

## Also in this PR

- **Enable DFlash on ``qwen3.6-27b-8bit``** (drafter ``z-lab/Qwen3.6-27B-DFlash``, structurally matches the 3.5 cousin)
- **Version bump 0.6.36 → 0.6.37** — combined into this PR so auto-release fires on merge
- **Regression test** ``test_run_dflash_server_loads_models_on_executor_thread`` pins the load-on-executor invariant — mocks ``mlx_vlm.load`` + ``load_runtime`` to assert ``threading.current_thread().name`` starts with ``dflash-worker``.

## Local validation

Verified end-to-end on local M3 Ultra with mlx-vlm 0.5.0:

| Mode     | tok/s | Speedup |
|----------|-------|---------|
| Baseline | 19.25 | 1.00×   |
| DFlash   | 35.76 | 1.86×   |

(matches z-lab's reported 1.83-2.18× on the architecturally-matched Qwen3.5-27B-8bit)

## Test plan

- [x] 639 DFlash + alias-contract tests pass
- [x] Broader unit suite: 3243 pass, 4 pre-existing failures in ``test_batching_deterministic`` (mlx-lm thread-local Stream in BatchedEngine path — confirmed pre-existing in PR #362's pre-merge run, unrelated to this fix)
- [x] ``ruff check && ruff format --check`` clean
- [x] End-to-end live test on qwen3.6-27b-8bit: server boots, chat completion returns coherent output, 1.86× measured speedup
- [ ] CI matrix green
- [ ] Auto-release fires on squash-merge → v0.6.37 on PyPI + Homebrew

## Notes for future expansion (v0.6.38)

MoE expansion (qwen3.5-35b / qwen3.6-35b-8bit / qwen3.5-122b-8bit) deferred to v0.6.38. Research finding: our PoC ``"1.5 tok/round regression"`` on Qwen3.6-35B-A3B was a misread — that's 1.5/15 ≈ 10% acceptance on a 15-token block, not 1.5× speedup. z-lab's own published bench on the same model shows ~7/16 acceptance and 2.9× speedup. Worth re-benching independently before lifting the MoE guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)