### PR TITLE
chore: bump version to 0.6.39 (recover from 0.6.38 sdist 400)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,34 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
 
-      - name: Build package
-        run: python -m build
+      - name: Build package (retry on magic-byte collision)
+        # PyPI's _is_valid_dist_file rejects any file where both
+        # zipfile.is_zipfile() and tarfile.is_tarfile() return True
+        # (https://github.com/pypi/warehouse/blob/main/warehouse/forklift/legacy.py).
+        # Compressed output is non-deterministic; ~rare rebuilds emit
+        # bytes that coincidentally match the other format's magic.
+        # We rebuild up to 5 times until neither artifact collides.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            rm -rf dist/ build/
+            python -m build
+            if python3 -c "
+          import glob, sys, tarfile, zipfile
+          ok = True
+          for f in sorted(glob.glob('dist/*')):
+              z = zipfile.is_zipfile(f); t = tarfile.is_tarfile(f)
+              print(f'  {f}: zip={z} tar={t}')
+              if z and t: ok = False
+          sys.exit(0 if ok else 2)
+          "; then
+              echo "Build attempt $attempt: clean (no PyPI magic-byte collision)"
+              exit 0
+            fi
+            echo "Build attempt $attempt: magic-byte collision detected, rebuilding..."
+          done
+          echo "ERROR: 5 builds in a row hit PyPI's zip+tar collision check"
+          exit 1
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -44,7 +70,12 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
+        # skip-existing lets the workflow recover from a partial upload
+        # (e.g. wheel succeeded but sdist 400'd) without needing a fresh
+        # version bump on retry.
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   update-homebrew:
     needs: publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.38"
+version = "0.6.39"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version 0.6.38 → 0.6.39.
- Harden `.github/workflows/publish.yml` against PyPI's `_is_valid_dist_file` magic-byte collision (root cause of the v0.6.38 publish failure).

## What happened with v0.6.38

`auto-release.yml` fired correctly on the squash-merge of PR #364 and created the v0.6.38 GitHub Release. `publish.yml` then partially failed:

| Artifact | Result |
|---|---|
| wheel `rapid_mlx-0.6.38-py3-none-any.whl` | uploaded to PyPI ✓ |
| sdist `rapid_mlx-0.6.38.tar.gz` | **400 Bad Request** — `Invalid distribution file. File is both a zip and a tar file` |
| Homebrew formula | not updated (depends on sdist URL) |

A manual rerun produced the same 400 error, but this time on the **wheel** (the sdist was never attempted).

## Root cause

Warehouse's [`_is_valid_dist_file`](https://github.com/pypi/warehouse/blob/main/warehouse/forklift/legacy.py) runs both `zipfile.is_zipfile()` and `tarfile.is_tarfile()` on every uploaded artifact:

```python
is_zipfile = bool(filename and zipfile.is_zipfile(filename))
is_tarfile = bool(filename and tarfile.is_tarfile(filename))
if is_zipfile and is_tarfile:
    return False, "File is both a zip and a tar file"
```

- `zipfile.is_zipfile()` scans the last ~64 KB for the EOCD signature `PK\x05\x06`.
- `tarfile.is_tarfile()` tries to read the file as gzip+tar.

Compressed output is non-deterministic — file ordering, timestamps, and zlib's internal state all vary between builds. Rare rebuilds produce bytes that coincidentally satisfy the *other* format's magic. Locally my v0.6.38 artifacts pass both checks correctly (`zip=True tar=False` for wheel; `zip=False tar=True` for sdist). CI's rebuilds got unlucky twice in a row.

## Fix

**`publish.yml` build step** — rebuild up to 5 times until both artifacts satisfy `is_zipfile XOR is_tarfile` (matches PyPI's exact check):

```yaml
- name: Build package (retry on magic-byte collision)
  run: |
    set -euo pipefail
    for attempt in 1 2 3 4 5; do
      rm -rf dist/ build/
      python -m build
      if python3 -c "..."; then exit 0; fi
    done
    exit 1
```

**`publish.yml` publish step** — `skip-existing: true` so a partial upload (wheel succeeded, sdist 400'd) can be recovered without a fresh version bump:

```yaml
- uses: pypa/gh-action-pypi-publish@release/v1
  with:
    skip-existing: true
```

## Post-merge plan (per Release SOP §11)

After v0.6.39 publishes cleanly end-to-end (PyPI wheel + sdist, Homebrew formula updated):

1. Verify `pip install rapid-mlx==0.6.39` works in a fresh venv.
2. Verify `brew info raullenchai/tap/rapid-mlx` shows 0.6.39.
3. `twine yank rapid-mlx==0.6.38` to prevent new pip installs of the broken release (the wheel is on PyPI but no sdist, and Homebrew never picked it up).

## Test plan

- [x] `python3.12 -m build` locally on 0.6.39 — both artifacts have `is_zipfile XOR is_tarfile` (no collision)
  - wheel: `7985679ee974786da626edd3a56a42580fe660f7ed4b9c0578c2746724c4f39b`
  - sdist: `b958a2ae9b67ae2e44d705298e004bd5eb9d1d2d810c5840450820b41e90ed20`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` → YAML OK
- [x] `ruff check pyproject.toml` → All checks passed
- [x] No new GitHub Actions; no new permissions; no new external deps (supply-chain pre-flight clean)
- [ ] CI green
- [ ] Auto-release fires, GitHub Release v0.6.39 created
- [ ] publish.yml succeeds, sdist + wheel on PyPI
- [ ] Homebrew formula updated to 0.6.39
- [ ] Fresh-install verification (pip + brew) from real registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)