### PR TITLE
feat: add MiniMax-M2.7 model aliases (4-bit and 8-bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The model has to fit in your Mac's RAM. If your Mac slows down or Activity Monit
 | **Llama / Hermes** | `llama3-1b`, `-3b`, `hermes3-8b`, `hermes4-70b` | |
 | **GLM** | `glm4.5-air`, `glm4.7-9b` | |
 | **GPT-OSS** | `gpt-oss-20b` | Harmony native |
-| **MiniMax / Kimi** | `minimax-m2.5`, `kimi-48b`, `kimi-k2.5` | |
+| **MiniMax / Kimi** | `minimax-m2.5`, `minimax-m2.7`, `minimax-m2.7-8bit`, `kimi-48b`, `kimi-k2.5` | |
 | **Mistral / Devstral** | `mistral-24b`, `devstral-24b`, `devstral-v2-24b`, `ministral-3b` | |
 | **Other** | `phi4-14b`, `smollm3-3b`, `nemotron-30b` / `-nano`, `bonsai-1.7b/4b/8b`, `granite4-tiny` | |
 
@@ -454,7 +454,7 @@ Parsers are **auto-detected from the model name** — you don't need to specify 
 | DeepSeek R1 (older) | `deepseek` | `deepseek_r1` | With reasoning |
 | DeepSeek V3 / V2.5 | `deepseek` | *(none)* | No reasoning parser |
 | GLM-4.7 | `glm47` | *(none)* | 100% tool calling |
-| MiniMax-M2.5 | `minimax` | `minimax` | XML tool format |
+| MiniMax-M2.5 / M2.7 | `minimax` | `minimax` | XML tool format |
 | GPT-OSS | `harmony` | `harmony` | Native format |
 | Kimi-Linear | `kimi` | *(none)* | Kimi tool format |
 | Llama 3.x | `llama` | *(none)* | JSON tool format |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.39"
+version = "0.6.40"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -294,6 +294,20 @@
     "is_hybrid": false,
     "supports_spec_decode": true
   },
+  "minimax-m2.7": {
+    "hf_path": "mlx-community/MiniMax-M2.7-4bit",
+    "tool_call_parser": "minimax",
+    "reasoning_parser": "minimax",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "minimax-m2.7-8bit": {
+    "hf_path": "mlx-community/MiniMax-M2.7-8bit",
+    "tool_call_parser": "minimax",
+    "reasoning_parser": "minimax",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
   "deepseek-r1-8b": {
     "hf_path": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
     "tool_call_parser": "deepseek_v31",


### PR DESCRIPTION
## What does this PR do?

Add two new model aliases for MiniMax-M2.7 to the alias registry:

| Alias | HF Path | Quantization |
|-------|---------|-------------|
| `minimax-m2.7` | `mlx-community/MiniMax-M2.7-4bit` | 4-bit |
| `minimax-m2.7-8bit` | `mlx-community/MiniMax-M2.7-8bit` | 8-bit |

Both reuse the existing `minimax` tool_call_parser and reasoning_parser (already registered from the M2.5 alias). Updated README model table and bumped version to 0.6.40.

## Why is this needed?

MiniMax-M2.7 is the latest model in the MiniMax family (229B params). MLX-quantized versions are available on HuggingFace (`mlx-community/MiniMax-M2.7-*`) and users can already serve them with full HF paths, but having short aliases (`minimax-m2.7`, `minimax-m2.7-8bit`) makes them discoverable via `rapid-mlx models` and servable with `rapid-mlx serve minimax-m2.7`.

The existing `minimax-m2.5` alias already has full parser support (tool calling + reasoning), so M2.7 inherits the same configuration — this is pure alias bookkeeping.

## AI assistance disclosure

Claude Code (claude-sonnet-4-6) authored the alias entries and README updates. I verified:
- `aliases.json` entries follow the existing `minimax-m2.5` pattern exactly
- HF paths `mlx-community/MiniMax-M2.7-4bit` and `mlx-community/MiniMax-M2.7-8bit` exist on HuggingFace
- Both parsers (`minimax` tool + reasoning) are registered in the parser registries
- All 629 unit + contract tests pass (1 pre-existing failure: `test_negative_control_dflash_on_moe_is_caught` requires `mlx` module)

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- [x] `python3 -m pytest tests/test_model_aliases.py tests/test_aliases_contract.py -x -q` — 629 passed, 1 skipped (mlx dep)
- [x] Manual verification: `resolve_model('minimax-m2.7')` → `mlx-community/MiniMax-M2.7-4bit`
- [x] Manual verification: `resolve_profile('minimax-m2.7')` has correct parser/capability flags
- [x] `detect_model_config('minimax-m2.7')` auto-detects via alias profile
- [x] Existing `minimax-m2.5` alias unaffected

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [ ] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — will run after PR creation
- [ ] If new tests touch a critical code path — N/A (alias-only change)
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API