### PR TITLE
fix(mllm): release preprocessed vision inputs after encoding (#442)

### DIFF
--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -600,6 +600,15 @@ class MLLMBatchGenerator:
         output = self.model(input_ids, cache=cache, **kwargs)
         request.vision_encoded = True
 
+        # Release preprocessed vision inputs now that they have been encoded
+        # into the KV cache.  pixel_values can be hundreds of MB for multi-
+        # image requests; holding them pins Metal buffers for the entire
+        # generation duration (issue #442).
+        request.pixel_values = None
+        request.attention_mask = None
+        request.image_grid_thw = None
+        request.extra_kwargs.clear()
+
         # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
             return output.logits
@@ -715,6 +724,16 @@ class MLLMBatchGenerator:
         y = mx.array(first_tokens)
 
         self._stats.prompt_time += time.perf_counter() - tic
+
+        # Release preprocessed vision inputs for all requests now that
+        # they have been encoded into the batch KV cache.  pixel_values,
+        # input_ids, etc. can be hundreds of MB per request; holding them
+        # for the entire generation duration pins Metal buffers (issue #442).
+        for req in requests:
+            req.pixel_values = None
+            req.attention_mask = None
+            req.image_grid_thw = None
+            req.extra_kwargs.clear()
 
         return MLLMBatch(
             uids=[req.uid for req in requests],


### PR DESCRIPTION
## Summary

Cherry-pick of the missing mllm portion of upstream waybarrios/vllm-mlx#453 (commit `1f6bb20`).

PR #249 absorbed the `scheduler.py` portion of #453 (request `prompt_cache` / `_extracted_cache` cleanup) but skipped the `mllm_batch_generator.py` hunks. The same leak pattern exists for MLLM: `pixel_values` / `attention_mask` / `image_grid_thw` / `extra_kwargs` are set during preprocessing and never cleared after vision encoding. For multi-image requests these can be hundreds of MB; holding them for the entire generation duration pins Metal buffers in wired memory.

Release the references at two safe points:

- Inside `_run_vision_encoding`, immediately after the VLM forward pass copies state into the KV cache.
- At the end of `_process_prompts` before returning the batch, as a safety net for requests that raise before reaching `vision_encoded = True`.

Both assignments are idempotent (None → None), so the outer loop costs nothing on the happy path.

## Why now

Surfacing during upstream-absorb sweep. Address-of: issue #442 in upstream.

## Test plan

- [x] Targeted: `tests/test_batched_engine_output_router.py` → 7 passed
- [x] Full unit suite: `python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py --ignore=tests/test_mllm*.py --ignore=tests/test_video.py` → 3258 passed; the 4 `test_batching_deterministic.py` fails are **pre-existing** thread-affinity flakes (verified identical failures on parent `c9147b2` with `git stash` — same error, different stream IDs)
- [x] `ruff check && ruff format --check` clean on changed file
- [ ] MLLM tests gated by CI matrix (need real Qwen3-VL weights, hang locally per CLAUDE.md)
- [ ] `make check` — N/A: change is bounded to the MLLM batch path; cleanup is mechanically equivalent to upstream's `request.prompt_cache = None` cleanup we already adopted via #249

## Out of scope

This PR only covers the missing mllm hunks. Upstream tier B sweep continues separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)