### PR TITLE
fix(engine/batched): normalize tool-call replay arguments before chat templating (upstream #470)

### DIFF
--- a/tests/test_batched_engine_tool_call_normalization.py
+++ b/tests/test_batched_engine_tool_call_normalization.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for OpenAI tool-call replay normalization before chat templating.
+
+Cherry-pick coverage of upstream waybarrios/vllm-mlx#470. Many chat templates
+iterate ``message.tool_calls[i].function.arguments`` as a mapping; OpenAI's API
+contract gives it as a JSON string. Without normalization the template render
+raises mid-batch with ``AttributeError: 'str' object has no attribute 'items'``.
+"""
+
+from vllm_mlx.engine.batched import _normalize_tool_call_arguments_for_template
+
+
+class TestToolCallReplayNormalization:
+    def test_parses_function_arguments_string_to_mapping(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Tokyo"}',
+                        },
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "city": "Tokyo"
+        }
+        # Original is not mutated — API surface keeps the JSON-string contract.
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
+            '{"city": "Tokyo"}'
+        )
+
+    def test_wraps_non_mapping_arguments_for_template_items(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "echo",
+                            "arguments": '["not", "object"]',
+                        }
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "value": ["not", "object"]
+        }
+
+    def test_wraps_malformed_json_arguments(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "bad",
+                            "arguments": "{not valid json",
+                        }
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "value": "{not valid json"
+        }
+
+    def test_non_assistant_messages_are_untouched(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized == messages
+
+    def test_already_mapping_arguments_are_left_alone(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "Tokyo"},
+                        }
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "city": "Tokyo"
+        }
+
+    def test_missing_tool_calls_field_is_safe(self):
+        messages = [{"role": "assistant", "content": "no tool calls"}]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized == messages

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -12,6 +12,7 @@ LLM engine), so text-only requests must also be routed through it.
 """
 
 import functools
+import json
 import logging
 from collections.abc import AsyncIterator
 from dataclasses import replace
@@ -24,6 +25,45 @@ from ..utils.chat_template import apply_chat_template as shared_apply_chat_templ
 from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_tool_call_arguments_for_template(messages: list[dict]) -> list[dict]:
+    """Normalize OpenAI tool-call replay for templates expecting mappings.
+
+    OpenAI's API contract has ``message.tool_calls[i].function.arguments`` as a
+    JSON string, but many chat templates iterate that field as a mapping
+    (e.g., ``{% for k, v in tool_call.function.arguments.items() %}``) and
+    blow up on a string. Parse the JSON string back into a dict before
+    handing the message list to ``apply_chat_template``; wrap non-mapping
+    parsed values (``["a","b"]`` etc.) so the template still gets a dict.
+
+    Returns a deep-copied, mutated message list; the original is left alone
+    so the API surface (where ``arguments`` must remain a string) is intact.
+    """
+    normalized = json.loads(json.dumps(messages, default=str))
+    for message in normalized:
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                parsed = json.loads(arguments)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                parsed = {"value": arguments}
+            if not isinstance(parsed, dict):
+                parsed = {"value": parsed}
+            function["arguments"] = parsed
+    return normalized
 
 
 def _probe_mllm_cache_type(language_model: Any) -> str | None:
@@ -568,6 +608,8 @@ class BatchedEngine(BaseEngine):
             num_images: Number of images (triggers MLLM message preparation).
             enable_thinking: Whether to enable thinking mode (None = auto).
         """
+        messages = _normalize_tool_call_arguments_for_template(messages)
+
         # Choose the best template applicator.
         # For MLLM models, the processor handles special vision tokens.
         # For text-only models, the tokenizer is sufficient.


### PR DESCRIPTION
## Summary

Cherry-pick of the \`engine/batched.py\` portion of upstream waybarrios/vllm-mlx#470 (\"Fix streamed tool-call qualification\").

OpenAI's API contract has \`message.tool_calls[i].function.arguments\` as a JSON string, but many chat templates iterate that field as a mapping (\`{% for k, v in tool_call.function.arguments.items() %}\` and the like) and blow up mid-batch with \`AttributeError: 'str' object has no attribute 'items'\` when an assistant message with tool calls is replayed in a multi-turn agentic flow.

## Fix

\`_normalize_tool_call_arguments_for_template\` deep-copies the message list, parses each tool-call's \`arguments\` JSON string into a dict (wrapping non-mapping parsed values like JSON arrays under \`{\"value\": …}\` so the template still gets a dict), and substitutes the parsed form. Called at the top of \`_apply_chat_template\` so every template-render path benefits — chat completions, Anthropic messages, prefill-only token counting, etc.

## What's not included

Upstream's PR also adds the same normalization to \`bench_serve.py\` and a matching test file, but we don't have \`vllm_mlx/bench_serve.py\` in our fork. That portion is dropped — the engine/batched.py portion is the substantive correctness fix.

## Test plan

- [x] new \`tests/test_batched_engine_tool_call_normalization.py\` — **6 passed** (string→mapping, non-mapping wrap, malformed JSON, non-assistant pass-through, already-mapping pass-through, missing tool_calls)
- [x] Full unit suite (with documented MLLM/video/integration ignores): **3282 passed, 18 skipped, 1 xfailed** — zero new failures
- [x] \`ruff check && ruff format --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)