### PR TITLE
feat(api): add request cancellation endpoints (upstream #426)

### DIFF
--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /v1/requests/{id}/cancel and BatchedEngine.abort_request routing.
+
+Cherry-pick coverage of upstream waybarrios/vllm-mlx#426 adapted to our
+routes/ split (their endpoint lives on the FastAPI app; ours lives on the
+health router).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _StubAsyncEngine:
+    """Minimal async engine stub exposing ``abort_request`` as a coroutine."""
+
+    def __init__(self, returns: bool):
+        self._returns = returns
+        self.calls: list[str] = []
+
+    async def abort_request(self, request_id: str) -> bool:
+        self.calls.append(request_id)
+        return self._returns
+
+
+class _StubSyncMllmScheduler:
+    """Minimal sync MLLM scheduler stub."""
+
+    def __init__(self, returns: bool):
+        self._returns = returns
+        self.calls: list[str] = []
+
+    def abort_request(self, request_id: str) -> bool:
+        self.calls.append(request_id)
+        return self._returns
+
+
+class TestBatchedEngineAbortRouting:
+    @pytest.mark.asyncio
+    async def test_routes_to_mllm_scheduler_when_present(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._mllm_scheduler = _StubSyncMllmScheduler(returns=True)
+        engine._engine = _StubAsyncEngine(returns=False)
+
+        result = await engine.abort_request("req-mllm")
+
+        assert result is True
+        assert engine._mllm_scheduler.calls == ["req-mllm"]
+        assert engine._engine.calls == []
+
+    @pytest.mark.asyncio
+    async def test_routes_to_text_engine_when_no_mllm_scheduler(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._mllm_scheduler = None
+        engine._engine = _StubAsyncEngine(returns=True)
+
+        result = await engine.abort_request("req-text")
+
+        assert result is True
+        assert engine._engine.calls == ["req-text"]
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_engine_loaded(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._mllm_scheduler = None
+        engine._engine = None
+
+        result = await engine.abort_request("req-none")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_handles_sync_text_engine_abort(self):
+        """Synthetic engine returning bool directly (not a coroutine)."""
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        sync_engine = MagicMock()
+        sync_engine.abort_request = MagicMock(return_value=True)
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._mllm_scheduler = None
+        engine._engine = sync_engine
+
+        result = await engine.abort_request("req-sync")
+
+        assert result is True
+        sync_engine.abort_request.assert_called_once_with("req-sync")
+
+
+class TestBaseEngineDefaultAbort:
+    @pytest.mark.asyncio
+    async def test_default_returns_false(self):
+        """Invoke ``BaseEngine.abort_request`` via the unbound method to dodge
+        the abstract-method instantiation guard. We only care that the default
+        returns False — no engine state is needed."""
+        from vllm_mlx.engine.base import BaseEngine
+
+        sentinel = object()
+        result = await BaseEngine.abort_request(sentinel, "any")  # type: ignore[arg-type]
+        assert result is False
+
+
+class TestCancelRequestEndpoint:
+    @pytest.fixture
+    def client_with_engine(self):
+        """Build a FastAPI test client with a stub engine wired into the
+        process-wide ``ServerConfig`` singleton."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes.health import router
+
+        cfg = get_config()
+        prev_engine, prev_model_name = cfg.engine, cfg.model_name
+
+        engine = AsyncMock()
+        engine.abort_request = AsyncMock(return_value=True)
+        cfg.engine = engine
+        cfg.model_name = "test-model"
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        try:
+            yield client, engine
+        finally:
+            cfg.engine = prev_engine
+            cfg.model_name = prev_model_name
+
+    def test_post_cancel_returns_200_when_engine_aborts(self, client_with_engine):
+        client, engine = client_with_engine
+
+        response = client.post("/v1/requests/chatcmpl-abc123/cancel")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["object"] == "request.cancel"
+        assert body["id"] == "chatcmpl-abc123"
+        assert body["cancelled"] is True
+        assert body["model"] == "test-model"
+        engine.abort_request.assert_awaited_once_with("chatcmpl-abc123")
+
+    def test_post_cancel_returns_404_when_engine_returns_false(
+        self, client_with_engine
+    ):
+        client, engine = client_with_engine
+        engine.abort_request.return_value = False
+
+        response = client.post("/v1/requests/missing/cancel")
+
+        assert response.status_code == 404
+        assert "Request not found" in response.json()["detail"]
+
+    def test_delete_alias_returns_200(self, client_with_engine):
+        client, _ = client_with_engine
+
+        response = client.delete("/v1/requests/chatcmpl-xyz")
+
+        assert response.status_code == 200
+        assert response.json()["cancelled"] is True
+
+    def test_post_cancel_returns_503_when_no_engine(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes.health import router
+
+        cfg = get_config()
+        prev_engine = cfg.engine
+        cfg.engine = None
+        try:
+            app = FastAPI()
+            app.include_router(router)
+            client = TestClient(app)
+
+            response = client.post("/v1/requests/any/cancel")
+
+            assert response.status_code == 503
+        finally:
+            cfg.engine = prev_engine

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -209,3 +209,7 @@ class BaseEngine(ABC):
     def get_cache_stats(self) -> dict[str, Any] | None:
         """Get cache statistics. Override in subclasses."""
         return None
+
+    async def abort_request(self, request_id: str) -> bool:
+        """Abort an active or queued request when the engine supports it."""
+        return False

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1242,6 +1242,27 @@ class BatchedEngine(BaseEngine):
             return self._engine.get_cache_stats()
         return None
 
+    async def abort_request(self, request_id: str) -> bool:
+        """Abort an active or queued batched request by request ID.
+
+        Routes to whichever backend is loaded:
+        - MLLMScheduler.abort_request is sync (returns bool).
+        - AsyncEngineCore.abort_request is async (returns coroutine).
+
+        Returns ``True`` when the engine accepted the abort, ``False`` if no
+        backend is available or the request was already finished/not found.
+        """
+        import inspect
+
+        if self._mllm_scheduler is not None:
+            return self._mllm_scheduler.abort_request(request_id)
+        if self._engine is not None and hasattr(self._engine, "abort_request"):
+            result = self._engine.abort_request(request_id)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        return False
+
     def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk for persistence across restarts."""
         if self._engine:

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -2,11 +2,14 @@
 """Health, status, and cache management endpoints."""
 
 import gc
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..config import get_config
 from ..middleware.auth import verify_api_key
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(verify_api_key)])
 
@@ -67,6 +70,49 @@ async def health_ready():
     if not cfg.ready:
         raise HTTPException(status_code=503, detail="model loading")
     return {"ready": True, "model": cfg.model_name}
+
+
+@router.post("/v1/requests/{request_id}/cancel")
+async def cancel_request(request_id: str):
+    """Cancel an active or queued request.
+
+    The ``request_id`` is the ``chatcmpl-xxx`` ID returned in the first SSE
+    streaming chunk (or in the non-streaming response body). Returns 404 if
+    the request is not found, has already finished, or the loaded engine
+    does not implement abort.
+    """
+    cfg = get_config()
+    if cfg.engine is None:
+        raise HTTPException(status_code=503, detail="Engine not loaded")
+
+    try:
+        aborted = await cfg.engine.abort_request(request_id)
+    except Exception as exc:  # pragma: no cover - engine-side errors are rare
+        logger.exception("Failed to cancel request %s", request_id)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to cancel request {request_id}: {exc}",
+        ) from exc
+
+    if not aborted:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Request not found or cancellation is unsupported: {request_id}",
+        )
+
+    logger.info("[cancel_request] accepted request_id=%s", request_id)
+    return {
+        "object": "request.cancel",
+        "id": request_id,
+        "cancelled": True,
+        "model": cfg.model_name,
+    }
+
+
+@router.delete("/v1/requests/{request_id}")
+async def delete_request(request_id: str):
+    """OpenAI-style alias for cancelling an active or queued request."""
+    return await cancel_request(request_id)
 
 
 @router.post("/v1/cache/clear")


### PR DESCRIPTION
## Summary

Cherry-pick of upstream waybarrios/vllm-mlx#426 adapted to our \`routes/\` split: their endpoint lives directly on the FastAPI app; ours mounts on the health router.

Adds two new endpoints that let clients abort an in-flight or queued generation without restarting the server:

- \`POST /v1/requests/{request_id}/cancel\` — primary cancel endpoint.
- \`DELETE /v1/requests/{request_id}\` — OpenAI-style alias.

The endpoints route through a new \`engine.abort_request(request_id)\` method:

- \`BaseEngine.abort_request\` returns False by default (engines without abort support no-op).
- \`BatchedEngine.abort_request\` dispatches to \`self._mllm_scheduler\` (sync, returns bool) when the MLLM backend is loaded, otherwise to \`self._engine\` (text-only AsyncEngineCore — async, returns coroutine). Uses \`inspect.isawaitable\` to handle both shapes uniformly.

Returns **200** when the engine accepted the abort, **404** when the request is not found / already finished / engine has no abort, **503** when no engine is loaded.

## Why now

Picked up during upstream-absorb sweep. Long-running multi-turn agentic flows (OpenCode, Cline, Aider, etc.) need a way to abort a stuck or no-longer-needed request without restarting the server.

## Test plan

- [x] new \`tests/test_request_cancellation.py\`: **9 passed** — routing to MLLM scheduler vs text engine, async-vs-sync engine handling, default \`BaseEngine\` no-op, 200/404/503 HTTP responses, DELETE alias
- [x] Full unit suite (with documented MLLM/video/integration ignores): **3291 passed, 18 skipped, 1 xfailed** — zero new failures
- [x] \`ruff check && ruff format --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)