### PR TITLE
fix(aliases): wire deepseek_r1 reasoning_parser on deepseek-v4-flash family

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.39"
+version = "0.6.40"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -420,6 +420,31 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         )
 
 
+def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
+    """The DeepSeek-V4-Flash chat template emits ``<think>...</think>``
+    blocks (gated by ``thinking_mode``). Without ``reasoning_parser`` set,
+    that text leaks into ``choices[0].message.content`` as user-visible
+    chain-of-thought. Pin the wiring so a future PR can't silently revert
+    it to ``null``.
+
+    Verified format source:
+    https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit/resolve/main/chat_template.jinja
+    """
+    profiles = list_profiles()
+    family = [
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-2bit",
+        "deepseek-v4-flash-4bit",
+        "deepseek-v4-flash-8bit",
+    ]
+    for alias in family:
+        assert alias in profiles, f"{alias} missing from aliases.json"
+        assert profiles[alias].reasoning_parser == "deepseek_r1", (
+            f"{alias}: reasoning_parser must be 'deepseek_r1' (V4-Flash emits "
+            f"`<think>` blocks). Got {profiles[alias].reasoning_parser!r}."
+        )
+
+
 def test_default_max_tokens_is_positive_or_none() -> None:
     """``default_max_tokens`` is None or a positive int. A negative or
     zero default would make every request return empty completions."""

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -117,7 +117,17 @@ class TestDetectModelConfig:
         config = detect_model_config(model_path)
         assert config is not None
         assert config.tool_call_parser == "deepseek"
-        assert config.reasoning_parser is None
+        # V4-Flash chat template emits `<think>...</think>` blocks gated
+        # by ``thinking_mode``; ``deepseek_r1`` handles that format. The
+        # base ``deepseek-ai/DeepSeek-V4`` path is resolved via family
+        # detection (no aliases.json entry), so it currently gets no
+        # reasoning_parser — only the MLX variants benefit from the
+        # alias wiring. Track both shapes here so a refactor that flips
+        # the family default has to update this test consciously.
+        if model_path == "deepseek-ai/DeepSeek-V4":
+            assert config.reasoning_parser is None
+        else:
+            assert config.reasoning_parser == "deepseek_r1"
         assert config.is_hybrid is False
         assert config.supports_spec_decode is True
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -128,28 +128,28 @@
   "deepseek-v4-flash": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": null,
+    "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-2bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": null,
+    "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-8bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": null,
+    "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-4bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-4bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": null,
+    "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "supports_spec_decode": true
   },


### PR DESCRIPTION
## Summary

Wires `reasoning_parser=\"deepseek_r1\"` on the four `deepseek-v4-flash*` aliases. Today these alias entries set `reasoning_parser=null`, so the `<think>...</think>` blocks emitted by DeepSeek-V4-Flash leak into `choices[0].message.content` as user-visible chain-of-thought.

Verified format source: the [chat_template.jinja for `mlx-community/DeepSeek-V4-Flash-4bit`](https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit/resolve/main/chat_template.jinja) gates emission of `<think>` on a `thinking_mode` template variable — identical surface to DeepSeek-R1, so the existing `deepseek_r1` parser handles it directly.

Touched aliases (4): `deepseek-v4-flash`, `-2bit`, `-4bit`, `-8bit`.

## Why now

First gap surfaced by the new Model Onboarding SOP audit against `aliases.json`. The 4 deepseek-v4-flash entries are the lowest-risk, highest-signal fix in that audit: confirmed format, existing parser reuse, no new code.

## Test plan

- [x] `tests/test_aliases_contract.py` — new positive contract test `test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser` pins the wiring so a future PR can't silently revert to null
- [x] `tests/test_model_auto_config.py::test_deepseek_v4` updated: MLX variants now resolve `deepseek_r1`; the upstream `deepseek-ai/DeepSeek-V4` path still resolves null (no aliases.json entry routes it — family detection only sees the HF path)
- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py --ignore=tests/test_mllm*.py --ignore=tests/test_video.py` → **3292 passed, 18 skipped, 7 deselected, 1 xfailed**
- [x] `ruff check` / `ruff format --check` on changed paths → clean
- [x] PR Merge SOP §7 \"make check\" — skipped per blast-radius rule: this is a surface-touching alias-registry edit, not an inference-path change. The wiring exercise is covered by the contract test; the parser implementation itself is unchanged.

## SOP context

This is the first concrete fix from the new Model Onboarding SOP audit (see `CLAUDE.md` § \"Model Onboarding SOP\"). Remaining audit gaps (queued, not in this PR):
- Absorb upstream #440 to ship a `glm4` reasoning parser → unblocks `glm4.7-9b`, `glm4.5-air`
- Verify nemotron / kimi / hermes4 / granite4 reasoning-tag format; wire or add parser per SOP step 3
- Verify `bonsai-*` tool-call format; set `tool_call_parser` per SOP step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)