### PR TITLE
feat(reasoning): add GLM-4 reasoning parser (upstream #295)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.40"
+version = "0.6.41"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -1043,3 +1043,143 @@ class TestDeepSeekNoTagThreshold:
         # Reset should clear it
         parser.reset_state()
         assert not parser._saw_any_tag
+
+
+class TestGlm4Parser:
+    """Tests for the GLM-4 reasoning parser.
+
+    Ported from upstream waybarrios/vllm-mlx#295's TestGlm4Parser, adapted
+    to our base class shape (``_saw_any_tag`` flag vs upstream's
+    ``_phase`` enum). The behavioural contract is the same.
+
+    Key contract: GLM-4's chat template does NOT inject ``<think>`` in
+    the prompt, so an output with no tags at all is pure content. The
+    base class default ("no tags seen yet → treat as reasoning") is
+    wrong here and the parser must override it.
+    """
+
+    @pytest.fixture
+    def parser(self):
+        from vllm_mlx.reasoning import get_parser
+
+        return get_parser("glm4")()
+
+    def test_registry_includes_glm4(self):
+        from vllm_mlx.reasoning import list_parsers
+
+        assert "glm4" in list_parsers()
+
+    # ---- Non-streaming ----
+
+    def test_extract_with_both_tags(self, parser):
+        """Standard case: both tags present."""
+        output = "<think>Let me analyze this</think>The answer is 42."
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "Let me analyze this"
+        assert content == "The answer is 42."
+
+    def test_no_tags_returns_content(self, parser):
+        """Critical GLM-4 contract: no tags at all means pure content.
+
+        This is the divergence from Qwen3. If a future refactor reverts
+        this behaviour, ``<think>`` blocks would still be parsed but
+        no-thinking turns would have their text misclassified as
+        reasoning, leaking into ``message.reasoning`` instead of
+        ``message.content``.
+        """
+        output = "Just a regular response."
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning is None
+        assert content == output
+
+    def test_implicit_mode_only_closing_tag(self, parser):
+        """Agent-injected mode: only ``</think>`` in output."""
+        output = "reasoning text</think>content text"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "reasoning text"
+        assert content == "content text"
+
+    def test_strips_box_tags_pure_content(self, parser):
+        """GLM-4.6V wraps content in <|begin_of_box|>...<|end_of_box|>."""
+        output = "<|begin_of_box|>Paris<|end_of_box|>"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning is None
+        assert content == "Paris"
+
+    def test_strips_box_tags_with_thinking(self, parser):
+        """Box tags should not survive into either field, even when
+        interleaved with think tags."""
+        output = (
+            "<think><|begin_of_box|>analysis</think>"
+            "<|begin_of_box|>answer<|end_of_box|>"
+        )
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "analysis"
+        assert content == "answer"
+
+    # ---- Streaming ----
+
+    def test_streaming_no_tags_emits_content(self, parser):
+        """The signature GLM-4 streaming contract: no tags → content."""
+        parser.reset_state()
+        result = parser.extract_reasoning_streaming("", "Hello", "Hello")
+        assert result is not None
+        assert result.content == "Hello"
+        assert result.reasoning is None
+
+    def test_streaming_with_thinking(self, parser):
+        """Standard streaming: <think>...</think> then content."""
+        parser.reset_state()
+        tokens = ["<think>", "analyze", "</think>", "answer"]
+        accumulated = ""
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result is None:
+                continue
+            if result.reasoning:
+                reasoning_parts.append(result.reasoning)
+            if result.content:
+                content_parts.append(result.content)
+        assert "analyze" in "".join(reasoning_parts)
+        assert "answer" in "".join(content_parts)
+
+    def test_streaming_strips_box_tags(self, parser):
+        """Box tags should be removed from streaming content."""
+        parser.reset_state()
+        tokens = ["<|begin_of_box|>", "Paris", "<|end_of_box|>"]
+        accumulated = ""
+        content_parts: list[str] = []
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result is not None and result.content:
+                content_parts.append(result.content)
+        full = "".join(content_parts)
+        assert "Paris" in full
+        assert "<|begin_of_box|>" not in full
+        assert "<|end_of_box|>" not in full
+
+    def test_streaming_pure_box_tag_delta_returns_none(self, parser):
+        """A delta that contains only a box tag yields no message —
+        prevents an empty content chunk on the wire."""
+        parser.reset_state()
+        result = parser.extract_reasoning_streaming(
+            "", "<|begin_of_box|>", "<|begin_of_box|>"
+        )
+        assert result is None
+
+    def test_streaming_state_resets(self, parser):
+        """Once tags have been seen, state persists until ``reset_state``."""
+        parser.reset_state()
+        parser.extract_reasoning_streaming("", "<think>x", "<think>x")
+        assert parser._saw_any_tag
+        parser.reset_state()
+        assert not parser._saw_any_tag
+        # And after reset, the no-tags-yet branch fires again as content
+        result = parser.extract_reasoning_streaming("", "fresh", "fresh")
+        assert result is not None and result.content == "fresh"

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -269,14 +269,14 @@
   "glm4.7-9b": {
     "hf_path": "mlx-community/GLM-4.7-4bit",
     "tool_call_parser": "glm47",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "glm4.5-air": {
     "hf_path": "mlx-community/GLM-4.5-Air-0111-4bit",
     "tool_call_parser": "glm47",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true
   },

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -77,6 +77,7 @@ def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import DeepSeekR1ReasoningParser
     from .gemma4_parser import Gemma4ReasoningParser
+    from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
     from .minimax_parser import MiniMaxReasoningParser
@@ -85,6 +86,7 @@ def _register_builtin_parsers():
     register_parser("gemma4", Gemma4ReasoningParser)
     register_parser("qwen3", Qwen3ReasoningParser)
     register_parser("deepseek_r1", DeepSeekR1ReasoningParser)
+    register_parser("glm4", Glm4ReasoningParser)
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("minimax", MiniMaxReasoningParser)

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for the GLM-4 family (GLM-4.5-Air, GLM-4.6V, GLM-4.7).
+
+GLM-4 uses ``<think>...</think>`` tags for reasoning content. Unlike
+Qwen3 and DeepSeek-R1, GLM-4's chat template does NOT inject ``<think>``
+in the prompt — the model decides autonomously whether to reason. So:
+
+- Output with both tags: reasoning + content (standard case).
+- Output with no tags at all: pure content, NOT implicit reasoning.
+  The base class' "no tags yet → treat as reasoning" default is correct
+  for Qwen3 (where ``<think>`` is injected in the prompt and missing
+  tags mean truncated reasoning) but wrong for GLM-4. This parser
+  overrides that one branch.
+
+GLM-4.6V additionally wraps content in
+``<|begin_of_box|>...<|end_of_box|>`` container markers; we strip them
+so the user-facing content stays clean.
+
+Adapted from upstream waybarrios/vllm-mlx#295 (``Glm4ReasoningParser``).
+Upstream uses a ``_phase`` enum state machine; our base class uses a
+``_saw_any_tag`` flag (see ``think_parser.py``). The behavioural
+divergence is the same — only the override surface differs.
+"""
+
+from .base import DeltaMessage
+from .think_parser import BaseThinkingReasoningParser
+
+_BOX_START = "<|begin_of_box|>"
+_BOX_END = "<|end_of_box|>"
+
+
+class Glm4ReasoningParser(BaseThinkingReasoningParser):
+    """Reasoning parser for the GLM-4 family.
+
+    Diverges from the base class on exactly one streaming path: when
+    neither ``<think>`` nor ``</think>`` has appeared yet, GLM-4 output
+    is pure content. The base class defaults to reasoning for that
+    branch (correct for Qwen3-style prompt injection, wrong here).
+
+    Also strips GLM-4.6V ``<|begin_of_box|>`` / ``<|end_of_box|>``
+    container markers in both the streaming and non-streaming paths.
+    """
+
+    @property
+    def start_token(self) -> str:
+        return "<think>"
+
+    @property
+    def end_token(self) -> str:
+        return "</think>"
+
+    @staticmethod
+    def _strip_box(text: str) -> str:
+        return text.replace(_BOX_START, "").replace(_BOX_END, "")
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+    ) -> tuple[str | None, str | None]:
+        # Strip 4.6V box markers before tag inspection. They're whole
+        # special tokens, never embedded inside actual reasoning prose,
+        # so a literal replace is safe.
+        return super().extract_reasoning(self._strip_box(model_output))
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        # 4.6V box tags are whole special tokens, never split across
+        # deltas. Strip from delta + accumulated text so downstream tag
+        # detection sees the clean string.
+        if _BOX_START in delta_text or _BOX_END in delta_text:
+            delta_text = self._strip_box(delta_text)
+            if not delta_text:
+                return None
+            previous_text = self._strip_box(previous_text)
+            current_text = self._strip_box(current_text)
+
+        # Diverge from the base class here, and only here. GLM-4 doesn't
+        # inject ``<think>``, so an early token before any tag appears
+        # is genuine content, not implicit reasoning. The base class
+        # default (``reasoning=delta_text``) would misclassify it.
+        has_tags = self.start_token in current_text or self.end_token in current_text
+        if not has_tags and not self._saw_any_tag:
+            return DeltaMessage(content=delta_text)
+
+        return super().extract_reasoning_streaming(
+            previous_text, current_text, delta_text
+        )


### PR DESCRIPTION
## Summary

Ports the `Glm4ReasoningParser` from upstream waybarrios/vllm-mlx#295, adapted to our base class shape (`_saw_any_tag` flag vs upstream's `_phase` enum). Wires it on the two GLM-4 aliases.

**Why GLM-4 needs its own parser:** unlike Qwen3 and DeepSeek-R1, GLM-4's chat template does NOT inject `<think>` in the prompt — the model decides autonomously whether to reason. So an output with no tags at all is pure content, *not* implicit reasoning. The base class default ("no tags yet → treat as reasoning") would misclassify such turns, leaking assistant text into `message.reasoning` instead of `message.content`. The parser overrides exactly that one streaming branch.

GLM-4.6V additionally wraps content in `<|begin_of_box|>...<|end_of_box|>` container markers; the parser strips them in both streaming and non-streaming paths.

## Files

- `vllm_mlx/reasoning/glm4_parser.py` — new, ~95 LOC
- `vllm_mlx/reasoning/__init__.py` — register \`glm4\`
- `vllm_mlx/aliases.json` — \`glm4.7-9b\` and \`glm4.5-air\` get \`reasoning_parser=\"glm4\"\`
- `tests/test_reasoning_parser.py` — new \`TestGlm4Parser\` class (+10 tests)

## Adaptation notes

Upstream's base class uses a 3-state \`_phase\` enum (\`pre_think\` → \`thinking\` → \`content\`). Our base class uses a single \`_saw_any_tag\` flag (see \`vllm_mlx/reasoning/think_parser.py\`). The behavioural contract is identical; the divergence shows up only in the shape of the override. Result: ~95 LOC parser body vs upstream's 107.

## Test plan

- [x] New \`TestGlm4Parser\` class covers both contracts: standard \`<think>...</think>\` handling AND the no-tags-is-content divergence from base
- [x] \`python3.12 -m pytest tests/test_reasoning_parser.py tests/test_aliases_contract.py\` → 680 passed
- [x] \`python3.12 -m pytest tests/ --ignore=...\` (full unit suite minus MLLM/video) → **3303 passed, 18 skipped, 7 deselected, 1 xfailed** (net +11 from new GLM-4 tests)
- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] PR Merge SOP §7 \`make check\` — skipped per blast-radius rule: this is a new parser added to the reasoning registry (no existing inference-path code modified). The parser is exercised by the new unit tests; integration is covered by the parser-registry wiring tests already in CI.

## SOP context

Second concrete fix from the Model Onboarding SOP audit (after #373 wired \`deepseek_r1\` on the \`deepseek-v4-flash\` family). Remaining audit gaps:
- Item 3 (queued, research done): wire \`reasoning_parser=\"qwen3\"\` on \`nemotron-30b\`, \`nemotron-nano\`, \`kimi-k2.5\`, \`hermes4-70b\` (templates verified to use the standard \`<think>\`/\`</think>\` Qwen3 pattern)
- Item 4 (queued): verify \`bonsai-*\` tool-call format; set \`tool_call_parser\` per SOP step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)