### PR TITLE
fix(aliases): wire reasoning/tool parsers on audit batch (nemotron/kimi/hermes4/bonsai)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.41"
+version = "0.6.42"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -420,6 +420,55 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         )
 
 
+def test_audit_batch_reasoning_parser_wirings() -> None:
+    """Pin the Model Onboarding SOP audit fixes for reasoning_parser
+    on nemotron / kimi-k2.5 / hermes4 aliases. Each was previously
+    ``null`` despite the model emitting ``<think>``/``</think>``
+    blocks — without the parser, those blocks leak into
+    ``message.content``.
+
+    Parser choice rationale:
+    - nemotron-30b/nano + kimi-k2.5 use a Qwen3-style template that
+      INJECTS ``<think>`` into the prompt (gated by ``enable_thinking``
+      / ``thinking`` flag). ``qwen3`` parser's ``finalize_streaming``
+      correction handles the "no </think> ever appeared → emit as
+      content" case correctly.
+    - hermes4-70b: the chat template does NOT inject ``<think>``;
+      the model decides autonomously. Same contract as GLM-4 → reuse
+      ``glm4`` parser (no-tags-yet → content semantics).
+    """
+    profiles = list_profiles()
+    expected = {
+        "nemotron-30b": "qwen3",
+        "nemotron-nano": "qwen3",
+        "kimi-k2.5": "qwen3",
+        "hermes4-70b": "glm4",
+    }
+    for alias, parser in expected.items():
+        assert alias in profiles, f"{alias} missing from aliases.json"
+        assert profiles[alias].reasoning_parser == parser, (
+            f"{alias}: reasoning_parser must be {parser!r} per audit. "
+            f"Got {profiles[alias].reasoning_parser!r}."
+        )
+
+
+def test_audit_batch_bonsai_tool_call_parser_wired() -> None:
+    """Pin the Model Onboarding SOP audit fix for the Bonsai family.
+    The chat template emits ``<tool_call>...</tool_call>`` blocks
+    (hermes pattern); leaving ``tool_call_parser=null`` made every
+    tool call land in ``message.content`` as plain text. Verified the
+    template format directly against
+    https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked.
+    """
+    profiles = list_profiles()
+    for alias in ("bonsai-1.7b", "bonsai-4b", "bonsai-8b"):
+        assert alias in profiles, f"{alias} missing from aliases.json"
+        assert profiles[alias].tool_call_parser == "hermes", (
+            f"{alias}: tool_call_parser must be 'hermes' per audit. "
+            f"Got {profiles[alias].tool_call_parser!r}."
+        )
+
+
 def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
     """The DeepSeek-V4-Flash chat template emits ``<think>...</think>``
     blocks (gated by ``thinking_mode``). Without ``reasoning_parser`` set,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -352,7 +352,7 @@
   "kimi-k2.5": {
     "hf_path": "mlx-community/Kimi-K2.5-3bit",
     "tool_call_parser": "kimi",
-    "reasoning_parser": null,
+    "reasoning_parser": "qwen3",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
@@ -371,7 +371,7 @@
   "hermes4-70b": {
     "hf_path": "lmstudio-community/Hermes-4-70B-MLX-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",
@@ -461,7 +461,7 @@
   "nemotron-30b": {
     "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
     "is_moe": true
@@ -469,14 +469,14 @@
   "nemotron-nano": {
     "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
     "is_moe": true
   },
   "bonsai-1.7b": {
     "hf_path": "prism-ml/Bonsai-1.7B-unpacked",
-    "tool_call_parser": null,
+    "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -490,7 +490,7 @@
   },
   "bonsai-4b": {
     "hf_path": "prism-ml/Bonsai-4B-unpacked",
-    "tool_call_parser": null,
+    "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -503,7 +503,7 @@
   },
   "bonsai-8b": {
     "hf_path": "prism-ml/Bonsai-8B-unpacked",
-    "tool_call_parser": null,
+    "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,


### PR DESCRIPTION
## Summary

Third batch from the Model Onboarding SOP audit. Wires the previously-null `reasoning_parser` / `tool_call_parser` on 7 alias rows whose model output was silently misrouting.

## reasoning_parser wirings

| Alias | parser | template evidence |
|---|---|---|
| `nemotron-30b` / `nemotron-nano` | `qwen3` | [chat_template.jinja](https://huggingface.co/lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit/resolve/main/chat_template.jinja) — injects `<think>` when `enable_thinking=True`, emits `<think></think>` when off |
| `kimi-k2.5` | `qwen3` | [chat_template.jinja](https://huggingface.co/mlx-community/Kimi-K2.5-3bit/resolve/main/chat_template.jinja) — same shape (gated by a `thinking` flag) |
| `hermes4-70b` | `glm4` | [chat_template.jinja](https://huggingface.co/lmstudio-community/Hermes-4-70B-MLX-4bit/resolve/main/chat_template.jinja) — does NOT inject `<think>`; autonomous, same contract as GLM-4 |

**Parser-choice rationale:**

- Nemotron/Kimi-K2.5 use a Qwen3-style template that injects `<think>` into the prompt. The `qwen3` parser's `finalize_streaming` correction handles the "no `</think>` ever appeared → emit as content" case correctly.
- Hermes-4's chat template does NOT inject `<think>`; the model decides autonomously. Same contract as GLM-4 → reuse the `glm4` parser added in PR #374 (no-tags-yet → content semantics).

## tool_call_parser wirings

| Alias | parser | template evidence |
|---|---|---|
| `bonsai-1.7b` / `bonsai-4b` / `bonsai-8b` | `hermes` | [chat_template.jinja](https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked/resolve/main/chat_template.jinja) — hermes-style `<tool_call>`/`</tool_call>` sentinels |

## Out of scope (deferred)

- `kimi-48b` (Kimi-K2-Instruct): chat template is empty (29 chars) → likely non-reasoning. Leaving `null` is correct until verified against a live response.
- `granite4-tiny`: chat template has no reasoning markers. Leaving `null` is correct.
- `bonsai-*` `reasoning_parser`: template injects an EMPTY `<think></think>` by default. Non-trivial decision (which parser handles default-empty plus optional explicit reasoning best); separate from this PR.

## Test plan

- [x] New `test_audit_batch_reasoning_parser_wirings` + `test_audit_batch_bonsai_tool_call_parser_wired` in `tests/test_aliases_contract.py` pin each wiring so a future PR can't silently revert
- [x] Existing per-alias contract suite (~660 tests) validates every row passes the parser-registered / mutually-exclusive / DFlash gates
- [x] `python3.12 -m pytest tests/ --ignore=...` (full unit suite) → **3304 passed, 19 skipped, 7 deselected, 1 xfailed**
- [x] `ruff check` / `ruff format --check` clean
- [x] PR Merge SOP §7 `make check` — skipped per blast-radius rule: surface-touching alias-registry edits + a contract test. No inference-path code modified; the parsers themselves are unchanged.

## SOP context

Third concrete fix batch from the Model Onboarding SOP audit:
1. #373 — wired `deepseek_r1` on the `deepseek-v4-flash` family (0.6.40)
2. #374 — added the `glm4` reasoning parser; wired it on `glm4.7-9b` + `glm4.5-air` (0.6.41)
3. **This PR** — wired `qwen3` / `glm4` / `hermes` on 7 audit-flagged aliases (0.6.42)

After this PR the audit's critical / high-severity gaps are closed. Remaining items are bench backlog (suffix-decoding tier sweep for ~17 dense aliases) — not silent regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)