### PR TITLE
fix(aliases): wire glm4 reasoning_parser on bonsai-1.7b/4b/8b

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.42"
+version = "0.6.43"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -452,6 +452,30 @@ def test_audit_batch_reasoning_parser_wirings() -> None:
         )
 
 
+def test_bonsai_family_wires_glm4_reasoning_parser() -> None:
+    """The Bonsai chat template (verified at
+    https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked/resolve/main/chat_template.jinja)
+    injects an empty ``<think>\\n\\n</think>`` block when
+    ``add_generation_prompt=True`` — the model's actual output stream
+    then contains only content, no tags. The base class' "no tags
+    yet, treat as reasoning" default would misclassify every Bonsai
+    token; the ``glm4`` parser overrides exactly that branch.
+
+    If a downstream user enables thinking via ``reasoning_content``
+    on a prior assistant turn, the model may emit real
+    ``<think>...</think>`` blocks; the same glm4 parser splits those
+    correctly. Net effect: glm4 is strictly safer than null with
+    zero behavioural downside for non-thinking turns.
+    """
+    profiles = list_profiles()
+    for alias in ("bonsai-1.7b", "bonsai-4b", "bonsai-8b"):
+        assert alias in profiles, f"{alias} missing from aliases.json"
+        assert profiles[alias].reasoning_parser == "glm4", (
+            f"{alias}: reasoning_parser must be 'glm4' per audit. "
+            f"Got {profiles[alias].reasoning_parser!r}."
+        )
+
+
 def test_audit_batch_bonsai_tool_call_parser_wired() -> None:
     """Pin the Model Onboarding SOP audit fix for the Bonsai family.
     The chat template emits ``<tool_call>...</tool_call>`` blocks

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -477,7 +477,7 @@
   "bonsai-1.7b": {
     "hf_path": "prism-ml/Bonsai-1.7B-unpacked",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",
@@ -491,7 +491,7 @@
   "bonsai-4b": {
     "hf_path": "prism-ml/Bonsai-4B-unpacked",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",
@@ -504,7 +504,7 @@
   "bonsai-8b": {
     "hf_path": "prism-ml/Bonsai-8B-unpacked",
     "tool_call_parser": "hermes",
-    "reasoning_parser": null,
+    "reasoning_parser": "glm4",
     "is_hybrid": false,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",


### PR DESCRIPTION
## Summary

Closes the last "verify" item from the Model Onboarding SOP audit. Wires `reasoning_parser="glm4"` on the three Bonsai aliases.

**Why glm4 (not null, not qwen3):**

Bonsai's chat template (verified at [prism-ml/Bonsai-1.7B-unpacked/chat_template.jinja](https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked/resolve/main/chat_template.jinja)) injects an empty `<think>\n\n</think>` block on `add_generation_prompt`. So the model's actual output stream contains content only — no tags.

| Parser | Streaming behavior on Bonsai output |
|---|---|
| `null` | Tags would leak into content if model ever emits them (no parser) |
| `qwen3` | Treats early tokens as reasoning; relies on `finalize_streaming` correction to fix at end-of-stream |
| `glm4` | Treats early tokens as content directly (matches Bonsai's contract); splits real `<think>...</think>` if they appear |

`glm4` is strictly safer than null and more streaming-friendly than qwen3 for this template shape, with **zero behavioral downside** for non-thinking turns.

## Audit closure

After this PR:
- **0 aliases** with null `tool_call_parser` on tool-capable models
- **15 of 19** remaining null `reasoning_parser` proven correct (genuine non-reasoning IT models — Llama3, Gemma3, Mistral, Devstral, Phi-4-mini, Hermes-3, Qwen3-Coder, Kimi-K2-Instruct, Granite-4, Ministral)
- **0 silent regressions remain**

The only outstanding audit item is the suffix-decoding tier sweep for 17 dense aliases — pure performance backlog (no startup hint), not correctness.

## Test plan

- [x] New `test_bonsai_family_wires_glm4_reasoning_parser` in `tests/test_aliases_contract.py` pins the wiring
- [x] `python3.12 -m pytest tests/test_aliases_contract.py` → 592 passed
- [x] `python3.12 -m pytest tests/ --ignore=...` (full unit) → **3305 passed**, 19 skipped, 7 deselected, 1 xfailed
- [x] `ruff check` / `ruff format --check` clean
- [x] PR Merge SOP §7 `make check` — skipped per blast-radius rule: surface-touching alias wiring + contract test, no inference-path code modified

## SOP context

Fourth concrete fix from the Model Onboarding SOP audit:
1. #373 — deepseek_r1 on deepseek-v4-flash family (0.6.40)
2. #374 — glm4 reasoning parser absorbed; wired on glm4.7-9b + glm4.5-air (0.6.41)
3. #375 — qwen3/glm4/hermes on nemotron/kimi-k2.5/hermes4/bonsai-tool-calls (0.6.42)
4. **This PR** — glm4 on bonsai-* reasoning (0.6.43) — final audit gap closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)