### PR TITLE
fix(aliases): repair 6 broken hf_paths + bench suffix tier on 5 dense aliases

### DIFF
--- a/evals/results/suffix_devstral-24b.json
+++ b/evals/results/suffix_devstral-24b.json
@@ -1,0 +1,215 @@
+{
+  "model": "mlx-community/Devstral-Small-2507-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 47.3,
+    "json_array": 46.8,
+    "tool_loop": 48.8,
+    "code_edit": 46.7
+  },
+  "suffix_tps": {
+    "chat": 30.9,
+    "json_array": 34.4,
+    "tool_loop": 34.0,
+    "code_edit": 30.4
+  },
+  "speedup": {
+    "chat": 0.653,
+    "json_array": 0.736,
+    "tool_loop": 0.697,
+    "code_edit": 0.65
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 47.4,
+          "completion_tokens": 155,
+          "decode_time": 3.273,
+          "total_time": 6.873,
+          "rejected_reason": null
+        },
+        {
+          "tps": 47.3,
+          "completion_tokens": 155,
+          "decode_time": 3.274,
+          "total_time": 6.867,
+          "rejected_reason": null
+        },
+        {
+          "tps": 47.3,
+          "completion_tokens": 155,
+          "decode_time": 3.277,
+          "total_time": 6.875,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 47.2,
+          "completion_tokens": 175,
+          "decode_time": 3.707,
+          "total_time": 7.389,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.8,
+          "completion_tokens": 175,
+          "decode_time": 3.739,
+          "total_time": 7.425,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.8,
+          "completion_tokens": 175,
+          "decode_time": 3.74,
+          "total_time": 7.44,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 48.8,
+          "completion_tokens": 39,
+          "decode_time": 0.799,
+          "total_time": 1.484,
+          "rejected_reason": null
+        },
+        {
+          "tps": 48.8,
+          "completion_tokens": 39,
+          "decode_time": 0.8,
+          "total_time": 1.482,
+          "rejected_reason": null
+        },
+        {
+          "tps": 48.8,
+          "completion_tokens": 39,
+          "decode_time": 0.8,
+          "total_time": 1.484,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 46.7,
+          "completion_tokens": 93,
+          "decode_time": 1.99,
+          "total_time": 5.761,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.7,
+          "completion_tokens": 93,
+          "decode_time": 1.993,
+          "total_time": 5.764,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.7,
+          "completion_tokens": 93,
+          "decode_time": 1.991,
+          "total_time": 5.761,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 30.7,
+          "completion_tokens": 155,
+          "decode_time": 5.052,
+          "total_time": 8.672,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.9,
+          "completion_tokens": 155,
+          "decode_time": 5.01,
+          "total_time": 8.615,
+          "rejected_reason": null
+        },
+        {
+          "tps": 31.3,
+          "completion_tokens": 155,
+          "decode_time": 4.951,
+          "total_time": 8.556,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 33.0,
+          "completion_tokens": 175,
+          "decode_time": 5.299,
+          "total_time": 8.985,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.4,
+          "completion_tokens": 175,
+          "decode_time": 5.08,
+          "total_time": 8.767,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.4,
+          "completion_tokens": 175,
+          "decode_time": 5.081,
+          "total_time": 8.769,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 34.0,
+          "completion_tokens": 39,
+          "decode_time": 1.147,
+          "total_time": 1.826,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.0,
+          "completion_tokens": 39,
+          "decode_time": 1.147,
+          "total_time": 1.825,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.9,
+          "completion_tokens": 39,
+          "decode_time": 1.149,
+          "total_time": 1.827,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 30.4,
+          "completion_tokens": 94,
+          "decode_time": 3.097,
+          "total_time": 6.861,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.4,
+          "completion_tokens": 94,
+          "decode_time": 3.096,
+          "total_time": 6.861,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.3,
+          "completion_tokens": 94,
+          "decode_time": 3.098,
+          "total_time": 6.862,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma-3n-e4b.json
+++ b/evals/results/suffix_gemma-3n-e4b.json
@@ -1,0 +1,215 @@
+{
+  "model": "mlx-community/gemma-3n-E4B-it-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {},
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "json_array": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "unknown",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.075,
+          "total_time": 0.075,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.075,
+          "total_time": 0.075,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.08,
+          "total_time": 0.08,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.076,
+          "total_time": 0.076,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.079,
+          "total_time": 0.079,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.078,
+          "total_time": 0.078,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.076,
+          "total_time": 0.076,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma3-1b.json
+++ b/evals/results/suffix_gemma3-1b.json
@@ -1,0 +1,216 @@
+{
+  "model": "mlx-community/gemma-3-1b-it-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 261.5,
+    "json_array": 259.7,
+    "tool_loop": 253.8,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 238.1,
+    "json_array": 287.4,
+    "tool_loop": 280.7,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.91,
+    "json_array": 1.106,
+    "tool_loop": 1.106
+  },
+  "skipped": {
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 261.5,
+          "completion_tokens": 256,
+          "decode_time": 0.979,
+          "total_time": 1.129,
+          "rejected_reason": null
+        },
+        {
+          "tps": 261.1,
+          "completion_tokens": 256,
+          "decode_time": 0.981,
+          "total_time": 1.123,
+          "rejected_reason": null
+        },
+        {
+          "tps": 261.5,
+          "completion_tokens": 256,
+          "decode_time": 0.979,
+          "total_time": 1.12,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 259.7,
+          "completion_tokens": 256,
+          "decode_time": 0.986,
+          "total_time": 1.164,
+          "rejected_reason": null
+        },
+        {
+          "tps": 259.3,
+          "completion_tokens": 256,
+          "decode_time": 0.987,
+          "total_time": 1.133,
+          "rejected_reason": null
+        },
+        {
+          "tps": 260.1,
+          "completion_tokens": 256,
+          "decode_time": 0.984,
+          "total_time": 1.135,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 253.8,
+          "completion_tokens": 256,
+          "decode_time": 1.009,
+          "total_time": 1.233,
+          "rejected_reason": null
+        },
+        {
+          "tps": 253.8,
+          "completion_tokens": 256,
+          "decode_time": 1.009,
+          "total_time": 1.167,
+          "rejected_reason": null
+        },
+        {
+          "tps": 253.7,
+          "completion_tokens": 256,
+          "decode_time": 1.009,
+          "total_time": 1.168,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.407,
+          "total_time": 0.556,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.407,
+          "total_time": 0.557,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.407,
+          "total_time": 0.563,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 214.8,
+          "completion_tokens": 256,
+          "decode_time": 1.192,
+          "total_time": 1.334,
+          "rejected_reason": null
+        },
+        {
+          "tps": 243.3,
+          "completion_tokens": 256,
+          "decode_time": 1.052,
+          "total_time": 1.185,
+          "rejected_reason": null
+        },
+        {
+          "tps": 238.1,
+          "completion_tokens": 256,
+          "decode_time": 1.075,
+          "total_time": 1.208,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 285.9,
+          "completion_tokens": 256,
+          "decode_time": 0.895,
+          "total_time": 1.043,
+          "rejected_reason": null
+        },
+        {
+          "tps": 287.8,
+          "completion_tokens": 256,
+          "decode_time": 0.889,
+          "total_time": 1.036,
+          "rejected_reason": null
+        },
+        {
+          "tps": 287.4,
+          "completion_tokens": 256,
+          "decode_time": 0.891,
+          "total_time": 1.038,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 282.8,
+          "completion_tokens": 256,
+          "decode_time": 0.905,
+          "total_time": 1.066,
+          "rejected_reason": null
+        },
+        {
+          "tps": 280.7,
+          "completion_tokens": 256,
+          "decode_time": 0.912,
+          "total_time": 1.076,
+          "rejected_reason": null
+        },
+        {
+          "tps": 279.3,
+          "completion_tokens": 256,
+          "decode_time": 0.916,
+          "total_time": 1.084,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.415,
+          "total_time": 0.59,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.413,
+          "total_time": 0.578,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 106,
+          "decode_time": 0.409,
+          "total_time": 0.565,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_gemma3-27b.json
+++ b/evals/results/suffix_gemma3-27b.json
@@ -1,0 +1,215 @@
+{
+  "model": "mlx-community/gemma-3-27b-it-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": null,
+    "json_array": null,
+    "tool_loop": null,
+    "code_edit": null
+  },
+  "speedup": {},
+  "skipped": {
+    "chat": "vanilla all runs rejected",
+    "json_array": "vanilla all runs rejected",
+    "tool_loop": "vanilla all runs rejected",
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "unknown",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.078,
+          "total_time": 0.078,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.075,
+          "total_time": 0.075,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "json_array": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.078,
+          "total_time": 0.078,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.074,
+          "total_time": 0.074,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.072,
+          "total_time": 0.072,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 0,
+          "decode_time": 0.073,
+          "total_time": 0.073,
+          "rejected_reason": "zero_completion_tokens"
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_glm4.5-air.json
+++ b/evals/results/suffix_glm4.5-air.json
@@ -1,0 +1,215 @@
+{
+  "model": "mlx-community/GLM-4.5-Air-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 53.8,
+    "json_array": 50.2,
+    "tool_loop": 53.0,
+    "code_edit": 55.5
+  },
+  "suffix_tps": {
+    "chat": 40.6,
+    "json_array": 34.5,
+    "tool_loop": 37.9,
+    "code_edit": 43.7
+  },
+  "speedup": {
+    "chat": 0.755,
+    "json_array": 0.688,
+    "tool_loop": 0.715,
+    "code_edit": 0.787
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 53.6,
+          "completion_tokens": 528,
+          "decode_time": 9.846,
+          "total_time": 10.121,
+          "rejected_reason": null
+        },
+        {
+          "tps": 53.8,
+          "completion_tokens": 528,
+          "decode_time": 9.813,
+          "total_time": 10.085,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.9,
+          "completion_tokens": 528,
+          "decode_time": 9.618,
+          "total_time": 9.88,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 50.2,
+          "completion_tokens": 2086,
+          "decode_time": 41.594,
+          "total_time": 41.972,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.2,
+          "completion_tokens": 2086,
+          "decode_time": 41.515,
+          "total_time": 41.899,
+          "rejected_reason": null
+        },
+        {
+          "tps": 50.1,
+          "completion_tokens": 2086,
+          "decode_time": 41.673,
+          "total_time": 42.06,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 52.6,
+          "completion_tokens": 126,
+          "decode_time": 2.397,
+          "total_time": 3.669,
+          "rejected_reason": null
+        },
+        {
+          "tps": 53.0,
+          "completion_tokens": 126,
+          "decode_time": 2.377,
+          "total_time": 3.655,
+          "rejected_reason": null
+        },
+        {
+          "tps": 53.7,
+          "completion_tokens": 126,
+          "decode_time": 2.348,
+          "total_time": 3.617,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 55.8,
+          "completion_tokens": 127,
+          "decode_time": 2.277,
+          "total_time": 2.779,
+          "rejected_reason": null
+        },
+        {
+          "tps": 55.5,
+          "completion_tokens": 127,
+          "decode_time": 2.288,
+          "total_time": 2.79,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.3,
+          "completion_tokens": 127,
+          "decode_time": 2.339,
+          "total_time": 2.848,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 40.6,
+          "completion_tokens": 509,
+          "decode_time": 12.53,
+          "total_time": 12.807,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.6,
+          "completion_tokens": 503,
+          "decode_time": 12.385,
+          "total_time": 12.656,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.1,
+          "completion_tokens": 400,
+          "decode_time": 9.972,
+          "total_time": 10.3,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 39.2,
+          "completion_tokens": 1682,
+          "decode_time": 42.949,
+          "total_time": 43.335,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.5,
+          "completion_tokens": 1525,
+          "decode_time": 44.191,
+          "total_time": 44.628,
+          "rejected_reason": null
+        },
+        {
+          "tps": 34.4,
+          "completion_tokens": 1525,
+          "decode_time": 44.289,
+          "total_time": 44.726,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 38.1,
+          "completion_tokens": 126,
+          "decode_time": 3.307,
+          "total_time": 4.573,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.9,
+          "completion_tokens": 126,
+          "decode_time": 3.324,
+          "total_time": 4.593,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.8,
+          "completion_tokens": 126,
+          "decode_time": 3.335,
+          "total_time": 4.608,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 40.2,
+          "completion_tokens": 193,
+          "decode_time": 4.804,
+          "total_time": 5.368,
+          "rejected_reason": null
+        },
+        {
+          "tps": 43.7,
+          "completion_tokens": 109,
+          "decode_time": 2.495,
+          "total_time": 3.008,
+          "rejected_reason": null
+        },
+        {
+          "tps": 46.2,
+          "completion_tokens": 123,
+          "decode_time": 2.664,
+          "total_time": 3.176,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_glm4.7-9b.json
+++ b/evals/results/suffix_glm4.7-9b.json
@@ -1,0 +1,215 @@
+{
+  "model": "mlx-community/GLM-4.7-Flash-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 70.7,
+    "json_array": 70.1,
+    "tool_loop": 70.3,
+    "code_edit": 70.6
+  },
+  "suffix_tps": {
+    "chat": 81.7,
+    "json_array": 93.7,
+    "tool_loop": 60.3,
+    "code_edit": 49.3
+  },
+  "speedup": {
+    "chat": 1.155,
+    "json_array": 1.337,
+    "tool_loop": 0.859,
+    "code_edit": 0.699
+  },
+  "skipped": {},
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 70.7,
+          "completion_tokens": 668,
+          "decode_time": 9.443,
+          "total_time": 9.628,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.3,
+          "completion_tokens": 668,
+          "decode_time": 9.499,
+          "total_time": 9.676,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.8,
+          "completion_tokens": 668,
+          "decode_time": 9.429,
+          "total_time": 9.607,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 70.5,
+          "completion_tokens": 2304,
+          "decode_time": 32.693,
+          "total_time": 32.969,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.1,
+          "completion_tokens": 2304,
+          "decode_time": 32.869,
+          "total_time": 33.086,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.1,
+          "completion_tokens": 2304,
+          "decode_time": 33.322,
+          "total_time": 33.534,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 70.3,
+          "completion_tokens": 271,
+          "decode_time": 3.856,
+          "total_time": 4.494,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.4,
+          "completion_tokens": 271,
+          "decode_time": 3.847,
+          "total_time": 4.325,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.7,
+          "completion_tokens": 271,
+          "decode_time": 3.887,
+          "total_time": 4.365,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 70.2,
+          "completion_tokens": 1283,
+          "decode_time": 18.28,
+          "total_time": 18.544,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.6,
+          "completion_tokens": 1283,
+          "decode_time": 18.182,
+          "total_time": 18.428,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.8,
+          "completion_tokens": 1283,
+          "decode_time": 18.126,
+          "total_time": 18.374,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 81.7,
+          "completion_tokens": 721,
+          "decode_time": 8.825,
+          "total_time": 9.019,
+          "rejected_reason": null
+        },
+        {
+          "tps": 81.8,
+          "completion_tokens": 721,
+          "decode_time": 8.815,
+          "total_time": 8.992,
+          "rejected_reason": null
+        },
+        {
+          "tps": 81.6,
+          "completion_tokens": 721,
+          "decode_time": 8.833,
+          "total_time": 9.01,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 93.7,
+          "completion_tokens": 2304,
+          "decode_time": 24.593,
+          "total_time": 24.799,
+          "rejected_reason": null
+        },
+        {
+          "tps": 93.7,
+          "completion_tokens": 2304,
+          "decode_time": 24.595,
+          "total_time": 24.805,
+          "rejected_reason": null
+        },
+        {
+          "tps": 93.7,
+          "completion_tokens": 2304,
+          "decode_time": 24.58,
+          "total_time": 24.801,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 60.3,
+          "completion_tokens": 2304,
+          "decode_time": 38.182,
+          "total_time": 38.792,
+          "rejected_reason": null
+        },
+        {
+          "tps": 60.5,
+          "completion_tokens": 2304,
+          "decode_time": 38.113,
+          "total_time": 38.621,
+          "rejected_reason": null
+        },
+        {
+          "tps": 60.3,
+          "completion_tokens": 2304,
+          "decode_time": 38.217,
+          "total_time": 38.729,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 44.2,
+          "completion_tokens": 1894,
+          "decode_time": 42.895,
+          "total_time": 43.149,
+          "rejected_reason": null
+        },
+        {
+          "tps": 49.7,
+          "completion_tokens": 1501,
+          "decode_time": 30.181,
+          "total_time": 30.431,
+          "rejected_reason": null
+        },
+        {
+          "tps": 49.3,
+          "completion_tokens": 1470,
+          "decode_time": 29.805,
+          "total_time": 30.053,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/suffix_qwen3-vl-4b.json
+++ b/evals/results/suffix_qwen3-vl-4b.json
@@ -1,0 +1,216 @@
+{
+  "model": "mlx-community/Qwen3-VL-4B-Instruct-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 130.3,
+    "json_array": 129.5,
+    "tool_loop": null,
+    "code_edit": 92.8
+  },
+  "suffix_tps": {
+    "chat": 131.1,
+    "json_array": 130.0,
+    "tool_loop": null,
+    "code_edit": 92.9
+  },
+  "speedup": {
+    "chat": 1.006,
+    "json_array": 1.004,
+    "code_edit": 1.001
+  },
+  "skipped": {
+    "tool_loop": "vanilla all runs rejected"
+  },
+  "tier": "neutral",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 128.5,
+          "completion_tokens": 230,
+          "decode_time": 1.79,
+          "total_time": 1.79,
+          "rejected_reason": null
+        },
+        {
+          "tps": 131.1,
+          "completion_tokens": 230,
+          "decode_time": 1.754,
+          "total_time": 1.754,
+          "rejected_reason": null
+        },
+        {
+          "tps": 130.3,
+          "completion_tokens": 230,
+          "decode_time": 1.765,
+          "total_time": 1.765,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 129.5,
+          "completion_tokens": 244,
+          "decode_time": 1.884,
+          "total_time": 1.884,
+          "rejected_reason": null
+        },
+        {
+          "tps": 129.9,
+          "completion_tokens": 244,
+          "decode_time": 1.878,
+          "total_time": 1.878,
+          "rejected_reason": null
+        },
+        {
+          "tps": 128.8,
+          "completion_tokens": 244,
+          "decode_time": 1.895,
+          "total_time": 1.895,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.015,
+          "total_time": 0.628,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.017,
+          "total_time": 0.575,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.015,
+          "total_time": 0.574,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 92.8,
+          "completion_tokens": 48,
+          "decode_time": 0.517,
+          "total_time": 0.517,
+          "rejected_reason": null
+        },
+        {
+          "tps": 93.1,
+          "completion_tokens": 48,
+          "decode_time": 0.515,
+          "total_time": 0.515,
+          "rejected_reason": null
+        },
+        {
+          "tps": 92.6,
+          "completion_tokens": 48,
+          "decode_time": 0.518,
+          "total_time": 0.518,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 131.1,
+          "completion_tokens": 230,
+          "decode_time": 1.755,
+          "total_time": 1.755,
+          "rejected_reason": null
+        },
+        {
+          "tps": 131.4,
+          "completion_tokens": 230,
+          "decode_time": 1.75,
+          "total_time": 1.75,
+          "rejected_reason": null
+        },
+        {
+          "tps": 129.6,
+          "completion_tokens": 230,
+          "decode_time": 1.774,
+          "total_time": 1.774,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 130.0,
+          "completion_tokens": 244,
+          "decode_time": 1.877,
+          "total_time": 1.877,
+          "rejected_reason": null
+        },
+        {
+          "tps": 130.7,
+          "completion_tokens": 244,
+          "decode_time": 1.866,
+          "total_time": 1.866,
+          "rejected_reason": null
+        },
+        {
+          "tps": 129.7,
+          "completion_tokens": 244,
+          "decode_time": 1.881,
+          "total_time": 1.881,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.015,
+          "total_time": 0.578,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.018,
+          "total_time": 0.576,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 20,
+          "decode_time": 0.015,
+          "total_time": 0.574,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": 92.2,
+          "completion_tokens": 48,
+          "decode_time": 0.52,
+          "total_time": 0.52,
+          "rejected_reason": null
+        },
+        {
+          "tps": 92.9,
+          "completion_tokens": 48,
+          "decode_time": 0.517,
+          "total_time": 0.517,
+          "rejected_reason": null
+        },
+        {
+          "tps": 92.9,
+          "completion_tokens": 48,
+          "decode_time": 0.517,
+          "total_time": 0.517,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.43"
+version = "0.6.44"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -518,6 +518,60 @@ def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
         )
 
 
+def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:
+    """Pin replacement paths for aliases that previously pointed at HF
+    repos that no longer exist (or never existed).
+
+    Three aliases shipped with hf_paths that 404 on HuggingFace —
+    ``rapid-mlx serve <alias>`` would download-fail at first user
+    contact. Each replacement was selected by manually browsing the
+    mlx-community namespace for an extant repo of the same family.
+
+    The substring guards below ensure a future "revert that aliases
+    change" commit doesn't quietly restore the broken path.
+    """
+    profiles = list_profiles()
+    # qwen3-vl-4b: stale ``-MLX-`` suffix not used by upstream uploads
+    assert "MLX-4bit" not in profiles["qwen3-vl-4b"].hf_path, (
+        "qwen3-vl-4b previously pointed at "
+        "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit which 404s; the "
+        "current upload is Qwen3-VL-4B-Instruct-4bit (no '-MLX-' suffix)."
+    )
+    # devstral-24b: ``2503`` snapshot was never re-uploaded as MLX-4bit;
+    # 2505/2507 are the canonical Devstral-Small v1 releases.
+    assert "2503" not in profiles["devstral-24b"].hf_path, (
+        "devstral-24b previously pointed at Devstral-Small-2503-MLX-4bit "
+        "which 404s. Use the 2507 (or 2505) MLX 4-bit upload."
+    )
+    # glm4.5-air: ``-0111-`` date suffix was a community-only tag that
+    # got rolled into the default release.
+    assert "0111" not in profiles["glm4.5-air"].hf_path, (
+        "glm4.5-air previously pointed at GLM-4.5-Air-0111-4bit which "
+        "404s. The current canonical upload is GLM-4.5-Air-4bit."
+    )
+    # glm4.7-9b previously pointed at the full GLM-4.7 (355B MoE,
+    # ~185 GB at 4-bit) — the alias name implies a 9B model. The
+    # correct upload is the Flash variant (~16 GB).
+    assert "Flash" in profiles["glm4.7-9b"].hf_path, (
+        "glm4.7-9b must point at the GLM-4.7-Flash upload, not the full "
+        "GLM-4.7 (355B MoE) which is ~12x larger and won't fit on most "
+        "user disks."
+    )
+    # gpt-oss-20b previously pointed at mlx-community/GPT-OSS-20B-4bit
+    # which 404s; the canonical mlx-community release uses the
+    # MXFP4-Q8 hybrid quantization.
+    assert profiles["gpt-oss-20b"].hf_path != "mlx-community/GPT-OSS-20B-4bit", (
+        "gpt-oss-20b must not regress to the 404 path; current canonical "
+        "upload is mlx-community/gpt-oss-20b-MXFP4-Q8."
+    )
+    # kimi-48b previously pointed at mlx-community/Kimi-K2-Instruct-Q4_0-MLX
+    # (404). The replacement Kimi-K2-Instruct-4bit is large
+    # (~540 GB) but is the actual mlx-community Kimi K2 Instruct release.
+    assert "Q4_0" not in profiles["kimi-48b"].hf_path, (
+        "kimi-48b must not regress to the Q4_0 path which 404s."
+    )
+
+
 def test_default_max_tokens_is_positive_or_none() -> None:
     """``default_max_tokens`` is None or a positive int. A negative or
     zero default would make every request return empty completions."""

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -302,6 +302,85 @@ class TestIsMllmModelConfigPriority:
         assert _config_indicates_vlm({"architectures": "Qwen3ForCausalLM"}) is False
 
 
+class TestIsMllmModelHubOverride:
+    """Verifies the hub config override for substring false-positives.
+
+    The legacy substring matcher catches family names like ``gemma-3`` /
+    ``gemma3`` which are correct for the vision variants (4b/12b/27b) but
+    misclassify the text-only 1B (``Gemma3ForCausalLM``, no
+    ``vision_config``). Detection now fetches just ``config.json`` from
+    the repo and lets the model's own metadata override a substring
+    false-positive — but only in the True → False direction, so repos
+    whose names lack a VLM token retain their existing text routing
+    even if their config exposes a vision branch.
+    """
+
+    def test_text_only_config_overrides_substring_match(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        # Substring "gemma-3" would flag this as MLLM. Hub config says
+        # Gemma3ForCausalLM (text-only) → override to False.
+        monkeypatch.setattr(
+            utils_mod,
+            "_try_read_hub_config_json",
+            lambda name: {"architectures": ["Gemma3ForCausalLM"]},
+        )
+        assert is_mllm_model("mlx-community/gemma-3-1b-it-4bit") is False
+
+    def test_vlm_config_keeps_substring_match(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        # Substring "gemma-3" matches and hub config also says VLM.
+        monkeypatch.setattr(
+            utils_mod,
+            "_try_read_hub_config_json",
+            lambda name: {
+                "architectures": ["Gemma3ForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1024},
+            },
+        )
+        assert is_mllm_model("mlx-community/gemma-3-27b-it-4bit") is True
+
+    def test_hub_unreachable_falls_back_to_substring(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        # Substring matches; hub call returns None (404, gated, offline).
+        # Should preserve the legacy True result.
+        monkeypatch.setattr(utils_mod, "_try_read_hub_config_json", lambda name: None)
+        assert is_mllm_model("mlx-community/gemma-3-4b-it-4bit") is True
+
+    def test_no_substring_match_skips_hub_call(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        # Repos whose names don't match MLLM_PATTERNS short-circuit to
+        # False without consulting the hub — preserves existing routing
+        # for models like Qwen3.5/3.6 whose configs happen to expose a
+        # vision branch even though we've always routed them as text.
+        called = []
+
+        def spy(name):
+            called.append(name)
+            return {"vision_config": {}}
+
+        monkeypatch.setattr(utils_mod, "_try_read_hub_config_json", spy)
+        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+        assert called == [], (
+            "hub config should not be consulted when substring rules out MLLM"
+        )
+
+    def test_hub_helper_rejects_local_path_lookalikes(self):
+        from vllm_mlx.api.utils import _try_read_hub_config_json
+
+        # Defensive: hub helper must not interpret local-path-like strings
+        # as repo IDs and trigger a network call.
+        assert _try_read_hub_config_json("/abs/path/model") is None
+        assert _try_read_hub_config_json("./relative/model") is None
+        assert _try_read_hub_config_json("../up/model") is None
+        assert _try_read_hub_config_json("~/cache/model") is None
+        # No slash at all → not a repo ID shape.
+        assert _try_read_hub_config_json("just-a-name") is None
+
+
 class TestExtractMultimodalContent:
     """Tests for extract_multimodal_content function."""
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -161,11 +161,17 @@
     "supports_spec_decode": false
   },
   "qwen3-vl-4b": {
-    "hf_path": "mlx-community/Qwen3-VL-4B-Instruct-MLX-4bit",
+    "hf_path": "mlx-community/Qwen3-VL-4B-Instruct-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "neutral",
+    "suffix_bench_speedup": {
+      "chat": 1.006,
+      "json_array": 1.004,
+      "code_edit": 1.001
+    }
   },
   "llama3-1b": {
     "hf_path": "mlx-community/Llama-3.2-1B-Instruct-4bit",
@@ -260,28 +266,49 @@
     "supports_spec_decode": true
   },
   "devstral-24b": {
-    "hf_path": "mlx-community/Devstral-Small-2503-MLX-4bit",
+    "hf_path": "mlx-community/Devstral-Small-2507-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.653,
+      "json_array": 0.736,
+      "tool_loop": 0.697,
+      "code_edit": 0.65
+    }
   },
   "glm4.7-9b": {
-    "hf_path": "mlx-community/GLM-4.7-4bit",
+    "hf_path": "mlx-community/GLM-4.7-Flash-4bit",
     "tool_call_parser": "glm47",
     "reasoning_parser": "glm4",
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 1.155,
+      "json_array": 1.337,
+      "tool_loop": 0.859,
+      "code_edit": 0.699
+    }
   },
   "glm4.5-air": {
-    "hf_path": "mlx-community/GLM-4.5-Air-0111-4bit",
+    "hf_path": "mlx-community/GLM-4.5-Air-4bit",
     "tool_call_parser": "glm47",
     "reasoning_parser": "glm4",
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.755,
+      "json_array": 0.688,
+      "tool_loop": 0.715,
+      "code_edit": 0.787
+    }
   },
   "gpt-oss-20b": {
-    "hf_path": "mlx-community/GPT-OSS-20B-4bit",
+    "hf_path": "mlx-community/gpt-oss-20b-MXFP4-Q8",
     "tool_call_parser": "harmony",
     "reasoning_parser": "harmony",
     "is_hybrid": false,
@@ -343,7 +370,7 @@
     "supports_spec_decode": false
   },
   "kimi-48b": {
-    "hf_path": "mlx-community/Kimi-K2-Instruct-Q4_0-MLX",
+    "hf_path": "mlx-community/Kimi-K2-Instruct-4bit",
     "tool_call_parser": "kimi",
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -449,7 +476,13 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.91,
+      "json_array": 1.106,
+      "tool_loop": 1.106
+    }
   },
   "gemma3-27b": {
     "hf_path": "mlx-community/gemma-3-27b-it-4bit",

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -5,6 +5,7 @@ Utility functions for text processing and model detection.
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -651,6 +652,53 @@ def _try_read_config_json(name_or_path: str) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+def _try_read_hub_config_json(model_name: str) -> dict | None:
+    """Read a cached config.json for an HF repo ID without going online.
+
+    Looks up the repo in the local ``huggingface_hub`` cache via
+    ``try_to_load_from_cache``. If the model has already been downloaded
+    (or even just had its config fetched), the file is on disk and we
+    can read it authoritatively. If nothing is cached, returns None —
+    the caller falls back to legacy substring matching rather than
+    making a network call. Never raises; never reaches the network.
+
+    Only runs for inputs that look like repo IDs (``owner/name``), so
+    arbitrary strings and local-path lookalikes can't accidentally
+    trigger a cache lookup.
+    """
+    if not isinstance(model_name, str) or "/" not in model_name:
+        return None
+    if model_name.startswith(("/", "./", "../", "~")):
+        return None
+
+    try:
+        from huggingface_hub import _CACHED_NO_EXIST, try_to_load_from_cache
+    except ImportError:
+        return None
+
+    try:
+        cached = try_to_load_from_cache(model_name, "config.json")
+    except Exception:
+        return None
+    if cached is None or cached is _CACHED_NO_EXIST:
+        return None
+    if not isinstance(cached, (str, os.PathLike)):
+        return None
+
+    try:
+        config_path = Path(cached)
+        if not config_path.is_file():
+            return None
+        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
+            return None
+        with config_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
 def _config_indicates_vlm(config: dict) -> bool:
     """Inspect a parsed config.json dict for multimodal markers."""
     archs = config.get("architectures") or []
@@ -683,17 +731,27 @@ def _check_legacy_string_patterns(model_name: str) -> bool:
 def is_mllm_model(model_name: str) -> bool:
     """Check if a model name or path indicates a multimodal language model.
 
-    Two complementary validations are run:
+    Three complementary validations are run, in order:
 
-    1. config.json inspection: when ``model_name`` resolves to a local
-       directory containing a readable config.json, inspect the model's
-       own metadata (``architectures`` field, ``vision_config``,
-       ``audio_config``, etc.). Authoritative when available because it
-       reflects what the model actually is, not how it is named on disk.
+    1. Local config.json inspection: when ``model_name`` resolves to a
+       local directory containing a readable config.json, inspect the
+       model's own metadata (``architectures`` field, ``vision_config``,
+       ``audio_config``, etc.). Authoritative when available.
 
-    2. Legacy substring match against ``MLLM_PATTERNS``: applied when no
-       config.json is reachable (e.g., a HuggingFace repo ID before the
-       weights are downloaded). Preserves the historical behaviour.
+    2. Legacy substring match against ``MLLM_PATTERNS``: when no local
+       config is reachable, the historical name-based heuristic decides.
+
+    3. Cached-config override (false-positive correction): when the
+       legacy substring says "MLLM" but the repo's own config (already
+       in the local HF cache from a prior download or warmup call)
+       disagrees (e.g. ``mlx-community/gemma-3-1b-it-4bit`` matches the
+       ``gemma-3`` substring yet ships as ``Gemma3ForCausalLM`` with no
+       ``vision_config``), the cached config wins and the result flips
+       to False. The cache lookup is purely local — no network call,
+       so tests don't slow down or flake on HF outages. We deliberately
+       only override the True → False direction: the False direction is
+       preserved as-is so existing text-routed models with vision-capable
+       architectures keep their routing.
 
     Args:
         model_name: HuggingFace repo ID or local filesystem path.
@@ -704,7 +762,17 @@ def is_mllm_model(model_name: str) -> bool:
     config = _try_read_config_json(model_name)
     if config is not None:
         return _config_indicates_vlm(config)
-    return _check_legacy_string_patterns(model_name)
+
+    legacy = _check_legacy_string_patterns(model_name)
+    if not legacy:
+        return False
+
+    # Substring says "MLLM" — verify via the repo's own config and let it
+    # override a name-based false positive (e.g. text-only Gemma 3 1B).
+    hub_config = _try_read_hub_config_json(model_name)
+    if hub_config is not None and not _config_indicates_vlm(hub_config):
+        return False
+    return True
 
 
 # Backwards compatibility alias


### PR DESCRIPTION
## Summary

- **6 hf_path fixes** in `aliases.json` — entries that 404 on HuggingFace (5 cases) or resolve to a 12× too-large model (`glm4.7-9b` → 355B GLM-4.7 instead of 9B GLM-4.7-Flash). `rapid-mlx serve <alias>` would have failed at first user contact for all 6.
- **is_mllm_model false-positive fix** — `mlx-community/gemma-3-1b-it-4bit` (text-only `Gemma3ForCausalLM`) used to be misrouted to the MLLM loader via the `gemma-3` substring; detection now consults the cached `config.json` (offline, no network call) and lets it override the substring match. Unblocks `rapid-mlx serve gemma3-1b`.
- **Suffix-decoding tier sweep** on 5 dense aliases (gemma3-1b, glm4.7-9b, qwen3-vl-4b, devstral-24b, glm4.5-air) — 4 `avoid`, 1 `neutral`. Two MLLM aliases (gemma-3n-e4b, gemma3-27b) couldn't be classified due to a separate zero-tokens bug in the MLLM-text path; tier stays `unknown`, tracked as follow-up.
- **Version bump** 0.6.43 → 0.6.44

## hf_path fixes

| alias          | was                                           | now                                       | size  |
|----------------|-----------------------------------------------|-------------------------------------------|-------|
| `qwen3-vl-4b`  | `Qwen3-VL-4B-Instruct-MLX-4bit` (404)         | `Qwen3-VL-4B-Instruct-4bit`               | 2.9G  |
| `devstral-24b` | `Devstral-Small-2503-MLX-4bit` (404)          | `Devstral-Small-2507-4bit`                | 12.4G |
| `glm4.5-air`   | `GLM-4.5-Air-0111-4bit` (404)                 | `GLM-4.5-Air-4bit`                        | 56.0G |
| `glm4.7-9b`    | `GLM-4.7-4bit` (355B MoE, ~185G — alias name implies 9B) | `GLM-4.7-Flash-4bit`           | 15.7G |
| `gpt-oss-20b`  | `GPT-OSS-20B-4bit` (404)                      | `gpt-oss-20b-MXFP4-Q8`                    | 11.3G |
| `kimi-48b`     | `Kimi-K2-Instruct-Q4_0-MLX` (404)             | `Kimi-K2-Instruct-4bit`                   | 537G  |

Pinned in `test_aliases_with_known_broken_hf_paths_stay_fixed` so a drift-back fails CI.

## is_mllm_model detection

Cache-based override; the legacy substring matcher still decides when nothing is cached and when the matcher returns False. We only override **True → False** (substring false-positives) and never expand detection — this preserves routing for Qwen3.5/3.6 hybrid models whose configs technically expose a vision branch.

5 new mocked tests in `TestIsMllmModelHubOverride` pin:

- True → False override fires when cached config disagrees
- True → True stays when both substring and config agree
- True remains when cache empty (offline / 404 fallback)
- False short-circuits without consulting cache
- Cache helper rejects local-path lookalikes (no accidental I/O)

## Suffix-decoding tier results

Methodology: `scripts/bench_suffix_decoding_integrated.py --max-tokens 256 --runs 3` (PR #284 reliability gates: `--disable-prefix-cache`, decode-time floor, TPS ceiling). Raw JSONs checked into `evals/results/suffix_*.json`.

| alias          | tier    | chat   | json_array | tool_loop | code_edit | reading                                     |
|----------------|---------|--------|------------|-----------|-----------|---------------------------------------------|
| `gemma3-1b`    | avoid   | 0.91x  | 1.106x     | 1.106x    | skipped   | chat regression dominates; code skipped (decode <0.5s) |
| `glm4.7-9b`    | avoid   | 1.155x | 1.337x     | 0.859x    | 0.699x    | structured wins, code/tool regress          |
| `qwen3-vl-4b`  | neutral | 1.006x | 1.004x     | skipped   | 1.001x    | flat — small enough that suffix is measurement noise |
| `devstral-24b` | avoid   | 0.653x | 0.736x     | 0.697x    | 0.65x     | uniform regression — coding model output too unique to benefit |
| `glm4.5-air`   | avoid   | 0.755x | 0.688x     | 0.715x    | 0.787x    | same pattern as devstral, all 4 workloads regress |

`gemma-3n-e4b` and `gemma3-27b` benches both produced zero-token completions through the MLLM-text path on every workload. Tier stays default `unknown`. This is a real latent bug — text-only chat completions on these specific Gemma 3 vision models don't emit anything through the MLLM scheduler. Out of scope for this PR; will track as a separate follow-up.

## Verification

- `tests/test_api_utils.py::TestIsMllmModelHubOverride` — 5 new mocked tests, 0.07s.
- `tests/test_aliases_contract.py::test_aliases_with_known_broken_hf_paths_stay_fixed` — substring guards on all 6 corrected paths.
- Targeted: 822 passed, 1 skipped (`aliases_contract + api_utils + model_aliases + model_auto_config + cli_models + cli_info + version_check`).
- Broader unit suite: 3311 passed, 19 skipped, 1 xfailed (known pre-existing `test_batching_deterministic` flake).
- `ruff check && ruff format --check`: clean.

`make check` skipped — no inference-path changes (parsers, scheduler, KV cache, BatchedEngine all untouched).

## Test plan

- [x] is_mllm_model fix doesn't change behaviour for the 16 existing repos in `TestIsMllmModel` (substring + config in agreement)
- [x] gemma3-1b now resolves to text path; bench runs to completion
- [x] glm4.7-9b resolves to the Flash variant (~16 GB) not the 355B (~185 GB) MoE
- [x] All 5 benched aliases get the right `tier` field per `classify_suffix_decoding_tier`
- [x] `suffix_bench_speedup` only contains workloads that produced valid TPS (skipped ones omitted)
- [ ] Post-merge: auto-release fires on `chore: bump version to 0.6.44` squash subject (will use `--subject` flag on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)