### PR TITLE
fix(gemma): unblock text-only path for Gemma3 and Gemma3n MLLMs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.44"
+version = "0.6.45"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_batched_engine_chat_template.py
+++ b/tests/test_batched_engine_chat_template.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for BatchedEngine chat-template applicator selection.
+
+Some MLLM processors (notably ``Gemma3nProcessor`` and ``Gemma3Processor`` as
+loaded by ``mlx_vlm.load``) expose ``apply_chat_template`` as a method but
+ship ``chat_template=None`` at the processor layer — only the inner tokenizer
+carries the Jinja template. ``_apply_chat_template`` must detect this and
+fall back to the tokenizer; otherwise every request to those models returns
+zero tokens.
+"""
+
+from vllm_mlx.engine.batched import BatchedEngine
+
+
+class _RecordingApplicator:
+    """Tokenizer/processor stub that records which applicator handled the call."""
+
+    def __init__(self, label: str, chat_template: object):
+        self._label = label
+        self.chat_template = chat_template
+        self.last_messages = None
+        self.last_kwargs = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_kwargs = kwargs
+        return f"<{self._label}>"
+
+
+class _ProcessorStub:
+    """MLLM processor stub.
+
+    Mirrors the real ``Gemma3Processor``/``Gemma3nProcessor`` shape: exposes
+    ``apply_chat_template`` and ``chat_template`` at the processor layer, plus
+    an inner ``tokenizer`` attribute that the engine's ``tokenizer`` property
+    unwraps to.
+    """
+
+    def __init__(self, label: str, chat_template: object, inner_tokenizer):
+        self._applicator = _RecordingApplicator(label, chat_template)
+        self.chat_template = chat_template
+        self.tokenizer = inner_tokenizer
+
+    def apply_chat_template(self, messages, **kwargs):
+        return self._applicator.apply_chat_template(messages, **kwargs)
+
+    @property
+    def last_messages(self):
+        return self._applicator.last_messages
+
+
+def _make_engine(
+    *,
+    is_mllm: bool,
+    processor: _ProcessorStub | None,
+    tokenizer: _RecordingApplicator,
+) -> BatchedEngine:
+    engine = BatchedEngine("test-model")
+    engine._loaded = True
+    engine._is_mllm = is_mllm
+    engine._processor = processor
+    engine._tokenizer = tokenizer
+    return engine
+
+
+def test_falls_back_to_tokenizer_when_mllm_processor_chat_template_is_none():
+    """Gemma-family processors expose apply_chat_template but chat_template=None."""
+    tokenizer = _RecordingApplicator(label="TOK", chat_template="{{ messages }}")
+    processor = _ProcessorStub(
+        label="PROC", chat_template=None, inner_tokenizer=tokenizer
+    )
+    engine = _make_engine(is_mllm=True, processor=processor, tokenizer=tokenizer)
+
+    result = engine._apply_chat_template([{"role": "user", "content": "hi"}])
+
+    assert result == "<TOK>"
+    assert processor.last_messages is None  # processor was never invoked
+
+
+def test_falls_back_to_tokenizer_when_mllm_processor_chat_template_is_empty_string():
+    """Empty string chat_template is just as broken as None — same fallback path."""
+    tokenizer = _RecordingApplicator(label="TOK", chat_template="{{ messages }}")
+    processor = _ProcessorStub(
+        label="PROC", chat_template="", inner_tokenizer=tokenizer
+    )
+    engine = _make_engine(is_mllm=True, processor=processor, tokenizer=tokenizer)
+
+    result = engine._apply_chat_template([{"role": "user", "content": "hi"}])
+
+    assert result == "<TOK>"
+    assert processor.last_messages is None
+
+
+def test_uses_processor_when_chat_template_is_present():
+    """When the processor has a real template, MLLM path keeps using it."""
+    tokenizer = _RecordingApplicator(label="TOK", chat_template="{{ messages }}")
+    processor = _ProcessorStub(
+        label="PROC", chat_template="{{ messages }}", inner_tokenizer=tokenizer
+    )
+    engine = _make_engine(is_mllm=True, processor=processor, tokenizer=tokenizer)
+
+    result = engine._apply_chat_template([{"role": "user", "content": "hi"}])
+
+    assert result == "<PROC>"
+    assert tokenizer.last_messages is None  # tokenizer was never invoked
+
+
+def test_text_only_engine_always_uses_tokenizer():
+    """Non-MLLM engines bypass the processor branch regardless of processor state."""
+    tokenizer = _RecordingApplicator(label="TOK", chat_template="{{ messages }}")
+    processor = _ProcessorStub(
+        label="PROC", chat_template="{{ messages }}", inner_tokenizer=tokenizer
+    )
+    engine = _make_engine(is_mllm=False, processor=processor, tokenizer=tokenizer)
+
+    result = engine._apply_chat_template([{"role": "user", "content": "hi"}])
+
+    assert result == "<TOK>"
+    assert processor.last_messages is None
+
+
+def test_mllm_without_processor_uses_tokenizer():
+    """MLLM engine that hasn't populated its processor still works via tokenizer."""
+    tokenizer = _RecordingApplicator(label="TOK", chat_template="{{ messages }}")
+    engine = _make_engine(is_mllm=True, processor=None, tokenizer=tokenizer)
+
+    result = engine._apply_chat_template([{"role": "user", "content": "hi"}])
+
+    assert result == "<TOK>"

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for MLLMBatchGenerator model-call kwargs.
+
+Some mlx-vlm model classes (notably ``Gemma3ForConditionalGeneration``)
+declare ``pixel_values`` as a *required* positional kwarg in ``__call__``,
+even though the inner ``get_input_embeddings`` already handles ``None`` for
+the text-only path. Omitting the kwarg raises ``TypeError`` for every
+text-only request to those models, so ``_run_vision_encoding`` must always
+pass it through — including when it's ``None``.
+"""
+
+import mlx.core as mx
+
+from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
+
+
+class _RecordingModel:
+    """VLM model stub that captures kwargs from its ``__call__``."""
+
+    def __init__(self):
+        self.last_call_kwargs = None
+        self.last_input_ids = None
+        # Provide a language_model attribute so the generator's
+        # is_vlm branch picks it up without warnings.
+        self.language_model = object()
+
+    def __call__(self, input_ids, cache=None, **kwargs):
+        self.last_input_ids = input_ids
+        self.last_call_kwargs = kwargs
+        # Return a dummy logits tensor — generator only inspects shape via
+        # ``hasattr(output, "logits")``; the value is irrelevant for this test.
+        return mx.zeros((1, 1, 8))
+
+
+def _make_generator(model: _RecordingModel) -> MLLMBatchGenerator:
+    """Construct a generator without booting Metal / vision cache plumbing."""
+    return MLLMBatchGenerator(
+        model=model,
+        processor=object(),
+        mm_processor=None,
+        enable_vision_cache=False,
+    )
+
+
+def _make_request(*, pixel_values, extra_kwargs=None) -> MLLMBatchRequest:
+    return MLLMBatchRequest(
+        uid=0,
+        request_id="r0",
+        prompt="hello",
+        max_tokens=8,
+        input_ids=mx.array([1, 2, 3], dtype=mx.int32),
+        pixel_values=pixel_values,
+        extra_kwargs=extra_kwargs or {},
+    )
+
+
+def test_run_vision_encoding_passes_pixel_values_none_for_text_only_request():
+    """Text-only request still includes pixel_values=None in kwargs.
+
+    Gemma3ForConditionalGeneration's ``__call__`` declares ``pixel_values``
+    as a required kwarg, so we must always forward it — even when None.
+    """
+    model = _RecordingModel()
+    gen = _make_generator(model)
+    request = _make_request(pixel_values=None)
+
+    gen._run_vision_encoding(request, cache=None)
+
+    assert "pixel_values" in model.last_call_kwargs
+    assert model.last_call_kwargs["pixel_values"] is None
+
+
+def test_run_vision_encoding_forwards_pixel_values_when_set():
+    """Multimodal request keeps forwarding the real pixel tensor."""
+    model = _RecordingModel()
+    gen = _make_generator(model)
+    pixels = mx.zeros((1, 3, 4, 4))
+    request = _make_request(pixel_values=pixels)
+
+    gen._run_vision_encoding(request, cache=None)
+
+    assert "pixel_values" in model.last_call_kwargs
+    # Must be the same object we put in — generator should not silently copy
+    # or downcast pixel_values before the forward pass.
+    assert model.last_call_kwargs["pixel_values"] is pixels
+
+
+def test_run_vision_encoding_preserves_extra_kwargs_alongside_pixel_values():
+    """Extra processor kwargs (e.g. token_type_ids) survive alongside pixel_values."""
+    model = _RecordingModel()
+    gen = _make_generator(model)
+    request = _make_request(
+        pixel_values=None,
+        extra_kwargs={"token_type_ids": mx.array([0, 0, 1])},
+    )
+
+    gen._run_vision_encoding(request, cache=None)
+
+    assert "pixel_values" in model.last_call_kwargs
+    assert model.last_call_kwargs["pixel_values"] is None
+    assert "token_type_ids" in model.last_call_kwargs

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -613,11 +613,24 @@ class BatchedEngine(BaseEngine):
         # Choose the best template applicator.
         # For MLLM models, the processor handles special vision tokens.
         # For text-only models, the tokenizer is sufficient.
+        #
+        # Subtlety: some MLLM processors (notably ``Gemma3nProcessor`` and
+        # ``Gemma3Processor`` as loaded by ``mlx_vlm.load``) expose
+        # ``apply_chat_template`` as a method but ship ``chat_template=None``
+        # at the processor layer — only the inner tokenizer carries the
+        # Jinja template. Calling ``processor.apply_chat_template`` then
+        # raises ``ValueError: Cannot use apply_chat_template because this
+        # processor does not have a chat template.`` and every request
+        # returns zero tokens. The inner tokenizer's template understands
+        # the same image/audio content types (it's the source the processor
+        # would have copied from), so falling back to it is safe for both
+        # text-only and vision requests.
         template_applicator = None
         if (
             self._is_mllm
             and self._processor
             and hasattr(self._processor, "apply_chat_template")
+            and getattr(self._processor, "chat_template", None)
         ):
             template_applicator = self._processor
         elif hasattr(self.tokenizer, "apply_chat_template"):

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -580,11 +580,20 @@ class MLLMBatchGenerator:
         Returns:
             Logits from the forward pass
         """
-        # Build model call kwargs
+        # Build model call kwargs.
+        #
+        # ``pixel_values`` must be passed *even when None* — some mlx-vlm
+        # model classes (notably ``Gemma3ForConditionalGeneration``)
+        # declare it as a required positional kwarg in ``__call__``, so
+        # omitting it raises ``TypeError: missing 1 required positional
+        # argument: 'pixel_values'`` for every text-only request. The
+        # inner ``get_input_embeddings`` already handles ``None`` (text
+        # path skips the vision tower); the signature is just stricter
+        # than the implementation. Other vision families
+        # (Gemma3n / Qwen3-VL / LLaVA) keep working unchanged because
+        # their signatures already mark ``pixel_values`` Optional.
         kwargs = dict(request.extra_kwargs)
-
-        if request.pixel_values is not None:
-            kwargs["pixel_values"] = request.pixel_values
+        kwargs["pixel_values"] = request.pixel_values
         if request.attention_mask is not None:
             kwargs["attention_mask"] = request.attention_mask
         if request.image_grid_thw is not None:


### PR DESCRIPTION
## Summary

Two independent latent bugs caused **every text-only request** to Gemma family MLLM models (`gemma3-27b`, `gemma-3n-e4b`) to return zero completion tokens. Surfaced during the SuffixDecoding tier sweep when both aliases returned `completion_tokens: 0`.

### Fix #1 — `BatchedEngine._apply_chat_template` (`vllm_mlx/engine/batched.py`)

`Gemma3nProcessor` and `Gemma3Processor` (as loaded by `mlx_vlm.load`) expose `apply_chat_template` as a method but ship `chat_template=None` at the processor layer — only the inner tokenizer carries the Jinja template. The previous applicator-selection logic picked the processor whenever the method existed, then the call raised:

```
ValueError: Cannot use apply_chat_template because this processor does not have a chat template.
```

Mid-templating, every request short-circuited with empty content. Fixed by also requiring `processor.chat_template` to be truthy before picking the processor; otherwise fall back to the inner tokenizer (which has the right template — it's the source the processor would have copied from).

### Fix #2 — `MLLMBatchGenerator._run_vision_encoding` (`vllm_mlx/mllm_batch_generator.py`)

`Gemma3ForConditionalGeneration.__call__` declares `pixel_values` as a **required positional kwarg** (unlike Gemma3n / Qwen3-VL / LLaVA, which mark it `Optional`). Omitting it for text-only requests raised:

```
TypeError: Model.__call__() missing 1 required positional argument: 'pixel_values'
```

The inner `get_input_embeddings` already handles `None` cleanly — the model's signature is just stricter than its implementation. Fixed by always forwarding `pixel_values` to the model call, even when `None`. Other vision families keep working unchanged because their signatures already accept `None`.

## Coverage

- **`tests/test_batched_engine_chat_template.py`** — 5 cases pinning processor-vs-tokenizer applicator selection across the `chat_template={None, "", "{{ messages }}"}` matrix and the MLLM/non-MLLM and `processor=None` branches.
- **`tests/test_mllm_batch_generator.py`** — 3 cases pinning that `pixel_values` is always forwarded (both `None` and tensor paths) and that `extra_kwargs` survive alongside it.

Regression-checked: with both fixes reverted, 4 of the new 8 tests fail; with fixes applied, all 8 pass.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] Affected tests: 8/8 pass
- [x] Full unit suite: 3319 passed, 19 skipped, 7 deselected, 1 xfailed (no regressions)
- [x] Manual smoke `gemma-3n-e4b` after fixes: returns real content (was zero tokens before)
- [x] Manual smoke `gemma3-27b` after fixes: returns "HELLO27" (was TypeError before)
- [ ] CI green on all matrix jobs (lint, type-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests)

## Notes

- Version bumped 0.6.44 → 0.6.45 so the fix ships immediately. Merge must use `--subject "chore: bump version to 0.6.45"` to trigger auto-release (default `(#NN)` suffix breaks the regex).
- Re-benching gemma SuffixDecoding tiers is deferred to a separate PR — these fixes are urgent (real user-facing breakage); tier classification is purely informational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)