### PR TITLE
data(aliases): curate recommended_sampling for empty-stub model families (v0.6.48)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.47"
+version = "0.6.48"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/fixtures/generation_configs/devstral-24b.json
+++ b/tests/fixtures/generation_configs/devstral-24b.json
@@ -1,0 +1,7 @@
+{
+  "_from_model_config": true,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "pad_token_id": 11,
+  "transformers_version": "4.53.1"
+}

--- a/tests/fixtures/generation_configs/gemma-3n-e4b.json
+++ b/tests/fixtures/generation_configs/gemma-3n-e4b.json
@@ -1,0 +1,13 @@
+{
+  "bos_token_id": 2,
+  "cache_implementation": "hybrid",
+  "do_sample": true,
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "pad_token_id": 0,
+  "top_k": 64,
+  "top_p": 0.95,
+  "transformers_version": "4.54.0.dev0"
+}

--- a/tests/fixtures/generation_configs/gemma3-27b.json
+++ b/tests/fixtures/generation_configs/gemma3-27b.json
@@ -1,0 +1,11 @@
+{
+  "_from_model_config": true,
+  "bos_token_id": 2,
+  "cache_implementation": "hybrid",
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "pad_token_id": 0,
+  "transformers_version": "4.50.0.dev0"
+}

--- a/tests/fixtures/generation_configs/glm4.5-air.json
+++ b/tests/fixtures/generation_configs/glm4.5-air.json
@@ -1,0 +1,10 @@
+{
+  "_from_model_config": true,
+  "eos_token_id": [
+    151329,
+    151336,
+    151338
+  ],
+  "pad_token_id": 151329,
+  "transformers_version": "4.54.0"
+}

--- a/tests/fixtures/generation_configs/glm4.7-9b.json
+++ b/tests/fixtures/generation_configs/glm4.7-9b.json
@@ -1,0 +1,11 @@
+{
+  "_from_model_config": true,
+  "eos_token_id": [
+    154820,
+    154827,
+    154829
+  ],
+  "pad_token_id": 154820,
+  "temperature": 1.0,
+  "transformers_version": "5.0.0.dev0"
+}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -588,23 +588,35 @@ def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:
 # haven't been audited yet (most of the missing-locally bucket).
 _CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
     # Devstral 1.x — Mistral code-tuned model card example uses 0.15
-    # for interactive coding. Same pattern in Devstral 2 (no shipped
-    # gen_config either).
+    # for interactive coding (see model card on huggingface.co/mistralai).
+    # Devstral 2.x ships the same empty stub; same pattern applies.
     "devstral-24b": {"temperature": 0.15},
     "devstral-v2-24b": {"temperature": 0.15},
-    # Gemma 3 / 4 family — Google's docs recommend (1.0, 0.95, 64).
-    # gemma-3n-E4B ships top_p/top_k but no temperature; the 27b and
-    # all 3-12b / 3-1b / 4-26b / 4-31b ship empty stubs.
+    # Gemma 3 family — Google's Gemma docs recommend
+    # (temperature=1.0, top_p=0.95, top_k=64) for the chat-tuned models.
+    # All of gemma-3-1b / gemma-3-12b / gemma-3-27b ship an empty stub
+    # locally (`_from_model_config: true` plus eos/pad tokens only).
     "gemma3-1b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma3-12b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma3-27b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
-    "gemma-3n-e4b": {"temperature": 1.0},  # top_p/top_k come from upstream
+    # gemma-3n-E4B ships top_p=0.95 and top_k=64 upstream but no
+    # temperature. We bake in the full triple anyway (matches the
+    # rest of the Gemma family) so a future mlx-community re-quant
+    # that drops generation_config.json doesn't silently regress to
+    # the framework fallback (0.7 / 0.9).
+    "gemma-3n-e4b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    # Gemma 4 — official Google sampling guidance hasn't been
+    # published yet at the time of writing; we extrapolate from the
+    # Gemma 3 family card. Revisit when an official Gemma 4 doc lands.
     "gemma-4-26b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-31b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
-    # GLM family — THUDM model cards recommend (0.6, 0.95) for chat.
-    # GLM-4.5-Air ships an empty stub; GLM-4.7-Flash ships only
-    # ``temperature: 1.0`` so we only add the missing top_p.
+    # GLM-4.5-Air — THUDM publishes two recommendations: temperature=0.6
+    # for *thinking* mode, ~1.0 for non-thinking. The alias has
+    # reasoning_parser=glm4 → thinking IS the default response path,
+    # so 0.6 is the right pick. (Users who want non-thinking can pass
+    # temperature explicitly per-request.)
     "glm4.5-air": {"temperature": 0.6, "top_p": 0.95},
+    # GLM-4.7-Flash ships temperature=1.0 upstream; we add only top_p.
     "glm4.7-9b": {"top_p": 0.95},
 }
 
@@ -634,34 +646,68 @@ def test_curated_recommended_sampling_matches_pinned_values() -> None:
         )
 
 
-def test_curated_aliases_do_not_contradict_local_generation_config() -> None:
-    """For every curated alias whose ``generation_config.json`` is also
-    available in the local HF cache, the curated value must not
-    *contradict* what the model author shipped. (Filling a gap is
-    fine; flipping a non-empty value is a red flag.)
+def test_curated_aliases_do_not_contradict_fixture_generation_config() -> None:
+    """For each curated alias with a checked-in upstream snapshot under
+    ``tests/fixtures/generation_configs/<alias>.json``, the curated
+    value must not *contradict* what the model author shipped.
+    Gap-filling is fine; flipping a non-empty value is a red flag and
+    means the curation needs explicit justification.
 
-    Skips when no local snapshot is present — the test is gated on
-    evidence, not network access.
+    The fixtures are byte-for-byte copies of the upstream JSON pulled
+    from the local HF cache at curation time. They're committed so the
+    test runs deterministically on a fresh CI runner (no HF cache
+    required) and so future re-quants that change upstream values
+    surface as a fixture mismatch rather than silently shifting which
+    layer of the cascade wins.
+
+    To refresh after an upstream update:
+      cp ~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/generation_config.json \\
+         tests/fixtures/generation_configs/<alias>.json
+    Then re-verify the curated value still matches the new upstream.
     """
+    import tempfile
+
     from vllm_mlx.utils.generation_config import load_generation_config_sampling
 
+    fixture_dir = Path(__file__).parent / "fixtures" / "generation_configs"
     profiles = list_profiles()
+
+    coverage = 0
     for alias in _CURATED_RECOMMENDED_SAMPLING:
+        fixture = fixture_dir / f"{alias}.json"
+        if not fixture.is_file():
+            continue  # no fixture yet — alias is "trust the curation"
+        coverage += 1
+        # Stage the fixture in a temp dir so the loader (which expects
+        # a model directory with ``generation_config.json`` inside)
+        # exercises the same parsing path the cascade uses at runtime.
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "generation_config.json").write_bytes(fixture.read_bytes())
+            shipped = load_generation_config_sampling(td)
+
         profile = profiles[alias]
-        shipped = load_generation_config_sampling(profile.hf_path)
-        if not shipped:
-            continue  # no local snapshot or empty stub — nothing to contradict
         curated = dict(profile.recommended_sampling or ())
         for key, shipped_value in shipped.items():
             if key not in curated:
                 continue  # curated is silent on this key — upstream wins
             assert curated[key] == shipped_value, (
                 f"{alias}: curated recommended_sampling[{key!r}]="
-                f"{curated[key]} contradicts upstream "
-                f"generation_config.json[{key!r}]={shipped_value}. "
-                f"Either remove the curated key (upstream wins) or "
-                f"document why upstream is wrong."
+                f"{curated[key]} contradicts upstream fixture "
+                f"{fixture.name}[{key!r}]={shipped_value}. "
+                f"Either drop the curated key (let upstream win) or "
+                f"document why upstream is wrong in the comment above "
+                f"_CURATED_RECOMMENDED_SAMPLING."
             )
+
+    # Sanity floor: if every fixture got removed by accident, the test
+    # would silently become a no-op. Pin a minimum coverage of 3 so a
+    # bulk-delete of the fixtures directory is caught at PR time.
+    assert coverage >= 3, (
+        f"Only {coverage} curated aliases have a fixture under "
+        f"{fixture_dir}; expected ≥3. Did the fixtures directory get "
+        f"deleted? Restore the *.json files referenced by "
+        f"_CURATED_RECOMMENDED_SAMPLING."
+    )
 
 
 def test_default_max_tokens_is_positive_or_none() -> None:

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -52,6 +52,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "suffix_bench_speedup",
         "supports_dflash",
         "dflash_draft_model",
+        "recommended_sampling",
     }
 )
 
@@ -570,6 +571,97 @@ def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:
     assert "Q4_0" not in profiles["kimi-48b"].hf_path, (
         "kimi-48b must not regress to the Q4_0 path which 404s."
     )
+
+
+# Curated ``recommended_sampling`` overrides — one entry per alias whose
+# upstream ``generation_config.json`` is an empty stub (e.g. Gemma 3 /
+# GLM-4.5-Air ship only eos/pad tokens) or partial (GLM-4.7 ships only
+# ``temperature``). Each entry is a gap-fill against the model card,
+# never a contradiction of upstream values.
+#
+# Pinned in a test so a future bulk edit to ``aliases.json`` can't
+# silently drop or mutate one of these without the author looking up
+# the model card again and confirming the value still applies.
+#
+# Phase 2 ships 10 entries; the other 48 aliases either inherit usable
+# values from ``generation_config.json`` (Qwen3 family, Qwen3-VL) or
+# haven't been audited yet (most of the missing-locally bucket).
+_CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
+    # Devstral 1.x — Mistral code-tuned model card example uses 0.15
+    # for interactive coding. Same pattern in Devstral 2 (no shipped
+    # gen_config either).
+    "devstral-24b": {"temperature": 0.15},
+    "devstral-v2-24b": {"temperature": 0.15},
+    # Gemma 3 / 4 family — Google's docs recommend (1.0, 0.95, 64).
+    # gemma-3n-E4B ships top_p/top_k but no temperature; the 27b and
+    # all 3-12b / 3-1b / 4-26b / 4-31b ship empty stubs.
+    "gemma3-1b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma3-12b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma3-27b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-3n-e4b": {"temperature": 1.0},  # top_p/top_k come from upstream
+    "gemma-4-26b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-31b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    # GLM family — THUDM model cards recommend (0.6, 0.95) for chat.
+    # GLM-4.5-Air ships an empty stub; GLM-4.7-Flash ships only
+    # ``temperature: 1.0`` so we only add the missing top_p.
+    "glm4.5-air": {"temperature": 0.6, "top_p": 0.95},
+    "glm4.7-9b": {"top_p": 0.95},
+}
+
+
+def test_curated_recommended_sampling_matches_pinned_values() -> None:
+    """Pin every curated ``recommended_sampling`` override against the
+    table above so a stray bulk edit to ``aliases.json`` can't silently
+    drop or mutate a value. If you intentionally change a value, update
+    this test too — that's the prompt to re-verify against the model
+    card you originally consulted."""
+    profiles = list_profiles()
+    for alias, expected in _CURATED_RECOMMENDED_SAMPLING.items():
+        assert alias in profiles, f"{alias}: missing from aliases.json"
+        actual_tuple = profiles[alias].recommended_sampling
+        assert actual_tuple is not None, (
+            f"{alias}: recommended_sampling was curated but is now None; "
+            f"either restore the entry or remove it from "
+            f"_CURATED_RECOMMENDED_SAMPLING in this test."
+        )
+        actual = dict(actual_tuple)
+        assert actual == expected, (
+            f"{alias}: recommended_sampling drifted.\n"
+            f"  expected: {expected}\n"
+            f"  actual:   {actual}\n"
+            f"If this is intentional, update _CURATED_RECOMMENDED_SAMPLING "
+            f"and re-verify against the model card."
+        )
+
+
+def test_curated_aliases_do_not_contradict_local_generation_config() -> None:
+    """For every curated alias whose ``generation_config.json`` is also
+    available in the local HF cache, the curated value must not
+    *contradict* what the model author shipped. (Filling a gap is
+    fine; flipping a non-empty value is a red flag.)
+
+    Skips when no local snapshot is present — the test is gated on
+    evidence, not network access.
+    """
+    from vllm_mlx.utils.generation_config import load_generation_config_sampling
+
+    profiles = list_profiles()
+    for alias in _CURATED_RECOMMENDED_SAMPLING:
+        profile = profiles[alias]
+        shipped = load_generation_config_sampling(profile.hf_path)
+        if not shipped:
+            continue  # no local snapshot or empty stub — nothing to contradict
+        curated = dict(profile.recommended_sampling or ())
+        for key, shipped_value in shipped.items():
+            if key not in curated:
+                continue  # curated is silent on this key — upstream wins
+            assert curated[key] == shipped_value, (
+                f"{alias}: curated recommended_sampling[{key!r}]="
+                f"{curated[key]} contradicts upstream "
+                f"generation_config.json[{key!r}]={shipped_value}. "
+                f"Either remove the curated key (upstream wins) or "
+                f"document why upstream is wrong."
+            )
 
 
 def test_default_max_tokens_is_positive_or_none() -> None:

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -222,6 +222,11 @@
     "suffix_decoding_tier": "avoid",
     "suffix_bench_speedup": {
       "json_array": 0.203
+    },
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
     }
   },
   "gemma-4-31b": {
@@ -235,6 +240,11 @@
       "chat": 1.468,
       "json_array": 0.67,
       "code_edit": 0.996
+    },
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
     }
   },
   "gemma3-12b": {
@@ -242,7 +252,12 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
   },
   "phi4-14b": {
     "hf_path": "mlx-community/phi-4-mini-instruct-4bit",
@@ -277,6 +292,9 @@
       "json_array": 0.736,
       "tool_loop": 0.697,
       "code_edit": 0.65
+    },
+    "recommended_sampling": {
+      "temperature": 0.15
     }
   },
   "glm4.7-9b": {
@@ -291,6 +309,9 @@
       "json_array": 1.337,
       "tool_loop": 0.859,
       "code_edit": 0.699
+    },
+    "recommended_sampling": {
+      "top_p": 0.95
     }
   },
   "glm4.5-air": {
@@ -305,6 +326,10 @@
       "json_array": 0.688,
       "tool_loop": 0.715,
       "code_edit": 0.787
+    },
+    "recommended_sampling": {
+      "temperature": 0.6,
+      "top_p": 0.95
     }
   },
   "gpt-oss-20b": {
@@ -447,6 +472,9 @@
       "chat": 0.992,
       "json_array": 1.015,
       "code_edit": 1.029
+    },
+    "recommended_sampling": {
+      "temperature": 0.15
     }
   },
   "qwen3-coder-30b": {
@@ -469,7 +497,10 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0
+    }
   },
   "gemma3-1b": {
     "hf_path": "mlx-community/gemma-3-1b-it-4bit",
@@ -482,6 +513,11 @@
       "chat": 0.91,
       "json_array": 1.106,
       "tool_loop": 1.106
+    },
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
     }
   },
   "gemma3-27b": {
@@ -489,7 +525,12 @@
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
   },
   "nemotron-30b": {
     "hf_path": "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -499,7 +499,9 @@
     "is_hybrid": false,
     "supports_spec_decode": true,
     "recommended_sampling": {
-      "temperature": 1.0
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
     }
   },
   "gemma3-1b": {


### PR DESCRIPTION
## Summary

Phase 2 of the sampling-defaults cascade landed in v0.6.47. This PR is pure **data curation** — adds `recommended_sampling` overrides to 10 aliases whose upstream `generation_config.json` is empty / partial.

| Family | Aliases | Curated values | Source |
|---|---|---|---|
| Devstral 1.x / 2.x | `devstral-24b`, `devstral-v2-24b` | `temperature=0.15` | Mistral model card example |
| Gemma 3 | `gemma3-1b`, `gemma3-12b`, `gemma3-27b` | `temperature=1.0, top_p=0.95, top_k=64` | Google Gemma docs |
| Gemma 3n | `gemma-3n-e4b` | `temperature=1.0, top_p=0.95, top_k=64` (full triple baked in) | Google Gemma docs |
| Gemma 4 | `gemma-4-26b`, `gemma-4-31b` | `temperature=1.0, top_p=0.95, top_k=64` | Extrapolated from Gemma 3 (no official Gemma 4 sampling doc yet) |
| GLM 4.5 | `glm4.5-air` | `temperature=0.6, top_p=0.95` | THUDM model card (0.6 is the thinking-mode default; alias defaults to thinking) |
| GLM 4.7 | `glm4.7-9b` | `top_p=0.95` (upstream ships `temperature=1.0`) | THUDM model card |

**Curation is gap-filling only**: no entry contradicts a non-empty upstream value. Pinned by `test_curated_aliases_do_not_contradict_fixture_generation_config` using checked-in fixtures under `tests/fixtures/generation_configs/`.

## User-visible behavior change

These aliases previously fell through to the framework hard-fallback (`temperature=0.7, top_p=0.9`) for any request that omitted the field. After this PR they get the model author's curated values. Concretely:

- All 5 Gemma 3 / Gemma 3n / 3 aliases + 2 Gemma 4 aliases: `0.7 / 0.9 / —` → `1.0 / 0.95 / 64`
- 2 Devstral aliases: `0.7` → `0.15` (temperature only)
- `glm4.5-air`: `0.7 / 0.9` → `0.6 / 0.95`
- `glm4.7-9b`: `— / 0.9` → `— / 0.95` (`temperature` still comes from upstream `generation_config.json`)

This is the correctness fix the cascade was built for — request defaults now match the model author's published recommendation rather than a framework-wide one-size-fits-all. Users with pinned benchmarks should expect TPS / quality shifts on these models.

## Why these 10

Local audit of `~/.cache/huggingface/hub` for every alias's `generation_config.json`:
- 6 ship full curated values → no action (Qwen3 family is well-covered upstream)
- 3 ship empty stubs (only eos / pad tokens) → curate full set
- 2 ship partial stubs → curate the missing fields only
- 5 Gemma-3 / Gemma-4 family siblings extended from the empty-stub pattern (all Gemma releases ship empty stubs)

The remaining 48 aliases either inherit usable values from a shipped `generation_config.json` (Qwen3 / Qwen3-VL) or haven't been audited yet (most of the missing-locally bucket — to be done as users pull each model).

## Tests

- `tests/test_aliases_contract.py::test_curated_recommended_sampling_matches_pinned_values` — pins each curated entry against a table at the top of the test
- `tests/test_aliases_contract.py::test_curated_aliases_do_not_contradict_fixture_generation_config` — fixture-based, runs on every CI runner regardless of HF cache state. 5 upstream snapshots committed; test enforces ≥3 fixtures so a bulk-delete fails loud.
- 3383 existing unit tests pass unchanged.

## Test plan

- [x] All 10 entries parse through `AliasProfile._coerce` correctly
- [x] End-to-end cascade check on `gemma3-27b` returns `1.0 / 0.95 / 64` for unset request params
- [x] Request body value wins over the curated overlay
- [x] Fixture-based contradiction test fires when artificially injecting `glm4.7-9b temperature=0.5` vs upstream `1.0`
- [x] `ruff check`, `ruff format --check` clean
- [x] Broader unit suite: 3383 pass, no new regressions
- [x] CI green (8/8 checks)
- [ ] `make check --model qwen3.5-4b` — skip per CLAUDE.md SOP §7: data-only PR, no inference-path code change. qwen3.5-4b doesn't have a curated entry anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)