### PR TITLE
feat(bench): DFlash sweep harness + 6 new 8-bit aliases

### DIFF
--- a/evals/results/dflash_gemma-4-31b-8bit.json
+++ b/evals/results/dflash_gemma-4-31b-8bit.json
@@ -1,0 +1,272 @@
+{
+  "model": "gemma-4-31b-8bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "non_code_floor": 1.0,
+  "base_tps": {
+    "fibonacci": 19.0,
+    "quicksort": 18.9,
+    "hashtable": 18.9,
+    "sortedlist": 18.9,
+    "chat": 19.0
+  },
+  "dflash_tps": {
+    "fibonacci": 54.6,
+    "quicksort": 32.7,
+    "hashtable": 41.6,
+    "sortedlist": 33.1,
+    "chat": 13.5
+  },
+  "speedup": {
+    "fibonacci": 2.87,
+    "quicksort": 1.725,
+    "hashtable": 2.202,
+    "sortedlist": 1.756,
+    "chat": 0.71
+  },
+  "code_median": 1.979,
+  "non_code_speedups": {
+    "chat": 0.71
+  },
+  "median_speedup": 1.756,
+  "skipped": {},
+  "decision": "DO NOT SHIP (non-code regression: chat 0.71x)",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 19.1,
+          "completion_tokens": 185,
+          "decode_time": 9.674,
+          "total_time": 10.189,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.0,
+          "completion_tokens": 185,
+          "decode_time": 9.722,
+          "total_time": 10.254,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.0,
+          "completion_tokens": 185,
+          "decode_time": 9.745,
+          "total_time": 10.275,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.555,
+          "total_time": 14.203,
+          "rejected_reason": null
+        },
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.514,
+          "total_time": 14.159,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.1,
+          "completion_tokens": 256,
+          "decode_time": 13.435,
+          "total_time": 14.072,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.537,
+          "total_time": 14.072,
+          "rejected_reason": null
+        },
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.538,
+          "total_time": 14.075,
+          "rejected_reason": null
+        },
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.545,
+          "total_time": 14.075,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 18.9,
+          "completion_tokens": 256,
+          "decode_time": 13.566,
+          "total_time": 14.22,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.0,
+          "completion_tokens": 256,
+          "decode_time": 13.509,
+          "total_time": 14.154,
+          "rejected_reason": null
+        },
+        {
+          "tps": 18.8,
+          "completion_tokens": 256,
+          "decode_time": 13.582,
+          "total_time": 14.218,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 19.0,
+          "completion_tokens": 122,
+          "decode_time": 6.411,
+          "total_time": 6.812,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.0,
+          "completion_tokens": 122,
+          "decode_time": 6.405,
+          "total_time": 6.799,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.0,
+          "completion_tokens": 122,
+          "decode_time": 6.407,
+          "total_time": 6.813,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 54.6,
+          "completion_tokens": 185,
+          "decode_time": 3.387,
+          "total_time": 3.878,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.5,
+          "completion_tokens": 185,
+          "decode_time": 3.392,
+          "total_time": 3.885,
+          "rejected_reason": null
+        },
+        {
+          "tps": 54.7,
+          "completion_tokens": 185,
+          "decode_time": 3.382,
+          "total_time": 3.874,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 32.7,
+          "completion_tokens": 256,
+          "decode_time": 7.828,
+          "total_time": 8.442,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.7,
+          "completion_tokens": 256,
+          "decode_time": 7.835,
+          "total_time": 8.449,
+          "rejected_reason": null
+        },
+        {
+          "tps": 32.7,
+          "completion_tokens": 256,
+          "decode_time": 7.84,
+          "total_time": 8.457,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 41.7,
+          "completion_tokens": 256,
+          "decode_time": 6.142,
+          "total_time": 6.637,
+          "rejected_reason": null
+        },
+        {
+          "tps": 41.6,
+          "completion_tokens": 256,
+          "decode_time": 6.148,
+          "total_time": 6.64,
+          "rejected_reason": null
+        },
+        {
+          "tps": 41.6,
+          "completion_tokens": 256,
+          "decode_time": 6.147,
+          "total_time": 6.641,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 33.1,
+          "completion_tokens": 256,
+          "decode_time": 7.725,
+          "total_time": 8.342,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.2,
+          "completion_tokens": 256,
+          "decode_time": 7.718,
+          "total_time": 8.334,
+          "rejected_reason": null
+        },
+        {
+          "tps": 33.1,
+          "completion_tokens": 256,
+          "decode_time": 7.726,
+          "total_time": 8.341,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 13.5,
+          "completion_tokens": 122,
+          "decode_time": 9.024,
+          "total_time": 9.51,
+          "rejected_reason": null
+        },
+        {
+          "tps": 13.5,
+          "completion_tokens": 122,
+          "decode_time": 9.028,
+          "total_time": 9.515,
+          "rejected_reason": null
+        },
+        {
+          "tps": 13.5,
+          "completion_tokens": 122,
+          "decode_time": 9.021,
+          "total_time": 9.508,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/dflash_qwen3.5-27b-8bit.json
+++ b/evals/results/dflash_qwen3.5-27b-8bit.json
@@ -1,0 +1,272 @@
+{
+  "model": "qwen3.5-27b-8bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "non_code_floor": 1.0,
+  "base_tps": {
+    "fibonacci": 22.5,
+    "quicksort": 22.5,
+    "hashtable": 22.5,
+    "sortedlist": 22.7,
+    "chat": 22.8
+  },
+  "dflash_tps": {
+    "fibonacci": 48.2,
+    "quicksort": 37.0,
+    "hashtable": 31.9,
+    "sortedlist": 37.8,
+    "chat": 17.3
+  },
+  "speedup": {
+    "fibonacci": 2.142,
+    "quicksort": 1.645,
+    "hashtable": 1.42,
+    "sortedlist": 1.67,
+    "chat": 0.759
+  },
+  "code_median": 1.657,
+  "non_code_speedups": {
+    "chat": 0.759
+  },
+  "median_speedup": 1.645,
+  "skipped": {},
+  "decision": "DO NOT SHIP (non-code regression: chat 0.76x)",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 22.6,
+          "completion_tokens": 256,
+          "decode_time": 11.351,
+          "total_time": 11.848,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.369,
+          "total_time": 11.852,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.382,
+          "total_time": 11.871,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.383,
+          "total_time": 11.965,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.6,
+          "completion_tokens": 256,
+          "decode_time": 11.349,
+          "total_time": 11.934,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.383,
+          "total_time": 11.968,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.39,
+          "total_time": 11.878,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.389,
+          "total_time": 11.875,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.5,
+          "completion_tokens": 256,
+          "decode_time": 11.402,
+          "total_time": 11.892,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 22.6,
+          "completion_tokens": 256,
+          "decode_time": 11.323,
+          "total_time": 11.909,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.7,
+          "completion_tokens": 256,
+          "decode_time": 11.299,
+          "total_time": 11.878,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.7,
+          "completion_tokens": 256,
+          "decode_time": 11.274,
+          "total_time": 11.851,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 22.8,
+          "completion_tokens": 184,
+          "decode_time": 8.088,
+          "total_time": 8.454,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.7,
+          "completion_tokens": 184,
+          "decode_time": 8.101,
+          "total_time": 8.472,
+          "rejected_reason": null
+        },
+        {
+          "tps": 22.8,
+          "completion_tokens": 184,
+          "decode_time": 8.085,
+          "total_time": 8.456,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 48.3,
+          "completion_tokens": 256,
+          "decode_time": 5.302,
+          "total_time": 5.738,
+          "rejected_reason": null
+        },
+        {
+          "tps": 48.2,
+          "completion_tokens": 256,
+          "decode_time": 5.314,
+          "total_time": 5.75,
+          "rejected_reason": null
+        },
+        {
+          "tps": 48.2,
+          "completion_tokens": 256,
+          "decode_time": 5.307,
+          "total_time": 5.743,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 37.0,
+          "completion_tokens": 256,
+          "decode_time": 6.92,
+          "total_time": 7.457,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.0,
+          "completion_tokens": 256,
+          "decode_time": 6.923,
+          "total_time": 7.459,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.0,
+          "completion_tokens": 256,
+          "decode_time": 6.921,
+          "total_time": 7.458,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 31.8,
+          "completion_tokens": 256,
+          "decode_time": 8.041,
+          "total_time": 8.477,
+          "rejected_reason": null
+        },
+        {
+          "tps": 31.9,
+          "completion_tokens": 256,
+          "decode_time": 8.022,
+          "total_time": 8.458,
+          "rejected_reason": null
+        },
+        {
+          "tps": 31.9,
+          "completion_tokens": 256,
+          "decode_time": 8.022,
+          "total_time": 8.458,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 37.8,
+          "completion_tokens": 256,
+          "decode_time": 6.766,
+          "total_time": 7.304,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.8,
+          "completion_tokens": 256,
+          "decode_time": 6.767,
+          "total_time": 7.305,
+          "rejected_reason": null
+        },
+        {
+          "tps": 37.8,
+          "completion_tokens": 256,
+          "decode_time": 6.769,
+          "total_time": 7.306,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 17.3,
+          "completion_tokens": 174,
+          "decode_time": 10.079,
+          "total_time": 10.388,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.3,
+          "completion_tokens": 174,
+          "decode_time": 10.079,
+          "total_time": 10.388,
+          "rejected_reason": null
+        },
+        {
+          "tps": 17.3,
+          "completion_tokens": 174,
+          "decode_time": 10.077,
+          "total_time": 10.386,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/dflash_qwen3.5-4b-8bit.json
+++ b/evals/results/dflash_qwen3.5-4b-8bit.json
@@ -1,0 +1,272 @@
+{
+  "model": "qwen3.5-4b-8bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "non_code_floor": 1.0,
+  "base_tps": {
+    "fibonacci": 112.0,
+    "quicksort": 111.2,
+    "hashtable": 111.3,
+    "sortedlist": 111.1,
+    "chat": 111.1
+  },
+  "dflash_tps": {
+    "fibonacci": 184.9,
+    "quicksort": 121.8,
+    "hashtable": 137.4,
+    "sortedlist": 153.5,
+    "chat": 62.6
+  },
+  "speedup": {
+    "fibonacci": 1.651,
+    "quicksort": 1.095,
+    "hashtable": 1.234,
+    "sortedlist": 1.382,
+    "chat": 0.563
+  },
+  "code_median": 1.308,
+  "non_code_speedups": {
+    "chat": 0.563
+  },
+  "median_speedup": 1.234,
+  "skipped": {},
+  "decision": "DO NOT SHIP (non-code regression: chat 0.56x)",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 112.0,
+          "completion_tokens": 256,
+          "decode_time": 2.286,
+          "total_time": 2.476,
+          "rejected_reason": null
+        },
+        {
+          "tps": 112.7,
+          "completion_tokens": 256,
+          "decode_time": 2.272,
+          "total_time": 2.454,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.7,
+          "completion_tokens": 256,
+          "decode_time": 2.291,
+          "total_time": 2.465,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 111.5,
+          "completion_tokens": 256,
+          "decode_time": 2.296,
+          "total_time": 2.496,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.2,
+          "completion_tokens": 256,
+          "decode_time": 2.302,
+          "total_time": 2.517,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.2,
+          "completion_tokens": 256,
+          "decode_time": 2.302,
+          "total_time": 2.514,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 111.3,
+          "completion_tokens": 256,
+          "decode_time": 2.299,
+          "total_time": 2.487,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.4,
+          "completion_tokens": 256,
+          "decode_time": 2.299,
+          "total_time": 2.485,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.3,
+          "completion_tokens": 256,
+          "decode_time": 2.3,
+          "total_time": 2.487,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 111.1,
+          "completion_tokens": 256,
+          "decode_time": 2.305,
+          "total_time": 2.51,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.1,
+          "completion_tokens": 256,
+          "decode_time": 2.305,
+          "total_time": 2.512,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.1,
+          "completion_tokens": 256,
+          "decode_time": 2.305,
+          "total_time": 2.515,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 111.1,
+          "completion_tokens": 236,
+          "decode_time": 2.124,
+          "total_time": 2.308,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.1,
+          "completion_tokens": 236,
+          "decode_time": 2.124,
+          "total_time": 2.302,
+          "rejected_reason": null
+        },
+        {
+          "tps": 111.3,
+          "completion_tokens": 236,
+          "decode_time": 2.12,
+          "total_time": 2.301,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 185.5,
+          "completion_tokens": 256,
+          "decode_time": 1.38,
+          "total_time": 1.473,
+          "rejected_reason": null
+        },
+        {
+          "tps": 184.9,
+          "completion_tokens": 256,
+          "decode_time": 1.385,
+          "total_time": 1.477,
+          "rejected_reason": null
+        },
+        {
+          "tps": 184.9,
+          "completion_tokens": 256,
+          "decode_time": 1.385,
+          "total_time": 1.478,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 121.5,
+          "completion_tokens": 256,
+          "decode_time": 2.107,
+          "total_time": 2.217,
+          "rejected_reason": null
+        },
+        {
+          "tps": 121.8,
+          "completion_tokens": 256,
+          "decode_time": 2.103,
+          "total_time": 2.213,
+          "rejected_reason": null
+        },
+        {
+          "tps": 121.8,
+          "completion_tokens": 256,
+          "decode_time": 2.103,
+          "total_time": 2.213,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 137.2,
+          "completion_tokens": 256,
+          "decode_time": 1.866,
+          "total_time": 1.959,
+          "rejected_reason": null
+        },
+        {
+          "tps": 137.4,
+          "completion_tokens": 256,
+          "decode_time": 1.863,
+          "total_time": 1.955,
+          "rejected_reason": null
+        },
+        {
+          "tps": 137.4,
+          "completion_tokens": 256,
+          "decode_time": 1.863,
+          "total_time": 1.955,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 153.5,
+          "completion_tokens": 256,
+          "decode_time": 1.668,
+          "total_time": 1.778,
+          "rejected_reason": null
+        },
+        {
+          "tps": 153.6,
+          "completion_tokens": 256,
+          "decode_time": 1.667,
+          "total_time": 1.777,
+          "rejected_reason": null
+        },
+        {
+          "tps": 153.5,
+          "completion_tokens": 256,
+          "decode_time": 1.668,
+          "total_time": 1.778,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 62.6,
+          "completion_tokens": 234,
+          "decode_time": 3.738,
+          "total_time": 3.809,
+          "rejected_reason": null
+        },
+        {
+          "tps": 62.6,
+          "completion_tokens": 234,
+          "decode_time": 3.739,
+          "total_time": 3.81,
+          "rejected_reason": null
+        },
+        {
+          "tps": 62.6,
+          "completion_tokens": 234,
+          "decode_time": 3.738,
+          "total_time": 3.809,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/dflash_qwen3.5-9b-8bit.json
+++ b/evals/results/dflash_qwen3.5-9b-8bit.json
@@ -1,0 +1,218 @@
+{
+  "model": "qwen3.5-9b-8bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "base_tps": {
+    "fibonacci": 69.0,
+    "quicksort": 69.5,
+    "hashtable": 68.9,
+    "sortedlist": 68.8
+  },
+  "dflash_tps": {
+    "fibonacci": 139.8,
+    "quicksort": 70.9,
+    "hashtable": 73.6,
+    "sortedlist": 83.6
+  },
+  "speedup": {
+    "fibonacci": 2.026,
+    "quicksort": 1.02,
+    "hashtable": 1.068,
+    "sortedlist": 1.216
+  },
+  "median_speedup": 1.142,
+  "skipped": {},
+  "decision": "DO NOT SHIP",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 69.0,
+          "completion_tokens": 256,
+          "decode_time": 3.711,
+          "total_time": 3.956,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.0,
+          "completion_tokens": 256,
+          "decode_time": 3.712,
+          "total_time": 3.949,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.1,
+          "completion_tokens": 256,
+          "decode_time": 3.706,
+          "total_time": 3.941,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 69.5,
+          "completion_tokens": 256,
+          "decode_time": 3.684,
+          "total_time": 3.935,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.4,
+          "completion_tokens": 256,
+          "decode_time": 3.688,
+          "total_time": 3.939,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.5,
+          "completion_tokens": 256,
+          "decode_time": 3.681,
+          "total_time": 3.935,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 68.8,
+          "completion_tokens": 256,
+          "decode_time": 3.719,
+          "total_time": 3.95,
+          "rejected_reason": null
+        },
+        {
+          "tps": 68.9,
+          "completion_tokens": 256,
+          "decode_time": 3.718,
+          "total_time": 3.954,
+          "rejected_reason": null
+        },
+        {
+          "tps": 68.9,
+          "completion_tokens": 256,
+          "decode_time": 3.715,
+          "total_time": 3.954,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 68.8,
+          "completion_tokens": 256,
+          "decode_time": 3.723,
+          "total_time": 3.985,
+          "rejected_reason": null
+        },
+        {
+          "tps": 68.8,
+          "completion_tokens": 256,
+          "decode_time": 3.723,
+          "total_time": 3.986,
+          "rejected_reason": null
+        },
+        {
+          "tps": 68.7,
+          "completion_tokens": 256,
+          "decode_time": 3.725,
+          "total_time": 3.988,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 139.8,
+          "completion_tokens": 256,
+          "decode_time": 1.832,
+          "total_time": 1.982,
+          "rejected_reason": null
+        },
+        {
+          "tps": 139.9,
+          "completion_tokens": 256,
+          "decode_time": 1.83,
+          "total_time": 1.979,
+          "rejected_reason": null
+        },
+        {
+          "tps": 139.8,
+          "completion_tokens": 256,
+          "decode_time": 1.832,
+          "total_time": 1.981,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 70.9,
+          "completion_tokens": 256,
+          "decode_time": 3.611,
+          "total_time": 3.791,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.9,
+          "completion_tokens": 256,
+          "decode_time": 3.613,
+          "total_time": 3.793,
+          "rejected_reason": null
+        },
+        {
+          "tps": 70.9,
+          "completion_tokens": 256,
+          "decode_time": 3.612,
+          "total_time": 3.792,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 73.6,
+          "completion_tokens": 256,
+          "decode_time": 3.48,
+          "total_time": 3.629,
+          "rejected_reason": null
+        },
+        {
+          "tps": 73.4,
+          "completion_tokens": 256,
+          "decode_time": 3.487,
+          "total_time": 3.637,
+          "rejected_reason": null
+        },
+        {
+          "tps": 73.6,
+          "completion_tokens": 256,
+          "decode_time": 3.478,
+          "total_time": 3.628,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 83.6,
+          "completion_tokens": 256,
+          "decode_time": 3.061,
+          "total_time": 3.241,
+          "rejected_reason": null
+        },
+        {
+          "tps": 83.5,
+          "completion_tokens": 256,
+          "decode_time": 3.065,
+          "total_time": 3.244,
+          "rejected_reason": null
+        },
+        {
+          "tps": 83.6,
+          "completion_tokens": 256,
+          "decode_time": 3.061,
+          "total_time": 3.24,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/dflash_qwen3.6-27b-8bit.json
+++ b/evals/results/dflash_qwen3.6-27b-8bit.json
@@ -1,0 +1,272 @@
+{
+  "model": "qwen3.6-27b-8bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "non_code_floor": 1.0,
+  "base_tps": {
+    "fibonacci": 19.6,
+    "quicksort": 19.8,
+    "hashtable": 19.8,
+    "sortedlist": 19.6,
+    "chat": 19.6
+  },
+  "dflash_tps": {
+    "fibonacci": 56.5,
+    "quicksort": 30.1,
+    "hashtable": 40.9,
+    "sortedlist": 35.2,
+    "chat": 15.3
+  },
+  "speedup": {
+    "fibonacci": 2.876,
+    "quicksort": 1.519,
+    "hashtable": 2.065,
+    "sortedlist": 1.799,
+    "chat": 0.782
+  },
+  "code_median": 1.932,
+  "non_code_speedups": {
+    "chat": 0.782
+  },
+  "median_speedup": 1.799,
+  "skipped": {},
+  "decision": "DO NOT SHIP (non-code regression: chat 0.78x)",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 19.6,
+          "completion_tokens": 234,
+          "decode_time": 11.919,
+          "total_time": 12.496,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 234,
+          "decode_time": 11.914,
+          "total_time": 12.49,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 234,
+          "decode_time": 11.913,
+          "total_time": 12.476,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.921,
+          "total_time": 13.577,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.919,
+          "total_time": 13.565,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.918,
+          "total_time": 13.559,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.93,
+          "total_time": 13.485,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.938,
+          "total_time": 13.489,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.8,
+          "completion_tokens": 256,
+          "decode_time": 12.922,
+          "total_time": 13.478,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 19.6,
+          "completion_tokens": 256,
+          "decode_time": 13.055,
+          "total_time": 13.694,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 256,
+          "decode_time": 13.078,
+          "total_time": 13.744,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 256,
+          "decode_time": 13.074,
+          "total_time": 13.727,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 19.6,
+          "completion_tokens": 183,
+          "decode_time": 9.326,
+          "total_time": 9.778,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.6,
+          "completion_tokens": 183,
+          "decode_time": 9.331,
+          "total_time": 9.777,
+          "rejected_reason": null
+        },
+        {
+          "tps": 19.7,
+          "completion_tokens": 183,
+          "decode_time": 9.297,
+          "total_time": 9.744,
+          "rejected_reason": null
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 56.5,
+          "completion_tokens": 256,
+          "decode_time": 4.532,
+          "total_time": 4.996,
+          "rejected_reason": null
+        },
+        {
+          "tps": 56.4,
+          "completion_tokens": 256,
+          "decode_time": 4.536,
+          "total_time": 5.002,
+          "rejected_reason": null
+        },
+        {
+          "tps": 56.5,
+          "completion_tokens": 256,
+          "decode_time": 4.53,
+          "total_time": 4.999,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 30.1,
+          "completion_tokens": 256,
+          "decode_time": 8.505,
+          "total_time": 9.073,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.1,
+          "completion_tokens": 256,
+          "decode_time": 8.502,
+          "total_time": 9.069,
+          "rejected_reason": null
+        },
+        {
+          "tps": 30.1,
+          "completion_tokens": 256,
+          "decode_time": 8.502,
+          "total_time": 9.07,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 40.9,
+          "completion_tokens": 256,
+          "decode_time": 6.259,
+          "total_time": 6.71,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.9,
+          "completion_tokens": 256,
+          "decode_time": 6.26,
+          "total_time": 6.714,
+          "rejected_reason": null
+        },
+        {
+          "tps": 40.9,
+          "completion_tokens": 256,
+          "decode_time": 6.261,
+          "total_time": 6.713,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 35.3,
+          "completion_tokens": 256,
+          "decode_time": 7.252,
+          "total_time": 7.822,
+          "rejected_reason": null
+        },
+        {
+          "tps": 35.2,
+          "completion_tokens": 256,
+          "decode_time": 7.268,
+          "total_time": 7.841,
+          "rejected_reason": null
+        },
+        {
+          "tps": 35.2,
+          "completion_tokens": 256,
+          "decode_time": 7.271,
+          "total_time": 7.841,
+          "rejected_reason": null
+        }
+      ],
+      "chat": [
+        {
+          "tps": 15.3,
+          "completion_tokens": 184,
+          "decode_time": 11.995,
+          "total_time": 12.346,
+          "rejected_reason": null
+        },
+        {
+          "tps": 15.3,
+          "completion_tokens": 184,
+          "decode_time": 11.998,
+          "total_time": 12.348,
+          "rejected_reason": null
+        },
+        {
+          "tps": 15.3,
+          "completion_tokens": 184,
+          "decode_time": 11.993,
+          "total_time": 12.345,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/evals/results/dflash_qwen3.6-35b-8bit-poc.json
+++ b/evals/results/dflash_qwen3.6-35b-8bit-poc.json
@@ -1,0 +1,219 @@
+{
+  "model": "qwen3.6-35b-8bit-poc",
+  "max_tokens": 256,
+  "runs": 3,
+  "gate": 1.3,
+  "base_tps": {
+    "fibonacci": 72.9,
+    "quicksort": 72.9,
+    "hashtable": 72.4,
+    "sortedlist": null
+  },
+  "dflash_tps": {
+    "fibonacci": 60.3,
+    "quicksort": 69.2,
+    "hashtable": 64.7,
+    "sortedlist": 64.7
+  },
+  "speedup": {
+    "fibonacci": 0.827,
+    "quicksort": 0.95,
+    "hashtable": 0.894
+  },
+  "median_speedup": 0.894,
+  "skipped": {
+    "sortedlist": "baseline all runs rejected"
+  },
+  "decision": "DO NOT SHIP",
+  "bypass_moe_gate": false,
+  "raw_runs": {
+    "base": {
+      "fibonacci": [
+        {
+          "tps": 72.9,
+          "completion_tokens": 2304,
+          "decode_time": 31.591,
+          "total_time": 31.591,
+          "rejected_reason": null
+        },
+        {
+          "tps": 73.4,
+          "completion_tokens": 2304,
+          "decode_time": 31.383,
+          "total_time": 31.383,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.7,
+          "completion_tokens": 2304,
+          "decode_time": 31.709,
+          "total_time": 31.709,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 74.0,
+          "completion_tokens": 2304,
+          "decode_time": 31.127,
+          "total_time": 31.127,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.9,
+          "completion_tokens": 2304,
+          "decode_time": 31.623,
+          "total_time": 31.623,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.7,
+          "completion_tokens": 2304,
+          "decode_time": 31.68,
+          "total_time": 31.68,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 74.5,
+          "completion_tokens": 2304,
+          "decode_time": 30.947,
+          "total_time": 30.947,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.4,
+          "completion_tokens": 2304,
+          "decode_time": 31.835,
+          "total_time": 31.835,
+          "rejected_reason": null
+        },
+        {
+          "tps": 72.4,
+          "completion_tokens": 2304,
+          "decode_time": 31.802,
+          "total_time": 31.802,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 0.202,
+          "total_time": 31.189,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 0.197,
+          "total_time": 32.026,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 2304,
+          "decode_time": 0.188,
+          "total_time": 31.816,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "dflash": {
+      "fibonacci": [
+        {
+          "tps": 60.4,
+          "completion_tokens": 256,
+          "decode_time": 4.239,
+          "total_time": 4.363,
+          "rejected_reason": null
+        },
+        {
+          "tps": 60.3,
+          "completion_tokens": 256,
+          "decode_time": 4.243,
+          "total_time": 4.367,
+          "rejected_reason": null
+        },
+        {
+          "tps": 60.3,
+          "completion_tokens": 256,
+          "decode_time": 4.244,
+          "total_time": 4.367,
+          "rejected_reason": null
+        }
+      ],
+      "quicksort": [
+        {
+          "tps": 69.2,
+          "completion_tokens": 256,
+          "decode_time": 3.698,
+          "total_time": 3.828,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.2,
+          "completion_tokens": 256,
+          "decode_time": 3.697,
+          "total_time": 3.826,
+          "rejected_reason": null
+        },
+        {
+          "tps": 69.2,
+          "completion_tokens": 256,
+          "decode_time": 3.697,
+          "total_time": 3.826,
+          "rejected_reason": null
+        }
+      ],
+      "hashtable": [
+        {
+          "tps": 64.8,
+          "completion_tokens": 256,
+          "decode_time": 3.95,
+          "total_time": 4.077,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.7,
+          "completion_tokens": 256,
+          "decode_time": 3.954,
+          "total_time": 4.077,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.7,
+          "completion_tokens": 256,
+          "decode_time": 3.954,
+          "total_time": 4.078,
+          "rejected_reason": null
+        }
+      ],
+      "sortedlist": [
+        {
+          "tps": 64.7,
+          "completion_tokens": 256,
+          "decode_time": 3.955,
+          "total_time": 4.095,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.8,
+          "completion_tokens": 256,
+          "decode_time": 3.953,
+          "total_time": 4.093,
+          "rejected_reason": null
+        },
+        {
+          "tps": 64.7,
+          "completion_tokens": 256,
+          "decode_time": 3.959,
+          "total_time": 4.099,
+          "rejected_reason": null
+        }
+      ]
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.48"
+version = "0.6.49"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -161,6 +161,10 @@ class ServerHandle:
     proc: subprocess.Popen
     base_url: str
     model: str
+    # File the child's stdout/stderr is piped into. Held for the
+    # lifetime of the server so the OS keeps the descriptor open for
+    # writes from the child; closed in stop() once the process exits.
+    logf: object = None
 
     def stop(self) -> None:
         try:
@@ -169,6 +173,12 @@ class ServerHandle:
         except subprocess.TimeoutExpired:
             self.proc.kill()
             self.proc.wait()
+        finally:
+            if self.logf is not None:
+                try:
+                    self.logf.close()
+                except Exception:
+                    pass
 
 
 def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
@@ -226,7 +236,9 @@ def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
                 r = httpx.get(f"{base_url}/models", timeout=2.0)
                 if r.status_code == 200:
                     logger.info("  server up at %s", base_url)
-                    return ServerHandle(proc=proc, base_url=base_url, model=model)
+                    return ServerHandle(
+                        proc=proc, base_url=base_url, model=model, logf=logf
+                    )
             except Exception:
                 pass
             time.sleep(2)

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -196,39 +196,46 @@ def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
 
     logger.info("  starting server: port=%d dflash=%s", port, dflash)
     logf = open(log_path, "w")
-    proc = subprocess.Popen(
-        cmd,
-        stdout=logf,
-        stderr=subprocess.STDOUT,
-        env={**os.environ, "PYTHONUNBUFFERED": "1"},
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+            env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        )
+    except Exception:
+        logf.close()
+        raise
 
     base_url = f"http://127.0.0.1:{port}/v1"
     # 15 min: cold-cache model load + Metal kernel compile + drafter load
     deadline = time.time() + 900
-    while time.time() < deadline:
-        if proc.poll() is not None:
-            logf.close()
-            logger.error("  server exited; tail of %s:", log_path)
+    try:
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                logger.error("  server exited; tail of %s:", log_path)
+                try:
+                    with open(log_path) as f:
+                        tail_lines = f.readlines()[-30:]
+                    for line in tail_lines:
+                        logger.error("    %s", line.rstrip())
+                except OSError as e:
+                    logger.error("    (could not read log: %s)", e)
+                raise RuntimeError("server died during startup")
             try:
-                with open(log_path) as f:
-                    tail_lines = f.readlines()[-30:]
-                for line in tail_lines:
-                    logger.error("    %s", line.rstrip())
-            except OSError as e:
-                logger.error("    (could not read log: %s)", e)
-            raise RuntimeError("server died during startup")
-        try:
-            r = httpx.get(f"{base_url}/models", timeout=2.0)
-            if r.status_code == 200:
-                logger.info("  server up at %s", base_url)
-                return ServerHandle(proc=proc, base_url=base_url, model=model)
-        except Exception:
-            pass
-        time.sleep(2)
+                r = httpx.get(f"{base_url}/models", timeout=2.0)
+                if r.status_code == 200:
+                    logger.info("  server up at %s", base_url)
+                    return ServerHandle(proc=proc, base_url=base_url, model=model)
+            except Exception:
+                pass
+            time.sleep(2)
 
-    proc.kill()
-    raise RuntimeError(f"server did not become ready within deadline (port={port})")
+        proc.kill()
+        raise RuntimeError(f"server did not become ready within deadline (port={port})")
+    except BaseException:
+        logf.close()
+        raise
 
 
 # ---- Workload execution ---------------------------------------------------
@@ -282,6 +289,10 @@ def run_workload(
         json=payload,
         timeout=300.0,
     ) as r:
+        # Surface 4xx/5xx as a proper error rather than treating the
+        # error body as a stream of decoded events (would silently
+        # produce a 0-token run otherwise).
+        r.raise_for_status()
         for line in r.iter_lines():
             if not line or not line.startswith("data: "):
                 continue
@@ -474,14 +485,21 @@ def main(argv: list[str] | None = None) -> int:
 
     median_speedup = median(speedup.values()) if speedup else None
 
+    # Boolean ship/no-ship is the load-bearing signal; the human-readable
+    # ``decision`` string is just for the scorecard. Keeping them separate
+    # avoids string-shape coupling in callers / exit codes.
     if code_median is None:
+        ship = False
         decision = "DO NOT SHIP (no valid code workloads)"
     elif code_median < args.gate:
+        ship = False
         decision = "DO NOT SHIP"
     elif non_code_regress:
+        ship = False
         regressed = ", ".join(f"{k} {v:.2f}x" for k, v in non_code_regress.items())
         decision = f"DO NOT SHIP (non-code regression: {regressed})"
     else:
+        ship = True
         decision = "SHIP (supports_dflash=true)"
 
     def _serialize_runs(raw: dict[str, list[WorkloadRun]]) -> dict[str, list[dict]]:
@@ -554,7 +572,7 @@ def main(argv: list[str] | None = None) -> int:
     logger.info("  decision: %s", decision)
     logger.info("  written: %s", output)
 
-    return 0 if decision.startswith("SHIP") else 1
+    return 0 if ship else 1
 
 
 if __name__ == "__main__":

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash speculative-decoding speedup bench (Model Onboarding SOP §6).
+
+Measures the per-workload TPS speedup of ``--enable-dflash`` vs the
+baseline (autoregressive) decode on a fixed prompt set. Mirrors the
+sequential two-server pattern of ``bench_suffix_decoding_integrated.py``
+and reuses the same reliability gates (decode-time floor, TPS ceiling,
+raw-runs persistence).
+
+Workloads are code-generation-heavy (Fibonacci, Quicksort, HashTable,
+SortedList) — DFlash drafters were trained on code distributions and
+this is the regime where users see the headline speedup. Mixed
+math/text workloads accept less, but those are not what the ≥1.3× SOP
+gate is designed to validate.
+
+Decision rule (SOP §6 / Model Onboarding SOP):
+    median(speedup over workloads) ≥ 1.30  →  ship supports_dflash=true
+    otherwise                               →  keep supports_dflash=false
+
+Usage:
+    python3.12 scripts/bench_dflash.py \\
+        --model qwen3.5-4b-8bit --runs 3 --max-tokens 256
+
+The script does NOT auto-edit aliases.json. It prints the patch the
+contributor can paste, and persists the raw bench data to
+``evals/results/dflash_<model>.json`` for the PR record.
+
+Special: ``RAPID_MLX_DFLASH_BYPASS_MOE_GATE=1`` env var is honored so a
+PoC can re-verify a previously-rejected MoE alias without first having
+to land a code change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+logger = logging.getLogger("bench_dflash")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+# ---- Workloads ------------------------------------------------------------
+#
+# Code-gen prompts pulled from the DFlash family of papers / z-lab's
+# canonical demo set. Each prompt is sized so a ~256-token budget hits
+# the decode-time floor on M-series hardware. Adding a fifth workload
+# is fine; removing one shifts the median speedup and should be
+# documented in the PR.
+
+FIBONACCI_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Write a Python function ``fibonacci(n)`` that returns the "
+                "n-th Fibonacci number using memoized recursion. Include "
+                "a docstring describing the function, time complexity, and "
+                "one usage example in a comment. Do not include tests."
+            ),
+        }
+    ],
+}
+
+QUICKSORT_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Implement an in-place ``quicksort(arr, lo, hi)`` in Python "
+                "using the Lomuto partition scheme. Include a docstring "
+                "describing the algorithm, average-case and worst-case time "
+                "complexity, and one usage example in a comment. Do not "
+                "include tests."
+            ),
+        }
+    ],
+}
+
+HASHTABLE_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Implement a Python ``HashTable`` class with ``put``, "
+                "``get`` and ``remove`` methods using separate-chaining for "
+                "collision resolution. Include a docstring on the class "
+                "and one usage example in a comment. Do not include tests."
+            ),
+        }
+    ],
+}
+
+SORTEDLIST_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Implement a Python ``SortedList`` class with ``add(x)``, "
+                "``remove(x)``, and ``pop_min()`` methods using a sorted "
+                "internal array and ``bisect``. Include a docstring on the "
+                "class and one usage example in a comment. Do not include "
+                "tests."
+            ),
+        }
+    ],
+}
+
+# Chat workload — required since prior bench rounds discovered that
+# DFlash speedup on Qwen3.5/3.6 family is heavily code-gen-biased; the
+# same drafter that hits 1.3-1.7× on code can regress to <1.0× on
+# open-ended chat (lower token-tree overlap). Adding chat to the SHIP
+# gate keeps us honest on the assistant-style users see in practice.
+CHAT_WORKLOAD = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "Write a short, friendly explanation of why the sky "
+                "appears blue. Two paragraphs, no bullet points."
+            ),
+        }
+    ],
+}
+
+WORKLOADS: dict[str, dict] = {
+    "fibonacci": FIBONACCI_WORKLOAD,
+    "quicksort": QUICKSORT_WORKLOAD,
+    "hashtable": HASHTABLE_WORKLOAD,
+    "sortedlist": SORTEDLIST_WORKLOAD,
+    "chat": CHAT_WORKLOAD,
+}
+
+# Workloads counted as "code" for the gate; the rest go in the "non-code"
+# bucket and must individually not regress (chat ≥1.00x). Keeps the
+# gate honest: code median up, chat at least flat.
+_CODE_WORKLOADS: frozenset[str] = frozenset(
+    {"fibonacci", "quicksort", "hashtable", "sortedlist"}
+)
+
+
+# ---- Server lifecycle -----------------------------------------------------
+
+
+@dataclass
+class ServerHandle:
+    proc: subprocess.Popen
+    base_url: str
+    model: str
+
+    def stop(self) -> None:
+        try:
+            self.proc.send_signal(signal.SIGINT)
+            self.proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+
+
+def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
+    """Spin up ``rapid-mlx serve`` and wait for /v1/models to answer.
+
+    Sets ``--disable-prefix-cache`` to prevent disk-persisted cache
+    entries from a prior session pinning TPS to bogus 1000+ tok/s.
+    DFlash speedup measurement requires real decode work on every run.
+    """
+    log_path = f"/tmp/bench_dflash_{port}.log"
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        model,
+        "--port",
+        str(port),
+        "--log-level",
+        "WARNING",
+        "--disable-prefix-cache",
+    ]
+    if dflash:
+        cmd.append("--enable-dflash")
+
+    logger.info("  starting server: port=%d dflash=%s", port, dflash)
+    logf = open(log_path, "w")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=logf,
+        stderr=subprocess.STDOUT,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    base_url = f"http://127.0.0.1:{port}/v1"
+    # 15 min: cold-cache model load + Metal kernel compile + drafter load
+    deadline = time.time() + 900
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            logf.close()
+            logger.error("  server exited; tail of %s:", log_path)
+            try:
+                with open(log_path) as f:
+                    tail_lines = f.readlines()[-30:]
+                for line in tail_lines:
+                    logger.error("    %s", line.rstrip())
+            except OSError as e:
+                logger.error("    (could not read log: %s)", e)
+            raise RuntimeError("server died during startup")
+        try:
+            r = httpx.get(f"{base_url}/models", timeout=2.0)
+            if r.status_code == 200:
+                logger.info("  server up at %s", base_url)
+                return ServerHandle(proc=proc, base_url=base_url, model=model)
+        except Exception:
+            pass
+        time.sleep(2)
+
+    proc.kill()
+    raise RuntimeError(f"server did not become ready within deadline (port={port})")
+
+
+# ---- Workload execution ---------------------------------------------------
+
+# Same reliability gates as bench_suffix_decoding_integrated.py.
+MIN_DECODE_TIME = 0.5
+TPS_CEILING = 500.0
+
+
+@dataclass
+class WorkloadRun:
+    tps: float | None
+    completion_tokens: int
+    decode_time: float
+    total_time: float
+    rejected_reason: str | None = None
+
+
+def run_workload(
+    handle: ServerHandle,
+    workload_body: dict,
+    max_tokens: int,
+) -> WorkloadRun:
+    payload = {
+        "model": handle.model,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        **workload_body,
+        # Greedy: DFlash drafter targets are exact-match; sampling temp
+        # would silently lower acceptance and the bench would understate
+        # speedup. Same contract as the suffix-decoding bench.
+        "temperature": 0.0,
+        # Disable thinking mode (Qwen3/Gemma-4 reasoning-capable). With
+        # thinking on, the model emits 1500+ reasoning_content tokens
+        # before the first content delta — TTFT below would land at
+        # end-of-reasoning, decode_time computes to ~0.2s, and the
+        # MIN_DECODE_TIME gate rejects every reasoning-heavy workload.
+        # z-lab's canonical demo (scripts/demo_dflash.py) uses /no_think
+        # in the prompt for the same reason. The kwarg path is more
+        # robust since not every model honors the /no_think sentinel.
+        "enable_thinking": False,
+    }
+    t0 = time.perf_counter()
+    ttft: float | None = None
+    completion_tokens: int = 0
+
+    with httpx.stream(
+        "POST",
+        f"{handle.base_url}/chat/completions",
+        json=payload,
+        timeout=300.0,
+    ) as r:
+        for line in r.iter_lines():
+            if not line or not line.startswith("data: "):
+                continue
+            blob = line[len("data: ") :]
+            if blob.strip() == "[DONE]":
+                break
+            try:
+                obj = json.loads(blob)
+            except json.JSONDecodeError:
+                continue
+            if ttft is None:
+                choices = obj.get("choices") or []
+                # Defense in depth: count first reasoning_content as the
+                # decode start too, in case a thinking-disabled-by-kwarg
+                # request still emits some <think>…</think> tokens.
+                # Without this, decode_time would only count the visible
+                # content phase, understating real decode work.
+                if choices and (
+                    choices[0].get("delta", {}).get("content")
+                    or choices[0].get("delta", {}).get("reasoning_content")
+                    or choices[0].get("delta", {}).get("tool_calls")
+                ):
+                    ttft = time.perf_counter() - t0
+            usage = obj.get("usage")
+            if usage and usage.get("completion_tokens") is not None:
+                completion_tokens = int(usage["completion_tokens"])
+
+    total = time.perf_counter() - t0
+    decode_time = max(total - (ttft or 0.0), 0.0)
+    return _classify_run(completion_tokens, decode_time, total)
+
+
+def _classify_run(
+    completion_tokens: int, decode_time: float, total_time: float
+) -> WorkloadRun:
+    if completion_tokens <= 0:
+        return WorkloadRun(
+            None, completion_tokens, decode_time, total_time, "zero_completion_tokens"
+        )
+    if decode_time < MIN_DECODE_TIME:
+        return WorkloadRun(
+            None,
+            completion_tokens,
+            decode_time,
+            total_time,
+            f"decode_time<{MIN_DECODE_TIME}s",
+        )
+    tps = completion_tokens / decode_time
+    if tps > TPS_CEILING:
+        return WorkloadRun(
+            None,
+            completion_tokens,
+            decode_time,
+            total_time,
+            f"tps>{TPS_CEILING}_ceiling",
+        )
+    return WorkloadRun(tps, completion_tokens, decode_time, total_time, None)
+
+
+# ---- Driver ---------------------------------------------------------------
+
+
+@dataclass
+class ModeResult:
+    median_tps: dict[str, float | None]
+    raw_runs: dict[str, list[WorkloadRun]]
+
+
+def bench_one_mode(
+    model: str,
+    port: int,
+    dflash: bool,
+    runs: int,
+    max_tokens: int,
+) -> ModeResult:
+    handle = start_server(model, port, dflash)
+    try:
+        # Discard warmup: Metal JIT + cache population + drafter load.
+        run_workload(handle, WORKLOADS["fibonacci"], max_tokens=32)
+        median_tps: dict[str, float | None] = {}
+        raw: dict[str, list[WorkloadRun]] = {}
+        for name, body in WORKLOADS.items():
+            workload_runs: list[WorkloadRun] = []
+            for i in range(runs):
+                wr = run_workload(handle, body, max_tokens=max_tokens)
+                tag = (
+                    f"{wr.tps:.1f} tok/s"
+                    if wr.tps is not None
+                    else f"REJECTED ({wr.rejected_reason}, {wr.completion_tokens}t/{wr.decode_time:.2f}s decode)"
+                )
+                logger.info(
+                    "  [%s] %s run %d/%d: %s",
+                    "DFlash" if dflash else "base  ",
+                    name,
+                    i + 1,
+                    runs,
+                    tag,
+                )
+                workload_runs.append(wr)
+            valid = [r.tps for r in workload_runs if r.tps is not None]
+            median_tps[name] = median(valid) if valid else None
+            raw[name] = workload_runs
+        return ModeResult(median_tps=median_tps, raw_runs=raw)
+    finally:
+        handle.stop()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bench DFlash speedup for one alias (Model Onboarding SOP §6)."
+    )
+    parser.add_argument("--model", required=True, help="HF repo or alias")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--runs", type=int, default=3, help="runs per workload")
+    parser.add_argument("--port", type=int, default=8765, help="ephemeral port")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON result file (defaults to evals/results/dflash_<model>.json)",
+    )
+    parser.add_argument(
+        "--gate",
+        type=float,
+        default=1.30,
+        help="Code-median speedup gate for ship/no-ship (default 1.30)",
+    )
+    parser.add_argument(
+        "--non-code-floor",
+        type=float,
+        default=1.00,
+        help=(
+            "Per-workload floor for non-code workloads (chat etc.) — any "
+            "regression below this fails the SHIP gate (default 1.00)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    logger.info("Bench DFlash: %s", args.model)
+    if os.environ.get("RAPID_MLX_DFLASH_BYPASS_MOE_GATE") == "1":
+        logger.warning(
+            "  RAPID_MLX_DFLASH_BYPASS_MOE_GATE=1 — eligibility MoE gate "
+            "bypassed (PoC mode)"
+        )
+
+    logger.info("--- baseline (autoregressive) ---")
+    base = bench_one_mode(
+        args.model,
+        args.port,
+        dflash=False,
+        runs=args.runs,
+        max_tokens=args.max_tokens,
+    )
+
+    logger.info("--- DFlash ---")
+    dflash = bench_one_mode(
+        args.model,
+        args.port,
+        dflash=True,
+        runs=args.runs,
+        max_tokens=args.max_tokens,
+    )
+
+    speedup: dict[str, float] = {}
+    skipped: dict[str, str] = {}
+    for name in WORKLOADS:
+        v = base.median_tps.get(name)
+        s = dflash.median_tps.get(name)
+        if v is None or s is None or v <= 0:
+            reason = (
+                "baseline all runs rejected"
+                if v is None or v <= 0
+                else "dflash all runs rejected"
+            )
+            skipped[name] = reason
+            continue
+        speedup[name] = round(s / v, 3)
+
+    # Code median = the four code-gen workloads only. Chat is graded
+    # separately as a non-regression floor — prior bench rounds showed
+    # DFlash speedup is heavily code-biased and SHIPping a 1.3x code
+    # model that regresses to 0.8x on chat would be a bad user trade.
+    code_speedups = [v for k, v in speedup.items() if k in _CODE_WORKLOADS]
+    code_median = median(code_speedups) if code_speedups else None
+    non_code_speedups = {k: v for k, v in speedup.items() if k not in _CODE_WORKLOADS}
+    non_code_floor = args.non_code_floor
+    non_code_regress = {
+        k: v for k, v in non_code_speedups.items() if v < non_code_floor
+    }
+
+    median_speedup = median(speedup.values()) if speedup else None
+
+    if code_median is None:
+        decision = "DO NOT SHIP (no valid code workloads)"
+    elif code_median < args.gate:
+        decision = "DO NOT SHIP"
+    elif non_code_regress:
+        regressed = ", ".join(f"{k} {v:.2f}x" for k, v in non_code_regress.items())
+        decision = f"DO NOT SHIP (non-code regression: {regressed})"
+    else:
+        decision = "SHIP (supports_dflash=true)"
+
+    def _serialize_runs(raw: dict[str, list[WorkloadRun]]) -> dict[str, list[dict]]:
+        return {
+            name: [
+                {
+                    "tps": round(r.tps, 1) if r.tps is not None else None,
+                    "completion_tokens": r.completion_tokens,
+                    "decode_time": round(r.decode_time, 3),
+                    "total_time": round(r.total_time, 3),
+                    "rejected_reason": r.rejected_reason,
+                }
+                for r in runs
+            ]
+            for name, runs in raw.items()
+        }
+
+    summary = {
+        "model": args.model,
+        "max_tokens": args.max_tokens,
+        "runs": args.runs,
+        "gate": args.gate,
+        "non_code_floor": non_code_floor,
+        "base_tps": {
+            k: (round(v, 1) if v is not None else None)
+            for k, v in base.median_tps.items()
+        },
+        "dflash_tps": {
+            k: (round(v, 1) if v is not None else None)
+            for k, v in dflash.median_tps.items()
+        },
+        "speedup": speedup,
+        "code_median": round(code_median, 3) if code_median is not None else None,
+        "non_code_speedups": non_code_speedups,
+        "median_speedup": round(median_speedup, 3)
+        if median_speedup is not None
+        else None,
+        "skipped": skipped,
+        "decision": decision,
+        "bypass_moe_gate": os.environ.get("RAPID_MLX_DFLASH_BYPASS_MOE_GATE") == "1",
+        "raw_runs": {
+            "base": _serialize_runs(base.raw_runs),
+            "dflash": _serialize_runs(dflash.raw_runs),
+        },
+    }
+
+    output = args.output or REPO_ROOT / "evals/results" / (
+        f"dflash_{args.model.replace('/', '_').lower()}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2) + "\n")
+
+    logger.info("--- summary ---")
+    for k in WORKLOADS:
+        if k in skipped:
+            logger.info("  %-12s SKIPPED (%s)", k, skipped[k])
+        else:
+            v = speedup[k]
+            bucket = "code" if k in _CODE_WORKLOADS else "non-code"
+            threshold = args.gate if bucket == "code" else non_code_floor
+            marker = "↑" if v >= threshold else ("↓" if v < non_code_floor else "·")
+            logger.info("  %-12s %5.2fx %s  [%s]", k, v, marker, bucket)
+    if code_median is not None:
+        logger.info("  code median: %.2fx (gate %.2fx)", code_median, args.gate)
+    if non_code_speedups:
+        non_code_summary = ", ".join(
+            f"{k} {v:.2f}x" for k, v in non_code_speedups.items()
+        )
+        logger.info("  non-code: %s (floor %.2fx)", non_code_summary, non_code_floor)
+    logger.info("  decision: %s", decision)
+    logger.info("  written: %s", output)
+
+    return 0 if decision.startswith("SHIP") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -24,6 +24,7 @@ Adding a new alias?
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -390,9 +391,11 @@ def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
         d = profile.dflash_draft_model or ""
         ok = any(d.startswith(p) for p in valid_drafter_prefixes)
         # ``DFlash`` may appear at end of repo name OR before a tag
-        # suffix (``-b16``, ``-UltraChat``, etc.). Both are accepted as
-        # long as the prefix is on the curated allow-list.
-        has_marker = "DFlash" in d
+        # suffix (``-b16``, ``-UltraChat``, etc.). Anchored on ``-`` /
+        # end-of-string so we don't accept ``-notDFlash-utils`` or
+        # other strings where ``DFlash`` is just a substring of an
+        # unrelated word.
+        has_marker = bool(re.search(r"(?:^|-)DFlash(?:$|-)", d))
         assert has_marker and ok, (
             f"{alias}: dflash_draft_model={d!r} doesn't match the "
             f"expected ``z-lab/{{Qwen3,Qwen3.5,Qwen3.6,gemma-4,LLaMA3.1}}-*"

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -370,24 +370,34 @@ def test_dflash_excludes_4bit_precision(alias: str) -> None:
 
 
 def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
-    """DFlash drafters published today are Qwen-family-specific. Any
-    eligible alias must point at a ``z-lab/Qwen3.5-*-DFlash`` or
-    ``z-lab/Qwen3.6-*-DFlash`` drafter. Catches an accidental copy-paste
-    that swaps the drafter to an incompatible model."""
+    """DFlash drafters today are published by ``z-lab/`` for Qwen3,
+    Qwen3.5, Qwen3.6, Gemma-4 and LLaMA-3.1 families. Any eligible
+    alias must point at one of these prefixes and bear the ``DFlash``
+    marker (the ``-b16`` / ``-UltraChat`` / etc. suffix is permitted —
+    z-lab uses it for training-data and precision tags). Catches an
+    accidental copy-paste that swaps the drafter to an incompatible
+    model."""
     valid_drafter_prefixes = (
+        "z-lab/Qwen3-",
         "z-lab/Qwen3.5-",
         "z-lab/Qwen3.6-",
+        "z-lab/gemma-4-",
+        "z-lab/LLaMA3.1-",
     )
     for alias, profile in list_profiles().items():
         if not profile.supports_dflash:
             continue
         d = profile.dflash_draft_model or ""
         ok = any(d.startswith(p) for p in valid_drafter_prefixes)
-        assert d.endswith("-DFlash") and ok, (
+        # ``DFlash`` may appear at end of repo name OR before a tag
+        # suffix (``-b16``, ``-UltraChat``, etc.). Both are accepted as
+        # long as the prefix is on the curated allow-list.
+        has_marker = "DFlash" in d
+        assert has_marker and ok, (
             f"{alias}: dflash_draft_model={d!r} doesn't match the "
-            f"expected ``z-lab/Qwen3.5-*-DFlash`` or "
-            f"``z-lab/Qwen3.6-*-DFlash`` shape. If you've validated a "
-            f"new drafter family, update this allow-list."
+            f"expected ``z-lab/{{Qwen3,Qwen3.5,Qwen3.6,gemma-4,LLaMA3.1}}-*"
+            f"DFlash*`` shape. If you've validated a new drafter family, "
+            f"update this allow-list."
         )
 
 

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -100,14 +100,14 @@ def test_orphan_aliases_now_covered() -> None:
 def test_list_aliases_returns_legacy_string_view() -> None:
     """Old callers (doctor harness, tests) expect ``{alias: hf_path}``."""
     aliases = list_aliases()
-    assert len(aliases) == 58
+    assert len(aliases) == 64
     assert all(isinstance(p, str) for p in aliases.values())
     assert aliases["qwen3.5-4b"] == "mlx-community/Qwen3.5-4B-MLX-4bit"
 
 
 def test_list_profiles_returns_rich_dataclass_view() -> None:
     profiles = list_profiles()
-    assert len(profiles) == 58
+    assert len(profiles) == 64
     p = profiles["qwen3.5-4b"]
     assert isinstance(p, AliasProfile)
     assert p.hf_path == "mlx-community/Qwen3.5-4B-MLX-4bit"
@@ -298,7 +298,7 @@ def test_qwen35_family_aliases_share_hybrid_flag() -> None:
     schema enables."""
     profiles = list_profiles()
     family = {a: p for a, p in profiles.items() if a.startswith("qwen3.5-")}
-    assert len(family) == 8
+    assert len(family) == 10
     flags = {(p.is_hybrid, p.supports_spec_decode) for p in family.values()}
     assert flags == {(True, False)}, (
         f"qwen3.5-* family disagrees on capability flags: {flags}"

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -6,11 +6,27 @@
     "is_hybrid": true,
     "supports_spec_decode": false
   },
+  "qwen3.5-4b-8bit": {
+    "hf_path": "mlx-community/Qwen3.5-4B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
   "qwen3.5-9b": {
     "hf_path": "mlx-community/Qwen3.5-9B-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
+    "supports_spec_decode": false
+  },
+  "qwen3.5-9b-8bit": {
+    "hf_path": "mlx-community/Qwen3.5-9B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_moe": false,
     "supports_spec_decode": false
   },
   "qwen3.5-27b": {
@@ -153,6 +169,30 @@
     "is_hybrid": false,
     "supports_spec_decode": true
   },
+  "qwen3-4b-8bit": {
+    "hf_path": "mlx-community/Qwen3-4B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
+  "qwen3-8b-8bit": {
+    "hf_path": "mlx-community/Qwen3-8B-8bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
+  "llama-3.1-8b-8bit": {
+    "hf_path": "mlx-community/Meta-Llama-3.1-8B-Instruct-8bit",
+    "tool_call_parser": "llama",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
   "qwen3-coder": {
     "hf_path": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
     "tool_call_parser": "hermes",
@@ -241,6 +281,19 @@
       "json_array": 0.67,
       "code_edit": 0.996
     },
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-31b-8bit": {
+    "hf_path": "mlx-community/gemma-4-31b-it-8bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
     "recommended_sampling": {
       "temperature": 1.0,
       "top_p": 0.95,


### PR DESCRIPTION
## Summary

- New `scripts/bench_dflash.py` - reliable two-server DFlash bench harness with code-median + chat-floor SHIP gate, `--disable-prefix-cache`, decode-time floor, TPS ceiling, and `enable_thinking=false` payload fix for Qwen3-family thinking-mode TTFT artifacts.
- 6 new 8-bit aliases in `aliases.json`, all shipped **without** DFlash (none passed the strict chat-floor gate, and 3 cannot use DFlash at all due to mlx-vlm 0.5.0's registry).
- 6 raw bench JSONs in `evals/results/` documenting the sweep.
- Contract-test allow-list extension for future z-lab drafter families (`Qwen3-`, `gemma-4-`, `LLaMA3.1-`).
- Version bump 0.6.48 → 0.6.49 (Release SOP applies).

## Sweep results (3 runs x 5 workloads each)

| Model | Code median | Chat | Code-only gate (SOP §6) | Strict gate (this PR) |
|---|---|---|---|---|
| qwen3.5-4b-8bit | 1.31x | 0.56x | SHIP | DO NOT SHIP |
| qwen3.5-9b-8bit | 1.14x | - | DO NOT SHIP | DO NOT SHIP |
| qwen3.5-27b-8bit | 1.66x | 0.76x | SHIP | DO NOT SHIP |
| qwen3.6-27b-8bit | 1.93x | 0.78x | SHIP | DO NOT SHIP |
| qwen3.6-35b-A3B (MoE re-bench) | 0.89x | - | DO NOT SHIP | DO NOT SHIP |
| gemma-4-31b-8bit | 1.98x | 0.71x | SHIP | DO NOT SHIP |

**Pattern:** code workloads strongly favor DFlash (peak fibonacci 2.88x on Qwen3.6-27B-8bit), but **chat regresses 22-44% on every dense candidate.** MoE re-bench confirms z-lab's latest 65K-download A3B drafter still loses on MoE - the MoE eligibility gate stays.

**mlx-vlm registry limit discovered**: `mlx_vlm.speculative.drafters` only ships base loaders for `qwen3_5`, `qwen3_5_moe`, `gemma3`, `gemma4`, `kimi_k25`, `llama4`. Qwen3 (non-3.5) and Llama-3.1 cannot use DFlash regardless of drafter availability - the 3 corresponding new 8-bit aliases ship without DFlash for this reason, not because of a bench result.

## Out of scope (separate policy call)

This PR is **purely additive** for the alias data - production `qwen3.5-27b-8bit` and `qwen3.6-27b-8bit` retain `supports_dflash: true` (code 1.66x / 1.93x respectively, current SOP §6 code-only gate accepts them). Whether to **retroactively** apply the new strict chat-floor gate to those two production aliases is left for a follow-up - that's a user-visible code-TPS regression for current DFlash users and warrants its own decision/PR.

Three policy paths surfaced in `memory/knowledge/dflash_sweep_2026-05-13.md`:
- (a) Strict gate, retroactive downgrade
- (b) Workload-tier metadata + opt-in (`dflash_recommendation`)
- (c) Status quo + document chat trade-off

## PR Merge SOP

- [x] Pre-flight: branch rebased, blast=medium (surface-touching)
- [x] Codex review (multi-round, converged): R1 (4 findings) → R2 (1 follow-on) → R3 (1 false positive — deepseek conflated `supports_spec_decode` with `supports_dflash`; verified at `scheduler.py:1090`)
- [x] Supply-chain pre-flight: no hooks, deps clean, no suspicious patterns
- [x] Lint + format: `ruff check && ruff format --check` clean
- [x] Targeted tests: `tests/test_aliases_contract.py` (655 pass), `tests/test_model_profiles_ssot.py` (23 pass), `tests/test_dflash_eligibility.py` (21 pass)
- [x] Broader unit: `3552 passed, 19 skipped, 16 deselected, 1 xfailed` in 44s
- [x] `pr_validate`: all steps PASS (stress_e2e_bench skipped by gating predicate — low-blast)
- [x] make check: skipped (no inference-path changes — data + bench script only)

## Release SOP (gates for the version bump)

- [x] **Pre-flight inventory**: 4 commits since v0.6.48, all on this branch; classification = surface-touching only (per CLAUDE.md, step 5 perf re-bench optional)
- [x] **Install size audit**: 448 MB in clean venv vs ~445 MB at v0.6.48 baseline (1.007x — well within 1.05x soft warn / 1.10x hard fail)
- [x] **Supply-chain re-audit**:
  - `pip-audit`: no known vulnerabilities
  - Dep freshness (Shai-Hulud guard): transformers 5.8.1 uploaded 2026-05-13 (1 day) — verified upstream tag `v5.8.1` exists, release notes non-empty (Deepseek V4 integration fix). All other critical deps >5 days old. Safe.
  - Workflow tampering: no commits since v0.6.48 touched `install.sh` / `.github/workflows/` / `setup.py` / `MANIFEST.in`
  - OIDC publish-scope: `id-token: write` only (publish), `contents: write` only (auto-release) — minimal
  - 3rd-party action SHA-pinning: 3 actions on moving tags (`peter-evans/repository-dispatch@v3`, `codecov/codecov-action@v4`, `peaceiris/actions-gh-pages@v4`) — **pre-existing on main, not introduced by this PR**, deferred to a separate hardening PR
- [x] **Pre-merge artifact SHAs** (Release SOP §8 — must match post-publish `pip download rapid-mlx==0.6.49`):
  - wheel:  `167294f382553f0e4b06073fb412d72ca6282c3e05b81e77097269fae40dfb9a`
  - sdist:  `d1dc9e97e8581f59fe3b288b51ab23fdbef78b5053a7c10412f2c1e13ca684c3`
- [ ] **Fresh-install user simulation**: in-progress (subagent simulating a brand-new user installing 0.6.49 from the local wheel and walking through the CLI)
- [ ] **CI matrix green**: in-progress
- [ ] **Post-release verification**: pending merge (PyPI propagation + Homebrew tap update + post-publish SHA re-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)