### PR TITLE
feat(parsers): schema-aware tool-call coercion + upstream regression tests (cherry-pick #204/#206)

### DIFF
--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for tool_calling.py"""
 
+import json
 from unittest.mock import MagicMock
 
 from vllm_mlx.api.tool_calling import (
@@ -153,6 +154,20 @@ class TestParseRawJsonToolCalls:
         assert len(result) == 1
         assert result[0]["name"] == "func1"
 
+    def test_text_with_json_file_content(self):
+        """Tool JSON with braces inside a string argument is still extracted."""
+        text = (
+            'Now write this file: {"name": "write_file", "arguments": {'
+            '"path": "/tmp/tsconfig.json", '
+            '"content": "{\\n  \\"compilerOptions\\": {\\n    \\"strict\\": true\\n  }\\n}\\n"'
+            "}}"
+        )
+        result = _parse_raw_json_tool_calls(text)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "write_file"
+        assert '"compilerOptions"' in result[0]["arguments"]["content"]
+
     def test_arguments_extracted_as_dict(self):
         """Test that arguments are extracted as dict when present."""
         text = '{"name": "func", "arguments": {"key": "value", "num": 42}}'
@@ -258,6 +273,43 @@ class TestParseToolCalls:
         cleaned, tool_calls = parse_tool_calls(text, request=request)
 
         assert tool_calls is not None
+
+    def test_schema_string_arguments_serialize_objects(self):
+        """Object values for string parameters are serialized before OpenAI output."""
+        text = (
+            '{"name": "write_file", "arguments": '
+            '{"path": "/tmp/tsconfig.json", "content": {"compilerOptions": {"strict": true}}}}'
+        )
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+
+        _, tool_calls = parse_tool_calls(text, request=request)
+
+        assert tool_calls is not None
+        # Round-trip the serialized arguments to assert the full structure rather than
+        # a substring — guards against extra junk that would still pass an `in` check.
+        args = json.loads(tool_calls[0].function.arguments)
+        assert set(args.keys()) == {"path", "content"}
+        assert args["path"] == "/tmp/tsconfig.json"
+        # `content` is declared `string` in schema, so the object value should serialize
+        # to a JSON string rather than be passed through as a dict.
+        assert isinstance(args["content"], str)
+        assert json.loads(args["content"]) == {"compilerOptions": {"strict": True}}
 
 
 class TestConvertToolsForTemplate:

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from vllm_mlx.api.tool_calling import parse_tool_calls
 from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
@@ -1847,3 +1848,63 @@ class TestTextFormatToolCallFallback:
             for call in calls:
                 parsed = json.loads(call["arguments"])
                 assert isinstance(parsed, dict)
+
+
+class TestGenericToolCallParsing:
+    """OpenAI-translation helpers: schema-aware coercion + bare `Calling tool:` parsing."""
+
+    def test_bare_calling_tool_is_parsed_and_removed(self):
+        text = (
+            "Thinking first.\n"
+            'Calling tool: write({"filePath": "/tmp/app.tsx", "content": "ok"})'
+        )
+
+        cleaned_text, tool_calls = parse_tool_calls(text)
+
+        assert cleaned_text == "Thinking first."
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "write"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args == {"filePath": "/tmp/app.tsx", "content": "ok"}
+
+    def test_tool_arguments_decode_stringified_arrays(self):
+        text = (
+            'Calling tool: todowrite({"todos": '
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"'
+            "})"
+        )
+
+        _, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
+    def test_tool_arguments_coerce_schema_numbers(self):
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string"},
+                                "timeout": {"type": "number"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        text = 'Calling tool: bash({"command": "npm test", "timeout": "60000"})'
+
+        _, tool_calls = parse_tool_calls(text, request)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["command"] == "npm test"
+        assert args["timeout"] == 60000.0

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1069,6 +1069,78 @@ class TestQwen3CoderUpstreamNonStreaming:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args["obj_param"] == {"key": "value"}
 
+    def test_array_parameter_double_encoded_json_string(self, qwen3coder_parser):
+        """Array parameters may arrive as double-encoded JSON strings."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
+    def test_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Schemas may encode nullable arrays as type lists."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        output = (
+            "<tool_call>\n<function=todowrite>\n"
+            "<parameter=todos>\n"
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+        result = qwen3coder_parser.extract_tool_calls(output, request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
+
     def test_fallback_no_tool_call_tags(self, qwen3coder_parser, qwen3coder_request):
         """Bare <function=...> without <tool_call> wrapper also works."""
         output = (
@@ -1203,6 +1275,58 @@ class TestQwen3CoderUpstreamStreaming:
         assert full_args.endswith("}")
         parsed = json.loads(full_args)
         assert parsed["city"] == "Dallas"
+
+    def test_streaming_array_parameter_nullable_type_list(self, qwen3coder_parser):
+        """Streaming conversion also handles nullable array schemas."""
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "todowrite",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "todos": {
+                                    "type": ["array", "null"],
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        deltas = [
+            "<tool_call>\n<function=todowrite>\n",
+            "<parameter=todos>\n",
+            '"[{\\"content\\": \\"Initialize\\", \\"status\\": \\"in_progress\\"}]"\n'
+            "</parameter>\n",
+            "</function>\n</tool_call>",
+        ]
+        text = ""
+        collected = []
+        for delta in deltas:
+            previous = text
+            text += delta
+            result = qwen3coder_parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=text,
+                delta_text=delta,
+                request=request,
+            )
+            if result:
+                collected.append(result)
+
+        arg_parts = [
+            chunk["tool_calls"][0]["function"]["arguments"]
+            for chunk in collected
+            if "tool_calls" in chunk
+            and "arguments" in chunk["tool_calls"][0].get("function", {})
+        ]
+        args = json.loads("".join(arg_parts))
+        assert isinstance(args["todos"], list)
+        assert args["todos"][0]["content"] == "Initialize"
 
     def test_streaming_coarse_deltas_complete(
         self, qwen3coder_parser, qwen3coder_request

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -24,6 +24,216 @@ from .models import FunctionCall, ResponseFormat, ToolCall
 logger = logging.getLogger(__name__)
 
 
+def _decode_json_like(value: Any) -> Any:
+    """Decode JSON-looking strings, including one level of double encoding."""
+    if not isinstance(value, str):
+        return value
+
+    current: Any = value.strip()
+    for _ in range(3):
+        if not isinstance(current, str):
+            return current
+        stripped = current.strip()
+        if not stripped or stripped[0] not in '[{"':
+            return current
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return current
+        if parsed == current:
+            return parsed
+        current = parsed
+    return current
+
+
+def _get_tool_param_config(
+    tool_name: str | None, request: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Return JSON schema properties for a requested tool."""
+    if not tool_name or not isinstance(request, dict):
+        return {}
+    tools = request.get("tools")
+    if not isinstance(tools, list):
+        return {}
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict) or function.get("name") != tool_name:
+            continue
+        parameters = function.get("parameters")
+        if not isinstance(parameters, dict):
+            return {}
+        properties = parameters.get("properties")
+        if isinstance(properties, dict):
+            return properties
+        return parameters
+    return {}
+
+
+def _schema_type(schema: Any) -> str | None:
+    if isinstance(schema, str):
+        return schema.strip().lower()
+    if not isinstance(schema, dict):
+        return None
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    if isinstance(schema_type, str):
+        return schema_type.strip().lower()
+    for key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(key)
+        if isinstance(options, list):
+            for option in options:
+                option_type = _schema_type(option)
+                if option_type and option_type != "null":
+                    return option_type
+    if "items" in schema:
+        return "array"
+    if "properties" in schema or "additionalProperties" in schema:
+        return "object"
+    if "enum" in schema:
+        return "string"
+    return None
+
+
+def _coerce_schema_value(value: Any, schema: Any) -> Any:
+    value = _decode_json_like(value)
+    schema_type = _schema_type(schema)
+    if schema_type is None:
+        return value
+    if value is None:
+        return None
+    if schema_type in ("string", "str", "text", "varchar", "char", "enum"):
+        if isinstance(value, str):
+            return value
+        return json.dumps(value, ensure_ascii=False)
+    if schema_type in ("array", "object"):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    try:
+        if schema_type in ("integer", "int"):
+            return int(stripped)
+        if schema_type in ("number", "float"):
+            return float(stripped)
+    except (TypeError, ValueError):
+        return value
+    if schema_type in ("boolean", "bool"):
+        if stripped.lower() == "true":
+            return True
+        if stripped.lower() == "false":
+            return False
+    return value
+
+
+def _normalize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> Any:
+    """Normalize parsed tool arguments before OpenAI serialization."""
+    arguments = _decode_json_like(arguments)
+    if isinstance(arguments, dict):
+        param_config = _get_tool_param_config(tool_name, request)
+        return {
+            key: _coerce_schema_value(value, param_config.get(key))
+            for key, value in arguments.items()
+        }
+    return arguments
+
+
+def _serialize_tool_arguments(
+    arguments: Any,
+    tool_name: str | None = None,
+    request: dict[str, Any] | None = None,
+) -> str:
+    """Serialize tool arguments as a valid OpenAI function.arguments JSON string."""
+    arguments = _normalize_tool_arguments(arguments, tool_name, request)
+    if isinstance(arguments, str):
+        decoded = _decode_json_like(arguments)
+        if decoded is not arguments:
+            arguments = decoded
+    if isinstance(arguments, str):
+        return arguments
+    return json.dumps(arguments, ensure_ascii=False)
+
+
+def _iter_calling_tool_calls(text: str):
+    """Yield Qwen-style `Calling tool: name({...})` spans with balanced JSON args."""
+    marker = "Calling tool:"
+    search_from = 0
+    while True:
+        marker_idx = text.find(marker, search_from)
+        if marker_idx == -1:
+            return
+
+        i = marker_idx + len(marker)
+        while i < len(text) and text[i].isspace():
+            i += 1
+
+        name_start = i
+        while i < len(text) and (text[i].isalnum() or text[i] in "_.-"):
+            i += 1
+        name = text[name_start:i].strip()
+        if not name:
+            search_from = marker_idx + len(marker)
+            continue
+
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "(":
+            search_from = i
+            continue
+        i += 1
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if i >= len(text) or text[i] != "{":
+            search_from = i
+            continue
+
+        args_start = i
+        depth = 0
+        in_string = False
+        escaped = False
+        while i < len(text):
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        args_end = i + 1
+                        j = args_end
+                        while j < len(text) and text[j].isspace():
+                            j += 1
+                        if j < len(text) and text[j] == ")":
+                            j += 1
+                            if j < len(text) and text[j] == "]":
+                                j += 1
+                            start = marker_idx
+                            if marker_idx > 0 and text[marker_idx - 1] == "[":
+                                start = marker_idx - 1
+                            yield start, j, name, text[args_start:args_end]
+                            search_from = j
+                            break
+            i += 1
+        else:
+            return
+
+
 def _is_tool_call_json(obj: dict) -> bool:
     """
     Check if a JSON object looks like a tool call.
@@ -52,7 +262,7 @@ def _is_tool_call_json(obj: dict) -> bool:
     if not isinstance(obj["name"], str) or not obj["name"].strip():
         return False
 
-    # "arguments" must be a dict or string
+    # "arguments" must be JSON-like
     args = obj["arguments"]
     if not isinstance(args, (dict, str)):
         return False
@@ -97,13 +307,27 @@ def _parse_raw_json_tool_calls(text: str) -> list[dict] | None:
         except json.JSONDecodeError:
             pass
 
-    # Find JSON objects with balanced braces
+    # Find JSON objects with balanced braces. Respect quoted strings so
+    # file contents like '{"compilerOptions": {...}}' do not corrupt depth.
     tool_calls = []
     depth = 0
     start = None
+    in_string = False
+    escaped = False
 
     for i, char in enumerate(text):
-        if char == "{":
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
             if depth == 0:
                 start = i
             depth += 1
@@ -132,7 +356,7 @@ def parse_tool_calls(
     Parse tool calls from model output.
 
     Supports multiple formats:
-    - Qwen3 bracket: [Calling tool: function_name({...})]
+    - Qwen3: [Calling tool: function_name({...})] or Calling tool: function_name({...})
     - Qwen:
     - Llama:
     - Nemotron:
@@ -149,11 +373,11 @@ def parse_tool_calls(
     tool_calls = []
     cleaned_text = text
 
-    # Pattern for Qwen3 bracket-style: [Calling tool: function_name({...})]
-    bracket_pattern = r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]"
-    bracket_matches = re.findall(bracket_pattern, text, re.DOTALL)
+    # Pattern for Qwen3 calling-tool style. Some models omit the outer brackets,
+    # and arguments can contain nested braces in strings, so use a balanced scan.
+    calling_tool_matches = list(_iter_calling_tool_calls(text))
 
-    for name, args_str in bracket_matches:
+    for _, _, name, args_str in calling_tool_matches:
         try:
             arguments = json.loads(args_str)
             tool_calls.append(
@@ -162,10 +386,8 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
                         ),
                     ),
                 )
@@ -173,11 +395,11 @@ def parse_tool_calls(
         except json.JSONDecodeError:
             continue
 
-    # Remove bracket tool calls from cleaned text
-    if bracket_matches:
-        cleaned_text = re.sub(
-            r"\[Calling tool:\s*\w+\(\{.*?\}\)\]", "", cleaned_text, flags=re.DOTALL
-        ).strip()
+    # Remove Qwen calling-tool spans from cleaned text
+    if calling_tool_matches:
+        for start, end, _, _ in reversed(calling_tool_matches):
+            cleaned_text = cleaned_text[:start] + cleaned_text[end:]
+        cleaned_text = cleaned_text.strip()
 
     # Pattern for Nemotron-style:
     # Format 1: <tool_call><function=name><parameter=key>val</parameter></function></tool_call>
@@ -205,7 +427,10 @@ def parse_tool_calls(
                 id=f"call_{uuid.uuid4().hex[:8]}",
                 type="function",
                 function=FunctionCall(
-                    name=name.strip(), arguments=json.dumps(arguments)
+                    name=name.strip(),
+                    arguments=_serialize_tool_arguments(
+                        arguments, name.strip(), request
+                    ),
                 ),
             )
         )
@@ -241,11 +466,7 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name,
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
+                        arguments=_serialize_tool_arguments(arguments, name, request),
                     ),
                 )
             )
@@ -276,10 +497,8 @@ def parse_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=name.strip(),
-                        arguments=(
-                            json.dumps(arguments)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
+                        arguments=_serialize_tool_arguments(
+                            arguments, name.strip(), request
                         ),
                     ),
                 )
@@ -317,10 +536,8 @@ def parse_tool_calls(
                         type="function",
                         function=FunctionCall(
                             name=call_data["name"],
-                            arguments=(
-                                json.dumps(call_data["arguments"])
-                                if isinstance(call_data["arguments"], dict)
-                                else str(call_data["arguments"])
+                            arguments=_serialize_tool_arguments(
+                                call_data["arguments"], call_data["name"], request
                             ),
                         ),
                     )

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -22,6 +22,7 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
+from ..api.tool_calling import _decode_json_like, _schema_type
 from .abstract_tool_parser import (
     ExtractedToolCallInformation,
     ToolParser,
@@ -47,8 +48,6 @@ def _get_arguments_config(func_name: str, tools: list[dict] | None) -> dict:
             params = func.get("parameters", {})
             if isinstance(params, dict) and "properties" in params:
                 return params["properties"]
-            elif isinstance(params, dict):
-                return params
             return {}
     return {}
 
@@ -61,13 +60,12 @@ def _convert_param_value(
         return None
 
     if param_name not in param_config:
-        return param_value
+        return _decode_json_like(param_value)
 
     cfg = param_config[param_name]
-    if isinstance(cfg, dict) and "type" in cfg:
-        param_type = str(cfg["type"]).strip().lower()
-    else:
-        param_type = "string"
+    param_type = _schema_type(cfg)
+    if param_type is None:
+        return _decode_json_like(param_value)
 
     if param_type in ("string", "str", "text", "varchar", "char", "enum"):
         return param_value
@@ -87,10 +85,9 @@ def _convert_param_value(
         if param_type in ("object", "array", "arr") or param_type.startswith(
             ("dict", "list")
         ):
-            try:
-                return json.loads(param_value)
-            except (json.JSONDecodeError, TypeError, ValueError):
-                pass
+            decoded = _decode_json_like(param_value)
+            if decoded is not param_value:
+                return decoded
         try:
             return ast.literal_eval(param_value)
         except (ValueError, SyntaxError):
@@ -253,6 +250,8 @@ class Qwen3CoderToolParser(ToolParser):
     ) -> dict[str, Any] | None:
         if not previous_text:
             self._reset_streaming_state()
+            self._streaming_request = request
+        elif request is not None and self._streaming_request is None:
             self._streaming_request = request
 
         if not delta_text:


### PR DESCRIPTION
## Summary

Selectively cherry-picks the safe additive parser improvements from @samuelfaj's PR #204 + #206, dropping the contaminating CI/memory_cache/chat-route changes. Net surface: **5 files, +495/-42** (~30% of his original 1900-LOC submission).

This is the "merge-and-ship-his-value" path discussed in the #204 / #206 review threads — credit to @samuelfaj for the actual fix work; we're isolating the parts that are safe under our SOP.

## What's in this PR (additive, no overlap with main)

- **`vllm_mlx/api/tool_calling.py`** — 7 new helper functions: `_decode_json_like`, `_get_tool_param_config`, `_schema_type`, `_coerce_schema_value` (with the PR #206 string-coercion fix), `_normalize_tool_arguments`, `_serialize_tool_arguments`, `_iter_calling_tool_calls`. Backbone for schema-aware OpenAI-translation of tool-call arguments.
- **`vllm_mlx/tool_parsers/qwen3coder_tool_parser.py`** — refactor to import the new helpers from `tool_calling.py` (used #204's clean version, not #206's which duplicated the helpers locally).
- **`tests/test_upstream_regression.py`** — 124 lines of ported upstream vLLM tool-parser tests (double-encoded JSON args, etc.).
- **`tests/test_tool_calling.py`** — 2 new test functions for JSON-with-braces-in-string parsing and schema-string serialize-objects coercion. Test assertion tightened to round-trip via `json.loads` (codex P2 fix; original was substring-only).
- **`tests/test_tool_parsers.py`** — new `TestGenericToolCallParsing` class (3 tests: bare `Calling tool:` parsing, stringified arrays, schema number coercion).

## What was deliberately NOT cherry-picked from #204/#206

These had silent regressions that would have shipped to PyPI on auto-deploy:

- ❌ `.github/workflows/ci.yml` — silently swapped ruff for black, narrowed lint scope, **removed 7 test files including `test_tool_calling.py`** (the file that would catch regressions in his own tool-call changes).
- ❌ `vllm_mlx/memory_cache.py` — removed `_safetensors_is_complete()` (the validator that catches truncated KV files that would silently mmap as zeros → wrong-output bugs) and removed deep-copy on cache fetch (correctness regression for MambaCache/ArraysCache).
- ❌ `vllm_mlx/service/postprocessor.py` — overlaps with PR #208 (tool_call tag leak fix) and PR #259 (OutputRouter for gemma4/harmony) since his branch was 8 commits behind main.
- ❌ `vllm_mlx/service/helpers.py` — would revert the v0.6.48 sampling cascade.
- ❌ `vllm_mlx/routes/chat.py` — would revert PR #208's `_finalize_content_and_reasoning` and adds the `_looks_like_deferred_tool_use` retry logic that triggers on common verbs ("let me", "fix", "test", "verify") with synthetic-user-message injection invisible to the client.
- ❌ `tests/test_postprocessor.py` + `tests/test_tool_parsers.py` deletions — would have removed 6 critical regression tests including the PR #181 multi-tool streaming dedup guard (the `'readread'`/`'{}{}'` corruption fix).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/test_tool_calling.py tests/test_tool_parsers.py tests/test_upstream_regression.py` — **262 passed**
- [x] `pytest tests/test_postprocessor.py tests/test_chat_route_tool_tag_leak.py tests/test_streaming_pipeline_integration.py tests/test_streaming_tool_filter.py tests/test_streaming_think_router.py` (downstream files that import from `tool_calling.py`) — **130 passed**
- [x] Full unit suite (`pytest tests/ --ignore=integrations --ignore=mllm/video/event_loop`) — **3451 passed, 19 skipped, 7 deselected, 1 xfailed** (matches current main baseline)
- [x] DeepSeek V4 Pro adversarial codex review — 6 findings; P1 duplicate-helpers + P2 overpermissive-assertion fixed in this branch; remaining 4 are judgment calls on string-type decoding behavior (preserved as the original PR's intended UX) and edge cases for follow-up.
- [ ] CI green (await this PR's run)

## Follow-ups (out of scope here)

- Close #204 with link to this PR + thank-you to @samuelfaj
- Close #206 with same
- The `Calling tool:` bare marker handling in the postprocessor was not taken (overlaps with PR #208/#259); if users hit this, file as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)