### PR TITLE
fix(api): honor chat_template_kwargs.enable_thinking (#387)

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #387: chat_template_kwargs.enable_thinking passthrough.
+
+Before this fix, ``ChatCompletionRequest`` did not declare a
+``chat_template_kwargs`` field at all, so Pydantic silently dropped the
+key on parse and the chat template ran with thinking enabled by default.
+External user @smallhadroncollider hit this on v0.6.49 with qwen3.6-27b-8bit
+(2996 reasoning tokens for a one-line joke). See issue #387.
+
+The contract under test is the precedence in ``_resolve_enable_thinking``:
+    1. server ``--no-thinking`` (cfg.no_thinking) → False
+    2. ``request.chat_template_kwargs["enable_thinking"]`` (OpenAI ext spec)
+    3. ``request.enable_thinking`` (top-level field, our extension)
+    4. None (template default)
+
+These tests guard the helper, the request-model field, and the call sites
+in routes/chat.py + routes/anthropic.py + speculative/dflash/server.py.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm_mlx.api.models import ChatCompletionRequest
+from vllm_mlx.service.helpers import (
+    _extract_thinking_from_request,
+    _resolve_enable_thinking,
+)
+
+
+def _fake_cfg(no_thinking: bool = False) -> SimpleNamespace:
+    """Minimal stand-in for the ServerConfig singleton.
+
+    The helper only reads ``cfg.no_thinking`` — keeping this a SimpleNamespace
+    avoids dragging the full singleton + cascade machinery into a unit test.
+    """
+    return SimpleNamespace(no_thinking=no_thinking)
+
+
+# ── Pydantic model: chat_template_kwargs is now declared ────────────────
+
+
+class TestRequestModel:
+    def test_chat_template_kwargs_field_accepted(self):
+        """Before #387 fix: this dict was silently dropped on parse."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        assert r.chat_template_kwargs == {"enable_thinking": False}
+
+    def test_chat_template_kwargs_default_is_none(self):
+        r = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}])
+        assert r.chat_template_kwargs is None
+
+    def test_chat_template_kwargs_arbitrary_keys_preserved(self):
+        """Unknown keys are accepted — caller may inspect them later."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True, "future_key": "x"},
+        )
+        assert r.chat_template_kwargs == {"enable_thinking": True, "future_key": "x"}
+
+
+# ── _resolve_enable_thinking precedence ─────────────────────────────────
+
+
+class TestResolveEnableThinking:
+    def test_chat_template_kwargs_false_overrides_default(self):
+        """The actual #387 bug: this used to be silently dropped."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is False
+
+    def test_chat_template_kwargs_true_propagates(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is True
+
+    def test_top_level_enable_thinking_used_when_no_ctk(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            enable_thinking=True,
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is True
+
+    def test_chat_template_kwargs_wins_over_top_level(self):
+        """Both set: nested key wins (matches OpenAI spec semantics)."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+            enable_thinking=True,
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is False
+
+    def test_server_no_thinking_overrides_everything(self):
+        """Operator-level --no-thinking is the hard kill switch."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True},
+            enable_thinking=True,
+        )
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=_fake_cfg(no_thinking=True),
+        ):
+            assert _resolve_enable_thinking(r) is False
+
+    def test_unset_returns_none(self):
+        """None lets the chat template apply its own default."""
+        r = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}])
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is None
+
+    def test_string_form_false_tolerated(self):
+        """Some HTTP clients stringify booleans — accept "false" / "true"."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": "false"},
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is False
+
+    def test_string_form_true_tolerated(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": "TRUE"},
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is True
+
+    def test_garbage_value_in_ctk_falls_through(self):
+        """Non-bool, non-string-bool values should not poison the precedence."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": 42},
+            enable_thinking=True,
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            # ctk value rejected, fall through to top-level
+            assert _resolve_enable_thinking(r) is True
+
+    def test_chat_template_kwargs_without_enable_thinking_key_falls_through(self):
+        """A ctk dict that doesn't carry the key is not opinionated about thinking."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"some_other_key": "x"},
+            enable_thinking=False,
+        )
+        with patch("vllm_mlx.service.helpers.get_config", return_value=_fake_cfg()):
+            assert _resolve_enable_thinking(r) is False
+
+
+# ── _extract_thinking_from_request: shared with dflash route ────────────
+
+
+class TestExtractThinkingFromRequest:
+    """The dflash route shares this sub-helper directly. The OpenAI/anthropic
+    helper layers ``cfg.no_thinking`` on top; dflash layers its own closure
+    ``no_thinking`` arg on top. The string-bool tolerance lives here once.
+    """
+
+    def test_ctk_false(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        assert _extract_thinking_from_request(r) is False
+
+    def test_ctk_wins_over_top_level(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+            enable_thinking=True,
+        )
+        assert _extract_thinking_from_request(r) is False
+
+    def test_top_level_used_when_no_ctk(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            enable_thinking=True,
+        )
+        assert _extract_thinking_from_request(r) is True
+
+    def test_neither_set_returns_none(self):
+        r = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}])
+        assert _extract_thinking_from_request(r) is None
+
+    def test_string_bool_tolerance_lives_here(self):
+        """If we ever extend the tolerance (e.g. "1"/"0") this is the one
+        function to update — both routes pick it up automatically."""
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": "false"},
+        )
+        assert _extract_thinking_from_request(r) is False
+
+    def test_does_not_consult_global_config(self):
+        """The dflash route relies on this — must not touch get_config().
+
+        Even with cfg.no_thinking=True patched, the request-only helper must
+        return what's in the request (the cfg consult happens in the OpenAI/
+        anthropic wrapper, not here).
+        """
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=_fake_cfg(no_thinking=True),
+        ):
+            assert _extract_thinking_from_request(r) is True
+
+
+# ── dflash inline precedence (closure no_thinking + extractor) ──────────
+
+
+class TestDflashPrecedence:
+    """Mirror of the dflash route's branch in
+    ``vllm_mlx/speculative/dflash/server.py`` — kept in sync via the
+    shared ``_extract_thinking_from_request`` helper.
+    """
+
+    @staticmethod
+    def _resolve_dflash(no_thinking: bool, request) -> bool | None:
+        """Replicates the dflash route's enable_thinking resolution."""
+        if no_thinking:
+            return False
+        return _extract_thinking_from_request(request)
+
+    def test_closure_no_thinking_overrides_ctk_true(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        assert self._resolve_dflash(no_thinking=True, request=r) is False
+
+    def test_closure_no_thinking_false_lets_ctk_through(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        assert self._resolve_dflash(no_thinking=False, request=r) is False
+
+    def test_closure_off_top_level_true_returns_true(self):
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            enable_thinking=True,
+        )
+        assert self._resolve_dflash(no_thinking=False, request=r) is True
+
+    def test_dflash_does_not_consult_cfg_no_thinking(self):
+        """Regression for codex round 1 finding #2: dflash must NOT inherit
+        the OpenAI route's cfg.no_thinking semantics. Even if cfg says off,
+        dflash with closure no_thinking=False must respect ctk=True.
+        """
+        r = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=_fake_cfg(no_thinking=True),
+        ):
+            assert self._resolve_dflash(no_thinking=False, request=r) is True

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -216,6 +216,11 @@ class ChatCompletionRequest(BaseModel):
     timeout: float | None = None
     # Thinking/reasoning control (Qwen3 style).  None = server default.
     enable_thinking: bool | None = None
+    # OpenAI extended spec: arbitrary kwargs forwarded to the chat template.
+    # We currently honor the ``enable_thinking`` key here; other keys are
+    # accepted (no Pydantic drop) but not yet forwarded — see
+    # ``_resolve_enable_thinking`` in service/helpers.py for precedence.
+    chat_template_kwargs: dict | None = None
     # Number of completions (only n=1 supported)
     n: int | None = None
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -34,6 +34,7 @@ from ..service.helpers import (
     _build_usage,
     _disconnect_guard,
     _parse_tool_calls_with_parser,
+    _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_temperature,
     _resolve_top_p,
@@ -148,7 +149,7 @@ async def create_anthropic_message(
     chat_kwargs = {
         "max_tokens": _resolve_max_tokens(
             openai_request.max_tokens,
-            getattr(openai_request, "enable_thinking", None),
+            _resolve_enable_thinking(openai_request),
         ),
         **_resolved_sampling_kwargs(openai_request),
     }
@@ -156,10 +157,11 @@ async def create_anthropic_message(
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
     cfg = get_config()
-    if openai_request.enable_thinking is not None:
-        chat_kwargs["enable_thinking"] = openai_request.enable_thinking
-    elif cfg.no_thinking:
-        chat_kwargs["enable_thinking"] = False
+    # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
+    # passthrough). Same precedence as the OpenAI route.
+    resolved_thinking = _resolve_enable_thinking(openai_request)
+    if resolved_thinking is not None:
+        chat_kwargs["enable_thinking"] = resolved_thinking
 
     start_time = time.perf_counter()
     timeout = cfg.default_timeout
@@ -349,7 +351,7 @@ async def _stream_anthropic_messages(
     chat_kwargs = {
         "max_tokens": _resolve_max_tokens(
             openai_request.max_tokens,
-            getattr(openai_request, "enable_thinking", None),
+            _resolve_enable_thinking(openai_request),
         ),
         **_resolved_sampling_kwargs(openai_request),
     }
@@ -357,10 +359,11 @@ async def _stream_anthropic_messages(
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
     cfg = get_config()
-    if openai_request.enable_thinking is not None:
-        chat_kwargs["enable_thinking"] = openai_request.enable_thinking
-    elif cfg.no_thinking:
-        chat_kwargs["enable_thinking"] = False
+    # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
+    # passthrough). Same precedence as the OpenAI route.
+    resolved_thinking = _resolve_enable_thinking(openai_request)
+    if resolved_thinking is not None:
+        chat_kwargs["enable_thinking"] = resolved_thinking
 
     # Emit message_start
     message_start = {

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -48,6 +48,7 @@ from ..service.helpers import (
     _inject_json_instruction,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
+    _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_model_name,
     _resolve_temperature,
@@ -335,9 +336,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         if json_instruction:
             messages = _inject_json_instruction(messages, json_instruction)
 
+    # Resolve enable_thinking once and reuse — drives both the
+    # max_tokens default (thinking models need more headroom) and the
+    # chat_template kwarg below. (#387)
+    resolved_thinking = _resolve_enable_thinking(request)
+
     # Prepare kwargs
     chat_kwargs = {
-        "max_tokens": _resolve_max_tokens(request.max_tokens, request.enable_thinking),
+        "max_tokens": _resolve_max_tokens(request.max_tokens, resolved_thinking),
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
         "stop": request.stop,
@@ -361,11 +367,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     if request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
-    # Pass through enable_thinking if explicitly set by the client
-    if request.enable_thinking is not None:
-        chat_kwargs["enable_thinking"] = request.enable_thinking
-    elif cfg.no_thinking:
-        chat_kwargs["enable_thinking"] = False
+    if resolved_thinking is not None:
+        chat_kwargs["enable_thinking"] = resolved_thinking
 
     # Cloud routing: offload large-context requests to cloud LLM
     if cfg.cloud_router and not engine.is_mllm and hasattr(engine, "build_prompt"):

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -171,6 +171,57 @@ def _resolve_frequency_penalty(request_value: float | None) -> float | None:
     return float(value) if value is not None else None
 
 
+def _extract_thinking_from_request(request) -> bool | None:
+    """Read enable_thinking from a request without consulting global config.
+
+    Order (first wins):
+      1. ``request.chat_template_kwargs["enable_thinking"]`` (OpenAI ext spec)
+      2. ``request.enable_thinking`` (top-level field, our extension)
+      3. ``None`` (caller decides — usually means "template default")
+
+    Pulled out so the dflash route can share the request-side precedence
+    without inheriting the OpenAI/anthropic ``cfg.no_thinking`` consult
+    (dflash's "no_thinking" lives in a closure, not the singleton).
+    Single source of truth for the string-bool tolerance below.
+    """
+    ctk = getattr(request, "chat_template_kwargs", None)
+    if isinstance(ctk, dict) and "enable_thinking" in ctk:
+        v = ctk["enable_thinking"]
+        if isinstance(v, bool):
+            return v
+        # Tolerate JSON string forms ("true"/"false") for client friendliness.
+        if isinstance(v, str):
+            lowered = v.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+    return getattr(request, "enable_thinking", None)
+
+
+def _resolve_enable_thinking(request) -> bool | None:
+    """Resolve enable_thinking precedence for OpenAI/anthropic routes.
+
+    Order (first wins):
+      1. server ``--no-thinking`` (cfg.no_thinking) → ``False``
+      2. ``request.chat_template_kwargs["enable_thinking"]`` (OpenAI ext spec)
+      3. ``request.enable_thinking`` (top-level field, our extension)
+      4. ``None`` (template default)
+
+    Reported as #387: passing ``chat_template_kwargs={"enable_thinking":false}``
+    used to be silently dropped because the request model didn't declare the
+    field. Both this helper and the model field were added together.
+
+    The dflash route does NOT call this helper — it has its own
+    closure-scoped ``no_thinking`` and skips the cfg consult. See
+    ``vllm_mlx/speculative/dflash/server.py`` for that path.
+    """
+    cfg = get_config()
+    if cfg.no_thinking:
+        return False
+    return _extract_thinking_from_request(request)
+
+
 def build_extended_sampling_kwargs(request) -> dict:
     """Resolve top_k / min_p / penalties through the 4-layer cascade.
 

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -186,12 +186,19 @@ def _build_app(
         # tokenizer-side reasoning/tool markers match what the model was
         # trained on; no rapid-mlx-side prompt mutation happens here.
         #
-        # Resolve enable_thinking precedence: server --no-thinking wins;
-        # else request-level enable_thinking; else None (template default).
+        # Resolve enable_thinking (#387). The dflash app captures its own
+        # ``no_thinking`` by closure rather than going through the
+        # ServerConfig singleton, so we apply that override first then
+        # delegate the request-side precedence (chat_template_kwargs >
+        # request.enable_thinking > None) to the shared extractor — same
+        # source of truth as the OpenAI/anthropic helper, but without the
+        # ``cfg.no_thinking`` consult that doesn't apply to dflash.
+        from ...service.helpers import _extract_thinking_from_request
+
         if no_thinking:
             enable_thinking: bool | None = False
         else:
-            enable_thinking = request.enable_thinking
+            enable_thinking = _extract_thinking_from_request(request)
         prompt = _render_prompt(
             processor, model, request, enable_thinking=enable_thinking
         )


### PR DESCRIPTION
## Summary

Reported as #387 by @smallhadroncollider on v0.6.49: passing `chat_template_kwargs: {enable_thinking: false}` to `/v1/chat/completions` was silently ignored, so qwen3.6-27b-8bit burned ~3000 reasoning tokens for a one-line joke.

**Root cause:** `ChatCompletionRequest` did not declare `chat_template_kwargs` at all — Pydantic accepted the payload but dropped the unknown field on parse, so the chat template ran with thinking enabled by default. llama.cpp + vLLM upstream both honor this OpenAI extended-spec field.

## Fix

- Add `chat_template_kwargs: dict | None = None` to `ChatCompletionRequest` (api/models.py)
- Add `_extract_thinking_from_request(request)` — request-only precedence (ctk.enable_thinking → request.enable_thinking → None), with string-bool tolerance (`"true"`/`"false"`) for client-friendliness. Single source of truth used by both wrappers below.
- Add `_resolve_enable_thinking(request)` — adds the cfg.no_thinking layer on top of the extractor for the OpenAI/anthropic routes.
- Wire the helper into `routes/chat.py` and `routes/anthropic.py` (×2 call sites — non-streaming and streaming).
- `routes/chat.py`: also resolve the max_tokens default through the same thinking flag (was based on top-level `enable_thinking` only, giving the smaller thinking-off budget when ctk said thinking-on).
- `speculative/dflash/server.py`: layers its own closure `no_thinking` arg on top of `_extract_thinking_from_request` (NOT the cfg-aware helper — dflash never sets `cfg.no_thinking`, and consulting it would inject a hidden global-state dependency).

### Precedence (OpenAI / anthropic routes)
1. server `--no-thinking` (cfg.no_thinking) → `False`
2. `request.chat_template_kwargs["enable_thinking"]` (OpenAI ext spec)
3. `request.enable_thinking` (top-level field, our extension)
4. `None` (template default)

### Precedence (dflash route)
1. dflash closure `--no-thinking` → `False`
2. `request.chat_template_kwargs["enable_thinking"]`
3. `request.enable_thinking`
4. `None`

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/test_chat_template_kwargs.py` — **23 passed** (3 model-field tests + 10 OpenAI/anthropic helper tests + 6 extractor tests + 4 dflash precedence tests including a regression guard for "dflash must NOT consult cfg.no_thinking even when set")
- [x] Full unit suite (`pytest tests/ --ignore=integrations --ignore=mllm/video/event_loop`) — **3474 passed** (3451 baseline + 23 new), 19 skipped, 7 deselected, 1 xfailed — no regressions
- [x] DeepSeek V4 Pro adversarial review: 3 rounds to convergence
  - R1: surfaced dflash hidden cfg dependency → fixed by inlining
  - R2: surfaced drift risk + missing dflash test → fixed by extracting `_extract_thinking_from_request` and adding `TestDflashPrecedence`
  - R3: "No blocking issues found."
- [ ] CI green (await this PR's run)
- [ ] After merge: bump 0.6.49 → 0.6.50 (separate PR per Release SOP)

Closes #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)