### PR TITLE
chore: bump version to 0.6.50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.49"
+version = "0.6.50"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Same-day patch for #387 (chat_template_kwargs.enable_thinking silently ignored on v0.6.49) which landed in #389 / 744a9190.

Reported by @smallhadroncollider on Mac Studio M4 Max with qwen3.6-27b-8bit — the model burned ~3000 reasoning tokens for a one-line joke because Pydantic was dropping the unknown `chat_template_kwargs` field on parse.

## Changelog

- fix(api): honor `chat_template_kwargs.enable_thinking` (#387, via #389)

## Pre-merge SHA capture (Release SOP §8 audit anchor)

```
wheel:  3db4cd7a28ab8271ac39bb0bff1bf40f1e58bacad0913dd34142611eff7336c4
sdist:  5c29d56b355a5e3d0cf403dfdbcf8f5df5d8a7badad7bd444d974c6f622abbc6
```

These prove the bytes I built locally from this bump-PR HEAD. They will NOT byte-match the post-publish artifacts because `publish.yml` rebuilds from source on GitHub Actions and setuptools wheels are not byte-reproducible. Audit anchor only — provenance verification (CI built from tagged commit, no other path uploads to PyPI) per SOP §8 note.

## Release SOP gates

- [x] **§1 inventory** — 1 commit since v0.6.49 (the #387 fix in #389)
- [x] **§2 PR Merge SOP on #389** — full gauntlet (3-round codex convergence, 23 new tests, 3474-test full suite green, lint clean, 7 CI checks SUCCESS, squash-merged)
- [ ] **§3 install size** — skipped, no dep changes (audit confirmed)
- [ ] **§4 fresh-install subagent** — deferred to §10 post-publish verify (will run against real PyPI/Homebrew once published)
- [x] **§5 perf regression** — `make check --model qwen3.5-35b` ran 222.1s, **13/14 metrics improved 4-5×** (composite_score +229%, decode_tps +528%, cold_tps +480%), single regression on `long_ttft_ms` (625ms → 793ms, -27%) which is one long-context TTFT sample and orthogonal to this diff (request-schema + `enable_thinking` resolution only, zero contact with prefill/cache/forward). Mass improvement signals the baseline is stale; the single-sample TTFT delta is within noise. Accepting per §5 ("blocks unless explicitly accepted with a reason"). Report: `harness/runs/2026-05-15-071352-check/`
- [x] **§6 agent integration smoke** — live curl against `mlx-community/Qwen3-0.6B-8bit` on local server:
   - OpenAI `/v1/chat/completions` + `chat_template_kwargs.enable_thinking=false` → `reasoning_content=None`, 12 completion tokens
   - OpenAI + `enable_thinking=true` (control) → 1674 chars reasoning, 418 reasoning_tokens
   - Anthropic `/v1/messages` + `chat_template_kwargs.enable_thinking=false` → 0 thinking blocks, text-only response
   - Confirms #387 fix lands through both surfaces in production-shape
- [x] **§7B dep freshness (Shai-Hulud guard)** — uvicorn 0.47.0 uploaded 1d ago, verified at upstream tag `encode/uvicorn@479a2c0c`. Not a new floor on our side (still `>=0.23.0`)
- [x] **§7C-E workflow/OIDC/SHA-pin tampering** — no diff vs v0.6.49 (`git log v0.6.49..HEAD -- install.sh .github/workflows/ pyproject.toml setup.py` shows only this 1-line bump). OIDC scopes unchanged (publish.yml `id-token: write`, auto-release.yml `contents: write` — both minimal). Pre-existing moving-tag actions (`peaceiris/actions-gh-pages@v4`, `peter-evans/repository-dispatch@v3`) flagged as follow-up — not introduced by this bump.
- [x] **§8 pre-merge SHA capture** — above

## Auto-deploy expectations

Squash-merge fires `auto-release.yml` → tags `v0.6.50` → `publish.yml` uploads to PyPI + Homebrew within ~5-10 min. Will close #387 after `pip index versions rapid-mlx` shows 0.6.50 (§10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)