### PR TITLE
perf(scheduler): drop per-decode list() copy of output_token_ids

### DIFF
--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -528,12 +528,13 @@ class MLLMScheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
-            # Create output
+            # output_token_ids is a live reference (not a defensive copy):
+            # consumers read it synchronously; the per-decode list() was O(n).
             output = RequestOutput(
                 request_id=request_id,
                 new_token_ids=[response.token],
                 new_text=new_text,
-                output_token_ids=list(request.output_tokens),
+                output_token_ids=request.output_tokens,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
             )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2693,12 +2693,13 @@ class Scheduler:
                 else:
                     new_text = self._decode_tokens([response.token])
 
-            # Create output
+            # output_token_ids is a live reference (not a defensive copy):
+            # consumers read it synchronously; the per-decode list() was O(n).
             output = RequestOutput(
                 request_id=request_id,
                 new_token_ids=[response.token],
                 new_text=new_text,
-                output_token_ids=list(request.output_token_ids),
+                output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
                 logprobs=response.logprobs,


### PR DESCRIPTION
## Summary

Cherry-pick of [waybarrios/vllm-mlx#526](https://github.com/waybarrios/vllm-mlx/pull/526) (commit `83f746b`, branch `perf/caja-a`), adapted to our fork's `Scheduler` and `MLLMScheduler`.

The per-decode `RequestOutput` construction in both schedulers wrapped `request.output_token_ids` (text) / `request.output_tokens` (MLLM) in `list(...)` as a defensive copy. None of the downstream consumers mutate the list — they all read it synchronously and drop it:

- `vllm_mlx/output_collector.py:145` — merges `new.output_token_ids` into a new RequestOutput then yields
- `vllm_mlx/engine_core.py:450` — buffers in `_stream_buffers[rid]`, replaced on every merge before flush
- `vllm_mlx/engine/batched.py:739` — passes through to `GenerationOutput`

The defensive copy was a per-decode O(n_output_so_far) allocation with no observable effect.

## Why this is safe

`RequestOutput.output_token_ids` represents "all output tokens so far". The two storage sites that hold it past one decode iteration (`output_collector._merge` and `engine_core._stream_buffers`) replace it with the latest cumulative on every merge then flush. A live reference always reflects the current cumulative state at flush time — which is what the streaming contract already promises. The per-iteration delta lives in `new_token_ids`, which is freshly allocated.

## Why only this commit from #526

The other three commits in upstream's PR don't apply cleanly:
- `662ecd9` (JsonSchemaParser memoise) — targets `constrained/json_schema_processor.py`, we use outlines via `api/guided.py`
- `26e8a05` (hoist `tools_by_name` out of streaming loop) — we don't use that pattern; checked `tool_calling.py`
- `6bd3176` (bound stop-string accumulator) — needs separate audit of our stop-detection path in `scheduler.py:2725-2730`; tracked as follow-up

## Expected impact

Upstream measured the four-commit bundle at median **+4.4% gen tok/s, -7.1% TTFT, -4.6% TPOT, -6.5% e2e** across a 16-model bench (M4 Max, c=1+8, greedy). This commit is one of four; expected partial fraction. Free win regardless — pure allocation removal, no semantic change.

## PR Validation SOP — verdict: **MERGE-SAFE**

| Gate | Status | Detail |
|---|---|---|
| §1 pre-flight | PASS | 0 commits behind main, 1 ahead, clean |
| §2 deepseek V4 Pro adversarial review | PASS | **no blocking issues** (143s) |
| §2.5 supply-chain | PASS | no deps/CI/install hooks touched |
| §3 test coverage | N/A | pure perf optimization, no new behavior — existing streaming/batching tests cover the contract |
| §4 lint (ruff check + format) | PASS | clean on both files |
| §5 broader unit suite | PASS | 3583 passed, 19 skipped, 16 deselected, 1 xfailed (47.6s) |
| §6 pr_validate runner | PASS | full pipeline incl. stress_e2e_bench matrix 3×3 (774s — qwen3-0.6b + qwen3.5-35b + qwen3.6-27b) |
| §7 make check (inference-touching gate) | PASS | doctor `check` on qwen3.5-4b: 6 pass, 0 regression |
| §8 CI gate | PASS | all 7 GitHub checks SUCCESS, mergeStateStatus=CLEAN |

## Test plan (audit trail)

- [x] Lint: `ruff check vllm_mlx/scheduler.py vllm_mlx/mllm_scheduler.py && ruff format --check ...` — clean
- [x] Targeted streaming + batching: `tests/test_batching.py test_batching_deterministic.py test_request.py test_streaming_latency.py test_stop_string_enforcement.py test_continuous_batching.py test_streaming.py test_streaming_pipeline_integration.py` — 147 passed (1 xfailed: known pre-existing flake)
- [x] Full unit suite: 3583 passed via pr_validate runner
- [x] Doctor check: `python3.12 -m vllm_mlx.cli doctor check --model qwen3.5-4b` — 6 pass, 0 regression, 0 fail (baseline_diff skipped: no 4b baseline)
- [x] DeepSeek V4 Pro adversarial review via `scripts.pr_validate`: no blocking issues
- [x] Stress + 3-model integration matrix via pr_validate runner: PASSED

## Out of scope

Stop-buffer bound + JsonSchemaParser cache + tools_by_name hoist from #526 — analyzed in this PR body, deferred or non-applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)