### PR TITLE
fix(prefix-cache): slice 3D KV state along the right axis

### DIFF
--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -764,3 +764,9 @@ class TestBlockAwarePrefixCache:
         assert cache._cache_state_seq_axis((four_d, four_d)) == 2
         assert cache._cache_state_seq_axis((four_d,)) is None
         assert cache._cache_state_seq_axis((four_d, mx.zeros((2, 8)))) is None
+        # Partial-None state must reject up-front rather than relying on
+        # downstream ``.shape`` access to crash (caught by outer try/except,
+        # but fragile). Regression for codex round-2 finding on PR #392.
+        assert cache._cache_state_seq_axis((four_d, None)) is None
+        assert cache._cache_state_seq_axis((None, four_d)) is None
+        assert cache._cache_state_seq_axis((None, None)) is None

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -770,3 +770,27 @@ class TestBlockAwarePrefixCache:
         assert cache._cache_state_seq_axis((four_d, None)) is None
         assert cache._cache_state_seq_axis((None, four_d)) is None
         assert cache._cache_state_seq_axis((None, None)) is None
+        # Class-name gate: a Mamba/DeltaNet ``ArraysCache`` may happen to
+        # hold two same-shape 3D tensors, but its tensors are NOT seq-
+        # indexed. The gate must reject any class outside the allowlist.
+        # Regression for codex round-3 finding on PR #392.
+        assert (
+            cache._cache_state_seq_axis((kv_keys, kv_values), class_name="ArraysCache")
+            is None
+        )
+        assert (
+            cache._cache_state_seq_axis((four_d, four_d), class_name="RotatingKVCache")
+            is None
+        )
+        assert cache._cache_state_seq_axis((four_d, four_d), class_name="KVCache") == 2
+        # When class_name is omitted, fall back to the shape-only heuristic.
+        assert cache._cache_state_seq_axis((four_d, four_d)) == 2
+        # Extract path itself rejects layers whose class_name is not KVCache,
+        # even when their tensors look slicable.
+        non_kv_layer = {
+            "state": (kv_keys, kv_values),
+            "meta_state": "",
+            "class_ref": None,
+            "class_name": "ArraysCache",
+        }
+        assert cache._extract_block_tensor_slice([non_kv_layer], 0, 4) is None

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -794,3 +794,31 @@ class TestBlockAwarePrefixCache:
             "class_name": "ArraysCache",
         }
         assert cache._extract_block_tensor_slice([non_kv_layer], 0, 4) is None
+
+    def test_reconstruct_refuses_non_kvcache_class_name(self):
+        """``reconstruct_cache`` must refuse to host anything other than a
+        vanilla ``KVCache`` even if ``block.cache_data`` somehow contains
+        4D tensors. Defense in depth against a future writer that bypasses
+        ``_extract_block_tensor_slice``. Regression for codex pr_validate
+        finding on PR #392."""
+        import mlx.core as mx
+
+        from vllm_mlx.paged_cache import BlockTable, PagedCacheManager
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        paged_manager = PagedCacheManager(block_size=4, max_blocks=10)
+        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
+
+        # Manually plant a block as if some non-KV writer had populated it.
+        block = paged_manager.allocate_block()
+        four_d = mx.zeros((1, 2, 4, 8))
+        block.cache_data = [(four_d, four_d)]
+        block.cache_class_name = "RotatingKVCache"
+
+        table = BlockTable(request_id="req", block_ids=[block.block_id], num_tokens=4)
+        assert cache.reconstruct_cache(table) is None
+
+        # And the happy path still works once class_name is correct.
+        block.cache_class_name = "KVCache"
+        out = cache.reconstruct_cache(table)
+        assert out is not None and len(out) == 1

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -822,3 +822,51 @@ class TestBlockAwarePrefixCache:
         block.cache_class_name = "KVCache"
         out = cache.reconstruct_cache(table)
         assert out is not None and len(out) == 1
+
+    def test_extract_rejects_layer_without_class_name(self):
+        """If a layer dict lacks an explicit ``class_name``, ``_extract``
+        must refuse to slice. Otherwise the block would be stored with
+        ``cache_class_name=None`` and silently rejected at reconstruct,
+        wasting a paged-cache slot. Regression for codex pr_validate
+        round-2 finding on PR #392."""
+        import mlx.core as mx
+
+        from vllm_mlx.paged_cache import PagedCacheManager
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        paged_manager = PagedCacheManager(block_size=4, max_blocks=10)
+        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
+        four_d = mx.zeros((1, 2, 8, 3))
+
+        # Missing class_name key entirely.
+        no_class_layer = {"state": (four_d, four_d), "meta_state": ""}
+        assert cache._extract_block_tensor_slice([no_class_layer], 0, 4) is None
+        # Explicit None.
+        explicit_none = dict(no_class_layer, class_name=None)
+        assert cache._extract_block_tensor_slice([explicit_none], 0, 4) is None
+        # Any non-allowlisted class.
+        for forbidden in ("ArraysCache", "RotatingKVCache", "QuantizedKVCache"):
+            layer = dict(no_class_layer, class_name=forbidden)
+            assert cache._extract_block_tensor_slice([layer], 0, 4) is None
+
+    def test_cow_copy_propagates_cache_class_name(self):
+        """``PagedCacheManager.copy_block`` must propagate
+        ``cache_class_name`` so the COW destination satisfies the
+        (cache_data, cache_class_name) invariant. Regression for codex
+        pr_validate round-2 finding on PR #392."""
+        import mlx.core as mx
+
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=4, max_blocks=10)
+        src = manager.allocate_block()
+        four_d = mx.zeros((1, 2, 4, 8))
+        src.cache_data = [(four_d, four_d)]
+        src.cache_class_name = "KVCache"
+        # Bump the source ref so copy_block treats it as shared (its COW
+        # contract decrements the source from a shared state).
+        manager.increment_ref(src.block_id)
+        dst = manager._cow_copy_block(src)
+        assert dst is not None
+        assert dst.cache_data == src.cache_data
+        assert dst.cache_class_name == "KVCache"

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -726,3 +726,41 @@ class TestBlockAwarePrefixCache:
         stats = cache.get_stats()
         # After clear, null block is still allocated (vLLM style)
         assert stats["allocated_blocks"] == 1  # only null block
+
+    def test_slices_3d_kv_along_seq_axis(self):
+        """3D KV state (Qwen3.5-style ``(n_kv_heads, seq, head_dim)``) must
+        be sliced along seq (axis 1), not axis 2 (which is ``head_dim``).
+        Regression for upstream waybarrios#286 — pre-fix, the 4D-hardcoded
+        slice ``keys[:, :, start:end, :]`` crashed on 3D state and dropped
+        the whole entry, masking the issue. ``reconstruct_cache`` still
+        refuses 3D state because mlx_lm's ``KVCache`` accessors hard-code
+        ``shape[2]`` for seq; hosting 3D state there would silently corrupt
+        downstream generation."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.paged_cache import PagedCacheManager
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        paged_manager = PagedCacheManager(block_size=4, max_blocks=10)
+        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
+
+        kv_keys = mx.arange(2 * 8 * 3).reshape(2, 8, 3)
+        kv_values = mx.arange(1000, 1000 + (2 * 8 * 3)).reshape(2, 8, 3)
+        layer_state = {
+            "state": (kv_keys, kv_values),
+            "meta_state": "",
+            "class_ref": KVCache,
+            "class_name": "KVCache",
+        }
+
+        sliced = cache._extract_block_tensor_slice([layer_state], 0, 4)
+        assert sliced is not None and len(sliced) == 1
+        sliced_keys, sliced_values = sliced[0]
+        assert sliced_keys.tolist() == kv_keys[:, :4, :].tolist()
+        assert sliced_values.tolist() == kv_values[:, :4, :].tolist()
+        assert cache._cache_state_seq_axis((kv_keys, kv_values)) == 1
+        four_d = mx.zeros((1, 2, 8, 3))
+        assert cache._cache_state_seq_axis((four_d, four_d)) == 2
+        assert cache._cache_state_seq_axis((four_d,)) is None
+        assert cache._cache_state_seq_axis((four_d, mx.zeros((2, 8)))) is None

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -115,6 +115,11 @@ class CacheBlock:
     # Actual tensor data for this block
     # List of (keys, values) per layer, shape: (1, n_kv_heads, block_tokens, head_dim)
     cache_data: list[tuple[Any, Any]] | None = None
+    # mlx-lm cache class that produced ``cache_data``. Reconstruction must
+    # check this before hosting the slices in an ``mlx_lm.KVCache`` — two
+    # different cache classes may emit same-shape state but have different
+    # seq-axis semantics (e.g. ``RotatingKVCache`` vs ``KVCache``).
+    cache_class_name: str | None = None
 
     # Metadata
     token_count: int = 0

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -709,6 +709,7 @@ class PagedCacheManager:
 
             block.reset_hash()
             block.cache_data = None  # Free tensor memory
+            block.cache_class_name = None
             self.stats.evictions += 1
             return True
 
@@ -1119,6 +1120,9 @@ class PagedCacheManager:
 
         new_block.token_count = source_block.token_count
         new_block.cache_data = source_block.cache_data
+        # cache_class_name is part of the (cache_data, cache_class_name)
+        # invariant required by ``BlockAwarePrefixCache.reconstruct_cache``.
+        new_block.cache_class_name = source_block.cache_class_name
 
         source_block.ref_count -= 1
         if source_block.ref_count == 1:
@@ -1303,6 +1307,7 @@ class PagedCacheManager:
             for block in self.blocks:
                 block.reset_hash()
                 block.cache_data = None
+                block.cache_class_name = None
 
             self.stats.evictions = 0
             self.stats.cache_hits = 0

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -702,19 +702,20 @@ class BlockAwarePrefixCache:
         if not isinstance(state, (list, tuple)) or not state:
             return None
 
-        ndims = {
-            len(tensor.shape)
-            for tensor in state
-            if tensor is not None and hasattr(tensor, "shape")
-        }
+        # KV-cache state is always (keys, values); anything else is some
+        # other cache class (Mamba conv state + recurrent state, etc.).
+        # Reject up-front when either side is missing or non-tensorlike so
+        # downstream ``keys.shape`` / ``values.shape`` access is safe.
+        if len(state) != 2:
+            return None
+        if any(t is None or not hasattr(t, "shape") for t in state):
+            return None
+
+        ndims = {len(tensor.shape) for tensor in state}
         if len(ndims) != 1:
             return None
 
         ndim = next(iter(ndims))
-        # KV-cache state is always (keys, values); anything else is some
-        # other cache class (Mamba conv state + recurrent state, etc.).
-        if len(state) != 2:
-            return None
         if ndim == 4:
             return 2
         # Qwen3.5-style KV caches use (n_kv_heads, seq, head_dim).

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -655,10 +655,11 @@ class BlockAwarePrefixCache:
                 )
                 if block_kv_data:
                     block.cache_data = block_kv_data
-                    # Record the originating cache class. ``_extract`` only
-                    # returns non-None when every layer is in
-                    # ``_SEQ_AXIS_KV_CLASSES``, so reading any one is safe.
-                    block.cache_class_name = cache_data[0].get("class_name")
+                    # ``_extract_block_tensor_slice`` only returns non-None
+                    # when every layer's ``class_name`` is in
+                    # ``_SEQ_AXIS_KV_CLASSES``, so reading the first layer's
+                    # name is safe and guaranteed non-None.
+                    block.cache_class_name = cache_data[0]["class_name"]
                     logger.debug(
                         f"Stored tensor slice for block {block.block_id}: "
                         f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
@@ -773,18 +774,22 @@ class BlockAwarePrefixCache:
 
                 keys, values = layer_state["state"]
 
-                # Gate on class_name so a Mamba/DeltaNet ``ArraysCache``
-                # holding two same-shape tensors can't be misclassified as
-                # KV and sliced along the wrong axis.
+                # Reject layers without an explicit allowlisted class_name
+                # *before* slicing — otherwise we'd store the block but
+                # ``reconstruct_cache`` would later refuse to host it,
+                # silently wasting a paged-cache slot. Mamba/DeltaNet
+                # ``ArraysCache`` and any future variant are bounced here.
+                class_name = layer_state.get("class_name")
+                if class_name not in self._SEQ_AXIS_KV_CLASSES:
+                    return None
+
                 seq_axis = self._cache_state_seq_axis(
-                    (keys, values),
-                    class_name=layer_state.get("class_name"),
+                    (keys, values), class_name=class_name
                 )
                 if seq_axis is None:
-                    # Unsupported layout (e.g. Mamba/DeltaNet state tuple in
-                    # a hybrid model). Bail out entirely — a partial slice
-                    # list would silently corrupt the cache when later
-                    # concatenated/reconstructed.
+                    # Tensor shape didn't match any known KV layout even
+                    # though the class name was right (e.g. corrupted
+                    # state). Bail out entirely.
                     return None
 
                 # Take the min over both tensors. ``keys`` and ``values``

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -758,7 +758,11 @@ class BlockAwarePrefixCache:
                     # concatenated/reconstructed.
                     return None
 
-                seq_len = keys.shape[seq_axis] if hasattr(keys, "shape") else 0
+                # Take the min over both tensors. ``keys`` and ``values``
+                # share a seq axis by contract, but a paranoid floor avoids
+                # an IndexError if one is shorter than the other (e.g. a
+                # partially-written cache during a torn shutdown).
+                seq_len = min(keys.shape[seq_axis], values.shape[seq_axis])
 
                 if end_idx > seq_len:
                     # Requested range extends beyond available data

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -655,6 +655,10 @@ class BlockAwarePrefixCache:
                 )
                 if block_kv_data:
                     block.cache_data = block_kv_data
+                    # Record the originating cache class. ``_extract`` only
+                    # returns non-None when every layer is in
+                    # ``_SEQ_AXIS_KV_CLASSES``, so reading any one is safe.
+                    block.cache_class_name = cache_data[0].get("class_name")
                     logger.debug(
                         f"Stored tensor slice for block {block.block_id}: "
                         f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
@@ -930,6 +934,20 @@ class BlockAwarePrefixCache:
 
                 if block.cache_data is None:
                     logger.debug(f"Block {block_id} has no tensor data stored")
+                    return None
+
+                # Belt-and-suspenders: even though the store path gates on
+                # ``class_name``, refuse to host anything but a vanilla
+                # ``KVCache`` here. mlx_lm's ``KVCache`` accessors hard-code
+                # ``shape[2]`` for seq; a rotating/chunked cache with the
+                # same 4D shape would be silently misinterpreted.
+                if block.cache_class_name not in self._SEQ_AXIS_KV_CLASSES:
+                    logger.debug(
+                        f"Block {block_id} cache_class_name="
+                        f"{block.cache_class_name!r} not in "
+                        f"{sorted(self._SEQ_AXIS_KV_CLASSES)}; refusing to "
+                        "reconstruct as KVCache."
+                    )
                     return None
 
                 all_block_data.append(block.cache_data)

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -689,15 +689,30 @@ class BlockAwarePrefixCache:
 
         return block_table
 
-    def _cache_state_seq_axis(self, state: Any) -> int | None:
+    # Cache classes whose ``state`` is ``(keys, values)`` and whose seq
+    # axis is well-defined by ndim alone. Other classes (Mamba/DeltaNet
+    # ``ArraysCache``, ``QuantizedKVCache`` with tri-tuple values, rotating
+    # caches with non-monotonic seq positions) are explicitly rejected
+    # even when their tensors happen to look 3D/4D and same-shape.
+    _SEQ_AXIS_KV_CLASSES = frozenset({"KVCache"})
+
+    def _cache_state_seq_axis(
+        self, state: Any, *, class_name: str | None = None
+    ) -> int | None:
         """Return the sequence axis for cache states that support block concat.
 
         Supports two KV-cache layouts emitted by mlx-lm:
         - 4D ``(batch, n_kv_heads, seq, head_dim)`` → seq_axis = 2
         - 3D ``(n_kv_heads, seq, head_dim)`` (Qwen3.5-style) → seq_axis = 1
 
-        Returns ``None`` for unsupported shapes (e.g. mixed dims across keys/
-        values, scalars, MambaCache state tuples).
+        ``class_name``, when supplied, must be in ``_SEQ_AXIS_KV_CLASSES`` —
+        a Mamba/DeltaNet ``ArraysCache`` may incidentally hold two same-
+        shape 3D tensors but is NOT seq-indexed, and slicing it along axis
+        1 would silently corrupt the cache. When ``class_name`` is omitted
+        the legacy shape-only heuristic is used (kept for the standalone
+        unit test that does not flow through the full extract path).
+
+        Returns ``None`` for unsupported shapes or class names.
         """
         if not isinstance(state, (list, tuple)) or not state:
             return None
@@ -709,6 +724,9 @@ class BlockAwarePrefixCache:
         if len(state) != 2:
             return None
         if any(t is None or not hasattr(t, "shape") for t in state):
+            return None
+
+        if class_name is not None and class_name not in self._SEQ_AXIS_KV_CLASSES:
             return None
 
         ndims = {len(tensor.shape) for tensor in state}
@@ -751,7 +769,13 @@ class BlockAwarePrefixCache:
 
                 keys, values = layer_state["state"]
 
-                seq_axis = self._cache_state_seq_axis((keys, values))
+                # Gate on class_name so a Mamba/DeltaNet ``ArraysCache``
+                # holding two same-shape tensors can't be misclassified as
+                # KV and sliced along the wrong axis.
+                seq_axis = self._cache_state_seq_axis(
+                    (keys, values),
+                    class_name=layer_state.get("class_name"),
+                )
                 if seq_axis is None:
                     # Unsupported layout (e.g. Mamba/DeltaNet state tuple in
                     # a hybrid model). Bail out entirely — a partial slice

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -689,6 +689,39 @@ class BlockAwarePrefixCache:
 
         return block_table
 
+    def _cache_state_seq_axis(self, state: Any) -> int | None:
+        """Return the sequence axis for cache states that support block concat.
+
+        Supports two KV-cache layouts emitted by mlx-lm:
+        - 4D ``(batch, n_kv_heads, seq, head_dim)`` → seq_axis = 2
+        - 3D ``(n_kv_heads, seq, head_dim)`` (Qwen3.5-style) → seq_axis = 1
+
+        Returns ``None`` for unsupported shapes (e.g. mixed dims across keys/
+        values, scalars, MambaCache state tuples).
+        """
+        if not isinstance(state, (list, tuple)) or not state:
+            return None
+
+        ndims = {
+            len(tensor.shape)
+            for tensor in state
+            if tensor is not None and hasattr(tensor, "shape")
+        }
+        if len(ndims) != 1:
+            return None
+
+        ndim = next(iter(ndims))
+        # KV-cache state is always (keys, values); anything else is some
+        # other cache class (Mamba conv state + recurrent state, etc.).
+        if len(state) != 2:
+            return None
+        if ndim == 4:
+            return 2
+        # Qwen3.5-style KV caches use (n_kv_heads, seq, head_dim).
+        if ndim == 3:
+            return 1
+        return None
+
     def _extract_block_tensor_slice(
         self,
         cache_data: list[dict[str, Any]],
@@ -717,26 +750,36 @@ class BlockAwarePrefixCache:
 
                 keys, values = layer_state["state"]
 
-                # KV cache shape: (batch, n_kv_heads, seq_len, head_dim)
-                # Slice along seq_len dimension (axis 2)
-                seq_len = keys.shape[2] if hasattr(keys, "shape") else 0
+                seq_axis = self._cache_state_seq_axis((keys, values))
+                if seq_axis is None:
+                    # Unsupported layout (e.g. Mamba/DeltaNet state tuple in
+                    # a hybrid model). Bail out entirely — a partial slice
+                    # list would silently corrupt the cache when later
+                    # concatenated/reconstructed.
+                    return None
+
+                seq_len = keys.shape[seq_axis] if hasattr(keys, "shape") else 0
 
                 if end_idx > seq_len:
                     # Requested range extends beyond available data
                     logger.debug(
                         f"Block slice [{start_idx}:{end_idx}] exceeds seq_len {seq_len}"
                     )
-                    # Use whatever is available
                     actual_end = min(end_idx, seq_len)
                     if start_idx >= actual_end:
                         continue
-                    keys_slice = keys[:, :, start_idx:actual_end, :]
-                    values_slice = values[:, :, start_idx:actual_end, :]
                 else:
-                    keys_slice = keys[:, :, start_idx:end_idx, :]
-                    values_slice = values[:, :, start_idx:end_idx, :]
+                    actual_end = end_idx
 
-                block_slices.append((keys_slice, values_slice))
+                # Build a slice tuple that addresses only the seq axis; all
+                # other axes pass through. Avoids hardcoding rank (3D vs 4D).
+                key_slices: list[slice] = [slice(None)] * len(keys.shape)
+                val_slices: list[slice] = [slice(None)] * len(values.shape)
+                key_slices[seq_axis] = slice(start_idx, actual_end)
+                val_slices[seq_axis] = slice(start_idx, actual_end)
+                block_slices.append(
+                    (keys[tuple(key_slices)], values[tuple(val_slices)])
+                )
 
             return block_slices if block_slices else None
 
@@ -886,10 +929,23 @@ class BlockAwarePrefixCache:
                 if not layer_keys:
                     continue
 
-                # Concatenate along sequence dimension (axis 2)
-                # Shape: (batch, n_kv_heads, seq_len, head_dim)
-                concat_keys = mx.concatenate(layer_keys, axis=2)
-                concat_values = mx.concatenate(layer_values, axis=2)
+                # Only 4D ``(batch, n_kv_heads, seq, head_dim)`` states can
+                # be hosted by mlx_lm's ``KVCache`` — its accessors are hard-
+                # coded to ``shape[2]`` for seq. 3D states (Qwen3.5-style
+                # ``(n_kv_heads, seq, head_dim)``) come from non-standard
+                # caches and would be silently misinterpreted as 4D here,
+                # corrupting any subsequent generation off this prefix.
+                seq_axis = self._cache_state_seq_axis((layer_keys[0], layer_values[0]))
+                if seq_axis != 2:
+                    logger.warning(
+                        "Cache layer has non-4D KV shape "
+                        f"({getattr(layer_keys[0], 'shape', '?')}); skipping "
+                        "reconstruction — mlx_lm.KVCache requires 4D layout."
+                    )
+                    return None
+
+                concat_keys = mx.concatenate(layer_keys, axis=seq_axis)
+                concat_values = mx.concatenate(layer_values, axis=seq_axis)
 
                 # Create KVCache object
                 # Try to use mlx_lm's KVCache.from_state if available
@@ -898,23 +954,22 @@ class BlockAwarePrefixCache:
 
                     # Create new cache and set its state
                     cache = KVCache()
-                    seq_len = concat_keys.shape[2]
 
                     # Set internal state directly
                     # KVCache stores keys/values and offset
                     cache.keys = concat_keys
                     cache.values = concat_values
-                    cache.offset = seq_len
+                    cache.offset = concat_keys.shape[seq_axis]
 
                     reconstructed_caches.append(cache)
 
                 except ImportError:
                     # Fallback: create a simple cache-like object
                     class SimpleKVCache:
-                        def __init__(self, keys, values):
+                        def __init__(self, keys, values, offset: int):
                             self.keys = keys
                             self.values = values
-                            self.offset = keys.shape[2]
+                            self.offset = offset
 
                         @property
                         def state(self):
@@ -924,7 +979,9 @@ class BlockAwarePrefixCache:
                         def meta_state(self):
                             return (str(self.offset),)
 
-                    cache = SimpleKVCache(concat_keys, concat_values)
+                    cache = SimpleKVCache(
+                        concat_keys, concat_values, concat_keys.shape[seq_axis]
+                    )
                     reconstructed_caches.append(cache)
 
             if not reconstructed_caches:


### PR DESCRIPTION
## Summary

Port of upstream [waybarrios#286](https://github.com/waybarrios/vllm-mlx/pull/286), adapted to keep our reconstruct path safe against 3D state.

`BlockAwarePrefixCache._extract_block_tensor_slice` was hardcoded to `keys[:, :, start:end, :]` — a 4D-only slice that silently crashes the outer `try/except` for 3D KV layouts (Qwen3.5-style `(n_kv_heads, seq, head_dim)`), dropping the whole entry from the paged cache.

- New `_cache_state_seq_axis()` helper detects 4D vs 3D layouts and reports the correct seq axis (2 for 4D, 1 for 3D). Strict: requires `len(state) == 2` and consistent rank across both tensors; any other shape (e.g. Mamba/DeltaNet conv-state tuple, single tensor, mismatched dims) returns `None`.
- `_extract_block_tensor_slice()` now slices along the detected axis using inline slice-list construction; unsupported layouts trigger an **all-or-nothing return** so we never store a partial slice list.
- `reconstruct_cache()` still **refuses 3D state**: mlx_lm's `KVCache` accessors hard-code `shape[2]` for seq, so hosting 3D state there would silently misinterpret `head_dim` as seq and corrupt downstream generation off the cached prefix.

## Test plan

- [x] `python3.12 -m pytest tests/test_paged_cache.py -q` — 38/38 pass (new `test_slices_3d_kv_along_seq_axis` covers the helper + slicing semantics).
- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py --ignore=tests/test_mllm*.py --ignore=tests/test_video.py -q` — 3475 passed, 19 skipped, 1 xfailed.
- [x] `ruff check && ruff format --check` clean on touched files.
- [x] `make check --model qwen3.5-4b` — PASS 6/0/0/1 (hybrid; this model uses memory-aware cache and is unaffected by the paged-cache code path).
- [x] No `is_hybrid` model uses paged cache by default; the regression-prone path is gated behind `--use-paged-cache`.

## Why this is safe

- Default install uses memory-aware cache (`use_paged_cache=False`), so the codepath this PR touches is opt-in. The fix avoids regressions for the small set of users running with paged cache enabled.
- The reconstruct refusal of 3D state preserves pre-existing failure semantics — pre-fix, the 4D slice crashed and dropped the entry; post-fix, the entry is stored but skipped during reconstruction. Either way, the cache reuse can't produce a corrupt downstream KVCache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)