### PR TITLE
feat(json-output): strip spurious backslashes before non-ASCII chars

### DIFF
--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -377,5 +377,59 @@ class TestStructuredOutputIntegration:
         assert isinstance(data["colors"], list)
 
 
+class TestStripBackslashBeforeUnicode:
+    """Cherry-picked from upstream waybarrios#525.
+
+    ``lm-format-enforcer``'s grammar permits ``\\`` followed by any
+    codepoint as a valid JSON escape, so a model emitting JSON with
+    non-ASCII content can produce strings like ``"\\빠\\르\\게"``: valid
+    JSON, but the decoded value carries literal backslashes that look
+    like corruption to clients. The helper in ``routes/chat.py`` strips
+    those spurious backslashes recursively across dicts / lists / strs.
+    """
+
+    def test_strips_backslash_before_cjk(self):
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        assert _strip_backslash_before_unicode("\\빠\\르\\게") == "빠르게"
+
+    def test_preserves_valid_ascii_escapes(self):
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        # ``\\n`` decodes to a newline; the helper sees an actual newline
+        # (non-ASCII codepoint? no — newline is ASCII), so it must remain
+        # untouched.  Same for ``\\\\`` (literal backslash).
+        assert _strip_backslash_before_unicode("line1\nline2") == "line1\nline2"
+        assert _strip_backslash_before_unicode("path\\\\to") == "path\\\\to"
+
+    def test_recurses_into_dict_and_list(self):
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        nested = {
+            "title": "\\안\\녕",
+            "items": ["a", "\\🚀", {"name": "\\한\\글"}],
+        }
+        cleaned = _strip_backslash_before_unicode(nested)
+        assert cleaned == {
+            "title": "안녕",
+            "items": ["a", "🚀", {"name": "한글"}],
+        }
+
+    def test_non_string_scalars_pass_through(self):
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        assert _strip_backslash_before_unicode(42) == 42
+        assert _strip_backslash_before_unicode(True) is True
+        assert _strip_backslash_before_unicode(None) is None
+
+    def test_emoji_with_surrogate_pair(self):
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        # Emoji past U+FFFF — the regex matches by codepoint, not by
+        # UTF-16 surrogate, so the single backslash before the emoji
+        # should still be stripped.
+        assert _strip_backslash_before_unicode("hi \\🎉 there") == "hi 🎉 there"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -443,6 +443,20 @@ class TestStripBackslashBeforeUnicode:
         # should still be stripped.
         assert _strip_backslash_before_unicode("hi \\🎉 there") == "hi 🎉 there"
 
+    def test_key_collision_logs_and_keeps_first(self, caplog):
+        """Codex review round 2 finding: two dirty keys can collapse to
+        the same clean key (``"\\한"`` and ``"한"`` both → ``"한"``).
+        Silently dropping one is data loss; we keep the first occurrence
+        and log a warning."""
+        import logging
+
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        with caplog.at_level(logging.WARNING, logger="vllm_mlx.routes.chat"):
+            cleaned = _strip_backslash_before_unicode({"\\한": 1, "한": 2})
+        assert cleaned == {"한": 1}
+        assert any("key collision" in rec.message for rec in caplog.records)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -5,6 +5,7 @@ Tests for structured output (JSON Schema) functionality.
 Tests the JSON parsing, validation, and response_format handling.
 """
 
+import importlib.util
 import json
 
 import pytest
@@ -16,6 +17,8 @@ from vllm_mlx.api.tool_calling import (
     parse_json_output,
     validate_json_schema,
 )
+
+_MLX_AVAILABLE = importlib.util.find_spec("mlx") is not None
 
 
 class TestValidateJsonSchema:
@@ -377,6 +380,10 @@ class TestStructuredOutputIntegration:
         assert isinstance(data["colors"], list)
 
 
+@pytest.mark.skipif(
+    not _MLX_AVAILABLE,
+    reason="routes.chat transitively imports mlx (skipped on no-MLX CI)",
+)
 class TestStripBackslashBeforeUnicode:
     """Cherry-picked from upstream waybarrios#525.
 

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -457,6 +457,46 @@ class TestStripBackslashBeforeUnicode:
         assert cleaned == {"한": 1}
         assert any("key collision" in rec.message for rec in caplog.records)
 
+    def test_end_to_end_response_format_cleanup(self):
+        """Integration: drive the exact chain ``routes/chat.py`` runs on
+        a response_format='json_object' request whose model output
+        contains spurious ``\\`` before non-ASCII chars. This is the
+        regression that exercises wiring — if a future refactor moves
+        the helper to a different module or skips it, this test fails.
+
+        Codex review round 2 asked for this end-to-end coverage so the
+        unit test alone isn't the only safeguard against the wiring
+        getting accidentally dropped."""
+        import json as _json
+
+        from vllm_mlx.api.tool_calling import parse_json_output
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        # Simulated model output: looks like JSON, but every CJK char
+        # carries a leading backslash (lm-format-enforcer behavior).
+        # Use double-escaped backslashes because the model emits the
+        # literal characters ``\``, ``빠``, ``\``, ``르``, …
+        raw_model_text = (
+            '{"message": "안녕 \\\\빠\\\\르\\\\게", "name": "\\\\한\\\\글"}'
+        )
+        response_format = {"type": "json_object"}
+
+        _, parsed_json, is_valid, _ = parse_json_output(raw_model_text, response_format)
+        assert is_valid, "json_object parser should accept this input"
+        assert parsed_json is not None
+
+        # The chat route now applies the helper before re-serializing.
+        cleaned = _strip_backslash_before_unicode(parsed_json)
+        final = _json.dumps(cleaned, ensure_ascii=False)
+
+        # Final body is what the client sees in ``message.content``.
+        # No spurious backslashes before the CJK characters.
+        assert "\\빠" not in final
+        assert "\\한" not in final
+        # CJK content survives intact (not double-escaped to \uXXXX).
+        assert "빠르게" in final
+        assert "한글" in final
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -415,6 +415,19 @@ class TestStripBackslashBeforeUnicode:
             "items": ["a", "🚀", {"name": "한글"}],
         }
 
+    def test_cleans_non_ascii_keys(self):
+        """Codex review round 1 finding: keys can also carry spurious
+        backslashes (``lm-format-enforcer`` makes no distinction between
+        JSON keys and values). The cleaner must strip both."""
+        from vllm_mlx.routes.chat import _strip_backslash_before_unicode
+
+        # Key with backslashes before CJK; value also dirty.
+        assert _strip_backslash_before_unicode({"\\제\\목": "\\값"}) == {"제목": "값"}
+        # Nested case: the inner dict's key must also be cleaned.
+        assert _strip_backslash_before_unicode({"items": [{"\\이\\름": "raul"}]}) == {
+            "items": [{"이름": "raul"}]
+        }
+
     def test_non_string_scalars_pass_through(self):
         from vllm_mlx.routes.chat import _strip_backslash_before_unicode
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -72,6 +72,22 @@ router = APIRouter()
 # as a valid JSON escape, so a model emitting JSON with CJK / emoji content
 # can produce strings like ``"\\빠\\르\\게"`` — valid JSON, but the decoded
 # value carries literal backslashes. Strip them so clients see clean text.
+#
+# Scope / known tradeoff: this is applied only on the ``response_format``
+# json-output path (see line ~632 below), not to tool-call arguments or
+# regular text content. The cleanup is unconditional within that path,
+# matching upstream waybarrios#525. A JSON object that LEGITIMATELY
+# contains a backslash before a non-ASCII codepoint (e.g. a Windows path
+# ``"C:\\사용자\\file.txt"`` in a response_format=json_object reply) will
+# be mutated to ``"C:사용자file.txt"``. We accept this tradeoff because:
+#  (a) the lm-format-enforcer bug is the overwhelming source of these
+#      sequences in JSON-output responses; the file-path case is rare,
+#  (b) gating the cleanup on a heuristic ("looks like enforcer output")
+#      would be fragile and only catch the obvious patterns,
+#  (c) clients that need raw backslash + non-ASCII can fall back to
+#      ``response_format=text`` and parse the JSON themselves.
+# If a user reports the false-positive in practice, revisit by adding a
+# config flag (``--no-strip-spurious-backslashes``) rather than a heuristic.
 _BACKSLASH_BEFORE_UNICODE = re.compile(r"\\([^\x00-\x7F])")
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -80,10 +80,24 @@ def _strip_backslash_before_unicode(obj: object) -> object:
         # Clean both keys and values: ``lm-format-enforcer`` can produce
         # ``"\\한\\글": "value"`` (valid JSON, ugly key). Stripping only
         # values would leak the bug into client-visible object keys.
-        return {
-            _strip_backslash_before_unicode(k): _strip_backslash_before_unicode(v)
-            for k, v in obj.items()
-        }
+        cleaned: dict[object, object] = {}
+        for k, v in obj.items():
+            new_key = _strip_backslash_before_unicode(k)
+            new_val = _strip_backslash_before_unicode(v)
+            if new_key in cleaned:
+                # Two distinct dirty keys can collapse to the same clean
+                # key (e.g. ``"\\한"`` and ``"한"`` both → ``"한"``). Keep
+                # the first occurrence and surface the collision rather
+                # than silently dropping a field.
+                logger.warning(
+                    "JSON key collision after backslash strip: %r dropped "
+                    "in favor of earlier value (cleaned key=%r)",
+                    k,
+                    new_key,
+                )
+                continue
+            cleaned[new_key] = new_val
+        return cleaned
     if isinstance(obj, list):
         return [_strip_backslash_before_unicode(v) for v in obj]
     if isinstance(obj, str):
@@ -616,9 +630,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             )
             if parsed_json is not None:
                 parsed_json = _strip_backslash_before_unicode(parsed_json)
-                # ensure_ascii=False keeps non-ASCII characters as-is rather
-                # than escaping them — preserves user-visible CJK / emoji in
-                # the cleaned text without double-encoding.
+                # ``ensure_ascii=False`` keeps non-ASCII characters as
+                # raw UTF-8 rather than escaping them to ``\uXXXX``. This
+                # is the standard recommendation for JSON-over-HTTP with
+                # international content (matches OpenAI's own response
+                # encoding); FastAPI emits this body as UTF-8 anyway, so
+                # the on-wire bytes are smaller and clients don't have to
+                # un-escape user-visible CJK / emoji a second time.
                 cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
             if not is_valid:
                 logger.warning(f"JSON validation failed: {error}")

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -77,7 +77,13 @@ _BACKSLASH_BEFORE_UNICODE = re.compile(r"\\([^\x00-\x7F])")
 
 def _strip_backslash_before_unicode(obj: object) -> object:
     if isinstance(obj, dict):
-        return {k: _strip_backslash_before_unicode(v) for k, v in obj.items()}
+        # Clean both keys and values: ``lm-format-enforcer`` can produce
+        # ``"\\한\\글": "value"`` (valid JSON, ugly key). Stripping only
+        # values would leak the bug into client-visible object keys.
+        return {
+            _strip_backslash_before_unicode(k): _strip_backslash_before_unicode(v)
+            for k, v in obj.items()
+        }
     if isinstance(obj, list):
         return [_strip_backslash_before_unicode(v) for v in obj]
     if isinstance(obj, str):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4,6 +4,7 @@
 import gc
 import json
 import logging
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -64,6 +65,24 @@ from ..service.helpers import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# Matches a single backslash directly followed by a non-ASCII codepoint.
+# ``lm-format-enforcer``'s grammar permits ``\\`` followed by any codepoint
+# as a valid JSON escape, so a model emitting JSON with CJK / emoji content
+# can produce strings like ``"\\빠\\르\\게"`` — valid JSON, but the decoded
+# value carries literal backslashes. Strip them so clients see clean text.
+_BACKSLASH_BEFORE_UNICODE = re.compile(r"\\([^\x00-\x7F])")
+
+
+def _strip_backslash_before_unicode(obj: object) -> object:
+    if isinstance(obj, dict):
+        return {k: _strip_backslash_before_unicode(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_backslash_before_unicode(v) for v in obj]
+    if isinstance(obj, str):
+        return _BACKSLASH_BEFORE_UNICODE.sub(r"\1", obj)
+    return obj
 
 
 def _finalize_content_and_reasoning(
@@ -590,7 +609,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 json_input, response_format
             )
             if parsed_json is not None:
-                cleaned_text = json.dumps(parsed_json)
+                parsed_json = _strip_backslash_before_unicode(parsed_json)
+                # ensure_ascii=False keeps non-ASCII characters as-is rather
+                # than escaping them — preserves user-visible CJK / emoji in
+                # the cleaned text without double-encoding.
+                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
             if not is_valid:
                 logger.warning(f"JSON validation failed: {error}")
         except Exception as e:


### PR DESCRIPTION
## Summary

Cherry-picks the portable half of upstream [waybarrios#525](https://github.com/waybarrios/vllm-mlx/pull/525).

\`lm-format-enforcer\`'s JSON grammar permits \`\\\\\` followed by any codepoint as a valid escape. A model emitting structured JSON with non-ASCII content (CJK, emoji, …) can therefore produce strings like \`"\\\\빠\\\\르\\\\게"\` — valid JSON, but the decoded value carries literal backslashes that look like corruption to clients.

This PR adds a small helper in \`routes/chat.py\` that:

- Recursively walks dict / list / str values returned by the JSON parser
- Strips a single backslash placed immediately before any non-ASCII codepoint
- Re-serializes with \`ensure_ascii=False\` so cleaned text keeps the characters as-is rather than re-escaping

## What I did NOT port

The off-by-one fix in upstream's \`vllm_mlx/constrained/json_schema_processor.py\` — that module doesn't exist in our tree (we don't use \`lm-format-enforcer\`-driven token enforcement; our JSON output path is parse-after-the-fact in \`routes/chat.py\`).

## Test plan

- [x] \`python3.12 -m pytest tests/test_structured_output.py -v\` — 5 new \`TestStripBackslashBeforeUnicode\` cases pass (CJK, valid escapes preserved, recursion through dict/list, non-string scalars pass through, emoji past U+FFFF).
- [x] \`python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py --ignore=tests/test_mllm*.py --ignore=tests/test_video.py -q\` — 3483 passed.
- [x] \`ruff check && ruff format --check\` clean on touched files.

## Blast radius

Low — single helper, called only when \`response_format\` is set AND the model emits parseable JSON. No effect on tool-calling, streaming, or any non-JSON response path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)