### PR TITLE
docs(contributing): codify test precision policy (correctness=8bit, perf=4bit)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -30,33 +30,36 @@ pytest --cov=vllm_mlx tests/
 
 ### Test Precision Policy
 
-Repo-wide rule when picking which model variant to use in a test:
+Repo-wide rule when picking which model variant to use in a test. Three buckets, in order of strictness:
 
-> **Correctness tests run on 8-bit (or higher). Performance tests run on 4-bit.**
+> 1. **Correctness tests** — use **8-bit (or higher)**. Quant noise must not be a confounder.
+> 2. **Performance tests** — use **4-bit**. ~80% of rapid-mlx users run 4-bit on M-series machines, so perf numbers must come from 4-bit to represent real user experience.
+> 3. **Smoke / boot sanity** — small 4-bit model is acceptable for speed (the test only proves "the engine starts and emits a sane response," not strict format conformance). Currently applies only to `make check`.
 
-A correctness test asks *"does the model + our code produce the right output?"* — quant noise on a 4-bit model is pure interference here. Performance tests ask *"how fast / how much memory?"* — and since ~80% of rapid-mlx users run 4-bit on M-series machines, perf numbers must come from 4-bit to represent real user experience.
+A correctness test asks *"does the model + our code produce the right output?"* A performance test asks *"how fast / how much memory?"* A smoke test asks *"did anything explode?"* — the third bucket exists because forcing every test into one of the first two would either slow down per-PR feedback (running 8-bit smoke on every push) or pollute the perf signal (running correctness on 4-bit). Keep the smoke bucket small and well-justified; default to one of the first two.
 
-| Suite | Bucket | Precision today |
+| Suite | Bucket | Model used today |
 |---|---|---|
-| `tests/` unit + integration | correctness | 8-bit small (`mlx-community/Qwen3-0.6B-8bit`) |
-| `scripts/pr_validate/` stress + agent matrix | correctness | 8-bit (`scripts/pr_validate/golden_models.yaml`) |
-| `scripts/bench_dflash.py`, `scripts/bench_suffix_decoding_integrated.py`, `harness/runs/` | perf | 4-bit (user reality) |
-| `make check` doctor smoke | correctness today on 4-bit small (legacy; migration to 8-bit small is acceptable when speed cost is negligible) | qwen3.5-4b 4-bit |
+| `tests/` unit + integration | correctness | `mlx-community/Qwen3-0.6B-8bit` |
+| `scripts/pr_validate/` stress + agent matrix | correctness | per `scripts/pr_validate/golden_models.yaml` (all 8-bit) |
+| `scripts/bench_dflash.py`, `scripts/bench_suffix_decoding_integrated.py`, `harness/runs/` | perf | 4-bit aliases (user reality) |
+| `make check` doctor smoke | smoke / boot sanity | `mlx-community/Qwen3.5-4B-MLX-4bit` (4-bit, ~30s boot) |
 | `make full` doctor harness | mixed | 8-bit for correctness suites, 4-bit for bench suites; separate baselines per precision |
 | `evals/run_all_models.sh` scorecard | scoring + perf column | scoring on 8-bit; perf column on 4-bit |
 
-**Why the split:** quant noise on a 4-bit model produces failures that look like engine bugs but aren't. Concrete reproducible example (2026-05-15): `Qwen3.6-27B-4bit` + thinking-mode enabled + 2-tool composition reliably generates a 4000-token natural-language ramble without ever emitting a valid `<tool_call><function=...>` XML, hitting the 300s client timeout in PydanticAI's multi-tool test. The 8-bit variant emits both tool calls in 286 tokens. Same engine code in both runs — the only variable is quant noise interacting with the model's strict-format tool-call output under deliberation. If a correctness gate runs 4-bit, this failure looks like an engine regression; running 8-bit attributes the failure cleanly to where it belongs (the 4-bit quant + multi-tool capability ceiling, not rapid-mlx).
+**Why the split matters in practice.** Quant noise on a 4-bit model produces failures that look like engine bugs but aren't. Reproducible example: `mlx-community/Qwen3.6-27B-4bit` with thinking enabled and a 2-tool composition prompt (`Compute (3+4)*5 using add and multiply`) reliably generates a 4000+ token natural-language ramble without ever emitting a valid `<tool_call><function=...>` XML, hitting the 300s client timeout in PydanticAI's multi-tool test. The 8-bit variant (`unsloth/Qwen3.6-27B-MLX-8bit`) emits both tool calls in 286 tokens. Same engine code in both runs — the only variable is quant noise interacting with the model's strict-format tool-call output under deliberation. If a correctness gate runs 4-bit, the failure looks like an engine regression; running 8-bit attributes it cleanly to where it belongs (the 4-bit quant + multi-tool capability ceiling, not rapid-mlx).
 
 **Hardware constraints:**
 
-- GitHub `test-apple-silicon` (macos-14, M1/M2, 16 GB RAM) — large 8-bit models don't fit. Stick to 8-bit *small* models on CI (`qwen3-0.6b-8bit`, `qwen3.5-4b-8bit` at most). The big-model 8-bit correctness gate runs in `pr_validate` on the maintainer's M-series box, not on GitHub CI.
+- GitHub `test-apple-silicon` (macos-14, M1/M2, 16 GB RAM) — large 8-bit models don't fit. Stick to 8-bit *small* models on CI (`mlx-community/Qwen3-0.6B-8bit`, `mlx-community/Qwen3.5-4B-MLX-8bit` at most). The big-model 8-bit correctness gate runs in `pr_validate` on the maintainer's M-series box, not on GitHub CI.
 - Local M-series with 64 GB+ — no constraint, run anything.
 
 **When adding a new test:**
 
 - New correctness test → pick 8-bit. If your family has no 8-bit option (rare), document why in the test file.
 - New perf bench → pick 4-bit (it's what users run).
-- New test that's "kind of both" → split it into two test files, one per bucket. Mixed-purpose tests collapse the signal.
+- New smoke test → justify why it can't be a correctness test (usually: "boot speed matters more than precision here"). The smoke bucket should not grow without reason.
+- A test that's "kind of both" → split it into two test files, one per bucket. Mixed-purpose tests collapse the signal.
 
 ### Code Style
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -28,6 +28,36 @@ pytest tests/test_paged_cache.py -v
 pytest --cov=vllm_mlx tests/
 ```
 
+### Test Precision Policy
+
+Repo-wide rule when picking which model variant to use in a test:
+
+> **Correctness tests run on 8-bit (or higher). Performance tests run on 4-bit.**
+
+A correctness test asks *"does the model + our code produce the right output?"* — quant noise on a 4-bit model is pure interference here. Performance tests ask *"how fast / how much memory?"* — and since ~80% of rapid-mlx users run 4-bit on M-series machines, perf numbers must come from 4-bit to represent real user experience.
+
+| Suite | Bucket | Precision today |
+|---|---|---|
+| `tests/` unit + integration | correctness | 8-bit small (`mlx-community/Qwen3-0.6B-8bit`) |
+| `scripts/pr_validate/` stress + agent matrix | correctness | 8-bit (`scripts/pr_validate/golden_models.yaml`) |
+| `scripts/bench_dflash.py`, `scripts/bench_suffix_decoding_integrated.py`, `harness/runs/` | perf | 4-bit (user reality) |
+| `make check` doctor smoke | correctness today on 4-bit small (legacy; migration to 8-bit small is acceptable when speed cost is negligible) | qwen3.5-4b 4-bit |
+| `make full` doctor harness | mixed | 8-bit for correctness suites, 4-bit for bench suites; separate baselines per precision |
+| `evals/run_all_models.sh` scorecard | scoring + perf column | scoring on 8-bit; perf column on 4-bit |
+
+**Why the split:** quant noise on a 4-bit model produces failures that look like engine bugs but aren't. Concrete reproducible example (2026-05-15): `Qwen3.6-27B-4bit` + thinking-mode enabled + 2-tool composition reliably generates a 4000-token natural-language ramble without ever emitting a valid `<tool_call><function=...>` XML, hitting the 300s client timeout in PydanticAI's multi-tool test. The 8-bit variant emits both tool calls in 286 tokens. Same engine code in both runs — the only variable is quant noise interacting with the model's strict-format tool-call output under deliberation. If a correctness gate runs 4-bit, this failure looks like an engine regression; running 8-bit attributes the failure cleanly to where it belongs (the 4-bit quant + multi-tool capability ceiling, not rapid-mlx).
+
+**Hardware constraints:**
+
+- GitHub `test-apple-silicon` (macos-14, M1/M2, 16 GB RAM) — large 8-bit models don't fit. Stick to 8-bit *small* models on CI (`qwen3-0.6b-8bit`, `qwen3.5-4b-8bit` at most). The big-model 8-bit correctness gate runs in `pr_validate` on the maintainer's M-series box, not on GitHub CI.
+- Local M-series with 64 GB+ — no constraint, run anything.
+
+**When adding a new test:**
+
+- New correctness test → pick 8-bit. If your family has no 8-bit option (rare), document why in the test file.
+- New perf bench → pick 4-bit (it's what users run).
+- New test that's "kind of both" → split it into two test files, one per bucket. Mixed-purpose tests collapse the signal.
+
 ### Code Style
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a "Test Precision Policy" section to `docs/development/contributing.md` with the rule **correctness tests run on 8-bit (or higher); performance tests run on 4-bit**.
- Documents which existing suites fall in which bucket today (`tests/`, `pr_validate`, bench scripts, `make check`, `make full`, `evals/`).
- Explains the hardware constraint that caps GitHub's `test-apple-silicon` runner to 8-bit *small* models.
- Adds "when writing a new test, pick the bucket first" guidance so future contributors don't accidentally collapse correctness + perf into one mixed-signal suite.

## Why

The principle already governs `pr_validate`'s golden-model matrix (per the YAML comments — Qwen3.5-35B-A3B was specifically picked at 8-bit for this reason). Companion PR #395 extends the same policy to the Qwen3.6 family in the same matrix. This doc PR makes the rule discoverable to external contributors and to future maintainers, instead of being tribal knowledge buried in YAML comments.

The motivation is concrete and reproducible: quant noise on 4-bit models generates failures that look like engine bugs but aren't.

| Variant | Thinking | PydanticAI Test 6 (multi-tool composition) |
|---|---|---|
| Qwen3.6-27B-**4bit** | enabled (default) | **runaway** — 4048 tokens of natural-language rambling, no `<tool_call>` XML emitted |
| Qwen3.6-27B-**4bit** | `enable_thinking=false` | **PASS** — 71 tokens, both `add(3,4)` and `multiply(7,5)` emitted |
| Qwen3.6-27B-**8bit** | enabled (default) | **PASS** — 286 tokens (173 reasoning + valid XML tool calls) |

Same engine code throughout. If a correctness gate runs 4-bit, the failure looks like a rapid-mlx engine regression — but no engine code is involved.

## Test plan

- [x] Doc-only change; no code paths touched
- [x] Lint clean (markdown only)
- [x] Internal cross-references hold (mentions `scripts/pr_validate/golden_models.yaml`, `scripts/bench_dflash.py`, etc. — all exist on main)

## Related

- #395 — applies the same policy to `pr_validate`'s qwen3.6 entry (4-bit → 8-bit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)