### PR TITLE
chore: bump version to 0.6.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 
 > **"No matching distribution" error?** Your Python is too old. Run `python3 --version` — if it says 3.9, install a newer Python: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`
 
+> **`Tapping homebrew/core` / `Operation not permitted` during `brew install`?** Brew 5.x's install sandbox can't auto-tap `homebrew/core` mid-install. Pre-tap it once, then retry:
+> ```bash
+> brew tap homebrew/core --force   # ~1.3 GB, one-time
+> brew install raullenchai/rapid-mlx/rapid-mlx
+> ```
+
 **Step 2 — Serve a model:**
 ```bash
 rapid-mlx serve qwen3.5-4b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.50"
+version = "0.6.51"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -302,6 +302,142 @@ class TestIsMllmModelConfigPriority:
         assert _config_indicates_vlm({"architectures": "Qwen3ForCausalLM"}) is False
 
 
+class TestIsMllmModelWeightsPresenceOverride:
+    """Verifies the local weights-presence override for text-only forks of
+    multimodal architectures.
+
+    Regression coverage for issue #393: ``Qwen3.6-35B-A3B-MLX-8bit`` ships
+    ``config.json`` with a populated ``vision_config`` block (because the
+    base ``Qwen3_5MoeForConditionalGeneration`` architecture is multimodal-
+    capable), but the user's safetensors checkpoint only contains language
+    tensors — no ``vision_tower.*`` weights. Detection used to trust the
+    config and route the model into the MLLM batched engine, which then
+    crashed at first request because there was no vision tower to call.
+
+    The fix: when config says VLM AND the path is a local directory with
+    a ``model.safetensors.index.json``, scan the index for actual
+    multimodal tensor prefixes. If none are present, override to text.
+    """
+
+    @staticmethod
+    def _make_model_dir(tmp_path, name, config, weight_names):
+        """Build a fake local model dir with config.json + sharded index.
+
+        ``weight_names`` is the list of tensor names to embed in the
+        ``weight_map`` of ``model.safetensors.index.json`` — controls
+        whether the weights-presence override fires.
+        """
+        model_dir = tmp_path / name
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps(config))
+        weight_map = {name: "model-00001-of-00001.safetensors" for name in weight_names}
+        (model_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": 0}, "weight_map": weight_map})
+        )
+        return model_dir
+
+    def test_vision_config_but_no_vision_weights_is_text_only(self, tmp_path):
+        """The #393 fix path. Config declares vision_config but the index
+        has only language tensors — must return False (route as text)."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "Qwen3.6-35B-A3B-MLX-8bit",
+            {
+                "model_type": "qwen3_5_moe",
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152, "depth": 27},
+                "image_token_id": 151655,
+            },
+            weight_names=[
+                "language_model.lm_head.weight",
+                "language_model.model.embed_tokens.weight",
+                "language_model.model.layers.0.self_attn.q_proj.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is False
+
+    def test_vision_config_with_vision_weights_is_vlm(self, tmp_path):
+        """Same config shape as above, but the index DOES carry
+        vision_tower tensors — must remain True (route as VLM). Mirrors
+        the genuine mlx-community/Qwen3.5-35B-A3B-8bit shape."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "Qwen3.5-35B-A3B-8bit",
+            {
+                "model_type": "qwen3_5_moe",
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152, "depth": 27},
+            },
+            weight_names=[
+                "language_model.lm_head.weight",
+                "vision_tower.blocks.0.attn.qkv.weight",
+                "vision_tower.blocks.0.mlp.linear_fc1.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_audio_only_checkpoint_with_audio_weights(self, tmp_path):
+        """Same principle but for the audio branch (audio_tower prefix)."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "some-audio-vlm",
+            {"model_type": "custom_audio", "audio_config": {"sample_rate": 16000}},
+            weight_names=[
+                "language_model.lm_head.weight",
+                "audio_tower.encoder.layer.0.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_missing_index_falls_back_to_config(self, tmp_path):
+        """Single-file safetensors (no sharded index) → the
+        weights-presence probe returns None, and we trust the config.
+        This is the conservative side: we'd rather route a small VLM
+        correctly than risk wrong-False on a real one. The cost of a
+        wrong-True (text path errors clearly at request time) is much
+        less than a wrong-False (silent corruption)."""
+        model_dir = tmp_path / "Qwen-VL-tiny"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "architectures": ["Qwen2VLForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 768},
+                }
+            )
+        )
+        # No index file.
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_unreadable_index_falls_back_to_config(self, tmp_path):
+        model_dir = tmp_path / "broken-index"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "architectures": ["LlavaForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            )
+        )
+        (model_dir / "model.safetensors.index.json").write_text("{ not json")
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_text_only_config_skips_weights_probe(self, tmp_path):
+        """If config says text-only, the weights probe must not fire —
+        irrelevant tensor names shouldn't suddenly promote a model to
+        MLLM routing. Preserves the existing text-routing decision."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "qwen3-text",
+            {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]},
+            # Even if the dir somehow had vision-named tensors (shouldn't
+            # happen with a text-only config, but defensive), config wins.
+            weight_names=["language_model.lm_head.weight", "vision_tower.fake"],
+        )
+        assert is_mllm_model(str(model_dir)) is False
+
+
 class TestIsMllmModelHubOverride:
     """Verifies the hub config override for substring false-positives.
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -718,6 +718,68 @@ def _config_indicates_vlm(config: dict) -> bool:
     return False
 
 
+# Tensor-name prefixes that indicate actual vision/audio weights live in
+# the checkpoint. Used to distinguish text-only forks of multimodal
+# architectures (where config.json declares ``vision_config`` but the
+# safetensors ship no ``vision_tower.*`` tensors) from genuine VLMs.
+# See issue #393 (Qwen3.6-35B-A3B text-only fork misrouted into MLLM
+# batched path because Qwen3.5MoeForConditionalGeneration declares
+# vision_config even when the user's safetensors are language-only).
+_MULTIMODAL_TENSOR_PREFIXES = (
+    "vision_tower",
+    "vision_model",
+    "visual.",
+    "audio_tower",
+    "audio_model",
+    "mm_projector",
+    "patch_embed.",
+)
+
+
+def _local_checkpoint_has_multimodal_weights(model_dir: Path) -> bool | None:
+    """Probe a local model dir for actual vision/audio tensor weights.
+
+    Returns:
+        ``True`` if at least one tensor name in ``model.safetensors.index.json``
+        matches a known multimodal prefix (``vision_tower``, ``visual.``,
+        ``mm_projector``, …).
+        ``False`` if the index is present, readable, and contains zero
+        such tensors — meaning the checkpoint is text-only despite
+        whatever ``config.json`` declares.
+        ``None`` when we can't authoritatively answer (no index file,
+        single-file safetensors, unreadable index). Caller should fall
+        back to the config-based decision rather than flipping it.
+
+    The single-file-safetensors branch returns ``None`` rather than
+    parsing the file header ourselves — the cost of a wrong False (text
+    routing for a real VLM → crash later on first image input) is much
+    larger than the cost of a wrong True (current behavior, the bug we
+    want to fix only for the multi-file case Tylast reported in #393).
+    """
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        # No sharded index. Caller must rely on config-based detection.
+        return None
+    try:
+        if index_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
+            # Unreasonably large index — bail rather than guess.
+            return None
+        with index_path.open(encoding="utf-8") as f:
+            idx = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    weight_map = idx.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return None
+    for tensor_name in weight_map:
+        if not isinstance(tensor_name, str):
+            continue
+        for prefix in _MULTIMODAL_TENSOR_PREFIXES:
+            if prefix in tensor_name:
+                return True
+    return False
+
+
 def _check_legacy_string_patterns(model_name: str) -> bool:
     """Validation 1: substring match of MLLM_PATTERNS against the input string.
 
@@ -731,17 +793,29 @@ def _check_legacy_string_patterns(model_name: str) -> bool:
 def is_mllm_model(model_name: str) -> bool:
     """Check if a model name or path indicates a multimodal language model.
 
-    Three complementary validations are run, in order:
+    Four complementary validations are run, in order:
 
     1. Local config.json inspection: when ``model_name`` resolves to a
        local directory containing a readable config.json, inspect the
        model's own metadata (``architectures`` field, ``vision_config``,
-       ``audio_config``, etc.). Authoritative when available.
+       ``audio_config``, etc.).
 
-    2. Legacy substring match against ``MLLM_PATTERNS``: when no local
+    2. Local weights-presence override: when (1) said "VLM" but the
+       directory ships a ``model.safetensors.index.json`` with NO
+       multimodal tensors (``vision_tower``, ``visual.``, ``mm_projector``,
+       …), the checkpoint is a text-only fork of a multimodal
+       architecture. Flip the answer to False so the model loads
+       through the text path instead of crashing in the MLLM batched
+       engine on a missing vision tower. Fixes #393 (Qwen3.6-35B-A3B
+       text-only fork — config.json declares ``vision_config`` because
+       the base ``Qwen3_5MoeForConditionalGeneration`` architecture is
+       multimodal-capable, but the user's safetensors only contain
+       language tensors).
+
+    3. Legacy substring match against ``MLLM_PATTERNS``: when no local
        config is reachable, the historical name-based heuristic decides.
 
-    3. Cached-config override (false-positive correction): when the
+    4. Cached-config override (false-positive correction): when the
        legacy substring says "MLLM" but the repo's own config (already
        in the local HF cache from a prior download or warmup call)
        disagrees (e.g. ``mlx-community/gemma-3-1b-it-4bit`` matches the
@@ -761,7 +835,26 @@ def is_mllm_model(model_name: str) -> bool:
     """
     config = _try_read_config_json(model_name)
     if config is not None:
-        return _config_indicates_vlm(config)
+        if not _config_indicates_vlm(config):
+            return False
+        # Config says VLM. For local directories, verify the checkpoint
+        # actually carries vision/audio tensors — text-only forks of
+        # multimodal architectures (#393) ship a config that declares
+        # vision_config but no vision_tower weights, and routing them
+        # to the MLLM batched engine crashes at first request.
+        try:
+            model_dir = Path(model_name)
+        except (TypeError, ValueError):
+            return True
+        if model_dir.is_dir():
+            verdict = _local_checkpoint_has_multimodal_weights(model_dir)
+            if verdict is False:
+                return False
+            # verdict is True or None (unable to authoritatively decide);
+            # trust the config in both cases — wrong-True here means an
+            # unnecessary text-path attempt that returns a clear error,
+            # vs wrong-False which would corrupt every request silently.
+        return True
 
     legacy = _check_legacy_string_patterns(model_name)
     if not legacy:


### PR DESCRIPTION
## Summary

User-facing changes since v0.6.50:

- **fix(api)**: detect text-only forks of multimodal architectures (#393) — `Qwen3.6-35B-A3B-MLX-8bit` and similar Qwen3.5/3.6 hybrid text-only checkpoints were being incorrectly routed to the MLLM batched engine because their `config.json` declares `vision_config` (the base architecture is multimodal-capable) even when the actual safetensors carry zero vision weights. Detection now scans `model.safetensors.index.json` for `vision_tower.*` / `mm_projector.*` / `audio_tower.*` tensor prefixes when config says VLM, and falls back to text routing if none exist. Bundled into v0.6.51 so Tylast's report doesn't have to wait for v0.6.52. Re-opened #385 (same class, was wrong-spam-classified).
- **fix(prefix-cache)**: slice 3D KV state along the right axis (#392) — inference correctness fix; was silently emitting `!!!!!!` (token id 0) on prefix-cache-hit prompts when KV tensors had shape `(B, H, S)`.
- **perf(scheduler)**: drop per-decode `list()` copy of `output_token_ids` (#391) — small per-token allocation removed from the decode hot path.
- **feat(json-output)**: strip spurious backslashes before non-ASCII chars (#394) — JSON-emitting models occasionally emit `\\é` during constrained generation; now stripped so `json.loads` doesn't choke.
- **docs(install)**: add brew 5.x `homebrew/core` pre-flight hint (this PR) — brew 5.x's install sandbox cannot tap `homebrew/core` mid-install for third-party formulas with core deps. Reproduced on a fresh-API-only brew box (Persona C HARD FAIL). README now tells users to `brew tap homebrew/core --force` first if they hit "Operation not permitted".

Dev/docs:
- **docs(contributing)**: codify test precision policy correctness=8-bit / perf=4-bit (#396)
- **chore(pr_validate)**: swap Qwen3.6-27B-4bit → 8-bit primary in stress matrix; 4-bit retained as `quality_tier: smoke` fallback for ≤32 GB hosts (#395)

## Release SOP gates

| Gate | Result |
|---|---|
| §3 install size | **448 MB** vs v0.6.48 baseline 445 MB → +0.67% (under 1.05× soft-warn). #393 fix added zero size delta. |
| §4 user-onboarding personas | **0 v0.6.51-specific blockers.** Persona A (install.sh): SOFT FAIL — UX findings only (quickstart suggests 122B on 16 GB Airs; banner-before-bind). Persona B original (pip + OpenAI SDK + qwen3-coder-30b): **PASS** — clean tool call, `finish_reason=tool_calls`, JSON-parseable args. Persona B retry (Anthropic SDK + devstral-24b): SOFT FAIL — model-side refusal under `tool_choice: required`. Persona C (brew): HARD FAIL → root-caused to brew 5.x sandbox + fixed (see §358 below). |
| §5 perf (`make full`) | **No v0.6.51-specific regression.** First run showed `qwen3.6-35b long_ttft 818ms` (vs baseline 784ms) — bisected to **noise**: rerun gave 143ms (better than baseline). Stable metrics (decode_tps, cached_ttft, mt_tps) identical to v0.6.50 ±5%. |
| §5b bisect | Confirmed: vs v0.6.50, cached/mt/decode metrics on qwen3.6-35b actually **improved** 6-11% in v0.6.51; cold metrics within noise band. |
| §6 agent integration smoke | Covered by Persona B original PASS (Python `openai` SDK + Qwen3-Coder-30B + `get_weather` tool round-trip). v0.6.51 changes don't touch tool-call/agent surfaces, so full 7-integration suite skipped for ~0 incremental coverage. |
| §7 supply chain | CVE scan via OSV: 0 vulns on critical deps. HF hub 1.15.0 (today) + transformers 5.8.1 (3 days) verified legit upstream. No install.sh / workflows / pyproject.toml diffs since v0.6.50. OIDC scope minimal. |
| §8 SHA capture (post-#393-fix + post-brew-hint) | wheel `11b16ab58e1b46064eeb53f0ba0960b9c50b6905073889cda1cc05bc406c816d` / sdist `3b0e38bc5e5293aacbbb77520a67061ba78f98a66d26ce20416072299301a39a` |
| §358 brew install P0 (Persona C) | **Reproduced + fixed.** Root cause: brew 5.1.11 install sandbox can't write `/opt/homebrew/Library/Taps/homebrew/`, so when the third-party formula's pre-install resolves `depends_on "python@3.12"` / `"rust"` (both `homebrew/core`), the implicit core-tap fails with "Operation not permitted". Pre-tapping outside the sandbox (`brew tap homebrew/core --force`) lets the install complete cleanly in 17s / 441 MB. Fix in this PR: README pre-flight hint. Formula caveats not useful (post-install only). Persona C's P0 #1 (tap path) was a docs-convention misunderstanding — README already uses the correct `raullenchai/rapid-mlx/rapid-mlx` form. |

## Known stale items (not v0.6.51 blockers)

- Harness baselines in `harness/baselines/full-*.json` are from PR #208 (months old). All "regression" labels in §5 output are cumulative since #208, not v0.6.51-specific. Follow-up: `make full --update-baselines` post-release.
- 3 third-party GitHub Actions still pinned by moving tag (peter-evans, peaceiris, codecov) rather than commit SHA. Pre-existing.

## Persona-discovered follow-ups (post-release, not blocking)

- [Persona A, P0] Quickstart line `rapid-mlx serve qwen3.5-122b` is suggested to all readers — silently OOM-explodes on 16 GB Airs. Re-tier by RAM.
- [Persona A, P1] "Ready: http://localhost:8000/v1" banner prints ~33 s before uvicorn actually binds the port.
- [Persona A, P1] Persona pool listed `gemma3-4b` as a valid quickstart alias; not present.
- [Persona B, P1] Persona pool listed `devstral-medium`; actual aliases are `devstral-24b`/`devstral-v2-24b`. Doc/pool issue.
- [Persona B, P1] Anthropic-compat path docs ambiguity (`/v1/messages` vs `/anthropic/v1/messages`).
- [Persona B, P2] Mistral regex tokenizer warning on devstral load is cosmetic noise.
- [Persona B, P2] hf-xet progress bar visually stalls 7/17 for ~90 s; users may assume crash.
- [Persona C, P1] Formula declares `python@3.12` but installer pours `python@3.14` (rust's transitive dep).
- [Persona C, P1] LLVM 1.9 GB as transitive runtime dep via rust — heavy for a "fast install" pitch.
- [upstream brew] Brew 5.x sandbox blocking implicit `homebrew/core` tap during install of third-party formulas with core deps. File upstream issue.

## Test plan

- [x] §3 install size audit
- [x] §4 user-onboarding personas (all 3 reported; 0 v0.6.51 blockers)
- [x] §5 perf gate (`make full`) — bisected confirming no v0.6.51 regression
- [x] §6 agent integration smoke — covered by Persona B PASS
- [x] §7 supply chain re-audit
- [x] §8 pre-merge artifact SHA capture (refreshed post-#393-fix + post-brew-hint)
- [x] §358 brew install P0 reproduced + fixed (README pre-flight)
- [x] #393 fix: 102 tests pass (was 96), lint clean
- [x] CI: lint, type-check, version-check, test-matrix (3.10/3.11/3.12), test-apple-silicon, tests — all SUCCESS on commit 488a7f9
- [ ] §10 post-release: re-run personas against real PyPI v0.6.51, ask Tylast to verify #393 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)