### PR TITLE
fix: MLLM shutdown traceback + Ready banner before bind (post-v0.6.51 onboarding findings)

### DIFF
--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -99,3 +99,72 @@ def test_run_vision_encoding_preserves_extra_kwargs_alongside_pixel_values():
     assert "pixel_values" in model.last_call_kwargs
     assert model.last_call_kwargs["pixel_values"] is None
     assert "token_type_ids" in model.last_call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Shutdown — mx.synchronize must not propagate cross-thread errors
+# ---------------------------------------------------------------------------
+
+
+def test_close_swallows_synchronize_thread_error(monkeypatch):
+    """`close()` must not propagate RuntimeError from mx.synchronize.
+
+    mlx-lm 0.31.3+ streams are thread-local. When the engine is torn down
+    from a thread that isn't the one that owns MLLMBatchGenerator._stream,
+    mx.synchronize raises `There is no Stream(gpu, N) in current thread`.
+    Pre-fix this propagated out of the lifespan shutdown and produced a
+    scary traceback (Persona E v0.6.51 onboarding finding). The sync is
+    best-effort on shutdown; the wired-limit reset is what matters.
+    """
+    import mlx.core as mx
+
+    # Construct a generator and force the wired-limit branch to execute.
+    gen = _make_generator(_RecordingModel())
+    gen._old_wired_limit = 1234  # any sentinel triggers the close path
+
+    sync_calls: list[object] = []
+    set_limit_calls: list[int] = []
+
+    def _raising_sync(stream):
+        sync_calls.append(stream)
+        raise RuntimeError("There is no Stream(gpu, 2) in current thread")
+
+    def _record_set_limit(value):
+        set_limit_calls.append(value)
+        return value
+
+    monkeypatch.setattr(mx, "synchronize", _raising_sync)
+    monkeypatch.setattr(mx, "set_wired_limit", _record_set_limit)
+
+    # Must not raise.
+    gen.close()
+
+    # Best-effort sync attempted exactly once.
+    assert len(sync_calls) == 1
+    # Wired limit was still reset to the original value — the important
+    # cleanup is not skipped just because the cross-thread sync failed.
+    assert set_limit_calls == [1234]
+    # State is cleared so __del__ is a no-op afterward.
+    assert gen._old_wired_limit is None
+
+
+def test_close_propagates_non_runtime_errors_from_set_wired_limit(monkeypatch):
+    """Errors from set_wired_limit are unrelated to the thread bug — keep
+    propagating them so a real OS-level failure isn't silently swallowed.
+    """
+    import mlx.core as mx
+
+    gen = _make_generator(_RecordingModel())
+    gen._old_wired_limit = 999
+
+    monkeypatch.setattr(mx, "synchronize", lambda _s: None)
+
+    def _boom(value):
+        raise OSError("metal API call failed")
+
+    monkeypatch.setattr(mx, "set_wired_limit", _boom)
+
+    import pytest
+
+    with pytest.raises(OSError, match="metal API call failed"):
+        gen.close()

--- a/tests/test_ready_banner_timing.py
+++ b/tests/test_ready_banner_timing.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: the "Ready:" banner must print only AFTER warmup completes.
+
+Persona A's 16 GB Air onboarding (v0.6.51) found that the banner printed
+~6 s before uvicorn actually bound the port, so a user who curled
+immediately got connection-refused while GatedDeltaNet kernels compiled.
+The CLI now prints a "Starting server …" line up-front, stashes bind
+host/port on ServerConfig, and defers the real "Ready:" banner to the
+lifespan hook — fires only after `get_config().ready = True`.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+import vllm_mlx.server as server
+from vllm_mlx.config import get_config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_server_state():
+    """Snapshot+restore the engine handle and bind fields each test."""
+    cfg = get_config()
+    saved = (
+        server._engine,
+        cfg.bind_host,
+        cfg.bind_port,
+        cfg.ready,
+    )
+    server._engine = None
+    cfg.bind_host = None
+    cfg.bind_port = None
+    cfg.ready = False
+    yield
+    server._engine, cfg.bind_host, cfg.bind_port, cfg.ready = saved
+
+
+async def _enter_then_exit_lifespan() -> str:
+    """Drive the lifespan generator through startup, capture stdout, exit."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        agen = server.lifespan(server.app)
+        await agen.__anext__()  # startup phase — runs through the yield
+        try:
+            await agen.__anext__()  # shutdown phase
+        except StopAsyncIteration:
+            pass
+    return buf.getvalue()
+
+
+async def test_ready_banner_emitted_when_bind_fields_set():
+    """With bind_host/bind_port stashed by CLI, the lifespan prints the banner."""
+    cfg = get_config()
+    cfg.bind_host = "localhost"
+    cfg.bind_port = 8765
+
+    out = await _enter_then_exit_lifespan()
+
+    assert "Ready: http://localhost:8765/v1" in out
+    assert "Docs:  http://localhost:8765/docs" in out
+    # `ready` flag must be flipped before the banner so /health/ready and
+    # the banner agree on the moment of readiness.
+    assert cfg.ready is False  # reset on shutdown (second next())
+
+
+async def test_ready_banner_suppressed_when_no_bind_info():
+    """Embedded usage (uvicorn owned elsewhere) leaves bind_* unset — silent."""
+    cfg = get_config()
+    cfg.bind_host = None
+    cfg.bind_port = None
+
+    out = await _enter_then_exit_lifespan()
+
+    assert "Ready:" not in out
+    assert "Docs:" not in out
+
+
+async def test_ready_banner_uses_displayed_host_not_zero_bind():
+    """CLI translates 0.0.0.0 → localhost before stashing, so the banner
+    shows a URL a user can actually curl."""
+    cfg = get_config()
+    cfg.bind_host = "localhost"  # CLI maps 0.0.0.0 → localhost up-front
+    cfg.bind_port = 9999
+
+    out = await _enter_then_exit_lifespan()
+
+    assert "http://localhost:9999/v1" in out
+    assert "0.0.0.0" not in out
+
+
+async def test_ready_banner_fires_after_ready_flag_flip():
+    """The banner must come AFTER `get_config().ready = True` in the
+    lifespan body — otherwise a client racing /health/ready could see
+    the banner before the readiness flag is honored. This is a source-level
+    invariant; verifying via execution order is impractical, so assert on
+    the source.
+    """
+    import inspect
+
+    src = inspect.getsource(server.lifespan)
+    ready_flip_idx = src.index("_cfg.ready = True")
+    banner_idx = src.index("Ready: http://")
+    assert ready_flip_idx < banner_idx, (
+        "Ready banner must print AFTER the readiness flag is set "
+        "so the banner and /health/ready agree on the moment of readiness."
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -832,16 +832,28 @@ def serve_command(args):
         sys.exit(1)
 
     # Start server
-    # Note: Metal shader warmup runs in the FastAPI lifespan hook (server.py)
-    # so it works for all engine types.
+    # Note: Metal shader warmup runs in the FastAPI lifespan hook (server.py).
+    # The "Ready:" banner is printed FROM that hook once warmup completes and
+    # the port is actually bound — printing it here would lie to users who
+    # curl immediately and get connection-refused while shaders compile.
     print()
     host_display = "localhost" if args.host == "0.0.0.0" else args.host
-    print(f"  Ready: http://{host_display}:{args.port}/v1")
-    print(f"  Docs:  http://{host_display}:{args.port}/docs")
+    print(
+        f"  Starting server on http://{host_display}:{args.port} (warming up — this can take a few seconds)"
+    )
     from vllm_mlx._version_check import print_staleness_warning_if_any
 
     print_staleness_warning_if_any()
     print()
+
+    # Stash host/port so the lifespan hook can print the real "Ready:" banner
+    # after warmup. ServerConfig.bind_host/bind_port → used in server.lifespan().
+    from vllm_mlx.config import get_config
+
+    _cfg = get_config()
+    _cfg.bind_host = host_display
+    _cfg.bind_port = args.port
+
     uvicorn.run(
         app,
         host=args.host,

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -37,6 +37,14 @@ class ServerConfig:
     # in-progress warmup. Reset to False during lifespan shutdown.
     ready: bool = False
 
+    # Bind address and port stashed by the CLI before uvicorn.run() so the
+    # lifespan hook can print the "Ready:" banner with the real URL only
+    # AFTER warmup completes (and the port is actually bound). Without this
+    # the banner prints before uvicorn binds the port, and a user who curls
+    # immediately gets a connection-refused.
+    bind_host: str | None = None
+    bind_port: int | None = None
+
     # --- Defaults ---
     default_max_tokens: int = 4096
     thinking_token_budget: int = 2048

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -369,7 +369,16 @@ class MLLMBatchGenerator:
     def close(self) -> None:
         """Release resources and reset wired limit."""
         if self._old_wired_limit is not None:
-            mx.synchronize(MLLMBatchGenerator._stream)
+            # mlx-lm 0.31.3+ streams are thread-local. On shutdown the
+            # owning worker thread may already be torn down, in which case
+            # mx.synchronize raises "There is no Stream(gpu, N) in current
+            # thread". The sync is best-effort here — pending ops complete
+            # during process exit anyway, and the wired-limit reset still
+            # needs to run to free reserved memory.
+            try:
+                mx.synchronize(MLLMBatchGenerator._stream)
+            except RuntimeError as e:
+                logger.debug(f"mx.synchronize skipped during close: {e}")
             mx.set_wired_limit(self._old_wired_limit)
             self._old_wired_limit = None
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -331,7 +331,18 @@ async def lifespan(app: FastAPI):
     # All slow startup work done. Flip the readiness flag so /health/ready
     # starts returning 200. Anything that races a request before this point
     # would otherwise hit a not-yet-warmed engine.
-    get_config().ready = True
+    _cfg = get_config()
+    _cfg.ready = True
+
+    # Print the real "Ready:" banner now — only here is the port truly
+    # accepting connections AND the engine warmed up. The CLI's earlier
+    # "Starting server …" line is replaced by this. If bind_host/bind_port
+    # weren't stashed (e.g. embedded usage where uvicorn is owned elsewhere),
+    # fall back silently.
+    if _cfg.bind_host and _cfg.bind_port:
+        print(f"  Ready: http://{_cfg.bind_host}:{_cfg.bind_port}/v1")
+        print(f"  Docs:  http://{_cfg.bind_host}:{_cfg.bind_port}/docs")
+        print()
 
     yield
 


### PR DESCRIPTION
## Summary

Two bugs surfaced by the 5-persona post-release onboarding test on real PyPI v0.6.51 (#397). Both are user-visible quality issues with simple, surgical fixes.

### 1. MLLM shutdown traceback (Persona E — NEW finding)

Killing the VLM server emitted a scary traceback:
```
RuntimeError: There is no Stream(gpu, 2) in current thread
  at vllm_mlx/mllm_batch_generator.py:close()
```

mlx-lm 0.31.3+ streams are thread-local. `MLLMBatchGenerator.close()` runs `mx.synchronize(_stream)` from whatever thread calls it — typically the asyncio loop thread on shutdown, not the `mllm-step` worker that created the stream. Port still freed, server still exited, no data loss — but the traceback looks like a real crash to users.

**Fix**: catch `RuntimeError` from `mx.synchronize`, log at debug, continue to the wired-limit reset. The sync is best-effort on shutdown (pending ops complete during process exit); the wired-limit reset (freeing reserved Metal memory) is what actually matters.

### 2. "Ready:" banner prints before bind (Persona A — pre-existing, re-confirmed)

The `Ready: http://localhost:8000/v1` banner printed up-front in cli.py BEFORE the FastAPI lifespan hook ran Metal shader warmup. On hybrid models with GatedDeltaNet, the gap was 5-30s. Users who copy-pasted a curl from the README got connection-refused.

**Fix**: split the banner into two stages:
- CLI prints `Starting server on http://... (warming up — this can take a few seconds)` up-front so the user knows the process is alive.
- CLI stashes `host` + `port` on `ServerConfig` (new `bind_host` / `bind_port` fields).
- The lifespan hook prints the real `Ready:` + `Docs:` banner AFTER flipping `get_config().ready = True` (i.e., after warmup completes AND uvicorn has the port bound).
- Falls back silently when bind fields are unset (embedded usage where uvicorn is owned elsewhere).

## Live smoke proof (qwen3.5-4b on this branch)

```
line 24:   Starting server on http://localhost:1899 (warming up — this can take a few seconds)
line 47:  INFO:vllm_mlx.server:Warmup complete (0.2s)
line 433: INFO:     Application startup complete.
line 434: INFO:     Uvicorn running on http://0.0.0.0:1899 (Press CTRL+C to quit)
line 435:   Ready: http://localhost:1899/v1
line 436:   Docs:  http://localhost:1899/docs
```
`curl /v1/models` immediately after the `Ready:` line returns `HTTP 200 in 0.001s`.

## Tests

- **5 tests in `tests/test_mllm_batch_generator.py`** — 2 specifically for the shutdown fix (cross-thread RuntimeError swallowed + wired-limit reset still runs; non-RuntimeError from set_wired_limit still propagates), 3 pre-existing.
- **4 new tests in `tests/test_ready_banner_timing.py`** — banner emitted when bind fields set, suppressed when unset, uses display host (not 0.0.0.0), source-level invariant that banner print follows readiness-flag flip.
- **Full repo suite**: `3606 passed, 19 skipped, 16 deselected, 1 xfailed` in 44s. No regressions.
- **Lint + format**: clean on entire repo.

## Files changed

| File | Δ | Purpose |
|---|---|---|
| `vllm_mlx/mllm_batch_generator.py` | +9 / -1 | `close()` swallows cross-thread sync error |
| `vllm_mlx/config/server_config.py` | +8 | New `bind_host` / `bind_port` fields |
| `vllm_mlx/cli.py` | +14 / -3 | "Starting…" line + stash bind fields |
| `vllm_mlx/server.py` | +12 / -2 | Lifespan prints `Ready:` after readiness flip |
| `tests/test_mllm_batch_generator.py` | +71 | 2 shutdown regression tests |
| `tests/test_ready_banner_timing.py` | +109 (new) | 4 lifespan banner tests |

## Test plan

- [x] 2 new MLLM shutdown tests pass
- [x] 4 new banner-timing tests pass
- [x] Full 3606-test suite passes
- [x] Live smoke on qwen3.5-4b (hybrid + GatedDeltaNet, worst-case banner-before-bind path) — banner now emits after bind
- [x] Lint + format clean
- [ ] CI (lint, type-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)