### PR TITLE
chore(spam-guard): downgrade to advisory — drop auto-close + lock

### DIFF
--- a/.github/workflows/spam-issue-guard.yml
+++ b/.github/workflows/spam-issue-guard.yml
@@ -8,9 +8,13 @@ name: Spam issue guard
 #
 # Issue forms (the ``.yml`` templates) auto-apply a label on submission, so any
 # new issue with zero labels was almost certainly NOT submitted via a form.
-# We use that as the spam signal: zero labels + non-member author → close, lock,
-# label ``spam-suspected``. False-positive risk on legitimate API users is
-# accepted because the close message tells them how to recover.
+# We use that as the soft signal: zero labels + non-member author → leave a
+# template-reminder comment and apply the ``spam-suspected`` label for triage
+# filtering. We do NOT auto-close or lock — the v1 of this workflow (May 2026)
+# did, but the false-positive rate was ~25% on legitimate external reports
+# (theta55 #385 — upstream of #393 — was wrong-classified and had to be
+# manually re-opened). Maintainers now sweep the ``spam-suspected`` label and
+# close real spam by hand; legit reports stay open and discoverable.
 
 on:
   issues:
@@ -30,7 +34,7 @@ jobs:
       github.event.issue.author_association != 'MEMBER' &&
       github.event.issue.author_association != 'COLLABORATOR'
     steps:
-      - name: Close + lock if no template label present
+      - name: Advisory comment + spam-suspected label if no template label present
         uses: actions/github-script@v7
         with:
           script: |
@@ -48,24 +52,24 @@ jobs:
               return;
             }
 
-            core.info(`Issue #${issue.number} has no template label — closing as suspected spam.`);
+            core.info(`Issue #${issue.number} has no template label — adding advisory comment + spam-suspected label.`);
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
               body: [
-                "This issue was opened without using one of the project's issue templates.",
+                "Heads up: this issue was opened without one of the project's issue templates (Bug / Performance / Feature / Model Support / Benchmark), so it's been tagged `spam-suspected` for triage.",
                 "",
-                "We require the templates because they ask for the minimum context (version, hardware, serve command, reproduction) needed to act on a report. Issues that bypass the templates are usually spam, so this one is being closed automatically.",
+                "**If this is a real report, please add the missing context the relevant template asks for** — Rapid-MLX version, hardware, the exact `rapid-mlx serve …` command, and a minimal reproduction. A maintainer will triage from there and remove the label.",
                 "",
-                "**If this is a real issue:** please re-open via https://github.com/raullenchai/Rapid-MLX/issues/new/choose and pick the template that matches (Bug Report / Performance Issue / Feature Request / Model Support / Benchmark Report). A maintainer will re-open it from there.",
+                "Template index: https://github.com/raullenchai/Rapid-MLX/issues/new/choose",
               ].join("\n"),
             });
 
             // ``addLabels`` will 404 if the label hasn't been pre-created on
-            // the repo. Don't let that block the close+lock — the comment is
-            // the user-facing signal; the label is just for triage filtering.
+            // the repo. That's fine — the comment is the user-facing signal;
+            // the label is just for maintainer triage filtering.
             try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
@@ -76,18 +80,3 @@ jobs:
             } catch (err) {
               core.warning(`Could not add 'spam-suspected' label (create it on the repo to enable triage filtering): ${err.message}`);
             }
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              state: 'closed',
-              state_reason: 'not_planned',
-            });
-
-            await github.rest.issues.lock({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              lock_reason: 'spam',
-            });


### PR DESCRIPTION
## Why

The v1 spam-issue-guard workflow (#318) auto-closed + locked any external-author issue without a template label. False-positive rate over 8 days: **~25%** (1/4 closures was a legitimate report — #385 theta55, the upstream of #393 Tylast, which had to be manually re-opened and turned into a real v0.6.51 ship-blocker).

Locked auto-closures are also a bad UX for legit reporters — they can't even comment to push back; have to start over via the template picker.

## What

Keep the soft signals (advisory comment + `spam-suspected` label for triage filtering), drop the close + lock calls. Real spam still takes a single click to close manually; real reports stay open + discoverable while the reporter adds context.

Comment text rewritten from "we're closing this" to "here's what's missing — a maintainer will triage from here."

## Diff

- `.github/workflows/spam-issue-guard.yml`: -25 / +14 (removed `update state: closed` + `lock` blocks, reworded the user-facing comment, updated header docstring with the false-positive rationale).

## Test plan

- [x] YAML syntax valid (existing workflow file structure preserved, just dropped two blocks)
- [ ] Once merged, next external-author issue without a template label should see: comment posted + `spam-suspected` label applied + issue stays OPEN + UNLOCKED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)