### PR TITLE
fix(cli): plumb --prefill-step-size into SchedulerConfig + add fidelity audit (#400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check vllm_mlx/ tests/
 
+      # Structural check — catches "silent flag drop" bugs where a CLI
+      # arg is defined but never plumbed to its target config (#400).
+      # Pure stdlib + AST — no mlx import required, runs on Linux.
+      - name: CLI ↔ Config fidelity audit
+        run: python scripts/audit_cli_config_fidelity.py
+
   type-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help smoke check full benchmark update-baselines lint test stress soak clean
+.PHONY: help smoke check full benchmark update-baselines lint audit test stress soak clean
 
 # Pick the interpreter:
 #   1. Active venv ($VIRTUAL_ENV/bin/python) — wins so contributors using
@@ -30,8 +30,9 @@ help:
 	@echo ""
 	@echo "  Dev testing (scripts/dev_test.py):"
 	@echo "    make lint               ruff lint (~10s)"
+	@echo "    make audit              CLI ↔ Config fidelity audit (~1s)"
 	@echo "    make test               pytest unit suite (~30s)"
-	@echo "    make smoke              lint + unit (~1 min)"
+	@echo "    make smoke              lint + audit + unit (~1 min)"
 	@echo "    make stress             8-scenario stress test (needs server)"
 	@echo "    make soak               10-min agent soak test (needs server)"
 	@echo ""
@@ -46,6 +47,9 @@ help:
 # ---------- dev testing (scripts/dev_test.py) ----------
 lint:
 	$(DEV_TEST) lint
+
+audit:
+	$(DEV_TEST) audit
 
 test:
 	$(DEV_TEST) unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.51"
+version = "0.6.52"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/audit_cli_config_fidelity.py
+++ b/scripts/audit_cli_config_fidelity.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+CLI ↔ Config fidelity audit.
+
+Catches "silent flag drop" bugs where a CLI argparse flag is defined and
+plumbed *somewhere*, but never actually reaches the engine config it was
+supposed to set.
+
+Motivation: #400 — `--prefill-step-size 32768` was defined in argparse,
+passed to `load_model(prefill_step_size=...)` (where it was discarded),
+but never added to the `SchedulerConfig(...)` construction kwargs.
+`SchedulerConfig.prefill_step_size` silently kept its 2048 default,
+which the MLLM batch path then used as a hard cap → user-visible bug.
+
+This audit is structural and runs in <1s. Add to release gate.
+
+Exit code: 0 if clean, 1 if drift detected.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLI_PATH = REPO_ROOT / "vllm_mlx" / "cli.py"
+SCHEDULER_PATH = REPO_ROOT / "vllm_mlx" / "scheduler.py"
+
+
+def _dataclass_field_names(source_path: Path, class_name: str) -> set[str]:
+    """Extract field names of a @dataclass via AST — no runtime import.
+
+    Reading the source directly avoids pulling mlx.core (and the rest of
+    the engine) into the audit, so this script runs on plain Linux CI
+    without the apple-silicon stack.
+    """
+    tree = ast.parse(source_path.read_text())
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.ClassDef) and node.name == class_name):
+            continue
+        names: set[str] = set()
+        for stmt in node.body:
+            # `name: type = default` or `name: type`
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                names.add(stmt.target.id)
+        return names
+    raise RuntimeError(f"class {class_name} not found in {source_path}")
+
+
+def _function_args_refs(func_node: ast.FunctionDef) -> set[str]:
+    """Every `args.<X>` attribute access inside the function body."""
+    refs: set[str] = set()
+    for sub in ast.walk(func_node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id == "args"
+        ):
+            refs.add(sub.attr)
+    return refs
+
+
+def audit(cli_path: Path, config_source: Path, config_cls_name: str) -> list[str]:
+    """Return a list of drift lines. Empty list = clean.
+
+    Drift definition: a function reads `args.X`, AND calls
+    `<config_cls>(...)` without passing `X=`, AND `X` is a field on
+    `<config_cls>`. The 3-way intersection means: the user *can* set this
+    flag in the subparser this command owns, the config *has* a slot for
+    it, but the construction site silently drops the user's value.
+
+    This is narrower than a global flag-vs-field check: it scopes to the
+    command function, so benchmark-only flags don't false-positive against
+    serve-only construction sites.
+    """
+    source = cli_path.read_text()
+    tree = ast.parse(source)
+
+    field_names = _dataclass_field_names(config_source, config_cls_name)
+    issues: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+
+        arg_refs = _function_args_refs(node)
+        if not arg_refs:
+            continue
+
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            if not (
+                isinstance(call.func, ast.Name) and call.func.id == config_cls_name
+            ):
+                continue
+
+            kwargs = {kw.arg for kw in call.keywords if kw.arg}
+            # Fields that this function CAN supply (args.X is referenced) but
+            # this construction site does NOT pass.
+            dropped = (field_names & arg_refs) - kwargs
+            for field_name in sorted(dropped):
+                flag = "--" + field_name.replace("_", "-")
+                issues.append(
+                    f"{cli_path.name}:{call.lineno} (in {node.name})  "
+                    f"{config_cls_name}({flag} dropped) — function reads "
+                    f"args.{field_name} and {config_cls_name} has the "
+                    f"field, but the kwarg is not passed here."
+                )
+
+    return issues
+
+
+def main() -> int:
+    # (source_file, dataclass_name). Add more configs as their CLI surface grows.
+    targets = [
+        (SCHEDULER_PATH, "SchedulerConfig"),
+    ]
+
+    all_issues: list[str] = []
+    for source, cls_name in targets:
+        all_issues.extend(audit(CLI_PATH, source, cls_name))
+
+    if not all_issues:
+        print("CLI ↔ Config fidelity: OK")
+        return 0
+
+    print("CLI ↔ Config fidelity: DRIFT DETECTED")
+    print()
+    for line in all_issues:
+        print(f"  {line}")
+    print()
+    print(
+        "Each line above is a user-visible silent-failure bug: the user can "
+        "type the flag, argparse will accept it, but the engine will never "
+        "see the value. Add the kwarg at the construction site."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_cli_config_fidelity.py
+++ b/scripts/audit_cli_config_fidelity.py
@@ -24,8 +24,16 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CLI_PATH = REPO_ROOT / "vllm_mlx" / "cli.py"
 SCHEDULER_PATH = REPO_ROOT / "vllm_mlx" / "scheduler.py"
+
+# Files that parse argparse args AND construct (or should construct) an
+# engine config. Each one is a user-facing entrypoint with the same
+# silent-flag-drop risk as #400. Order: primary CLI first, then secondary
+# entries (python -m vllm_mlx.server, mise run).
+CLI_ENTRY_PATHS = [
+    REPO_ROOT / "vllm_mlx" / "cli.py",
+    REPO_ROOT / "vllm_mlx" / "server.py",
+]
 
 
 def _dataclass_field_names(source_path: Path, class_name: str) -> set[str]:
@@ -119,8 +127,9 @@ def main() -> int:
     ]
 
     all_issues: list[str] = []
-    for source, cls_name in targets:
-        all_issues.extend(audit(CLI_PATH, source, cls_name))
+    for entry_path in CLI_ENTRY_PATHS:
+        for source, cls_name in targets:
+            all_issues.extend(audit(entry_path, source, cls_name))
 
     if not all_issues:
         print("CLI ↔ Config fidelity: OK")

--- a/scripts/dev_test.py
+++ b/scripts/dev_test.py
@@ -60,6 +60,17 @@ def run_lint():
     return False
 
 
+def run_audit():
+    # Structural check — runs in <1s, catches "silent flag drop" bugs
+    # where a CLI arg is defined but never plumbed to its target config.
+    # See scripts/audit_cli_config_fidelity.py for rationale (#400).
+    return run(
+        [PY, os.path.join(SCRIPTS_DIR, "audit_cli_config_fidelity.py")],
+        "CLI ↔ Config fidelity audit",
+        timeout=30,
+    )
+
+
 def run_unit():
     return run(
         [
@@ -132,6 +143,7 @@ def main():
         "tier",
         choices=[
             "lint",
+            "audit",
             "unit",
             "smoke",
             "stress",
@@ -158,6 +170,9 @@ def main():
 
     if args.tier in ("lint", "smoke", "all", "full"):
         results["lint"] = run_lint()
+
+    if args.tier in ("audit", "smoke", "all", "full"):
+        results["audit"] = run_audit()
 
     if args.tier in ("unit", "smoke", "all", "full"):
         results["unit"] = run_unit()

--- a/tests/test_cli_config_fidelity.py
+++ b/tests/test_cli_config_fidelity.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for the CLI ↔ Config fidelity story.
+
+Two layers:
+  1. The #400 fix itself — `--prefill-step-size` lands in SchedulerConfig.
+  2. The audit script — proves it would catch the regression if it ever
+     comes back, and proves it stays quiet when correct.
+
+The audit script (scripts/audit_cli_config_fidelity.py) is pure AST and
+imports no mlx/vllm_mlx runtime — it must work on plain Linux CI.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AUDIT = REPO_ROOT / "scripts" / "audit_cli_config_fidelity.py"
+CLI_SOURCE = REPO_ROOT / "vllm_mlx" / "cli.py"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: the #400 fix
+# ---------------------------------------------------------------------------
+
+
+def _serve_command_scheduler_config_kwargs() -> set[str]:
+    """Return kwargs passed to SchedulerConfig() inside serve_command."""
+    tree = ast.parse(CLI_SOURCE.read_text())
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name == "serve_command"):
+            continue
+        for call in ast.walk(node):
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "SchedulerConfig"
+            ):
+                return {kw.arg for kw in call.keywords if kw.arg}
+    raise AssertionError("serve_command or its SchedulerConfig(...) call not found")
+
+
+def test_prefill_step_size_is_plumbed_in_serve_command():
+    """#400 regression — serve_command must pass --prefill-step-size to SchedulerConfig.
+
+    Pre-fix, `serve_command` built `SchedulerConfig(...)` without
+    `prefill_step_size=args.prefill_step_size`. The field kept its
+    dataclass default (2048), which MLLMBatchGenerator then used as a
+    hard per-batch cap → user's prompts >2048 tokens rejected with
+    "exceeds safe limit (2048)".
+    """
+    kwargs = _serve_command_scheduler_config_kwargs()
+    assert "prefill_step_size" in kwargs, (
+        "regression: SchedulerConfig in serve_command no longer receives "
+        "prefill_step_size — see #400. Add `prefill_step_size=args.prefill_step_size` "
+        "to the SchedulerConfig(...) construction."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: the audit script behavior
+# ---------------------------------------------------------------------------
+
+
+def test_audit_passes_on_current_main():
+    """After the #400 fix, the audit must be clean (exit 0)."""
+    result = subprocess.run(
+        [sys.executable, str(AUDIT)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"audit reported drift on current main:\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_audit_detects_synthetic_drift(tmp_path):
+    """Audit must fail (exit 1) when a CLI flag is dropped at the
+    construction site. This is the structural invariant that catches #400."""
+    fake_cli = tmp_path / "cli.py"
+    fake_cli.write_text(
+        textwrap.dedent(
+            """
+            from vllm_mlx.scheduler import SchedulerConfig
+
+            def serve_command(args):
+                # args.prefill_step_size is read here (would be from argparse)
+                print(args.prefill_step_size)
+                # ...but never plumbed into SchedulerConfig — the bug pattern.
+                cfg = SchedulerConfig(max_num_seqs=args.max_num_seqs)
+                return cfg
+            """
+        )
+    )
+
+    # Run the audit as a script and patch CLI_PATH via env-free monkey-import.
+    # The simplest test: import the audit's `audit()` function directly with
+    # our synthetic cli.py + the real SchedulerConfig source.
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        import importlib
+
+        mod = importlib.import_module("audit_cli_config_fidelity")
+        issues = mod.audit(
+            cli_path=fake_cli,
+            config_source=REPO_ROOT / "vllm_mlx" / "scheduler.py",
+            config_cls_name="SchedulerConfig",
+        )
+    finally:
+        sys.path.pop(0)
+
+    assert issues, "audit did not flag obvious synthetic drift"
+    assert any("prefill_step_size" in line for line in issues), (
+        f"expected prefill_step_size flagged; got: {issues}"
+    )
+
+
+def test_audit_no_false_positive_when_field_unused(tmp_path):
+    """Audit must NOT flag a SchedulerConfig site if the function doesn't
+    even read args.X — that's correct subparser-scoped behavior (e.g. the
+    bench command doesn't expose --prefill-step-size and so doesn't need
+    to pass it). Without this guard the audit would over-flag and become
+    noise."""
+    fake_cli = tmp_path / "cli.py"
+    fake_cli.write_text(
+        textwrap.dedent(
+            """
+            from vllm_mlx.scheduler import SchedulerConfig
+
+            def benchmark_command(args):
+                # This subparser only exposes max_num_seqs — args.prefill_step_size
+                # is not referenced. SchedulerConfig correctly uses the default.
+                cfg = SchedulerConfig(max_num_seqs=args.max_num_seqs)
+                return cfg
+            """
+        )
+    )
+
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        import importlib
+
+        mod = importlib.import_module("audit_cli_config_fidelity")
+        issues = mod.audit(
+            cli_path=fake_cli,
+            config_source=REPO_ROOT / "vllm_mlx" / "scheduler.py",
+            config_cls_name="SchedulerConfig",
+        )
+    finally:
+        sys.path.pop(0)
+
+    assert not issues, f"audit produced false positive(s): {issues}"

--- a/tests/test_cli_config_fidelity.py
+++ b/tests/test_cli_config_fidelity.py
@@ -29,11 +29,18 @@ CLI_SOURCE = REPO_ROOT / "vllm_mlx" / "cli.py"
 # ---------------------------------------------------------------------------
 
 
+SERVER_SOURCE = REPO_ROOT / "vllm_mlx" / "server.py"
+
+
 def _serve_command_scheduler_config_kwargs() -> set[str]:
-    """Return kwargs passed to SchedulerConfig() inside serve_command."""
-    tree = ast.parse(CLI_SOURCE.read_text())
+    return _function_scheduler_config_kwargs(CLI_SOURCE, "serve_command")
+
+
+def _function_scheduler_config_kwargs(source_path: Path, func_name: str) -> set[str]:
+    """Return kwargs passed to SchedulerConfig() inside the named function."""
+    tree = ast.parse(source_path.read_text())
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.FunctionDef) and node.name == "serve_command"):
+        if not (isinstance(node, ast.FunctionDef) and node.name == func_name):
             continue
         for call in ast.walk(node):
             if (
@@ -42,7 +49,9 @@ def _serve_command_scheduler_config_kwargs() -> set[str]:
                 and call.func.id == "SchedulerConfig"
             ):
                 return {kw.arg for kw in call.keywords if kw.arg}
-    raise AssertionError("serve_command or its SchedulerConfig(...) call not found")
+    raise AssertionError(
+        f"function {func_name} or its SchedulerConfig(...) call not found in {source_path}"
+    )
 
 
 def test_prefill_step_size_is_plumbed_in_serve_command():
@@ -59,6 +68,22 @@ def test_prefill_step_size_is_plumbed_in_serve_command():
         "regression: SchedulerConfig in serve_command no longer receives "
         "prefill_step_size — see #400. Add `prefill_step_size=args.prefill_step_size` "
         "to the SchedulerConfig(...) construction."
+    )
+
+
+def test_prefill_step_size_is_plumbed_in_server_main():
+    """#400 regression for the standalone entry —
+    `python -m vllm_mlx.server --prefill-step-size N` must reach
+    SchedulerConfig too. Pre-0.6.52 this entrypoint also silently dropped
+    the flag; codex round 3 on PR #405 caught it as the same bug class
+    in a sibling file the patch already touched.
+    """
+    kwargs = _function_scheduler_config_kwargs(SERVER_SOURCE, "main")
+    assert "prefill_step_size" in kwargs, (
+        "regression: SchedulerConfig in server.main no longer receives "
+        "prefill_step_size — see #400 / PR #405 codex round 3. The "
+        "`python -m vllm_mlx.server` / `mise run` entry must construct a "
+        "SchedulerConfig and pass args.prefill_step_size."
     )
 
 

--- a/tests/test_cli_config_fidelity.py
+++ b/tests/test_cli_config_fidelity.py
@@ -124,6 +124,67 @@ def test_audit_detects_synthetic_drift(tmp_path):
     )
 
 
+def test_load_model_prefill_step_size_back_compat_translation():
+    """back-compat — load_model(prefill_step_size=X) must still be ACCEPTED
+    (no TypeError) and must translate the value into scheduler_config so it
+    actually takes effect this time. Pre-0.6.52 it was a silent no-op (#400).
+
+    External callers written against the previous documented signature
+    (``load_model(..., prefill_step_size=X)``) would otherwise hit a hard
+    TypeError on upgrade.
+    """
+    import inspect
+    import warnings
+
+    from vllm_mlx import server
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    # Signature must still accept the kwarg.
+    sig = inspect.signature(server.load_model)
+    assert "prefill_step_size" in sig.parameters, (
+        "load_model must keep the prefill_step_size kwarg for back-compat — "
+        "removing it in a patch release breaks external callers (#405 codex round 2)."
+    )
+
+    # Translation must work: passing the kwarg without scheduler_config
+    # should produce a SchedulerConfig with the value set, AND emit a
+    # DeprecationWarning. We exercise just the translation block — we do not
+    # actually load a model (which would require an mlx download).
+    captured_scheduler_config = {}
+
+    def fake_engine_init(*args, **kwargs):
+        captured_scheduler_config["value"] = kwargs.get("scheduler_config")
+        raise RuntimeError("stop after translation — we only need the kwarg")
+
+    # Monkeypatch BatchedEngine to halt after the translation step.
+    import vllm_mlx.engine.batched as batched_mod
+
+    original = batched_mod.BatchedEngine.__init__
+    batched_mod.BatchedEngine.__init__ = fake_engine_init
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                server.load_model("dummy-model", prefill_step_size=9999)
+            except RuntimeError as exc:
+                assert "stop after translation" in str(exc)
+
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert dep, "expected DeprecationWarning for load_model(prefill_step_size=...)"
+        assert "deprecated" in str(dep[0].message).lower()
+    finally:
+        batched_mod.BatchedEngine.__init__ = original
+
+    cfg = captured_scheduler_config.get("value")
+    assert isinstance(cfg, SchedulerConfig), (
+        "load_model(prefill_step_size=X) without scheduler_config must "
+        "synthesise a SchedulerConfig so the value actually takes effect."
+    )
+    assert cfg.prefill_step_size == 9999, (
+        f"translation failed: cfg.prefill_step_size={cfg.prefill_step_size}, expected 9999"
+    )
+
+
 def test_audit_no_false_positive_when_field_unused(tmp_path):
     """Audit must NOT flag a SchedulerConfig site if the function doesn't
     even read args.X — that's correct subparser-scoped behavior (e.g. the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -678,6 +678,11 @@ def serve_command(args):
         max_cache_blocks=args.max_cache_blocks,
         # Chunked prefill
         chunked_prefill_tokens=args.chunked_prefill_tokens,
+        # Prefill step size (chunk size). Must be plumbed here — BatchedEngine
+        # reads it off scheduler_config only; the legacy load_model kwarg was
+        # accepted but never used. See #400 and the CLI ↔ Config fidelity
+        # audit at scripts/audit_cli_config_fidelity.py.
+        prefill_step_size=args.prefill_step_size,
         # MTP
         enable_mtp=args.enable_mtp,
         mtp_num_draft_tokens=args.mtp_num_draft_tokens,
@@ -803,7 +808,6 @@ def serve_command(args):
             max_tokens=args.max_tokens,
             force_mllm=args.mllm,
             gpu_memory_utilization=args.gpu_memory_utilization,
-            prefill_step_size=args.prefill_step_size,
             cloud_model=args.cloud_model,
             cloud_threshold=args.cloud_threshold,
             cloud_api_base=args.cloud_api_base,

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -665,9 +665,10 @@ class MLLMBatchGenerator:
         max_batch_tokens = self.prefill_step_size * len(requests)
         if total_prompt_tokens > max_batch_tokens:
             raise ValueError(
-                f"Total prompt tokens ({total_prompt_tokens}) exceeds safe limit "
-                f"({max_batch_tokens}) for {len(requests)} requests. "
-                f"Reduce prompt length or batch size."
+                f"Total prompt tokens ({total_prompt_tokens}) exceeds the "
+                f"per-batch cap ({max_batch_tokens} = prefill_step_size "
+                f"{self.prefill_step_size} × {len(requests)} request(s)). "
+                f"Raise the cap with --prefill-step-size, or shorten the prompt."
             )
 
         # Run vision encoding for each request with its own KVCache.

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -498,6 +498,7 @@ def load_model(
     max_tokens: int = 32768,
     force_mllm: bool = False,
     gpu_memory_utilization: float = 0.90,
+    prefill_step_size: int | None = None,
     cloud_model: str | None = None,
     cloud_threshold: int = 20000,
     cloud_api_base: str | None = None,
@@ -515,8 +516,32 @@ def load_model(
         max_tokens: Default max tokens for generation
         force_mllm: Force loading as MLLM even if not auto-detected
         gpu_memory_utilization: Fraction of device memory (0.0-1.0, default 0.90)
+        prefill_step_size: DEPRECATED — pass via
+            ``scheduler_config.prefill_step_size`` instead. Pre-0.6.52 this
+            parameter was accepted but silently ignored (the value never
+            reached BatchedEngine — root cause of #400). Kept here for
+            back-compat with external callers; if provided it is translated
+            into ``scheduler_config.prefill_step_size`` and a DeprecationWarning
+            is emitted. Will be removed in a future release.
         mtp: Enable native MTP speculative decoding
     """
+    if prefill_step_size is not None:
+        import warnings
+
+        from .scheduler import SchedulerConfig
+
+        warnings.warn(
+            "load_model(prefill_step_size=...) is deprecated; "
+            "pass via scheduler_config.prefill_step_size instead. "
+            "Pre-0.6.52 this kwarg was silently ignored (#400).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if scheduler_config is None:
+            scheduler_config = SchedulerConfig(prefill_step_size=prefill_step_size)
+        else:
+            scheduler_config.prefill_step_size = prefill_step_size
+
     global \
         _engine, \
         _model_name, \

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1085,9 +1085,20 @@ Examples:
     # Pre-load embedding model if specified
     load_embedding_model(args.embedding_model, lock=True)
 
+    # Build a SchedulerConfig so user-supplied flags on this standalone entry
+    # (`python -m vllm_mlx.server` / `mise run`) reach the engine. Pre-0.6.52
+    # this entrypoint forwarded args.prefill_step_size to load_model where it
+    # was silently dropped — same bug class as #400. The unified rapid-mlx
+    # CLI builds a richer SchedulerConfig in cli.py; the standalone path only
+    # exposes a small subset of flags, so we plumb just those.
+    from .scheduler import SchedulerConfig
+
+    scheduler_config = SchedulerConfig(prefill_step_size=args.prefill_step_size)
+
     # Load model before starting server
     load_model(
         args.model,
+        scheduler_config=scheduler_config,
         max_tokens=args.max_tokens,
         force_mllm=args.mllm,
         cloud_model=args.cloud_model,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -498,7 +498,6 @@ def load_model(
     max_tokens: int = 32768,
     force_mllm: bool = False,
     gpu_memory_utilization: float = 0.90,
-    prefill_step_size: int = 2048,
     cloud_model: str | None = None,
     cloud_threshold: int = 20000,
     cloud_api_base: str | None = None,
@@ -516,7 +515,6 @@ def load_model(
         max_tokens: Default max tokens for generation
         force_mllm: Force loading as MLLM even if not auto-detected
         gpu_memory_utilization: Fraction of device memory (0.0-1.0, default 0.90)
-        prefill_step_size: Tokens to process per prefill chunk (default: 2048)
         mtp: Enable native MTP speculative decoding
     """
     global \
@@ -1067,7 +1065,6 @@ Examples:
         args.model,
         max_tokens=args.max_tokens,
         force_mllm=args.mllm,
-        prefill_step_size=args.prefill_step_size,
         cloud_model=args.cloud_model,
         cloud_threshold=args.cloud_threshold,
         cloud_api_base=args.cloud_api_base,


### PR DESCRIPTION
## Summary

Fixes #400 and adds a structural release gate so the same class of silent-flag-drop bug can't recur.

### The bug (#400)

User runs:
```
rapid-mlx serve <vlm-model> --prefill-step-size 32768 --continuous-batching
```
Sends an 11.5k-token prompt. Gets:
```
ERROR:vllm_mlx.mllm_scheduler:Batch generation failed: Total prompt tokens (11573) exceeds safe limit (2048) for 1 requests.
```

### Root cause

`serve_command` in `vllm_mlx/cli.py` built `SchedulerConfig(...)` **without** `prefill_step_size=args.prefill_step_size`. The field kept its 2048 dataclass default. The MLLM batch path then used 2048 as a per-batch cap (`prefill_step_size × len(requests)`) and rejected the prompt.

The CLI flag was being passed to `load_model(prefill_step_size=...)` but that parameter was accepted and **silently discarded** — `BatchedEngine` reads the value off `scheduler_config` only. So `--prefill-step-size` has been a dead flag on the LLM and MLLM continuous-batching paths since it was introduced. The standalone `python -m vllm_mlx.server` / `mise run` entry had the same bug pattern.

### Why SOPs missed it

- Smoke / doctor / pr_validate all run with default flags → bug only fires when the user deviates.
- The flag goes through three hops (argparse → load_model → SchedulerConfig), each hop looked plausible in isolation, but `load_model` discarded the value.
- No "dead parameter" check. ruff/mypy don't flag unused function parameters.
- MLLM path systematically less covered than the LLM path.

## Changes

**Fix:**
- `vllm_mlx/cli.py` — pass `prefill_step_size=args.prefill_step_size` to `SchedulerConfig(...)` in `serve_command`.
- `vllm_mlx/server.py:main` — build a `SchedulerConfig(prefill_step_size=...)` so the standalone entry also forwards the flag.
- `vllm_mlx/server.py:load_model` — keep the `prefill_step_size=` kwarg as deprecated-but-functional (back-compat: any external caller written against the previous signature still works; the value is now translated into `scheduler_config.prefill_step_size` with a `DeprecationWarning`).
- `vllm_mlx/mllm_batch_generator.py` — error message now names the actual cap formula and points at `--prefill-step-size`:

  > Total prompt tokens (11573) exceeds the per-batch cap (2048 = prefill_step_size 2048 × 1 request(s)). Raise the cap with --prefill-step-size, or shorten the prompt.

**New SOP gate — CLI ↔ Config fidelity audit:**
- `scripts/audit_cli_config_fidelity.py` — AST-only audit. For every function in cli.py *and* server.py, finds the 3-way intersection of (function reads `args.X`) ∧ (`SchedulerConfig` has field `X`) ∧ (kwarg `X` not passed at the call site). Each hit is a user-visible silent-flag-drop bug. Zero-import (parses dataclass fields from source via AST), runs on plain Linux CI in <1s.
- `scripts/dev_test.py` — new `audit` tier, included in `smoke` / `all` / `full`.
- `Makefile` — `make audit` target; `make smoke` now runs lint → audit → unit.
- `.github/workflows/ci.yml` — audit step in the `lint` job, so every PR and every push to main gets the gate for free.

**Tests:**
- `tests/test_cli_config_fidelity.py` — 6 tests:
  1. `test_prefill_step_size_is_plumbed_in_serve_command` — AST regression for #400 (cli.py).
  2. `test_prefill_step_size_is_plumbed_in_server_main` — same for the `python -m vllm_mlx.server` entry.
  3. `test_audit_passes_on_current_main` — audit exits 0 on fixed main.
  4. `test_audit_detects_synthetic_drift` — audit flags a synthetic cli.py with the bug pattern.
  5. `test_load_model_prefill_step_size_back_compat_translation` — deprecated kwarg still accepted, emits `DeprecationWarning`, value flows to `scheduler_config.prefill_step_size`.
  6. `test_audit_no_false_positive_when_field_unused` — audit stays quiet when a function legitimately doesn't expose the field (subparser-scoped behavior).

### Independent verification of the audit

Before this PR, the new audit against v0.6.51 main (without the fix) produces:
```
cli.py:665 (in serve_command)  SchedulerConfig(--prefill-step-size dropped)
```
Had this gate existed during v0.6.51 cut, #400 would never have shipped.

## SOP gates run before merge

- [x] **Codex review × 4 rounds** — R1 clean → R2 P2 (load_model back-compat) FIXED → R3 P2 (server.py:main flag drop) FIXED → R4 confirmed clean.
- [x] **pr_validate** — `MERGE-SAFE` (1004s, 3×3 model×{stress, agents, bench} matrix all PASS).
- [x] **make check** — 4 pass / 2 fail / 0 regression. Both fails (`regression_suite[qwen3.5-35b]`, `smoke_matrix[qwen3.5-35b]`) are pre-existing on main — verified by identical signatures in `harness/runs/2026-05-16-104300-full/report.md` (cut day before this PR). Both have memory notes about fixes landing for the `-4b` variant only.
- [x] **Live #400 repro** — `rapid-mlx serve mlx-community/MedGemma-4b-it-4bit --prefill-step-size 8192 --continuous-batching` accepts a 5625-token MLLM prompt with HTTP 200; pre-fix this would have been rejected with `exceeds safe limit (2048)`.
- [x] **Audit clean on this PR's HEAD** — `python3.12 scripts/audit_cli_config_fidelity.py` exit 0.
- [x] **CI**: lint (incl. new audit step), test-matrix (3.10/3.11/3.12), test-apple-silicon, type-check, version-check — all green.

## Test plan

- [x] `python3.12 scripts/audit_cli_config_fidelity.py` → exit 0
- [x] `python3.12 -m pytest tests/test_cli_config_fidelity.py -v` → 6 passed
- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations` → 3616 passed, 19 skipped, 1 xfailed
- [x] `ruff check vllm_mlx/ tests/ scripts/` + `ruff format --check` → clean
- [x] Live: `rapid-mlx serve` with `--prefill-step-size 8192 --continuous-batching` boots, accepts >2048-token prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)