### PR TITLE
fix(mlx): probe-and-cache shim for M5 single-stream GPU (#404)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.52"
+version = "0.6.53"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -3,12 +3,20 @@
 Tests for the MLX hardware-compat shim (#404 M5 single-stream).
 
 We can't test on actual M5 from CI, but we can:
-1. Verify the shim is installed by importing vllm_mlx.
+1. Verify the shim is installed *before* any module-level
+   ``mx.new_thread_local_stream`` capture inside ``mlx_lm.generate``,
+   by checking that importing ``vllm_mlx.scheduler`` triggers install().
 2. Mock the probe failure and assert the fallback path returns
    ``mx.default_stream(...)``.
 3. Verify idempotency — install() can be called multiple times safely.
 4. Verify the shim is transparent on hardware that works (this runs on
    the dev's actual hardware in the test-apple-silicon CI job).
+
+We do NOT test that ``import vllm_mlx`` installs the shim — that is the
+*wrong* contract. We deliberately keep top-level ``import vllm_mlx``
+free of ``mlx.core`` import so the package stays usable for metadata-only
+access on systems where ``mlx`` is installed but Metal is unavailable
+(``import mlx.core`` SIGABRTs there with an uncatchable NSException).
 """
 
 from __future__ import annotations
@@ -20,18 +28,60 @@ import pytest
 pytest.importorskip("mlx.core")
 
 
-def test_shim_installed_after_vllm_mlx_import():
-    """Importing vllm_mlx must install the compat shim before any submodule
-    that loads mlx_lm.generate gets a chance to capture the original API."""
+def test_shim_installed_when_scheduler_imports():
+    """Importing vllm_mlx.scheduler must install the compat shim — that's
+    the gate that protects the module-level ``mx.new_thread_local_stream``
+    call inside mlx_lm.generate (which scheduler imports at module top)."""
     import mlx.core as mx
 
-    # Drop the flag if a previous test left it set, then re-import.
+    # Re-install explicitly so this test is order-independent: even if
+    # scheduler was already imported by a prior test, install() is
+    # idempotent and the assertion still holds.
+    from vllm_mlx import _mlx_compat
+
     if hasattr(mx, "_rapid_mlx_compat_installed"):
         delattr(mx, "_rapid_mlx_compat_installed")
+    import vllm_mlx.scheduler  # noqa: F401
 
+    if not getattr(mx, "_rapid_mlx_compat_installed", False):
+        # scheduler may already be in sys.modules from a previous test —
+        # in which case its module-level install() didn't re-run. Confirm
+        # that calling install() directly works.
+        _mlx_compat.install()
+    assert getattr(mx, "_rapid_mlx_compat_installed", False) is True
+
+
+def test_vllm_mlx_import_does_not_touch_mlx_core():
+    """`import vllm_mlx` must NOT import mlx.core — preserves usability
+    on systems where mlx is installed but Metal is broken (the package
+    surface like __version__ should still work for metadata callers)."""
+    import sys
+
+    # Drop both modules so the import is fresh.
+    for mod in list(sys.modules):
+        if mod == "vllm_mlx" or mod.startswith("vllm_mlx."):
+            del sys.modules[mod]
+    # NOTE: we cannot also drop mlx.core because other tests may have
+    # already imported it. Instead, capture the "was it already loaded"
+    # state and check that importing vllm_mlx doesn't load it if it
+    # wasn't already there. On a clean test environment mlx.core IS
+    # already loaded (because we used `importorskip` at module top), so
+    # this test really verifies that vllm_mlx itself doesn't ADD an
+    # import dependency — checked structurally by reading __init__.py.
     import vllm_mlx  # noqa: F401
 
-    assert getattr(mx, "_rapid_mlx_compat_installed", False) is True
+    init_source = (
+        importlib.resources.files("vllm_mlx").joinpath("__init__.py").read_text()
+    )
+    assert "import mlx" not in init_source, (
+        "vllm_mlx/__init__.py must not import mlx — it would break "
+        "metadata-only usage on systems with broken Metal init."
+    )
+    assert "_mlx_compat.install()" not in init_source, (
+        "vllm_mlx/__init__.py must not call _mlx_compat.install() — that "
+        "would eagerly import mlx.core (which can SIGABRT on Metal-less "
+        "systems). The shim must install at scheduler-import time instead."
+    )
 
 
 def test_install_is_idempotent():

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the MLX hardware-compat shim (#404 M5 single-stream).
+
+We can't test on actual M5 from CI, but we can:
+1. Verify the shim is installed by importing vllm_mlx.
+2. Mock the probe failure and assert the fallback path returns
+   ``mx.default_stream(...)``.
+3. Verify idempotency — install() can be called multiple times safely.
+4. Verify the shim is transparent on hardware that works (this runs on
+   the dev's actual hardware in the test-apple-silicon CI job).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+
+def test_shim_installed_after_vllm_mlx_import():
+    """Importing vllm_mlx must install the compat shim before any submodule
+    that loads mlx_lm.generate gets a chance to capture the original API."""
+    import mlx.core as mx
+
+    # Drop the flag if a previous test left it set, then re-import.
+    if hasattr(mx, "_rapid_mlx_compat_installed"):
+        delattr(mx, "_rapid_mlx_compat_installed")
+
+    import vllm_mlx  # noqa: F401
+
+    assert getattr(mx, "_rapid_mlx_compat_installed", False) is True
+
+
+def test_install_is_idempotent():
+    import mlx.core as mx
+
+    from vllm_mlx import _mlx_compat
+
+    _mlx_compat.install()
+    first = mx.new_thread_local_stream
+    _mlx_compat.install()
+    second = mx.new_thread_local_stream
+    assert first is second, "second install() must not re-wrap the function"
+
+
+def test_fallback_engages_when_probe_raises(monkeypatch):
+    """Simulate M5: probe raises 'no Stream(gpu, 1)' → patched function must
+    return mx.default_stream(device) instead of the unusable stream."""
+    import mlx.core as mx
+
+    from vllm_mlx import _mlx_compat
+
+    # Make `_probe` always fail with the M5-shaped error. We poke the
+    # ``mx`` namespace because the patch wires `with mx.stream(stream)`
+    # → `mx.array(...) + mx.array(...)` — substituting `mx.stream`
+    # itself is the cleanest interception point.
+    class _BoomStream:
+        def __init__(self, stream):
+            self.stream = stream
+
+        def __enter__(self):
+            raise RuntimeError("There is no Stream(gpu, 1) in current thread.")
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(mx, "stream", _BoomStream)
+
+    # Force a fresh install with our broken probe environment.
+    monkeypatch.setattr(mx, "_rapid_mlx_compat_installed", False, raising=False)
+    importlib.reload(_mlx_compat)
+    _mlx_compat.install()
+
+    device = mx.default_device()
+    fallback = mx.new_thread_local_stream(device)
+    expected = mx.default_stream(device)
+    # mx.default_stream is comparable by repr; compare structurally.
+    assert repr(fallback) == repr(expected), (
+        f"M5 fallback should return mx.default_stream({device!r}); got {fallback!r}"
+    )
+
+
+def test_fallback_does_not_engage_on_unrelated_runtime_error(monkeypatch):
+    """If `with mx.stream(stream)` raises a RuntimeError that doesn't look
+    like the M5 single-stream signature, the shim must NOT swallow it —
+    we want unexpected failures to surface, not get silently degraded."""
+    import mlx.core as mx
+
+    from vllm_mlx import _mlx_compat
+
+    class _BoomStream:
+        def __init__(self, stream):
+            pass
+
+        def __enter__(self):
+            raise RuntimeError("Some completely unrelated MLX error")
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(mx, "stream", _BoomStream)
+    monkeypatch.setattr(mx, "_rapid_mlx_compat_installed", False, raising=False)
+    importlib.reload(_mlx_compat)
+    _mlx_compat.install()
+
+    with pytest.raises(RuntimeError, match="completely unrelated"):
+        mx.new_thread_local_stream(mx.default_device())
+
+
+def test_happy_path_unchanged_on_real_hardware():
+    """On hardware where the original API works (M1–M4), the patched
+    function must return a usable stream — and `with mx.stream(stream)`
+    must run a trivial op. This is the test that confirms the shim is
+    transparent for users who don't need it."""
+    import mlx.core as mx
+
+    from vllm_mlx import _mlx_compat
+
+    # Cleanup from prior monkeypatched tests
+    if hasattr(mx, "_rapid_mlx_compat_installed"):
+        delattr(mx, "_rapid_mlx_compat_installed")
+    importlib.reload(_mlx_compat)
+    _mlx_compat.install()
+
+    stream = mx.new_thread_local_stream(mx.default_device())
+    with mx.stream(stream):
+        result = (mx.array([1.0]) + mx.array([2.0])).item()
+    assert result == 3.0

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -52,25 +52,16 @@ def test_shim_installed_when_scheduler_imports():
     assert getattr(mx, "_rapid_mlx_compat_installed", False) is True
 
 
-def test_vllm_mlx_import_does_not_touch_mlx_core():
-    """`import vllm_mlx` must NOT import mlx.core — preserves usability
-    on systems where mlx is installed but Metal is broken (the package
-    surface like __version__ should still work for metadata callers)."""
-    import sys
+def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
+    """`vllm_mlx/__init__.py` must NOT import mlx or call _mlx_compat.install().
+    Both would eagerly load `mlx.core`, which SIGABRTs (uncatchable from
+    Python) on systems where the `mlx` package is installed but Metal is
+    unavailable — breaking metadata-only callers (`__version__`, etc.).
 
-    # Drop both modules so the import is fresh.
-    for mod in list(sys.modules):
-        if mod == "vllm_mlx" or mod.startswith("vllm_mlx."):
-            del sys.modules[mod]
-    # NOTE: we cannot also drop mlx.core because other tests may have
-    # already imported it. Instead, capture the "was it already loaded"
-    # state and check that importing vllm_mlx doesn't load it if it
-    # wasn't already there. On a clean test environment mlx.core IS
-    # already loaded (because we used `importorskip` at module top), so
-    # this test really verifies that vllm_mlx itself doesn't ADD an
-    # import dependency — checked structurally by reading __init__.py.
-    import vllm_mlx  # noqa: F401
-
+    Pure source-text audit; no module manipulation so the test is safe
+    in a shared pytest process. The shim must be installed lazily at
+    the top of every module that imports `mlx_lm.generate` instead
+    (verified by `test_every_mlx_lm_generate_consumer_installs_shim`)."""
     init_source = (
         importlib.resources.files("vllm_mlx").joinpath("__init__.py").read_text()
     )

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -22,6 +22,7 @@ access on systems where ``mlx`` is installed but Metal is unavailable
 from __future__ import annotations
 
 import importlib
+import importlib.resources
 
 import pytest
 
@@ -81,6 +82,41 @@ def test_vllm_mlx_import_does_not_touch_mlx_core():
         "vllm_mlx/__init__.py must not call _mlx_compat.install() — that "
         "would eagerly import mlx.core (which can SIGABRT on Metal-less "
         "systems). The shim must install at scheduler-import time instead."
+    )
+
+
+def test_every_mlx_lm_generate_consumer_installs_shim():
+    """Any vllm_mlx file that imports `mlx_lm.generate` (either via
+    `from mlx_lm.generate import ...` or `importlib.import_module(
+    "mlx_lm.generate")`) MUST also call `_mlx_compat.install()` in the
+    same file. Otherwise that import path triggers `mlx_lm/generate.py`
+    module-level `mx.new_thread_local_stream` capture on M5 before our
+    shim runs, and the bug from #404 returns.
+
+    This is a structural audit: a new file that adds the import without
+    the install will fail here at unit-test time, catching the slip
+    before any M5 user does.
+    """
+    import pathlib
+
+    pkg_root = pathlib.Path(
+        str(importlib.resources.files("vllm_mlx").joinpath(""))
+    ).resolve()
+    offenders = []
+    for path in pkg_root.rglob("*.py"):
+        if path.name == "_mlx_compat.py":
+            continue  # the shim itself; nothing to install
+        source = path.read_text()
+        imports_generate = (
+            "from mlx_lm.generate" in source
+            or 'import_module("mlx_lm.generate")' in source
+            or "import_module('mlx_lm.generate')" in source
+        )
+        if imports_generate and "_mlx_compat.install()" not in source:
+            offenders.append(str(path.relative_to(pkg_root)))
+    assert not offenders, (
+        "Files import mlx_lm.generate without calling _mlx_compat.install() "
+        "first — #404 M5 regression risk:\n  " + "\n  ".join(offenders)
     )
 
 

--- a/vllm_mlx/__init__.py
+++ b/vllm_mlx/__init__.py
@@ -19,6 +19,16 @@ try:
 except Exception:
     __version__ = "0.0.0"  # fallback for editable installs without metadata
 
+# Install MLX hardware-compatibility shims BEFORE any mlx_lm import.
+# mlx_lm/generate.py captures `mx.new_thread_local_stream(...)` at module
+# top level — by the time our scheduler/etc. imports it, it's too late to
+# patch. Running this here guarantees the patch is in place because Python
+# loads __init__.py before any submodule (including any submodule that
+# imports mlx_lm.generate). See _mlx_compat.py for #404 M5 background.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 # All imports are lazy to allow usage on non-Apple Silicon platforms
 # (e.g., CI running on Linux) where mlx_lm is not available.
 

--- a/vllm_mlx/__init__.py
+++ b/vllm_mlx/__init__.py
@@ -19,18 +19,13 @@ try:
 except Exception:
     __version__ = "0.0.0"  # fallback for editable installs without metadata
 
-# Install MLX hardware-compatibility shims BEFORE any mlx_lm import.
-# mlx_lm/generate.py captures `mx.new_thread_local_stream(...)` at module
-# top level — by the time our scheduler/etc. imports it, it's too late to
-# patch. Running this here guarantees the patch is in place because Python
-# loads __init__.py before any submodule (including any submodule that
-# imports mlx_lm.generate). See _mlx_compat.py for #404 M5 background.
-from . import _mlx_compat as _mlx_compat
-
-_mlx_compat.install()
-
 # All imports are lazy to allow usage on non-Apple Silicon platforms
-# (e.g., CI running on Linux) where mlx_lm is not available.
+# (e.g., CI running on Linux) where mlx_lm is not available. The MLX
+# hardware-compat shim (#404 M5 single-stream) lives in `_mlx_compat`
+# and is installed at the top of every submodule that imports
+# `mlx_lm.generate` — NOT here, so that `import vllm_mlx` stays free of
+# mlx.core import (which can SIGABRT on systems with mlx installed but
+# Metal unavailable).
 
 
 def __getattr__(name):

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLX hardware-compatibility shims.
+
+Currently handles one upstream issue:
+
+**M5 single-stream GPU (#404)**: `mlx_lm/generate.py` does
+
+    generation_stream = mx.new_thread_local_stream(mx.default_device())
+
+at module-import time. On M1–M4, this returns a usable thread-local stream.
+On M5, the call appears to succeed (returning a Stream handle), but later
+``with mx.stream(generation_stream):`` raises
+
+    RuntimeError: There is no Stream(gpu, 1) in current thread.
+
+because the M5 GPU only exposes a single stream slot. Every pure-attention
+model crashes at first prompt evaluation. Hybrid models (Qwen3.5/3.6) work
+because their custom path doesn't import ``mlx_lm.generate``.
+
+Fix: monkey-patch ``mx.new_thread_local_stream`` with a probe-and-cache
+wrapper. On the first call we attempt a trivial op inside ``mx.stream(s)``;
+if it raises, we cache that fact and return ``mx.default_stream(device)``
+for all subsequent calls. Single-stream devices then run with the default
+stream, losing parallel-issue throughput but staying functional. Hardware
+that supports multiple streams gets the original behavior — the probe is
+one-time per device.
+
+This patch must execute *before* any ``import mlx_lm.generate``, since
+that module captures the returned stream at module level. The hook lives
+in ``vllm_mlx/__init__.py``, which Python guarantees runs before any
+submodule is loaded.
+
+Upstream tracking: file mlx-lm bug + remove this shim when upstream lands
+a device-capability check.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def install() -> None:
+    """Install M5-compat shim. Safe to call multiple times (idempotent).
+
+    No-op when mlx.core can't be imported (non-Apple-Silicon CI). Logging
+    is at debug level on success to keep startup quiet for the 99% of
+    users on hardware where the original API works.
+    """
+    try:
+        import mlx.core as mx
+    except ImportError:
+        return  # Linux CI / no MLX
+
+    if getattr(mx, "_rapid_mlx_compat_installed", False):
+        return
+
+    original = mx.new_thread_local_stream
+
+    # Tri-state cache per device:
+    #   None  → not probed yet
+    #   True  → original works on this device
+    #   False → original is unusable, must fall back to default_stream
+    _probe_cache: dict = {}
+
+    def _probe(stream, device) -> bool:
+        """True if `with mx.stream(stream)` can run a trivial op."""
+        try:
+            with mx.stream(stream):
+                # Force evaluation so the stream is actually exercised.
+                _ = (mx.array([0.0]) + mx.array([1.0])).item()
+            return True
+        except RuntimeError as e:
+            msg = str(e)
+            # Be permissive about the exact wording: upstream may change it.
+            if "Stream" in msg and ("no Stream" in msg or "not exist" in msg):
+                logger.warning(
+                    "MLX device %s rejects secondary streams (%s) — "
+                    "falling back to default_stream. "
+                    "Throughput on parallel ops may be reduced. "
+                    "This is the #404 M5 single-stream workaround.",
+                    device,
+                    msg,
+                )
+                return False
+            raise
+
+    def patched_new_thread_local_stream(device):
+        cached = _probe_cache.get(repr(device))
+        if cached is False:
+            return mx.default_stream(device)
+        if cached is True:
+            return original(device)
+
+        # First call for this device — probe. Log at INFO so that anyone
+        # filing a hardware-shaped bug report has the device family in
+        # their startup output. Future M5+/Apple chip families will land
+        # here first; greppable on "rapid-mlx compat".
+        stream = original(device)
+        if _probe(stream, device):
+            _probe_cache[repr(device)] = True
+            logger.info(
+                "rapid-mlx compat: device %s supports thread-local streams (no shim).",
+                device,
+            )
+            return stream
+        _probe_cache[repr(device)] = False
+        logger.info(
+            "rapid-mlx compat: device %s uses default_stream fallback (#404 M5 path).",
+            device,
+        )
+        return mx.default_stream(device)
+
+    mx.new_thread_local_stream = patched_new_thread_local_stream
+    mx._rapid_mlx_compat_installed = True
+    logger.debug("MLX compat shim installed (#404 M5 single-stream guard).")

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -27,9 +27,14 @@ that supports multiple streams gets the original behavior — the probe is
 one-time per device.
 
 This patch must execute *before* any ``import mlx_lm.generate``, since
-that module captures the returned stream at module level. The hook lives
-in ``vllm_mlx/__init__.py``, which Python guarantees runs before any
-submodule is loaded.
+that module captures the returned stream at module level. The install
+hook is called at the top of every consumer that imports
+``mlx_lm.generate`` (currently ``vllm_mlx/scheduler.py`` and
+``vllm_mlx/pipeline/decode.py``) — *not* from ``vllm_mlx/__init__.py``.
+We deliberately keep ``import vllm_mlx`` free of any ``mlx.core`` import
+so the package stays usable for metadata-only access on systems where
+``mlx`` is installed but Metal is unavailable (``import mlx.core``
+SIGABRTs there with an uncatchable NSException).
 
 Upstream tracking: file mlx-lm bug + remove this shim when upstream lands
 a device-capability check.

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -380,6 +380,14 @@ class MLXModelRunner:
             List of generated token IDs
         """
         try:
+            # Install MLX hardware-compat shim (#404 M5 single-stream guard)
+            # BEFORE importing mlx_lm.generate — that module captures
+            # `mx.new_thread_local_stream(mx.default_device())` at top level.
+            # Idempotent: no-op once installed.
+            from vllm_mlx import _mlx_compat as _mlx_compat
+
+            _mlx_compat.install()
+
             from mlx_lm.generate import generate_step
             from mlx_lm.sample_utils import make_sampler
 

--- a/vllm_mlx/pipeline/decode.py
+++ b/vllm_mlx/pipeline/decode.py
@@ -22,9 +22,15 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from mlx_lm.generate import BatchGenerator
+# MUST install the MLX hardware-compat shim BEFORE importing mlx_lm.generate;
+# see vllm_mlx/_mlx_compat.py + #404 for the M5 single-stream background.
+from vllm_mlx import _mlx_compat as _mlx_compat
 
-from .interfaces import DecodeRequest, DecodeStrategy, TokenResult
+_mlx_compat.install()
+
+from mlx_lm.generate import BatchGenerator  # noqa: E402
+
+from .interfaces import DecodeRequest, DecodeStrategy, TokenResult  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -18,11 +18,21 @@ from enum import Enum
 from typing import Any
 
 import mlx.core as mx
-from mlx_lm.generate import BatchGenerator
-from mlx_lm.sample_utils import make_logits_processors, make_sampler
-from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
-from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+# MUST install the MLX hardware-compat shim BEFORE importing mlx_lm.generate.
+# mlx_lm/generate.py captures `mx.new_thread_local_stream(mx.default_device())`
+# at module-import time; on M5 single-stream GPUs that stream is unusable
+# (#404). The shim is idempotent and a no-op on hardware where the original
+# API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.generate import BatchGenerator  # noqa: E402
+from mlx_lm.sample_utils import make_logits_processors, make_sampler  # noqa: E402
+from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer  # noqa: E402
+
+from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
 from .request import Request, RequestOutput, RequestStatus, SamplingParams

--- a/vllm_mlx/utils/mamba_cache.py
+++ b/vllm_mlx/utils/mamba_cache.py
@@ -104,6 +104,12 @@ def patch_mlx_lm_for_mamba():
     """
     import importlib
 
+    # Install MLX hardware-compat shim (#404 M5 single-stream guard) BEFORE
+    # importing mlx_lm.generate. Idempotent: no-op once installed.
+    from vllm_mlx import _mlx_compat as _mlx_compat
+
+    _mlx_compat.install()
+
     gen_module = importlib.import_module("mlx_lm.generate")
     from mlx_lm.models.cache import (
         ArraysCache,


### PR DESCRIPTION
## Summary

Fixes #404 (M5 Apple Silicon: every pure-attention model crashes with `There is no Stream(gpu, 1) in current thread.`).

- `vllm_mlx/_mlx_compat.py` — probe-and-cache wrapper around `mx.new_thread_local_stream` (transparent on M1–M4, falls back to `mx.default_stream(device)` on M5 single-stream GPUs).
- Lazy install at the top of every module that imports `mlx_lm.generate`: `vllm_mlx/scheduler.py`, `vllm_mlx/pipeline/decode.py`, `vllm_mlx/model_runner.py::_generate_for_request`, `vllm_mlx/utils/mamba_cache.py::patch_mlx_lm_for_mamba`.
- `vllm_mlx/__init__.py` intentionally does **not** call install — would eagerly import `mlx.core`, which SIGABRTs with an uncatchable NSException on systems where mlx is installed but Metal is unavailable. The shim must be installed at scheduler-import time so `import vllm_mlx` stays free of `mlx.core`.
- `tests/test_mlx_compat.py` — 7 tests: install-hook fires before `mlx_lm.generate` import, idempotency, M5-fallback via monkeypatched `mx.stream`, unrelated-`RuntimeError` propagation, happy-path unchanged on dev hardware, structural audit that `__init__.py` never installs the shim, structural audit that every `mlx_lm.generate` consumer file calls `_mlx_compat.install()` (catches future drift).

## Why this bug existed

`mlx_lm/generate.py` does at module top level:

```python
generation_stream = mx.new_thread_local_stream(mx.default_device())
```

On M1–M4 this returns a usable stream. On M5, the call appears to succeed (returns a `Stream` handle), but later `with mx.stream(generation_stream):` raises `RuntimeError: There is no Stream(gpu, 1) in current thread.` because the M5 GPU exposes only a single stream slot. The capture is at *import time* of `mlx_lm.generate`, so by the time anything in `vllm_mlx` imports the scheduler, it's already too late to patch.

Hybrid models (Qwen3.5/3.6) sidestep this because their custom decode path doesn't import `mlx_lm.generate` — which is why #404 reports "Qwen3.5 works, everything else crashes."

## Fix design

Probe-and-cache:

1. First call per device → run a trivial `mx.array + mx.array` inside `with mx.stream(stream):`. If it raises the M5-shaped error, cache `False` and return `mx.default_stream(device)`.
2. If the probe succeeds, cache `True` and return the original stream.
3. Subsequent calls hit the cache; the probe is one-time per device.
4. The shim is *opt-out* — preserves original behavior on every device where it works. M5 users lose parallel-issue throughput but gain a functioning pure-attention path.

The `RuntimeError` filter is narrow: only swallows errors whose message contains `Stream` AND (`no Stream` OR `not exist`). Unrelated MLX errors propagate unchanged (covered by `test_fallback_does_not_engage_on_unrelated_runtime_error`).

## Why our SOPs didn't catch this

The miss was structural, not a process slip:

- **Doctor harness runs on the developer's hardware** (M3 here). Same chip family as upstream's CI. The bug only manifests on M5 — a family we don't own.
- **No cross-chip-family gate on mlx/mlx-lm version bumps.** Upstream landed the module-level `mx.new_thread_local_stream` call in a routine version refresh. We bumped the pin without auditing for new top-level GPU API usage that might not be portable.
- **No mock-the-failure-shape regression-test pattern.** Even without M5 hardware we could have written a test that monkeypatches `mx.stream` to raise the M5 error and asserts a graceful fallback — exactly what this PR's `test_fallback_engages_when_probe_raises` does.

SOP fix (added to `release_workflow.md`):

> **Step 9: MLX-version-bump cross-chip-family gate.** Triggers only when this release bumps `mlx` / `mlx-lm` / `mlx-vlm` / `mlx-metal`. Diff the upstream package for new module-level `mx.*stream*`, `mx.metal.*`, `mx.default_device`, or device-introspection calls. If any found: write a regression test that monkeypatches the call to raise the shape we'd see on the absent chip family, asserting our shim/fallback engages. Don't trust "works on my M3" — every M-series family has had at least one capability divergence.

## Verification

- `python3.12 -m pytest tests/test_mlx_compat.py -v` → 7/7 pass on M3 Ultra.
- Full unit suite: 3625 passed, 19 skipped, 1 xfailed (identical-quality to main + our 7 new tests).
- pr_validate: **MERGE-SAFE** — fetch / supply_chain / lint / targeted / full_unit / stress_e2e_bench (3×3 matrix qwen3-smoke + qwen3.5-35B + qwen3.6-27B) all PASS.
- Codex review × 3 rounds: R1 caught eager-mlx-import and order-dependent test (fixed), R2 caught untouched lazy import sites and missing `importlib.resources` (fixed), R3 clean.
- Ruff lint + format clean across all 7 modified files.
- **M5 hardware verification still needed** — asking the reporter @777stupid777 to confirm the fix on a real M5 before we merge.

## Test plan

- [x] All 7 unit tests pass on M3.
- [x] Lint + format clean.
- [x] Full pytest suite green (3625 passed).
- [x] pr_validate MERGE-SAFE (incl. 3×3 stress matrix).
- [x] codex review × 3 rounds clean.
- [x] Structural audit test guards against future drift (any new mlx_lm.generate consumer must call _mlx_compat.install()).
- [ ] M5 user @777stupid777 reproduces and confirms fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)