### PR TITLE
harden(sop §10): registry-derived routing gates + red-team-driven hardening (6 rounds)

### DIFF
--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1448,6 +1448,17 @@ def _param_is_bool(param: inspect.Parameter) -> bool:
         # No annotation — fall back to default. ``type(default) is bool``
         # is strict (won't match int).
         return type(param.default) is bool
+    # PEP 604 ``bool | None`` / typing.Optional[bool] / typing.Union[...]
+    # — these become real ``types.UnionType`` / ``typing.Union`` objects
+    # when the module does NOT use ``from __future__ import annotations``.
+    # Codex R1 (PR #409 review) flagged this gap: a positional
+    # ``flag: bool | None = None`` annotated without PEP 563 slips the
+    # bool detection above.
+    import typing
+
+    args = typing.get_args(annotation)
+    if args and any(a is bool for a in args):
+        return True
     return False
 
 
@@ -1489,6 +1500,50 @@ def _param_default_has_custom_bool(param: inspect.Parameter) -> bool:
     if default_type.__module__ == "builtins":
         return False
     return type(param.default).__bool__ is not object.__bool__
+
+
+def test_param_is_bool_handles_pep604_unions():
+    """Codex R1 regression: ``bool | None`` / ``Optional[bool]`` on a
+    positional parameter slipped the previous detector because the
+    annotation was a real ``types.UnionType``, not ``bool`` and not a
+    string. Lock the union-aware branch so a future regression to the
+    old behavior fails this test loudly.
+    """
+    import typing
+
+    def _param_with(annotation, default=inspect.Parameter.empty) -> inspect.Parameter:
+        return inspect.Parameter(
+            "f",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=annotation,
+            default=default,
+        )
+
+    # Real PEP 604 / typing.Optional / typing.Union — must be detected.
+    # noqa for UP045/UP007: this test verifies BOTH the legacy typing
+    # forms AND the PEP 604 forms are detected — that's the point.
+    assert _param_is_bool(_param_with(bool))
+    assert _param_is_bool(_param_with(bool | None, default=None))
+    assert _param_is_bool(_param_with(typing.Optional[bool], default=None))  # noqa: UP045
+    assert _param_is_bool(_param_with(typing.Union[bool, str], default=False))  # noqa: UP007
+
+    # Stringified.
+    assert _param_is_bool(_param_with("bool"))
+    assert _param_is_bool(_param_with("bool | None"))
+    assert _param_is_bool(_param_with("Optional[bool]"))
+
+    # No annotation, bool default.
+    assert _param_is_bool(_param_with(inspect.Parameter.empty, default=False))
+    assert _param_is_bool(_param_with(inspect.Parameter.empty, default=True))
+
+    # Negative cases — must NOT trigger.
+    assert not _param_is_bool(_param_with(int))
+    assert not _param_is_bool(_param_with(str))
+    assert not _param_is_bool(_param_with(int | None, default=None))
+    assert not _param_is_bool(_param_with("int"))
+    assert not _param_is_bool(_param_with("Optional[int]"))
+    assert not _param_is_bool(_param_with(inspect.Parameter.empty, default=0))
+    assert not _param_is_bool(_param_with(inspect.Parameter.empty, default=None))
 
 
 def test_hybrid_overrides_mutually_exclusive_in_load_model():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1481,14 +1481,21 @@ def _param_default_has_custom_bool(param: inspect.Parameter) -> bool:
     isn't a bool, isn't a routing-named param, and isn't any of the
     annotation shapes ``_param_is_bool`` checks.
 
-    Heuristic: if the default value's type overrides ``__bool__``
-    (i.e. ``type(default).__bool__ is not object.__bool__``), treat
-    it as a candidate truthy-laundering bypass.
+    Heuristic: if the default value's type defines its own ``__bool__``
+    method, treat it as a candidate truthy-laundering bypass.
+
+    Codex R3 fix: previous version dereferenced ``object.__bool__``
+    directly, but stock ``object`` does NOT define ``__bool__`` at all
+    (Python's truthiness defaults are hardcoded in CPython without an
+    explicit method on the type). That made ``object.__bool__`` raise
+    AttributeError on any non-builtin default whose class didn't
+    define ``__bool__`` — crashing the gate instead of returning
+    False. Now uses ``getattr(..., None)`` for safety.
 
     False positives are rare — most real Python types either inherit
-    ``object.__bool__`` (always True for non-empty) or are built-in
-    types (int/str/dict/list) whose ``__bool__`` is at type-level,
-    not class-level. The check is intentionally conservative."""
+    no ``__bool__`` (default-True for non-empty) or are built-in
+    types whose ``__bool__`` is at the type level. The check is
+    intentionally conservative."""
     if param.default is inspect.Parameter.empty:
         return False
     if param.default is None:
@@ -1499,7 +1506,53 @@ def _param_default_has_custom_bool(param: inspect.Parameter) -> bool:
     # classes that override __bool__.
     if default_type.__module__ == "builtins":
         return False
-    return type(param.default).__bool__ is not object.__bool__
+    # Compare via getattr-with-default — both sides None means default
+    # truthiness behavior (no custom __bool__); any difference means
+    # the type has overridden it.
+    object_bool = getattr(object, "__bool__", None)
+    return getattr(default_type, "__bool__", None) is not object_bool
+
+
+def test_param_default_has_custom_bool_does_not_crash():
+    """Codex R3 regression: ``object`` does NOT define ``__bool__``
+    on stock Python (truthiness is hardcoded in CPython). The previous
+    implementation read ``object.__bool__`` directly, which raises
+    AttributeError on any non-builtin default whose class also lacks
+    a custom ``__bool__`` — crashing the gate. This test locks the
+    getattr-with-default fix: ordinary user-defined classes return
+    False, custom-__bool__ classes return True, builtins return False.
+    """
+
+    class _Plain:
+        pass
+
+    class _CustomBool:
+        def __bool__(self):
+            return False
+
+    def _param_with_default(default) -> inspect.Parameter:
+        return inspect.Parameter(
+            "f",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=default,
+        )
+
+    # Plain class — no custom __bool__, must NOT crash, must return False.
+    assert _param_default_has_custom_bool(_param_with_default(_Plain())) is False
+    # Custom __bool__ — must be detected.
+    assert _param_default_has_custom_bool(_param_with_default(_CustomBool())) is True
+    # Builtins must return False (early skip via __module__ == "builtins").
+    assert _param_default_has_custom_bool(_param_with_default(0)) is False
+    assert _param_default_has_custom_bool(_param_with_default("")) is False
+    assert _param_default_has_custom_bool(_param_with_default([])) is False
+    # None / empty defaults must return False.
+    assert _param_default_has_custom_bool(_param_with_default(None)) is False
+    assert (
+        _param_default_has_custom_bool(
+            inspect.Parameter("f", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        )
+        is False
+    )
 
 
 def test_param_is_bool_handles_pep604_unions():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -376,31 +376,6 @@ def _all_add_argument_flags(source: str) -> set[str]:
     return flags
 
 
-def _all_add_argument_dests(source: str) -> set[str]:
-    """All ``dest=`` values passed to ``add_argument()`` calls. Used by
-    ``test_no_unregistered_routing_shaped_flags`` to catch round-4
-    cat-1 ``dest=`` aliasing — a contributor registers an innocent-
-    looking flag like ``--turbo-mode`` with ``dest="force_mllm"``, so
-    the flag name evades the routing-shape regex but argparse still
-    sets ``args.force_mllm=True``."""
-    tree = ast.parse(source)
-    dests: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
-            continue
-        for kw in node.keywords:
-            if (
-                kw.arg == "dest"
-                and isinstance(kw.value, ast.Constant)
-                and isinstance(kw.value.value, str)
-            ):
-                dests.add(kw.value.value)
-    return dests
-
-
 def _add_argument_calls_with_custom_action(source: str) -> list[tuple[int, str]]:
     """Find ``add_argument(..., action=<non-stdlib>)`` calls — a
     contributor can sneak routing by writing a custom
@@ -766,6 +741,47 @@ def test_registry_invariants():
             "(round-3 red-team #2.1 — liar-registry bypass)."
         )
 
+    # (d) DeepSeek-V4 round 2 fix (PR #409): every forwarded_kwargs entry
+    # must actually exist as a parameter on load_model AND
+    # BatchedEngine.__init__. A typo like "force_hyrbid" silently
+    # satisfies the invariants above, then fails downstream with a bare
+    # KeyError in the keyword-only test. Catching it here gives a
+    # descriptive failure with the offending pair name.
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.server import load_model
+
+    load_params = set(inspect.signature(load_model).parameters)
+    batched_params = set(inspect.signature(BatchedEngine.__init__).parameters)
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        for kwarg in pair.forwarded_kwargs:
+            assert kwarg in load_params, (
+                f"Registry pair {pair.force_on}/{pair.force_off} forwards "
+                f"`{kwarg}` but load_model has no such parameter — typo or "
+                "stale refactor."
+            )
+            assert kwarg in batched_params, (
+                f"Registry pair {pair.force_on}/{pair.force_off} forwards "
+                f"`{kwarg}` but BatchedEngine.__init__ has no such "
+                "parameter — typo or stale refactor."
+            )
+
+    # (e) DeepSeek-V4 round 2 fix (PR #409): for pairs with
+    # ``model_config_field`` set, exactly 2 forwarded_kwargs are
+    # required (force-on first, force-off second) — convention
+    # enforced by ``_engine_core_override_cases()``. Previously this
+    # check lived at parametrize-collection time, where a violation
+    # aborts pytest with a collection error before any test runs.
+    # Move it here so the failure is a normal, named test failure.
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if pair.model_config_field is None:
+            continue
+        assert len(pair.forwarded_kwargs) == 2, (
+            f"Registry pair {pair.force_on}/{pair.force_off} declares "
+            f"model_config_field={pair.model_config_field!r} but has "
+            f"{len(pair.forwarded_kwargs)} forwarded kwargs; "
+            "exactly 2 required (force-on first, force-off second)."
+        )
+
 
 def test_registry_is_not_runtime_mutated():
     """Round-4 cat-5 hardening: the registry is the SSOT for every gate,
@@ -798,8 +814,17 @@ def test_registry_is_not_runtime_mutated():
     # literal RoutingFlagPair(...) calls inside it. The assignment is
     # annotated (``: tuple[RoutingFlagPair, ...]``) so it parses as
     # ast.AnnAssign, not ast.Assign.
+    #
+    # DeepSeek-V4 round 2 fix (PR #409): walk ONLY direct children of
+    # the module body, not arbitrary descendants. A local variable also
+    # named ``AUTO_ROUTING_FLAG_PAIRS`` inside any function or class in
+    # this file could be visited first by ``ast.walk`` (whose order is
+    # unspecified) and replace ``expected_pairs`` with a different
+    # Tuple — causing a spurious "runtime mutation detected" failure.
+    # Restricting to ``tree.body`` makes the scan deterministic and
+    # impossible to shadow.
     expected_pairs: list[dict[str, object]] = []
-    for node in ast.walk(tree):
+    for node in tree.body:
         target_name: str | None = None
         value_node: ast.AST | None = None
         if isinstance(node, ast.Assign):
@@ -922,7 +947,24 @@ def test_aliases_json_has_no_routing_shaped_keys():
 
     pkg_root = _pkg_root()
     aliases_path = pkg_root / "aliases.json"
-    raw = json.loads(aliases_path.read_text())
+    # DeepSeek-V4 round 2 fix (PR #409): wrap read+parse in a
+    # descriptive failure. Bare FileNotFoundError / JSONDecodeError on
+    # this gate would confuse anyone investigating the failure — the
+    # test isn't about file IO. Spell out the precondition.
+    try:
+        raw = json.loads(aliases_path.read_text())
+    except FileNotFoundError as exc:
+        pytest.fail(
+            f"aliases.json missing at {aliases_path} — routing-shape "
+            f"audit cannot run. Restore the file or update _pkg_root(). "
+            f"Underlying error: {exc}"
+        )
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"aliases.json at {aliases_path} is not valid JSON — "
+            f"routing-shape audit cannot run. Fix the syntax error first. "
+            f"Underlying error: {exc}"
+        )
 
     offenders: list[str] = []
     for alias, value in raw.items():
@@ -1406,8 +1448,16 @@ def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
             offenders.append(
                 (
                     name,
-                    "positional param with custom-__bool__ default — bypass of "
-                    "bool detection (round-3 red-team #3.5)",
+                    "positional param whose default's type defines __bool__ "
+                    "(or inherits a non-object __bool__) — could be a "
+                    "round-3 red-team #3.5 truthy-laundering bypass, but is "
+                    "also triggered by harmless stdlib defaults like "
+                    "pathlib.Path / enum.Enum / uuid.UUID. If your default "
+                    "is one of those, move the param to keyword-only and "
+                    "the gate will stop firing. The heuristic is "
+                    "intentionally conservative — keyword-only is always "
+                    "safe; positional + custom __bool__ shifts every later "
+                    "positional caller silently",
                 )
             )
 
@@ -1673,6 +1723,20 @@ def test_routing_override_kwargs_are_keyword_only_in_load_model():
     batched_sig = inspect.signature(BatchedEngine.__init__)
 
     for kwarg in expected:
+        # DeepSeek-V4 round 2 fix (PR #409): assert the kwarg exists in
+        # both signatures FIRST. Without this, a typo in
+        # ``RoutingFlagPair.forwarded_kwargs`` (e.g. "force_hyrbid")
+        # crashes with bare ``KeyError: 'force_hyrbid'`` — descriptive
+        # failure beats cryptic crash.
+        assert kwarg in load_sig.parameters, (
+            f"Registry declares forwarded kwarg `{kwarg}` but it does not "
+            "exist on load_model — typo in AUTO_ROUTING_FLAG_PAIRS or stale "
+            "refactor. Fix the registry entry or add the kwarg to load_model."
+        )
+        assert kwarg in batched_sig.parameters, (
+            f"Registry declares forwarded kwarg `{kwarg}` but it does not "
+            "exist on BatchedEngine.__init__ — typo or stale refactor."
+        )
         assert load_sig.parameters[kwarg].kind == inspect.Parameter.KEYWORD_ONLY, (
             f"load_model({kwarg}=...) must be KEYWORD_ONLY to preserve "
             "positional-arg compatibility. See codex R2 on PR #407."
@@ -1747,16 +1811,19 @@ def _engine_core_override_cases() -> list[tuple[str, str, bool]]:
     is the force-on direction (sets field True) and
     ``forwarded_kwargs[1]`` is the force-off direction (sets False).
     """
+    # DeepSeek-V4 round 2 fix (PR #409): the 2-kwarg invariant is
+    # enforced by ``test_registry_invariants`` (execution-time test,
+    # descriptive failure). Asserting it again here would fire at
+    # parametrize-collection time — pytest aborts with a collection
+    # error before any test runs, which is much harder to debug than a
+    # named test failure. Here we just SKIP malformed entries; the
+    # invariants test catches the malformation with full context.
     cases: list[tuple[str, str, bool]] = []
     for pair in AUTO_ROUTING_FLAG_PAIRS:
         if pair.model_config_field is None:
             continue
-        assert len(pair.forwarded_kwargs) == 2, (
-            f"Registry pair {pair.force_on}/{pair.force_off} declares "
-            f"model_config_field={pair.model_config_field!r} but has "
-            f"{len(pair.forwarded_kwargs)} forwarded kwargs; "
-            "exactly 2 required (force-on first, force-off second)."
-        )
+        if len(pair.forwarded_kwargs) != 2:
+            continue
         on_kwarg, off_kwarg = pair.forwarded_kwargs
         cases.append((pair.model_config_field, on_kwarg, True))
         cases.append((pair.model_config_field, off_kwarg, False))

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1773,9 +1773,24 @@ def _make_engine_core_for_override_test(monkeypatch, cfg, *, base=None):
     real."""
     from unittest.mock import MagicMock
 
-    from vllm_mlx import engine_core as ec
-    from vllm_mlx import model_auto_config as mac
-    from vllm_mlx.model_auto_config import ModelConfig
+    # Codex round-A fix (PR #409): in headless CI / sandboxed macOS
+    # environments without a Metal device, importing engine_core
+    # triggers a chain (scheduler.py → mlx_lm → mlx.core) that raises
+    # RuntimeError at module-load time — BEFORE the monkeypatch below
+    # can stub Scheduler. Catch that and skip; the test's purpose is
+    # the EngineCore.__init__ routing-mutation block, which can't be
+    # exercised without a usable MLX runtime anyway. On machines with
+    # Metal (the SOP's intended audit surface), the import succeeds
+    # and the gate fires.
+    try:
+        from vllm_mlx import engine_core as ec
+        from vllm_mlx import model_auto_config as mac
+        from vllm_mlx.model_auto_config import ModelConfig
+    except RuntimeError as exc:
+        pytest.skip(
+            f"MLX runtime unavailable ({exc}) — EngineCore routing-mutation "
+            "audit requires a working Metal device. Skipped on headless CI."
+        )
 
     if base is None:
         base = ModelConfig(is_hybrid=True, supports_spec_decode=False)
@@ -1995,17 +2010,22 @@ def test_friendly_error_does_not_swallow_unrelated_valueerror(monkeypatch):
     """An unrelated ValueError (e.g. config parsing) must NOT trigger
     the friendly-error path — it should propagate as-is so genuine bugs
     surface and don't get misattributed to vision-tower issues."""
-    import importlib
+    import importlib.util
     import sys
 
-    try:
-        importlib.import_module("mlx_vlm")
-    except ImportError:
+    # Codex round-A fix (PR #409): in headless CI without a Metal
+    # device, importlib.import_module("mlx_vlm") raises RuntimeError
+    # from MLX init (not ImportError), bypassing the
+    # ``except ImportError`` skip. Use find_spec to verify mlx_vlm is
+    # installable without actually loading it — the test only needs
+    # the module slot in sys.modules to exist before we replace it
+    # with a fake. Skip if the package isn't installed at all.
+    if importlib.util.find_spec("mlx_vlm") is None:
         pytest.skip("mlx_vlm not installed (vision extra)")
 
     from vllm_mlx.models import mllm as mllm_mod
 
-    real_mlx_vlm = sys.modules["mlx_vlm"]
+    real_mlx_vlm = sys.modules.get("mlx_vlm")
 
     class _FakeMlxVlm:
         @staticmethod
@@ -2026,4 +2046,9 @@ def test_friendly_error_does_not_swallow_unrelated_valueerror(monkeypatch):
         with pytest.raises(ValueError, match="invalid model_type"):
             inst.load()
     finally:
-        sys.modules["mlx_vlm"] = real_mlx_vlm
+        # monkeypatch.setitem already restores on teardown, but the
+        # original test had a paranoid manual restore. Preserve that
+        # only when there's something to restore — find_spec-based
+        # detection means we may not have imported it.
+        if real_mlx_vlm is not None:
+            sys.modules["mlx_vlm"] = real_mlx_vlm

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -376,6 +376,155 @@ def _all_add_argument_flags(source: str) -> set[str]:
     return flags
 
 
+def _all_add_argument_dests(source: str) -> set[str]:
+    """All ``dest=`` values passed to ``add_argument()`` calls. Used by
+    ``test_no_unregistered_routing_shaped_flags`` to catch round-4
+    cat-1 ``dest=`` aliasing — a contributor registers an innocent-
+    looking flag like ``--turbo-mode`` with ``dest="force_mllm"``, so
+    the flag name evades the routing-shape regex but argparse still
+    sets ``args.force_mllm=True``."""
+    tree = ast.parse(source)
+    dests: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "dest"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                dests.add(kw.value.value)
+    return dests
+
+
+def _add_argument_calls_with_custom_action(source: str) -> list[tuple[int, str]]:
+    """Find ``add_argument(..., action=<non-stdlib>)`` calls — a
+    contributor can sneak routing by writing a custom
+    ``argparse.Action`` subclass whose ``__call__`` mutates the
+    namespace bypassing every name/regex/dest check. Returns
+    ``(lineno, action_repr)`` pairs.
+
+    Allowed stdlib actions are the documented argparse strings:
+    ``store``, ``store_const``, ``store_true``, ``store_false``,
+    ``append``, ``append_const``, ``count``, ``help``, ``version``,
+    ``extend``. Anything else — a Name, Attribute, or non-allowlisted
+    string — is flagged for review. Closes round-4 cat-1 #A2 + cat-2
+    #4 (custom Action subclass routing flips).
+    """
+    _STDLIB_ACTION_STRINGS = frozenset(
+        {
+            "store",
+            "store_const",
+            "store_true",
+            "store_false",
+            "append",
+            "append_const",
+            "count",
+            "help",
+            "version",
+            "extend",
+        }
+    )
+    # Stdlib Action classes that may appear via Attribute reference
+    # (e.g. ``argparse.BooleanOptionalAction``). Trustworthy because they
+    # come from the standard library and don't write to attributes
+    # outside their declared dest.
+    _STDLIB_ACTION_CLASSES = frozenset(
+        {
+            "BooleanOptionalAction",  # Python 3.9+
+        }
+    )
+    tree = ast.parse(source)
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "action":
+                continue
+            if (
+                isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+                and kw.value.value in _STDLIB_ACTION_STRINGS
+            ):
+                continue
+            # `argparse.BooleanOptionalAction` (Attribute) or a bare
+            # `BooleanOptionalAction` (Name) is also stdlib.
+            if (
+                isinstance(kw.value, ast.Attribute)
+                and kw.value.attr in _STDLIB_ACTION_CLASSES
+            ):
+                continue
+            if isinstance(kw.value, ast.Name) and kw.value.id in _STDLIB_ACTION_CLASSES:
+                continue
+            # Anything else — custom class, non-allowlisted string — is suspicious.
+            try:
+                repr_str = ast.unparse(kw.value)
+            except Exception:
+                repr_str = "<unparseable>"
+            offenders.append((node.lineno, repr_str))
+    return offenders
+
+
+def _add_argument_calls_with_non_literal_flag(source: str) -> list[int]:
+    """Find ``add_argument(<non-Constant>, ...)`` calls where the first
+    positional argument is a variable, attribute, function call, or
+    subscript — i.e. the flag name is computed at runtime so the
+    static scan can't see it. Closes round-4 cat-2 #3 (helper-function
+    indirection like ``_add_routing_flag(p, "--force-text-mode", ...)``
+    where the constant lives in the call site of the helper, not the
+    ``add_argument`` itself)."""
+    tree = ast.parse(source)
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant):
+            continue
+        # Allow `argparse.SUPPRESS` — the only legitimate non-literal
+        # first arg in our codebase.
+        if isinstance(first, ast.Attribute) and first.attr == "SUPPRESS":
+            continue
+        offenders.append(node.lineno)
+    return offenders
+
+
+def _routing_shaped_constants_in_module(source: str) -> set[str]:
+    """Find string constants in a module that LOOK LIKE a single pure
+    routing flag (``--force-*``, ``--no-*``, etc.), regardless of where
+    they appear. Catches round-4 cat-2 #3 and #5 where the flag literal
+    lives in a helper-function call site (``_add_routing_flag(p,
+    "--force-text-mode", ...)``) or a plugin-registry call
+    (``register_plugin("--no-vision-tower", ...)``) instead of an
+    ``add_argument()`` call.
+
+    Anchored regex requires the whole string to be a single flag —
+    ``"--force-hybrid"`` matches, ``"--force-hybrid and --no-hybrid are
+    mutually exclusive"`` (an error message) does not. Embedded flag
+    names in error messages and docstrings are noise, not bypass."""
+    routing_pattern = re.compile(r"^--(?:force|no|enable|disable)-[a-z0-9-]+$")
+    tree = ast.parse(source)
+    flags: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if routing_pattern.match(node.value):
+                flags.add(node.value)
+    return flags
+
+
 # ---------------------------------------------------------------------------
 # Auto-discovered entrypoint set (closes round-3 red-team bypass #1.4/#4.4).
 #
@@ -560,6 +709,228 @@ def test_registry_invariants():
         )
 
 
+def test_registry_is_not_runtime_mutated():
+    """Round-4 cat-5 hardening: the registry is the SSOT for every gate,
+    so it must equal what's literally written in source. Catches three
+    classes of trust-attack on the registry:
+
+      - Bypass #3 (conftest inject): a ``conftest.py`` mutates
+        ``AUTO_ROUTING_FLAG_PAIRS`` at import time to absorb a new
+        sneaky flag, making the parity check pass.
+      - Bypass #4 (duck-typed entry): conftest replaces entries with
+        non-dataclass duck types that satisfy attribute access but
+        defeat the dataclass-aware invariants gate.
+      - Bypass #5 (frozen-bypass): ``object.__setattr__`` mutates a
+        frozen ``RoutingFlagPair`` to clear ``forwarded_kwargs`` and
+        disable the forwarding gate.
+
+    The defense: AST-parse THIS source file for literal
+    ``RoutingFlagPair(...)`` calls, reconstruct the expected tuple of
+    field values, then compare to the runtime tuple. Any divergence —
+    in length, types, or field values — is a runtime mutation and
+    fails loudly. This catches all three bypasses with one check
+    because each of them produces a runtime tuple that disagrees with
+    what's in source.
+    """
+    test_file = pathlib.Path(__file__).resolve()
+    source = test_file.read_text()
+    tree = ast.parse(source)
+
+    # Find the AUTO_ROUTING_FLAG_PAIRS = (...) assignment and parse the
+    # literal RoutingFlagPair(...) calls inside it. The assignment is
+    # annotated (``: tuple[RoutingFlagPair, ...]``) so it parses as
+    # ast.AnnAssign, not ast.Assign.
+    expected_pairs: list[dict[str, object]] = []
+    for node in ast.walk(tree):
+        target_name: str | None = None
+        value_node: ast.AST | None = None
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    target_name = t.id
+                    break
+            value_node = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_name = node.target.id
+            value_node = node.value
+        else:
+            continue
+        if target_name != "AUTO_ROUTING_FLAG_PAIRS":
+            continue
+        if not isinstance(value_node, ast.Tuple):
+            continue
+        for elt in value_node.elts:
+            if not (
+                isinstance(elt, ast.Call)
+                and isinstance(elt.func, ast.Name)
+                and elt.func.id == "RoutingFlagPair"
+            ):
+                continue
+            fields: dict[str, object] = {}
+            for kw in elt.keywords:
+                if kw.arg is None:
+                    pytest.fail(
+                        "RoutingFlagPair() call uses **unpack — disallowed "
+                        "by registry-mutation gate (round-4 cat-5)."
+                    )
+                try:
+                    fields[kw.arg] = ast.literal_eval(kw.value)
+                except ValueError:
+                    pytest.fail(
+                        f"RoutingFlagPair(...).{kw.arg} is not a literal value. "
+                        "The registry-mutation gate requires every field to "
+                        "be a literal so it can be reconstructed from source."
+                    )
+            expected_pairs.append(fields)
+        break
+
+    # Length must match — closes round-4 #3/#4 (added entries at runtime).
+    assert len(AUTO_ROUTING_FLAG_PAIRS) == len(expected_pairs), (
+        f"AUTO_ROUTING_FLAG_PAIRS has {len(AUTO_ROUTING_FLAG_PAIRS)} runtime "
+        f"entries but source defines {len(expected_pairs)} literal entries. "
+        "Runtime mutation detected (round-4 cat-5 #3/#4 — conftest inject "
+        "or duck-type registry replacement)."
+    )
+
+    # Every runtime entry must be a real RoutingFlagPair (not a duck
+    # type) AND match the source literal field-by-field.
+    for i, (runtime_pair, expected) in enumerate(
+        zip(AUTO_ROUTING_FLAG_PAIRS, expected_pairs)
+    ):
+        assert isinstance(runtime_pair, RoutingFlagPair), (
+            f"AUTO_ROUTING_FLAG_PAIRS[{i}] is {type(runtime_pair).__name__}, "
+            "not RoutingFlagPair — runtime mutation injected a duck type "
+            "(round-4 cat-5 #4)."
+        )
+        for field_name, expected_value in expected.items():
+            actual = getattr(runtime_pair, field_name)
+            assert actual == expected_value, (
+                f"AUTO_ROUTING_FLAG_PAIRS[{i}].{field_name} = {actual!r} "
+                f"but source declares {expected_value!r}. Runtime mutation "
+                "of a frozen dataclass detected (round-4 cat-5 #5 — "
+                "object.__setattr__ bypass). If you intended to change the "
+                "registry, edit AUTO_ROUTING_FLAG_PAIRS in source."
+            )
+
+
+def test_alias_profile_has_no_routing_shaped_fields():
+    """Round-4 env-config #5: a contributor adds ``force_mllm: true``
+    to an alias entry and a matching field on ``AliasProfile``, then
+    consults the field inside load_model — a covert per-alias routing
+    flip that bypasses CLI and load_model kwargs entirely.
+
+    The ``aliases.json`` half is closed by ``_ALLOWED_PROFILE_KEYS``
+    in ``model_aliases.py::_coerce`` (rejects unknown JSON keys). This
+    test closes the dataclass half: no AliasProfile field may be
+    routing-shaped (``force_*``, ``no_*``, ``enable_*``, ``disable_*``).
+    Routing dimensions belong in ``AUTO_ROUTING_FLAG_PAIRS`` with full
+    CLI surface, not as silent per-alias data.
+    """
+    import dataclasses
+
+    from vllm_mlx.model_aliases import AliasProfile
+
+    routing_shaped = [
+        f.name
+        for f in dataclasses.fields(AliasProfile)
+        if _ROUTING_PARAM_NAME_RE.match(f.name)
+    ]
+    assert not routing_shaped, (
+        f"AliasProfile has routing-shaped field(s): {routing_shaped}. "
+        "Per-alias routing data is an out-of-band escape hatch "
+        "(round-4 env-config #5). Routing dimensions must be registered "
+        "in AUTO_ROUTING_FLAG_PAIRS with full CLI + load_model surface, "
+        "not silently flipped by alias metadata."
+    )
+
+
+def test_aliases_json_has_no_routing_shaped_keys():
+    """Companion check to ``test_alias_profile_has_no_routing_shaped_fields``:
+    scan the actual ``aliases.json`` for any routing-shaped key. The
+    closed-set check in ``_coerce`` already rejects unknown keys at
+    load time, but this gate makes the failure visible at PR review
+    time (test failure) rather than only at runtime."""
+    import json
+
+    pkg_root = _pkg_root()
+    aliases_path = pkg_root / "aliases.json"
+    raw = json.loads(aliases_path.read_text())
+
+    offenders: list[str] = []
+    for alias, value in raw.items():
+        if not isinstance(value, dict):
+            continue
+        for key in value:
+            if _ROUTING_PARAM_NAME_RE.match(key):
+                offenders.append(f"{alias}.{key}")
+
+    assert not offenders, (
+        f"aliases.json contains routing-shaped key(s): {offenders}. "
+        "Per-alias routing data is forbidden (round-4 env-config #5). "
+        "Move the routing decision to AUTO_ROUTING_FLAG_PAIRS so it's "
+        "visible at CLI + load_model."
+    )
+
+
+def test_conftests_do_not_deselect_or_replace_collection():
+    """Round-4 cat-5 #6: a ``conftest.py`` deselects SOP gate tests via
+    ``pytest_collection_modifyitems`` that calls ``items.remove(...)``,
+    ``items[:] = ...``, or ``items.clear()``. The legitimate use of
+    that hook is ``item.add_marker(skip_X)`` which leaves the items
+    list intact; deselection is the attack pattern.
+
+    Walks every conftest.py under ``tests/`` and AST-rejects calls
+    that remove items from the collection list. Adding a new
+    conftest that needs to filter the collection? Either justify in a
+    PR-review comment and add an explicit allowlist entry, or use
+    ``item.add_marker(pytest.mark.skip(...))`` instead.
+    """
+    pkg_root = _pkg_root()
+    repo_root = pkg_root.parent
+    tests_dir = repo_root / "tests"
+
+    offenders: list[str] = []
+    for conftest in tests_dir.rglob("conftest.py"):
+        try:
+            source = conftest.read_text()
+        except UnicodeDecodeError:
+            continue
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            # Match `items.remove(...)`, `items.pop(...)`, `items.clear()`.
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "items"
+                    and func.attr in {"remove", "pop", "clear"}
+                ):
+                    offenders.append(
+                        f"{conftest.relative_to(repo_root)}:{node.lineno} "
+                        f"calls items.{func.attr}(...) — drops tests from "
+                        "collection (round-4 cat-5 #6 attack pattern). "
+                        "Use item.add_marker(pytest.mark.skip(...)) to skip "
+                        "without removing."
+                    )
+            # Match `items[:] = ...` and `items[:] = ...` (Assign with Subscript).
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "items"
+                    ):
+                        offenders.append(
+                            f"{conftest.relative_to(repo_root)}:{node.lineno} "
+                            "assigns to items[...] — rewrites collection list "
+                            "(round-4 cat-5 #6 attack pattern). Use markers "
+                            "to skip tests instead."
+                        )
+
+    assert not offenders, "\n".join(offenders)
+
+
 def test_auto_routing_flags_have_force_on_and_force_off_pair():
     """SOP gate (#393 lesson): every binary auto-routing decision must
     expose BOTH a force-on and a force-off CLI flag.
@@ -650,28 +1021,114 @@ def test_no_unregistered_routing_shaped_flags():
 
     discovered: set[str] = set()
     pkg_root = _pkg_root()
+    registered_kwargs = KWARGS_THAT_MUST_BE_FORWARDED
+    failures: list[str] = []
     for relpath in _discover_entrypoints():
         source = (pkg_root / relpath).read_text()
+
+        # Prong 1: positional flag-string literals in add_argument calls
+        # (original gate).
         for flag in _all_add_argument_flags(source):
             if routing_pattern.match(flag):
                 discovered.add(flag)
 
+        # Prong 2: routing-shaped string constants anywhere in the
+        # module — catches helper-function indirection (round-4 cat-2
+        # #3) and plugin-registry calls (round-4 cat-2 #5) where the
+        # literal lives outside the add_argument() call.
+        for flag in _routing_shaped_constants_in_module(source):
+            discovered.add(flag)
+
+        # Prong 3: `dest=` aliasing — innocent-looking flag with a
+        # routing-kwarg dest is still a routing flag (round-4 cat-1).
+        # Walk each add_argument call individually so we can pair the
+        # dest= with its actual flag name. A registered flag using its
+        # natural dest (e.g. `--force-hybrid` + `dest="force_hybrid"`)
+        # is fine; an unregistered flag aliasing onto a routing kwarg
+        # is the attack.
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+                continue
+            dest_val: str | None = None
+            for kw in node.keywords:
+                if (
+                    kw.arg == "dest"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    dest_val = kw.value.value
+            if dest_val is None or dest_val not in registered_kwargs:
+                continue
+            # dest IS a registered routing kwarg. Allow ONLY when at
+            # least one positional flag name on this call matches a
+            # registered routing flag — that's the legitimate "explicit
+            # dest=" pattern. If every flag name on the call is
+            # unregistered, this is dest= aliasing.
+            flag_names_on_call = [
+                arg.value
+                for arg in node.args
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+            ]
+            registered_flag_set = _registered_flag_names()
+            if not any(fn in registered_flag_set for fn in flag_names_on_call):
+                failures.append(
+                    f"{relpath}:{node.lineno} add_argument({flag_names_on_call!r}, "
+                    f"dest={dest_val!r}) — dest aliases a registered routing "
+                    "kwarg under an unregistered flag name (round-4 cat-1). "
+                    "Either rename the flag to a registered routing flag, "
+                    "or remove dest= and route through cli.py main() with "
+                    "an explicit name."
+                )
+
+        # Prong 4: custom argparse.Action subclasses — these can mutate
+        # the namespace bypassing every name-based check (round-4
+        # cat-1 #A2 + cat-2 #4).
+        for lineno, action_repr in _add_argument_calls_with_custom_action(source):
+            failures.append(
+                f"{relpath}:{lineno} uses non-stdlib argparse action "
+                f"{action_repr!r}. Custom Action subclasses can mutate the "
+                "namespace bypassing every routing check — write the routing "
+                "logic in cli.py main() with explicit kwargs to load_model "
+                "instead (round-4 cat-1 #A2 + cat-2 #4). If you genuinely "
+                "need a custom Action for non-routing reasons, add an "
+                "allowlist branch to _add_argument_calls_with_custom_action "
+                "with a comment."
+            )
+
+        # Prong 5: helper-function indirection — add_argument(<non-Constant>,
+        # ...) where the flag name is computed at runtime (round-4 cat-2 #3).
+        for lineno in _add_argument_calls_with_non_literal_flag(source):
+            failures.append(
+                f"{relpath}:{lineno} calls add_argument() with a non-literal "
+                "first positional argument. Flag names must be string "
+                "literals so the SOP gate can audit them. Helper functions "
+                "that wrap add_argument() defeat AST scanning (round-4 cat-2 "
+                "#3). Spell out the add_argument call site directly."
+            )
+
     registered = _registered_flag_names()
     unregistered = discovered - registered - NON_ROUTING_FLAGS_ALLOWLIST
 
-    assert not unregistered, (
-        f"Found {len(unregistered)} routing-shaped flag(s) not in either "
-        f"AUTO_ROUTING_FLAG_PAIRS or NON_ROUTING_FLAGS_ALLOWLIST:\n  "
-        + "\n  ".join(sorted(unregistered))
-        + "\n\nFor each, choose ONE:\n"
-        "  (a) Register the pair in AUTO_ROUTING_FLAG_PAIRS (preferred — "
-        "every binary auto-routing decision needs both directions per "
-        "SOP §10, and this auto-extends every other gate in this file).\n"
-        "  (b) Add to NON_ROUTING_FLAGS_ALLOWLIST if the flag is a feature "
-        "toggle / UX knob, NOT a binary auto-detection.\n"
-        "Don't pick (b) unless you're sure — the wrong choice lets the next "
-        "#393 ship silently."
-    )
+    if unregistered:
+        failures.append(
+            f"Found {len(unregistered)} routing-shaped flag(s) not in either "
+            f"AUTO_ROUTING_FLAG_PAIRS or NON_ROUTING_FLAGS_ALLOWLIST:\n  "
+            + "\n  ".join(sorted(unregistered))
+            + "\n\nFor each, choose ONE:\n"
+            "  (a) Register the pair in AUTO_ROUTING_FLAG_PAIRS (preferred — "
+            "every binary auto-routing decision needs both directions per "
+            "SOP §10, and this auto-extends every other gate in this file).\n"
+            "  (b) Add to NON_ROUTING_FLAGS_ALLOWLIST if the flag is a feature "
+            "toggle / UX knob, NOT a binary auto-detection.\n"
+            "Don't pick (b) unless you're sure — the wrong choice lets the next "
+            "#393 ship silently."
+        )
+
+    assert not failures, "\n\n".join(failures)
 
 
 def test_routing_override_kwargs_are_forwarded_to_load_model():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -24,7 +24,169 @@ These tests verify:
 
 from __future__ import annotations
 
+import ast
+import importlib.resources
+import inspect
+import pathlib
+import re
+from dataclasses import dataclass
+
 import pytest
+
+# ---------------------------------------------------------------------------
+# SOP §10 routing registry — single source of truth.
+#
+# Every binary auto-routing decision in rapid-mlx has an entry here. Other
+# gates in this file derive their checks from this registry instead of
+# carrying parallel hand-maintained lists — adding a new pair only requires
+# editing this one place. The 5-subagent red-team in PR #408 verified that
+# every test below now catches every previously-discovered bypass.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutingFlagPair:
+    """A binary auto-routing decision exposed via paired CLI flags.
+
+    Fields:
+        force_on: ``--force-*`` / ``--mllm``-style flag that forces the
+            auto-detected behavior on.
+        force_off: ``--no-*``-style flag that forces it off.
+        desc: human-readable description used in test failure messages.
+        required_files: source files (relative to ``vllm_mlx/``) where
+            BOTH flags must appear in an ``add_argument()`` call. Every
+            CLI entrypoint that takes a model name and runs the
+            corresponding auto-detection is required. Adding a new
+            model-taking entrypoint = adding it to every relevant pair.
+        forwarded_kwargs: ``load_model(...)`` kwargs the CLI forwards
+            when this pair is set. Empty tuple = the override is
+            consumed at a higher layer (e.g. parser opt-outs short-
+            circuit in cli.py before ``load_model``). When non-empty,
+            ``test_routing_override_kwargs_are_forwarded_to_load_model``
+            requires every ``load_model`` call site that forwards any
+            one of these to forward all of them.
+        model_config_field: ``ModelConfig`` attribute that
+            ``EngineCore.__init__`` mutates when this pair's
+            ``EngineConfig`` field is set. ``None`` = the override
+            doesn't go through ModelConfig (e.g. ``--no-mllm`` mutates
+            ``BatchedEngine._is_mllm``). When non-``None``,
+            ``test_engine_core_applies_routing_overrides_from_registry``
+            asserts the mutation actually happens.
+    """
+
+    force_on: str
+    force_off: str
+    desc: str
+    required_files: tuple[str, ...]
+    forwarded_kwargs: tuple[str, ...]
+    model_config_field: str | None = None
+
+
+AUTO_ROUTING_FLAG_PAIRS: tuple[RoutingFlagPair, ...] = (
+    RoutingFlagPair(
+        force_on="--mllm",
+        force_off="--no-mllm",
+        desc="MLLM vs text-only routing (#393)",
+        required_files=("cli.py", "server.py", "benchmark.py"),
+        forwarded_kwargs=("force_mllm", "force_text"),
+        # --mllm acts on BatchedEngine._is_mllm, not ModelConfig.
+        model_config_field=None,
+    ),
+    RoutingFlagPair(
+        force_on="--tool-call-parser",
+        force_off="--no-tool-call-parser",
+        desc="AliasProfile tool-call parser auto-selection",
+        required_files=("cli.py", "server.py"),
+        # Parser opt-outs are consumed in cli.py / server.py main()
+        # before load_model is ever called.
+        forwarded_kwargs=(),
+        model_config_field=None,
+    ),
+    RoutingFlagPair(
+        force_on="--reasoning-parser",
+        force_off="--no-reasoning-parser",
+        desc="AliasProfile reasoning parser auto-selection",
+        required_files=("cli.py", "server.py"),
+        forwarded_kwargs=(),
+        model_config_field=None,
+    ),
+    RoutingFlagPair(
+        force_on="--force-hybrid",
+        force_off="--no-hybrid",
+        desc="ModelConfig.is_hybrid (gates spec/suffix decode)",
+        required_files=("cli.py", "server.py"),
+        forwarded_kwargs=("force_hybrid", "no_hybrid"),
+        model_config_field="is_hybrid",
+    ),
+    RoutingFlagPair(
+        force_on="--force-spec-decode",
+        force_off="--no-spec-decode",
+        desc="ModelConfig.supports_spec_decode (gates MTP/DFlash/suffix)",
+        required_files=("cli.py", "server.py"),
+        forwarded_kwargs=("force_spec_decode", "no_spec_decode"),
+        model_config_field="supports_spec_decode",
+    ),
+)
+
+
+# Flags whose name matches the routing-shape pattern (--force-*, --no-*,
+# --enable-*, --disable-*) but are intentionally NOT auto-routing
+# decisions. Feature toggles, prompt-template knobs, and runtime-perf
+# opt-ins live here. Add to this list if and only if the flag is
+# definitively not a binary auto-detection that could ever need a paired
+# escape hatch — when in doubt, register the pair in
+# AUTO_ROUTING_FLAG_PAIRS instead.
+NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Auto-tool-choice is a behavior knob, not auto-detection.
+        "--enable-auto-tool-choice",
+        # Performance opt-in for jump-forward decoding bias.
+        "--enable-tool-logits-bias",
+        # Feature flags for speculative-decode backends. The routing
+        # decision (which one is eligible) is gated by --force/no-spec-
+        # decode (registered pair); these just enable the implementation.
+        "--enable-mtp",
+        "--enable-dflash",
+        "--enable-suffix-decoding",
+        "--enable-kv-cache-quantization",
+        "--enable-kv-cache-turboquant",
+        "--enable-prefix-cache",
+        "--disable-prefix-cache",
+        # Chat-template toggle, not engine routing.
+        "--no-thinking",
+        # CORS toggle.
+        "--enable-cors",
+        # Perf / UX toggles, not routing decisions.
+        "--force-disk-check",  # forces eager disk-space check
+        "--no-gc-control",  # disables Python GC tuning
+        "--no-memory-aware-cache",  # disables memory-aware cache sizing
+        # Privacy toggle.
+        "--no-telemetry",
+    }
+)
+
+
+# Derived from the registry — never edit these by hand. The whole point
+# of the dataclass restructure is that adding a new RoutingFlagPair
+# entry transparently extends every gate below.
+KWARGS_THAT_MUST_BE_FORWARDED: frozenset[str] = frozenset(
+    kw for p in AUTO_ROUTING_FLAG_PAIRS for kw in p.forwarded_kwargs
+)
+
+
+def _registered_flag_names() -> set[str]:
+    """All flag strings (force-on + force-off) currently in the registry."""
+    out: set[str] = set()
+    for p in AUTO_ROUTING_FLAG_PAIRS:
+        out.add(p.force_on)
+        out.add(p.force_off)
+    return out
+
+
+def _pkg_root() -> pathlib.Path:
+    return pathlib.Path(
+        str(importlib.resources.files("vllm_mlx").joinpath(""))
+    ).resolve()
 
 
 def test_force_text_overrides_auto_detection(monkeypatch):
@@ -177,8 +339,6 @@ def _flag_in_add_argument_calls(source: str, flag: str) -> bool:
 
     Strengthened version (codex R1 PR #407) of the previous
     "string-search" check that was a false-positive guard."""
-    import ast
-
     tree = ast.parse(source)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -193,6 +353,29 @@ def _flag_in_add_argument_calls(source: str, flag: str) -> bool:
     return False
 
 
+def _all_add_argument_flags(source: str) -> set[str]:
+    """All positional string literals passed to any ``add_argument()``
+    call in ``source``. Used by ``test_no_unregistered_routing_shaped_flags``
+    to enumerate every argparse flag in an entrypoint without missing
+    subparser blocks or argparse group calls."""
+    tree = ast.parse(source)
+    flags: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        for arg in node.args:
+            if (
+                isinstance(arg, ast.Constant)
+                and isinstance(arg.value, str)
+                and arg.value.startswith("-")
+            ):
+                flags.add(arg.value)
+    return flags
+
+
 def test_auto_routing_flags_have_force_on_and_force_off_pair():
     """SOP gate (#393 lesson): every binary auto-routing decision must
     expose BOTH a force-on and a force-off CLI flag.
@@ -204,11 +387,13 @@ def test_auto_routing_flags_have_force_on_and_force_off_pair():
     the user needs an escape hatch *immediately*, not in a follow-up
     release that ships ~2 weeks later.
 
-    Registry below is the source of truth: every routing flag we expose
-    must appear with both directions. Adding a new auto-detection
-    *requires* adding both flags and registering them here. If someone
-    in the future removes one direction of the pair, CI fails with a
-    pointer to this principle.
+    Registry (module-level ``AUTO_ROUTING_FLAG_PAIRS``) is the single
+    source of truth: every routing flag we expose must appear with
+    both directions. Adding a new auto-detection *requires* adding
+    both flags and registering them in the dataclass list above. Every
+    other gate in this file derives from that same registry, so adding
+    a new entry transparently extends keyword-only checks, kwarg
+    forwarding checks, and EngineCore-mutation checks too.
 
     Past incidents this rule would have caught:
       - #393: ``--mllm`` had no inverse → Tylast had to wait for a
@@ -225,134 +410,99 @@ def test_auto_routing_flags_have_force_on_and_force_off_pair():
         legacy-parser fallback for any per-request failure. If a
         false-positive surfaces, add an override flag here.
     """
-    import importlib.resources
-    import pathlib
-
-    pkg_root = pathlib.Path(
-        str(importlib.resources.files("vllm_mlx").joinpath(""))
-    ).resolve()
-    cli_source = (pkg_root / "cli.py").read_text()
-    server_source = (pkg_root / "server.py").read_text()
-    bench_source = (pkg_root / "benchmark.py").read_text()
-
-    # Every entry: (force-on flag, force-off flag, what it routes,
-    # entrypoint_files_required). The 4th element is a tuple of
-    # entrypoint source files where BOTH directions must appear — this
-    # is how we enforce that ``rapid-mlx serve`` and ``python -m
-    # vllm_mlx.server`` (and any other CLI taking a model name) all
-    # expose the same escape hatches. Adding a new entrypoint that
-    # takes a model name means adding it to every pair's required list.
-    AUTO_ROUTING_FLAG_PAIRS = [
-        (
-            "--mllm",
-            "--no-mllm",
-            "MLLM vs text-only routing (#393)",
-            ("cli.py", "server.py", "benchmark.py"),
-        ),
-        (
-            "--tool-call-parser",
-            "--no-tool-call-parser",
-            "AliasProfile tool-call parser auto-selection",
-            ("cli.py", "server.py"),
-        ),
-        (
-            "--reasoning-parser",
-            "--no-reasoning-parser",
-            "AliasProfile reasoning parser auto-selection",
-            ("cli.py", "server.py"),
-        ),
-        (
-            "--force-hybrid",
-            "--no-hybrid",
-            "ModelConfig.is_hybrid (gates spec/suffix decode)",
-            ("cli.py", "server.py"),
-        ),
-        (
-            "--force-spec-decode",
-            "--no-spec-decode",
-            "ModelConfig.supports_spec_decode (gates MTP/DFlash/suffix)",
-            ("cli.py", "server.py"),
-        ),
-    ]
-
+    pkg_root = _pkg_root()
     sources_by_file = {
-        "cli.py": cli_source,
-        "server.py": server_source,
-        "benchmark.py": bench_source,
+        fname: (pkg_root / fname).read_text()
+        for fname in ("cli.py", "server.py", "benchmark.py")
     }
 
-    missing = []
-    for force_on, force_off, desc, required_files in AUTO_ROUTING_FLAG_PAIRS:
-        # AST-based check: flag must appear as a positional literal in
-        # an ``add_argument`` call (not just anywhere in the source).
-        # Closes the false-positive gap codex caught in PR #407 R1.
-        for fname in required_files:
+    missing: list[str] = []
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        for fname in pair.required_files:
             src = sources_by_file[fname]
-            if not _flag_in_add_argument_calls(src, force_on):
+            if not _flag_in_add_argument_calls(src, pair.force_on):
                 missing.append(
-                    f"force-on flag {force_on} not registered via "
-                    f"add_argument() in {fname} ({desc}) — every "
+                    f"force-on flag {pair.force_on} not registered via "
+                    f"add_argument() in {fname} ({pair.desc}) — every "
                     "entrypoint that takes a model name needs the same "
                     "routing escape hatches (SOP §10)."
                 )
-            if not _flag_in_add_argument_calls(src, force_off):
+            if not _flag_in_add_argument_calls(src, pair.force_off):
                 missing.append(
-                    f"force-off flag {force_off} not registered via "
-                    f"add_argument() in {fname} ({desc}) — every binary "
+                    f"force-off flag {pair.force_off} not registered via "
+                    f"add_argument() in {fname} ({pair.desc}) — every binary "
                     "auto-routing decision needs an escape hatch in BOTH "
                     "directions; see #393 for the past incident this rule "
                     "encodes."
                 )
-        # Legacy substring guard: catch flags present only in cli.py or
-        # only in server.py without explicit entrypoint registration.
-        # Keep both checks; the per-file required_files loop above is
-        # the stronger invariant.
-        on_in_cli = _flag_in_add_argument_calls(cli_source, force_on)
-        on_in_server = _flag_in_add_argument_calls(server_source, force_on)
-        off_in_cli = _flag_in_add_argument_calls(cli_source, force_off)
-        off_in_server = _flag_in_add_argument_calls(server_source, force_off)
-        if (on_in_cli and not on_in_server) or (on_in_server and not on_in_cli):
-            missing.append(
-                f"force-on flag {force_on} present in only one entrypoint "
-                f"({'cli.py' if on_in_cli else 'server.py'}); both CLI paths "
-                "must expose every routing escape hatch (SOP §10)."
-            )
-        if (off_in_cli and not off_in_server) or (off_in_server and not off_in_cli):
-            missing.append(
-                f"force-off flag {force_off} present in only one entrypoint "
-                f"({'cli.py' if off_in_cli else 'server.py'}); both CLI paths "
-                "must expose every routing escape hatch (SOP §10)."
-            )
     assert not missing, "\n".join(missing)
 
 
+def test_no_unregistered_routing_shaped_flags():
+    """SOP gate (red-team #1, PR #408): every CLI flag whose name
+    matches the routing-shape pattern (``--force-*``, ``--no-*``,
+    ``--enable-*``, ``--disable-*``) MUST be in
+    ``AUTO_ROUTING_FLAG_PAIRS`` (registered as a binary routing
+    decision) OR in ``NON_ROUTING_FLAGS_ALLOWLIST`` (intentionally a
+    feature toggle, not a routing decision).
+
+    The previous registry was a closed-set check — it only verified
+    "known pairs are intact" and silently passed when a contributor
+    added a new ``--audio`` / ``--enable-thinking`` flag without
+    realizing they'd added an auto-routing decision. This test is the
+    complement: enumerate every routing-shaped flag in the source and
+    require a deliberate registration or allowlist decision.
+
+    Pick option 2 (allowlist) only when you're sure the flag is a UX
+    knob, not a binary auto-detection that could ever go wrong. When
+    in doubt, register the pair — the cost of an extra registry entry
+    is zero, the cost of a missed escape hatch is a Tylast-style
+    issue + patch release."""
+    routing_pattern = re.compile(r"^--(?:force|no|enable|disable)-")
+
+    discovered: set[str] = set()
+    pkg_root = _pkg_root()
+    for fname in ("cli.py", "server.py", "benchmark.py"):
+        source = (pkg_root / fname).read_text()
+        for flag in _all_add_argument_flags(source):
+            if routing_pattern.match(flag):
+                discovered.add(flag)
+
+    registered = _registered_flag_names()
+    unregistered = discovered - registered - NON_ROUTING_FLAGS_ALLOWLIST
+
+    assert not unregistered, (
+        f"Found {len(unregistered)} routing-shaped flag(s) not in either "
+        f"AUTO_ROUTING_FLAG_PAIRS or NON_ROUTING_FLAGS_ALLOWLIST:\n  "
+        + "\n  ".join(sorted(unregistered))
+        + "\n\nFor each, choose ONE:\n"
+        "  (a) Register the pair in AUTO_ROUTING_FLAG_PAIRS (preferred — "
+        "every binary auto-routing decision needs both directions per "
+        "SOP §10, and this auto-extends every other gate in this file).\n"
+        "  (b) Add to NON_ROUTING_FLAGS_ALLOWLIST if the flag is a feature "
+        "toggle / UX knob, NOT a binary auto-detection.\n"
+        "Don't pick (b) unless you're sure — the wrong choice lets the next "
+        "#393 ship silently."
+    )
+
+
 def test_routing_override_kwargs_are_forwarded_to_load_model():
-    """Strengthened SOP gate (codex R1 PR #407): catching the flag
-    appears in argparse is not enough — it must also be forwarded to
-    ``server.load_model`` so the override actually reaches EngineCore.
+    """Strengthened SOP gate (codex R1 PR #407 + red-team #4 PR #408):
+    catching the flag in argparse is not enough — it must also be
+    forwarded to ``server.load_model`` so the override actually
+    reaches EngineCore.
 
     Walks the AST of every ``load_model(...)`` call in cli.py and
-    server.py and confirms each of the 4 routing-override kwargs is
-    either passed as a keyword arg OR not passed at all (the
-    ``load_model`` default is False). The failure mode this catches:
-    flag registered, mutex check present, but the kwarg is silently
-    dropped between argparse and the load call → override no-ops."""
-    import ast
-    import importlib.resources
-    import pathlib
+    server.py and confirms each kwarg in ``KWARGS_THAT_MUST_BE_FORWARDED``
+    (derived from the registry) is either passed as a keyword arg OR
+    not passed at all. The failure mode this catches: flag registered,
+    mutex check present, but the kwarg is silently dropped between
+    argparse and the load call → override no-ops.
 
-    pkg_root = pathlib.Path(
-        str(importlib.resources.files("vllm_mlx").joinpath(""))
-    ).resolve()
-
-    KWARGS_THAT_MUST_BE_FORWARDED = {
-        "force_text",
-        "force_mllm",
-        "force_hybrid",
-        "no_hybrid",
-        "force_spec_decode",
-        "no_spec_decode",
-    }
+    The set of required kwargs is DERIVED from
+    ``AUTO_ROUTING_FLAG_PAIRS[*].forwarded_kwargs`` so adding a new
+    registry entry automatically extends this gate."""
+    pkg_root = _pkg_root()
 
     def _find_load_model_calls(source: str) -> list[ast.Call]:
         tree = ast.parse(source)
@@ -370,17 +520,16 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
                     calls.append(node)
         return calls
 
-    failures = []
+    failures: list[str] = []
     for fname in ("cli.py", "server.py"):
         source = (pkg_root / fname).read_text()
         for call in _find_load_model_calls(source):
             kwarg_names = {kw.arg for kw in call.keywords if kw.arg is not None}
-            # Note: load_model has defaults of False for every routing
-            # override, so omitting them all is fine for callers that
-            # never need to override. But once a CALLER references one
-            # of these kwargs in argparse, it must forward it. We
-            # approximate that by requiring the *full set* in any call
-            # that forwards at least one of them.
+            # ``load_model`` defaults every routing override to False, so
+            # omitting them all is fine for callers that never need to
+            # override. But once a CALLER references one of these
+            # kwargs, it must forward all of them — otherwise the
+            # caller is half-wired and the override silently no-ops.
             overlap = kwarg_names & KWARGS_THAT_MUST_BE_FORWARDED
             if overlap and overlap != KWARGS_THAT_MUST_BE_FORWARDED:
                 missing = KWARGS_THAT_MUST_BE_FORWARDED - overlap
@@ -388,9 +537,71 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
                     f"{fname} load_model() call at line {call.lineno} forwards "
                     f"{sorted(overlap)} but omits {sorted(missing)} — every "
                     "routing-override kwarg must be forwarded from any caller "
-                    "that forwards any one of them (SOP §10)."
+                    "that forwards any one of them (SOP §10). This list is "
+                    "auto-derived from AUTO_ROUTING_FLAG_PAIRS[*].forwarded_kwargs."
                 )
     assert not failures, "\n".join(failures)
+
+
+def test_load_model_has_no_unkeyworded_bool_params_beyond_baseline():
+    """SOP gate (red-team #3, PR #408): every bool parameter on
+    ``load_model`` must be keyword-only EXCEPT explicitly grandfathered
+    pre-PR-#407 ones. Catches the codex R2 bug shape: a new bool kwarg
+    inserted before the ``*,`` separator silently shifts every
+    downstream positional arg by one slot, flipping the semantics of
+    existing callers.
+
+    The grandfather list is FROZEN. If you genuinely need to add a
+    positional bool (almost never), update it with a comment
+    explaining why — the explicit edit forces the discussion."""
+    from vllm_mlx.server import load_model
+
+    sig = inspect.signature(load_model)
+
+    # Pre-SOP positional bools. Do NOT extend casually — see test
+    # docstring. Every entry needs a 1-line reason.
+    grandfathered = frozenset(
+        {
+            "force_mllm",  # original MLLM force-on flag, pre-#393
+            "mtp",  # native MTP enable, pre-PR #407
+        }
+    )
+
+    offenders: list[str] = []
+    for name, param in sig.parameters.items():
+        if not _param_is_bool(param):
+            continue
+        if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+            if name not in grandfathered:
+                offenders.append(name)
+
+    assert not offenders, (
+        f"load_model has {len(offenders)} non-grandfathered POSITIONAL bool "
+        f"param(s): {offenders}. NEW bool params must be keyword-only "
+        f"(after the `*,` separator) to avoid silently shifting downstream "
+        f"positional args. See codex R2 on PR #407 for the bug shape this "
+        f"prevents — a new positional bool changes the slot of every kwarg "
+        f"after it, so existing callers like "
+        f"`load_model(name, None, 1, 32768, False, 0.5)` start passing 0.5 "
+        f"as a truthy value to the wrong field. If you genuinely need a "
+        f"positional bool (almost never), update `grandfathered` in this "
+        f"test with the reason."
+    )
+
+
+def _param_is_bool(param: inspect.Parameter) -> bool:
+    """Best-effort detection of bool-typed parameters across annotation
+    styles (real type, stringified PEP 563, or just inferred from
+    default value)."""
+    if param.annotation is bool:
+        return True
+    if isinstance(param.annotation, str) and param.annotation == "bool":
+        return True
+    if param.annotation is inspect.Parameter.empty:
+        # No annotation — fall back to default. ``type(default) is bool``
+        # is strict (won't match int) which is exactly what we want.
+        return type(param.default) is bool
+    return False
 
 
 def test_hybrid_overrides_mutually_exclusive_in_load_model():
@@ -420,28 +631,44 @@ def test_spec_decode_overrides_mutually_exclusive_in_load_model():
         )
 
 
-def test_routing_override_kwargs_are_keyword_only_in_load_model():
-    """Regression: same lesson as test_force_text_is_keyword_only — the
-    4 new routing-override flags must be KEYWORD_ONLY so existing
-    positional callers don't silently get a True ``force_hybrid`` etc.
-    when they meant something else. See codex R2 on PR #407."""
-    import inspect
+def _post_sop_forwarded_kwargs() -> frozenset[str]:
+    """Forwarded kwargs from the registry MINUS pre-SOP grandfathered
+    ones. Used by the keyword-only test — pre-SOP positional bools
+    (``force_mllm``) can't be retroactively moved without breaking
+    callers, but every NEW kwarg added via the registry must be
+    keyword-only."""
+    return KWARGS_THAT_MUST_BE_FORWARDED - {"force_mllm"}
 
+
+def test_routing_override_kwargs_are_keyword_only_in_load_model():
+    """Every routing-override kwarg derived from the registry must be
+    KEYWORD_ONLY in both ``load_model`` and ``BatchedEngine.__init__``,
+    so existing positional callers don't silently get a True
+    ``force_X`` etc. when they meant something else. See codex R2 on
+    PR #407.
+
+    Derived from ``AUTO_ROUTING_FLAG_PAIRS[*].forwarded_kwargs`` so
+    adding a new pair to the registry automatically extends this
+    check. The pre-SOP grandfathered ``force_mllm`` is excluded — its
+    positional position is fixed for back-compat (verified by
+    ``test_load_model_has_no_unkeyworded_bool_params_beyond_baseline``
+    elsewhere)."""
+    from vllm_mlx.engine.batched import BatchedEngine
     from vllm_mlx.server import load_model
 
-    sig = inspect.signature(load_model)
-    for kwarg in ("force_hybrid", "no_hybrid", "force_spec_decode", "no_spec_decode"):
-        assert sig.parameters[kwarg].kind == inspect.Parameter.KEYWORD_ONLY, (
-            f"{kwarg} must be KEYWORD_ONLY to preserve positional-arg "
-            "compatibility. See codex R2 on PR #407."
+    expected = _post_sop_forwarded_kwargs()
+    assert expected, "Registry should produce at least one post-SOP kwarg"
+
+    load_sig = inspect.signature(load_model)
+    batched_sig = inspect.signature(BatchedEngine.__init__)
+
+    for kwarg in expected:
+        assert load_sig.parameters[kwarg].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"load_model({kwarg}=...) must be KEYWORD_ONLY to preserve "
+            "positional-arg compatibility. See codex R2 on PR #407."
         )
-
-    from vllm_mlx.engine.batched import BatchedEngine
-
-    sig = inspect.signature(BatchedEngine.__init__)
-    for kwarg in ("force_hybrid", "no_hybrid", "force_spec_decode", "no_spec_decode"):
-        assert sig.parameters[kwarg].kind == inspect.Parameter.KEYWORD_ONLY, (
-            f"BatchedEngine.__init__ {kwarg} must be KEYWORD_ONLY too."
+        assert batched_sig.parameters[kwarg].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"BatchedEngine.__init__({kwarg}=...) must be KEYWORD_ONLY too."
         )
 
 
@@ -474,46 +701,101 @@ def _make_engine_core_for_override_test(monkeypatch, cfg):
     return ec.EngineCore(model=model, tokenizer=MagicMock(), config=cfg)
 
 
+def _engine_core_override_cases() -> list[tuple[str, str, bool]]:
+    """Build parametrize cases ``(model_config_field, kwarg, expected)``
+    from the registry. Every routing pair whose ``model_config_field``
+    is not None contributes 2 cases: one for the force-on kwarg
+    (expected True) and one for the force-off kwarg (expected False).
+
+    Convention enforced by ``_assert_registry_kwarg_convention``: for
+    every ``model_config_field``-bearing pair, ``forwarded_kwargs[0]``
+    is the force-on direction (sets field True) and
+    ``forwarded_kwargs[1]`` is the force-off direction (sets False).
+    """
+    cases: list[tuple[str, str, bool]] = []
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if pair.model_config_field is None:
+            continue
+        assert len(pair.forwarded_kwargs) == 2, (
+            f"Registry pair {pair.force_on}/{pair.force_off} declares "
+            f"model_config_field={pair.model_config_field!r} but has "
+            f"{len(pair.forwarded_kwargs)} forwarded kwargs; "
+            "exactly 2 required (force-on first, force-off second)."
+        )
+        on_kwarg, off_kwarg = pair.forwarded_kwargs
+        cases.append((pair.model_config_field, on_kwarg, True))
+        cases.append((pair.model_config_field, off_kwarg, False))
+    return cases
+
+
 @pytest.mark.parametrize(
-    "flags,expected_hybrid,expected_spec",
-    [
-        ({"no_hybrid": True}, False, False),
-        ({"force_hybrid": True}, True, False),
-        ({"force_spec_decode": True}, True, True),
-        ({"no_spec_decode": True}, True, False),
-        ({"no_hybrid": True, "force_spec_decode": True}, False, True),
-        ({}, True, False),  # no flags → auto-detection result unchanged
-    ],
+    "model_config_field,kwarg,expected",
+    _engine_core_override_cases(),
+    ids=lambda v: str(v) if isinstance(v, (str, bool)) else "?",
 )
-def test_engine_core_applies_routing_overrides_to_model_config(
-    monkeypatch, flags, expected_hybrid, expected_spec
+def test_engine_core_applies_routing_overrides_from_registry(
+    monkeypatch, model_config_field, kwarg, expected
 ):
-    """EngineCore.__init__ must mutate ``self.model_config.is_hybrid``
-    and ``self.model_config.supports_spec_decode`` when the matching
-    override flag is set on ``EngineConfig``. This is the *only* place
-    in the call chain that talks to ModelConfig — if it stops working,
-    every routing escape hatch silently no-ops and the user gets the
-    old buggy behavior back."""
+    """For every routing pair in the registry with a non-None
+    ``model_config_field``, ``EngineCore.__init__`` must mutate
+    ``self.model_config.<field>`` when the corresponding kwarg is set
+    on ``EngineConfig``. Catches red-team #5 from PR #408: a new
+    EngineConfig field plumbed end-to-end but never actually applied
+    to ModelConfig.
+
+    Parametrize is DERIVED from the registry, so adding a new
+    ``RoutingFlagPair`` with a ``model_config_field`` automatically
+    adds new test cases. If your new pair's mutation block is missing
+    from ``EngineCore.__init__``, this test fails immediately —
+    nothing silently no-ops."""
     from vllm_mlx.engine_core import EngineConfig
 
-    cfg = EngineConfig(model_name="fake/model", **flags)
+    cfg = EngineConfig(model_name="fake/model", **{kwarg: True})
     core = _make_engine_core_for_override_test(monkeypatch, cfg)
 
-    assert core.model_config.is_hybrid is expected_hybrid
-    assert core.model_config.supports_spec_decode is expected_spec
+    actual = getattr(core.model_config, model_config_field)
+    assert actual is expected, (
+        f"Setting EngineConfig.{kwarg}=True must mutate "
+        f"ModelConfig.{model_config_field} to {expected}, but got {actual}. "
+        f"EngineCore.__init__ likely missing the mutation block for this "
+        f"routing pair — add it after enrich_model_config() and before "
+        f"`self.scheduler.model_config = self.model_config`."
+    )
 
 
-@pytest.mark.parametrize(
-    "flags",
-    [
-        {"force_hybrid": True, "no_hybrid": True},
-        {"force_spec_decode": True, "no_spec_decode": True},
-    ],
-)
+def test_engine_core_no_override_leaves_model_config_unchanged(monkeypatch):
+    """Sanity: when no override kwarg is set, EngineCore leaves the
+    enriched ModelConfig untouched. Pairs with the parametrized
+    mutation test above — together they prove "fires when set, doesn't
+    fire when not set"."""
+    from vllm_mlx.engine_core import EngineConfig
+
+    cfg = EngineConfig(model_name="fake/model")
+    core = _make_engine_core_for_override_test(monkeypatch, cfg)
+    # Stub returns is_hybrid=True, supports_spec_decode=False.
+    assert core.model_config.is_hybrid is True
+    assert core.model_config.supports_spec_decode is False
+
+
+def _engine_core_mutex_cases() -> list[dict[str, bool]]:
+    """Build mutex-conflict parametrize cases from the registry. For
+    every pair with ``model_config_field`` not None, generate one
+    conflict case where both directions are True."""
+    cases: list[dict[str, bool]] = []
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if pair.model_config_field is None:
+            continue
+        on_kwarg, off_kwarg = pair.forwarded_kwargs
+        cases.append({on_kwarg: True, off_kwarg: True})
+    return cases
+
+
+@pytest.mark.parametrize("flags", _engine_core_mutex_cases())
 def test_engine_core_rejects_conflicting_routing_overrides(monkeypatch, flags):
     """Second line of defense: EngineCore raises ValueError if both
-    directions of a routing-override pair are set on EngineConfig.
-    Programmatic callers that bypass the CLI mutex still get caught."""
+    directions of a registry-known routing-override pair are set on
+    EngineConfig. Programmatic callers that bypass the CLI mutex still
+    get caught. Derived from registry."""
     from vllm_mlx.engine_core import EngineConfig
 
     cfg = EngineConfig(model_name="fake/model", **flags)

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -376,6 +376,190 @@ def _all_add_argument_flags(source: str) -> set[str]:
     return flags
 
 
+# ---------------------------------------------------------------------------
+# Auto-discovered entrypoint set (closes round-3 red-team bypass #1.4/#4.4).
+#
+# Previously the SOP checks hardcoded ("cli.py", "server.py", "benchmark.py")
+# and never noticed routing-shape flags or load_model() callers added to
+# new files. Now we walk every .py file under vllm_mlx/ and discover any
+# file that calls add_argument() OR load_model() — that's the closure of
+# "places a contributor could regress an SOP gate". If your new file
+# starts appearing here, the gates automatically include it.
+#
+# Excluded: ``__pycache__``, ``__init__.py`` (re-exports only), test
+# fixtures. We re-check this list against the static seed below so the
+# discovery can't silently drop entrypoints either.
+# ---------------------------------------------------------------------------
+
+
+# Static seed (current known entrypoints). Discovery must produce a
+# SUPERSET of this — if discovery returns fewer files, something
+# downstream changed and we want a loud failure.
+_KNOWN_ENTRYPOINTS_SEED: frozenset[str] = frozenset(
+    {"cli.py", "server.py", "benchmark.py"}
+)
+
+
+def _discover_entrypoints() -> set[str]:
+    """Discover every file under ``vllm_mlx/`` that either calls
+    ``add_argument(...)`` or ``load_model(...)``. Returns paths
+    relative to the package root (e.g. ``"cli.py"`` or
+    ``"routes/audio_route.py"``).
+
+    Closes round-3 bypass: contributor adds a new entrypoint file
+    (e.g. ``vllm_mlx/serve.py`` with its own argparse) that the
+    hardcoded gate-file list would never check."""
+    root = _pkg_root()
+    discovered: set[str] = set()
+
+    for path in root.rglob("*.py"):
+        # Skip __pycache__ and other dunder dirs.
+        if any(part.startswith("__") for part in path.parts[len(root.parts) :]):
+            continue
+        if path.name == "__init__.py":
+            # __init__ files are usually re-exports; if a real
+            # entrypoint shows up there it's still discovered via the
+            # AST checks below.
+            pass
+
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        has_routing_shape = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else (func.attr if isinstance(func, ast.Attribute) else None)
+            )
+            if name == "add_argument":
+                # Only flag this file if at least one add_argument call
+                # is a routing-shape flag. Files that only register
+                # config knobs (e.g. --max-tokens) don't need to be in
+                # the parity/forwarding checks.
+                for arg in node.args:
+                    if (
+                        isinstance(arg, ast.Constant)
+                        and isinstance(arg.value, str)
+                        and arg.value.startswith("--")
+                    ):
+                        has_routing_shape = True
+                        break
+            elif name == "load_model":
+                # Any caller of load_model is by definition an
+                # entrypoint that needs the forwarding check.
+                has_routing_shape = True
+
+            if has_routing_shape:
+                break
+
+        if has_routing_shape:
+            rel = path.relative_to(root).as_posix()
+            discovered.add(rel)
+
+    missing_seed = _KNOWN_ENTRYPOINTS_SEED - discovered
+    assert not missing_seed, (
+        f"Entrypoint discovery dropped known files: {sorted(missing_seed)}. "
+        "Either a known entrypoint was deleted or the discovery logic "
+        "regressed. If deletion was intentional, update "
+        "_KNOWN_ENTRYPOINTS_SEED to match."
+    )
+    return discovered
+
+
+def test_registry_invariants():
+    """Round-3 hardening (PR #408): the registry IS the source of
+    truth for every gate, so the registry itself must be sane.
+    Catches red-team attacks where the registry is silently corrupted
+    or duplicated to defeat the derived gates:
+
+      - Bypass #2.1 (liar registry): a contributor sets
+        ``model_config_field=None`` on a pair that REALLY does mutate
+        ModelConfig. Parametrize then produces zero cases, no test
+        complains. This invariant test demands proof: every pair
+        whose ``forwarded_kwargs`` includes a ``force_*`` / ``no_*``
+        kwarg pair AND whose semantics flow through ModelConfig must
+        declare its field — we sanity-check by requiring any pair
+        with non-empty ``forwarded_kwargs`` to either (a) have
+        ``model_config_field`` set OR (b) be in
+        ``KWARGS_FORWARDED_BUT_NOT_VIA_MODEL_CONFIG`` (explicit
+        exception list, ``force_mllm``/``force_text`` go here).
+
+      - Bypass #2.5 (duplicate entry): contributor inserts the same
+        pair twice. We assert all ``(force_on, force_off)`` tuples
+        are unique.
+
+      - Hygiene: every ``model_config_field`` must actually exist on
+        ``ModelConfig``. Bogus field names get caught here loudly
+        instead of producing cryptic AttributeError at parametrize
+        execution time.
+    """
+    from vllm_mlx.model_auto_config import ModelConfig
+
+    # (a) No duplicate flag pairs.
+    pair_keys = [(p.force_on, p.force_off) for p in AUTO_ROUTING_FLAG_PAIRS]
+    assert len(pair_keys) == len(set(pair_keys)), (
+        f"AUTO_ROUTING_FLAG_PAIRS has duplicate (force_on, force_off) entries: "
+        f"{[pk for pk in pair_keys if pair_keys.count(pk) > 1]}. "
+        "Round-3 red-team #2.5 — duplicates silently waste gate cycles "
+        "without surfacing the issue."
+    )
+
+    # (b) Every model_config_field exists on ModelConfig.
+    mc = ModelConfig()
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if pair.model_config_field is None:
+            continue
+        assert hasattr(mc, pair.model_config_field), (
+            f"Registry pair {pair.force_on}/{pair.force_off} declares "
+            f"model_config_field={pair.model_config_field!r} but that "
+            "attribute doesn't exist on ModelConfig. Typo or stale field "
+            "name — fix or remove."
+        )
+
+    # (c) Forwarded kwargs that don't go through ModelConfig must be
+    # explicitly listed. Catches the round-3 "liar" registry bypass:
+    # contributor sets model_config_field=None on a pair that really
+    # does mutate ModelConfig to silently disable the derived gate.
+    KWARGS_FORWARDED_BUT_NOT_VIA_MODEL_CONFIG = frozenset(
+        {
+            # --mllm / --no-mllm route through BatchedEngine._is_mllm,
+            # not ModelConfig. Verified by test_force_text_overrides_auto_detection.
+            "force_mllm",
+            "force_text",
+        }
+    )
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if not pair.forwarded_kwargs:
+            continue
+        if pair.model_config_field is not None:
+            continue
+        # forwarded_kwargs non-empty AND model_config_field None — must
+        # be an explicit exception.
+        unexplained = set(pair.forwarded_kwargs) - (
+            KWARGS_FORWARDED_BUT_NOT_VIA_MODEL_CONFIG
+        )
+        assert not unexplained, (
+            f"Registry pair {pair.force_on}/{pair.force_off} forwards "
+            f"kwargs {sorted(pair.forwarded_kwargs)} but has "
+            "model_config_field=None and is not in "
+            "KWARGS_FORWARDED_BUT_NOT_VIA_MODEL_CONFIG. Either set "
+            "model_config_field (so the EngineCore mutation test parametrize "
+            "covers it) or add these kwargs to the exception list with a "
+            "comment explaining where the override actually takes effect "
+            "(round-3 red-team #2.1 — liar-registry bypass)."
+        )
+
+
 def test_auto_routing_flags_have_force_on_and_force_off_pair():
     """SOP gate (#393 lesson): every binary auto-routing decision must
     expose BOTH a force-on and a force-off CLI flag.
@@ -453,6 +637,10 @@ def test_no_unregistered_routing_shaped_flags():
     complement: enumerate every routing-shaped flag in the source and
     require a deliberate registration or allowlist decision.
 
+    Scans every file discovered by ``_discover_entrypoints()`` — not
+    a hardcoded list. Adding a new entrypoint file is automatically
+    included (round-3 bypass #1.4 fix).
+
     Pick option 2 (allowlist) only when you're sure the flag is a UX
     knob, not a binary auto-detection that could ever go wrong. When
     in doubt, register the pair — the cost of an extra registry entry
@@ -462,8 +650,8 @@ def test_no_unregistered_routing_shaped_flags():
 
     discovered: set[str] = set()
     pkg_root = _pkg_root()
-    for fname in ("cli.py", "server.py", "benchmark.py"):
-        source = (pkg_root / fname).read_text()
+    for relpath in _discover_entrypoints():
+        source = (pkg_root / relpath).read_text()
         for flag in _all_add_argument_flags(source):
             if routing_pattern.match(flag):
                 discovered.add(flag)
@@ -487,17 +675,22 @@ def test_no_unregistered_routing_shaped_flags():
 
 
 def test_routing_override_kwargs_are_forwarded_to_load_model():
-    """Strengthened SOP gate (codex R1 PR #407 + red-team #4 PR #408):
-    catching the flag in argparse is not enough — it must also be
-    forwarded to ``server.load_model`` so the override actually
-    reaches EngineCore.
+    """Strengthened SOP gate (codex R1 PR #407 + red-team #4 PR #408 +
+    round-3 hardening): catching the flag in argparse is not enough —
+    it must also be forwarded to ``server.load_model`` so the
+    override actually reaches EngineCore.
 
-    Walks the AST of every ``load_model(...)`` call in cli.py and
-    server.py and confirms each kwarg in ``KWARGS_THAT_MUST_BE_FORWARDED``
-    (derived from the registry) is either passed as a keyword arg OR
-    not passed at all. The failure mode this catches: flag registered,
-    mutex check present, but the kwarg is silently dropped between
-    argparse and the load call → override no-ops.
+    Walks the AST of every ``load_model(...)`` call in every file
+    discovered by ``_discover_entrypoints()`` (no longer hardcoded;
+    closes round-3 bypass #4.4 where a new ``vllm_mlx/serve.py``
+    entrypoint would never be scanned).
+
+    Also REJECTS ``load_model(**expanded_dict)`` constructs (round-3
+    bypass #4.1): with ``**`` the kwarg names are invisible to AST,
+    so any call site using ``**`` to forward routing kwargs MUST
+    instead spell them out so this gate can audit each one. Helper
+    functions returning kwarg dicts are exactly the bypass shape we
+    can't audit statically.
 
     The set of required kwargs is DERIVED from
     ``AUTO_ROUTING_FLAG_PAIRS[*].forwarded_kwargs`` so adding a new
@@ -521,10 +714,28 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
         return calls
 
     failures: list[str] = []
-    for fname in ("cli.py", "server.py"):
-        source = (pkg_root / fname).read_text()
+    for relpath in _discover_entrypoints():
+        source = (pkg_root / relpath).read_text()
         for call in _find_load_model_calls(source):
+            # ``kw.arg is None`` indicates a `**unpack` construct. Allow
+            # it ONLY if the call is empty of routing kwargs (i.e. no
+            # explicit routing kwargs and no risk of partial forwarding
+            # via the unpack). Otherwise reject — the unpacked dict is
+            # opaque to AST audit.
+            star_unpacks = [kw for kw in call.keywords if kw.arg is None]
             kwarg_names = {kw.arg for kw in call.keywords if kw.arg is not None}
+
+            if star_unpacks:
+                failures.append(
+                    f"{relpath} load_model() call at line {call.lineno} uses "
+                    "`**` unpacking which hides kwarg names from the SOP "
+                    "audit. Spell out every routing kwarg explicitly "
+                    f"({sorted(KWARGS_THAT_MUST_BE_FORWARDED)}) — otherwise a "
+                    "helper that builds the dict can silently drop a routing "
+                    "override (round-3 red-team bypass #4.1)."
+                )
+                continue
+
             # ``load_model`` defaults every routing override to False, so
             # omitting them all is fine for callers that never need to
             # override. But once a CALLER references one of these
@@ -534,7 +745,7 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
             if overlap and overlap != KWARGS_THAT_MUST_BE_FORWARDED:
                 missing = KWARGS_THAT_MUST_BE_FORWARDED - overlap
                 failures.append(
-                    f"{fname} load_model() call at line {call.lineno} forwards "
+                    f"{relpath} load_model() call at line {call.lineno} forwards "
                     f"{sorted(overlap)} but omits {sorted(missing)} — every "
                     "routing-override kwarg must be forwarded from any caller "
                     "that forwards any one of them (SOP §10). This list is "
@@ -544,28 +755,37 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
 
 
 def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
-    """SOP gate (red-team #3 PR #408 + round-2 hardening): every
-    positional parameter on ``load_model`` that is EITHER bool-typed
-    OR routing-named MUST be keyword-only, except explicitly
-    grandfathered pre-#407 entries.
+    """SOP gate (red-team #3 PR #408, rounds 2 + 3): every positional
+    parameter on ``load_model`` that is EITHER bool-typed OR
+    routing-named OR has truthy-laundering shape MUST be keyword-only,
+    except explicitly grandfathered pre-#407 entries.
 
-    Two complementary detection prongs:
+    Three complementary detection prongs:
 
     1. ``_param_is_bool``: catches positional bools regardless of
-       annotation style (real ``bool``, stringified ``"bool"``,
-       ``"Optional[bool]"`` etc., or inferred from default value).
-       Prevents the codex R2 bug shape — a new bool kwarg before
-       ``*,`` shifts every downstream positional slot.
+       annotation style (real ``bool``, stringified ``"bool"`` or
+       ``"Optional[bool]"``, or inferred from default value). Prevents
+       the codex R2 bug shape — a new bool kwarg before ``*,`` shifts
+       every downstream positional slot.
 
     2. ``_param_is_routing_shape``: catches positional params NAMED
        like routing overrides (``force_*``, ``no_*``, ``enable_*``,
-       ``disable_*``) regardless of type. Round-2 red-team found 3
-       bypasses on the bool-only check: ``force_quant: int = 0``,
-       ``force_quant=0`` (no annotation), and
-       ``force_quant: "Optional[bool]" = False`` all slipped past
-       bool detection but semantically routed via truthy/falsy
-       evaluation. The name pattern check closes that whole class —
-       if you NAMED it like a routing decision, it IS one.
+       ``disable_*``) regardless of type. Closes the type-laundering
+       bypass found in round 2.
+
+    3. ``_param_default_has_custom_bool``: catches params whose
+       default value is an instance of a class with a custom
+       ``__bool__`` method. Closes round-3 bypass #3.5 where a
+       ``_Flag`` class with ``__bool__`` returning False slipped all
+       three previous prongs.
+
+    Also: ``inspect.unwrap`` is called on ``load_model`` before
+    introspection so decorators that don't use ``functools.wraps``
+    can't hide the underlying signature (round-3 bypass #3.3).
+
+    Also: rejects ``**var_keyword`` params on ``load_model``. A
+    ``**routing_overrides: bool`` would hide every individual flag
+    from the keyword-only check (round-3 bypass #3.6).
 
     The grandfather list is FROZEN. If you genuinely need to add a
     positional bool/routing param (almost never), update it with a
@@ -573,7 +793,10 @@ def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
     """
     from vllm_mlx.server import load_model
 
-    sig = inspect.signature(load_model)
+    # Round-3 bypass #3.3: a non-functools.wraps decorator hides the
+    # underlying signature. Unwrap explicitly.
+    unwrapped = inspect.unwrap(load_model)
+    sig = inspect.signature(unwrapped)
 
     # Pre-SOP positional bools/routing names. Do NOT extend casually
     # — see docstring. Every entry needs a 1-line reason.
@@ -583,6 +806,14 @@ def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
             "mtp",  # native MTP enable, pre-PR #407
         }
     )
+
+    # Round-3 bypass #3.6: reject **var_keyword on load_model.
+    for name, param in sig.parameters.items():
+        assert param.kind != inspect.Parameter.VAR_KEYWORD, (
+            f"load_model has VAR_KEYWORD param `**{name}` — this hides "
+            "individual routing kwargs from SOP audit. Spell out every "
+            "routing kwarg explicitly. See PR #408 round-3 red-team #3.6."
+        )
 
     offenders: list[tuple[str, str]] = []
     for name, param in sig.parameters.items():
@@ -594,6 +825,14 @@ def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
             offenders.append((name, "bool-typed positional param"))
         elif _param_is_routing_shape(name):
             offenders.append((name, "routing-shape name (force_/no_/enable_/disable_)"))
+        elif _param_default_has_custom_bool(param):
+            offenders.append(
+                (
+                    name,
+                    "positional param with custom-__bool__ default — bypass of "
+                    "bool detection (round-3 red-team #3.5)",
+                )
+            )
 
     assert not offenders, (
         f"load_model has {len(offenders)} non-grandfathered positional "
@@ -661,6 +900,33 @@ def _param_is_routing_shape(name: str) -> bool:
     be keyword-only regardless of type — see PR #408 round-2
     red-team."""
     return bool(_ROUTING_PARAM_NAME_RE.match(name))
+
+
+def _param_default_has_custom_bool(param: inspect.Parameter) -> bool:
+    """Catches round-3 bypass #3.5: a custom class with ``__bool__``
+    behaves as a routing toggle (``bool(default)`` returns False) but
+    isn't a bool, isn't a routing-named param, and isn't any of the
+    annotation shapes ``_param_is_bool`` checks.
+
+    Heuristic: if the default value's type overrides ``__bool__``
+    (i.e. ``type(default).__bool__ is not object.__bool__``), treat
+    it as a candidate truthy-laundering bypass.
+
+    False positives are rare — most real Python types either inherit
+    ``object.__bool__`` (always True for non-empty) or are built-in
+    types (int/str/dict/list) whose ``__bool__`` is at type-level,
+    not class-level. The check is intentionally conservative."""
+    if param.default is inspect.Parameter.empty:
+        return False
+    if param.default is None:
+        return False
+    default_type = type(param.default)
+    # Builtins (int, str, float, bool, list, dict, tuple, set, frozenset, None)
+    # all have valid __bool__ — skip them. We're looking for user-defined
+    # classes that override __bool__.
+    if default_type.__module__ == "builtins":
+        return False
+    return type(param.default).__bool__ is not object.__bool__
 
 
 def test_hybrid_overrides_mutually_exclusive_in_load_model():
@@ -731,27 +997,52 @@ def test_routing_override_kwargs_are_keyword_only_in_load_model():
         )
 
 
-def _make_engine_core_for_override_test(monkeypatch, cfg):
+def _make_engine_core_for_override_test(monkeypatch, cfg, *, base=None):
     """Build an ``EngineCore`` with heavy dependencies stubbed so the
     routing-override block in ``__init__`` can be exercised in
     isolation. Returns the constructed core (or raises if __init__
-    does)."""
+    does).
+
+    Round-3 fix #5.2: the stub ``enrich_model_config`` previously
+    captured ``base`` from closure and ignored its ``_base`` argument.
+    That allowed bypass #5.2 (pre-enrich mutation): a contributor
+    could mutate ``base_cfg`` BEFORE enrich runs and the override
+    would survive in the test, even though in production enrich
+    overwrites with a fresh ModelConfig instance. Now the stub
+    correctly clones from its argument so any pre-enrich mutation is
+    discarded — matching production behavior.
+
+    Round-3 fix #5.5: the default ``base`` was hardcoded
+    ``ModelConfig(is_hybrid=True, supports_spec_decode=False)``. Tests
+    that expected ``is_hybrid=False`` after a force-off override
+    could pass even if the mutation never fired, because the base
+    already happened to be ... wait, base was True for is_hybrid so
+    that doesn't apply. The genuine #5.5 issue is for fields whose
+    default matches the force-off expected value. We address this by
+    making ``base`` parameter-overridable so callers can pre-set the
+    field to the OPPOSITE of expected, forcing the mutation to be
+    real."""
     from unittest.mock import MagicMock
 
     from vllm_mlx import engine_core as ec
     from vllm_mlx import model_auto_config as mac
     from vllm_mlx.model_auto_config import ModelConfig
 
-    base = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+    if base is None:
+        base = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+
     monkeypatch.setattr(mac, "detect_model_config", lambda _name: base)
-    monkeypatch.setattr(
-        mac,
-        "enrich_model_config",
-        lambda _base, _model: ModelConfig(
-            is_hybrid=base.is_hybrid,
-            supports_spec_decode=base.supports_spec_decode,
-        ),
-    )
+
+    # Stub respects its argument (not closure). This means pre-enrich
+    # mutation of ``base_cfg`` is invisible — matching production
+    # behavior where enrich produces a fresh ModelConfig.
+    def _stub_enrich(_base, _model):
+        return ModelConfig(
+            is_hybrid=_base.is_hybrid,
+            supports_spec_decode=_base.supports_spec_decode,
+        )
+
+    monkeypatch.setattr(mac, "enrich_model_config", _stub_enrich)
     # Scheduler construction is heavy and pulls in MLX. Replace with
     # MagicMock so we only test the override block.
     monkeypatch.setattr(ec, "Scheduler", MagicMock())

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -741,14 +741,54 @@ def test_registry_invariants():
             "(round-3 red-team #2.1 — liar-registry bypass)."
         )
 
-    # (d) DeepSeek-V4 round 2 fix (PR #409): every forwarded_kwargs entry
-    # must actually exist as a parameter on load_model AND
-    # BatchedEngine.__init__. A typo like "force_hyrbid" silently
-    # satisfies the invariants above, then fails downstream with a bare
-    # KeyError in the keyword-only test. Catching it here gives a
-    # descriptive failure with the offending pair name.
-    from vllm_mlx.engine.batched import BatchedEngine
-    from vllm_mlx.server import load_model
+    # (d) DeepSeek-V4 round 2 fix (PR #409): for pairs with
+    # ``model_config_field`` set, exactly 2 forwarded_kwargs are
+    # required (force-on first, force-off second) — convention
+    # enforced by ``_engine_core_override_cases()``. Previously this
+    # check lived at parametrize-collection time, where a violation
+    # aborts pytest with a collection error before any test runs.
+    # Move it here so the failure is a normal, named test failure.
+    #
+    # NOTE: the forwarded_kwargs name-existence check (each kwarg is
+    # an actual parameter on ``load_model`` / ``BatchedEngine.__init__``)
+    # was moved to ``test_registry_forwarded_kwargs_exist_on_signatures``
+    # in codex round-C — importing those modules requires MLX, and
+    # this static registry invariants test should remain importable on
+    # headless CI without a Metal device.
+    for pair in AUTO_ROUTING_FLAG_PAIRS:
+        if pair.model_config_field is None:
+            continue
+        assert len(pair.forwarded_kwargs) == 2, (
+            f"Registry pair {pair.force_on}/{pair.force_off} declares "
+            f"model_config_field={pair.model_config_field!r} but has "
+            f"{len(pair.forwarded_kwargs)} forwarded kwargs; "
+            "exactly 2 required (force-on first, force-off second)."
+        )
+
+
+def test_registry_forwarded_kwargs_exist_on_signatures():
+    """DeepSeek-V4 round 2 + codex round-C (PR #409): every entry in
+    ``forwarded_kwargs`` must be a real parameter on both
+    ``load_model`` and ``BatchedEngine.__init__``. A typo like
+    "force_hyrbid" silently satisfies the lighter registry invariants
+    and only crashes downstream with a bare KeyError. This test
+    catches it with a descriptive failure naming the offending pair.
+
+    Codex round-C fix: split out from ``test_registry_invariants``
+    because importing ``BatchedEngine`` / ``load_model`` triggers
+    ``mlx_lm`` / ``mlx`` initialization, which raises RuntimeError on
+    headless macOS / sandboxed CI without a Metal device. The static
+    invariants gate above must stay importable; this signature-check
+    gate is allowed to skip when MLX isn't available.
+    """
+    try:
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.server import load_model
+    except RuntimeError as exc:
+        pytest.skip(
+            f"MLX runtime unavailable ({exc}) — signature audit requires "
+            "loading the MLX-backed engine stack. Skipped on headless CI."
+        )
 
     load_params = set(inspect.signature(load_model).parameters)
     batched_params = set(inspect.signature(BatchedEngine.__init__).parameters)
@@ -764,23 +804,6 @@ def test_registry_invariants():
                 f"`{kwarg}` but BatchedEngine.__init__ has no such "
                 "parameter — typo or stale refactor."
             )
-
-    # (e) DeepSeek-V4 round 2 fix (PR #409): for pairs with
-    # ``model_config_field`` set, exactly 2 forwarded_kwargs are
-    # required (force-on first, force-off second) — convention
-    # enforced by ``_engine_core_override_cases()``. Previously this
-    # check lived at parametrize-collection time, where a violation
-    # aborts pytest with a collection error before any test runs.
-    # Move it here so the failure is a normal, named test failure.
-    for pair in AUTO_ROUTING_FLAG_PAIRS:
-        if pair.model_config_field is None:
-            continue
-        assert len(pair.forwarded_kwargs) == 2, (
-            f"Registry pair {pair.force_on}/{pair.force_off} declares "
-            f"model_config_field={pair.model_config_field!r} but has "
-            f"{len(pair.forwarded_kwargs)} forwarded kwargs; "
-            "exactly 2 required (force-on first, force-off second)."
-        )
 
 
 def test_registry_is_not_runtime_mutated():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -964,53 +964,68 @@ def test_conftests_do_not_deselect_or_replace_collection():
         except UnicodeDecodeError:
             continue
         tree = ast.parse(source)
-        for node in ast.walk(tree):
-            # Match `items.remove(...)`, `items.pop(...)`, `items.clear()`.
-            if isinstance(node, ast.Call):
-                func = node.func
-                if (
-                    isinstance(func, ast.Attribute)
-                    and isinstance(func.value, ast.Name)
-                    and func.value.id == "items"
-                    and func.attr in {"remove", "pop", "clear"}
-                ):
-                    offenders.append(
-                        f"{conftest.relative_to(repo_root)}:{node.lineno} "
-                        f"calls items.{func.attr}(...) — drops tests from "
-                        "collection (round-4 cat-5 #6 attack pattern). "
-                        "Use item.add_marker(pytest.mark.skip(...)) to skip "
-                        "without removing."
-                    )
-            # Match `items[:] = ...` and `items[:] = ...` (Assign with Subscript).
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
+
+        # DeepSeek-V4 review fix (PR #409): only flag deselection-shaped
+        # mutations INSIDE pytest_collection_modifyitems. A helper
+        # function that happens to declare a local list named `items`
+        # and calls items.remove(...) on it is unrelated to the
+        # collection hook and shouldn't false-positive. Gate by
+        # enclosing function name.
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if func_node.name != "pytest_collection_modifyitems":
+                continue
+            for node in ast.walk(func_node):
+                # Match `items.remove(...)`, `items.pop(...)`, `items.clear()`.
+                if isinstance(node, ast.Call):
+                    func = node.func
                     if (
-                        isinstance(target, ast.Subscript)
-                        and isinstance(target.value, ast.Name)
-                        and target.value.id == "items"
+                        isinstance(func, ast.Attribute)
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "items"
+                        and func.attr in {"remove", "pop", "clear"}
                     ):
                         offenders.append(
                             f"{conftest.relative_to(repo_root)}:{node.lineno} "
-                            "assigns to items[...] — rewrites collection list "
-                            "(round-4 cat-5 #6 attack pattern). Use markers "
-                            "to skip tests instead."
+                            f"calls items.{func.attr}(...) inside "
+                            "pytest_collection_modifyitems — drops tests from "
+                            "collection (round-4 cat-5 #6 attack pattern). "
+                            "Use item.add_marker(pytest.mark.skip(...)) to "
+                            "skip without removing."
                         )
-            # Round-5 subagent 3 #H: `del items[i]` / `del items[:]`
-            # achieves the same deselection as items.remove() but via
-            # ast.Delete. Match Delete-of-Subscript on items.
-            if isinstance(node, ast.Delete):
-                for target in node.targets:
-                    if (
-                        isinstance(target, ast.Subscript)
-                        and isinstance(target.value, ast.Name)
-                        and target.value.id == "items"
-                    ):
-                        offenders.append(
-                            f"{conftest.relative_to(repo_root)}:{node.lineno} "
-                            "uses `del items[...]` — drops tests from "
-                            "collection (round-5 subagent 3 #H bypass). Use "
-                            "item.add_marker(pytest.mark.skip(...)) instead."
-                        )
+                # Match `items[:] = ...` (Assign with Subscript).
+                if isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if (
+                            isinstance(target, ast.Subscript)
+                            and isinstance(target.value, ast.Name)
+                            and target.value.id == "items"
+                        ):
+                            offenders.append(
+                                f"{conftest.relative_to(repo_root)}:{node.lineno} "
+                                "assigns to items[...] inside "
+                                "pytest_collection_modifyitems — rewrites "
+                                "collection list (round-4 cat-5 #6 attack "
+                                "pattern). Use markers to skip tests instead."
+                            )
+                # Round-5 subagent 3 #H: `del items[i]` / `del items[:]`
+                # achieves the same deselection via ast.Delete.
+                if isinstance(node, ast.Delete):
+                    for target in node.targets:
+                        if (
+                            isinstance(target, ast.Subscript)
+                            and isinstance(target.value, ast.Name)
+                            and target.value.id == "items"
+                        ):
+                            offenders.append(
+                                f"{conftest.relative_to(repo_root)}:{node.lineno} "
+                                "uses `del items[...]` inside "
+                                "pytest_collection_modifyitems — drops tests "
+                                "from collection (round-5 subagent 3 #H "
+                                "bypass). Use item.add_marker(pytest.mark."
+                                "skip(...)) instead."
+                            )
 
     assert not offenders, "\n".join(offenders)
 
@@ -1767,19 +1782,32 @@ def test_engine_core_applies_routing_overrides_from_registry(
     ``RoutingFlagPair`` with a ``model_config_field`` automatically
     adds new test cases. If your new pair's mutation block is missing
     from ``EngineCore.__init__``, this test fails immediately —
-    nothing silently no-ops."""
+    nothing silently no-ops.
+
+    DeepSeek-V4 review fix (PR #409): previously the stub default base
+    happened to already match `expected` for two of four parametrized
+    cases (force_hybrid=True / no_spec_decode=False), so those cases
+    silently passed even if EngineCore stopped mutating ModelConfig.
+    Now we force ``base.<field> = not expected`` so the mutation MUST
+    fire to flip it back to ``expected`` — the only path to success
+    is the actual mutation block running."""
     from vllm_mlx.engine_core import EngineConfig
+    from vllm_mlx.model_auto_config import ModelConfig
 
     cfg = EngineConfig(model_name="fake/model", **{kwarg: True})
-    core = _make_engine_core_for_override_test(monkeypatch, cfg)
+    # Force base to the OPPOSITE of expected. Now the only way for the
+    # final config to equal expected is for EngineCore.__init__ to
+    # actively mutate it — there's no "happens to match the default" path.
+    base = ModelConfig(**{model_config_field: not expected})
+    core = _make_engine_core_for_override_test(monkeypatch, cfg, base=base)
 
     actual = getattr(core.model_config, model_config_field)
     assert actual is expected, (
         f"Setting EngineConfig.{kwarg}=True must mutate "
-        f"ModelConfig.{model_config_field} to {expected}, but got {actual}. "
-        f"EngineCore.__init__ likely missing the mutation block for this "
-        f"routing pair — add it after enrich_model_config() and before "
-        f"`self.scheduler.model_config = self.model_config`."
+        f"ModelConfig.{model_config_field} from {not expected} to {expected}, "
+        f"but got {actual}. EngineCore.__init__ likely missing the mutation "
+        f"block for this routing pair — add it after enrich_model_config() "
+        f"and before `self.scheduler.model_config = self.model_config`."
     )
 
 

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1241,17 +1241,22 @@ def test_load_model_callers_register_every_routing_flag():
         # ``vllm_mlx.server`` function). A file is a "load_model caller"
         # iff it imports ``load_model`` from ``vllm_mlx.server`` (or as
         # ``server.load_model``) AND invokes it.
-        imports_ours = False
+        #
+        # Codex round-E fix (PR #409): also track the LOCAL ALIAS of
+        # ``load_model``. A new entrypoint could write
+        # ``from vllm_mlx.server import load_model as lm`` and call
+        # ``lm(...)`` — the literal-name check alone would miss it.
+        local_aliases: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module in (
                 "vllm_mlx.server",
                 "..server",
                 ".server",
             ):
-                if any(alias.name == "load_model" for alias in node.names):
-                    imports_ours = True
-                    break
-        if not imports_ours:
+                for alias in node.names:
+                    if alias.name == "load_model":
+                        local_aliases.add(alias.asname or "load_model")
+        if not local_aliases:
             continue
 
         for node in ast.walk(tree):
@@ -1263,7 +1268,7 @@ def test_load_model_callers_register_every_routing_flag():
                 if isinstance(func, ast.Name)
                 else (func.attr if isinstance(func, ast.Attribute) else None)
             )
-            if name == "load_model":
+            if name in local_aliases:
                 load_model_callers.add(rel)
                 break
 

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -543,23 +543,40 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
     assert not failures, "\n".join(failures)
 
 
-def test_load_model_has_no_unkeyworded_bool_params_beyond_baseline():
-    """SOP gate (red-team #3, PR #408): every bool parameter on
-    ``load_model`` must be keyword-only EXCEPT explicitly grandfathered
-    pre-PR-#407 ones. Catches the codex R2 bug shape: a new bool kwarg
-    inserted before the ``*,`` separator silently shifts every
-    downstream positional arg by one slot, flipping the semantics of
-    existing callers.
+def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
+    """SOP gate (red-team #3 PR #408 + round-2 hardening): every
+    positional parameter on ``load_model`` that is EITHER bool-typed
+    OR routing-named MUST be keyword-only, except explicitly
+    grandfathered pre-#407 entries.
+
+    Two complementary detection prongs:
+
+    1. ``_param_is_bool``: catches positional bools regardless of
+       annotation style (real ``bool``, stringified ``"bool"``,
+       ``"Optional[bool]"`` etc., or inferred from default value).
+       Prevents the codex R2 bug shape — a new bool kwarg before
+       ``*,`` shifts every downstream positional slot.
+
+    2. ``_param_is_routing_shape``: catches positional params NAMED
+       like routing overrides (``force_*``, ``no_*``, ``enable_*``,
+       ``disable_*``) regardless of type. Round-2 red-team found 3
+       bypasses on the bool-only check: ``force_quant: int = 0``,
+       ``force_quant=0`` (no annotation), and
+       ``force_quant: "Optional[bool]" = False`` all slipped past
+       bool detection but semantically routed via truthy/falsy
+       evaluation. The name pattern check closes that whole class —
+       if you NAMED it like a routing decision, it IS one.
 
     The grandfather list is FROZEN. If you genuinely need to add a
-    positional bool (almost never), update it with a comment
-    explaining why — the explicit edit forces the discussion."""
+    positional bool/routing param (almost never), update it with a
+    comment explaining why — the explicit edit forces the discussion.
+    """
     from vllm_mlx.server import load_model
 
     sig = inspect.signature(load_model)
 
-    # Pre-SOP positional bools. Do NOT extend casually — see test
-    # docstring. Every entry needs a 1-line reason.
+    # Pre-SOP positional bools/routing names. Do NOT extend casually
+    # — see docstring. Every entry needs a 1-line reason.
     grandfathered = frozenset(
         {
             "force_mllm",  # original MLLM force-on flag, pre-#393
@@ -567,41 +584,83 @@ def test_load_model_has_no_unkeyworded_bool_params_beyond_baseline():
         }
     )
 
-    offenders: list[str] = []
+    offenders: list[tuple[str, str]] = []
     for name, param in sig.parameters.items():
-        if not _param_is_bool(param):
+        if param.kind != inspect.Parameter.POSITIONAL_OR_KEYWORD:
             continue
-        if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
-            if name not in grandfathered:
-                offenders.append(name)
+        if name in grandfathered:
+            continue
+        if _param_is_bool(param):
+            offenders.append((name, "bool-typed positional param"))
+        elif _param_is_routing_shape(name):
+            offenders.append((name, "routing-shape name (force_/no_/enable_/disable_)"))
 
     assert not offenders, (
-        f"load_model has {len(offenders)} non-grandfathered POSITIONAL bool "
-        f"param(s): {offenders}. NEW bool params must be keyword-only "
-        f"(after the `*,` separator) to avoid silently shifting downstream "
-        f"positional args. See codex R2 on PR #407 for the bug shape this "
-        f"prevents — a new positional bool changes the slot of every kwarg "
-        f"after it, so existing callers like "
-        f"`load_model(name, None, 1, 32768, False, 0.5)` start passing 0.5 "
-        f"as a truthy value to the wrong field. If you genuinely need a "
-        f"positional bool (almost never), update `grandfathered` in this "
-        f"test with the reason."
+        f"load_model has {len(offenders)} non-grandfathered positional "
+        f"param(s) that should be keyword-only:\n  "
+        + "\n  ".join(f"{n} — {reason}" for n, reason in offenders)
+        + "\n\nMove each one AFTER the `*,` separator in load_model's "
+        "signature. NEW bool/routing params must be keyword-only to avoid "
+        "silently shifting downstream positional args (codex R2 lesson on "
+        "PR #407) — a new positional changes the slot of every kwarg after "
+        "it, so existing callers like "
+        "`load_model(name, None, 1, 32768, False, 0.5)` start passing 0.5 "
+        "as a truthy value to the wrong field. If you genuinely need a "
+        "positional (almost never), update `grandfathered` in this test "
+        "with the reason."
     )
 
 
 def _param_is_bool(param: inspect.Parameter) -> bool:
     """Best-effort detection of bool-typed parameters across annotation
-    styles (real type, stringified PEP 563, or just inferred from
-    default value)."""
-    if param.annotation is bool:
+    styles. Strengthened in PR #408 round-2 red-team after subagent
+    found 3 bypasses on the original ``annotation is bool`` check:
+
+      - Stringified container annotations (``"Optional[bool]"``,
+        ``"bool | None"``) defeated the literal ``annotation == "bool"``
+        match. Now we AST-parse the annotation string and look for any
+        ``Name(id="bool")`` node — catches arbitrary nesting.
+      - Type laundering with ``int`` (``force_quant: int = 0``)
+        semantically routes (truthy/falsy) but isn't a bool. NOT
+        caught here — the complementary ``_param_is_routing_shape``
+        name-pattern check handles that case in the test below.
+      - No-annotation + non-bool falsy default (``force_quant=0``)
+        also slips bool detection — same complementary name check
+        catches it.
+    """
+    annotation = param.annotation
+    if annotation is bool:
         return True
-    if isinstance(param.annotation, str) and param.annotation == "bool":
-        return True
-    if param.annotation is inspect.Parameter.empty:
+    if isinstance(annotation, str):
+        # PEP 563 (``from __future__ import annotations``) stringifies
+        # every annotation. AST-walk the string so wrappers don't hide
+        # the bool reference.
+        try:
+            tree = ast.parse(annotation, mode="eval")
+        except SyntaxError:
+            return False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id == "bool":
+                return True
+        return False
+    if annotation is inspect.Parameter.empty:
         # No annotation — fall back to default. ``type(default) is bool``
-        # is strict (won't match int) which is exactly what we want.
+        # is strict (won't match int).
         return type(param.default) is bool
     return False
+
+
+_ROUTING_PARAM_NAME_RE = re.compile(r"^(force_|no_|enable_|disable_)")
+
+
+def _param_is_routing_shape(name: str) -> bool:
+    """Does the parameter NAME look like a routing decision? Catches
+    type-laundering bypasses (``force_quant: int = 0``) where the
+    semantic role is "routing override" but the type annotation
+    defeats ``_param_is_bool``. A parameter named in this shape MUST
+    be keyword-only regardless of type — see PR #408 round-2
+    red-team."""
+    return bool(_ROUTING_PARAM_NAME_RE.match(name))
 
 
 def test_hybrid_overrides_mutually_exclusive_in_load_model():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -878,15 +878,25 @@ def _discover_entrypoints() -> set[str]:
         # direct ``Attribute`` add_argument call, a new entrypoint
         # using only the indirect shape would skip discovery AND skip
         # the ban — the very bypass the bans exist to catch.
-        # Broaden discovery: flag any file that mentions the literal
-        # STRING "add_argument" anywhere (catches getattr / __dict__
-        # access / dynamic dispatch). No legitimate code references
-        # that identifier outside argparse contexts.
+        # Broaden discovery: flag a file that mentions the literal
+        # STRING "add_argument" AND imports argparse. The combination
+        # catches indirect shapes (getattr / __dict__ / dynamic
+        # dispatch) without false-positiving on a stray docstring or
+        # log message that happens to mention "add_argument" outside
+        # an argparse context (DeepSeek round-5 #4).
         mentions_add_argument_literal = any(
             isinstance(n, ast.Constant)
             and isinstance(n.value, str)
             and n.value == "add_argument"
             for n in ast.walk(tree)
+        )
+        imports_argparse = any(
+            (isinstance(n, ast.Import) and any(a.name == "argparse" for a in n.names))
+            or (isinstance(n, ast.ImportFrom) and n.module == "argparse")
+            for n in ast.walk(tree)
+        )
+        mentions_indirect_add_argument = (
+            mentions_add_argument_literal and imports_argparse
         )
 
         has_routing_shape = False
@@ -914,11 +924,12 @@ def _discover_entrypoints() -> set[str]:
             if has_routing_shape:
                 break
 
-        if not has_routing_shape and mentions_add_argument_literal:
-            # Codex round-H: the file references "add_argument" via
-            # something other than a direct Attribute call — exactly
-            # the indirect shape that the later add_argument-shape
-            # bans want to scan. Force discovery so those bans run.
+        if not has_routing_shape and mentions_indirect_add_argument:
+            # Codex round-H + DeepSeek round-5 #4: the file references
+            # "add_argument" via something other than a direct Attribute
+            # call AND imports argparse — exactly the indirect shape
+            # the later add_argument-shape bans want to scan. Force
+            # discovery so those bans run.
             has_routing_shape = True
 
         if has_routing_shape:
@@ -1185,6 +1196,27 @@ def test_registry_is_not_runtime_mutated():
         "or duck-type registry replacement)."
     )
 
+    # DeepSeek round-5 #1 fix (PR #409): also require every declared
+    # dataclass field to appear in the source AST keyword list. The
+    # original gate only compared fields PRESENT in source — a runtime
+    # mutation of a defaulted field (e.g. ``model_config_field=None``
+    # changed to ``"is_hybrid"`` at runtime) would not be caught
+    # because the source never mentioned it. Force every field to be
+    # spelled out at the call site so the AST scan can reconstruct
+    # 100% of state.
+    import dataclasses
+
+    declared_field_names = {f.name for f in dataclasses.fields(RoutingFlagPair)}
+    for i, expected in enumerate(expected_pairs):
+        missing_fields = declared_field_names - set(expected)
+        assert not missing_fields, (
+            f"AUTO_ROUTING_FLAG_PAIRS[{i}] in source omits fields "
+            f"{sorted(missing_fields)} (relying on dataclass defaults). "
+            "The registry-mutation gate cannot detect runtime mutation "
+            "of defaulted fields. Spell out every field explicitly so "
+            "the AST scan compares 100% of state (DeepSeek round-5 #1)."
+        )
+
     # Every runtime entry must be a real RoutingFlagPair (not a duck
     # type) AND match the source literal field-by-field.
     for i, (runtime_pair, expected) in enumerate(
@@ -1265,6 +1297,16 @@ def test_aliases_json_has_no_routing_shaped_keys():
             f"routing-shape audit cannot run. Fix the syntax error first. "
             f"Underlying error: {exc}"
         )
+
+    # DeepSeek round-5 #2 fix (PR #409): the file must be a JSON
+    # OBJECT (dict). A JSON array, string, or number would parse fine
+    # but then ``raw.items()`` would raise AttributeError — confusing
+    # trace for a non-IO test. Spell out the precondition.
+    assert isinstance(raw, dict), (
+        f"aliases.json at {aliases_path} parsed to "
+        f"{type(raw).__name__}, not dict. The routing-shape audit "
+        "expects a JSON object mapping alias names → alias profiles."
+    )
 
     offenders: list[str] = []
     for alias, value in raw.items():

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1008,15 +1008,36 @@ def test_conftests_do_not_deselect_or_replace_collection():
         tree = ast.parse(source)
 
         # DeepSeek-V4 review fix (PR #409): only flag deselection-shaped
-        # mutations INSIDE pytest_collection_modifyitems. A helper
-        # function that happens to declare a local list named `items`
-        # and calls items.remove(...) on it is unrelated to the
-        # collection hook and shouldn't false-positive. Gate by
-        # enclosing function name.
+        # mutations INSIDE functions whose signature takes ``items`` as
+        # a parameter. A helper function that happens to declare a
+        # local list named `items` and calls items.remove(...) on it is
+        # unrelated to the collection hook and shouldn't false-positive.
+        #
+        # Codex round-B fix (PR #409): the previous narrow gating to
+        # `pytest_collection_modifyitems` missed deselection delegated
+        # to a helper:
+        #     def drop(items): items.clear()
+        #     def pytest_collection_modifyitems(config, items): drop(items)
+        # The helper takes `items` as a parameter, so we still scan it;
+        # an unrelated helper using a LOCAL variable named `items`
+        # wouldn't (parameter shape vs local shape disambiguates).
+        def _has_items_parameter(
+            f: ast.FunctionDef | ast.AsyncFunctionDef,
+        ) -> bool:
+            arg_lists = (
+                f.args.args,
+                f.args.posonlyargs,
+                f.args.kwonlyargs,
+            )
+            for arg_list in arg_lists:
+                if any(a.arg == "items" for a in arg_list):
+                    return True
+            return False
+
         for func_node in ast.walk(tree):
             if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            if func_node.name != "pytest_collection_modifyitems":
+            if not _has_items_parameter(func_node):
                 continue
             for node in ast.walk(func_node):
                 # Match `items.remove(...)`, `items.pop(...)`, `items.clear()`.
@@ -1030,8 +1051,8 @@ def test_conftests_do_not_deselect_or_replace_collection():
                     ):
                         offenders.append(
                             f"{conftest.relative_to(repo_root)}:{node.lineno} "
-                            f"calls items.{func.attr}(...) inside "
-                            "pytest_collection_modifyitems — drops tests from "
+                            f"calls items.{func.attr}(...) inside a "
+                            "function that takes `items` as a parameter — drops tests from "
                             "collection (round-4 cat-5 #6 attack pattern). "
                             "Use item.add_marker(pytest.mark.skip(...)) to "
                             "skip without removing."

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1178,6 +1178,124 @@ def test_auto_routing_flags_have_force_on_and_force_off_pair():
     assert not missing, "\n".join(missing)
 
 
+# Files that call ``load_model(...)`` but are NOT user-facing model-
+# serving entrypoints (test helpers, internal probes, doctor harness
+# etc.) — these don't need to expose every routing override flag.
+# Each entry requires a one-line reason. Adding to this allowlist is
+# a deliberate PR-review act.
+LOAD_MODEL_ENTRYPOINT_EXEMPTIONS: frozenset[str] = frozenset(
+    {
+        # Doctor harness — runs internal probes, not user-facing
+        # request serving. The doctor checks own routing via the
+        # serve command they spawn.
+        "doctor/checks/perf.py",
+        "doctor/checks/api.py",
+        "doctor/checks/benchmark.py",
+        "doctor/checks/load.py",
+        "doctor/server.py",
+        # Eval harness — bench / scoring tool, not a serving entrypoint.
+        "agents/testing.py",
+    }
+)
+
+
+def test_load_model_callers_register_every_routing_flag():
+    """Codex round-D bypass (PR #409): the existing parity test only
+    inspects the hardcoded ``cli.py``, ``server.py``, ``benchmark.py``.
+    A NEW user-facing entrypoint that calls ``load_model(...)`` but
+    forgets to expose ``--no-mllm`` / ``--no-hybrid`` / etc. would slip
+    every existing gate and ship without escape hatches.
+
+    This test scans every file under ``vllm_mlx/`` for ``load_model(``
+    invocations (the canonical engine entrypoint). Each such file
+    must EITHER (a) register all routing-pair flags via argparse,
+    matching the existing parity gate's expectation, OR (b) be
+    explicitly exempted in ``LOAD_MODEL_ENTRYPOINT_EXEMPTIONS`` with
+    a one-line reason. Exempted entries are typically test/doctor
+    helpers that don't serve user requests.
+
+    Adding a new entrypoint that takes a model alias and accepts
+    requests must NEVER go via the exemption list — register the
+    flags so users have the same escape hatches every other
+    entrypoint provides.
+    """
+    pkg_root = _pkg_root()
+    load_model_callers: set[str] = set()
+
+    for path in pkg_root.rglob("*.py"):
+        if any(part.startswith("__") for part in path.parts[len(pkg_root.parts) :]):
+            continue
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        # The name ``load_model`` is overloaded — mlx_lm.utils, mlx_audio.*,
+        # and several internal worker classes define their own
+        # ``load_model``. Filter to only OUR engine entrypoint (the
+        # ``vllm_mlx.server`` function). A file is a "load_model caller"
+        # iff it imports ``load_model`` from ``vllm_mlx.server`` (or as
+        # ``server.load_model``) AND invokes it.
+        imports_ours = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in (
+                "vllm_mlx.server",
+                "..server",
+                ".server",
+            ):
+                if any(alias.name == "load_model" for alias in node.names):
+                    imports_ours = True
+                    break
+        if not imports_ours:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else (func.attr if isinstance(func, ast.Attribute) else None)
+            )
+            if name == "load_model":
+                load_model_callers.add(rel)
+                break
+
+    # server.py is where load_model is defined; skip its self-reference.
+    load_model_callers.discard("server.py")
+
+    missing: list[str] = []
+    for rel in sorted(load_model_callers):
+        if rel in LOAD_MODEL_ENTRYPOINT_EXEMPTIONS:
+            continue
+        source = (pkg_root / rel).read_text()
+        for pair in AUTO_ROUTING_FLAG_PAIRS:
+            if not _flag_in_add_argument_calls(source, pair.force_on):
+                missing.append(
+                    f"{rel} calls load_model() but does NOT register the "
+                    f"`{pair.force_on}` flag (force-on of {pair.desc}). "
+                    "Every user-facing entrypoint MUST expose the same "
+                    "routing escape hatches (SOP §10). Register the flag "
+                    "or add a one-line exemption in "
+                    "LOAD_MODEL_ENTRYPOINT_EXEMPTIONS with a reason."
+                )
+            if not _flag_in_add_argument_calls(source, pair.force_off):
+                missing.append(
+                    f"{rel} calls load_model() but does NOT register the "
+                    f"`{pair.force_off}` flag (force-off of {pair.desc}). "
+                    "Every binary auto-routing decision needs an escape "
+                    "hatch in BOTH directions (#393 lesson)."
+                )
+
+    assert not missing, "\n".join(missing)
+
+
 def test_no_unregistered_routing_shaped_flags():
     """SOP gate (red-team #1, PR #408): every CLI flag whose name
     matches the routing-shape pattern (``--force-*``, ``--no-*``,

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -229,6 +229,63 @@ def test_force_mllm_still_works_when_force_text_is_false():
     assert engine._is_mllm is True
 
 
+def test_load_model_alias_resolver_handles_every_import_shape():
+    """Codex rounds E/F/G regression (PR #409): every scanner that
+    looks for ``vllm_mlx.server.load_model`` invocations must resolve
+    aliases. The whack-a-mole over 3 rounds proves the literal-name
+    match is bypass-prone; this test pins the shared resolver so all
+    common import shapes flow through one code path.
+
+    Shapes covered:
+      1. ``from vllm_mlx.server import load_model`` → ``load_model(...)``
+      2. ``from vllm_mlx.server import load_model as lm`` → ``lm(...)``
+      3. ``from vllm_mlx import server`` → ``server.load_model(...)``
+      4. ``import vllm_mlx.server as srv`` → ``srv.load_model(...)``
+      5. ``import vllm_mlx.server`` →
+         ``vllm_mlx.server.load_model(...)``
+
+    Negative controls:
+      6. ``from mlx_lm.utils import load_model`` then ``load_model(...)``
+         — NOT our entrypoint, must NOT be recognized
+      7. Bare ``load_model(...)`` with no import — must NOT be recognized
+    """
+    shapes = {
+        "direct": "from vllm_mlx.server import load_model\nload_model('q')\n",
+        "as-aliased": ("from vllm_mlx.server import load_model as lm\nlm('q')\n"),
+        "from-module": ("from vllm_mlx import server\nserver.load_model('q')\n"),
+        "import-as": ("import vllm_mlx.server as srv\nsrv.load_model('q')\n"),
+        "import-bare": ("import vllm_mlx.server\nvllm_mlx.server.load_model('q')\n"),
+    }
+    for shape, source in shapes.items():
+        tree = ast.parse(source)
+        direct, module = _load_model_aliases_in_tree(tree)
+        hits = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and _call_targets_load_model(n, direct, module)
+        ]
+        assert len(hits) == 1, (
+            f"alias shape `{shape}` must produce exactly one resolved "
+            f"call, got {len(hits)} (direct={direct}, module={module})"
+        )
+
+    # Negative controls: foreign load_model + unimported load_model.
+    foreign = "from mlx_lm.utils import load_model\nload_model('foreign')\n"
+    tree = ast.parse(foreign)
+    direct, module = _load_model_aliases_in_tree(tree)
+    assert not direct and not module, (
+        "mlx_lm.utils.load_model MUST NOT register as our alias — "
+        "would false-positive the entrypoint parity gate."
+    )
+
+    bare = "load_model('q')\n"
+    tree = ast.parse(bare)
+    direct, module = _load_model_aliases_in_tree(tree)
+    assert not direct and not module, (
+        "load_model without an import is NOT our entrypoint."
+    )
+
+
 def test_force_text_is_keyword_only_in_load_model():
     """Regression: ``force_text`` must remain keyword-only so existing
     positional callers (e.g. ``load_model(name, None, 1, 32768, False,
@@ -582,6 +639,80 @@ _KNOWN_ENTRYPOINTS_SEED: frozenset[str] = frozenset(
 )
 
 
+# Codex round-G hardening (PR #409): every scanner that looks for
+# ``load_model(...)`` calls must resolve aliases. The name is
+# overloaded (mlx_lm / mlx_audio / internal workers), and rounds E/F
+# showed `from vllm_mlx.server import load_model as lm` and
+# `from vllm_mlx import server; server.load_model(...)` both slip a
+# literal-name match. Single helper used by every scan to stop the
+# whack-a-mole.
+def _load_model_aliases_in_tree(
+    tree: ast.AST,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(direct_aliases, module_aliases)``:
+
+    - ``direct_aliases``: local names bound to ``load_model`` (e.g.
+      ``"load_model"`` from ``from vllm_mlx.server import load_model``,
+      or ``"lm"`` from ``... import load_model as lm``).
+    - ``module_aliases``: local names bound to the ``vllm_mlx.server``
+      module (e.g. ``"server"`` from ``from vllm_mlx import server``,
+      ``"srv"`` from ``import vllm_mlx.server as srv``, or the
+      two-segment ``"vllm_mlx.server"`` from bare
+      ``import vllm_mlx.server``).
+    """
+    direct: set[str] = set()
+    module: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in ("vllm_mlx.server", "..server", ".server"):
+                for alias in node.names:
+                    if alias.name == "load_model":
+                        direct.add(alias.asname or "load_model")
+            elif node.module in ("vllm_mlx", ".."):
+                for alias in node.names:
+                    if alias.name == "server":
+                        module.add(alias.asname or "server")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "vllm_mlx.server":
+                    module.add(alias.asname or "vllm_mlx.server")
+    return frozenset(direct), frozenset(module)
+
+
+def _call_targets_load_model(
+    call: ast.Call,
+    direct_aliases: frozenset[str],
+    module_aliases: frozenset[str],
+) -> bool:
+    """Return True iff ``call`` invokes ``vllm_mlx.server.load_model``
+    (under any of the import shapes captured by
+    ``_load_model_aliases_in_tree``). Handles:
+
+      - ``load_model(...)`` / ``lm(...)`` — direct alias name
+      - ``server.load_model(...)`` / ``srv.load_model(...)`` —
+        single-level Attribute receiver
+      - ``vllm_mlx.server.load_model(...)`` — two-level Attribute
+        receiver collapsed against ``module_aliases``
+    """
+    func = call.func
+    if isinstance(func, ast.Name) and func.id in direct_aliases:
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "load_model":
+        receiver = func.value
+        receiver_name: str | None = None
+        if isinstance(receiver, ast.Name):
+            receiver_name = receiver.id
+        elif (
+            isinstance(receiver, ast.Attribute)
+            and isinstance(receiver.value, ast.Name)
+            and f"{receiver.value.id}.{receiver.attr}" == "vllm_mlx.server"
+        ):
+            receiver_name = "vllm_mlx.server"
+        if receiver_name is not None and receiver_name in module_aliases:
+            return True
+    return False
+
+
 def _discover_entrypoints() -> set[str]:
     """Discover every file under ``vllm_mlx/`` that either calls
     ``add_argument(...)`` or ``load_model(...)``. Returns paths
@@ -613,21 +744,19 @@ def _discover_entrypoints() -> set[str]:
         except SyntaxError:
             continue
 
+        # Codex round-G: detect ALL load_model alias shapes before the
+        # call scan, so a new entrypoint using `from vllm_mlx import
+        # server` / `import vllm_mlx.server as srv` doesn't slip
+        # discovery.
+        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
+
         has_routing_shape = False
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            name = (
-                func.id
-                if isinstance(func, ast.Name)
-                else (func.attr if isinstance(func, ast.Attribute) else None)
-            )
-            if name == "add_argument":
-                # Only flag this file if at least one add_argument call
-                # is a routing-shape flag. Files that only register
-                # config knobs (e.g. --max-tokens) don't need to be in
-                # the parity/forwarding checks.
+            # add_argument detection (unchanged) — argparse method.
+            if isinstance(func, ast.Attribute) and func.attr == "add_argument":
                 for arg in node.args:
                     if (
                         isinstance(arg, ast.Constant)
@@ -636,9 +765,9 @@ def _discover_entrypoints() -> set[str]:
                     ):
                         has_routing_shape = True
                         break
-            elif name == "load_model":
-                # Any caller of load_model is by definition an
-                # entrypoint that needs the forwarding check.
+            elif _call_targets_load_model(node, direct_aliases, module_aliases):
+                # Any caller of OUR load_model (under any alias) is by
+                # definition an entrypoint that needs the forwarding check.
                 has_routing_shape = True
 
             if has_routing_shape:
@@ -1237,71 +1366,22 @@ def test_load_model_callers_register_every_routing_flag():
 
         # The name ``load_model`` is overloaded — mlx_lm.utils, mlx_audio.*,
         # and several internal worker classes define their own
-        # ``load_model``. Filter to only OUR engine entrypoint (the
-        # ``vllm_mlx.server`` function). A file is a "load_model caller"
-        # iff it imports ``load_model`` from ``vllm_mlx.server`` (or as
-        # ``server.load_model``) AND invokes it.
-        #
-        # Codex round-E fix (PR #409): also track the LOCAL ALIAS of
-        # ``load_model``. A new entrypoint could write
-        # ``from vllm_mlx.server import load_model as lm`` and call
-        # ``lm(...)`` — the literal-name check alone would miss it.
-        #
-        # Codex round-F fix (PR #409): also track MODULE aliases. A
-        # new entrypoint could write
-        # ``from vllm_mlx import server`` or
-        # ``import vllm_mlx.server as srv`` and call
-        # ``server.load_model(...)`` / ``srv.load_model(...)``. We need
-        # to recognize both attribute-access shapes.
-        direct_aliases: set[str] = set()  # local names bound to load_model
-        module_aliases: set[str] = set()  # local names bound to vllm_mlx.server
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom):
-                if node.module in ("vllm_mlx.server", "..server", ".server"):
-                    for alias in node.names:
-                        if alias.name == "load_model":
-                            direct_aliases.add(alias.asname or "load_model")
-                # `from vllm_mlx import server` — module-level alias.
-                elif node.module in ("vllm_mlx", ".."):
-                    for alias in node.names:
-                        if alias.name == "server":
-                            module_aliases.add(alias.asname or "server")
-            elif isinstance(node, ast.Import):
-                # `import vllm_mlx.server` / `import vllm_mlx.server as srv`.
-                for alias in node.names:
-                    if alias.name == "vllm_mlx.server":
-                        module_aliases.add(alias.asname or "vllm_mlx.server")
+        # ``load_model``. Use the shared alias resolver to detect
+        # invocations of OUR ``vllm_mlx.server.load_model`` under any
+        # import shape (direct / as-aliased / module-aliased / fully-
+        # qualified). The single helper closes rounds D/E/F/G bypasses
+        # at once and means every other scanner in this file picks up
+        # the same coverage.
+        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
         if not (direct_aliases or module_aliases):
             continue
 
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            # Direct call form: lm(...) / load_model(...)
-            if isinstance(func, ast.Name) and func.id in direct_aliases:
+            if isinstance(node, ast.Call) and _call_targets_load_model(
+                node, direct_aliases, module_aliases
+            ):
                 load_model_callers.add(rel)
                 break
-            # Attribute call form: server.load_model(...) /
-            # srv.load_model(...) / vllm_mlx.server.load_model(...)
-            if isinstance(func, ast.Attribute) and func.attr == "load_model":
-                # The receiver is a Name (single-level alias) or an
-                # Attribute (vllm_mlx.server.load_model). Reduce both to
-                # the leftmost Name for lookup against module_aliases.
-                receiver = func.value
-                if isinstance(receiver, ast.Name):
-                    receiver_name = receiver.id
-                elif (
-                    isinstance(receiver, ast.Attribute)
-                    and isinstance(receiver.value, ast.Name)
-                    and f"{receiver.value.id}.{receiver.attr}" == "vllm_mlx.server"
-                ):
-                    receiver_name = "vllm_mlx.server"
-                else:
-                    receiver_name = None
-                if receiver_name in module_aliases:
-                    load_model_callers.add(rel)
-                    break
 
     # server.py is where load_model is defined; skip its self-reference.
     load_model_callers.discard("server.py")
@@ -1515,19 +1595,22 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
     pkg_root = _pkg_root()
 
     def _find_load_model_calls(source: str) -> list[ast.Call]:
+        # Codex round-G fix (PR #409): use the shared alias resolver so
+        # this forwarding audit catches aliased load_model calls
+        # (`from vllm_mlx.server import load_model as lm`,
+        # `import vllm_mlx.server as srv`, etc.). The previous literal-
+        # name match let an aliased caller forward one routing kwarg
+        # while omitting the rest — gate passed silently.
         tree = ast.parse(source)
+        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
+        if not (direct_aliases or module_aliases):
+            return []
         calls = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                func = node.func
-                # Match `load_model(...)` and `module.load_model(...)`.
-                name = (
-                    func.id
-                    if isinstance(func, ast.Name)
-                    else (func.attr if isinstance(func, ast.Attribute) else None)
-                )
-                if name == "load_model":
-                    calls.append(node)
+            if isinstance(node, ast.Call) and _call_targets_load_model(
+                node, direct_aliases, module_aliases
+            ):
+                calls.append(node)
         return calls
 
     failures: list[str] = []

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -663,7 +663,16 @@ def _routing_shaped_constants_in_module(source: str) -> set[str]:
     ``"--force-hybrid"`` matches, ``"--force-hybrid and --no-hybrid are
     mutually exclusive"`` (an error message) does not. Embedded flag
     names in error messages and docstrings are noise, not bypass."""
-    routing_pattern = re.compile(r"^--(?:force|no|enable|disable)-[a-z0-9-]+$")
+    # DeepSeek round-4 fix (PR #409): real argparse flag names accept
+    # uppercase letters (`--enable-TurboQuant`). The lowercase-only
+    # character class let any such flag escape the Constant-string
+    # scan (prong 2 of test_no_unregistered_routing_shaped_flags).
+    # IGNORECASE on the whole pattern keeps the prefix list (force/no/
+    # enable/disable) case-insensitive too — there is no legitimate
+    # reason to spell those uppercase, but bypass-proof beats minimal.
+    routing_pattern = re.compile(
+        r"^--(?:force|no|enable|disable)-[a-zA-Z0-9-]+$", re.IGNORECASE
+    )
     tree = ast.parse(source)
     flags: set[str] = set()
     for node in ast.walk(tree):
@@ -1419,15 +1428,28 @@ def test_auto_routing_flags_have_force_on_and_force_off_pair():
         false-positive surfaces, add an override flag here.
     """
     pkg_root = _pkg_root()
-    sources_by_file = {
-        fname: (pkg_root / fname).read_text()
-        for fname in ("cli.py", "server.py", "benchmark.py")
-    }
+    # DeepSeek round-4 fix (PR #409): read each required file on
+    # demand (cached per-test) instead of hardcoding the current three.
+    # A future pair could add a new entrypoint to `required_files`; the
+    # prior dict-lookup would raise a bare KeyError, this loop now
+    # raises a descriptive failure (or silently includes the new file).
+    sources_by_file: dict[str, str] = {}
+
+    def _read_required(fname: str) -> str:
+        if fname not in sources_by_file:
+            path = pkg_root / fname
+            assert path.exists(), (
+                f"RoutingFlagPair.required_files lists `{fname}` but the "
+                f"file does not exist at {path}. Fix the registry or "
+                "restore the entrypoint."
+            )
+            sources_by_file[fname] = path.read_text()
+        return sources_by_file[fname]
 
     missing: list[str] = []
     for pair in AUTO_ROUTING_FLAG_PAIRS:
         for fname in pair.required_files:
-            src = sources_by_file[fname]
+            src = _read_required(fname)
             if not _flag_in_add_argument_calls(src, pair.force_on):
                 missing.append(
                     f"force-on flag {pair.force_on} not registered via "
@@ -1491,7 +1513,12 @@ def test_load_model_callers_register_every_routing_flag():
     load_model_callers: set[str] = set()
 
     for path in pkg_root.rglob("*.py"):
-        if any(part.startswith("__") for part in path.parts[len(pkg_root.parts) :]):
+        # DeepSeek round-4 fix (PR #409): use ``path.parent.parts`` so
+        # ``__init__.py`` files are NOT dropped (matches the equivalent
+        # fix in _discover_entrypoints — these two scans must stay in
+        # lockstep or one gate gets coverage the other doesn't).
+        parent_parts = path.parent.parts[len(pkg_root.parts) :]
+        if any(part.startswith("__") for part in parent_parts):
             continue
         rel = path.relative_to(pkg_root).as_posix()
         try:
@@ -1512,7 +1539,13 @@ def test_load_model_callers_register_every_routing_flag():
         # at once and means every other scanner in this file picks up
         # the same coverage.
         direct_aliases, module_aliases, pkg_aliases = _load_model_aliases_in_tree(tree)
-        if not (direct_aliases or module_aliases):
+        # DeepSeek round-4 fix (PR #409): include pkg_aliases in the
+        # early-exit guard. ``import vllm_mlx`` (no .server) followed
+        # by ``vllm_mlx.server.load_model(...)`` populates ONLY
+        # pkg_aliases; the previous guard would short-circuit before
+        # _call_targets_load_model could consider the package-attribute
+        # path, silently losing entrypoint coverage.
+        if not (direct_aliases or module_aliases or pkg_aliases):
             continue
 
         for node in ast.walk(tree):
@@ -1742,7 +1775,9 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
         # while omitting the rest — gate passed silently.
         tree = ast.parse(source)
         direct_aliases, module_aliases, pkg_aliases = _load_model_aliases_in_tree(tree)
-        if not (direct_aliases or module_aliases):
+        # DeepSeek round-4 fix (PR #409): include pkg_aliases in the
+        # short-circuit so `import vllm_mlx` callers aren't dropped.
+        if not (direct_aliases or module_aliases or pkg_aliases):
             return []
         calls = []
         for node in ast.walk(tree):
@@ -1830,7 +1865,17 @@ def test_load_model_has_no_unkeyworded_bool_or_routing_params_beyond_baseline():
     positional bool/routing param (almost never), update it with a
     comment explaining why — the explicit edit forces the discussion.
     """
-    from vllm_mlx.server import load_model
+    # DeepSeek round-4 fix (PR #409): graceful skip on headless CI
+    # (mirrors the pattern in test_routing_override_kwargs_are_
+    # keyword_only_in_load_model and _make_engine_core_for_override_test).
+    try:
+        from vllm_mlx.server import load_model
+    except RuntimeError as exc:
+        pytest.skip(
+            f"MLX runtime unavailable ({exc}) — load_model signature "
+            "audit requires importing vllm_mlx.server. Skipped on "
+            "headless CI."
+        )
 
     # Round-3 bypass #3.3: a non-functools.wraps decorator hides the
     # underlying signature. Unwrap explicitly.
@@ -2133,8 +2178,22 @@ def test_routing_override_kwargs_are_keyword_only_in_load_model():
     positional position is fixed for back-compat (verified by
     ``test_load_model_has_no_unkeyworded_bool_params_beyond_baseline``
     elsewhere)."""
-    from vllm_mlx.engine.batched import BatchedEngine
-    from vllm_mlx.server import load_model
+    # DeepSeek round-4 fix (PR #409): on headless CI without a Metal
+    # device, importing these modules raises RuntimeError before any
+    # assertion can run. Skip gracefully — the gate's intent is a
+    # signature/positional audit that only matters on machines that
+    # can actually run vllm-mlx. Mirrors the pattern in
+    # `test_registry_forwarded_kwargs_exist_on_signatures` and
+    # `_make_engine_core_for_override_test`.
+    try:
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.server import load_model
+    except RuntimeError as exc:
+        pytest.skip(
+            f"MLX runtime unavailable ({exc}) — keyword-only audit "
+            "requires importing the MLX-backed engine stack. Skipped "
+            "on headless CI."
+        )
 
     expected = _post_sop_forwarded_kwargs()
     assert expected, "Registry should produce at least one post-SOP kwarg"

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1246,31 +1246,62 @@ def test_load_model_callers_register_every_routing_flag():
         # ``load_model``. A new entrypoint could write
         # ``from vllm_mlx.server import load_model as lm`` and call
         # ``lm(...)`` — the literal-name check alone would miss it.
-        local_aliases: set[str] = set()
+        #
+        # Codex round-F fix (PR #409): also track MODULE aliases. A
+        # new entrypoint could write
+        # ``from vllm_mlx import server`` or
+        # ``import vllm_mlx.server as srv`` and call
+        # ``server.load_model(...)`` / ``srv.load_model(...)``. We need
+        # to recognize both attribute-access shapes.
+        direct_aliases: set[str] = set()  # local names bound to load_model
+        module_aliases: set[str] = set()  # local names bound to vllm_mlx.server
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module in (
-                "vllm_mlx.server",
-                "..server",
-                ".server",
-            ):
+            if isinstance(node, ast.ImportFrom):
+                if node.module in ("vllm_mlx.server", "..server", ".server"):
+                    for alias in node.names:
+                        if alias.name == "load_model":
+                            direct_aliases.add(alias.asname or "load_model")
+                # `from vllm_mlx import server` — module-level alias.
+                elif node.module in ("vllm_mlx", ".."):
+                    for alias in node.names:
+                        if alias.name == "server":
+                            module_aliases.add(alias.asname or "server")
+            elif isinstance(node, ast.Import):
+                # `import vllm_mlx.server` / `import vllm_mlx.server as srv`.
                 for alias in node.names:
-                    if alias.name == "load_model":
-                        local_aliases.add(alias.asname or "load_model")
-        if not local_aliases:
+                    if alias.name == "vllm_mlx.server":
+                        module_aliases.add(alias.asname or "vllm_mlx.server")
+        if not (direct_aliases or module_aliases):
             continue
 
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            name = (
-                func.id
-                if isinstance(func, ast.Name)
-                else (func.attr if isinstance(func, ast.Attribute) else None)
-            )
-            if name in local_aliases:
+            # Direct call form: lm(...) / load_model(...)
+            if isinstance(func, ast.Name) and func.id in direct_aliases:
                 load_model_callers.add(rel)
                 break
+            # Attribute call form: server.load_model(...) /
+            # srv.load_model(...) / vllm_mlx.server.load_model(...)
+            if isinstance(func, ast.Attribute) and func.attr == "load_model":
+                # The receiver is a Name (single-level alias) or an
+                # Attribute (vllm_mlx.server.load_model). Reduce both to
+                # the leftmost Name for lookup against module_aliases.
+                receiver = func.value
+                if isinstance(receiver, ast.Name):
+                    receiver_name = receiver.id
+                elif (
+                    isinstance(receiver, ast.Attribute)
+                    and isinstance(receiver.value, ast.Name)
+                    and f"{receiver.value.id}.{receiver.attr}" == "vllm_mlx.server"
+                ):
+                    receiver_name = "vllm_mlx.server"
+                else:
+                    receiver_name = None
+                if receiver_name in module_aliases:
+                    load_model_callers.add(rel)
+                    break
 
     # server.py is where load_model is defined; skip its self-reference.
     load_model_callers.discard("server.py")

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -262,14 +262,21 @@ def test_load_model_alias_resolver_handles_every_import_shape():
         "rel-direct": "from .server import load_model\nload_model('q')\n",
         "rel-aliased": "from .server import load_model as lm\nlm('q')\n",
         "rel-from-module": "from . import server\nserver.load_model('q')\n",
+        # DeepSeek round-3 #3: ``import vllm_mlx`` followed by
+        # ``vllm_mlx.server.load_model(...)``. The receiver is an
+        # Attribute(value=Name("vllm_mlx"), attr="server") — needs the
+        # new pkg_aliases bucket.
+        "import-pkg": "import vllm_mlx\nvllm_mlx.server.load_model('q')\n",
+        "import-pkg-aliased": "import vllm_mlx as vm\nvm.server.load_model('q')\n",
     }
     for shape, source in shapes.items():
         tree = ast.parse(source)
-        direct, module = _load_model_aliases_in_tree(tree)
+        direct, module, pkg = _load_model_aliases_in_tree(tree)
         hits = [
             n
             for n in ast.walk(tree)
-            if isinstance(n, ast.Call) and _call_targets_load_model(n, direct, module)
+            if isinstance(n, ast.Call)
+            and _call_targets_load_model(n, direct, module, pkg)
         ]
         assert len(hits) == 1, (
             f"alias shape `{shape}` must produce exactly one resolved "
@@ -279,18 +286,62 @@ def test_load_model_alias_resolver_handles_every_import_shape():
     # Negative controls: foreign load_model + unimported load_model.
     foreign = "from mlx_lm.utils import load_model\nload_model('foreign')\n"
     tree = ast.parse(foreign)
-    direct, module = _load_model_aliases_in_tree(tree)
-    assert not direct and not module, (
+    direct, module, pkg = _load_model_aliases_in_tree(tree)
+    assert not direct and not module and not pkg, (
         "mlx_lm.utils.load_model MUST NOT register as our alias — "
         "would false-positive the entrypoint parity gate."
     )
 
     bare = "load_model('q')\n"
     tree = ast.parse(bare)
-    direct, module = _load_model_aliases_in_tree(tree)
-    assert not direct and not module, (
+    direct, module, pkg = _load_model_aliases_in_tree(tree)
+    assert not direct and not module and not pkg, (
         "load_model without an import is NOT our entrypoint."
     )
+
+
+def test_no_star_imports_from_vllm_mlx_server():
+    """DeepSeek round-3 #2 (PR #409): ``from vllm_mlx.server import *``
+    hides the ``load_model`` binding from the SOP §10 alias resolver —
+    ``__all__`` isn't statically discoverable from source alone, so any
+    star import defeats the forwarding audit. Ban it loudly at gate
+    time so contributors spell their imports explicitly.
+
+    Scans every .py file under ``vllm_mlx/`` for a star ImportFrom
+    targeting ``vllm_mlx.server`` (absolute or relative form). Found
+    → fail.
+    """
+    offenders: list[str] = []
+    pkg_root = _pkg_root()
+    for path in pkg_root.rglob("*.py"):
+        parent_parts = path.parent.parts[len(pkg_root.parts) :]
+        if any(part.startswith("__") for part in parent_parts):
+            continue
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            absolute_server = node.level == 0 and node.module == "vllm_mlx.server"
+            relative_server = node.level >= 1 and node.module == "server"
+            if (absolute_server or relative_server) and any(
+                a.name == "*" for a in node.names
+            ):
+                offenders.append(
+                    f"{rel}:{node.lineno} uses `from vllm_mlx.server "
+                    "import *` (or its relative form). Star imports "
+                    "defeat the load_model alias resolver — spell the "
+                    "imports out so the forwarding audit can verify "
+                    "each routing kwarg (DeepSeek round-3 #2)."
+                )
+    assert not offenders, "\n".join(offenders)
 
 
 def test_force_text_is_keyword_only_in_load_model():
@@ -655,8 +706,8 @@ _KNOWN_ENTRYPOINTS_SEED: frozenset[str] = frozenset(
 # whack-a-mole.
 def _load_model_aliases_in_tree(
     tree: ast.AST,
-) -> tuple[frozenset[str], frozenset[str]]:
-    """Return ``(direct_aliases, module_aliases)``:
+) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+    """Return ``(direct_aliases, module_aliases, pkg_aliases)``:
 
     - ``direct_aliases``: local names bound to ``load_model`` (e.g.
       ``"load_model"`` from ``from vllm_mlx.server import load_model``,
@@ -666,9 +717,18 @@ def _load_model_aliases_in_tree(
       ``"srv"`` from ``import vllm_mlx.server as srv``, or the
       two-segment ``"vllm_mlx.server"`` from bare
       ``import vllm_mlx.server``).
+    - ``pkg_aliases``: local names bound to the top-level ``vllm_mlx``
+      package (e.g. ``"vllm_mlx"`` from ``import vllm_mlx`` or
+      ``"vm"`` from ``import vllm_mlx as vm``). Used to recognize
+      ``<pkg_alias>.server.load_model(...)`` call shapes
+      (DeepSeek round-3 #3).
     """
+    # ``pkg_aliases``: top-level package aliases used with
+    # ``<pkg>.server.load_model(...)`` access (DeepSeek round-3 #3).
+    # Tracked here, consulted by ``_call_targets_load_model``.
     direct: set[str] = set()
     module: set[str] = set()
+    pkg_aliases: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             # ImportFrom shapes that reference vllm_mlx.server:
@@ -704,13 +764,22 @@ def _load_model_aliases_in_tree(
             for alias in node.names:
                 if alias.name == "vllm_mlx.server":
                     module.add(alias.asname or "vllm_mlx.server")
-    return frozenset(direct), frozenset(module)
+                # DeepSeek round-3 fix #3: `import vllm_mlx` lets
+                # callers write `vllm_mlx.server.load_model(...)`. We
+                # track the top-level package alias separately so
+                # `_call_targets_load_model` can reach into the
+                # ``<alias>.server.load_model`` two-level attribute
+                # chain even when only the package was imported.
+                if alias.name == "vllm_mlx":
+                    pkg_aliases.add(alias.asname or "vllm_mlx")
+    return frozenset(direct), frozenset(module), frozenset(pkg_aliases)
 
 
 def _call_targets_load_model(
     call: ast.Call,
     direct_aliases: frozenset[str],
     module_aliases: frozenset[str],
+    pkg_aliases: frozenset[str] = frozenset(),
 ) -> bool:
     """Return True iff ``call`` invokes ``vllm_mlx.server.load_model``
     (under any of the import shapes captured by
@@ -718,9 +787,12 @@ def _call_targets_load_model(
 
       - ``load_model(...)`` / ``lm(...)`` — direct alias name
       - ``server.load_model(...)`` / ``srv.load_model(...)`` —
-        single-level Attribute receiver
+        single-level Attribute receiver against ``module_aliases``
       - ``vllm_mlx.server.load_model(...)`` — two-level Attribute
         receiver collapsed against ``module_aliases``
+      - ``<pkg>.server.load_model(...)`` where ``<pkg>`` is in
+        ``pkg_aliases`` — DeepSeek round-3 #3 fix for the
+        ``import vllm_mlx`` shape.
     """
     func = call.func
     if isinstance(func, ast.Name) and func.id in direct_aliases:
@@ -738,6 +810,15 @@ def _call_targets_load_model(
             receiver_name = "vllm_mlx.server"
         if receiver_name is not None and receiver_name in module_aliases:
             return True
+        # DeepSeek round-3 #3: ``<pkg_alias>.server.load_model(...)``
+        # — receiver is an Attribute(value=Name(pkg_alias), attr="server").
+        if (
+            isinstance(receiver, ast.Attribute)
+            and isinstance(receiver.value, ast.Name)
+            and receiver.attr == "server"
+            and receiver.value.id in pkg_aliases
+        ):
+            return True
     return False
 
 
@@ -754,14 +835,16 @@ def _discover_entrypoints() -> set[str]:
     discovered: set[str] = set()
 
     for path in root.rglob("*.py"):
-        # Skip __pycache__ and other dunder dirs.
-        if any(part.startswith("__") for part in path.parts[len(root.parts) :]):
+        # DeepSeek round-3 fix (PR #409): skip only DIRECTORY parts
+        # starting with ``__`` (e.g. ``__pycache__``). The previous
+        # check walked ``path.parts`` which includes the filename, so
+        # ``__init__.py`` matched the dunder prefix and was skipped —
+        # silently dropping any entrypoint code that lives in an
+        # ``__init__.py``. Now only the directory chain (``parent.parts``)
+        # is checked.
+        parent_parts = path.parent.parts[len(root.parts) :]
+        if any(part.startswith("__") for part in parent_parts):
             continue
-        if path.name == "__init__.py":
-            # __init__ files are usually re-exports; if a real
-            # entrypoint shows up there it's still discovered via the
-            # AST checks below.
-            pass
 
         try:
             source = path.read_text()
@@ -776,7 +859,7 @@ def _discover_entrypoints() -> set[str]:
         # call scan, so a new entrypoint using `from vllm_mlx import
         # server` / `import vllm_mlx.server as srv` doesn't slip
         # discovery.
-        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
+        direct_aliases, module_aliases, pkg_aliases = _load_model_aliases_in_tree(tree)
 
         # Codex round-H fix (PR #409): the later prongs in
         # ``test_no_unregistered_routing_shaped_flags`` ban indirect
@@ -812,7 +895,9 @@ def _discover_entrypoints() -> set[str]:
                     ):
                         has_routing_shape = True
                         break
-            elif _call_targets_load_model(node, direct_aliases, module_aliases):
+            elif _call_targets_load_model(
+                node, direct_aliases, module_aliases, pkg_aliases
+            ):
                 # Any caller of OUR load_model (under any alias) is by
                 # definition an entrypoint that needs the forwarding check.
                 has_routing_shape = True
@@ -1426,13 +1511,13 @@ def test_load_model_callers_register_every_routing_flag():
         # qualified). The single helper closes rounds D/E/F/G bypasses
         # at once and means every other scanner in this file picks up
         # the same coverage.
-        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
+        direct_aliases, module_aliases, pkg_aliases = _load_model_aliases_in_tree(tree)
         if not (direct_aliases or module_aliases):
             continue
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and _call_targets_load_model(
-                node, direct_aliases, module_aliases
+                node, direct_aliases, module_aliases, pkg_aliases
             ):
                 load_model_callers.add(rel)
                 break
@@ -1656,13 +1741,13 @@ def test_routing_override_kwargs_are_forwarded_to_load_model():
         # name match let an aliased caller forward one routing kwarg
         # while omitting the rest — gate passed silently.
         tree = ast.parse(source)
-        direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
+        direct_aliases, module_aliases, pkg_aliases = _load_model_aliases_in_tree(tree)
         if not (direct_aliases or module_aliases):
             return []
         calls = []
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and _call_targets_load_model(
-                node, direct_aliases, module_aliases
+                node, direct_aliases, module_aliases, pkg_aliases
             ):
                 calls.append(node)
         return calls

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -255,6 +255,13 @@ def test_load_model_alias_resolver_handles_every_import_shape():
         "from-module": ("from vllm_mlx import server\nserver.load_model('q')\n"),
         "import-as": ("import vllm_mlx.server as srv\nsrv.load_model('q')\n"),
         "import-bare": ("import vllm_mlx.server\nvllm_mlx.server.load_model('q')\n"),
+        # Codex round-H regression: relative imports are what cli.py
+        # actually uses today. ast.ImportFrom encodes these as
+        # ``module="server", level=1`` / ``module=None, level=1`` — the
+        # prior absolute-only match silently dropped them.
+        "rel-direct": "from .server import load_model\nload_model('q')\n",
+        "rel-aliased": "from .server import load_model as lm\nlm('q')\n",
+        "rel-from-module": "from . import server\nserver.load_model('q')\n",
     }
     for shape, source in shapes.items():
         tree = ast.parse(source)
@@ -664,11 +671,32 @@ def _load_model_aliases_in_tree(
     module: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if node.module in ("vllm_mlx.server", "..server", ".server"):
+            # ImportFrom shapes that reference vllm_mlx.server:
+            #   absolute:  from vllm_mlx.server import load_model
+            #              (module="vllm_mlx.server", level=0)
+            #   absolute:  from vllm_mlx import server
+            #              (module="vllm_mlx", level=0)
+            #   relative:  from .server import load_model
+            #              (module="server", level=1)
+            #   relative:  from . import server
+            #              (module=None, level=1)
+            #
+            # Codex round-H fix (PR #409): the prior absolute-only
+            # matching missed cli.py's `from .server import load_model`
+            # and `from . import server`, silently dropping cli.py from
+            # the forwarding-audit gate. Recognize relative forms by
+            # checking ``node.level >= 1`` and matching the residual
+            # module-name suffix.
+            absolute_server = node.level == 0 and node.module == "vllm_mlx.server"
+            relative_server = node.level >= 1 and node.module == "server"
+            absolute_pkg = node.level == 0 and node.module == "vllm_mlx"
+            relative_pkg = node.level >= 1 and node.module is None
+
+            if absolute_server or relative_server:
                 for alias in node.names:
                     if alias.name == "load_model":
                         direct.add(alias.asname or "load_model")
-            elif node.module in ("vllm_mlx", ".."):
+            elif absolute_pkg or relative_pkg:
                 for alias in node.names:
                     if alias.name == "server":
                         module.add(alias.asname or "server")
@@ -750,12 +778,31 @@ def _discover_entrypoints() -> set[str]:
         # discovery.
         direct_aliases, module_aliases = _load_model_aliases_in_tree(tree)
 
+        # Codex round-H fix (PR #409): the later prongs in
+        # ``test_no_unregistered_routing_shaped_flags`` ban indirect
+        # add_argument shapes (``getattr(p, "add_argument")(...)``,
+        # ``**unpack`` kwargs, custom Action subclasses). Those bans
+        # only run on discovered files, so if discovery requires a
+        # direct ``Attribute`` add_argument call, a new entrypoint
+        # using only the indirect shape would skip discovery AND skip
+        # the ban — the very bypass the bans exist to catch.
+        # Broaden discovery: flag any file that mentions the literal
+        # STRING "add_argument" anywhere (catches getattr / __dict__
+        # access / dynamic dispatch). No legitimate code references
+        # that identifier outside argparse contexts.
+        mentions_add_argument_literal = any(
+            isinstance(n, ast.Constant)
+            and isinstance(n.value, str)
+            and n.value == "add_argument"
+            for n in ast.walk(tree)
+        )
+
         has_routing_shape = False
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            # add_argument detection (unchanged) — argparse method.
+            # add_argument detection (direct form): argparse method.
             if isinstance(func, ast.Attribute) and func.attr == "add_argument":
                 for arg in node.args:
                     if (
@@ -772,6 +819,13 @@ def _discover_entrypoints() -> set[str]:
 
             if has_routing_shape:
                 break
+
+        if not has_routing_shape and mentions_add_argument_literal:
+            # Codex round-H: the file references "add_argument" via
+            # something other than a direct Attribute call — exactly
+            # the indirect shape that the later add_argument-shape
+            # bans want to scan. Force discovery so those bans run.
+            has_routing_shape = True
 
         if has_routing_shape:
             rel = path.relative_to(root).as_posix()

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -473,6 +473,64 @@ def _add_argument_calls_with_custom_action(source: str) -> list[tuple[int, str]]
     return offenders
 
 
+def _add_argument_calls_with_dict_kwarg_unpack(source: str) -> list[int]:
+    """Find ``add_argument(..., **dict_literal_or_var)`` calls. Round-5
+    subagent 1 #P2-3: dest aliasing via ``**{"dest": "force_mllm"}`` is
+    invisible to the per-kwarg scan because the keyword arg has
+    ``kw.arg is None``. Reject the unpack outright in entrypoint files
+    — there's no legitimate use of ``**`` for add_argument, and helper
+    dicts hide audit surface."""
+    tree = ast.parse(source)
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        for kw in node.keywords:
+            if kw.arg is None:
+                offenders.append(node.lineno)
+                break
+    return offenders
+
+
+def _getattr_add_argument_calls(source: str) -> list[int]:
+    """Find ``getattr(p, "add_argument")(...)`` and string-concat
+    variants. Round-5 subagent 1 #P2-5: a ``getattr`` indirection
+    defeats the ``isinstance(func, ast.Attribute) and func.attr ==
+    "add_argument"`` predicate at the heart of every prong. There's no
+    legitimate use case in argparse code, so we ban the shape outright."""
+    tree = ast.parse(source)
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Outer Call has Call as func (the result of getattr being called).
+        if not isinstance(node.func, ast.Call):
+            continue
+        inner = node.func
+        if not (isinstance(inner.func, ast.Name) and inner.func.id == "getattr"):
+            continue
+        if len(inner.args) < 2:
+            continue
+        name_arg = inner.args[1]
+        # Constant "add_argument" or string concat resolving to it.
+        if isinstance(name_arg, ast.Constant) and name_arg.value == "add_argument":
+            offenders.append(node.lineno)
+            continue
+        # String concat shape: "add_" + "argument".
+        try:
+            value = ast.literal_eval(name_arg)
+            if isinstance(value, str) and value == "add_argument":
+                offenders.append(node.lineno)
+        except (ValueError, TypeError):
+            # Non-literal — also suspicious (could resolve to add_argument
+            # at runtime). Flag the dynamic indirection.
+            offenders.append(node.lineno)
+    return offenders
+
+
 def _add_argument_calls_with_non_literal_flag(source: str) -> list[int]:
     """Find ``add_argument(<non-Constant>, ...)`` calls where the first
     positional argument is a variable, attribute, function call, or
@@ -766,6 +824,16 @@ def test_registry_is_not_runtime_mutated():
                 and elt.func.id == "RoutingFlagPair"
             ):
                 continue
+            # Round-5 subagent 3 #E: RoutingFlagPair(*list) positional /
+            # starred args bypass the kwargs check. Require every field
+            # to be passed by keyword name so the source AST can verify.
+            if elt.args:
+                pytest.fail(
+                    "RoutingFlagPair() call uses positional / starred args. "
+                    "Every field must be passed by keyword name so the "
+                    "source-AST scan can reconstruct it (round-5 subagent 3 "
+                    "#E bypass)."
+                )
             fields: dict[str, object] = {}
             for kw in elt.keywords:
                 if kw.arg is None:
@@ -926,6 +994,22 @@ def test_conftests_do_not_deselect_or_replace_collection():
                             "assigns to items[...] — rewrites collection list "
                             "(round-4 cat-5 #6 attack pattern). Use markers "
                             "to skip tests instead."
+                        )
+            # Round-5 subagent 3 #H: `del items[i]` / `del items[:]`
+            # achieves the same deselection as items.remove() but via
+            # ast.Delete. Match Delete-of-Subscript on items.
+            if isinstance(node, ast.Delete):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "items"
+                    ):
+                        offenders.append(
+                            f"{conftest.relative_to(repo_root)}:{node.lineno} "
+                            "uses `del items[...]` — drops tests from "
+                            "collection (round-5 subagent 3 #H bypass). Use "
+                            "item.add_marker(pytest.mark.skip(...)) instead."
                         )
 
     assert not offenders, "\n".join(offenders)
@@ -1108,6 +1192,27 @@ def test_no_unregistered_routing_shaped_flags():
                 "literals so the SOP gate can audit them. Helper functions "
                 "that wrap add_argument() defeat AST scanning (round-4 cat-2 "
                 "#3). Spell out the add_argument call site directly."
+            )
+
+        # Prong 6: add_argument(..., **dict-unpack) — round-5 subagent 1
+        # #P2-3 (dest aliasing via unpacked dict literal). Reject the
+        # ** shape outright in entrypoint files.
+        for lineno in _add_argument_calls_with_dict_kwarg_unpack(source):
+            failures.append(
+                f"{relpath}:{lineno} calls add_argument() with **dict-unpack. "
+                "Spell out every kwarg explicitly so the SOP gate can audit "
+                "dest=/action=/etc (round-5 subagent 1 #P2-3 bypass)."
+            )
+
+        # Prong 7: getattr(p, "add_argument")(...) — round-5 subagent 1
+        # #P2-5 (Attribute-access indirection). No legitimate use of
+        # getattr on a parser for add_argument; ban the shape.
+        for lineno in _getattr_add_argument_calls(source):
+            failures.append(
+                f"{relpath}:{lineno} uses getattr(...)('add_argument')(...) "
+                "indirection — defeats every AST predicate that matches "
+                "Attribute(attr='add_argument'). Use p.add_argument(...) "
+                "directly (round-5 subagent 1 #P2-5 bypass)."
             )
 
     registered = _registered_flag_names()

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -128,6 +128,42 @@ SETTER_METHOD_ROUTING_PATTERN = re.compile(
 )
 
 
+def _field_type_is_str(t: object) -> bool:
+    """True iff ``t`` (a ``dataclasses.Field.type`` value) represents
+    ``str``, ``Optional[str]``, or ``str | None`` — regardless of
+    whether the annotation is a real type, a stringified annotation
+    (PEP 563), or a PEP 604 ``types.UnionType``.
+
+    Codex R1 (PR #409 review) flagged that the original ``f.type == "str |
+    None"`` string match misses real ``types.UnionType`` objects, which
+    is what ``dataclasses.fields()`` returns on Python 3.10+ when the
+    module does NOT use ``from __future__ import annotations``. The
+    consequence was that ``tool_call_parser: str | None`` slipped the
+    allowlist check entirely — a future ``multimodal_mode: str | None``
+    would have done the same.
+    """
+    import typing
+
+    if t is str:
+        return True
+    # Stringified annotation (PEP 563 / from __future__ import annotations).
+    if isinstance(t, str):
+        try:
+            tree = ast.parse(t, mode="eval")
+        except SyntaxError:
+            return False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id == "str":
+                return True
+        return False
+    # Real ``types.UnionType`` (PEP 604 ``str | None``) or
+    # ``typing.Optional[str]`` / ``typing.Union[str, None]``.
+    args = typing.get_args(t)
+    if args:
+        return any(a is str for a in args)
+    return False
+
+
 def _pkg_root() -> pathlib.Path:
     return pathlib.Path(
         str(importlib.resources.files("vllm_mlx").joinpath(""))
@@ -628,6 +664,39 @@ def test_no_routing_shaped_request_headers():
     assert not offenders, "\n".join(offenders)
 
 
+def test_field_type_is_str_handles_pep604_unions():
+    """Codex R1 regression: ``f.type`` from ``dataclasses.fields()`` is
+    a real ``types.UnionType`` (not a string) on Python 3.10+ when the
+    module doesn't use ``from __future__ import annotations``. The
+    original ``f.type == "str | None"`` string compare missed every
+    optional-str dataclass field, defeating the routing check.
+
+    Lock the helper down: every flavor of "this annotation includes
+    str" must return True, and obvious non-str annotations must return
+    False. If anyone reverts the union-args path, this fails loudly.
+    """
+    import typing
+
+    # Real annotations (without PEP 563).
+    # noqa for UP045/UP007: this test verifies BOTH legacy typing forms
+    # AND PEP 604 forms are detected — that's the point.
+    assert _field_type_is_str(str)
+    assert _field_type_is_str(str | None)
+    assert _field_type_is_str(typing.Optional[str])  # noqa: UP045
+    assert _field_type_is_str(typing.Union[str, int])  # noqa: UP007
+    # Stringified (PEP 563) annotations.
+    assert _field_type_is_str("str")
+    assert _field_type_is_str("str | None")
+    assert _field_type_is_str("Optional[str]")
+    # Non-str annotations must NOT trigger.
+    assert not _field_type_is_str(int)
+    assert not _field_type_is_str(int | None)
+    assert not _field_type_is_str("int")
+    assert not _field_type_is_str("bool")
+    assert not _field_type_is_str(typing.Optional[int])  # noqa: UP045
+    assert not _field_type_is_str(tuple[tuple[str, float], ...] | None)
+
+
 def test_alias_profile_str_fields_are_explicitly_listed():
     """Round-5 subagent 3 #D: an attacker adds ``multimodal_mode: str =
     "auto"`` to ``AliasProfile`` (passes round-4's name-shape check
@@ -662,9 +731,7 @@ def test_alias_profile_str_fields_are_explicitly_listed():
     )
 
     str_fields = [
-        f.name
-        for f in dataclasses.fields(AliasProfile)
-        if f.type is str or f.type == "str" or f.type == "str | None"
+        f.name for f in dataclasses.fields(AliasProfile) if _field_type_is_str(f.type)
     ]
     unlisted = set(str_fields) - ALLOWED_STR_FIELDS
     assert not unlisted, (

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -57,6 +57,19 @@ ROUTING_ATTRS: frozenset[str] = frozenset(
 
 # Functions that MAY write to routing attributes. Anything else is an
 # escape hatch.
+#
+# Codex round-D fix (PR #409): allowlisting by NAME alone is bypass-
+# prone — any module can define a helper or method literally named
+# ``load_model`` / ``detect_model_config`` / ``_coerce`` etc. that
+# writes routing attrs and passes this gate. Each non-constructor
+# allowlist entry must be PINNED to the canonical module path(s)
+# where the production function actually lives. Per-call lookup uses
+# ``ROUTING_WRITE_ALLOWED_LOCATIONS`` below.
+#
+# Constructor entries (``__init__``, ``model_post_init``) are NOT
+# pinned by location — they have an orthogonal class-ancestor check
+# in ``_func_is_method_of_class``, which already prevents top-level
+# helpers from claiming the name.
 ROUTING_WRITE_ALLOWED_FUNCS: frozenset[str] = frozenset(
     {
         "__init__",  # Constructor — the canonical write site.
@@ -72,6 +85,20 @@ ROUTING_WRITE_ALLOWED_FUNCS: frozenset[str] = frozenset(
         "model_post_init",
     }
 )
+
+
+# Codex round-D fix (PR #409): canonical module path(s) for each
+# non-constructor allowlist entry. A function may write routing
+# attributes only if it lives in one of the listed files (paths are
+# relative to ``vllm_mlx/``). Adding a new canonical location requires
+# an explicit edit + PR review.
+ROUTING_WRITE_ALLOWED_LOCATIONS: dict[str, frozenset[str]] = {
+    "load_model": frozenset({"server.py"}),
+    "detect_model_config": frozenset({"model_auto_config.py"}),
+    "enrich_model_config": frozenset({"model_auto_config.py"}),
+    "_coerce": frozenset({"model_aliases.py"}),
+    "_load": frozenset({"model_aliases.py"}),
+}
 
 
 # RAPID_MLX_* env vars that are allowed to exist. Routing-shaped env
@@ -520,6 +547,7 @@ def test_routing_fields_written_only_in_allowed_scopes():
             # though it's not a constructor at all. Same logic applies
             # to `model_post_init` (Pydantic constructor-equivalent).
             CONSTRUCTOR_NAMES = {"__init__", "model_post_init"}
+            bypass_found = False
             for fn in chain:
                 if fn.name in CONSTRUCTOR_NAMES and not _func_is_method_of_class(
                     parents, fn
@@ -534,6 +562,30 @@ def test_routing_fields_written_only_in_allowed_scopes():
                         "pass. Routing writes must live inside a real "
                         "constructor (defined in a `class` block) or "
                         f"one of {sorted(ROUTING_WRITE_ALLOWED_FUNCS - CONSTRUCTOR_NAMES)}."
+                    )
+                    bypass_found = True
+                    break
+            if bypass_found:
+                continue
+
+            # Codex round-D fix (PR #409): pin non-constructor allowlist
+            # entries to their canonical module paths. A helper or
+            # method named `load_model` / `detect_model_config` /
+            # `_coerce` etc. defined ANYWHERE else would otherwise
+            # pass — the function-name check alone is bypass-prone.
+            for fn in chain:
+                pinned = ROUTING_WRITE_ALLOWED_LOCATIONS.get(fn.name)
+                if pinned is None:
+                    continue
+                if rel not in pinned:
+                    offenders.append(
+                        f"{rel}:{node.lineno} writes routing attribute "
+                        f"`.{attr_name}` inside `{fn.name}` — but the "
+                        f"canonical location for `{fn.name}` is "
+                        f"{sorted(pinned)}, not `{rel}` (codex round-D "
+                        "bypass). Define this function only in the "
+                        "canonical module, or move the routing write "
+                        "to a real constructor."
                     )
                     break
 
@@ -1165,4 +1217,38 @@ def test_os_environ_composed_key_is_detected():
             assert not isinstance(key, (ast.BinOp, ast.JoinedStr, ast.Call)), (
                 f"benign key shape `{type(key).__name__}` MUST NOT be "
                 "flagged — would false-positive on module-level constants."
+            )
+
+
+def test_routing_write_allowed_locations_pins_canonical_paths():
+    """Codex round-D regression (PR #409): allowlisting routing-write
+    functions by NAME alone is bypass-prone. Any module can define a
+    helper or method named ``load_model`` / ``detect_model_config`` /
+    ``_coerce`` etc. and the function-chain check would accept it.
+    The fix pins each non-constructor allowlist entry to its canonical
+    module path(s) via ``ROUTING_WRITE_ALLOWED_LOCATIONS``.
+
+    This regression test asserts two things:
+      1. Every non-constructor entry in ``ROUTING_WRITE_ALLOWED_FUNCS``
+         has a corresponding entry in ``ROUTING_WRITE_ALLOWED_LOCATIONS``
+         (no name slips through unlocated).
+      2. Each pinned path actually exists in the vllm_mlx/ tree.
+    """
+    CONSTRUCTOR_NAMES = {"__init__", "model_post_init"}
+    non_constructor = ROUTING_WRITE_ALLOWED_FUNCS - CONSTRUCTOR_NAMES
+    unlocated = non_constructor - set(ROUTING_WRITE_ALLOWED_LOCATIONS)
+    assert not unlocated, (
+        f"Non-constructor allowlist names {sorted(unlocated)} have NO "
+        "canonical location pin. Add an entry to "
+        "ROUTING_WRITE_ALLOWED_LOCATIONS so name-only bypass (codex "
+        "round-D) doesn't reopen."
+    )
+
+    pkg_root = _pkg_root()
+    for name, paths in ROUTING_WRITE_ALLOWED_LOCATIONS.items():
+        for rel in paths:
+            assert (pkg_root / rel).exists(), (
+                f"ROUTING_WRITE_ALLOWED_LOCATIONS[{name!r}] pins to "
+                f"`{rel}` but that file does not exist in vllm_mlx/. "
+                "Stale pin — fix or remove."
             )

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -217,6 +217,75 @@ def _enclosing_function_chain(
     return chain
 
 
+def _os_environ_key_expr(node: ast.AST) -> ast.AST | None:
+    """Codex round-B helper (PR #409): return the key expression of an
+    ``os.environ`` access if ``node`` is one of:
+
+      - ``os.environ[key]`` / ``os.environ[key] = …`` — Subscript
+      - ``os.environ.get(key)`` / ``os.environ.get(key, default)`` — Call
+      - ``os.environ.pop(key, …)`` — Call (mutation form)
+      - ``os.environ.setdefault(key, …)`` — Call
+
+    Returns the key AST node so the caller can check if it's a
+    single Constant or a composed expression. Returns None for any
+    other node (so callers can blanket-skip).
+    """
+    # os.environ[key] form.
+    if isinstance(node, ast.Subscript):
+        value = node.value
+        if (
+            isinstance(value, ast.Attribute)
+            and value.attr == "environ"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "os"
+        ):
+            return node.slice
+        return None
+    # os.environ.get(...) / .pop(...) / .setdefault(...) form.
+    if isinstance(node, ast.Call):
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return None
+        if func.attr not in {"get", "pop", "setdefault"}:
+            return None
+        receiver = func.value
+        if not (
+            isinstance(receiver, ast.Attribute)
+            and receiver.attr == "environ"
+            and isinstance(receiver.value, ast.Name)
+            and receiver.value.id == "os"
+        ):
+            return None
+        if not node.args:
+            return None
+        return node.args[0]
+    return None
+
+
+def _func_is_method_of_class(
+    parents: dict[int, ast.AST],
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """Codex round-B fix (PR #409): an `__init__` allowlisted by name
+    only is bypass-prone — a route module can declare a top-level
+    `def __init__(engine): engine._is_mllm = False` and call it per
+    request to flip routing without ever touching a real constructor.
+
+    A genuine constructor lives inside a `class` block: walk up the
+    parent chain from `fn` and return True iff we hit an ``ast.ClassDef``
+    before bottoming out. The check is per-function so callers can apply
+    it selectively (only `__init__`-named entries in the allowlist
+    benefit from the constructor requirement; `load_model`,
+    `_coerce`, etc. are module-level by design).
+    """
+    cur: ast.AST | None = parents.get(id(fn))
+    while cur is not None:
+        if isinstance(cur, ast.ClassDef):
+            return True
+        cur = parents.get(id(cur))
+    return False
+
+
 def _routing_attr_write_targets(node: ast.AST) -> list[tuple[str, ast.AST]]:
     """Return ``(attr_name, source_node)`` pairs for every routing-attr
     write expressed by ``node``. Covers many indirect attribute-write
@@ -442,6 +511,31 @@ def test_routing_fields_written_only_in_allowed_scopes():
                     "Assign, AnnAssign, AugAssign, Subscript (vars/__dict__), "
                     "setattr(), object.__setattr__(), and ast.Delete."
                 )
+                continue
+
+            # Codex round-B fix (PR #409): names alone aren't enough.
+            # `__init__` MUST be a real constructor — i.e. defined inside
+            # a `class` block. A top-level or helper function literally
+            # named `__init__` would otherwise pass this gate, even
+            # though it's not a constructor at all. Same logic applies
+            # to `model_post_init` (Pydantic constructor-equivalent).
+            CONSTRUCTOR_NAMES = {"__init__", "model_post_init"}
+            for fn in chain:
+                if fn.name in CONSTRUCTOR_NAMES and not _func_is_method_of_class(
+                    parents, fn
+                ):
+                    offenders.append(
+                        f"{rel}:{node.lineno} writes routing attribute "
+                        f"`.{attr_name}` inside a function named "
+                        f"`{fn.name}` that is NOT a method of a class "
+                        "(codex round-B bypass). Allowlist by name "
+                        "alone is bypass-prone: any top-level/helper "
+                        f"function literally named `{fn.name}` would "
+                        "pass. Routing writes must live inside a real "
+                        "constructor (defined in a `class` block) or "
+                        f"one of {sorted(ROUTING_WRITE_ALLOWED_FUNCS - CONSTRUCTOR_NAMES)}."
+                    )
+                    break
 
     assert not offenders, "\n".join(offenders)
 
@@ -517,6 +611,35 @@ def test_no_routing_shaped_rapid_mlx_env_vars():
                     "either `os.environb` or `from os import environb`). Use "
                     "os.environ.get() with a documented str key instead."
                 )
+
+        # Codex round-B fix (PR #409): the string-Constant scan only
+        # sees fully-literal keys. Composed names like
+        # ``os.environ.get("RAPID_MLX_" + "FORCE_MLLM")`` or
+        # ``f"{prefix}FORCE_MLLM"`` never present the full routing-shape
+        # string to ``_check_env_constant`` — the gate passes even
+        # though the runtime read targets the exact out-of-band routing
+        # override this test forbids. Ban os.environ accesses whose
+        # KEY is a composed expression (BinOp / JoinedStr / Call) —
+        # those are the bypass shapes. A bare ``Name``/``Attribute``
+        # reference (e.g. ``os.environ.get(ENV_VAR)``) is allowed
+        # because the constant's underlying string literal still flows
+        # through the Constant scan above.
+        for node in ast.walk(tree):
+            key_expr = _os_environ_key_expr(node)
+            if key_expr is None:
+                continue
+            if not isinstance(key_expr, (ast.BinOp, ast.JoinedStr, ast.Call)):
+                continue
+            shape = type(key_expr).__name__
+            offenders.append(
+                f"{rel}:{node.lineno} reads/writes os.environ with a "
+                f"COMPOSED key ({shape}: concat / f-string / call). "
+                "Composed env-var names defeat the routing-shape scan: "
+                "use a single string literal or a module-level "
+                "constant whose value is a literal. Composing the "
+                "name at the call site is the codex round-B bypass "
+                "shape (e.g. `os.environ.get('RAPID_MLX_' + 'FORCE_MLLM')`)."
+            )
 
     assert not offenders, "\n".join(offenders)
 
@@ -965,3 +1088,81 @@ def test_conftest_deselect_gate_scoped_to_pytest_hook():
     assert _gated_offenders(hook_source) == 1, (
         "gate MUST still fire on items.remove() inside pytest_collection_modifyitems."
     )
+
+
+def test_func_is_method_of_class_distinguishes_real_constructors():
+    """Codex round-B regression (PR #409): the routing-write allowlist
+    treats ``__init__`` (and ``model_post_init``) as constructor
+    surfaces — but allowlisting by NAME alone is bypass-prone. A
+    top-level helper like ``def __init__(engine): engine._is_mllm =
+    False`` passes the name check, even though it's not a constructor
+    at all and can be called per request. The fix requires the
+    function to live inside a ``class`` block; this test pins both
+    directions.
+    """
+    method_source = (
+        "class Engine:\n    def __init__(self):\n        self._is_mllm = False\n"
+    )
+    helper_source = "def __init__(engine):\n    engine._is_mllm = False\n"
+
+    def _check(source: str, target_func_name: str) -> bool:
+        tree = ast.parse(source)
+        parents = _build_parent_map(tree)
+        for n in ast.walk(tree):
+            if (
+                isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and n.name == target_func_name
+            ):
+                return _func_is_method_of_class(parents, n)
+        raise AssertionError(f"function {target_func_name} not found in source")
+
+    assert _check(method_source, "__init__") is True, (
+        "Engine.__init__ defined inside `class Engine` MUST be "
+        "recognized as a class method."
+    )
+    assert _check(helper_source, "__init__") is False, (
+        "Top-level `def __init__(engine)` is NOT a constructor; the "
+        "helper must return False to surface the codex round-B bypass."
+    )
+
+
+def test_os_environ_composed_key_is_detected():
+    """Codex round-B regression (PR #409): ``os.environ.get(...)``
+    with a literal-Constant key is the only safe shape — composed
+    keys (concatenation / f-strings / calls) defeat the routing-name
+    Constant scan above. Lock the detector so a future refactor of
+    ``_os_environ_key_expr`` can't silently drop one of these shapes.
+    """
+    composed_sources = {
+        "concat": "import os\nos.environ.get('RAPID_MLX_' + 'FORCE_MLLM')\n",
+        "fstring": "import os\nprefix = 'RAPID_MLX_'\nos.environ.get(f'{prefix}FORCE_MLLM')\n",
+        "call": "import os\nos.environ.get('RAPID_'.join(['MLX_FORCE_MLLM']))\n",
+    }
+    for shape, source in composed_sources.items():
+        tree = ast.parse(source)
+        flagged: list[tuple[str, int]] = []
+        for node in ast.walk(tree):
+            key = _os_environ_key_expr(node)
+            if key is None:
+                continue
+            if isinstance(key, (ast.BinOp, ast.JoinedStr, ast.Call)):
+                flagged.append((type(key).__name__, node.lineno))
+        assert flagged, f"composed key shape `{shape}` must be detected"
+
+    # Negative control: literal Constant + module-level Name reference
+    # must NOT be flagged (these are legitimate patterns used in
+    # vllm_mlx/mcp/config.py and vllm_mlx/telemetry/state.py).
+    benign_sources = (
+        "import os\nos.environ.get('VLLM_MLX_MCP_CONFIG')\n",
+        "import os\nENV_VAR = 'RAPID_MLX_TELEMETRY'\nos.environ.get(ENV_VAR)\n",
+    )
+    for source in benign_sources:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            key = _os_environ_key_expr(node)
+            if key is None:
+                continue
+            assert not isinstance(key, (ast.BinOp, ast.JoinedStr, ast.Call)), (
+                f"benign key shape `{type(key).__name__}` MUST NOT be "
+                "flagged — would false-positive on module-level constants."
+            )

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -238,27 +238,40 @@ def _routing_attr_write_targets(node: ast.AST) -> list[tuple[str, ast.AST]]:
     """
     pairs: list[tuple[str, ast.AST]] = []
 
+    # Codex R2 fix: destructuring assignment `self._is_mllm, other = ...`
+    # nests the Attribute target inside a Tuple/List. Walk targets
+    # recursively so destructuring forms are scanned the same as
+    # direct assignment.
+    def _flatten_targets(t: ast.AST) -> list[ast.AST]:
+        if isinstance(t, (ast.Tuple, ast.List)):
+            out: list[ast.AST] = []
+            for elt in t.elts:
+                out.extend(_flatten_targets(elt))
+            return out
+        # Unwrap Starred (e.g. `*rest, self._is_mllm = ...`).
+        if isinstance(t, ast.Starred):
+            return _flatten_targets(t.value)
+        return [t]
+
     # 1. Direct Attribute assignment / augassign / annassign.
     attr_targets: list[ast.Attribute] = []
+    flat_targets: list[ast.AST] = []
     if isinstance(node, ast.Assign):
         for t in node.targets:
-            if isinstance(t, ast.Attribute):
-                attr_targets.append(t)
-    elif (
-        isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Attribute)
-    ) or (isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Attribute)):
-        attr_targets.append(node.target)
+            flat_targets.extend(_flatten_targets(t))
+    elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+        flat_targets.append(node.target)
+
+    for t in flat_targets:
+        if isinstance(t, ast.Attribute):
+            attr_targets.append(t)
     for tgt in attr_targets:
         pairs.append((tgt.attr, node))
 
     # 2. Subscript assignment to .__dict__["x"] or vars(obj)["x"].
-    subscript_targets: list[ast.Subscript] = []
-    if isinstance(node, ast.Assign):
-        for t in node.targets:
-            if isinstance(t, ast.Subscript):
-                subscript_targets.append(t)
-    elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Subscript):
-        subscript_targets.append(node.target)
+    subscript_targets: list[ast.Subscript] = [
+        t for t in flat_targets if isinstance(t, ast.Subscript)
+    ]
 
     # ast.Delete: `del self.x` / `del vars(self)["x"]` — these clear a
     # routing decision the same way an assignment of False would.
@@ -280,31 +293,50 @@ def _routing_attr_write_targets(node: ast.AST) -> list[tuple[str, ast.AST]]:
             if isinstance(key, ast.Constant) and isinstance(key.value, str):
                 pairs.append((key.value, node))
 
-    # 3. Call-form setattr / __setattr__ — second arg is the attr name.
+    # 3. Call-form setattr / __setattr__ — check both possible arg
+    # positions. Codex R2: bound `engine.__setattr__("x", v)` puts the
+    # name at args[0]; unbound `object.__setattr__(engine, "x", v)`
+    # puts it at args[1]. Rather than try to distinguish the binding
+    # statically (fragile), inspect ALL leading string-Constant args
+    # against ROUTING_ATTRS. If any matches, it's a routing write.
     if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
         call = node.value
     elif isinstance(node, ast.Call):
         call = node
     else:
         call = None
-    # Also handle setattr as statement target (e.g. inside `if x: setattr(...)`).
-    # Walking standalone Call nodes inside the broader scanner picks them up,
-    # but for ``x := setattr(...)`` / list-comprehension wrappers the call is
-    # in an arbitrary expression context — those are scanned elsewhere too.
     if call is not None:
-        func = call.func
-        if (
-            isinstance(func, ast.Name) and func.id == "setattr" and len(call.args) >= 2
-        ) or (
-            isinstance(func, ast.Attribute)
-            and func.attr == "__setattr__"
-            and len(call.args) >= 2
-        ):
-            name_arg = call.args[1]
-            if isinstance(name_arg, ast.Constant) and isinstance(name_arg.value, str):
-                pairs.append((name_arg.value, node))
+        pairs.extend(_setattr_routing_writes(call, node))
 
     return pairs
+
+
+def _setattr_routing_writes(
+    call: ast.Call, owner_node: ast.AST
+) -> list[tuple[str, ast.AST]]:
+    """If ``call`` is a setattr-family invocation, return every
+    string-constant arg paired with ``owner_node``. Cheap superset
+    over ``args[0]`` and ``args[1]`` so both bound and unbound forms
+    are covered:
+
+    - ``setattr(obj, "x", v)`` — args[0]=obj, args[1]="x"
+    - ``object.__setattr__(obj, "x", v)`` — args[0]=obj, args[1]="x"
+    - ``engine.__setattr__("x", v)`` — args[0]="x"
+
+    The downstream gate filters by ROUTING_ATTRS so non-routing
+    setattr calls (``setattr(obj, "some_other_key", v)``) don't match.
+    """
+    out: list[tuple[str, ast.AST]] = []
+    func = call.func
+    is_setattr_name = isinstance(func, ast.Name) and func.id == "setattr"
+    is_setattr_method = isinstance(func, ast.Attribute) and func.attr == "__setattr__"
+    if not (is_setattr_name or is_setattr_method):
+        return out
+    # Inspect leading args 0 and 1 (covers both bound and unbound shapes).
+    for arg in call.args[:2]:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            out.append((arg.value, owner_node))
+    return out
 
 
 def _all_routing_write_calls(tree: ast.AST) -> list[tuple[str, ast.AST]]:
@@ -317,23 +349,10 @@ def _all_routing_write_calls(tree: ast.AST) -> list[tuple[str, ast.AST]]:
     for node in ast.walk(tree):
         out.extend(_routing_attr_write_targets(node))
         # Standalone call inside any expression context — setattr()
-        # via walrus or as a comprehension element.
+        # via walrus or as a comprehension element. Uses the same
+        # arg-position-agnostic helper as the per-node path.
         if isinstance(node, ast.Call):
-            func = node.func
-            if (
-                isinstance(func, ast.Name)
-                and func.id == "setattr"
-                and len(node.args) >= 2
-            ) or (
-                isinstance(func, ast.Attribute)
-                and func.attr == "__setattr__"
-                and len(node.args) >= 2
-            ):
-                name_arg = node.args[1]
-                if isinstance(name_arg, ast.Constant) and isinstance(
-                    name_arg.value, str
-                ):
-                    out.append((name_arg.value, node))
+            out.extend(_setattr_routing_writes(node, node))
     # Dedupe — Expr(Call(...)) and the inner Call both produce the same hit.
     seen: set[tuple[int, str]] = set()
     deduped: list[tuple[str, ast.AST]] = []
@@ -662,6 +681,69 @@ def test_no_routing_shaped_request_headers():
                 )
 
     assert not offenders, "\n".join(offenders)
+
+
+def test_routing_attr_write_detects_destructuring_and_bound_setattr():
+    """Codex R2 regression-lock: two specific shapes that previously
+    slipped the routing-attr write scanner.
+
+    (a) Destructuring assignment: ``self._is_mllm, other = False, x``
+        — outer target is Tuple, the Attribute is nested inside.
+    (b) Bound ``engine.__setattr__("_is_mllm", False)`` — name is at
+        args[0], not args[1] like the unbound classmethod form.
+
+    Both forms must be detected by ``_routing_attr_write_targets``.
+    If either regresses, this test fails loudly with a specific
+    pointer to the bypass."""
+
+    # (a) destructuring
+    src_destruct = "self._is_mllm, other = False, x"
+    tree = ast.parse(src_destruct)
+    found = []
+    for node in ast.walk(tree):
+        found.extend(_routing_attr_write_targets(node))
+    assert any(attr == "_is_mllm" for attr, _ in found), (
+        f"Destructuring assignment `{src_destruct}` was NOT detected as a "
+        "routing-attr write. The scanner must walk nested Tuple/List "
+        "targets recursively (codex R2 fix)."
+    )
+
+    # (b) bound __setattr__ — args[0] is the name
+    src_bound = 'engine.__setattr__("_is_mllm", False)'
+    tree = ast.parse(src_bound)
+    found = []
+    for node in ast.walk(tree):
+        found.extend(_routing_attr_write_targets(node))
+    assert any(attr == "_is_mllm" for attr, _ in found), (
+        f"Bound `{src_bound}` was NOT detected as a routing write. The "
+        "scanner must check both args[0] (bound form) and args[1] (unbound "
+        "form) — codex R2 fix."
+    )
+
+    # (b') unbound object.__setattr__ — args[1] is the name (must still work)
+    src_unbound = 'object.__setattr__(engine, "_is_mllm", False)'
+    tree = ast.parse(src_unbound)
+    found = []
+    for node in ast.walk(tree):
+        found.extend(_routing_attr_write_targets(node))
+    assert any(attr == "_is_mllm" for attr, _ in found), (
+        f"Unbound `{src_unbound}` was NOT detected — original arg-1 path "
+        "regressed when adding arg-0 coverage."
+    )
+
+    # Negative: non-routing setattr must NOT match.
+    src_negative = 'setattr(engine, "some_unrelated_key", True)'
+    tree = ast.parse(src_negative)
+    found = []
+    for node in ast.walk(tree):
+        found.extend(_routing_attr_write_targets(node))
+    # Found pairs may contain "some_unrelated_key" but should NOT
+    # contain any ROUTING_ATTRS member.
+    matching_routing = [attr for attr, _ in found if attr in ROUTING_ATTRS]
+    assert not matching_routing, (
+        f"Non-routing setattr `{src_negative}` falsely matched routing "
+        f"attrs: {matching_routing}."
+    )
 
 
 def test_field_type_is_str_handles_pep604_unions():

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -353,11 +353,19 @@ def _all_routing_write_calls(tree: ast.AST) -> list[tuple[str, ast.AST]]:
         # arg-position-agnostic helper as the per-node path.
         if isinstance(node, ast.Call):
             out.extend(_setattr_routing_writes(node, node))
-    # Dedupe — Expr(Call(...)) and the inner Call both produce the same hit.
-    seen: set[tuple[int, str]] = set()
+    # Dedupe — Expr(Call(...)) and the inner Call share the same source
+    # location but are distinct objects, so id(n) lets both through and
+    # the offender list double-prints. DeepSeek-V4 review fix (PR #409):
+    # key by source position + attr so siblings at the same line are
+    # collapsed, regardless of which AST wrapper node we walked through.
+    seen: set[tuple[int, int, str]] = set()
     deduped: list[tuple[str, ast.AST]] = []
     for attr, n in out:
-        key = (id(n), attr)
+        key = (
+            getattr(n, "lineno", -1),
+            getattr(n, "col_offset", -1),
+            attr,
+        )
         if key in seen:
             continue
         seen.add(key)
@@ -488,16 +496,25 @@ def test_no_routing_shaped_rapid_mlx_env_vars():
 
         # Round-5 subagent 3 #B: ban os.environb references entirely.
         # No legitimate use, bytes-form env reads are a parallel surface.
+        # DeepSeek-V4 review fix (PR #409): also catch the bare-name
+        # form `from os import environb; environb[b"…"]` — the rename
+        # via `from … import` strips the `os.` Attribute wrapper, so the
+        # attribute-only scan above misses it. Matching every reference
+        # to a name `environb` is safe: there is no legitimate variable
+        # by that name in the codebase.
         for node in ast.walk(tree):
-            if (
+            os_attribute_form = (
                 isinstance(node, ast.Attribute)
                 and node.attr == "environb"
                 and isinstance(node.value, ast.Name)
                 and node.value.id == "os"
-            ):
+            )
+            bare_name_form = isinstance(node, ast.Name) and node.id == "environb"
+            if os_attribute_form or bare_name_form:
                 offenders.append(
-                    f"{rel}:{node.lineno} uses `os.environb` — bytes-form env "
-                    "var access bypasses the string-Constant scan. Use "
+                    f"{rel}:{node.lineno} references `environb` — bytes-form env "
+                    "var access bypasses the string-Constant scan (matches "
+                    "either `os.environb` or `from os import environb`). Use "
                     "os.environ.get() with a documented str key instead."
                 )
 
@@ -824,4 +841,127 @@ def test_alias_profile_str_fields_are_explicitly_listed():
         "escape hatches — name-shape regex misses them, value-space scans "
         "are unreliable. The fix is closed-set: a new str field requires "
         "explicit review."
+    )
+
+
+def test_environb_detection_catches_bare_name_form():
+    """DeepSeek-V4 review regression (PR #409): the original
+    ``os.environb`` ban only matched ``Attribute(attr='environb',
+    value=Name(id='os'))``. An attacker who writes
+    ``from os import environb; environb[b'RAPID_MLX_FORCE_MLLM'] = b'1'``
+    creates an ``ast.Subscript`` whose ``.value`` is a bare ``Name(id=
+    'environb')`` with no ``os.`` prefix — the Attribute-only scan
+    misses it entirely. The fix adds a second predicate matching
+    ``Name(id='environb')`` directly.
+
+    This test parses both forms as standalone source snippets and
+    confirms the bare-name form is recognized by the same logic the
+    gate uses. We avoid replicating the full file-walk; we instead
+    exercise the predicate directly by running an AST walk and
+    counting matches.
+    """
+    bare_form_source = (
+        "from os import environb\nenvironb[b'RAPID_MLX_FORCE_MLLM'] = b'1'\n"
+    )
+    attribute_form_source = "import os\nos.environb[b'RAPID_MLX_FORCE_MLLM'] = b'1'\n"
+
+    def _count_environb_hits(source: str) -> int:
+        tree = ast.parse(source)
+        hits = 0
+        for node in ast.walk(tree):
+            os_attribute_form = (
+                isinstance(node, ast.Attribute)
+                and node.attr == "environb"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "os"
+            )
+            bare_name_form = isinstance(node, ast.Name) and node.id == "environb"
+            if os_attribute_form or bare_name_form:
+                hits += 1
+        return hits
+
+    assert _count_environb_hits(bare_form_source) >= 1, (
+        "bare-name `environb` reference must be detected — DeepSeek "
+        "regression: `from os import environb` strips the os. prefix."
+    )
+    assert _count_environb_hits(attribute_form_source) >= 1, (
+        "`os.environb` reference must still be detected (existing path)."
+    )
+
+
+def test_routing_write_dedup_is_location_based():
+    """DeepSeek-V4 review regression (PR #409): ``_all_routing_write_calls``
+    previously deduped by ``(id(node), attr)``. ``ast.walk`` yields the
+    enclosing ``ast.Expr`` AND the inner ``ast.Call`` for a statement
+    like ``setattr(engine, '_is_mllm', True)`` — same source location,
+    different Python object ids. The old key let both through; the
+    offender list double-printed the same offense.
+
+    The fix keys by ``(lineno, col_offset, attr)``. This regression
+    test parses a sample with a setattr() call, runs the dedup helper,
+    and asserts exactly one entry per source location.
+    """
+    source = "def f(engine):\n    setattr(engine, '_is_mllm', True)\n"
+    tree = ast.parse(source)
+    writes = _all_routing_write_calls(tree)
+    # Filter to the routing attr (avoids interference if helper grows).
+    is_mllm_writes = [w for w in writes if w[0] == "_is_mllm"]
+    assert len(is_mllm_writes) == 1, (
+        f"dedup must collapse Expr+Call sharing a source location, "
+        f"got {len(is_mllm_writes)} entries: {is_mllm_writes!r}."
+    )
+
+
+def test_conftest_deselect_gate_scoped_to_pytest_hook():
+    """DeepSeek-V4 review regression (PR #409): the conftest deselect
+    gate in ``test_no_mllm_flag.py`` previously walked every node in
+    every ``conftest.py`` looking for ``items.remove/pop/clear`` and
+    ``del items[…]`` — without checking the enclosing function name.
+    A legitimate helper that happens to use a local list named
+    ``items`` (e.g. ``def sort_records(records): items = ...;
+    items.remove(stale)``) would false-positive.
+
+    The fix scopes the AST scan to functions named
+    ``pytest_collection_modifyitems`` only. This regression test
+    parses both shapes in-memory and asserts the gated walker fires
+    only on the pytest hook form.
+    """
+    helper_source = (
+        "def some_helper(records):\n"
+        "    items = list(records)\n"
+        "    items.remove('stale')\n"
+        "    return items\n"
+    )
+    hook_source = (
+        "def pytest_collection_modifyitems(config, items):\n"
+        "    items.remove(items[0])\n"
+    )
+
+    def _gated_offenders(source: str) -> int:
+        tree = ast.parse(source)
+        hits = 0
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if func_node.name != "pytest_collection_modifyitems":
+                continue
+            for node in ast.walk(func_node):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "items"
+                    and func.attr in {"remove", "pop", "clear"}
+                ):
+                    hits += 1
+        return hits
+
+    assert _gated_offenders(helper_source) == 0, (
+        "gate must NOT fire on a local `items` list inside an unrelated "
+        "helper function — DeepSeek false-positive regression."
+    )
+    assert _gated_offenders(hook_source) == 1, (
+        "gate MUST still fire on items.remove() inside pytest_collection_modifyitems."
     )

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SOP §10 complement: no out-of-band routing escape hatches.
+
+``tests/test_no_mllm_flag.py`` gates the CLI + ``load_model`` surface.
+This file gates every OTHER surface where a contributor could sneak a
+routing decision in:
+
+  - Per-request: request body fields, headers, middleware
+  - Runtime mutation: setter methods, post-init writes to routing
+    attributes
+  - Environment: ``os.environ.get("RAPID_MLX_FORCE_*")`` etc.
+  - Engine API: ``engine.set_force_*`` / ``engine.set_*_mllm`` setters
+
+Round-4 red-team found 13 bypasses across these surfaces (5 per-request,
+5 env/config, 3 trust-attack). The SOP-§10 gate caught zero — the
+attacks didn't touch CLI or load_model at all. This file is the
+companion gate. The invariant: **routing fields are write-only inside
+their constructor (``__init__``) or the canonical load path
+(``load_model`` / ``detect_model_config`` / ``enrich_model_config``)
+from kwargs that are themselves registered in
+``AUTO_ROUTING_FLAG_PAIRS``**.
+
+When this fails: either move the routing decision into the registry
+(register a new ``RoutingFlagPair`` + plumb a CLI flag) or remove the
+shortcut. There is no third option — the whole point of the registry
+is that routing changes are visible and reviewable.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.resources
+import pathlib
+import re
+
+# ---------------------------------------------------------------------------
+# Constants — kept LOCAL to this file (not imported from test_no_mllm_flag)
+# so the two gates can evolve independently and a failure in one doesn't
+# cascade silently into the other.
+# ---------------------------------------------------------------------------
+
+
+# Attributes that ARE the routing decision. Any write to one of these is
+# a routing decision. The whitelist below names the only legitimate
+# write locations.
+ROUTING_ATTRS: frozenset[str] = frozenset(
+    {
+        "_is_mllm",  # BatchedEngine
+        "is_hybrid",  # ModelConfig
+        "is_moe",  # ModelConfig / AliasProfile
+        "supports_spec_decode",  # ModelConfig
+        "is_multimodal",  # ModelConfig (auto-detection output)
+        "supports_dflash",  # ModelConfig / AliasProfile
+    }
+)
+
+
+# Functions that MAY write to routing attributes. Anything else is an
+# escape hatch.
+ROUTING_WRITE_ALLOWED_FUNCS: frozenset[str] = frozenset(
+    {
+        "__init__",  # Constructor — the canonical write site.
+        "load_model",  # server.py public entry, hands kwargs to EngineCore.
+        # Model-config detection / enrichment. These compute routing
+        # fields from upstream sources (HF config.json, alias profile).
+        "detect_model_config",
+        "enrich_model_config",
+        "_coerce",  # model_aliases.py — builds AliasProfile.
+        "_load",  # model_aliases.py — file loader.
+        # `model_post_init` is Pydantic v2's standard "after validation"
+        # hook. Treated as constructor-equivalent.
+        "model_post_init",
+    }
+)
+
+
+# RAPID_MLX_* env vars that are allowed to exist. Routing-shaped env
+# vars (``RAPID_MLX_FORCE_*`` etc.) are NEVER allowed — they bypass
+# every CLI gate. Add a knob here only if it's a non-routing toggle
+# (debug verbosity, version-check disable, etc.).
+ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
+    {
+        "RAPID_MLX_DISABLE_VERSION_CHECK",  # opt-out of version check
+        "RAPID_MLX_PROFILE_VERBOSE",  # debug verbosity for profile logs
+        # Test/integration helpers — server URL for integration suites,
+        # not consulted at runtime by the engine.
+        "RAPID_MLX_BASE_URL",
+        # Telemetry consent toggle (off/on), not engine routing.
+        "RAPID_MLX_TELEMETRY",
+        # Port for doctor harness probe checks, not engine routing.
+        "RAPID_MLX_PORT",
+    }
+)
+
+
+# Per-request fields whose name happens to match the routing-shape
+# regex but are documented non-routing knobs (UX, chat-template,
+# behavior toggles). Same logic as ``NON_ROUTING_FLAGS_ALLOWLIST`` in
+# ``test_no_mllm_flag.py`` — explicit allowlist forces a discussion
+# in PR review.
+NON_ROUTING_PYDANTIC_FIELDS_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # OpenAI-compatible chat-template toggle (mirrors --no-thinking
+        # CLI flag, also non-routing-allowlisted there).
+        "enable_thinking",
+    }
+)
+
+
+ENV_VAR_ROUTING_PATTERN = re.compile(r"^RAPID_MLX_(?:FORCE|NO|ENABLE|DISABLE)_[A-Z_]+$")
+
+
+PYDANTIC_FIELD_ROUTING_PATTERN = re.compile(r"^(force_|no_|enable_|disable_)")
+
+
+SETTER_METHOD_ROUTING_PATTERN = re.compile(r"^set_(?:force_|no_|enable_|disable_|is_)")
+
+
+def _pkg_root() -> pathlib.Path:
+    return pathlib.Path(
+        str(importlib.resources.files("vllm_mlx").joinpath(""))
+    ).resolve()
+
+
+def _iter_module_files() -> list[pathlib.Path]:
+    """Every .py file under vllm_mlx/, excluding __pycache__ and vendored
+    upstream files. Vendored files (deepseek_v4.py) are explicitly
+    excluded because they're upstream code held as-is for clean sync."""
+    root = _pkg_root()
+    _VENDORED = frozenset({"models/deepseek_v4.py"})
+    out: list[pathlib.Path] = []
+    for path in root.rglob("*.py"):
+        if any(part.startswith("__") for part in path.parts[len(root.parts) :]):
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel in _VENDORED:
+            continue
+        out.append(path)
+    return out
+
+
+def _find_enclosing_function(
+    tree: ast.AST, target: ast.AST
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return the innermost function that contains ``target`` in
+    ``tree``, or ``None`` if ``target`` is at module level. Uses a
+    parent walk built from the tree."""
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+
+    cur: ast.AST | None = parents.get(id(target))
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def test_routing_fields_written_only_in_allowed_scopes():
+    """Round-4 cat-3 (per-request routing) — all 5 attacks bypassed the
+    SOP §10 gate by writing to ``engine._is_mllm`` / ``model_config.<routing
+    field>`` from a request handler, middleware, sampling helper, admin
+    endpoint, or env-var-driven branch — none of which the CLI/load_model
+    gate watches.
+
+    This test asserts the inverse invariant: routing fields are
+    write-only inside constructors and the canonical load path. Any
+    other write is an out-of-band escape hatch.
+
+    Allowed functions: ``__init__``, ``load_model``,
+    ``detect_model_config``, ``enrich_model_config``, ``_coerce``,
+    ``_load``, ``model_post_init``. See ``ROUTING_WRITE_ALLOWED_FUNCS``.
+
+    If you need to mutate a routing field from a new location, the
+    answer is almost always "add a new ``RoutingFlagPair`` entry in
+    ``test_no_mllm_flag.py`` and wire it through ``EngineCore.__init__``
+    via a kwarg". Adding to the allowlist here requires a written
+    justification (PR description) explaining why constructor mutation
+    isn't sufficient.
+    """
+    offenders: list[str] = []
+    pkg_root = _pkg_root()
+    for path in _iter_module_files():
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            # Match ``Assign`` to ``Attribute`` and ``AugAssign`` to
+            # ``Attribute`` (e.g. ``self.x |= ...``).
+            attr_targets: list[ast.Attribute] = []
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Attribute):
+                        attr_targets.append(t)
+            elif (
+                isinstance(node, ast.AugAssign)
+                and isinstance(node.target, ast.Attribute)
+                or isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Attribute)
+            ):
+                attr_targets.append(node.target)
+
+            for tgt in attr_targets:
+                if tgt.attr not in ROUTING_ATTRS:
+                    continue
+                enclosing = _find_enclosing_function(tree, node)
+                if enclosing is None:
+                    # Module-level write — always forbidden for routing fields.
+                    offenders.append(
+                        f"{rel}:{node.lineno} module-level write to routing "
+                        f"attribute `.{tgt.attr}` — not inside any function, "
+                        "no review surface. Routing decisions must live in "
+                        "AUTO_ROUTING_FLAG_PAIRS and be set by EngineCore.__init__."
+                    )
+                    continue
+                if enclosing.name in ROUTING_WRITE_ALLOWED_FUNCS:
+                    continue
+                offenders.append(
+                    f"{rel}:{node.lineno} writes routing attribute "
+                    f"`.{tgt.attr}` inside function `{enclosing.name}` — "
+                    f"only {sorted(ROUTING_WRITE_ALLOWED_FUNCS)} may write "
+                    "routing fields (round-4 cat-3 per-request bypass). "
+                    "If you need a new routing decision, add a "
+                    "RoutingFlagPair entry in test_no_mllm_flag.py and "
+                    "wire it through EngineCore.__init__."
+                )
+
+    assert not offenders, "\n".join(offenders)
+
+
+def test_no_routing_shaped_rapid_mlx_env_vars():
+    """Round-4 cat-4 (env-var/config routing) — 3 of 5 attacks read an
+    env var (``RAPID_MLX_FORCE_MLLM``, ``RAPID_MLX_FORCE_TEXT_MODE``)
+    at startup or request time and mutated routing without ever
+    touching the CLI surface.
+
+    This test forbids env var NAMES that match the routing-shape
+    pattern (``RAPID_MLX_(FORCE|NO|ENABLE|DISABLE)_*``). The check is
+    on the CONSTANT — even if the attacker reads the env var, the
+    constant string has to appear somewhere in source, and that string
+    can't be routing-shaped.
+
+    Non-routing env vars (``RAPID_MLX_PROFILE_VERBOSE``,
+    ``RAPID_MLX_DISABLE_VERSION_CHECK``) are allowlisted explicitly.
+    Add new non-routing env vars to ``ALLOWED_RAPID_MLX_ENV_VARS``
+    with a justification comment. NEVER add a routing-shaped name to
+    the allowlist — register a CLI flag pair instead.
+    """
+    offenders: list[str] = []
+    pkg_root = _pkg_root()
+    for path in _iter_module_files():
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant):
+                continue
+            if not isinstance(node.value, str):
+                continue
+            value = node.value
+            if not value.startswith("RAPID_MLX_"):
+                continue
+            if value in ALLOWED_RAPID_MLX_ENV_VARS:
+                continue
+            if ENV_VAR_ROUTING_PATTERN.match(value):
+                offenders.append(
+                    f"{rel}:{node.lineno} references env var `{value}` — "
+                    "matches the routing-shape pattern "
+                    "RAPID_MLX_(FORCE|NO|ENABLE|DISABLE)_*. Routing decisions "
+                    "must go through CLI flags, not env vars (round-4 cat-4 "
+                    "bypass). Register a RoutingFlagPair instead."
+                )
+            else:
+                offenders.append(
+                    f"{rel}:{node.lineno} references env var `{value}` — "
+                    "not in ALLOWED_RAPID_MLX_ENV_VARS. If this is a non-"
+                    "routing knob, add it to the allowlist with a comment. "
+                    "Routing env vars are forbidden."
+                )
+
+    assert not offenders, "\n".join(offenders)
+
+
+def test_no_routing_shaped_pydantic_fields_in_api():
+    """Round-4 cat-3 #1, #3 — attackers added ``force_mllm: bool`` to
+    ``ChatCompletionRequest`` and ``routing_override: dict`` to a
+    sampling-params helper. Both are per-request routing escape hatches
+    invisible to SOP §10.
+
+    This test forbids routing-shaped field names anywhere in
+    ``vllm_mlx/api/`` (Pydantic request/response models) and
+    ``vllm_mlx/routes/`` (handler-local fields). Catches the field
+    declaration regardless of where the handler reads it.
+    """
+    pkg_root = _pkg_root()
+    api_dir = pkg_root / "api"
+    routes_dir = pkg_root / "routes"
+
+    paths: list[pathlib.Path] = []
+    if api_dir.exists():
+        paths.extend(api_dir.rglob("*.py"))
+    if routes_dir.exists():
+        paths.extend(routes_dir.rglob("*.py"))
+
+    offenders: list[str] = []
+    for path in paths:
+        if any(part.startswith("__") for part in path.parts):
+            continue
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            # Pydantic field declarations are AnnAssign at class body
+            # level (e.g. ``force_mllm: bool = False``).
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                name = node.target.id
+                if name in NON_ROUTING_PYDANTIC_FIELDS_ALLOWLIST:
+                    continue
+                if PYDANTIC_FIELD_ROUTING_PATTERN.match(name):
+                    offenders.append(
+                        f"{rel}:{node.lineno} declares field `{name}` matching "
+                        "routing-shape pattern (force_/no_/enable_/disable_). "
+                        "Per-request routing fields are an out-of-band escape "
+                        "hatch (round-4 cat-3 #1/#3). Move the routing decision "
+                        "to a CLI flag in AUTO_ROUTING_FLAG_PAIRS."
+                    )
+
+    assert not offenders, "\n".join(offenders)
+
+
+def test_no_routing_setter_methods_on_engine():
+    """Round-4 cat-3 #4 — attacker added ``def set_force_mllm(self, v)``
+    to ``BatchedEngine`` and exposed it via an admin endpoint, flipping
+    routing live. SOP §10 watches ``__init__`` signatures but not
+    method names.
+
+    This test forbids method names matching ``set_(force_|no_|enable_|
+    disable_|is_)`` on any class in ``vllm_mlx/engine/``,
+    ``vllm_mlx/engine_core.py``, or ``vllm_mlx/server.py``. The
+    setter-method shape is the entire signal — read-only properties
+    and getters are fine.
+    """
+    pkg_root = _pkg_root()
+    targets = [
+        pkg_root / "engine_core.py",
+        pkg_root / "server.py",
+    ]
+    engine_dir = pkg_root / "engine"
+    if engine_dir.exists():
+        targets.extend(engine_dir.rglob("*.py"))
+
+    offenders: list[str] = []
+    for path in targets:
+        if not path.exists():
+            continue
+        if any(part.startswith("__") for part in path.parts):
+            continue
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if SETTER_METHOD_ROUTING_PATTERN.match(node.name):
+                offenders.append(
+                    f"{rel}:{node.lineno} defines `{node.name}` — routing-"
+                    "shaped setter method on engine/server. Routing fields "
+                    "are write-once at construction; runtime setters are an "
+                    "out-of-band escape hatch (round-4 cat-3 #4). Remove the "
+                    "setter and require a process restart for routing changes."
+                )
+
+    assert not offenders, "\n".join(offenders)
+
+
+def test_no_routing_shaped_request_headers():
+    """Round-4 cat-3 #2 — attacker added ``X-Rapid-MLX-Force-MLLM``
+    header read in middleware, mutating routing per-request. The
+    header NAME has to appear as a string constant somewhere.
+
+    Forbid any string constant matching ``X-Rapid-MLX-(Force|No|Enable|
+    Disable)-*`` in ``vllm_mlx/middleware/`` and ``vllm_mlx/routes/``.
+    The Rapid-MLX-prefixed header is our namespace, and the
+    routing-shape inside it has no legitimate use.
+    """
+    pkg_root = _pkg_root()
+    header_pattern = re.compile(
+        r"^X-Rapid-MLX-(?:Force|No|Enable|Disable)-", re.IGNORECASE
+    )
+
+    paths: list[pathlib.Path] = []
+    middleware_dir = pkg_root / "middleware"
+    routes_dir = pkg_root / "routes"
+    if middleware_dir.exists():
+        paths.extend(middleware_dir.rglob("*.py"))
+    if routes_dir.exists():
+        paths.extend(routes_dir.rglob("*.py"))
+
+    offenders: list[str] = []
+    for path in paths:
+        if any(part.startswith("__") for part in path.parts):
+            continue
+        rel = path.relative_to(pkg_root).as_posix()
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant):
+                continue
+            if not isinstance(node.value, str):
+                continue
+            if header_pattern.match(node.value):
+                offenders.append(
+                    f"{rel}:{node.lineno} references header `{node.value}` — "
+                    "routing-shaped per-request header. Routing decisions "
+                    "must come from process startup, not per-request "
+                    "(round-4 cat-3 #2)."
+                )
+
+    assert not offenders, "\n".join(offenders)

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -107,13 +107,25 @@ NON_ROUTING_PYDANTIC_FIELDS_ALLOWLIST: frozenset[str] = frozenset(
 )
 
 
-ENV_VAR_ROUTING_PATTERN = re.compile(r"^RAPID_MLX_(?:FORCE|NO|ENABLE|DISABLE)_[A-Z_]+$")
+ENV_VAR_ROUTING_PATTERN = re.compile(
+    # Round-5 subagent 3 broadened — drop RAPID_ prefix requirement so
+    # MLX_FORCE_*/NO_*/ENABLE_*/DISABLE_* are caught regardless of
+    # whether the contributor remembered the RAPID_ namespace.
+    r"^(?:RAPID_)?MLX_(?:FORCE|NO|ENABLE|DISABLE)_[A-Z_]+$"
+)
 
 
 PYDANTIC_FIELD_ROUTING_PATTERN = re.compile(r"^(force_|no_|enable_|disable_)")
 
 
-SETTER_METHOD_ROUTING_PATTERN = re.compile(r"^set_(?:force_|no_|enable_|disable_|is_)")
+SETTER_METHOD_ROUTING_PATTERN = re.compile(
+    # Round-5 subagent 2 broadened: also catch set_*mllm*, set_*hybrid*,
+    # set_*routing*, set_*moe*, set_*dflash*, set_*multimodal*, plus
+    # configure_*routing* — these all describe runtime routing flips
+    # without using the strict force_/no_ prefix.
+    r"^(?:set|configure)_(?:force_|no_|enable_|disable_|is_)"
+    r"|^(?:set|configure)_.*(?:mllm|hybrid|routing|moe|dflash|multimodal|spec_decode)"
+)
 
 
 def _pkg_root() -> pathlib.Path:
@@ -139,23 +151,163 @@ def _iter_module_files() -> list[pathlib.Path]:
     return out
 
 
-def _find_enclosing_function(
-    tree: ast.AST, target: ast.AST
-) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
-    """Return the innermost function that contains ``target`` in
-    ``tree``, or ``None`` if ``target`` is at module level. Uses a
-    parent walk built from the tree."""
+def _build_parent_map(tree: ast.AST) -> dict[int, ast.AST]:
     parents: dict[int, ast.AST] = {}
     for parent in ast.walk(tree):
         for child in ast.iter_child_nodes(parent):
             parents[id(child)] = parent
+    return parents
 
+
+def _enclosing_function_chain(
+    parents: dict[int, ast.AST], target: ast.AST
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return EVERY enclosing function from innermost to outermost.
+
+    Round-5 hardening (subagent 2 bypass): a nested function NAMED
+    ``__init__`` inside a real (non-allowed) method would pass the
+    innermost-only check because the immediate enclosing function name
+    matches the allowlist. By returning the full chain we let the
+    caller require EVERY ancestor function to be allowlisted — a
+    fake-nested-init slips past the innermost check but is caught
+    when we see the outer real handler isn't allowed.
+    """
+    chain: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
     cur: ast.AST | None = parents.get(id(target))
     while cur is not None:
         if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            return cur
+            chain.append(cur)
         cur = parents.get(id(cur))
-    return None
+    return chain
+
+
+def _routing_attr_write_targets(node: ast.AST) -> list[tuple[str, ast.AST]]:
+    """Return ``(attr_name, source_node)`` pairs for every routing-attr
+    write expressed by ``node``. Covers many indirect attribute-write
+    forms beyond ``Attribute`` assignment:
+
+      - ``self.x = ...`` (Assign target = Attribute)
+      - ``self.x: int = ...`` (AnnAssign with Attribute target)
+      - ``self.x |= ...`` (AugAssign with Attribute target)
+      - ``setattr(self, "x", ...)`` (round-5 subagent 5 #1)
+      - ``object.__setattr__(self, "x", ...)`` (#3)
+      - ``type(self).__setattr__(self, "x", ...)`` (#4)
+      - ``self.__dict__["x"] = ...`` (#5/6)
+      - ``vars(self)["x"] = ...`` (#5/7)
+      - ``del self.x`` / ``del vars(self)["x"]`` (also a routing mutation)
+
+    Round-5 subagent 5 demonstrated 11/14 setattr-style bypasses on the
+    previous Attribute-only scanner. This helper unifies all the shapes
+    so the gate doesn't drift.
+    """
+    pairs: list[tuple[str, ast.AST]] = []
+
+    # 1. Direct Attribute assignment / augassign / annassign.
+    attr_targets: list[ast.Attribute] = []
+    if isinstance(node, ast.Assign):
+        for t in node.targets:
+            if isinstance(t, ast.Attribute):
+                attr_targets.append(t)
+    elif (
+        isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Attribute)
+    ) or (isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Attribute)):
+        attr_targets.append(node.target)
+    for tgt in attr_targets:
+        pairs.append((tgt.attr, node))
+
+    # 2. Subscript assignment to .__dict__["x"] or vars(obj)["x"].
+    subscript_targets: list[ast.Subscript] = []
+    if isinstance(node, ast.Assign):
+        for t in node.targets:
+            if isinstance(t, ast.Subscript):
+                subscript_targets.append(t)
+    elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Subscript):
+        subscript_targets.append(node.target)
+
+    # ast.Delete: `del self.x` / `del vars(self)["x"]` — these clear a
+    # routing decision the same way an assignment of False would.
+    if isinstance(node, ast.Delete):
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Attribute):
+                pairs.append((tgt.attr, node))
+            elif isinstance(tgt, ast.Subscript):
+                subscript_targets.append(tgt)
+
+    for sub in subscript_targets:
+        # ``self.__dict__["x"] = ...`` — value is Attribute(attr="__dict__")
+        if (isinstance(sub.value, ast.Attribute) and sub.value.attr == "__dict__") or (
+            isinstance(sub.value, ast.Call)
+            and isinstance(sub.value.func, ast.Name)
+            and sub.value.func.id == "vars"
+        ):
+            key = sub.slice
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                pairs.append((key.value, node))
+
+    # 3. Call-form setattr / __setattr__ — second arg is the attr name.
+    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+        call = node.value
+    elif isinstance(node, ast.Call):
+        call = node
+    else:
+        call = None
+    # Also handle setattr as statement target (e.g. inside `if x: setattr(...)`).
+    # Walking standalone Call nodes inside the broader scanner picks them up,
+    # but for ``x := setattr(...)`` / list-comprehension wrappers the call is
+    # in an arbitrary expression context — those are scanned elsewhere too.
+    if call is not None:
+        func = call.func
+        if (
+            isinstance(func, ast.Name) and func.id == "setattr" and len(call.args) >= 2
+        ) or (
+            isinstance(func, ast.Attribute)
+            and func.attr == "__setattr__"
+            and len(call.args) >= 2
+        ):
+            name_arg = call.args[1]
+            if isinstance(name_arg, ast.Constant) and isinstance(name_arg.value, str):
+                pairs.append((name_arg.value, node))
+
+    return pairs
+
+
+def _all_routing_write_calls(tree: ast.AST) -> list[tuple[str, ast.AST]]:
+    """Walk every node in ``tree`` and return all
+    ``(routing_attr, node)`` writes. Distinct from
+    ``_routing_attr_write_targets`` (which is per-node) so the gate
+    can also catch setattr() / __dict__[] writes that aren't the
+    top-level statement node (e.g. inside walrus, comprehension)."""
+    out: list[tuple[str, ast.AST]] = []
+    for node in ast.walk(tree):
+        out.extend(_routing_attr_write_targets(node))
+        # Standalone call inside any expression context — setattr()
+        # via walrus or as a comprehension element.
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Name)
+                and func.id == "setattr"
+                and len(node.args) >= 2
+            ) or (
+                isinstance(func, ast.Attribute)
+                and func.attr == "__setattr__"
+                and len(node.args) >= 2
+            ):
+                name_arg = node.args[1]
+                if isinstance(name_arg, ast.Constant) and isinstance(
+                    name_arg.value, str
+                ):
+                    out.append((name_arg.value, node))
+    # Dedupe — Expr(Call(...)) and the inner Call both produce the same hit.
+    seen: set[tuple[int, str]] = set()
+    deduped: list[tuple[str, ast.AST]] = []
+    for attr, n in out:
+        key = (id(n), attr)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((attr, n))
+    return deduped
 
 
 def test_routing_fields_written_only_in_allowed_scopes():
@@ -193,45 +345,39 @@ def test_routing_fields_written_only_in_allowed_scopes():
         except SyntaxError:
             continue
 
-        for node in ast.walk(tree):
-            # Match ``Assign`` to ``Attribute`` and ``AugAssign`` to
-            # ``Attribute`` (e.g. ``self.x |= ...``).
-            attr_targets: list[ast.Attribute] = []
-            if isinstance(node, ast.Assign):
-                for t in node.targets:
-                    if isinstance(t, ast.Attribute):
-                        attr_targets.append(t)
-            elif (
-                isinstance(node, ast.AugAssign)
-                and isinstance(node.target, ast.Attribute)
-                or isinstance(node, ast.AnnAssign)
-                and isinstance(node.target, ast.Attribute)
-            ):
-                attr_targets.append(node.target)
-
-            for tgt in attr_targets:
-                if tgt.attr not in ROUTING_ATTRS:
-                    continue
-                enclosing = _find_enclosing_function(tree, node)
-                if enclosing is None:
-                    # Module-level write — always forbidden for routing fields.
-                    offenders.append(
-                        f"{rel}:{node.lineno} module-level write to routing "
-                        f"attribute `.{tgt.attr}` — not inside any function, "
-                        "no review surface. Routing decisions must live in "
-                        "AUTO_ROUTING_FLAG_PAIRS and be set by EngineCore.__init__."
-                    )
-                    continue
-                if enclosing.name in ROUTING_WRITE_ALLOWED_FUNCS:
-                    continue
+        parents = _build_parent_map(tree)
+        for attr_name, node in _all_routing_write_calls(tree):
+            if attr_name not in ROUTING_ATTRS:
+                continue
+            chain = _enclosing_function_chain(parents, node)
+            if not chain:
+                offenders.append(
+                    f"{rel}:{node.lineno} module-level write to routing "
+                    f"attribute `.{attr_name}` — not inside any function, "
+                    "no review surface. Routing decisions must live in "
+                    "AUTO_ROUTING_FLAG_PAIRS and be set by EngineCore.__init__."
+                )
+                continue
+            # Round-5 hardening: require EVERY ancestor function to be
+            # allowlisted, not just the innermost. A real handler
+            # `chat_completion` containing a nested `def __init__(): ...`
+            # would pass the old innermost-only check; the all-ancestors
+            # check catches it because `chat_completion` is not allowed.
+            disallowed = [
+                fn.name for fn in chain if fn.name not in ROUTING_WRITE_ALLOWED_FUNCS
+            ]
+            if disallowed:
                 offenders.append(
                     f"{rel}:{node.lineno} writes routing attribute "
-                    f"`.{tgt.attr}` inside function `{enclosing.name}` — "
-                    f"only {sorted(ROUTING_WRITE_ALLOWED_FUNCS)} may write "
-                    "routing fields (round-4 cat-3 per-request bypass). "
-                    "If you need a new routing decision, add a "
-                    "RoutingFlagPair entry in test_no_mllm_flag.py and "
-                    "wire it through EngineCore.__init__."
+                    f"`.{attr_name}` inside function chain "
+                    f"{[fn.name for fn in chain][::-1]} — function(s) "
+                    f"{disallowed} not in "
+                    f"{sorted(ROUTING_WRITE_ALLOWED_FUNCS)}. Round-5 subagent "
+                    "found nested-fn-named-__init__ inside non-allowed methods "
+                    "slips innermost-only checks; this gate now requires every "
+                    "ancestor to be allowlisted. Detected shapes include "
+                    "Assign, AnnAssign, AugAssign, Subscript (vars/__dict__), "
+                    "setattr(), object.__setattr__(), and ast.Delete."
                 )
 
     assert not offenders, "\n".join(offenders)
@@ -269,32 +415,67 @@ def test_no_routing_shaped_rapid_mlx_env_vars():
             continue
 
         for node in ast.walk(tree):
+            # Round-5 subagent 3 #B: bytes literal env vars
+            # (os.environb[b"RAPID_MLX_FORCE_MLLM"]) — decode and check
+            # the same pattern.
+            if isinstance(node, ast.Constant) and isinstance(node.value, bytes):
+                try:
+                    value = node.value.decode("ascii")
+                except UnicodeDecodeError:
+                    continue
+                _check_env_constant(value, rel, node.lineno, offenders)
+                continue
             if not isinstance(node, ast.Constant):
                 continue
             if not isinstance(node.value, str):
                 continue
-            value = node.value
-            if not value.startswith("RAPID_MLX_"):
-                continue
-            if value in ALLOWED_RAPID_MLX_ENV_VARS:
-                continue
-            if ENV_VAR_ROUTING_PATTERN.match(value):
+            _check_env_constant(node.value, rel, node.lineno, offenders)
+
+        # Round-5 subagent 3 #B: ban os.environb references entirely.
+        # No legitimate use, bytes-form env reads are a parallel surface.
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "environb"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "os"
+            ):
                 offenders.append(
-                    f"{rel}:{node.lineno} references env var `{value}` — "
-                    "matches the routing-shape pattern "
-                    "RAPID_MLX_(FORCE|NO|ENABLE|DISABLE)_*. Routing decisions "
-                    "must go through CLI flags, not env vars (round-4 cat-4 "
-                    "bypass). Register a RoutingFlagPair instead."
-                )
-            else:
-                offenders.append(
-                    f"{rel}:{node.lineno} references env var `{value}` — "
-                    "not in ALLOWED_RAPID_MLX_ENV_VARS. If this is a non-"
-                    "routing knob, add it to the allowlist with a comment. "
-                    "Routing env vars are forbidden."
+                    f"{rel}:{node.lineno} uses `os.environb` — bytes-form env "
+                    "var access bypasses the string-Constant scan. Use "
+                    "os.environ.get() with a documented str key instead."
                 )
 
     assert not offenders, "\n".join(offenders)
+
+
+def _check_env_constant(
+    value: str, rel: str, lineno: int, offenders: list[str]
+) -> None:
+    """Run the env-var routing checks against a single constant string."""
+    # Strip RAPID_ prefix for the routing-shape check so both
+    # RAPID_MLX_FORCE_* and MLX_FORCE_* are caught.
+    if not (value.startswith("RAPID_MLX_") or value.startswith("MLX_")):
+        return
+    if value in ALLOWED_RAPID_MLX_ENV_VARS:
+        return
+    if ENV_VAR_ROUTING_PATTERN.match(value):
+        offenders.append(
+            f"{rel}:{lineno} references env var `{value}` — matches the "
+            "routing-shape pattern (RAPID_)?MLX_(FORCE|NO|ENABLE|DISABLE)_*. "
+            "Routing decisions must go through CLI flags, not env vars "
+            "(round-4 cat-4 + round-5 subagent 3 #C). Register a "
+            "RoutingFlagPair instead."
+        )
+    elif value.startswith("RAPID_MLX_"):
+        # Only treat RAPID_MLX_ as our namespace; bare MLX_ may be from
+        # upstream mlx-lm or transformers.
+        offenders.append(
+            f"{rel}:{lineno} references env var `{value}` — not in "
+            "ALLOWED_RAPID_MLX_ENV_VARS. If this is a non-routing knob, "
+            "add it to the allowlist with a comment. Routing env vars "
+            "are forbidden."
+        )
 
 
 def test_no_routing_shaped_pydantic_fields_in_api():
@@ -408,28 +589,19 @@ def test_no_routing_shaped_request_headers():
     header read in middleware, mutating routing per-request. The
     header NAME has to appear as a string constant somewhere.
 
-    Forbid any string constant matching ``X-Rapid-MLX-(Force|No|Enable|
-    Disable)-*`` in ``vllm_mlx/middleware/`` and ``vllm_mlx/routes/``.
-    The Rapid-MLX-prefixed header is our namespace, and the
-    routing-shape inside it has no legitimate use.
+    Round-5 subagent 2 expanded scope: previously the scan was limited
+    to ``middleware/`` and ``routes/``; an attacker writing the same
+    header in ``server.py`` or ``api/`` slipped. Now scans every file
+    under ``vllm_mlx/`` because ``X-Rapid-MLX-`` is OUR namespace and
+    the routing-shape inside it has no legitimate use anywhere.
     """
     pkg_root = _pkg_root()
     header_pattern = re.compile(
         r"^X-Rapid-MLX-(?:Force|No|Enable|Disable)-", re.IGNORECASE
     )
 
-    paths: list[pathlib.Path] = []
-    middleware_dir = pkg_root / "middleware"
-    routes_dir = pkg_root / "routes"
-    if middleware_dir.exists():
-        paths.extend(middleware_dir.rglob("*.py"))
-    if routes_dir.exists():
-        paths.extend(routes_dir.rglob("*.py"))
-
     offenders: list[str] = []
-    for path in paths:
-        if any(part.startswith("__") for part in path.parts):
-            continue
+    for path in _iter_module_files():
         rel = path.relative_to(pkg_root).as_posix()
         try:
             source = path.read_text()
@@ -454,3 +626,53 @@ def test_no_routing_shaped_request_headers():
                 )
 
     assert not offenders, "\n".join(offenders)
+
+
+def test_alias_profile_str_fields_are_explicitly_listed():
+    """Round-5 subagent 3 #D: an attacker adds ``multimodal_mode: str =
+    "auto"`` to ``AliasProfile`` (passes round-4's name-shape check
+    because the name doesn't start with ``force_``/``no_``) and code
+    that branches on the value to flip routing. The previous gate
+    looked only at name shape — string-enum routing fields slip.
+
+    The defense: require an explicit per-field decision for every
+    ``str`` field on ``AliasProfile``. The allowlist below names every
+    legitimate string field with a one-line reason. Adding a new
+    string field requires editing this allowlist AND explaining what
+    the values mean — surfaces the routing-vs-data tradeoff at PR
+    review.
+    """
+    import dataclasses
+
+    from vllm_mlx.model_aliases import AliasProfile
+
+    # Explicit allowlist of AliasProfile string-typed fields. Every
+    # entry needs a 1-line reason describing the field's value space.
+    # Strings whose value space is open-ended (HF paths, parser names)
+    # are not routing decisions; strings whose value space is a small
+    # closed enum are LIKELY routing and should be flagged.
+    ALLOWED_STR_FIELDS: frozenset[str] = frozenset(
+        {
+            "hf_path",  # HF repo path, open-ended URL-like string
+            "tool_call_parser",  # parser key, see PARSER_REGISTRY
+            "reasoning_parser",  # parser key, see PARSER_REGISTRY
+            "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data
+            "dflash_draft_model",  # HF path for the spec-decode drafter
+        }
+    )
+
+    str_fields = [
+        f.name
+        for f in dataclasses.fields(AliasProfile)
+        if f.type is str or f.type == "str" or f.type == "str | None"
+    ]
+    unlisted = set(str_fields) - ALLOWED_STR_FIELDS
+    assert not unlisted, (
+        f"AliasProfile has unlisted string field(s): {sorted(unlisted)}. "
+        "Every str field on AliasProfile must be in ALLOWED_STR_FIELDS with "
+        "a 1-line reason. Round-5 subagent 3 #D showed that string-enum "
+        "fields (e.g. multimodal_mode: str = 'auto') are silent routing "
+        "escape hatches — name-shape regex misses them, value-space scans "
+        "are unreliable. The fix is closed-set: a new str field requires "
+        "explicit review."
+    )

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -117,6 +117,36 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: value must be a string or an object with "
             f"'hf_path', got {type(value).__name__}"
         )
+    # Closed-key schema: any unknown key is rejected at load time so a
+    # contributor can't sneak a covert routing flip into aliases.json
+    # (round-4 env-config attack #5). Adding a NEW field requires
+    # editing this set AND the dataclass — surfacing the change in
+    # review.
+    _ALLOWED_PROFILE_KEYS = frozenset(
+        {
+            "hf_path",
+            "tool_call_parser",
+            "reasoning_parser",
+            "is_hybrid",
+            "is_moe",
+            "supports_spec_decode",
+            "default_max_tokens",
+            "suffix_decoding_tier",
+            "suffix_bench_speedup",
+            "supports_dflash",
+            "dflash_draft_model",
+            "recommended_sampling",
+        }
+    )
+    unknown_keys = set(value.keys()) - _ALLOWED_PROFILE_KEYS
+    if unknown_keys:
+        raise ValueError(
+            f"alias {alias!r}: unknown key(s) {sorted(unknown_keys)}; allowed: "
+            f"{sorted(_ALLOWED_PROFILE_KEYS)}. If you intend to add a new "
+            "field, update both AliasProfile and _ALLOWED_PROFILE_KEYS — and "
+            "if the field is a routing decision (force_*/no_*), it must be "
+            "registered in tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS."
+        )
     hf_path = value["hf_path"]
     if not isinstance(hf_path, str) or not hf_path:
         raise ValueError(


### PR DESCRIPTION
## Summary

Tests-only PR. Extends SOP §10 (the routing-flag escape-hatch rule introduced for #393 in PR #407) into a registry-derived gate that catches almost every regression a contributor could introduce. Six rounds of adversarial red-team (5 subagents in parallel each round) drove the iteration; final state catches every realistic-contributor bypass found across 26 + ~13 attacks.

- **33 SOP gate tests** across 2 files, all derived from a single dataclass registry `AUTO_ROUTING_FLAG_PAIRS`
- **5 commits** stacked on `main` (v0.6.54): rounds 2 → 3 → 4 → 5 → 6
- **No production code changes** beyond a closed-key schema check in `vllm_mlx/model_aliases.py::_coerce`
- Full suite green: **3658 passed** (was 3648, +10 new tests)

## What this protects against

Adding a new auto-routing decision (e.g. \`--mllm\` in #393) requires editing exactly one place: \`AUTO_ROUTING_FLAG_PAIRS\` in \`tests/test_no_mllm_flag.py\`. That single edit auto-extends every check:

- Both \`--force-X\` and \`--no-X\` flags exist in every relevant CLI entrypoint
- \`load_model(...)\` accepts the override kwargs as keyword-only
- Every \`load_model\` call site forwards every override kwarg
- \`EngineCore.__init__\` actually mutates the corresponding \`ModelConfig\` field
- Mutex check fires if both directions are set
- Routing fields are write-only in allowed scopes (no per-request mutation)
- No covert escape hatches via env vars, headers, alias data, or setter methods

## Architecture (final state at \`46e7547\`)

| Surface | File | Gate count |
|---|---|---|
| CLI flags + load_model signature + EngineCore mutation | \`tests/test_no_mllm_flag.py\` | 27 tests |
| Per-request + env + alias-data + setter methods | \`tests/test_no_out_of_band_routing.py\` | 6 tests |
| AliasProfile JSON schema | \`vllm_mlx/model_aliases.py::_ALLOWED_PROFILE_KEYS\` | closed-key check |

### Detection prongs in \`test_no_unregistered_routing_shaped_flags\`
1. Positional literal flag in \`add_argument(...)\`
2. Routing-shaped string constant anywhere in entrypoint module
3. \`dest=\` aliasing onto a registered routing kwarg
4. Custom \`argparse.Action\` subclass (allowlist stdlib only)
5. Helper-function indirection (\`add_argument(<non-Constant>, ...)\`)
6. \`add_argument(..., **dict)\` unpack
7. \`getattr(p, \"add_argument\")(...)\` indirection

### Detection layers in \`test_routing_fields_written_only_in_allowed_scopes\`
- Direct \`self.x = ...\` (Assign/AnnAssign/AugAssign on Attribute)
- \`setattr(obj, \"x\", ...)\`, \`object.__setattr__(...)\`
- \`vars(obj)[\"x\"] = ...\`, \`obj.__dict__[\"x\"] = ...\`
- \`del obj.x\` / \`del vars(obj)[\"x\"]\`
- ALL ancestor functions must be allowlisted (catches fake-nested-\`__init__\`)

## Red-team iteration log

| Round | Attack count | Slipped | Action |
|-------|------|---------|--------|
| 2 | ~5 | 3 | Single-registry refactor (commit \`985b2f0\`) |
| 3 | ~10 | 7 | AST-parse stringified annotations, custom-\`__bool__\` detection, entrypoint discovery, registry invariants (\`014b0e7\`) |
| 4 | 26 across 5 categories | 18 | dest= scan, custom Action ban, registry-mutation gate, out-of-band routing gate, alias schema lock (\`8bc45ae\`) |
| 5 | ~13 | (all closed in round 6) | — |
| 6 | n/a (fixes) | — | setattr/dict/del coverage, ancestor-chain check, MLX_FORCE_* broadening, os.environb ban, AliasProfile str-field allowlist, RoutingFlagPair *args ban, conftest del items[i] (\`46e7547\`) |

Worktree contention bit us in round 4 — subagents using shared paths corrupted the local \`harden/sop-gate-coverage\` ref with attack commits. Recovered via reset to \`raullenchai/harden/sop-gate-coverage\`. Round 5+ explicitly instructed subagents to stay in their isolated worktree.

## Acknowledged out-of-AST gaps
- \`exec(\"engine._is_mllm = True\")\` — string-quoted assignment
- \`importlib.import_module(...)\` of external .py with routing writes
- \`monkeypatch pathlib.Path.read_text\` to mask the source-AST scan

These require deliberate conspicuous code; rely on PR review.

## Test plan
- [x] \`python3.12 -m pytest tests/test_no_mllm_flag.py tests/test_no_out_of_band_routing.py -v\` → 33 passed
- [x] \`python3.12 -m pytest tests/ -q --ignore=tests/integrations --ignore=tests/test_event_loop.py\` → 3658 passed, 19 skipped, 16 deselected, 1 xfailed
- [x] \`ruff check tests/test_no_mllm_flag.py tests/test_no_out_of_band_routing.py vllm_mlx/model_aliases.py\` → clean
- [x] \`ruff format --check\` → clean
- [ ] Manually verify the AliasProfile schema-lock doesn't false-positive on any aliases.json edits in flight
- [ ] Codex multi-round review

## Follow-ups (not in this PR)
- #408 (v0.6.53+ import crash on mlx 0.31.2) — separate hotfix, 1-line hasattr guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)