### PR TITLE
fix(#413): Anthropic non-streaming preserves reasoning via thinking block

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -382,8 +382,18 @@ class TestAnthropicToOpenai:
 class TestOpenaiToAnthropic:
     """Tests for openai_to_anthropic conversion."""
 
-    def _make_response(self, content="hello", finish_reason="stop", tool_calls=None):
-        msg = AssistantMessage(content=content, tool_calls=tool_calls)
+    def _make_response(
+        self,
+        content="hello",
+        finish_reason="stop",
+        tool_calls=None,
+        reasoning_content=None,
+    ):
+        msg = AssistantMessage(
+            content=content,
+            tool_calls=tool_calls,
+            reasoning_content=reasoning_content,
+        )
         choice = ChatCompletionChoice(message=msg, finish_reason=finish_reason)
         return ChatCompletionResponse(
             model="default",
@@ -473,3 +483,44 @@ class TestOpenaiToAnthropic:
         result = openai_to_anthropic(resp, "test-model")
         assert result.id.startswith("msg_")
         assert result.model == "test-model"
+
+    def test_reasoning_content_becomes_thinking_block(self):
+        """#413 fix: reasoning_content on the OpenAI response must appear
+        as a ``thinking`` content block on the Anthropic response,
+        placed BEFORE the text block to match Anthropic's
+        extended-thinking SDK convention."""
+        resp = self._make_response(
+            content="Final answer.",
+            reasoning_content="Let me think.",
+        )
+        result = openai_to_anthropic(resp, "default")
+        assert len(result.content) == 2
+        assert result.content[0].type == "thinking"
+        assert result.content[0].thinking == "Let me think."
+        assert result.content[1].type == "text"
+        assert result.content[1].text == "Final answer."
+
+    def test_reasoning_content_with_tool_calls(self):
+        """Thinking block + text + tool_use coexist, in that order."""
+        tc = ToolCall(
+            id="call_1",
+            type="function",
+            function=FunctionCall(name="search", arguments='{"q":"x"}'),
+        )
+        resp = self._make_response(
+            content="Calling search.",
+            reasoning_content="I need to look this up.",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+        result = openai_to_anthropic(resp, "default")
+        assert [b.type for b in result.content] == ["thinking", "text", "tool_use"]
+        assert result.content[0].thinking == "I need to look this up."
+
+    def test_no_reasoning_content_omits_thinking_block(self):
+        """Absence of reasoning_content must NOT produce a thinking
+        block (avoids leaking empty placeholders into clients that
+        check ``content_block[0].type``)."""
+        resp = self._make_response(content="hi", reasoning_content=None)
+        result = openai_to_anthropic(resp, "default")
+        assert all(b.type != "thinking" for b in result.content)

--- a/tests/test_chat_route_tool_tag_leak.py
+++ b/tests/test_chat_route_tool_tag_leak.py
@@ -17,7 +17,7 @@ reasoning parser to recover reasoning_text from the raw output.
 from types import SimpleNamespace
 
 from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
-from vllm_mlx.routes.chat import _finalize_content_and_reasoning
+from vllm_mlx.service.helpers import _finalize_content_and_reasoning
 from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
 
 

--- a/tests/test_paired_compat.py
+++ b/tests/test_paired_compat.py
@@ -324,36 +324,20 @@ def test_plain_text_agrees(stream):
     assert openai["tool_calls"] == anthropic["tool_calls"] == []
 
 
-@pytest.mark.parametrize(
-    "stream",
-    [
-        True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(
-                strict=False,
-                reason=(
-                    "strict=False: Anthropic non-streaming drops reasoning "
-                    "content silently — surface-divergence bug discovered by "
-                    "this gate (issue #413). Un-xfail once routes/anthropic.py "
-                    "non-streaming path populates reasoning_content and "
-                    "api/anthropic_adapter.py emits a thinking block."
-                ),
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("stream", [True, False])
 def test_reasoning_extracted_consistently(stream):
     """A delta stream containing ``<think>...</think>answer`` must
     decompose identically through both routes' reasoning parser
-    (qwen3 → reasoning_content for OpenAI, thinking_delta for Anthropic).
+    (qwen3 → reasoning_content for OpenAI, thinking_delta / thinking
+    block for Anthropic).
 
     This is the exact class #288/#289 hit: the parser routed correctly
     on one surface and silently leaked tags to the other.
 
-    Non-streaming is currently xfail — see #413. The fact that this
-    gate immediately surfaced a latent bug the moment it was wired up
-    is exactly the value we're paying for.
+    Non-streaming used to xfail under #413 — Anthropic dropped reasoning
+    on the floor while OpenAI preserved it. Closed by populating
+    reasoning_content in the non-streaming path and emitting a
+    ``thinking`` content block from the adapter.
     """
     # With server-default thinking on, qwen3 parser routes pre-</think>
     # text to reasoning, post-</think> text to content.

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -119,6 +119,18 @@ def openai_to_anthropic(
     choice = response.choices[0] if response.choices else None
 
     if choice:
+        # Add thinking block FIRST so it appears before the answer text,
+        # matching Anthropic's extended-thinking SDK convention. Without
+        # this block ``<think>...</think>`` reasoning would silently
+        # disappear from the non-streaming response — issue #413.
+        if choice.message.reasoning_content:
+            content.append(
+                AnthropicResponseContentBlock(
+                    type="thinking",
+                    thinking=choice.message.reasoning_content,
+                )
+            )
+
         # Add text content
         if choice.message.content:
             content.append(

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -84,8 +84,10 @@ class AnthropicUsage(BaseModel):
 class AnthropicResponseContentBlock(BaseModel):
     """A content block in the Anthropic response."""
 
-    type: str  # "text" or "tool_use"
+    type: str  # "text", "thinking", or "tool_use"
     text: str | None = None
+    # thinking-block field (Anthropic extended-thinking surface)
+    thinking: str | None = None
     # tool_use fields
     id: str | None = None
     name: str | None = None

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -24,6 +24,7 @@ from ..api.utils import (
     StreamingToolCallFilter,
     clean_output_text,
     extract_multimodal_content,
+    sanitize_output,
     strip_special_tokens,
     strip_thinking_tags,
 )
@@ -33,6 +34,7 @@ from ..middleware.auth import check_rate_limit_or_x_api_key, verify_api_key_or_x
 from ..service.helpers import (
     _build_usage,
     _disconnect_guard,
+    _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -200,9 +202,25 @@ async def create_anthropic_message(
         output.text, openai_request
     )
 
+    # Extract reasoning content via the same orchestration the OpenAI route
+    # uses (chat.py). Skipping this is what #413 fixed — the Anthropic surface
+    # used to silently drop ``<think>...</think>`` content on the non-streaming
+    # path while OpenAI preserved it as ``reasoning_content``.
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text=output.text,
+        cleaned_text=cleaned_text,
+        tool_calls=tool_calls,
+        reasoning_parser=cfg.reasoning_parser,
+    )
+
     final_content = None
     if cleaned_text:
         final_content = strip_thinking_tags(clean_output_text(cleaned_text))
+        # Final defense against special-token / markup leakage — mirrors
+        # chat.py:669 so the two surfaces don't diverge on what they
+        # consider "sanitized" client-facing content. Pre-existing gap
+        # flagged by codex during the #413 review.
+        final_content = sanitize_output(final_content)
 
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
 
@@ -212,12 +230,13 @@ async def create_anthropic_message(
             ChatCompletionChoice(
                 message=AssistantMessage(
                     content=final_content,
+                    reasoning_content=reasoning_text,
                     tool_calls=tool_calls,
                 ),
                 finish_reason=finish_reason,
             )
         ],
-        usage=_build_usage(output, None),
+        usage=_build_usage(output, reasoning_text),
     )
 
     anthropic_response = openai_to_anthropic(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -46,6 +46,7 @@ from ..service.helpers import (
     _build_usage,
     _disconnect_guard,
     _extract_streaming_token_logprobs,
+    _finalize_content_and_reasoning,
     _inject_json_instruction,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
@@ -119,42 +120,6 @@ def _strip_backslash_before_unicode(obj: object) -> object:
     if isinstance(obj, str):
         return _BACKSLASH_BEFORE_UNICODE.sub(r"\1", obj)
     return obj
-
-
-def _finalize_content_and_reasoning(
-    raw_text: str,
-    cleaned_text: str,
-    tool_calls: list,
-    reasoning_parser,
-) -> tuple[str, str | None]:
-    """Compute final ``content`` + ``reasoning_text`` after tool parsing.
-
-    Pulled out of the request handler so the regression suite can drive
-    the EXACT same orchestration the production path uses, instead of
-    maintaining a parallel reimplementation that can silently drift.
-
-    Rule (drives the unclosed-`<tool_call>` leak fix in PR #208): when
-    the tool parser successfully extracted ``tool_calls`` its
-    ``cleaned_text`` is authoritative — both ``<think>`` and tool tags
-    are already stripped. Run the reasoning parser on the raw output
-    only to recover ``reasoning_text``, never to overwrite
-    ``cleaned_text`` (that path would re-introduce the tool tags the
-    parser stripped, since the reasoning parser only knows about
-    ``<think>``).
-
-    When no tool_calls fire, the reasoning parser is the only thing
-    that can pull ``<think>`` out — run it on cleaned_text (or raw
-    output if cleaning produced an empty string).
-    """
-    reasoning_text = None
-    if reasoning_parser is None:
-        return cleaned_text, reasoning_text
-    if tool_calls:
-        reasoning_text, _ = reasoning_parser.extract_reasoning(raw_text)
-    else:
-        text_to_parse = cleaned_text or raw_text
-        reasoning_text, cleaned_text = reasoning_parser.extract_reasoning(text_to_parse)
-    return cleaned_text, reasoning_text
 
 
 @router.post(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -38,6 +38,43 @@ _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
 
 
+def _finalize_content_and_reasoning(
+    raw_text: str,
+    cleaned_text: str,
+    tool_calls: list,
+    reasoning_parser,
+) -> tuple[str, str | None]:
+    """Compute final ``content`` + ``reasoning_text`` after tool parsing.
+
+    Shared between the OpenAI ``/v1/chat/completions`` and Anthropic
+    ``/v1/messages`` non-streaming paths so both surfaces extract
+    reasoning identically — bypassing this on one route was the
+    silent-divergence bug filed as issue #413.
+
+    Rule (drives the unclosed-`<tool_call>` leak fix in PR #208): when
+    the tool parser successfully extracted ``tool_calls`` its
+    ``cleaned_text`` is authoritative — both ``<think>`` and tool tags
+    are already stripped. Run the reasoning parser on the raw output
+    only to recover ``reasoning_text``, never to overwrite
+    ``cleaned_text`` (that path would re-introduce the tool tags the
+    parser stripped, since the reasoning parser only knows about
+    ``<think>``).
+
+    When no tool_calls fire, the reasoning parser is the only thing
+    that can pull ``<think>`` out — run it on cleaned_text (or raw
+    output if cleaning produced an empty string).
+    """
+    reasoning_text = None
+    if reasoning_parser is None:
+        return cleaned_text, reasoning_text
+    if tool_calls:
+        reasoning_text, _ = reasoning_parser.extract_reasoning(raw_text)
+    else:
+        text_to_parse = cleaned_text or raw_text
+        reasoning_text, cleaned_text = reasoning_parser.extract_reasoning(text_to_parse)
+    return cleaned_text, reasoning_text
+
+
 def _cascade(cli_value, alias_key: str, gen_key: str | None = None):
     """Layers 3+4 of the sampling resolve chain.
 


### PR DESCRIPTION
Closes #413.

## Summary
- ``/v1/messages`` with ``stream: false`` used to silently drop ``<think>...</think>`` content. OpenAI ``/v1/chat/completions`` non-streaming preserved it as ``reasoning_content``. The paired-compat gate added in #412 found this and the corresponding parametrize case was xfailed pending this fix.
- Moves the shared orchestration (``_finalize_content_and_reasoning``) into ``service/helpers.py`` so both routes use byte-identical extraction logic.
- Adds a ``thinking: str | None`` field to ``AnthropicResponseContentBlock``; ``openai_to_anthropic`` emits a ``thinking`` block before the text block when ``reasoning_content`` is set, matching Anthropic's extended-thinking SDK ordering.
- Bonus parity fix flagged by codex during this review: adds the missing ``sanitize_output(final_content)`` call on the Anthropic non-streaming path (pre-existing gap vs chat.py:669, special-token last-defense leakage).
- Un-xfails ``test_reasoning_extracted_consistently[False]`` in the paired-compat suite.

## Test plan
- [x] ``python3.12 -m pytest tests/test_paired_compat.py -v`` — 10 passed, 0 xfailed (was 9 + 1)
- [x] ``python3.12 -m pytest tests/test_anthropic_adapter.py -v`` — pre-existing + 3 new tests pin: thinking block with text-only, with tool_calls (ordering: thinking→text→tool_use), absent
- [x] Full unit suite: ``3660 passed, 19 skipped, 1 xfailed`` (unrelated)
- [x] Lint + format clean on all 8 touched files
- [x] Codex review converged in 2 rounds (round 1 flagged sanitize_output parity gap → fixed in this same commit)
- [ ] CI green
- [ ] ``make smoke`` (inference-touching gate per SOP) — running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)