### PR TITLE
fix(api): R10 sweep validation hardening + LB-friendly probes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.56"
+version = "0.6.57"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/integrations/test_anthropic_sdk.py
+++ b/tests/integrations/test_anthropic_sdk.py
@@ -35,12 +35,21 @@ def _first_text(response) -> str:
 
 results = {}
 
+# Reasoning models burn dozens-to-hundreds of tokens inside the
+# ``thinking`` block before emitting any visible text — give them
+# enough headroom on small models (qwen3-0.6b) to finish thinking +
+# answer. Per-test caps are unchanged in spirit (small enough that a
+# loop is still bounded); they're just lifted off the old 50-token
+# floor that pre-dated thinking-block emission in v0.6.56.
+_MAX_TOKENS_SHORT = 256
+_MAX_TOKENS_LONG = 384
+
 # === 1. Plain message ===
 print("=== Test 1: Plain message ===")
 try:
     r = client.messages.create(
         model=MODEL_ID,
-        max_tokens=50,
+        max_tokens=_MAX_TOKENS_SHORT,
         messages=[
             {"role": "user", "content": "What is 2+2? Reply with just the number."}
         ],
@@ -58,7 +67,7 @@ print("\n=== Test 2: System prompt ===")
 try:
     r = client.messages.create(
         model=MODEL_ID,
-        max_tokens=50,
+        max_tokens=_MAX_TOKENS_SHORT,
         system="You are a calculator. Output only the integer result.",
         messages=[{"role": "user", "content": "9 * 8"}],
     )
@@ -78,7 +87,9 @@ try:
         {"role": "assistant", "content": "Got it, your favorite color is blue."},
         {"role": "user", "content": "What is my favorite color?"},
     ]
-    r = client.messages.create(model=MODEL_ID, max_tokens=80, messages=msgs)
+    r = client.messages.create(
+        model=MODEL_ID, max_tokens=_MAX_TOKENS_LONG, messages=msgs
+    )
     text = _first_text(r)
     assert "blue" in text.lower(), text
     print(f"PASS: {text[:80]}")
@@ -93,7 +104,7 @@ try:
     chunks = []
     with client.messages.stream(
         model=MODEL_ID,
-        max_tokens=80,
+        max_tokens=_MAX_TOKENS_LONG,
         messages=[{"role": "user", "content": "Count from 1 to 5, comma-separated."}],
     ) as stream:
         for text in stream.text_stream:

--- a/tests/integrations/test_anthropic_sdk.py
+++ b/tests/integrations/test_anthropic_sdk.py
@@ -18,6 +18,21 @@ client = Anthropic(
     api_key="not-needed",
 )
 
+
+def _first_text(response) -> str:
+    """Return the first text block's text from an Anthropic response.
+
+    Models with reasoning enabled now emit a ``thinking`` block first
+    (PR #414, v0.6.56), so the legacy ``response.content[0].text`` lookup
+    raises ``AttributeError: 'ThinkingBlock' object has no attribute 'text'``.
+    Walk the content list and return the first ``type='text'`` block.
+    """
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            return block.text
+    raise AssertionError(f"No text block in response.content: {response.content}")
+
+
 results = {}
 
 # === 1. Plain message ===
@@ -30,7 +45,7 @@ try:
             {"role": "user", "content": "What is 2+2? Reply with just the number."}
         ],
     )
-    text = r.content[0].text
+    text = _first_text(r)
     assert "4" in text, text
     print(f"PASS: {text[:80]}")
     results["1_plain"] = "PASS"
@@ -47,7 +62,7 @@ try:
         system="You are a calculator. Output only the integer result.",
         messages=[{"role": "user", "content": "9 * 8"}],
     )
-    text = r.content[0].text
+    text = _first_text(r)
     assert "72" in text, text
     print(f"PASS: {text[:80]}")
     results["2_system"] = "PASS"
@@ -64,7 +79,7 @@ try:
         {"role": "user", "content": "What is my favorite color?"},
     ]
     r = client.messages.create(model=MODEL_ID, max_tokens=80, messages=msgs)
-    text = r.content[0].text
+    text = _first_text(r)
     assert "blue" in text.lower(), text
     print(f"PASS: {text[:80]}")
     results["3_multi_turn"] = "PASS"

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -9,6 +9,8 @@ These are pure Pydantic models with no MLX dependency.
 import json
 import time
 
+import pytest
+
 from vllm_mlx.api.models import (
     AssistantMessage,
     AudioSeparationRequest,
@@ -285,6 +287,25 @@ class TestChatCompletion:
         assert req.video_fps == 1.0
         assert req.video_max_frames == 16
 
+    def test_logit_bias_declared(self):
+        """logit_bias must round-trip through the schema. Without an
+        explicit declaration Pydantic silently drops the field on parse,
+        so any rejection in the route handler never sees it."""
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+            logit_bias={"50000": -100.0, "12345": 5.5},
+        )
+        assert req.logit_bias == {"50000": -100.0, "12345": 5.5}
+
+    def test_logit_bias_defaults_none(self):
+        """logit_bias is optional and defaults to None when omitted."""
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+        )
+        assert req.logit_bias is None
+
     def test_assistant_message_reasoning(self):
         msg = AssistantMessage(
             content="The answer is 42.",
@@ -542,6 +563,32 @@ class TestEmbeddingModels:
         data = EmbeddingData(index=0, embedding=[0.1, 0.2, 0.3])
         assert data.object == "embedding"
         assert len(data.embedding) == 3
+
+    def test_embedding_data_accepts_base64_string(self):
+        """embedding may also be a base64-encoded string when the request
+        used encoding_format=base64."""
+        data = EmbeddingData(index=0, embedding="AAAAAA==")
+        assert data.embedding == "AAAAAA=="
+
+    def test_embedding_request_accepts_dimensions(self):
+        """OpenAI MRL-style truncation field must round-trip; previously
+        the field was silently dropped by the schema."""
+        req = EmbeddingRequest(input="hi", model="bert", dimensions=128)
+        assert req.dimensions == 128
+
+    def test_embedding_request_accepts_user(self):
+        """OpenAI abuse-tracking field must be accepted (not validated)."""
+        req = EmbeddingRequest(input="hi", model="bert", user="account-42")
+        assert req.user == "account-42"
+
+    def test_embedding_request_rejects_unknown_fields(self):
+        """extra='forbid' surfaces unknown fields as 422 errors rather
+        than silently dropping them. Catches typos like ``encodingformat``
+        or fields the server hasn't implemented yet."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            EmbeddingRequest(input="hi", model="bert", unknown_field="oops")
 
     def test_embedding_usage(self):
         usage = EmbeddingUsage(prompt_tokens=5, total_tokens=5)

--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -227,6 +227,9 @@ def _build_embed_app(patch_cfg, monkeypatch, embed_return):
 
 class TestEmbeddingsRoute:
     def test_dimensions_truncates_vector(self, patched_config, monkeypatch):
+        """Slice to the requested length, then L2-normalize so the
+        result is still a valid embedding (see
+        test_truncated_vector_is_unit_norm for the why)."""
         embed = [[0.1 * i for i in range(384)]]
         client, _ = _build_embed_app(patched_config, monkeypatch, embed)
         r = client.post(
@@ -236,7 +239,9 @@ class TestEmbeddingsRoute:
         assert r.status_code == 200, r.text
         vec = r.json()["data"][0]["embedding"]
         assert len(vec) == 64
-        assert vec[:3] == [0.0, 0.1, 0.2]
+        import math as _m
+
+        assert abs(_m.sqrt(sum(x * x for x in vec)) - 1.0) < 1e-6
 
     def test_dimensions_zero_rejected(self, patched_config, monkeypatch):
         embed = [[0.0] * 16]
@@ -283,7 +288,7 @@ class TestEmbeddingsRoute:
 
     def test_base64_plus_dimensions_combine(self, patched_config, monkeypatch):
         """Truncation happens BEFORE base64 encoding so the packed
-        length matches `dimensions`."""
+        length matches `dimensions`. Result is also L2-normalized."""
         original = [float(i) for i in range(16)]
         client, _ = _build_embed_app(patched_config, monkeypatch, [original])
 
@@ -298,8 +303,71 @@ class TestEmbeddingsRoute:
         )
         assert r.status_code == 200
         encoded = r.json()["data"][0]["embedding"]
-        decoded = struct.unpack("<4f", base64.b64decode(encoded))
-        assert list(decoded) == [0.0, 1.0, 2.0, 3.0]
+        decoded = list(struct.unpack("<4f", base64.b64decode(encoded)))
+        # Truncated [0,1,2,3] L2-normalized: norm=sqrt(14)
+        import math as _m
+
+        norm = _m.sqrt(sum(x * x for x in [0.0, 1.0, 2.0, 3.0]))
+        expected = [x / norm for x in [0.0, 1.0, 2.0, 3.0]]
+        for got, want in zip(decoded, expected):
+            assert abs(got - want) < 1e-6
+
+    def test_dimensions_above_model_dim_rejected(self, patched_config, monkeypatch):
+        """Per OpenAI spec: requesting more dimensions than the model
+        produces must 400, not silently return the full vector."""
+        client, _ = _build_embed_app(
+            patched_config, monkeypatch, [[0.1, 0.2, 0.3, 0.4]]
+        )
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "any", "input": "hi", "dimensions": 9999},
+        )
+        assert r.status_code == 400
+        assert "dimensions" in r.json()["detail"].lower()
+
+    def test_truncated_vector_is_unit_norm(self, patched_config, monkeypatch):
+        """MRL-style truncation requires L2-renormalization for the
+        result to be a valid cosine-similarity embedding (OpenAI
+        cookbook for text-embedding-3-large). A naive slice without
+        normalization is mathematically wrong for any MRL model."""
+        embed = [[3.0, 4.0, 0.0, 0.0, 0.0]]
+        client, _ = _build_embed_app(patched_config, monkeypatch, embed)
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "any", "input": "hi", "dimensions": 2},
+        )
+        assert r.status_code == 200
+        vec = r.json()["data"][0]["embedding"]
+        import math as _m
+
+        norm = _m.sqrt(sum(x * x for x in vec))
+        # Expect unit norm. Sliced (3,4) has norm 5 → normalized (0.6,0.8).
+        assert abs(norm - 1.0) < 1e-6
+        assert abs(vec[0] - 0.6) < 1e-6
+        assert abs(vec[1] - 0.8) < 1e-6
+
+
+class TestEmbeddingsEncodingFormatLiteral:
+    """Pydantic Literal narrowing replaces the silent-fallback bug:
+    unknown encoding_format values now 422 at parse time."""
+
+    def test_unknown_encoding_format_rejected(self):
+        """Catches typos like 'base65', 'BASE64', 'json' — previously
+        they all silently returned a float list."""
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        for bogus in ["base65", "BASE64", "json", "raw"]:
+            with pytest.raises(ValidationError):
+                EmbeddingRequest(input="hi", model="x", encoding_format=bogus)
+
+    def test_valid_encoding_formats_accepted(self):
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        for ok in ["float", "base64"]:
+            req = EmbeddingRequest(input="hi", model="x", encoding_format=ok)
+            assert req.encoding_format == ok
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Route-level validation hardening (R10 sweep follow-up).
+
+Each test pins behavior that the onboarding sweep showed was silently
+broken — e.g. ``model: ""`` returning 200 with the default model,
+``top_p=2.0`` accepted without error, ``logit_bias`` silently dropped,
+``encoding_format=base64`` ignored on /v1/embeddings.
+"""
+
+import argparse
+import base64
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    """Patch select fields on the global cfg singleton and restore on exit.
+
+    Mirrors the pattern in test_routes.py — avoids the ``setattr``/``leak
+    into next test`` hazard of touching the singleton directly.
+    """
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+# ---------------------------------------------------------------------------
+# _validate_model_name — empty string must 400, not silently use default
+# ---------------------------------------------------------------------------
+
+
+class TestValidateModelName:
+    def test_empty_string_raises_400(self):
+        """``model: ""`` used to short-circuit to the default model,
+        masking client bugs (typos, unset env vars)."""
+        from vllm_mlx.service.helpers import _validate_model_name
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_model_name("")
+        assert ei.value.status_code == 400
+        assert "empty" in ei.value.detail.lower()
+
+    def test_none_still_passes_through(self):
+        """``None`` continues to be a no-op so callers that pass an
+        unset request.model field don't break."""
+        from vllm_mlx.service.helpers import _validate_model_name
+
+        # Should not raise.
+        _validate_model_name(None)
+
+
+# ---------------------------------------------------------------------------
+# Chat completion validation block — top_p, max_tokens cap, logit_bias
+# ---------------------------------------------------------------------------
+
+
+def _build_chat_app(patch_cfg, monkeypatch):
+    """Mount the chat router with a stub engine so we can hit the
+    validation block without touching mlx weights."""
+    from vllm_mlx.routes import chat as chat_route
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+
+    # get_engine() inside the route resolves to this stub; if validation
+    # passes, the test's other assertions take over (or the engine call
+    # fails downstream, which is fine — we only care about the 400 path).
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+    # raise_server_exceptions=False so downstream-pipeline failures
+    # (the mocked engine returns non-coroutines) come back as 500s
+    # rather than re-raising into pytest — we only care about the
+    # validator response.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestChatValidation:
+    def test_top_p_above_one_rejected(self, patched_config, monkeypatch):
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "top_p": 2.0,
+            },
+        )
+        assert r.status_code == 400
+        assert "top_p" in r.json()["detail"]
+
+    def test_top_p_zero_rejected(self, patched_config, monkeypatch):
+        """0 is invalid per OpenAI spec — the valid range is (0, 1]."""
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "top_p": 0,
+            },
+        )
+        assert r.status_code == 400
+        assert "top_p" in r.json()["detail"]
+
+    def test_top_p_one_passes_validation(self, patched_config, monkeypatch):
+        """1.0 is the OpenAI default and must not trigger the top_p
+        validator. If downstream plumbing fails (likely, since we stub
+        the engine), the failure must NOT be a top_p complaint."""
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "top_p": 1.0,
+            },
+        )
+        if r.status_code == 400:
+            assert "top_p" not in r.json().get("detail", "")
+
+    def test_max_tokens_over_ceiling_rejected(self, patched_config, monkeypatch):
+        """Sanity ceiling at 1_000_000. Combined with admission control
+        (separate PR) this prevents OOM from a buggy client passing
+        max_tokens=999_999_999."""
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 999_999_999,
+            },
+        )
+        assert r.status_code == 400
+        assert "max_tokens" in r.json()["detail"]
+
+    def test_logit_bias_rejected_with_clear_400(self, patched_config, monkeypatch):
+        """Previously silently dropped (field not declared in schema).
+        Declared + rejected with a clear message so clients can fall
+        back without seeing wrong-output."""
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "logit_bias": {"50000": -100},
+            },
+        )
+        assert r.status_code == 400
+        assert "logit_bias" in r.json()["detail"]
+
+    def test_empty_logit_bias_does_not_trigger_400(self, patched_config, monkeypatch):
+        """Defensive clients sometimes always send ``logit_bias: {}``;
+        the empty dict must NOT trigger the validator."""
+        client = _build_chat_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "logit_bias": {},
+            },
+        )
+        if r.status_code == 400:
+            assert "logit_bias" not in r.json().get("detail", "")
+
+
+# ---------------------------------------------------------------------------
+# Embeddings — dimensions truncation + base64 encoding
+# ---------------------------------------------------------------------------
+
+
+def _build_embed_app(patch_cfg, monkeypatch, embed_return):
+    from vllm_mlx.routes import embeddings as emb_route
+
+    app = FastAPI()
+    app.include_router(emb_route.router)
+
+    engine = MagicMock()
+    engine.count_tokens.return_value = 3
+    engine.embed.return_value = embed_return
+    patch_cfg(
+        embedding_engine=engine,
+        embedding_model_locked=None,
+        api_key=None,
+    )
+
+    monkeypatch.setattr(
+        "vllm_mlx.server.load_embedding_model",
+        lambda *_a, **_kw: None,
+        raising=False,
+    )
+
+    return TestClient(app), engine
+
+
+class TestEmbeddingsRoute:
+    def test_dimensions_truncates_vector(self, patched_config, monkeypatch):
+        embed = [[0.1 * i for i in range(384)]]
+        client, _ = _build_embed_app(patched_config, monkeypatch, embed)
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "any", "input": "hello", "dimensions": 64},
+        )
+        assert r.status_code == 200, r.text
+        vec = r.json()["data"][0]["embedding"]
+        assert len(vec) == 64
+        assert vec[:3] == [0.0, 0.1, 0.2]
+
+    def test_dimensions_zero_rejected(self, patched_config, monkeypatch):
+        embed = [[0.0] * 16]
+        client, _ = _build_embed_app(patched_config, monkeypatch, embed)
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "any", "input": "hi", "dimensions": 0},
+        )
+        assert r.status_code == 400
+
+    def test_base64_encoding_round_trip(self, patched_config, monkeypatch):
+        """encoding_format=base64 must produce a base64 string that
+        decodes back to the original float32 vector. Catches both the
+        silent-drop bug AND any byte-ordering mistake."""
+        original = [0.5, -1.25, 3.0, 0.0]
+        client, _ = _build_embed_app(patched_config, monkeypatch, [original])
+
+        r = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "any",
+                "input": "hello",
+                "encoding_format": "base64",
+            },
+        )
+        assert r.status_code == 200, r.text
+        encoded = r.json()["data"][0]["embedding"]
+        assert isinstance(encoded, str)
+
+        decoded = struct.unpack(f"<{len(original)}f", base64.b64decode(encoded))
+        assert list(decoded) == original
+
+    def test_float_format_still_returns_list(self, patched_config, monkeypatch):
+        """Default encoding_format='float' is unchanged."""
+        client, _ = _build_embed_app(patched_config, monkeypatch, [[0.1, 0.2]])
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "any", "input": "hi"},
+        )
+        assert r.status_code == 200
+        vec = r.json()["data"][0]["embedding"]
+        assert isinstance(vec, list)
+        assert vec == [0.1, 0.2]
+
+    def test_base64_plus_dimensions_combine(self, patched_config, monkeypatch):
+        """Truncation happens BEFORE base64 encoding so the packed
+        length matches `dimensions`."""
+        original = [float(i) for i in range(16)]
+        client, _ = _build_embed_app(patched_config, monkeypatch, [original])
+
+        r = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "any",
+                "input": "hi",
+                "dimensions": 4,
+                "encoding_format": "base64",
+            },
+        )
+        assert r.status_code == 200
+        encoded = r.json()["data"][0]["embedding"]
+        decoded = struct.unpack("<4f", base64.b64decode(encoded))
+        assert list(decoded) == [0.0, 1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# --log-level accepts lowercase (industry convention)
+# ---------------------------------------------------------------------------
+
+
+class TestLogLevelLowercase:
+    def _make_parser(self):
+        """Mirror the same ``type`` contract used by serve_parser in
+        vllm_mlx/cli.py and vllm_mlx/server.py."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--log-level",
+            type=lambda s: s.upper(),
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+            default="INFO",
+        )
+        return parser
+
+    @pytest.mark.parametrize("flag", ["debug", "info", "warning", "error"])
+    def test_lowercase_accepted(self, flag):
+        ns = self._make_parser().parse_args(["--log-level", flag])
+        assert ns.log_level == flag.upper()
+
+    @pytest.mark.parametrize("flag", ["DEBUG", "Info", "Warning"])
+    def test_mixed_case_accepted(self, flag):
+        ns = self._make_parser().parse_args(["--log-level", flag])
+        assert ns.log_level == flag.upper()
+
+    def test_unknown_level_still_rejected(self):
+        with pytest.raises(SystemExit):
+            self._make_parser().parse_args(["--log-level", "trace"])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -59,9 +59,10 @@ def mock_registry():
 
 class TestHealthRoutes:
     def _make_app(self):
-        from vllm_mlx.routes.health import router
+        from vllm_mlx.routes.health import probe_router, router
 
         app = FastAPI()
+        app.include_router(probe_router)
         app.include_router(router)
         return app
 
@@ -182,16 +183,20 @@ class TestHealthRoutes:
     @pytest.mark.parametrize(
         ("method", "path"),
         [
-            ("get", "/health"),
-            ("get", "/health/ready"),
             ("post", "/v1/cache/clear"),
             ("get", "/v1/status"),
             ("get", "/v1/cache/stats"),
             ("delete", "/v1/cache"),
         ],
     )
-    def test_health_router_requires_api_key_when_configured(self, method, path):
-        """Health, status, and cache management routes honor API auth."""
+    def test_management_router_requires_api_key_when_configured(self, method, path):
+        """Management routes (cache, status) honor API auth.
+
+        Probe endpoints (/health, /healthz, /livez, /readyz) are NOT in
+        this list — they live on a separate no-auth router so k8s/LB
+        liveness checks work when --api-key is set. See
+        test_probes_bypass_api_key.
+        """
         orig = self._patch_config(api_key="test-secret", ready=True)
         try:
             app = self._make_app()
@@ -201,6 +206,64 @@ class TestHealthRoutes:
 
             assert r.status_code == 401
             assert r.json()["detail"] == "API key required"
+        finally:
+            self._restore_config(orig)
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/healthz", "/health/ready", "/readyz", "/livez"],
+    )
+    def test_probes_bypass_api_key(self, path, mock_engine):
+        """Probe endpoints must be reachable without auth, even when
+        --api-key is configured. k8s/AWS ALB/GCP probes cannot send
+        Authorization headers by default; without this split, every probe
+        marks the pod unhealthy."""
+        orig = self._patch_config(
+            api_key="test-secret",
+            engine=mock_engine,
+            mcp_manager=None,
+            model_name="test-model",
+            ready=True,
+        )
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+
+            r = client.get(path)
+
+            assert r.status_code == 200, (
+                f"{path} should return 200 with no auth header, got "
+                f"{r.status_code}: {r.text}"
+            )
+        finally:
+            self._restore_config(orig)
+
+    @pytest.mark.parametrize(
+        ("path", "expected_keys"),
+        [
+            ("/healthz", {"status", "ready", "model_loaded"}),
+            ("/readyz", {"ready", "model"}),
+            ("/livez", {"status"}),
+        ],
+    )
+    def test_k8s_probe_aliases_match_canonical_shape(
+        self, path, expected_keys, mock_engine
+    ):
+        """k8s-convention aliases return the same JSON shape as their
+        canonical counterparts (/health, /health/ready) so dashboards
+        and probe specs can use either path interchangeably."""
+        orig = self._patch_config(
+            engine=mock_engine,
+            mcp_manager=None,
+            model_name="test-model",
+            ready=True,
+        )
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+            r = client.get(path)
+            assert r.status_code == 200
+            assert expected_keys.issubset(r.json().keys())
         finally:
             self._restore_config(orig)
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -12,7 +12,7 @@ These models define the request and response schemas for:
 import time
 import uuid
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -209,6 +209,10 @@ class ChatCompletionRequest(BaseModel):
     # Logprobs
     logprobs: bool | None = None
     top_logprobs: int | None = None  # 0-20, per OpenAI spec
+    # OpenAI extended spec — declared so Pydantic stops silently dropping
+    # it. Currently rejected with 400 in routes/chat.py if non-empty;
+    # mapping to mlx-lm's logits processor is tracked separately.
+    logit_bias: dict[str, float] | None = None
     # MLLM-specific parameters
     video_fps: float | None = None
     video_max_frames: int | None = None
@@ -455,9 +459,22 @@ class AudioSeparationRequest(BaseModel):
 class EmbeddingRequest(BaseModel):
     """Request for text embeddings (OpenAI compatible)."""
 
+    # extra="forbid" turns silent-drop into a 422 with a clear field name.
+    # Without it, fields like `dimensions` or `encoding_format` typos pass
+    # through and the user only notices when the response shape is wrong.
+    model_config = ConfigDict(extra="forbid")
+
     input: str | list[str]
     model: str
     encoding_format: str | None = "float"  # "float" or "base64"
+    # OpenAI spec: per-vector truncation. Common for MRL-style models
+    # (text-embedding-3-large, nomic-embed-text-v1.5). Implemented as a
+    # post-embed slice; models that don't support MRL just return the
+    # truncated tensor (caller is responsible for picking sensible dims).
+    dimensions: int | None = None
+    # OpenAI abuse-tracking field. Accepted (not validated) so clients
+    # using the upstream SDK don't see a 422 on unknown field.
+    user: str | None = None
 
 
 class EmbeddingData(BaseModel):
@@ -465,7 +482,9 @@ class EmbeddingData(BaseModel):
 
     object: str = "embedding"
     index: int
-    embedding: list[float]
+    # `list[float]` for encoding_format="float"; base64-encoded float32
+    # bytes (str) for encoding_format="base64".
+    embedding: list[float] | str
 
 
 class EmbeddingUsage(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -11,6 +11,7 @@ These models define the request and response schemas for:
 
 import time
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -462,15 +463,23 @@ class EmbeddingRequest(BaseModel):
     # extra="forbid" turns silent-drop into a 422 with a clear field name.
     # Without it, fields like `dimensions` or `encoding_format` typos pass
     # through and the user only notices when the response shape is wrong.
-    model_config = ConfigDict(extra="forbid")
+    # protected_namespaces=() suppresses the Pydantic v2 warning about
+    # the `model` field colliding with the reserved `model_` prefix; a
+    # future Pydantic point release could otherwise promote that warning
+    # to an error and 500 every embeddings request.
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     input: str | list[str]
     model: str
-    encoding_format: str | None = "float"  # "float" or "base64"
+    # Literal so an unknown value (typo like "base65" or "BASE64") 422s
+    # at parse time rather than silently falling back to float — that
+    # silent fallback is the same class of bug this PR exists to close.
+    encoding_format: Literal["float", "base64"] | None = "float"
     # OpenAI spec: per-vector truncation. Common for MRL-style models
-    # (text-embedding-3-large, nomic-embed-text-v1.5). Implemented as a
-    # post-embed slice; models that don't support MRL just return the
-    # truncated tensor (caller is responsible for picking sensible dims).
+    # (text-embedding-3-large, nomic-embed-text-v1.5). Implemented in
+    # the route as a post-embed slice + L2 renormalization (required
+    # for the truncated vector to remain a valid embedding for cosine
+    # similarity per the OpenAI cookbook).
     dimensions: int | None = None
     # OpenAI abuse-tracking field. Accepted (not validated) so clients
     # using the upstream SDK don't see a 422 on unknown field.
@@ -483,7 +492,7 @@ class EmbeddingData(BaseModel):
     object: str = "embedding"
     index: int
     # `list[float]` for encoding_format="float"; base64-encoded float32
-    # bytes (str) for encoding_format="base64".
+    # little-endian bytes (as ASCII string) for encoding_format="base64".
     embedding: list[float] | str
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2736,10 +2736,10 @@ Examples:
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
     serve_parser.add_argument(
         "--log-level",
-        type=str,
+        type=lambda s: s.upper(),
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
-        help="Log level for Python logging and uvicorn",
+        help="Log level for Python logging and uvicorn (case-insensitive)",
     )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -17,6 +17,15 @@ import os
 import sys
 
 
+def _log_level_choice(value: str) -> str:
+    """Argparse ``type`` callable: normalize to upper-case so
+    ``--log-level info`` is accepted as ``INFO``. Named (not a lambda)
+    so argparse's error messages read sensibly instead of
+    ``invalid <lambda> value``.
+    """
+    return value.upper()
+
+
 def _print_unknown_model_help(name: str, *, full_path_example: str) -> None:
     """Print fuzzy suggestions + a curated popular-models hint.
 
@@ -2736,7 +2745,7 @@ Examples:
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
     serve_parser.add_argument(
         "--log-level",
-        type=lambda s: s.upper(),
+        type=_log_level_choice,
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
         help="Log level for Python logging and uvicorn (case-insensitive)",

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -194,11 +194,18 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             detail="n > 1 is not supported. Rapid-MLX generates one completion per request.",
         )
 
-    # Validate max_tokens (must be positive)
+    # Validate max_tokens. Lower bound: must be positive. Upper bound: a
+    # hard sanity ceiling so a buggy client passing 999_999_999 cannot
+    # combine with unbounded admission to OOM the Metal allocator.
     if request.max_tokens is not None and request.max_tokens < 1:
         raise HTTPException(
             status_code=400,
             detail="max_tokens must be at least 1",
+        )
+    if request.max_tokens is not None and request.max_tokens > 1_000_000:
+        raise HTTPException(
+            status_code=400,
+            detail="max_tokens must be at most 1000000",
         )
 
     # Validate temperature range (OpenAI spec: 0-2)
@@ -210,6 +217,15 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             detail="temperature must be between 0 and 2",
         )
 
+    # Validate top_p range (OpenAI spec: (0, 1]). Without this, top_p=2.0
+    # is silently accepted while sister field `temperature` is checked,
+    # so clients with a bug see no signal.
+    if request.top_p is not None and (request.top_p <= 0 or request.top_p > 1):
+        raise HTTPException(
+            status_code=400,
+            detail="top_p must be in (0, 1]",
+        )
+
     # Validate top_logprobs range (OpenAI spec: 0-20)
     if request.top_logprobs is not None and (
         request.top_logprobs < 0 or request.top_logprobs > 20
@@ -217,6 +233,15 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         raise HTTPException(
             status_code=400,
             detail="top_logprobs must be between 0 and 20",
+        )
+
+    # Reject non-empty logit_bias with a clear 400 rather than silently
+    # dropping it. We accept {} so defensive clients that always include
+    # the field don't break.
+    if request.logit_bias:
+        raise HTTPException(
+            status_code=400,
+            detail="logit_bias is not supported on this server",
         )
 
     # --- Detailed request logging ---

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Embeddings endpoint."""
 
+import base64
 import logging
+import struct
 import time
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -64,6 +66,12 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
         if not texts:
             raise HTTPException(status_code=400, detail="Input must not be empty")
 
+        if request.dimensions is not None and request.dimensions < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="dimensions must be a positive integer",
+            )
+
         start_time = time.perf_counter()
         prompt_tokens = cfg.embedding_engine.count_tokens(texts)
         embeddings = cfg.embedding_engine.embed(texts)
@@ -72,9 +80,28 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
             f"Embeddings: {len(texts)} inputs, {prompt_tokens} tokens in {elapsed:.2f}s"
         )
 
-        data = [
-            EmbeddingData(index=i, embedding=vec) for i, vec in enumerate(embeddings)
-        ]
+        # Optional truncation (OpenAI MRL semantics). Sliced post-embed
+        # because mlx-embeddings doesn't expose a native dim parameter.
+        if request.dimensions is not None:
+            embeddings = [list(vec)[: request.dimensions] for vec in embeddings]
+
+        # encoding_format=base64 per OpenAI spec — float32 little-endian
+        # bytes, base64-encoded as ASCII. Saves ~2-4× bandwidth on large
+        # batches and is the default for several OpenAI client SDKs.
+        if request.encoding_format == "base64":
+            encoded: list[list[float] | str] = []
+            for vec in embeddings:
+                vec_list = list(vec)
+                packed = struct.pack(f"<{len(vec_list)}f", *vec_list)
+                encoded.append(base64.b64encode(packed).decode("ascii"))
+            data = [
+                EmbeddingData(index=i, embedding=enc) for i, enc in enumerate(encoded)
+            ]
+        else:
+            data = [
+                EmbeddingData(index=i, embedding=list(vec))
+                for i, vec in enumerate(embeddings)
+            ]
 
         return EmbeddingResponse(
             data=data,

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+import math
 import struct
 import time
 
@@ -81,9 +82,29 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
         )
 
         # Optional truncation (OpenAI MRL semantics). Sliced post-embed
-        # because mlx-embeddings doesn't expose a native dim parameter.
+        # because mlx-embeddings doesn't expose a native dim parameter,
+        # then L2-renormalized so the resulting vector is still a valid
+        # unit-norm embedding for cosine similarity (matches OpenAI
+        # cookbook recommendation for text-embedding-3-large).
         if request.dimensions is not None:
-            embeddings = [list(vec)[: request.dimensions] for vec in embeddings]
+            full_dim = len(list(embeddings[0]))
+            if request.dimensions > full_dim:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"dimensions={request.dimensions} exceeds the "
+                        f"model's native embedding size of {full_dim}"
+                    ),
+                )
+
+            truncated: list[list[float]] = []
+            for vec in embeddings:
+                sliced = list(vec)[: request.dimensions]
+                norm = math.sqrt(sum(x * x for x in sliced))
+                if norm > 0:
+                    sliced = [x / norm for x in sliced]
+                truncated.append(sliced)
+            embeddings = truncated
 
         # encoding_format=base64 per OpenAI spec — float32 little-endian
         # bytes, base64-encoded as ASCII. Saves ~2-4× bandwidth on large

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -11,10 +11,17 @@ from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
 
+# Probe endpoints (no auth) — exposed for k8s/LB liveness+readiness checks
+# which cannot send Authorization headers by default. Without splitting,
+# `--api-key X` makes every probe fail and pods get marked unhealthy.
+probe_router = APIRouter()
+
+# Management endpoints (auth-gated when --api-key is configured) — request
+# cancellation, cache clears, internal /v1/status snapshot.
 router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
-@router.get("/health")
+@probe_router.get("/health")
 async def health():
     """Health check endpoint.
 
@@ -55,7 +62,7 @@ async def health():
     }
 
 
-@router.get("/health/ready")
+@probe_router.get("/health/ready")
 async def health_ready():
     """Strict readiness probe — 503 until lifespan startup is fully done.
 
@@ -70,6 +77,27 @@ async def health_ready():
     if not cfg.ready:
         raise HTTPException(status_code=503, detail="model loading")
     return {"ready": True, "model": cfg.model_name}
+
+
+@probe_router.get("/healthz")
+async def healthz():
+    """k8s-convention alias for /health. Many orchestrator templates default
+    to /healthz; without this alias they 404 and the operator has to override
+    every chart."""
+    return await health()
+
+
+@probe_router.get("/readyz")
+async def readyz():
+    """k8s-convention alias for /health/ready."""
+    return await health_ready()
+
+
+@probe_router.get("/livez")
+async def livez():
+    """k8s liveness probe — 200 if the process is alive. Does not check
+    model readiness; for that use /readyz."""
+    return {"status": "alive"}
 
 
 @router.post("/v1/requests/{request_id}/cancel")
@@ -166,9 +194,15 @@ async def status():
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),
             "cache_memory_gb": stats.get("metal_cache_memory_gb"),
         },
-        "cache": stats.get("memory_aware_cache")
-        or stats.get("paged_cache")
-        or stats.get("prefix_cache"),
+        # Always emit an object (never null) so dashboards with strict
+        # number-or-object schemas don't crash when prefix cache is
+        # disabled via --disable-prefix-cache.
+        "cache": (
+            stats.get("memory_aware_cache")
+            or stats.get("paged_cache")
+            or stats.get("prefix_cache")
+            or {"enabled": False}
+        ),
         "requests": stats.get("requests", []),
     }
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -826,10 +826,12 @@ from .routes.audio import router as _audio_router
 from .routes.chat import router as _chat_router
 from .routes.completions import router as _completions_router
 from .routes.embeddings import router as _embeddings_router
+from .routes.health import probe_router as _probe_router
 from .routes.health import router as _health_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.models import router as _models_router
 
+app.include_router(_probe_router)
 app.include_router(_health_router)
 app.include_router(_models_router)
 app.include_router(_chat_router)
@@ -882,10 +884,10 @@ Examples:
     )
     parser.add_argument(
         "--log-level",
-        type=str,
+        type=lambda s: s.upper(),
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
-        help="Log level for Python logging and uvicorn",
+        help="Log level for Python logging and uvicorn (case-insensitive)",
     )
     parser.add_argument(
         "--mllm",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -884,7 +884,7 @@ Examples:
     )
     parser.add_argument(
         "--log-level",
-        type=lambda s: s.upper(),
+        type=normalize_log_level,
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
         help="Log level for Python logging and uvicorn (case-insensitive)",

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -406,8 +406,16 @@ def get_engine(model_name: str | None = None) -> BaseEngine:
 
 def _validate_model_name(request_model: str) -> None:
     """Validate that the request model name matches a served model."""
-    if not request_model:
+    if request_model is None:
         return
+    # Empty string used to short-circuit to the default model silently,
+    # masking client bugs (a typo or unset env var would still get a 200).
+    # OpenAI returns 400 for empty model fields; do the same.
+    if request_model == "":
+        raise HTTPException(
+            status_code=400,
+            detail="model must not be empty",
+        )
 
     cfg = get_config()
     if cfg.model_registry and request_model in cfg.model_registry:


### PR DESCRIPTION
## Summary

Bundles the cheap, additive subset of bugs surfaced by the recent 10-round × 3-persona onboarding sweep into one PR. Nothing here touches inference codepaths; the goal is to close the silent-wrong-output and silent-drop gaps that turn first-time-user mistakes into hard-to-debug 200 OKs.

### What this fixes

| # | Area | Before | After |
|---|------|--------|-------|
| C5 / H28 | LB probes | `/health` returned 401 under `--api-key`; no `/healthz`/`/readyz`/`/livez` | Probes split to no-auth router + k8s aliases |
| H2 | empty model | `model: ""` silently used default | 400 with clear message |
| H4 | top_p | `top_p=2.0` silently accepted | 400, range (0, 1] |
| H3 | max_tokens | `max_tokens=999_999_999` accepted | 400, hard ceiling 1_000_000 |
| H5 | logit_bias | silently dropped (not in schema) | declared + 400 if non-empty |
| C11 | embeddings dims | `dimensions` silently dropped | post-embed slice |
| C12 | embeddings base64 | `encoding_format=base64` silently dropped | float32 LE → base64 ASCII |
| M4 / M5 | embeddings schema | unknown fields silently dropped | `user` declared + `extra=forbid` |
| M17 | /v1/status | `cache: null` crashed strict dashboards | `{"enabled": false}` stub |
| H25 | --log-level | rejected `info` / `debug` | case-insensitive via `type=str.upper` |

### Test coverage
- `tests/test_api_validation_bundle.py` (new, 335 LOC) — route-level: empty-model 400, top_p bounds, max_tokens cap, logit_bias rejection, embeddings dimensions + base64 round-trip, log-level case-insensitivity
- `tests/test_api_models.py` — schema-level: `logit_bias` declared, embedding `dimensions`/`user`/`extra=forbid`/base64-string
- `tests/test_routes.py` — split auth parametrize: probes no-auth, management endpoints auth; k8s alias shape parity

### Out of scope (deliberate)
Each of these needs its own design + PR:
- **C4** Metal OOM admission control (scheduler)
- **C7/C8/C9** Prometheus + OTel + `X-Request-Id` middleware
- **C10** SSE disconnect detection
- **C13–15** audio install/route bundle
- **H1** hybrid prefix cache trim-by-replay
- **C2/C3** vision silent-fail bundle
- **C16** guided.py nested-array degradation

### Verification
- [x] `pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py` — 3693 passed, 19 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` clean across changed files
- [ ] `pr_validate` — pending
- [ ] codex review — pending

## Test plan
- [ ] CI on this PR (pr_validate matrix)
- [ ] Manual smoke: start server with `--api-key X --log-level info`, curl `/healthz` (200 no auth), `/v1/chat/completions {"model":""}` → 400, `/v1/embeddings {"dimensions":64}` → 64-dim response
- [ ] Hit `/v1/embeddings {"encoding_format":"base64"}` and decode struct-unpack round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)