### PR TITLE
fix(api): H6+H22+C4 — embeddings 4-format input, 1800s timeout, admission control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.58"
+version = "0.6.59"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -21,7 +21,9 @@ class TestServerConfig:
         assert cfg.model_name is None
         assert cfg.default_max_tokens == 4096
         assert cfg.thinking_token_budget == 2048
-        assert cfg.default_timeout == 300.0
+        # Bumped 300 → 1800 (PR H22): 5min default silently truncated
+        # reasoning generations and 30B+ greedy decodes.
+        assert cfg.default_timeout == 1800.0
         assert cfg.api_key is None
         assert cfg.gc_control is True
         assert cfg.enable_auto_tool_choice is False

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -595,6 +595,12 @@ class TestAdmissionControl:
         # cap; the in-flight count comes from ``_admission_reservations``
         # under the engine lock, so we don't need to populate
         # ``scheduler.requests`` here.
+        #
+        # ``self._engine`` is the ``AsyncEngineCore`` wrapper; the
+        # real ``Scheduler`` lives on its inner ``.engine`` attribute.
+        # Mirror that nesting so the production lookup path is
+        # exercised, not just the dataclass — codex R4 BLOCKER root
+        # cause was the lookup walking the wrong indirection.
         class _Stub:
             pass
 
@@ -602,9 +608,12 @@ class TestAdmissionControl:
         scheduler_stub.config = SchedulerConfig(max_concurrent_requests=1)
         scheduler_stub.requests = {}
 
-        engine_stub = _Stub()
-        engine_stub.scheduler = scheduler_stub
-        eng._engine = engine_stub
+        inner_engine_stub = _Stub()
+        inner_engine_stub.scheduler = scheduler_stub
+
+        async_engine_stub = _Stub()
+        async_engine_stub.engine = inner_engine_stub
+        eng._engine = async_engine_stub
 
         # First reservation: succeeds (counter 0 → 1).
         eng.check_admission()
@@ -685,9 +694,13 @@ class TestAdmissionControl:
         scheduler_stub.config = SchedulerConfig(max_concurrent_requests=2)
         scheduler_stub.requests = {}
 
-        engine_stub = _Stub()
-        engine_stub.scheduler = scheduler_stub
-        engine._engine = engine_stub
+        # ``self._engine.engine.scheduler`` — mirror the real
+        # AsyncEngineCore-wrapping-EngineCore nesting (codex R4).
+        inner_engine_stub = _Stub()
+        inner_engine_stub.scheduler = scheduler_stub
+        async_engine_stub = _Stub()
+        async_engine_stub.engine = inner_engine_stub
+        engine._engine = async_engine_stub
 
         # Bind the real methods so the counter is the source of truth.
         engine.check_admission = lambda: BatchedEngine.check_admission(engine)
@@ -745,3 +758,64 @@ class TestAdmissionControl:
         # route-level finally.
         assert statuses == [400, 400, 400, 400, 400], statuses
         assert engine._admission_reservations == 0
+
+    def test_check_admission_finds_llm_scheduler_through_async_wrapper(self):
+        """Codex R4 BLOCKER closure: the LLM admission lookup must
+        walk through ``AsyncEngineCore`` to its inner ``EngineCore``
+        scheduler. Pre-fix it did ``getattr(self._engine,
+        "scheduler", None)`` which silently returned ``None`` on
+        every text engine — so streaming text requests at cap
+        degraded to 200 SSE error chunks instead of 503.
+
+        Reproduce the exact production nesting (``self._engine`` is
+        the wrapper; the scheduler is at ``self._engine.engine.scheduler``)
+        and assert the gate actually fires at the cap. Without the
+        fix the second ``check_admission`` would return silently
+        because ``cap`` would be derived from a missing scheduler."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.scheduler import BackpressureError, SchedulerConfig
+
+        eng = BatchedEngine.__new__(BatchedEngine)
+        eng._is_mllm = False
+        eng._mllm_scheduler = None
+        eng._admission_lock = threading.Lock()
+        eng._admission_reservations = 0
+
+        class _Stub:
+            pass
+
+        scheduler_stub = _Stub()
+        scheduler_stub.config = SchedulerConfig(max_concurrent_requests=1)
+        scheduler_stub.requests = {}
+
+        # Match the production indirection exactly.
+        inner_engine_stub = _Stub()
+        inner_engine_stub.scheduler = scheduler_stub
+        async_engine_stub = _Stub()
+        async_engine_stub.engine = inner_engine_stub
+        eng._engine = async_engine_stub
+
+        eng.check_admission()
+        assert eng._admission_reservations == 1
+        with pytest.raises(BackpressureError):
+            eng.check_admission()
+
+        # Sanity: without the inner indirection (the pre-fix lookup
+        # path), the gate would silently no-op. Drop the inner
+        # engine and verify check_admission does NOT reserve — pins
+        # the codex R4 root cause so a future regression that
+        # forgets the wrapper would fail this test too.
+        eng_no_inner = BatchedEngine.__new__(BatchedEngine)
+        eng_no_inner._is_mllm = False
+        eng_no_inner._mllm_scheduler = None
+        eng_no_inner._admission_lock = threading.Lock()
+        eng_no_inner._admission_reservations = 0
+        # ``self._engine`` exists but has no ``engine`` attribute —
+        # exactly the pre-fix shape that bypassed admission. The
+        # gate should treat this as "not initialised yet" (early
+        # return) rather than crash.
+        eng_no_inner._engine = _Stub()
+        eng_no_inner.check_admission()
+        assert eng_no_inner._admission_reservations == 0

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -804,21 +804,56 @@ class TestAdmissionControl:
 
         # Sanity: without the inner indirection (the pre-fix lookup
         # path), the gate would silently no-op. Drop the inner
-        # engine and verify check_admission does NOT reserve — pins
-        # the codex R4 root cause so a future regression that
-        # forgets the wrapper would fail this test too.
+        # engine and verify check_admission does NOT reserve unless
+        # a ``_scheduler_config`` is present (cold-start fallback,
+        # codex R6 P2). With neither, the gate cleanly no-ops
+        # rather than crash.
         eng_no_inner = BatchedEngine.__new__(BatchedEngine)
         eng_no_inner._is_mllm = False
         eng_no_inner._mllm_scheduler = None
         eng_no_inner._admission_lock = threading.Lock()
         eng_no_inner._admission_reservations = 0
+        eng_no_inner._scheduler_config = None
         # ``self._engine`` exists but has no ``engine`` attribute —
-        # exactly the pre-fix shape that bypassed admission. The
+        # exactly the pre-R4 shape that bypassed admission. The
         # gate should treat this as "not initialised yet" (early
-        # return) rather than crash.
+        # return via the cap=None fallback) rather than crash.
         eng_no_inner._engine = _Stub()
         eng_no_inner.check_admission()
         assert eng_no_inner._admission_reservations == 0
+
+    def test_check_admission_uses_scheduler_config_during_cold_start(self):
+        """Codex R6 P2 closure: during cold-start (``self._engine``
+        not yet wired or its inner ``engine.scheduler`` not yet
+        constructed), a burst of streaming requests must still be
+        gated against the *configured* cap, not slip through and have
+        the loser raise ``BackpressureError`` inside the response
+        generator.
+
+        Reproduce the cold-start window by leaving ``self._engine``
+        unset and assert ``check_admission`` reads the cap from
+        ``self._scheduler_config`` and reserves under the atomic
+        lock just like the post-init path."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.scheduler import BackpressureError, SchedulerConfig
+
+        eng = BatchedEngine.__new__(BatchedEngine)
+        eng._is_mllm = False
+        eng._mllm_scheduler = None
+        # No engine yet — pre-``start()`` cold-start window.
+        eng._engine = None
+        eng._admission_lock = threading.Lock()
+        eng._admission_reservations = 0
+        eng._scheduler_config = SchedulerConfig(max_concurrent_requests=1)
+
+        eng.check_admission()
+        assert eng._admission_reservations == 1
+        # Second reservation: cap reached, must raise.
+        with pytest.raises(BackpressureError):
+            eng.check_admission()
+        assert eng._admission_reservations == 1
 
     def test_mllm_scheduler_inherits_configured_concurrent_cap(self):
         """Codex R5 closure: a server started with

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -871,22 +871,158 @@ class TestAdmissionControl:
 
         configured = SchedulerConfig(max_concurrent_requests=4)
         # Mirror the propagation site in ``_start_mllm``.
-        forwarded = getattr(configured, "max_concurrent_requests", None)
+        forwarded = getattr(configured, "max_concurrent_requests", 256)
         assert forwarded == 4
         mllm_cfg = MLLMSchedulerConfig(max_concurrent_requests=forwarded)
         assert mllm_cfg.max_concurrent_requests == 4
 
-        # Sanity: omitting the field on the source config falls back
-        # to the dataclass default so MLLMSchedulerConfig ends up with
-        # the same cap as a no-override LLM server.
+        # Sanity: omitting the source field falls back to 256 — same
+        # as ``MLLMSchedulerConfig``'s dataclass default. Codex R8
+        # caught the prior version which forwarded ``None`` here,
+        # silently disabling both the engine-level
+        # ``check_admission`` and the scheduler-level
+        # ``MLLMScheduler.add_request`` cap check.
         bare = object()
-        forwarded = getattr(bare, "max_concurrent_requests", None) or 256
+        forwarded = getattr(bare, "max_concurrent_requests", 256)
+        assert forwarded == 256
         assert (
             MLLMSchedulerConfig(
                 max_concurrent_requests=forwarded
             ).max_concurrent_requests
             == 256
         )
+
+    def test_cloud_routed_chat_releases_local_admission_slot(self, monkeypatch):
+        """Codex R8 P2 closure: when ``cfg.cloud_router`` decides to
+        route a chat completion to the cloud, the local admission
+        slot reserved at route entry must be released immediately —
+        the cloud round-trip uses no local scheduler/Metal resources.
+        Without this, a burst of long cloud-routed requests could
+        exhaust the local cap and 503 unrelated local requests while
+        the local engine sits idle."""
+        import threading
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.routes import chat as chat_route
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+
+        # Build a MagicMock engine with the real admission methods so
+        # the counter is the source of truth (mirrors the R3 test).
+        engine = MagicMock()
+        engine.is_mllm = False
+        engine.supports_guided_generation = False
+        # ``build_prompt`` + ``estimate_new_tokens`` are read by the
+        # cloud-routing branch — return non-zero so the threshold
+        # check fires.
+        engine.build_prompt.return_value = "prompt"
+        engine.model.estimate_new_tokens.return_value = (1000, 1000)
+        # ``preserve_native_tool_format`` is read during message prep.
+        engine.preserve_native_tool_format = False
+
+        engine._admission_lock = threading.Lock()
+        engine._admission_reservations = 0
+        engine._is_mllm = False
+        engine._mllm_scheduler = None
+
+        class _Stub:
+            pass
+
+        scheduler_stub = _Stub()
+        scheduler_stub.config = SchedulerConfig(max_concurrent_requests=2)
+        scheduler_stub.requests = {}
+        inner_engine_stub = _Stub()
+        inner_engine_stub.scheduler = scheduler_stub
+        async_engine_stub = _Stub()
+        async_engine_stub.engine = inner_engine_stub
+        engine._engine = async_engine_stub
+
+        engine.check_admission = lambda: BatchedEngine.check_admission(engine)
+        engine.release_admission_reservation = lambda: (
+            BatchedEngine.release_admission_reservation(engine)
+        )
+
+        # Stub the cloud router: ``should_route_to_cloud`` returns True
+        # so the branch fires; ``completion`` returns a minimal dict.
+        cloud_router = MagicMock()
+        cloud_router.should_route_to_cloud.return_value = True
+        cloud_router.threshold = 500
+        cloud_router.cloud_model = "cloud-x"
+
+        async def _fake_completion(*_a, **_kw):
+            return {
+                "id": "cloud-1",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "cloud-x",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+
+        cloud_router.completion = _fake_completion
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "engine",
+                "model_name",
+                "model_alias",
+                "model_path",
+                "model_registry",
+                "tool_call_parser",
+                "reasoning_parser",
+                "ready",
+                "api_key",
+                "cloud_router",
+                "pin_system_prompt",
+            )
+        }
+        cfg.engine = engine
+        cfg.model_name = "stub"
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.model_registry = None
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser = None
+        cfg.ready = True
+        cfg.api_key = None
+        cfg.cloud_router = cloud_router
+        cfg.pin_system_prompt = False
+
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "stub",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+
+        # Cloud completion succeeded → 200; the local admission slot
+        # must have been released before the cloud call returned, so
+        # the reservation counter is back at zero.
+        assert r.status_code == 200, r.text
+        assert engine._admission_reservations == 0
 
     def test_scheduler_config_accepts_explicit_admission_cap(self):
         """Codex R7 closure (via explicit CLI flag rather than

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -819,3 +819,35 @@ class TestAdmissionControl:
         eng_no_inner._engine = _Stub()
         eng_no_inner.check_admission()
         assert eng_no_inner._admission_reservations == 0
+
+    def test_mllm_scheduler_inherits_configured_concurrent_cap(self):
+        """Codex R5 closure: a server started with
+        ``SchedulerConfig(max_concurrent_requests=N)`` must apply the
+        same cap to the MLLM scheduler. Pre-fix, ``_start_mllm`` built
+        ``MLLMSchedulerConfig(...)`` without forwarding the field, so
+        the MLLM admission gate always saw the default 256 and ignored
+        memory-constrained deployments' lower cap.
+
+        Drives the cap propagation directly: simulate the
+        ``_start_mllm`` plumbing by reading the field off
+        ``BatchedEngine._scheduler_config`` and asserting the
+        resulting ``MLLMSchedulerConfig`` carries it. The full
+        ``_start_mllm`` requires loading a vision model so we exercise
+        the configuration path the same way the production code does
+        — via ``getattr(_scheduler_config, ..., 256)``."""
+        from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        configured = SchedulerConfig(max_concurrent_requests=4)
+        # Mirror the propagation site in ``_start_mllm``.
+        forwarded = getattr(configured, "max_concurrent_requests", 256)
+        assert forwarded == 4
+        mllm_cfg = MLLMSchedulerConfig(max_concurrent_requests=forwarded)
+        assert mllm_cfg.max_concurrent_requests == 4
+
+        # Sanity: the fallback (no override on the source config)
+        # matches MLLMSchedulerConfig's own default so omitting the
+        # field doesn't silently downgrade.
+        bare = object()
+        assert getattr(bare, "max_concurrent_requests", 256) == 256
+        assert MLLMSchedulerConfig().max_concurrent_requests == 256

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H6 + H22 + C4 bundle — empirical reproducers + regression tests.
+
+Each test block starts with a 1-2 sentence rationale citing the
+reproducer that originally surfaced the bug, then pins the corrected
+behavior. The structure is:
+
+- H6 — OpenAI embeddings spec supports four input formats: ``str``,
+  ``list[str]``, ``list[int]`` (pre-tokenized one input), and
+  ``list[list[int]]`` (batch of pre-tokenized). Production pipelines
+  using a shared tokenizer send the latter two; pre-PR these 422'd at
+  parse time.
+- H22 — Default request timeout was 300s, which silently cuts long
+  reasoning generations. Industry baseline (vLLM, OpenAI proxy) is
+  600-1800s. Bump to 1800.
+- C4 — No admission control. A buggy client (or simple fork bomb) can
+  schedule unbounded concurrent requests, OOM the Metal allocator,
+  and crash the server for every other client. Add a cap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# H6 — Pydantic model accepts all four OpenAI input shapes
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingInputFourShapes:
+    """Reproducer:
+        curl /v1/embeddings -d '{"input": [[1,2,3]]}'   →  422 pre-PR
+
+    The OpenAI spec
+    (https://platform.openai.com/docs/api-reference/embeddings/create#embeddings/create-input)
+    lists all four shapes as valid; clients using a pre-tokenized
+    pipeline (LangChain, LlamaIndex with custom tokenizer) send the
+    int forms by default.
+    """
+
+    def test_str_accepted(self):
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        req = EmbeddingRequest(model="x", input="hello")
+        assert req.input == "hello"
+
+    def test_list_str_accepted(self):
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        req = EmbeddingRequest(model="x", input=["a", "b"])
+        assert req.input == ["a", "b"]
+
+    def test_list_int_accepted(self):
+        """list[int] — single pre-tokenized input."""
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        req = EmbeddingRequest(model="x", input=[101, 2023, 2003, 102])
+        assert req.input == [101, 2023, 2003, 102]
+
+    def test_list_list_int_accepted(self):
+        """list[list[int]] — batch of pre-tokenized inputs."""
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        req = EmbeddingRequest(model="x", input=[[1, 2, 3], [4, 5, 6]])
+        assert req.input == [[1, 2, 3], [4, 5, 6]]
+
+    def test_mixed_str_and_int_rejected(self):
+        """Sanity: mixing strings and ints in the same list is NOT in
+        the spec and would be ambiguous (is [1, "a"] one tokenized
+        input or one int + one string?). Stay strict to avoid
+        silent-wrong behavior."""
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        with pytest.raises(ValidationError):
+            EmbeddingRequest(model="x", input=[1, "a", 3])
+
+
+# ---------------------------------------------------------------------------
+# H6 — route dispatches pre-tokenized inputs without re-tokenizing
+# ---------------------------------------------------------------------------
+
+
+def _build_embed_app(monkeypatch, engine):
+    """Mount the embeddings router with a stubbed engine."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import embeddings as emb_route
+
+    app = FastAPI()
+    app.include_router(emb_route.router)
+
+    cfg = get_config()
+    saved = {
+        "embedding_engine": cfg.embedding_engine,
+        "embedding_model_locked": cfg.embedding_model_locked,
+        "api_key": cfg.api_key,
+    }
+    cfg.embedding_engine = engine
+    cfg.embedding_model_locked = None
+    cfg.api_key = None
+
+    monkeypatch.setattr(
+        "vllm_mlx.server.load_embedding_model",
+        lambda *_a, **_kw: None,
+        raising=False,
+    )
+
+    def _restore():
+        for k, v in saved.items():
+            setattr(cfg, k, v)
+
+    return TestClient(app), _restore
+
+
+class TestEmbeddingRouteAcceptsTokenInputs:
+    def test_list_int_input_uses_token_path(self, monkeypatch):
+        """The engine's ``embed`` for str must NOT be called when input
+        is already tokens — there's nothing to tokenize. Calling the
+        string path on int input would coerce numbers to ``str(int)``
+        and produce embeddings for the WORD "123", not the token id 123."""
+        engine = MagicMock()
+        engine.count_tokens.return_value = 4
+        engine.embed_tokens.return_value = [[0.1, 0.2]]
+        # If the route mistakenly hit the str path, this would fire:
+        engine.embed.side_effect = AssertionError(
+            "embed(str) called on pre-tokenized input"
+        )
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "any", "input": [101, 2023, 2003, 102]},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        # Embed must have been called with the wrapped batch.
+        engine.embed_tokens.assert_called_once()
+        called_with = engine.embed_tokens.call_args[0][0]
+        assert called_with == [[101, 2023, 2003, 102]]
+
+    def test_list_list_int_input_passes_batch_through(self, monkeypatch):
+        engine = MagicMock()
+        engine.count_tokens.return_value = 6
+        engine.embed_tokens.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        engine.embed.side_effect = AssertionError(
+            "embed(str) called on pre-tokenized input"
+        )
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "any", "input": [[1, 2, 3], [4, 5, 6]]},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        engine.embed_tokens.assert_called_once_with([[1, 2, 3], [4, 5, 6]])
+
+    def test_str_input_still_uses_text_path(self, monkeypatch):
+        """Regression: don't break the text path while adding the
+        token path."""
+        engine = MagicMock()
+        engine.count_tokens.return_value = 3
+        engine.embed.return_value = [[0.5, 0.5]]
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "any", "input": "hi"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200
+        engine.embed.assert_called_once()
+
+
+class TestEmbeddingEngineEmbedTokens:
+    """The engine must implement ``embed_tokens`` so the route has
+    a place to send pre-tokenized batches."""
+
+    def test_embed_tokens_method_exists(self):
+        from vllm_mlx.embedding import EmbeddingEngine
+
+        assert hasattr(EmbeddingEngine, "embed_tokens"), (
+            "EmbeddingEngine must expose embed_tokens(list[list[int]]) "
+            "for OpenAI spec input formats 3 and 4."
+        )
+
+
+# ---------------------------------------------------------------------------
+# H22 — default_timeout 300s → 1800s
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultTimeout:
+    """Reproducer: a DeepSeek-R1 / Qwen-thinking generation that takes
+    400s is silently truncated by the 300s default. 1800s (30 min)
+    matches what vLLM and most OpenAI-compat proxies ship today."""
+
+    def test_server_config_default_is_1800(self):
+        from vllm_mlx.config.server_config import ServerConfig
+
+        cfg = ServerConfig()
+        assert cfg.default_timeout == 1800.0, (
+            f"default_timeout regressed to {cfg.default_timeout}s. "
+            "Reasoning models and 30B+ generations need >5min headroom; "
+            "1800s is the post-PR baseline."
+        )
+
+    def test_server_module_default_matches_config(self):
+        """If someone bumps one default and forgets the other, the
+        CLI and the route layer disagree and timeouts get applied at
+        whichever lower default the request happens to hit first."""
+        import vllm_mlx.server as srv
+        from vllm_mlx.config.server_config import ServerConfig
+
+        assert srv._default_timeout == ServerConfig().default_timeout
+
+
+# ---------------------------------------------------------------------------
+# C4 — admission control on concurrent requests
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionControl:
+    """Reproducer: a fork-bomb client (or naive concurrent batch
+    job) spawns N concurrent requests with large max_tokens; Metal
+    allocator OOMs, server crashes, every other client gets 503/
+    connection reset. Cap concurrent in-flight requests at a
+    configurable max.
+    """
+
+    def test_scheduler_config_has_cap(self):
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        cfg = SchedulerConfig()
+        assert hasattr(cfg, "max_concurrent_requests"), (
+            "SchedulerConfig must expose max_concurrent_requests for "
+            "admission control (default conservative)."
+        )
+        # Default must be set (not None) — admission control is on by default.
+        assert cfg.max_concurrent_requests is not None
+        assert cfg.max_concurrent_requests > 0
+
+    def test_add_request_raises_backpressure_at_cap(self):
+        """When in-flight count equals the cap, the next add_request
+        must raise BackpressureError (route converts to 503). Counting
+        scheduler.requests directly because that's the canonical
+        in-flight ledger (see Scheduler.add_request line ~2285)."""
+        from vllm_mlx.scheduler import BackpressureError
+
+        # Custom exception must exist and be a discriminable type so
+        # routes can catch it specifically (not BaseException).
+        assert issubclass(BackpressureError, Exception)
+        assert not issubclass(BackpressureError, BaseException) or (
+            BackpressureError is not BaseException
+        )
+
+    def test_admission_returns_503_with_retry_after(self, monkeypatch):
+        """End-to-end: a request that would push in-flight over the
+        cap returns 503 with a Retry-After header (RFC 9110 §10.2.4).
+        Backed-off clients can then retry without further
+        ceremony."""
+        # Build a stub chat route that hits a stub engine; the engine's
+        # generate() raises BackpressureError to simulate cap-exceeded.
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes import chat as chat_route
+        from vllm_mlx.scheduler import BackpressureError
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+
+        engine = MagicMock()
+        engine.is_mllm = False
+        # Tool-call parser / guided gen short-circuits we don't want
+        # to hit on this path.
+        engine.supports_guided_generation = False
+
+        async def _boom(*_a, **_kw):
+            raise BackpressureError("max_concurrent_requests exceeded")
+
+        # The chat route invokes ``engine.chat(...)`` on the
+        # non-streaming, non-guided path (see routes/chat.py:597).
+        engine.chat = _boom
+
+        cfg = get_config()
+        saved = {
+            "engine": cfg.engine,
+            "model_name": cfg.model_name,
+            "model_alias": cfg.model_alias,
+            "model_path": cfg.model_path,
+            "model_registry": cfg.model_registry,
+            "tool_call_parser": cfg.tool_call_parser,
+            "reasoning_parser": cfg.reasoning_parser,
+            "ready": cfg.ready,
+            "api_key": cfg.api_key,
+        }
+        cfg.engine = engine
+        cfg.model_name = "stub"
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.model_registry = None
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser = None
+        cfg.ready = True
+        cfg.api_key = None
+
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "stub",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+
+        assert r.status_code == 503, r.text
+        assert r.headers.get("Retry-After") is not None
+        # Body should hint at backpressure so SDK error messages are useful.
+        detail = r.json().get("detail", "").lower()
+        assert "concurrent" in detail or "backpressure" in detail or "busy" in detail

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -633,3 +633,115 @@ class TestAdmissionControl:
         eng.release_admission_reservation()
         eng.release_admission_reservation()
         assert eng._admission_reservations == 0
+
+    def test_validation_error_does_not_leak_admission_slot(self, monkeypatch):
+        """Codex R3 BLOCKER closure: a 400 from validation (here,
+        ``messages=[]``) raised AFTER ``_check_admission_or_503``
+        reserved a slot must not leak the reservation. Under the old
+        flow, after ``max_concurrent_requests`` such bad requests the
+        cap was permanently exhausted and every subsequent valid
+        request received 503 until restart.
+
+        The route-level ``finally`` calls
+        ``_release_admission_unless_committed`` so the slot is
+        returned. Uses a ``MagicMock`` engine with the real atomic
+        admission counter + lock + ``release_admission_reservation``
+        method attached so the helper-side accounting under the
+        FastAPI test client is exercised end-to-end."""
+        import threading
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.routes import chat as chat_route
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+
+        # MagicMock engine — ``MagicMock`` doesn't enforce
+        # ``BatchedEngine``'s read-only ``@property`` definitions, so
+        # we can set ``is_mllm`` / ``supports_guided_generation``
+        # directly while still binding the real admission methods to
+        # exercise the production accounting.
+        engine = MagicMock()
+        engine.is_mllm = False
+        engine.supports_guided_generation = False
+
+        # Wire the real admission state onto the mock. The route
+        # handler calls ``engine.check_admission()`` and
+        # ``engine.release_admission_reservation()`` — both bind
+        # through ``BatchedEngine`` against the mock's namespace, so
+        # ``engine._admission_reservations`` is what we'll assert
+        # against at the end.
+        engine._admission_lock = threading.Lock()
+        engine._admission_reservations = 0
+        engine._is_mllm = False
+        engine._mllm_scheduler = None
+
+        class _Stub:
+            pass
+
+        scheduler_stub = _Stub()
+        scheduler_stub.config = SchedulerConfig(max_concurrent_requests=2)
+        scheduler_stub.requests = {}
+
+        engine_stub = _Stub()
+        engine_stub.scheduler = scheduler_stub
+        engine._engine = engine_stub
+
+        # Bind the real methods so the counter is the source of truth.
+        engine.check_admission = lambda: BatchedEngine.check_admission(engine)
+        engine.release_admission_reservation = lambda: (
+            BatchedEngine.release_admission_reservation(engine)
+        )
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "engine",
+                "model_name",
+                "model_alias",
+                "model_path",
+                "model_registry",
+                "tool_call_parser",
+                "reasoning_parser",
+                "ready",
+                "api_key",
+            )
+        }
+        cfg.engine = engine
+        cfg.model_name = "stub"
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.model_registry = None
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser = None
+        cfg.ready = True
+        cfg.api_key = None
+
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            # Fire 5 requests that all fail validation with empty
+            # ``messages``. With cap=2, the old leaky flow would
+            # exhaust the cap after the 2nd request and the 3rd+
+            # would return 503 instead of 400.
+            statuses = []
+            for _ in range(5):
+                r = client.post(
+                    "/v1/chat/completions",
+                    json={"model": "stub", "messages": []},
+                )
+                statuses.append(r.status_code)
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+
+        # Every request must surface as 400 (validation) — never 503
+        # (admission exhaustion). The reservation counter must end at
+        # zero, proving each request's slot was released by the
+        # route-level finally.
+        assert statuses == [400, 400, 400, 400, 400], statuses
+        assert engine._admission_reservations == 0

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -802,12 +802,14 @@ class TestAdmissionControl:
         with pytest.raises(BackpressureError):
             eng.check_admission()
 
-        # Sanity: without the inner indirection (the pre-fix lookup
-        # path), the gate would silently no-op. Drop the inner
-        # engine and verify check_admission does NOT reserve unless
-        # a ``_scheduler_config`` is present (cold-start fallback,
-        # codex R6 P2). With neither, the gate cleanly no-ops
-        # rather than crash.
+        # Sanity: without the inner indirection (the pre-R4 lookup
+        # path), AND without an explicit ``_scheduler_config``, the
+        # gate must still enforce the SchedulerConfig dataclass
+        # default of 256 (codex R10 closure — the prior behavior
+        # of silently no-op'ing here let cold-start streaming
+        # bursts slip past preflight and only the late
+        # scheduler-level BackpressureError fired, degrading to a
+        # 200 SSE error chunk).
         eng_no_inner = BatchedEngine.__new__(BatchedEngine)
         eng_no_inner._is_mllm = False
         eng_no_inner._mllm_scheduler = None
@@ -815,12 +817,11 @@ class TestAdmissionControl:
         eng_no_inner._admission_reservations = 0
         eng_no_inner._scheduler_config = None
         # ``self._engine`` exists but has no ``engine`` attribute —
-        # exactly the pre-R4 shape that bypassed admission. The
-        # gate should treat this as "not initialised yet" (early
-        # return via the cap=None fallback) rather than crash.
+        # the pre-R4 shape. The gate now reserves under the
+        # default cap (256) rather than no-op'ing.
         eng_no_inner._engine = _Stub()
         eng_no_inner.check_admission()
-        assert eng_no_inner._admission_reservations == 0
+        assert eng_no_inner._admission_reservations == 1
 
     def test_check_admission_uses_scheduler_config_during_cold_start(self):
         """Codex R6 P2 closure: during cold-start (``self._engine``
@@ -1044,6 +1045,42 @@ class TestAdmissionControl:
         # max_num_seqs (or anything else) for memory protection.
         cfg = SchedulerConfig(max_num_seqs=8, max_concurrent_requests=8)
         assert cfg.max_concurrent_requests == 8
+
+    def test_cold_start_admission_uses_default_cap_when_config_is_none(self):
+        """Codex R10 closure: when ``BatchedEngine`` is constructed
+        without an explicit ``scheduler_config`` (the ``load_model``
+        default + direct test callers), ``self._scheduler_config`` is
+        ``None`` until the engine finishes starting. The cold-start
+        fallback must default to ``SchedulerConfig().max_concurrent_requests``
+        (256) rather than silently no-op'ing — otherwise a streaming
+        burst at startup slips past preflight and only the
+        scheduler-level ``BackpressureError`` fires, degrading to a
+        200 SSE error chunk."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.scheduler import BackpressureError, SchedulerConfig
+
+        engine = MagicMock(spec=BatchedEngine)
+        engine._admission_lock = threading.Lock()
+        engine._is_mllm = False
+        engine._mllm_scheduler = None
+        # No scheduler yet (cold-start) AND no scheduler_config (the
+        # exact path codex R10 flagged).
+        engine._engine = None
+        engine._scheduler_config = None
+
+        default_cap = SchedulerConfig().max_concurrent_requests
+        engine._admission_reservations = default_cap
+
+        with pytest.raises(BackpressureError):
+            BatchedEngine.check_admission(engine)
+
+        # One slot below cap still admits — confirms the gate is
+        # active and using the default cap, not unbounded.
+        engine._admission_reservations = default_cap - 1
+        BatchedEngine.check_admission(engine)
+        assert engine._admission_reservations == default_cap
 
     def test_cloud_routable_chat_not_rejected_at_local_cap(self, monkeypatch):
         """Codex R9 closure: when ``cfg.cloud_router`` is enabled and

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -863,26 +863,48 @@ class TestAdmissionControl:
         the MLLM admission gate always saw the default 256 and ignored
         memory-constrained deployments' lower cap.
 
-        Drives the cap propagation directly: simulate the
-        ``_start_mllm`` plumbing by reading the field off
-        ``BatchedEngine._scheduler_config`` and asserting the
-        resulting ``MLLMSchedulerConfig`` carries it. The full
-        ``_start_mllm`` requires loading a vision model so we exercise
-        the configuration path the same way the production code does
-        — via ``getattr(_scheduler_config, ..., 256)``."""
+        Drives the cap propagation directly: read the field off a
+        ``SchedulerConfig`` instance and assert the resulting
+        ``MLLMSchedulerConfig`` carries it."""
         from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
         from vllm_mlx.scheduler import SchedulerConfig
 
         configured = SchedulerConfig(max_concurrent_requests=4)
         # Mirror the propagation site in ``_start_mllm``.
-        forwarded = getattr(configured, "max_concurrent_requests", 256)
+        forwarded = getattr(configured, "max_concurrent_requests", None)
         assert forwarded == 4
         mllm_cfg = MLLMSchedulerConfig(max_concurrent_requests=forwarded)
         assert mllm_cfg.max_concurrent_requests == 4
 
-        # Sanity: the fallback (no override on the source config)
-        # matches MLLMSchedulerConfig's own default so omitting the
-        # field doesn't silently downgrade.
+        # Sanity: omitting the field on the source config falls back
+        # to the dataclass default so MLLMSchedulerConfig ends up with
+        # the same cap as a no-override LLM server.
         bare = object()
-        assert getattr(bare, "max_concurrent_requests", 256) == 256
-        assert MLLMSchedulerConfig().max_concurrent_requests == 256
+        forwarded = getattr(bare, "max_concurrent_requests", None) or 256
+        assert (
+            MLLMSchedulerConfig(
+                max_concurrent_requests=forwarded
+            ).max_concurrent_requests
+            == 256
+        )
+
+    def test_scheduler_config_accepts_explicit_admission_cap(self):
+        """Codex R7 closure (via explicit CLI flag rather than
+        auto-tracking ``max_num_seqs``): operators on memory-
+        constrained devices can pass ``--max-concurrent-requests N``
+        to lower the admission cap independently of
+        ``--max-num-seqs``. The dataclass default stays at 256 so
+        existing tests that intentionally send more requests than
+        ``max_num_seqs`` to exercise the queue still work."""
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        # Default — cap stays at 256 even when max_num_seqs is lower.
+        # This preserves queue depth for tests/deployments that count
+        # on it.
+        cfg = SchedulerConfig(max_num_seqs=8)
+        assert cfg.max_concurrent_requests == 256
+
+        # Explicit override — operator can tighten the cap to match
+        # max_num_seqs (or anything else) for memory protection.
+        cfg = SchedulerConfig(max_num_seqs=8, max_concurrent_requests=8)
+        assert cfg.max_concurrent_requests == 8

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -347,42 +347,59 @@ class TestAdmissionControl:
         assert cfg.max_concurrent_requests > 0
 
     def test_add_request_raises_backpressure_at_cap(self):
-        """When in-flight count equals the cap, the next add_request
-        must raise BackpressureError. Exercise the actual gate by
-        constructing a stub scheduler with the dict pre-populated up
-        to the cap — proves the check fires before tokenization, not
-        just that the exception class exists (codex R1 found the prior
-        version passed by accident)."""
-        from vllm_mlx.scheduler import BackpressureError
+        """Driving ``Scheduler.add_request`` directly — not a re-
+        implemented copy of the gate — proves the production cap
+        check fires before tokenization. Codex R2 flagged the earlier
+        version as test-by-accident because it inlined the gate
+        logic; this version constructs a real ``Scheduler`` instance
+        (via ``__new__`` so we skip the expensive
+        tokenizer/model/engine wiring) and calls the bound method."""
+        from vllm_mlx.request import Request, SamplingParams
+        from vllm_mlx.scheduler import BackpressureError, Scheduler, SchedulerConfig
 
         # 1) The class itself must be an ordinary Exception subclass so
         #    handlers can ``except BackpressureError`` safely.
         assert issubclass(BackpressureError, Exception)
 
-        # 2) Drive add_request via a minimal stand-in. Constructing a
-        #    full Scheduler requires a tokenizer + model + ~20 args;
-        #    inline the gate's actual logic (kept in sync with
-        #    Scheduler.add_request) so this test breaks if someone
-        #    removes the guard.
-        from vllm_mlx.scheduler import Scheduler, SchedulerConfig
-
+        # 2) Build a minimal Scheduler stand-in with the in-flight
+        #    dict pre-populated to cap. Skip __init__ — full
+        #    construction needs a tokenizer + model + ~20 args; we
+        #    only need ``self.requests`` and ``self.config`` for the
+        #    gate to fire.
         sched = Scheduler.__new__(Scheduler)
         sched.config = SchedulerConfig(max_concurrent_requests=2)
         sched.requests = {"req-1": object(), "req-2": object()}
 
-        # Re-run the gate from add_request directly — at cap, raises.
-        cap = sched.config.max_concurrent_requests
-        with pytest.raises(BackpressureError):
-            if cap is not None and cap > 0 and len(sched.requests) >= cap:
-                raise BackpressureError(
-                    f"max_concurrent_requests={cap} reached "
-                    f"(currently {len(sched.requests)} in-flight)"
-                )
+        new_req = Request(
+            request_id="req-3",
+            prompt="hi",
+            sampling_params=SamplingParams(max_tokens=8),
+        )
 
-        # 3) Below cap → no exception.
+        # The real ``add_request`` runs the cap check at the top —
+        # any later attribute access (tokenizer / block_aware_cache /
+        # …) would AttributeError on this bare stub, so a passing
+        # ``raises(BackpressureError)`` here is proof the gate fired
+        # *first*.
+        with pytest.raises(BackpressureError):
+            Scheduler.add_request(sched, new_req)
+
+        # 3) Below cap → the gate passes silently. We intercept the
+        #    very next attribute access (``self.tokenizer``) to stop
+        #    before tokenization without needing a real model.
         sched.requests = {"req-1": object()}
-        if cap is not None and cap > 0 and len(sched.requests) >= cap:
-            pytest.fail("BackpressureError raised below cap")
+        below_cap_req = Request(
+            request_id="req-3",
+            prompt="hi",
+            sampling_params=SamplingParams(max_tokens=8),
+        )
+        # ``AttributeError`` proves the gate did not raise — execution
+        # advanced past the cap check into the tokenize step that our
+        # bare stub doesn't satisfy. If the gate had spuriously raised
+        # ``BackpressureError`` below the cap, that exception would
+        # surface here instead.
+        with pytest.raises(AttributeError):
+            Scheduler.add_request(sched, below_cap_req)
 
     def test_admission_returns_503_with_retry_after(self, monkeypatch):
         """End-to-end: a request that would push in-flight over the
@@ -549,3 +566,70 @@ class TestAdmissionControl:
 
         assert r.status_code == 503, r.text
         assert r.headers.get("Retry-After") is not None
+
+    def test_check_admission_reservation_is_atomic(self):
+        """Codex R2 BLOCKER closure: ``check_admission`` is *reserve-
+        on-success*, not check-then-act. Two callers racing at cap-1
+        cannot both succeed — exactly one wins the slot, the other
+        raises ``BackpressureError``. Without the reservation counter,
+        both would pass and the loser would only fail later inside
+        ``add_request`` (too late for streaming to return a clean
+        HTTP 503).
+
+        Drives the real ``BatchedEngine.check_admission`` against a
+        synthesised scheduler stub so we exercise the production
+        lock/counter, not a copy of the gate logic."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.scheduler import BackpressureError, SchedulerConfig
+
+        eng = BatchedEngine.__new__(BatchedEngine)
+        eng._is_mllm = False
+        eng._mllm_scheduler = None
+        eng._admission_lock = threading.Lock()
+        eng._admission_reservations = 0
+
+        # Synthetic scheduler with cap=1. ``check_admission`` only
+        # reads ``scheduler.config.max_concurrent_requests`` for the
+        # cap; the in-flight count comes from ``_admission_reservations``
+        # under the engine lock, so we don't need to populate
+        # ``scheduler.requests`` here.
+        class _Stub:
+            pass
+
+        scheduler_stub = _Stub()
+        scheduler_stub.config = SchedulerConfig(max_concurrent_requests=1)
+        scheduler_stub.requests = {}
+
+        engine_stub = _Stub()
+        engine_stub.scheduler = scheduler_stub
+        eng._engine = engine_stub
+
+        # First reservation: succeeds (counter 0 → 1).
+        eng.check_admission()
+        assert eng._admission_reservations == 1
+
+        # Second reservation at cap: must raise. Without the atomic
+        # reserve-on-success, a check-then-act gate would let both
+        # through because ``scheduler.requests`` is still empty.
+        with pytest.raises(BackpressureError):
+            eng.check_admission()
+
+        # Counter unchanged after the failed reservation — the cap
+        # check happens before the increment under the same lock,
+        # so a raise must not bump the counter.
+        assert eng._admission_reservations == 1
+
+        # Release returns the slot; next reservation succeeds again.
+        eng.release_admission_reservation()
+        assert eng._admission_reservations == 0
+        eng.check_admission()
+        assert eng._admission_reservations == 1
+
+        # Release floor: extra releases do not drive the counter
+        # negative (idempotent below zero).
+        eng.release_admission_reservation()
+        eng.release_admission_reservation()
+        eng.release_admission_reservation()
+        assert eng._admission_reservations == 0

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -1044,3 +1044,130 @@ class TestAdmissionControl:
         # max_num_seqs (or anything else) for memory protection.
         cfg = SchedulerConfig(max_num_seqs=8, max_concurrent_requests=8)
         assert cfg.max_concurrent_requests == 8
+
+    def test_cloud_routable_chat_not_rejected_at_local_cap(self, monkeypatch):
+        """Codex R9 closure: when ``cfg.cloud_router`` is enabled and
+        the request crosses the cloud threshold, admission must not
+        gate it on local-engine capacity. The local cap is pre-filled
+        to the configured maximum so any pre-cloud admission check
+        would 503; the cloud branch must instead return 200 with the
+        cloud response, and the local reservation counter must remain
+        unchanged (the cloud round-trip uses no local resources)."""
+        import threading
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.routes import chat as chat_route
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+
+        engine = MagicMock()
+        engine.is_mllm = False
+        engine.supports_guided_generation = False
+        engine.build_prompt.return_value = "prompt"
+        engine.model.estimate_new_tokens.return_value = (1000, 1000)
+        engine.preserve_native_tool_format = False
+
+        engine._admission_lock = threading.Lock()
+        # Pre-fill the reservation counter to the cap. Any local-path
+        # admission check at this point would raise BackpressureError
+        # → 503. The cloud-routable request must bypass this.
+        engine._admission_reservations = 2
+        engine._is_mllm = False
+        engine._mllm_scheduler = None
+
+        class _Stub:
+            pass
+
+        scheduler_stub = _Stub()
+        scheduler_stub.config = SchedulerConfig(max_concurrent_requests=2)
+        scheduler_stub.requests = {}
+        inner_engine_stub = _Stub()
+        inner_engine_stub.scheduler = scheduler_stub
+        async_engine_stub = _Stub()
+        async_engine_stub.engine = inner_engine_stub
+        engine._engine = async_engine_stub
+
+        engine.check_admission = lambda: BatchedEngine.check_admission(engine)
+        engine.release_admission_reservation = lambda: (
+            BatchedEngine.release_admission_reservation(engine)
+        )
+
+        cloud_router = MagicMock()
+        cloud_router.should_route_to_cloud.return_value = True
+        cloud_router.threshold = 500
+        cloud_router.cloud_model = "cloud-x"
+
+        async def _fake_completion(*_a, **_kw):
+            return {
+                "id": "cloud-r9",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "cloud-x",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+
+        cloud_router.completion = _fake_completion
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "engine",
+                "model_name",
+                "model_alias",
+                "model_path",
+                "model_registry",
+                "tool_call_parser",
+                "reasoning_parser",
+                "ready",
+                "api_key",
+                "cloud_router",
+                "pin_system_prompt",
+            )
+        }
+        cfg.engine = engine
+        cfg.model_name = "stub"
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.model_registry = None
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser = None
+        cfg.ready = True
+        cfg.api_key = None
+        cfg.cloud_router = cloud_router
+        cfg.pin_system_prompt = False
+
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "stub",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+
+        # Cloud routing won despite local cap being full: 200, not 503.
+        assert r.status_code == 200, r.text
+        # Local reservation counter unchanged — cloud path never
+        # touched it (no acquire, no release).
+        assert engine._admission_reservations == 2

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -80,6 +80,77 @@ class TestEmbeddingInputFourShapes:
         with pytest.raises(ValidationError):
             EmbeddingRequest(model="x", input=[1, "a", 3])
 
+    def test_numeric_string_not_coerced_to_int(self):
+        """Pydantic by default coerces ``"123"`` → 123. Without
+        ``StrictInt``, ``[["1", "2"]]`` would silently become token
+        ids [1, 2] — a different embedding from the words "1" and
+        "2" the caller actually sent. Codex R1 caught this."""
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        with pytest.raises(ValidationError):
+            EmbeddingRequest(model="x", input=[["1", "2"]])
+        with pytest.raises(ValidationError):
+            EmbeddingRequest(model="x", input=["1", 2])
+
+    def test_bool_not_accepted_as_int(self):
+        """In Python, ``bool`` is a subclass of ``int`` — JSON ``true``
+        would silently become token id 1 without ``StrictInt``. A
+        client passing ``[true, false]`` clearly means a boolean
+        feature, not token ids."""
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import EmbeddingRequest
+
+        with pytest.raises(ValidationError):
+            EmbeddingRequest(model="x", input=[True, False])
+
+
+class TestEmbeddingRouteEmptyTokens:
+    """Empty inner token lists were silently passed through pre-fix:
+    ``[[]]`` produced a zero-width tensor and ``[[1, 2], []]`` gave
+    one row whose attention mask is all zeros. The pooled embedding
+    is then either NaN or a meaningless zero vector — silently wrong
+    output to a vector store. Reject with 400 instead."""
+
+    def test_empty_outer_list_rejected(self, monkeypatch):
+        engine = MagicMock()
+        engine.count_tokens.return_value = 0
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post("/v1/embeddings", json={"model": "any", "input": []})
+        finally:
+            restore()
+        assert r.status_code == 400
+
+    def test_empty_inner_token_list_rejected(self, monkeypatch):
+        engine = MagicMock()
+        engine.embed_tokens.return_value = [[0.0]]
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "any", "input": [[1, 2, 3], []]},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400
+        assert "empty" in r.json()["detail"].lower()
+
+    def test_double_wrapped_empty_rejected(self, monkeypatch):
+        engine = MagicMock()
+        engine.embed_tokens.return_value = [[0.0]]
+        client, restore = _build_embed_app(monkeypatch, engine)
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "any", "input": [[]]},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # H6 — route dispatches pre-tokenized inputs without re-tokenizing
@@ -222,6 +293,33 @@ class TestDefaultTimeout:
 
         assert srv._default_timeout == ServerConfig().default_timeout
 
+    def test_cli_and_server_argparse_default_is_1800(self):
+        """Codex R1 caught this: ServerConfig had been bumped to
+        1800 but BOTH CLI argparse (vllm_mlx/cli.py) AND server
+        argparse (vllm_mlx/server.py) still defaulted to 300, so
+        ``rapid-mlx serve`` overwrote the config default at startup
+        and users still got 5min.
+
+        Source-grep instead of parser invocation because both
+        parsers are constructed inline in ``main()``/equivalent and
+        re-running them would import the world. Pin the literal
+        ``default=1800.0`` near the ``--timeout`` flag in each file.
+        """
+        from pathlib import Path
+
+        import vllm_mlx.cli as cli_mod
+        import vllm_mlx.server as srv_mod
+
+        for mod_label, mod in (("cli", cli_mod), ("server", srv_mod)):
+            src = Path(mod.__file__).read_text()
+            idx = src.find('"--timeout"')
+            assert idx != -1, f"{mod_label}.py no longer declares --timeout"
+            window = src[idx : idx + 400]
+            assert "default=1800" in window, (
+                f"{mod_label}.py --timeout default regressed away from "
+                "1800.0 (set both this AND ServerConfig.default_timeout)"
+            )
+
 
 # ---------------------------------------------------------------------------
 # C4 — admission control on concurrent requests
@@ -250,17 +348,41 @@ class TestAdmissionControl:
 
     def test_add_request_raises_backpressure_at_cap(self):
         """When in-flight count equals the cap, the next add_request
-        must raise BackpressureError (route converts to 503). Counting
-        scheduler.requests directly because that's the canonical
-        in-flight ledger (see Scheduler.add_request line ~2285)."""
+        must raise BackpressureError. Exercise the actual gate by
+        constructing a stub scheduler with the dict pre-populated up
+        to the cap — proves the check fires before tokenization, not
+        just that the exception class exists (codex R1 found the prior
+        version passed by accident)."""
         from vllm_mlx.scheduler import BackpressureError
 
-        # Custom exception must exist and be a discriminable type so
-        # routes can catch it specifically (not BaseException).
+        # 1) The class itself must be an ordinary Exception subclass so
+        #    handlers can ``except BackpressureError`` safely.
         assert issubclass(BackpressureError, Exception)
-        assert not issubclass(BackpressureError, BaseException) or (
-            BackpressureError is not BaseException
-        )
+
+        # 2) Drive add_request via a minimal stand-in. Constructing a
+        #    full Scheduler requires a tokenizer + model + ~20 args;
+        #    inline the gate's actual logic (kept in sync with
+        #    Scheduler.add_request) so this test breaks if someone
+        #    removes the guard.
+        from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+        sched = Scheduler.__new__(Scheduler)
+        sched.config = SchedulerConfig(max_concurrent_requests=2)
+        sched.requests = {"req-1": object(), "req-2": object()}
+
+        # Re-run the gate from add_request directly — at cap, raises.
+        cap = sched.config.max_concurrent_requests
+        with pytest.raises(BackpressureError):
+            if cap is not None and cap > 0 and len(sched.requests) >= cap:
+                raise BackpressureError(
+                    f"max_concurrent_requests={cap} reached "
+                    f"(currently {len(sched.requests)} in-flight)"
+                )
+
+        # 3) Below cap → no exception.
+        sched.requests = {"req-1": object()}
+        if cap is not None and cap > 0 and len(sched.requests) >= cap:
+            pytest.fail("BackpressureError raised below cap")
 
     def test_admission_returns_503_with_retry_after(self, monkeypatch):
         """End-to-end: a request that would push in-flight over the
@@ -331,3 +453,99 @@ class TestAdmissionControl:
         # Body should hint at backpressure so SDK error messages are useful.
         detail = r.json().get("detail", "").lower()
         assert "concurrent" in detail or "backpressure" in detail or "busy" in detail
+
+    def test_mllm_scheduler_has_cap(self):
+        """Codex R1 caught this: cap was on the LLM SchedulerConfig
+        only, so MLLM requests could bypass admission entirely. Mirror
+        the field on MLLMSchedulerConfig and exercise the gate."""
+        from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+
+        cfg = MLLMSchedulerConfig()
+        assert hasattr(cfg, "max_concurrent_requests")
+        assert cfg.max_concurrent_requests is not None
+        assert cfg.max_concurrent_requests > 0
+
+    def test_mllm_add_request_raises_at_cap(self):
+        """Pin the actual MLLM gate: pre-populate ``requests`` up to
+        the cap, then call add_request and expect BackpressureError.
+        Codex R1's prior test only checked the class existed."""
+        from vllm_mlx.mllm_scheduler import (
+            MLLMScheduler,
+            MLLMSchedulerConfig,
+        )
+        from vllm_mlx.scheduler import BackpressureError
+
+        sched = MLLMScheduler.__new__(MLLMScheduler)
+        sched.config = MLLMSchedulerConfig(max_concurrent_requests=1)
+        sched.requests = {"req-0": MagicMock()}
+        sched.waiting = []
+
+        with pytest.raises(BackpressureError):
+            sched.add_request(prompt="hi")
+
+    def test_streaming_admission_returns_503(self, monkeypatch):
+        """Codex R1's biggest miss: the streaming path didn't 503 —
+        ``_disconnect_guard`` swallowed BackpressureError into an SSE
+        error chunk on a 200 stream. Pre-flight ``check_admission``
+        at route entry must surface 503 BEFORE StreamingResponse
+        starts. Triggered by setting ``engine.check_admission`` to
+        raise (simulating a saturated scheduler)."""
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes import chat as chat_route
+        from vllm_mlx.scheduler import BackpressureError
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+
+        engine = MagicMock()
+        engine.is_mllm = False
+        engine.supports_guided_generation = False
+
+        def _block():
+            raise BackpressureError("cap exceeded")
+
+        engine.check_admission = _block
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "engine",
+                "model_name",
+                "model_alias",
+                "model_path",
+                "model_registry",
+                "tool_call_parser",
+                "reasoning_parser",
+                "ready",
+                "api_key",
+            )
+        }
+        cfg.engine = engine
+        cfg.model_name = "stub"
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.model_registry = None
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser = None
+        cfg.ready = True
+        cfg.api_key = None
+
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "stub",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+
+        assert r.status_code == 503, r.text
+        assert r.headers.get("Retry-After") is not None

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -474,7 +474,13 @@ class EmbeddingRequest(BaseModel):
     # to an error and 500 every embeddings request.
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
-    input: str | list[str]
+    # OpenAI spec lists 4 input shapes: ``str``, ``list[str]``,
+    # ``list[int]`` (single pre-tokenized input), and
+    # ``list[list[int]]`` (batch of pre-tokenized inputs). Production
+    # pipelines that pre-tokenize with a shared HF tokenizer send the
+    # latter two forms — refusing them broke LangChain / LlamaIndex
+    # integrations that hard-code the spec shape (R10 sweep H6).
+    input: str | list[str] | list[int] | list[list[int]]
     model: str
     # Literal so an unknown value (typo like "base65" or "BASE64") 422s
     # at parse time rather than silently falling back to float — that

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -480,7 +480,13 @@ class EmbeddingRequest(BaseModel):
     # pipelines that pre-tokenize with a shared HF tokenizer send the
     # latter two forms — refusing them broke LangChain / LlamaIndex
     # integrations that hard-code the spec shape (R10 sweep H6).
-    input: str | list[str] | list[int] | list[list[int]]
+    #
+    # ``StrictInt`` / ``StrictStr`` so Pydantic does NOT silently
+    # coerce ``"123"`` → 123 (would be treated as token id 123, a
+    # different embedding from the word "123") or ``True`` → 1
+    # (Python ``bool`` is an ``int`` subclass; without ``StrictInt``
+    # a JSON ``true`` would pass as token id 1).
+    input: StrictStr | list[StrictStr] | list[StrictInt] | list[list[StrictInt]]
     model: str
     # Literal so an unknown value (typo like "base65" or "BASE64") 422s
     # at parse time rather than silently falling back to float — that

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3076,8 +3076,8 @@ Examples:
     serve_parser.add_argument(
         "--timeout",
         type=float,
-        default=300.0,
-        help="Default request timeout in seconds (default: 300)",
+        default=1800.0,
+        help="Default request timeout in seconds (default: 1800 = 30 min)",
     )
     # Tool calling options
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -706,6 +706,7 @@ def serve_command(args):
 
     scheduler_config = SchedulerConfig(
         max_num_seqs=args.max_num_seqs,
+        max_concurrent_requests=args.max_concurrent_requests,
         prefill_batch_size=args.prefill_batch_size,
         completion_batch_size=args.completion_batch_size,
         enable_prefix_cache=enable_prefix_cache,
@@ -989,6 +990,7 @@ def bench_command(args):
 
         scheduler_config = SchedulerConfig(
             max_num_seqs=args.max_num_seqs,
+            max_concurrent_requests=getattr(args, "max_concurrent_requests", 256),
             prefill_batch_size=args.prefill_batch_size,
             completion_batch_size=args.completion_batch_size,
             enable_prefix_cache=enable_prefix_cache,
@@ -2760,6 +2762,17 @@ Examples:
     )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"
+    )
+    serve_parser.add_argument(
+        "--max-concurrent-requests",
+        type=int,
+        default=256,
+        help=(
+            "Admission cap on in-flight requests (queued + running). When "
+            "exceeded, new requests return HTTP 503 with Retry-After. "
+            "Default 256; operators on memory-constrained devices may want "
+            "to set this near ``--max-num-seqs`` to limit queue depth."
+        ),
     )
     serve_parser.add_argument(
         "--prefill-batch-size", type=int, default=8, help="Prefill batch size"

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -48,7 +48,12 @@ class ServerConfig:
     # --- Defaults ---
     default_max_tokens: int = 4096
     thinking_token_budget: int = 2048
-    default_timeout: float = 300.0
+    # 1800s (30 min) matches vLLM and most OpenAI-compat proxy
+    # defaults. The old 300s default silently truncated reasoning
+    # generations (DeepSeek-R1, Qwen-thinking) and 30B+ greedy
+    # completions that needed >5 min of decode. Override via
+    # CLI ``--timeout`` or per-request ``timeout`` field.
+    default_timeout: float = 1800.0
     default_temperature: float | None = None
     default_top_p: float | None = None
     default_top_k: int | None = None

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -84,6 +84,55 @@ class EmbeddingEngine:
         # Convert to Python lists for JSON serialization
         return embeds.tolist()
 
+    def embed_tokens(self, token_batches: list[list[int]]) -> list[list[float]]:
+        """Embed pre-tokenized inputs (OpenAI spec input formats 3 and 4).
+
+        Skips the tokenizer entirely — the caller has already produced
+        token IDs (typically from a shared HF tokenizer in a retrieval
+        pipeline). We still need to right-pad to a uniform length to
+        form a batch tensor and build the matching attention mask.
+
+        Args:
+            token_batches: List of pre-tokenized inputs. Each inner
+                list is a sequence of token IDs.
+
+        Returns:
+            List of embedding vectors (one per input).
+        """
+        self._ensure_loaded()
+
+        if not token_batches:
+            return []
+
+        # Pad each sequence to the longest in the batch, capped at the
+        # same 512 ceiling as the str path so client-controlled
+        # ``input`` cannot allocate unbounded memory.
+        max_len = min(max(len(ids) for ids in token_batches), 512)
+        pad_id = (
+            getattr(self._tokenizer, "pad_token_id", None)
+            or getattr(
+                getattr(self._tokenizer, "_tokenizer", self._tokenizer),
+                "pad_token_id",
+                None,
+            )
+            or 0
+        )
+        padded = []
+        masks = []
+        for ids in token_batches:
+            ids = list(ids)[:max_len]
+            n = len(ids)
+            pad = max_len - n
+            padded.append(ids + [pad_id] * pad)
+            masks.append([1] * n + [0] * pad)
+
+        input_ids = mx.array(padded)
+        attention_mask = mx.array(masks)
+
+        output = self._model(input_ids, attention_mask=attention_mask)
+        embeds: mx.array = output.text_embeds
+        return embeds.tolist()
+
     def count_tokens(self, texts: str | list[str]) -> int:
         """Approximate token count for usage reporting."""
         self._ensure_loaded()

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -389,11 +389,18 @@ class BatchedEngine(BaseEngine):
             )
             scheduler = getattr(inner_engine, "scheduler", None)
             if scheduler is None:
-                # Engine not fully initialised yet — admission control
-                # only applies once a scheduler exists. Let the actual
-                # add_request handle it (or fail naturally).
-                return
-            cap = getattr(scheduler.config, "max_concurrent_requests", None)
+                # Cold-start / pre-load window — the scheduler may not
+                # exist yet but a burst of streaming requests can
+                # still pour in. Fall back to the configured cap from
+                # ``self._scheduler_config`` so the reservation
+                # counter enforces backpressure even before
+                # ``_start_llm``/``_start_mllm`` finishes (codex R6
+                # P2: without this, cold-start requests slipped past
+                # admission and the late ``BackpressureError`` from
+                # ``add_request`` degraded to a 200 SSE error chunk).
+                cap = getattr(self._scheduler_config, "max_concurrent_requests", None)
+            else:
+                cap = getattr(scheduler.config, "max_concurrent_requests", None)
 
         if cap is None or cap <= 0:
             return

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -559,14 +559,15 @@ class BatchedEngine(BaseEngine):
         # Carry the user-configured admission cap across to the MLLM
         # scheduler. Without this, a server started with
         # ``SchedulerConfig(max_concurrent_requests=N)`` would always
-        # admission-gate MLLM routes against the default 256 — leaving
-        # memory-constrained vision deployments without the
+        # admission-gate MLLM routes against the dataclass default —
+        # leaving memory-constrained vision deployments without the
         # configured backpressure protection (codex R5). The fallback
-        # (256) matches ``MLLMSchedulerConfig``'s own dataclass default
-        # so a stripped-down test config object behaves identically to
-        # the no-override production path.
+        # (``None``) is then resolved by ``MLLMSchedulerConfig.__post_init__``
+        # to ``max_num_seqs`` so an operator who only lowered
+        # ``--max-num-seqs`` (codex R7) still gets the matching cap
+        # rather than the old hard-coded 256.
         max_concurrent_requests = getattr(
-            self._scheduler_config, "max_concurrent_requests", 256
+            self._scheduler_config, "max_concurrent_requests", None
         )
 
         mllm_config = MLLMSchedulerConfig(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -549,6 +549,18 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "completion_batch_size", 32
         )
         prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", 2048)
+        # Carry the user-configured admission cap across to the MLLM
+        # scheduler. Without this, a server started with
+        # ``SchedulerConfig(max_concurrent_requests=N)`` would always
+        # admission-gate MLLM routes against the default 256 — leaving
+        # memory-constrained vision deployments without the
+        # configured backpressure protection (codex R5). The fallback
+        # (256) matches ``MLLMSchedulerConfig``'s own dataclass default
+        # so a stripped-down test config object behaves identically to
+        # the no-override production path.
+        max_concurrent_requests = getattr(
+            self._scheduler_config, "max_concurrent_requests", 256
+        )
 
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
@@ -557,6 +569,7 @@ class BatchedEngine(BaseEngine):
             prefill_step_size=prefill_step_size,
             enable_vision_cache=True,
             vision_cache_size=100,
+            max_concurrent_requests=max_concurrent_requests,
         )
 
         # Create and start MLLM scheduler — pass the model-owning executor so

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -398,7 +398,19 @@ class BatchedEngine(BaseEngine):
                 # P2: without this, cold-start requests slipped past
                 # admission and the late ``BackpressureError`` from
                 # ``add_request`` degraded to a 200 SSE error chunk).
-                cap = getattr(self._scheduler_config, "max_concurrent_requests", None)
+                # When the engine was constructed without an explicit
+                # ``scheduler_config`` (e.g. ``load_model`` defaults,
+                # tests, or programmatic ``BatchedEngine(...)``
+                # callers), ``self._scheduler_config`` is ``None`` —
+                # use the dataclass default so the gate still
+                # enforces 256 instead of silently degrading to a
+                # no-op (codex R10 P2).
+                from ..scheduler import SchedulerConfig
+
+                sc = self._scheduler_config
+                if sc is None:
+                    sc = SchedulerConfig()
+                cap = getattr(sc, "max_concurrent_requests", None)
             else:
                 cap = getattr(scheduler.config, "max_concurrent_requests", None)
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -374,15 +374,26 @@ class BatchedEngine(BaseEngine):
 
         if self._is_mllm and self._mllm_scheduler is not None:
             cap = getattr(self._mllm_scheduler.config, "max_concurrent_requests", None)
-        elif self._engine is not None and getattr(self._engine, "scheduler", None):
-            cap = getattr(
-                self._engine.scheduler.config, "max_concurrent_requests", None
-            )
         else:
-            # Engine not fully initialised yet — admission control
-            # only applies once a scheduler exists. Let the actual
-            # add_request handle it (or fail naturally).
-            return
+            # ``self._engine`` is an ``AsyncEngineCore`` wrapper; the
+            # actual ``Scheduler`` lives on its inner ``EngineCore`` —
+            # ``self._engine.engine.scheduler``. The old
+            # ``getattr(self._engine, "scheduler", None)`` lookup
+            # silently returned ``None`` because ``AsyncEngineCore``
+            # does not expose ``scheduler`` directly, so the LLM
+            # admission gate was a no-op (codex R4 BLOCKER: streaming
+            # text requests at cap were degrading to 200 SSE error
+            # chunks instead of the intended 503 + Retry-After).
+            inner_engine = (
+                getattr(self._engine, "engine", None) if self._engine else None
+            )
+            scheduler = getattr(inner_engine, "scheduler", None)
+            if scheduler is None:
+                # Engine not fully initialised yet — admission control
+                # only applies once a scheduler exists. Let the actual
+                # add_request handle it (or fail naturally).
+                return
+            cap = getattr(scheduler.config, "max_concurrent_requests", None)
 
         if cap is None or cap <= 0:
             return

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -14,6 +14,7 @@ LLM engine), so text-only requests must also be routed through it.
 import functools
 import json
 import logging
+import threading
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -319,6 +320,19 @@ class BatchedEngine(BaseEngine):
         self._loaded = False
         self._engine_started = False  # Track if engine loop is running
 
+        # Atomic admission counter. Tracks in-flight requests admitted
+        # via ``check_admission``; released by
+        # ``release_admission_reservation`` once the route handler is
+        # done (response sent / streaming generator closed). The cap
+        # check + bump runs under ``_admission_lock`` so two concurrent
+        # route handlers cannot both pass admission at ``cap-1`` — the
+        # race codex R2 flagged on the streaming path.
+        # ``threading.Lock`` (not ``asyncio.Lock``) because the scheduler
+        # step thread also calls these methods in defence-in-depth
+        # checks; an asyncio lock would only serialise the event loop.
+        self._admission_lock = threading.Lock()
+        self._admission_reservations = 0
+
     @property
     def model_name(self) -> str:
         """Get the model name."""
@@ -330,42 +344,67 @@ class BatchedEngine(BaseEngine):
         return self._is_mllm
 
     def check_admission(self) -> None:
-        """Synchronous admission control gate.
+        """Atomic admission gate that *reserves* a slot on success.
 
-        Raises ``BackpressureError`` if scheduling another request
-        would exceed ``max_concurrent_requests``. Routes call this
-        BEFORE returning a ``StreamingResponse`` so streaming
-        backpressure surfaces as HTTP 503 (not as a 200 stream with
-        an error-data chunk).
+        Under ``_admission_lock``, compares
+        ``_admission_reservations`` to ``max_concurrent_requests``;
+        if the cap is reached, raises ``BackpressureError``; otherwise
+        bumps the counter so a second concurrent caller sees the cap
+        immediately. Closes the streaming race codex R2 flagged where
+        two requests at ``cap-1`` could both pass a plain check-then-
+        act gate and then have the loser raise ``BackpressureError``
+        *inside* the response generator (which would degrade to a 200
+        SSE error chunk instead of a clean HTTP 503).
 
-        There IS a residual race: between this check and the actual
-        ``add_request``, another request may fill the slot. The
-        second ``add_request`` then raises ``BackpressureError`` too,
-        which ``_wait_with_disconnect`` already catches for the
-        non-streaming path. For streaming, the race window is one
-        scheduler step (~milliseconds) so this is acceptable.
+        The reservation counter is authoritative for the cap — the
+        scheduler's own ``len(requests) >= cap`` check in
+        ``Scheduler.add_request`` is retained as defence in depth (a
+        direct ``add_request`` caller that bypasses the engine would
+        still hit it) but the route-handler path lives entirely on
+        this counter, so a request never double-counts.
+
+        The caller MUST call ``release_admission_reservation`` exactly
+        once per successful ``check_admission`` — when the request is
+        finished (response sent, generator closed, validation error,
+        whatever). ``_disconnect_guard`` and ``_wait_with_disconnect``
+        do this from a ``finally`` clause so route handlers don't have
+        to thread it manually.
         """
         from ..scheduler import BackpressureError
 
         if self._is_mllm and self._mllm_scheduler is not None:
             cap = getattr(self._mllm_scheduler.config, "max_concurrent_requests", None)
-            in_flight = len(getattr(self._mllm_scheduler, "requests", {}) or {})
         elif self._engine is not None and getattr(self._engine, "scheduler", None):
             cap = getattr(
                 self._engine.scheduler.config, "max_concurrent_requests", None
             )
-            in_flight = len(getattr(self._engine.scheduler, "requests", {}) or {})
         else:
             # Engine not fully initialised yet — admission control
             # only applies once a scheduler exists. Let the actual
             # add_request handle it (or fail naturally).
             return
 
-        if cap is not None and cap > 0 and in_flight >= cap:
-            raise BackpressureError(
-                f"max_concurrent_requests={cap} reached "
-                f"(currently {in_flight} in-flight)"
-            )
+        if cap is None or cap <= 0:
+            return
+
+        with self._admission_lock:
+            if self._admission_reservations >= cap:
+                raise BackpressureError(
+                    f"max_concurrent_requests={cap} reached "
+                    f"(currently {self._admission_reservations} in-flight)"
+                )
+            self._admission_reservations += 1
+
+    def release_admission_reservation(self) -> None:
+        """Release a slot reserved by ``check_admission``.
+
+        Idempotent below zero — a stray extra release (e.g. both
+        success path and a finally clause firing on an unusual
+        cancellation) cannot corrupt the cap accounting.
+        """
+        with self._admission_lock:
+            if self._admission_reservations > 0:
+                self._admission_reservations -= 1
 
     @property
     def tokenizer(self) -> Any:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -329,6 +329,44 @@ class BatchedEngine(BaseEngine):
         """Check if this is a multimodal model."""
         return self._is_mllm
 
+    def check_admission(self) -> None:
+        """Synchronous admission control gate.
+
+        Raises ``BackpressureError`` if scheduling another request
+        would exceed ``max_concurrent_requests``. Routes call this
+        BEFORE returning a ``StreamingResponse`` so streaming
+        backpressure surfaces as HTTP 503 (not as a 200 stream with
+        an error-data chunk).
+
+        There IS a residual race: between this check and the actual
+        ``add_request``, another request may fill the slot. The
+        second ``add_request`` then raises ``BackpressureError`` too,
+        which ``_wait_with_disconnect`` already catches for the
+        non-streaming path. For streaming, the race window is one
+        scheduler step (~milliseconds) so this is acceptable.
+        """
+        from ..scheduler import BackpressureError
+
+        if self._is_mllm and self._mllm_scheduler is not None:
+            cap = getattr(self._mllm_scheduler.config, "max_concurrent_requests", None)
+            in_flight = len(getattr(self._mllm_scheduler, "requests", {}) or {})
+        elif self._engine is not None and getattr(self._engine, "scheduler", None):
+            cap = getattr(
+                self._engine.scheduler.config, "max_concurrent_requests", None
+            )
+            in_flight = len(getattr(self._engine.scheduler, "requests", {}) or {})
+        else:
+            # Engine not fully initialised yet — admission control
+            # only applies once a scheduler exists. Let the actual
+            # add_request handle it (or fail naturally).
+            return
+
+        if cap is not None and cap > 0 and in_flight >= cap:
+            raise BackpressureError(
+                f"max_concurrent_requests={cap} reached "
+                f"(currently {in_flight} in-flight)"
+            )
+
     @property
     def tokenizer(self) -> Any:
         """Get the tokenizer."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -561,13 +561,14 @@ class BatchedEngine(BaseEngine):
         # ``SchedulerConfig(max_concurrent_requests=N)`` would always
         # admission-gate MLLM routes against the dataclass default —
         # leaving memory-constrained vision deployments without the
-        # configured backpressure protection (codex R5). The fallback
-        # (``None``) is then resolved by ``MLLMSchedulerConfig.__post_init__``
-        # to ``max_num_seqs`` so an operator who only lowered
-        # ``--max-num-seqs`` (codex R7) still gets the matching cap
-        # rather than the old hard-coded 256.
+        # configured backpressure protection (codex R5). Fallback 256
+        # matches ``MLLMSchedulerConfig``'s own dataclass default so
+        # the no-explicit-config programmatic construction path (no
+        # ``scheduler_config`` passed to ``BatchedEngine``) still
+        # admission-gates rather than passing ``None`` through and
+        # silently disabling the cap (codex R8).
         max_concurrent_requests = getattr(
-            self._scheduler_config, "max_concurrent_requests", None
+            self._scheduler_config, "max_concurrent_requests", 256
         )
 
         mllm_config = MLLMSchedulerConfig(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -67,7 +67,10 @@ class MLLMSchedulerConfig:
     # Admission control: hard cap on concurrent in-flight MLLM
     # requests (queued + running). Matches the LLM scheduler
     # convention so ``max_concurrent_requests`` is uniform across
-    # both engines; default 256 matches MLLM ``max_num_seqs`` headroom.
+    # both engines. Default 256 provides queue depth on top of
+    # ``max_num_seqs`` (waiting requests cost only the tokenised
+    # prompt, not KV state). Operators who want admission tied to
+    # ``max_num_seqs`` pass ``--max-concurrent-requests`` explicitly.
     max_concurrent_requests: int = 256
 
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -64,6 +64,11 @@ class MLLMSchedulerConfig:
     default_video_fps: float = 2.0
     # Maximum video frames
     max_video_frames: int = 128
+    # Admission control: hard cap on concurrent in-flight MLLM
+    # requests (queued + running). Matches the LLM scheduler
+    # convention so ``max_concurrent_requests`` is uniform across
+    # both engines; default 256 matches MLLM ``max_num_seqs`` headroom.
+    max_concurrent_requests: int = 256
 
 
 @dataclass
@@ -317,6 +322,17 @@ class MLLMScheduler:
         """
         if request_id is None:
             request_id = str(uuid.uuid4())
+
+        # Admission control: same gate as the LLM scheduler so MLLM
+        # paths can't bypass the cap by going through this code path.
+        cap = getattr(self.config, "max_concurrent_requests", None)
+        if cap is not None and cap > 0 and len(self.requests) >= cap:
+            from .scheduler import BackpressureError
+
+            raise BackpressureError(
+                f"max_concurrent_requests={cap} reached "
+                f"(currently {len(self.requests)} in-flight)"
+            )
 
         sampling_params = SamplingParams(
             max_tokens=max_tokens,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -33,6 +33,7 @@ from ..engine import BaseEngine
 from ..middleware.auth import check_rate_limit_or_x_api_key, verify_api_key_or_x_api_key
 from ..service.helpers import (
     _build_usage,
+    _check_admission_or_503,
     _disconnect_guard,
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
@@ -106,6 +107,9 @@ async def create_anthropic_message(
 
     _validate_model_name(anthropic_request.model)
     engine = get_engine(anthropic_request.model)
+
+    # Pre-flight admission gate (C4) — see routes/chat.py for rationale.
+    _check_admission_or_503(engine)
 
     # --- Detailed request logging ---
     n_msgs = len(anthropic_request.messages)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -138,6 +138,7 @@ async def create_anthropic_message(
             _disconnect_guard(
                 _stream_anthropic_messages(engine, openai_request, anthropic_request),
                 request,
+                engine=engine,
             ),
             media_type="text/event-stream",
             headers={
@@ -177,6 +178,7 @@ async def create_anthropic_message(
             engine.chat(messages=messages, **chat_kwargs),
             request,
             timeout=timeout,
+            engine=engine,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -37,6 +37,7 @@ from ..service.helpers import (
     _disconnect_guard,
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
+    _release_admission_unless_committed,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_temperature,
@@ -109,149 +110,159 @@ async def create_anthropic_message(
     engine = get_engine(anthropic_request.model)
 
     # Pre-flight admission gate (C4) — see routes/chat.py for rationale.
+    # Reservation released by the route-level ``finally`` below; on the
+    # streaming path ``_admission_committed`` flips to True so
+    # ``_disconnect_guard`` owns the release once the SSE generator
+    # closes. Closes the codex R3 leak (validation errors between the
+    # reservation and the helper used to pin the slot until restart).
     _check_admission_or_503(engine)
-
-    # --- Detailed request logging ---
-    n_msgs = len(anthropic_request.messages)
-    total_chars = 0
-    last_user_preview = ""
-    for m in anthropic_request.messages:
-        content = m.content if isinstance(m.content, str) else str(m.content)
-        total_chars += len(content)
-        if m.role == "user":
-            last_user_preview = content[:300]
-    sys_chars = len(anthropic_request.system) if anthropic_request.system else 0
-    n_tools = len(anthropic_request.tools) if anthropic_request.tools else 0
-    logger.info(
-        f"[REQUEST] POST /v1/messages (anthropic) stream={anthropic_request.stream} "
-        f"model={anthropic_request.model!r} max_tokens={anthropic_request.max_tokens} "
-        f"msgs={n_msgs} total_chars={total_chars} system_chars={sys_chars} "
-        f"tools={n_tools}"
-    )
-    logger.debug(f"[REQUEST] last user message preview: {last_user_preview!r}")
-
-    # Convert Anthropic request -> OpenAI request
-    openai_request = anthropic_to_openai(anthropic_request)
-
-    if anthropic_request.stream:
-        return StreamingResponse(
-            _disconnect_guard(
-                _stream_anthropic_messages(engine, openai_request, anthropic_request),
-                request,
-                engine=engine,
-            ),
-            media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-            },
-        )
-
-    # Non-streaming: run inference through existing engine
-    messages, images, videos = extract_multimodal_content(
-        openai_request.messages,
-        preserve_native_format=engine.preserve_native_tool_format,
-    )
-
-    chat_kwargs = {
-        "max_tokens": _resolve_max_tokens(
-            openai_request.max_tokens,
-            _resolve_enable_thinking(openai_request),
-        ),
-        **_resolved_sampling_kwargs(openai_request),
-    }
-
-    if openai_request.tools:
-        chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
-    cfg = get_config()
-    # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
-    # passthrough). Same precedence as the OpenAI route.
-    resolved_thinking = _resolve_enable_thinking(openai_request)
-    if resolved_thinking is not None:
-        chat_kwargs["enable_thinking"] = resolved_thinking
-
-    start_time = time.perf_counter()
-    timeout = cfg.default_timeout
-
+    _admission_committed = False
     try:
-        output = await _wait_with_disconnect(
-            engine.chat(messages=messages, **chat_kwargs),
-            request,
-            timeout=timeout,
-            engine=engine,
+        # --- Detailed request logging ---
+        n_msgs = len(anthropic_request.messages)
+        total_chars = 0
+        last_user_preview = ""
+        for m in anthropic_request.messages:
+            content = m.content if isinstance(m.content, str) else str(m.content)
+            total_chars += len(content)
+            if m.role == "user":
+                last_user_preview = content[:300]
+        sys_chars = len(anthropic_request.system) if anthropic_request.system else 0
+        n_tools = len(anthropic_request.tools) if anthropic_request.tools else 0
+        logger.info(
+            f"[REQUEST] POST /v1/messages (anthropic) stream={anthropic_request.stream} "
+            f"model={anthropic_request.model!r} max_tokens={anthropic_request.max_tokens} "
+            f"msgs={n_msgs} total_chars={total_chars} system_chars={sys_chars} "
+            f"tools={n_tools}"
         )
-    except HTTPException:
-        raise
-    except Exception as e:
-        err_msg = str(e)
-        err_type = type(e).__name__
-        if (
-            "TemplateError" in err_type
-            or "template" in err_msg.lower()
-            or ("user" in err_msg.lower() and "found" in err_msg.lower())
-        ):
-            raise HTTPException(
-                status_code=400, detail=f"Chat template error: {err_msg}"
-            )
-        raise
-    if output is None:
-        return Response(status_code=499)
+        logger.debug(f"[REQUEST] last user message preview: {last_user_preview!r}")
 
-    elapsed = time.perf_counter() - start_time
-    tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
-    logger.info(
-        f"Anthropic messages: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
-    )
+        # Convert Anthropic request -> OpenAI request
+        openai_request = anthropic_to_openai(anthropic_request)
 
-    # Parse tool calls
-    cleaned_text, tool_calls = _parse_tool_calls_with_parser(
-        output.text, openai_request
-    )
-
-    # Extract reasoning content via the same orchestration the OpenAI route
-    # uses (chat.py). Skipping this is what #413 fixed — the Anthropic surface
-    # used to silently drop ``<think>...</think>`` content on the non-streaming
-    # path while OpenAI preserved it as ``reasoning_content``.
-    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
-        raw_text=output.text,
-        cleaned_text=cleaned_text,
-        tool_calls=tool_calls,
-        reasoning_parser=cfg.reasoning_parser,
-    )
-
-    final_content = None
-    if cleaned_text:
-        final_content = strip_thinking_tags(clean_output_text(cleaned_text))
-        # Final defense against special-token / markup leakage — mirrors
-        # chat.py:669 so the two surfaces don't diverge on what they
-        # consider "sanitized" client-facing content. Pre-existing gap
-        # flagged by codex during the #413 review.
-        final_content = sanitize_output(final_content)
-
-    finish_reason = "tool_calls" if tool_calls else output.finish_reason
-
-    openai_response = ChatCompletionResponse(
-        model=cfg.model_name or openai_request.model,
-        choices=[
-            ChatCompletionChoice(
-                message=AssistantMessage(
-                    content=final_content,
-                    reasoning_content=reasoning_text,
-                    tool_calls=tool_calls,
+        if anthropic_request.stream:
+            _admission_committed = True
+            return StreamingResponse(
+                _disconnect_guard(
+                    _stream_anthropic_messages(
+                        engine, openai_request, anthropic_request
+                    ),
+                    request,
+                    engine=engine,
                 ),
-                finish_reason=finish_reason,
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
             )
-        ],
-        usage=_build_usage(output, reasoning_text),
-    )
 
-    anthropic_response = openai_to_anthropic(
-        openai_response, cfg.model_name or anthropic_request.model
-    )
-    return Response(
-        content=anthropic_response.model_dump_json(exclude_none=True),
-        media_type="application/json",
-    )
+        # Non-streaming: run inference through existing engine
+        messages, images, videos = extract_multimodal_content(
+            openai_request.messages,
+            preserve_native_format=engine.preserve_native_tool_format,
+        )
+
+        chat_kwargs = {
+            "max_tokens": _resolve_max_tokens(
+                openai_request.max_tokens,
+                _resolve_enable_thinking(openai_request),
+            ),
+            **_resolved_sampling_kwargs(openai_request),
+        }
+
+        if openai_request.tools:
+            chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        cfg = get_config()
+        # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
+        # passthrough). Same precedence as the OpenAI route.
+        resolved_thinking = _resolve_enable_thinking(openai_request)
+        if resolved_thinking is not None:
+            chat_kwargs["enable_thinking"] = resolved_thinking
+
+        start_time = time.perf_counter()
+        timeout = cfg.default_timeout
+
+        try:
+            output = await _wait_with_disconnect(
+                engine.chat(messages=messages, **chat_kwargs),
+                request,
+                timeout=timeout,
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            err_msg = str(e)
+            err_type = type(e).__name__
+            if (
+                "TemplateError" in err_type
+                or "template" in err_msg.lower()
+                or ("user" in err_msg.lower() and "found" in err_msg.lower())
+            ):
+                raise HTTPException(
+                    status_code=400, detail=f"Chat template error: {err_msg}"
+                )
+            raise
+        if output is None:
+            return Response(status_code=499)
+
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Anthropic messages: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+        )
+
+        # Parse tool calls
+        cleaned_text, tool_calls = _parse_tool_calls_with_parser(
+            output.text, openai_request
+        )
+
+        # Extract reasoning content via the same orchestration the OpenAI route
+        # uses (chat.py). Skipping this is what #413 fixed — the Anthropic surface
+        # used to silently drop ``<think>...</think>`` content on the non-streaming
+        # path while OpenAI preserved it as ``reasoning_content``.
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=output.text,
+            cleaned_text=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning_parser=cfg.reasoning_parser,
+        )
+
+        final_content = None
+        if cleaned_text:
+            final_content = strip_thinking_tags(clean_output_text(cleaned_text))
+            # Final defense against special-token / markup leakage — mirrors
+            # chat.py:669 so the two surfaces don't diverge on what they
+            # consider "sanitized" client-facing content. Pre-existing gap
+            # flagged by codex during the #413 review.
+            final_content = sanitize_output(final_content)
+
+        finish_reason = "tool_calls" if tool_calls else output.finish_reason
+
+        openai_response = ChatCompletionResponse(
+            model=cfg.model_name or openai_request.model,
+            choices=[
+                ChatCompletionChoice(
+                    message=AssistantMessage(
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=tool_calls,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=_build_usage(output, reasoning_text),
+        )
+
+        anthropic_response = openai_to_anthropic(
+            openai_response, cfg.model_name or anthropic_request.model
+        )
+        return Response(
+            content=anthropic_response.model_dump_json(exclude_none=True),
+            media_type="application/json",
+        )
+    finally:
+        _release_admission_unless_committed(engine, _admission_committed)
 
 
 @router.post(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -489,6 +489,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                                 **cloud_kwargs,
                             ),
                             raw_request,
+                            engine=engine,
                         ),
                         media_type="text/event-stream",
                     )
@@ -497,6 +498,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         cfg.cloud_router.completion(cloud_messages, **cloud_kwargs),
                         raw_request,
                         timeout=request.timeout or cfg.default_timeout,
+                        engine=engine,
                     )
                     if result is None:
                         return Response(status_code=499, content="Client disconnected")
@@ -540,6 +542,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             _disconnect_guard(
                 stream_chat_completion(engine, messages, request, **chat_kwargs),
                 raw_request,
+                engine=engine,
             ),
             media_type="text/event-stream",
         )
@@ -590,22 +593,31 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                     ),
                     raw_request,
                     timeout=timeout,
+                    engine=engine,
                 )
             except Exception as guided_err:
                 logger.warning(
                     f"Guided generation failed, falling back to standard: {guided_err}"
                 )
                 logger.debug(f"Problematic schema: {json_schema}")
+                # Re-reserve before falling back: the failed
+                # ``generate_with_schema`` already released the original
+                # reservation in its finally clause. Without a fresh
+                # ``check_admission`` the cap accounting would drift
+                # negative once the fallback's finally runs.
+                _check_admission_or_503(engine)
                 output = await _wait_with_disconnect(
                     engine.chat(messages=messages, **chat_kwargs),
                     raw_request,
                     timeout=timeout,
+                    engine=engine,
                 )
         else:
             output = await _wait_with_disconnect(
                 engine.chat(messages=messages, **chat_kwargs),
                 raw_request,
                 timeout=timeout,
+                engine=engine,
             )
     except HTTPException:
         raise
@@ -632,6 +644,21 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         if cfg.gc_control and gc_was_enabled:
             gc.enable()
             gc.collect()
+        # Safety net for the want_logprobs/non-stream branch which calls
+        # ``engine.stream_chat`` directly (no ``_wait_with_disconnect``
+        # to handle release). The other branches already released via
+        # ``_wait_with_disconnect.finally``; ``release_admission_reservation``
+        # is idempotent below zero so calling it twice is harmless.
+        if want_logprobs and not use_guided:
+            release = getattr(engine, "release_admission_reservation", None)
+            if release is not None:
+                try:
+                    release()
+                except Exception:
+                    logger.warning(
+                        "release_admission_reservation raised",
+                        exc_info=True,
+                    )
 
     if output is None:
         return Response(status_code=499)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -173,26 +173,26 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     _validate_model_name(request.model)
     engine = get_engine(request.model)
 
-    # Pre-flight admission gate (C4). Runs BEFORE returning the
-    # StreamingResponse so a backpressured streaming request surfaces
-    # as HTTP 503 (Retry-After) instead of a 200 stream with an
-    # error-data chunk. The reservation is released by the route-level
-    # ``finally`` (calls ``_release_admission_unless_committed``);
-    # on the streaming path ``_commit_state[0]`` is flipped to True so
-    # ``_disconnect_guard`` (via its ``engine=`` kwarg) owns the
-    # release once the SSE generator closes. Closes the codex R3 leak
-    # where validation errors raised between the reservation and the
-    # helper used to pin the slot until restart — after
-    # ``max_concurrent_requests`` such bad requests the cap was
-    # permanently exhausted.
-    _check_admission_or_503(engine)
+    # Admission reservation is acquired LATER — after cloud-routing
+    # decision (codex R9: cloud-routable requests must not be 503'd
+    # solely because the local engine is at cap; they bypass local
+    # generation entirely) and after the cheap validation that may
+    # raise HTTPException (codex R3: validation errors used to pin
+    # the slot until restart, exhausting the cap via a trivial
+    # malformed-JSON DoS). ``_commit_state[0] = True`` is flipped
+    # right before returning a StreamingResponse so
+    # ``_disconnect_guard`` owns release after the SSE generator
+    # closes; the route-level ``finally`` releases for non-streaming
+    # and cloud paths.
     _commit_state = [False]
+    _admission_acquired = [False]
     try:
         return await _create_chat_completion_impl(
-            request, raw_request, engine, _commit_state
+            request, raw_request, engine, _commit_state, _admission_acquired
         )
     finally:
-        _release_admission_unless_committed(engine, _commit_state[0])
+        if _admission_acquired[0]:
+            _release_admission_unless_committed(engine, _commit_state[0])
 
 
 async def _create_chat_completion_impl(
@@ -200,10 +200,13 @@ async def _create_chat_completion_impl(
     raw_request: Request,
     engine,
     _commit_state: list[bool],
+    _admission_acquired: list[bool],
 ):
-    """Inner impl for ``create_chat_completion`` after admission has
-    been acquired by the wrapper. ``_commit_state[0] = True`` defers
-    the slot release to ``_disconnect_guard`` for streaming paths."""
+    """Inner impl for ``create_chat_completion``. Admission is
+    reserved inside this function — after cloud-routing decision
+    and after cheap validation — to avoid (a) 503'ing
+    cloud-routable requests when the local engine is full and
+    (b) leaking the slot on validation HTTPException paths."""
     # Validate messages is non-empty
     if not request.messages:
         raise HTTPException(
@@ -506,15 +509,14 @@ async def _create_chat_completion_impl(
                         for t in request.tools
                     ]
                 # Cloud-routed request: the local scheduler/Metal path
-                # is bypassed entirely, so the admission slot reserved
-                # at route entry shouldn't be held for the cloud
-                # round-trip. Release it now (and flip the commit flag
-                # so the route-level finally doesn't double-release).
-                # Without this, a burst of long cloud-routed requests
-                # could exhaust the local cap and 503 unrelated local
-                # requests while the local engine is idle (codex R8).
-                _release_admission_unless_committed(engine, _commit_state[0])
-                _commit_state[0] = True
+                # is bypassed entirely, so admission is not acquired
+                # for cloud paths. The wrapper's ``finally`` checks
+                # ``_admission_acquired[0]`` (still False here) and
+                # skips the release. Without this ordering (admission
+                # check moved BELOW the cloud routing block), a burst
+                # of local requests filling the cap would 503
+                # cloud-routable requests that never touch the local
+                # engine (codex R9).
                 if request.stream:
                     return StreamingResponse(
                         _disconnect_guard(
@@ -548,6 +550,15 @@ async def _create_chat_completion_impl(
             logger.warning(
                 f"[CLOUD ROUTE] Error during routing check: {e}, falling back to local"
             )
+
+    # Local-path admission gate: reserve a slot before kicking the
+    # engine. Placed AFTER cloud routing so cloud-routable requests
+    # don't 503 just because the local cap is full (codex R9), and
+    # AFTER the cheap validation above so a malformed request can't
+    # pin a slot until restart (codex R3). The wrapper's ``finally``
+    # uses ``_admission_acquired`` to decide whether to release.
+    _check_admission_or_503(engine)
+    _admission_acquired[0] = True
 
     if request.stream:
         # Validate chat template eagerly so template errors return 400

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -51,6 +51,7 @@ from ..service.helpers import (
     _inject_json_instruction,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
+    _release_admission_unless_committed,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -175,10 +176,34 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Pre-flight admission gate (C4). Runs BEFORE returning the
     # StreamingResponse so a backpressured streaming request surfaces
     # as HTTP 503 (Retry-After) instead of a 200 stream with an
-    # error-data chunk. Non-streaming requests get a second-chance
-    # catch inside ``_wait_with_disconnect`` for the race window.
+    # error-data chunk. The reservation is released by the route-level
+    # ``finally`` (calls ``_release_admission_unless_committed``);
+    # on the streaming path ``_commit_state[0]`` is flipped to True so
+    # ``_disconnect_guard`` (via its ``engine=`` kwarg) owns the
+    # release once the SSE generator closes. Closes the codex R3 leak
+    # where validation errors raised between the reservation and the
+    # helper used to pin the slot until restart — after
+    # ``max_concurrent_requests`` such bad requests the cap was
+    # permanently exhausted.
     _check_admission_or_503(engine)
+    _commit_state = [False]
+    try:
+        return await _create_chat_completion_impl(
+            request, raw_request, engine, _commit_state
+        )
+    finally:
+        _release_admission_unless_committed(engine, _commit_state[0])
 
+
+async def _create_chat_completion_impl(
+    request: ChatCompletionRequest,
+    raw_request: Request,
+    engine,
+    _commit_state: list[bool],
+):
+    """Inner impl for ``create_chat_completion`` after admission has
+    been acquired by the wrapper. ``_commit_state[0] = True`` defers
+    the slot release to ``_disconnect_guard`` for streaming paths."""
     # Validate messages is non-empty
     if not request.messages:
         raise HTTPException(
@@ -481,6 +506,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         for t in request.tools
                     ]
                 if request.stream:
+                    _commit_state[0] = True
                     return StreamingResponse(
                         _disconnect_guard(
                             cfg.cloud_router.stream_completion(
@@ -498,7 +524,6 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         cfg.cloud_router.completion(cloud_messages, **cloud_kwargs),
                         raw_request,
                         timeout=request.timeout or cfg.default_timeout,
-                        engine=engine,
                     )
                     if result is None:
                         return Response(status_code=499, content="Client disconnected")
@@ -538,6 +563,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         detail=f"Chat template error: {err_msg}",
                     )
                 raise
+        _commit_state[0] = True
         return StreamingResponse(
             _disconnect_guard(
                 stream_chat_completion(engine, messages, request, **chat_kwargs),
@@ -593,31 +619,26 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                     ),
                     raw_request,
                     timeout=timeout,
-                    engine=engine,
                 )
             except Exception as guided_err:
                 logger.warning(
                     f"Guided generation failed, falling back to standard: {guided_err}"
                 )
                 logger.debug(f"Problematic schema: {json_schema}")
-                # Re-reserve before falling back: the failed
-                # ``generate_with_schema`` already released the original
-                # reservation in its finally clause. Without a fresh
-                # ``check_admission`` the cap accounting would drift
-                # negative once the fallback's finally runs.
-                _check_admission_or_503(engine)
+                # Fallback runs under the outer admission reservation
+                # still held by the wrapper's ``finally`` — no
+                # re-acquire needed (the helper does not release on
+                # its own now that release lives at the route level).
                 output = await _wait_with_disconnect(
                     engine.chat(messages=messages, **chat_kwargs),
                     raw_request,
                     timeout=timeout,
-                    engine=engine,
                 )
         else:
             output = await _wait_with_disconnect(
                 engine.chat(messages=messages, **chat_kwargs),
                 raw_request,
                 timeout=timeout,
-                engine=engine,
             )
     except HTTPException:
         raise
@@ -644,21 +665,6 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         if cfg.gc_control and gc_was_enabled:
             gc.enable()
             gc.collect()
-        # Safety net for the want_logprobs/non-stream branch which calls
-        # ``engine.stream_chat`` directly (no ``_wait_with_disconnect``
-        # to handle release). The other branches already released via
-        # ``_wait_with_disconnect.finally``; ``release_admission_reservation``
-        # is idempotent below zero so calling it twice is harmless.
-        if want_logprobs and not use_guided:
-            release = getattr(engine, "release_admission_reservation", None)
-            if release is not None:
-                try:
-                    release()
-                except Exception:
-                    logger.warning(
-                        "release_admission_reservation raised",
-                        exc_info=True,
-                    )
 
     if output is None:
         return Response(status_code=499)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -505,8 +505,17 @@ async def _create_chat_completion_impl(
                         t.model_dump() if hasattr(t, "model_dump") else t
                         for t in request.tools
                     ]
+                # Cloud-routed request: the local scheduler/Metal path
+                # is bypassed entirely, so the admission slot reserved
+                # at route entry shouldn't be held for the cloud
+                # round-trip. Release it now (and flip the commit flag
+                # so the route-level finally doesn't double-release).
+                # Without this, a burst of long cloud-routed requests
+                # could exhaust the local cap and 503 unrelated local
+                # requests while the local engine is idle (codex R8).
+                _release_admission_unless_committed(engine, _commit_state[0])
+                _commit_state[0] = True
                 if request.stream:
-                    _commit_state[0] = True
                     return StreamingResponse(
                         _disconnect_guard(
                             cfg.cloud_router.stream_completion(
@@ -515,7 +524,6 @@ async def _create_chat_completion_impl(
                                 **cloud_kwargs,
                             ),
                             raw_request,
-                            engine=engine,
                         ),
                         media_type="text/event-stream",
                     )

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -44,6 +44,7 @@ from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
     _TOOL_USE_SYSTEM_SUFFIX,
     _build_usage,
+    _check_admission_or_503,
     _disconnect_guard,
     _extract_streaming_token_logprobs,
     _finalize_content_and_reasoning,
@@ -170,6 +171,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     """
     _validate_model_name(request.model)
     engine = get_engine(request.model)
+
+    # Pre-flight admission gate (C4). Runs BEFORE returning the
+    # StreamingResponse so a backpressured streaming request surfaces
+    # as HTTP 503 (Retry-After) instead of a 200 stream with an
+    # error-data chunk. Non-streaming requests get a second-chance
+    # catch inside ``_wait_with_disconnect`` for the race window.
+    _check_admission_or_503(engine)
 
     # Validate messages is non-empty
     if not request.messages:

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -19,6 +19,7 @@ from ..api.models import (
 from ..config import get_config
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
+    _check_admission_or_503,
     _disconnect_guard,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -52,6 +53,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             ),
         )
     engine = get_engine(request.model)
+
+    # Pre-flight admission gate (C4) — see chat.py for rationale.
+    _check_admission_or_503(engine)
 
     # Handle single prompt or list of prompts
     prompts = request.prompt if isinstance(request.prompt, list) else [request.prompt]

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -74,6 +74,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             _disconnect_guard(
                 stream_completion(engine, prompts[0], request),
                 raw_request,
+                engine=engine,
             ),
             media_type="text/event-stream",
         )
@@ -87,33 +88,47 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
     extended_kwargs = build_extended_sampling_kwargs(request)
 
-    for i, prompt in enumerate(prompts):
-        output = await _wait_with_disconnect(
-            engine.generate(
-                prompt=prompt,
-                max_tokens=_resolve_max_tokens(request.max_tokens),
-                temperature=_resolve_temperature(request.temperature),
-                top_p=_resolve_top_p(request.top_p),
-                stop=request.stop,
-                **extended_kwargs,
-            ),
-            raw_request,
-            timeout=timeout,
-        )
-        if output is None:
-            return Response(status_code=499)  # Client closed request
-
-        choices.append(
-            CompletionChoice(
-                index=i,
-                text=output.text,
-                finish_reason=output.finish_reason,
+    # Reservation released exactly once after the per-prompt loop —
+    # passing ``engine`` to each ``_wait_with_disconnect`` would over-
+    # release for multi-prompt requests (one acquire vs N releases).
+    try:
+        for i, prompt in enumerate(prompts):
+            output = await _wait_with_disconnect(
+                engine.generate(
+                    prompt=prompt,
+                    max_tokens=_resolve_max_tokens(request.max_tokens),
+                    temperature=_resolve_temperature(request.temperature),
+                    top_p=_resolve_top_p(request.top_p),
+                    stop=request.stop,
+                    **extended_kwargs,
+                ),
+                raw_request,
+                timeout=timeout,
             )
-        )
-        total_completion_tokens += output.completion_tokens
-        total_prompt_tokens += (
-            output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
-        )
+            if output is None:
+                return Response(status_code=499)  # Client closed request
+
+            choices.append(
+                CompletionChoice(
+                    index=i,
+                    text=output.text,
+                    finish_reason=output.finish_reason,
+                )
+            )
+            total_completion_tokens += output.completion_tokens
+            total_prompt_tokens += (
+                output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
+            )
+    finally:
+        release = getattr(engine, "release_admission_reservation", None)
+        if release is not None:
+            try:
+                release()
+            except Exception:
+                logger.warning(
+                    "release_admission_reservation raised",
+                    exc_info=True,
+                )
 
     elapsed = time.perf_counter() - start_time
     tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -21,6 +21,7 @@ from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
     _check_admission_or_503,
     _disconnect_guard,
+    _release_admission_unless_committed,
     _resolve_max_tokens,
     _resolve_model_name,
     _resolve_temperature,
@@ -54,44 +55,49 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         )
     engine = get_engine(request.model)
 
-    # Pre-flight admission gate (C4) — see chat.py for rationale.
+    # Pre-flight admission gate (C4). Reservation is released by the
+    # ``finally`` block below; on the streaming path we flip
+    # ``_admission_committed`` to True so ``_disconnect_guard`` owns
+    # the release once the SSE generator closes. Closes the codex R3
+    # leak where any HTTPException between this call and the
+    # streaming/non-streaming helper pinned the slot until restart.
     _check_admission_or_503(engine)
-
-    # Handle single prompt or list of prompts
-    prompts = request.prompt if isinstance(request.prompt, list) else [request.prompt]
-
-    # --- Detailed request logging ---
-    prompt_preview = prompts[0][:200] if prompts else "(empty)"
-    prompt_len = sum(len(p) for p in prompts)
-    logger.info(
-        f"[REQUEST] POST /v1/completions stream={request.stream} "
-        f"max_tokens={request.max_tokens} temp={request.temperature} "
-        f"prompt_chars={prompt_len} prompt_preview={prompt_preview!r}"
-    )
-
-    if request.stream:
-        return StreamingResponse(
-            _disconnect_guard(
-                stream_completion(engine, prompts[0], request),
-                raw_request,
-                engine=engine,
-            ),
-            media_type="text/event-stream",
+    _admission_committed = False
+    try:
+        # Handle single prompt or list of prompts
+        prompts = (
+            request.prompt if isinstance(request.prompt, list) else [request.prompt]
         )
 
-    # Non-streaming response with timing and timeout
-    start_time = time.perf_counter()
-    timeout = request.timeout or get_config().default_timeout
-    choices = []
-    total_completion_tokens = 0
-    total_prompt_tokens = 0
+        # --- Detailed request logging ---
+        prompt_preview = prompts[0][:200] if prompts else "(empty)"
+        prompt_len = sum(len(p) for p in prompts)
+        logger.info(
+            f"[REQUEST] POST /v1/completions stream={request.stream} "
+            f"max_tokens={request.max_tokens} temp={request.temperature} "
+            f"prompt_chars={prompt_len} prompt_preview={prompt_preview!r}"
+        )
 
-    extended_kwargs = build_extended_sampling_kwargs(request)
+        if request.stream:
+            _admission_committed = True
+            return StreamingResponse(
+                _disconnect_guard(
+                    stream_completion(engine, prompts[0], request),
+                    raw_request,
+                    engine=engine,
+                ),
+                media_type="text/event-stream",
+            )
 
-    # Reservation released exactly once after the per-prompt loop —
-    # passing ``engine`` to each ``_wait_with_disconnect`` would over-
-    # release for multi-prompt requests (one acquire vs N releases).
-    try:
+        # Non-streaming response with timing and timeout
+        start_time = time.perf_counter()
+        timeout = request.timeout or get_config().default_timeout
+        choices = []
+        total_completion_tokens = 0
+        total_prompt_tokens = 0
+
+        extended_kwargs = build_extended_sampling_kwargs(request)
+
         for i, prompt in enumerate(prompts):
             output = await _wait_with_disconnect(
                 engine.generate(
@@ -119,36 +125,28 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             total_prompt_tokens += (
                 output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
             )
+
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Completion: {total_prompt_tokens} prompt + {total_completion_tokens} completion tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+        )
+
+        comp_response = CompletionResponse(
+            model=_resolve_model_name(request.model),
+            choices=choices,
+            usage=Usage(
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
+                total_tokens=total_prompt_tokens + total_completion_tokens,
+            ),
+        )
+        return Response(
+            content=comp_response.model_dump_json(exclude_none=True),
+            media_type="application/json",
+        )
     finally:
-        release = getattr(engine, "release_admission_reservation", None)
-        if release is not None:
-            try:
-                release()
-            except Exception:
-                logger.warning(
-                    "release_admission_reservation raised",
-                    exc_info=True,
-                )
-
-    elapsed = time.perf_counter() - start_time
-    tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
-    logger.info(
-        f"Completion: {total_prompt_tokens} prompt + {total_completion_tokens} completion tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
-    )
-
-    comp_response = CompletionResponse(
-        model=_resolve_model_name(request.model),
-        choices=choices,
-        usage=Usage(
-            prompt_tokens=total_prompt_tokens,
-            completion_tokens=total_completion_tokens,
-            total_tokens=total_prompt_tokens + total_completion_tokens,
-        ),
-    )
-    return Response(
-        content=comp_response.model_dump_json(exclude_none=True),
-        media_type="application/json",
-    )
+        _release_admission_unless_committed(engine, _admission_committed)
 
 
 async def stream_completion(

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -62,10 +62,34 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
 
         load_embedding_model(model_name, lock=False, reuse_existing=True)
 
-        texts = request.input if isinstance(request.input, list) else [request.input]
-
-        if not texts:
+        # OpenAI spec supports 4 input shapes (see EmbeddingRequest):
+        #   str                — single text
+        #   list[str]          — batch of texts
+        #   list[int]          — single pre-tokenized
+        #   list[list[int]]    — batch of pre-tokenized
+        # The int forms must NOT go through the str path: ``str(101)``
+        # is a different embedding from token id 101.
+        raw_input = request.input
+        token_batches: list[list[int]] | None = None
+        texts: list[str] | None = None
+        if isinstance(raw_input, str):
+            texts = [raw_input]
+        elif isinstance(raw_input, list) and not raw_input:
             raise HTTPException(status_code=400, detail="Input must not be empty")
+        elif isinstance(raw_input, list) and all(isinstance(x, str) for x in raw_input):
+            texts = raw_input
+        elif isinstance(raw_input, list) and all(isinstance(x, int) for x in raw_input):
+            token_batches = [list(raw_input)]
+        elif isinstance(raw_input, list) and all(
+            isinstance(x, list) and all(isinstance(t, int) for t in x)
+            for x in raw_input
+        ):
+            token_batches = [list(x) for x in raw_input]
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=("input must be str, list[str], list[int], or list[list[int]]"),
+            )
 
         if request.dimensions is not None and request.dimensions < 1:
             raise HTTPException(
@@ -74,11 +98,19 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
             )
 
         start_time = time.perf_counter()
-        prompt_tokens = cfg.embedding_engine.count_tokens(texts)
-        embeddings = cfg.embedding_engine.embed(texts)
+        if token_batches is not None:
+            # count_tokens for pre-tokenized: trust the caller's count
+            # (capped at 512 same as embed_tokens does).
+            prompt_tokens = sum(min(len(b), 512) for b in token_batches)
+            embeddings = cfg.embedding_engine.embed_tokens(token_batches)
+            n_inputs = len(token_batches)
+        else:
+            prompt_tokens = cfg.embedding_engine.count_tokens(texts)
+            embeddings = cfg.embedding_engine.embed(texts)
+            n_inputs = len(texts)
         elapsed = time.perf_counter() - start_time
         logger.info(
-            f"Embeddings: {len(texts)} inputs, {prompt_tokens} tokens in {elapsed:.2f}s"
+            f"Embeddings: {n_inputs} inputs, {prompt_tokens} tokens in {elapsed:.2f}s"
         )
 
         # Optional truncation (OpenAI MRL semantics). Sliced post-embed

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -91,6 +91,18 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
                 detail=("input must be str, list[str], list[int], or list[list[int]]"),
             )
 
+        # Reject empty token sequences. ``[[]]`` would produce a
+        # zero-width tensor; ``[[1, 2], []]`` produces a row whose
+        # attention mask is all zeros (mlx-embeddings would either
+        # NaN or return a meaningless zero vector depending on the
+        # pooling head). Better to 400 with a clear message than
+        # ship garbage embeddings to a vector store.
+        if token_batches is not None and any(len(b) == 0 for b in token_batches):
+            raise HTTPException(
+                status_code=400,
+                detail="input must not contain empty token sequences",
+            )
+
         if request.dimensions is not None and request.dimensions < 1:
             raise HTTPException(
                 status_code=400,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -145,8 +145,14 @@ class SchedulerConfig:
     # be able to OOM the Metal allocator and crash the server for all
     # other clients; ``add_request`` now raises ``BackpressureError``
     # at the cap and routes return 503 with Retry-After. Default 256
-    # matches ``max_num_seqs`` so admission only fires when the batch
-    # generator itself is at saturation.
+    # provides ample queue depth on top of ``max_num_seqs`` — waiting
+    # requests only carry their tokenised prompt, not KV cache state,
+    # so the memory cost of a queue is small even when ``max_num_seqs``
+    # is constrained. Operators who want admission to mirror
+    # ``max_num_seqs`` exactly can pass ``--max-concurrent-requests``
+    # (codex R7 flagged the gap; the explicit override resolves it
+    # without breaking existing tests that intentionally send more
+    # requests than ``max_num_seqs`` to exercise the queue).
     max_concurrent_requests: int = 256
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -140,6 +140,25 @@ class SchedulerConfig:
     # accepting most useful drafts on tool/JSON workloads.
     suffix_min_draft_len: int = 2
 
+    # Admission control: hard cap on concurrent in-flight requests
+    # (queued + running). A buggy client (or simple fork bomb) used to
+    # be able to OOM the Metal allocator and crash the server for all
+    # other clients; ``add_request`` now raises ``BackpressureError``
+    # at the cap and routes return 503 with Retry-After. Default 256
+    # matches ``max_num_seqs`` so admission only fires when the batch
+    # generator itself is at saturation.
+    max_concurrent_requests: int = 256
+
+
+class BackpressureError(Exception):
+    """Raised when admission control rejects a new request.
+
+    Caught by route handlers and converted to HTTP 503 with a
+    Retry-After header so well-behaved clients back off and retry.
+    Distinguished from ``ValueError`` so the scheduler's narrow
+    batch-error catch path doesn't swallow it.
+    """
+
 
 @dataclass
 class SchedulerOutput:
@@ -2281,9 +2300,25 @@ class Scheduler:
 
         Args:
             request: The request to add
+
+        Raises:
+            BackpressureError: If the in-flight request count is at or
+                above ``config.max_concurrent_requests``. Routes catch
+                this and return 503 with Retry-After.
         """
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
+
+        # Admission control: cap concurrent in-flight requests so a
+        # buggy/abusive client can't OOM Metal and crash the server
+        # for everyone else. Check BEFORE tokenization so the cost of
+        # being over the cap is just a dict lookup.
+        cap = self.config.max_concurrent_requests
+        if cap is not None and cap > 0 and len(self.requests) >= cap:
+            raise BackpressureError(
+                f"max_concurrent_requests={cap} reached "
+                f"(currently {len(self.requests)} in-flight)"
+            )
 
         # Tokenize if needed
         if request.prompt_token_ids is None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -993,8 +993,8 @@ Examples:
     parser.add_argument(
         "--timeout",
         type=float,
-        default=300.0,
-        help="Default request timeout in seconds (default: 300)",
+        default=1800.0,
+        help="Default request timeout in seconds (default: 1800 = 30 min)",
     )
     parser.add_argument(
         "--rate-limit",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -176,7 +176,7 @@ _model_path: str | None = (
 )
 _default_max_tokens: int = 4096
 _thinking_token_budget: int = 2048  # Extra tokens added for thinking models
-_default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
+_default_timeout: float = 1800.0  # Default request timeout in seconds (30 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
 _default_top_k: int | None = None  # Set via --default-top-k

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -38,6 +38,28 @@ _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
 
 
+def _raise_backpressure_503(exc: Exception) -> None:
+    """Convert ``BackpressureError`` from the scheduler into HTTP 503
+    with a Retry-After header (RFC 9110 §10.2.4).
+
+    Backpressure is a normal load-shedding outcome, not a bug — clients
+    that respect Retry-After can simply re-queue. Without this catch,
+    the error reaches FastAPI's generic 500 handler and the client
+    sees an opaque ``Internal server error`` body, defeating the
+    point of admission control.
+    """
+    raise HTTPException(
+        status_code=503,
+        # 1s is a sensible default — the cap usually clears within
+        # a few tokens of decode on the saturated batch.
+        headers={"Retry-After": "1"},
+        detail=(
+            "Server is busy (max concurrent requests reached). "
+            f"Retry after the Retry-After delay. ({exc})"
+        ),
+    )
+
+
 def _finalize_content_and_reasoning(
     raw_text: str,
     cleaned_text: str,
@@ -769,8 +791,17 @@ async def _wait_with_disconnect(
     timeout: float,
     poll_interval: float = 0.5,
 ):
-    """Run a coroutine with both timeout and client disconnect detection."""
+    """Run a coroutine with both timeout and client disconnect detection.
+
+    Also catches ``BackpressureError`` from admission control and
+    re-raises as HTTP 503 with Retry-After (RFC 9110 §10.2.4). Doing
+    the conversion here means every route that goes through this
+    helper (chat, completions, anthropic) gets correct 503 semantics
+    without each one wiring its own try/except.
+    """
     import time as _time
+
+    from ..scheduler import BackpressureError
 
     _t0 = _time.monotonic()
 
@@ -822,7 +853,10 @@ async def _wait_with_disconnect(
                 pass
             return None
 
-        return task.result()
+        try:
+            return task.result()
+        except BackpressureError as exc:
+            _raise_backpressure_503(exc)
 
     finally:
         if not disconnect_task.done():

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -38,6 +38,32 @@ _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
 
 
+def _check_admission_or_503(engine) -> None:
+    """Pre-flight admission gate for route handlers.
+
+    Calls ``engine.check_admission()`` (sync, ~µs); if the cap is
+    exceeded, raises HTTP 503 with Retry-After before any response
+    body is sent. This is necessary for streaming routes — once
+    ``StreamingResponse`` starts yielding, headers are flushed and
+    the only way to signal backpressure would be an SSE error chunk
+    on a 200 response.
+
+    Engines without a scheduler yet (mid-init) silently no-op via
+    ``check_admission``'s own guard.
+    """
+    from ..scheduler import BackpressureError
+
+    check = getattr(engine, "check_admission", None)
+    if check is None:
+        # Engine doesn't implement admission control (e.g. test stub) —
+        # fall through to the runtime catch in ``_wait_with_disconnect``.
+        return
+    try:
+        check()
+    except BackpressureError as exc:
+        _raise_backpressure_503(exc)
+
+
 def _raise_backpressure_503(exc: Exception) -> None:
     """Convert ``BackpressureError`` from the scheduler into HTTP 503
     with a Retry-After header (RFC 9110 §10.2.4).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -71,6 +71,39 @@ def _check_admission_or_503(engine) -> None:
         _raise_backpressure_503(exc)
 
 
+def _release_admission_unless_committed(engine, committed: bool) -> None:
+    """Release a slot reserved by ``_check_admission_or_503`` unless
+    release responsibility has been handed off to a streaming helper.
+
+    Pair with a route-handler ``try/finally``: set a local
+    ``_admission_committed_to_helper = False`` right after the
+    reservation, flip to ``True`` immediately before returning a
+    ``StreamingResponse(_disconnect_guard(..., engine=engine))``
+    (the helper releases when the SSE generator closes), and call
+    this from the ``finally``. Closes the codex R3 leak — validation
+    errors (``messages=[]``, invalid ``max_tokens``, unsupported
+    image-on-text, ``response_format`` schema errors,
+    chat-template errors, …) that previously pinned a slot until
+    restart now drop the slot via this finally.
+
+    ``release_admission_reservation`` is idempotent below zero so a
+    stray double release (defensive callers, helper fires just as
+    the route handler also releases) cannot corrupt the accounting.
+    """
+    if committed:
+        return
+    release = getattr(engine, "release_admission_reservation", None)
+    if release is None:
+        return
+    try:
+        release()
+    except Exception:
+        logger.warning(
+            "release_admission_reservation raised on route finally",
+            exc_info=True,
+        )
+
+
 def _raise_backpressure_503(exc: Exception) -> None:
     """Convert ``BackpressureError`` from the scheduler into HTTP 503
     with a Retry-After header (RFC 9110 §10.2.4).
@@ -843,7 +876,6 @@ async def _wait_with_disconnect(
     raw_request: Request,
     timeout: float,
     poll_interval: float = 0.5,
-    engine=None,
 ):
     """Run a coroutine with both timeout and client disconnect detection.
 
@@ -853,11 +885,12 @@ async def _wait_with_disconnect(
     helper (chat, completions, anthropic) gets correct 503 semantics
     without each one wiring its own try/except.
 
-    When ``engine`` is provided, releases its admission reservation in
-    the ``finally`` clause — mirrors ``_disconnect_guard`` for the
-    non-streaming path so a slot acquired by ``_check_admission_or_503``
-    is always returned to the pool (whether the request completed,
-    timed out, the client disconnected, or backpressure fired).
+    Admission release is the caller's responsibility — wrap the route
+    handler in ``with _admission_slot(engine):`` so the slot is
+    released on ``with`` exit (covering normal completion, validation
+    errors, timeouts, and disconnects). Releasing inside this helper
+    would drop the slot *before* the route handler's post-processing
+    finishes, briefly under-counting in-flight requests.
     """
     import time as _time
 
@@ -923,13 +956,3 @@ async def _wait_with_disconnect(
             disconnect_task.cancel()
         if not task.done():
             task.cancel()
-        if engine is not None:
-            release = getattr(engine, "release_admission_reservation", None)
-            if release is not None:
-                try:
-                    release()
-                except Exception:
-                    logger.warning(
-                        "[wait_with_disconnect] release_admission_reservation raised",
-                        exc_info=True,
-                    )

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -39,17 +39,24 @@ _FALLBACK_TOP_P = 0.9
 
 
 def _check_admission_or_503(engine) -> None:
-    """Pre-flight admission gate for route handlers.
+    """Atomic admission gate for route handlers — reserves a slot.
 
-    Calls ``engine.check_admission()`` (sync, ~µs); if the cap is
-    exceeded, raises HTTP 503 with Retry-After before any response
-    body is sent. This is necessary for streaming routes — once
-    ``StreamingResponse`` starts yielding, headers are flushed and
-    the only way to signal backpressure would be an SSE error chunk
-    on a 200 response.
+    Calls ``engine.check_admission()`` which, under
+    ``_admission_lock``, checks the cap and increments the engine's
+    reservation counter. If the cap is reached, raises HTTP 503 with
+    Retry-After before any response body is sent. This is necessary
+    for streaming routes — once ``StreamingResponse`` starts yielding,
+    headers are flushed and the only way to signal backpressure would
+    be an SSE error chunk on a 200 response.
 
-    Engines without a scheduler yet (mid-init) silently no-op via
-    ``check_admission``'s own guard.
+    The reservation is released by ``_disconnect_guard`` (streaming)
+    or ``_wait_with_disconnect`` (non-streaming) via their ``finally``
+    clauses when the caller passes ``engine=engine`` to them. Routes
+    that bypass both (e.g. the chat ``want_logprobs`` branch) must
+    call ``engine.release_admission_reservation()`` themselves.
+
+    Engines without a ``check_admission`` attribute (test stubs)
+    silently no-op.
     """
     from ..scheduler import BackpressureError
 
@@ -712,8 +719,18 @@ async def _disconnect_guard(
     generator: AsyncIterator[str],
     raw_request: Request,
     poll_interval: float = 0.5,
+    engine=None,
 ) -> AsyncIterator[str]:
-    """Wrap streaming generator to abort on client disconnect."""
+    """Wrap streaming generator to abort on client disconnect.
+
+    When ``engine`` is provided, releases its admission reservation in
+    the ``finally`` clause so the slot acquired by
+    ``_check_admission_or_503`` is returned to the pool once the
+    streaming response finishes (or the client disconnects, or the
+    generator raises). The release is the safety net for the
+    streaming path; non-streaming routes mirror it via
+    ``_wait_with_disconnect``.
+    """
     import time as _time
 
     _t0 = _time.monotonic()
@@ -806,6 +823,16 @@ async def _disconnect_guard(
             await generator.aclose()
         except Exception:
             pass
+        if engine is not None:
+            release = getattr(engine, "release_admission_reservation", None)
+            if release is not None:
+                try:
+                    release()
+                except Exception:
+                    logger.warning(
+                        "[disconnect_guard] release_admission_reservation raised",
+                        exc_info=True,
+                    )
         logger.info(
             f"[disconnect_guard] CLEANUP done, {chunk_count} chunks total, elapsed={_elapsed()}"
         )
@@ -816,6 +843,7 @@ async def _wait_with_disconnect(
     raw_request: Request,
     timeout: float,
     poll_interval: float = 0.5,
+    engine=None,
 ):
     """Run a coroutine with both timeout and client disconnect detection.
 
@@ -824,6 +852,12 @@ async def _wait_with_disconnect(
     the conversion here means every route that goes through this
     helper (chat, completions, anthropic) gets correct 503 semantics
     without each one wiring its own try/except.
+
+    When ``engine`` is provided, releases its admission reservation in
+    the ``finally`` clause — mirrors ``_disconnect_guard`` for the
+    non-streaming path so a slot acquired by ``_check_admission_or_503``
+    is always returned to the pool (whether the request completed,
+    timed out, the client disconnected, or backpressure fired).
     """
     import time as _time
 
@@ -889,3 +923,13 @@ async def _wait_with_disconnect(
             disconnect_task.cancel()
         if not task.done():
             task.cancel()
+        if engine is not None:
+            release = getattr(engine, "release_admission_reservation", None)
+            if release is not None:
+                try:
+                    release()
+                except Exception:
+                    logger.warning(
+                        "[wait_with_disconnect] release_admission_reservation raised",
+                        exc_info=True,
+                    )


### PR DESCRIPTION
## Summary

Three user-facing reliability bugs from the R10 onboarding sweep, all empirically reproduced on v0.6.58 with a live qwen3.5-4b server before writing the test that pins each fix. Followup to PR #416.

H6, H22, C4 originally appeared on the next-PR-pool list as separate items. Bundled here because each is small and the fixes touch disjoint subsystems (route schema vs config default vs scheduler admission); reviewing once is cheaper than three near-empty PRs.

## Fixes

| ID | File(s) | Behavior change |
|----|---------|-----------------|
| H6 | api/models.py, embedding.py, routes/embeddings.py | ``EmbeddingRequest.input`` now accepts all 4 OpenAI spec shapes (``str``, ``list[str]``, ``list[int]``, ``list[list[int]]``). Pre-tokenized inputs dispatch to new ``EmbeddingEngine.embed_tokens`` so they bypass the str tokenizer — calling the str path on ints would coerce ``101`` to the word ""101"" (different embedding from token id 101). |
| H22 | config/server_config.py, server.py | ``default_timeout`` bumped 300 → 1800 (30 min). Reasoning generations and 30B+ greedy decodes were silently truncated at 5 min. 1800s matches vLLM and the common OpenAI-compat proxy baseline; CLI ``--timeout`` and per-request ``timeout`` still override. |
| C4 | scheduler.py, service/helpers.py | New ``SchedulerConfig.max_concurrent_requests`` (default 256, matches ``max_num_seqs``); new ``BackpressureError`` raised by ``Scheduler.add_request`` at the cap; ``_wait_with_disconnect`` catches and re-raises as HTTP 503 with ``Retry-After: 1`` (RFC 9110 §10.2.4). All routes going through the helper inherit backpressure semantics — no per-route try/except needed. |

## Empirical reproducers (run against v0.6.58, captured pre-fix)

- **H6**: ``curl /v1/embeddings -d '{""input"": [[1,2,3]]}'`` → 422 with ""Input should be a valid string""
- **H22**: ``grep default_timeout vllm_mlx/config/server_config.py`` → ``300.0``
- **C4**: ``grep -rn 'admission\|max_concurrent' vllm_mlx/scheduler.py`` → no hits; route comment at chat.py:199 even admits ""unbounded admission""

## Test plan

- [x] ``python3.12 -m pytest tests/test_embeddings_timeout_admission.py -v`` — 14/14 new tests pass
- [x] ``python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py`` — 3727 passed, 19 skipped (one pre-existing test pinning 300s timeout updated to 1800s)
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [ ] PR validate gauntlet (live integration tests)
- [ ] codex review to convergence
- [ ] CI green
- [ ] release-smoke against PyPI 0.6.59

🤖 Generated with [Claude Code](https://claude.com/claude-code)