### PR TITLE
chore: bump version to 0.6.60

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.59"
+version = "0.6.60"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Ships PR #419 — guided generation schema passthrough fix.

The previous code projected `response_format: json_schema` requests through `json_schema_to_pydantic` — a shallow converter that silently dropped `$defs`/`$ref`/`anyOf`/`enum`/numeric bounds/`additionalProperties: false`. Outlines was then asked to enforce a strict superset of the user's schema, so on real-world schemas the model could emit JSON that failed validation against the user's own schema (e.g. a JSON array where the schema required an object).

PR #419 routes the raw schema dict directly to `outlines.types.dsl.JsonSchema`, which natively understands all those constructs. Adds unit tests pinning the constraint passthrough wiring and an e2e `regression_suite.test_11` with `jsonschema.validate` as authoritative leaf check.

## Pre-release validation (per `release_workflow.md`)

- [x] `make release-smoke` — clean-room install+import OK
- [x] `scripts/audit_cli_config_fidelity.py` — CLI ↔ Config fidelity OK
- [x] `make smoke` — lint + 3774 unit tests pass
- [x] `make stress` — 8/8 stress scenarios pass
- [x] Boot server + e2e repro: complex `$defs`+`$ref`+`anyOf`+`enum`+`additionalProperties: false` schema → `jsonschema.validate` PASS
- [x] Integration: `test_anthropic_sdk.py` 5/5, `test_smolagents_full.py` 4/4, `test_pydantic_ai_full.py` 5/6 (test 5 multi-turn fail is pre-existing finish_reason issue, unrelated)
- [x] Guided-path latency: 10 sequential json_schema requests stable at median 0.74s, stdev 0.01s
- [ ] N/A microbenchmark — no perf-critical code path changed (removed a converter call)
- [ ] N/A MLX-version-bump cross-chip-family gate — no mlx version bump
- [ ] N/A auto-detection escape-hatch gate — no new auto-routing

## Closes

- Closes the silent json_schema-decode-superset bug found while reproducing upstream waybarrios#546 on Qwen3-Coder-30B-A3B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)