### PR TITLE
fix(chat): route stream=true + json_schema through guided generation

### DIFF
--- a/tests/regression_suite.py
+++ b/tests/regression_suite.py
@@ -522,6 +522,140 @@ def test_11():
     return all_pass
 
 
+def test_12():
+    """Streaming variant of test_11: stream=true must preserve schema enforcement.
+
+    SOP-gate added after Gap #2 of the v0.6.60 onboarding sweep: pre-fix,
+    ``stream=true`` requests with ``response_format: json_schema`` silently
+    bypassed ``GuidedGenerator`` because the stream branch of
+    ``_create_chat_completion_impl`` went straight to
+    ``engine.stream_chat`` with no constraint hookup. The model would
+    emit unconstrained tokens (e.g. a ```json ... ``` markdown fence
+    around the JSON), defeating the user's intent.
+
+    This test sends the same complex schema as ``test_11`` but with
+    ``stream=true``, reassembles the SSE chunks, and asserts the joined
+    content passes ``jsonschema.validate`` against the same schema —
+    locking in the streaming guided contract.
+    """
+    print("=" * 60)
+    print("TEST 12: Streaming json_schema enforcement (Gap #2 — stream=true)")
+    schema = {
+        "type": "object",
+        "$defs": {
+            "Item": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "qty": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                },
+                "required": ["name", "qty"],
+                "additionalProperties": False,
+            }
+        },
+        "properties": {
+            "label": {"type": "string", "enum": ["red", "green", "blue"]},
+            "score": {"type": "integer", "minimum": 1, "maximum": 10},
+            "items": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Item"},
+                "minItems": 1,
+            },
+        },
+        "required": ["label", "score", "items"],
+        "additionalProperties": False,
+    }
+
+    try:
+        text, lines = stream_call(
+            "/v1/chat/completions",
+            {
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Pick a color and rate it 7/10 with two items.",
+                    }
+                ],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Pick",
+                        "schema": schema,
+                        "strict": True,
+                    },
+                },
+                "max_tokens": 400,
+                "temperature": 0.1,
+                "stream": True,
+            },
+        )
+    except Exception as e:
+        print(f"  Streaming call failed: {e}")
+        print("  RESULT: FAIL")
+        return False
+
+    print(f"  SSE lines received: {len(lines)}")
+    print(f"  Joined content: {text[:200]}")
+
+    # The streaming path must terminate with [DONE]. Without this gate,
+    # a half-emitted stream would still appear to pass the schema check
+    # if the partial JSON happens to parse.
+    saw_done = any("[DONE]" in line for line in lines)
+
+    try:
+        parsed = json.loads(text)
+    except Exception as e:
+        print(f"  JSON parse failed: {e}")
+        print("  RESULT: FAIL")
+        return False
+
+    p = parsed if isinstance(parsed, dict) else {}
+    items_value = p.get("items")
+    items_iter = items_value if isinstance(items_value, list) else []
+    checks = [
+        ("SSE stream terminated with [DONE]", saw_done),
+        ("top-level is object", isinstance(parsed, dict)),
+        ("label is enum", p.get("label") in {"red", "green", "blue"}),
+        (
+            "score is int in [1,10]",
+            isinstance(p.get("score"), int) and 1 <= p["score"] <= 10,
+        ),
+        ("items is list", isinstance(items_value, list)),
+        ("items is non-empty (minItems: 1)", len(items_iter) >= 1),
+        (
+            "every item is object with required fields",
+            all(
+                isinstance(it, dict) and "name" in it and "qty" in it
+                for it in items_iter
+            ),
+        ),
+    ]
+
+    # Authoritative leaf check — same pattern as test_11. ``jsonschema``
+    # is a hard project dependency (no soft ImportError fallback).
+    import jsonschema  # noqa: E402
+
+    try:
+        jsonschema.validate(instance=parsed, schema=schema)
+        schema_check_ok = True
+        schema_error: str | None = None
+    except jsonschema.exceptions.ValidationError as e:
+        schema_check_ok = False
+        schema_error = str(e)
+    checks.append(
+        ("matches declared json_schema (jsonschema.validate)", schema_check_ok)
+    )
+
+    all_pass = all(ok for _, ok in checks)
+    for label, ok in checks:
+        print(f"  {'PASS' if ok else 'FAIL'}: {label}")
+    if schema_error is not None:
+        print(f"  jsonschema error: {schema_error}")
+    print(f"  RESULT: {'PASS' if all_pass else 'FAIL'}")
+    return all_pass
+
+
 if __name__ == "__main__":
     results = {}
     for i, test_fn in enumerate(
@@ -537,6 +671,7 @@ if __name__ == "__main__":
             test_9,
             test_10,
             test_11,
+            test_12,
         ],
         1,
     ):
@@ -550,7 +685,7 @@ if __name__ == "__main__":
     print("=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    for i in range(1, 12):
+    for i in range(1, 13):
         status = "PASS" if results.get(i) else "FAIL"
         print(f"  Test {i:2d}: {status}")
     passed = sum(1 for v in results.values() if v)

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming + guided generation route contract.
+
+Pins Gap #2 from the v0.6.60 onboarding sweep: ``stream=true`` requests
+with ``response_format: json_schema`` must route through
+``engine.generate_with_schema`` (constrained), NOT ``engine.stream_chat``
+(unconstrained). Pre-fix, the stream branch of
+``_create_chat_completion_impl`` ignored ``supports_guided_generation``
+entirely and the model would emit unconstrained tokens (e.g. a
+``\\`\\`\\`json ... \\`\\`\\`\\`` markdown fence) defeating the user's intent.
+
+Two contract tests:
+
+1. **Success path** — guided streaming is used, fallback engine.stream_chat
+   is not called, the synthesized SSE stream carries the constrained text.
+
+2. **Fallback path** — if ``generate_with_schema`` raises, the helper
+   falls back to ``engine.stream_chat`` so request liveness is preserved
+   (clients in strict-mode use cases should validate themselves; this
+   matches the non-streaming fallback semantics).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+
+
+class _GuidedEngine:
+    """Mock engine that supports guided generation.
+
+    Records every call to ``generate_with_schema`` and ``stream_chat``
+    so tests can assert which path the route dispatched to.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = True
+    tokenizer = None
+
+    def __init__(
+        self, *, guided_text: str = '{"k": "v"}', raise_in_guided: bool = False
+    ):
+        self._guided_text = guided_text
+        self._raise = raise_in_guided
+        self.guided_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        # Stream branch validates the template eagerly; return a no-op
+        # string so that pre-flight passes without exercising a real
+        # chat-template engine.
+        return "PROMPT"
+
+    async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+        self.guided_calls.append(
+            {"messages": messages, "json_schema": json_schema, "kwargs": kwargs}
+        )
+        if self._raise:
+            raise RuntimeError("simulated outlines failure")
+        return GenerationOutput(
+            text=self._guided_text,
+            new_text=self._guided_text,
+            prompt_tokens=4,
+            completion_tokens=5,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        """Unconstrained fallback path: emit a single text delta."""
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        text = "FALLBACK"
+        yield GenerationOutput(
+            text=text,
+            new_text=text,
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+def _make_client(engine: _GuidedEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _parse_sse_events(text: str) -> tuple[list[dict], bool]:
+    """Return ``(parsed_events, saw_done)``.
+
+    ``parsed_events`` excludes the ``[DONE]`` sentinel.
+    """
+    events: list[dict] = []
+    saw_done = False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            saw_done = True
+            continue
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            continue
+    return events, saw_done
+
+
+_SCHEMA = {
+    "type": "object",
+    "$defs": {
+        "Item": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "qty": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            },
+            "required": ["name", "qty"],
+            "additionalProperties": False,
+        }
+    },
+    "properties": {
+        "label": {"type": "string", "enum": ["red", "green", "blue"]},
+        "items": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/Item"},
+            "minItems": 1,
+        },
+    },
+    "required": ["label", "items"],
+    "additionalProperties": False,
+}
+
+
+_GUIDED_OUTPUT = json.dumps({"label": "red", "items": [{"name": "alpha", "qty": 2}]})
+
+
+def test_streaming_json_schema_routes_through_guided_generation():
+    """stream=true + json_schema must call generate_with_schema, NOT stream_chat.
+
+    The bug class this gates: a refactor that re-wires the stream branch
+    to ``engine.stream_chat`` without consulting ``supports_guided_generation``
+    would silently downgrade strict-mode requests to unconstrained tokens
+    — invisible in unit smoke (small schemas the model would emit anyway)
+    but catastrophic for adversarial / complex schemas.
+    """
+    engine = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
+    client = _make_client(engine)
+
+    payload = {
+        "model": "test-model",
+        "stream": True,
+        "max_tokens": 64,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": "pick a color"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "Pick", "schema": _SCHEMA, "strict": True},
+        },
+    }
+
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    # Constraint dispatch: guided path called exactly once, stream_chat
+    # never invoked. This is the load-bearing assertion for Gap #2.
+    assert len(engine.guided_calls) == 1
+    assert engine.stream_calls == []
+
+    # The route must hand the RAW schema dict to generate_with_schema —
+    # not the strict outer ``response_format`` wrapper. Hand-off through
+    # the wrapper would silently re-introduce the schema-projection bug
+    # that PR #419 fixed.
+    assert engine.guided_calls[0]["json_schema"] == _SCHEMA
+
+    events, saw_done = _parse_sse_events(resp.text)
+    assert saw_done, "streaming response must terminate with [DONE]"
+
+    # Reassemble the content from delta chunks; it must equal the
+    # constrained text the engine returned.
+    content_parts: list[str] = []
+    saw_role = False
+    saw_finish = False
+    for event in events:
+        for choice in event.get("choices", []):
+            delta = choice.get("delta", {}) or {}
+            if delta.get("role") == "assistant":
+                saw_role = True
+            if "content" in delta and delta["content"]:
+                content_parts.append(delta["content"])
+            if choice.get("finish_reason"):
+                saw_finish = True
+
+    assert saw_role, "first SSE chunk must announce assistant role"
+    assert saw_finish, "stream must emit a finish_reason chunk"
+    assert "".join(content_parts) == _GUIDED_OUTPUT
+
+
+def test_streaming_guided_falls_back_to_unconstrained_on_engine_failure():
+    """If generate_with_schema raises, the helper must fall back to
+    stream_chat so the request still returns a response.
+
+    Fallback rationale: a failure in outlines (import error at runtime,
+    grammar compilation error on a pathological schema, etc.) should
+    degrade to unconstrained generation rather than 500. Strict-mode
+    clients can validate the response themselves; defensive servers
+    log the failure with full traceback (via logger.exception in
+    GuidedGenerator.generate_json) so the regression surfaces in ops
+    visibility — see knowledge/sop_gap_guided_schema_passthrough.md.
+    """
+    engine = _GuidedEngine(raise_in_guided=True)
+    client = _make_client(engine)
+
+    payload = {
+        "model": "test-model",
+        "stream": True,
+        "max_tokens": 64,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": "pick a color"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "Pick", "schema": _SCHEMA, "strict": True},
+        },
+    }
+
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    # Guided path was attempted and raised; fallback unconstrained path
+    # was exercised. Both calls must be recorded.
+    assert len(engine.guided_calls) == 1
+    assert len(engine.stream_calls) == 1
+
+    _, saw_done = _parse_sse_events(resp.text)
+    assert saw_done, "fallback streaming response must still terminate with [DONE]"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -225,6 +225,86 @@ def test_streaming_json_schema_routes_through_guided_generation():
     assert "".join(content_parts) == _GUIDED_OUTPUT
 
 
+def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
+    """When ``stream_options.include_usage`` is True, usage must appear
+    ONLY in the dedicated usage chunk, NOT in the finish chunk too —
+    emitting it in both places would have aggregating clients
+    double-count tokens. DeepSeek review caught this on first pass; a
+    later refactor that re-introduces the duplication trips this gate.
+
+    When ``include_usage`` is False (default), usage stays on the finish
+    chunk so basic clients still receive token counts. The two pin
+    assertions below lock both branches.
+    """
+    engine = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
+    client = _make_client(engine)
+
+    # include_usage=True branch: usage only in dedicated chunk.
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "Pick", "schema": _SCHEMA, "strict": True},
+            },
+            "stream_options": {"include_usage": True},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events, saw_done = _parse_sse_events(resp.text)
+    assert saw_done
+
+    finish_events = [
+        e for e in events for c in e.get("choices", []) if c.get("finish_reason")
+    ]
+    usage_only_events = [e for e in events if not e.get("choices") and e.get("usage")]
+    assert len(finish_events) == 1, "exactly one finish chunk expected"
+    assert finish_events[0].get("usage") is None, (
+        "finish chunk must NOT carry usage when include_usage=True — "
+        "double-emission would have clients double-count tokens"
+    )
+    assert len(usage_only_events) == 1, (
+        "expected exactly one dedicated usage chunk when include_usage=True"
+    )
+
+    # include_usage default-False branch: usage stays on the finish chunk
+    # (legacy behavior — bare clients that don't set the flag still get
+    # token counts in the final delta).
+    engine2 = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
+    client2 = _make_client(engine2)
+    resp2 = client2.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "Pick", "schema": _SCHEMA, "strict": True},
+            },
+        },
+    )
+    assert resp2.status_code == 200, resp2.text
+    events2, _ = _parse_sse_events(resp2.text)
+    finish_events2 = [
+        e for e in events2 for c in e.get("choices", []) if c.get("finish_reason")
+    ]
+    usage_only_events2 = [e for e in events2 if not e.get("choices") and e.get("usage")]
+    assert len(finish_events2) == 1
+    assert finish_events2[0].get("usage") is not None, (
+        "finish chunk MUST carry usage when include_usage is unset — "
+        "matches the legacy stream_chat_completion behavior"
+    )
+    assert usage_only_events2 == [], (
+        "no dedicated usage chunk when include_usage is unset"
+    )
+
+
 def test_streaming_guided_falls_back_to_unconstrained_on_engine_failure():
     """If generate_with_schema raises, the helper must fall back to
     stream_chat so the request still returns a response.

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -316,6 +316,50 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     )
 
 
+def test_streaming_guided_fallback_preserves_id_and_created():
+    """Fallback to unconstrained streaming must share id/created with
+    what the outer helper would emit on the success path. Without this,
+    a client tracking the completion id across the guided→unconstrained
+    handoff would see two different ids/timestamps for what is logically
+    one request (DeepSeek pr_validate round 5 finding).
+
+    The contract is enforced by passing ``response_id`` and ``created``
+    kwargs to ``stream_chat_completion``. The mock fallback stream emits
+    its standard chunks; this test reassembles them and asserts every
+    chunk shares one id and one created value (the outer helper's).
+    """
+    engine = _GuidedEngine(raise_in_guided=True)
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "pick a color"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "Pick", "schema": _SCHEMA, "strict": True},
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events, saw_done = _parse_sse_events(resp.text)
+    assert saw_done
+
+    ids = {e["id"] for e in events if "id" in e}
+    createds = {e["created"] for e in events if "created" in e}
+    assert len(ids) == 1, (
+        f"all chunks must share one id across the guided→unconstrained "
+        f"fallback handoff; saw {ids}"
+    )
+    assert len(createds) == 1, (
+        f"all chunks must share one created timestamp across the "
+        f"guided→unconstrained fallback handoff; saw {createds}"
+    )
+
+
 def test_streaming_guided_falls_back_to_unconstrained_on_engine_failure():
     """If generate_with_schema raises, the helper must fall back to
     stream_chat so the request still returns a response.

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -192,6 +192,16 @@ def test_streaming_json_schema_routes_through_guided_generation():
     # that PR #419 fixed.
     assert engine.guided_calls[0]["json_schema"] == _SCHEMA
 
+    # ``raise_on_failure=True`` is load-bearing: it forces the engine
+    # to raise instead of silently falling back to ``self.chat(...)``
+    # (which would buffer a long unconstrained reply into a single
+    # content chunk and defeat SSE). The streaming helper catches the
+    # raise and delegates to the unconstrained streaming fallback
+    # instead (codex Round 2 finding). A refactor that drops this
+    # kwarg silently re-introduces the buffered-reply-pretending-to-be-
+    # streaming bug.
+    assert engine.guided_calls[0]["kwargs"].get("raise_on_failure") is True
+
     events, saw_done = _parse_sse_events(resp.text)
     assert saw_done, "streaming response must terminate with [DONE]"
 

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -271,6 +271,17 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
         "expected exactly one dedicated usage chunk when include_usage=True"
     )
 
+    # All chunks in one completion stream must share a single ``created``
+    # timestamp per the OpenAI streaming spec. The new helper pre-computes
+    # ``_sse_created`` and passes it explicitly to ChatCompletionChunk —
+    # without that, ``ChatCompletionChunk.created`` would default-factory
+    # to a fresh ``int(time.time())`` per instantiation and break the
+    # invariant (DeepSeek pr_validate round 2 finding).
+    created_values = {e["created"] for e in events if "created" in e}
+    assert len(created_values) == 1, (
+        f"all SSE chunks must share one created timestamp; saw {created_values}"
+    )
+
     # include_usage default-False branch: usage stays on the finish chunk
     # (legacy behavior — bare clients that don't set the flag still get
     # token counts in the final delta).

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -463,6 +463,68 @@ class TestGuidedGenerationStepThread:
         assert called["n"] == 1
         assert result.text == '{"ok": true}'
 
+    @pytest.mark.asyncio
+    async def test_raise_on_failure_skips_unconstrained_fallback(self, monkeypatch):
+        """When ``_run_guided_generation`` returns None, the default path
+        silently falls back to ``self.chat(...)``. The streaming guided
+        route needs the engine to RAISE instead so it can delegate to
+        its own SSE-aware unconstrained fallback (buffering a long
+        unconstrained reply into a single content chunk defeats SSE —
+        codex Round 2 finding on the guided-streaming PR).
+
+        Default (False): falls back via ``self.chat`` — no raise.
+        Opt-in (True): raises RuntimeError, never calls ``self.chat``.
+        """
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._model = MagicMock()
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        engine._tokenizer.encode = MagicMock(return_value=[1])
+        engine._model_load_executor = None
+        engine._engine = None
+
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.base import GenerationOutput
+
+        monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+
+        # Simulate outlines failure: _run_guided_generation returns None.
+        engine._run_guided_generation = lambda **_: None
+
+        # Track whether self.chat was invoked (default fallback path).
+        chat_calls = {"n": 0}
+
+        async def fake_chat(messages, **kwargs):
+            chat_calls["n"] += 1
+            return GenerationOutput(
+                text="FALLBACK",
+                finished=True,
+                finish_reason="stop",
+            )
+
+        engine.chat = fake_chat
+
+        # Default path: falls back via self.chat.
+        result = await engine.generate_with_schema(
+            messages=[{"role": "user", "content": "hi"}],
+            json_schema={"type": "object"},
+        )
+        assert result.text == "FALLBACK"
+        assert chat_calls["n"] == 1
+
+        # Opt-in path: raises instead, self.chat is never called again.
+        with pytest.raises(RuntimeError, match="Guided generation produced no result"):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                raise_on_failure=True,
+            )
+        assert chat_calls["n"] == 1  # unchanged — raise short-circuited self.chat
+
 
 class TestMLLMSchedulerStepThread:
     """#170 regression: MLLMScheduler must run every step on the mllm-step

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -493,7 +493,11 @@ class TestGuidedGenerationStepThread:
         monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
 
         # Simulate outlines failure: _run_guided_generation returns None.
-        engine._run_guided_generation = lambda **_: None
+        # Use MagicMock (not a bare lambda) so the test fails loud if the
+        # call site's positional/kwarg signature changes — a bare
+        # ``lambda **_: None`` would silently swallow signature drift and
+        # let a real call-site regression slip through.
+        engine._run_guided_generation = MagicMock(return_value=None)
 
         # Track whether self.chat was invoked (default fallback path).
         chat_calls = {"n": 0}

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1458,6 +1458,7 @@ class BatchedEngine(BaseEngine):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        raise_on_failure: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """Generate JSON output constrained to a schema using guided decoding.
@@ -1465,6 +1466,18 @@ class BatchedEngine(BaseEngine):
         Uses outlines for constrained generation to guarantee the output is
         valid JSON matching the specified schema.  Runs synchronously in a
         thread pool to avoid blocking the event loop.
+
+        Args:
+            raise_on_failure: When True, raise ``RuntimeError`` instead of
+                silently falling back to unconstrained ``self.chat(...)`` if
+                ``_run_guided_generation`` returns ``None`` (outlines
+                import/grammar failure caught upstream). The non-streaming
+                route leaves this False — a buffered unconstrained reply
+                is acceptable degradation. The streaming route passes
+                True so it can route the failure to
+                ``stream_chat_completion`` instead of stalling on a
+                buffered unconstrained response that defeats SSE
+                (codex Round 2 finding on the guided-streaming PR).
         """
         import asyncio
 
@@ -1528,7 +1541,15 @@ class BatchedEngine(BaseEngine):
             )
 
         if result is None:
-            # Fallback to standard generation
+            # Fallback to standard generation. The streaming caller passes
+            # raise_on_failure=True so it can delegate to its own SSE
+            # fallback rather than buffer a long unconstrained chat
+            # response into a single content chunk.
+            if raise_on_failure:
+                raise RuntimeError(
+                    "Guided generation produced no result "
+                    "(outlines import/grammar failure — see prior log)"
+                )
             logger.warning(
                 "Guided generation failed, falling back to regular generation"
             )

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1057,10 +1057,20 @@ async def stream_chat_completion_guided(
         # fallback the unconstrained helper emits its own complete
         # SSE stream (role → content → DONE); a pre-emitted role would
         # produce a duplicate role chunk in the fallback path.
+        #
+        # ``raise_on_failure=True`` is critical: without it,
+        # ``generate_with_schema`` silently falls back to
+        # ``self.chat(...)`` on guided-engine failure and returns a
+        # buffered unconstrained ``GenerationOutput``. From this
+        # helper's POV that looks like a successful guided result and
+        # we would emit one giant content chunk at the end —
+        # defeating SSE for clients/proxies that rely on early chunks
+        # (codex Round 2 finding).
         try:
             output = await engine.generate_with_schema(
                 messages=messages,
                 json_schema=json_schema,
+                raise_on_failure=True,
                 **kwargs,
             )
         except Exception as guided_err:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -812,12 +812,24 @@ async def stream_chat_completion(
     engine,
     messages: list,
     request: ChatCompletionRequest,
+    *,
+    response_id: str | None = None,
+    created: int | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response.
 
     Uses StreamingPostProcessor for reasoning/tool/sanitization pipeline.
     SSE formatting stays inline for performance (fast path bypasses Pydantic).
+
+    Args:
+        response_id: Optional pre-computed response id (``chatcmpl-…``).
+            When provided, all SSE chunks share this id instead of one
+            generated fresh here. Used by ``stream_chat_completion_guided``
+            on its unconstrained fallback path so the client-visible
+            stream stays self-consistent across the guided→unconstrained
+            handoff (DeepSeek pr_validate round 5 finding).
+        created: Optional pre-computed Unix timestamp. Same rationale.
     """
     from ..service.postprocessor import StreamingPostProcessor
 
@@ -827,7 +839,8 @@ async def stream_chat_completion(
         gc.disable()
 
     try:
-        response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+        if response_id is None:
+            response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
         start_time = time.perf_counter()
 
         # Check if we should include usage in the final chunk
@@ -847,7 +860,7 @@ async def stream_chat_completion(
             return ChoiceLogProbs(content=entries) if entries else None
 
         # Pre-compute SSE template parts that don't change per-token.
-        _sse_created = int(time.time())
+        _sse_created = created if created is not None else int(time.time())
         _model_escaped = json.dumps(_resolve_model_name(request.model))
         _sse_prefix = (
             f'data: {{"id":"{response_id}","object":"chat.completion.chunk",'
@@ -1105,8 +1118,19 @@ async def stream_chat_completion_guided(
             logger.debug(
                 f"Problematic schema shape: keys={_schema_keys} required={_required}"
             )
+            # Forward the pre-computed response_id + _sse_created so the
+            # fallback stream's chunks share id/created with this outer
+            # helper's would-be chunks. Without this, a client that
+            # tracks the completion id across the guided→unconstrained
+            # handoff sees two different ids/timestamps for what is
+            # logically one request (DeepSeek pr_validate round 5).
             async for chunk in stream_chat_completion(
-                engine, messages, request, **kwargs
+                engine,
+                messages,
+                request,
+                response_id=response_id,
+                created=_sse_created,
+                **kwargs,
             ):
                 yield chunk
             return

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1097,9 +1097,26 @@ async def stream_chat_completion_guided(
         completion_tokens = getattr(output, "completion_tokens", 0) or 0
         finish_reason = getattr(output, "finish_reason", None) or "stop"
 
-        # Final chunk with finish_reason. Usage is attached here on the
-        # final delta (matches the non-streaming response shape and the
-        # stream_chat_completion finish-chunk semantics).
+        # Final chunk with finish_reason. Usage placement:
+        #  - When ``stream_options.include_usage`` is True, usage MUST
+        #    appear ONLY in the dedicated usage chunk below (per the
+        #    OpenAI spec; emitting it in both places would have clients
+        #    that aggregate usage double-count). DeepSeek review caught
+        #    the duplication on first pass.
+        #  - When False, attach usage to the finish chunk so a client
+        #    that doesn't set ``include_usage`` still receives token
+        #    counts in the final delta (matches the legacy behavior of
+        #    ``stream_chat_completion`` and the non-streaming response
+        #    shape).
+        finish_usage = (
+            None
+            if include_usage
+            else Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            )
+        )
         finish_chunk = ChatCompletionChunk(
             id=response_id,
             model=_resolve_model_name(request.model),
@@ -1109,11 +1126,7 @@ async def stream_chat_completion_guided(
                     finish_reason=finish_reason,
                 )
             ],
-            usage=Usage(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-            ),
+            usage=finish_usage,
         )
         yield f"data: {finish_chunk.model_dump_json(exclude_none=True)}\n\n"
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -560,6 +560,24 @@ async def _create_chat_completion_impl(
     _check_admission_or_503(engine)
     _admission_acquired[0] = True
 
+    # Detect guided generation BEFORE the stream/non-stream split so the
+    # streaming branch can also route json_schema requests through the
+    # constrained path. Pre-fix, only the non-stream branch consulted
+    # ``supports_guided_generation`` and stream=true silently bypassed
+    # ``GuidedGenerator`` — the model would emit unconstrained tokens
+    # (e.g. a ```json ... ``` markdown fence) even with a json_schema
+    # response_format set. Surfaced by Gap #2 of the v0.6.60 onboarding
+    # sweep; mirrors the constraint-then-emit pattern from upstream
+    # waybarrios#548.
+    use_guided = False
+    json_schema = None
+    if response_format and not request.tools:
+        json_schema = extract_json_schema_for_guided(response_format)
+        if json_schema and hasattr(engine, "supports_guided_generation"):
+            use_guided = engine.supports_guided_generation
+            if use_guided:
+                logger.info("Using guided generation for JSON schema enforcement")
+
     if request.stream:
         # Validate chat template eagerly so template errors return 400
         if hasattr(engine, "build_prompt") and not engine.is_mllm:
@@ -583,6 +601,21 @@ async def _create_chat_completion_impl(
                     )
                 raise
         _commit_state[0] = True
+        if use_guided and json_schema:
+            # Constrained streaming: run guided generation buffered, then
+            # synthesize an SSE stream from the buffered output. Falls
+            # back to the unconstrained streaming helper on guided
+            # failure (logged), matching the non-streaming fallback.
+            return StreamingResponse(
+                _disconnect_guard(
+                    stream_chat_completion_guided(
+                        engine, messages, request, json_schema, **chat_kwargs
+                    ),
+                    raw_request,
+                    engine=engine,
+                ),
+                media_type="text/event-stream",
+            )
         return StreamingResponse(
             _disconnect_guard(
                 stream_chat_completion(engine, messages, request, **chat_kwargs),
@@ -605,16 +638,6 @@ async def _create_chat_completion_impl(
     want_logprobs = request.logprobs and request.top_logprobs
     top_k_logprobs = request.top_logprobs or 0
     token_logprobs_list: list[TokenLogProb] = []
-
-    # Check if we should use guided generation for JSON schema
-    use_guided = False
-    json_schema = None
-    if response_format and not request.tools:
-        json_schema = extract_json_schema_for_guided(response_format)
-        if json_schema and hasattr(engine, "supports_guided_generation"):
-            use_guided = engine.supports_guided_generation
-            if use_guided:
-                logger.info("Using guided generation for JSON schema enforcement")
 
     try:
         if want_logprobs and not use_guided:
@@ -957,6 +980,140 @@ async def stream_chat_completion(
         )
 
         # Send final chunk with usage if requested
+        if include_usage:
+            usage_chunk = ChatCompletionChunk(
+                id=response_id,
+                model=_resolve_model_name(request.model),
+                choices=[],
+                usage=Usage(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=prompt_tokens + completion_tokens,
+                ),
+            )
+            yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
+
+        yield "data: [DONE]\n\n"
+    finally:
+        if cfg.gc_control and gc_was_enabled:
+            gc.enable()
+            gc.collect()
+
+
+async def stream_chat_completion_guided(
+    engine,
+    messages: list,
+    request: ChatCompletionRequest,
+    json_schema: dict,
+    **kwargs,
+) -> AsyncIterator[str]:
+    """Stream chat completion with json_schema constrained decoding.
+
+    Runs ``engine.generate_with_schema`` (which produces a single buffered
+    ``GenerationOutput`` — outlines integration has no native streaming
+    interface), then synthesizes an SSE stream from the buffered text.
+    Pre-fix, ``stream=true`` requests with ``response_format: json_schema``
+    silently bypassed ``GuidedGenerator`` because the stream branch of
+    ``_create_chat_completion_impl`` went straight to ``engine.stream_chat``
+    with no constraint hookup — the model would emit unconstrained tokens
+    (e.g. a ```json ... ``` markdown fence around the JSON), defeating the
+    user's intent (Gap #2, v0.6.60 onboarding sweep).
+
+    On guided failure (exception from ``generate_with_schema``), delegates
+    to the unconstrained ``stream_chat_completion`` helper to preserve
+    request liveness — matches the non-streaming fallback semantics in
+    ``_create_chat_completion_impl``. Clients in strict-mode use cases
+    should validate the response against their schema regardless.
+    """
+    cfg = get_config()
+    gc_was_enabled = gc.isenabled()
+    if cfg.gc_control and gc_was_enabled:
+        gc.disable()
+
+    try:
+        response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+        start_time = time.perf_counter()
+
+        include_usage = bool(
+            request.stream_options and request.stream_options.include_usage
+        )
+
+        # Pre-compute SSE template parts (mirrors stream_chat_completion's
+        # fast path so chunk encoding is identical for clients).
+        _sse_created = int(time.time())
+        _model_escaped = json.dumps(_resolve_model_name(request.model))
+        _sse_prefix = (
+            f'data: {{"id":"{response_id}","object":"chat.completion.chunk",'
+            f'"created":{_sse_created},"model":{_model_escaped},'
+            f'"choices":[{{"index":0,"delta":{{'
+        )
+        _sse_suffix = "}}]}\n\n"
+
+        # Run guided generation buffered. If it raises, fall through to
+        # the unconstrained streaming helper — this preserves request
+        # liveness (constraints best-effort, response always emitted)
+        # and matches the non-streaming fallback semantics. We DO NOT
+        # emit our own role chunk before the guided call, because on
+        # fallback the unconstrained helper emits its own complete
+        # SSE stream (role → content → DONE); a pre-emitted role would
+        # produce a duplicate role chunk in the fallback path.
+        try:
+            output = await engine.generate_with_schema(
+                messages=messages,
+                json_schema=json_schema,
+                **kwargs,
+            )
+        except Exception as guided_err:
+            logger.warning(
+                "Guided streaming generation failed, falling back to "
+                f"unconstrained streaming: {guided_err}"
+            )
+            logger.debug(f"Problematic schema: {json_schema}")
+            async for chunk in stream_chat_completion(
+                engine, messages, request, **kwargs
+            ):
+                yield chunk
+            return
+
+        # Success path: synthesize SSE stream from the buffered output.
+        # First chunk with role.
+        yield f'{_sse_prefix}"role":"assistant"{_sse_suffix}'
+
+        content = output.text or ""
+        if content:
+            yield f'{_sse_prefix}"content":{json.dumps(content)}{_sse_suffix}'
+
+        prompt_tokens = getattr(output, "prompt_tokens", 0) or 0
+        completion_tokens = getattr(output, "completion_tokens", 0) or 0
+        finish_reason = getattr(output, "finish_reason", None) or "stop"
+
+        # Final chunk with finish_reason. Usage is attached here on the
+        # final delta (matches the non-streaming response shape and the
+        # stream_chat_completion finish-chunk semantics).
+        finish_chunk = ChatCompletionChunk(
+            id=response_id,
+            model=_resolve_model_name(request.model),
+            choices=[
+                ChatCompletionChunkChoice(
+                    delta=ChatCompletionChunkDelta(),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+        yield f"data: {finish_chunk.model_dump_json(exclude_none=True)}\n\n"
+
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Chat completion (guided stream): {completion_tokens} tokens "
+            f"in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+        )
+
         if include_usage:
             usage_chunk = ChatCompletionChunk(
                 id=response_id,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -575,6 +575,19 @@ async def _create_chat_completion_impl(
         json_schema = extract_json_schema_for_guided(response_format)
         if json_schema and hasattr(engine, "supports_guided_generation"):
             use_guided = engine.supports_guided_generation
+            # Belt-and-suspenders: a future custom engine could advertise
+            # ``supports_guided_generation=True`` yet not implement
+            # ``generate_with_schema``. Without this guard the streaming
+            # path would 500 with AttributeError on the first guided
+            # request; the non-stream branch would do the same. Match
+            # the contract surface that ``stream_chat_completion_guided``
+            # and the non-stream guided dispatch actually call.
+            if use_guided and not hasattr(engine, "generate_with_schema"):
+                logger.warning(
+                    "Engine advertises supports_guided_generation=True but "
+                    "is missing generate_with_schema; disabling guided path"
+                )
+                use_guided = False
             if use_guided:
                 logger.info("Using guided generation for JSON schema enforcement")
 
@@ -1078,7 +1091,20 @@ async def stream_chat_completion_guided(
                 "Guided streaming generation failed, falling back to "
                 f"unconstrained streaming: {guided_err}"
             )
-            logger.debug(f"Problematic schema: {json_schema}")
+            # Log only the schema's top-level shape, not the full body —
+            # user-supplied schemas may embed PII (default values),
+            # internal endpoint names, or be megabytes large. Keys +
+            # required-list are enough to disambiguate the failure
+            # without flooding ops logs or exposing payload contents.
+            _schema_keys = (
+                list(json_schema.keys()) if isinstance(json_schema, dict) else None
+            )
+            _required = (
+                json_schema.get("required") if isinstance(json_schema, dict) else None
+            )
+            logger.debug(
+                f"Problematic schema shape: keys={_schema_keys} required={_required}"
+            )
             async for chunk in stream_chat_completion(
                 engine, messages, request, **kwargs
             ):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1117,8 +1117,17 @@ async def stream_chat_completion_guided(
                 total_tokens=prompt_tokens + completion_tokens,
             )
         )
+        # ``created`` must be passed explicitly: the SSE prefix-style
+        # chunks above already share ``_sse_created`` (computed once at
+        # the top of the helper). ``ChatCompletionChunk.created`` has
+        # ``default_factory=lambda: int(time.time())``, so a default
+        # instantiation here would stamp a fresh timestamp on the finish
+        # chunk and break the OpenAI streaming-spec invariant that all
+        # chunks in one completion share a single ``created`` value
+        # (DeepSeek pr_validate round 2 finding).
         finish_chunk = ChatCompletionChunk(
             id=response_id,
+            created=_sse_created,
             model=_resolve_model_name(request.model),
             choices=[
                 ChatCompletionChunkChoice(
@@ -1140,6 +1149,7 @@ async def stream_chat_completion_guided(
         if include_usage:
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
+                created=_sse_created,
                 model=_resolve_model_name(request.model),
                 choices=[],
                 usage=Usage(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1095,7 +1095,14 @@ async def stream_chat_completion_guided(
 
         prompt_tokens = getattr(output, "prompt_tokens", 0) or 0
         completion_tokens = getattr(output, "completion_tokens", 0) or 0
-        finish_reason = getattr(output, "finish_reason", None) or "stop"
+        # Pass the engine's finish_reason through directly. Matches the
+        # convention in ``stream_chat_completion`` (line ~925:
+        # ``finish_reason=event.finish_reason``), which never coerces a
+        # falsy value. ``GenerationOutput.finish_reason`` defaults to
+        # "stop" anyway, so the prior ``or "stop"`` was redundant and
+        # would have silently rewritten any legitimately-None value the
+        # engine emits (DeepSeek pr_validate round 3 finding).
+        finish_reason = getattr(output, "finish_reason", None)
 
         # Final chunk with finish_reason. Usage placement:
         #  - When ``stream_options.include_usage`` is True, usage MUST


### PR DESCRIPTION
## Summary

Closes Gap #2 of the v0.6.60 PyPI onboarding sweep: `stream=true` requests with `response_format: json_schema` silently bypassed `GuidedGenerator` because the stream branch of `_create_chat_completion_impl` went straight to `engine.stream_chat` with no constraint hookup. The model would emit unconstrained tokens (e.g. a markdown ` ```json ... ``` ` fence around the JSON) even with a strict schema declared — defeating the user's intent.

## Repro (pre-fix, on v0.6.60 PyPI wheel)

Same prompt + schema on the same server:
- `stream: false` → clean `{"name": "Oberon", "temperature_k": 280}`
- `stream: true` → ` ```json\n{...}\n``` ` (markdown fence; not parseable as JSON)

## Fix

- Hoist `use_guided` + `json_schema` detection above the stream/non-stream split in `_create_chat_completion_impl` so both branches can dispatch.
- New `stream_chat_completion_guided` helper: runs `engine.generate_with_schema` (buffered — outlines has no native streaming interface) and synthesizes an SSE stream from the constrained output (role → content → finish → optional usage → `[DONE]`). Mirrors the constraint-then-emit pattern from upstream waybarrios#548.
- On guided engine failure, fall back to the unconstrained `stream_chat_completion` helper to preserve request liveness — matches the non-streaming fallback semantics.

## Gates (locks in the contract)

- **`tests/test_chat_streaming_guided.py`** (new) — two contract tests:
  - **Success path**: `stream=true` + `response_format: json_schema` dispatches to `generate_with_schema`, NOT `stream_chat`. Asserts the raw schema dict (not the outer `response_format` wrapper) is what reaches the guided engine — re-introducing the schema-projection bug PR #419 closed would trip here.
  - **Fallback path**: if `generate_with_schema` raises, `stream_chat` is called as fallback so the request still completes with a `[DONE]`-terminated SSE stream.
- **`tests/regression_suite.py::test_12`** (new) — e2e streaming variant of `test_11`. Same complex `$defs`+`$ref`+`anyOf`+`enum` schema, but with `stream=true`. Reassembles the SSE chunks and runs `jsonschema.validate` against the declared schema as the authoritative leaf check. Lands in the doctor harness `check` tier so future regressions trip CI, not user reports.

## Why a buffered+synthesized SSE stream, not true token-by-token streaming

`engine.generate_with_schema` returns a single `GenerationOutput` — the outlines integration has no native streaming interface and the route layer can't predict token boundaries inside a constrained grammar. Buffer + synthesize is the simplest correct fix and matches what upstream waybarrios#548 does in spirit. True token-level streaming through the constraint engine would require deeper engine-level changes and is not necessary to close the user-visible bug.

## Test plan

- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py` — 3786 passed, 19 skipped, 1 xfailed (no regressions)
- [x] `python3.12 -m pytest tests/test_chat_streaming_guided.py -v` — 2 passed (new contract gates)
- [x] `ruff check && ruff format --check` — clean
- [ ] `python3.12 -m scripts.pr_validate <PR#>` — full pipeline (will run after this PR is open)
- [ ] Multi-round codex review until convergence + 1 DeepSeek round
- [ ] `make check` — doctor harness against qwen3.5-4b (includes new test_12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)