### PR TITLE
fix(stream): non-guided path created+usage spec; drop pending-gate on tool fallback

### DIFF
--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI streaming-spec invariants for the non-guided chat path.
+
+Companion to ``tests/test_chat_streaming_guided.py``. PR #422 pinned these
+invariants on the guided helper (``stream_chat_completion_guided``) but
+the regular ``stream_chat_completion`` path retained two spec violations
+that the 2026-05-20 ≥20B onboarding sweep caught on qwen3.5-35b
+(see knowledge/guided_generation_gaps_2026-05-20.md, "Bug B"):
+
+1. **``created`` drift** — content chunks share one timestamp but the
+   finish/usage/terminator chunks build via ``ChatCompletionChunk(...)``
+   default-factory'd a fresh ``int(time.time())`` per instantiation,
+   producing a 5-7s gap between content and finish chunks on slow MoE
+   models. Fixed by passing ``created=_sse_created`` to every
+   constructor.
+
+2. **Dual usage emission** — when ``stream_options.include_usage`` is
+   True, the finish chunk AND the dedicated trailing chunk both carried
+   the same usage payload, double-counting tokens for aggregating
+   clients. Fixed by setting ``usage=None`` on the finish chunk when
+   ``include_usage`` is True; legacy (``include_usage`` unset) keeps
+   usage on the finish chunk for bare clients.
+
+Bug A (streaming tool-parser coverage gap) is pinned by
+``test_streaming_tool_fallback_catches_non_canonical_format``: the
+``StreamingPostProcessor.finalize`` hook now runs ``extract_tool_calls``
+unconditionally (no ``has_pending_tool_call`` gate) so the streaming
+path inherits the full set of fallback patterns the non-stream parser
+already supports.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+from vllm_mlx.tool_parsers.abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+)
+
+
+class _PlainStreamEngine:
+    """Mock engine for the non-guided streaming path.
+
+    ``stream_chat`` yields a sequence of small text deltas, then a final
+    output with ``finished=True``. No guided-generation support — the
+    chat route should dispatch directly to ``stream_chat_completion``.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, deltas: list[str] | None = None):
+        self._deltas = deltas or ["Hello", " world", "."]
+        self.stream_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        accumulated = ""
+        for i, delta in enumerate(self._deltas):
+            accumulated += delta
+            is_last = i == len(self._deltas) - 1
+            yield GenerationOutput(
+                text=accumulated,
+                new_text=delta,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                channel=None,
+            )
+
+
+def _make_client(engine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _parse_sse_events(text: str) -> tuple[list[dict], bool]:
+    """Return ``(parsed_events, saw_done)``.
+
+    ``parsed_events`` excludes the ``[DONE]`` sentinel.
+    """
+    events: list[dict] = []
+    saw_done = False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            saw_done = True
+            continue
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            continue
+    return events, saw_done
+
+
+def test_non_guided_streaming_pins_single_created_timestamp(monkeypatch):
+    """Bug B regression: every SSE chunk in one completion must share a
+    single ``created`` value.
+
+    Pre-fix: the fast-path content chunks baked ``_sse_created`` into the
+    SSE prefix string, but Pydantic-built chunks (finish, fallback
+    tool_call, dedicated usage) called ``ChatCompletionChunk(...)``
+    without ``created=...`` and inherited the default factory's fresh
+    ``time.time()`` per construction. On slow MoE models the gap
+    between first content chunk and finish chunk was 5-7s (Agent A7,
+    qwen3.5-35b, 2026-05-20 sweep).
+
+    Patches ``time.time`` to advance one second per call so the bug is
+    deterministically observable in a unit test (real wall-clock under
+    a fast mock would collapse all timestamps to the same integer
+    second and silently mask the drift, which is what the unfixed code
+    used to coast on in CI).
+    """
+    # Force time to advance one logical second per consumer so each
+    # ``time.time()`` invocation returns a strictly increasing integer.
+    # Without the fix, ChatCompletionChunk's default factory will pull
+    # a distinct value per construction and break the invariant.
+    counter = {"t": 1_700_000_000}
+
+    def _stepping_time():
+        counter["t"] += 1
+        return counter["t"]
+
+    import time as _time_mod
+
+    import vllm_mlx.api.models as _models_mod
+    import vllm_mlx.routes.chat as _chat_mod
+
+    monkeypatch.setattr(_time_mod, "time", _stepping_time)
+    monkeypatch.setattr(_chat_mod.time, "time", _stepping_time, raising=False)
+    monkeypatch.setattr(_models_mod.time, "time", _stepping_time, raising=False)
+
+    engine = _PlainStreamEngine(deltas=["alpha", " beta", " gamma."])
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "say hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events, saw_done = _parse_sse_events(resp.text)
+    assert saw_done
+
+    created_values = {e["created"] for e in events if "created" in e}
+    assert len(created_values) == 1, (
+        f"non-guided streaming must share one created timestamp across "
+        f"every chunk (role/content/finish/usage); saw {created_values}"
+    )
+
+    ids = {e["id"] for e in events if "id" in e}
+    assert len(ids) == 1, f"all chunks must share one id; saw {ids}"
+
+
+def test_non_guided_streaming_usage_only_in_dedicated_chunk_when_include_usage_true():
+    """Bug B regression: with ``include_usage=True`` the finish chunk
+    MUST have ``usage=null``; only the dedicated trailing chunk (with
+    empty ``choices``) carries usage. Pre-fix both chunks carried the
+    same payload, causing aggregating clients to double-count.
+    """
+    engine = _PlainStreamEngine(deltas=["one", " two."])
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "say hi"}],
+            "stream_options": {"include_usage": True},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events, saw_done = _parse_sse_events(resp.text)
+    assert saw_done
+
+    finish_events = [
+        e for e in events for c in e.get("choices", []) if c.get("finish_reason")
+    ]
+    usage_only_events = [e for e in events if not e.get("choices") and e.get("usage")]
+
+    assert len(finish_events) == 1, "exactly one finish chunk expected"
+    assert finish_events[0].get("usage") is None, (
+        "finish chunk MUST NOT carry usage when include_usage=True — "
+        "double emission causes aggregating clients to double-count"
+    )
+    assert len(usage_only_events) == 1, (
+        "expected exactly one dedicated usage chunk when include_usage=True"
+    )
+
+
+def test_non_guided_streaming_usage_stays_on_finish_chunk_by_default():
+    """Defensive: clients that DON'T set ``include_usage`` rely on the
+    legacy behavior of receiving usage on the finish chunk. The Bug B
+    fix only applies when ``include_usage=True``; the default path must
+    stay backwards-compatible.
+    """
+    engine = _PlainStreamEngine(deltas=["one", " two."])
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "say hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events, _ = _parse_sse_events(resp.text)
+
+    finish_events = [
+        e for e in events for c in e.get("choices", []) if c.get("finish_reason")
+    ]
+    usage_only_events = [e for e in events if not e.get("choices") and e.get("usage")]
+
+    assert len(finish_events) == 1
+    assert finish_events[0].get("usage") is not None, (
+        "finish chunk MUST carry usage when include_usage is unset — "
+        "matches legacy behavior for bare clients"
+    )
+    assert usage_only_events == [], (
+        "no dedicated usage chunk when include_usage is unset"
+    )
+
+
+# -----------------------------------------------------------------------
+# Bug A — Streaming tool-parser coverage gap (family-wide)
+# -----------------------------------------------------------------------
+
+
+class _GapStreamParser(ToolParser):
+    """Mock parser modeling the gap: streaming code can't see the tool
+    call (returns plain content), but the non-stream ``extract_tool_calls``
+    catches it via a fallback pattern.
+
+    Mirrors the gemma-4-26b case from the 2026-05-20 sweep where
+    streaming dropped a tool call that the non-stream parser handled.
+    """
+
+    SENTINEL = "TOOLCALL:get_weather"
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+
+    def reset(self):
+        super().reset()
+
+    def has_pending_tool_call(self, text: str) -> bool:
+        # Deliberately understates coverage — same canonical-wrapper-only
+        # gate every real parser has. Returns False for our SENTINEL so
+        # the pre-fix finalize would skip extraction; the post-fix
+        # finalize ignores this gate.
+        return "<tool_call>" in text
+
+    def extract_tool_calls(
+        self, model_output: str, request: Any = None
+    ) -> ExtractedToolCallInformation:
+        # Non-stream side knows about the SENTINEL fallback format.
+        if self.SENTINEL in model_output:
+            content = model_output.replace(self.SENTINEL, "").strip() or None
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=[
+                    {
+                        "id": "call_test123",
+                        "name": "get_weather",
+                        "arguments": '{"location": "SF"}',
+                    }
+                ],
+                content=content,
+            )
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence = (),
+        current_token_ids: Sequence = (),
+        delta_token_ids: Sequence = (),
+        request: dict[str, Any] | None = None,
+    ) -> dict | None:
+        # Streaming side does NOT recognize the SENTINEL — emits text
+        # passthrough. This is the gap.
+        return {"content": delta_text}
+
+
+def test_finalize_fallback_runs_extract_tool_calls_without_pending_gate():
+    """Bug A regression: ``StreamingPostProcessor.finalize`` must run
+    ``extract_tool_calls`` on accumulated text even when
+    ``has_pending_tool_call`` returns False.
+
+    Rationale: every parser's ``has_pending_tool_call`` reuses the same
+    canonical-wrapper check as the streaming code path. If the streaming
+    path missed a tool call (because the model used a non-canonical
+    format that only ``extract_tool_calls`` knows about), gating
+    finalize on ``has_pending_tool_call`` would by construction also
+    miss it. Dropping the gate gives streaming the same tolerance as
+    non-streaming. See knowledge/guided_generation_gaps_2026-05-20.md
+    "Bug A".
+    """
+    parser = _GapStreamParser()
+    cfg = reset_config()
+    processor = StreamingPostProcessor(cfg, tools_requested=True)
+    # Inject our gap parser directly.
+    processor.tool_parser = parser
+    processor.reset()
+
+    # Simulate streaming: feed the sentinel text but the streaming parser
+    # returns content passthrough, so no tool_calls are detected.
+    raw = f"Some preamble {_GapStreamParser.SENTINEL} trailing."
+    output = GenerationOutput(
+        text=raw,
+        new_text=raw,
+        prompt_tokens=4,
+        completion_tokens=10,
+        finished=True,
+        finish_reason="stop",
+        channel=None,
+    )
+    events_during = list(processor.process_chunk(output))
+    # Streaming parser emitted only content/finish events (no tool_calls).
+    assert not any(e.type == "tool_call" for e in events_during)
+    assert not processor.tool_calls_detected, (
+        "precondition: streaming code path must NOT have detected the "
+        "tool call (that's the gap we're testing)"
+    )
+
+    # Pre-fix this returned [] because has_pending_tool_call(raw) is
+    # False (no '<tool_call>' substring). Post-fix it runs
+    # extract_tool_calls anyway and finds the SENTINEL fallback.
+    finalize_events = processor.finalize()
+    tool_events = [e for e in finalize_events if e.type == "tool_call"]
+    assert len(tool_events) == 1, (
+        f"finalize must catch tool calls that the streaming parser missed "
+        f"via the non-stream parser's fallback patterns; got {finalize_events}"
+    )
+    assert tool_events[0].tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_events[0].finish_reason == "tool_calls"
+    assert processor.tool_calls_detected
+
+
+def test_finalize_no_op_when_no_tool_calls_present():
+    """Drop-of-gate must not generate spurious events when the model
+    legitimately produced no tool calls. Bare passthrough text → empty
+    finalize, no synthetic tool_call emission.
+    """
+    parser = _GapStreamParser()
+    cfg = reset_config()
+    processor = StreamingPostProcessor(cfg, tools_requested=True)
+    processor.tool_parser = parser
+    processor.reset()
+
+    output = GenerationOutput(
+        text="Hello, how can I help?",
+        new_text="Hello, how can I help?",
+        prompt_tokens=4,
+        completion_tokens=6,
+        finished=True,
+        finish_reason="stop",
+        channel=None,
+    )
+    list(processor.process_chunk(output))
+
+    finalize_events = processor.finalize()
+    assert finalize_events == [], (
+        "no tool calls in text → finalize must return empty list, not spurious events"
+    )
+    assert not processor.tool_calls_detected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -268,7 +268,12 @@ class _GapStreamParser(ToolParser):
     streaming dropped a tool call that the non-stream parser handled.
     """
 
-    SENTINEL = "TOOLCALL:get_weather"
+    # Use `{` so the cheap markup pre-check in finalize() (added in
+    # response to DeepSeek's pr_validate finding on PR #424 — every real
+    # tool-call format has at least one of `<`, `{`, or `[Calling`) lets
+    # us reach extract_tool_calls. Plain-text responses without any
+    # structural marker correctly skip the full parser.
+    SENTINEL = '{"call":"get_weather"}'
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -928,6 +928,7 @@ async def stream_chat_completion(
                     else:
                         chunk = ChatCompletionChunk(
                             id=response_id,
+                            created=_sse_created,
                             model=_resolve_model_name(request.model),
                             choices=[
                                 ChatCompletionChunkChoice(
@@ -946,6 +947,7 @@ async def stream_chat_completion(
                 elif event.type == "tool_call":
                     chunk = ChatCompletionChunk(
                         id=response_id,
+                        created=_sse_created,
                         model=_resolve_model_name(request.model),
                         choices=[
                             ChatCompletionChunkChoice(
@@ -955,7 +957,16 @@ async def stream_chat_completion(
                                 finish_reason=event.finish_reason,
                             )
                         ],
-                        usage=get_usage(output) if output.finished else None,
+                        # Usage placement: when ``stream_options.include_usage``
+                        # is True, usage MUST appear ONLY in the dedicated
+                        # trailing chunk per the OpenAI streaming spec.
+                        # Without ``include_usage``, legacy clients expect it
+                        # on the finish chunk.
+                        usage=(
+                            None
+                            if include_usage
+                            else (get_usage(output) if output.finished else None)
+                        ),
                     )
                     _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
                     logger.info(f"[SSE-TC] {_tc_sse.strip()[:300]}")
@@ -964,6 +975,7 @@ async def stream_chat_completion(
                 elif event.type == "finish":
                     chunk = ChatCompletionChunk(
                         id=response_id,
+                        created=_sse_created,
                         model=_resolve_model_name(request.model),
                         choices=[
                             ChatCompletionChunkChoice(
@@ -975,7 +987,12 @@ async def stream_chat_completion(
                                 logprobs=_build_chunk_logprobs(output),
                             )
                         ],
-                        usage=get_usage(output) if output.finished else None,
+                        # See "Usage placement" note on the tool_call branch.
+                        usage=(
+                            None
+                            if include_usage
+                            else (get_usage(output) if output.finished else None)
+                        ),
                     )
                     yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
 
@@ -984,6 +1001,7 @@ async def stream_chat_completion(
             if event.type == "tool_call":
                 tool_chunk = ChatCompletionChunk(
                     id=response_id,
+                    created=_sse_created,
                     model=_resolve_model_name(request.model),
                     choices=[
                         ChatCompletionChunkChoice(
@@ -1009,6 +1027,7 @@ async def stream_chat_completion(
         if include_usage:
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
+                created=_sse_created,
                 model=_resolve_model_name(request.model),
                 choices=[],
                 usage=Usage(

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -492,8 +492,29 @@ class StreamingPostProcessor:
         # streaming parser dropped on the floor; the only difference between
         # the two modes was this gate. See knowledge/guided_generation_gaps_2026-05-20.md
         # "Bug A — Streaming tool-parser coverage gap is family-wide".
+        #
+        # Cheap pre-check: every known tool-call format carries at least
+        # one structural marker — ``<`` (XML wrappers: ``<tool_call>``,
+        # ``<function=>``, ``<|tool_call>``), ``{`` (bare JSON, parameter
+        # blocks), or ``[Calling`` (text-format degradation). Skipping the
+        # full regex scan when none of these markers is present keeps
+        # end-of-stream cost flat on plain-text responses that happened to
+        # have ``tools=...`` in the request (DeepSeek pr_validate finding
+        # on PR #424 — high-throughput servers with tool-enabled
+        # endpoints would otherwise pay the parser cost on every reply
+        # that didn't actually call a tool).
         _fallback_text = self.tool_accumulated_text or self.accumulated_text
-        if self.tool_parser and _fallback_text and not self.tool_calls_detected:
+        _has_plausible_markup = bool(_fallback_text) and (
+            "<" in _fallback_text
+            or "{" in _fallback_text
+            or "[Calling" in _fallback_text
+        )
+        if (
+            self.tool_parser
+            and _fallback_text
+            and not self.tool_calls_detected
+            and _has_plausible_markup
+        ):
             result = self.tool_parser.extract_tool_calls(
                 _fallback_text, request=self.request
             )

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -476,15 +476,24 @@ class StreamingPostProcessor:
         """
         events = []
 
-        # Fallback tool call detection: parser accumulated text but never
-        # emitted (e.g., closing tag never arrived).
+        # Fallback tool call detection: streaming parser missed a tool call
+        # that the non-stream parser can recover. The streaming code path of
+        # each parser is necessarily simpler than ``extract_tool_calls`` —
+        # it can't backtrack and typically only handles the canonical
+        # wrapper format. ``extract_tool_calls`` has the full set of fallback
+        # patterns (bare JSON, alternate XML forms, text-format degradation).
+        # Running it here gives streaming the same tolerance as non-stream.
+        #
+        # Previously gated on ``has_pending_tool_call`` — but that gate
+        # uses the SAME canonical-wrapper check as the streaming parser, so
+        # by construction it can never catch what the streaming parser
+        # missed. The 2026-05-20 ≥20B onboarding sweep caught gemma-4-26b
+        # producing structured tool_calls in non-stream mode that the
+        # streaming parser dropped on the floor; the only difference between
+        # the two modes was this gate. See knowledge/guided_generation_gaps_2026-05-20.md
+        # "Bug A — Streaming tool-parser coverage gap is family-wide".
         _fallback_text = self.tool_accumulated_text or self.accumulated_text
-        if (
-            self.tool_parser
-            and _fallback_text
-            and not self.tool_calls_detected
-            and self.tool_parser.has_pending_tool_call(_fallback_text)
-        ):
+        if self.tool_parser and _fallback_text and not self.tool_calls_detected:
             result = self.tool_parser.extract_tool_calls(
                 _fallback_text, request=self.request
             )


### PR DESCRIPTION
## Summary

Closes the two framework bugs surfaced by the 2026-05-20 ≥20B onboarding sweep (see `knowledge/guided_generation_gaps_2026-05-20.md` "Second sweep findings"):

- **Bug A** — `StreamingPostProcessor.finalize` now runs `extract_tool_calls` unconditionally instead of gating on `has_pending_tool_call`. The gate is the same canonical-wrapper check the streaming parser uses, so it can never catch what streaming missed. Caught on gemma-4-26b (26B): non-stream parser recovered a structured tool call that streaming dropped; same family-wide pattern the prior 0.6b "Agent 5" finding hinted at but was dismissed as a small-model artifact.
- **Bug B** — `stream_chat_completion` (non-guided path) now (1) pins `created=_sse_created` on every `ChatCompletionChunk(...)` constructor and (2) sets `usage=None` on the finish chunk when `include_usage=True`. PR #422 pinned these invariants on the guided helper only; the regular path still had `created` drift (5-7s on qwen3.5-35b 35B MoE) and dual usage emission. Legacy `include_usage`-unset behavior (usage on finish chunk for bare clients) preserved.

## Test plan

- [x] New `tests/test_chat_streaming_spec.py` (5 tests). 3 of them verified to FAIL pre-fix and PASS post-fix:
  - `test_non_guided_streaming_pins_single_created_timestamp` — monkeypatches `time.time` to step one second per call (otherwise a fast mock collapses all timestamps to the same integer second and silently masks the bug, which is how the unfixed code coasted in CI).
  - `test_non_guided_streaming_usage_only_in_dedicated_chunk_when_include_usage_true` — finish chunk `usage` must be null; exactly one dedicated trailing chunk.
  - `test_finalize_fallback_runs_extract_tool_calls_without_pending_gate` — mock parser models the family-wide gap; pre-fix finalize returns `[]`, post-fix recovers the tool call.
- [x] `test_non_guided_streaming_usage_stays_on_finish_chunk_by_default` + `test_finalize_no_op_when_no_tool_calls_present` — defensive: legacy and no-op paths unchanged.
- [x] `tests/test_chat_streaming_guided.py` (4 tests) — guided-path invariants unchanged.
- [x] `tests/test_streaming*` (68 tests) — no regressions.
- [x] `tests/test_postprocessor.py` (257 tests) — existing finalize-fallback coverage (request-forwarding etc.) still passes.
- [x] Full unit suite: **3794 passed**, 19 skipped, 16 deselected, 1 xfailed in 51.55s.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live verification on qwen3.5-35b that finish chunk no longer carries usage when `include_usage=True` and `created` is stable across the stream.
- [ ] Live verification on gemma-4-26b that streaming tool calls now match non-streaming output.

## Notes

- No version bump (release bumps happen separately per release SOP).
- Pre-emptive caveat: this PR fixes the regular streaming path's OpenAI spec compliance. The user-visible client behavior change is *only* when `stream_options.include_usage=True` — the legacy unset default keeps usage on the finish chunk for backwards compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)