### PR TITLE
streaming finalize: cross-format fallback to parse_tool_calls (fixes #425)

### DIFF
--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for StreamingPostProcessor — the unified streaming pipeline."""
 
+import json
 from unittest.mock import MagicMock
 
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
@@ -367,8 +368,6 @@ class TestStreamingPostProcessorToolCalls:
         tc = events[0].tool_calls[0]
         assert tc["function"]["name"] == "read_file"
         # arguments is a JSON string; parse to assert the value
-        import json
-
         assert json.loads(tc["function"]["arguments"]) == {"path": "/etc/hostname"}
         assert pp.tool_calls_detected is True
 
@@ -392,6 +391,63 @@ class TestStreamingPostProcessorToolCalls:
         pp.tool_accumulated_text = "the value of x < 10 is fine"
 
         events = pp.finalize()
+        assert events == []
+        assert pp.tool_calls_detected is False
+
+    def test_finalize_cross_format_fallback_both_parsers_fail(self):
+        """Structural markup is present (passes the ``<`` pre-check) but the text
+        is not a parseable tool call in any known format. Both the configured
+        parser and ``parse_tool_calls`` return no calls. finalize() must return
+        ``[]`` cleanly and leave ``tool_calls_detected`` False — not raise, not
+        emit a spurious event."""
+        tool_parser = self._make_tool_parser()
+        tool_parser.extract_tool_calls.return_value = MagicMock(
+            tools_called=False, tool_calls=[]
+        )
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        # XML-shaped but not actually a tool call — no <function=...> or
+        # [Calling tool: ...] or {"name":...} structure parse_tool_calls
+        # recognises.
+        pp.tool_accumulated_text = "<tool_call>garbled junk no actual call</tool_call>"
+
+        events = pp.finalize()
+        assert events == []
+        assert pp.tool_calls_detected is False
+
+    def test_finalize_cross_format_fallback_swallows_parser_exception(self):
+        """``parse_tool_calls`` must not be allowed to abort the stream. If the
+        multi-format scanner raises (regex pathology, adversarial input), the
+        fallback logs a warning and returns ``[]`` rather than propagating.
+        Mirrors the defensive ``try/except`` in ``service/helpers.py:605-607``."""
+        tool_parser = self._make_tool_parser()
+        tool_parser.extract_tool_calls.return_value = MagicMock(
+            tools_called=False, tool_calls=[]
+        )
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+        pp.tool_accumulated_text = "<tool_call>anything</tool_call>"
+
+        # Force the fallback parser to raise
+        from unittest.mock import patch
+
+        with patch(
+            "vllm_mlx.service.postprocessor.parse_tool_calls",
+            side_effect=RuntimeError("boom"),
+        ):
+            events = pp.finalize()
+
         assert events == []
         assert pp.tool_calls_detected is False
 

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -321,6 +321,80 @@ class TestStreamingPostProcessorToolCalls:
         assert events[0].type == "tool_call"
         assert events[0].finish_reason == "tool_calls"
 
+    def test_finalize_cross_format_fallback_recovers_xml_tool_call(self):
+        """Configured parser is wire-format-specific; finalize must fall back to
+        the multi-format ``parse_tool_calls`` when the configured parser fails.
+
+        Reproduces #425: ``--tool-call-parser qwen3_xml`` resolves to
+        ``QwenToolParser`` (JSON inside ``<tool_call>``) but vanilla
+        Qwen3.6-35B-A3B emits the XML-bodied variant
+        (``<function=...><parameter=...>``). The configured parser returns
+        ``tools_called=False`` on the wire-mismatched text; without a
+        cross-format fallback the stream emits zero ``tool_calls`` deltas
+        while the same text non-streaming returns a structured call via the
+        ``parse_tool_calls`` fallback in ``service/helpers.py``.
+        """
+        tool_parser = self._make_tool_parser()
+        # Configured parser fails to extract (wire-format mismatch)
+        tool_parser.extract_tool_calls.return_value = MagicMock(
+            tools_called=False, tool_calls=[]
+        )
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        # Qwen3.6 vanilla wire format: XML body inside <tool_call>
+        pp.tool_accumulated_text = (
+            "<tool_call>\n"
+            "<function=read_file>\n"
+            "<parameter=path>\n"
+            "/etc/hostname\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+
+        events = pp.finalize()
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        assert events[0].finish_reason == "tool_calls"
+        assert events[0].tool_calls is not None
+        assert len(events[0].tool_calls) == 1
+        tc = events[0].tool_calls[0]
+        assert tc["function"]["name"] == "read_file"
+        # arguments is a JSON string; parse to assert the value
+        import json
+
+        assert json.loads(tc["function"]["arguments"]) == {"path": "/etc/hostname"}
+        assert pp.tool_calls_detected is True
+
+    def test_finalize_cross_format_fallback_noop_on_plain_text(self):
+        """Plain text in the accumulator must NOT trigger a spurious tool_call
+        from the cross-format fallback. Guards against the structural pre-check
+        passing on bare ``<`` characters in normal prose."""
+        tool_parser = self._make_tool_parser()
+        tool_parser.extract_tool_calls.return_value = MagicMock(
+            tools_called=False, tool_calls=[]
+        )
+
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        # Plain prose that just happens to contain a literal "<" character
+        pp.tool_accumulated_text = "the value of x < 10 is fine"
+
+        events = pp.finalize()
+        assert events == []
+        assert pp.tool_calls_detected is False
+
 
 class TestStreamingPostProcessorNemotron:
     """Tests for Nemotron thinking prefix."""

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ..api.tool_calling import parse_tool_calls
 from ..api.utils import sanitize_output, strip_special_tokens
 from ..domain.events import StreamEvent
 
@@ -540,6 +541,44 @@ class StreamingPostProcessor:
                     )
                 )
                 self.tool_calls_detected = True
+            else:
+                # Cross-format fallback. The configured streaming parser is
+                # tightly bound to ONE wire format — e.g. ``qwen3_xml`` is
+                # registered to ``QwenToolParser`` which expects
+                # ``<tool_call>{"name":"...","arguments":{...}}</tool_call>``
+                # (JSON inside the wrapper), while vanilla Qwen3.6-35B-A3B
+                # emits the XML-bodied variant
+                # ``<tool_call><function=name><parameter=key>value</parameter></function></tool_call>``.
+                # ``parse_tool_calls`` in ``api/tool_calling.py`` scans every
+                # known format and recovers calls the per-parser
+                # ``extract_tool_calls`` misses. The non-stream path in
+                # ``service/helpers.py:604`` already falls back to it; this
+                # mirrors that on the streaming path so a wire-format
+                # mismatch surfaces as a structured tool call rather than
+                # ``finish_reason: stop`` with zero deltas. See #425.
+                _, fb_tcs = parse_tool_calls(_fallback_text, self.request)
+                if fb_tcs:
+                    tc_list = [
+                        {
+                            "index": i,
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            },
+                        }
+                        for i, tc in enumerate(fb_tcs)
+                    ]
+                    events.append(
+                        StreamEvent(
+                            type="tool_call",
+                            tool_calls=tc_list,
+                            finish_reason="tool_calls",
+                            tool_calls_detected=True,
+                        )
+                    )
+                    self.tool_calls_detected = True
 
         return events
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -522,7 +522,12 @@ class StreamingPostProcessor:
             if result.tools_called:
                 events.append(
                     self._build_tool_call_event(
-                        ({"id": tc["id"], "name": tc["name"], "arguments": tc["arguments"]} for tc in result.tool_calls)
+                        {
+                            "id": tc["id"],
+                            "name": tc["name"],
+                            "arguments": tc["arguments"],
+                        }
+                        for tc in result.tool_calls
                     )
                 )
                 self.tool_calls_detected = True
@@ -554,7 +559,12 @@ class StreamingPostProcessor:
                     )
                     events.append(
                         self._build_tool_call_event(
-                            ({"id": tc.id, "name": tc.function.name, "arguments": tc.function.arguments} for tc in fb_tcs)
+                            {
+                                "id": tc.id,
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            }
+                            for tc in fb_tcs
                         )
                     )
                     self.tool_calls_detected = True

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -520,67 +520,68 @@ class StreamingPostProcessor:
                 _fallback_text, request=self.request
             )
             if result.tools_called:
-                tc_list = [
-                    {
-                        "index": i,
-                        "id": tc["id"],
-                        "type": "function",
-                        "function": {
-                            "name": tc["name"],
-                            "arguments": tc["arguments"],
-                        },
-                    }
-                    for i, tc in enumerate(result.tool_calls)
-                ]
                 events.append(
-                    StreamEvent(
-                        type="tool_call",
-                        tool_calls=tc_list,
-                        finish_reason="tool_calls",
-                        tool_calls_detected=True,
+                    self._build_tool_call_event(
+                        ({"id": tc["id"], "name": tc["name"], "arguments": tc["arguments"]} for tc in result.tool_calls)
                     )
                 )
                 self.tool_calls_detected = True
             else:
-                # Cross-format fallback. The configured streaming parser is
-                # tightly bound to ONE wire format — e.g. ``qwen3_xml`` is
-                # registered to ``QwenToolParser`` which expects
-                # ``<tool_call>{"name":"...","arguments":{...}}</tool_call>``
-                # (JSON inside the wrapper), while vanilla Qwen3.6-35B-A3B
-                # emits the XML-bodied variant
-                # ``<tool_call><function=name><parameter=key>value</parameter></function></tool_call>``.
-                # ``parse_tool_calls`` in ``api/tool_calling.py`` scans every
-                # known format and recovers calls the per-parser
-                # ``extract_tool_calls`` misses. The non-stream path in
-                # ``service/helpers.py:604`` already falls back to it; this
-                # mirrors that on the streaming path so a wire-format
-                # mismatch surfaces as a structured tool call rather than
-                # ``finish_reason: stop`` with zero deltas. See #425.
-                _, fb_tcs = parse_tool_calls(_fallback_text, self.request)
+                # Cross-format fallback. The configured streaming parser is bound to
+                # ONE wire format; ``parse_tool_calls`` in ``api/tool_calling.py``
+                # scans every known format and recovers calls the per-parser path
+                # misses (e.g. ``qwen3_xml`` is registered to ``QwenToolParser``
+                # which expects JSON inside ``<tool_call>``, but Qwen3.6-35B-A3B
+                # emits the ``<function=name><parameter=...>`` XML body). The
+                # non-stream path at ``service/helpers.py:604`` already falls back;
+                # this mirrors it on streaming. Wrapped defensively to match the
+                # non-stream try/except — a parser bug must not abort the stream.
+                # See #425.
+                try:
+                    _, fb_tcs = parse_tool_calls(_fallback_text, self.request)
+                except Exception as e:
+                    logger.warning(
+                        "finalize cross-format fallback parser raised: %s", e
+                    )
+                    fb_tcs = None
                 if fb_tcs:
-                    tc_list = [
-                        {
-                            "index": i,
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for i, tc in enumerate(fb_tcs)
-                    ]
+                    logger.info(
+                        "[finalize] cross-format fallback recovered %d tool_call(s); "
+                        "configured parser=%r returned tools_called=False — "
+                        "consider whether --tool-call-parser matches the model's wire format",
+                        len(fb_tcs),
+                        getattr(self.cfg, "tool_call_parser", None),
+                    )
                     events.append(
-                        StreamEvent(
-                            type="tool_call",
-                            tool_calls=tc_list,
-                            finish_reason="tool_calls",
-                            tool_calls_detected=True,
+                        self._build_tool_call_event(
+                            ({"id": tc.id, "name": tc.function.name, "arguments": tc.function.arguments} for tc in fb_tcs)
                         )
                     )
                     self.tool_calls_detected = True
 
         return events
+
+    def _build_tool_call_event(self, items) -> StreamEvent:
+        """Build a tool_call StreamEvent from an iterable of {id, name, arguments} dicts.
+
+        Used by both finalize() branches (configured parser succeeded, and the
+        cross-format ``parse_tool_calls`` fallback) so the two paths can't drift
+        in wire shape.
+        """
+        return StreamEvent(
+            type="tool_call",
+            tool_calls=[
+                {
+                    "index": i,
+                    "id": tc["id"],
+                    "type": "function",
+                    "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                }
+                for i, tc in enumerate(items)
+            ],
+            finish_reason="tool_calls",
+            tool_calls_detected=True,
+        )
 
     def _detect_tool_calls(self, content: str) -> dict | None:
         """Run incremental tool call detection.


### PR DESCRIPTION
## What does this PR do?

Adds a cross-format fallback to `StreamingPostProcessor.finalize()` so streaming wire-format mismatches surface as a structured `tool_calls` delta instead of dropping the entire response.

When the configured `--tool-call-parser`'s `extract_tool_calls()` returns `tools_called=False` and the accumulated text passes the existing structural pre-check (`<` / `{` / `[Calling`), `finalize()` now calls `api.tool_calling.parse_tool_calls` — the same multi-format scanner the non-stream path already uses at `service/helpers.py:604` — and emits a `tool_call` event if it finds one. The new path is defensive (try/except matching helpers.py) and emits an INFO log naming the configured parser when it recovers a call, so a wire-format mismatch is visible in server logs.

Both finalize branches now go through a shared `_build_tool_call_event()` helper so the configured-parser and fallback paths can't drift in wire shape.

## Why is this needed?

Fixes #425.

`--tool-call-parser qwen3_xml` is registered to `QwenToolParser`, which expects `<tool_call>{"name":..., "arguments":...}</tool_call>` (JSON body). Vanilla `Qwen3.6-35B-A3B` (and the mlx-community 4-bit-DWQ checkpoint many users run) emits the XML-body variant: `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>`. The configured parser returns `tools_called=False`, the existing 0.6.61 finalize fallback (#424) calls only the configured parser, and the stream emits zero `tool_call` deltas with `finish_reason: stop` — while the same prompt non-streaming returns a clean structured `tool_calls` array (because non-stream already falls back to the multi-format scanner).

Concrete user impact: agent harnesses like Pi, Cursor, Aider, Continue.dev all use `stream=True`. With `qwen3_xml` selected (a documented CLI choice), tool calls silently fail on Qwen3.6-35B-A3B — the model emits the right markup, the wire drops it.

## AI assistance disclosure

Claude (Anthropic) wrote the diagnosis probes, the postprocessor change, and the tests. I read the surrounding code independently to verify the diagnosis (`vllm_mlx/service/postprocessor.py`, `service/helpers.py:540-607`, `tool_parsers/qwen_tool_parser.py:28`, `tool_parsers/qwen3coder_tool_parser.py:97`, `api/tool_calling.py:352-440`, `routes/chat.py:999-1017`), confirmed the live wire trace on my machine end-to-end against `mlx-community/Qwen3.6-35B-A3B-4bit-DWQ` on `rapid-mlx 0.6.61` (M4 Pro 48 GB, macOS 26.2), ran the full `test_postprocessor.py` suite myself, and addressed staff-level code review feedback (try/except, observability log, helper extraction, negative tests) in a follow-up commit. I can explain the intent, risk, and behavior of every change in this PR.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- `python3 -m pytest tests/test_postprocessor.py -x -q` → 78 passed (4 new tests under `TestStreamingPostProcessorToolCalls`)
- `ruff check vllm_mlx/service/postprocessor.py tests/test_postprocessor.py` → clean
- `ruff format --check vllm_mlx/service/postprocessor.py tests/test_postprocessor.py` → clean
- `PR_VALIDATE_NO_DEEPSEEK=1 PR_VALIDATE_NO_STRESS=1 python3 -m scripts.pr_validate.pr_validate 426` → `fetch`, `supply_chain`, `lint`, `targeted_tests` all PASS. `full_unit` FAILs in the validator environment with 32 `ModuleNotFoundError: No module named 'mlx'` collection errors — that's pr_validate running under a pyenv 3.12 that lacks the mlx wheel, not a regression from this diff. The same errors reproduce on `main` in that env. Per [CONTRIBUTING.md](../CONTRIBUTING.md#what-if-my-pr-fails-on-a-pre-existing-main-bug), flagging here for a maintainer to confirm.
- Live end-to-end: `mlx-community/Qwen3.6-35B-A3B-4bit-DWQ` on `rapid-mlx 0.6.61`, M4 Pro 48 GB, macOS 26.2, with the user-facing config from #425.

Before the fix (whole wire output for the streaming repro from #425):

```
data: {"choices":[{"delta":{"role":"assistant"}}]}
data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":27,...}}
data: [DONE]
```

After the fix:

```
data: {"choices":[{"delta":{"role":"assistant"}}]}
data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":27,...}}
data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_c35c322d","type":"function","function":{"name":"read_file","arguments":"{\"path\": \"/etc/hostname\"}"}}]},"finish_reason":"tool_calls"}]}
data: [DONE]
```

Repeated 3× with different paths to confirm reliability. Plain text streaming unchanged (regression check): `Say hello` → `Hello! How can I help you today?` streams as before.

Server logs the recovery so a future user with a misconfigured `--tool-call-parser` has a breadcrumb:

```
INFO:vllm_mlx.service.postprocessor:[finalize] cross-format fallback recovered 1 tool_call(s); configured parser='qwen3_xml' returned tools_called=False — consider whether --tool-call-parser matches the model's wire format
```

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`) — 78/78 in `test_postprocessor.py`; `full_unit` in pr_validate fails on the pre-existing env issue noted above.
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 426` — see Test plan for the `full_unit` env caveat.
- [x] New tests touch a critical code path (streaming tool-call recovery). Spot-checked that `test_finalize_cross_format_fallback_recovers_xml_tool_call` fails when the new fallback branch is removed (configured parser returns `tools_called=False` ⇒ no event emitted), and that `test_finalize_cross_format_fallback_both_parsers_fail` / `test_finalize_cross_format_fallback_swallows_parser_exception` exercise the empty-result and exception paths.
- [x] No docs update needed — no user-facing API change. Behavior change is documented in the inline comment at `postprocessor.py` and the new log line. Happy to add a note to `knowledge/guided_generation_gaps_2026-05-20.md` (referenced from #424's release notes) if that's the project convention for follow-on fixes.
- [x] No breaking changes to existing API. The `tools_called=True` branch is untouched; the new fallback only runs in the `tools_called=False` branch that previously emitted nothing.

## Scope, and what this does NOT fix

This handles the case where the streaming parser swallows the entire tool call (`--no-thinking` path, model jumps straight to `<tool_call>`). The related but distinct case where a `<tool_call>` block sits inside a `<think>...</think>` reasoning block — the reasoning parser gobbles it into `reasoning_content` before tool detection runs — is the existing open issue #344 (port `waybarrios/vllm-mlx@9a6253a`). That requires changes to `vllm_mlx/reasoning/think_parser.py` and is out of scope here.

One observation worth a separate issue: `qwen3_xml` at `tool_parsers/qwen_tool_parser.py:28` is registered to `QwenToolParser` (JSON body) but the `tool_parsers/__init__.py` docstring implies it covers the XML-body Qwen3 family. This PR fixes the symptom (streaming silently drops tool calls); the registration itself may also be worth correcting. Happy to file as a follow-up if the maintainer agrees.
