### PR TITLE
fix(stream): TOOL_CALL body across single-token flush + feat: serve upgrade prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.61"
+version = "0.6.62"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_batched_engine_output_router.py
+++ b/tests/test_batched_engine_output_router.py
@@ -195,6 +195,67 @@ async def test_stream_chat_routes_tool_call_channel_on_finish():
 
 
 @pytest.mark.asyncio
+async def test_stream_chat_preserves_tool_call_body_across_single_token_flush():
+    """Single-token engine flush must not clobber the router's multi-token body.
+
+    Regression: ``Channel.TOOL_CALL`` is a *deferred aggregate* — the router
+    silently buffers body tokens during ``RouterState.TOOL_CALL`` and emits
+    one event on the end marker with ``event.text`` carrying the full decoded
+    body. The single-token-flush optimization that lets CONTENT/REASONING
+    chunks reuse the scheduler's detokenized ``output.new_text`` would, if
+    applied to TOOL_CALL events, override the accumulated body with just the
+    end-marker token's text ('<tool_call|>'), silently dropping the call body.
+    Caught post-v0.6.61 on gemma-4-26b — non-stream extracted a valid tool
+    call from the same generation that streaming returned as bare content.
+    """
+    engine = _make_engine(FakeTokenizer(GEMMA4_VOCAB))
+
+    body_tokens = [
+        48,  # <|tool_call>
+        6639,  # call
+        236787,  # :
+        828,  # get
+        236779,  # _
+        19323,  # weather
+        236782,  # {
+        13319,  # city
+        236787,  # :
+        89265,  # Tokyo
+        236783,  # }
+        49,  # <tool_call|>
+    ]
+
+    _id_to_text = {v: k for k, v in GEMMA4_VOCAB.items()}
+
+    async def fake_stream_generate(**kwargs):
+        for i, tid in enumerate(body_tokens):
+            finished = i == len(body_tokens) - 1
+            yield GenerationOutput(
+                text="",
+                new_text=_id_to_text[tid],
+                tokens=[tid],
+                finished=finished,
+                finish_reason="stop" if finished else None,
+            )
+
+    engine.stream_generate = fake_stream_generate
+
+    outputs = await _collect(
+        engine.stream_chat(messages=[{"role": "user", "content": "hi"}])
+    )
+
+    tool_call_outputs = [o for o in outputs if o.channel == "tool_call"]
+    assert len(tool_call_outputs) == 1
+    body = tool_call_outputs[0].new_text
+    assert "<|tool_call>" in body, f"start marker dropped: {body!r}"
+    assert "get_weather" in body, f"function name dropped: {body!r}"
+    assert "Tokyo" in body, f"argument value dropped: {body!r}"
+    assert "<tool_call|>" in body, f"end marker dropped: {body!r}"
+    assert tool_call_outputs[0].finished is True
+    assert tool_call_outputs[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
 async def test_stream_chat_uses_incremental_new_text_for_single_token_events():
     """Single-token routed chunks preserve scheduler detokenizer text."""
     vocab = {

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -368,15 +368,60 @@ def test_prompt_returns_false_when_local_ahead(monkeypatch, interactive):
         inp.assert_not_called()
 
 
-def test_prompt_returns_false_when_dev_build_unparseable(monkeypatch, interactive):
-    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62.dev1+gabcdef")
-    monkeypatch.setattr(
-        vc, "_parse_version", lambda s: None if "dev" in s else (0, 6, 62)
-    )
-    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+@pytest.mark.parametrize(
+    "dev_version",
+    [
+        "0.6.62.dev1+gabcdef",  # editable dev build
+        "0.6.61.dev1",  # dev base of in-progress next bump
+        "0.6.62rc1",  # release candidate
+        "0.6.62a1",  # alpha
+        "0.6.62b1",  # beta
+        "0.6.62.post1",  # post-release
+        "0.6.62+local.build",  # PEP 440 local version
+    ],
+)
+def test_prompt_returns_false_for_pep440_non_final_release(
+    monkeypatch, interactive, dev_version
+):
+    """Real ``_parse_version`` tolerates dev/rc/+ suffixes and returns a tuple,
+    which would otherwise let a dev on ``0.6.61.dev1`` get a false prompt for
+    ``0.6.62``. The dev-build guard must skip BEFORE parsing, using the real
+    parser unmocked so a future regression of the parser doesn't silently
+    bypass the guard. DeepSeek finding #3 on PR #428.
+    """
+    monkeypatch.setattr(vc, "_installed_version", lambda: dev_version)
+    # Real _parse_version intentionally NOT mocked — guard must fire first.
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.7.0")
     with patch("builtins.input") as inp:
         assert vc.prompt_upgrade_if_available() is False
         inp.assert_not_called()
+
+
+def test_prompt_returns_false_when_upgrade_subprocess_fails(monkeypatch, interactive):
+    """Brew/pip failure (network, conflict, sudo prompt) must NOT cause
+    serve to exit silently. Return False so the caller continues booting
+    with the current version. DeepSeek finding #2 on PR #428.
+    """
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="brew",
+            upgrade_command="brew upgrade raullenchai/tap/rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "raullenchai/tap/rapid-mlx"],
+        ),
+    )
+    fake_result = MagicMock(returncode=1)
+    with (
+        patch("builtins.input", return_value="y"),
+        patch("subprocess.run", return_value=fake_result),
+    ):
+        # Failed upgrade → return False so serve continues with the
+        # current installed version. The user sees the exit code and can
+        # retry manually.
+        assert vc.prompt_upgrade_if_available() is False
 
 
 def test_prompt_returns_false_when_offline(monkeypatch, interactive):

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -334,7 +334,8 @@ def test_prompt_returns_false_when_disabled(monkeypatch, interactive):
     monkeypatch.setenv("RAPID_MLX_DISABLE_VERSION_CHECK", "1")
     # Disabled MUST short-circuit before fetching anything.
     monkeypatch.setattr(
-        vc, "get_latest_version",
+        vc,
+        "get_latest_version",
         lambda force_refresh=False: pytest.fail("network leaked on disabled"),
     )
     assert vc.prompt_upgrade_if_available() is False
@@ -343,7 +344,8 @@ def test_prompt_returns_false_when_disabled(monkeypatch, interactive):
 def test_prompt_returns_false_when_stdin_not_tty(monkeypatch, interactive):
     monkeypatch.setattr(vc.sys.stdin, "isatty", lambda: False)
     monkeypatch.setattr(
-        vc, "get_latest_version",
+        vc,
+        "get_latest_version",
         lambda force_refresh=False: pytest.fail("network leaked on non-TTY"),
     )
     assert vc.prompt_upgrade_if_available() is False
@@ -368,7 +370,9 @@ def test_prompt_returns_false_when_local_ahead(monkeypatch, interactive):
 
 def test_prompt_returns_false_when_dev_build_unparseable(monkeypatch, interactive):
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62.dev1+gabcdef")
-    monkeypatch.setattr(vc, "_parse_version", lambda s: None if "dev" in s else (0, 6, 62))
+    monkeypatch.setattr(
+        vc, "_parse_version", lambda s: None if "dev" in s else (0, 6, 62)
+    )
     monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
     with patch("builtins.input") as inp:
         assert vc.prompt_upgrade_if_available() is False

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -315,3 +316,162 @@ def test_detect_install_method_no_binary_falls_back_to_pip(monkeypatch):
     info = vc.detect_install_method()
     assert info.method == "pip"
     assert info.binary_path is None
+
+
+# --- prompt_upgrade_if_available ------------------------------------------
+
+
+@pytest.fixture
+def interactive(monkeypatch):
+    """Enable the prompt path: TTY on stdin+stderr, not disabled, not in CI."""
+    monkeypatch.delenv("RAPID_MLX_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(vc.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(vc.sys.stderr, "isatty", lambda: True)
+
+
+def test_prompt_returns_false_when_disabled(monkeypatch, interactive):
+    monkeypatch.setenv("RAPID_MLX_DISABLE_VERSION_CHECK", "1")
+    # Disabled MUST short-circuit before fetching anything.
+    monkeypatch.setattr(
+        vc, "get_latest_version",
+        lambda force_refresh=False: pytest.fail("network leaked on disabled"),
+    )
+    assert vc.prompt_upgrade_if_available() is False
+
+
+def test_prompt_returns_false_when_stdin_not_tty(monkeypatch, interactive):
+    monkeypatch.setattr(vc.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        vc, "get_latest_version",
+        lambda force_refresh=False: pytest.fail("network leaked on non-TTY"),
+    )
+    assert vc.prompt_upgrade_if_available() is False
+
+
+def test_prompt_returns_false_when_already_current(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    with patch("builtins.input") as inp:
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_not_called()
+
+
+def test_prompt_returns_false_when_local_ahead(monkeypatch, interactive):
+    """Dev build one bump ahead of latest — never prompt downward."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.63")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    with patch("builtins.input") as inp:
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_not_called()
+
+
+def test_prompt_returns_false_when_dev_build_unparseable(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62.dev1+gabcdef")
+    monkeypatch.setattr(vc, "_parse_version", lambda s: None if "dev" in s else (0, 6, 62))
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    with patch("builtins.input") as inp:
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_not_called()
+
+
+def test_prompt_returns_false_when_offline(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: None)
+    with patch("builtins.input") as inp:
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_not_called()
+
+
+def test_prompt_returns_false_when_user_declines(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="pip",
+            upgrade_command="pip install -U rapid-mlx",
+            upgrade_argv=["pip", "install", "-U", "rapid-mlx"],
+        ),
+    )
+    with (
+        patch("builtins.input", return_value="n"),
+        patch("subprocess.run") as run,
+    ):
+        assert vc.prompt_upgrade_if_available() is False
+        run.assert_not_called()
+
+
+def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="brew",
+            upgrade_command="brew upgrade raullenchai/tap/rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "raullenchai/tap/rapid-mlx"],
+        ),
+    )
+    fake_result = MagicMock(returncode=0)
+    # Empty answer == default Y.
+    with (
+        patch("builtins.input", return_value=""),
+        patch("subprocess.run", return_value=fake_result) as run,
+    ):
+        assert vc.prompt_upgrade_if_available() is True
+        run.assert_called_once_with(
+            ["brew", "upgrade", "raullenchai/tap/rapid-mlx"], check=False
+        )
+
+
+def test_prompt_crosses_minor_boundary(monkeypatch, interactive):
+    """``staleness_warning`` stays silent across minor bumps, but the
+    interactive prompt opts in — user can still say no."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.7.0")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="pip",
+            upgrade_command="pip",
+            upgrade_argv=["pip"],
+        ),
+    )
+    with patch("builtins.input", return_value="n") as inp:
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_called_once()
+
+
+def test_prompt_never_raises(monkeypatch, interactive):
+    """A bug in detect_install_method or _installed_version must never crash
+    the CLI — silently skip and return False so serve continues to boot.
+    """
+
+    def boom():
+        raise RuntimeError("simulated bug")
+
+    monkeypatch.setattr(vc, "_installed_version", boom)
+    # Must not raise.
+    assert vc.prompt_upgrade_if_available() is False
+
+
+def test_prompt_returns_false_on_keyboard_interrupt(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="pip", upgrade_command="pip", upgrade_argv=["pip"]
+        ),
+    )
+    with (
+        patch("builtins.input", side_effect=KeyboardInterrupt()),
+        patch("subprocess.run") as run,
+    ):
+        assert vc.prompt_upgrade_if_available() is False
+        run.assert_not_called()

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -198,6 +198,79 @@ def print_staleness_warning_if_any() -> None:
         pass
 
 
+def prompt_upgrade_if_available() -> bool:
+    """Interactive Y/n prompt when a newer release is on GitHub.
+
+    Designed for the top of long-lived entry points (``rapid-mlx serve``):
+    if the network has a newer release than what's installed, ask once
+    before booting the model. On accept, dispatch the right upgrade
+    command (brew/pip/install.sh — same dispatcher as ``rapid-mlx
+    upgrade``) and return ``True`` so the caller can exit. Returns
+    ``False`` when no prompt was shown (disabled, non-TTY, already
+    current, dev build, network down) or the user declined.
+
+    Distinct from ``staleness_warning()`` in two ways: (1) prompts on ANY
+    newer release, not only ≥2-patch lag, because if we're going to
+    interrupt a long-running boot we may as well save the user the
+    re-launch; (2) crosses minor-version boundaries, because an
+    interactive opt-in is safer than the silent banner's automatic
+    cross-minor restraint.
+    """
+    try:
+        if _disabled():
+            return False
+        # Need stdin for the prompt too — _disabled checks stderr only.
+        if not sys.stdin.isatty():
+            return False
+
+        installed_str = _installed_version()
+        if not installed_str:
+            return False
+        installed = _parse_version(installed_str)
+        if installed is None:
+            return False  # dev build
+
+        latest_str = get_latest_version()
+        if not latest_str:
+            return False
+        latest = _parse_version(latest_str)
+        if latest is None or latest <= installed:
+            return False
+
+        import subprocess
+
+        info = detect_install_method()
+        print(
+            f"\nA newer rapid-mlx is available: {latest_str} "
+            f"(current: {installed_str})."
+        )
+        print(f"  Upgrade command: {info.upgrade_command}")
+        try:
+            answer = input("  Run it now? [Y/n] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return False
+        if answer and answer not in ("y", "yes"):
+            return False
+
+        print()
+        try:
+            result = subprocess.run(info.upgrade_argv, check=False)
+        except FileNotFoundError as e:
+            print(f"  Upgrade command not found: {e}\n")
+            return False
+        except KeyboardInterrupt:
+            print("\n  Interrupted.\n")
+            return False
+        if result.returncode == 0:
+            print("\nUpgrade complete. Please re-run your command.\n")
+        else:
+            print(f"\nUpgrade exited with code {result.returncode}.\n")
+        return True
+    except Exception:  # noqa: BLE001 — never break the CLI
+        return False
+
+
 # --- install-method detection (used by ``rapid-mlx upgrade``) -----------
 
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -226,9 +226,20 @@ def prompt_upgrade_if_available() -> bool:
         installed_str = _installed_version()
         if not installed_str:
             return False
+        # Skip pre-release / dev / local-version builds. ``_parse_version``
+        # tolerates ``0.6.62.dev1`` → ``(0, 6, 62)`` so the tuple can be
+        # compared at all, but for an interactive prompt the dev-base case
+        # can fire a false "newer release available" against the dev's
+        # own in-progress branch (installed ``0.6.61.dev1`` vs latest
+        # ``0.6.62`` → prompt). A clean PEP 440 final release is digits
+        # and dots only; anything else (``dev``/``a``/``b``/``rc``/
+        # ``post``/``+local``) is non-final and gets the dev-build skip
+        # path. DeepSeek finding #1 on PR #428.
+        if any(c.isalpha() or c == "+" for c in installed_str.lstrip("v")):
+            return False
         installed = _parse_version(installed_str)
         if installed is None:
-            return False  # dev build
+            return False  # unparseable
 
         latest_str = get_latest_version()
         if not latest_str:
@@ -264,9 +275,18 @@ def prompt_upgrade_if_available() -> bool:
             return False
         if result.returncode == 0:
             print("\nUpgrade complete. Please re-run your command.\n")
-        else:
-            print(f"\nUpgrade exited with code {result.returncode}.\n")
-        return True
+            return True
+        # Failed upgrade: return False so the caller continues booting with
+        # the current version rather than exiting silently. The user has
+        # been shown the exit code and can retry manually if they care.
+        # DeepSeek finding #2 on PR #428: returning True here would have
+        # `serve_command` do ``sys.exit(0)`` and leave the user with no
+        # running server and only an error message.
+        print(
+            f"\nUpgrade exited with code {result.returncode}; "
+            f"continuing with rapid-mlx {installed_str}.\n"
+        )
+        return False
     except Exception:  # noqa: BLE001 — never break the CLI
         return False
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -384,6 +384,15 @@ def serve_command(args):
 
     import uvicorn
 
+    # Interactive auto-upgrade prompt — when serve runs interactively and a
+    # newer release is available, ask once before booting the model. Honors
+    # RAPID_MLX_DISABLE_VERSION_CHECK, CI=1, and non-TTY stdin. Cached
+    # piggy-backs on the existing staleness check's cache (24h TTL).
+    from vllm_mlx._version_check import prompt_upgrade_if_available
+
+    if prompt_upgrade_if_available():
+        sys.exit(0)
+
     # Import unified server
     from . import server
     from .middleware.auth import configure_rate_limiter

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1260,7 +1260,22 @@ class BatchedEngine(BaseEngine):
                     event = router.feed(token_id)
                     if event is None:
                         continue
-                    event_text = output.new_text if len(token_ids) == 1 else event.text
+                    # TOOL_CALL events are deferred multi-token aggregates: the
+                    # router suppresses tokens during RouterState.TOOL_CALL and
+                    # emits once on the end marker with event.text carrying the
+                    # full decoded body. The single-token-flush optimization
+                    # (use output.new_text) is correct for one-token-in /
+                    # one-event-out channels (CONTENT, REASONING), but for
+                    # TOOL_CALL it would override the accumulated body with
+                    # just the end-marker token's text, dropping the body on
+                    # the floor and breaking streaming tool calls for gemma4
+                    # and harmony — caught on gemma-4-26b post-v0.6.61.
+                    if event.channel == Channel.TOOL_CALL:
+                        event_text = event.text
+                    else:
+                        event_text = (
+                            output.new_text if len(token_ids) == 1 else event.text
+                        )
                     routed_outputs.append(
                         self._make_routed_output(
                             output,


### PR DESCRIPTION
## Summary

Two changes for v0.6.62:

1. **`fix(stream)`**: gemma-4-26b post-v0.6.61 surfaced that streaming returned `finish_reason='stop'` and zero `tool_calls` even though non-stream extracted a schema-valid `get_weather({"city":"Tokyo"})` from the **same generation**. Root cause is one line in `_stream_with_output_router`: the single-token-flush optimization overrides the router's accumulated multi-token TOOL_CALL body with just the end-marker token's text (`'<tool_call|>'`), dropping the call body on the floor. The v0.6.61 finalize fallback couldn't recover because the start marker had already been consumed by the router. Fix: special-case `Channel.TOOL_CALL` to always use `event.text` (the router's accumulated decoded body); other channels keep the optimization.

2. **`feat(cli)`**: interactive upgrade prompt on `rapid-mlx serve` startup. When a newer release is on GitHub, asks `Run it now? [Y/n]` and dispatches the right upgrade command (brew/pip/install.sh) via the existing `detect_install_method()`. Reuses the staleness check's 24h cache and opt-out story (`RAPID_MLX_DISABLE_VERSION_CHECK`, `CI=1`, non-TTY stdin all skip). Other entry points keep the existing static banner.

## Repro (Bug A)

Before v0.6.62:

```
$ rapid-mlx serve gemma-4-26b
$ curl -sN -X POST :8000/v1/chat/completions -d '{"stream":true,"messages":[{"role":"user","content":"What is the weather in Tokyo?"}],"tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]}'
# stream: finish_reason='stop', tool_calls=[]  ❌
# non-stream (same prompt): tool_calls=[{name: get_weather, arguments: {"city":"Tokyo"}}]  ✅
```

After v0.6.62: stream matches non-stream — `finish_reason='tool_calls'` + schema-valid arguments.

## Test plan

- [x] `tests/test_batched_engine_output_router.py` — new one-token-per-flush variant of the TOOL_CALL channel test. Bisect-verified: body=='<tool_call|>' without fix, full body with fix.
- [x] `tests/test_version_check.py` — 8 new cases for `prompt_upgrade_if_available` (disabled/non-TTY/current/local-ahead/dev-build/offline/decline/accept/never-raises).
- [x] `make smoke`: 3671 unit tests pass, lint pass, CLI fidelity audit pass.
- [x] **Gate 6 (real-server)**: gemma-4-26b 4bit booted with the fix; streaming `get_weather` request now returns `finish_reason='tool_calls'` with `arguments='{"city":"Tokyo"}'`. Matches non-stream control exactly. Plain (no-tool) streaming clean — no spurious tool_calls.
- [ ] pr_validate (to be run on this PR)
- [ ] Codex review × 2 rounds

## Meta-problem closure

`pr_validate`'s stress matrix had gemma4 commented out (instruction-following weakness), so all four OutputRouter-enabled families (gemma4, harmony, +their variants) had zero coverage. The new router-integrated test plugs the gap at the engine layer; the matrix gap itself is tracked separately in `knowledge/guided_generation_gaps_2026-05-20.md`.