### PR TITLE
feat(tool-parsers): declare-your-formats invariant

### DIFF
--- a/tests/test_tool_parser_wire_formats.py
+++ b/tests/test_tool_parser_wire_formats.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Declare-your-formats invariant for every registered ToolParser.
+
+Forcing function for the bug class surfaced by #425 (jpcarranza94, PR #426)
+and the v0.6.62 #429 meta-fix: when a new parser is added, the wire
+format(s) it handles MUST be declared as a class attribute
+``EXPECTED_WIRE_FORMATS``, drawn from the canonical
+``WIRE_FORMAT_LABELS`` set in ``vllm_mlx/tool_parsers/abstract_tool_parser.py``.
+
+The point is to make the parser ↔ format mapping *machine-checkable*
+rather than buried in regex patterns. Three concrete consumers:
+
+  1. ``tests/test_tool_call_streaming_parity.py`` (PR #430): parity
+     fixtures use the same labels declared here.
+  2. ``scripts/audit_tool_parser_coverage.py`` (PR #431): matrix-coverage
+     audit can cross-reference declared formats.
+  3. Future docs / CLI ``--help`` listing: can render the format-handled
+     summary mechanically instead of free-form prose that rots.
+
+Two layers, same shape as the audit gate:
+
+  - Coverage assertion: every concrete (non-meta) parser declares at
+    least one well-known format label.
+  - Label-set integrity: every declared label exists in
+    ``WIRE_FORMAT_LABELS`` — typo'd labels fail CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.tool_parsers import ToolParserManager
+from vllm_mlx.tool_parsers.abstract_tool_parser import WIRE_FORMAT_LABELS
+
+# Meta-parsers that don't handle a wire format themselves — they route to
+# concrete parsers. ``EXPECTED_WIRE_FORMATS = ()`` is the correct value;
+# this set documents them explicitly so a future contributor adding a
+# class to the meta tier can't accidentally bypass the declaration
+# requirement by forgetting to set the attribute.
+_META_PARSER_CLASSES: set[str] = {
+    "AutoToolParser",  # "auto" / "generic" — routing meta-parser
+}
+
+
+def _registered_parser_classes() -> dict[type, set[str]]:
+    """Return {parser_class: {registered_name, ...}}.
+
+    Dedupes the registry — the same class can be registered under
+    multiple alias names (e.g. ``hermes`` / ``nous`` / ``qwen3_coder`` all
+    point at ``HermesToolParser``). We test each class once.
+    """
+    by_class: dict[type, set[str]] = {}
+    for name, cls in ToolParserManager.tool_parsers.items():
+        by_class.setdefault(cls, set()).add(name)
+    return by_class
+
+
+@pytest.mark.parametrize(
+    "parser_cls, names",
+    sorted(
+        _registered_parser_classes().items(),
+        key=lambda kv: kv[0].__name__,
+    ),
+    ids=lambda v: v.__name__ if isinstance(v, type) else "",
+)
+def test_every_parser_declares_wire_formats(parser_cls, names):
+    """Every concrete (non-meta) ToolParser subclass must declare
+    ``EXPECTED_WIRE_FORMATS`` with at least one label from
+    ``WIRE_FORMAT_LABELS``.
+
+    Forcing function: adding a new parser without this attribute fails
+    CI here. The author is required to (a) think about what wire format
+    they handle, (b) reuse an existing label or deliberately add a new
+    one to ``WIRE_FORMAT_LABELS``. Both keep the audit/parity surfaces
+    aligned with the actual parser landscape.
+
+    Meta-parsers (``AutoToolParser``) are exempt — listed in
+    ``_META_PARSER_CLASSES`` with a documented reason.
+    """
+    formats = parser_cls.EXPECTED_WIRE_FORMATS
+
+    if parser_cls.__name__ in _META_PARSER_CLASSES:
+        assert formats == (), (
+            f"{parser_cls.__name__} is in _META_PARSER_CLASSES but declares "
+            f"EXPECTED_WIRE_FORMATS={formats!r}. Meta-parsers route to other "
+            f"parsers and should declare an empty tuple. Either remove from "
+            f"_META_PARSER_CLASSES or unset the attribute."
+        )
+        return
+
+    assert formats, (
+        f"{parser_cls.__name__} (registered as {sorted(names)!r}) does not "
+        f"declare EXPECTED_WIRE_FORMATS. Set it to a tuple of one or more "
+        f"labels from WIRE_FORMAT_LABELS in "
+        f"vllm_mlx/tool_parsers/abstract_tool_parser.py. If this is a "
+        f"meta/router parser with no wire format of its own, add the "
+        f"class name to _META_PARSER_CLASSES in this test file."
+    )
+
+    unknown = set(formats) - WIRE_FORMAT_LABELS
+    assert not unknown, (
+        f"{parser_cls.__name__} declares unknown wire-format label(s) "
+        f"{sorted(unknown)!r}. Allowed labels are: "
+        f"{sorted(WIRE_FORMAT_LABELS)!r}. If you intend to add a new label, "
+        f"do so deliberately in WIRE_FORMAT_LABELS (with a docstring note "
+        f"describing the format) and re-run this test."
+    )
+
+
+def test_wire_format_labels_have_consumers():
+    """Every label in ``WIRE_FORMAT_LABELS`` should be claimed by at
+    least one registered parser. Unclaimed labels are dead vocabulary
+    and should be removed (or have a parser added that uses them).
+
+    Soft-failure mode: report unclaimed labels but pass — adding a label
+    for a planned-but-not-yet-implemented parser is legitimate (e.g.
+    declaring ``llama_python_tag`` before the Llama parser is upgraded
+    to handle it). This test exists so the unused-label drift surfaces
+    in CI logs without blocking PRs.
+    """
+    claimed: set[str] = set()
+    for cls in _registered_parser_classes():
+        claimed.update(getattr(cls, "EXPECTED_WIRE_FORMATS", ()) or ())
+    unclaimed = WIRE_FORMAT_LABELS - claimed
+    # Print for CI visibility without failing — these are "TODO" labels.
+    if unclaimed:
+        print(
+            f"NOTE: {len(unclaimed)} WIRE_FORMAT_LABELS not yet claimed by "
+            f"any parser: {sorted(unclaimed)!r}. This is fine for "
+            f"planned-but-unimplemented formats; remove the label if it's "
+            f"truly dead."
+        )
+
+
+def test_meta_parser_classes_exist():
+    """Sanity: every name in ``_META_PARSER_CLASSES`` resolves to an
+    actually-registered class. Guards against typos that would silently
+    bypass the assertion (a typo'd class name wouldn't match anything,
+    so a real meta-parser would fall into the "must declare formats"
+    branch and the audit would falsely complain)."""
+    registered_class_names = {cls.__name__ for cls in _registered_parser_classes()}
+    missing = _META_PARSER_CLASSES - registered_class_names
+    assert not missing, (
+        f"_META_PARSER_CLASSES references class names that aren't "
+        f"registered: {sorted(missing)!r}. Either the class was renamed or "
+        f"the name is a typo. Registered classes: "
+        f"{sorted(registered_class_names)!r}"
+    )

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -51,6 +51,62 @@ class ExtractedToolCallInformation:
     """Any content that wasn't part of tool calls."""
 
 
+# Canonical wire-format labels each ToolParser subclass declares it handles.
+# Adding a new label here is a deliberate act — the audit script and the
+# parity test (test_tool_call_streaming_parity.py) cross-reference these
+# strings, so reusing existing labels keeps the surfaces aligned. Define
+# new labels only when an actually-novel wire format is introduced.
+#
+# Canonical formats (and which parsers handle them):
+#   tool_call_json        — <tool_call>{"name":...,"arguments":...}</tool_call>
+#                           (Hermes, Qwen, Qwen3-Coder JSON variant)
+#   tool_call_xml_body    — <tool_call><function=name><parameter=p>v</parameter>
+#                           </function></tool_call>  (Qwen3.6, Nemotron, Hermes
+#                           fallback, Qwen3-Coder XML variant)
+#   function_bare         — <function=name>...</function>  without <tool_call>
+#                           wrapper (Hermes BARE_FUNCTION_PATTERN)
+#   raw_json              — bare {"name":...,"arguments":...} (Hermes fallback,
+#                           xLAM, Llama JSON variant)
+#   calling_tool_text     — [Calling tool="name" k="v"]  text fallback for
+#                           low-quant degradation
+#   gemma4_native         — <|tool_call>call:name{k:v}<tool_call|>  (Gemma 4)
+#   harmony_commentary    — <|channel|>commentary to=functions.X<|message|>
+#                           {...}<|call|>  (GPT-OSS / Harmony)
+#   mistral_tool_calls    — [TOOL_CALLS][{"name":...,"arguments":...}]
+#   llama_python_tag      — <|python_tag|>{"name":..."parameters":...}
+#   glm_named_tool_call   — <tool_call>name\n{json}</tool_call>  (GLM-4.5/4.7)
+#   functionary_native    — <|from|>assistant<|recipient|>name<|content|>...
+#   granite_native        — <|tool_call|>[{...}]  (Granite 3/4)
+#   kimi_native           — <|tool_calls_section_begin|>...<|tool_calls_section_end|>
+#   minimax_native        — <tool_calls>[...]</tool_calls>  (MiniMax M2/M2.5)
+#   seed_oss_native       — Seed-OSS specific (TBD; placeholder)
+#   deepseek_native       — DeepSeek V3 specific
+#   deepseek_v31_native   — DeepSeek V3.1 / R1-0528 specific
+#   qwen3_coder_xml_named — Qwen3-Coder XML variant with named function tags
+WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
+    {
+        "tool_call_json",
+        "tool_call_xml_body",
+        "function_bare",
+        "raw_json",
+        "calling_tool_text",
+        "gemma4_native",
+        "harmony_commentary",
+        "mistral_tool_calls",
+        "llama_python_tag",
+        "glm_named_tool_call",
+        "functionary_native",
+        "granite_native",
+        "kimi_native",
+        "minimax_native",
+        "seed_oss_native",
+        "deepseek_native",
+        "deepseek_v31_native",
+        "qwen3_coder_xml_named",
+    }
+)
+
+
 class ToolParser(ABC):
     """
     Abstract base class for tool call parsers.
@@ -63,6 +119,17 @@ class ToolParser(ABC):
     # can handle role="tool" messages and tool_calls fields directly,
     # without needing conversion to text format.
     SUPPORTS_NATIVE_TOOL_FORMAT: bool = False
+
+    # Declarative list of wire formats this parser handles. Every concrete
+    # subclass MUST override this with at least one label from
+    # ``WIRE_FORMAT_LABELS``. The structural test
+    # ``tests/test_tool_parser_wire_formats.py::test_every_parser_declares_formats``
+    # enforces this. Forcing function for the #425-class meta-fix: when a
+    # new parser ships, the wire format(s) it handles MUST be documented
+    # at the class level rather than buried in the regex patterns. This is
+    # what makes the audit + parity matrices machine-checkable rather than
+    # reading-the-source archeology.
+    EXPECTED_WIRE_FORMATS: tuple[str, ...] = ()
 
     @classmethod
     def supports_native_format(cls) -> bool:

--- a/vllm_mlx/tool_parsers/deepseek_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_tool_parser.py
@@ -44,6 +44,8 @@ class DeepSeekToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser deepseek are set.
     """
 
+    EXPECTED_WIRE_FORMATS = ("deepseek_native",)
+
     # DeepSeek V3 chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -42,6 +42,7 @@ class DeepSeekV31ToolParser(ToolParser):
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("deepseek_v31_native",)
 
     TOOL_CALLS_START = "<｜tool▁calls▁begin｜>"
     TOOL_CALLS_END = "<｜tool▁calls▁end｜>"

--- a/vllm_mlx/tool_parsers/functionary_tool_parser.py
+++ b/vllm_mlx/tool_parsers/functionary_tool_parser.py
@@ -42,6 +42,7 @@ class FunctionaryToolParser(ToolParser):
 
     # Functionary chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("functionary_native", "function_bare")
 
     # Functionary v3 format
     RECIPIENT_PATTERN = re.compile(

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -82,6 +82,8 @@ class Gemma4ToolParser(ToolParser):
     Format: <|tool_call>call:func_name{key:<|"|>value<|"|>}<tool_call|>
     """
 
+    EXPECTED_WIRE_FORMATS = ("gemma4_native", "calling_tool_text")
+
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
         self._emitted_tool_count = 0

--- a/vllm_mlx/tool_parsers/glm47_tool_parser.py
+++ b/vllm_mlx/tool_parsers/glm47_tool_parser.py
@@ -43,6 +43,7 @@ class Glm47ToolParser(ToolParser):
     # tool calls back to the model in their native form instead of converting
     # them to a synthetic <function=…> string.
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("glm_named_tool_call",)
 
     # Match entire tool call block
     TOOL_CALL_PATTERN = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)

--- a/vllm_mlx/tool_parsers/granite_tool_parser.py
+++ b/vllm_mlx/tool_parsers/granite_tool_parser.py
@@ -40,6 +40,7 @@ class GraniteToolParser(ToolParser):
 
     # Granite 3.1 chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("granite_native",)
 
     BOT_TOKEN = "<|tool_call|>"
     BOT_STRING = "<tool_call>"

--- a/vllm_mlx/tool_parsers/harmony_tool_parser.py
+++ b/vllm_mlx/tool_parsers/harmony_tool_parser.py
@@ -69,6 +69,8 @@ class HarmonyToolParser(ToolParser):
     # which breaks the model's understanding of the tool flow.
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 
+    EXPECTED_WIRE_FORMATS = ("harmony_commentary",)
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -68,6 +68,18 @@ class HermesToolParser(ToolParser):
     # proper <tool_call> XML after a few rounds of tool use.
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 
+    # Hermes is the most flexible parser — handles JSON body inside
+    # <tool_call>, the Nemotron-style XML body fallback (covers vanilla
+    # Qwen3.6), bare <function=...> blocks, raw JSON tool calls, and the
+    # [Calling tool:] text-fallback for low-quant degradation.
+    EXPECTED_WIRE_FORMATS = (
+        "tool_call_json",
+        "tool_call_xml_body",
+        "function_bare",
+        "raw_json",
+        "calling_tool_text",
+    )
+
     # Standard format: <tool_call>{"name": ..., "arguments": ...}</tool_call>
     TOOL_CALL_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
     # Lenient format: <tool_call or <tool_call> followed by JSON (handles malformed tags)

--- a/vllm_mlx/tool_parsers/kimi_tool_parser.py
+++ b/vllm_mlx/tool_parsers/kimi_tool_parser.py
@@ -40,6 +40,7 @@ class KimiToolParser(ToolParser):
 
     # Kimi chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("kimi_native",)
 
     # Kimi tokens
     TOOL_CALLS_START = "<|tool_calls_section_begin|>"

--- a/vllm_mlx/tool_parsers/llama_tool_parser.py
+++ b/vllm_mlx/tool_parsers/llama_tool_parser.py
@@ -37,6 +37,10 @@ class LlamaToolParser(ToolParser):
 
     # Llama 3+ chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    # NOTE: this parser implements the bare <function=...> form; the
+    # llama_python_tag label is reserved for future expansion if/when
+    # Llama 3.1+ <|python_tag|> handling is added here.
+    EXPECTED_WIRE_FORMATS = ("function_bare",)
 
     # Pattern for Llama-style: <function=name>{"json"}</function>
     FUNCTION_PATTERN = re.compile(r"<function=([^>]+)>(\{.*?\})</function>", re.DOTALL)

--- a/vllm_mlx/tool_parsers/minimax_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minimax_tool_parser.py
@@ -42,6 +42,8 @@ class MiniMaxToolParser(ToolParser):
         </minimax:tool_call>
     """
 
+    EXPECTED_WIRE_FORMATS = ("minimax_native",)
+
     TOOL_CALL_BLOCK = re.compile(
         r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
     )

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -48,6 +48,7 @@ class MistralToolParser(ToolParser):
 
     # Mistral chat templates support native tool message format
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("mistral_tool_calls",)
 
     BOT_TOKEN = "[TOOL_CALLS]"
     TOOL_CALL_REGEX = re.compile(r"\[{.*}\]", re.DOTALL)

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -40,6 +40,8 @@ class NemotronToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser nemotron are set.
     """
 
+    EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
+
     # Pattern for Nemotron-style with parameters
     TOOL_CALL_PATTERN = re.compile(
         r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -106,6 +106,7 @@ class Qwen3CoderToolParser(ToolParser):
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("qwen3_coder_xml_named", "tool_call_xml_body")
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -35,7 +35,17 @@ class QwenToolParser(ToolParser):
     - Bracket: [Calling tool: func_name({"arg": "value"})]
 
     Used when --enable-auto-tool-choice --tool-call-parser qwen are set.
+
+    Note on naming: "qwen3_xml" in the registration list refers to the XML
+    *wrapper* (<tool_call>...</tool_call> tags), NOT to XML-body parameters.
+    The JSON body inside the wrapper is what this parser extracts. Vanilla
+    Qwen3.6 non-reasoning models emit XML-body parameters, which this parser
+    does NOT handle on its own — the cross-format fallback at
+    service/postprocessor.py::finalize() (PR #426, fixes #425) routes those
+    through api.tool_calling.parse_tool_calls.
     """
+
+    EXPECTED_WIRE_FORMATS = ("tool_call_json", "calling_tool_text")
 
     # Pattern for XML-style: <tool_call>{"json"}</tool_call>
     XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)

--- a/vllm_mlx/tool_parsers/seed_oss_tool_parser.py
+++ b/vllm_mlx/tool_parsers/seed_oss_tool_parser.py
@@ -108,6 +108,7 @@ class SeedOssToolParser(ToolParser):
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("seed_oss_native",)
 
     TOOL_CALL_START = "<seed:tool_call>"
     TOOL_CALL_END = "</seed:tool_call>"

--- a/vllm_mlx/tool_parsers/xlam_tool_parser.py
+++ b/vllm_mlx/tool_parsers/xlam_tool_parser.py
@@ -39,6 +39,8 @@ class xLAMToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser xlam are set.
     """
 
+    EXPECTED_WIRE_FORMATS = ("raw_json",)
+
     # Patterns for extracting JSON
     CODE_BLOCK_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
     THINKING_PATTERN = re.compile(r"</think>\s*([\s\S]*)")


### PR DESCRIPTION
## Summary

Final layer of the #425-class meta-fix stack. Every concrete \`ToolParser\` subclass must now declare \`EXPECTED_WIRE_FORMATS: tuple[str, ...]\` — a tuple of labels drawn from a canonical \`WIRE_FORMAT_LABELS\` frozenset defined in \`abstract_tool_parser.py\`.

## Why

Make parser ↔ format mapping **machine-checkable** instead of buried in regex patterns. Three downstream consumers benefit:

1. \`tests/test_tool_call_streaming_parity.py\` (PR #430) — parity fixtures reference the same labels.
2. \`scripts/audit_tool_parser_coverage.py\` (PR #431) — matrix-coverage audit can cross-reference declared formats.
3. Future CLI \`--help\` listing / docs auto-render — emit "this parser handles X / Y / Z" mechanically instead of free-form prose that rots.

Forcing function: new parsers without \`EXPECTED_WIRE_FORMATS\` fail \`test_every_parser_declares_wire_formats\`. Typo'd labels also fail (must exist in \`WIRE_FORMAT_LABELS\`).

## Full stack now in place

| layer | PR | scope |
|---|---|---|
| Bug fix | #426 (jpcarranza94, 847ea15) | Stream finalize cross-format fallback |
| Parity invariant | #430 (f0d927a) | Stream ↔ non-stream extraction equivalence |
| Matrix coverage gate | #431 (c2f7…) | Every \`--tool-call-parser\` exercised or exempt |
| Declare-your-formats | **this PR** | Every parser declares its wire formats |

## 17 concrete parsers categorized

| Parser | Declared formats |
|---|---|
| Hermes | tool_call_json + tool_call_xml_body + function_bare + raw_json + calling_tool_text |
| Qwen | tool_call_json + calling_tool_text |
| Qwen3-Coder | qwen3_coder_xml_named + tool_call_xml_body |
| Gemma4 | gemma4_native + calling_tool_text |
| Harmony | harmony_commentary |
| Nemotron | tool_call_xml_body |
| Llama | function_bare |
| Mistral | mistral_tool_calls |
| GLM-4.7 | glm_named_tool_call |
| Functionary | functionary_native + function_bare |
| Granite | granite_native |
| Kimi | kimi_native |
| MiniMax | minimax_native |
| xLAM | raw_json |
| Seed-OSS | seed_oss_native |
| DeepSeek | deepseek_native |
| DeepSeekV31 | deepseek_v31_native |

AutoToolParser (meta-router, no own wire format) exempted via \`_META_PARSER_CLASSES\`.

I also added a docstring note to \`QwenToolParser\` clarifying that \`qwen3_xml\` in the registration list refers to the XML *wrapper* (\`<tool_call>\` tags), NOT XML-body parameters — the historical confusion that contributed to #425.

## Test plan

- [x] 20/20 wire-format tests pass (1 parametrized × 18 classes + 2 sanity)
- [x] 172/172 broader sweep: \`test_tool_parser_wire_formats / test_tool_parser_coverage / test_tool_call_streaming_parity / test_tool_parsers / test_batched_engine_output_router\`
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] No engine-source touch, no version bump, no release

🤖 Generated with [Claude Code](https://claude.com/claude-code)