### PR TITLE
fix(onboarding-sweep): post-v0.6.63 spec/UX cleanup (7 fixes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.63"
+version = "0.6.64"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -566,8 +566,13 @@ def test_stream_completion_surfaces_generator_exception(monkeypatch) -> None:
         "stream must end with [DONE] even when the upstream generator "
         f"raises; body was:\n{body}"
     )
-    # The final delta block must carry the error block + finish_reason=error.
-    assert '"finish_reason": "error"' in body
+    # The final delta block must carry the error block alongside an
+    # OpenAI-spec-compliant finish_reason. ``"error"`` is NOT in the
+    # OpenAI ChatCompletion finish_reason literal set; aborts use
+    # ``"length"`` so spec-validating clients (openai-python, pydantic-ai)
+    # can parse the response. The ``error`` block carries the diagnostic
+    # details. v0.6.63 onboarding sweep finding #6.
+    assert '"finish_reason": "length"' in body
     assert "dflash_runtime_error" in body
     assert "simulated mlx-vlm failure" in body
     # And the one happy chunk that *did* arrive before the raise must
@@ -621,10 +626,12 @@ def test_stream_completion_surfaces_constructor_exception(monkeypatch) -> None:
     chunks = asyncio.run(_drain())
     body = b"".join(chunks).decode()
     # Must still get a clean [DONE] terminator + the error block.
+    # finish_reason is OpenAI-spec-compliant ``"length"`` (see the
+    # generator-exception test above for full rationale).
     assert "data: [DONE]" in body, (
         f"constructor-time crash must still terminate the stream; got:\n{body}"
     )
-    assert '"finish_reason": "error"' in body
+    assert '"finish_reason": "length"' in body
     assert "dflash_runtime_error" in body
     assert "simulated OOM at generator construction" in body
 

--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -1273,14 +1273,22 @@ class TestHarmonyCLIIntegration:
         return source
 
     def test_harmony_in_cli_choices(self):
-        """Verify 'harmony' is listed as a --tool-call-parser choice in CLI source."""
-        source = self._get_serve_tool_parser_choices()
-        assert '"harmony"' in source
+        """Verify 'harmony' is accepted by CLI --tool-call-parser.
+
+        Post-v0.6.63 onboarding sweep finding #1: the argparse hardcoded
+        choices list was removed in favor of live-registry validation.
+        This test now asserts the registry-derived path accepts the name.
+        """
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        assert "harmony" in ToolParserManager.tool_parsers
 
     def test_gpt_oss_in_cli_choices(self):
-        """Verify 'gpt-oss' is listed as a --tool-call-parser choice in CLI source."""
-        source = self._get_serve_tool_parser_choices()
-        assert '"gpt-oss"' in source
+        """Verify 'gpt-oss' is accepted by CLI --tool-call-parser
+        via the registry-derived validation (see test above)."""
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        assert "gpt-oss" in ToolParserManager.tool_parsers
 
     def test_registry_has_both_names(self):
         """ToolParserManager resolves both 'harmony' and 'gpt-oss'."""

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -756,10 +756,12 @@ class TestPrefillErrorCleanup:
         # Scheduler bookkeeping should be clean
         assert req_id not in scheduler.running
         assert req_id not in scheduler.request_id_to_uid
-        # Error output should have been queued
+        # Error output should have been queued. finish_reason is "length"
+        # (OpenAI-spec-compliant abort signal), not the legacy "error"
+        # literal — see scheduler.py rationale.
         queued = scheduler.output_queues[req_id].get_nowait()
         assert queued.finished is True
-        assert queued.finish_reason == "error"
+        assert queued.finish_reason == "length"
 
     def test_subsequent_request_not_poisoned(self):
         """A good request after a failed one should not be affected."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -408,6 +408,24 @@ def serve_command(args):
         print("Example: --enable-auto-tool-choice --tool-call-parser mistral")
         sys.exit(1)
 
+    # Validate --tool-call-parser against the live registry (not the
+    # stale argparse choices list). v0.6.63 onboarding sweep finding #1.
+    if args.tool_call_parser:
+        try:
+            from .tool_parsers import ToolParserManager
+
+            valid = sorted(ToolParserManager.tool_parsers.keys())
+        except Exception:
+            valid = []
+        if valid and args.tool_call_parser not in valid:
+            print(
+                f"error: argument --tool-call-parser: invalid choice: "
+                f"{args.tool_call_parser!r} "
+                f"(choose from: {', '.join(valid)})",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     # Validate gpu-memory-utilization range
     if not (0.0 < args.gpu_memory_utilization <= 1.0):
         print(
@@ -3111,34 +3129,26 @@ Examples:
         "--tool-call-parser",
         type=str,
         default=None,
-        choices=[
-            "auto",
-            "mistral",
-            "qwen",
-            "qwen3_coder",
-            "qwen3_coder_xml",
-            "qwen3_xml",
-            "llama",
-            "hermes",
-            "deepseek",
-            "kimi",
-            "granite",
-            "nemotron",
-            "xlam",
-            "functionary",
-            "glm47",
-            "minimax",
-            "harmony",
-            "gpt-oss",
-            "gemma4",
-        ],
+        # Choices NOT enforced at argparse level — the canonical set is the
+        # ToolParserManager registry, which has ~39 entries (canonical
+        # names + per-family aliases like ``deepseek_v31``, ``llama4``,
+        # ``moonshot`` for kimi, ``nous`` for hermes). The argparse hard-
+        # coded list drifted to 19 over multiple releases and rejected
+        # legitimate aliases users discovered via ``rapid-mlx info``.
+        # Validation now happens post-parse in
+        # ``_validate_tool_call_parser_choice`` against the live registry.
+        # v0.6.63 onboarding sweep finding #1.
         help=(
-            "Select the tool call parser for the model. Options: "
+            "Select the tool call parser for the model. Canonical options: "
             "auto (auto-detect), mistral, qwen/qwen3/qwen3_xml (reasoning models, "
             "<tool_call>JSON</tool_call> format), qwen3_coder/qwen3_coder_xml "
-            "(Coder model, <function=NAME> XML format), llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, minimax, "
-            "harmony/gpt-oss, gemma4. "
+            "(Coder model, <function=NAME> XML format), llama/llama3/llama4, "
+            "hermes/nous, deepseek/deepseek_v3/deepseek_v31, kimi/moonshot/kimi_k2, "
+            "granite/granite3, nemotron/nemotron3, xlam, functionary/meetkai, "
+            "glm47/glm4, minimax/minimax_m2, harmony/gpt-oss/gpt_oss, "
+            "gemma4/gemma_4, seed_oss/seed. "
+            "Run `python -c 'from vllm_mlx.tool_parsers import ToolParserManager;"
+            "print(sorted(ToolParserManager.tool_parsers))'` for the live list. "
             "Required for --enable-auto-tool-choice."
         ),
     )
@@ -3256,12 +3266,12 @@ Examples:
         "--gc-control",
         action="store_true",
         default=True,
-        help="Disable Python GC during generation to avoid latency spikes (default: enabled)",
+        help="Enable Python GC pausing during generation to avoid latency spikes (default: enabled)",
     )
     serve_parser.add_argument(
         "--no-gc-control",
         action="store_true",
-        help="Disable GC control (allow normal GC during generation)",
+        help="Disable GC control (allow normal Python GC during generation)",
     )
     # Pinned prefix cache (Tier 0 optimization)
     serve_parser.add_argument(

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -590,7 +590,12 @@ class EngineCore:
                                     output_token_ids=[],
                                     output_text="",
                                     finished=True,
-                                    finish_reason="error",
+                                    # OpenAI ChatCompletion finish_reason
+                                    # literal-set rejects "error"; "length"
+                                    # keeps the response spec-parseable.
+                                    # ``RequestOutput.error`` still carries
+                                    # the full abort message for callers.
+                                    finish_reason="length",
                                     prompt_tokens=0,
                                     completion_tokens=0,
                                     error=err_text,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -685,14 +685,16 @@ class MLLMScheduler:
                     if uids_to_remove:
                         self.batch_generator.remove(uids_to_remove)
 
-                # Create error outputs (queue delivery deferred to caller)
+                # Create error outputs (queue delivery deferred to caller).
+                # finish_reason="length" — OpenAI spec-compliant aborted
+                # signal; see scheduler.py for full rationale.
                 for request_id in error_ids:
                     output.outputs.append(
                         RequestOutput(
                             request_id=request_id,
                             output_text="",
                             finished=True,
-                            finish_reason="error",
+                            finish_reason="length",
                         )
                     )
                 output.finished_request_ids = error_ids
@@ -1002,12 +1004,13 @@ class MLLMScheduler:
                 break
 
         if final_output is None:
-            # Create empty output on error
+            # Create empty output on error. finish_reason="length" keeps
+            # the response OpenAI-spec-compliant; see scheduler.py rationale.
             final_output = RequestOutput(
                 request_id=request_id,
                 output_text="",
                 finished=True,
-                finish_reason="error",
+                finish_reason="length",
             )
 
         # Cleanup

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -590,6 +590,27 @@ async def _create_chat_completion_impl(
                 use_guided = False
             if use_guided:
                 logger.info("Using guided generation for JSON schema enforcement")
+            else:
+                # Surface the silent-degradation case: client asked for
+                # json_schema strict mode but the engine can't enforce it
+                # (most commonly: the user installed `rapid-mlx` without
+                # the `[guided]` extra, so outlines is unavailable). The
+                # request will still be served with unconstrained
+                # decoding, but the schema contract is NOT being honored
+                # — without this warning, the client sees garbage
+                # (e.g. the model thinks for max_tokens and never emits
+                # JSON) with no diagnostic signal. v0.6.63 onboarding
+                # sweep finding #5.
+                logger.warning(
+                    "json_schema response_format requested but guided "
+                    "generation is unavailable (engine="
+                    "%s.supports_guided_generation=False). Falling back "
+                    "to unconstrained decoding — schema will NOT be "
+                    "enforced. Install with `pip install "
+                    "'rapid-mlx[guided]'` to enable outlines-backed "
+                    "schema enforcement.",
+                    type(engine).__name__,
+                )
 
     if request.stream:
         # Validate chat template eagerly so template errors return 400
@@ -912,6 +933,15 @@ async def stream_chat_completion(
         prompt_tokens = 0
         completion_tokens = 0
 
+        # Buffer the terminal "finish" event so the cross-format fallback in
+        # processor.finalize() (#425) gets a chance to recover a missed tool
+        # call BEFORE we emit a terminal chunk. Without this buffer the route
+        # emits a finish_reason="stop" chunk first and then a separate
+        # finish_reason="tool_calls" chunk from the fallback path — spec-
+        # compliant clients stop reading at the first finish_reason and
+        # silently drop the tool call (#v0.6.63 onboarding sweep finding #3).
+        buffered_finish: tuple | None = None
+
         # Stream content — PostProcessor handles reasoning/tool/sanitize
         async for output in engine.stream_chat(messages=messages, **kwargs):
             if hasattr(output, "prompt_tokens") and output.prompt_tokens:
@@ -973,48 +1003,96 @@ async def stream_chat_completion(
                     yield _tc_sse
 
                 elif event.type == "finish":
-                    chunk = ChatCompletionChunk(
-                        id=response_id,
-                        created=_sse_created,
-                        model=_resolve_model_name(request.model),
-                        choices=[
-                            ChatCompletionChunkChoice(
-                                delta=ChatCompletionChunkDelta(
-                                    content=event.content,
-                                    reasoning_content=event.reasoning,
-                                ),
-                                finish_reason=event.finish_reason,
-                                logprobs=_build_chunk_logprobs(output),
-                            )
-                        ],
-                        # See "Usage placement" note on the tool_call branch.
-                        usage=(
-                            None
-                            if include_usage
-                            else (get_usage(output) if output.finished else None)
-                        ),
-                    )
-                    yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+                    # Defer emission: finalize() (below) may recover a
+                    # missed tool call via cross-format fallback. If it
+                    # does, we must merge the recovered tool_calls into
+                    # this single terminal chunk and re-stamp the
+                    # finish_reason as "tool_calls" — not emit two
+                    # contradictory finish chunks.
+                    buffered_finish = (event, output)
 
-        # Fallback tool call detection
+        # Fallback tool call detection (post-stream). Collect ALL fallback
+        # tool_call events before emitting; they get merged into the
+        # buffered finish chunk so the stream produces exactly one
+        # terminal chunk with one finish_reason (OpenAI spec).
+        fallback_tool_calls: list = []
         for event in processor.finalize():
             if event.type == "tool_call":
-                tool_chunk = ChatCompletionChunk(
-                    id=response_id,
-                    created=_sse_created,
-                    model=_resolve_model_name(request.model),
-                    choices=[
-                        ChatCompletionChunkChoice(
-                            delta=ChatCompletionChunkDelta(
-                                tool_calls=event.tool_calls,
-                            ),
-                            finish_reason="tool_calls",
-                        )
-                    ],
+                fallback_tool_calls.extend(event.tool_calls or [])
+
+        # Emit the terminal chunk. Three cases:
+        #   (a) Streaming parser already emitted tool_calls during the
+        #       loop → buffered_finish has finish_reason="tool_calls"
+        #       and fallback_tool_calls is empty. Emit as-is.
+        #   (b) Streaming parser missed the call but finalize() recovered
+        #       it via cross-format fallback → merge tool_calls into the
+        #       buffered finish and override finish_reason="tool_calls".
+        #   (c) No tool calls at all → emit the buffered finish unchanged.
+        if buffered_finish is not None:
+            finish_event, finish_output = buffered_finish
+            if fallback_tool_calls:
+                logger.info(
+                    "[SSE-FALLBACK-TC-MERGED] merging %d recovered tool_call(s) "
+                    "into terminal chunk; overriding finish_reason -> tool_calls",
+                    len(fallback_tool_calls),
                 )
-                _fb_sse = f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
-                logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
-                yield _fb_sse
+            final_chunk = ChatCompletionChunk(
+                id=response_id,
+                created=_sse_created,
+                model=_resolve_model_name(request.model),
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(
+                            content=finish_event.content,
+                            reasoning_content=finish_event.reasoning,
+                            tool_calls=(
+                                fallback_tool_calls
+                                if fallback_tool_calls
+                                else None
+                            ),
+                        ),
+                        finish_reason=(
+                            "tool_calls"
+                            if fallback_tool_calls
+                            else finish_event.finish_reason
+                        ),
+                        logprobs=_build_chunk_logprobs(finish_output),
+                    )
+                ],
+                # See "Usage placement" note on the tool_call branch.
+                usage=(
+                    None
+                    if include_usage
+                    else (
+                        get_usage(finish_output)
+                        if finish_output.finished
+                        else None
+                    )
+                ),
+            )
+            yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"
+        elif fallback_tool_calls:
+            # Defensive: stream ended without a "finish" event but the
+            # fallback still recovered tool calls (shouldn't normally
+            # happen — process_chunk emits finish on output.finished).
+            # Emit a synthetic terminal chunk so the client gets the
+            # tool calls instead of a dangling stream.
+            tool_chunk = ChatCompletionChunk(
+                id=response_id,
+                created=_sse_created,
+                model=_resolve_model_name(request.model),
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(
+                            tool_calls=fallback_tool_calls,
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ],
+            )
+            _fb_sse = f"data: {tool_chunk.model_dump_json(exclude_none=True)}\n\n"
+            logger.info(f"[SSE-FALLBACK-TC] {_fb_sse.strip()[:300]}")
+            yield _fb_sse
 
         # Log throughput
         elapsed = time.perf_counter() - start_time
@@ -1023,17 +1101,28 @@ async def stream_chat_completion(
             f"Chat completion (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
-        # Send final chunk with usage if requested
+        # Send final chunk with usage if requested. Mirror non-streaming
+        # shape by populating completion_tokens_details.reasoning_tokens
+        # when the postprocessor saw a reasoning split — v0.6.63
+        # onboarding sweep finding #5 (streaming previously dropped this
+        # field even when non-streaming had it).
         if include_usage:
+            # Build a synthetic GenerationOutput-shaped namespace so
+            # _build_usage can compute the reasoning_tokens breakdown.
+            class _UsageOutput:
+                pass
+
+            _u = _UsageOutput()
+            _u.prompt_tokens = prompt_tokens
+            _u.completion_tokens = completion_tokens
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
                 created=_sse_created,
                 model=_resolve_model_name(request.model),
                 choices=[],
-                usage=Usage(
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    total_tokens=prompt_tokens + completion_tokens,
+                usage=_build_usage(
+                    _u,
+                    processor.accumulated_reasoning or None,
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1046,9 +1046,7 @@ async def stream_chat_completion(
                             content=finish_event.content,
                             reasoning_content=finish_event.reasoning,
                             tool_calls=(
-                                fallback_tool_calls
-                                if fallback_tool_calls
-                                else None
+                                fallback_tool_calls if fallback_tool_calls else None
                             ),
                         ),
                         finish_reason=(
@@ -1063,11 +1061,7 @@ async def stream_chat_completion(
                 usage=(
                     None
                     if include_usage
-                    else (
-                        get_usage(finish_output)
-                        if finish_output.finished
-                        else None
-                    )
+                    else (get_usage(finish_output) if finish_output.finished else None)
                 ),
             )
             yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3195,7 +3195,14 @@ class Scheduler:
                         RequestOutput(
                             request_id=rid,
                             finished=True,
-                            finish_reason="error",
+                            # OpenAI ChatCompletion only accepts {stop, length,
+                            # tool_calls, content_filter, function_call}. We
+                            # report "length" for aborted requests so spec-
+                            # validating clients (openai-python, pydantic-ai)
+                            # can parse the response; callers reading
+                            # ``RequestOutput.error`` still see the abort
+                            # details. (#v0.6.63 onboarding sweep)
+                            finish_reason="length",
                         )
                     )
                 output.finished_request_ids = aborted_ids

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -213,9 +213,26 @@ def _resolve_model_name(request_model: str | None) -> str:
 def _resolve_max_tokens(
     request_value: int | None, enable_thinking: bool | None = None
 ) -> int:
-    """Resolve max_tokens with thinking budget for reasoning models."""
+    """Resolve max_tokens with thinking budget for reasoning models.
+
+    OpenAI semantics: ``max_tokens`` from the client is a hard upper
+    bound on completion tokens (including reasoning). Three independent
+    onboarding agents flagged the prior behavior (silently adding the
+    thinking budget on top of the client's explicit cap) as
+    spec-violating — clients send ``max_tokens=40`` for a short reply
+    and the server scheduled ``max_tokens=2088``. v0.6.63 onboarding
+    sweep finding #2.
+
+    The thinking budget still applies when the client did NOT specify
+    ``max_tokens`` (server default in effect): reasoning models need
+    headroom to think *and* respond, and the server-side default is
+    the right place to bake that in.
+    """
+    if request_value is not None:
+        # Hard cap per client contract.
+        return request_value
     cfg = get_config()
-    base = request_value if request_value is not None else cfg.default_max_tokens
+    base = cfg.default_max_tokens
     if enable_thinking is False:
         return base
     if cfg.reasoning_parser_name and base > 0 and base < 4096:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -118,6 +118,12 @@ class StreamingPostProcessor:
         # State
         self.accumulated_text = ""
         self.tool_accumulated_text = ""
+        # Accumulated reasoning content (split out by the reasoning parser
+        # from the raw model output). Surfaced on the streaming Usage
+        # chunk so clients see ``completion_tokens_details.reasoning_tokens``
+        # in parity with the non-streaming response shape. v0.6.63
+        # onboarding sweep finding #5.
+        self.accumulated_reasoning = ""
         self.tool_calls_detected = False
         self.tool_markup_possible = False
 
@@ -189,6 +195,7 @@ class StreamingPostProcessor:
         """
         self.accumulated_text = ""
         self.tool_accumulated_text = ""
+        self.accumulated_reasoning = ""
         self.tool_calls_detected = False
         self.tool_markup_possible = False
         self._think_prefix_sent = False
@@ -313,6 +320,9 @@ class StreamingPostProcessor:
 
         content = delta_msg.content
         reasoning = delta_msg.reasoning
+
+        if reasoning:
+            self.accumulated_reasoning += reasoning
 
         # MiniMax redirect: tool calls wrapped in <think> blocks
         if self.tool_parser and reasoning:

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -403,7 +403,10 @@ async def _stream_completion(
                 exc_info=gen_or_err,
             )
             error_message = f"{type(gen_or_err).__name__}: {gen_or_err}"
-            finish_reason = "error"
+            # OpenAI ChatCompletion only accepts {stop, length, tool_calls,
+            # content_filter, function_call}. The error block on the final
+            # SSE chunk carries the abort details for clients.
+            finish_reason = "length"
             gen = None
         else:
             gen = gen_or_err
@@ -434,7 +437,8 @@ async def _stream_completion(
                         exc_info=chunk,
                     )
                     error_message = f"{type(chunk).__name__}: {chunk}"
-                    finish_reason = "error"
+                    # See above for OpenAI spec literal-set rationale.
+                    finish_reason = "length"
                     break
                 # Always sync token counts from the chunk — even when text
                 # is empty (mlx-vlm occasionally emits trailing flush


### PR DESCRIPTION
## Summary

Bundle of 7 fixes surfaced by the 10-agent fresh-PyPI onboarding sweep against v0.6.63. None are release blockers individually, but each is reproducible and either violates an external spec or breaks a clear user contract. Multiple agents independently confirmed each finding.

## OpenAI spec compliance

**A1. `finish_reason=\"error\"` → `\"length\"`** at 5 emit sites (scheduler, engine_core, mllm_scheduler ×2, dflash ×2). The `\"error\"` literal is not in the OpenAI ChatCompletion finish_reason literal set (`{stop, length, tool_calls, content_filter, function_call}`). Spec-validating clients (openai-python, pydantic-ai, Anthropic SDK) rejected the response with a Pydantic `literal_error`. Surfaced by agent #6 against pydantic-ai — also explains the \"4B-model multi-turn flake\" noted in earlier release runs (it was server-side, not model quality). `RequestOutput.error` still carries the diagnostic message for internal callers.

**A2. Streaming tool-call cross-format fallback emits ONE merged terminal chunk.** Previously the route emitted a `finish_reason:\"stop\"` chunk first (with `usage`), then a separate `finish_reason:\"tool_calls\"` chunk from `processor.finalize()` — spec-compliant clients stop at the first `finish_reason` and silently drop the recovered tool call. The #425 fix engaged correctly but the terminal-chunk order was wrong. Validated end-to-end:
- Before: 2 chunks, `stop` then `tool_calls`
- After: 1 chunk with `delta:{tool_calls:[...]}, finish_reason:\"tool_calls\", usage:{...}`

**A3. Surface a warning when `response_format: json_schema` is requested but guided generation is unavailable.** Was silently falling back to unconstrained decoding with no diagnostic signal — model would happily think for max_tokens without ever producing JSON.

## Client contracts

**B1. `_resolve_max_tokens` treats client-supplied `max_tokens` as a hard cap.** Previously added `thinking_token_budget` on top, so `max_tokens=40` → scheduled `max_tokens=2088`. Three independent agents (#2, #4, #5) flagged this. The budget still applies when the client does NOT specify `max_tokens` (server default in effect) — reasoning models need headroom for thinking + reply, and that's the right place to bake it in.

**B5. Streaming `Usage` chunk populates `completion_tokens_details.reasoning_tokens`.** Non-streaming had it; streaming dropped it. Validated:
```
\"usage\":{\"prompt_tokens\":21,\"completion_tokens\":80,\"total_tokens\":101,\"completion_tokens_details\":{\"reasoning_tokens\":71}}
```

## CLI / discovery

**B2. `--tool-call-parser` validates against the live `ToolParserManager` registry (39 names) instead of a stale hardcoded list (19 names).** Legitimate aliases like `deepseek_v31`, `llama3`, `nous`, `moonshot`, `kimi_k2` were rejected by argparse; users had to read source code to know the canonical names. The full registered list now surfaces in the error message.

**C1. `--gc-control` help text corrected.** Was `\"Disable...\"` (contradicting actual behavior — it enables GC pausing during generation). Both `--gc-control` and `--no-gc-control` previously said \"Disable\".

## Test plan

- [x] `make smoke` — lint + 3712+ unit tests pass
- [x] A2 live-validated: `qwen3_xml` parser against hermes-emitting `qwen3.5-4b` model now produces single merged terminal chunk (log: `[SSE-FALLBACK-TC-MERGED] merging 1 recovered tool_call(s) into terminal chunk`)
- [x] B5 live-validated: streaming usage chunk has `reasoning_tokens: 71`
- [x] B1 live-validated: `max_tokens=80` honored (no padding to 2128)
- [x] B2 live-validated: `--tool-call-parser deepseek_v31` accepted; `--tool-call-parser bogus_xyz` rejected with full 39-name list
- [ ] Real-server stress + integration SDKs (not run; should pass given smoke is green and the fixes are scoped to wire-format/CLI surfaces)

## Findings deferred to follow-up

From the same sweep, still TODO:
- B3: prefix-cache poisoning silent crash (entries logged as \"skipping\" still poison the engine)
- B4: Anthropic `/v1/messages` non-streaming returns reasoning inside `content[0].text`; streaming splits correctly
- C2: log banner says `tools: qwen3_xml` but `model_auto_config` log keeps `tool_call_parser=hermes` after override
- C3/C4: tool-call / Anthropic text deltas not incrementally streamed (parser design, not bug)
- C5: `doctor check/full/benchmark` gated on repo clone but exposed in `--help` from wheel
- C6: no `/metrics` Prometheus or `/logs` endpoint (new feature)
- C7: `smolagents[openai]` extra undocumented
- C8: reasoning leak into `content` for long-context prompts (parser improvement)