### PR TITLE
chore: codex follow-ups to #433 (cli/test/stream cleanup)

### DIFF
--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -1252,25 +1252,14 @@ class TestHarmonyHelperFunctions:
 
 
 class TestHarmonyCLIIntegration:
-    """Tests that harmony and gpt-oss are valid CLI parser choices."""
+    """Tests that harmony and gpt-oss are valid CLI parser choices.
 
-    @staticmethod
-    def _get_serve_tool_parser_choices():
-        """Extract --tool-call-parser choices from the CLI serve subcommand.
-
-        We inspect the argparse tree rather than calling main() so no server
-        is started.
-        """
-        import importlib
-        import inspect
-
-        # Read the source of cli.main to find the choices list.
-        # Alternatively, we can build the parser by importing and inspecting.
-        # The safest approach: grep the choices from the source itself.
-        mod = importlib.import_module("vllm_mlx.cli")
-        source = inspect.getsource(mod.main)
-        # The choices list is defined literally in the source
-        return source
+    Pre-PR #433 these tests grepped a hardcoded ``choices=[...]`` list in
+    ``vllm_mlx/cli.py``. PR #433 removed that list in favor of validating
+    against the live ``ToolParserManager`` registry, so the helper that
+    read the source is gone — the tests now assert registry membership
+    directly. Codex follow-up dead-code cleanup.
+    """
 
     def test_harmony_in_cli_choices(self):
         """Verify 'harmony' is accepted by CLI --tool-call-parser.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -411,13 +411,25 @@ def serve_command(args):
     # Validate --tool-call-parser against the live registry (not the
     # stale argparse choices list). v0.6.63 onboarding sweep finding #1.
     if args.tool_call_parser:
+        # Narrow the catch: only swallow import-time / attribute access
+        # failures (broken install, missing module file). Anything else
+        # — a corrupt registry that's loaded but malformed, a TypeError
+        # from a buggy parser's __init_subclass__, etc. — is a real bug
+        # we want to surface, not paper over with "validation skipped".
+        # Codex follow-up to PR #433.
+        valid: list[str] | None = None
         try:
             from .tool_parsers import ToolParserManager
 
             valid = sorted(ToolParserManager.tool_parsers.keys())
-        except Exception:
-            valid = []
-        if valid and args.tool_call_parser not in valid:
+        except (ImportError, AttributeError) as e:
+            print(
+                "warning: --tool-call-parser validation skipped — "
+                f"tool_parsers registry unavailable ({type(e).__name__}: {e}). "
+                "Proceeding without input check.",
+                file=sys.stderr,
+            )
+        if valid is not None and args.tool_call_parser not in valid:
             print(
                 f"error: argument --tool-call-parser: invalid choice: "
                 f"{args.tool_call_parser!r} "

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -429,7 +429,12 @@ def serve_command(args):
                 "Proceeding without input check.",
                 file=sys.stderr,
             )
-        if valid is not None and args.tool_call_parser not in valid:
+        # Treat an empty registry (degenerate install) the same as a
+        # failed import — skip validation rather than reject every input.
+        # Without this guard, a successful import with zero registered
+        # parsers would hard-fail every CLI invocation; DeepSeek
+        # follow-up to PR #434.
+        if valid and args.tool_call_parser not in valid:
             print(
                 f"error: argument --tool-call-parser: invalid choice: "
                 f"{args.tool_call_parser!r} "

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1080,8 +1080,17 @@ async def stream_chat_completion(
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
-                            content=processor.accumulated_text or None,
-                            reasoning_content=processor.accumulated_reasoning or None,
+                            # getattr guard: a future processor (e.g.
+                            # non-reasoning parser) may not define these
+                            # attributes; falling back to None keeps the
+                            # synthetic chunk well-formed instead of
+                            # raising AttributeError mid-stream.
+                            content=getattr(processor, "accumulated_text", None)
+                            or None,
+                            reasoning_content=getattr(
+                                processor, "accumulated_reasoning", None
+                            )
+                            or None,
                             tool_calls=fallback_tool_calls,
                         ),
                         finish_reason="tool_calls",

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1070,7 +1070,9 @@ async def stream_chat_completion(
             # fallback still recovered tool calls (shouldn't normally
             # happen — process_chunk emits finish on output.finished).
             # Emit a synthetic terminal chunk so the client gets the
-            # tool calls instead of a dangling stream.
+            # tool calls instead of a dangling stream. Carry through any
+            # accumulated content/reasoning so the synthetic chunk
+            # doesn't silently truncate text the model produced.
             tool_chunk = ChatCompletionChunk(
                 id=response_id,
                 created=_sse_created,
@@ -1078,6 +1080,8 @@ async def stream_chat_completion(
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
+                            content=processor.accumulated_text or None,
+                            reasoning_content=processor.accumulated_reasoning or None,
                             tool_calls=fallback_tool_calls,
                         ),
                         finish_reason="tool_calls",


### PR DESCRIPTION
## Summary

Three small internal-quality cleanups surfaced by DeepSeek/codex review of v0.6.64 (PR #433). All additive — no behavior change for clients on the happy path.

- **F2** (`vllm_mlx/cli.py`): narrow tool-parser registry exception handling to `(ImportError, AttributeError)` and emit a stderr warning when validation is skipped, instead of a silent bare except that could mask unrelated faults.
- **F3** (`tests/test_harmony_parsers.py`): remove dead `_get_serve_tool_parser_choices` static method. The surviving tests already assert registry membership via `ToolParserManager.tool_parsers`.
- **F5** (`vllm_mlx/routes/chat.py`): in the defensive `elif fallback_tool_calls:` branch of `stream_chat_completion`, carry `processor.accumulated_text` and `processor.accumulated_reasoning` into the synthetic terminal chunk's `delta` so the chunk doesn't silently truncate any content the model emitted before the parser missed the tool call.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on modified files
- [x] `TestHarmonyCLIIntegration` (5/5) pass
- [x] 244 chat/streaming/tool/postprocessor tests pass (243 passed + 1 pre-existing skip)
- [x] `python -c "from vllm_mlx.tool_parsers import ToolParserManager; ..."` shows 39 registered parsers — F2 registry lookup confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)