### PR TITLE
fix(harmony): gpt-oss-20b tool calls extracted as plain text

### DIFF
--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -693,15 +693,98 @@ class TestHarmonyToolDefinitionConverter:
 # ============================================================================
 
 
+class TestHarmonyEnginePipeline:
+    """End-to-end through the engine layer: clean_output_text → tool parser.
+
+    Reproduces the v0.6.64 bug where gpt-oss-20b's commentary-only tool
+    calls came back as plain text instead of structured ``tool_calls``.
+    Root cause: ``_clean_gpt_oss_output`` in ``api/utils.py`` only matched
+    a ``<|channel|>final<|message|>`` block; commentary-only output fell
+    through to the "strip all channel/structural tokens" branch, which
+    consumed ``<|channel|>commentary to=functions.*<|call|>`` markers
+    that the harmony tool parser needed intact. anthropic_sdk /
+    langchain / pydantic_ai all received tool-call args inlined into
+    user-facing text.
+
+    These tests drive the exact engine-layer pipeline (``clean_output_text``
+    then ``HarmonyToolParser.extract_tool_calls``) so the suite catches
+    a future regression in either layer.
+    """
+
+    def test_commentary_only_output_extracts_tool_call(self):
+        """Real gpt-oss-20b output for a single tool call.
+
+        Captured verbatim from ``mlx-community/gpt-oss-20b-MXFP4-Q8`` via
+        ``/v1/chat/completions`` with ``tools=[get_weather]`` (2026-05-22).
+        Note: no trailing ``<|call|>`` — the engine consumed it as a
+        harmony stop token. Pre-fix: ``clean_output_text`` ate the
+        commentary structure, parser returned 0 calls, args leaked
+        into content as plain text.
+        """
+        from vllm_mlx.api.utils import clean_output_text
+
+        raw = (
+            "<|channel|>analysis<|message|>We need to call get_weather "
+            'with city "Tokyo".<|end|>'
+            "<|start|>assistant<|channel|>commentary "
+            "to=functions.get_weather <|constrain|>json<|message|>"
+            '{"city":"Tokyo"}'
+        )
+
+        # Engine-layer cleanup MUST preserve the commentary structure
+        engine_text = clean_output_text(raw)
+        assert "<|channel|>commentary" in engine_text, (
+            "Engine layer stripped commentary structure — tool parser "
+            "will see plain text and extract zero calls. "
+            f"Got: {engine_text!r}"
+        )
+
+        # Harmony tool parser MUST then extract the call
+        parser = HarmonyToolParser()
+        result = parser.extract_tool_calls(engine_text)
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(result.tool_calls[0]["arguments"])["city"] == "Tokyo"
+
+    def test_final_only_output_still_strips_normally(self):
+        """Sanity: final-channel-only output keeps its established
+        cleanup behavior (extract just the answer text). The
+        commentary-preservation guard must NOT regress this path —
+        chat responses with no tool calls would otherwise leak
+        channel markers all the way to the wire.
+        """
+        from vllm_mlx.api.utils import clean_output_text
+
+        raw = (
+            "<|channel|>analysis<|message|>thinking<|end|>"
+            "<|channel|>final<|message|>The answer is 42.<|return|>"
+        )
+        cleaned = clean_output_text(raw)
+        assert cleaned == "The answer is 42."
+
+
 class TestHarmonyEdgeCases:
     """Edge case tests for Harmony parsers."""
 
-    def test_tool_parser_incomplete_call(self):
-        """Incomplete tool call (missing <|call|>) is not parsed."""
+    def test_tool_parser_unterminated_call_is_now_parsed(self):
+        """Commentary block without trailing ``<|call|>`` IS parsed now.
+
+        Earlier behavior treated a missing ``<|call|>`` terminator as
+        "incomplete". Empirically (gpt-oss-20b via /v1/chat/completions,
+        2026-05-22) ``<|call|>`` is part of the harmony stop-token set,
+        so the engine consumes it and ``output_text`` ends with the
+        JSON args alone. Refusing to parse meant zero tool calls
+        extracted on every real harmony invocation — same regression
+        class as PR #436's hermes unclosed-``<tool_call>`` fix. The
+        parser now accepts end-of-string OR the next channel marker
+        as an alternative terminator.
+        """
         parser = HarmonyToolParser()
         text = '<|channel|>commentary to=functions.func\n<|message|>{"arg": "value"}'
         result = parser.extract_tool_calls(text)
-        assert not result.tools_called
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "func"
+        assert json.loads(result.tool_calls[0]["arguments"])["arg"] == "value"
 
     def test_tool_parser_unicode_content(self):
         """Handle unicode in tool arguments."""
@@ -908,16 +991,25 @@ class TestHarmonyExtractToolCalls:
         assert not result.tools_called
         assert result.tool_calls == []
 
-    def test_malformed_missing_call_tag(self, parser):
-        """Commentary block without <|call|> is not a complete tool call."""
+    def test_missing_call_tag_is_now_parsed(self, parser):
+        """Commentary block without trailing ``<|call|>`` IS parsed now.
+
+        Counterpart of TestHarmonyEdgeCases::
+        ``test_tool_parser_unterminated_call_is_now_parsed``. Empirically
+        the engine stops emission at ``<|call|>`` (harmony stop token),
+        so ``output_text`` ends with the JSON args. Accept end-of-string
+        / next channel marker as alternative terminator.
+        """
         text = (
             "<|channel|>commentary to=functions.func\n"
             "<|constrain|>json\n"
             '<|message|>{"key": "value"}\n'
-            # Missing <|call|>
+            # No <|call|> — engine consumed it as stop token.
         )
         result = parser.extract_tool_calls(text)
-        assert not result.tools_called
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "func"
+        assert json.loads(result.tool_calls[0]["arguments"])["key"] == "value"
 
     def test_malformed_missing_message_tag(self, parser):
         """Commentary block without <|message|> tag."""

--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -762,6 +762,62 @@ class TestHarmonyEnginePipeline:
         cleaned = clean_output_text(raw)
         assert cleaned == "The answer is 42."
 
+    def test_hyphenated_tool_name_extracted(self):
+        """Tool names with hyphens (``get-weather``, ``my-tool``) must
+        be captured. DeepSeek round-2 review flagged ``\\w+`` would
+        silently drop them — both the engine-layer guard and the tool
+        parser need ``[\\w-]+``.
+        """
+        from vllm_mlx.api.utils import clean_output_text
+
+        raw = (
+            "<|channel|>analysis<|message|>thinking<|end|>"
+            "<|channel|>commentary to=functions.get-weather "
+            '<|constrain|>json<|message|>{"city":"Tokyo"}'
+        )
+        cleaned = clean_output_text(raw)
+        # Commentary block must survive cleanup for the hyphenated name
+        assert "to=functions.get-weather" in cleaned, (
+            "Engine-layer guard failed to detect hyphenated tool name "
+            f"(cleaned={cleaned!r})"
+        )
+        parser = HarmonyToolParser()
+        result = parser.extract_tool_calls(cleaned)
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get-weather"
+        assert json.loads(result.tool_calls[0]["arguments"])["city"] == "Tokyo"
+
+    def test_commentary_isolation_from_trailing_text(self):
+        """``arguments`` payload must not absorb non-commentary text that
+        precedes the commentary block. When commentary is present,
+        ``clean_output_text`` returns the raw text untouched so the
+        reasoning parser can still see the analysis channel — the
+        harmony tool parser's regex is anchored at
+        ``<|channel|>commentary to=functions.NAME`` and so does not
+        attach prior analysis text to the tool args.
+        """
+        from vllm_mlx.api.utils import clean_output_text
+
+        raw = (
+            "<|channel|>analysis<|message|>SHOULD_NOT_LEAK<|end|>"
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather "
+            '<|constrain|>json<|message|>{"city":"Tokyo"}'
+        )
+        cleaned = clean_output_text(raw)
+        parser = HarmonyToolParser()
+        result = parser.extract_tool_calls(cleaned)
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"city": "Tokyo"}, f"args payload leaked trailing text: {args!r}"
+        # Tool args must not absorb the analysis-channel content
+        assert "SHOULD_NOT_LEAK" not in result.tool_calls[0]["arguments"]
+        # Analysis channel is preserved in cleaned so HarmonyReasoningParser
+        # downstream can extract reasoning_content. Stripping it here broke
+        # pydantic_ai multi-tool turn loops (model lost prior-call context).
+        assert "<|channel|>analysis" in cleaned
+        assert "SHOULD_NOT_LEAK" in cleaned
+
 
 class TestHarmonyEdgeCases:
     """Edge case tests for Harmony parsers."""

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -104,10 +104,13 @@ _FINAL_CHANNEL_RE = re.compile(
 # stripping. Matches:
 #   <|channel|>commentary to=functions.NAME ... <|message|>...<|call|>
 #   to=functions.NAME<|channel|>commentary ... <|message|>...<|call|>
+# Tool names follow the OpenAI/Anthropic naming spec (letters, digits,
+# underscores, hyphens) — ``[\w-]+`` covers all of those. ``\w+`` alone
+# would silently drop ``get-weather`` and any hyphenated builtin.
 _COMMENTARY_TOOL_CALL_RE = re.compile(
-    r"<\|channel\|>commentary\s+to=functions\."
+    r"<\|channel\|>commentary\s+to=functions\.[\w-]+"
     r"|"
-    r"to=functions\.\w+<\|channel\|>commentary"
+    r"to=functions\.[\w-]+<\|channel\|>commentary"
 )
 
 
@@ -136,6 +139,15 @@ def _clean_gpt_oss_output(text: str) -> str:
     # Same regression class as PR #436 but for the tool parser. Final
     # channel is unaffected because the route runs ``clean_output_text``
     # again after parsers run (chat.py / anthropic.py).
+    #
+    # Reasoning-channel context is also preserved here: HarmonyReasoningParser
+    # needs the analysis-channel markers intact to extract reasoning_content.
+    # A previous "defense in depth" version stripped non-commentary tokens
+    # before re-emitting commentary, which dropped the analysis channel and
+    # broke pydantic_ai multi-tool turn loops (model lost its prior-call
+    # context because reasoning_content came back empty, then called the
+    # same tool repeatedly). Keep the bail-out simple: hand the entire
+    # text to downstream parsers untouched.
     if _COMMENTARY_TOOL_CALL_RE.search(text):
         return text
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -98,6 +98,18 @@ _FINAL_CHANNEL_RE = re.compile(
     r"<\|channel\|>final[^<]*(?:<\|constrain\|>[^<]*)?<\|message\|>"
 )
 
+# Commentary-channel tool-call markers (both legacy and current forms).
+# If ANY of these are present, the output carries tool-call structure
+# that the harmony tool parser needs to see intact — bail out of
+# stripping. Matches:
+#   <|channel|>commentary to=functions.NAME ... <|message|>...<|call|>
+#   to=functions.NAME<|channel|>commentary ... <|message|>...<|call|>
+_COMMENTARY_TOOL_CALL_RE = re.compile(
+    r"<\|channel\|>commentary\s+to=functions\."
+    r"|"
+    r"to=functions\.\w+<\|channel\|>commentary"
+)
+
 
 def _clean_gpt_oss_output(text: str) -> str:
     """
@@ -116,6 +128,17 @@ def _clean_gpt_oss_output(text: str) -> str:
     Returns:
         Extracted final content, or text with channel tokens stripped.
     """
+    # Tool-call structure must survive to the harmony tool parser:
+    # if the model emitted ``<|channel|>commentary to=functions.X...<|call|>``
+    # (which gpt-oss-20b does for every tool invocation), the parser needs
+    # those structural tokens intact to extract the call. Stripping them
+    # here drops the args into plain text and the parser returns 0 calls.
+    # Same regression class as PR #436 but for the tool parser. Final
+    # channel is unaffected because the route runs ``clean_output_text``
+    # again after parsers run (chat.py / anthropic.py).
+    if _COMMENTARY_TOOL_CALL_RE.search(text):
+        return text
+
     match = _FINAL_CHANNEL_RE.search(text)
     if match:
         content = text[match.end() :]

--- a/vllm_mlx/tool_parsers/harmony_tool_parser.py
+++ b/vllm_mlx/tool_parsers/harmony_tool_parser.py
@@ -40,15 +40,19 @@ def _generate_tool_id() -> str:
 # end-of-string OR the next channel marker as alternative terminators
 # so a complete-but-unterminated tool call still parses. Same regression
 # class as PR #436's hermes unclosed-``<tool_call>`` fix.
+#
+# Tool names follow the OpenAI/Anthropic spec (letters, digits,
+# underscores, hyphens) — ``[\w-]+`` covers them. ``\w+`` alone would
+# silently drop hyphenated names (``get-weather``, ``my-tool``).
 _COMMENTARY_BLOCK_PATTERN = re.compile(
     r"(?:"
     # Real format: to=functions.NAME<|channel|>commentary [content_type]<|message|>
-    r"to=functions\.(\w+)<\|channel\|>commentary(?:\s+\w+)?<\|message\|>"
+    r"to=functions\.([\w-]+)<\|channel\|>commentary(?:\s+\w+)?<\|message\|>"
     r"(.*?)"
     r"(?:<\|call\|>|<\|channel\|>|<\|start\|>|<\|end\|>|<\|return\|>|$)"
     r"|"
     # Legacy format: <|channel|>commentary to=functions.NAME ... <|message|>
-    r"<\|channel\|>commentary\s+to=functions\.(\w+)(?:\s*<\|constrain\|>\w+)?\s*<\|message\|>"
+    r"<\|channel\|>commentary\s+to=functions\.([\w-]+)(?:\s*<\|constrain\|>\w+)?\s*<\|message\|>"
     r"(.*?)"
     r"(?:<\|call\|>|<\|channel\|>|<\|start\|>|<\|end\|>|<\|return\|>|$)"
     r")",

--- a/vllm_mlx/tool_parsers/harmony_tool_parser.py
+++ b/vllm_mlx/tool_parsers/harmony_tool_parser.py
@@ -32,13 +32,25 @@ def _generate_tool_id() -> str:
 # Tool call pattern — supports both formats from the harmony spec:
 #   Model-generated: <|channel|>commentary to=functions.NAME <|constrain|>json<|message|>ARGS<|call|>
 #   Template-encoded (history): to=functions.NAME<|channel|>commentary json<|message|>ARGS<|call|>
+# Terminator: ``<|call|>`` is the in-output token, but the engine stops
+# generation when it emits it (``<|call|>`` is part of the harmony EOS
+# set), so the token is consumed and never appears in ``output_text``.
+# Empirically (gpt-oss-20b via /v1/chat/completions, 2026-05-22) the
+# commentary block ends with the JSON args and no terminator. Accept
+# end-of-string OR the next channel marker as alternative terminators
+# so a complete-but-unterminated tool call still parses. Same regression
+# class as PR #436's hermes unclosed-``<tool_call>`` fix.
 _COMMENTARY_BLOCK_PATTERN = re.compile(
     r"(?:"
     # Real format: to=functions.NAME<|channel|>commentary [content_type]<|message|>
-    r"to=functions\.(\w+)<\|channel\|>commentary(?:\s+\w+)?<\|message\|>(.*?)<\|call\|>"
+    r"to=functions\.(\w+)<\|channel\|>commentary(?:\s+\w+)?<\|message\|>"
+    r"(.*?)"
+    r"(?:<\|call\|>|<\|channel\|>|<\|start\|>|<\|end\|>|<\|return\|>|$)"
     r"|"
     # Legacy format: <|channel|>commentary to=functions.NAME ... <|message|>
-    r"<\|channel\|>commentary\s+to=functions\.(\w+)(?:\s*<\|constrain\|>\w+)?\s*<\|message\|>(.*?)<\|call\|>"
+    r"<\|channel\|>commentary\s+to=functions\.(\w+)(?:\s*<\|constrain\|>\w+)?\s*<\|message\|>"
+    r"(.*?)"
+    r"(?:<\|call\|>|<\|channel\|>|<\|start\|>|<\|end\|>|<\|return\|>|$)"
     r")",
     re.DOTALL,
 )


### PR DESCRIPTION
## Summary

PR #436 validation showed gpt-oss-20b agent integrations stuck at 12/17 PASS, with the remaining 5 failures all "model emits tool args as text". Initial conclusion was model behavior. **It's our bug.** Direct ``mlx_lm.generate`` proves the model emits correct harmony commentary channels — our pipeline strips them.

Two-layer fix:

### 1. ``_clean_gpt_oss_output`` (api/utils.py)

Helper only handled ``<|channel|>final<|message|>``. Commentary-only output (tool call without final channel — the normal pattern for "function call needed before answer") fell through to the "strip all channel/structural tokens" branch, consuming the ``<|channel|>commentary to=functions.X<|message|>...<|call|>`` markers the harmony tool parser needs.

Same class as PR #436's empty-TextBlock bug. Fix: bail out of stripping when commentary tool-call markers are present.

### 2. ``HarmonyToolParser._COMMENTARY_BLOCK_PATTERN`` (tool_parsers/harmony_tool_parser.py)

Pattern required ``<|call|>`` terminator. ``<|call|>`` is part of the harmony stop-token set — engine consumes it, never appears in ``output_text``. Strict pattern matched zero calls on every real invocation.

Same class as PR #436's hermes unclosed-``<tool_call>`` fix. Accept end-of-string OR next channel marker as alternative terminator.

## Empirical impact (gpt-oss-20b-MXFP4-Q8)

| agent          | post-PR #436 | this PR |
|----------------|--------------|---------|
| anthropic_sdk  | 4/5          | **5/5** |
| langchain      | 4/6          | **6/6** |
| pydantic_ai    | 4/6          | **6/6** |
| **total**      | **12/17**    | **17/17** |

## Tests

- New ``TestHarmonyEnginePipeline`` drives the exact engine pipeline (``clean_output_text`` → ``HarmonyToolParser``) end-to-end so a regression in either layer is caught here, not in stress_e2e_bench.
- Two pre-existing tests updated: they embedded the wrong assumption "missing ``<|call|>`` = not parsed" — that captured the regex's intent rather than production output reality.
- Full suite: 232/232 pass.

## Test plan

- [x] Direct probe against live gpt-oss-20b server: tool_calls extracted, finish_reason=tool_calls
- [x] Re-ran all 3 agent integrations against live server → 17/17 PASS
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] ``pytest tests/test_harmony_parsers.py tests/test_anthropic_streaming_reasoning.py tests/test_anthropic_stream_reasoning.py tests/test_chat_route_tool_tag_leak.py tests/test_reasoning_parsers.py`` → 232/232

🤖 Generated with [Claude Code](https://claude.com/claude-code)