### PR TITLE
fix(harmony): rescue reasoning_content on non-stream + no-tools path

### DIFF
--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -31,6 +31,7 @@ class _BaseEngine:
 @dataclass
 class _GenerationOutput:
     text: str
+    raw_text: str = ""
     tokens: list[int] = field(default_factory=list)
     prompt_tokens: int = 0
     completion_tokens: int = 0

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for harmony reasoning_content silently dropping on the
+non-streaming + no-tools path.
+
+Bug surfaced 2026-05-22 in a fresh-PyPI v0.6.65 onboarding smoke test
+against ``mlx-community/gpt-oss-20b-MXFP4-Q8``: a reasoning prompt with
+no tools came back with ``reasoning_content=""`` while the full
+chain-of-thought leaked into ``content``. Tool calls and streaming both
+worked — only ``non-stream + no-tools + harmony`` broke.
+
+Root cause: the engine calls ``clean_output_text`` on the raw harmony
+output before constructing ``GenerationOutput``. ``_clean_gpt_oss_output``
+extracts the final-channel content and strips all channel markers, so by
+the time the route's ``_finalize_content_and_reasoning`` runs the
+reasoning parser, the ``<|channel|>analysis<|message|>…<|end|>`` block
+no longer exists in ``cleaned_text``. ``HarmonyReasoningParser`` finds
+nothing and returns ``(None, None)``. PR #436 added a guard that
+preserved ``content`` from being clobbered to None, but did not rescue
+``reasoning_content`` — that's what this test pins.
+
+Fix: ``GenerationOutput`` now carries ``raw_text`` (the pre-clean output).
+Routes pass it to the helper, which retries the reasoning parser on
+``raw_text`` whenever the first parse against ``cleaned_text`` yielded
+no reasoning. Non-harmony parsers (``<think>``-based) are unaffected
+because their first parse succeeds on cleaned_text — they never enter
+the retry branch.
+"""
+
+from __future__ import annotations
+
+from vllm_mlx.reasoning.harmony_parser import HarmonyReasoningParser
+from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
+from vllm_mlx.service.helpers import _finalize_content_and_reasoning
+
+# A realistic gpt-oss-20b harmony non-stream response: analysis channel
+# (CoT) followed by final channel (answer), terminated with <|return|>.
+_HARMONY_RAW = (
+    "<|channel|>analysis<|message|>"
+    "Let me think step by step. 17 * 23 = 17*20 + 17*3 = 340 + 51 = 391."
+    "<|end|>"
+    "<|start|>assistant<|channel|>final<|message|>"
+    "The answer is 391."
+    "<|return|>"
+)
+
+# What the engine's ``clean_output_text`` would emit for that raw output —
+# the final-channel content only, channel markers stripped.
+_HARMONY_CLEANED = "The answer is 391."
+
+
+def test_harmony_no_tools_recovers_reasoning_from_raw_text():
+    """The bug: ``_finalize_content_and_reasoning`` with cleaned_text that
+    has had harmony channels stripped used to return ``reasoning=None``.
+    With ``raw_text`` carrying the pre-clean output, the helper retries
+    on it and recovers the analysis-channel content.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_HARMONY_RAW,
+        cleaned_text=_HARMONY_CLEANED,
+        tool_calls=[],
+        reasoning_parser=HarmonyReasoningParser(),
+    )
+    assert reasoning is not None, (
+        "harmony non-tool path dropped reasoning_content — "
+        "the engine-pre-cleaned cleaned_text has no channel markers, so "
+        "the parser must be re-run on raw_text"
+    )
+    assert "17 * 23" in reasoning, (
+        f"recovered reasoning is missing analysis-channel content: {reasoning!r}"
+    )
+    # cleaned_text retains the parser's final-channel extraction (or the
+    # input cleaned_text if the parser produced no new cleaned value).
+    assert cleaned and "391" in cleaned
+
+
+def test_harmony_no_tools_no_raw_text_keeps_existing_behavior():
+    """When ``raw_text`` matches ``cleaned_text`` (e.g. an old caller that
+    didn't populate the new ``GenerationOutput.raw_text`` field, so the
+    route falls back to passing ``output.text`` for both), the retry
+    branch must NOT fire — there's nothing new to try.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_HARMONY_CLEANED,
+        cleaned_text=_HARMONY_CLEANED,
+        tool_calls=[],
+        reasoning_parser=HarmonyReasoningParser(),
+    )
+    # Reasoning is still lost — but cleaned_text survives (PR #436 guard).
+    # This pins the pre-fix behavior so we know the new retry only kicks
+    # in when raw_text was actually populated.
+    assert reasoning is None
+    assert cleaned == _HARMONY_CLEANED
+
+
+def test_qwen3_think_parser_unaffected_by_retry():
+    """``<think>`` parsers find their reasoning on the first pass against
+    ``cleaned_text``, so the retry branch never executes — no double-work
+    and no risk of overwriting a successful extraction with raw_text.
+    """
+    # The tool parser would have already stripped <think> off, leaving
+    # just the answer as cleaned_text. We simulate the path where the
+    # reasoning parser is the one that pulls <think> out.
+    raw = "<think>compute 2+2 = 4</think>The answer is 4."
+    cleaned_input = raw  # no tool parser ran first
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=cleaned_input,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(tokenizer=None),
+    )
+    assert reasoning is not None and "2+2" in reasoning
+    # Qwen3 parser strips <think>...</think> so cleaned should not
+    # contain the thinking block.
+    assert cleaned is not None
+    assert "<think>" not in cleaned
+
+
+def test_harmony_with_tool_calls_unchanged():
+    """The tool-call branch already parses raw_text directly — this test
+    pins that the retry logic only lives in the no-tools branch and
+    doesn't perturb tool-call behavior.
+    """
+    raw = (
+        "<|channel|>analysis<|message|>need to call get_weather<|end|>"
+        "<|start|>assistant<|channel|>commentary to=functions.get_weather"
+        '<|message|>{"location":"Paris"}<|call|>'
+    )
+    # Simulate that the tool parser already extracted a tool call and
+    # produced an empty cleaned_text.
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text="",
+        tool_calls=[{"id": "x", "type": "function", "function": {}}],
+        reasoning_parser=HarmonyReasoningParser(),
+    )
+    assert reasoning is not None and "get_weather" in reasoning
+
+
+def test_no_reasoning_parser_short_circuits():
+    """When the model has no reasoning parser configured, the helper must
+    not attempt any extraction (raw_text retry included) and must return
+    cleaned_text untouched, reasoning_text=None.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_HARMONY_RAW,
+        cleaned_text=_HARMONY_CLEANED,
+        tool_calls=[],
+        reasoning_parser=None,
+    )
+    assert reasoning is None
+    assert cleaned == _HARMONY_CLEANED

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -18,6 +18,14 @@ class GenerationOutput:
     """
 
     text: str
+    # Pre-cleaning model output, preserved so the route's reasoning parser
+    # can see harmony channel markers that ``clean_output_text`` strips out
+    # of ``text``. Without this, ``HarmonyReasoningParser.extract_reasoning``
+    # on the non-stream + no-tool path runs on already-cleaned text and
+    # returns ``(None, None)`` — leaking the analysis channel into
+    # ``content`` and emitting empty ``reasoning_content`` to clients.
+    # Empty string default keeps callers that don't populate it working.
+    raw_text: str = ""
     tokens: list[int] = field(default_factory=list)
     prompt_tokens: int = 0
     completion_tokens: int = 0

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -890,6 +890,7 @@ class BatchedEngine(BaseEngine):
 
             return GenerationOutput(
                 text=clean_output_text(output.output_text),
+                raw_text=output.output_text,
                 tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
@@ -938,6 +939,7 @@ class BatchedEngine(BaseEngine):
 
         return GenerationOutput(
             text=text,
+            raw_text=output.output_text,
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -222,7 +222,7 @@ async def create_anthropic_message(
         # used to silently drop ``<think>...</think>`` content on the non-streaming
         # path while OpenAI preserved it as ``reasoning_content``.
         cleaned_text, reasoning_text = _finalize_content_and_reasoning(
-            raw_text=output.text,
+            raw_text=output.raw_text or output.text,
             cleaned_text=cleaned_text,
             tool_calls=tool_calls,
             reasoning_parser=cfg.reasoning_parser,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -764,7 +764,7 @@ async def _create_chat_completion_impl(
     # _finalize_content_and_reasoning so the regression test suite can exercise
     # the same orchestration without re-implementing it.
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
-        raw_text=output.text,
+        raw_text=output.raw_text or output.text,
         cleaned_text=cleaned_text,
         tool_calls=tool_calls,
         reasoning_parser=cfg.reasoning_parser,

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -172,6 +172,22 @@ def _finalize_content_and_reasoning(
     else:
         text_to_parse = cleaned_text or raw_text
         new_reasoning, new_cleaned = reasoning_parser.extract_reasoning(text_to_parse)
+        # Harmony retry: the engine's ``clean_output_text`` strips
+        # ``<|channel|>analysis<|message|>…`` markers before the route
+        # ever sees the output, so a ``HarmonyReasoningParser`` running
+        # on ``cleaned_text`` finds no channels and returns ``None``.
+        # When the engine populated ``raw_text`` with the pre-clean
+        # output, re-run the parser on it to recover the analysis-channel
+        # content. Only triggers when (a) first parse found no reasoning
+        # AND (b) raw_text actually differs from the text we just parsed
+        # — non-harmony parsers (``<think>``) are unaffected because
+        # their first parse succeeds on cleaned_text. (Counterpart to
+        # PR #436's empty-TextBlock fix: that PR rescued ``content``
+        # from being clobbered to None; this rescues ``reasoning``.)
+        if new_reasoning is None and raw_text and raw_text != text_to_parse:
+            retry_reasoning, _ = reasoning_parser.extract_reasoning(raw_text)
+            if retry_reasoning is not None:
+                new_reasoning = retry_reasoning
         reasoning_text = new_reasoning
         # Only overwrite cleaned_text when the parser explicitly
         # produced new content. ``new_cleaned is None`` means the


### PR DESCRIPTION
## Summary
- Engine pre-cleans harmony channels before the route's reasoning parser runs; non-stream + no-tools calls returned empty `reasoning_content` while CoT leaked into `content`.
- `GenerationOutput` gains a `raw_text` field carrying the pre-clean output; helper retries reasoning extraction on `raw_text` only when the cleaned-text parse yielded nothing AND raw_text actually differs.
- Non-harmony (`<think>`) parsers never enter the retry — guaranteed no-op for them.

## Background

Surfaced **2026-05-22** by a fresh-PyPI v0.6.65 onboarding smoke against `mlx-community/gpt-oss-20b-MXFP4-Q8`:

> Reasoning (non-stream): PARTIAL — `reasoning_content` came back **empty (len=0)**, model emitted full step-by-step solution into `content` instead. Tested with default and `reasoning_effort: "high"` — same result.

Tool calls and streaming both worked — only `non-stream + no-tools + harmony` broke.

**Root cause:** `BatchedEngine.generate` calls `clean_output_text(output.output_text)` on the raw mlx-lm output; `_clean_gpt_oss_output` extracts only the `<|channel|>final<|message|>…<|return|>` content and strips all channel markers. By the time `_finalize_content_and_reasoning` runs `HarmonyReasoningParser.extract_reasoning` on `cleaned_text`, the `<|channel|>analysis<|message|>…<|end|>` block no longer exists. PR #436 added a guard that prevented `content` from being clobbered to None, but didn't rescue `reasoning_content` — that's what this PR fixes.

## Changes
- `vllm_mlx/engine/base.py` — add `raw_text: str = ""` to `GenerationOutput`.
- `vllm_mlx/engine/batched.py` — populate `raw_text=output.output_text` on both non-streaming entry points (LLM-only and MLLM paths).
- `vllm_mlx/routes/chat.py` + `vllm_mlx/routes/anthropic.py` — pass `raw_text=output.raw_text or output.text` to the helper.
- `vllm_mlx/service/helpers.py` — in the no-tools branch, retry `extract_reasoning(raw_text)` when the first parse found no reasoning AND `raw_text != text_to_parse`.
- `tests/test_finalize_harmony_raw_text.py` (new) — 5 cases pinning the contract.
- `tests/test_anthropic_route_auth.py` — added the new field to its `_GenerationOutput` stub.

## E2E verification (post-install of this branch)

Booted `mlx-community/gpt-oss-20b-MXFP4-Q8` from this branch on port 8503, hit `/v1/chat/completions` with `stream:false`, no tools, prompt: "Compute 17 * 23 step by step.":

| field | before fix | after fix |
|---|---|---|
| `reasoning_content` length | 0 | **1039** |
| `content` length | ~1900 (full CoT leaked in) | **1044** (final answer only) |
| `finish_reason` | stop | stop |

`reasoning_content` starts with: `User: "Compute 17 * 23 step by step." We need to show multiplication step by step. 17 * 23 = 391? Let's calculate…` (analysis channel)
`content` starts with: `Sure! Let's work through the multiplication \(17 \times 23\) step by step.` (final channel)

## Test plan
- [x] `pytest tests/test_finalize_harmony_raw_text.py` — 5/5 pass
- [x] `pytest tests/test_chat_route_tool_tag_leak.py tests/test_reasoning_parsers.py tests/test_postprocessor.py tests/test_paired_compat.py tests/test_prefix_boundary_path_parity.py` — 223/223 pass
- [x] Full unit suite — 3891 pass (2 unrelated event_loop env flakes fail on main too)
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] E2E verification on `mlx-community/gpt-oss-20b-MXFP4-Q8`: reasoning_content non-empty on non-stream + no-tools (1039 chars, separate from content's 1044 chars) — see table above
- [x] pr_validate re-run after E2E box checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)