### PR TITLE
fix(harmony): suppress role-name token between <|start|> and <|channel|>

### DIFF
--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -127,6 +127,12 @@ HARMONY_VOCAB = {
     "ing": 3,
     "Answer": 4,
     "Plain": 5,
+    # Role-name token following ``<|start|>``. Real harmony tokenizes
+    # ``assistant`` as a single token; if it weren't suppressed it would
+    # decode as literal ``assistant`` text and leak into delta.content.
+    "assistant": 173781,
+    "user": 173782,
+    " to=functions.get_weather": 173783,
 }
 
 HARMONY_TOKENIZER = FakeTokenizer(HARMONY_VOCAB)
@@ -616,6 +622,106 @@ class TestHarmonyRouting:
         event = router.feed(5)
         assert event is not None
         assert event.channel == Channel.CONTENT
+
+    def test_start_followed_by_role_name_swallows_role(self):
+        """``<|start|>assistant<|channel|>`` — the assistant role token
+        must not leak as CONTENT.
+
+        Regression for the second-and-later assistant-turn streaming leak
+        surfaced by the v0.6.65 fresh-PyPI onboarding smoke on
+        ``mlx-community/gpt-oss-20b-MXFP4-Q8``: streamed ``delta.content``
+        began with literal ``assistant`` before the real answer. Without
+        ``AFTER_START`` state, the role-name token fell through to the
+        default CONTENT emission path.
+        """
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200006) is None  # <|start|>
+        assert router.state == RouterState.AFTER_START
+        # The role-name token MUST be suppressed (returns None). Before
+        # the fix this returned a CONTENT event with text='assistant'.
+        assert router.feed(173781) is None  # ``assistant`` — role token
+        assert router.state == RouterState.AFTER_START
+        assert router.feed(200005) is None  # <|channel|>
+        assert router.state == RouterState.AWAITING_CHANNEL_TYPE
+        assert router.feed(17196) is None  # final
+        assert router.feed(200008) is None  # <|message|>
+
+        event = router.feed(4)  # Answer
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+        assert event.text == "Answer"
+
+    def test_start_with_recipient_info_swallows_all(self):
+        """``<|start|>assistant to=functions.get_weather<|channel|>`` —
+        every header token (role + recipient metadata) is swallowed,
+        only the payload after ``<|message|>`` is emitted.
+        """
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200006) is None  # <|start|>
+        assert router.feed(173781) is None  # assistant
+        assert router.feed(173783) is None  # " to=functions.get_weather"
+        assert router.feed(200005) is None  # <|channel|>
+        assert router.feed(17196) is None  # final (channel)
+        assert router.feed(200008) is None  # <|message|>
+
+        event = router.feed(4)
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+
+    def test_start_message_path_skips_channel(self):
+        """``<|start|>{role}<|message|>{body}`` — system/user/tool turns
+        with no channel marker still suppress the role and emit only
+        the body. Harmony spec allows this shorter header form.
+        """
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        assert router.feed(200006) is None  # <|start|>
+        assert router.feed(173782) is None  # user (role)
+        assert router.feed(200008) is None  # <|message|>
+        assert router.state == RouterState.CONTENT
+
+        event = router.feed(5)  # Plain
+        assert event is not None
+        assert event.channel == Channel.CONTENT
+        assert event.text == "Plain"
+
+    def test_second_assistant_turn_no_role_leak_end_to_end(self):
+        """Full reproduction of the bug. The model emits an analysis
+        channel terminated with ``<|end|>``, then opens a SECOND header
+        ``<|start|>assistant<|channel|>final<|message|>…``. Before the
+        fix, the second turn's ``assistant`` token leaked into CONTENT
+        because ``<|end|>`` transitioned state to CONTENT but the
+        next-up ``<|start|>`` didn't establish AFTER_START.
+        """
+        router = OutputRouter.from_tokenizer(HARMONY_TOKENIZER)
+        assert router is not None
+
+        result = router.feed_sequence(
+            [
+                200005,  # <|channel|>
+                35644,  # analysis
+                200008,  # <|message|>
+                2,  # Reason
+                3,  # ing
+                200007,  # <|end|>  → state=CONTENT
+                200006,  # <|start|>  → state=AFTER_START (the fix)
+                173781,  # assistant ← THIS USED TO LEAK AS CONTENT
+                200005,  # <|channel|>
+                17196,  # final
+                200008,  # <|message|>
+                4,  # Answer
+                200002,  # <|return|>
+            ]
+        )
+        assert result["reasoning"] == "Reasoning"
+        assert result["content"] == "Answer", (
+            f"role token leaked into content: {result['content']!r}"
+        )
 
     def test_feed_sequence_separates_analysis_and_final(self):
         """Batch routing separates Harmony analysis and final channels."""

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -111,6 +111,14 @@ class RouterState(Enum):
     TOOL_CALL = auto()  # inside tool call
     AWAITING_CHANNEL_TYPE = auto()  # saw <|channel>, waiting for thought/content/final
     AWAITING_MESSAGE = auto()  # saw Harmony channel name, waiting for <|message|>
+    # Saw ``<|start|>`` (harmony header). The next tokens are the role
+    # name + optional recipient info (e.g. ``assistant``, ``user``,
+    # ``tool to=functions.get_weather``) — all metadata that must be
+    # swallowed before the payload starts. We stay here until
+    # ``<|channel|>`` (transition to AWAITING_CHANNEL_TYPE) or
+    # ``<|message|>`` (transition straight to CONTENT — used by
+    # system/user/tool turns that have no channel marker).
+    AFTER_START = auto()
 
 
 class OutputRouter:
@@ -167,7 +175,33 @@ class OutputRouter:
             self._pending_control_tokens = []
             return None
 
-        if token_id in (m.harmony_start, m.harmony_call, m.harmony_constrain):
+        # ``<|start|>`` opens a header block: ``<|start|>{role}[ recipient
+        # info]<|channel|>{channel}<|message|>...`` (assistant turns) or
+        # ``<|start|>{role}<|message|>...`` (system/user/tool turns).
+        # Swallow header tokens until the next channel/message marker —
+        # otherwise the role name (``assistant``) leaks into ``content``
+        # at the start of every second-and-later assistant turn, since
+        # without a state transition the role token falls through to the
+        # default CONTENT path.
+        if token_id == m.harmony_start:
+            self.state = RouterState.AFTER_START
+            self._pending_channel_style = None
+            self._pending_message_channel = None
+            self._pending_control_tokens = []
+            return None
+
+        if token_id in (m.harmony_call, m.harmony_constrain):
+            return None
+
+        # In AFTER_START we swallow every non-special token until the
+        # payload boundary is hit. ``<|channel|>`` is handled above (it
+        # already transitions to AWAITING_CHANNEL_TYPE). ``<|message|>``
+        # opens a payload directly (no channel) — go straight to CONTENT
+        # so the body is emitted as content text.
+        if self.state == RouterState.AFTER_START:
+            if token_id == m.harmony_message:
+                self.state = RouterState.CONTENT
+                return None
             return None
 
         # Suppress tool-related markers that may appear without proper nesting


### PR DESCRIPTION
## Summary
- Streaming `delta.content` on gpt-oss-20b began with literal `assistant` text (e.g. `assistantHello!`) on the second-and-later assistant turn.
- `OutputRouter.feed` suppressed `<|start|>` but didn't transition state, so the role-name token that follows fell through to the default CONTENT emission path.
- Fix: introduce `RouterState.AFTER_START`. `<|start|>` transitions into it; tokens are swallowed until `<|channel|>` (resumes channel-type detection) or `<|message|>` (transitions to CONTENT for header-less turns).

## Background

Surfaced **2026-05-22** by fresh-PyPI v0.6.65 onboarding smokes — confirmed reproducible across two iterations. First iter noted it briefly; second iter pinned it: streaming `delta.content` consistently started with `'assistantHello world!'` or `'assistantHello!'` instead of just the answer.

The first assistant turn was unaffected because the model started inside an analysis channel (no leading `<|start|>{role}`). Only the **second and later** turns hit the boundary `<|end|> → <|start|>assistant<|channel|>final<|message|>...`, where `<|end|>` set state=CONTENT, `<|start|>` was suppressed but kept state=CONTENT, and the next token (`assistant`, a plain-text vocab token) decoded straight into the content channel.

## Changes
- `vllm_mlx/output_router.py` — add `RouterState.AFTER_START`; `<|start|>` now transitions into it (and clears any pending channel-style state); in `AFTER_START` we swallow every non-special token until `<|channel|>` or `<|message|>`.
- `tests/test_output_router.py` — add `assistant`/`user`/recipient tokens to `HARMONY_VOCAB`; add 4 new tests:
  - `test_start_followed_by_role_name_swallows_role` — minimal repro
  - `test_start_with_recipient_info_swallows_all` — multi-token headers
  - `test_start_message_path_skips_channel` — system/user/tool turns with no channel
  - `test_second_assistant_turn_no_role_leak_end_to_end` — full production reproduction

## E2E verification (post-install of this branch)

Booted `mlx-community/gpt-oss-20b-MXFP4-Q8` from this branch on port 8513, streamed `chat/completions` with prompt "Say hello in one sentence.":

| metric | before fix | after fix |
|---|---|---|
| First 80 chars of joined `delta.content` | `assistantHello world!` | `Hello!` |
| `reasoning_content` chunks | split correctly | split correctly (unchanged) |
| `finish_reason` | stop | stop |

## Test plan
- [x] `pytest tests/test_output_router.py` — 44/44 pass (40 existing + 4 new)
- [x] Full unit suite — 3894/3894 pass (event_loop env flakes excluded as on main)
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] E2E on `mlx-community/gpt-oss-20b-MXFP4-Q8`: streaming content no longer prefixed with `assistant` — see table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)