### PR TITLE
fix(engine): use OutputRouter for non-stream reasoning extraction (#442)

### DIFF
--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pins the engine non-streaming path's use of ``OutputRouter`` for
+channel-aware content/reasoning extraction — the root-cause fix for
+issue #442.
+
+Before this change, the engine produced ``GenerationOutput.text`` via
+``clean_output_text`` (text-based regex parsing of decoded output) and
+left reasoning extraction entirely to the route's ``ReasoningParser``.
+That had three failure modes that all reduced to "regex requires
+terminators the model didn't emit":
+
+  1. Truncated analysis (no ``<|end|>``) → ``HarmonyReasoningParser``
+     pattern missed the block, ``reasoning_content`` came back ``None``.
+  2. Same truncation → ``_clean_gpt_oss_output`` "no final channel"
+     branch only stripped marker tokens, leaving the analysis BODY
+     in ``message.content`` (issue #442's titular leak).
+  3. The streaming path *already* used ``OutputRouter`` correctly via
+     ``_stream_with_output_router`` — non-streaming silently diverged.
+
+The fix routes the completed token sequence through the same
+``OutputRouter`` state machine the streaming path trusts. The router
+tracks channel state at the token level (it doesn't care about ``<|end|>``
+markers — it knows it's in analysis the moment the analysis word token
+fires), so truncated output is handled identically to terminated.
+
+The engine's ``_route_tokens_for_channels`` returns
+``(reasoning_text, content_text)``; the content override only fires
+when the router authoritatively says "no content, only reasoning" so
+tool-call paths (where harmony commentary needs to survive intact for
+the route's tool parser) keep their existing behavior. These tests pin
+each branch of that override decision.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.engine.batched import BatchedEngine
+
+
+class _FakeTokenizer:
+    """Minimal stand-in matching the ``OutputRouter.from_tokenizer``
+    interface — only ``get_vocab`` and ``decode`` are touched."""
+
+    def __init__(self, vocab: dict[str, int]):
+        self._vocab = vocab
+        self._id_to_text = {v: k for k, v in vocab.items()}
+
+    def get_vocab(self) -> dict[str, int]:
+        return self._vocab
+
+    def decode(self, ids):
+        return "".join(self._id_to_text.get(i, f"<UNK:{i}>") for i in ids)
+
+
+# Harmony token IDs from openai/gpt-oss-20b (same constants the real
+# router reads). Keep in sync with tests/test_output_router.py.
+_HARMONY_VOCAB = {
+    "<|return|>": 200002,
+    "<|constrain|>": 200003,
+    "<|channel|>": 200005,
+    "<|start|>": 200006,
+    "<|end|>": 200007,
+    "<|message|>": 200008,
+    "<|call|>": 200012,
+    "analysis": 35644,
+    "final": 17196,
+    "assistant": 173781,
+    "Reason": 1,
+    "ing": 2,
+    "Answer": 3,
+    "Plain": 4,
+}
+
+
+@pytest.fixture
+def engine() -> BatchedEngine:
+    """Engine with a harmony tokenizer wired in. We don't load a real
+    model — ``_route_tokens_for_channels`` only touches the tokenizer
+    and the router state machine.
+    """
+    eng = BatchedEngine("test-model")
+    eng._loaded = True
+    eng._is_mllm = False
+    eng._tokenizer = _FakeTokenizer(_HARMONY_VOCAB)
+    return eng
+
+
+def test_truncated_analysis_drops_content_and_recovers_reasoning(engine):
+    """The exact #442 production failure: model finishes mid-thinking
+    (no ``<|end|>``), no final channel ever opened. Before the fix,
+    ``clean_output_text``'s else-branch returned the analysis body as
+    ``content`` and the parser couldn't recover ``reasoning_content``.
+    Router-based extraction sees the analysis channel from the
+    ``analysis`` word token regardless of whether ``<|end|>`` fires.
+    """
+    # <|channel|> analysis <|message|> Reason ing  (no <|end|>)
+    token_ids = [200005, 35644, 200008, 1, 2]
+    reasoning, content = engine._route_tokens_for_channels(
+        token_ids, fallback_text="Reasoning"
+    )
+    assert reasoning == "Reasoning", (
+        f"#442: router did not recover reasoning from truncated analysis: {reasoning!r}"
+    )
+    assert content == "", f"#442: analysis body leaked into content: {content!r}"
+
+
+def test_terminated_analysis_only_also_drops_content(engine):
+    """``<|channel|>analysis<|message|>...<|end|>`` with no final
+    channel: same behavior as truncated — content must be empty,
+    reasoning must be populated. Pins the symmetric case (the bug
+    reproduces both with and without ``<|end|>``).
+    """
+    token_ids = [200005, 35644, 200008, 1, 2, 200007]
+    reasoning, content = engine._route_tokens_for_channels(
+        token_ids, fallback_text="anything"
+    )
+    assert reasoning == "Reasoning"
+    assert content == ""
+
+
+def test_analysis_then_final_keeps_fallback_content(engine):
+    """Happy path: analysis followed by final channel. The router sees
+    BOTH a CONTENT event (final-channel "Answer") and a REASONING event
+    (analysis-channel "Reasoning"). Override condition (content is None
+    AND reasoning exists) is FALSE → keep the fallback text from
+    ``clean_output_text``. This pins the existing PR #436 / #440
+    behavior so the new override doesn't regress the common case.
+    """
+    token_ids = [
+        200005,
+        35644,
+        200008,  # <|channel|>analysis<|message|>
+        1,
+        2,  # Reasoning
+        200007,  # <|end|>
+        200006,
+        173781,  # <|start|>assistant  (PR #441 swallows the role)
+        200005,
+        17196,
+        200008,  # <|channel|>final<|message|>
+        3,  # Answer
+        200002,  # <|return|>
+    ]
+    reasoning, content = engine._route_tokens_for_channels(
+        token_ids, fallback_text="Answer"
+    )
+    assert reasoning == "Reasoning"
+    assert content == "Answer", "happy path must not clobber the text-cleaning result"
+
+
+def test_pure_content_no_thinking_keeps_fallback(engine):
+    """``<|channel|>final<|message|>Plain<|return|>`` — content-only,
+    no analysis. Router emits CONTENT and no REASONING. Override
+    condition is FALSE (reasoning empty) → fallback content preserved.
+    Without this guard the engine would clobber pure-content responses
+    with ``text=""`` on every non-reasoning model.
+    """
+    token_ids = [200005, 17196, 200008, 4, 200002]
+    reasoning, content = engine._route_tokens_for_channels(
+        token_ids, fallback_text="Plain"
+    )
+    assert reasoning == ""
+    assert content == "Plain"
+
+
+def test_no_router_returns_fallback_untouched(engine):
+    """If ``_create_output_router`` returns ``None`` (tokenizer doesn't
+    have channel tokens — e.g. plain Llama), the engine must NOT try
+    to do anything channel-aware. Returns empty reasoning + the
+    original ``fallback_text`` so routes' ReasoningParser path keeps
+    handling extraction for older formats.
+    """
+    plain_engine = BatchedEngine("test-model")
+    plain_engine._loaded = True
+    plain_engine._is_mllm = False
+    plain_engine._tokenizer = _FakeTokenizer({"plain": 100})
+    reasoning, content = plain_engine._route_tokens_for_channels(
+        [100, 100], fallback_text="plain text"
+    )
+    assert reasoning == ""
+    assert content == "plain text"
+
+
+def test_empty_token_list_returns_fallback(engine):
+    """Defensive: empty token IDs (race during error paths) must not
+    crash. Returns empty reasoning + the fallback text.
+    """
+    reasoning, content = engine._route_tokens_for_channels([], fallback_text="whatever")
+    assert reasoning == ""
+    assert content == "whatever"
+
+
+def test_router_exception_falls_back_cleanly(engine, monkeypatch):
+    """If the router blows up mid-sequence (e.g. token id outside the
+    vocab causes a decode failure), the engine must not propagate the
+    exception — fall back to text-based cleaning. The streaming router
+    handles this the same way; symmetry matters.
+    """
+
+    def _exploding_router():
+        class _BoomRouter:
+            def reset(self):
+                pass
+
+            def feed_sequence(self, _ids):
+                raise RuntimeError("explosion in router")
+
+        return _BoomRouter()
+
+    monkeypatch.setattr(engine, "_create_output_router", _exploding_router)
+    reasoning, content = engine._route_tokens_for_channels(
+        [1, 2, 3], fallback_text="fallback"
+    )
+    assert reasoning == ""
+    assert content == "fallback"

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -149,3 +149,57 @@ def test_no_reasoning_parser_short_circuits():
     )
     assert reasoning is None
     assert cleaned == _HARMONY_CLEANED
+
+
+def test_engine_reasoning_text_short_circuits_parser():
+    """When the engine populated ``reasoning_text`` via ``OutputRouter``,
+    the helper trusts it as authoritative and skips the text-based
+    parser. This is the root-cause fix for issue #442 — token-level
+    routing replaces fragile regex parsing of decoded output. The
+    parser would have returned None on this truncated input (no
+    ``<|end|>`` to anchor against); the engine-provided text wins.
+    """
+    truncated_raw = (
+        "<|channel|>analysis<|message|>User wants multiple actions. We must use tools."
+    )
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=truncated_raw,
+        cleaned_text="",
+        tool_calls=[],
+        reasoning_parser=HarmonyReasoningParser(),
+        engine_reasoning_text="User wants multiple actions. We must use tools.",
+    )
+    assert reasoning == "User wants multiple actions. We must use tools."
+    assert cleaned == ""
+
+
+def test_engine_reasoning_text_overrides_even_when_parser_could_match():
+    """When the engine populated ``reasoning_text``, its value wins even
+    if the text-based parser COULD have found something — token-level
+    routing is the authoritative source. This pins the precedence so a
+    future change can't accidentally re-prefer the regex result.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_HARMONY_RAW,
+        cleaned_text=_HARMONY_CLEANED,
+        tool_calls=[],
+        reasoning_parser=HarmonyReasoningParser(),
+        engine_reasoning_text="ENGINE-ROUTED-VALUE",
+    )
+    assert reasoning == "ENGINE-ROUTED-VALUE"
+
+
+def test_engine_reasoning_empty_falls_through_to_parser():
+    """Empty ``engine_reasoning_text`` means the engine couldn't route
+    (no ``OutputRouter`` for this tokenizer, or a non-channel model).
+    Helper falls through to the existing parser-based extraction so
+    older formats (e.g. plain ``<think>`` tags) keep working.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_HARMONY_RAW,
+        cleaned_text=_HARMONY_CLEANED,
+        tool_calls=[],
+        reasoning_parser=HarmonyReasoningParser(),
+        engine_reasoning_text="",
+    )
+    assert reasoning is not None and "17 * 23" in reasoning

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -26,6 +26,19 @@ class GenerationOutput:
     # ``content`` and emitting empty ``reasoning_content`` to clients.
     # Empty string default keeps callers that don't populate it working.
     raw_text: str = ""
+    # Token-level reasoning extraction, populated by the engine via
+    # ``OutputRouter.feed_sequence`` for tokenizers it supports
+    # (Harmony / Gemma 4 / Qwen3 / DeepSeek R1 — see
+    # ``output_router.from_tokenizer``). This is the AUTHORITATIVE source
+    # of reasoning_content for non-streaming responses: it tracks channel
+    # state at the token level instead of regex-parsing the decoded text
+    # after the fact, so truncated outputs (``finish_reason=length``,
+    # no ``<|end|>`` terminator) still produce correct
+    # ``reasoning_content`` without leaking the analysis body into
+    # ``content``. Empty string means the engine didn't populate it
+    # (no router, or router failed) — routes fall back to the
+    # text-based ``ReasoningParser`` in that case. Issue #442.
+    reasoning_text: str = ""
     tokens: list[int] = field(default_factory=list)
     prompt_tokens: int = 0
     completion_tokens: int = 0

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -936,10 +936,28 @@ class BatchedEngine(BaseEngine):
         )
 
         text = clean_output_text(output.output_text)
+        # Token-level channel extraction via ``OutputRouter`` — the SAME
+        # state machine the streaming path already uses
+        # (``_stream_with_output_router``). For non-streaming we feed the
+        # full token sequence through ``feed_sequence`` to get the
+        # authoritative reasoning/content split. Text-based regex
+        # cleaning above (``clean_output_text``) keeps working for the
+        # happy paths (final channel present, or tool-call commentary
+        # bail-out); the router result tells us when text-based cleaning
+        # would be WRONG — specifically the "analysis channel only, no
+        # final" case where ``_clean_gpt_oss_output``'s else branch
+        # would otherwise leak the analysis body into ``content``
+        # (issue #442). The router doesn't care about ``<|end|>``
+        # terminators so it also recovers reasoning from truncated
+        # output (``finish_reason=length`` mid-thinking).
+        reasoning_text, text = self._route_tokens_for_channels(
+            output.output_token_ids, fallback_text=text
+        )
 
         return GenerationOutput(
             text=text,
             raw_text=output.output_text,
+            reasoning_text=reasoning_text,
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
@@ -1207,6 +1225,54 @@ class BatchedEngine(BaseEngine):
             return lcp
         except Exception:
             return 0
+
+    def _route_tokens_for_channels(
+        self, token_ids: list[int] | None, *, fallback_text: str
+    ) -> tuple[str, str]:
+        """Run ``OutputRouter.feed_sequence`` on a completed token list.
+
+        Returns ``(reasoning_text, content_text)`` for the non-streaming
+        path. The router is the token-level state machine that the
+        streaming path already trusts (``_stream_with_output_router``);
+        using it here closes a long-standing gap where non-streaming
+        relied on text-based ``clean_output_text`` regex parsing and
+        leaked analysis-channel content into ``content`` when the
+        model finished mid-thinking (``finish_reason=length`` — issue
+        #442) or otherwise emitted no ``final`` channel.
+
+        ``fallback_text`` is the result of ``clean_output_text`` —
+        we keep it as ``content`` for cases the router doesn't override
+        (e.g. tool-call paths where harmony commentary text needs to
+        survive intact for the route's tool parser; the router only
+        knows about ``analysis`` and ``final`` for harmony, so we don't
+        clobber its decisions). The override fires only when the router
+        is authoritative AND text-based cleaning is known wrong —
+        specifically when the router sees REASONING tokens but no
+        CONTENT tokens, which means there was no ``final`` channel and
+        ``message.content`` should be empty.
+        """
+        if not token_ids:
+            return "", fallback_text
+        router = self._create_output_router()
+        if router is None:
+            return "", fallback_text
+        try:
+            router.reset()
+            routed = router.feed_sequence(token_ids)
+        except Exception as e:
+            logger.debug("OutputRouter sequence routing failed: %s", e)
+            return "", fallback_text
+
+        reasoning = routed.get("reasoning") or ""
+        # Override content ONLY when the router authoritatively says
+        # there is no content channel AND there is reasoning. In every
+        # other case we keep ``fallback_text`` so tool-call commentary
+        # text reaches the route's tool parser unchanged, and so non-
+        # reasoning models (router emits CONTENT only) keep their
+        # text-cleaning result.
+        if routed.get("content") is None and reasoning:
+            return reasoning, ""
+        return reasoning, fallback_text
 
     def _create_output_router(self) -> OutputRouter | None:
         """Create a per-request token router for supported tokenizer formats."""

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -226,6 +226,7 @@ async def create_anthropic_message(
             cleaned_text=cleaned_text,
             tool_calls=tool_calls,
             reasoning_parser=cfg.reasoning_parser,
+            engine_reasoning_text=getattr(output, "reasoning_text", "") or "",
         )
 
         final_content = None

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -768,6 +768,7 @@ async def _create_chat_completion_impl(
         cleaned_text=cleaned_text,
         tool_calls=tool_calls,
         reasoning_parser=cfg.reasoning_parser,
+        engine_reasoning_text=getattr(output, "reasoning_text", "") or "",
     )
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -131,6 +131,7 @@ def _finalize_content_and_reasoning(
     cleaned_text: str,
     tool_calls: list,
     reasoning_parser,
+    engine_reasoning_text: str = "",
 ) -> tuple[str, str | None]:
     """Compute final ``content`` + ``reasoning_text`` after tool parsing.
 
@@ -165,6 +166,18 @@ def _finalize_content_and_reasoning(
     integrations, v0.6.64 pr_validate baseline).
     """
     reasoning_text = None
+    # Engine-level token routing is authoritative when present. The
+    # ``OutputRouter`` state machine tracks channel boundaries at the
+    # token level (same code path the streaming route already trusts),
+    # so the text-based retry below is redundant — and would in fact
+    # be wrong for truncated harmony output, where the engine cleaner
+    # leaks analysis content into ``cleaned_text`` and the parser's
+    # regex misses it without an ``<|end|>`` terminator. When the
+    # engine populated ``reasoning_text``, use it directly and skip
+    # the parser. (No reasoning_parser is still a short-circuit
+    # below.) Issue #442.
+    if engine_reasoning_text:
+        return cleaned_text, engine_reasoning_text
     if reasoning_parser is None:
         return cleaned_text, reasoning_text
     if tool_calls:


### PR DESCRIPTION
## Summary
- Root cause of #442: non-streaming reasoning extraction was text-based regex parsing anchored on `<|end|>`. Streaming already uses the token-level `OutputRouter` state machine — non-streaming silently diverged.
- Fix: feed the completed token sequence through the same `OutputRouter` (`feed_sequence`) on the non-stream path. Populates new `GenerationOutput.reasoning_text` authoritatively, and overrides `content` to empty when the router sees REASONING-only output.
- Helper short-circuits its parser path when the engine populated `reasoning_text`. The earlier draft of this PR extended regex patterns at the cleaner/parser layer — that was a layer-level patch on the wrong layer; replaced by this token-level approach.

## Background

Surfaced **2026-05-22** in iter-2 of the onboarding loop, filed as #442. Reproduced in iter-3 against main HEAD with `tool_choice: required` + many-tool prompt + tight `max_tokens` (model hits length before committing to a tool):

```
before fix:
  finish_reason: length
  content: 263 chars of "User wants multiple actions..." (analysis-channel leak)
  reasoning_content: null
  tool_calls: null

after fix:
  finish_reason: length
  content: ""
  reasoning_content: 263 chars of analysis
  tool_calls: null
```

Both halves of the failure had the same root cause: text-based regex parsing requires marker tokens (`<|end|>`) that the model didn't get a chance to emit. The `OutputRouter` state machine doesn't have that dependency — it transitions on the `analysis`/`final` word tokens themselves, so truncation is invisible to it.

## Changes
- `vllm_mlx/engine/base.py` — add `reasoning_text: str = ""` to `GenerationOutput`.
- `vllm_mlx/engine/batched.py` — add `_route_tokens_for_channels` helper that runs `OutputRouter.feed_sequence` on the completed token IDs; non-stream generate path calls it. Override condition (`content is None AND reasoning exists`) fires only when text-based cleaning is known wrong, so tool-call commentary text reaches the route's tool parser unchanged.
- `vllm_mlx/service/helpers.py` — `_finalize_content_and_reasoning` accepts `engine_reasoning_text`; non-empty value short-circuits the parser entirely.
- `vllm_mlx/routes/chat.py`, `vllm_mlx/routes/anthropic.py` — forward `output.reasoning_text` to the helper.
- `tests/test_engine_router_non_stream.py` (new, 7 cases) — pins each branch of the engine's content override decision: truncated analysis recovers reasoning + zeros content; terminated-analysis-only same; analysis+final preserves fallback content; pure content preserves fallback; no-router fallthrough; empty token list; router exception falls back cleanly.
- `tests/test_finalize_harmony_raw_text.py` — 3 new cases for the helper's `engine_reasoning_text` short-circuit precedence.

## E2E verification (post-install of this branch)

Booted `mlx-community/gpt-oss-20b-MXFP4-Q8` from this branch on port 8516:

| scenario | before fix | after fix |
|---|---|---|
| #442 sad path (truncated analysis, no tools, `tool_choice: required`) | content=263 chars analysis leak, reasoning=0 | **content=0, reasoning=263 chars** |
| happy path (`Compute 17 * 23`, full multi-channel response) | content="17 × 23 = 391" reasoning=159 chars | same — **no regression** |
| streaming `delta.content` (PR #441 path) | starts with `Hello!...` | same — **no regression** |

## Test plan
- [x] `pytest tests/test_engine_router_non_stream.py tests/test_finalize_harmony_raw_text.py` — 15/15 pass
- [x] Full unit suite — 3904 pass (event_loop env flakes excluded as on main)
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] E2E on `mlx-community/gpt-oss-20b-MXFP4-Q8`: #442 sad path + happy path + streaming all verified — see table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)