### PR TITLE
fix(chat): enforce tool_choice none and specific-function at prompt level (#445)

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt-level ``tool_choice`` enforcement on the chat route (#445).
+
+Pre-fix: ``tool_choice`` was forwarded only to the cloud router — local
+inference accepted the field but never enforced it, so ``"none"`` and
+specific-function modes silently behaved as ``"auto"``. On harmony/hybrid
+models this meant a user explicitly disabling tools (``"none"``) still
+got tool_calls back, and a user forcing function X got whatever the
+model preferred instead.
+
+Fix (``routes/chat.py``): before any downstream consumption of
+``request.tools`` (suffix injection at line ~398, chat-template
+``tools=`` kwarg at line ~474, build_prompt at line ~483), normalize
+the request based on ``tool_choice``:
+
+- ``"none"``: ``request.tools = None`` — the model never sees tools,
+  no suffix injection fires, the chat template renders without tools.
+- ``{"type":"function","function":{"name":X}}``: filter ``request.tools``
+  to only the named function. Raises HTTP 400 if X is not in
+  ``request.tools`` (matches OpenAI spec).
+- ``"auto"`` / ``"required"`` / ``None``: tools untouched. ``"required"``
+  enforcement is tracked separately under #442 (needs decoder-level
+  constraints).
+
+These tests fire HTTP requests through the live FastAPI router and
+assert on what the engine receives in ``chat_kwargs``. A unit-level
+inspection of the request object alone would miss regressions where
+the normalization happens but ``chat_kwargs["tools"]`` is later set
+from a stale local reference instead of ``request.tools``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+
+
+class _RecordingEngine:
+    """Mock engine that captures the kwargs passed to ``chat()``.
+
+    Returns a vanilla GenerationOutput so the route's post-processing
+    runs without errors. We only care about what the engine sees on
+    its way in.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.last_chat_kwargs: dict[str, Any] | None = None
+        self.last_messages: Any = None
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_chat_kwargs = kwargs
+        return GenerationOutput(
+            text="ok",
+            raw_text="ok",
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+def _make_client(engine: _RecordingEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+_TOOLS_FIXTURE = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    },
+]
+
+
+def test_tool_choice_none_strips_tools_from_engine_kwargs():
+    """``tool_choice: "none"`` must drop ``tools`` from the engine call
+    entirely. Without this the model still sees the tools in the chat
+    template and ignores the choice. Spec: "none" means do NOT call
+    any tool — model must respond in natural language.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "what's the weather in Tokyo?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "none",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert engine.last_chat_kwargs is not None
+    assert "tools" not in engine.last_chat_kwargs or not engine.last_chat_kwargs.get(
+        "tools"
+    ), (
+        f"tool_choice='none' must strip tools from engine call; "
+        f"got tools={engine.last_chat_kwargs.get('tools')!r}"
+    )
+
+
+def test_tool_choice_specific_function_filters_to_named_only():
+    """``tool_choice: {type: function, function: {name: X}}`` must
+    filter ``tools`` to a single entry — the named function. Without
+    this the model sees both candidates and picks the one it prefers,
+    silently ignoring the user's force choice.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "what time is it in Tokyo?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_time"},
+            },
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    tools = engine.last_chat_kwargs.get("tools") if engine.last_chat_kwargs else None
+    assert tools and len(tools) == 1, (
+        f"specific-function tool_choice must filter to one tool; "
+        f"got {len(tools) if tools else 0} tool(s)"
+    )
+    # The chat template converter may reshape the tool, but the
+    # function name must survive intact.
+    fn = tools[0].get("function") if isinstance(tools[0], dict) else None
+    name = fn.get("name") if isinstance(fn, dict) else None
+    assert name == "get_time", f"filtered tool must be 'get_time'; got {name!r}"
+
+
+def test_tool_choice_specific_function_unknown_name_returns_400():
+    """Specific-function ``tool_choice`` for a name NOT in ``tools``
+    is an invalid request — return 400 per OpenAI spec rather than
+    silently delivering an empty tool list to the model (which would
+    look like an internal server error to clients).
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do something"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "nonexistent_function"},
+            },
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+    assert "nonexistent_function" in resp.text
+
+
+def test_tool_choice_function_missing_name_returns_400():
+    """``tool_choice: {type: function}`` with no ``function.name`` is
+    malformed per OpenAI spec — return 400 explicitly rather than
+    silently treating it as ``auto``.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do something"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("choice", ["auto", "required", None])
+def test_tool_choice_auto_required_none_field_leave_tools_untouched(choice):
+    """``"auto"``, ``"required"``, and unset ``tool_choice`` must NOT
+    mutate ``request.tools``. ``"required"`` enforcement is tracked
+    separately (#442 needs FSM constraints); for now it falls through
+    to model behavior — same as ``"auto"``. This test pins that the
+    normalization layer is precisely scoped to ``"none"`` and the
+    specific-function form and doesn't accidentally rewrite the other
+    paths.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    payload: dict[str, Any] = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "what's the weather?"}],
+        "tools": _TOOLS_FIXTURE,
+        "max_tokens": 32,
+    }
+    if choice is not None:
+        payload["tool_choice"] = choice
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200, resp.text
+    tools = engine.last_chat_kwargs.get("tools") if engine.last_chat_kwargs else None
+    assert tools and len(tools) == 2, (
+        f"tool_choice={choice!r} must leave the full tools array intact; "
+        f"got {len(tools) if tools else 0} tool(s)"
+    )
+
+
+def test_tool_choice_none_with_no_tools_is_noop():
+    """``tool_choice: "none"`` on a request that has no tools to begin
+    with is a no-op — the request must succeed cleanly without
+    raising 400 or otherwise misbehaving. Pins the defensive branch
+    that checks ``request.tools`` before mutation.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "none",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -303,6 +303,38 @@ async def _create_chat_completion_impl(
 
     cfg = get_config()
 
+    # Enforce ``tool_choice`` at the prompt level (#445). The OpenAI spec
+    # accepts four modes: "auto", "none", "required", and
+    # ``{"type":"function","function":{"name":X}}``. Local inference has no
+    # native enforcement (no FSM constraint), so the only reliable lever for
+    # ``"none"`` and the specific-function form is to mutate what the model
+    # sees: drop ``tools`` entirely for ``"none"``, or filter to just the
+    # named function for the specific case. ``"auto"`` and ``"required"``
+    # leave tools untouched — ``"required"`` enforcement is tracked
+    # separately under #442 (needs decoder-level constraints, PR #132).
+    tc = request.tool_choice
+    if tc is not None and request.tools:
+        if tc == "none":
+            request.tools = None
+        elif isinstance(tc, dict) and tc.get("type") == "function":
+            fn = tc.get("function") or {}
+            target = fn.get("name")
+            if not target:
+                raise HTTPException(
+                    status_code=400,
+                    detail=("tool_choice with type='function' requires function.name"),
+                )
+            filtered = [t for t in request.tools if t.function.get("name") == target]
+            if not filtered:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"tool_choice references function {target!r} which "
+                        "is not present in the 'tools' array"
+                    ),
+                )
+            request.tools = filtered
+
     # Save original messages (clean dicts) for cloud routing BEFORE
     # local mutations (extract_multimodal_content, developer→system, suffix injection).
     if cfg.cloud_router:


### PR DESCRIPTION
## Summary

Fixes the prompt-level half of #445 (`tool_choice` enforcement gap): `"none"` and `{"type":"function","function":{"name":X}}` modes are now honored locally. `"required"` remains tracked under #442 (needs decoder-level constraints — PR #132's FSM work).

## Root cause

`vllm_mlx/routes/chat.py:499-500` was the only `tool_choice` reference — and it only fed the cloud-routing passthrough. Local inference accepted the field but never enforced it, so all four modes silently behaved as `"auto"`. Surfaced on 2026-05-22 fresh-PyPI v0.6.65 onboarding sweep against `mlx-community/gpt-oss-20b-MXFP4-Q8`.

## Fix

Before any downstream consumption of `request.tools` (suffix injection at chat.py:~398, chat-template `tools=` kwarg at ~474, `build_prompt` at ~483), normalize `request.tools` based on `tool_choice`:

| `tool_choice` value | Behavior |
|---|---|
| `"none"` | `request.tools = None` — model sees no tools, no suffix injection fires, chat template renders without tools. |
| `{"type":"function","function":{"name":X}}` | Filter `request.tools` to just X. Returns HTTP 400 if X is not in the tools array (matches OpenAI spec). |
| `"auto"` / `"required"` / unset / `None` | Tools untouched. `"required"` enforcement is tracked separately under #442. |

The mutation happens on `request.tools` directly so the cloud-routing path (chat.py:506-510) and local chat-template path both see the normalized set — keeps the two backends in sync. Cloud providers still receive `tool_choice` (line 499-500) and enforce on their side; the prompt-level filter is defense-in-depth for local.

## Why not decoder-level enforcement

Decoder-level enforcement (e.g. via outlines-core FSM grammar) is more correct for `"required"` and specific-function but lives in PR #132 (paused draft). The prompt-level filter is cheap, ships now, and correctly handles `"none"` (impossible to violate when the model can't see tools) and the common case of specific-function (filters the candidate set; model still has to choose, but the choice set is exactly 1). When PR #132 lands, the FSM layer composes cleanly on top.

## Test plan

- [x] 6 new tests under `tests/test_chat_route_tool_choice_enforcement.py` pin each branch: `"none"` strips tools, specific-function filters, unknown name returns 400, missing name returns 400, `"auto"`/`"required"`/unset leave tools untouched, `"none"` + no tools is a no-op.
- [x] Tests drive the live FastAPI router with `_RecordingEngine` so they catch regressions where normalization happens but `chat_kwargs["tools"]` is later set from a stale local reference.
- [x] Pre-existing chat-route regression tests still pass (46 total in `test_chat_route_*.py`, `test_chat_streaming_*.py`, `test_chat_template_kwargs.py`).
- [x] `ruff check` clean; `ruff format --check` clean.

## Out of scope

- `"required"` enforcement: tracked under #442. Needs FSM or retry policy.
- Multi-tool-call truncation observed on harmony non-stream (iter 6 finding): may be model behavior, needs isolated repro before filing.
- `extra_body.enable_thinking` ergonomics: not a server bug (OpenAI SDK unpacks `extra_body` client-side).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>