### PR TITLE
fix(tokenizer): load chat_template.json sidecar for newer HF repos

### DIFF
--- a/tests/test_chat_template_sidecar.py
+++ b/tests/test_chat_template_sidecar.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Chat-template sidecar loading (``_apply_chat_template_sidecar``).
+
+Surfaced on 2026-05-22 fresh-PyPI v0.6.65 onboarding sweep:
+``mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit`` ships its
+chat template in a standalone ``chat_template.json`` file next to
+``tokenizer_config.json`` instead of embedded. AutoTokenizer in
+transformers ≤5.6 doesn't auto-merge that sidecar, so
+``tokenizer.chat_template`` comes back ``None`` and every
+``/v1/chat/completions`` request 400s with
+"Cannot use chat template functions". Same gap applies to any
+mlx-community / mistral-community / unsloth repo that follows the
+``chat_template.json`` convention.
+
+These tests pin the recovery helper:
+
+  1. ``.jinja`` sidecar takes precedence over ``.json``.
+  2. ``.json`` sidecar is unwrapped from ``{"chat_template": "..."}``.
+  3. Already-populated ``tokenizer.chat_template`` is never overwritten
+     (the helper is purely a fallback for the missing-template case).
+  4. Malformed or sidecar-missing-key cases don't raise — they log
+     and leave ``tokenizer.chat_template`` untouched.
+  5. UTF-8 BOM in ``.jinja`` is stripped so jinja2 doesn't choke on
+     a stray ``﻿`` at the start of the template.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.utils.tokenizer import _apply_chat_template_sidecar
+
+
+@pytest.fixture
+def tmp_model_dir(tmp_path: Path) -> Path:
+    """Minimal model directory — caller writes whichever sidecar(s) they
+    want to test.
+    """
+    return tmp_path
+
+
+def _make_tokenizer_stub(chat_template=None):
+    """Stand-in for the ``TokenizerWrapper`` / ``PreTrainedTokenizerFast``
+    interface — the helper only reads/writes ``.chat_template``.
+    """
+    return SimpleNamespace(chat_template=chat_template)
+
+
+def test_json_sidecar_populates_chat_template(tmp_model_dir):
+    """The Mistral Small 3.1 case: ``chat_template.json`` with the
+    ``{"chat_template": "..."}`` wrapper. Helper must extract the inner
+    string and set it on the tokenizer.
+    """
+    template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+    (tmp_model_dir / "chat_template.json").write_text(
+        json.dumps({"chat_template": template})
+    )
+    tok = _make_tokenizer_stub()
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is True
+    assert tok.chat_template == template
+
+
+def test_jinja_sidecar_populates_chat_template(tmp_model_dir):
+    """The DeepSeek V4 case: ``chat_template.jinja`` is raw jinja text,
+    no JSON wrapper. Helper must read it verbatim.
+    """
+    template = "{% for m in messages %}<msg>{{ m['content'] }}</msg>{% endfor %}"
+    (tmp_model_dir / "chat_template.jinja").write_text(template)
+    tok = _make_tokenizer_stub()
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is True
+    assert tok.chat_template == template
+
+
+def test_jinja_takes_precedence_over_json(tmp_model_dir):
+    """If both sidecars exist, ``.jinja`` wins — it's the modern HF
+    convention (transformers ≥4.43) and the ``.json`` form is the
+    older Tokenizers sidecar layout. A repo shipping both probably
+    transcribed an upstream .jinja into .json as a compatibility shim;
+    trust the canonical .jinja.
+    """
+    jinja_template = "JINJA-TEMPLATE"
+    json_template = "JSON-TEMPLATE"
+    (tmp_model_dir / "chat_template.jinja").write_text(jinja_template)
+    (tmp_model_dir / "chat_template.json").write_text(
+        json.dumps({"chat_template": json_template})
+    )
+    tok = _make_tokenizer_stub()
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is True
+    assert tok.chat_template == jinja_template
+
+
+def test_existing_chat_template_is_not_overwritten(tmp_model_dir):
+    """The helper is a fallback. If ``tokenizer.chat_template`` was
+    already populated (e.g. by AutoTokenizer reading
+    ``tokenizer_config.json[chat_template]``), don't clobber it — the
+    embedded version is the authoritative one for that repo.
+    """
+    embedded = "EMBEDDED-TEMPLATE"
+    sidecar = "SIDECAR-TEMPLATE"
+    (tmp_model_dir / "chat_template.json").write_text(
+        json.dumps({"chat_template": sidecar})
+    )
+    tok = _make_tokenizer_stub(chat_template=embedded)
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is False
+    assert tok.chat_template == embedded
+
+
+def test_no_sidecar_returns_false(tmp_model_dir):
+    """No sidecar files present → helper is a no-op, returns False,
+    leaves the tokenizer alone. Callers downstream can then apply
+    Nemotron / ChatML defaults or raise.
+    """
+    tok = _make_tokenizer_stub()
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is False
+    assert tok.chat_template is None
+
+
+def test_json_sidecar_missing_key_logs_and_skips(tmp_model_dir, caplog):
+    """A ``chat_template.json`` that's well-formed JSON but doesn't
+    have the ``"chat_template"`` key (e.g. someone shipped a different
+    JSON wrapper) must not raise — log a warning and return False so
+    the next fallback (Nemotron / ChatML / etc.) can run.
+    """
+    (tmp_model_dir / "chat_template.json").write_text(
+        json.dumps({"wrong_key": "ignored"})
+    )
+    tok = _make_tokenizer_stub()
+    with caplog.at_level("WARNING"):
+        applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is False
+    assert tok.chat_template is None
+    assert any("chat_template" in r.message for r in caplog.records)
+
+
+def test_json_sidecar_malformed_json_logs_and_skips(tmp_model_dir, caplog):
+    """A corrupt ``chat_template.json`` (invalid JSON) must not crash
+    the entire model load — log a warning and fall through.
+    """
+    (tmp_model_dir / "chat_template.json").write_text("{not json at all")
+    tok = _make_tokenizer_stub()
+    with caplog.at_level("WARNING"):
+        applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is False
+    assert tok.chat_template is None
+    assert any("chat_template.json" in r.message for r in caplog.records)
+
+
+def test_jinja_with_utf8_bom_is_stripped(tmp_model_dir):
+    """If a ``.jinja`` file was saved with a UTF-8 BOM (some Windows
+    editors do this), the BOM character ``\\ufeff`` must NOT survive
+    into the template — jinja2 treats it as literal text at the start
+    of the first ``{% %}`` block and breaks rendering. utf-8-sig
+    decoding strips it.
+    """
+    template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+    # Write with explicit BOM bytes (b'\xef\xbb\xbf' = UTF-8 BOM)
+    (tmp_model_dir / "chat_template.jinja").write_bytes(
+        b"\xef\xbb\xbf" + template.encode("utf-8")
+    )
+    tok = _make_tokenizer_stub()
+    applied = _apply_chat_template_sidecar(tmp_model_dir, tok)
+    assert applied is True
+    assert tok.chat_template == template
+    assert not tok.chat_template.startswith("﻿")

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -28,6 +28,81 @@ def _needs_tokenizer_fallback(model_name: str) -> bool:
     return any(pattern.lower() in model_lower for pattern in FALLBACK_MODELS)
 
 
+def _apply_chat_template_sidecar(model_path: Path, tokenizer) -> bool:
+    """Populate ``tokenizer.chat_template`` from a sidecar file if missing.
+
+    Newer HuggingFace repos ship the chat template as a standalone file
+    next to ``tokenizer_config.json`` instead of embedding it. Two
+    conventions exist:
+
+      - ``chat_template.jinja`` (raw jinja, the modern transformers
+        ≥4.43 default — DeepSeek V4, some Qwen builds)
+      - ``chat_template.json`` (single-key ``{"chat_template": "..."}``
+        wrapper — used by mlx-community Mistral Small 3.1 and newer
+        repos that follow the older HF Tokenizers sidecar convention)
+
+    Both ``AutoTokenizer.from_pretrained`` and ``mlx_lm.load``'s
+    ``TokenizerWrapper`` fail to auto-merge ``chat_template.json`` on
+    transformers ≤5.6 — ``tokenizer.chat_template`` comes back ``None``
+    and every ``/v1/chat/completions`` request 400s with
+    "Cannot use chat template functions". Surfaced on 2026-05-22
+    fresh-PyPI v0.6.65 onboarding sweep against
+    ``mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit``.
+
+    Returns True if a sidecar template was applied, False otherwise.
+    """
+    if getattr(tokenizer, "chat_template", None):
+        return False
+
+    jinja_path = model_path / "chat_template.jinja"
+    if jinja_path.exists():
+        # utf-8-sig strips a UTF-8 BOM if the file was saved with one —
+        tokenizer.chat_template = jinja_path.read_text(encoding="utf-8-sig")
+        logger.info("Chat template loaded from chat_template.jinja sidecar")
+        return True
+
+    json_path = model_path / "chat_template.json"
+    if json_path.exists():
+        try:
+            with open(json_path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(
+                f"Found chat_template.json at {json_path} but failed to parse: {e}"
+            )
+            return False
+        template = data.get("chat_template")
+        if isinstance(template, str) and template:
+            tokenizer.chat_template = template
+            logger.info("Chat template loaded from chat_template.json sidecar")
+            return True
+        logger.warning(
+            f"chat_template.json at {json_path} has no 'chat_template' string key; "
+            f"got keys={list(data.keys())}"
+        )
+    return False
+
+
+def _resolve_model_path(model_name: str) -> Path | None:
+    """Resolve a HuggingFace ``model_name`` to a local snapshot directory.
+
+    Returns ``None`` (instead of raising) when the model can't be located
+    locally — callers use this for best-effort sidecar lookup and should
+    skip the sidecar branch silently if the path can't be resolved
+    (offline / non-existent model / weird hub state).
+    """
+    local = Path(model_name)
+    if local.is_dir():
+        return local
+    try:
+        from huggingface_hub import snapshot_download
+
+        return Path(snapshot_download(model_name))
+    except Exception as e:
+        logger.debug(f"_resolve_model_path({model_name}) failed: {e}")
+        return None
+
+
 def _register_vendored_archs() -> None:
     """Make vendored model architectures visible to mlx-lm's importlib lookup.
 
@@ -121,6 +196,10 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
             # Try native mlx-lm load first (0.31+)
             model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
             logger.info("Gemma 4 loaded natively via mlx-lm")
+            if not getattr(tokenizer, "chat_template", None):
+                mp = _resolve_model_path(model_name)
+                if mp is not None:
+                    _apply_chat_template_sidecar(mp, tokenizer)
             return model, tokenizer
         except Exception as e:
             # Fall back to our wrapper for older mlx-lm versions
@@ -140,6 +219,15 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
         # layers and the model came back without a .mtp attribute;
         # if so, re-inject from the safetensors on disk.
         _try_inject_mtp_post_load(model, model_name)
+        # Sidecar chat-template recovery: AutoTokenizer doesn't merge
+        # ``chat_template.json`` on transformers ≤5.6, leaving
+        # ``tokenizer.chat_template`` None for newer mlx-community repos
+        # like Mistral Small 3.1. /v1/chat/completions then 400s. Try
+        # to load the sidecar before returning so chat endpoints work.
+        if not getattr(tokenizer, "chat_template", None):
+            mp = _resolve_model_path(model_name)
+            if mp is not None:
+                _apply_chat_template_sidecar(mp, tokenizer)
         return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers, OR newer model_types
@@ -189,6 +277,7 @@ def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     )
     # Inject MTP support if model has MTP config + weights
     _try_inject_mtp(model, model_path, config)
+    _apply_chat_template_sidecar(model_path, tokenizer)
     return model, tokenizer
 
 
@@ -260,6 +349,7 @@ def _load_non_strict(model_name: str, tokenizer_config: dict = None):
 
     model, _ = load_model(model_path, strict=False)
     tokenizer = load_tokenizer(model_path, tokenizer_config or {})
+    _apply_chat_template_sidecar(model_path, tokenizer)
     return model, tokenizer
 
 
@@ -305,16 +395,6 @@ def _load_with_tokenizer_fallback(model_name: str):
                 unk_token = config.get("unk_token", unk_token)
                 chat_template = config.get("chat_template")
 
-        # HF convention (transformers >=4.43): chat_template.jinja sits
-        # alongside tokenizer_config.json. DeepSeek V4 ships it that way.
-        # utf-8-sig strips a UTF-8 BOM if the file was saved with one —
-        # jinja2 would otherwise treat \ufeff as part of the template.
-        if chat_template is None:
-            chat_template_jinja = model_path / "chat_template.jinja"
-            if chat_template_jinja.exists():
-                chat_template = chat_template_jinja.read_text(encoding="utf-8-sig")
-                logger.info("Chat template loaded from chat_template.jinja")
-
         tokenizer = PreTrainedTokenizerFast(
             tokenizer_object=base_tokenizer,
             bos_token=bos_token,
@@ -323,10 +403,15 @@ def _load_with_tokenizer_fallback(model_name: str):
             pad_token="<pad>",
         )
 
-        # Set chat template if available
+        # Set chat template if available. Sidecar fallback (.jinja then
+        # .json) is delegated to ``_apply_chat_template_sidecar`` so the
+        # primary load path and this fallback stay in sync (Mistral
+        # Small 3.1 ships .json sidecar; DeepSeek V4 ships .jinja).
         if chat_template:
             tokenizer.chat_template = chat_template
             logger.info("Chat template loaded from tokenizer_config.json")
+        elif _apply_chat_template_sidecar(model_path, tokenizer):
+            pass  # helper logs the sidecar source
         elif _needs_tokenizer_fallback(model_name):
             # Use official Nemotron chat template with thinking support
             tokenizer.chat_template = NEMOTRON_CHAT_TEMPLATE


### PR DESCRIPTION
## Summary

Mistral Small 3.1, and likely most mlx-community / mistral-community / unsloth repos shipped in the past few months, are unusable via `/v1/chat/completions` on rapid-mlx v0.6.65. The model loads, the tokenizer loads, the server boots — but every chat call returns:

```
400 Chat template error: Cannot use chat template functions because tokenizer.chat_template is not set
```

`/v1/completions` (raw generation, no chat template) works fine.

## Root cause

Newer HF repos ship the chat template in a standalone **`chat_template.json`** sidecar (single-key wrapper `{"chat_template": "..."}`) next to `tokenizer_config.json` instead of embedding it. `transformers ≤5.6` `AutoTokenizer.from_pretrained` doesn't auto-merge that sidecar — the merge code only lands in transformers ≥6, but mlx-lm pins ≤5.x. Result: `tokenizer.chat_template is None`.

Repro on stock v0.6.65:
```python
from mlx_lm import load
model, tok = load("mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit")
assert tok.chat_template is None  # bug
```

Surfaced on 2026-05-22 fresh-PyPI v0.6.65 onboarding sweep against `mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit` (every chat call 400s).

## Fix

Extract `_apply_chat_template_sidecar(model_path, tokenizer)` helper in `vllm_mlx/utils/tokenizer.py`. When `tokenizer.chat_template` is missing it tries:

1. **`chat_template.jinja`** — transformers ≥4.43 standalone format (DeepSeek V4, some Qwen builds). Already partially handled in `_load_with_tokenizer_fallback`; now centralized with utf-8-sig BOM stripping preserved.
2. **`chat_template.json`** — older HF Tokenizers sidecar format. Unwraps `{"chat_template": "..."}`.

Apply at every return point where `mlx_lm.load` / `load_tokenizer` hands back a tokenizer with potentially-missing chat_template:

| Call site | Path |
|---|---|
| `load_model_with_fallback` main path | line ~213 |
| `load_model_with_fallback` Gemma 4 native path | line ~196 |
| `_load_strict_false` | VLM/MTP retry path |
| `_load_non_strict` | non-strict load |
| `_load_with_tokenizer_fallback` | Nemotron / vendored archs |

Defensive: malformed JSON / missing `chat_template` key / no sidecar file all log a warning and return False so downstream fallbacks (Nemotron template, default ChatML, raise) can still run. Never overwrites an already-populated chat_template.

## End-to-end verification

After the fix:
```
$ python3.12 -c "from vllm_mlx.utils.tokenizer import load_model_with_fallback; \
                  m, t = load_model_with_fallback('mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit'); \
                  print(t.chat_template is not None, len(t.chat_template))"
True 2081
```

Chat template now loads from the `.json` sidecar.

## Test plan

- [x] 8 new tests under `tests/test_chat_template_sidecar.py` pin each branch: `.json` wrapper unwrapping, `.jinja` sidecar, `.jinja` precedence over `.json`, no-overwrite of existing template, no-sidecar no-op, missing-key warning, malformed-JSON warning, UTF-8 BOM stripping.
- [x] Existing chat-template tests still pass (36 total in `test_chat_template_*.py` + `test_batched_engine_chat_template.py`).
- [x] End-to-end verified against the actual `mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit` weights — template now populates.
- [x] `ruff check` clean; `ruff format --check` clean.

## Out of scope

- The Mistral Small 3.1 alias also has `tool_call_parser: hermes` in `aliases.json` — should be `mistral` per the model's expected `[TOOL_CALLS]` JSON format. Separate trivial change, deferring to a follow-up so this PR stays scoped to the load-path fix.
- transformers ≥6 will auto-merge `chat_template.json` natively; when mlx-lm bumps to ≥6, this helper becomes a no-op but stays as a safety net for any sidecar conventions transformers still doesn't handle.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>