### PR TITLE
fix(logprobs): use chunk.tokens fallback when new_token_ids attribute missing

### DIFF
--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -699,6 +699,83 @@ class TestExtractStreamingTokenLogprobs:
         chunk = self._make_chunk(logprobs=[], new_text="hi", new_token_ids=[])
         assert _extract_streaming_token_logprobs(chunk, MagicMock(), top_k=3) == []
 
+    def test_logprobs_works_with_real_generation_output(self):
+        """Pre-fix bug: ``_extract_streaming_token_logprobs`` reached for
+        ``chunk.new_token_ids`` but that attribute exists on the engine's
+        internal ``RequestOutput`` — NOT on the public ``GenerationOutput``
+        dataclass the route actually receives. Every ``logprobs=true``
+        request returned HTTP 500 with
+        ``AttributeError: 'GenerationOutput' object has no attribute 'new_token_ids'``.
+
+        The earlier ``SimpleNamespace``-based tests in this class masked
+        the bug — they fabricated ``new_token_ids`` on the chunk stub.
+        This test uses the REAL dataclass so a future change can't
+        re-introduce the AttributeError without breaking pinning.
+
+        Surfaced on 2026-05-23 fresh-PyPI v0.6.65 onboarding sweep
+        against ``unsloth/Qwen3.6-27B-MLX-8bit``.
+        """
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        assert not hasattr(GenerationOutput, "new_token_ids"), (
+            "If new_token_ids was added to GenerationOutput, update this "
+            "test to also verify it's actually populated downstream — "
+            "the helper still needs the chunk.tokens fallback for any "
+            "engine path that forgets to populate the new field."
+        )
+
+        mock, arr = self._make_logprob_array()
+        tok = MagicMock()
+        tok.decode.return_value = "x"
+
+        chunk = GenerationOutput(
+            text="hi",
+            new_text="hi",
+            tokens=[7],
+            logprobs=mock,
+        )
+
+        with patch("numpy.array", return_value=arr):
+            result = _extract_streaming_token_logprobs(chunk, tok, top_k=3)
+
+        assert len(result) == 1, (
+            f"GenerationOutput chunk with one delta token must yield "
+            f"exactly one TokenLogProb entry; got {len(result)}. "
+            "Pre-fix this raised AttributeError → 500."
+        )
+
+    def test_logprobs_multi_token_real_generation_output(self):
+        """Multi-token delta on real ``GenerationOutput``: when an
+        upstream flush carries 3 tokens (``stream_interval > 1``), all 3
+        per-step logprob distributions must produce 3 TokenLogProb
+        entries. Pre-fix this also crashed via the missing attribute;
+        post-fix the ``chunk.tokens`` fallback supplies the per-step
+        token list correctly.
+        """
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.service.helpers import _extract_streaming_token_logprobs
+
+        mock_a, arr_a = self._make_logprob_array()
+        mock_b, arr_b = self._make_logprob_array()
+        mock_c, arr_c = self._make_logprob_array()
+        tok = MagicMock()
+        tok.decode.return_value = "x"
+
+        chunk = GenerationOutput(
+            text="abc",
+            new_text="abc",
+            tokens=[10, 11, 12],
+            logprobs=[mock_a, mock_b, mock_c],
+        )
+
+        with patch("numpy.array", side_effect=[arr_a, arr_b, arr_c]):
+            result = _extract_streaming_token_logprobs(chunk, tok, top_k=3)
+
+        assert len(result) == 3, (
+            f"3-token delta must yield 3 TokenLogProb entries; got {len(result)}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _validate_tool_call_params

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -499,15 +499,27 @@ def _extract_streaming_token_logprobs(
     steps (under ``stream_interval > 1``, after PR #210). The downstream
     SSE consumer expects one entry per *generated token*, not per flush
     — so we must iterate, pairing each per-step distribution with the
-    corresponding ``new_token_ids`` entry. Without this iteration the
-    list-form gets passed to ``_extract_token_logprob`` as one giant
-    flattened array, and ``argmax`` reads from concatenated unrelated
-    vocab dims (#220).
+    corresponding token id. Without this iteration the list-form gets
+    passed to ``_extract_token_logprob`` as one giant flattened array,
+    and ``argmax`` reads from concatenated unrelated vocab dims (#220).
+
+    The token-id source is ``chunk.tokens`` (the delta-token list per
+    ``GenerationOutput`` — populated by ``BatchedEngine.stream_chat`` as
+    ``tokens=output.new_token_ids``). The pre-fix code reached for
+    ``chunk.new_token_ids`` directly, but that attribute exists on
+    ``RequestOutput`` (engine internal) and was never added to
+    ``GenerationOutput`` (engine public surface) — so every real
+    streaming chunk raised ``AttributeError`` and the route returned
+    HTTP 500 on any ``logprobs=true`` request. The earlier
+    ``SimpleNamespace``-based tests masked this because they fabricated
+    a ``new_token_ids`` attribute on the chunk stub — pinned now by
+    ``test_logprobs_works_with_real_generation_output`` against the
+    actual dataclass.
     """
     if chunk.logprobs is None or not getattr(chunk, "new_text", None):
         return []
     lps = chunk.logprobs if isinstance(chunk.logprobs, list) else [chunk.logprobs]
-    tids = chunk.new_token_ids or ([chunk.tokens[-1]] if chunk.tokens else [0])
+    tids = getattr(chunk, "new_token_ids", None) or chunk.tokens or [0]
     return [
         _extract_token_logprob(lp, tid, tokenizer, top_k) for lp, tid in zip(lps, tids)
     ]


### PR DESCRIPTION
## Summary

Every `/v1/chat/completions` request with `logprobs: true` on rapid-mlx v0.6.65 returns HTTP 500. Affects all models (not model-specific). Surfaced on 2026-05-23 fresh-PyPI onboarding sweep.

```
500 Internal Server Error
AttributeError: 'GenerationOutput' object has no attribute 'new_token_ids'
  File "vllm_mlx/service/helpers.py", line 510, in _extract_streaming_token_logprobs
```

## Root cause

`_extract_streaming_token_logprobs` reaches for `chunk.new_token_ids` (line 510), but `new_token_ids` exists on the engine's internal `RequestOutput` (engine/request.py:214) — NOT on the public `GenerationOutput` dataclass (engine/base.py) that the route actually receives via `stream_chat`. `BatchedEngine.stream_chat` constructs `GenerationOutput(tokens=output.new_token_ids, ...)` at `engine/batched.py:1014` and `:1058` — the delta-token list ends up on the `tokens` field, not under the original name.

The existing `TestExtractStreamingTokenLogprobs` cases passed because they fabricated chunks via `SimpleNamespace(new_token_ids=[...], tokens=[...], ...)` — the stub had the attribute the real dataclass doesn't.

## Affected call sites

- **Non-stream `logprobs=true`** (`routes/chat.py:709-717`) — accumulates per-chunk logprobs internally via `stream_chat`.
- **Streaming `logprobs=true`** (`routes/chat.py:911`).

Both crash on the first chunk.

## Fix

Use `getattr(chunk, "new_token_ids", None) or chunk.tokens or [0]` so the helper falls back to `chunk.tokens` (which is the delta-token list in production). `getattr` keeps a hypothetical future `GenerationOutput.new_token_ids` working without re-introducing the crash.

## Test plan

- [x] 2 new regression tests in `TestExtractStreamingTokenLogprobs` use the REAL `GenerationOutput` dataclass:
  - `test_logprobs_works_with_real_generation_output` — single-token chunk.
  - `test_logprobs_multi_token_real_generation_output` — 3-token chunk from `stream_interval > 1`.
- [x] First test also asserts `not hasattr(GenerationOutput, "new_token_ids")` so anyone adding that field to the dataclass gets a fail pointing at the helper for in-lockstep updates.
- [x] All 8 pre-existing logprobs tests (SimpleNamespace-based, including the `test_list_pairs_with_new_token_ids` pinning) still pass.
- [x] Full chat-route regression suite passes (80 tests across `test_server_utils.py`, `test_chat_streaming_spec.py`, `test_chat_streaming_guided.py`, `test_chat_route_tool_choice_enforcement.py`).
- [x] `ruff check` clean; `ruff format --check` clean.

## Out of scope

- Adding `new_token_ids` as a first-class field on `GenerationOutput` for clarity: could be done but the current attribute is just a naming choice — `tokens` already carries the right data. Leaving the rename as a separate change so this fix stays minimal.
- The `stop: ["</think>"]` issue from the same sweep (sequence not honored) is a separate, harder problem — needs investigation in scheduler stop-string handling, not in this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>