### PR TITLE
fix(release-066): codex round-1 — positional GenerationOutput + tool_choice no-tools 400

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -264,3 +264,59 @@ def test_tool_choice_none_with_no_tools_is_noop():
         },
     )
     assert resp.status_code == 200, resp.text
+
+
+def test_tool_choice_specific_function_with_no_tools_returns_400():
+    """``tool_choice: {type:function, function:{name:X}}`` with no
+    ``tools`` array (or empty) is malformed — must return 400 instead
+    of silently passing through. Codex round-1 review of v0.6.66
+    caught the earlier guard ``if tc is not None and request.tools:``
+    skipping validation entirely for the no-tools case. Pin the fix
+    so future refactors don't reintroduce silent acceptance.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    # No ``tools`` key at all.
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do it"}],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+    assert "get_weather" in resp.text
+    # Empty ``tools`` array — same outcome.
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do it"}],
+            "tools": [],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+    assert "get_weather" in resp.text
+
+
+def test_tool_choice_function_missing_name_with_no_tools_returns_400():
+    """The ``function:{}`` malformed-payload check must also fire when
+    there are no ``tools`` — the validation is unconditional on the
+    ``tool_choice`` shape, not gated by ``tools`` truthiness.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do it"}],
+            "tool_choice": {"type": "function", "function": {}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -964,3 +964,83 @@ class TestConfigureLogging:
         assert _logging.getLogger("httpx").level == _logging.NOTSET
         server.configure_logging("INFO")
         assert _logging.getLogger("httpx").level == _logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# GenerationOutput field-ordering positional-compat regression
+# ---------------------------------------------------------------------------
+
+
+class TestGenerationOutputFieldOrder:
+    """Pin the dataclass field order so the engine's public-surface
+    positional-construction contract stays stable.
+
+    Codex round-1 review of v0.6.66 (PR #443) caught ``raw_text`` and
+    ``reasoning_text`` inserted at positions 2 and 3 of the dataclass,
+    silently rebinding ``GenerationOutput("text", [1, 2])`` so that
+    ``[1, 2]`` landed in ``raw_text`` (which expects ``str``) and
+    ``tokens`` defaulted to ``[]``. The fix moves both new fields to
+    the END of the dataclass after ``channel``. These tests pin that
+    the contract stays as: positions 0..9 are the v0.6.65 surface
+    (``text, tokens, prompt_tokens, completion_tokens, finish_reason,
+    new_text, finished, logprobs, channel``), and anything added after
+    that must be appended, never inserted.
+    """
+
+    def test_positional_text_tokens_binding(self):
+        """The minimal positional form — ``(text, tokens)`` — must bind
+        as it always did: text → ``.text``, list[int] → ``.tokens``.
+        """
+        out = GenerationOutput("hello", [1, 2, 3])
+        assert out.text == "hello"
+        assert out.tokens == [1, 2, 3]
+        # All optional fields take their defaults.
+        assert out.raw_text == ""
+        assert out.reasoning_text == ""
+        assert out.prompt_tokens == 0
+        assert out.completion_tokens == 0
+
+    def test_positional_full_v065_surface(self):
+        """Full positional construction of the v0.6.65 surface must
+        still bind to the right fields. Caller order:
+        text, tokens, prompt_tokens, completion_tokens, finish_reason,
+        new_text, finished, logprobs, channel.
+        """
+        out = GenerationOutput(
+            "T",
+            [9, 8],
+            10,
+            20,
+            "stop",
+            "delta",
+            True,
+            None,
+            "content",
+        )
+        assert out.text == "T"
+        assert out.tokens == [9, 8]
+        assert out.prompt_tokens == 10
+        assert out.completion_tokens == 20
+        assert out.finish_reason == "stop"
+        assert out.new_text == "delta"
+        assert out.finished is True
+        assert out.logprobs is None
+        assert out.channel == "content"
+        # New fields default to empty when not passed.
+        assert out.raw_text == ""
+        assert out.reasoning_text == ""
+
+    def test_field_order_appends_new_fields_at_end(self):
+        """Make the rule machine-checkable: ``raw_text`` and
+        ``reasoning_text`` must be the LAST two fields. If a refactor
+        ever reorders them back into the middle, this test fails loud
+        instead of producing silent positional-bind regressions.
+        """
+        from dataclasses import fields
+
+        names = [f.name for f in fields(GenerationOutput)]
+        assert names[-2:] == ["raw_text", "reasoning_text"], (
+            f"raw_text and reasoning_text must remain the LAST two fields "
+            f"of GenerationOutput to preserve positional-arg compatibility "
+            f"for the v0.6.65 surface. Current order: {names}"
+        )

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -18,27 +18,6 @@ class GenerationOutput:
     """
 
     text: str
-    # Pre-cleaning model output, preserved so the route's reasoning parser
-    # can see harmony channel markers that ``clean_output_text`` strips out
-    # of ``text``. Without this, ``HarmonyReasoningParser.extract_reasoning``
-    # on the non-stream + no-tool path runs on already-cleaned text and
-    # returns ``(None, None)`` — leaking the analysis channel into
-    # ``content`` and emitting empty ``reasoning_content`` to clients.
-    # Empty string default keeps callers that don't populate it working.
-    raw_text: str = ""
-    # Token-level reasoning extraction, populated by the engine via
-    # ``OutputRouter.feed_sequence`` for tokenizers it supports
-    # (Harmony / Gemma 4 / Qwen3 / DeepSeek R1 — see
-    # ``output_router.from_tokenizer``). This is the AUTHORITATIVE source
-    # of reasoning_content for non-streaming responses: it tracks channel
-    # state at the token level instead of regex-parsing the decoded text
-    # after the fact, so truncated outputs (``finish_reason=length``,
-    # no ``<|end|>`` terminator) still produce correct
-    # ``reasoning_content`` without leaking the analysis body into
-    # ``content``. Empty string means the engine didn't populate it
-    # (no router, or router failed) — routes fall back to the
-    # text-based ``ReasoningParser`` in that case. Issue #442.
-    reasoning_text: str = ""
     tokens: list[int] = field(default_factory=list)
     prompt_tokens: int = 0
     completion_tokens: int = 0
@@ -50,6 +29,31 @@ class GenerationOutput:
     logprobs: Any = None
     # Semantic channel: "content", "reasoning", "tool_call", or None
     channel: str | None = None
+    # NOTE: keep the following two fields LAST. They were added after v0.6.65
+    # and inserting them in the middle silently rebound positional
+    # constructor args for downstream callers (text, tokens, ...) — see
+    # codex round-1 review of the v0.6.66 release. New optional fields go
+    # at the end of this dataclass to preserve positional compatibility.
+    # Pre-cleaning model output, preserved so the route's reasoning parser
+    # can see harmony channel markers that ``clean_output_text`` strips out
+    # of ``text``. Without this, ``HarmonyReasoningParser.extract_reasoning``
+    # on the non-stream + no-tool path runs on already-cleaned text and
+    # returns ``(None, None)`` — leaking the analysis channel into
+    # ``content`` and emitting empty ``reasoning_content`` to clients.
+    raw_text: str = ""
+    # Token-level reasoning extraction, populated by the engine via
+    # ``OutputRouter.feed_sequence`` for tokenizers it supports
+    # (Harmony / Gemma 4 / Qwen3 / DeepSeek R1 — see
+    # ``output_router.from_tokenizer``). AUTHORITATIVE source of
+    # reasoning_content for non-streaming responses: it tracks channel
+    # state at the token level instead of regex-parsing the decoded text
+    # after the fact, so truncated outputs (``finish_reason=length``,
+    # no ``<|end|>`` terminator) still produce correct
+    # ``reasoning_content`` without leaking the analysis body into
+    # ``content``. Empty string means the engine didn't populate it
+    # (no router, or router failed) — routes fall back to the
+    # text-based ``ReasoningParser`` in that case. Issue #442.
+    reasoning_text: str = ""
 
 
 class BaseEngine(ABC):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -313,16 +313,28 @@ async def _create_chat_completion_impl(
     # leave tools untouched — ``"required"`` enforcement is tracked
     # separately under #442 (needs decoder-level constraints, PR #132).
     tc = request.tool_choice
-    if tc is not None and request.tools:
-        if tc == "none":
-            request.tools = None
-        elif isinstance(tc, dict) and tc.get("type") == "function":
+    if tc is not None:
+        # Validation runs even when ``tools`` is empty/None: the OpenAI spec
+        # treats ``tool_choice`` with a specific function but no matching
+        # ``tools`` entry as a malformed request (400), not a silent
+        # fall-through. Codex round-1 review of #446 flagged the previous
+        # guard ``if tc is not None and request.tools:`` as silently
+        # accepting these requests.
+        if isinstance(tc, dict) and tc.get("type") == "function":
             fn = tc.get("function") or {}
             target = fn.get("name")
             if not target:
                 raise HTTPException(
                     status_code=400,
                     detail=("tool_choice with type='function' requires function.name"),
+                )
+            if not request.tools:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"tool_choice references function {target!r} but the "
+                        "request has no 'tools' array"
+                    ),
                 )
             filtered = [t for t in request.tools if t.function.get("name") == target]
             if not filtered:
@@ -334,6 +346,8 @@ async def _create_chat_completion_impl(
                     ),
                 )
             request.tools = filtered
+        elif tc == "none" and request.tools:
+            request.tools = None
 
     # Save original messages (clean dicts) for cloud routing BEFORE
     # local mutations (extract_multimodal_content, developer→system, suffix injection).


### PR DESCRIPTION
## Summary
Two P1 fixes caught by codex on the v0.6.66 release candidate. **Must merge before bumping** since both touch behavior that ships in the 0.6.66 wheel.

- **P1-A: `GenerationOutput` positional regression** — PR #443 inserted `raw_text`/`reasoning_text` at positions 2/3 of the dataclass, breaking `GenerationOutput("text", [tokens])` positional construction (silently binds tokens to `raw_text`). Fix: move both to END after `channel`. Internal call sites are all keyword-args so no in-tree breakage, but the dataclass is engine public surface.
- **P1-B: `tool_choice` no-tools silent pass** — PR #446 guarded the validation behind `if tc is not None and request.tools:`. `tool_choice={"type":"function","function":{"name":"x"}}` with no `tools` array proceeded silently instead of returning 400. Fix: widen guard, raise 400 explicitly when `tools` is missing or doesn't contain the named function.

## Regression tests added
- `tests/test_server_utils.py::TestGenerationOutputFieldOrder` (3 cases — positional bind, full v0.6.65 surface, machine-checkable "last two fields" invariant)
- `tests/test_chat_route_tool_choice_enforcement.py::test_tool_choice_specific_function_with_no_tools_returns_400`
- `tests/test_chat_route_tool_choice_enforcement.py::test_tool_choice_function_missing_name_with_no_tools_returns_400`

## Validation
- 13/13 targeted tool_choice + field-order tests pass
- `make smoke` — lint + audit + 3787 unit tests all green
- `make release-smoke` — clean-room install+import green
- Codex round 2 verdict: **CONVERGED — no P0/P1 remaining**

## Test plan
- [x] Targeted tests pass
- [x] Full unit suite passes
- [x] Release-smoke passes
- [x] Codex round 2 converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)