### PR TITLE
chore: bump version to 0.6.66

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.65"
+version = "0.6.66"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Cuts release **v0.6.66**. Bundles the fresh-PyPI v0.6.65 onboarding sweep fixes:

| # | Fix |
|---|---|
| #440 | harmony reasoning_content rescue on non-stream + no-tools path |
| #441 | harmony role-name token suppression between `<\|start\|>` and `<\|channel\|>` |
| #443 | OutputRouter for non-stream reasoning extraction (closes #442) |
| #446 | `tool_choice=none` + specific-function prompt-level enforcement (closes #445) |
| #449 | `chat_template.json` sidecar loader (Mistral Small 3.1 et al.) |
| #450 | logprobs `chunk.tokens` fallback when `new_token_ids` absent (HTTP 500 fix) |
| #451 | codex round-1: `GenerationOutput` positional regression + `tool_choice` no-tools 400 |

## Release SOP — all 11 gates green
1. ✅ `make release-smoke` — clean-room install+import
2. ✅ Codex review × 2 rounds — round 1 found 2 P1s (fixed in #451), **round 2 CONVERGED**
3. ✅ CLI ↔ Config fidelity audit (exit 0)
4. ✅ `make smoke` — lint + audit + 3787 unit tests
5. ✅ `make stress` — 8/8 scenarios on qwen3.5-4b
6. ✅ E2E real-server repro of every fix on qwen3.5-4b / mistral-24b / gpt-oss-20b
7. ✅ Integration tests: anthropic SDK 5/5, pydantic_ai 6/6, smolagents 4/4
8. ✅ Microbenchmark — all changed paths sub-microsecond per request
9. ✅ Server latency — 136 tok/s stable (stdev 6) on qwen3.5-4b
10. ✅ MLX-version-bump gate — no mlx/mlx-lm/mlx-vlm bump
11. ✅ Auto-detection escape-hatch gate — no new auto-routing helpers in diff

## Test plan
- [x] All 11 release SOP gates pass
- [ ] After merge: auto-release.yml fires → tag `v0.6.66` → publish.yml → PyPI + Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)