### PR TITLE
fix(streaming): populate reasoning_tokens in usage chunk for OutputRouter models

### DIFF
--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -116,6 +116,52 @@ class TestStreamingPostProcessorChannelRouted:
         assert events[0].content == "Hello"
         parser.extract_reasoning_streaming.assert_not_called()
 
+    def test_channel_routed_accumulators_populated(self):
+        """OutputRouter path must update accumulated_text + accumulated_reasoning.
+
+        Regression for v0.6.66 onboarding sweep finding: the streaming
+        usage chunk dropped ``completion_tokens_details.reasoning_tokens``
+        entirely for Gemma 4 / harmony because ``_process_channel_routed``
+        emitted events to the client but never updated the per-processor
+        accumulators that ``_build_usage`` reads to compute the
+        reasoning/content split. Confirmed by parallel onboarding agents
+        on gemma-4-26b and gpt-oss-20b.
+        """
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        # Interleave reasoning + content chunks across multiple calls
+        # (the real stream emits one channel-tagged token at a time).
+        pp.process_chunk(_make_output("Let ", channel="reasoning"))
+        pp.process_chunk(_make_output("me ", channel="reasoning"))
+        pp.process_chunk(_make_output("think.", channel="reasoning"))
+        pp.process_chunk(_make_output("The ", channel="content"))
+        pp.process_chunk(_make_output("answer ", channel="content"))
+        pp.process_chunk(_make_output("is 42.", channel="content"))
+
+        assert pp.accumulated_reasoning == "Let me think."
+        assert pp.accumulated_text == "The answer is 42."
+
+    def test_channel_routed_accumulators_skip_empty_after_sanitize(self):
+        """Sanitized-empty chunks must NOT accumulate (avoid phantom tokens).
+
+        ``sanitize_output`` can return None when a chunk is entirely
+        special tokens; the accumulator must respect that so the usage
+        char-ratio doesn't include suppressed content.
+        """
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        pp.process_chunk(_make_output("real ", channel="content"))
+        pp.process_chunk(_make_output("<|endoftext|>", channel="content"))
+        pp.process_chunk(_make_output("text", channel="content"))
+
+        # Special-token-only chunk is dropped from accumulation.
+        assert "<|endoftext|>" not in pp.accumulated_text
+        assert pp.accumulated_text == "real text"
+
 
 class TestStreamingPostProcessorReasoning:
     """Tests for text-based reasoning parser integration."""

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -283,6 +283,19 @@ class StreamingPostProcessor:
             if not content:
                 content = None
 
+        # Accumulate post-sanitize so the final usage chunk can compute
+        # ``completion_tokens_details.reasoning_tokens`` via _build_usage's
+        # proportional split (PR #453 logic). Without this, OutputRouter
+        # models (Gemma 4, harmony/gpt-oss) emit reasoning_content deltas
+        # to the client but leave both accumulators empty — _build_usage
+        # then sees ``reasoning_text=None`` and omits the field entirely,
+        # creating stream/non-stream usage shape drift. Verified on
+        # gemma-4-26b + gpt-oss-20b during the v0.6.66 onboarding sweep.
+        if content:
+            self.accumulated_text += content
+        if reasoning:
+            self.accumulated_reasoning += reasoning
+
         # When finish_reason is set, emit ONE finish event with content/reasoning
         # merged in to avoid double-emission.
         if finish_reason:


### PR DESCRIPTION
## Summary

`_process_channel_routed` (the OutputRouter path used by Gemma 4 + harmony/gpt-oss) emitted reasoning/content StreamEvents to the client but never updated `self.accumulated_text` / `self.accumulated_reasoning`. The final streaming usage chunk reads those accumulators to compute the proportional reasoning/content split added in #453 — empty accumulators caused `_build_usage` to see `reasoning_text=None` and silently drop `completion_tokens_details.reasoning_tokens` from the usage shape entirely, creating stream vs. non-stream drift.

## Why this matters

OpenAI-compatible clients depend on `usage.completion_tokens_details.reasoning_tokens` to bill / display reasoning vs. content separately. Today on rapid-mlx v0.6.66:
- Non-stream: `usage.completion_tokens_details.reasoning_tokens=16` ok
- Stream + `include_usage=true`: `usage = {prompt_tokens, completion_tokens, total_tokens}` — field missing

Independently reproduced by parallel onboarding agents on:
- `gemma-4-26b` (mlx-community/gemma-4-26b-a4b-it-4bit)
- `gpt-oss-20b` (mlx-community/gpt-oss-20b-MXFP4-Q8)

Both showed clean non-stream + missing-field stream — confirming this is family-wide for OutputRouter models, not model-specific.

## What changed

- `vllm_mlx/service/postprocessor.py`: accumulate post-sanitize `content`/`reasoning` into `self.accumulated_text` / `self.accumulated_reasoning` just before emitting events. Mirrors the text-parser path semantics so `_build_usage` (`_u.text = processor.accumulated_text`, `_build_usage(_u, processor.accumulated_reasoning or None)` at chat.py:1185) gets the same shape it does for text-parser models.
- `tests/test_postprocessor.py`: two regression tests pin the contract — interleaved channel chunks populate both accumulators correctly; sanitized-empty chunks don't inflate the char ratio.

## Out of scope (deferred)

This PR does NOT address two streaming routing bugs the same onboarding sweep surfaced:
- #444 — harmony streaming tool_calls leak as raw `commentary to=functions...` content deltas
- #447 — Gemma 4 streaming tool-call leaks `thought\n<reasoning body>` into delta.content

Both need OutputRouter channel-detection investigation (router logs the channel correctly, but `output.channel` isn't being set on tool-call paths in stream mode). Filed separately, fix in a follow-up.

## Test plan

- [x] `pytest tests/test_postprocessor.py tests/test_chat_streaming_spec.py tests/test_server_utils.py` — 157 passed
- [x] `ruff check + format --check` on changed files — clean
- [x] pr_validate: fetch/supply_chain/lint/targeted_tests/full_unit all PASS (3935 passed)
- [x] Live stream test against gpt-oss-20b — final usage chunk: `usage.completion_tokens_details.reasoning_tokens=116` (pre-fix: field MISSING per onboarding agent repro)