### PR TITLE
fix(engine): propagate per-token logprobs through OutputRouter (gemma4 + harmony)

### DIFF
--- a/tests/test_batched_engine_output_router.py
+++ b/tests/test_batched_engine_output_router.py
@@ -129,6 +129,123 @@ async def test_stream_chat_routes_supported_tokenizer_channels():
 
 
 @pytest.mark.asyncio
+async def test_router_propagates_per_token_logprobs_to_routed_outputs():
+    """OutputRouter must forward source.logprobs to each routed chunk.
+
+    Regression for the v0.6.66 onboarding sweep finding: ``logprobs=true +
+    top_logprobs=5`` requests against harmony/gpt-oss returned HTTP 200
+    with no ``logprobs`` field in the response. Root cause: the engine's
+    ``_make_routed_output`` hardcoded ``logprobs=None`` on every routed
+    chunk, so ``_extract_streaming_token_logprobs`` saw
+    ``chunk.logprobs is None`` and returned ``[]`` for every chunk;
+    ``token_logprobs_list`` stayed empty and the route built a response
+    with ``choice_logprobs=None``. PR #450 fixed a related AttributeError
+    on the non-router path but couldn't surface this gap because its
+    tests use single-token GenerationOutput stubs that never go through
+    the router.
+    """
+    engine = _make_engine(FakeTokenizer(HARMONY_VOCAB))
+
+    sentinel_lps = ["LP-Reason", "LP-ing", "LP-Answer"]
+
+    async def fake_stream_generate(**kwargs):
+        # Single-token flushes (stream_interval=1) — exactly the shape
+        # OutputRouter hits in production for content/reasoning tokens.
+        yield GenerationOutput(
+            text="",
+            new_text="<|channel|>analysis<|message|>",
+            tokens=[200005, 35644, 200008],
+            finished=False,
+            logprobs=None,  # control marker tokens carry no per-step lp
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="Reason",
+            tokens=[2],
+            finished=False,
+            logprobs=sentinel_lps[0],
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="ing",
+            tokens=[3],
+            finished=False,
+            logprobs=sentinel_lps[1],
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="<|start|><|channel|>final<|message|>",
+            tokens=[200006, 200005, 17196, 200008],
+            finished=False,
+            logprobs=None,
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="Answer",
+            tokens=[4],
+            finished=True,
+            finish_reason="stop",
+            logprobs=sentinel_lps[2],
+        )
+
+    engine.stream_generate = fake_stream_generate
+
+    outputs = await _collect(
+        engine.stream_chat(messages=[{"role": "user", "content": "hi"}])
+    )
+
+    text_lps = [(o.new_text, o.logprobs) for o in outputs if o.new_text]
+    assert text_lps == [
+        ("Reason", sentinel_lps[0]),
+        ("ing", sentinel_lps[1]),
+        ("Answer", sentinel_lps[2]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_propagates_logprobs_list_form_per_index():
+    """When source.logprobs is a list, each routed token must pair with logprobs[i].
+
+    The ``stream_interval > 1`` path (PR #210) accumulates per-step
+    distributions into ``list[mx.array]`` paired with a multi-token
+    ``tokens`` list. The router must split them back out so each routed
+    chunk carries the correct per-step distribution — passing the whole
+    list to every routed chunk would let ``_extract_streaming_token_logprobs``
+    re-iterate the full list per chunk and emit duplicate entries.
+    """
+    engine = _make_engine(FakeTokenizer(HARMONY_VOCAB))
+
+    async def fake_stream_generate(**kwargs):
+        yield GenerationOutput(
+            text="",
+            new_text="<|channel|>final<|message|>",
+            tokens=[200005, 17196, 200008],
+            finished=False,
+            logprobs=["LP-channel", "LP-final", "LP-message"],
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="ReasoningAnswer",
+            tokens=[2, 4],
+            finished=True,
+            finish_reason="stop",
+            logprobs=["LP-Reason", "LP-Answer"],
+        )
+
+    engine.stream_generate = fake_stream_generate
+
+    outputs = await _collect(
+        engine.stream_chat(messages=[{"role": "user", "content": "hi"}])
+    )
+
+    text_lps = [(o.new_text, o.logprobs) for o in outputs if o.new_text]
+    assert text_lps == [
+        ("Reason", "LP-Reason"),
+        ("Answer", "LP-Answer"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_chat_keeps_think_tag_tokenizers_on_legacy_path():
     """Think-tag routers are detected but not engine-enabled until validated."""
     engine = _make_engine(FakeTokenizer(QWEN3_VOCAB))

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1300,6 +1300,7 @@ class BatchedEngine(BaseEngine):
         new_text: str | None = None,
         finished: bool = False,
         finish_reason: str | None = None,
+        logprobs=None,
     ) -> GenerationOutput:
         return GenerationOutput(
             text=source.text,
@@ -1309,7 +1310,7 @@ class BatchedEngine(BaseEngine):
             completion_tokens=source.completion_tokens,
             finished=finished,
             finish_reason=finish_reason,
-            logprobs=None,
+            logprobs=logprobs,
             channel=_channel_name(event.channel),
         )
 
@@ -1375,9 +1376,29 @@ class BatchedEngine(BaseEngine):
                 yield output
                 continue
 
+            # Normalize source logprobs to a per-step list so each routed
+            # output can carry its own per-token distribution. Without this,
+            # OutputRouter models (gemma4, harmony/gpt-oss) silently drop
+            # ALL logprobs to the route — every ``logprobs=true`` request
+            # returns a response missing the ``logprobs`` field entirely
+            # because ``_extract_streaming_token_logprobs`` sees
+            # ``chunk.logprobs is None`` for every routed chunk. Confirmed
+            # on gpt-oss-20b PyPI v0.6.66 during the 2026-05-23 onboarding
+            # sweep. PR #450 fixed the pre-existing AttributeError on the
+            # non-routed path but couldn't surface this gap because its
+            # tests use single-token GenerationOutput stubs that never go
+            # through the router.
+            src_logprobs = output.logprobs
+            if isinstance(src_logprobs, list):
+                lps_per_step = src_logprobs
+            elif src_logprobs is not None:
+                lps_per_step = [src_logprobs]
+            else:
+                lps_per_step = None
+
             routed_outputs: list[GenerationOutput] = []
             try:
-                for token_id in token_ids:
+                for tok_idx, token_id in enumerate(token_ids):
                     event = router.feed(token_id)
                     if event is None:
                         continue
@@ -1393,15 +1414,26 @@ class BatchedEngine(BaseEngine):
                     # and harmony — caught on gemma-4-26b post-v0.6.61.
                     if event.channel == Channel.TOOL_CALL:
                         event_text = event.text
+                        # Tool-call channel aggregates many tokens; the
+                        # OpenAI spec doesn't define per-token logprobs for
+                        # tool_calls deltas, so leave them off — matches
+                        # pre-fix behavior for this channel only.
+                        token_logprob = None
                     else:
                         event_text = (
                             output.new_text if len(token_ids) == 1 else event.text
+                        )
+                        token_logprob = (
+                            lps_per_step[tok_idx]
+                            if lps_per_step is not None and tok_idx < len(lps_per_step)
+                            else None
                         )
                     routed_outputs.append(
                         self._make_routed_output(
                             output,
                             event,
                             new_text=event_text,
+                            logprobs=token_logprob,
                         )
                     )
             except Exception as e:


### PR DESCRIPTION
## Summary

`_make_routed_output` (in `vllm_mlx/engine/batched.py`) hardcoded `logprobs=None` on every routed chunk, so for every OutputRouter model (Gemma 4, harmony/gpt-oss) the route's `_extract_streaming_token_logprobs` saw `chunk.logprobs is None` and returned `[]`. The non-stream chat path internally iterates `stream_chat` and accumulates per-chunk logprobs into `token_logprobs_list` — empty list → `choice_logprobs = None` → response shipped with no `logprobs` field at all on a 200 OK.

Confirmed on gpt-oss-20b fresh PyPI v0.6.66 during the 2026-05-23 onboarding sweep. PR #450 fixed a separate AttributeError on the non-router path (qwen3.5-4b etc.) but couldn't surface this gap because its tests construct single-token GenerationOutput stubs that never go through `_stream_with_output_router`.

## Repro (before fix)

```bash
curl -s -X POST http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"hello"}],"max_tokens":10,"logprobs":true,"top_logprobs":5}' \
  | jq '.choices[0] | keys'
# Pre-fix:  ["index","message","finish_reason"]   ← no logprobs
# Post-fix: ["index","message","finish_reason","logprobs"]
```

## What changed

- `vllm_mlx/engine/batched.py`:
  - `_make_routed_output` gains a `logprobs` kwarg (was hardcoded `None`).
  - Routing loop in `_stream_with_output_router` normalizes `output.logprobs` into a per-step list and pairs each routed token with the corresponding step's distribution by index.
  - Tool-call channel explicitly keeps `logprobs=None` (OpenAI streaming spec doesn't define per-token logprobs for tool_calls deltas).
- `tests/test_batched_engine_output_router.py`:
  - `test_router_propagates_per_token_logprobs_to_routed_outputs` — single-token-flush (stream_interval=1, the common path).
  - `test_router_propagates_logprobs_list_form_per_index` — multi-token-flush (stream_interval > 1, PR #210 path) pins index-alignment between `tokens[i]` and `logprobs[i]`.

## Out of scope (deferred)

This PR does NOT address:
- #444 / #455 — OutputRouter streaming tool_calls leak as content/text deltas (separate routing investigation).
- #447 — Gemma 4 streaming thought-marker leak (same family).
- Minor schema gap from this iteration's hybrid agent (missing `model` field accepts 200 with silent fallback) — separate one-line fix.

## Test plan

- [x] `pytest tests/test_batched_engine_output_router.py tests/test_server_utils.py tests/test_postprocessor.py tests/test_engine_router_non_stream.py tests/test_finalize_harmony_raw_text.py tests/test_chat_streaming_spec.py` — 183 passed
- [x] `ruff check + format` clean
- [x] Live test against gpt-oss-20b on the editable repo branch: `logprobs:true + top_logprobs:5` → `choice.logprobs.content` populated with 7 tokens, each with full top_logprobs distribution (pre-fix: field absent from response entirely)
- [x] pr_validate MERGE-SAFE (run below)