### PR TITLE
fix(mllm): propagate VLM image fetch errors to HTTP 400 (#457)

### DIFF
--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -200,6 +200,61 @@ class TestImageProcessing:
         result = process_image_input({"url": test_image_path})
         assert Path(result).exists()
 
+    def test_prepare_images_raises_on_fetch_failure(self, monkeypatch):
+        """MLLMModel._prepare_images must raise (not swallow) image-fetch errors.
+
+        Regression for #457: image-fetch errors used to be caught with
+        ``try/except + logger.warning + continue``, leaving the request to
+        proceed with zero images. VLMs then returned HTTP 200 + empty
+        completion + ``finish_reason=length`` (or hallucinated content from
+        no input), which was indistinguishable from a model refusal.
+
+        The fix raises ``ValueError("Failed to process image: ...")``, which
+        the chat/anthropic route exception handlers convert to HTTP 400 with
+        a descriptive detail.
+        """
+        from vllm_mlx import models
+        from vllm_mlx.models.mllm import MLXMultimodalLM
+
+        def _boom(img):
+            raise RuntimeError("404 Client Error: NOT FOUND for url: http://x/y.jpg")
+
+        monkeypatch.setattr(models.mllm, "process_image_input", _boom)
+
+        # Construct minimally — _prepare_images doesn't touch self at all,
+        # so __new__ avoids the heavy __init__ (no model load).
+        instance = MLXMultimodalLM.__new__(MLXMultimodalLM)
+
+        with pytest.raises(ValueError, match="Failed to process image"):
+            instance._prepare_images(["http://x/y.jpg"])
+
+    def test_prepare_images_propagates_first_failure(self, monkeypatch):
+        """First image failure raises immediately — no partial-image fallback.
+
+        OpenAI's GPT-4V fails strict on any image error. Mirroring that
+        prevents the silent-partial-failure mode where some images load but
+        others get skipped and the model answers based on incomplete input.
+        """
+        from vllm_mlx import models
+        from vllm_mlx.models.mllm import MLXMultimodalLM
+
+        call_count = {"n": 0}
+
+        def _boom_on_second(img):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return "/tmp/ok.jpg"
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(models.mllm, "process_image_input", _boom_on_second)
+        instance = MLXMultimodalLM.__new__(MLXMultimodalLM)
+
+        with pytest.raises(ValueError, match="Failed to process image"):
+            instance._prepare_images(["ok", "bad"])
+
+        # Failed on second image (after first succeeded) — strict semantics.
+        assert call_count["n"] == 2
+
 
 class TestVideoProcessing:
     """Test video processing functions."""

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -995,6 +995,87 @@ class TestMLLMSchedulerIntegration:
             await scheduler.stop()
 
 
+class TestMLLMSchedulerErrorPropagation:
+    """Pin the contract that scheduler client errors (image/video fetch
+    failures) surface to the route as exceptions — NOT as silent
+    HTTP 200 + empty content + finish_reason=length.
+
+    Regression for #457: prior behavior was that the scheduler's
+    ``except (ValueError, RuntimeError)`` around ``batch_generator.next()``
+    caught image-fetch errors raised from ``mllm_batch_generator.py:485``
+    and synthesized a fake-success RequestOutput with empty text and
+    ``finish_reason="length"``. The route layer then returned 200 OK,
+    making client errors indistinguishable from model refusals or
+    aggressive max_tokens caps.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stream_outputs_raises_when_request_output_has_error(self):
+        """When a queued RequestOutput carries ``error``, stream_outputs
+        must raise ValueError instead of yielding the fake-success output."""
+        import asyncio
+
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import RequestOutput
+
+        sched = MLLMScheduler.__new__(MLLMScheduler)
+        sched.output_queues = {}
+
+        req_id = "req-test-image-fail"
+        queue: asyncio.Queue = asyncio.Queue()
+        sched.output_queues[req_id] = queue
+
+        await queue.put(
+            RequestOutput(
+                request_id=req_id,
+                output_text="",
+                finished=True,
+                error="Failed to process image: 404 Client Error",
+                finish_reason="error",
+            )
+        )
+
+        with pytest.raises(
+            ValueError, match=r"Failed to process image: 404 Client Error"
+        ):
+            async for _ in sched.stream_outputs(req_id):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_stream_outputs_yields_normally_when_no_error(self):
+        """Non-error outputs MUST continue to flow through stream_outputs
+        unchanged — the error check is additive, not a behavior swap."""
+        import asyncio
+
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import RequestOutput
+
+        sched = MLLMScheduler.__new__(MLLMScheduler)
+        sched.output_queues = {}
+
+        req_id = "req-test-normal"
+        queue: asyncio.Queue = asyncio.Queue()
+        sched.output_queues[req_id] = queue
+
+        await queue.put(
+            RequestOutput(
+                request_id=req_id,
+                output_text="hello",
+                new_text="hello",
+                finished=True,
+                finish_reason="stop",
+            )
+        )
+
+        outputs = []
+        async for output in sched.stream_outputs(req_id):
+            outputs.append(output)
+
+        assert len(outputs) == 1
+        assert outputs[0].finish_reason == "stop"
+        assert outputs[0].error is None
+
+
 # Run tests
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -671,7 +671,8 @@ class MLLMScheduler:
             except (ValueError, RuntimeError) as e:
                 # Oversized prompt or other unrecoverable error — fail all
                 # running requests instead of retrying forever.
-                logger.error(f"Batch generation failed: {e}")
+                err_msg = str(e)
+                logger.error(f"Batch generation failed: {err_msg}")
                 error_ids = set(self.running.keys())
 
                 # Remove from batch generator BEFORE scheduler cleanup so
@@ -685,16 +686,32 @@ class MLLMScheduler:
                     if uids_to_remove:
                         self.batch_generator.remove(uids_to_remove)
 
+                # Differentiate CLIENT errors (image/video fetch failures)
+                # from SERVER errors (oversized prompt, runtime crash).
+                # Client errors get a non-None ``error`` field so
+                # ``stream_outputs`` can raise — letting the route layer
+                # convert to HTTP 400 instead of the previous silent
+                # 200+empty-content+finish_reason=length pattern that
+                # caused #457 (Anthropic SDK clients + curl saw a 200 OK
+                # with no signal that the image fetch had failed).
+                #
+                # Non-client errors keep the legacy
+                # finish_reason="length"+empty-text behavior to avoid
+                # breaking callers that handle oversized-prompt as a soft
+                # truncation rather than a hard failure.
+                is_client_error = (
+                    "Failed to process image" in err_msg
+                    or "Failed to process video" in err_msg
+                )
                 # Create error outputs (queue delivery deferred to caller).
-                # finish_reason="length" — OpenAI spec-compliant aborted
-                # signal; see scheduler.py for full rationale.
                 for request_id in error_ids:
                     output.outputs.append(
                         RequestOutput(
                             request_id=request_id,
                             output_text="",
                             finished=True,
-                            finish_reason="length",
+                            error=err_msg if is_client_error else None,
+                            finish_reason="error" if is_client_error else "length",
                         )
                     )
                 output.finished_request_ids = error_ids
@@ -958,6 +975,14 @@ class MLLMScheduler:
                 if output is None:
                     finished_normally = True
                     break
+                if output.error:
+                    # Surface scheduler-side client errors (image/video
+                    # fetch failures, etc.) as exceptions so the route
+                    # layer can map to a meaningful HTTP status (#457).
+                    # Mark finished BEFORE raising so the finally block
+                    # doesn't double-abort what's already cleaned up.
+                    finished_normally = True
+                    raise ValueError(output.error)
                 yield output
                 if output.finished:
                     finished_normally = True

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -809,14 +809,20 @@ class MLXMultimodalLM:
         return self.processor.tokenizer
 
     def _prepare_images(self, images: list) -> list[str]:
-        """Process image inputs and return local file paths."""
+        """Process image inputs and return local file paths.
+
+        Image-fetch failures are raised (not swallowed) so the route layer
+        can convert to HTTP 400 — the silent-failure pattern (continue with
+        zero images) caused #457 where requests hit upstream 4xx returned
+        200 with empty completion + finish_reason=length.
+        """
         processed = []
         for img in images:
             try:
                 path = process_image_input(img)
-                processed.append(path)
             except Exception as e:
-                logger.warning(f"Failed to process image: {e}")
+                raise ValueError(f"Failed to process image: {e}") from e
+            processed.append(path)
         return processed
 
     def _prepare_video(

--- a/vllm_mlx/multimodal_processor.py
+++ b/vllm_mlx/multimodal_processor.py
@@ -121,16 +121,21 @@ class MultimodalProcessor:
         from mlx_vlm.utils import prepare_inputs
 
         # Process raw images
+        # Image-fetch failures used to be swallowed with logger.warning + continue,
+        # leaving the request to proceed with an empty image list. The model would
+        # then either emit an empty completion (case in #457) or hallucinate plausible
+        # content from no input. Raise to surface a clean HTTP 400 at the route layer
+        # — mirrors the pattern already used by mllm_batch_generator.py:485.
         all_images = []
         if images:
             for img in images:
                 try:
                     path = process_image_input(img)
-                    all_images.append(path)
                 except Exception as e:
-                    logger.warning(f"Failed to process image: {e}")
+                    raise ValueError(f"Failed to process image: {e}") from e
+                all_images.append(path)
 
-        # Extract frames from videos
+        # Extract frames from videos — same semantics as images above.
         if videos:
             for video in videos:
                 try:
@@ -141,10 +146,10 @@ class MultimodalProcessor:
                         max_frames=video_max_frames,
                     )
                     frame_paths = save_frames_to_temp(frames)
-                    all_images.extend(frame_paths)
-                    logger.debug(f"Extracted {len(frame_paths)} frames from video")
                 except Exception as e:
-                    logger.warning(f"Failed to process video: {e}")
+                    raise ValueError(f"Failed to process video: {e}") from e
+                all_images.extend(frame_paths)
+                logger.debug(f"Extracted {len(frame_paths)} frames from video")
 
         # Determine add_special_tokens based on model type
         if self.config and self.config.model_type in ["gemma3", "gemma3n"]:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -202,6 +202,12 @@ async def create_anthropic_message(
                 raise HTTPException(
                     status_code=400, detail=f"Chat template error: {err_msg}"
                 )
+            # Multimodal fetch failures → 400 (parity with chat route, #457).
+            if (
+                "Failed to process image" in err_msg
+                or "Failed to process video" in err_msg
+            ):
+                raise HTTPException(status_code=400, detail=err_msg)
             raise
         if output is None:
             return Response(status_code=499)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -782,6 +782,13 @@ async def _create_chat_completion_impl(
             raise HTTPException(
                 status_code=400, detail=f"Chat template error: {err_msg}"
             )
+        # Image / video fetch failures surface from multimodal_processor
+        # (and models/mllm.py:_prepare_images) as ValueError with a
+        # "Failed to process image|video" prefix. Convert to 400 so VLM
+        # clients get a clear error instead of a 200 with empty completion
+        # (#457).
+        if "Failed to process image" in err_msg or "Failed to process video" in err_msg:
+            raise HTTPException(status_code=400, detail=err_msg)
         raise
     finally:
         if cfg.gc_control and gc_was_enabled:


### PR DESCRIPTION
## Summary

Fixes #457. VLM requests with unreachable `image_url` (404, network error, malformed URL) used to return HTTP 200 with empty assistant content and `finish_reason="length"` despite 0 tokens generated. Now returns HTTP 400 with the underlying fetch error as detail.

## Root cause (two layers)

**Layer 1 — image-fetch sites silently swallowed errors:**
- `vllm_mlx/multimodal_processor.py:126-131` and `vllm_mlx/models/mllm.py:_prepare_images` (line 811-820) caught `Exception` → `logger.warning` → continued with zero images.
- `mllm_batch_generator.py:485` already raised ValueError (per PR #416's earlier fix).

**Layer 2 — MLLM scheduler swallowed the raised ValueError:**
- `mllm_scheduler.py:_step_no_queue` (lines 671-702) caught the raised ValueError via `except (ValueError, RuntimeError)` and synthesized a fake-success `RequestOutput` with `output_text=""` and `finish_reason="length"` for all batched requests. The route then returned 200 OK.

The agent's repro went through MLLMScheduler → MLLMBatchGenerator (which DID raise) → swallowed by Layer 2. So Layer 1 sites alone wouldn't have surfaced the bug, but they were latent silent-drop patterns waiting to be hit.

## Fix layers

| File | Change |
|---|---|
| `multimodal_processor.py`, `models/mllm.py:_prepare_images` | Replace `warning+continue` with `raise ValueError("Failed to process image: ...")` — strict semantics (any image fail fails the request) match OpenAI GPT-4V. |
| `mllm_scheduler.py` | Differentiate CLIENT errors (image/video fetch) from SERVER errors (oversized prompt, runtime). Client errors set `RequestOutput.error` + `finish_reason="error"`; non-client keep legacy `finish_reason="length"` + empty-text behavior so callers that handle oversized-prompt as soft truncation aren't broken. |
| `mllm_scheduler.stream_outputs` | When queued `RequestOutput` carries `error`, raise `ValueError(output.error)` so the engine→route chain sees an exception. Mirrors the engine_core pattern at `engine_core.py:785`. |
| `routes/chat.py` + `routes/anthropic.py` | Extend existing TemplateError→400 exception handler with `"Failed to process image\|video"` substring check → HTTP 400 with the underlying error as detail. |

## Live verify on qwen3-vl-4b (post-fix)

### TEST 1 — httpbin 404 URL
```
HTTP 400
{"detail": "Failed to process image: 502 Server Error: Bad Gateway for url: https://httpbin.org/status/404"}
```
(httpbin returned 502 instead of 404 today — the point is non-200 image fetch surfaces as HTTP 400 instead of silent HTTP 200 + empty content.)

### TEST 2 — Wikimedia thumbnail URL (rejected by their server today)
```
HTTP 400
{"detail": "Failed to process image: 400 Client Error: Use thumbnail sizes listed on https://w.wiki/GHai for url: ..."}
```
Pre-fix this would have been HTTP 200 + empty content. Post-fix the user gets a clear actionable error.

## Tests

- `tests/test_mllm.py::TestImageProcessing` — 2 new tests pin the raise-vs-swallow contract at the model layer (`_prepare_images`).
- `tests/test_mllm_continuous_batching.py::TestMLLMSchedulerErrorPropagation` — 2 new tests pin that `stream_outputs` raises when output carries `error` and yields normally otherwise.
- Existing `tests/test_api_validation_bundle.py::TestMLLMBatchGeneratorFailsLoud` source-grep tests (PR #416) still pass — the scheduler's narrow `(ValueError, RuntimeError)` catch is preserved, only its internal handling is refined.

## Out of scope

- The hybrid agent's secondary observations from this iteration: `prompt_tokens=0` for all MLLM responses (cosmetic but breaks cost accounting), and `/metrics` returns 404 on stock `rapid-mlx serve` (likely gated; needs doc clarification). Separate issues.

## Test plan

- [x] `pytest tests/test_mllm.py tests/test_mllm_batch_generator.py tests/test_mllm_continuous_batching.py tests/test_api_validation_bundle.py` — 102 passed
- [x] `ruff check + format` clean
- [x] Live test against `qwen3-vl-4b` on the editable repo branch — both 404 URL and Wikimedia-rejection URL now return HTTP 400 with descriptive detail (pre-fix: silent HTTP 200 + empty content)
- [x] pr_validate MERGE-SAFE — 7 files +198/-13, blast=high, all gates incl. stress_e2e_bench 3x3 matrix PASS