### PR TITLE
fix(api): honor max_completion_tokens on chat completions

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -10,6 +10,7 @@ import json
 import time
 
 import pytest
+from pydantic import ValidationError
 
 from vllm_mlx.api.models import (
     AssistantMessage,
@@ -305,6 +306,37 @@ class TestChatCompletion:
             messages=[Message(role="user", content="Hello")],
         )
         assert req.logit_bias is None
+
+    def test_max_completion_tokens_normalized_to_max_tokens(self):
+        """OpenAI deprecated max_tokens for reasoning models in Sept 2024;
+        SDKs >=1.45 send max_completion_tokens only. Without the validator
+        Pydantic silently drops it and the request runs uncapped."""
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="hi")],
+            max_completion_tokens=42,
+        )
+        assert req.max_completion_tokens == 42
+        assert req.max_tokens == 42
+
+    def test_max_completion_tokens_equal_to_max_tokens_allowed(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=42,
+            max_completion_tokens=42,
+        )
+        assert req.max_tokens == 42
+
+    def test_max_completion_tokens_conflicts_with_max_tokens(self):
+        with pytest.raises(ValidationError) as excinfo:
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[Message(role="user", content="hi")],
+                max_tokens=10,
+                max_completion_tokens=42,
+            )
+        assert "max_completion_tokens" in str(excinfo.value)
 
     def test_assistant_message_reasoning(self):
         msg = AssistantMessage(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, model_validator
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -188,6 +188,11 @@ class ChatCompletionRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     max_tokens: int | None = None
+    # OpenAI-canonical token cap since Sept 2024 (preferred over max_tokens for
+    # reasoning models; newer SDKs >=1.45 send only this field). Normalized to
+    # max_tokens by a model_validator so all downstream code keeps reading the
+    # single max_tokens field.
+    max_completion_tokens: int | None = None
     stream: bool = False
     stream_options: StreamOptions | None = (
         None  # Streaming options (include_usage, etc.)
@@ -228,6 +233,20 @@ class ChatCompletionRequest(BaseModel):
     chat_template_kwargs: dict | None = None
     # Number of completions (only n=1 supported)
     n: int | None = None
+
+    @model_validator(mode="after")
+    def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
+        if self.max_completion_tokens is not None:
+            if (
+                self.max_tokens is not None
+                and self.max_tokens != self.max_completion_tokens
+            ):
+                raise ValueError(
+                    "Cannot specify both max_tokens and max_completion_tokens with "
+                    "different values; use max_completion_tokens only."
+                )
+            self.max_tokens = self.max_completion_tokens
+        return self
 
 
 class AssistantMessage(BaseModel):


### PR DESCRIPTION
## Summary

`max_completion_tokens` was silently dropped by Pydantic because the field was not declared on `ChatCompletionRequest`. OpenAI SDKs >=1.45 (Sept 2024 deprecation) send only this field for reasoning models, so client-supplied caps were ignored and requests ran with the server default.

This declares the field and normalizes it to `max_tokens` via a `model_validator` so all downstream code keeps reading the single `max_tokens` slot. Rejects conflicting non-equal values from both fields.

Surfaced by the recurring babysit-loop onboarding sweep on gpt-oss-20b (harmony channel-routed reasoning model):
\`\`\`
curl ... -d '{"...", "max_completion_tokens": 5}'
# Expected: completion_tokens <= 5, finish=length
# Actual:   completion_tokens = 153, finish=stop  (full content + reasoning emitted)
\`\`\`

## Test plan
- [x] `tests/test_api_models.py::TestChatCompletion::test_max_completion_tokens_normalized_to_max_tokens` — proves new field is honored
- [x] `tests/test_api_models.py::TestChatCompletion::test_max_completion_tokens_equal_to_max_tokens_allowed` — duplicate values accepted
- [x] `tests/test_api_models.py::TestChatCompletion::test_max_completion_tokens_conflicts_with_max_tokens` — conflicting values rejected
- [x] Full `tests/test_api_models.py`: 81/81 pass
- [x] `pr_validate` full_unit gate: 3944 passed, 19 skipped, 1 xfailed in 53s
- [x] Schema-level normalization is the only required coverage: downstream code reads `request.max_tokens` exclusively (see `routes/chat.py:233-244,499`), so once the validator populates that slot the route's existing path is exercised by the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)