### PR TITLE
fix(anthropic): forward stop_sequences to engine on /v1/messages

### DIFF
--- a/tests/test_anthropic_stop_sequences.py
+++ b/tests/test_anthropic_stop_sequences.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for /v1/messages dropping ``stop_sequences``.
+
+Bug: the Anthropic route's ``_resolved_sampling_kwargs`` helper forwarded
+``temperature``, ``top_p``, and extended sampling params to the engine but
+NOT ``stop`` — so ``stop_sequences`` from the request flowed through
+``anthropic_to_openai`` into ``openai_request.stop`` and then died at the
+route boundary. Engine ran uncapped, model emitted past the user's stop
+tokens. Surfaced by the iter8 onboarding sweep on gpt-oss-20b: same
+prompt + ``stop_sequences:["STOPHERE"]`` returned full text including
+"STOPHERE", finish_reason=end_turn. Identical prompt via /v1/chat/
+completions with ``stop:["STOPHERE"]`` stopped correctly. Fix: include
+``stop`` in the kwargs returned by ``_resolved_sampling_kwargs`` so both
+the non-stream and stream branches forward it.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.anthropic import router as anthropic_router
+
+
+class _RecordingEngine:
+    """Mock engine that records the kwargs passed to ``chat`` / ``stream_chat``.
+
+    The point of the test isn't whether the model stops — it's that the
+    request's ``stop_sequences`` reaches the engine. The previous bug was
+    the route dropping the field silently.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.chat_calls: list[dict[str, Any]] = []
+        self.stream_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text="ok",
+            new_text="ok",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        yield GenerationOutput(
+            text="ok",
+            new_text="ok",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+def _make_client(engine: _RecordingEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+    cfg.tool_parser = None
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    reset_config()
+
+
+def test_stop_sequences_forwarded_to_engine_non_stream():
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stop_sequences": ["STOPHERE", "ALSO_STOP"],
+            "messages": [{"role": "user", "content": "say STOPHERE then more"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(engine.chat_calls) == 1
+    forwarded_stop = engine.chat_calls[0]["kwargs"].get("stop")
+    assert forwarded_stop == ["STOPHERE", "ALSO_STOP"], (
+        f"stop_sequences must be forwarded as ``stop`` to engine.chat(); "
+        f"got {forwarded_stop!r}"
+    )
+
+
+def test_stop_sequences_forwarded_to_engine_streaming():
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+
+    with client.stream(
+        "POST",
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "stop_sequences": ["END"],
+            "messages": [{"role": "user", "content": "say END then more"}],
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        # drain the stream
+        for _ in resp.iter_lines():
+            pass
+
+    assert len(engine.stream_calls) == 1
+    forwarded_stop = engine.stream_calls[0]["kwargs"].get("stop")
+    assert forwarded_stop == ["END"], (
+        f"stop_sequences must be forwarded as ``stop`` to engine.stream_chat(); "
+        f"got {forwarded_stop!r}"
+    )
+
+
+def test_stop_sequences_none_when_omitted_non_stream():
+    """Sanity: when client omits stop_sequences, we don't synthesize one."""
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    forwarded_stop = engine.chat_calls[0]["kwargs"].get("stop")
+    assert forwarded_stop is None, (
+        f"omitted stop_sequences must forward as None; got {forwarded_stop!r}"
+    )

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -67,7 +67,7 @@ def _resolved_sampling_kwargs(openai_request) -> dict:
         # branches stay in sync. Note: the response stop_reason still
         # maps "stop" → "end_turn" (not "stop_sequence") because the
         # engine doesn't yet report WHICH stop fired; that's a follow-up.
-        "stop": openai_request.stop,
+        "stop": getattr(openai_request, "stop", None),
     }
     out.update(build_extended_sampling_kwargs(openai_request))
     return out

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -59,6 +59,15 @@ def _resolved_sampling_kwargs(openai_request) -> dict:
     out = {
         "temperature": _resolve_temperature(openai_request.temperature),
         "top_p": _resolve_top_p(openai_request.top_p),
+        # ``stop_sequences`` from the Anthropic request flows through the
+        # adapter as ``openai_request.stop``. Both /v1/messages branches
+        # (non-stream + stream) were dropping this, so the engine ran
+        # uncapped and the model emitted past the user's stop tokens.
+        # Forward via the single sampling-kwargs helper so the two
+        # branches stay in sync. Note: the response stop_reason still
+        # maps "stop" → "end_turn" (not "stop_sequence") because the
+        # engine doesn't yet report WHICH stop fired; that's a follow-up.
+        "stop": openai_request.stop,
     }
     out.update(build_extended_sampling_kwargs(openai_request))
     return out


### PR DESCRIPTION
## Summary

`/v1/messages` was silently dropping `stop_sequences`. The Anthropic adapter correctly mapped the field onto `openai_request.stop`, but `_resolved_sampling_kwargs` — the helper both the non-stream and stream branches use to build engine kwargs — only forwarded `temperature`, `top_p`, and extended sampling. The `stop` slot was never set, so the engine ran uncapped and the model emitted past every client-supplied stop sequence.

Add `stop` to the helper so both branches stay in sync with `/v1/chat/completions`.

Surfaced by iter8 onboarding sweep on gpt-oss-20b:
\`\`\`
# Same prompt via Anthropic API
curl ... /v1/messages -d '{... "stop_sequences":["STOPHERE"], "messages":[{"role":"user","content":"Write: alpha beta STOPHERE gamma delta"}]}'
# Actual: full "alpha beta STOPHERE gamma delta", stop_reason=end_turn
# Same prompt via OpenAI API correctly stops:
curl ... /v1/chat/completions -d '{... "stop":["STOPHERE"], "messages":[...]}'
# Stops at STOPHERE, finish_reason=stop
\`\`\`

**Note**: response `stop_reason` still maps engine `"stop"` → Anthropic `"end_turn"` because the engine doesn't yet report WHICH stop fired. Mapping to `"stop_sequence"` + populating the `stop_sequence` field needs an engine-side change and is a separate follow-up.

## Test plan
- [x] `tests/test_anthropic_stop_sequences.py::test_stop_sequences_forwarded_to_engine_non_stream` — POST `/v1/messages` records `stop` in engine kwargs
- [x] `tests/test_anthropic_stop_sequences.py::test_stop_sequences_forwarded_to_engine_streaming` — streaming branch likewise
- [x] `tests/test_anthropic_stop_sequences.py::test_stop_sequences_none_when_omitted_non_stream` — omitted field stays None (no synthesis)
- [x] Negative control: both forwarding tests FAIL on unpatched route with `stop=None`
- [x] Existing anthropic suites (`test_anthropic_streaming_reasoning`, `test_anthropic_models`, `test_anthropic_adapter`): 93/93 pass
- [x] Lint + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)