### PR TITLE
fix(api): honor parallel_tool_calls=false by capping response to 1 call

### DIFF
--- a/tests/test_parallel_tool_calls.py
+++ b/tests/test_parallel_tool_calls.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for ``parallel_tool_calls`` being silently dropped.
+
+Bug: ChatCompletionRequest did not declare ``parallel_tool_calls``, so
+Pydantic dropped it on parse. Clients setting ``parallel_tool_calls:false``
+still received multiple tool_calls back from models that emitted more than
+one. Same shape as #459 (max_completion_tokens) and #355 (logit_bias) —
+undeclared OpenAI-spec fields are dropped without warning.
+
+Fix: declare the field and cap the parsed list at length 1 in the chat
+route when the client passes False. The default (None / True) preserves
+multi-call output.
+"""
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    FunctionCall,
+    Message,
+    ToolCall,
+)
+
+
+class TestSchemaDeclaration:
+    """Field must round-trip through the request model."""
+
+    def test_parallel_tool_calls_round_trips(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[Message(role="user", content="hi")],
+            parallel_tool_calls=False,
+        )
+        assert req.parallel_tool_calls is False
+
+    def test_parallel_tool_calls_round_trips_true(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[Message(role="user", content="hi")],
+            parallel_tool_calls=True,
+        )
+        assert req.parallel_tool_calls is True
+
+    def test_parallel_tool_calls_defaults_to_none(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[Message(role="user", content="hi")],
+        )
+        assert req.parallel_tool_calls is None
+
+    def test_parallel_tool_calls_string_false_coerced(self):
+        """Pydantic v2 lax mode coerces "false" → False; document the
+        behavior so callers know they get coercion, not rejection."""
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[Message(role="user", content="hi")],
+            parallel_tool_calls="false",
+        )
+        assert req.parallel_tool_calls is False
+
+
+def _make_tool_call(name: str, args: str) -> ToolCall:
+    return ToolCall(
+        id=f"call_{name}",
+        function=FunctionCall(name=name, arguments=args),
+    )
+
+
+def _apply_parallel_tool_calls_cap(
+    tool_calls: list[ToolCall],
+    parallel_tool_calls: bool | None,
+) -> list[ToolCall]:
+    """Mirror the route's cap logic; isolates the gate for unit-testability.
+
+    Production wiring lives in ``routes/chat.py`` directly after
+    ``_parse_tool_calls_with_parser``. Keeping the gate trivial means the
+    test can pin its exact semantics without spinning up an engine.
+    """
+    if tool_calls and len(tool_calls) > 1 and parallel_tool_calls is False:
+        return tool_calls[:1]
+    return tool_calls
+
+
+class TestCapBehavior:
+    """The post-parse cap that the route applies to the parsed tool_calls."""
+
+    def test_false_caps_multi_call_to_one(self):
+        tcs = [
+            _make_tool_call("get_weather", '{"city":"Tokyo"}'),
+            _make_tool_call("get_weather", '{"city":"Paris"}'),
+        ]
+        out = _apply_parallel_tool_calls_cap(tcs, False)
+        assert len(out) == 1
+        assert out[0].function.name == "get_weather"
+        assert out[0].function.arguments == '{"city":"Tokyo"}'
+
+    def test_true_preserves_multi_call(self):
+        tcs = [
+            _make_tool_call("get_weather", '{"city":"Tokyo"}'),
+            _make_tool_call("get_time", '{"city":"NYC"}'),
+        ]
+        out = _apply_parallel_tool_calls_cap(tcs, True)
+        assert len(out) == 2
+
+    def test_none_preserves_multi_call(self):
+        """Default (field omitted) must NOT cap — only an explicit False does."""
+        tcs = [
+            _make_tool_call("a", "{}"),
+            _make_tool_call("b", "{}"),
+        ]
+        out = _apply_parallel_tool_calls_cap(tcs, None)
+        assert len(out) == 2
+
+    def test_single_call_unaffected_by_false(self):
+        tcs = [_make_tool_call("a", "{}")]
+        out = _apply_parallel_tool_calls_cap(tcs, False)
+        assert len(out) == 1
+        assert out is tcs  # returns input list unchanged when cap doesn't trip
+
+    def test_empty_list_unaffected(self):
+        out = _apply_parallel_tool_calls_cap([], False)
+        assert out == []
+
+
+class TestRouteIntegration:
+    """End-to-end: cap fires inside the chat route, response has 1 tool_call."""
+
+    def test_route_caps_when_parser_returns_two_tool_calls(self, monkeypatch):
+        """If the configured tool parser returns two tool_calls and the
+        request asks for parallel_tool_calls=false, the response must
+        surface only the first."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        # Patch the tool-call parser the route uses so we control output.
+        import vllm_mlx.routes.chat as chat_module
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.routes.chat import router as chat_router
+
+        def _fake_parse(text, request):
+            return (
+                "",
+                [
+                    _make_tool_call("get_weather", '{"city":"Tokyo"}'),
+                    _make_tool_call("get_weather", '{"city":"Paris"}'),
+                ],
+            )
+
+        monkeypatch.setattr(chat_module, "_parse_tool_calls_with_parser", _fake_parse)
+
+        class _StubEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+            supports_guided_generation = False
+            tokenizer = None
+
+            def build_prompt(self, messages, tools=None, enable_thinking=None):
+                return "PROMPT"
+
+            async def chat(self, messages, **kwargs):
+                return GenerationOutput(
+                    text="dummy",
+                    new_text="dummy",
+                    tokens=[1, 2, 3],
+                    prompt_tokens=4,
+                    completion_tokens=3,
+                    finished=True,
+                    finish_reason="stop",
+                    channel=None,
+                )
+
+        cfg = reset_config()
+        cfg.engine = _StubEngine()
+        cfg.model_name = "test-model"
+        cfg.model_registry = None
+        cfg.no_thinking = True
+        cfg.reasoning_parser = None
+        cfg.tool_parser = "hermes"  # any non-None parser; we patched the call
+
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "weather in two cities"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "parallel_tool_calls": False,
+                "max_tokens": 16,
+            },
+        )
+        try:
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            msg = body["choices"][0]["message"]
+            assert msg.get("tool_calls") is not None
+            assert len(msg["tool_calls"]) == 1, (
+                f"parallel_tool_calls=False must cap to 1; got "
+                f"{len(msg['tool_calls'])} tool_calls"
+            )
+            assert msg["tool_calls"][0]["function"]["arguments"] == (
+                '{"city":"Tokyo"}'
+            ), "the first parsed tool_call must be preserved"
+        finally:
+            reset_config()

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -210,6 +210,13 @@ class ChatCompletionRequest(BaseModel):
     # Tool calling
     tools: list[ToolDefinition] | None = None
     tool_choice: str | dict | None = None  # "auto", "none", or specific tool
+    # OpenAI extended spec — declared so Pydantic stops silently dropping it.
+    # When set to False, the route caps the parsed ``tool_calls`` list at
+    # length 1 in the response. Default None == True (model may emit
+    # multiple). Cannot rely on decoder-level enforcement; this is a
+    # post-generation truncation (the only reliable lever absent FSM
+    # constraints — see PR #132 / #442 for the decoder-level path).
+    parallel_tool_calls: bool | None = None
     # Structured output
     response_format: ResponseFormat | dict | None = None
     # Logprobs

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -840,6 +840,13 @@ async def _create_chat_completion_impl(
     # Parse tool calls from output using configured parser
     cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
 
+    # Honor ``parallel_tool_calls=false`` by capping the parsed list at one.
+    # No decoder-level enforcement exists, so this is a post-parse trim — the
+    # only reliable lever for OpenAI-compat clients that explicitly request a
+    # single tool call (see PR #132 for the longer-term FSM-constrained path).
+    if tool_calls and len(tool_calls) > 1 and request.parallel_tool_calls is False:
+        tool_calls = tool_calls[:1]
+
     # Validate tool call parameter values against schemas
     if tool_calls and request.tools:
         _validate_tool_call_params(tool_calls, request.tools)


### PR DESCRIPTION
## Summary

`ChatCompletionRequest` didn't declare `parallel_tool_calls`, so Pydantic dropped the field on parse. Clients passing `parallel_tool_calls:false` still received multiple tool_calls from models that emitted more than one. Same blind-spot shape as #459 (`max_completion_tokens`) and #355 (`logit_bias`) — undeclared OpenAI-spec fields die silently.

Declare the field and cap the parsed `tool_calls` list to length 1 in `routes/chat.py` when the client passes False. The default (None / True) preserves multi-call output. No decoder-level enforcement exists, so this is a post-parse trim — the only reliable lever absent FSM-constrained decoding (tracked in #132).

Surfaced by iter10 onboarding sweep on qwen3.6-27b-8bit:
\`\`\`
curl ... -d '{...,"parallel_tool_calls":false,"messages":[{"role":"user","content":"weather Tokyo and Paris"}],"tools":[{...get_weather}]}'
# Actual: tool_calls=[get_weather(Tokyo), get_weather(Paris)]  ← 2 calls
# Expected: tool_calls=[get_weather(Tokyo)]                    ← capped to 1
\`\`\`

## Test plan
- [x] `tests/test_parallel_tool_calls.py::TestSchemaDeclaration::*` — 4 tests for field round-trip + Pydantic v2 lax coercion of "false"
- [x] `tests/test_parallel_tool_calls.py::TestCapBehavior::*` — 5 tests pin the cap semantics (false caps, true/None pass through, single-call unaffected, empty-list unaffected)
- [x] `tests/test_parallel_tool_calls.py::TestRouteIntegration::test_route_caps_when_parser_returns_two_tool_calls` — end-to-end through chat route with `TestClient` + patched parser returning 2 tool_calls
- [x] Negative control: integration test FAILS without the route cap (got 2, expected 1 — exact iter10 bug shape)
- [x] Related suites pass: `test_api_models`, `test_chat_route_tool_tag_leak`, `test_chat_streaming_guided`, `test_chat_streaming_spec`, `test_chat_logprobs_channel_routing` (109 total)
- [x] Lint + ruff format clean

## Out of scope (deferred)
- Streaming path enforcement — emit one less tool_call event mid-stream when capped. Will need delta-counting state. File issue if there's demand; for now non-stream covers most agent-framework usage.
- `tool_choice:"required"` enforcement and `tool_choice:{...specific}` enforcement when model resists — both deferred to PR #132 (FSM-based decoding). Iter10 sweep confirmed both still gap, comment in `routes/chat.py:312-314` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)