### PR TITLE
fix(api): honor legacy functions/function_call by normalizing to tools

### DIFF
--- a/tests/test_legacy_functions_field.py
+++ b/tests/test_legacy_functions_field.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for legacy ``functions`` / ``function_call`` shape silently dropped.
+
+Bug: OpenAI's pre-1.0 SDK and several LangChain compat layers still emit the
+deprecated ``functions: [{name, parameters, description}]`` + ``function_call``
+fields instead of the modern ``tools`` + ``tool_choice``. ChatCompletionRequest
+didn't declare either, so Pydantic dropped them on parse and the request ran
+as if no tool exists — the model returned a plain-text refusal, no
+tool_calls fired. Same blind-spot family as #355 (logit_bias), #459
+(max_completion_tokens), #464 (parallel_tool_calls).
+
+Fix: declare both fields and normalize them to the modern slots via a
+``model_validator(mode="after")``. Modern wins when both shapes are
+provided, matching OpenAI's documented deprecation behavior.
+"""
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    Message,
+    ToolDefinition,
+)
+
+
+def _msg() -> list[Message]:
+    return [Message(role="user", content="hi")]
+
+
+class TestLegacyFunctionsNormalization:
+    """``functions`` → ``tools`` conversion."""
+
+    def test_functions_converted_to_tools(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            functions=[
+                {
+                    "name": "get_weather",
+                    "description": "fetch weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+        assert req.tools is not None
+        assert len(req.tools) == 1
+        assert req.tools[0].type == "function"
+        assert req.tools[0].function["name"] == "get_weather"
+        assert req.tools[0].function["description"] == "fetch weather"
+
+    def test_functions_multiple_converted_to_tools(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            functions=[
+                {"name": "a", "parameters": {"type": "object"}},
+                {"name": "b", "parameters": {"type": "object"}},
+            ],
+        )
+        assert len(req.tools) == 2
+        assert [t.function["name"] for t in req.tools] == ["a", "b"]
+
+    def test_modern_tools_take_precedence(self):
+        """If both legacy and modern are supplied, modern wins. This is
+        OpenAI's documented deprecation behavior — clients in the middle
+        of migrating may send both, and we should never silently downgrade."""
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            tools=[
+                ToolDefinition(
+                    type="function",
+                    function={"name": "modern", "parameters": {"type": "object"}},
+                )
+            ],
+            functions=[
+                {"name": "legacy", "parameters": {"type": "object"}},
+            ],
+        )
+        assert len(req.tools) == 1
+        assert req.tools[0].function["name"] == "modern"
+
+    def test_empty_functions_list_is_no_op(self):
+        """[] is truthy-empty; should not synthesize an empty tools list."""
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            functions=[],
+        )
+        assert req.tools is None  # empty list is falsy → skipped
+
+    def test_functions_omitted_leaves_tools_unchanged(self):
+        req = ChatCompletionRequest(model="m", messages=_msg())
+        assert req.tools is None
+        assert req.functions is None
+
+
+class TestLegacyFunctionCallNormalization:
+    """``function_call`` → ``tool_choice`` conversion."""
+
+    def test_function_call_auto_string(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            function_call="auto",
+        )
+        assert req.tool_choice == "auto"
+
+    def test_function_call_none_string(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            function_call="none",
+        )
+        assert req.tool_choice == "none"
+
+    def test_function_call_specific_function_dict(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            function_call={"name": "get_weather"},
+        )
+        assert req.tool_choice == {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        }
+
+    def test_modern_tool_choice_takes_precedence(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            tool_choice="auto",
+            function_call={"name": "ignored"},
+        )
+        assert req.tool_choice == "auto"
+
+    def test_function_call_omitted_leaves_tool_choice_unchanged(self):
+        req = ChatCompletionRequest(model="m", messages=_msg())
+        assert req.tool_choice is None
+        assert req.function_call is None
+
+
+class TestCombinedLegacy:
+    """End-to-end legacy → modern round-trip on a realistic legacy request."""
+
+    def test_full_legacy_request_normalized(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=_msg(),
+            functions=[
+                {
+                    "name": "get_weather",
+                    "description": "current weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ],
+            function_call={"name": "get_weather"},
+        )
+        # Both legacy slots round-trip (we don't blank them — clients may
+        # inspect what they sent), but modern slots are populated for the
+        # route layer.
+        assert req.functions is not None
+        assert req.function_call == {"name": "get_weather"}
+        assert req.tools is not None and len(req.tools) == 1
+        assert req.tools[0].function["name"] == "get_weather"
+        assert req.tool_choice == {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        }

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -217,6 +217,16 @@ class ChatCompletionRequest(BaseModel):
     # post-generation truncation (the only reliable lever absent FSM
     # constraints — see PR #132 / #442 for the decoder-level path).
     parallel_tool_calls: bool | None = None
+    # Legacy OpenAI tool-calling shape (pre-1.0 SDK + LangChain compat layers).
+    # When set and the modern ``tools``/``tool_choice`` slots are empty, the
+    # post-init validator below normalizes them to the modern equivalent so
+    # downstream code keeps reading a single shape. Declared so Pydantic
+    # stops silently dropping them (same blind-spot family as #355 /
+    # #459 / #464). If a client supplies BOTH shapes, modern wins —
+    # OpenAI's documented deprecation behavior — and the legacy slots are
+    # ignored.
+    functions: list[dict] | None = None
+    function_call: str | dict | None = None
     # Structured output
     response_format: ResponseFormat | dict | None = None
     # Logprobs
@@ -253,6 +263,29 @@ class ChatCompletionRequest(BaseModel):
                     "different values; use max_completion_tokens only."
                 )
             self.max_tokens = self.max_completion_tokens
+        return self
+
+    @model_validator(mode="after")
+    def _normalize_legacy_functions(self) -> "ChatCompletionRequest":
+        """Translate the pre-1.0 ``functions``/``function_call`` shape into
+        the modern ``tools``/``tool_choice`` slots so the route never has
+        to know about the legacy form. Modern fields take precedence when
+        a client supplies both — matches OpenAI's deprecation behavior."""
+        if self.functions and self.tools is None:
+            self.tools = [
+                ToolDefinition(type="function", function=fn) for fn in self.functions
+            ]
+        if self.function_call is not None and self.tool_choice is None:
+            fc = self.function_call
+            if isinstance(fc, str):
+                # "auto" / "none" map 1:1; anything else passes through and
+                # the existing tool_choice handler will 400 on it.
+                self.tool_choice = fc
+            elif isinstance(fc, dict) and "name" in fc:
+                self.tool_choice = {
+                    "type": "function",
+                    "function": {"name": fc["name"]},
+                }
         return self
 
 


### PR DESCRIPTION
## Summary

`ChatCompletionRequest` didn't declare `functions` or `function_call`, so Pydantic dropped them on parse. OpenAI's pre-1.0 SDK and several LangChain compat layers still emit the legacy shape; clients received plain-text refusals instead of tool calls because the model was never told about any tools.

Same blind-spot family as #355 (logit_bias), #459 (max_completion_tokens), #464 (parallel_tool_calls) — undeclared OpenAI-spec fields die silently with no warning or log.

Declare both fields and translate them to the modern `tools` / `tool_choice` slots via a `model_validator(mode="after")`. Modern wins when a client supplies both shapes — matches OpenAI's documented deprecation behavior.

Surfaced by the iter11 onboarding sweep on gpt-oss-20b:
\`\`\`
curl ... -d '{"messages":[...weather q...],"functions":[{...get_weather...}],"function_call":{"name":"get_weather"}}'
# Actual: HTTP 200, plain-text "I don't have real-time data", no tool_calls
# Expected: tool_call for get_weather (modern equivalent would have worked)
\`\`\`

## Test plan
- [x] `tests/test_legacy_functions_field.py::TestLegacyFunctionsNormalization::*` — 5 tests for `functions` → `tools` conversion (single, multiple, modern-precedence, empty-list no-op, omitted unchanged)
- [x] `tests/test_legacy_functions_field.py::TestLegacyFunctionCallNormalization::*` — 5 tests for `function_call` → `tool_choice` conversion (auto, none, specific dict, modern-precedence, omitted)
- [x] `tests/test_legacy_functions_field.py::TestCombinedLegacy::test_full_legacy_request_normalized` — realistic full legacy request round-trips correctly
- [x] Negative control: without fix, `functions` field is literally absent on the parsed model (`assert req.tools is not None` fails — exact silent-drop bug shape)
- [x] Related suites pass: `test_api_models`, `test_parallel_tool_calls`, `test_chat_route_tool_tag_leak` (108 total)
- [x] Lint + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)