### PR TITLE
fix(routes): reject audio_url on text-only models (mirror image/video gate)

### DIFF
--- a/tests/test_text_only_media_gate.py
+++ b/tests/test_text_only_media_gate.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for text-only models silently dropping audio content parts.
+
+Bug: ``vllm_mlx/routes/chat.py`` rejected ``image_url``/``image``/``video``/
+``video_url`` parts on text-only models (``engine.is_mllm = False``) with a
+clean HTTP 400, but ``audio_url``/``audio``/``input_audio`` were not in the
+reject list. ``extract_multimodal_content`` then silently stripped the audio
+part and the model hallucinated ("there is no audio attached") while the
+caller saw HTTP 200.
+
+Fix: extend the content-type reject set to include the three audio shapes
+OpenAI clients send and broaden the error message to "image, video, or audio".
+The R9P1 invariant ("text-only models never silently drop media") now covers
+the full set.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+
+
+class _TextOnlyEngine:
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        return GenerationOutput(
+            text="ok",
+            new_text="ok",
+            tokens=[1],
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+def _client() -> TestClient:
+    cfg = reset_config()
+    cfg.engine = _TextOnlyEngine()
+    cfg.model_name = "text-only-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+    cfg.tool_parser = None
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _media_request(part: dict) -> dict:
+    return {
+        "model": "text-only-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    part,
+                ],
+            }
+        ],
+        "max_tokens": 8,
+    }
+
+
+class TestTextOnlyMediaRejection:
+    """Each media shape must produce HTTP 400, not silent drop."""
+
+    def test_image_url_rejected(self):
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_media_request(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/i.png"},
+                    }
+                ),
+            )
+            assert resp.status_code == 400
+            assert "does not support" in resp.json()["detail"]
+        finally:
+            reset_config()
+
+    def test_video_url_rejected(self):
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_media_request(
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/v.mp4"},
+                    }
+                ),
+            )
+            assert resp.status_code == 400
+            assert "does not support" in resp.json()["detail"]
+        finally:
+            reset_config()
+
+    def test_audio_url_rejected(self):
+        """OpenAI shape: ``{"type": "audio_url", "audio_url": {"url": "..."}}``.
+
+        Pre-fix: HTTP 200, audio silently stripped, model hallucinated.
+        Post-fix: HTTP 400 mirroring image/video.
+        """
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_media_request(
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": "https://example.com/clip.mp3"},
+                    }
+                ),
+            )
+            assert resp.status_code == 400, resp.text
+            detail = resp.json()["detail"]
+            assert "does not support" in detail
+            assert "audio" in detail
+        finally:
+            reset_config()
+
+    def test_audio_short_form_rejected(self):
+        """Alt shape some clients send: ``{"type": "audio", "audio": "..."}``."""
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_media_request({"type": "audio", "audio": "base64data"}),
+            )
+            assert resp.status_code == 400, resp.text
+            assert "audio" in resp.json()["detail"]
+        finally:
+            reset_config()
+
+    def test_input_audio_rejected(self):
+        """OpenAI Realtime / gpt-4o-audio shape: ``input_audio``."""
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_media_request(
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": "base64data", "format": "wav"},
+                    }
+                ),
+            )
+            assert resp.status_code == 400, resp.text
+            assert "audio" in resp.json()["detail"]
+        finally:
+            reset_config()
+
+    def test_pure_text_passes(self):
+        """Sanity: plain text content still reaches the engine."""
+        client = _client()
+        try:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "text-only-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "max_tokens": 8,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            reset_config()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -363,11 +363,12 @@ async def _create_chat_completion_impl(
     else:
         _cloud_original_messages = None
 
-    # Reject image/video content when the loaded model has no vision
-    # head. Without this guard ``extract_multimodal_content`` silently
-    # drops the image parts on the text-only path and the model
-    # hallucinates a confident description of an image it never saw
-    # (R9P1: 600M text model returned "a red rose" for arbitrary images).
+    # Reject image/video/audio content when the loaded model has no
+    # multimodal head. Without this guard ``extract_multimodal_content``
+    # silently drops the media parts on the text-only path and the model
+    # hallucinates (R9P1: 600M text model returned "a red rose" for
+    # arbitrary images; iter12 onboarding: text-only model claimed
+    # "no audio attached" while silently dropping ``audio_url``).
     if not engine.is_mllm:
         for _msg in request.messages:
             _content = (
@@ -380,12 +381,20 @@ async def _create_chat_completion_impl(
                         if hasattr(_item, "type")
                         else (_item.get("type", "") if isinstance(_item, dict) else "")
                     )
-                    if _item_type in ("image_url", "image", "video", "video_url"):
+                    if _item_type in (
+                        "image_url",
+                        "image",
+                        "video",
+                        "video_url",
+                        "audio_url",
+                        "audio",
+                        "input_audio",
+                    ):
                         raise HTTPException(
                             status_code=400,
                             detail=(
                                 f"Model '{cfg.model_name}' does not support "
-                                "image or video inputs."
+                                "image, video, or audio inputs."
                             ),
                         )
 


### PR DESCRIPTION
## Summary
- Text-only models silently dropped `audio_url` / `audio` / `input_audio` content parts. The R9P1 reject gate in `routes/chat.py` only listed image and video shapes, so `extract_multimodal_content` stripped audio parts and the model hallucinated (`"no audio attached"`) while the caller saw HTTP 200.
- Extend the gate to the three audio shapes OpenAI clients send and broaden the error message to "image, video, or audio".
- Add 6 regression tests (`tests/test_text_only_media_gate.py`) covering image/video round-trip, three audio shapes, and a plain-text passthrough sanity case.

## Repro (pre-fix)
```bash
curl -X POST http://127.0.0.1:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen3.6-27b-8bit","messages":[{"role":"user","content":[
    {"type":"text","text":"Describe this audio."},
    {"type":"audio_url","audio_url":{"url":"https://example.com/clip.mp3"}}]}],"max_tokens":80}'
# pre-fix: HTTP 200, audio stripped, model hallucinates "no audio attached"
# post-fix: HTTP 400 {"detail":"Model '...' does not support image, video, or audio inputs."}
```
Identical behavior already existed for image_url / video_url; this restores parity.

## Why this matters
Same "silent-drop" shape as the `gotcha_max_completion_tokens_silently_dropped` family — the request runs, returns 200, and the caller never knows the input was ignored. The image/video gate was added in R9P1 for the same reason; audio just slipped through because no MLLM in the registry exercised it from a text-only path.

## Test plan
- [x] `python3.12 -m pytest tests/test_text_only_media_gate.py -v` — 6/6 pass
- [x] `python3.12 -m pytest tests/test_routes.py tests/test_parallel_tool_calls.py tests/test_legacy_functions_field.py tests/test_api_utils.py` — 169/169 pass (no regressions in adjacent route/utils suites)
- [x] `ruff check` + `ruff format --check` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)