### PR TITLE
feat(pr_validate): integrate Google eng-practices code-review tiering

### DIFF
--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -23,6 +23,8 @@ python3.12 -m scripts.pr_validate <PR#> -v
 | # | step | gate | runtime |
 |---|---|---|---|
 | 0 | `fetch` | always (fail-fast) | ~3s |
+| 0.5 | `test_plan_check` | always | <1s |
+| 0.7 | `cl_description_quality` | always (skip via `PR_VALIDATE_SKIP_DESC=1`) | <1s |
 | 6 | `deepseek_review` | always (skip if no API) | 30–90s |
 | 1 | `supply_chain` | always | ~5s |
 | 2 | `lint` | when diff has .py | ~3s |
@@ -30,12 +32,51 @@ python3.12 -m scripts.pr_validate <PR#> -v
 | 4 | `full_unit` | blast ≥ medium | ~25s |
 | 5 | `stress_e2e_bench` | blast == high | 5–10min |
 
-(DeepSeek review goes second by design: get cheap critical thinking
-*before* spending 10 minutes on tests.)
+(DeepSeek review goes near the front by design: get cheap critical
+thinking *before* spending 10 minutes on tests. The two cheapest
+description-quality gates run first so a bad title or empty body
+fails in under a second without burning the DeepSeek budget.)
 
 ## Verdict
 
 Strict — any single `fail` or `error` blocks merge. `skip` is neutral.
+
+The DeepSeek step uses [BLOCKING]/[NIT] tiering (see "Code Review
+Philosophy" below): only `[BLOCKING]` findings fail the gate; `[NIT]`
+findings surface in the scorecard so the author can decide.
+
+## Code Review Philosophy (Google eng-practices)
+
+The pipeline follows [Google's code-review standard](https://github.com/google/eng-practices/blob/master/review/reviewer/standard.md):
+
+> "Reviewers should favor approving a CL once it is in a state where
+> it definitely improves the overall code health, even if the CL
+> isn't perfect."
+
+Concretely we encode three principles:
+
+1. **Tiered findings.** The DeepSeek prompt requires every finding
+   to be prefixed `[BLOCKING]` (concrete bug, security issue, broken
+   contract, false-positive test) or `[NIT]` (style, future-proofing,
+   alternative naming). Only `[BLOCKING]` fails the gate. Default to
+   `[NIT]` if unsure. Caps: at most 5 BLOCKING + 5 NIT per review,
+   forcing the model to triage instead of pad. Untagged findings
+   default to `[BLOCKING]` so a forgotten prefix can't silently
+   downgrade a real bug.
+
+2. **Convergence over perfectionism.** Without tiering, DeepSeek
+   spirals: every round surfaces new style preferences and the PR
+   never merges. PR #467 hit this — 5 rounds, each producing fresh
+   "could be more defensive" findings. The tiered prompt converges
+   in 2–3 rounds because nits are visible but don't block.
+
+3. **Description quality is enforced, not advised.** The
+   `cl_description_quality` step rejects PRs with empty bodies, bad
+   titles (`fix bug`, `wip`, `update`, `tweaks`, …), and bodies with
+   no rationale signal (no `## Why` heading, no `Closes #NNN`, no
+   inline `Why:`). Google: "Should be informative enough that
+   future code searchers don't have to read your CL." Override with
+   `PR_VALIDATE_SKIP_DESC=1` for trivial dep-bumps; don't normalize.
 
 ## Blast radius
 
@@ -66,12 +107,39 @@ Wraps `gh pr view --json` + `gh pr diff`. Saves the diff to
 `<work_dir>/pr.diff`. Refuses CLOSED / MERGED / DIRTY (merge-conflict)
 PRs by design — re-open or rebase first.
 
-### `deepseek_review` (step 6, runs second)
+### `test_plan_check` (step 0.5)
+
+Reads the PR body for a `## Test plan` checklist. If any item is
+unchecked (`- [ ]`) the step fails — the author hasn't finished what
+they said they'd do. Lesson from #427.
+
+### `cl_description_quality` (step 0.7)
+
+Cheap title + body hygiene gate built from
+[Google's CL-descriptions guidance](https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md).
+Three checks:
+
+1. **Title**: not empty, ≥3 words after a conventional-commit prefix
+   strip (`fix(routes):`, `feat:`, …), and not in the bad-pattern
+   blacklist (`fix bug`, `wip`, `update`, `tweaks`, `cleanup`,
+   `various changes`, …).
+2. **Body exists**: empty body fails.
+3. **Body has rationale**: at least one of — a `## Why` /
+   `## Summary` / `## Rationale` / `## Motivation` / `## Background`
+   heading, an inline `Why:` line, a `Closes #` / `Fixes #` / `Refs #`
+   link, or a `because`-clause.
+
+Override: `PR_VALIDATE_SKIP_DESC=1` for two-line dep-bumps where
+rationale is genuinely overkill.
+
+### `deepseek_review` (step 6, runs early)
 
 Sends the diff to DeepSeek V4 Pro with the prompt at
-`prompts/deepseek_review.md`. Findings go in the scorecard. Skips if
-`PR_VALIDATE_NO_DEEPSEEK=1` or no API key. Skips on network failure
-(don't block PRs on a flaky API).
+`prompts/deepseek_review.md`. The prompt requires `[BLOCKING]`/`[NIT]`
+tiering on every finding (see "Code Review Philosophy" above). Only
+`[BLOCKING]` findings fail the gate; `[NIT]`s surface in the
+scorecard. Skips if `PR_VALIDATE_NO_DEEPSEEK=1` or no API key. Skips
+on network failure (don't block PRs on a flaky API).
 
 API key resolution: `$DEEPSEEK_API_KEY` → fallback to dev key in code
 (see `memory/knowledge/deepseek_api_key.md`).

--- a/scripts/pr_validate/prompts/deepseek_review.md
+++ b/scripts/pr_validate/prompts/deepseek_review.md
@@ -4,6 +4,43 @@ picky and specific. Quote line numbers from the diff. Find concrete
 problems, not generalities. Skip what is fine — only report what is
 broken or risky.
 
+# Review philosophy (Google eng-practices)
+
+This pipeline follows
+[Google's code-review standard](https://github.com/google/eng-practices/blob/master/review/reviewer/standard.md):
+
+> "Reviewers should favor approving a CL once it is in a state where
+> it definitely improves the overall code health, even if the CL
+> isn't perfect."
+
+Concretely:
+- **Approve when improvement is clear** — don't block on perfection.
+- **Decisions follow technical facts, not opinion** — back every
+  finding with a line citation + a specific failure mode.
+- **Style consistency over personal preference** — if the author's
+  choice is internally consistent and matches the surrounding code,
+  it's fine.
+- **Don't spiral** — each round of review should converge. If a
+  finding is genuinely a "nit" (style or future-proofing without a
+  concrete defect today), mark it `[NIT]` so the author can ship.
+
+# Tiering (REQUIRED)
+
+Prefix EVERY finding with one of two tiers:
+
+- **`[BLOCKING]`** — must fix before merge. Use ONLY for: a concrete
+  correctness bug, a security issue, an introduced regression, a
+  test that doesn't actually test what it claims, or a change that
+  breaks a documented external contract.
+- **`[NIT]`** — improvement worth considering but not required for
+  merge. Use for: style preferences, defensive-coding suggestions
+  for hypothetical futures, naming polish, alternative APIs, missing
+  comments that aren't load-bearing.
+
+Default to `[NIT]` if you're unsure. The pipeline fails the gate ONLY
+on `[BLOCKING]` findings; `[NIT]`s surface in the scorecard but don't
+block merge.
+
 # Reading the prompt
 
 The user message contains, in order:
@@ -17,51 +54,84 @@ The user message contains, in order:
 # What I want you to check
 
 For each item, only report if you find a CONCRETE issue with a
-line/file citation. Skip the category if it's clean.
+line/file citation. Skip the category if it's clean. Default tier
+shown in brackets — escalate or downgrade per the specific defect.
 
 1. **Correctness bugs** — off-by-one, wrong default, swapped args,
    missing await, wrong error type caught, leaked file handle, race
-   conditions, ordering bugs.
+   conditions, ordering bugs. [BLOCKING]
 
 2. **Security** — command injection, path traversal, unsanitized
    external input, secret in logs, hard-coded credentials,
    trust-on-first-use without verification, eval/exec on untrusted
-   data, pickle of untrusted data, SSRF, XXE.
+   data, pickle of untrusted data, SSRF, XXE. [BLOCKING]
 
 3. **Backward compat** — does the change break callers that worked
    yesterday? Migration path for old data formats? Deprecation warning?
+   [BLOCKING] if it breaks a documented contract; [NIT] for rough edges.
 
 4. **Tests** — does the test actually exercise the changed behavior?
    Does it pass by coincidence? Are the assertions specific or just
    "doesn't crash"? Any test that would still pass if the production
-   code were deleted?
+   code were deleted? [BLOCKING] if the test is false (green on
+   broken code); [NIT] if the test could be more specific.
 
 5. **Performance** — algorithmic regressions (O(n²) where O(n)
    existed), unnecessary allocations in a hot path, blocking I/O on
-   the event loop, lock-contention introduced.
+   the event loop, lock-contention introduced. [BLOCKING] if a real
+   regression; [NIT] if hypothetical.
 
 6. **Resource handling** — file handles, sockets, processes,
    subprocesses, threads — all closed/joined/cleaned up on every exit
-   path including exceptions?
+   path including exceptions? [BLOCKING].
 
 7. **Failure modes** — what happens when the network call times out?
    When the disk is full? When the subprocess exits non-zero? When
    the input file is missing or empty? Is the error message
-   actionable for a debugger?
+   actionable for a debugger? [BLOCKING] if unhandled crash; [NIT]
+   if message could be clearer.
 
 8. **API design** — surprising defaults, mutable default arguments,
    functions that return None on error vs raising, public functions
-   that should be private, leaky abstractions.
+   that should be private, leaky abstractions. [NIT] usually unless
+   it's a breaking shape.
 
-9. **Anything else** that a senior production reviewer would flag.
+9. **Design fit** — does this functionality belong here, or in a
+   library / sibling module / existing helper? Is it integrated
+   logically with the existing system? [NIT].
+
+10. **Complexity & over-engineering** — flag changes that solve
+    hypothetical future problems instead of the one in front of the
+    author. "Solve the problem you know needs solving now." [NIT].
+
+11. **Consistency with surrounding code** — does naming / structure
+    / patterns match the existing module? Style-guide violation is
+    [BLOCKING] (CI catches it anyway); inconsistency-only is [NIT].
+
+12. **Documentation** — README / public API docs updated when the
+    user-visible surface changed? [NIT] usually; [BLOCKING] only for
+    contract-changing public APIs.
+
+13. **Anything else** that a senior production reviewer would flag.
 
 # Output format
 
 Return a numbered list of CONCRETE issues. For each:
 
-- file:line citation
+- **Tier prefix `[BLOCKING]` or `[NIT]`** (REQUIRED — first thing on the line)
+- `file:line` citation
 - one-sentence description of what's wrong
 - one-sentence fix sketch
 
-Don't pad. Skip categories that are clean. Maximum 800 words total.
+Example:
+```
+1. [BLOCKING] vllm_mlx/routes/chat.py:918 — `assert isinstance(_msg, dict)` is stripped under `python -O`, leaving the guard inert in production. Fix: replace with `if not isinstance(_msg, dict): raise TypeError(...)`.
+2. [NIT] tests/test_x.py:42 — assertion is loose. Fix: replace `assert result` with `assert result.status_code == 200`.
+```
+
+Cap: at most **5 BLOCKING + 5 NIT** findings per review. If you have
+more than 5 BLOCKING items, report the 5 highest-severity and note
+"additional issues exist in <area>." Don't pad. Skip categories that
+are clean. Maximum 800 words total.
+
 If you find no issues, say "No blocking issues found." and stop.

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 from .base import Step
 from .context import Context
 from .scorecard import render_scorecard, verdict
+from .steps.cl_description_quality import CLDescriptionQualityStep
 from .steps.deepseek_review import DeepSeekReviewStep
 from .steps.fetch import FetchStep
 from .steps.full_unit import FullUnitStep
@@ -30,6 +31,7 @@ from .steps.test_plan_check import TestPlanCheckStep
 STEPS: list[Step] = [
     FetchStep(),  # 0 — fetch PR + diff + classify blast radius
     TestPlanCheckStep(),  # 0.5 — unchecked test-plan items block merge (#427 lesson)
+    CLDescriptionQualityStep(),  # 0.7 — title + body rationale (Google eng-practices)
     DeepSeekReviewStep(),  # 6 — adversarial review (moved to front)
     SupplyChainStep(),  # 1 — pip-audit, license, install hooks
     LintStep(),  # 2 — ruff check + format

--- a/scripts/pr_validate/steps/cl_description_quality.py
+++ b/scripts/pr_validate/steps/cl_description_quality.py
@@ -57,12 +57,11 @@ _BAD_TITLE_PATTERNS = (
     re.compile(r"^various\s+changes\.?$"),
     re.compile(r"^various\s+fixes\.?$"),
     re.compile(r"^tweaks?\.?$"),
-    re.compile(r"^update\.?$"),
+    re.compile(r"^updates?\.?$"),  # covers "update" and "updates"
     re.compile(r"^patch\.?$"),
     re.compile(r"^wip\.?$"),
     re.compile(r"^cleanup\.?$"),
     re.compile(r"^changes\.?$"),
-    re.compile(r"^updates?\.?$"),
     re.compile(r"^misc\.?$"),
     re.compile(r"^minor\s+(?:fix|change|update)\.?$"),
 )

--- a/scripts/pr_validate/steps/cl_description_quality.py
+++ b/scripts/pr_validate/steps/cl_description_quality.py
@@ -39,11 +39,10 @@ that the norm.
 
 from __future__ import annotations
 
-import os
 import re
 
 from ..base import Step, StepResult
-from ..context import Context
+from ..context import Context, env_truthy
 
 # Title patterns that fail. Matched against the LOWERCASED title with
 # leading conventional-commit prefix (e.g. ``fix:`` / ``feat(routes):``)
@@ -75,13 +74,18 @@ _CC_PREFIX = re.compile(r"^[a-z]+(?:\([^)]+\))?:\s*", re.IGNORECASE)
 
 # Rationale signals — any of these in the body satisfies the
 # "explain WHY" rule. Order = how cheap they are to look for.
+# Note: the leading ``[\s>*+\-]*`` tolerates whitespace and common
+# markdown list/quote prefixes (``- Why:``, ``* **Why:**``, ``> ##
+# Why``) so an indented or nested rationale line still counts.
+# ``re.MULTILINE`` makes ``^`` match each line's start.
+_LINE_PREFIX = r"[\s>*+\-]*"
 _RATIONALE_SIGNALS = (
     re.compile(
-        r"^#+\s*(?:why|summary|rationale|motivation|background|context)\b",
+        rf"^{_LINE_PREFIX}#+\s*(?:why|summary|rationale|motivation|background|context)\b",
         re.IGNORECASE | re.MULTILINE,
     ),
-    re.compile(r"^\*\*Why:\*\*", re.IGNORECASE | re.MULTILINE),
-    re.compile(r"^Why:\s", re.IGNORECASE | re.MULTILINE),
+    re.compile(rf"^{_LINE_PREFIX}\*\*Why:\*\*", re.IGNORECASE | re.MULTILINE),
+    re.compile(rf"^{_LINE_PREFIX}Why:\s", re.IGNORECASE | re.MULTILINE),
     re.compile(r"\b(?:closes|fixes|resolves|refs)\s+#\d+", re.IGNORECASE),
     re.compile(r"\bbecause\b", re.IGNORECASE),
 )
@@ -94,7 +98,10 @@ class CLDescriptionQualityStep(Step):
     description = "PR title + body have rationale (Google eng-practices)"
 
     def run(self, ctx: Context) -> StepResult:
-        if os.environ.get(_OVERRIDE_ENV):
+        # Use env_truthy so ``PR_VALIDATE_SKIP_DESC=0`` correctly leaves
+        # the gate enabled — bare ``os.environ.get`` would return the
+        # string "0" which is truthy in Python and would silently skip.
+        if env_truthy(_OVERRIDE_ENV):
             return StepResult(
                 name=self.name,
                 status="skip",

--- a/scripts/pr_validate/steps/cl_description_quality.py
+++ b/scripts/pr_validate/steps/cl_description_quality.py
@@ -68,9 +68,10 @@ _BAD_TITLE_PATTERNS = (
 )
 
 # Conventional-commit prefix (e.g. ``fix(routes):``, ``feat:``,
-# ``docs(benchmarks):``) is stripped before the bad-title check so the
-# substantive title is what we evaluate.
-_CC_PREFIX = re.compile(r"^[a-z]+(?:\([^)]+\))?:\s*", re.IGNORECASE)
+# ``docs(benchmarks):``, ``feat!:`` for breaking changes) is stripped
+# before the bad-title check so the substantive title is what we
+# evaluate. The ``!?`` permits the breaking-change marker spec uses.
+_CC_PREFIX = re.compile(r"^[a-z]+(?:\([^)]+\))?!?:\s*", re.IGNORECASE)
 
 # Rationale signals — any of these in the body satisfies the
 # "explain WHY" rule. Order = how cheap they are to look for.

--- a/scripts/pr_validate/steps/cl_description_quality.py
+++ b/scripts/pr_validate/steps/cl_description_quality.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step — PR description quality gate.
+
+Enforces the basic CL-description hygiene from Google eng-practices
+(https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md):
+
+> "A bad CL description... 'Fix bug' is not adequate. What bug? What
+> did you do to fix it? Other similarly bad descriptions include:
+> 'Fix build', 'Add patch', 'Moving code from A to B', 'Phase 1'."
+
+> "The first line should be: A short summary of what is being done.
+> Complete sentence, written as though it was an order. Followed by
+> a longer description... what problem is being solved, and why this
+> is the best approach. Any shortcomings of the approach."
+
+Concretely:
+
+1. **Title is informative** — at least 3 words and is NOT one of the
+   well-known bad patterns ("fix bug", "fix build", "wip", "various
+   changes", "small change", "patch", "update", "tweaks").
+2. **Body exists** — empty PR bodies fail (no rationale = no review
+   context = future-grep loses the why).
+3. **Body has rationale** — at least one of: a "## Why" / "## Summary"
+   / "## Rationale" / "## Motivation" section, OR a "Closes #" /
+   "Fixes #" / "Refs #" issue link, OR a `Why:` line. We're lenient
+   on form but strict on the principle: the PR must explain WHY
+   something is changing, not just WHAT.
+
+Why a STEP, not a comment-only warning: every other gate is hard, so
+description quality should be too. A poorly-described PR is hard to
+review, hard to bisect after the fact, and signals the author hasn't
+thought through the change. Failing the gate forces a 30-second
+rewrite that pays back forever in code archaeology.
+
+Override: an author who insists their two-line "Bump dep X to Y" PR
+needs no rationale can use ``PR_VALIDATE_SKIP_DESC=1``. Don't make
+that the norm.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from ..base import Step, StepResult
+from ..context import Context
+
+# Title patterns that fail. Matched against the LOWERCASED title with
+# leading conventional-commit prefix (e.g. ``fix:`` / ``feat(routes):``)
+# stripped. Each entry is a full-title regex anchored to ^…$ so we don't
+# accidentally flag "Fix bug in X-Y-Z scheduler" — only the bare phrase.
+_BAD_TITLE_PATTERNS = (
+    re.compile(r"^fix\s+bug\.?$"),
+    re.compile(r"^fix\s+build\.?$"),
+    re.compile(r"^fix\s+tests?\.?$"),
+    re.compile(r"^add\s+patch\.?$"),
+    re.compile(r"^small\s+change\.?$"),
+    re.compile(r"^various\s+changes\.?$"),
+    re.compile(r"^various\s+fixes\.?$"),
+    re.compile(r"^tweaks?\.?$"),
+    re.compile(r"^update\.?$"),
+    re.compile(r"^patch\.?$"),
+    re.compile(r"^wip\.?$"),
+    re.compile(r"^cleanup\.?$"),
+    re.compile(r"^changes\.?$"),
+    re.compile(r"^updates?\.?$"),
+    re.compile(r"^misc\.?$"),
+    re.compile(r"^minor\s+(?:fix|change|update)\.?$"),
+)
+
+# Conventional-commit prefix (e.g. ``fix(routes):``, ``feat:``,
+# ``docs(benchmarks):``) is stripped before the bad-title check so the
+# substantive title is what we evaluate.
+_CC_PREFIX = re.compile(r"^[a-z]+(?:\([^)]+\))?:\s*", re.IGNORECASE)
+
+# Rationale signals — any of these in the body satisfies the
+# "explain WHY" rule. Order = how cheap they are to look for.
+_RATIONALE_SIGNALS = (
+    re.compile(
+        r"^#+\s*(?:why|summary|rationale|motivation|background|context)\b",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    re.compile(r"^\*\*Why:\*\*", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^Why:\s", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"\b(?:closes|fixes|resolves|refs)\s+#\d+", re.IGNORECASE),
+    re.compile(r"\bbecause\b", re.IGNORECASE),
+)
+
+_OVERRIDE_ENV = "PR_VALIDATE_SKIP_DESC"
+
+
+class CLDescriptionQualityStep(Step):
+    name = "cl_description_quality"
+    description = "PR title + body have rationale (Google eng-practices)"
+
+    def run(self, ctx: Context) -> StepResult:
+        if os.environ.get(_OVERRIDE_ENV):
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=f"skipped via {_OVERRIDE_ENV}=1",
+            )
+
+        title = (ctx.pr_title or "").strip()
+        body = (ctx.pr_body or "").strip()
+
+        # 1) Title check — strip a conventional-commit prefix if present
+        # so "fix: bug" still trips the bad-pattern net, but
+        # "fix(routes): default empty content to ..." doesn't.
+        bare_title = _CC_PREFIX.sub("", title).strip().lower()
+        if not bare_title:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary="PR title is empty",
+                details=(
+                    "Title must be a short, informative summary. See "
+                    "Google's CL-descriptions guidance: "
+                    "https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md"
+                ),
+            )
+        if len(bare_title.split()) < 3:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"PR title too short ({len(bare_title.split())} words after prefix strip)",
+                details=(
+                    f"Title (after stripping any conventional-commit prefix): "
+                    f"`{bare_title}`\n\n"
+                    "Google eng-practices: 'Should be informative enough that "
+                    "future code searchers don't have to read your CL.' At "
+                    "least 3 meaningful words required. Examples: "
+                    "`fix(routes): reject audio_url on text-only models` vs "
+                    "`fix: bug`."
+                ),
+            )
+        for bad in _BAD_TITLE_PATTERNS:
+            if bad.match(bare_title):
+                return StepResult(
+                    name=self.name,
+                    status="fail",
+                    summary=f"PR title matches known weak pattern: '{bare_title}'",
+                    details=(
+                        f"Title (post-prefix-strip): `{bare_title}`\n\n"
+                        "Google eng-practices calls these out as bad CL "
+                        "descriptions: 'Fix bug', 'Fix build', 'Add patch', "
+                        "'WIP', etc. Rewrite to say WHAT and WHY in <70 "
+                        "chars. Examples:\n"
+                        "- `fix(api): honor max_completion_tokens on chat completions`\n"
+                        "- `docs(benchmarks): add DFlash bench for Qwen3.6-35B`\n"
+                        "- `refactor(scheduler): extract admission control to dedicated module`"
+                    ),
+                )
+
+        # 2) Body must exist
+        if not body:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary="PR body is empty",
+                details=(
+                    "Every PR needs a body explaining the WHY: what problem "
+                    "is being solved and why this approach. "
+                    "Google eng-practices: "
+                    "https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md\n\n"
+                    "Minimum useful template:\n"
+                    "```\n"
+                    "## Summary\n"
+                    "- <one-line of what changed>\n\n"
+                    "## Why\n"
+                    "<the problem this solves>\n\n"
+                    "## Test plan\n"
+                    "- [x] <verification>\n"
+                    "```"
+                ),
+            )
+
+        # 3) Body must contain a rationale signal
+        for pattern in _RATIONALE_SIGNALS:
+            if pattern.search(body):
+                return StepResult(
+                    name=self.name,
+                    status="pass",
+                    summary=f"title OK + body has rationale ({len(body)} chars)",
+                )
+
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary="PR body has no rationale signal (no 'why', no 'closes #', no 'because')",
+            details=(
+                f"Body is {len(body)} chars but contains no recognizable "
+                "rationale signal. Add one of:\n"
+                "- A heading like `## Why`, `## Rationale`, `## Motivation`, "
+                "or `## Background`.\n"
+                "- An issue link: `Closes #NNN` / `Fixes #NNN` / `Refs #NNN`.\n"
+                "- An inline `Why:` line.\n"
+                "- A `because`-clause explaining the change.\n\n"
+                "Google eng-practices: "
+                "'Explain... what problem is being solved, and why this "
+                "is the best approach.'"
+            ),
+        )

--- a/scripts/pr_validate/steps/deepseek_review.py
+++ b/scripts/pr_validate/steps/deepseek_review.py
@@ -192,21 +192,51 @@ class DeepSeekReviewStep(Step):
                 artifacts=[str(review_path), str(usage_path)],
             )
 
-        # Findings present → fail the step in strict mode. Maintainer
-        # decides per-finding whether to act; the scorecard surfaces
-        # them all in the details. (Some reviewers may want a
-        # human-decides flow here; that's what looking at the artifact
-        # is for. The step's role is to surface, not to triage.)
-        summary = f"{len(findings)} finding(s)"
+        # Tier findings: [BLOCKING] fails the gate, [NIT] surfaces but
+        # passes. This implements Google's "approve when improvement is
+        # clear" — see prompts/deepseek_review.md for the philosophy
+        # and the recurring-spiral failure mode this addresses.
+        blocking, nits = _split_findings_by_tier(findings)
+
+        truncation_note = ""
         if omitted_files:
-            summary += f" (diff truncated — {len(omitted_files)} file(s) not reviewed)"
+            truncation_note = (
+                f" (diff truncated — {len(omitted_files)} file(s) not reviewed)"
+            )
         elif truncated:
-            summary += " (diff truncated — single large file, partial review)"
+            truncation_note = " (diff truncated — single large file, partial review)"
+
+        # Build a labelled scorecard list — keep tier badges visible
+        # so a maintainer scanning the scorecard can decide instantly
+        # which findings to act on.
+        labelled = [f"[BLOCKING] {b}" for b in blocking] + [f"[NIT] {n}" for n in nits]
+
+        if not blocking:
+            # Only NITs → pass. Surface them in the scorecard for the
+            # author to consider, but don't block merge.
+            summary = (
+                f"no blocking findings ({len(nits)} nit(s) surfaced)" + truncation_note
+            )
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=summary,
+                findings=labelled,
+                details=(
+                    "**Full review:**\n\n"
+                    f"{content}\n\n"
+                    f"_(Saved to `{review_path}`. "
+                    f"Token usage: {usage.get('total_tokens', '?')})_"
+                ),
+                artifacts=[str(review_path), str(usage_path)],
+            )
+
+        summary = f"{len(blocking)} blocking + {len(nits)} nit(s)" + truncation_note
         return StepResult(
             name=self.name,
             status="fail",
             summary=summary,
-            findings=findings,
+            findings=labelled,
             details=(
                 "**Full review:**\n\n"
                 f"{content}\n\n"
@@ -511,3 +541,35 @@ def _extract_findings(text: str) -> list[str]:
             out.append(f)
             seen.add(f)
     return out
+
+
+# Tier prefixes the prompt asks for. ``[BLOCKING]`` is what fails the
+# gate; ``[NIT]`` surfaces in the scorecard but doesn't block merge
+# (Google eng-practices "approve when improvement clear" — see
+# prompts/deepseek_review.md). Untagged findings default to BLOCKING
+# so the model can't accidentally downgrade real bugs by forgetting
+# the prefix.
+_BLOCKING_PREFIX = re.compile(r"^\s*\[BLOCKING\]\s*", re.IGNORECASE)
+_NIT_PREFIX = re.compile(r"^\s*\[NIT\]\s*", re.IGNORECASE)
+
+
+def _split_findings_by_tier(findings: list[str]) -> tuple[list[str], list[str]]:
+    """Partition findings into (blocking, nit) by their tier prefix.
+
+    The prompt requires every finding to start with ``[BLOCKING]`` or
+    ``[NIT]``. Untagged findings default to BLOCKING so a forgotten
+    prefix can't silently downgrade a real bug. The tier prefix is
+    stripped from the returned strings for cleaner scorecard rendering.
+    """
+    blocking: list[str] = []
+    nits: list[str] = []
+    for f in findings:
+        if _NIT_PREFIX.match(f):
+            nits.append(_NIT_PREFIX.sub("", f, count=1).strip())
+        elif _BLOCKING_PREFIX.match(f):
+            blocking.append(_BLOCKING_PREFIX.sub("", f, count=1).strip())
+        else:
+            # Untagged → treat as BLOCKING. Preserve the original text
+            # so the reviewer sees the model forgot the prefix.
+            blocking.append(f)
+    return blocking, nits

--- a/tests/test_pr_validate_google_review.py
+++ b/tests/test_pr_validate_google_review.py
@@ -153,6 +153,48 @@ class TestCLDescriptionQualityTitle:
     @pytest.mark.parametrize(
         "title",
         [
+            "fix: memory leak",  # bare = "memory leak" (2 words)
+            "feat: new endpoint",  # bare = "new endpoint" (2 words)
+            "fix(routes): null deref",  # bare = "null deref" (2 words)
+        ],
+    )
+    def test_two_word_non_blacklisted_title_still_fails(self, title: str):
+        """Policy choice: even non-blacklisted 2-word titles fail because
+        the repo's actual title corpus is 5-10 words and Google's
+        "informative for future grep" principle wants more specificity.
+        E.g. `fix: memory leak` doesn't tell future searchers where the
+        leak was — `fix(routes): memory leak on websocket close` does.
+        This test pins the threshold so a future relaxation is intentional,
+        not accidental."""
+        result = CLDescriptionQualityStep().run(_ctx(title=title, body="Why: x"))
+        assert result.status == "fail", f"expected fail for title {title!r}"
+        assert "short" in result.summary.lower() or "weak" in result.summary.lower()
+
+    def test_breaking_change_marker_is_stripped(self):
+        """Conventional-commit `!:` marks a breaking change (e.g.
+        `feat!: drop python 3.10 support`). The prefix-strip regex must
+        handle the `!` so the substantive title is what gets evaluated
+        — otherwise the bad-pattern blacklist would never apply to
+        breaking-change titles."""
+        # Good breaking-change title — 5 words after strip, should pass.
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat!: drop python 3.10 support", body="Why: x")
+        )
+        assert result.status == "pass"
+
+        # Bad breaking-change title — bare is "wip", should fail.
+        result = CLDescriptionQualityStep().run(_ctx(title="feat!: wip", body="Why: x"))
+        assert result.status == "fail"
+
+        # Scoped breaking change: `feat(api)!: ...` should also strip.
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat(api)!: rename foo endpoint to bar", body="Why: x")
+        )
+        assert result.status == "pass"
+
+    @pytest.mark.parametrize(
+        "title",
+        [
             "fix bug",
             "fix build",
             "fix tests",

--- a/tests/test_pr_validate_google_review.py
+++ b/tests/test_pr_validate_google_review.py
@@ -259,6 +259,25 @@ class TestCLDescriptionQualityBody:
         )
         assert result.status == "pass"
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "  Why: the api shape changed",  # indented under no parent
+            "  - Why: bullet-nested rationale",  # bullet-nested
+            "    **Why:** indented bold form",  # 4-space indent (under list)
+            "  ## Why\n  indented heading",  # rare but legal
+        ],
+    )
+    def test_indented_rationale_signals_pass(self, body: str):
+        """Indented `Why:` / `**Why:**` / `## Why` lines (inside bullets,
+        block quotes, or list items) must still satisfy the gate.
+        Without leading-whitespace tolerance the regex misses valid PRs
+        whose rationale is nested under a parent bullet."""
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add the new helper", body=body)
+        )
+        assert result.status == "pass", f"expected pass for body {body!r}"
+
 
 class TestCLDescriptionQualityOverride:
     """The ``PR_VALIDATE_SKIP_DESC=1`` escape hatch — for two-line
@@ -272,5 +291,19 @@ class TestCLDescriptionQualityOverride:
 
     def test_no_override_runs_normally(self, monkeypatch):
         monkeypatch.delenv("PR_VALIDATE_SKIP_DESC", raising=False)
+        result = CLDescriptionQualityStep().run(_ctx(title="wip", body=""))
+        assert result.status == "fail"
+
+    def test_override_env_zero_does_not_skip(self, monkeypatch):
+        """``PR_VALIDATE_SKIP_DESC=0`` should keep the gate enabled —
+        users naturally write ``=0`` to mean "off" but ``os.environ.get``
+        treats it as truthy. The step uses ``env_truthy`` to match the
+        rest of the codebase's truthiness convention."""
+        monkeypatch.setenv("PR_VALIDATE_SKIP_DESC", "0")
+        result = CLDescriptionQualityStep().run(_ctx(title="wip", body=""))
+        assert result.status == "fail"
+
+    def test_override_env_false_does_not_skip(self, monkeypatch):
+        monkeypatch.setenv("PR_VALIDATE_SKIP_DESC", "false")
         result = CLDescriptionQualityStep().run(_ctx(title="wip", body=""))
         assert result.status == "fail"

--- a/tests/test_pr_validate_google_review.py
+++ b/tests/test_pr_validate_google_review.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Google eng-practices integration in ``pr_validate``.
+
+Covers two new pieces of functionality:
+
+1. ``_split_findings_by_tier`` — partitions DeepSeek findings into
+   ``[BLOCKING]`` (fails the gate) vs ``[NIT]`` (surfaces but passes),
+   with untagged findings defaulting to BLOCKING so a forgotten prefix
+   can't silently downgrade a real bug.
+
+2. ``CLDescriptionQualityStep`` — title + body hygiene gate from
+   Google's CL-descriptions guidance. Rejects bad titles, empty
+   bodies, and bodies with no rationale signal.
+
+Motivating example: PR #467 (chat-route empty content fix) spent 5
+rounds in a DeepSeek spiral because every reply produced fresh style
+preferences and the previous prompt couldn't downgrade them. With
+tiering, those would have been single-round ``[NIT]``s and the PR
+would have merged after one round of substantive fixes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.cl_description_quality import (
+    CLDescriptionQualityStep,
+)
+from scripts.pr_validate.steps.deepseek_review import _split_findings_by_tier
+
+# ---------------------------------------------------------------------------
+# _split_findings_by_tier
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFindingsByTier:
+    """The tier-split helper is what implements Google's "approve when
+    improvement is clear" — only ``[BLOCKING]`` findings fail the gate.
+    """
+
+    def test_empty_input_returns_empty_lists(self):
+        blocking, nits = _split_findings_by_tier([])
+        assert blocking == []
+        assert nits == []
+
+    def test_all_blocking(self):
+        findings = [
+            "[BLOCKING] routes/x.py:10 — race condition on shared dict.",
+            "[BLOCKING] routes/y.py:42 — missing await on async call.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert len(blocking) == 2
+        assert nits == []
+        # Prefix is stripped — keeps scorecard tidy.
+        assert all(not b.startswith("[BLOCKING]") for b in blocking)
+        assert "race condition" in blocking[0]
+
+    def test_all_nit(self):
+        findings = [
+            "[NIT] tests/x.py:5 — could rename `val` to `value`.",
+            "[NIT] tests/y.py:9 — comment could be clearer.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert blocking == []
+        assert len(nits) == 2
+        assert all(not n.startswith("[NIT]") for n in nits)
+
+    def test_mixed_tiers(self):
+        findings = [
+            "[BLOCKING] a.py:1 — real bug.",
+            "[NIT] b.py:2 — style.",
+            "[BLOCKING] c.py:3 — another bug.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert len(blocking) == 2
+        assert len(nits) == 1
+        assert "real bug" in blocking[0]
+        assert "another bug" in blocking[1]
+        assert "style" in nits[0]
+
+    def test_untagged_defaults_to_blocking(self):
+        """A finding without ``[BLOCKING]``/``[NIT]`` must default to
+        BLOCKING. A forgotten prefix should fail-safe (block merge) so
+        the model can't accidentally downgrade a real bug by skipping
+        the tag — and the reviewer notices the model forgot."""
+        findings = [
+            "routes/x.py:10 — missing input validation.",
+            "[NIT] tests/y.py:5 — minor style.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert len(blocking) == 1
+        assert len(nits) == 1
+        # The untagged finding keeps its original text verbatim so the
+        # reviewer sees the model forgot the prefix.
+        assert "missing input validation" in blocking[0]
+
+    def test_case_insensitive_prefix(self):
+        findings = [
+            "[blocking] a.py:1 — bug.",
+            "[Nit] b.py:2 — style.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert len(blocking) == 1
+        assert len(nits) == 1
+
+    def test_prefix_with_extra_whitespace(self):
+        """The regex tolerates leading/trailing whitespace inside the
+        tag area because some models indent or pad."""
+        findings = [
+            "  [BLOCKING]   a.py:1 — bug.",
+            "[NIT]    b.py:2 — style.",
+        ]
+        blocking, nits = _split_findings_by_tier(findings)
+        assert len(blocking) == 1
+        assert len(nits) == 1
+        assert blocking[0].startswith("a.py")
+        assert nits[0].startswith("b.py")
+
+
+# ---------------------------------------------------------------------------
+# CLDescriptionQualityStep
+# ---------------------------------------------------------------------------
+
+
+def _ctx(title: str = "", body: str = "") -> Context:
+    """Build a context shell with just title + body — the step only
+    reads those fields."""
+    ctx = Context(pr_number=999, repo="x/y")
+    ctx.pr_title = title
+    ctx.pr_body = body
+    return ctx
+
+
+class TestCLDescriptionQualityTitle:
+    """Title checks: empty, too-short, and bad-pattern blacklist."""
+
+    def test_empty_title_fails(self):
+        result = CLDescriptionQualityStep().run(_ctx(title="", body="Why: x"))
+        assert result.status == "fail"
+        assert "empty" in result.summary.lower()
+
+    def test_one_word_title_fails(self):
+        result = CLDescriptionQualityStep().run(_ctx(title="patch", body="Why: x"))
+        assert result.status == "fail"
+        assert "short" in result.summary.lower() or "weak" in result.summary.lower()
+
+    def test_two_word_title_fails(self):
+        """3-word minimum after CC-prefix strip. ``fix bug`` is 2 words."""
+        result = CLDescriptionQualityStep().run(_ctx(title="fix bug", body="Why: x"))
+        assert result.status == "fail"
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "fix bug",
+            "fix build",
+            "fix tests",
+            "add patch",
+            "wip",
+            "various changes",
+            "small change",
+            "patch",
+            "update",
+            "tweaks",
+            "cleanup",
+            "misc",
+            "minor fix",
+        ],
+    )
+    def test_bad_title_patterns_fail(self, title: str):
+        """The blacklist Google explicitly calls out as bad CL
+        descriptions. Each must fail the gate."""
+        result = CLDescriptionQualityStep().run(_ctx(title=title, body="Why: x"))
+        assert result.status == "fail", f"expected fail for title {title!r}"
+
+    def test_cc_prefix_stripped_before_bad_pattern_check(self):
+        """A bare ``fix: bug`` should fail. A proper
+        ``fix(routes): default empty content to ...`` (>3 substantive
+        words) must pass — the conventional-commit prefix is stripped."""
+        bad = CLDescriptionQualityStep().run(_ctx(title="fix: bug", body="Why: x"))
+        assert bad.status == "fail"
+
+        good = CLDescriptionQualityStep().run(
+            _ctx(
+                title="fix(routes): default empty content to satisfy openai shape",
+                body="Why: x",
+            )
+        )
+        assert good.status == "pass"
+
+    def test_cc_prefix_does_not_consume_real_word(self):
+        """A title like ``feat: add new endpoint`` is 3 words after
+        stripping ``feat:`` and should pass title check."""
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add new endpoint", body="Why: x")
+        )
+        assert result.status == "pass"
+
+    def test_good_title_with_long_descriptive_form(self):
+        result = CLDescriptionQualityStep().run(
+            _ctx(
+                title="fix(api): honor max_completion_tokens on chat completions",
+                body="Why: openai sdk >=1.45 stopped sending max_tokens",
+            )
+        )
+        assert result.status == "pass"
+
+
+class TestCLDescriptionQualityBody:
+    """Body checks: existence + rationale-signal detection."""
+
+    def test_empty_body_fails(self):
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add a new endpoint", body="")
+        )
+        assert result.status == "fail"
+        assert "body" in result.summary.lower() and "empty" in result.summary.lower()
+
+    def test_body_with_no_rationale_signal_fails(self):
+        """A body that's pure description with no ``why``, no
+        ``Closes #``, no ``because`` — Google's bar fails."""
+        body = "This patch changes the foo helper. It updates the bar list."
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add foo helper update", body=body)
+        )
+        assert result.status == "fail"
+        assert "rationale" in result.summary.lower()
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "## Why\nWe need this because the api changed.",
+            "## Summary\nFoo\n\n## Rationale\nBar.",
+            "## Motivation\nThe legacy path was broken.",
+            "## Background\nUsers reported timeouts.",
+            "Why: the api shape changed in v2",
+            "**Why:** the api shape changed in v2",
+            "Closes #123",
+            "fixes #456 — broken since last release",
+            "Resolves #789",
+            "Refs #100",
+            "Adds the helper because the legacy path was deprecated.",
+        ],
+    )
+    def test_body_with_rationale_signal_passes(self, body: str):
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add the new helper", body=body)
+        )
+        assert result.status == "pass", f"expected pass for body {body!r}"
+
+    def test_summary_heading_alone_is_sufficient(self):
+        """A ``## Summary`` heading counts as a rationale signal —
+        contributors often use the template's Summary section as their
+        primary explanation."""
+        body = "## Summary\n- new endpoint\n- updated docs"
+        result = CLDescriptionQualityStep().run(
+            _ctx(title="feat: add new endpoint", body=body)
+        )
+        assert result.status == "pass"
+
+
+class TestCLDescriptionQualityOverride:
+    """The ``PR_VALIDATE_SKIP_DESC=1`` escape hatch — for two-line
+    dep-bumps where rationale is genuinely overkill."""
+
+    def test_override_env_skips_step(self, monkeypatch):
+        monkeypatch.setenv("PR_VALIDATE_SKIP_DESC", "1")
+        result = CLDescriptionQualityStep().run(_ctx(title="wip", body=""))
+        assert result.status == "skip"
+        assert "PR_VALIDATE_SKIP_DESC" in result.summary
+
+    def test_no_override_runs_normally(self, monkeypatch):
+        monkeypatch.delenv("PR_VALIDATE_SKIP_DESC", raising=False)
+        result = CLDescriptionQualityStep().run(_ctx(title="wip", body=""))
+        assert result.status == "fail"

--- a/tests/test_pr_validate_google_review.py
+++ b/tests/test_pr_validate_google_review.py
@@ -27,7 +27,10 @@ from scripts.pr_validate.context import Context
 from scripts.pr_validate.steps.cl_description_quality import (
     CLDescriptionQualityStep,
 )
-from scripts.pr_validate.steps.deepseek_review import _split_findings_by_tier
+from scripts.pr_validate.steps.deepseek_review import (
+    _extract_findings,
+    _split_findings_by_tier,
+)
 
 # ---------------------------------------------------------------------------
 # _split_findings_by_tier
@@ -116,6 +119,37 @@ class TestSplitFindingsByTier:
         assert len(nits) == 1
         assert blocking[0].startswith("a.py")
         assert nits[0].startswith("b.py")
+
+    def test_pipeline_extract_then_split_realistic_model_output(self):
+        """End-to-end pipeline test: raw model review text →
+        ``_extract_findings`` → ``_split_findings_by_tier``. The two
+        helpers must compose correctly — if ``_extract_findings`` ever
+        starts preserving the leading list number, the tier-prefix
+        regex would silently fail to match and EVERY finding would
+        default to BLOCKING (defeating tiering). This test pins the
+        contract between the two helpers."""
+        review = (
+            "1. [BLOCKING] vllm_mlx/routes/chat.py:918 — `assert isinstance(_msg, dict)`\n"
+            "   is stripped under `python -O`, leaving the guard inert in production.\n"
+            "2. [NIT] tests/test_x.py:42 — assertion is loose; use `result.status_code`.\n"
+            "3. [BLOCKING] vllm_mlx/engine.py:55 — race condition on shared dict.\n"
+            "4. [NIT] tests/test_y.py:9 — comment could be clearer.\n"
+        )
+        findings = _extract_findings(review)
+        assert len(findings) == 4, (
+            f"_extract_findings produced {len(findings)} findings, expected 4"
+        )
+
+        blocking, nits = _split_findings_by_tier(findings)
+        # The contract: 2 blocking + 2 nits — NOT 4 blocking (which
+        # would mean leading numbers leaked through and broke tiering).
+        assert len(blocking) == 2, (
+            f"got {len(blocking)} blocking — leading list number likely "
+            f"leaked: {blocking!r}"
+        )
+        assert len(nits) == 2, f"got {len(nits)} nits, expected 2: {nits!r}"
+        assert "chat.py" in blocking[0]
+        assert "engine.py" in blocking[1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds two new gates to `pr_validate` inspired by [Google's eng-practices](https://github.com/google/eng-practices) and refactors the DeepSeek-review verdict from "any finding fails" to tiered `[BLOCKING]` / `[NIT]` so reviews converge instead of spiral.

- **DeepSeek prompt now requires `[BLOCKING]` or `[NIT]` on every finding.** Only `[BLOCKING]` fails the gate; `[NIT]`s surface in the scorecard. Caps: 5 BLOCKING + 5 NIT per review. Untagged findings default to `[BLOCKING]` (forgotten prefix can't downgrade a real bug).
- **New `cl_description_quality` step.** Title + body hygiene gate: title not empty + >=3 words + not in known-bad blacklist; body not empty + contains a rationale signal (`## Why` heading, `Closes #NNN`, inline `Why:`, or `because`-clause). Override: `PR_VALIDATE_SKIP_DESC=1`.

## Why

PR #467 (chat-route empty-content fix) spent 5 DeepSeek rounds in a spiral because every reply produced fresh \"could be more defensive\" findings and the previous binary-verdict prompt had no way to mark them as nits. Google's standard:

> \"Reviewers should favor approving a CL once it is in a state where it definitely improves the overall code health, even if the CL isn't perfect.\"

Tiered findings encode that principle — substantive bugs still block, but style preferences and future-proofing suggestions don't hold up merges. The CL-description gate addresses a parallel issue from Google's [CL-descriptions guidance](https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md): a PR titled `fix bug` with no body is hard to bisect later, and the 30-second fix is much cheaper than the future code-archaeology cost.

## Pipeline order

The new `cl_description_quality` step runs at position 0.7 — after `fetch` (0) and `test_plan_check` (0.5), before `deepseek_review` (6). Two sub-second cheap gates fail fast on description hygiene before we spend 30-90s on a DeepSeek call.

## Test plan

- [x] `pytest tests/test_pr_validate_google_review.py` — 42 new tests covering:
  - Tier-split (`_split_findings_by_tier`): untagged → BLOCKING default, mixed cases, case-insensitive prefix, whitespace tolerance, prefix stripping
  - CLDescriptionQualityStep title checks: empty/short/blacklisted patterns (13 parametrized), CC-prefix stripping
  - CLDescriptionQualityStep body checks: empty + 11 rationale signals (parametrized)
  - Override env: `PR_VALIDATE_SKIP_DESC=1` returns skip
- [x] `pytest tests/test_pr_validate_*` — all 79 pr_validate tests pass (no regressions)
- [x] `ruff check` + `ruff format --check` clean across all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)