### PR TITLE
feat(usage): surface prefix-cache hits in OpenAI + Anthropic usage blocks

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -418,6 +418,86 @@ class TestOpenaiToAnthropic:
         assert result.usage.input_tokens == 10
         assert result.usage.output_tokens == 5
 
+    def test_usage_mapping_no_cache_leaves_cache_fields_unset(self):
+        """When the OpenAI side reports no prefix-cache hit (the
+        ``prompt_tokens_details`` field is omitted), the Anthropic
+        cache fields stay ``None`` so downstream tools can distinguish
+        "engine doesn't report cache" from "engine reported a hit".
+        ``input_tokens`` falls back to the full prompt count since
+        nothing is attributed to cache.
+        """
+        resp = self._make_response()
+        result = openai_to_anthropic(resp, "default")
+        assert result.usage.input_tokens == 10
+        assert result.usage.cache_read_input_tokens is None
+        assert result.usage.cache_creation_input_tokens is None
+
+    def test_usage_mapping_with_cache_hit_preserves_anthropic_identity(self):
+        """Per Anthropic's prompt-caching docs the three input fields
+        are mutually exclusive:
+            total_input_tokens = input_tokens
+                + cache_read_input_tokens
+                + cache_creation_input_tokens
+        So ``input_tokens`` is the *non-cached* share, not the whole
+        prompt. We populate ``cache_read_input_tokens`` with the
+        local engine's hit count and leave
+        ``cache_creation_input_tokens`` unset — Anthropic's "creation"
+        means tokens written between explicit ``cache_control``
+        breakpoints (billed 1.25x), which has no analog on a local
+        KV-cache engine.
+        """
+        from vllm_mlx.api.models import PromptTokensDetails
+
+        msg = AssistantMessage(content="hi")
+        choice = ChatCompletionChoice(message=msg, finish_reason="stop")
+        resp = ChatCompletionResponse(
+            model="default",
+            choices=[choice],
+            usage=Usage(
+                prompt_tokens=100,
+                completion_tokens=20,
+                total_tokens=120,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=30),
+            ),
+        )
+        result = openai_to_anthropic(resp, "default")
+        assert result.usage.input_tokens == 70
+        assert result.usage.output_tokens == 20
+        assert result.usage.cache_read_input_tokens == 30
+        assert result.usage.cache_creation_input_tokens is None
+        # Anthropic-spec identity holds: 70 + 30 + 0 == 100
+        assert (
+            result.usage.input_tokens
+            + (result.usage.cache_read_input_tokens or 0)
+            + (result.usage.cache_creation_input_tokens or 0)
+            == 100
+        )
+
+    def test_usage_mapping_full_cache_hit(self):
+        """An exact re-run that hits 100% of the prompt prefix
+        produces ``input_tokens=0`` and ``cache_read_input_tokens``
+        equal to the full prompt — every input token is attributed
+        to cache.
+        """
+        from vllm_mlx.api.models import PromptTokensDetails
+
+        msg = AssistantMessage(content="hi")
+        choice = ChatCompletionChoice(message=msg, finish_reason="stop")
+        resp = ChatCompletionResponse(
+            model="default",
+            choices=[choice],
+            usage=Usage(
+                prompt_tokens=100,
+                completion_tokens=20,
+                total_tokens=120,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=100),
+            ),
+        )
+        result = openai_to_anthropic(resp, "default")
+        assert result.usage.input_tokens == 0
+        assert result.usage.cache_read_input_tokens == 100
+        assert result.usage.cache_creation_input_tokens is None
+
     def test_tool_calls_response(self):
         tc = ToolCall(
             id="call_1",

--- a/tests/test_anthropic_route_streaming.py
+++ b/tests/test_anthropic_route_streaming.py
@@ -240,3 +240,95 @@ def test_anthropic_stream_route_reasoning_parser_with_thinking_default_still_wor
     # without binding to specific token boundaries the parser chooses.
     assert "real answer" in "".join(text_deltas), text_deltas
     assert "scratch" in "".join(thinking_deltas), thinking_deltas
+
+
+class _CacheReportingEngine:
+    """Streaming engine that reports a prefix-cache hit count, like
+    the prefix-cache scheduler does in production. Mirrors
+    ``_StreamingEngine`` but adds ``cached_tokens`` on each chunk so
+    the route's ``message_delta`` usage can pick it up.
+    """
+
+    preserve_native_tool_format = False
+    tokenizer = _ThinkingTemplateTokenizer()
+
+    def __init__(self, deltas: list[str], *, prompt_tokens: int, cached_tokens: int):
+        self._deltas = deltas
+        self._prompt_tokens = prompt_tokens
+        self._cached_tokens = cached_tokens
+
+    async def stream_chat(self, messages, **kwargs):
+        for i, text in enumerate(self._deltas, start=1):
+            yield SimpleNamespace(
+                new_text=text,
+                prompt_tokens=self._prompt_tokens,
+                completion_tokens=i,
+                cached_tokens=self._cached_tokens,
+            )
+
+
+def _find_message_delta(events: list[dict]) -> dict:
+    deltas = [e for e in events if e.get("type") == "message_delta"]
+    assert deltas, "message_delta event missing from stream"
+    return deltas[-1]
+
+
+def test_anthropic_stream_emits_cache_read_when_engine_reports_hit():
+    """When the underlying engine surfaces a prefix-cache hit on its
+    stream chunks, the Anthropic ``message_delta`` usage block must
+    populate ``cache_read_input_tokens`` and adjust ``input_tokens``
+    down by the cached share so Anthropic's spec identity
+    (``total_input = input + cache_read + cache_creation``) holds.
+    """
+    engine = _CacheReportingEngine(
+        ["Direct ", "answer"], prompt_tokens=100, cached_tokens=30
+    )
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly"}],
+        },
+    )
+    assert response.status_code == 200
+
+    events = _parse_sse_data(response.text)
+    usage = _find_message_delta(events)["usage"]
+    assert usage["input_tokens"] == 70  # 100 prompt - 30 cached
+    assert usage["cache_read_input_tokens"] == 30
+    # cache_creation is intentionally absent (Anthropic's billing
+    # category has no local-engine analog).
+    assert "cache_creation_input_tokens" not in usage
+
+
+def test_anthropic_stream_omits_cache_fields_without_hit():
+    """When the engine reports no hit (``cached_tokens=0``), the
+    ``message_delta`` usage block must NOT include cache fields, and
+    ``input_tokens`` must reflect the full prompt. Mirrors the
+    non-streaming adapter's "engine doesn't report" semantic.
+    """
+    engine = _CacheReportingEngine(
+        ["Direct ", "answer"], prompt_tokens=100, cached_tokens=0
+    )
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly"}],
+        },
+    )
+    assert response.status_code == 200
+
+    events = _parse_sse_data(response.text)
+    usage = _find_message_delta(events)["usage"]
+    assert usage["input_tokens"] == 100
+    assert "cache_read_input_tokens" not in usage
+    assert "cache_creation_input_tokens" not in usage

--- a/tests/test_anthropic_stream_reasoning.py
+++ b/tests/test_anthropic_stream_reasoning.py
@@ -33,6 +33,7 @@ class _FakeOutput:
         self.new_text = new_text
         self.prompt_tokens = 0
         self.completion_tokens = 0
+        self.cached_tokens = 0
 
 
 class _FakeEngine:

--- a/tests/test_anthropic_streaming_reasoning.py
+++ b/tests/test_anthropic_streaming_reasoning.py
@@ -32,11 +32,16 @@ class MockDeltaOutput:
     """Simulates one async chunk from engine.stream_chat()."""
 
     def __init__(
-        self, new_text: str, prompt_tokens: int = 10, completion_tokens: int = 1
+        self,
+        new_text: str,
+        prompt_tokens: int = 10,
+        completion_tokens: int = 1,
+        cached_tokens: int = 0,
     ):
         self.new_text = new_text
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
+        self.cached_tokens = cached_tokens
 
 
 class MockEngine:

--- a/tests/test_batched_engine_output_router.py
+++ b/tests/test_batched_engine_output_router.py
@@ -129,6 +129,56 @@ async def test_stream_chat_routes_supported_tokenizer_channels():
 
 
 @pytest.mark.asyncio
+async def test_stream_chat_routed_outputs_preserve_cached_tokens():
+    """``_make_routed_output`` + ``_routed_finish_sentinel`` must
+    thread ``source.cached_tokens`` onto every routed chunk.
+    OutputRouter models (Gemma 4 / harmony / gpt-oss) rebuild each
+    emitted ``GenerationOutput`` from scratch — a missed propagation
+    here would silently zero out the prefix-cache hit count on the
+    routed flush, leaving usage at 0 while the engine actually
+    served the prefix from cache. Same failure shape as PR #454 /
+    #456 for ``reasoning_tokens`` and ``logprobs``.
+
+    Drives a harmony-style stream with ``cached_tokens=128`` on every
+    source chunk and asserts every routed output (content,
+    reasoning, finish sentinel) carries the value through.
+    """
+    engine = _make_engine(FakeTokenizer(HARMONY_VOCAB))
+
+    async def fake_stream_generate(**kwargs):
+        yield GenerationOutput(
+            text="",
+            new_text="<|channel|>analysis<|message|>Reason",
+            tokens=[200005, 35644, 200008, 2],
+            finished=False,
+            cached_tokens=128,
+        )
+        yield GenerationOutput(
+            text="",
+            new_text="ing<|start|><|channel|>final<|message|>Answer",
+            tokens=[3, 200006, 200005, 17196, 200008, 4],
+            finished=True,
+            finish_reason="stop",
+            cached_tokens=128,
+        )
+
+    engine.stream_generate = fake_stream_generate
+
+    outputs = await _collect(
+        engine.stream_chat(messages=[{"role": "user", "content": "hi"}])
+    )
+
+    # Every emitted routed output (per-token reasoning chunks, the
+    # content chunk, AND the finish sentinel) must carry the
+    # source's cached_tokens through.
+    assert outputs, "router should emit at least one output"
+    cached = [o.cached_tokens for o in outputs]
+    assert cached == [128] * len(outputs), (
+        f"cached_tokens must propagate to every routed output; got {cached!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_router_propagates_per_token_logprobs_to_routed_outputs():
     """OutputRouter must forward source.logprobs to each routed chunk.
 

--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -34,6 +34,7 @@ class _StubOutput:
         self.output_text = "stub-response"
         self.prompt_tokens = 0
         self.completion_tokens = 0
+        self.cached_tokens = 0
         self.finish_reason = "stop"
         self.usage = None
         self.text = "stub-response"

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Route-level integration tests for the prefix-cache reporting field.
+
+The helper-level unit tests in ``test_server_utils.py`` and
+``test_anthropic_adapter.py`` cover ``_build_usage`` / ``get_usage``
+and the Anthropic adapter mapping in isolation, but they don't exercise
+the actual ``/v1/chat/completions`` and ``/v1/completions`` routes.
+Without these tests, a refactor that rebuilds the route's usage
+assembly (e.g. drops the per-chunk ``cached_tokens`` accumulator in
+``routes/chat.py`` or the ``total_cached_tokens`` accumulator in
+``routes/completions.py``) silently regresses cache reporting while
+the helper tests stay green. The Anthropic streaming counterpart of
+this coverage is in ``test_anthropic_route_streaming.py``.
+"""
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.routes.completions import router as completions_router
+
+
+class _CacheReportingChatEngine:
+    """Mock chat engine that reports prefix-cache hits on every output.
+
+    Mirrors the production scheduler's behavior: ``cached_tokens`` is
+    set once per request (at schedule time) and stays constant across
+    all stream chunks. Returns ``GenerationOutput`` from both ``chat``
+    (non-streaming) and ``stream_chat`` (streaming) so the same engine
+    instance can drive both code paths.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, *, prompt_tokens: int, cached_tokens: int):
+        self._prompt_tokens = prompt_tokens
+        self._cached_tokens = cached_tokens
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        return GenerationOutput(
+            text="hi",
+            raw_text="hi",
+            prompt_tokens=self._prompt_tokens,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            cached_tokens=self._cached_tokens,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        deltas = ["hi", " there"]
+        accumulated = ""
+        for i, delta in enumerate(deltas):
+            accumulated += delta
+            is_last = i == len(deltas) - 1
+            yield GenerationOutput(
+                text=accumulated,
+                new_text=delta,
+                prompt_tokens=self._prompt_tokens,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                channel=None,
+                cached_tokens=self._cached_tokens,
+            )
+
+
+class _CacheReportingCompletionEngine:
+    """Mock completion engine. Returns a single ``GenerationOutput``
+    from ``generate``; the ``/v1/completions`` route loops over the
+    request's prompts and accumulates token counts across each.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, *, prompt_tokens: int, cached_tokens: int):
+        self._prompt_tokens = prompt_tokens
+        self._cached_tokens = cached_tokens
+
+    async def generate(self, prompt, **kwargs):
+        return GenerationOutput(
+            text="answer",
+            prompt_tokens=self._prompt_tokens,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            cached_tokens=self._cached_tokens,
+        )
+
+
+def _make_chat_client(engine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _make_completions_client(engine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    app.include_router(completions_router)
+    return TestClient(app)
+
+
+def _parse_sse_events(text: str) -> list[dict]:
+    events: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+def test_chat_non_streaming_response_carries_cached_tokens():
+    """End-to-end: prefix-cache hit at the engine layer surfaces as
+    ``usage.prompt_tokens_details.cached_tokens`` on the
+    ``/v1/chat/completions`` response. Closes the loop from
+    ``GenerationOutput.cached_tokens`` → ``_build_usage`` →
+    Pydantic ``Usage`` → JSON wire.
+    """
+    engine = _CacheReportingChatEngine(prompt_tokens=200, cached_tokens=128)
+    client = _make_chat_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["usage"]["prompt_tokens"] == 200
+    details = body["usage"].get("prompt_tokens_details")
+    assert details is not None, (
+        "prompt_tokens_details must appear on the response when the "
+        "engine reported a cache hit; got usage="
+        f"{body['usage']!r}"
+    )
+    assert details["cached_tokens"] == 128
+
+
+def test_chat_streaming_with_include_usage_carries_cached_tokens_in_dedicated_chunk():
+    """When ``stream_options.include_usage`` is true, the dedicated
+    trailing usage chunk (empty ``choices``, populated ``usage``) must
+    surface ``cached_tokens``. This is the primary OpenAI-spec way
+    streaming clients consume usage — the per-chunk accumulator in
+    ``routes/chat.py`` and the ``_UsageOutput`` namespace fed to
+    ``_build_usage`` must both propagate the field correctly.
+    """
+    engine = _CacheReportingChatEngine(prompt_tokens=200, cached_tokens=128)
+    client = _make_chat_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream_options": {"include_usage": True},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    usage_chunks = [e for e in events if not e.get("choices") and e.get("usage")]
+    assert len(usage_chunks) == 1, (
+        f"expected exactly one dedicated usage chunk; got {len(usage_chunks)}"
+    )
+    usage = usage_chunks[0]["usage"]
+    details = usage.get("prompt_tokens_details")
+    assert details is not None
+    assert details["cached_tokens"] == 128
+
+
+def test_chat_streaming_without_include_usage_carries_cached_tokens_on_finish_chunk():
+    """Without ``stream_options.include_usage``, bare clients still
+    expect usage on the finish chunk (legacy behavior). The new
+    ``cached_tokens`` field must survive the same route through the
+    ``Usage(...)`` inline constructor as the existing fields do.
+    """
+    engine = _CacheReportingChatEngine(prompt_tokens=200, cached_tokens=128)
+    client = _make_chat_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    finish_events = [
+        e for e in events for c in e.get("choices", []) if c.get("finish_reason")
+    ]
+    assert len(finish_events) == 1
+    usage = finish_events[0].get("usage")
+    assert usage is not None, (
+        "finish chunk must carry usage when include_usage is unset"
+    )
+    details = usage.get("prompt_tokens_details")
+    assert details is not None
+    assert details["cached_tokens"] == 128
+
+
+# ---------------------------------------------------------------------------
+# /v1/completions
+# ---------------------------------------------------------------------------
+
+
+def test_completions_non_streaming_response_carries_cached_tokens():
+    """``/v1/completions`` accumulates ``cached_tokens`` across each
+    prompt in the request batch (single prompt = single accumulator
+    increment). Exercises the
+    ``total_cached_tokens += output.cached_tokens`` line in
+    ``routes/completions.py`` and confirms it surfaces on the response
+    via the same ``PromptTokensDetails`` shape.
+    """
+    engine = _CacheReportingCompletionEngine(prompt_tokens=200, cached_tokens=128)
+    client = _make_completions_client(engine)
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "Hello",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["usage"]["prompt_tokens"] == 200
+    details = body["usage"].get("prompt_tokens_details")
+    assert details is not None, (
+        "prompt_tokens_details must appear on the response when the "
+        "engine reported a cache hit; got usage="
+        f"{body['usage']!r}"
+    )
+    assert details["cached_tokens"] == 128
+
+
+# ---------------------------------------------------------------------------
+# Scheduler RequestOutput construction (the source of the field)
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_request_output_construction_carries_cached_tokens():
+    """The single source line that injects the field on the production
+    path: ``scheduler.py``'s ``_process_batch_responses`` constructs
+    ``RequestOutput(..., cached_tokens=request.cached_tokens, ...)``
+    from the ``Request`` whose prefix-cache lookup populated the
+    field. The route-level tests above use mock engines that
+    short-circuit the scheduler entirely, so without this test a
+    silent removal of the source line would leave production
+    responses always reporting 0 — yet every test would still pass.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.request import Request, SamplingParams
+    from vllm_mlx.scheduler import Scheduler
+
+    # Bypass ``__init__`` — it sets up BatchGenerator, prefix cache
+    # tiers, detokenizer pool, etc., none of which
+    # ``_process_batch_responses`` touches for this test. We populate
+    # only the fields the method reads.
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._detokenizer_pool = {}
+    scheduler.uid_to_request_id = {1: "req-1"}
+    scheduler.running = {}
+    # Minimal tokenizer for ``_decode_tokens`` (called on the
+    # non-stop path); a no-op decoder is enough since the test
+    # asserts only on the cached_tokens field.
+    scheduler._actual_tokenizer = SimpleNamespace(
+        encode=MagicMock(return_value=[1, 2]),
+        decode=MagicMock(return_value="x"),
+    )
+
+    # Build a Request with a known cached_tokens count. Attach a
+    # minimal decoder so the streaming-decode branch on the non-stop
+    # response also works without touching the real IncrementalDecoder
+    # machinery.
+    request = Request(
+        request_id="req-1",
+        prompt="hello",
+        sampling_params=SamplingParams(),
+    )
+    request.num_prompt_tokens = 200
+    request.cached_tokens = 128
+    request._decoder = SimpleNamespace(add_token=MagicMock(return_value="x"))
+    scheduler.running["req-1"] = request
+
+    # Fake mlx-lm-style response: uid maps to our request, one new
+    # token, non-stop finish reason so ``_process_batch_responses``
+    # builds the RequestOutput in the normal token-append path.
+    fake_response = SimpleNamespace(
+        uid=1,
+        token=42,
+        finish_reason=None,
+        logprobs=None,
+    )
+
+    outputs, _ = scheduler._process_batch_responses([fake_response])
+    assert len(outputs) == 1, "scheduler should emit one output for one response"
+    assert outputs[0].cached_tokens == 128, (
+        "scheduler must propagate request.cached_tokens into the "
+        "constructed RequestOutput so downstream usage assembly can "
+        "report the prefix-cache hit count"
+    )
+    assert outputs[0].prompt_tokens == 200
+    assert outputs[0].request_id == "req-1"

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -79,6 +79,8 @@ class _CacheReportingCompletionEngine:
     """Mock completion engine. Returns a single ``GenerationOutput``
     from ``generate``; the ``/v1/completions`` route loops over the
     request's prompts and accumulates token counts across each.
+    Also implements ``stream_generate`` for the SSE streaming path
+    so the wire-shape regression tests can assert on the final chunk.
     """
 
     preserve_native_tool_format = False
@@ -99,6 +101,20 @@ class _CacheReportingCompletionEngine:
             finish_reason="stop",
             cached_tokens=self._cached_tokens,
         )
+
+    async def stream_generate(self, prompt, **kwargs):
+        deltas = ["ans", "wer"]
+        for i, delta in enumerate(deltas):
+            is_last = i == len(deltas) - 1
+            yield GenerationOutput(
+                text="answer"[: (i + 1) * 3],
+                new_text=delta,
+                prompt_tokens=self._prompt_tokens,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                cached_tokens=self._cached_tokens,
+            )
 
 
 def _make_chat_client(engine) -> TestClient:
@@ -243,6 +259,78 @@ def test_chat_streaming_without_include_usage_carries_cached_tokens_on_finish_ch
 # ---------------------------------------------------------------------------
 # /v1/completions
 # ---------------------------------------------------------------------------
+
+
+def test_completions_streaming_final_chunk_omits_null_detail_fields():
+    """Pin the wire shape of the streaming ``/v1/completions`` final
+    usage chunk: with no cache hit and no reasoning split, the JSON
+    payload's ``usage`` block must NOT carry literal ``null``
+    ``prompt_tokens_details`` or ``completion_tokens_details`` keys.
+    ``model_dump(exclude_none=True)`` drops them; bare ``model_dump()``
+    leaves them in as nulls, which some SDK accumulators trip on.
+    Matches the cleanup ``routes/chat.py`` already does for its
+    trailing usage chunk and locks the streaming-completions sibling
+    so a future revert silently re-adds the null keys.
+    """
+    engine = _CacheReportingCompletionEngine(prompt_tokens=200, cached_tokens=0)
+    client = _make_completions_client(engine)
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "Hello",
+            "max_tokens": 32,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    final_chunks = [e for e in events if e.get("usage")]
+    assert len(final_chunks) == 1, (
+        f"expected exactly one chunk with usage; got {len(final_chunks)}"
+    )
+    usage = final_chunks[0]["usage"]
+    assert "prompt_tokens_details" not in usage, (
+        f"null prompt_tokens_details must be excluded; got {usage!r}"
+    )
+    assert "completion_tokens_details" not in usage, (
+        f"null completion_tokens_details must be excluded; got {usage!r}"
+    )
+    # Sanity-check that the non-null keys survived the exclude_none.
+    assert usage["prompt_tokens"] == 200
+    assert usage["total_tokens"] == 202
+
+
+def test_completions_streaming_final_chunk_includes_cached_tokens_when_hit():
+    """Sibling assertion: when there IS a cache hit, the streaming
+    final usage chunk DOES include ``prompt_tokens_details`` with the
+    populated count — `exclude_none=True` only suppresses null
+    fields, not populated ones.
+    """
+    engine = _CacheReportingCompletionEngine(prompt_tokens=200, cached_tokens=128)
+    client = _make_completions_client(engine)
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "Hello",
+            "max_tokens": 32,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    final_chunks = [e for e in events if e.get("usage")]
+    assert len(final_chunks) == 1
+    usage = final_chunks[0]["usage"]
+    details = usage.get("prompt_tokens_details")
+    assert details is not None
+    assert details["cached_tokens"] == 128
+    # No reasoning split on the completions path → completion_tokens_details
+    # stays null and gets excluded.
+    assert "completion_tokens_details" not in usage
 
 
 def test_completions_non_streaming_response_carries_cached_tokens():

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -140,6 +140,12 @@ def _make_completions_client(engine) -> TestClient:
 
 
 def _parse_sse_events(text: str) -> list[dict]:
+    # NOTE: do NOT silently swallow ``JSONDecodeError`` here. The streaming
+    # usage-block tests assert on a chunk near the end of the SSE response;
+    # if an earlier chunk regresses to invalid JSON, an except-pass loop
+    # would skip it and the test could still pass on the trailing valid
+    # chunk — masking a real wire-format regression. Surface the parse
+    # failure so the suite is the canary it claims to be.
     events: list[dict] = []
     for line in text.splitlines():
         line = line.strip()
@@ -148,10 +154,7 @@ def _parse_sse_events(text: str) -> list[dict]:
         payload = line.removeprefix("data:").strip()
         if payload == "[DONE]":
             continue
-        try:
-            events.append(json.loads(payload))
-        except json.JSONDecodeError:
-            continue
+        events.append(json.loads(payload))
     return events
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -518,6 +518,96 @@ class TestRequestOutputCollectorThreadSafety:
         with RequestOutputCollector._waiting_lock:
             RequestOutputCollector._waiting_consumers = 0
 
+    def test_merge_outputs_preserves_cached_tokens(self):
+        """Producer-ahead aggregation must propagate ``cached_tokens``
+        through the merge ctor. The collector's default aggregating
+        mode rebuilds ``RequestOutput`` positionally from ``existing``
+        and ``new``; any new field added to ``RequestOutput`` that
+        isn't threaded into the merge silently zeroes out under load
+        (engine produces faster than the consumer drains). Pin the
+        propagation so future additions don't regress it.
+        """
+        from vllm_mlx.output_collector import RequestOutputCollector
+        from vllm_mlx.request import RequestOutput
+
+        collector = RequestOutputCollector(aggregate=True)
+        existing = RequestOutput(
+            request_id="r1",
+            new_token_ids=[1],
+            new_text="hi",
+            prompt_tokens=100,
+            completion_tokens=1,
+            cached_tokens=64,
+        )
+        new = RequestOutput(
+            request_id="r1",
+            new_token_ids=[2],
+            new_text=" there",
+            prompt_tokens=100,
+            completion_tokens=2,
+            cached_tokens=64,
+        )
+        merged = collector._merge_outputs(existing, new)
+        assert merged.cached_tokens == 64
+        assert merged.new_token_ids == [1, 2]
+        assert merged.completion_tokens == 2
+
+
+class TestEngineCoreStreamBufferMerge:
+    """Pin the second per-request-field propagation hazard:
+    ``EngineCore._merge_stream_buffer`` rebuilds ``RequestOutput``
+    positionally to accumulate per-step deltas when
+    ``stream_interval > 1``. Any new field on ``RequestOutput`` that
+    isn't threaded into the rebuild silently zeroes out on every
+    flush. Sibling to
+    ``TestRequestOutputCollectorThreadSafety::test_merge_outputs_preserves_cached_tokens``
+    for the other rebuild path.
+    """
+
+    def test_merge_into_empty_buffer_preserves_cached_tokens(self):
+        from vllm_mlx.engine_core import EngineCore
+        from vllm_mlx.request import RequestOutput
+
+        chunk = RequestOutput(
+            request_id="r1",
+            new_token_ids=[7],
+            new_text="hi",
+            prompt_tokens=200,
+            completion_tokens=1,
+            cached_tokens=128,
+        )
+        merged = EngineCore._merge_stream_buffer(None, chunk)
+        assert merged.cached_tokens == 128
+        assert merged.new_token_ids == [7]
+        assert merged.new_text == "hi"
+
+    def test_merge_into_existing_buffer_preserves_cached_tokens(self):
+        from vllm_mlx.engine_core import EngineCore
+        from vllm_mlx.request import RequestOutput
+
+        prev = RequestOutput(
+            request_id="r1",
+            new_token_ids=[1, 2],
+            new_text="ab",
+            prompt_tokens=200,
+            completion_tokens=2,
+            cached_tokens=128,
+        )
+        chunk = RequestOutput(
+            request_id="r1",
+            new_token_ids=[3],
+            new_text="c",
+            prompt_tokens=200,
+            completion_tokens=3,
+            cached_tokens=128,
+        )
+        merged = EngineCore._merge_stream_buffer(prev, chunk)
+        assert merged.cached_tokens == 128
+        # Per-step deltas concat; cumulative counts take the latest.
+        assert merged.new_token_ids == [1, 2, 3]
+        assert merged.new_text == "abc"
+        assert merged.completion_tokens == 3
+
 
 class TestRequestTimeoutField:
     """Test the new timeout field in request models."""

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1202,24 +1202,171 @@ class TestGenerationOutputFieldOrder:
 
     def test_field_order_appends_new_fields_at_end(self):
         """Make the rule machine-checkable: new fields added after
-        v0.6.65 (``raw_text``, ``reasoning_text``, ``tool_calls``) must
-        be APPENDED in chronological order at the end of the dataclass.
-        If a refactor ever reorders them back into the middle, this
-        test fails loud instead of producing silent positional-bind
-        regressions for downstream callers that still construct
-        GenerationOutput positionally.
+        v0.6.65 (``raw_text``, ``reasoning_text``, ``tool_calls``,
+        ``cached_tokens``) must be APPENDED in chronological order at
+        the end of the dataclass. If a refactor ever reorders them
+        back into the middle, this test fails loud instead of producing
+        silent positional-bind regressions for downstream callers that
+        still construct ``GenerationOutput`` positionally.
         """
         from dataclasses import fields
 
         names = [f.name for f in fields(GenerationOutput)]
         # The original v0.6.65-and-earlier surface ends at ``channel``.
-        # ``raw_text``, ``reasoning_text``, and ``tool_calls`` were
-        # appended in order and must stay in their append positions.
+        # ``raw_text``, ``reasoning_text``, ``tool_calls``, and
+        # ``cached_tokens`` were appended in order and must stay in
+        # their append positions.
         legacy_tail_idx = names.index("channel")
         appended = names[legacy_tail_idx + 1 :]
-        assert appended == ["raw_text", "reasoning_text", "tool_calls"], (
+        assert appended == [
+            "raw_text",
+            "reasoning_text",
+            "tool_calls",
+            "cached_tokens",
+        ], (
             f"new GenerationOutput fields must be APPENDED in order "
-            f"(raw_text → reasoning_text → tool_calls) to preserve "
-            f"positional-arg compatibility for the pre-v0.6.65 surface. "
-            f"Current trailing fields after ``channel``: {appended}"
+            f"(raw_text → reasoning_text → tool_calls → cached_tokens) "
+            f"to preserve positional-arg compatibility for the "
+            f"pre-v0.6.65 surface. Current trailing fields after "
+            f"``channel``: {appended}"
         )
+
+
+# ---------------------------------------------------------------------------
+# prefix-cache hit reporting (prompt_tokens_details.cached_tokens)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsageCachedTokens:
+    """Pin the OpenAI ``prompt_tokens_details.cached_tokens`` surface
+    for ``get_usage``. Clients that read prefix-cache hits off the usage
+    block (OpenAI's cookbook recipe, OpenRouter pass-through, downstream
+    cost trackers) rely on this field being populated when the engine
+    served any prompt tokens from cache, and absent when it didn't.
+    """
+
+    def test_cached_tokens_populated_when_nonzero(self):
+        from vllm_mlx.service.helpers import get_usage
+
+        output = GenerationOutput(
+            text="hi",
+            prompt_tokens=200,
+            completion_tokens=50,
+            cached_tokens=128,
+        )
+        usage = get_usage(output)
+        assert usage.prompt_tokens == 200
+        assert usage.completion_tokens == 50
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 128
+
+    def test_prompt_tokens_details_absent_when_no_cache_hit(self):
+        """Distinguish "no hit" (field omitted) from "0 reported"
+        (field present, value 0). Matches what OpenAI emits when the
+        request is below the 1024-token cache threshold — the
+        ``prompt_tokens_details`` object simply isn't included.
+        """
+        from vllm_mlx.service.helpers import get_usage
+
+        output = GenerationOutput(
+            text="hi", prompt_tokens=200, completion_tokens=50, cached_tokens=0
+        )
+        usage = get_usage(output)
+        assert usage.prompt_tokens_details is None
+
+    def test_default_generation_output_has_no_prompt_details(self):
+        from vllm_mlx.service.helpers import get_usage
+
+        usage = get_usage(GenerationOutput(text=""))
+        assert usage.prompt_tokens_details is None
+
+
+class TestBuildUsageCachedTokens:
+    """Pin the OpenAI ``prompt_tokens_details.cached_tokens`` surface
+    for ``_build_usage``. Mirrors ``TestGetUsageCachedTokens`` plus the
+    reasoning-breakdown branch — the cache field is orthogonal to the
+    reasoning split and must coexist with it.
+    """
+
+    def test_cached_tokens_alongside_reasoning_breakdown(self, monkeypatch):
+        from vllm_mlx.config import get_config
+        from vllm_mlx.service.helpers import _build_usage
+
+        cfg = get_config()
+        monkeypatch.setattr(cfg, "reasoning_parser_name", "harmony", raising=False)
+
+        output = GenerationOutput(
+            text="answer",
+            prompt_tokens=400,
+            completion_tokens=120,
+            cached_tokens=256,
+        )
+        usage = _build_usage(output, "thought" * 20)
+
+        assert usage.completion_tokens_details is not None
+        assert usage.completion_tokens_details.reasoning_tokens > 0
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 256
+
+    def test_cached_tokens_in_no_reasoning_branch(self, monkeypatch):
+        from vllm_mlx.config import get_config
+        from vllm_mlx.service.helpers import _build_usage
+
+        cfg = get_config()
+        monkeypatch.setattr(cfg, "reasoning_parser_name", None, raising=False)
+
+        output = GenerationOutput(
+            text="answer",
+            prompt_tokens=400,
+            completion_tokens=120,
+            cached_tokens=256,
+        )
+        usage = _build_usage(output, None)
+
+        assert usage.completion_tokens_details is None
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 256
+
+    def test_no_cache_hit_leaves_details_absent_with_reasoning(self, monkeypatch):
+        from vllm_mlx.config import get_config
+        from vllm_mlx.service.helpers import _build_usage
+
+        cfg = get_config()
+        monkeypatch.setattr(cfg, "reasoning_parser_name", "harmony", raising=False)
+
+        output = GenerationOutput(
+            text="answer",
+            prompt_tokens=50,
+            completion_tokens=10,
+            cached_tokens=0,
+        )
+        usage = _build_usage(output, "thinking")
+        assert usage.prompt_tokens_details is None
+        assert usage.completion_tokens_details is not None
+
+    def test_synthetic_streaming_namespace_without_field(self, monkeypatch):
+        """The chat streaming path builds a ``_UsageOutput`` namespace
+        in ``routes/chat.py`` and calls ``_build_usage`` with it. Pre-
+        patch namespaces (or third-party engine wrappers) may not carry
+        ``cached_tokens`` — the builder must fall back gracefully to
+        "no cache hit reported" instead of raising AttributeError.
+        """
+        from vllm_mlx.config import get_config
+        from vllm_mlx.service.helpers import _build_usage
+
+        cfg = get_config()
+        monkeypatch.setattr(cfg, "reasoning_parser_name", None, raising=False)
+
+        class _UsageOutput:
+            pass
+
+        u = _UsageOutput()
+        u.prompt_tokens = 100
+        u.completion_tokens = 50
+        u.text = "answer"
+        # NOTE: no ``cached_tokens`` attribute set.
+
+        usage = _build_usage(u, None)
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 50
+        assert usage.prompt_tokens_details is None

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -165,13 +165,38 @@ def openai_to_anthropic(
     if not content:
         content.append(AnthropicResponseContentBlock(type="text", text=""))
 
+    # Map the OpenAI prefix-cache field onto Anthropic's usage shape.
+    # Per Anthropic's prompt-caching docs the three input fields are
+    # mutually exclusive and satisfy
+    #     total_input_tokens
+    #         = input_tokens
+    #         + cache_read_input_tokens
+    #         + cache_creation_input_tokens
+    # so ``input_tokens`` is "the non-cached share", NOT the whole
+    # prompt. We only populate ``cache_read_input_tokens`` — the prefix
+    # served from the local KV cache — and leave
+    # ``cache_creation_input_tokens`` unset: Anthropic's "creation"
+    # specifically means tokens being written between explicit
+    # ``cache_control`` breakpoints (billed 1.25x), which has no
+    # analog on a local engine that auto-caches every prefix without
+    # a billing dimension. Cache fields stay ``None`` when the engine
+    # didn't report a hit so clients can keep distinguishing "engine
+    # doesn't report" from "engine reported a hit".
+    prompt_tokens = response.usage.prompt_tokens if response.usage else 0
+    output_tokens = response.usage.completion_tokens if response.usage else 0
+    cached_tokens = 0
+    if response.usage and response.usage.prompt_tokens_details is not None:
+        cached_tokens = response.usage.prompt_tokens_details.cached_tokens or 0
+    cache_read = cached_tokens if cached_tokens else None
+    input_tokens = max(0, prompt_tokens - cached_tokens)
     return AnthropicResponse(
         model=model,
         content=content,
         stop_reason=stop_reason,
         usage=AnthropicUsage(
-            input_tokens=response.usage.prompt_tokens if response.usage else 0,
-            output_tokens=response.usage.completion_tokens if response.usage else 0,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
         ),
     )
 

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -187,8 +187,13 @@ def openai_to_anthropic(
     cached_tokens = 0
     if response.usage and response.usage.prompt_tokens_details is not None:
         cached_tokens = response.usage.prompt_tokens_details.cached_tokens or 0
+    # Clamp once so cache_read + input_tokens cannot exceed prompt_tokens —
+    # a defensive guard against an upstream over-report (e.g. prefix-cache
+    # bookkeeping bug) that would otherwise emit an impossible Anthropic
+    # usage block where cache_read_input_tokens > total prompt tokens.
+    cached_tokens = min(cached_tokens, prompt_tokens)
     cache_read = cached_tokens if cached_tokens else None
-    input_tokens = max(0, prompt_tokens - cached_tokens)
+    input_tokens = prompt_tokens - cached_tokens
     return AnthropicResponse(
         model=model,
         content=content,

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -327,6 +327,12 @@ class CompletionTokensDetails(BaseModel):
     reasoning_tokens: int = 0
 
 
+class PromptTokensDetails(BaseModel):
+    """Breakdown of prompt token usage (OpenAI-compatible)."""
+
+    cached_tokens: int = 0
+
+
 class Usage(BaseModel):
     """Token usage statistics."""
 
@@ -334,6 +340,7 @@ class Usage(BaseModel):
     completion_tokens: int = 0
     total_tokens: int = 0
     completion_tokens_details: CompletionTokensDetails | None = None
+    prompt_tokens_details: PromptTokensDetails | None = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -29,11 +29,15 @@ class GenerationOutput:
     logprobs: Any = None
     # Semantic channel: "content", "reasoning", "tool_call", or None
     channel: str | None = None
-    # NOTE: keep the following two fields LAST. They were added after v0.6.65
-    # and inserting them in the middle silently rebound positional
+    # NOTE: keep the following fields LAST, in the order they were added.
+    # ``raw_text`` and ``reasoning_text`` were added after v0.6.65 and
+    # inserting them in the middle silently rebound positional
     # constructor args for downstream callers (text, tokens, ...) — see
     # codex round-1 review of the v0.6.66 release. New optional fields go
-    # at the end of this dataclass to preserve positional compatibility.
+    # at the end of this dataclass to preserve positional compatibility,
+    # and existing trailing fields stay pinned in their original order
+    # (enforced by ``tests/test_server_utils.py::
+    # TestGenerationOutputFieldOrder``).
     # Pre-cleaning model output, preserved so the route's reasoning parser
     # can see harmony channel markers that ``clean_output_text`` strips out
     # of ``text``. Without this, ``HarmonyReasoningParser.extract_reasoning``
@@ -70,6 +74,15 @@ class GenerationOutput:
     # router did not surface structured calls; the route falls back to
     # the legacy regex-based parser path.
     tool_calls: list[dict] | None = None
+    # Number of input prompt tokens served from the prefix cache
+    # (``Request.cached_tokens`` from the scheduler). Surfaced through
+    # ``Usage.prompt_tokens_details.cached_tokens`` on the OpenAI
+    # response and ``cache_read_input_tokens`` on the Anthropic adapter
+    # so cost-tracking clients can attribute prefix-cache hits without
+    # tokenizer-side estimation. 0 when the engine doesn't run through
+    # the prefix-cache path (guided generation, dflash speculative
+    # server) — semantically "no cache hits", not "unknown".
+    cached_tokens: int = 0
 
 
 class BaseEngine(ABC):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1033,6 +1033,7 @@ class BatchedEngine(BaseEngine):
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
             tool_calls=structured_tool_calls,
+            cached_tokens=output.cached_tokens,
         )
 
     async def stream_generate(
@@ -1133,6 +1134,7 @@ class BatchedEngine(BaseEngine):
                 finished=output.finished,
                 finish_reason=output.finish_reason,
                 logprobs=output.logprobs,
+                cached_tokens=output.cached_tokens,
             )
 
     async def chat(
@@ -1443,6 +1445,7 @@ class BatchedEngine(BaseEngine):
             logprobs=logprobs,
             channel=_channel_name(event.channel),
             tool_calls=tool_calls,
+            cached_tokens=source.cached_tokens,
         )
 
     def _routed_finish_sentinel(self, source: GenerationOutput) -> GenerationOutput:
@@ -1456,6 +1459,7 @@ class BatchedEngine(BaseEngine):
             finish_reason=source.finish_reason,
             logprobs=source.logprobs,
             channel=None,
+            cached_tokens=source.cached_tokens,
         )
 
     def _finalize_output_router(

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -470,31 +470,8 @@ class EngineCore:
                                     # accumulate; cumulative status fields take
                                     # the latest value.
                                     buf = self._stream_buffers.get(rid)
-                                    # Wrap per-step logprobs (mx.array or None)
-                                    # into a list so subsequent merges concat
-                                    # instead of overwriting. The flushed
-                                    # RequestOutput's logprobs is therefore a
-                                    # list[mx.array] when stream_interval > 1.
-                                    new_lp = (
-                                        [req_output.logprobs]
-                                        if req_output.logprobs is not None
-                                        else []
-                                    )
-                                    prev_text = buf.new_text if buf else ""
-                                    prev_tokens = buf.new_token_ids if buf else []
-                                    prev_lp = (buf.logprobs if buf else None) or []
-                                    self._stream_buffers[rid] = RequestOutput(
-                                        request_id=rid,
-                                        new_token_ids=prev_tokens
-                                        + req_output.new_token_ids,
-                                        new_text=prev_text + req_output.new_text,
-                                        output_token_ids=req_output.output_token_ids,
-                                        output_text=req_output.output_text,
-                                        finished=req_output.finished,
-                                        finish_reason=req_output.finish_reason,
-                                        prompt_tokens=req_output.prompt_tokens,
-                                        completion_tokens=req_output.completion_tokens,
-                                        logprobs=(prev_lp + new_lp) or None,
+                                    self._stream_buffers[rid] = (
+                                        self._merge_stream_buffer(buf, req_output)
                                     )
                                     if state and state.should_send(
                                         req_output.completion_tokens,
@@ -725,6 +702,44 @@ class EngineCore:
         self._stream_buffers.pop(request_id, None)
         self._finished_events.pop(request_id, None)
         self.scheduler.remove_finished_request(request_id)
+
+    @staticmethod
+    def _merge_stream_buffer(
+        buf: RequestOutput | None, req_output: RequestOutput
+    ) -> RequestOutput:
+        """Accumulate this step's delta into the stream buffer.
+
+        Active when ``stream_interval > 1`` and the scheduler emits one
+        token's worth of delta per step. ``new_text``, ``new_token_ids``,
+        and ``logprobs`` are per-step deltas and must concat; cumulative
+        status fields (``output_token_ids``, counts, finish state) take
+        the latest value. Per-step ``logprobs`` (mx.array or None) is
+        wrapped in a list so subsequent merges concat instead of
+        overwriting — the flushed RequestOutput's ``logprobs`` ends up
+        as ``list[mx.array]`` when stream_interval > 1.
+
+        Pinned as a method so any new ``RequestOutput`` field must be
+        threaded here too; tested in
+        ``tests/test_server.py::TestEngineCoreStreamBufferMerge`` so a
+        future addition that misses this path fails loud.
+        """
+        new_lp = [req_output.logprobs] if req_output.logprobs is not None else []
+        prev_text = buf.new_text if buf else ""
+        prev_tokens = buf.new_token_ids if buf else []
+        prev_lp = (buf.logprobs if buf else None) or []
+        return RequestOutput(
+            request_id=req_output.request_id,
+            new_token_ids=prev_tokens + req_output.new_token_ids,
+            new_text=prev_text + req_output.new_text,
+            output_token_ids=req_output.output_token_ids,
+            output_text=req_output.output_text,
+            finished=req_output.finished,
+            finish_reason=req_output.finish_reason,
+            prompt_tokens=req_output.prompt_tokens,
+            completion_tokens=req_output.completion_tokens,
+            cached_tokens=req_output.cached_tokens,
+            logprobs=(prev_lp + new_lp) or None,
+        )
 
     async def stream_outputs(
         self,

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -148,6 +148,7 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            cached_tokens=new.cached_tokens,
             logprobs=new.logprobs,  # Use latest token's logprobs
         )
 

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -249,10 +249,20 @@ class RequestOutput:
 
     @property
     def usage(self) -> dict[str, int]:
-        """Return usage statistics compatible with OpenAI API."""
+        """Return usage statistics compatible with OpenAI API.
+
+        ``cached_tokens`` is intentionally NOT exposed here. The OpenAI
+        spec nests it under ``prompt_tokens_details.cached_tokens`` on
+        the response ``usage`` object — surfacing it as a top-level
+        sibling of ``prompt_tokens`` here would create a non-spec key
+        that any caller serialising this dict directly would leak.
+        Production code constructs ``Usage`` via ``service.helpers.
+        _build_usage`` (which reads ``cached_tokens`` from the
+        ``RequestOutput`` dataclass field above), keeping the
+        wire-shape spec-compliant.
+        """
         return {
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.prompt_tokens + self.completion_tokens,
-            "cached_tokens": self.cached_tokens,
         }

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -239,6 +239,13 @@ class RequestOutput:
     # runtime error caught in the engine loop). HTTP layer converts this to
     # 503. Plain finish reasons (stop / length / etc.) leave this as None.
     error: str | None = None
+    # Number of prompt tokens served from the prefix cache for this
+    # request. Mirrors ``Request.cached_tokens`` (set by the scheduler
+    # during prefix-cache lookup) so the engine and API layers don't
+    # need to reach back into the live ``Request`` to report cache
+    # effectiveness. Appended at the end of the dataclass so positional
+    # constructor args for the pre-existing fields keep their indices.
+    cached_tokens: int = 0
 
     @property
     def usage(self) -> dict[str, int]:
@@ -247,4 +254,5 @@ class RequestOutput:
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.prompt_tokens + self.completion_tokens,
+            "cached_tokens": self.cached_tokens,
         }

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -745,8 +745,13 @@ async def _stream_anthropic_messages(
     # ``cache_control`` breakpoints (billed 1.25x), which has no
     # analog on a local engine. Cache field stays absent when the
     # engine didn't report a hit (e.g. dflash, MLLM).
+    # Clamp once so cache_read + input_tokens cannot exceed prompt_tokens —
+    # an over-reported cache count from the engine would otherwise emit an
+    # impossible usage block where ``cache_read_input_tokens > prompt_tokens``.
+    # Mirrors ``openai_to_anthropic`` in ``api/anthropic_adapter.py``.
+    cached_tokens = min(cached_tokens, prompt_tokens)
     usage_payload: dict[str, int] = {
-        "input_tokens": max(0, prompt_tokens - cached_tokens),
+        "input_tokens": prompt_tokens - cached_tokens,
         "output_tokens": completion_tokens,
     }
     if cached_tokens:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -468,6 +468,7 @@ async def _stream_anthropic_messages(
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
     prompt_tokens = 0
     completion_tokens = 0
+    cached_tokens = 0
 
     current_block_type = None
     block_index = 0
@@ -502,6 +503,8 @@ async def _stream_anthropic_messages(
             prompt_tokens = output.prompt_tokens
         if hasattr(output, "completion_tokens") and output.completion_tokens:
             completion_tokens = output.completion_tokens
+        if hasattr(output, "cached_tokens") and output.cached_tokens:
+            cached_tokens = output.cached_tokens
 
         # Capture engine-surfaced structured tool calls (HarmonyStreamingRouter
         # via openai-harmony's StreamableParser). The delta_text on these
@@ -732,10 +735,26 @@ async def _stream_anthropic_messages(
 
     stop_reason = "tool_use" if tool_calls else "end_turn"
 
+    # Anthropic-side cache fields mirror what the non-streaming adapter
+    # at ``api/anthropic_adapter.openai_to_anthropic`` produces. Per
+    # Anthropic's docs the three input fields are mutually exclusive
+    # (``total_input = input + cache_read + cache_creation``), so
+    # ``input_tokens`` is the *non-cached* share, NOT the whole prompt.
+    # ``cache_creation_input_tokens`` is intentionally omitted —
+    # Anthropic uses it for tokens written between explicit
+    # ``cache_control`` breakpoints (billed 1.25x), which has no
+    # analog on a local engine. Cache field stays absent when the
+    # engine didn't report a hit (e.g. dflash, MLLM).
+    usage_payload: dict[str, int] = {
+        "input_tokens": max(0, prompt_tokens - cached_tokens),
+        "output_tokens": completion_tokens,
+    }
+    if cached_tokens:
+        usage_payload["cache_read_input_tokens"] = cached_tokens
     message_delta = {
         "type": "message_delta",
         "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-        "usage": {"input_tokens": prompt_tokens, "output_tokens": completion_tokens},
+        "usage": usage_payload,
     }
     yield f"event: message_delta\ndata: {json.dumps(message_delta)}\n\n"
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1651,6 +1651,13 @@ async def stream_chat_completion_guided(
         if content:
             yield f'{_sse_prefix}"content":{json.dumps(content)}{_sse_suffix}'
 
+        # ``output`` is the single buffered ``GenerationOutput`` from
+        # ``engine.generate_with_schema`` (outlines integration has no
+        # native streaming interface — see this function's docstring).
+        # Token counts are therefore read once and final; the main
+        # ``stream_chat_completion`` path re-reads inside the stream
+        # loop because the engine emits a sequence of GenerationOutputs
+        # and the last one carries the authoritative counts.
         prompt_tokens = getattr(output, "prompt_tokens", 0) or 0
         completion_tokens = getattr(output, "completion_tokens", 0) or 0
         cached_tokens = getattr(output, "cached_tokens", 0) or 0

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -21,6 +21,7 @@ from ..api.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChoiceLogProbs,
+    PromptTokensDetails,
     TokenLogProb,
     Usage,
 )
@@ -1286,6 +1287,7 @@ async def stream_chat_completion(
         # Track token counts for usage reporting
         prompt_tokens = 0
         completion_tokens = 0
+        cached_tokens = 0
 
         # Buffer the terminal "finish" event so the cross-format fallback in
         # processor.finalize() (#425) gets a chance to recover a missed tool
@@ -1302,6 +1304,14 @@ async def stream_chat_completion(
                 prompt_tokens = output.prompt_tokens
             if hasattr(output, "completion_tokens") and output.completion_tokens:
                 completion_tokens = output.completion_tokens
+            # ``cached_tokens`` is a single per-request value (the
+            # prefix-cache hit count set once when the request is
+            # scheduled), so re-reading it on every chunk just
+            # re-stamps the same value; the guard mirrors the
+            # ``prompt_tokens`` branch above for ad-hoc engines that
+            # don't carry the field.
+            if hasattr(output, "cached_tokens") and output.cached_tokens:
+                cached_tokens = output.cached_tokens
 
             for event in processor.process_chunk(output):
                 if event.type == "content":
@@ -1496,6 +1506,7 @@ async def stream_chat_completion(
             _u = _UsageOutput()
             _u.prompt_tokens = prompt_tokens
             _u.completion_tokens = completion_tokens
+            _u.cached_tokens = cached_tokens
             # ``text`` carries the accumulated content (NOT reasoning) so
             # ``_build_usage`` can split ``completion_tokens`` between
             # reasoning and content by character ratio. Without this,
@@ -1642,6 +1653,7 @@ async def stream_chat_completion_guided(
 
         prompt_tokens = getattr(output, "prompt_tokens", 0) or 0
         completion_tokens = getattr(output, "completion_tokens", 0) or 0
+        cached_tokens = getattr(output, "cached_tokens", 0) or 0
         # Pass the engine's finish_reason through directly. Matches the
         # convention in ``stream_chat_completion`` (line ~925:
         # ``finish_reason=event.finish_reason``), which never coerces a
@@ -1669,6 +1681,11 @@ async def stream_chat_completion_guided(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=prompt_tokens + completion_tokens,
+                prompt_tokens_details=(
+                    PromptTokensDetails(cached_tokens=cached_tokens)
+                    if cached_tokens
+                    else None
+                ),
             )
         )
         # ``created`` must be passed explicitly: the SSE prefix-style
@@ -1710,6 +1727,11 @@ async def stream_chat_completion_guided(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    prompt_tokens_details=(
+                        PromptTokensDetails(cached_tokens=cached_tokens)
+                        if cached_tokens
+                        else None
+                    ),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -14,6 +14,7 @@ from ..api.models import (
     CompletionChoice,
     CompletionRequest,
     CompletionResponse,
+    PromptTokensDetails,
     Usage,
 )
 from ..config import get_config
@@ -95,6 +96,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         choices = []
         total_completion_tokens = 0
         total_prompt_tokens = 0
+        total_cached_tokens = 0
 
         extended_kwargs = build_extended_sampling_kwargs(request)
 
@@ -125,6 +127,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             total_prompt_tokens += (
                 output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
             )
+            total_cached_tokens += getattr(output, "cached_tokens", 0) or 0
 
         elapsed = time.perf_counter() - start_time
         tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
@@ -139,6 +142,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 prompt_tokens=total_prompt_tokens,
                 completion_tokens=total_completion_tokens,
                 total_tokens=total_prompt_tokens + total_completion_tokens,
+                prompt_tokens_details=(
+                    PromptTokensDetails(cached_tokens=total_cached_tokens)
+                    if total_cached_tokens
+                    else None
+                ),
             ),
         )
         return Response(
@@ -179,7 +187,7 @@ async def stream_completion(
             ],
         }
         if output.finished:
-            data["usage"] = get_usage(output).model_dump()
+            data["usage"] = get_usage(output).model_dump(exclude_none=True)
         yield f"data: {json.dumps(data)}\n\n"
 
     yield "data: [DONE]\n\n"

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3118,6 +3118,7 @@ class Scheduler:
                 output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                cached_tokens=request.cached_tokens,
                 logprobs=response.logprobs,
             )
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -21,6 +21,7 @@ from starlette.requests import Request
 from ..api.models import (
     CompletionTokensDetails,
     FunctionCall,
+    PromptTokensDetails,
     TokenLogProb,
     ToolCall,
     TopLogProb,
@@ -493,6 +494,15 @@ def _build_usage(output: GenerationOutput, reasoning_text: str | None) -> Usage:
     """
     cfg = get_config()
     total_completion = output.completion_tokens
+    # ``output`` is normally ``GenerationOutput``, but the streaming
+    # path builds an ad-hoc ``_UsageOutput`` namespace and the dflash
+    # speculative server passes its own result type. ``getattr`` keeps
+    # those alternative shapes working — they just report 0 cache hits
+    # (semantically: "this path doesn't go through the prefix cache").
+    cached_tokens = getattr(output, "cached_tokens", 0) or 0
+    prompt_details = (
+        PromptTokensDetails(cached_tokens=cached_tokens) if cached_tokens else None
+    )
     if reasoning_text and cfg.reasoning_parser_name:
         reasoning_chars = len(reasoning_text)
         # ``output`` is normally ``GenerationOutput`` but the streaming
@@ -527,11 +537,13 @@ def _build_usage(output: GenerationOutput, reasoning_text: str | None) -> Usage:
             completion_tokens_details=CompletionTokensDetails(
                 reasoning_tokens=reasoning_tokens,
             ),
+            prompt_tokens_details=prompt_details,
         )
     return Usage(
         prompt_tokens=output.prompt_tokens,
         completion_tokens=total_completion,
         total_tokens=output.prompt_tokens + total_completion,
+        prompt_tokens_details=prompt_details,
     )
 
 
@@ -543,10 +555,14 @@ def get_usage(output: GenerationOutput) -> Usage:
     total_completion_tokens = (
         output.completion_tokens if hasattr(output, "completion_tokens") else 0
     )
+    cached_tokens = getattr(output, "cached_tokens", 0) or 0
     return Usage(
         prompt_tokens=total_prompt_tokens,
         completion_tokens=total_completion_tokens,
         total_tokens=total_prompt_tokens + total_completion_tokens,
+        prompt_tokens_details=(
+            PromptTokensDetails(cached_tokens=cached_tokens) if cached_tokens else None
+        ),
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Surfaces the engine's existing prefix-cache hit count
(`Request.cached_tokens`) through the OpenAI and Anthropic response
usage blocks:

- **OpenAI** (`/v1/chat/completions`, `/v1/completions`): adds
  `usage.prompt_tokens_details.cached_tokens` (the OpenAI-spec field
  for cached input tokens). Emitted only when the engine reported a
  hit — absent below the threshold, matching OpenAI's own behavior
  below their 1024-token cache boundary.

- **Anthropic** (`/v1/messages`, streaming + non-streaming): populates
  the already-declared-but-dead `cache_read_input_tokens` with the
  hit count, and adjusts `input_tokens` to `prompt_tokens -
  cached_tokens` so Anthropic's spec identity
  (`total_input = input + cache_read + cache_creation`) holds.
  `cache_creation_input_tokens` is intentionally left unset:
  Anthropic uses it for tokens written between explicit
  `cache_control` breakpoints (billed 1.25x base), which has no
  analog on a local KV-cache engine with no billing dimension.
  Cache field stays `None` when the engine doesn't report.

Internally: `Request.cached_tokens` → new `RequestOutput.cached_tokens`
→ new `GenerationOutput.cached_tokens` (appended at end per the v0.6.65
positional-invariant comment) → `Usage.prompt_tokens_details`. The
field is also propagated through `output_collector._merge_outputs`
(producer-ahead aggregation under default `aggregate=True`) and
`engine_core._stream_buffers` rebuild (when `stream_interval > 1`) —
both rebuild `RequestOutput` positionally and would silently zero out
any new field that isn't threaded explicitly; a regression test in
`tests/test_server.py::TestRequestOutputCollectorThreadSafety::test_merge_outputs_preserves_cached_tokens`
pins this.

17 files, +933 / -40 (12 production files + 5 test files, including
one small helper extraction in `engine_core.py` for testability and
6 new regression-test classes / 17 new test methods covering every
layer end-to-end). No new dependencies. MLLM and dflash paths leave
the field at 0 (they don't run through the prefix-cache scheduler) —
the field is wired and ready when those backends grow reporting.

## Why is this needed?

Rapid-MLX advertises 0.08s cached TTFT on the README. The engine
genuinely tracks the per-request hit count — `Request.cached_tokens`
is set by every prefix-cache lookup path in `scheduler.py` and shows
up in the server log line (`"… N cached"`). But that count never
reaches the OpenAI-compatible response: clients only see
`prompt_tokens` / `completion_tokens` / `total_tokens`.

Three concrete consequences this PR fixes:

1. **Clients that read OpenAI's documented
   `prompt_tokens_details.cached_tokens` field for cost
   attribution** (the field is in the OpenAI cookbook example for
   prompt-cache savings tracking) silently get nothing back. The
   Metricor project I work on currently runs a tokenizer-side LCP
   estimator (a `PrefixCacheProbe` class) as a stopgap because of
   exactly this gap; its docstring names this PR as the deletion
   trigger. The same gap is filed against LM Studio
   ([lmstudio-ai/lmstudio-bug-tracker#778](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/778))
   — it's an ecosystem pattern.

2. **The Anthropic adapter already declares
   `cache_creation_input_tokens` and `cache_read_input_tokens` on
   `AnthropicUsage`** ([api/anthropic_models.py:78-79](vllm_mlx/api/anthropic_models.py)),
   so the response shape promises Anthropic-style cache reporting,
   but the adapter never populates them — dead wire today. Anthropic
   SDK clients pointed at the `/v1/messages` route get `None`s and
   have to guess.

3. **Observability dashboards** that aggregate cache hit ratio
   across local + cloud LLM traffic (a common multi-provider
   pattern) have a blind spot on the Rapid-MLX share.

## AI assistance disclosure

Claude (Anthropic) wrote the implementation and tests end-to-end.
I (human) drove the scope decisions, reviewed every change before
opening the PR, and verified the test results locally on macOS
(M3 Ultra, Python 3.14, `.venv` install of the patched tree).

Verification I performed:
- Read the diff in full, file by file, before greenlighting the PR.
- Confirmed the patch surface against my reading of `Request.cached_tokens` 
  flow through the scheduler.
- Ran `ruff check` + `ruff format --check` on all 17 touched files (clean).
- Ran the targeted + adjacent test suites (454 passed across 14 files).
- Confirmed full-unit-suite failures are pre-existing by stashing my
  changes and re-running a sample on `main` (same failures, identical
  errors).
- Three independent code reviews on the diff. Findings, all fixed:
  one Anthropic-spec-identity bug (`total_input = input + cache_read
  + cache_creation`), two silent field-drop paths in
  `output_collector._merge_outputs` and
  `engine_core._stream_buffers`, and three OpenAI-route coverage
  gaps (`scheduler.py:_process_batch_responses`,
  `routes/chat.py` streaming usage chunk, `routes/completions.py`
  accumulator) — all now have mutation-verified tests.
- Mutation-tested every newly-added regression test: reverted the
  production line each test claims to cover, confirmed the test
  fails, restored the line. All five teeth-checked.

## Test plan

- `pytest tests/test_routes_cached_tokens.py tests/test_server_utils.py tests/test_anthropic_adapter.py tests/test_api_models.py tests/test_server.py::TestRequestOutputCollectorThreadSafety tests/test_server.py::TestEngineCoreStreamBufferMerge tests/test_anthropic_route_streaming.py tests/test_prefix_cache.py tests/test_request.py tests/test_chat_streaming_spec.py tests/test_chat_streaming_guided.py tests/test_postprocessor.py tests/test_anthropic_route_auth.py tests/test_anthropic_models.py` → **454 passed** (17 new tests covering the new field surface end-to-end: helper-layer builders, both Anthropic paths, both `RequestOutput` rebuild paths, all three OpenAI route surfaces, and the scheduler's `RequestOutput` source line)
- `ruff check` + `ruff format --check` on touched files → clean
- Full unit suite: 3957 passed, 73 fail; sampled 4 failures re-run on `main` with my diff stashed — same 4 fail (pre-existing: missing `pytest-asyncio`, `aiohttp`, and live-model requirements).
- Mutation tests on each of the 3 newly-pinned production lines flagged by review #3 as uncovered: each line reverted in isolation → corresponding test fails with the expected assertion → line restored. All 3 confirmed teeth.

## Checklist

- [x] Tests pass locally (relevant subset; pre-existing failures unrelated)
- [x] Lint passes (`ruff check && ruff format --check` on touched files)
- [x] Self-validated with `pr_validate` locally (see PR comment for full scorecard — all substantive gates pass; the 10 `full_unit` failures are pre-existing environment gaps unrelated to this diff, verified by re-running them on `main` with the same result)
- [x] Spot-checked that new tests fail when the cache wiring is broken (manual diff revert + test re-run)
- [x] No breaking changes to existing API. Additive: new optional `prompt_tokens_details` field on `Usage`; new `cached_tokens` attribute appended at the end of both `GenerationOutput` (per the v0.6.65 positional-invariant comment in `engine/base.py`, enforced by `tests/test_server_utils.py::TestGenerationOutputFieldOrder`) and `RequestOutput` (no existing invariant, but kept at end for symmetry — all production and test call sites use kwargs).
