### PR TITLE
feat(chat): pre-launch UX polish — auto-bump, zombie reap, port probe, run+ls aliases, download gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,21 @@ curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 > brew install raullenchai/rapid-mlx/rapid-mlx
 > ```
 
-**Step 2 — Serve a model:**
+**Step 2 — Talk to a model right now** (one command, no second terminal):
+```bash
+rapid-mlx chat
+```
+Defaults to `qwen3.5-4b`. First run downloads the model (~2.5 GB) — you'll see a progress bar. Drops you into a REPL when it's ready. Type `/help` for slash commands, `/exit` to quit. Pass `--think` to surface chain-of-thought.
+
+**Step 2b — Or serve a model for use from other apps:**
 ```bash
 rapid-mlx serve qwen3.5-4b
 ```
-First run downloads the model (~2.5 GB) — you'll see a progress bar. Wait for `Ready: http://localhost:8000/v1`.
+Same model, same download — but this starts an OpenAI-compatible HTTP server instead of a REPL. Wait for `Ready: http://localhost:8000/v1`.
 
 > Want vision? `pip install 'rapid-mlx[vision]'` then `rapid-mlx serve gemma-4-26b` (~14 GB).
 
-**Step 3 — Chat** (open a **second** terminal tab):
+**Step 3 — Hit the API** (from a second terminal tab):
 ```bash
 curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -384,10 +390,10 @@ The model has to fit in your Mac's RAM. If your Mac slows down or Activity Monit
 
 ### Full model lineup
 
-58 short aliases across 21 families ship in v0.6.37. Run `rapid-mlx models` for the live list with quant tier, MoE / hybrid flags, and DFlash eligibility.
+65 short aliases across 21 families ship today. Run `rapid-mlx models` for the live list with quant tier, MoE / hybrid flags, and DFlash eligibility.
 
 <details>
-<summary><strong>Show all 58 aliases by family</strong></summary>
+<summary><strong>Show all 65 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -11,14 +11,12 @@ Performance benchmarks for rapid-mlx on Apple Silicon.
 ## Quick Commands
 
 ```bash
-# LLM benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+# LLM benchmark — short aliases work
+rapid-mlx bench qwen3.5-4b
 
-# Image benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
-
-# Video benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+# Or by full HF repo (vision/multimodal benches live in scripts/ — they are
+# dev-only and not shipped with `pip install rapid-mlx`)
+rapid-mlx bench mlx-community/Qwen3.5-9B-4bit
 ```
 
 ## Standalone Test Defaults
@@ -57,7 +55,7 @@ Results will vary on different Apple Silicon chips.
 If you have a different Apple Silicon chip, please share your results:
 
 ```bash
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+rapid-mlx bench qwen3.5-4b | tee results.txt
 ```
 
 Open an issue with your results at [GitHub Issues](https://github.com/raullenchai/Rapid-MLX/issues).

--- a/docs/benchmarks/image.md
+++ b/docs/benchmarks/image.md
@@ -2,12 +2,13 @@
 
 ## Running Image Benchmarks
 
-```bash
-# Full benchmark (10 resolutions)
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+The shipped `rapid-mlx bench` subcommand benches text generation only. The
+multi-resolution image benchmarks below were collected with the dev-only
+scripts under `scripts/` (not packaged with `pip install rapid-mlx`) — clone
+the repo if you want to reproduce them.
 
-# Quick benchmark (4 resolutions)
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --quick
+```bash
+rapid-mlx serve gemma-4-26b --mllm --port 8000   # then exercise the VLM via /v1/chat/completions
 ```
 
 ## Results - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)

--- a/docs/benchmarks/llm.md
+++ b/docs/benchmarks/llm.md
@@ -3,7 +3,7 @@
 ## Running LLM Benchmarks
 
 ```bash
-rapid-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 5 --max-tokens 256
+rapid-mlx bench qwen3.5-4b --num-prompts 5 --max-tokens 256
 ```
 
 ## Results (M4 Max, 128GB)
@@ -270,14 +270,14 @@ The streaming detokenizer is **not currently viable** for per-request usage due 
 ## Running Benchmarks
 
 ```bash
-# Basic benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+# Basic benchmark — short alias works
+rapid-mlx bench qwen3.5-4b
 
 # With more prompts
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --prompts 10
+rapid-mlx bench qwen3.5-4b --num-prompts 10
 
 # Save results
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+rapid-mlx bench qwen3.5-4b | tee results.txt
 
 # Continuous batching test
 python tests/test_continuous_batching.py

--- a/docs/benchmarks/video.md
+++ b/docs/benchmarks/video.md
@@ -2,16 +2,10 @@
 
 ## Running Video Benchmarks
 
-```bash
-# Full benchmark (10 configurations, 2-64 frames)
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
-
-# Quick benchmark (3 frame counts)
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --quick
-
-# Custom video
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --video-url https://example.com/video.mp4
-```
+The shipped `rapid-mlx bench` subcommand benches text generation only. The
+video benchmarks below were collected with the dev-only scripts under
+`scripts/` (not packaged with `pip install rapid-mlx`) — clone the repo to
+reproduce them. The numbers shown here are kept as a reference data point.
 
 ## Results - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -32,15 +32,14 @@
 
 ## Engine Architecture
 
-### Simple Engine
-- Direct mlx-lm/mlx-vlm wrapper
-- Maximum throughput for single user
-- Zero batching overhead
+`BatchedEngine` is the sole engine (the older `SimpleEngine` was deleted —
+single-request workloads pay zero batching overhead, so the split was no
+longer earning its keep).
 
-### Batched Engine
-- AsyncEngineCore with continuous batching
-- Multiple concurrent requests
+### BatchedEngine
+- `AsyncEngineCore` with continuous batching
 - Scheduler with priority queue
+- One engine instance handles both single-request and multi-tenant workloads
 
 ## Paged KV Cache Architecture
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -72,15 +72,16 @@ ruff format --check .
 ### Running Benchmarks
 
 ```bash
-# LLM benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+# LLM benchmark — short alias works
+rapid-mlx bench qwen3.5-4b
 
-# Image benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
-
-# Video benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+# Or by full HF repo
+rapid-mlx bench mlx-community/Qwen3.5-9B-4bit
 ```
+
+Run `rapid-mlx bench --help` for the full flag list. For multimodal (image /
+video) benchmarks, use `scripts/` (e.g. `scripts/bench_*` for the dev-only
+benchmarks not shipped with pip).
 
 ## Areas for Contribution
 
@@ -108,7 +109,7 @@ See [Architecture](architecture.md) for details on the codebase structure.
 If you have access to different Apple Silicon chips (M1, M2, M3, M4), benchmark results are valuable:
 
 ```bash
-rapid-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results_m4.json
+rapid-mlx bench qwen3.5-4b | tee results_m4.txt
 ```
 
 ## Questions?

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,64 +5,60 @@
 - macOS on Apple Silicon (M1/M2/M3/M4)
 - Python 3.10+
 
-## Install with uv (Recommended)
+## Install with Homebrew (recommended)
 
 ```bash
-git clone https://github.com/raullenchai/Rapid-MLX.git
-cd Rapid-MLX
-
-uv pip install -e .
+brew install raullenchai/rapid-mlx/rapid-mlx
 ```
 
 ## Install with pip
 
 ```bash
+pip install rapid-mlx
+```
+
+If `python3 --version` reports 3.9 (macOS default), install a newer Python
+first: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`.
+
+### One-liner with auto-setup
+
+```bash
+curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+```
+
+### From source (for development)
+
+```bash
 git clone https://github.com/raullenchai/Rapid-MLX.git
 cd Rapid-MLX
-
 pip install -e .
 ```
 
-### Optional: Vision Support
+## Optional Extras
 
-For video processing with transformers:
+The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 
-```bash
-pip install -e ".[vision]"
-```
-
-### Optional: Audio Support (STT/TTS)
-
-```bash
-pip install mlx-audio
-```
-
-### Optional: Embeddings
-
-```bash
-pip install mlx-embeddings
-```
-
-## What Gets Installed
-
-- `mlx`, `mlx-lm`, `mlx-vlm` - MLX framework and model libraries
-- `transformers`, `tokenizers` - HuggingFace libraries
-- `opencv-python` - Video processing
-- `gradio` - Chat UI
-- `psutil` - Resource monitoring
-- `mlx-audio` (optional) - Speech-to-Text and Text-to-Speech
-- `mlx-embeddings` (optional) - Text embeddings
+| Extra | Install | Adds |
+|---|---|---|
+| `vision` | `pip install 'rapid-mlx[vision]'` | mlx-vlm + opencv + torch (~322 MB) for VLMs (Gemma 4, Qwen-VL, video) |
+| `audio` | `pip install 'rapid-mlx[audio]'` | mlx-audio + spacy + scipy (~600 MB) for TTS / STT |
+| `embeddings` | `pip install 'rapid-mlx[embeddings]'` | mlx-embeddings (~50 MB) for `/v1/embeddings` |
+| `chat` | `pip install 'rapid-mlx[chat]'` | Gradio web UI (~150 MB) |
+| `guided` | `pip install 'rapid-mlx[guided]'` | outlines (~80 MB) for schema-constrained JSON |
+| `all` | `pip install 'rapid-mlx[all]'` | Everything above (~1.1 GB) |
 
 ## Verify Installation
 
 ```bash
-# Check CLI commands
+# Check CLI
 rapid-mlx --help
-rapid-mlx-bench --help
-rapid-mlx-chat --help
+rapid-mlx version
 
-# Test with a small model
-rapid-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 1
+# Self-diagnostic (works without downloading a model)
+rapid-mlx doctor
+
+# Smallest interactive smoke test (downloads ~2.5 GB on first run)
+rapid-mlx chat qwen3.5-4b
 ```
 
 ## Troubleshooting
@@ -85,5 +81,15 @@ huggingface-cli login
 
 Use a smaller quantized model:
 ```bash
-rapid-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
+rapid-mlx serve qwen3.5-4b
+```
+
+### `brew install` fails with `Operation not permitted`
+
+Brew 5.x's install sandbox sometimes can't auto-tap `homebrew/core` mid-install.
+Pre-tap it once, then retry:
+
+```bash
+brew tap homebrew/core --force   # ~1.3 GB, one-time
+brew install raullenchai/rapid-mlx/rapid-mlx
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,18 +1,30 @@
 # Quick Start
 
-## Option 1: OpenAI-Compatible Server
+## Option 1: Interactive Chat (fastest first taste)
+
+The shortest path to talking to a model — `chat` spawns its own server,
+downloads the model on first run (~2.5 GB for the default `qwen3.5-4b`), and
+drops you into a REPL.
+
+```bash
+rapid-mlx chat                  # defaults to qwen3.5-4b
+rapid-mlx chat qwen3.5-9b       # a larger model (5 GB)
+rapid-mlx chat --think          # surface chain-of-thought reasoning
+```
+
+In-REPL: `/help`, `/reset`, `/save <path>`, `/model <alias>`, `/exit`. Type
+`"""` on its own line to start/end a multi-line block. See the
+[CLI reference](../reference/cli.md#rapid-mlx-chat) for all flags.
+
+## Option 2: OpenAI-Compatible Server
 
 Start the server:
 
 ```bash
-# Simple mode - maximum throughput for single user
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
-
-# Continuous batching - for multiple concurrent users
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+rapid-mlx serve qwen3.5-4b --port 8000
 ```
 
-Use with OpenAI Python SDK:
+Use with the OpenAI Python SDK:
 
 ```python
 from openai import OpenAI
@@ -20,7 +32,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
 
 response = client.chat.completions.create(
-    model="mlx-community/Llama-3.2-3B-Instruct-4bit",
+    model="default",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)
@@ -34,35 +46,22 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
-## Option 2: Python Client
+## Option 3: Gradio Web UI
 
-```python
-from openai import OpenAI
-
-client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
-
-response = client.chat.completions.create(
-    model="default",
-    messages=[{"role": "user", "content": "What is the capital of France?"}],
-    max_tokens=100,
-)
-print(response.choices[0].message.content)
-```
-
-## Option 3: Gradio Chat UI
+A browser-based chat UI ships in the optional `[chat]` extra:
 
 ```bash
-rapid-mlx-chat --model mlx-community/Llama-3.2-3B-Instruct-4bit
+pip install 'rapid-mlx[chat]'
+# Then launch — see `rapid-mlx help` for the UI entry point in your install.
 ```
-
-Opens a web interface at http://localhost:7860
 
 ## Multimodal Models
 
-For image/video understanding, use a VLM model:
+For image / video understanding, use a VLM (requires the `[vision]` extra —
+`pip install 'rapid-mlx[vision]'`):
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+rapid-mlx serve gemma-4-26b --mllm --port 8000
 ```
 
 ```python
@@ -81,10 +80,12 @@ response = client.chat.completions.create(
 
 ## Reasoning Models
 
-Separate the model's thinking process from the final answer:
+Reasoning parsers are auto-detected from the model name. The server splits
+chain-of-thought into a separate `reasoning_content` field, leaving `content`
+clean.
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+rapid-mlx serve qwen3.5-9b --port 8000   # qwen3 reasoning parser auto-detected
 ```
 
 ```python
@@ -92,15 +93,17 @@ response = client.chat.completions.create(
     model="default",
     messages=[{"role": "user", "content": "What is 17 × 23?"}]
 )
-print(response.choices[0].message.content)  # Final answer
+print(response.choices[0].message.content)            # final answer
+print(response.choices[0].message.reasoning_content)  # thinking trace
 ```
 
 ## Embeddings
 
-Generate text embeddings for semantic search and RAG:
+Generate text embeddings for semantic search and RAG (install the
+`[embeddings]` extra first):
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
+rapid-mlx serve qwen3.5-4b --embedding-model mlx-community/multilingual-e5-small-mlx
 ```
 
 ```python
@@ -112,11 +115,18 @@ response = client.embeddings.create(
 
 ## Tool Calling
 
-Enable function calling with any supported model:
+Tool/function calling is on by default for supported model families (Qwen3.x,
+GLM-4.7, GPT-OSS, Llama, Mistral, etc.) — the right parser is auto-detected:
 
 ```bash
-rapid-mlx serve mlx-community/Devstral-Small-2507-4bit \
-  --enable-auto-tool-choice --tool-call-parser mistral
+rapid-mlx serve qwen3.5-9b --port 8000
+```
+
+If you need to pin the parser manually:
+
+```bash
+rapid-mlx serve devstral-24b \
+  --enable-auto-tool-choice --tool-call-parser hermes
 ```
 
 ## Next Steps

--- a/docs/guides/continuous-batching.md
+++ b/docs/guides/continuous-batching.md
@@ -1,11 +1,13 @@
 # Continuous Batching
 
-Continuous batching enables higher throughput when serving multiple concurrent users.
+Continuous batching enables higher throughput when serving multiple concurrent
+users. It is **on by default** — the `--continuous-batching` flag is accepted
+for back-compat but is a no-op.
 
-## Enabling Continuous Batching
+## Default Behaviour
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
+rapid-mlx serve qwen3.5-4b
 ```
 
 ## With Paged Cache
@@ -13,20 +15,16 @@ rapid-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
 For memory-efficient prefix sharing:
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
+rapid-mlx serve qwen3.5-4b --use-paged-cache
 ```
 
 ## How It Works
 
-### Simple Mode (Default)
-- One request at a time
-- Maximum throughput for single user
-- No overhead from batching
-
-### Continuous Batching Mode
-- Multiple requests processed together
-- Better throughput for concurrent users
-- Small overhead per request
+### Continuous Batching (always on)
+- Multiple requests processed together when concurrency > 1
+- Single-request workloads pay zero overhead
+- Implemented in `BatchedEngine` (the sole engine; the old `SimpleEngine` was
+  removed)
 
 ### Paged Cache
 - KV cache stored in fixed-size blocks
@@ -67,10 +65,10 @@ Control token delivery with `--stream-interval`:
 
 ```bash
 # Every token (smoothest)
-rapid-mlx serve model --continuous-batching --stream-interval 1
+rapid-mlx serve model --stream-interval 1
 
 # Batch tokens (better for high-latency)
-rapid-mlx serve model --continuous-batching --stream-interval 5
+rapid-mlx serve model --stream-interval 5
 ```
 
 | Value | Behavior |
@@ -85,13 +83,13 @@ For large models, the prefix cache can consume significant memory. The memory-aw
 
 ```bash
 # Auto-detect (uses 20% of available RAM)
-rapid-mlx serve model --continuous-batching
+rapid-mlx serve model
 
 # Explicit limit
-rapid-mlx serve model --continuous-batching --cache-memory-mb 2048
+rapid-mlx serve model --cache-memory-mb 2048
 
 # Custom percentage
-rapid-mlx serve model --continuous-batching --cache-memory-percent 0.10
+rapid-mlx serve model --cache-memory-percent 0.10
 ```
 
 | Option | Description |
@@ -157,18 +155,16 @@ python tests/test_prefix_cache.py
 
 ## When to Use
 
-| Scenario | Mode |
-|----------|------|
-| Single user, maximum speed | Simple (default) |
-| Multiple concurrent users | `--continuous-batching` |
-| Large models (7B+) | `--continuous-batching --cache-memory-mb 2048` |
-| Production with shared prompts | `--continuous-batching --use-paged-cache` |
+| Scenario | Flags |
+|----------|-------|
+| Default — any concurrency, any model | *(none — batching is on)* |
+| Large models on tight RAM | `--cache-memory-mb 2048` |
+| Production with shared prompts | `--use-paged-cache` |
 
 ## Production Setup
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
-  --continuous-batching \
+rapid-mlx serve qwen3.5-9b \
   --use-paged-cache \
   --port 8000
 ```

--- a/docs/guides/mcp-tools.md
+++ b/docs/guides/mcp-tools.md
@@ -51,11 +51,7 @@ Create `mcp.json`:
 ### 2. Start Server with MCP
 
 ```bash
-# Simple mode
-rapid-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
-
-# Continuous batching
-rapid-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
+rapid-mlx serve qwen3.5-4b --mcp-config mcp.json
 ```
 
 ### 3. Verify MCP Status

--- a/docs/guides/multimodal.md
+++ b/docs/guides/multimodal.md
@@ -227,15 +227,12 @@ Tested on Apple M4 Max with 128 GB unified memory.
 
 ### Running Benchmarks
 
+The shipped `rapid-mlx bench` is text-only. Multi-resolution image and video
+benches live in the dev-only `scripts/` directory (source checkout only). For
+a quick text-only sanity bench against a VLM, you can still run:
+
 ```bash
-# Quick benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --quick
-
-# Full benchmark with more resolutions
-rapid-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit
-
-# Video benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --video
+rapid-mlx bench qwen3-vl-4b
 ```
 
 ## MLLM Cache
@@ -306,10 +303,12 @@ When memory pressure occurs, least recently accessed entries are evicted first.
 
 ## Gradio Chat UI
 
-For interactive multimodal chat:
+For an interactive multimodal session, start a server and use any OpenAI-
+compatible web UI (Open WebUI, LibreChat, etc.) pointed at it:
 
 ```bash
-rapid-mlx-chat --model mlx-community/Qwen3-VL-4B-Instruct-3bit
+rapid-mlx serve qwen3-vl-4b --mllm --port 8000
 ```
 
-Supports drag-and-drop images and videos.
+The shipped `rapid-mlx chat` REPL is text-only. The optional Gradio web UI
+(`pip install 'rapid-mlx[chat]'`) supports image / video uploads.

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -1,31 +1,26 @@
 # OpenAI-Compatible Server
 
 rapid-mlx provides a FastAPI server with full OpenAI API compatibility.
+Continuous batching is on by default; `--continuous-batching` is accepted as
+a no-op for back-compat.
 
 ## Starting the Server
 
-### Simple Mode (Default)
-
-Maximum throughput for single user:
+### Default
 
 ```bash
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+rapid-mlx serve qwen3.5-4b --port 8000
 ```
 
-### Continuous Batching Mode
-
-For multiple concurrent users:
-
-```bash
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
-```
+Short aliases (see `rapid-mlx models`) work everywhere a model name is
+accepted. Full HuggingFace repo IDs (`mlx-community/...`) work too.
 
 ### With Paged Cache
 
-Memory-efficient caching for production:
+Memory-efficient caching for production / shared system prompts:
 
 ```bash
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
+rapid-mlx serve qwen3.5-9b --port 8000 --use-paged-cache
 ```
 
 ## Server Options
@@ -37,7 +32,7 @@ rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuou
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--timeout` | Request timeout in seconds | 300 |
-| `--continuous-batching` | Enable batching for multi-user | False |
+| `--continuous-batching` | Accepted for back-compat (continuous batching is always on) | on |
 | `--use-paged-cache` | Enable paged KV cache | False |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
@@ -46,7 +41,7 @@ rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuou
 | `--default-top-p` | Default top_p when not specified | None |
 | `--stream-interval` | Tokens per stream chunk | 1 |
 | `--mcp-config` | Path to MCP config file | None |
-| `--reasoning-parser` | Parser for reasoning models (`qwen3`, `deepseek_r1`) | None |
+| `--reasoning-parser` | Reasoning parser (`gemma4`, `qwen3`, `deepseek_r1`, `glm4`, `gpt_oss`, `harmony`, `minimax`). Auto-detected; explicit flag overrides. | auto |
 | `--embedding-model` | Pre-load an embedding model at startup | None |
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
 | `--tool-call-parser` | Tool call parser (see [Tool Calling](tool-calling.md)) | None |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ rapid-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 
 ### Getting Started
 - [Installation](getting-started/installation.md)
-- [Quick Start](getting-started/quickstart.md)
+- [Quick Start](getting-started/quickstart.md) — including `rapid-mlx chat` for an instant REPL
 
 ### User Guides
 - [OpenAI-Compatible Server](guides/server.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,8 +5,21 @@
 | Command | Description |
 |---------|-------------|
 | `rapid-mlx serve` | Start OpenAI-compatible server |
-| `rapid-mlx-bench` | Run performance benchmarks |
-| `rapid-mlx-chat` | Start Gradio chat interface |
+| `rapid-mlx chat` | Interactive chat REPL with a model |
+| `rapid-mlx bench` | Run performance benchmarks |
+| `rapid-mlx models` | List available model aliases |
+| `rapid-mlx info` | Show the per-model profile for an alias or repo |
+| `rapid-mlx pull` | Download a model into the HuggingFace cache |
+| `rapid-mlx rm` | Remove a cached model |
+| `rapid-mlx ps` | List running rapid-mlx servers |
+| `rapid-mlx agents` | List, configure, and test agent integrations |
+| `rapid-mlx doctor` | Run self-diagnostic / regression harness |
+| `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
+| `rapid-mlx upgrade` | Upgrade rapid-mlx (brew / pip / install.sh) |
+| `rapid-mlx version` | Show version number |
+| `rapid-mlx help <cmd>` | Show help for a subcommand |
+
+Run `rapid-mlx <cmd> --help` for the full flag list of any subcommand.
 
 ## `rapid-mlx serve`
 
@@ -41,65 +54,49 @@ rapid-mlx serve <model> [options]
 | `--gpu-memory-utilization` | Fraction of device memory for Metal allocation limit (0.0-1.0) | 0.90 |
 | `--default-temperature` | Default temperature when not specified in request | None |
 | `--default-top-p` | Default top_p when not specified in request | None |
-| `--reasoning-parser` | Parser for reasoning models (`qwen3`, `deepseek_r1`) | None |
+| `--reasoning-parser` | Reasoning parser (`gemma4`, `qwen3`, `deepseek_r1`, `glm4`, `gpt_oss`, `harmony`, `minimax`). Auto-detected; explicit flag overrides. | auto |
 | `--embedding-model` | Pre-load an embedding model at startup | None |
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
-| `--tool-call-parser` | Tool call parser (`auto`, `mistral`, `qwen`, `llama`, `hermes`, `deepseek`, `kimi`, `granite`, `nemotron`, `xlam`, `functionary`, `glm47`) | None |
+| `--tool-call-parser` | Tool call parser (e.g. `hermes`, `llama`, `deepseek`, `deepseek_v31`, `glm47`, `gemma4`, `minimax`, `kimi`, `harmony`, `qwen3_coder_xml`). Auto-detected from the model name; explicit flag overrides. | auto |
 
 ### Examples
 
 ```bash
-# Simple mode (single user, max throughput)
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+# Default — continuous batching is on by default; short aliases work
+rapid-mlx serve qwen3.5-4b
 
-# Continuous batching (multiple users)
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
+# A larger general-purpose model (5 GB)
+rapid-mlx serve qwen3.5-9b --port 8000
 
-# With memory limit for large models
-rapid-mlx serve mlx-community/GLM-4.7-Flash-4bit \
-  --continuous-batching \
-  --cache-memory-mb 2048
-
-# Production with paged cache
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
-  --continuous-batching \
-  --use-paged-cache \
-  --port 8000
+# Paged KV cache (memory-efficient prefix sharing)
+rapid-mlx serve qwen3.5-9b --use-paged-cache --port 8000
 
 # With MCP tools
-rapid-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+rapid-mlx serve qwen3.5-9b --mcp-config mcp.json
 
-# Multimodal model
-rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+# Multimodal (vision) model — requires the [vision] extra
+rapid-mlx serve gemma-4-26b --mllm
 
-# Reasoning model (separates thinking from answer)
-rapid-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+# Reasoning model — parser is auto-detected, but you can pin it
+rapid-mlx serve qwen3.5-9b --reasoning-parser qwen3
 
 # DeepSeek reasoning model
-rapid-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+rapid-mlx serve deepseek-r1-8b --reasoning-parser deepseek_r1
 
 # Tool calling with Mistral/Devstral
-rapid-mlx serve mlx-community/Devstral-Small-2507-4bit \
-  --enable-auto-tool-choice --tool-call-parser mistral
+rapid-mlx serve devstral-24b --enable-auto-tool-choice --tool-call-parser hermes
 
-# Tool calling with Granite
-rapid-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
-  --enable-auto-tool-choice --tool-call-parser granite
+# DFlash speculative decoding (single-user, single supported alias)
+rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 8000
 
-# With API key authentication
-rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
-
-# Large models (200GB+) — raise memory limit to avoid cache thrashing
-rapid-mlx serve mlx-community/Qwen3.5-397B-A17B-nvfp4 \
-  --continuous-batching \
-  --gpu-memory-utilization 0.95
+# API key authentication
+rapid-mlx serve qwen3.5-9b --api-key your-secret-key
 
 # Production setup with security options
-rapid-mlx serve mlx-community/Qwen3-4B-4bit \
+rapid-mlx serve qwen3.5-9b \
   --api-key your-secret-key \
   --rate-limit 60 \
-  --timeout 120 \
-  --continuous-batching
+  --timeout 120
 ```
 
 ### Security
@@ -126,75 +123,89 @@ curl http://localhost:8000/v1/models \
   -H "Authorization: Bearer your-secret-key"
 ```
 
-## `rapid-mlx-bench`
+## `rapid-mlx bench`
 
-Run performance benchmarks.
+Run a built-in performance benchmark against a model.
 
 ### Usage
 
 ```bash
-rapid-mlx-bench --model <model> [options]
+rapid-mlx bench <model> [options]
 ```
 
-### Options
+### Common Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--model` | Model name | Required |
-| `--prompts` | Number of prompts | 5 |
+| `<model>` | Model alias (e.g. `qwen3.5-4b`) or HF repo (positional) | *(required)* |
+| `--num-prompts` | Number of prompts | 5 |
 | `--max-tokens` | Max tokens per prompt | 256 |
-| `--quick` | Quick benchmark mode | False |
-| `--video` | Run video benchmark | False |
-| `--video-url` | Custom video URL | None |
-| `--video-path` | Custom video path | None |
+| `--enable-prefix-cache` / `--disable-prefix-cache` | Toggle prefix caching | enabled |
+| `--use-paged-cache` | Use paged KV cache layout | off |
+| `--kv-cache-quantization` | Quantize prefix cache entries | off |
+
+Run `rapid-mlx bench --help` for the full list (memory limits, batch sizes, etc.).
 
 ### Examples
 
 ```bash
-# LLM benchmark
-rapid-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit
+# Quick LLM benchmark using a short alias
+rapid-mlx bench qwen3.5-4b
 
-# Quick benchmark
-rapid-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --quick
-
-# Image benchmark (auto-detected for VLM models)
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
-
-# Video benchmark
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
-
-# Custom video
-rapid-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit \
-  --video --video-url https://example.com/video.mp4
+# Bench a vision-language model by full HF repo
+rapid-mlx bench mlx-community/Qwen3-VL-8B-Instruct-4bit
 ```
 
-## `rapid-mlx-chat`
+## `rapid-mlx chat`
 
-Start Gradio chat interface.
+Spawn (or attach to) a server and start an interactive REPL with a model. This
+is a terminal chat — not a web UI. (For the Gradio web UI, install the optional
+`[chat]` extra: `pip install 'rapid-mlx[chat]'`.)
 
 ### Usage
 
 ```bash
-rapid-mlx-chat --model <model> [options]
+rapid-mlx chat [model] [options]
 ```
 
 ### Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--model` | Model name | Required |
-| `--port` | Gradio port | 7860 |
-| `--text-only` | Disable multimodal | False |
+| `model` | Model alias or HF repo (positional, optional) | `qwen3.5-4b` |
+| `--system` | System prompt prepended to the conversation | *(none)* |
+| `--think` / `--no-think` | Enable / disable reasoning output in the REPL | off |
+| `--max-tokens` | Max tokens per assistant response | 2048 |
+| `--temperature` | Sampling temperature | 0.7 |
+| `--port` | Connect to an existing server on `127.0.0.1:<port>` instead of spawning | *(spawn)* |
+| `--base-url` | Connect to an existing server URL (overrides `--port`) | *(spawn)* |
+| `--ready-timeout` | Seconds to wait for the spawned server to become ready | 600 |
+| `--response-timeout` | Seconds to wait for a single response | 600 |
+
+> The REPL defaults to `--no-think` because reasoning models (Qwen3.5, etc.)
+> otherwise leak raw chain-of-thought and can loop until `max-tokens`. Pass
+> `--think` to surface reasoning.
 
 ### Examples
 
 ```bash
-# Multimodal chat (text + images + video)
-rapid-mlx-chat --model mlx-community/Qwen3-VL-4B-Instruct-3bit
+# Fastest path — defaults to qwen3.5-4b, spawns its own server
+rapid-mlx chat
 
-# Text-only chat
-rapid-mlx-chat --model mlx-community/Llama-3.2-3B-Instruct-4bit --text-only
+# A reasoning model with thinking surfaced
+rapid-mlx chat qwen3.5-9b --think
+
+# Attach to a server you're already running on :8000
+rapid-mlx serve qwen3.5-27b --port 8000 &
+rapid-mlx chat --port 8000
+
+# Pin a system prompt
+rapid-mlx chat qwen3.5-4b --system "You are a terse, friendly Mac shell tutor."
 ```
+
+In-REPL slash commands: `/help`, `/reset` (alias `/clear`), `/model <alias>`,
+`/save <path>` (write conversation to markdown), `/exit` (alias `/quit`).
+Type `"""` on its own line to start/end a multi-line block (pasting code).
 
 ## Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.66"
+version = "0.6.67"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1965,6 +1965,95 @@ def test_sigterm_handler_masks_second_sigterm(monkeypatch):
     )
 
 
+def test_main_pops_chat_spawn_env_so_grandchildren_do_not_inherit(monkeypatch):
+    """Codex round-2 BLOCKING #2: ``RAPID_MLX_CHAT_SPAWN=1`` must be
+    treated as a single-use marker. If the spawned ``serve`` itself
+    forks any subprocess (HF auth helper, doctor self-probe, future
+    hub plugin), that grandchild would otherwise inherit the bypass
+    and skip its own download gate."""
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", "1")
+    monkeypatch.setattr(cli, "serve_command", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rapid-mlx", "serve", "mlx-community/some-fake-7b"],
+    )
+    cli.main()
+    assert "RAPID_MLX_CHAT_SPAWN" not in os.environ, (
+        "main() must pop the marker so it does not leak to grandchildren; "
+        "this is what makes the 'single-use' contract real."
+    )
+
+
+def test_sigterm_handler_exits_even_if_cleanup_raises(monkeypatch):
+    """Codex round-2 NIT #3: the SIGTERM handler must call sys.exit(143)
+    via try/finally so a _teardown_proc raise (rare — only on
+    proc.kill() escalation) doesn't strand the process running. A hung
+    handler defeats the entire 'reap before exit' contract."""
+    import signal as _signal
+
+    handler_holder: dict = {}
+    real_signal = _signal.signal
+
+    def _spy_signal(signum, handler):
+        if signum == _signal.SIGTERM:
+            handler_holder["last"] = handler
+        return real_signal(signum, handler)
+
+    class _RaisingProc:
+        _rapid_mlx_log = None
+        _rapid_mlx_log_path = None
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            raise RuntimeError("simulated _teardown_proc failure")
+
+        def wait(self, timeout=None):
+            pass
+
+        def kill(self):
+            pass
+
+    def _fake_spawn(*_a, **_kw):
+        proc = _RaisingProc()
+        register_in = _kw.get("register_in")
+        if register_in is not None:
+            register_in.append(proc)
+        return proc, f"http://127.0.0.1:{port}"
+
+    monkeypatch.setattr("signal.signal", _spy_signal)
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: None)
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (fake_port, _payloads):
+        port = fake_port
+        first = {"sent": False}
+
+        def _input(_p=""):
+            if not first["sent"]:
+                first["sent"] = True
+                handler = handler_holder["last"]
+                # The cleanup raise propagates inside the handler — but
+                # the try/finally must still hand off to sys.exit(143).
+                with pytest.raises(SystemExit) as excinfo:
+                    handler(_signal.SIGTERM, None)
+                assert excinfo.value.code == 143
+            return "exit"
+
+        monkeypatch.setattr("builtins.input", _input)
+        ns = _ns_for_chat(fake_port)
+        ns.base_url = None
+        ns.port = None
+        try:
+            cli.chat_command(ns)
+        except SystemExit:
+            pass
+
+
 def test_chat_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
     """``--no-think`` and ``--no-thinking`` share the prefix ``--no-thi``.
     With ``allow_abbrev=False`` argparse must reject the ambiguous form

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1895,6 +1895,27 @@ def test_spawn_chat_server_sets_chat_spawn_env(monkeypatch, tmp_path):
         def poll(self):
             return None
 
+    # Mock socket too so the test doesn't depend on the runner being
+    # allowed to bind to 127.0.0.1 (codex sandbox / restricted CI both
+    # block this). The port number is captured via captured["cmd"] so
+    # the assertion below is what we actually care about.
+    class _FakeSocket:
+        def __init__(self, *_, **__):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def bind(self, _addr):
+            pass
+
+        def getsockname(self):
+            return ("127.0.0.1", 54321)
+
+    monkeypatch.setattr("socket.socket", _FakeSocket)
     monkeypatch.setattr("subprocess.Popen", _FakePopen)
 
     log_path = tmp_path / "fake.log"

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 import threading
 from contextlib import contextmanager
@@ -1174,3 +1175,560 @@ def test_stream_chat_response_repetition_truncates_at_cutoff_in_one_chunk(
     assert "repeating" in rendered or "repetition" in rendered, (
         "expected the repetition-abort hint to be visible"
     )
+
+
+# ----------------------------------------------------------------------
+# B1 — --think raises max_tokens default + length-cut warning
+# ----------------------------------------------------------------------
+
+
+def test_chat_think_bumps_max_tokens_default_to_4096():
+    """``--think`` with no explicit ``--max-tokens`` raises the default
+    from 2048 to 4096 so reasoning + final answer fit a small-model
+    budget. Round-1 finding: ``chat qwen3.5-4b --think`` consumed the
+    full 2048 budget with reasoning alone and emitted an empty answer
+    with ``finish_reason='length'``."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "qwen3.5-4b", "--think"]),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    # argparse layer: default sentinel is None; chat_command resolves.
+    # We test the resolved value by invoking chat_command's logic up to
+    # the resolution point via _ns_for_chat-style namespace.
+    assert captured[0].max_tokens is None, (
+        "argparse must leave --max-tokens unresolved so chat_command can "
+        "distinguish user-supplied 2048 from the unset sentinel"
+    )
+    assert captured[0].think is True
+
+
+def test_chat_think_default_resolution_runtime(monkeypatch, capsys):
+    """End-to-end: with ``--think`` and an unset ``--max-tokens``,
+    chat_command resolves to 4096 AND prints a one-line note."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(port, think=True, max_tokens=None)
+        cli.chat_command(ns)
+    # Resolved value lands in the payload.
+    assert payloads[0]["max_tokens"] == 4096
+    out = capsys.readouterr().out
+    assert "raised --max-tokens to 4096" in out, (
+        f"expected the --think bump notice in output; got: {out!r}"
+    )
+
+
+def test_chat_explicit_max_tokens_with_think_is_not_overridden(monkeypatch, capsys):
+    """User-supplied ``--max-tokens=512`` with ``--think`` is honored —
+    no silent bump, no banner. (Distinguishes "user passed 2048" from
+    "default sentinel".)"""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(port, think=True, max_tokens=512)
+        cli.chat_command(ns)
+    assert payloads[0]["max_tokens"] == 512
+    assert "raised --max-tokens" not in capsys.readouterr().out
+
+
+def test_chat_warns_on_length_cut_empty_content(monkeypatch, capsys):
+    """When the server emits ``finish_reason='length'`` AND no visible
+    content streamed (reasoning consumed the budget), the REPL must
+    warn so the user knows to bump --max-tokens."""
+    # Reasoning-only stream, length cut on the last chunk.
+    canned = [
+        {"choices": [{"delta": {"reasoning_content": "thinking ..."}}]},
+        {"choices": [{"delta": {}, "finish_reason": "length"}]},
+        {"choices": [], "usage": {"completion_tokens": 42}},
+    ]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "reasoning consumed" in out, f"expected length+empty warning; got: {out!r}"
+
+
+def test_chat_no_length_warning_when_content_present(monkeypatch, capsys):
+    """Length cut WITH visible content (model finished mid-sentence) is
+    a legitimate state and must NOT trigger the empty-answer warning."""
+    canned = [
+        _delta("here is half an answer"),
+        {"choices": [{"delta": {}, "finish_reason": "length"}]},
+        {"choices": [], "usage": {"completion_tokens": 8}},
+    ]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["q", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "reasoning consumed" not in out, (
+        "length cut WITH content must not trigger the empty-answer warning"
+    )
+
+
+def test_stream_chat_response_captures_finish_reason_into_metrics():
+    """``_stream_chat_response`` must record ``finish_reason`` in the
+    metrics dict so the REPL can decide whether to warn on length-cut."""
+    canned = [
+        _delta("hi"),
+        {"choices": [{"delta": {}, "finish_reason": "length"}]},
+    ]
+    metrics: dict = {}
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", io.StringIO()),
+    ):
+        cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+            metrics=metrics,
+        )
+    assert metrics.get("finish_reason") == "length"
+
+
+# ----------------------------------------------------------------------
+# B5 — port validator + pre-flight probe
+# ----------------------------------------------------------------------
+
+
+def test_chat_port_out_of_range_rejected_by_argparse(capsys):
+    """``--port 99999`` must exit via argparse with a clear message,
+    not drop into the REPL."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--port", "99999"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    # argparse exits 2 on a type error.
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "port must be between 1 and 65535" in err
+
+
+def test_chat_port_zero_rejected_by_argparse(capsys):
+    """Port 0 (would mean "let kernel pick") is not a valid connect target."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--port", "0"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 2
+    assert "port must be between 1 and 65535" in capsys.readouterr().err
+
+
+def test_chat_port_nonnumeric_rejected_by_argparse(capsys):
+    """Non-numeric ``--port`` value is rejected with a friendly error."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--port", "abc"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 2
+    assert "port must be an integer" in capsys.readouterr().err
+
+
+def test_chat_port_unbound_exits_with_friendly_error(capsys, monkeypatch):
+    """Valid-range port with nothing listening must surface a one-line
+    'no server reachable' error and exit, not drop into the REPL."""
+    import socket as _socket
+
+    s = _socket.socket()
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+
+    # Make sure we never reach input().
+    monkeypatch.setattr("builtins.input", lambda _p="": "exit")
+
+    ns = type("Args", (), {})()
+    ns.base_url = None
+    ns.port = dead_port
+    ns.system = None
+    ns.think = False
+    ns.max_tokens = 50
+    ns.temperature = 0.0
+    ns.ready_timeout = 1
+    ns.response_timeout = 1
+    ns.model = "qwen3.5-4b"
+    with pytest.raises(SystemExit) as exc:
+        cli.chat_command(ns)
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "no rapid-mlx server reachable" in out
+    assert f"127.0.0.1:{dead_port}" in out
+
+
+# ----------------------------------------------------------------------
+# D1 — `run` alias for chat
+# ----------------------------------------------------------------------
+
+
+def test_run_is_alias_for_chat(monkeypatch):
+    """``rapid-mlx run <model>`` must route to ``chat_command`` with the
+    same args as ``rapid-mlx chat <model>``."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "run", "qwen3.5-4b"]),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    ns = captured[0]
+    # All chat-only flags should be present with their defaults.
+    assert hasattr(ns, "think")
+    assert hasattr(ns, "max_tokens")
+    assert hasattr(ns, "port")
+    assert hasattr(ns, "base_url")
+    assert hasattr(ns, "system")
+
+
+def test_run_alias_accepts_chat_flags():
+    """Flags accepted by ``chat`` must be accepted by the ``run`` alias too."""
+    captured: list = []
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["rapid-mlx", "run", "qwen3.5-4b", "--think", "--max-tokens", "1024"],
+        ),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    assert captured[0].think is True
+    assert captured[0].max_tokens == 1024
+
+
+# ----------------------------------------------------------------------
+# D3 — /bye and /? slash aliases
+# ----------------------------------------------------------------------
+
+
+def test_chat_command_bye_exits_like_exit(monkeypatch, capsys):
+    """``/bye`` must terminate the REPL like ``/exit``."""
+    canned = [_delta("hi")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["hello", "/bye", "this would crash if /bye didnt exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    # /bye stopped iteration BEFORE the 3rd input was consumed → the
+    # iterator still has it. If /bye were ignored we'd hit StopIteration.
+    # The first turn ran, the second turn was the /bye exit.
+    assert len(payloads) == 1
+
+
+def test_chat_command_question_mark_lists_help(monkeypatch, capsys):
+    """``/?`` must print the help text (alias for ``/help``)."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, payloads):
+        inputs = iter(["/?", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    # Same content as /help — pin a couple of canonical strings.
+    assert "/help" in out
+    assert "/exit" in out
+    assert "/bye" in out
+    assert payloads == [], "/? must not POST"
+
+
+def test_chat_help_text_lists_bye_and_question_mark(monkeypatch, capsys):
+    """The ``/help`` body must advertise both alias sets so a user
+    skimming for "how do I quit" sees ``/bye`` and the equivalent
+    ``/?`` lookup."""
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["/help", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "/bye" in out
+    assert "/?" in out
+
+
+# ----------------------------------------------------------------------
+# D4 — cross-alias --no-thinking (chat) and --no-think (serve)
+# ----------------------------------------------------------------------
+
+
+def test_chat_accepts_no_thinking_as_alias_for_no_think():
+    """``chat --no-thinking`` (serve-style spelling) must land on the
+    same ``think=False`` destination as ``chat --no-think``."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--no-thinking"]),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    assert captured[0].think is False
+
+
+def test_serve_accepts_no_think_as_alias_for_no_thinking():
+    """``serve --no-think`` (chat-style spelling) must land on the same
+    ``no_thinking=True`` destination as ``serve --no-thinking``."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "qwen3.5-4b", "--no-think"]),
+        patch.object(cli, "serve_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    assert captured[0].no_thinking is True
+
+
+def test_chat_no_thinking_hidden_from_help():
+    """The cross-alias is back-compat-only; it must NOT appear in
+    ``chat --help`` (otherwise we double-document the same flag)."""
+    import argparse as _argparse
+
+    parser = _argparse.ArgumentParser()
+    sp = parser.add_subparsers(dest="command")
+    # Re-create the chat parser via main() inspection — easier to run
+    # the real CLI and capture --help output.
+    import subprocess as _sp
+
+    out = _sp.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "chat", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "--no-thinking" not in out.stdout, (
+        "hidden cross-alias must not appear in chat --help"
+    )
+
+
+# ----------------------------------------------------------------------
+# D8 — first-launch-only banner for "agents codex" tip
+# ----------------------------------------------------------------------
+
+
+def test_seen_tips_marker_round_trip(tmp_path, monkeypatch):
+    """``_has_seen_tip`` returns False before, True after ``_mark_tip_seen``."""
+    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
+    assert cli._has_seen_tip("chat_intro_codex") is False
+    cli._mark_tip_seen("chat_intro_codex")
+    assert cli._has_seen_tip("chat_intro_codex") is True
+    # Marker file landed in the override dir.
+    assert (tmp_path / "seen-tips.json").exists()
+
+
+def test_seen_tips_marker_survives_corrupt_file(tmp_path, monkeypatch):
+    """A corrupt marker (parse error) must be treated as 'not seen' so
+    the tip re-fires once, rather than being silently hidden forever."""
+    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "seen-tips.json").write_text("not json {{")
+    assert cli._has_seen_tip("chat_intro_codex") is False
+
+
+def test_chat_banner_shown_on_first_launch_only(monkeypatch, capsys, tmp_path):
+    """First chat launch shows the agents-codex tip; subsequent launches
+    do NOT. The marker file under ``RAPID_MLX_CONFIG_HOME`` records the
+    first-seen state."""
+    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
+
+    # Force the TTY/NO_COLOR gate to think we're interactive (otherwise
+    # the marker logic short-circuits to "skip everything").
+    class _Tty(io.StringIO):
+        def isatty(self):
+            return True
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    canned = [_delta("ok")]
+    # First launch.
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", _Tty()) as buf1,
+    ):
+        inputs = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+        first = buf1.getvalue()
+    assert "agents codex" in first, (
+        f"first launch should show the agents-codex tip; got {first!r}"
+    )
+
+    # Second launch — marker file now exists, banner should be suppressed.
+    canned2 = [_delta("ok")]
+    with (
+        _fake_server(canned2) as (port2, _payloads),
+        patch.object(sys, "stdout", _Tty()) as buf2,
+    ):
+        inputs2 = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs2))
+        cli.chat_command(_ns_for_chat(port2))
+        second = buf2.getvalue()
+    assert "agents codex" not in second, (
+        f"second launch must NOT re-show the banner; got {second!r}"
+    )
+
+
+def test_chat_banner_skipped_when_no_color_set(monkeypatch, capsys, tmp_path):
+    """``NO_COLOR`` or non-TTY stdout: skip the marker logic AND the
+    banner entirely so pipe/CI runs don't pollute the user's config."""
+    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    out = capsys.readouterr().out
+    assert "agents codex" not in out, "NO_COLOR run should suppress the banner entirely"
+    # And no marker file was written.
+    assert not (tmp_path / "seen-tips.json").exists(), (
+        "NO_COLOR run must not pollute the user's config dir"
+    )
+
+
+def test_chat_banner_write_failure_does_not_abort(monkeypatch, tmp_path, capsys):
+    """If the marker dir is unwritable (read-only FS / permission
+    denied), the tip should still print and chat must continue — best
+    effort only."""
+    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path / "no_perm"))
+
+    class _Tty(io.StringIO):
+        def isatty(self):
+            return True
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    # Mock os.makedirs to raise so the write path fails.
+    real_makedirs = os.makedirs
+
+    def _failing(*a, **kw):
+        if str(tmp_path / "no_perm") in str(a[0]):
+            raise PermissionError("read only fs")
+        return real_makedirs(*a, **kw)
+
+    monkeypatch.setattr("os.makedirs", _failing)
+
+    canned = [_delta("ok")]
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", _Tty()) as buf,
+    ):
+        inputs = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        # Must NOT raise.
+        cli.chat_command(_ns_for_chat(port))
+    # Banner still printed.
+    assert "agents codex" in buf.getvalue()
+
+
+# ----------------------------------------------------------------------
+# B3 — log file unlink policy
+# ----------------------------------------------------------------------
+
+
+def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
+    """``_teardown_proc`` (closed-over inside ``chat_command``) must
+    unlink a zero-byte log (no useful info) but PRESERVE a non-empty
+    log (post-mortem breadcrumbs).
+
+    Drive teardown via ``/model`` swap: the chat REPL spawns the
+    initial server, then ``/model <other>`` replaces it — which calls
+    ``_teardown_proc(old_proc)`` synchronously. That fires the unlink
+    policy without needing process-level atexit to fire.
+    """
+    empty_log = tmp_path / "empty.log"
+    full_log = tmp_path / "full.log"
+    empty_log.write_text("")
+    full_log.write_text("some real error trace\n")
+
+    class _FakeProc:
+        def __init__(self, log_path):
+            self._rapid_mlx_log = open(log_path, "a")
+            self._rapid_mlx_log_path = str(log_path)
+
+        def poll(self):
+            return 0  # already "exited"
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda alias: f"mlx-community/{alias}-resolved",
+    )
+
+    # --- Case 1: empty log → unlinked on swap ---
+    call_n = {"n": 0}
+
+    def _spawn_empty(model, log_path, served_name=None, *, register_in=None):
+        # First spawn: backed by empty_log (the one that should be
+        # unlinked when swapped out). Second spawn: a noop replacement.
+        call_n["n"] += 1
+        if call_n["n"] == 1:
+            p = _FakeProc(empty_log)
+        else:
+            tmp = tmp_path / f"new-{call_n['n']}.log"
+            tmp.write_text("")
+            p = _FakeProc(tmp)
+        if register_in is not None:
+            register_in.append(p)
+        return p, f"http://127.0.0.1:{port_e}"
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _spawn_empty)
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (fake_port, _payloads):
+        port_e = fake_port
+        inputs = iter(["/model other-alias", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(fake_port)
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    assert not empty_log.exists(), (
+        "empty log should be unlinked when swapped out (no debugging value)"
+    )
+
+    # --- Case 2: full log → preserved on swap ---
+    call_n2 = {"n": 0}
+
+    def _spawn_full(model, log_path, served_name=None, *, register_in=None):
+        call_n2["n"] += 1
+        if call_n2["n"] == 1:
+            p = _FakeProc(full_log)
+        else:
+            tmp = tmp_path / f"new2-{call_n2['n']}.log"
+            tmp.write_text("")
+            p = _FakeProc(tmp)
+        if register_in is not None:
+            register_in.append(p)
+        return p, f"http://127.0.0.1:{port_f}"
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _spawn_full)
+
+    canned2 = [_delta("ok")]
+    with _fake_server(canned2) as (fake_port2, _payloads):
+        port_f = fake_port2
+        inputs2 = iter(["/model other-alias", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs2))
+        ns = _ns_for_chat(fake_port2)
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    assert full_log.exists(), "full log was unexpectedly removed"
+    assert full_log.read_text() == "some real error trace\n"

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1732,3 +1732,259 @@ def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
 
     assert full_log.exists(), "full log was unexpectedly removed"
     assert full_log.read_text() == "some real error trace\n"
+
+
+# ---------------------------------------------------------------------------
+# Codex round-1 regression coverage.
+# ---------------------------------------------------------------------------
+
+
+def test_main_skips_download_gate_when_chat_spawn_env_set(monkeypatch):
+    """When the chat REPL spawns its own ``serve`` subprocess, the child
+    sees ``RAPID_MLX_CHAT_SPAWN=1`` and must NOT re-run the B2 gate. A
+    re-run would either (a) re-prompt on a TTY or (b) call the HF API
+    needlessly in the child."""
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", "1")
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    calls: list[str] = []
+
+    def _fake_gate(*_a, **_kw):  # pragma: no cover - assertion proves it isn't called
+        calls.append("gate")
+        return False
+
+    monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", _fake_gate)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.estimate_repo_size_bytes", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.confirm_or_abort",
+        lambda *_a, **_kw: calls.append("confirm") or True,
+    )
+
+    # Stub out serve_command so main() exits cleanly without booting an engine.
+    monkeypatch.setattr(cli, "serve_command", lambda *_a, **_kw: None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rapid-mlx", "serve", "mlx-community/some-uncached-fake-7b"],
+    )
+    cli.main()
+    assert calls == [], (
+        f"Spawn-child env should bypass the download gate entirely; got calls={calls}"
+    )
+
+
+def test_main_skips_size_estimate_in_non_tty_context(monkeypatch):
+    """The B2 gate must short-circuit on TTY/env checks BEFORE calling
+    ``estimate_repo_size_bytes`` — otherwise every CI run with
+    ``RAPID_MLX_AUTO_PULL=1`` pays a 5-second HF metadata round-trip."""
+    monkeypatch.delenv("RAPID_MLX_CHAT_SPAWN", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.estimate_repo_size_bytes",
+        lambda *_a, **_kw: calls.append("estimate") or None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.is_repo_cached",
+        lambda *_a, **_kw: calls.append("cached") or False,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.confirm_or_abort",
+        lambda *_a, **_kw: calls.append("confirm") or True,
+    )
+    monkeypatch.setattr(cli, "serve_command", lambda *_a, **_kw: None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rapid-mlx", "serve", "mlx-community/some-uncached-fake-7b"],
+    )
+    cli.main()
+
+    assert calls == [], (
+        f"Non-TTY context should never hit the HF metadata API or cache probe; "
+        f"got calls={calls}"
+    )
+
+
+def test_main_skips_size_estimate_when_auto_pull_env_set(monkeypatch):
+    """``RAPID_MLX_AUTO_PULL=1`` must short-circuit on the env check
+    BEFORE ``estimate_repo_size_bytes`` — the env is the documented
+    CI/unattended escape hatch and should not pay any network cost."""
+    monkeypatch.delenv("RAPID_MLX_CHAT_SPAWN", raising=False)
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "1")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.estimate_repo_size_bytes",
+        lambda *_a, **_kw: calls.append("estimate") or None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.is_repo_cached",
+        lambda *_a, **_kw: calls.append("cached") or False,
+    )
+    monkeypatch.setattr(cli, "serve_command", lambda *_a, **_kw: None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rapid-mlx", "serve", "mlx-community/some-uncached-fake-7b"],
+    )
+    cli.main()
+
+    assert calls == [], (
+        f"AUTO_PULL=1 should skip the cache probe and size estimate; got calls={calls}"
+    )
+
+
+def test_spawn_chat_server_sets_chat_spawn_env(monkeypatch, tmp_path):
+    """``_spawn_chat_server`` must pass ``RAPID_MLX_CHAT_SPAWN=1`` to the
+    child so the child main() bypasses the download gate."""
+    captured: dict = {}
+
+    class _FakePopen:
+        def __init__(
+            self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
+        ):
+            captured["env"] = env
+            captured["cmd"] = cmd
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+    log_path = tmp_path / "fake.log"
+    proc, base_url = cli._spawn_chat_server("qwen3.5-4b", str(log_path))
+
+    assert captured["env"] is not None
+    assert captured["env"].get("RAPID_MLX_CHAT_SPAWN") == "1"
+
+
+def test_sigterm_handler_masks_second_sigterm(monkeypatch):
+    """A second SIGTERM landing mid-cleanup must be silently dropped via
+    ``signal.SIG_IGN``, not re-invoke ``_cleanup`` (which would block on
+    a second ``proc.wait()`` for an already-terminating child)."""
+    import signal as _signal
+
+    handler_holder: dict = {}
+    signal_changes: list = []
+
+    real_signal = _signal.signal
+
+    def _spy_signal(signum, handler):
+        if signum == _signal.SIGTERM:
+            signal_changes.append(handler)
+            handler_holder["last"] = handler
+        return real_signal(signum, handler)
+
+    cleanup_calls = {"n": 0}
+
+    class _FakeProc:
+        _rapid_mlx_log = None
+        _rapid_mlx_log_path = None
+        terminate_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            type(self).terminate_calls += 1
+            cleanup_calls["n"] += 1
+            # Simulate the supervisor escalating: second SIGTERM arrives
+            # while the first one's _cleanup walk is mid-flight. Invoke
+            # the installed handler directly (the real signal would do
+            # exactly this).
+            current = handler_holder["last"]
+            if current is _signal.SIG_IGN:
+                return  # masked — correct behaviour
+            # If still the original handler, calling it would recurse;
+            # capture that so the assertion fires.
+            raise AssertionError(
+                "Second SIGTERM was NOT masked; the handler is still live "
+                "and would recurse into _cleanup."
+            )
+
+        def wait(self, timeout=None):
+            pass
+
+        def kill(self):
+            pass
+
+    def _fake_spawn(*_a, **_kw):
+        proc = _FakeProc()
+        register_in = _kw.get("register_in")
+        if register_in is not None:
+            register_in.append(proc)
+        return proc, f"http://127.0.0.1:{port}"
+
+    monkeypatch.setattr("signal.signal", _spy_signal)
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: None)
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (fake_port, _payloads):
+        port = fake_port
+
+        def _trigger_after_input(_p=""):
+            # On the first prompt, fire the installed SIGTERM handler in
+            # the foreground. Use a SystemExit-suppressing wrapper so the
+            # test thread is the one to observe the masking.
+            handler = handler_holder["last"]
+            try:
+                handler(_signal.SIGTERM, None)
+            except SystemExit:
+                pass
+            return "exit"
+
+        monkeypatch.setattr("builtins.input", _trigger_after_input)
+
+        ns = _ns_for_chat(fake_port)
+        ns.base_url = None
+        ns.port = None
+        try:
+            cli.chat_command(ns)
+        except SystemExit:
+            pass
+
+    # The second SIGTERM (delivered inside terminate()) hit SIG_IGN; if
+    # it had re-invoked the handler we'd have recursed and the
+    # AssertionError above would have surfaced.
+    assert _FakeProc.terminate_calls >= 1
+    assert _signal.SIG_IGN in signal_changes, (
+        f"Cleanup must install SIG_IGN to mask re-entry; "
+        f"signal_changes={signal_changes}"
+    )
+
+
+def test_chat_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
+    """``--no-think`` and ``--no-thinking`` share the prefix ``--no-thi``.
+    With ``allow_abbrev=False`` argparse must reject the ambiguous form
+    instead of silently resolving it to whichever flag was added first."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "qwen3.5-4b", "--no-thi"]),
+        pytest.raises(SystemExit),
+    ):
+        cli.main()
+    err = capsys.readouterr().err
+    assert "--no-thi" in err or "unrecognized" in err.lower()
+
+
+def test_serve_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
+    """Same as the chat case — ``serve`` also got the hidden cross-alias
+    and the same ambiguity must be reported, not silently resolved."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "qwen3.5-4b", "--no-thi"]),
+        pytest.raises(SystemExit),
+    ):
+        cli.main()
+    err = capsys.readouterr().err
+    assert "--no-thi" in err or "unrecognized" in err.lower()

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -894,6 +894,42 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     assert called == ["mlx-community/Fake-Model-1B"]
 
 
+def test_ensure_model_downloaded_uses_strict_cache_probe(monkeypatch):
+    """Codex round-3 BLOCKING #2 (sibling fix): the chat REPL's pre-download
+    probe used to short-circuit on cached ``config.json`` alone — same
+    bypass we closed in ``is_repo_cached``. After the fix it must defer
+    to ``is_repo_cached`` (weight-file-required) so a partial cache no
+    longer skips the foreground download and re-throws the user back into
+    the silent-spawn-then-download trap."""
+    # Force not-a-local-path.
+    monkeypatch.setattr("os.path.exists", lambda _p: False)
+
+    cache_calls: list = []
+
+    def _fake_is_cached(name: str) -> bool:
+        cache_calls.append(name)
+        return True
+
+    monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", _fake_is_cached)
+
+    # If the strict probe returns True the function must return without
+    # touching the disk gate or snapshot_download (cache hit path).
+    monkeypatch.setattr(
+        cli,
+        "_check_disk_space",
+        lambda *_a, **_kw: pytest.fail("disk gate must NOT fire on cache hit"),
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *_a, **_kw: pytest.fail("download must NOT fire on cache hit"),
+    )
+
+    cli._ensure_model_downloaded("mlx-community/Cached-Model-1B")
+    assert cache_calls == ["mlx-community/Cached-Model-1B"], (
+        "cache probe must be invoked exactly once with the repo id"
+    )
+
+
 def test_chat_command_heredoc_preserves_indentation_and_blank_lines(monkeypatch):
     """Heredoc must preserve leading whitespace (Python indentation) and
     trailing blank lines verbatim — calling ``.strip()`` corrupts exactly
@@ -2052,6 +2088,100 @@ def test_sigterm_handler_exits_even_if_cleanup_raises(monkeypatch):
             cli.chat_command(ns)
         except SystemExit:
             pass
+
+
+def test_cleanup_masks_sigint_so_ctrl_c_cannot_orphan_remaining_procs(monkeypatch):
+    """Codex round-3 BLOCKING #1: ``_cleanup`` must mask SIGINT (not only
+    SIGTERM) for the duration of its teardown loop. Without the mask, a
+    Ctrl-C landing during the walk raises KeyboardInterrupt, unwinds the
+    loop, the surrounding try/finally exits, and atexit's later call
+    sees the early ``done=True`` flag → procs after the interrupted one
+    are orphaned."""
+    import signal as _signal
+
+    handler_holder: dict = {}
+    sigint_changes: list = []
+
+    real_signal = _signal.signal
+
+    def _spy_signal(signum, handler):
+        if signum == _signal.SIGINT:
+            sigint_changes.append(handler)
+        if signum == _signal.SIGTERM and not isinstance(handler, type(_signal.SIG_IGN)):
+            # Capture only the user-installed handler; ignore the
+            # SIG_IGN re-mask the cleanup path issues internally.
+            handler_holder["last"] = handler
+        return real_signal(signum, handler)
+
+    teardown_calls = {"n": 0}
+
+    class _DummyProc:
+        _rapid_mlx_log = None
+        _rapid_mlx_log_path = None
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            teardown_calls["n"] += 1
+
+        def wait(self, timeout=None):
+            pass
+
+        def kill(self):
+            pass
+
+    procs: list = [_DummyProc(), _DummyProc(), _DummyProc()]
+
+    def _fake_spawn(*_a, **_kw):
+        register_in = _kw.get("register_in")
+        # Register all three so cleanup has to walk a non-trivial list.
+        if register_in is not None:
+            for p in procs:
+                register_in.append(p)
+        return procs[0], f"http://127.0.0.1:{port}"
+
+    monkeypatch.setattr("signal.signal", _spy_signal)
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: None)
+
+    canned = [_delta("ok")]
+    with _fake_server(canned) as (fake_port, _payloads):
+        port = fake_port
+        first = {"sent": False}
+
+        def _input(_p=""):
+            if not first["sent"]:
+                first["sent"] = True
+                # Fire the user-installed SIGTERM handler, which calls
+                # _cleanup. Inside _cleanup, SIGINT must be masked.
+                handler = handler_holder["last"]
+                try:
+                    handler(_signal.SIGTERM, None)
+                except SystemExit:
+                    pass
+            return "exit"
+
+        monkeypatch.setattr("builtins.input", _input)
+        ns = _ns_for_chat(fake_port)
+        ns.base_url = None
+        ns.port = None
+        try:
+            cli.chat_command(ns)
+        except SystemExit:
+            pass
+
+    # All three procs must have been torn down (the SIGINT mask would
+    # have prevented any Ctrl-C-driven unwind from leaving leftovers).
+    assert teardown_calls["n"] == 3, (
+        f"Cleanup must walk every proc; got {teardown_calls['n']}/3"
+    )
+    # SIG_IGN must appear in sigint_changes — proof that _cleanup masked
+    # SIGINT (rather than only SIGTERM as it did in round-2).
+    assert _signal.SIG_IGN in sigint_changes, (
+        f"_cleanup must install SIG_IGN on SIGINT; sigint_changes={sigint_changes}"
+    )
 
 
 def test_chat_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1448,15 +1448,37 @@ def test_run_alias_accepts_chat_flags():
 
 
 def test_chat_command_bye_exits_like_exit(monkeypatch, capsys):
-    """``/bye`` must terminate the REPL like ``/exit``."""
+    """``/bye`` must terminate the REPL like ``/exit``.
+
+    DeepSeek round-3 NIT #2: the original assertion only checked
+    ``len(payloads) == 1`` and relied on a comment to explain that the
+    third input was deliberately never consumed. A future REPL change
+    that consumes an extra prompt could pass that count assertion
+    while ``/bye`` is broken. Track consumption explicitly via a
+    sentinel that raises if reached.
+    """
+    sentinel = "this would crash if /bye didnt exit"
+    consumed: list = []
+
+    def _input(_prompt="") -> str:
+        for value in ("hello", "/bye", sentinel):
+            if value in consumed:
+                continue
+            consumed.append(value)
+            return value
+        raise AssertionError("inputs exhausted — REPL kept asking past /bye")
+
     canned = [_delta("hi")]
     with _fake_server(canned) as (port, payloads):
-        inputs = iter(["hello", "/bye", "this would crash if /bye didnt exit"])
-        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        monkeypatch.setattr("builtins.input", _input)
         cli.chat_command(_ns_for_chat(port))
-    # /bye stopped iteration BEFORE the 3rd input was consumed → the
-    # iterator still has it. If /bye were ignored we'd hit StopIteration.
-    # The first turn ran, the second turn was the /bye exit.
+
+    # /bye terminates the REPL → the sentinel is never asked for.
+    assert sentinel not in consumed, (
+        f"/bye must stop the input loop before the sentinel; consumed={consumed}"
+    )
+    assert consumed == ["hello", "/bye"]
+    # And the first turn (and only the first) hit the server.
     assert len(payloads) == 1
 
 
@@ -1520,26 +1542,29 @@ def test_serve_accepts_no_think_as_alias_for_no_thinking():
     assert captured[0].no_thinking is True
 
 
-def test_chat_no_thinking_hidden_from_help():
+def test_chat_no_thinking_hidden_from_help(capsys):
     """The cross-alias is back-compat-only; it must NOT appear in
-    ``chat --help`` (otherwise we double-document the same flag)."""
-    import argparse as _argparse
+    ``chat --help`` (otherwise we double-document the same flag).
 
-    parser = _argparse.ArgumentParser()
-    sp = parser.add_subparsers(dest="command")
-    # Re-create the chat parser via main() inspection — easier to run
-    # the real CLI and capture --help output.
-    import subprocess as _sp
-
-    out = _sp.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "chat", "--help"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    assert "--no-thinking" not in out.stdout, (
+    In-process help capture (DeepSeek round-3 NIT #3) — earlier version
+    forked ``python -m vllm_mlx.cli`` which is the only test in the
+    file that forks a subprocess, adds ~1s overhead, depends on
+    PYTHONPATH/install state, and breaks in restricted CI runners.
+    """
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "chat", "--help"]),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cli.main()
+    # argparse exits 0 on --help.
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    help_text = captured.out + captured.err
+    assert "--no-thinking" not in help_text, (
         "hidden cross-alias must not appear in chat --help"
     )
+    # Sanity check that we actually captured the chat help (not stdlib's).
+    assert "--think" in help_text or "--no-think" in help_text
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -226,12 +226,17 @@ def test_cached_view_renders_unmapped_for_unknown_repo(monkeypatch, capsys):
 
 
 def test_format_bytes_unit_selection():
-    """``_format_bytes`` picks the largest unit where value >= 1."""
+    """``_format_bytes`` picks the largest unit where value >= 1.
+
+    Suffixes are IEC base-1024 (KiB/MiB/GiB) — aligned with
+    ``_format_size`` in ``vllm_mlx._download_gate`` so the same byte
+    count is rendered identically by ``ls --cached`` and the B2 prompt
+    (DeepSeek round-3 NIT #4)."""
     assert cli._format_bytes(0) == "0 B"
     assert cli._format_bytes(512) == "512 B"
-    assert cli._format_bytes(2048) == "2.0 K"
-    assert cli._format_bytes(5 * 1024 * 1024) == "5.0 M"
-    assert cli._format_bytes(int(2.5 * 1024**3)) == "2.5 G"
+    assert cli._format_bytes(2048) == "2.0 KiB"
+    assert cli._format_bytes(5 * 1024 * 1024) == "5.0 MiB"
+    assert cli._format_bytes(int(2.5 * 1024**3)) == "2.5 GiB"
 
 
 def test_scan_hf_cache_models_filters_to_models_only(tmp_path, monkeypatch):

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -126,3 +126,131 @@ def test_models_command_subparser_smoke():
     ):
         cli.main()
     assert exc.value.code == 0
+
+
+# ----------------------------------------------------------------------
+# D2 — --cached / ls view
+# ----------------------------------------------------------------------
+
+
+def test_ls_subcommand_registered():
+    """``rapid-mlx ls --help`` exits 0 (top-level alias is wired)."""
+    import pytest
+
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "ls", "--help"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 0
+
+
+def test_ls_routes_to_models_with_cached(monkeypatch):
+    """``rapid-mlx ls`` invokes the cached view via ``models_command``
+    with ``args.cached = True``. We patch ``models_command`` to capture
+    the args namespace before the body runs."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "ls"]),
+        patch.object(cli, "models_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert len(captured) == 1
+    assert captured[0].cached is True
+
+
+def test_models_cached_flag_routes_to_cached_view(monkeypatch, capsys):
+    """``models --cached`` must call the cached-view path (not the
+    full alias table). We assert via the printed header difference."""
+    # No cached models will be found in a fresh tmp HF cache.
+    monkeypatch.setenv("HF_HOME", "/nonexistent_path_for_this_test_xyz")
+    # huggingface_hub.constants.HF_HUB_CACHE is evaluated at module load,
+    # so we instead patch the helper directly.
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "models", "--cached"]),
+        patch("vllm_mlx._version_check.print_staleness_warning_if_any"),
+    ):
+        cli.main()
+    out = capsys.readouterr().out
+    assert "No models cached yet" in out
+    # And the full alias table header is absent.
+    assert "Available models" not in out
+
+
+def test_models_default_view_unchanged(monkeypatch, capsys):
+    """Bare ``rapid-mlx models`` still prints the capability table —
+    --cached is opt-in. Backward-compat contract."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "models"]),
+        patch("vllm_mlx._version_check.print_staleness_warning_if_any"),
+    ):
+        cli.main()
+    out = capsys.readouterr().out
+    assert "Available models" in out
+    assert "Tools" in out and "Reasoning" in out
+
+
+def test_cached_view_renders_alias_for_known_repo(tmp_path, monkeypatch, capsys):
+    """A cached HF repo whose path matches an alias should render under
+    the alias name (e.g. ``qwen3.5-4b``), not the raw HF path."""
+    from vllm_mlx.model_aliases import list_profiles
+
+    profiles = list_profiles()
+    # Pick any alias for the test; we'll synthesize a fake cache entry
+    # at its hf_path.
+    alias = next(iter(profiles))
+    hf_path = profiles[alias].hf_path
+
+    monkeypatch.setattr(
+        cli, "_scan_hf_cache_models", lambda: [(hf_path, 1024 * 1024 * 100, 0.0)]
+    )
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+    assert alias in out, f"expected alias {alias!r} in cached view"
+    assert hf_path[:40] in out, "expected HF path in cached view"
+
+
+def test_cached_view_renders_unmapped_for_unknown_repo(monkeypatch, capsys):
+    """A cached HF repo with no alias entry must show ``(unmapped)``."""
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [("some/totally-unmapped-repo", 1024, 0.0)],
+    )
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+    assert "(unmapped)" in out
+    assert "totally-unmapped-repo" in out
+
+
+def test_format_bytes_unit_selection():
+    """``_format_bytes`` picks the largest unit where value >= 1."""
+    assert cli._format_bytes(0) == "0 B"
+    assert cli._format_bytes(512) == "512 B"
+    assert cli._format_bytes(2048) == "2.0 K"
+    assert cli._format_bytes(5 * 1024 * 1024) == "5.0 M"
+    assert cli._format_bytes(int(2.5 * 1024**3)) == "2.5 G"
+
+
+def test_scan_hf_cache_models_filters_to_models_only(tmp_path, monkeypatch):
+    """Only ``models--*`` directories should show in the listing — not
+    ``datasets--*`` or ``spaces--*``."""
+    cache_root = tmp_path / "hub"
+    cache_root.mkdir()
+    (cache_root / "models--mlx-community--FakeModel").mkdir()
+    (cache_root / "models--mlx-community--FakeModel" / "blob1").write_bytes(b"x" * 128)
+    (cache_root / "datasets--squad").mkdir()
+    (cache_root / "datasets--squad" / "data").write_bytes(b"y" * 999)
+    (cache_root / "spaces--gradio--demo").mkdir()
+
+    # Patch the constants lookup inside _scan_hf_cache_models.
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root), raising=False
+    )
+    rows = cli._scan_hf_cache_models()
+    repos = [r[0] for r in rows]
+    assert "mlx-community/FakeModel" in repos
+    assert all("squad" not in r for r in repos)
+    assert all("demo" not in r for r in repos)

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -494,6 +494,86 @@ def test_is_repo_cached_rejects_path_traversal_in_index(tmp_path, monkeypatch):
     assert gate.is_repo_cached("user/escape") is False
 
 
+def test_is_repo_cached_honours_resolved_revision_ref(tmp_path, monkeypatch):
+    """Codex round-9 BLOCKING: an old complete snapshot must not mask
+    the current incomplete one. After an interrupted ``snapshot_download``
+    update, HF leaves an empty snapshot dir at the new sha while the
+    previous sha's snapshot is still on disk. The loader resolves via
+    ``refs/main`` to the NEW sha and would crash on its incomplete
+    contents — so the gate must honour the ref, not fall through to
+    the older complete snapshot."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--mid-update"
+    snap_root = repo_root / "snapshots"
+
+    # Old complete snapshot — has a valid model.safetensors.
+    old_sha = "deadbeefdeadbeefdeadbeefdeadbeef"
+    old = snap_root / old_sha
+    old.mkdir(parents=True)
+    (old / "config.json").write_text("{}")
+    (old / "model.safetensors").write_bytes(b"x" * 4096)
+
+    # New snapshot dir exists (metadata fetched, weight pull
+    # interrupted) — but no weights yet.
+    new_sha = "feedfacefeedfacefeedfacefeedface"
+    new = snap_root / new_sha
+    new.mkdir()
+    (new / "config.json").write_text("{}")  # only metadata so far
+
+    # refs/main points at the NEW sha (this is the post-update state).
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(new_sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    # Old complete snapshot must NOT mask the new incomplete one.
+    assert gate.is_repo_cached("user/mid-update") is False
+
+    # Once the new weights land, gate flips to True.
+    (new / "model.safetensors").write_bytes(b"y" * 4096)
+    assert gate.is_repo_cached("user/mid-update") is True
+
+
+def test_is_repo_cached_falls_back_when_no_refs_dir(tmp_path, monkeypatch):
+    """When ``refs/`` doesn't exist (very fresh or non-standard cache
+    layout), the gate falls back to "any complete snapshot" rather
+    than over-prompting. The revision-mask attack from round-9
+    requires ``refs/`` to exist."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--no-refs" / "snapshots" / "abcd"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+    # NOTE: no refs/ dir.
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/no-refs") is True
+
+
+def test_is_repo_cached_handles_non_main_default_branch(tmp_path, monkeypatch):
+    """Repos whose default branch is renamed (``master``, ``trunk``,
+    etc.) ship a single non-main ref. The resolver falls back to the
+    single ref so the gate still pins to the right snapshot."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--master"
+    snap_root = repo_root / "snapshots"
+    sha = "1234123412341234123412341234123412341234"
+    snap = snap_root / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "master").write_text(sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/master") is True
+
+
 def test_is_repo_cached_rejects_symlink_to_directory(tmp_path, monkeypatch):
     """Codex round-8 BLOCKING: ``glob.glob("model*.safetensors")``
     returns symlinks-to-directories and dangling symlinks too, and

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -328,6 +328,25 @@ def test_is_repo_cached_recognises_npz_weights(tmp_path, monkeypatch):
     assert gate.is_repo_cached("mlx-community/legacy") is True
 
 
+def test_is_repo_cached_rejects_pytorch_bin_only(tmp_path, monkeypatch):
+    """Codex round-3 BLOCKING #2: ``.bin`` is the PyTorch shard format,
+    not loadable by mlx-lm. A repo that has cached PyTorch ``.bin``
+    weights but no MLX ``.safetensors`` should be treated as
+    uncached — otherwise the spawned ``serve`` silently downloads the
+    real MLX weights inside its log file."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--torch--legacy" / "snapshots" / "feed"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "tokenizer.json").write_text("{}")
+    (snap / "pytorch_model-00001-of-00002.bin").write_bytes(b"z" * 4096)
+    (snap / "pytorch_model-00002-of-00002.bin").write_bytes(b"z" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("torch/legacy") is False
+
+
 def test_is_repo_cached_walks_nested_snapshots(tmp_path, monkeypatch):
     """Sharded checkpoints sometimes nest weights one level deep. The
     walk must descend, not just glob the snapshot root."""

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -429,7 +429,25 @@ def test_is_repo_cached_is_case_sensitive(tmp_path, monkeypatch):
     """Codex round-6 BLOCKING #1: ``mlx_lm`` calls ``glob.glob`` which
     is case-sensitive on Linux and on case-sensitive macOS volumes. A
     repo whose file is named ``Model.safetensors`` (capital M) is NOT
-    picked up by the loader, so it must not pass the gate either."""
+    picked up by the loader, so it must not pass the gate either.
+
+    DeepSeek pr_validate round-3 raised this as a false-positive
+    BLOCKING (claiming macOS APFS case-insensitive default would
+    make ``glob`` match ``Model.safetensors``). Empirical verification
+    on the exact deployment platform (APFS volume on macOS 15) shows
+    Python's ``glob.glob`` filters case-sensitively even when the
+    underlying filesystem treats names case-insensitively for lookup::
+
+        >>> Path('Model.safetensors').write_bytes(b'x')
+        >>> os.path.exists('model.safetensors')   # FS case-insensitive
+        True
+        >>> glob.glob('model*.safetensors')       # glob case-sensitive
+        []
+
+    The implementation pins to that behaviour via
+    ``_is_model_weight_filename``'s case-sensitive ``startswith``.
+    Pin kept; DeepSeek finding noted in commit history.
+    """
     cache_root = tmp_path / "hf-cache"
     snap = cache_root / "models--user--capital-m" / "snapshots" / "abc"
     snap.mkdir(parents=True)

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -312,11 +312,13 @@ def test_is_repo_cached_false_on_zero_byte_weight(tmp_path, monkeypatch):
     assert gate.is_repo_cached("foo/inflight") is False
 
 
-def test_is_repo_cached_recognises_npz_weights(tmp_path, monkeypatch):
-    """Codex round-2 BLOCKING #1: older mlx-community exports + the
-    canonical mlx-lm convert format (pre-safetensors) ship as
-    ``weights.npz``. Must count as cached, otherwise legacy repos
-    re-prompt on every launch."""
+def test_is_repo_cached_rejects_npz_only(tmp_path, monkeypatch):
+    """Codex round-4 BLOCKING #2 (refinement of round-2): rapid-mlx
+    serves via ``mlx_lm.load``, which globs ``model*.safetensors`` and
+    never reads ``.npz``. A cache containing only ``weights.npz`` is
+    unusable from the chat code path, so it must NOT pass the gate —
+    otherwise the spawned ``serve`` will silently download the real
+    ``.safetensors`` shards inside its log file."""
     cache_root = tmp_path / "hf-cache"
     snap = cache_root / "models--mlx-community--legacy" / "snapshots" / "abc"
     snap.mkdir(parents=True)
@@ -325,7 +327,81 @@ def test_is_repo_cached_recognises_npz_weights(tmp_path, monkeypatch):
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate.is_repo_cached("mlx-community/legacy") is True
+    assert gate.is_repo_cached("mlx-community/legacy") is False
+
+
+def test_is_repo_cached_rejects_gguf_only(tmp_path, monkeypatch):
+    """Codex round-4 BLOCKING #2: mlx-lm has GGUF *export* support
+    (``convert_to_gguf``) but no load path — ``mlx_lm.load`` only globs
+    ``model*.safetensors``. A GGUF-only cache must NOT pass the gate."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--ggml--quant" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model-q4.gguf").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("ggml/quant") is False
+
+
+def test_is_repo_cached_requires_every_shard_listed_in_index(tmp_path, monkeypatch):
+    """Codex round-4 BLOCKING #1: ``model.safetensors.index.json`` lists
+    every shard mlx-lm will load. A snapshot with shard 1/2 present but
+    shard 2/2 missing must NOT pass — mlx-lm globs all shards and
+    crashes halfway through deserialisation, with the failure surfaced
+    in the spawned-serve log file instead of as a B2 prompt."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--mlx-community--sharded" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    index = {
+        "metadata": {"total_size": 2048},
+        "weight_map": {
+            "model.embed.weight": "model-00001-of-00002.safetensors",
+            "model.layers.0.weight": "model-00002-of-00002.safetensors",
+        },
+    }
+    (snap / "model.safetensors.index.json").write_text(json.dumps(index))
+    # Shard 1 cached, shard 2 absent.
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("mlx-community/sharded") is False
+
+    # And once shard 2 lands it does pass.
+    (snap / "model-00002-of-00002.safetensors").write_bytes(b"y" * 4096)
+    assert gate.is_repo_cached("mlx-community/sharded") is True
+
+
+def test_is_repo_cached_rejects_zero_byte_shard_in_index(tmp_path, monkeypatch):
+    """A shard that's listed in the index but zero-byte on disk (HF
+    in-flight placeholder) must NOT count as cached. Same family as
+    the partial-cache and zero-byte-weight cases above; the index
+    path needs the same check the single-file path got in round 1."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--mlx-community--inflight" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    index = {
+        "metadata": {"total_size": 4096},
+        "weight_map": {
+            "model.embed.weight": "model-00001-of-00002.safetensors",
+            "model.layers.0.weight": "model-00002-of-00002.safetensors",
+        },
+    }
+    (snap / "model.safetensors.index.json").write_text(json.dumps(index))
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"x" * 4096)
+    (snap / "model-00002-of-00002.safetensors").write_bytes(b"")  # placeholder
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("mlx-community/inflight") is False
 
 
 def test_is_repo_cached_rejects_pytorch_bin_only(tmp_path, monkeypatch):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -457,6 +457,74 @@ def test_is_repo_cached_validates_shard_filenames_in_index(tmp_path, monkeypatch
     assert gate.is_repo_cached("user/capm-index") is False
 
 
+def test_is_repo_cached_rejects_path_traversal_in_index(tmp_path, monkeypatch):
+    """Codex round-7 BLOCKING #1: shard names containing ``..`` or
+    absolute paths escape the snapshot root. The loader's glob is
+    rooted at snap_dir, so an escaped path is invisible to it; we
+    must reject it explicitly rather than walking the resolved
+    file outside ``snap_dir``."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--escape" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+
+    # Case A: relative traversal.
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"w": "../model-00001.safetensors"}})
+    )
+    # File exists at the escaped location.
+    (cache_root / "model-00001.safetensors").write_bytes(b"x" * 4096)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    assert gate.is_repo_cached("user/escape") is False
+
+    # Case B: absolute path.
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"w": "/tmp/model-00001.safetensors"}})
+    )
+    assert gate.is_repo_cached("user/escape") is False
+
+    # Case C: subdirectory (not nested loader behaviour).
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"w": "shards/model-00001.safetensors"}})
+    )
+    (snap / "shards").mkdir()
+    (snap / "shards" / "model-00001.safetensors").write_bytes(b"x" * 4096)
+    assert gate.is_repo_cached("user/escape") is False
+
+
+def test_is_repo_cached_rejects_zero_byte_extra_root_shard(tmp_path, monkeypatch):
+    """Codex round-7 BLOCKING #3: ``mlx_lm`` globs EVERY
+    ``model*.safetensors`` at the snapshot root and calls ``mx.load``
+    on each. A zero-byte placeholder next to a valid sharded cache
+    would crash the loader, so the gate must catch it too."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--extra-zero" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "w": "model-00001-of-00002.safetensors",
+                    "x": "model-00002-of-00002.safetensors",
+                }
+            }
+        )
+    )
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"x" * 4096)
+    (snap / "model-00002-of-00002.safetensors").write_bytes(b"y" * 4096)
+    # The extra zero-byte placeholder loader would still pick up.
+    (snap / "model-extra.safetensors").write_bytes(b"")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/extra-zero") is False
+
+
 def test_is_repo_cached_rejects_index_with_no_weight_map(tmp_path, monkeypatch):
     """Codex round-5 BLOCKING #1: if ``model.safetensors.index.json``
     exists but the schema doesn't yield a usable shard list (corrupt
@@ -547,17 +615,21 @@ def test_is_repo_cached_rejects_pytorch_bin_only(tmp_path, monkeypatch):
     assert gate.is_repo_cached("torch/legacy") is False
 
 
-def test_is_repo_cached_walks_nested_snapshots(tmp_path, monkeypatch):
-    """Sharded checkpoints sometimes nest weights one level deep. The
-    walk must descend, not just glob the snapshot root."""
+def test_is_repo_cached_rejects_nested_weights(tmp_path, monkeypatch):
+    """Codex round-7 BLOCKING #2: ``mlx_lm`` calls
+    ``glob.glob(model_path / "model*.safetensors")`` — a NON-recursive
+    glob. A snapshot whose weights live under ``shards/`` (or any
+    subdirectory) is not picked up by the loader, so it must NOT pass
+    the gate either. The earlier walk-the-tree behaviour was the bug."""
     cache_root = tmp_path / "hf-cache"
-    snap = cache_root / "models--foo--nested" / "snapshots" / "1234" / "shards"
-    snap.mkdir(parents=True)
-    (snap / "model-00001-of-00002.safetensors").write_bytes(b"y" * 4096)
+    snap_root = cache_root / "models--foo--nested" / "snapshots" / "1234"
+    nested = snap_root / "shards"
+    nested.mkdir(parents=True)
+    (nested / "model-00001-of-00002.safetensors").write_bytes(b"y" * 4096)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate.is_repo_cached("foo/nested") is True
+    assert gate.is_repo_cached("foo/nested") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -494,6 +494,43 @@ def test_is_repo_cached_rejects_path_traversal_in_index(tmp_path, monkeypatch):
     assert gate.is_repo_cached("user/escape") is False
 
 
+def test_is_repo_cached_rejects_symlink_to_directory(tmp_path, monkeypatch):
+    """Codex round-8 BLOCKING: ``glob.glob("model*.safetensors")``
+    returns symlinks-to-directories and dangling symlinks too, and
+    mlx-lm then calls ``mx.load`` on them and crashes. The gate must
+    REJECT such entries, not silently skip them via ``isfile``."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--badsymlink" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # Real weight file present.
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+    # Symlink at a model*.safetensors path that points to a directory.
+    a_dir = tmp_path / "decoy_dir"
+    a_dir.mkdir()
+    (snap / "model-extra.safetensors").symlink_to(a_dir)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/badsymlink") is False
+
+
+def test_is_repo_cached_rejects_dangling_symlink_at_model_path(tmp_path, monkeypatch):
+    """Same family: a dangling symlink whose name matches the loader
+    glob would also be returned by ``glob``. The loader's subsequent
+    ``mx.load`` raises; the gate must catch it."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--dangling" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+    (snap / "model-broken.safetensors").symlink_to(tmp_path / "nonexistent")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/dangling") is False
+
+
 def test_is_repo_cached_rejects_zero_byte_extra_root_shard(tmp_path, monkeypatch):
     """Codex round-7 BLOCKING #3: ``mlx_lm`` globs EVERY
     ``model*.safetensors`` at the snapshot root and calls ``mx.load``

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -312,6 +312,22 @@ def test_is_repo_cached_false_on_zero_byte_weight(tmp_path, monkeypatch):
     assert gate.is_repo_cached("foo/inflight") is False
 
 
+def test_is_repo_cached_recognises_npz_weights(tmp_path, monkeypatch):
+    """Codex round-2 BLOCKING #1: older mlx-community exports + the
+    canonical mlx-lm convert format (pre-safetensors) ship as
+    ``weights.npz``. Must count as cached, otherwise legacy repos
+    re-prompt on every launch."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--mlx-community--legacy" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "weights.npz").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("mlx-community/legacy") is True
+
+
 def test_is_repo_cached_walks_nested_snapshots(tmp_path, monkeypatch):
     """Sharded checkpoints sometimes nest weights one level deep. The
     walk must descend, not just glob the snapshot root."""

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -254,15 +254,34 @@ def test_format_size_friendly(num_bytes, expected):
 # ---------------------------------------------------------------------------
 
 
+def _seed_refs_main(repo_root, sha: str) -> None:
+    """Helper: write the ``refs/main`` file the round-9/10 fix requires.
+
+    ``snapshot_download(repo_id)`` resolves through ``refs/main`` by
+    default. ``is_repo_cached`` now pins to that specific snapshot
+    (no "any complete snapshot" fallback), so test fixtures must
+    populate ``refs/main`` for the True cases. The False / partial
+    cases either also populate it (to test that the pinned snapshot
+    is incomplete) or omit it (to assert the round-10 "no refs/main
+    → False" contract).
+    """
+    refs = repo_root / "refs"
+    refs.mkdir(exist_ok=True)
+    (refs / "main").write_text(sha)
+
+
 def test_is_repo_cached_true_when_weight_file_present(tmp_path, monkeypatch):
     """At least one non-empty weight file in the snapshot tree → True."""
     cache_root = tmp_path / "hf-cache"
-    snap = cache_root / "models--foo--cached" / "snapshots" / "abcd1234"
+    sha = "abcd1234"
+    repo_root = cache_root / "models--foo--cached"
+    snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     # Real cache layouts include config + tokenizer + the actual weights.
     (snap / "config.json").write_text("{}")
     (snap / "tokenizer.json").write_text("{}")
     (snap / "model.safetensors").write_bytes(b"x" * 2048)
+    _seed_refs_main(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
@@ -354,7 +373,9 @@ def test_is_repo_cached_requires_every_shard_listed_in_index(tmp_path, monkeypat
     import json
 
     cache_root = tmp_path / "hf-cache"
-    snap = cache_root / "models--mlx-community--sharded" / "snapshots" / "abc"
+    repo_root = cache_root / "models--mlx-community--sharded"
+    sha = "abc"
+    snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
     index = {
@@ -367,6 +388,7 @@ def test_is_repo_cached_requires_every_shard_listed_in_index(tmp_path, monkeypat
     (snap / "model.safetensors.index.json").write_text(json.dumps(index))
     # Shard 1 cached, shard 2 absent.
     (snap / "model-00001-of-00002.safetensors").write_bytes(b"x" * 4096)
+    _seed_refs_main(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
@@ -385,11 +407,14 @@ def test_is_repo_cached_rejects_adapter_only_safetensors(tmp_path, monkeypatch):
     and must NOT pass the gate — otherwise the spawned ``serve``
     silently pulls the real model weights."""
     cache_root = tmp_path / "hf-cache"
-    snap = cache_root / "models--user--lora" / "snapshots" / "abc"
+    repo_root = cache_root / "models--user--lora"
+    sha = "abc"
+    snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
     (snap / "adapter.safetensors").write_bytes(b"x" * 4096)
     (snap / "embeddings.safetensors").write_bytes(b"y" * 4096)
+    _seed_refs_main(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
@@ -535,11 +560,14 @@ def test_is_repo_cached_honours_resolved_revision_ref(tmp_path, monkeypatch):
     assert gate.is_repo_cached("user/mid-update") is True
 
 
-def test_is_repo_cached_falls_back_when_no_refs_dir(tmp_path, monkeypatch):
-    """When ``refs/`` doesn't exist (very fresh or non-standard cache
-    layout), the gate falls back to "any complete snapshot" rather
-    than over-prompting. The revision-mask attack from round-9
-    requires ``refs/`` to exist."""
+def test_is_repo_cached_rejects_when_no_refs_main(tmp_path, monkeypatch):
+    """Codex round-10 BLOCKING: when ``refs/main`` doesn't exist (fresh
+    cache, non-standard layout, or a repo whose default branch is not
+    ``main``), we DON'T know which sha ``snapshot_download(repo_id)``
+    will resolve to — so a complete snapshot at some other sha could
+    silently mask the actual current sha. The gate must err on the
+    side of re-prompting; the round-9 fallback to ``any complete
+    snapshot`` was the very bypass we're closing here."""
     cache_root = tmp_path / "hf-cache"
     snap = cache_root / "models--user--no-refs" / "snapshots" / "abcd"
     snap.mkdir(parents=True)
@@ -549,13 +577,16 @@ def test_is_repo_cached_falls_back_when_no_refs_dir(tmp_path, monkeypatch):
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate.is_repo_cached("user/no-refs") is True
+    assert gate.is_repo_cached("user/no-refs") is False
 
 
-def test_is_repo_cached_handles_non_main_default_branch(tmp_path, monkeypatch):
-    """Repos whose default branch is renamed (``master``, ``trunk``,
-    etc.) ship a single non-main ref. The resolver falls back to the
-    single ref so the gate still pins to the right snapshot."""
+def test_is_repo_cached_rejects_non_main_only_ref(tmp_path, monkeypatch):
+    """Codex round-10 BLOCKING: ``snapshot_download(repo_id)`` defaults
+    to the ``main`` revision via the HF API. A cache that only has
+    ``refs/master`` (e.g. a legacy repo whose default branch was
+    renamed upstream since the last download) doesn't tell us what
+    the current ``main`` resolves to — must re-prompt. The cost is a
+    one-time redundant prompt; the benefit is no silent download."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--user--master"
     snap_root = repo_root / "snapshots"
@@ -571,7 +602,7 @@ def test_is_repo_cached_handles_non_main_default_branch(tmp_path, monkeypatch):
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate.is_repo_cached("user/master") is True
+    assert gate.is_repo_cached("user/master") is False
 
 
 def test_is_repo_cached_rejects_symlink_to_directory(tmp_path, monkeypatch):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -254,30 +254,23 @@ def test_format_size_friendly(num_bytes, expected):
 # ---------------------------------------------------------------------------
 
 
-def test_is_repo_cached_true_when_try_to_load_finds_config(tmp_path, monkeypatch):
-    """The official ``try_to_load_from_cache`` hook is the primary probe."""
-    fake_cfg = tmp_path / "config.json"
-    fake_cfg.write_text("{}")
+def test_is_repo_cached_true_when_weight_file_present(tmp_path, monkeypatch):
+    """At least one non-empty weight file in the snapshot tree → True."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--foo--cached" / "snapshots" / "abcd1234"
+    snap.mkdir(parents=True)
+    # Real cache layouts include config + tokenizer + the actual weights.
+    (snap / "config.json").write_text("{}")
+    (snap / "tokenizer.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x" * 2048)
 
-    import huggingface_hub
-
-    monkeypatch.setattr(
-        huggingface_hub,
-        "try_to_load_from_cache",
-        lambda repo_id, fname: str(fake_cfg),
-    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate.is_repo_cached("foo/cached") is True
 
 
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
-    """No cache hit + empty HF cache directory → False."""
-    import huggingface_hub
-
-    monkeypatch.setattr(
-        huggingface_hub, "try_to_load_from_cache", lambda *_, **__: None
-    )
-
+    """Empty HF cache directory → False."""
     empty_cache = tmp_path / "hf-cache"
     empty_cache.mkdir()
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(empty_cache))
@@ -285,24 +278,51 @@ def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     assert gate.is_repo_cached("foo/missing") is False
 
 
-def test_is_repo_cached_falls_back_to_snapshot_dir(tmp_path, monkeypatch):
-    """If ``try_to_load_from_cache`` returns None but the snapshot dir exists
-    with at least one file, treat the repo as cached. Covers repos that
-    ship without a ``config.json`` at the same revision."""
-    import huggingface_hub
-
-    monkeypatch.setattr(
-        huggingface_hub, "try_to_load_from_cache", lambda *_, **__: None
-    )
-
+def test_is_repo_cached_false_on_partial_cache(tmp_path, monkeypatch):
+    """Codex round-1 BLOCKING: a partial cache (config + tokenizer only,
+    weight shards missing) must NOT pass the gate. The legacy
+    ``try_to_load_from_cache('config.json')`` probe returned True here,
+    letting the spawned ``serve`` subprocess silently download multi-GB
+    weight shards inside its log file."""
     cache_root = tmp_path / "hf-cache"
-    snap = cache_root / "models--foo--quirky" / "snapshots" / "abcd1234"
+    snap = cache_root / "models--foo--partial" / "snapshots" / "deadbeef"
     snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "tokenizer.json").write_text("{}")
     (snap / "chat_template.jinja").write_text("{{}}")
+    # Crucially: NO ``*.safetensors`` / ``*.bin`` / ``*.gguf`` file.
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate.is_repo_cached("foo/quirky") is True
+    assert gate.is_repo_cached("foo/partial") is False
+
+
+def test_is_repo_cached_false_on_zero_byte_weight(tmp_path, monkeypatch):
+    """HF stores in-flight blobs as 0-byte placeholders before the
+    download completes. A zero-byte ``*.safetensors`` must not count as
+    cached — same failure mode as the partial-cache case above."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--foo--inflight" / "snapshots" / "cafe"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"")  # placeholder
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("foo/inflight") is False
+
+
+def test_is_repo_cached_walks_nested_snapshots(tmp_path, monkeypatch):
+    """Sharded checkpoints sometimes nest weights one level deep. The
+    walk must descend, not just glob the snapshot root."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--foo--nested" / "snapshots" / "1234" / "shards"
+    snap.mkdir(parents=True)
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"y" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("foo/nested") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``vllm_mlx._download_gate``.
+
+Pins the auto-pull confirmation flow:
+
+* ``estimate_repo_size_bytes`` returns sane numbers from a mocked HF API
+  and ``None`` on failure (network down, gated repo, timeout).
+* ``confirm_or_abort`` honours the env override, TTY detection, the
+  size threshold, and yes/no user input.
+
+No test in this file hits the network — every HF API call is mocked.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import _download_gate as gate
+
+# ---------------------------------------------------------------------------
+# estimate_repo_size_bytes
+# ---------------------------------------------------------------------------
+
+
+def _fake_sibling(name: str, size: int | None, *, lfs_size: int | None = None):
+    """Build a fake ``RepoSibling``-like object that ``_sibling_size`` accepts."""
+    if lfs_size is not None:
+        lfs = SimpleNamespace(size=lfs_size)
+    else:
+        lfs = None
+    return SimpleNamespace(rfilename=name, size=size, lfs=lfs)
+
+
+def test_estimate_repo_size_sums_weight_files():
+    """Weight + tokenizer files are summed; .gitattributes/README are skipped."""
+    info = SimpleNamespace(
+        siblings=[
+            _fake_sibling("model-00001-of-00002.safetensors", 5 * 1024**3),
+            _fake_sibling("model-00002-of-00002.safetensors", 7 * 1024**3),
+            _fake_sibling("tokenizer.json", 5 * 1024**2),
+            _fake_sibling("config.json", 1024),
+            _fake_sibling(".gitattributes", 256),
+            _fake_sibling("README.md", 4096),
+        ]
+    )
+    with patch.object(gate, "_model_info_with_timeout", return_value=info):
+        total = gate.estimate_repo_size_bytes("mlx-community/Fake-12B-4bit")
+
+    assert total is not None
+    # 12 GiB of safetensors + 5 MiB tokenizer + 1 KiB config.
+    expected = (12 * 1024**3) + (5 * 1024**2) + 1024
+    assert total == expected
+
+
+def test_estimate_repo_size_prefers_lfs_size():
+    """When both ``size`` and ``lfs.size`` are populated, LFS wins (it's the
+    true blob size; the bare ``size`` field can report the pointer size)."""
+    info = SimpleNamespace(
+        siblings=[
+            _fake_sibling("model.safetensors", 134, lfs_size=4 * 1024**3),
+        ]
+    )
+    with patch.object(gate, "_model_info_with_timeout", return_value=info):
+        total = gate.estimate_repo_size_bytes("mlx-community/Fake-4B-4bit")
+
+    assert total == 4 * 1024**3
+
+
+def test_estimate_repo_size_returns_none_on_api_failure():
+    """Any exception from the HF API call surfaces as ``None`` — callers must
+    fall through silently rather than blocking on a flaky network."""
+    with patch.object(
+        gate, "_model_info_with_timeout", side_effect=RuntimeError("HF down")
+    ):
+        assert gate.estimate_repo_size_bytes("definitely/not-a-real-repo") is None
+
+
+def test_estimate_repo_size_returns_none_on_empty_repo():
+    """An info object with no weight files yields ``None`` (rather than 0) so
+    the caller's heads-up logic kicks in."""
+    info = SimpleNamespace(
+        siblings=[
+            _fake_sibling("README.md", 1024),
+            _fake_sibling(".gitattributes", 256),
+        ]
+    )
+    with patch.object(gate, "_model_info_with_timeout", return_value=info):
+        assert gate.estimate_repo_size_bytes("foo/empty") is None
+
+
+# ---------------------------------------------------------------------------
+# confirm_or_abort
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_passes_through_when_under_threshold(monkeypatch):
+    """A 5 GiB estimate against a 10 GiB threshold must not prompt."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    # Even if stdin is a TTY, small downloads pass through silently.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _=None: pytest.fail("input() must not be called for small repos"),
+    )
+
+    assert gate.confirm_or_abort("foo/small", 5 * 1024**3) is True
+
+
+def test_confirm_passes_through_when_env_var_set(monkeypatch):
+    """``RAPID_MLX_AUTO_PULL=1`` short-circuits even for huge downloads."""
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "1")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _=None: pytest.fail("input() must not be called when env set"),
+    )
+
+    assert gate.confirm_or_abort("foo/huge", 50 * 1024**3) is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "YES", "True"])
+def test_confirm_env_var_accepts_truthy_variants(monkeypatch, val):
+    """Common truthy spellings must all work — users will try all of them."""
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", val)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    assert gate.confirm_or_abort("foo/huge", 50 * 1024**3) is True
+
+
+def test_confirm_passes_through_when_non_tty(monkeypatch):
+    """Non-interactive stdin (CI, piped scripts) must not deadlock on input."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _=None: pytest.fail("input() must not be called in non-TTY mode"),
+    )
+
+    assert gate.confirm_or_abort("foo/huge", 50 * 1024**3) is True
+
+
+def test_confirm_proceeds_with_unknown_size(monkeypatch, capsys):
+    """Unknown size → heads-up + proceed (don't block on transient HF failures)."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _=None: pytest.fail("input() must not be called for unknown size"),
+    )
+
+    assert gate.confirm_or_abort("foo/unknown-size", None) is True
+    out = capsys.readouterr().out
+    assert "unknown" in out.lower()
+    assert "foo/unknown-size" in out
+
+
+def test_confirm_returns_true_on_yes(monkeypatch, capsys):
+    """``y`` input → proceed."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "y")
+
+    assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
+    out = capsys.readouterr().out
+    assert "foo/huge" in out
+    assert "41" in out  # size string contains 41 GB
+    assert "Continue?" not in out  # input prompt itself isn't captured to stdout
+
+
+def test_confirm_returns_true_on_yes_full_word(monkeypatch):
+    """``yes`` (full word, case-insensitive) also proceeds."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "YES")
+
+    assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
+
+
+def test_confirm_aborts_on_no(monkeypatch, capsys):
+    """``n`` input → ``sys.exit(1)`` with an actionable hint."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+    assert excinfo.value.code == 1
+
+    out = capsys.readouterr().out
+    assert "Aborted" in out
+    assert "rapid-mlx pull foo/huge" in out
+    assert "RAPID_MLX_AUTO_PULL" in out
+
+
+def test_confirm_aborts_on_empty_input(monkeypatch):
+    """Empty input (the default) → abort. ``[y/N]`` means N is the default."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "")
+
+    with pytest.raises(SystemExit):
+        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+
+
+def test_confirm_aborts_on_ctrl_c(monkeypatch):
+    """Ctrl-C at the prompt → treated as abort, not a stack trace."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    def _raise(_=None):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", _raise)
+
+    with pytest.raises(SystemExit):
+        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+
+
+def test_confirm_logfile_hint_appears_in_prompt(monkeypatch, capsys):
+    """When a logfile is supplied, the prompt tells the user where to tail."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "y")
+
+    gate.confirm_or_abort(
+        "foo/huge", 41 * 1024**3, logfile_hint="/tmp/serve.log"
+    )
+    out = capsys.readouterr().out
+    assert "/tmp/serve.log" in out
+
+
+# ---------------------------------------------------------------------------
+# _format_size — internal, but worth pinning so the prompt stays readable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_bytes,expected",
+    [
+        (0, "0 B"),
+        (512, "512 B"),
+        (780 * 1024**2, "780.0 MB"),
+        (int(2.4 * 1024**3), "2.4 GB"),
+        (int(42.3 * 1024**3), "42.3 GB"),
+    ],
+)
+def test_format_size_friendly(num_bytes, expected):
+    assert gate._format_size(num_bytes) == expected
+
+
+# ---------------------------------------------------------------------------
+# is_repo_cached
+# ---------------------------------------------------------------------------
+
+
+def test_is_repo_cached_true_when_try_to_load_finds_config(tmp_path, monkeypatch):
+    """The official ``try_to_load_from_cache`` hook is the primary probe."""
+    fake_cfg = tmp_path / "config.json"
+    fake_cfg.write_text("{}")
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "try_to_load_from_cache",
+        lambda repo_id, fname: str(fake_cfg),
+    )
+
+    assert gate.is_repo_cached("foo/cached") is True
+
+
+def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
+    """No cache hit + empty HF cache directory → False."""
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub, "try_to_load_from_cache", lambda *_, **__: None
+    )
+
+    empty_cache = tmp_path / "hf-cache"
+    empty_cache.mkdir()
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(empty_cache)
+    )
+
+    assert gate.is_repo_cached("foo/missing") is False
+
+
+def test_is_repo_cached_falls_back_to_snapshot_dir(tmp_path, monkeypatch):
+    """If ``try_to_load_from_cache`` returns None but the snapshot dir exists
+    with at least one file, treat the repo as cached. Covers repos that
+    ship without a ``config.json`` at the same revision."""
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub, "try_to_load_from_cache", lambda *_, **__: None
+    )
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--foo--quirky" / "snapshots" / "abcd1234"
+    snap.mkdir(parents=True)
+    (snap / "chat_template.jinja").write_text("{{}}")
+
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root)
+    )
+
+    assert gate.is_repo_cached("foo/quirky") is True
+
+
+# ---------------------------------------------------------------------------
+# Defensive guards — env value parsing.
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_env_var_falsy_value_does_not_short_circuit(monkeypatch):
+    """``RAPID_MLX_AUTO_PULL=0`` must NOT auto-confirm — the env is opt-in."""
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "0")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "n")
+
+    with pytest.raises(SystemExit):
+        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+
+
+def test_confirm_threshold_boundary(monkeypatch):
+    """Exactly at threshold → prompt fires (the docstring promises ``>=``)."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "y")
+
+    threshold = 10 * 1024**3
+    # One byte under threshold → no prompt.
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _=None: pytest.fail("input() called below threshold"),
+    )
+    assert gate.confirm_or_abort("foo/borderline", threshold - 1) is True
+
+    # At threshold → prompt fires; mock yes-response.
+    monkeypatch.setattr("builtins.input", lambda _=None: "y")
+    assert gate.confirm_or_abort("foo/border-on", threshold) is True
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: the module imports cleanly without huggingface_hub being a
+# hard runtime requirement at import time.
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_without_hf_call():
+    """Importing the module must NOT trigger any HF API call (lazy-imported)."""
+    # If huggingface_hub had been touched at module load, the patched
+    # ``_model_info_with_timeout`` in earlier tests would have failed.
+    # This test exists to make the contract explicit for future maintainers.
+    assert hasattr(gate, "estimate_repo_size_bytes")
+    assert hasattr(gate, "confirm_or_abort")
+    assert hasattr(gate, "is_repo_cached")
+    assert os.path.basename(gate.__file__) == "_download_gate.py"

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -377,6 +377,73 @@ def test_is_repo_cached_requires_every_shard_listed_in_index(tmp_path, monkeypat
     assert gate.is_repo_cached("mlx-community/sharded") is True
 
 
+def test_is_repo_cached_rejects_adapter_only_safetensors(tmp_path, monkeypatch):
+    """Codex round-5 BLOCKING #2: rapid-mlx's load path globs
+    ``model*.safetensors`` literally. A cache containing only
+    ``adapter.safetensors`` (LoRA / PEFT fine-tune) or
+    ``embeddings.safetensors`` (sidecar) is unusable from rapid-mlx
+    and must NOT pass the gate — otherwise the spawned ``serve``
+    silently pulls the real model weights."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--lora" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "adapter.safetensors").write_bytes(b"x" * 4096)
+    (snap / "embeddings.safetensors").write_bytes(b"y" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/lora") is False
+
+    # Once an actual ``model.safetensors`` lands, it does pass.
+    (snap / "model.safetensors").write_bytes(b"z" * 4096)
+    assert gate.is_repo_cached("user/lora") is True
+
+
+def test_is_repo_cached_rejects_index_with_no_weight_map(tmp_path, monkeypatch):
+    """Codex round-5 BLOCKING #1: if ``model.safetensors.index.json``
+    exists but the schema doesn't yield a usable shard list (corrupt
+    schema, alternate-key layout, metadata-only index), we must NOT
+    fall back to the single-file probe — the presence of the index
+    itself is the loader's signal that this is a sharded model."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--quirky-index" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # Index uses an alternate key (no ``weight_map`` at all).
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 4096}, "files": ["shard.safetensors"]})
+    )
+    # A stray single-file safetensors that would otherwise pass the
+    # single-file probe.
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/quirky-index") is False
+
+
+def test_is_repo_cached_rejects_index_with_empty_weight_map(tmp_path, monkeypatch):
+    """Same as the no-weight-map case but the key exists with an
+    empty dict value. Both must be treated as 'incomplete sharded'."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--empty-map" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 4096}, "weight_map": {}})
+    )
+    (snap / "model.safetensors").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/empty-map") is False
+
+
 def test_is_repo_cached_rejects_zero_byte_shard_in_index(tmp_path, monkeypatch):
     """A shard that's listed in the index but zero-byte on disk (HF
     in-flight placeholder) must NOT count as cached. Same family as

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -166,7 +166,7 @@ def test_confirm_returns_true_on_yes(monkeypatch, capsys):
     assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
     out = capsys.readouterr().out
     assert "foo/huge" in out
-    assert "41" in out  # size string contains 41 GB
+    assert "41" in out  # size string contains 41 GiB
     assert "Continue?" not in out  # input prompt itself isn't captured to stdout
 
 
@@ -240,9 +240,9 @@ def test_confirm_logfile_hint_appears_in_prompt(monkeypatch, capsys):
     [
         (0, "0 B"),
         (512, "512 B"),
-        (780 * 1024**2, "780.0 MB"),
-        (int(2.4 * 1024**3), "2.4 GB"),
-        (int(42.3 * 1024**3), "42.3 GB"),
+        (780 * 1024**2, "780.0 MiB"),
+        (int(2.4 * 1024**3), "2.4 GiB"),
+        (int(42.3 * 1024**3), "42.3 GiB"),
     ],
 )
 def test_format_size_friendly(num_bytes, expected):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -225,9 +225,7 @@ def test_confirm_logfile_hint_appears_in_prompt(monkeypatch, capsys):
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _=None: "y")
 
-    gate.confirm_or_abort(
-        "foo/huge", 41 * 1024**3, logfile_hint="/tmp/serve.log"
-    )
+    gate.confirm_or_abort("foo/huge", 41 * 1024**3, logfile_hint="/tmp/serve.log")
     out = capsys.readouterr().out
     assert "/tmp/serve.log" in out
 
@@ -282,9 +280,7 @@ def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
 
     empty_cache = tmp_path / "hf-cache"
     empty_cache.mkdir()
-    monkeypatch.setattr(
-        "huggingface_hub.constants.HF_HUB_CACHE", str(empty_cache)
-    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(empty_cache))
 
     assert gate.is_repo_cached("foo/missing") is False
 
@@ -304,9 +300,7 @@ def test_is_repo_cached_falls_back_to_snapshot_dir(tmp_path, monkeypatch):
     snap.mkdir(parents=True)
     (snap / "chat_template.jinja").write_text("{{}}")
 
-    monkeypatch.setattr(
-        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root)
-    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate.is_repo_cached("foo/quirky") is True
 

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -400,6 +400,63 @@ def test_is_repo_cached_rejects_adapter_only_safetensors(tmp_path, monkeypatch):
     assert gate.is_repo_cached("user/lora") is True
 
 
+def test_is_repo_cached_is_case_sensitive(tmp_path, monkeypatch):
+    """Codex round-6 BLOCKING #1: ``mlx_lm`` calls ``glob.glob`` which
+    is case-sensitive on Linux and on case-sensitive macOS volumes. A
+    repo whose file is named ``Model.safetensors`` (capital M) is NOT
+    picked up by the loader, so it must not pass the gate either."""
+    cache_root = tmp_path / "hf-cache"
+    snap = cache_root / "models--user--capital-m" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "Model.safetensors").write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/capital-m") is False
+
+
+def test_is_repo_cached_validates_shard_filenames_in_index(tmp_path, monkeypatch):
+    """Codex round-6 BLOCKING #2: the indexed path validated only that
+    ``weight_map`` values *exist*, not that the filenames match the
+    loader glob. An index pointing at ``adapter.safetensors`` or
+    ``Model-00001-of-00002.safetensors`` (capital M) would pass while
+    ``mlx_lm`` actually loads zero model weights."""
+    import json
+
+    # Case A: index references an adapter file (loader can't open).
+    cache_root = tmp_path / "hf-cache-adapter"
+    snap = cache_root / "models--user--adapter-index" / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"w": "adapter.safetensors"}})
+    )
+    (snap / "adapter.safetensors").write_bytes(b"x" * 4096)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    assert gate.is_repo_cached("user/adapter-index") is False
+
+    # Case B: index references capital-M shard names — same loader miss.
+    cache_root_b = tmp_path / "hf-cache-cap"
+    snap_b = cache_root_b / "models--user--capm-index" / "snapshots" / "abc"
+    snap_b.mkdir(parents=True)
+    (snap_b / "config.json").write_text("{}")
+    (snap_b / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "w1": "Model-00001-of-00002.safetensors",
+                    "w2": "Model-00002-of-00002.safetensors",
+                }
+            }
+        )
+    )
+    (snap_b / "Model-00001-of-00002.safetensors").write_bytes(b"x" * 4096)
+    (snap_b / "Model-00002-of-00002.safetensors").write_bytes(b"y" * 4096)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root_b))
+    assert gate.is_repo_cached("user/capm-index") is False
+
+
 def test_is_repo_cached_rejects_index_with_no_weight_map(tmp_path, monkeypatch):
     """Codex round-5 BLOCKING #1: if ``model.safetensors.index.json``
     exists but the schema doesn't yield a usable shard list (corrupt

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -154,6 +154,10 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         "--disable-prefix-cache",
         # Chat-template toggle, not engine routing.
         "--no-thinking",
+        # `--no-think` is a hidden back-compat alias of `--no-thinking` on
+        # `serve` (and the canonical name on `chat`). Same dest, same
+        # semantics — pure UX symmetry between the two subcommands.
+        "--no-think",
         # CORS toggle.
         "--enable-cors",
         # Perf / UX toggles, not routing decisions.

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -116,6 +116,12 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_TELEMETRY",
         # Port for doctor harness probe checks, not engine routing.
         "RAPID_MLX_PORT",
+        # Skip the [y/N] confirmation prompt before large model downloads
+        # (UX knob for unattended/CI usage; not consulted by the engine).
+        "RAPID_MLX_AUTO_PULL",
+        # Override the per-user config dir used to remember "seen-tips"
+        # banner state (chat REPL first-launch tip gating).
+        "RAPID_MLX_CONFIG_HOME",
     }
 )
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -122,6 +122,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # Override the per-user config dir used to remember "seen-tips"
         # banner state (chat REPL first-launch tip gating).
         "RAPID_MLX_CONFIG_HOME",
+        # Set by ``rapid-mlx chat`` on the spawned ``serve`` subprocess
+        # so the child's B2 download gate no-ops (parent already gated).
+        # Pure UX flag — never read by the engine or scheduler.
+        "RAPID_MLX_CHAT_SPAWN",
     }
 )
 

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from vllm_mlx.model_auto_config import (
     ModelConfig,
+    _suffix_tier_cell,
     classify_suffix_decoding_tier,
     format_profile_table,
     suffix_decoding_hint,
@@ -155,7 +156,13 @@ class TestProfileTableCell:
         table = format_profile_table("test/Model", cfg)
         assert "Suffix tier" in table
         assert "unknown" in table.lower()
-        assert "bench_suffix_decoding_integrated" in table
+        # The boxed table truncates the script name to keep alignment,
+        # but a discoverable prefix must remain so the user knows where
+        # to look. The un-truncated helper (called without ``max_width``)
+        # must still emit the full path for log scrapers / non-boxed
+        # callers.
+        assert "bench_suffix_decod" in table
+        assert "bench_suffix_decoding_integrated" in _suffix_tier_cell(cfg)
 
     def test_hybrid_says_n_a(self):
         cfg = ModelConfig(supports_spec_decode=False, is_hybrid=True)
@@ -182,6 +189,48 @@ class TestProfileTableCell:
         # AVOID surfaces the regression, not the peak.
         assert "chat" in table
         assert "0.78" in table
+
+    def test_long_avoid_note_fits_box_when_max_width_set(self):
+        """Regression: long ``avoid`` notes (e.g. ``gemma-4-26b``) used
+        to overflow the right ``│`` border. Truncation must keep the
+        tier word + numeric speedup whole while shortening the trailing
+        rationale to ``…)``."""
+        cfg = ModelConfig(
+            suffix_decoding_tier="avoid",
+            suffix_bench_speedup={"json_array": 0.20},
+        )
+        # 41 cols == the value-column width inside the rapid-mlx info
+        # box (inner=60 minus the 17-char key field and 2-char ``: ``).
+        cell = _suffix_tier_cell(cfg, max_width=41)
+        assert len(cell) <= 41
+        assert cell.startswith("avoid (json_array 0.20x")
+        assert cell.endswith("…)")
+
+    def test_short_tier_note_is_not_wrongly_truncated(self):
+        """Tier notes that already fit must pass through untouched —
+        the truncator should be a no-op on the common case."""
+        cfg = ModelConfig(supports_spec_decode=False, is_hybrid=True)
+        cell = _suffix_tier_cell(cfg, max_width=41)
+        assert cell == "n/a (hybrid arch — spec decode off)"
+        assert "…" not in cell
+
+    def test_table_rows_all_same_width_for_long_avoid(self):
+        """Box-frame alignment invariant: every bordered row must end at
+        the same column. Pre-fix the ``Suffix tier`` row for an alias
+        like ``gemma-4-26b`` would render past the right ``│``."""
+        cfg = ModelConfig(
+            suffix_decoding_tier="avoid",
+            suffix_bench_speedup={"json_array": 0.20},
+        )
+        table = format_profile_table("mlx-community/gemma-4-26b-a4b-it-4bit", cfg)
+        widths = {
+            len(line)
+            for line in table.splitlines()
+            if line.startswith(("│", "┌", "└"))
+        }
+        assert len(widths) == 1, (
+            f"All rows must be same printable width, got: {widths}\n{table}"
+        )
 
 
 class TestModelConfigDefaults:

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -224,9 +224,7 @@ class TestProfileTableCell:
         )
         table = format_profile_table("mlx-community/gemma-4-26b-a4b-it-4bit", cfg)
         widths = {
-            len(line)
-            for line in table.splitlines()
-            if line.startswith(("│", "┌", "└"))
+            len(line) for line in table.splitlines() if line.startswith(("│", "┌", "└"))
         }
         assert len(widths) == 1, (
             f"All rows must be same printable width, got: {widths}\n{table}"

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -339,6 +339,42 @@ def _root_model_files_all_non_empty(snap_dir: str) -> bool:
     return True
 
 
+def _resolved_snapshot_sha(repo_root: str) -> str | None:
+    """Read the sha that ``snapshot_download`` would resolve to.
+
+    HF's cache layout stores the resolved sha for each branch under
+    ``models--<repo>/refs/<branch>``. ``snapshot_download(repo_id)``
+    with no explicit revision defaults to ``main``; if ``main`` isn't
+    present we fall back to whatever single ref does exist (covers
+    repos whose default branch is renamed).
+
+    Codex round-9 BLOCKING: without this check, an old complete
+    snapshot could mask a newer-but-incomplete snapshot (interrupted
+    update). The loader resolves through ``refs/main`` to the NEWER
+    sha and crashes on the incomplete one even though we said "cached".
+    """
+    refs_dir = os.path.join(repo_root, "refs")
+    if not os.path.isdir(refs_dir):
+        return None
+    main_ref = os.path.join(refs_dir, "main")
+    try:
+        if os.path.isfile(main_ref):
+            with open(main_ref) as fh:
+                sha = fh.read().strip()
+            return sha or None
+        # Fallback for repos whose default branch isn't named "main".
+        entries = [
+            e for e in os.listdir(refs_dir) if os.path.isfile(os.path.join(refs_dir, e))
+        ]
+        if len(entries) == 1:
+            with open(os.path.join(refs_dir, entries[0])) as fh:
+                sha = fh.read().strip()
+            return sha or None
+    except OSError:
+        return None
+    return None
+
+
 def is_repo_cached(repo_id: str) -> bool:
     """True if ``repo_id`` has a usable model snapshot in the HF cache.
 
@@ -350,8 +386,15 @@ def is_repo_cached(repo_id: str) -> bool:
     sharded cache (shard 1/2 present, shard 2/2 missing) bypass the
     gate; mlx-lm's loader globs every shard and fails halfway through.
 
+    Revision pinning (Codex round-9 BLOCKING): when ``refs/main``
+    (or the single resolved ref) exists, ONLY the snapshot pointed to
+    by that ref counts — the loader resolves through the ref, and an
+    unrelated old-but-complete snapshot must not mask a current-but-
+    incomplete one after an interrupted ``snapshot_download`` update.
+
     The check delegates to ``_snapshot_is_complete`` so the doctor
-    pre-flight and the B2 gate share one source of truth.
+    pre-flight and the B2 gate share one source of truth (with the
+    intentional policy divergence documented there).
 
     Returns ``False`` on any internal exception so the caller defaults
     to the safe path (prompting, if the size warrants it).
@@ -359,13 +402,27 @@ def is_repo_cached(repo_id: str) -> bool:
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
 
-        snap_root = os.path.join(
+        repo_root = os.path.join(
             HF_HUB_CACHE,
             f"models--{repo_id.replace('/', '--')}",
-            "snapshots",
         )
+        snap_root = os.path.join(repo_root, "snapshots")
         if not os.path.isdir(snap_root):
             return False
+
+        # Prefer the resolved-revision check so a stale-but-complete
+        # snapshot can't mask the active-but-incomplete one.
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is not None:
+            snap_dir = os.path.join(snap_root, resolved_sha)
+            if not os.path.isdir(snap_dir):
+                return False
+            return _snapshot_is_complete(snap_dir)
+
+        # No refs/ entry at all — first-time cache or non-standard
+        # layout. Fall back to "any complete snapshot" rather than
+        # forcing a re-prompt; the revision-mask attack requires the
+        # refs/ entry to exist by definition.
         for entry in os.listdir(snap_root):
             snap_dir = os.path.join(snap_root, entry)
             if not os.path.isdir(snap_dir):

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -62,13 +62,17 @@ _WEIGHT_SUFFIXES: tuple[str, ...] = (
 # (Codex round-1 BLOCKING #3). Estimating download size, by contrast,
 # still cares about every payload byte (above).
 #
-# Codex round-2 BLOCKING #1: older mlx-community exports (and the
-# canonical mlx-lm convert format prior to the safetensors switch)
-# ship weights as ``weights.npz``. Without ``.npz`` here, cached
-# legacy repos returned False and re-prompted on every launch.
+# Format-by-format rationale (Codex round-3 BLOCKING #2 narrows this
+# to what mlx-lm actually loads):
+#   * ``.safetensors`` — canonical mlx-community / mlx-lm convert output
+#   * ``.gguf``        — mlx-lm has native GGUF loader support
+#   * ``.npz``         — legacy mlx-lm convert format (pre-safetensors)
+# ``.bin`` is INTENTIONALLY excluded: it's the PyTorch shard format,
+# not loadable by mlx-lm. A repo with cached PyTorch ``.bin`` weights
+# but missing MLX ``.safetensors`` would otherwise pass the gate and
+# the spawned ``serve`` would still silently pull the real weights.
 _WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (
     ".safetensors",
-    ".bin",
     ".gguf",
     ".npz",
 )

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-pull confirmation gate for large model downloads.
+
+Persona-3 ("Ollama switcher") feedback (2026-05): running
+
+    rapid-mlx chat qwen3-coder
+
+against an alias that wasn't yet cached silently kicked off a 41.8 GB
+download with no ``[y/N]`` prompt. The download itself ran fine, but
+because the spawned ``serve`` subprocess captured stdout to a logfile,
+the user saw a blank screen and assumed the CLI was hung.
+
+This module is the user-visible safety net. It is intentionally
+self-contained (no rapid-mlx imports) so it stays cheap to import from
+``cli.main()`` on every invocation.
+
+Public API:
+
+* :func:`estimate_repo_size_bytes` — best-effort HF API size lookup.
+* :func:`confirm_or_abort`         — prompt + abort path used by the CLI.
+* :func:`is_repo_cached`           — cache-presence probe (so callers can
+  short-circuit without re-implementing the path dance).
+
+Design choices:
+
+* The HF call is wrapped in a hard 5-second timeout and a blanket
+  ``except Exception`` — a flaky metadata query must never block a
+  perfectly-good cached load, and we already gate on cache presence
+  upstream of the size estimate.
+* The threshold defaults to 10 GiB. Anything under that is too small
+  to warrant interrupting the user's flow.
+* The env override (``RAPID_MLX_AUTO_PULL=1``) is the documented escape
+  hatch for non-interactive CI usage and ``--yes``-style workflows.
+* Non-TTY stdin → auto-confirm. Scripts that pipe input into
+  ``rapid-mlx`` must not deadlock on a missing terminal.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+# File suffixes that contribute to "model weight + tokenizer" footprint.
+# Anything outside this set (e.g. ``.gitattributes``, ``README.md``) is a
+# rounding error and is excluded so the prompt size matches what the user
+# actually waits on.
+_WEIGHT_SUFFIXES: tuple[str, ...] = (
+    ".safetensors",
+    ".bin",
+    ".gguf",
+    ".json",
+    ".txt",
+    ".model",
+    ".tiktoken",
+)
+
+# 5-second cap on the HF metadata call. Anything slower than this is a
+# signal we should fall through silently rather than block startup.
+_HF_API_TIMEOUT_SECONDS: float = 5.0
+
+
+def _format_size(num_bytes: int) -> str:
+    """Render ``num_bytes`` as a human-friendly string (e.g. ``42.3 GB``).
+
+    Uses base-1024 units to match the way HF Hub and macOS Finder
+    report file sizes. Picks the largest unit where the value is ``>= 1``.
+    """
+    if num_bytes < 0:
+        num_bytes = 0
+    units = ("B", "KB", "MB", "GB", "TB")
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == units[-1]:
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024.0
+    return f"{size:.1f} TB"  # unreachable, keeps mypy happy
+
+
+def _is_weight_file(name: str) -> bool:
+    """True if ``name`` should be counted in the download-size estimate."""
+    if not name or name.startswith(".git"):
+        return False
+    lower = name.lower()
+    return any(lower.endswith(s) for s in _WEIGHT_SUFFIXES)
+
+
+def _sibling_size(sibling) -> int:
+    """Extract the on-disk size of an HF ``RepoSibling``.
+
+    Newer huggingface_hub releases expose the LFS pointer's true size
+    under ``sibling.lfs.size``; older ones store it directly on
+    ``sibling.size``. Try both, prefer the LFS value when both are
+    populated (the regular ``size`` may report the pointer-file size,
+    not the resolved blob size).
+    """
+    lfs = getattr(sibling, "lfs", None)
+    if lfs is not None:
+        lfs_size = getattr(lfs, "size", None)
+        if isinstance(lfs_size, int) and lfs_size > 0:
+            return lfs_size
+    raw = getattr(sibling, "size", None)
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return 0
+
+
+def _model_info_with_timeout(repo_id: str, timeout: float):
+    """Call ``HfApi().model_info`` with a hard timeout.
+
+    huggingface_hub itself doesn't accept a timeout argument on
+    ``model_info`` in every release we support, so we run it in a worker
+    thread and join with a deadline. Worst case (network hang) the
+    daemon thread is leaked and reaped at interpreter exit — acceptable
+    for a CLI that's about to exit anyway one way or the other.
+    """
+    from huggingface_hub import HfApi
+
+    result: dict = {}
+
+    def _call() -> None:
+        try:
+            result["info"] = HfApi().model_info(repo_id, files_metadata=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            result["error"] = exc
+
+    worker = threading.Thread(target=_call, daemon=True)
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        raise TimeoutError(f"model_info({repo_id!r}) exceeded {timeout}s")
+    if "error" in result:
+        raise result["error"]
+    return result.get("info")
+
+
+def estimate_repo_size_bytes(repo_id: str) -> int | None:
+    """Best-effort total size of weight + tokenizer files in ``repo_id``.
+
+    Returns the sum of ``sibling.size`` (preferring LFS-reported size
+    when available) across files whose extension marks them as weight
+    or tokenizer payload. ``None`` on any failure (network down, gated
+    repo, HF outage, timeout) — callers should fall through silently.
+    """
+    try:
+        info = _model_info_with_timeout(repo_id, _HF_API_TIMEOUT_SECONDS)
+    except Exception:
+        return None
+
+    siblings = getattr(info, "siblings", None) or []
+    total = 0
+    for sib in siblings:
+        name = getattr(sib, "rfilename", "") or ""
+        if not _is_weight_file(name):
+            continue
+        total += _sibling_size(sib)
+    return total if total > 0 else None
+
+
+def is_repo_cached(repo_id: str) -> bool:
+    """True if ``repo_id`` already has at least a config.json in the HF cache.
+
+    Two probes:
+
+    1. ``huggingface_hub.try_to_load_from_cache(repo_id, "config.json")``
+       — the official "is this snapshot resolvable" hook.
+    2. Snapshot-directory fallback — handles repos whose layout is
+       non-standard (e.g. ``chat_template.jinja`` shipped without a
+       ``config.json`` at the same revision).
+
+    Returns ``False`` on any internal exception so the caller defaults
+    to the safe path (prompting, if the size warrants it).
+    """
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(repo_id, "config.json")
+        if isinstance(cached, str) and os.path.exists(cached):
+            return True
+    except Exception:
+        pass
+
+    # Snapshot-directory fallback.
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        snap_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+            "snapshots",
+        )
+        if os.path.isdir(snap_root):
+            for entry in os.listdir(snap_root):
+                snap_dir = os.path.join(snap_root, entry)
+                if os.path.isdir(snap_dir) and any(os.scandir(snap_dir)):
+                    return True
+    except Exception:
+        pass
+
+    return False
+
+
+def confirm_or_abort(
+    repo_id: str,
+    estimated_bytes: int | None,
+    *,
+    threshold_bytes: int = 10 * 1024**3,  # 10 GiB
+    auto_yes_env: str = "RAPID_MLX_AUTO_PULL",
+    logfile_hint: str | None = None,
+) -> bool:
+    """Interactive gate before a large model download begins.
+
+    Returns ``True`` (proceed) without prompting when:
+
+    * the env var ``auto_yes_env`` is set to a truthy value
+      (``"1"``/``"true"``/``"yes"``, case-insensitive), OR
+    * ``sys.stdin`` is not a TTY (scripts/CI), OR
+    * ``estimated_bytes`` is below ``threshold_bytes``.
+
+    When the size estimate is ``None`` (HF lookup failed) we print a
+    heads-up but proceed — blocking on a transient API failure would be
+    worse than the silent-download problem we're trying to fix.
+
+    When the user types anything other than ``y``/``yes``, we print a
+    one-line abort hint and call ``sys.exit(1)``.
+    """
+    # Env override always wins.
+    env_val = os.environ.get(auto_yes_env, "").strip().lower()
+    if env_val in {"1", "true", "yes"}:
+        return True
+
+    # Non-interactive: never block; we already burned the user's time
+    # if they piped a script that didn't pass --auto-pull.
+    if not sys.stdin.isatty():
+        return True
+
+    # Unknown size → noisy heads-up but proceed. We get here when the
+    # HF metadata API is down or the repo is gated; either way the
+    # actual download will surface its own error if there is one.
+    if estimated_bytes is None:
+        print()
+        print(f"  About to download {repo_id}")
+        print("    Estimated size: unknown (HF metadata lookup failed)")
+        print("    Proceeding without confirmation. Set "
+              f"{auto_yes_env}=1 to silence this notice.")
+        print()
+        return True
+
+    # Small downloads don't deserve interruption.
+    if estimated_bytes < threshold_bytes:
+        return True
+
+    size_str = _format_size(estimated_bytes)
+    print()
+    print(f"  About to download {repo_id}")
+    print(f"    Estimated size: {size_str} (this may take a while on first run)")
+    if logfile_hint:
+        print(
+            "    Download progress will appear in "
+            f"{logfile_hint}; tail it to watch."
+        )
+    print()
+    try:
+        answer = input("  Continue? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+
+    if answer in {"y", "yes"}:
+        return True
+
+    print(
+        f"  Aborted. Use 'rapid-mlx pull {repo_id}' to download separately, "
+        f"or set {auto_yes_env}=1 to skip this prompt."
+    )
+    sys.exit(1)

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -55,27 +55,22 @@ _WEIGHT_SUFFIXES: tuple[str, ...] = (
     ".tiktoken",
 )
 
-# Stricter set used by ``is_repo_cached`` only. A repo isn't usable
-# without actual model weight shards on disk — tokenizer.json /
-# config.json can land on their own (HF downloads metadata first), so
-# counting them as "cached" lets a partial download bypass the gate
-# (Codex round-1 BLOCKING #3). Estimating download size, by contrast,
-# still cares about every payload byte (above).
+# Suffixes treated as cache-proving by ``is_repo_cached``. mlx-lm's
+# high-level loader (the path rapid-mlx serve takes) only globs
+# ``model*.safetensors`` — see ``mlx_lm/utils.py:316``.
 #
-# Format-by-format rationale (Codex round-3 BLOCKING #2 narrows this
-# to what mlx-lm actually loads):
-#   * ``.safetensors`` — canonical mlx-community / mlx-lm convert output
-#   * ``.gguf``        — mlx-lm has native GGUF loader support
-#   * ``.npz``         — legacy mlx-lm convert format (pre-safetensors)
-# ``.bin`` is INTENTIONALLY excluded: it's the PyTorch shard format,
-# not loadable by mlx-lm. A repo with cached PyTorch ``.bin`` weights
-# but missing MLX ``.safetensors`` would otherwise pass the gate and
-# the spawned ``serve`` would still silently pull the real weights.
-_WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (
-    ".safetensors",
-    ".gguf",
-    ".npz",
-)
+# Codex round-4 BLOCKING #2 trimmed this list to ``.safetensors`` only:
+#   * ``.bin``  — PyTorch shards, never loaded by mlx-lm.
+#   * ``.gguf`` — mlx-lm has *export* support (convert_to_gguf) but
+#                 no load path; ``mx.save_gguf`` is one-way.
+#   * ``.npz``  — older mlx-lm convert format; current mlx-lm load
+#                 doesn't reach it either.
+#
+# Keeping these in the cache-proving set lets a non-loadable cache
+# (e.g. cached ``weights.npz`` from a 2024-era mlx-community fork) pass
+# the gate and route the user back into "silent download in the
+# spawned serve subprocess" — which is exactly what B2 exists to fix.
+_WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (".safetensors",)
 
 # 5-second cap on the HF metadata call. Anything slower than this is a
 # signal we should fall through silently rather than block startup.
@@ -182,14 +177,73 @@ def estimate_repo_size_bytes(repo_id: str) -> int | None:
     return total if total > 0 else None
 
 
+def _snapshot_is_complete(snap_dir: str) -> bool:
+    """True if ``snap_dir`` looks like a fully-downloaded model snapshot.
+
+    Mirrors ``vllm_mlx.doctor.discovery._is_complete_snapshot`` so the
+    two cache-completeness checks (doctor pre-flight + B2 gate) stay in
+    sync. The only behavior difference is suffix scope: B2 only cares
+    about formats mlx-lm's loader actually consumes (``.safetensors``).
+
+    Strategy:
+      1. ``model.safetensors.index.json`` present → parse ``weight_map``
+         and require every referenced shard to exist with non-zero
+         size. Codex round-4 BLOCKING #1: a sharded model with shard 1
+         present but shard 2 missing must NOT count as cached.
+      2. Otherwise, a single non-empty ``*.safetensors`` is sufficient
+         (covers single-file models).
+    """
+    index_path = os.path.join(snap_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        import json
+
+        try:
+            with open(index_path) as fh:
+                index = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            # Truncated index → safer to treat as incomplete and re-prompt.
+            return False
+        weight_map = index.get("weight_map") or {}
+        shard_names = set(weight_map.values())
+        if shard_names:
+            for shard in shard_names:
+                target = os.path.join(snap_dir, shard)
+                try:
+                    if os.path.getsize(target) <= 0:
+                        return False
+                except OSError:
+                    return False
+            return True
+        # Index parsed but empty weight_map — fall through to the
+        # single-file probe rather than declaring False on a quirk.
+
+    # Single-file (non-sharded) model.
+    for root, _dirs, files in os.walk(snap_dir):
+        for name in files:
+            lower = name.lower()
+            if not any(lower.endswith(s) for s in _WEIGHT_ONLY_SUFFIXES):
+                continue
+            try:
+                if os.path.getsize(os.path.join(root, name)) > 0:
+                    return True
+            except OSError:
+                continue
+    return False
+
+
 def is_repo_cached(repo_id: str) -> bool:
-    """True if ``repo_id`` has at least one weight file present in the HF cache.
+    """True if ``repo_id`` has a usable model snapshot in the HF cache.
 
     Codex review round 1 caught that an earlier "config.json exists →
     cached" check let a partial cache (config + tokenizer only, weight
     shards missing) bypass the gate. The serve subprocess would then
-    silently download the weights inside its log file. We require an
-    actual weight file in the snapshot before declaring "cached".
+    silently download the weights inside its log file. Round 4 then
+    caught that even "any one safetensors file present" let a partial
+    sharded cache (shard 1/2 present, shard 2/2 missing) bypass the
+    gate; mlx-lm's loader globs every shard and fails halfway through.
+
+    The check delegates to ``_snapshot_is_complete`` so the doctor
+    pre-flight and the B2 gate share one source of truth.
 
     Returns ``False`` on any internal exception so the caller defaults
     to the safe path (prompting, if the size warrants it).
@@ -208,25 +262,10 @@ def is_repo_cached(repo_id: str) -> bool:
             snap_dir = os.path.join(snap_root, entry)
             if not os.path.isdir(snap_dir):
                 continue
-            # Walk the snapshot tree (HF stores sharded weights in the
-            # snapshot root; some layouts may nest). Resolve through HF's
-            # symlinks: snapshot entries are symlinks into ``blobs/``, and
-            # a partially-downloaded blob exists as a 0-byte placeholder.
-            for root, _dirs, files in os.walk(snap_dir):
-                for name in files:
-                    lower = name.lower()
-                    if not any(lower.endswith(s) for s in _WEIGHT_ONLY_SUFFIXES):
-                        continue
-                    full = os.path.join(root, name)
-                    try:
-                        # ``getsize`` follows symlinks → real blob size.
-                        if os.path.getsize(full) > 0:
-                            return True
-                    except OSError:
-                        continue
+            if _snapshot_is_complete(snap_dir):
+                return True
     except Exception:
         pass
-
     return False
 
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -340,39 +340,35 @@ def _root_model_files_all_non_empty(snap_dir: str) -> bool:
 
 
 def _resolved_snapshot_sha(repo_root: str) -> str | None:
-    """Read the sha that ``snapshot_download`` would resolve to.
+    """Read the sha that ``snapshot_download(repo_id)`` would resolve to.
 
-    HF's cache layout stores the resolved sha for each branch under
-    ``models--<repo>/refs/<branch>``. ``snapshot_download(repo_id)``
-    with no explicit revision defaults to ``main``; if ``main`` isn't
-    present we fall back to whatever single ref does exist (covers
-    repos whose default branch is renamed).
+    ``snapshot_download`` with no explicit revision asks the HF API for
+    the default branch's HEAD sha and writes it to
+    ``models--<repo>/refs/<default_branch>``. For modern repos that
+    file is ``refs/main``.
 
-    Codex round-9 BLOCKING: without this check, an old complete
-    snapshot could mask a newer-but-incomplete snapshot (interrupted
-    update). The loader resolves through ``refs/main`` to the NEWER
-    sha and crashes on the incomplete one even though we said "cached".
+    Codex round-9 BLOCKING: without any pinning, an old complete
+    snapshot could mask a newer-but-incomplete one (interrupted
+    update). Codex round-10 BLOCKING: the round-9 fallbacks (single
+    non-main ref, "any complete snapshot" when no refs/ exists) could
+    mask the same attack a different way — a legacy ``refs/master``
+    can shadow what ``main`` resolves to upstream now, and a
+    no-refs/ cache could shadow any sha.
+
+    We now ONLY honour ``refs/main``. The cost is a redundant prompt
+    for repos whose default branch is renamed (rare; legacy
+    ``master`` mostly); the benefit is no silent download in any
+    other scenario.
     """
-    refs_dir = os.path.join(repo_root, "refs")
-    if not os.path.isdir(refs_dir):
-        return None
-    main_ref = os.path.join(refs_dir, "main")
+    main_ref = os.path.join(repo_root, "refs", "main")
     try:
-        if os.path.isfile(main_ref):
-            with open(main_ref) as fh:
-                sha = fh.read().strip()
-            return sha or None
-        # Fallback for repos whose default branch isn't named "main".
-        entries = [
-            e for e in os.listdir(refs_dir) if os.path.isfile(os.path.join(refs_dir, e))
-        ]
-        if len(entries) == 1:
-            with open(os.path.join(refs_dir, entries[0])) as fh:
-                sha = fh.read().strip()
-            return sha or None
+        if not os.path.isfile(main_ref):
+            return None
+        with open(main_ref) as fh:
+            sha = fh.read().strip()
+        return sha or None
     except OSError:
         return None
-    return None
 
 
 def is_repo_cached(repo_id: str) -> bool:
@@ -410,25 +406,18 @@ def is_repo_cached(repo_id: str) -> bool:
         if not os.path.isdir(snap_root):
             return False
 
-        # Prefer the resolved-revision check so a stale-but-complete
-        # snapshot can't mask the active-but-incomplete one.
+        # Codex round-10 BLOCKING: no "any complete snapshot"
+        # fallback. The only safe cache-presence answer is "the
+        # snapshot ``snapshot_download(repo_id)`` will actually use".
+        # Without ``refs/main``, we don't know which sha will resolve,
+        # so we must re-prompt and let the next run populate refs/.
         resolved_sha = _resolved_snapshot_sha(repo_root)
-        if resolved_sha is not None:
-            snap_dir = os.path.join(snap_root, resolved_sha)
-            if not os.path.isdir(snap_dir):
-                return False
-            return _snapshot_is_complete(snap_dir)
-
-        # No refs/ entry at all — first-time cache or non-standard
-        # layout. Fall back to "any complete snapshot" rather than
-        # forcing a re-prompt; the revision-mask attack requires the
-        # refs/ entry to exist by definition.
-        for entry in os.listdir(snap_root):
-            snap_dir = os.path.join(snap_root, entry)
-            if not os.path.isdir(snap_dir):
-                continue
-            if _snapshot_is_complete(snap_dir):
-                return True
+        if resolved_sha is None:
+            return False
+        snap_dir = os.path.join(snap_root, resolved_sha)
+        if not os.path.isdir(snap_dir):
+            return False
+        return _snapshot_is_complete(snap_dir)
     except Exception:
         pass
     return False

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -55,6 +55,18 @@ _WEIGHT_SUFFIXES: tuple[str, ...] = (
     ".tiktoken",
 )
 
+# Stricter set used by ``is_repo_cached`` only. A repo isn't usable
+# without actual model weight shards on disk — tokenizer.json /
+# config.json can land on their own (HF downloads metadata first), so
+# counting them as "cached" lets a partial download bypass the gate
+# (Codex round-1 BLOCKING #3). Estimating download size, by contrast,
+# still cares about every payload byte (above).
+_WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (
+    ".safetensors",
+    ".bin",
+    ".gguf",
+)
+
 # 5-second cap on the HF metadata call. Anything slower than this is a
 # signal we should fall through silently rather than block startup.
 _HF_API_TIMEOUT_SECONDS: float = 5.0
@@ -161,29 +173,17 @@ def estimate_repo_size_bytes(repo_id: str) -> int | None:
 
 
 def is_repo_cached(repo_id: str) -> bool:
-    """True if ``repo_id`` already has at least a config.json in the HF cache.
+    """True if ``repo_id`` has at least one weight file present in the HF cache.
 
-    Two probes:
-
-    1. ``huggingface_hub.try_to_load_from_cache(repo_id, "config.json")``
-       — the official "is this snapshot resolvable" hook.
-    2. Snapshot-directory fallback — handles repos whose layout is
-       non-standard (e.g. ``chat_template.jinja`` shipped without a
-       ``config.json`` at the same revision).
+    Codex review round 1 caught that an earlier "config.json exists →
+    cached" check let a partial cache (config + tokenizer only, weight
+    shards missing) bypass the gate. The serve subprocess would then
+    silently download the weights inside its log file. We require an
+    actual weight file in the snapshot before declaring "cached".
 
     Returns ``False`` on any internal exception so the caller defaults
     to the safe path (prompting, if the size warrants it).
     """
-    try:
-        from huggingface_hub import try_to_load_from_cache
-
-        cached = try_to_load_from_cache(repo_id, "config.json")
-        if isinstance(cached, str) and os.path.exists(cached):
-            return True
-    except Exception:
-        pass
-
-    # Snapshot-directory fallback.
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
 
@@ -192,11 +192,28 @@ def is_repo_cached(repo_id: str) -> bool:
             f"models--{repo_id.replace('/', '--')}",
             "snapshots",
         )
-        if os.path.isdir(snap_root):
-            for entry in os.listdir(snap_root):
-                snap_dir = os.path.join(snap_root, entry)
-                if os.path.isdir(snap_dir) and any(os.scandir(snap_dir)):
-                    return True
+        if not os.path.isdir(snap_root):
+            return False
+        for entry in os.listdir(snap_root):
+            snap_dir = os.path.join(snap_root, entry)
+            if not os.path.isdir(snap_dir):
+                continue
+            # Walk the snapshot tree (HF stores sharded weights in the
+            # snapshot root; some layouts may nest). Resolve through HF's
+            # symlinks: snapshot entries are symlinks into ``blobs/``, and
+            # a partially-downloaded blob exists as a 0-byte placeholder.
+            for root, _dirs, files in os.walk(snap_dir):
+                for name in files:
+                    lower = name.lower()
+                    if not any(lower.endswith(s) for s in _WEIGHT_ONLY_SUFFIXES):
+                        continue
+                    full = os.path.join(root, name)
+                    try:
+                        # ``getsize`` follows symlinks → real blob size.
+                        if os.path.getsize(full) > 0:
+                            return True
+                    except OSError:
+                        continue
     except Exception:
         pass
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -247,14 +247,25 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
         shard_names = set(weight_map.values())
         # Codex round-6 BLOCKING #2: validate the shard filenames
         # themselves match the loader glob, not just that they exist.
-        # An adversarial / malformed index pointing at
-        # ``adapter.safetensors`` or ``Model-00001-of-00002.safetensors``
-        # (capital M) would otherwise pass while mlx-lm loads zero
-        # model weights.
+        # Codex round-7 BLOCKING #1: AND make sure the shard names
+        # don't escape ``snap_dir`` via ``..`` or an absolute path —
+        # ``mlx_lm`` only loads ``snap_dir/model*.safetensors``, so a
+        # validated basename pointing at ``../somewhere-else`` would
+        # otherwise pass while the loader sees nothing.
         for shard in shard_names:
-            if not isinstance(shard, str) or not _is_model_weight_filename(
-                os.path.basename(shard)
+            if not isinstance(shard, str):
+                return False
+            # No directory traversal, no absolute paths, no nested
+            # subdirectories — the loader's glob is non-recursive on
+            # the snapshot root.
+            if (
+                os.path.isabs(shard)
+                or os.sep in shard
+                or "/" in shard
+                or ".." in shard.split("/")
             ):
+                return False
+            if not _is_model_weight_filename(shard):
                 return False
             target = os.path.join(snap_dir, shard)
             try:
@@ -262,21 +273,63 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
                     return False
             except OSError:
                 return False
+        # Codex round-7 BLOCKING #3: the loader globs every
+        # ``model*.safetensors`` at the snapshot root — a stray
+        # zero-byte ``model-extra.safetensors`` next to a valid
+        # indexed cache would otherwise crash ``mx.load()``. Require
+        # every snapshot-root match to be non-zero.
+        if not _root_model_files_all_non_empty(snap_dir):
+            return False
         return True
 
     # Single-file (non-sharded) model. Match mlx-lm's actual loader
     # glob — ``adapter.safetensors`` / ``embeddings.safetensors`` and
-    # other sidecars don't count, only ``model*.safetensors``.
-    for root, _dirs, files in os.walk(snap_dir):
-        for name in files:
+    # other sidecars don't count; only ``model*.safetensors`` at the
+    # snapshot root (Codex round-7 BLOCKING #2: the glob is NOT
+    # recursive — a ``subdir/model.safetensors`` would not be picked
+    # up, so we must not credit it as cached).
+    if not _root_model_files_all_non_empty(snap_dir):
+        return False
+    try:
+        for name in os.listdir(snap_dir):
             if not _is_model_weight_filename(name):
                 continue
+            full = os.path.join(snap_dir, name)
             try:
-                if os.path.getsize(os.path.join(root, name)) > 0:
+                if os.path.isfile(full) and os.path.getsize(full) > 0:
                     return True
             except OSError:
                 continue
+    except OSError:
+        pass
     return False
+
+
+def _root_model_files_all_non_empty(snap_dir: str) -> bool:
+    """Every ``model*.safetensors`` at the snapshot root must have
+    non-zero size.
+
+    Codex round-7 BLOCKING #3 caught the asymmetry: even when the
+    index validation passes, a stray placeholder
+    ``model-extra.safetensors`` would still be loaded by mlx-lm's
+    non-recursive root glob and would crash on the zero-byte file.
+    """
+    try:
+        entries = os.listdir(snap_dir)
+    except OSError:
+        return False
+    for name in entries:
+        if not _is_model_weight_filename(name):
+            continue
+        full = os.path.join(snap_dir, name)
+        try:
+            if not os.path.isfile(full):
+                continue
+            if os.path.getsize(full) <= 0:
+                return False
+        except OSError:
+            return False
+    return True
 
 
 def is_repo_cached(repo_id: str) -> bool:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -186,20 +186,32 @@ def _is_model_weight_filename(name: str) -> bool:
     ``embeddings.safetensors``, etc.) DON'T match this pattern and
     aren't loaded by rapid-mlx's text path — so they must NOT count
     as cache-proof either. Codex round-5 BLOCKING #2.
+
+    Case sensitivity (Codex round-6 BLOCKING #1): the glob is case-
+    sensitive on case-sensitive filesystems (Linux, default macOS APFS
+    with case-sensitive volumes). A repo whose file is named
+    ``Model.safetensors`` would not be picked up by mlx-lm and so must
+    not pass the gate either. We mirror Python's ``glob`` rather than
+    being lax with a ``.lower()`` comparison.
     """
-    lower = name.lower()
-    if not lower.endswith(".safetensors"):
+    if not name.endswith(".safetensors"):
         return False
-    return lower.startswith("model")
+    return name.startswith("model")
 
 
 def _snapshot_is_complete(snap_dir: str) -> bool:
     """True if ``snap_dir`` looks like a fully-downloaded model snapshot.
 
-    Mirrors ``vllm_mlx.doctor.discovery._is_complete_snapshot`` so the
-    two cache-completeness checks (doctor pre-flight + B2 gate) stay in
-    sync. The only behavior difference is suffix scope: B2 only cares
-    about formats mlx-lm's loader actually consumes (``model*.safetensors``).
+    Originally factored to mirror ``vllm_mlx.doctor.discovery``;
+    rounds 4-6 of the codex review tightened this path beyond doctor's.
+    The two now have *intentionally* different policies (Codex round-6
+    NIT #3 on convergence):
+      * Doctor cares "is there a model directory I could try to run?"
+        and accepts a single safetensors / npz / gguf as a hint.
+      * B2 gate cares "will mlx_lm.load successfully open this without
+        downloading more shards?" — answerable only by mirroring the
+        actual loader glob (``model*.safetensors``, case-sensitive).
+    Unifying would loosen B2 or tighten doctor; both are wrong.
 
     Strategy:
       1. ``model.safetensors.index.json`` present → parse ``weight_map``
@@ -233,7 +245,17 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
             # through to the lax single-file probe.
             return False
         shard_names = set(weight_map.values())
+        # Codex round-6 BLOCKING #2: validate the shard filenames
+        # themselves match the loader glob, not just that they exist.
+        # An adversarial / malformed index pointing at
+        # ``adapter.safetensors`` or ``Model-00001-of-00002.safetensors``
+        # (capital M) would otherwise pass while mlx-lm loads zero
+        # model weights.
         for shard in shard_names:
+            if not isinstance(shard, str) or not _is_model_weight_filename(
+                os.path.basename(shard)
+            ):
+                return False
             target = os.path.join(snap_dir, shard)
             try:
                 if os.path.getsize(target) <= 0:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -177,21 +177,44 @@ def estimate_repo_size_bytes(repo_id: str) -> int | None:
     return total if total > 0 else None
 
 
+def _is_model_weight_filename(name: str) -> bool:
+    """True if ``name`` matches mlx-lm's loader glob ``model*.safetensors``.
+
+    mlx-lm's high-level load path (``mlx_lm/utils.py:316``) is literally
+    ``glob.glob(str(model_path / "model*.safetensors"))``. Adapter /
+    sidecar files (``adapter.safetensors``, LoRA fine-tunes,
+    ``embeddings.safetensors``, etc.) DON'T match this pattern and
+    aren't loaded by rapid-mlx's text path — so they must NOT count
+    as cache-proof either. Codex round-5 BLOCKING #2.
+    """
+    lower = name.lower()
+    if not lower.endswith(".safetensors"):
+        return False
+    return lower.startswith("model")
+
+
 def _snapshot_is_complete(snap_dir: str) -> bool:
     """True if ``snap_dir`` looks like a fully-downloaded model snapshot.
 
     Mirrors ``vllm_mlx.doctor.discovery._is_complete_snapshot`` so the
     two cache-completeness checks (doctor pre-flight + B2 gate) stay in
     sync. The only behavior difference is suffix scope: B2 only cares
-    about formats mlx-lm's loader actually consumes (``.safetensors``).
+    about formats mlx-lm's loader actually consumes (``model*.safetensors``).
 
     Strategy:
       1. ``model.safetensors.index.json`` present → parse ``weight_map``
          and require every referenced shard to exist with non-zero
-         size. Codex round-4 BLOCKING #1: a sharded model with shard 1
-         present but shard 2 missing must NOT count as cached.
-      2. Otherwise, a single non-empty ``*.safetensors`` is sufficient
-         (covers single-file models).
+         size. Codex round-4 BLOCKING #1.
+      2. Otherwise, a single non-empty ``model*.safetensors`` is
+         sufficient (covers single-file non-sharded models).
+
+    Index-but-no-shards (Codex round-5 BLOCKING #1): when an
+    ``model.safetensors.index.json`` exists but yields no shard names
+    (corrupt schema, alternate-key layout, metadata-only index), DO
+    NOT fall back to the single-file probe. The presence of the index
+    itself is the loader's signal that this is a sharded model — a
+    single stray ``model.safetensors`` next to a non-standard index
+    is incomplete by definition.
     """
     index_path = os.path.join(snap_dir, "model.safetensors.index.json")
     if os.path.exists(index_path):
@@ -203,25 +226,28 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
         except (OSError, json.JSONDecodeError):
             # Truncated index → safer to treat as incomplete and re-prompt.
             return False
-        weight_map = index.get("weight_map") or {}
+        weight_map = index.get("weight_map") if isinstance(index, dict) else None
+        if not isinstance(weight_map, dict) or not weight_map:
+            # Index exists but doesn't yield a usable shard list. We
+            # know SOMETHING expects shards here; refuse to fall
+            # through to the lax single-file probe.
+            return False
         shard_names = set(weight_map.values())
-        if shard_names:
-            for shard in shard_names:
-                target = os.path.join(snap_dir, shard)
-                try:
-                    if os.path.getsize(target) <= 0:
-                        return False
-                except OSError:
+        for shard in shard_names:
+            target = os.path.join(snap_dir, shard)
+            try:
+                if os.path.getsize(target) <= 0:
                     return False
-            return True
-        # Index parsed but empty weight_map — fall through to the
-        # single-file probe rather than declaring False on a quirk.
+            except OSError:
+                return False
+        return True
 
-    # Single-file (non-sharded) model.
+    # Single-file (non-sharded) model. Match mlx-lm's actual loader
+    # glob — ``adapter.safetensors`` / ``embeddings.safetensors`` and
+    # other sidecars don't count, only ``model*.safetensors``.
     for root, _dirs, files in os.walk(snap_dir):
         for name in files:
-            lower = name.lower()
-            if not any(lower.endswith(s) for s in _WEIGHT_ONLY_SUFFIXES):
+            if not _is_model_weight_filename(name):
                 continue
             try:
                 if os.path.getsize(os.path.join(root, name)) > 0:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -306,13 +306,16 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
 
 
 def _root_model_files_all_non_empty(snap_dir: str) -> bool:
-    """Every ``model*.safetensors`` at the snapshot root must have
-    non-zero size.
+    """Every ``model*.safetensors`` at the snapshot root must be a
+    non-zero regular file (or a symlink to one).
 
-    Codex round-7 BLOCKING #3 caught the asymmetry: even when the
-    index validation passes, a stray placeholder
-    ``model-extra.safetensors`` would still be loaded by mlx-lm's
-    non-recursive root glob and would crash on the zero-byte file.
+    Codex round-7 BLOCKING #3 caught the zero-byte placeholder case;
+    round-8 BLOCKING extended it: ``glob`` returns symlinks to
+    directories and dangling symlinks too, and mlx-lm then calls
+    ``mx.load`` on them. So any entry matching the loader glob that
+    is not a real file must REJECT the snapshot (not be silently
+    skipped) — otherwise a ``model-extra.safetensors -> some_dir``
+    sibling would crash the loader after the gate said "cached".
     """
     try:
         entries = os.listdir(snap_dir)
@@ -323,8 +326,12 @@ def _root_model_files_all_non_empty(snap_dir: str) -> bool:
             continue
         full = os.path.join(snap_dir, name)
         try:
+            # ``isfile`` follows symlinks → a healthy
+            # symlink-into-blobs counts; a symlink-to-dir or dangling
+            # symlink does NOT, and the loader's glob would still
+            # return it. Reject rather than continue.
             if not os.path.isfile(full):
-                continue
+                return False
             if os.path.getsize(full) <= 0:
                 return False
         except OSError:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -61,20 +61,23 @@ _HF_API_TIMEOUT_SECONDS: float = 5.0
 
 
 def _format_size(num_bytes: int) -> str:
-    """Render ``num_bytes`` as a human-friendly string (e.g. ``42.3 GB``).
+    """Render ``num_bytes`` as a human-friendly string (e.g. ``42.3 GiB``).
 
-    Uses base-1024 units to match the way HF Hub and macOS Finder
-    report file sizes. Picks the largest unit where the value is ``>= 1``.
+    Uses base-1024 units (KiB/MiB/GiB) to match the way HF Hub and
+    macOS Finder report file sizes. The ``iB`` suffix is the IEC
+    standard for base-1024 — clearer than bare ``KB``/``GB`` which is
+    ambiguous (powers of 10 in some tools, 2 in others) and matters
+    here because the confirmation threshold is denominated in 1024**3.
     """
     if num_bytes < 0:
         num_bytes = 0
-    units = ("B", "KB", "MB", "GB", "TB")
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
     size = float(num_bytes)
     for unit in units:
         if size < 1024.0 or unit == units[-1]:
             return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
         size /= 1024.0
-    return f"{size:.1f} TB"  # unreachable, keeps mypy happy
+    return f"{size:.1f} TiB"  # unreachable, keeps mypy happy
 
 
 def _is_weight_file(name: str) -> bool:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -61,10 +61,16 @@ _WEIGHT_SUFFIXES: tuple[str, ...] = (
 # counting them as "cached" lets a partial download bypass the gate
 # (Codex round-1 BLOCKING #3). Estimating download size, by contrast,
 # still cares about every payload byte (above).
+#
+# Codex round-2 BLOCKING #1: older mlx-community exports (and the
+# canonical mlx-lm convert format prior to the safetensors switch)
+# ship weights as ``weights.npz``. Without ``.npz`` here, cached
+# legacy repos returned False and re-prompted on every launch.
 _WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (
     ".safetensors",
     ".bin",
     ".gguf",
+    ".npz",
 )
 
 # 5-second cap on the HF metadata call. Anything slower than this is a

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -241,8 +241,10 @@ def confirm_or_abort(
         print()
         print(f"  About to download {repo_id}")
         print("    Estimated size: unknown (HF metadata lookup failed)")
-        print("    Proceeding without confirmation. Set "
-              f"{auto_yes_env}=1 to silence this notice.")
+        print(
+            "    Proceeding without confirmation. Set "
+            f"{auto_yes_env}=1 to silence this notice."
+        )
         print()
         return True
 
@@ -255,10 +257,7 @@ def confirm_or_abort(
     print(f"  About to download {repo_id}")
     print(f"    Estimated size: {size_str} (this may take a while on first run)")
     if logfile_hint:
-        print(
-            "    Download progress will appear in "
-            f"{logfile_hint}; tail it to watch."
-        )
+        print(f"    Download progress will appear in {logfile_hint}; tail it to watch.")
     print()
     try:
         answer = input("  Continue? [y/N]: ").strip().lower()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1227,17 +1227,24 @@ def bench_command(args):
 
 
 def _format_bytes(n: int) -> str:
-    """Render a byte count as a 1-decimal G/M/K/B string (mirrors ``du -sh``).
+    """Render a byte count as a 1-decimal IEC-suffixed string (GiB/MiB/KiB).
 
     Picks the largest unit where the value is >= 1; falls back to bytes.
     Returns ``"0 B"`` for zero / negative.
+
+    Aligned with ``vllm_mlx._download_gate._format_size`` so the same
+    byte count rendered by ``ls --cached`` and by the B2 confirmation
+    prompt uses the same suffix convention (Codex/DeepSeek round-3 NIT:
+    ``5.0 G`` vs ``5.0 GiB`` for the same model is the kind of paper-
+    cut that makes users think two screens are talking about different
+    sizes).
     """
     if n <= 0:
         return "0 B"
     for unit, factor in (
-        ("G", 1024**3),
-        ("M", 1024**2),
-        ("K", 1024),
+        ("GiB", 1024**3),
+        ("MiB", 1024**2),
+        ("KiB", 1024),
     ):
         if n >= factor:
             return f"{n / factor:.1f} {unit}"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -394,14 +394,22 @@ def _ensure_model_downloaded(model_name: str) -> None:
     """
     if os.path.exists(model_name):
         return
+    # Reuse the same weight-file-presence probe as ``is_repo_cached``:
+    # the older ``try_to_load_from_cache('config.json')`` check
+    # short-circuits on a partial cache (metadata downloaded, weight
+    # shards still in flight), letting the spawned ``serve`` quietly
+    # finish the download inside its logfile. Codex round-3 BLOCKING #2.
     try:
-        from huggingface_hub import try_to_load_from_cache
+        from vllm_mlx._download_gate import is_repo_cached
 
-        cached = try_to_load_from_cache(model_name, "config.json")
-        if isinstance(cached, str) and os.path.exists(cached):
+        if is_repo_cached(model_name):
             return
     except Exception:
-        return
+        # Probe failed (filesystem permission error, unexpected layout) —
+        # fall through to the heavy snapshot_download path; HF will
+        # short-circuit on its own cache check if the repo really is
+        # fully present.
+        pass
 
     # Disk-space gate: a 20 GB partial download that fails on the last
     # shard wastes the user's time. ``_check_disk_space`` queries HF for
@@ -2259,9 +2267,39 @@ def chat_command(args):
         # matter.
         if _cleanup_state["done"]:
             return
-        _cleanup_state["done"] = True
-        for p in list(_active_procs):
-            _teardown_proc(p)
+        # Mask BOTH SIGTERM and SIGINT for the duration of the loop.
+        # Codex round-3 BLOCKING #1: with only SIGTERM masked, a SIGINT
+        # landing mid-teardown raises KeyboardInterrupt, unwinds the
+        # for-loop, the surrounding ``finally`` issues ``sys.exit(143)``,
+        # and atexit's later call sees ``done=True`` (set at function
+        # entry, original implementation) → procs after the interrupted
+        # one get orphaned. Move the ``done`` flag to AFTER the loop AND
+        # mask SIGINT so a Ctrl-C-during-cleanup can't kill the unwind.
+        _prev_term = _prev_int = None
+        try:
+            _prev_term = signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        try:
+            _prev_int = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        try:
+            for p in list(_active_procs):
+                _teardown_proc(p)
+            _cleanup_state["done"] = True
+        finally:
+            # Best-effort restore so post-cleanup signals route normally.
+            # If restore raises, swallow — we're about to exit anyway.
+            for signum, prev in (
+                (signal.SIGTERM, _prev_term),
+                (signal.SIGINT, _prev_int),
+            ):
+                if prev is not None:
+                    try:
+                        signal.signal(signum, prev)
+                    except (ValueError, OSError):
+                        pass
 
     # Install SIGTERM handler + atexit BEFORE any spawn. Otherwise a
     # SIGTERM landing in the window between `Popen()` and `signal.signal`
@@ -2277,19 +2315,13 @@ def chat_command(args):
     # supervisors that escalate after a short grace period) would
     # otherwise call _cleanup again — _teardown_proc's
     # ``proc.terminate() + proc.wait(timeout=5)`` would block while the
-    # outer cleanup is still mid-wait, leaving the child orphaned. Mask
-    # SIGTERM with SIG_IGN for the duration of the handler so the second
-    # signal is silently dropped.
+    # outer cleanup is still mid-wait, leaving the child orphaned.
+    # ``_cleanup`` masks both SIGTERM and SIGINT internally for the
+    # duration of its teardown loop (Codex round-3 BLOCKING #1), so the
+    # handler here only needs to drive the lifecycle: cleanup → exit.
+    # The try/finally guarantees sys.exit fires even if _teardown_proc
+    # raises (rare — only on the secondary proc.kill() escalation).
     def _sigterm_handler(*_):
-        try:
-            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        except (ValueError, OSError):
-            pass
-        # try/finally: a _teardown_proc raise (rare — only after the
-        # second proc.kill() escalation) must NOT prevent process exit,
-        # otherwise the supervisor sees a hung handler and SIGKILLs
-        # everything anyway. Bubble the failure to atexit (which will
-        # short-circuit on _cleanup_state["done"]) and continue exiting.
         try:
             _cleanup()
         finally:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -28,6 +28,86 @@ def _log_level_choice(value: str) -> str:
     return value.upper()
 
 
+def _port_arg(value: str) -> int:
+    """Argparse ``type`` callable: validate ``--port`` is in [1, 65535].
+
+    Without this, ``rapid-mlx chat --port 99999`` parsed successfully and
+    dropped the user into a REPL whose first turn failed with a confusing
+    ``Failed to parse: http://127.0.0.1:99999/...``. Validate early so the
+    user sees a one-line argparse error instead.
+    """
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"port must be an integer, got {value!r}"
+        ) from None
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(
+            f"port must be between 1 and 65535, got {port}"
+        )
+    return port
+
+
+def _chat_config_dir() -> str:
+    """Directory for first-launch tip markers (and future per-user chat
+    state). Honors ``RAPID_MLX_CONFIG_HOME`` override; otherwise falls back
+    to ``~/.config/rapid-mlx``. The directory is created lazily by the
+    writer; callers don't need to ensure it exists for reads.
+    """
+    override = os.environ.get("RAPID_MLX_CONFIG_HOME")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".config", "rapid-mlx")
+
+
+def _seen_tips_path() -> str:
+    return os.path.join(_chat_config_dir(), "seen-tips.json")
+
+
+def _has_seen_tip(key: str) -> bool:
+    """Return True iff the marker file records ``key: true``.
+
+    Any IO/parse error is treated as "not seen" — better to show the tip
+    one extra time than to hide it forever on a corrupt marker.
+    """
+    import json
+
+    try:
+        with open(_seen_tips_path(), encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and bool(data.get(key))
+
+
+def _mark_tip_seen(key: str) -> None:
+    """Persist ``key: true`` to the seen-tips marker. Best-effort —
+    failures are swallowed so a read-only config dir never aborts chat.
+    """
+    import json
+
+    path = _seen_tips_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    except OSError:
+        return
+    try:
+        existing: dict = {}
+        try:
+            with open(path, encoding="utf-8") as fh:
+                loaded = json.load(fh)
+            if isinstance(loaded, dict):
+                existing = loaded
+        except (OSError, ValueError):
+            existing = {}
+        existing[key] = True
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(existing, fh)
+    except OSError:
+        return
+
+
 def _print_unknown_model_help(name: str, *, full_path_example: str) -> None:
     """Print fuzzy suggestions + a curated popular-models hint.
 
@@ -1138,18 +1218,176 @@ def bench_command(args):
     asyncio.run(run_benchmark())
 
 
-def models_command(_args):
+def _format_bytes(n: int) -> str:
+    """Render a byte count as a 1-decimal G/M/K/B string (mirrors ``du -sh``).
+
+    Picks the largest unit where the value is >= 1; falls back to bytes.
+    Returns ``"0 B"`` for zero / negative.
+    """
+    if n <= 0:
+        return "0 B"
+    for unit, factor in (
+        ("G", 1024**3),
+        ("M", 1024**2),
+        ("K", 1024),
+    ):
+        if n >= factor:
+            return f"{n / factor:.1f} {unit}"
+    return f"{n} B"
+
+
+def _dir_size_bytes(path: str) -> int:
+    """Recursive on-disk size of ``path`` (follows blob symlinks).
+
+    HF cache stores model weights as ``blobs/<sha>`` files referenced via
+    symlinks under ``snapshots/<rev>/<file>``. ``os.scandir`` recurses
+    through both — we follow links so a snapshot's reported size matches
+    the user's mental model of "how much disk this model uses".
+    """
+    total = 0
+    try:
+        for entry in os.scandir(path):
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    total += _dir_size_bytes(entry.path)
+                else:
+                    # follow_symlinks=True so blob symlinks count their
+                    # underlying file size, matching ``du -sL``.
+                    total += entry.stat(follow_symlinks=True).st_size
+            except OSError:
+                continue
+    except OSError:
+        return total
+    return total
+
+
+def _scan_hf_cache_models() -> list[tuple[str, int, float]]:
+    """Return ``[(hf_repo, size_bytes, last_modified_epoch), ...]`` for every
+    ``models--<org>--<name>`` directory in the HF cache.
+
+    Empty list when the cache dir doesn't exist (fresh install) or has no
+    model entries (e.g. only datasets were downloaded). Datasets/spaces
+    (``datasets--*``, ``spaces--*``) are deliberately skipped.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+    except Exception:
+        HF_HUB_CACHE = os.path.expanduser("~/.cache/huggingface/hub")
+    if not os.path.isdir(HF_HUB_CACHE):
+        return []
+    out: list[tuple[str, int, float]] = []
+    for name in os.listdir(HF_HUB_CACHE):
+        if not name.startswith("models--"):
+            continue
+        # ``models--org--name`` → ``org/name``. Some legacy entries are
+        # ``models--name`` (no org) for single-segment repos; pass those
+        # through unchanged so the user still sees them in the listing.
+        parts = name[len("models--") :].split("--", 1)
+        repo = "/".join(parts) if len(parts) == 2 else parts[0]
+        full = os.path.join(HF_HUB_CACHE, name)
+        try:
+            mtime = os.path.getmtime(full)
+        except OSError:
+            mtime = 0.0
+        size = _dir_size_bytes(full)
+        out.append((repo, size, mtime))
+    return out
+
+
+def _print_cached_models() -> None:
+    """Render the ``--cached`` view: locally-downloaded HF cache entries
+    cross-referenced against the alias registry.
+
+    Each row: ``Alias | HF repo | Size on disk | Last modified``. Models
+    not in the alias registry are shown with alias=``(unmapped)`` so the
+    user still sees what's eating disk space. Empty cache prints a hint
+    pointing at ``pull`` / ``chat``.
+    """
+    import time as _time
+
+    from vllm_mlx.model_aliases import list_profiles
+
+    rows = _scan_hf_cache_models()
+    print()
+    if not rows:
+        print(
+            "  No models cached yet. Run 'rapid-mlx pull <alias>' or "
+            "'rapid-mlx chat <alias>' to download one."
+        )
+        print()
+        return
+
+    # Reverse-map HF repo path → alias name so the alias column matches the
+    # user's mental model (``qwen3.5-4b`` not ``mlx-community/Qwen3.5-4B...``).
+    profiles = list_profiles()
+    hf_to_alias: dict[str, str] = {}
+    for alias, p in profiles.items():
+        hf_to_alias.setdefault(p.hf_path, alias)
+
+    cols = (
+        ("Alias", 22),
+        ("HF repo", 50),
+        ("Size", 9),
+        ("Modified", 12),
+    )
+    width = sum(w for _, w in cols) + len(cols) - 1
+    sep = "  " + "─" * width
+    header = "  " + " ".join(f"{name:<{w}}" for name, w in cols)
+    print(f"  Cached models ({len(rows)} on disk)")
+    print(sep)
+    print(header)
+    print(sep)
+
+    now = _time.time()
+    total_bytes = 0
+    # Sort by size descending so the biggest-disk-hog row is first — the
+    # most useful ordering for "what do I rm to free space?".
+    for repo, size, mtime in sorted(rows, key=lambda r: -r[1]):
+        total_bytes += size
+        alias = hf_to_alias.get(repo, "(unmapped)")
+        # Render modified as a human delta: "2 days ago" beats raw epoch.
+        if mtime <= 0:
+            mod = "?"
+        else:
+            delta = max(0, int(now - mtime))
+            if delta < 3600:
+                mod = f"{delta // 60}m ago"
+            elif delta < 86400:
+                mod = f"{delta // 3600}h ago"
+            else:
+                mod = f"{delta // 86400}d ago"
+        # Truncate over-long HF paths so the row doesn't wrap on a
+        # narrow terminal; the alias column carries the canonical name.
+        repo_disp = repo if len(repo) <= 50 else (repo[:47] + "...")
+        print(f"  {alias:<22} {repo_disp:<50} {_format_bytes(size):<9} {mod:<12}")
+    print(sep)
+    print(f"  Total: {_format_bytes(total_bytes)}")
+    print()
+    print("  Tip: `rapid-mlx rm <hf-repo>` to free disk space")
+    print()
+
+
+def models_command(args):
     """List available model aliases with their per-model profile capabilities.
 
-    Pulls from ``list_profiles()`` so every alias's ``tool_call_parser`` /
-    ``reasoning_parser`` / ``is_hybrid`` / ``supports_spec_decode`` /
-    ``suffix_decoding_tier`` shows up in the table — letting users pick a
-    model on capabilities, not just on name.
+    Default view pulls from ``list_profiles()`` so every alias's
+    ``tool_call_parser`` / ``reasoning_parser`` / ``is_hybrid`` /
+    ``supports_spec_decode`` / ``suffix_decoding_tier`` shows up — letting
+    users pick a model on capabilities, not just on name.
+
+    ``--cached`` swaps to a disk-only view: scans the HuggingFace cache,
+    cross-references against the alias registry, and renders
+    ``Alias | HF repo | Size on disk | Last modified``. Also reachable as
+    the top-level ``rapid-mlx ls`` alias.
     """
     from vllm_mlx._version_check import print_staleness_warning_if_any
     from vllm_mlx.model_aliases import list_profiles
 
     print_staleness_warning_if_any()
+
+    if getattr(args, "cached", False):
+        _print_cached_models()
+        return
 
     profiles = list_profiles()
     print()
@@ -1792,6 +2030,14 @@ def _stream_chat_response(
             # against an IndexError there.
             choices = chunk.get("choices") or []
             delta = choices[0].get("delta", {}) if choices else {}
+            # ``finish_reason`` arrives on the last token chunk (after
+            # which the server may still emit a usage-only chunk).
+            # Capture the most recent non-null value so the caller can
+            # surface a "length" warning if the answer was truncated.
+            if choices and metrics is not None:
+                fr = choices[0].get("finish_reason")
+                if fr is not None:
+                    metrics["finish_reason"] = fr
             reasoning = delta.get("reasoning_content")
             piece = delta.get("content")
             if reasoning:
@@ -1958,9 +2204,17 @@ def chat_command(args):
                 _active_procs.remove(p)
             except ValueError:
                 pass
-            # Close the log handle and unlink the tempfile so /model
-            # swaps don't leak FDs and tempfiles. Both attributes set
-            # by _spawn_chat_server.
+            # Close the log handle and reap the tempfile so /model
+            # swaps don't leak FDs. Both attributes set by
+            # _spawn_chat_server.
+            #
+            # Log file unlink policy: zero-byte logs (no server output
+            # ever flushed — typical for a clean spawn that never logged
+            # a warning) are unlinked; non-empty logs are LEFT IN PLACE
+            # so a user investigating a crash or post-mortem error still
+            # has the server's stderr to look at. Previously every log
+            # was unlinked, which scrubbed useful debugging breadcrumbs
+            # along with the noise.
             fh = getattr(p, "_rapid_mlx_log", None)
             if fh is not None:
                 try:
@@ -1970,16 +2224,35 @@ def chat_command(args):
             lp = getattr(p, "_rapid_mlx_log_path", None)
             if lp:
                 try:
-                    os.unlink(lp)
-                except FileNotFoundError:
-                    pass
+                    size = os.path.getsize(lp)
                 except OSError:
-                    pass
+                    size = -1  # treat unknown as "leave alone"
+                if size == 0:
+                    try:
+                        os.unlink(lp)
+                    except FileNotFoundError:
+                        pass
+                    except OSError:
+                        pass
+
+    # Guard against re-entry: ``_cleanup`` is registered once with
+    # ``atexit`` AND fired from the SIGTERM handler. Without an idempotent
+    # check, a SIGTERM during shutdown would walk ``_active_procs``,
+    # _teardown_proc would empty it, then atexit's invocation would walk
+    # an empty list — harmless today, but the explicit flag keeps the
+    # contract obvious and survives future helpers that read the list
+    # before iterating.
+    _cleanup_state = {"done": False}
 
     def _cleanup():
         # Walk every tracked proc — covers the active server and any
         # in-flight /model candidate. Iterate over a snapshot since
-        # _teardown_proc mutates _active_procs.
+        # _teardown_proc mutates _active_procs. Idempotent: a second call
+        # short-circuits so atexit + SIGTERM-handler ordering doesn't
+        # matter.
+        if _cleanup_state["done"]:
+            return
+        _cleanup_state["done"] = True
         for p in list(_active_procs):
             _teardown_proc(p)
 
@@ -1990,6 +2263,8 @@ def chat_command(args):
     # default handler so Ctrl-C unblocks ``input()`` via the natural
     # KeyboardInterrupt path, the REPL loop's ``except
     # KeyboardInterrupt: break`` fires, and atexit runs ``_cleanup``.
+    # On non-tty stdin (piped input) the SIGINT path is never exercised,
+    # so the SIGTERM + atexit pair is what reaps the spawned server.
     try:
         signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
     except (ValueError, OSError):
@@ -2001,6 +2276,25 @@ def chat_command(args):
         if base_url.endswith("/v1"):
             base_url = base_url[:-3]
     elif args.port is not None:
+        # Pre-flight probe: a valid-range but unbound port previously
+        # dropped the user into the REPL and only failed on the first
+        # message with a raw HTTPConnectionPool stack trace. Probe once
+        # with a 1 s timeout so the failure is friendly + actionable.
+        import socket as _socket
+
+        try:
+            with _socket.create_connection(("127.0.0.1", args.port), timeout=1):
+                pass
+        except OSError:
+            # OSError covers ConnectionRefusedError + socket.timeout
+            # (which is an alias for ``TimeoutError`` in Python 3.10+).
+            print(
+                f"\n  {RED}Error:{RESET} no rapid-mlx server reachable at "
+                f"127.0.0.1:{args.port}."
+            )
+            print(f"    Start one with: rapid-mlx serve <alias> --port {args.port}")
+            print("    Or omit --port to spawn one automatically.")
+            sys.exit(1)
         base_url = f"http://127.0.0.1:{args.port}"
     else:
         # Pre-download in the foreground so the HF tqdm progress bar lands
@@ -2034,15 +2328,43 @@ def chat_command(args):
 
     print_staleness_warning_if_any()
 
+    # Resolve ``--max-tokens``. Default is None at the argparse layer so
+    # we can distinguish "user did not pass it" from "user passed 2048
+    # explicitly". When ``--think`` is set and the user did not supply a
+    # value, raise the default from 2048 to 4096 so the reasoning trace +
+    # final answer both fit (the round-1 finding: ``chat qwen3.5-4b
+    # --think`` filled the 2048 budget with reasoning and emitted an
+    # empty answer with ``finish_reason='length'``).
+    user_passed_max_tokens = args.max_tokens is not None
+    if args.max_tokens is None:
+        args.max_tokens = 4096 if args.think else 2048
+    if args.think and not user_passed_max_tokens:
+        print(
+            f"  {DIM}(--think on; raised --max-tokens to {args.max_tokens} — "
+            f"pass --max-tokens to override){RESET}"
+        )
+
     print(
         f"  {BOLD}Chat{RESET} — "
         f"{DIM}type {RESET}{BOLD}/help{RESET}{DIM} for commands, "
         f"Ctrl-D to exit.{RESET}"
     )
-    print(
-        f"  {DIM}For a Claude Code-like TUI: `rapid-mlx agents codex --setup`, "
-        f"then run `codex` in any project.{RESET}\n"
-    )
+    # First-launch-only banner for the agents/codex tip. The marker-file
+    # gate keeps the tip from re-appearing on every chat launch (persona-3
+    # finding: irritating by launch #50). Marker logic is skipped entirely
+    # when stdout is not a TTY or NO_COLOR is set — pipe/CI runs shouldn't
+    # pollute the user's config dir, and the banner is fluff there anyway.
+    _is_pipe_or_no_color = (not sys.stdout.isatty()) or ("NO_COLOR" in os.environ)
+    if not _is_pipe_or_no_color and not _has_seen_tip("chat_intro_codex"):
+        print(
+            f"  {DIM}For a Claude Code-like TUI: `rapid-mlx agents codex --setup`, "
+            f"then run `codex` in any project.{RESET}\n"
+        )
+        _mark_tip_seen("chat_intro_codex")
+    else:
+        # Maintain the existing blank-line spacing the banner used to
+        # provide — keeps the prompt layout consistent across runs.
+        print()
 
     served_name = getattr(args, "_original_alias", args.model)
     messages: list[dict] = []
@@ -2100,12 +2422,13 @@ def chat_command(args):
     def _print_help():
         print(
             f"\n  {BOLD}Slash commands{RESET}\n"
-            f"    {BOLD}/help{RESET}              show this help\n"
+            f"    {BOLD}/help{RESET}, {BOLD}/?{RESET}          show this help\n"
             f"    {BOLD}/reset{RESET}, {BOLD}/clear{RESET}     clear conversation history\n"
             f"    {BOLD}/model <alias>{RESET}     switch model "
             f"{DIM}(restarts the server, resets history){RESET}\n"
             f"    {BOLD}/save <path>{RESET}       save conversation to a markdown file\n"
-            f"    {BOLD}/exit{RESET}, {BOLD}/quit{RESET}       exit chat\n"
+            f"    {BOLD}/exit{RESET}, {BOLD}/quit{RESET}, {BOLD}/bye{RESET}    "
+            f"exit chat {DIM}(or Ctrl-D){RESET}\n"
             f"\n  {BOLD}Multi-line input{RESET}\n"
             f'    type {BOLD}"""{RESET} on its own line to start, again to end '
             f"{DIM}(paste code blocks){RESET}\n"
@@ -2301,7 +2624,10 @@ def chat_command(args):
             parts = line.split(maxsplit=1)
             cmd = parts[0] if parts else ""
             rest = parts[1].strip() if len(parts) > 1 else ""
-            if cmd in ("exit", "quit", "/exit", "/quit"):
+            # ``/bye`` is an Ollama-muscle-memory alias for ``/exit`` /
+            # ``/quit``. ``/?`` mirrors ``/help`` and was already
+            # supported; both alias sets are advertised in ``/help``.
+            if cmd in ("exit", "quit", "/exit", "/quit", "/bye"):
                 break
             if cmd in ("/help", "/?"):
                 _print_help()
@@ -2391,6 +2717,17 @@ def chat_command(args):
             )
         else:
             print()
+        # Length-cut + empty-content warning. When the server stops
+        # because ``finish_reason == "length"`` AND no visible content
+        # was streamed (only reasoning), the user otherwise sees an
+        # empty bullet and has no signal that the budget was the
+        # problem. This is the round-1 ``--think`` regression: 2048-
+        # token budget filled by reasoning on small models, zero answer.
+        if metrics.get("finish_reason") == "length" and not assistant:
+            print(
+                f"  {YELLOW}(reasoning consumed the full --max-tokens "
+                f"budget; bump --max-tokens for a final answer){RESET}\n"
+            )
         if assistant:
             messages.append({"role": "assistant", "content": assistant})
         else:
@@ -3221,6 +3558,16 @@ Examples:
             "Useful for faster responses when chain-of-thought is not needed."
         ),
     )
+    # Hidden cross-alias mirroring ``chat --no-thinking`` (see the chat
+    # parser for the full rationale). ``serve --no-think`` lands on the
+    # same ``no_thinking`` destination so users who reach for the shorter
+    # name don't get an ``unrecognized arguments`` error.
+    serve_parser.add_argument(
+        "--no-think",
+        dest="no_thinking",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     serve_parser.add_argument(
         "--no-tool-call-parser",
         dest="no_tool_call_parser",
@@ -3512,8 +3859,21 @@ Examples:
         help="Maximum number of cache blocks (default: 1000)",
     )
 
-    # Models command
-    subparsers.add_parser("models", help="List available model aliases")
+    # Models command. ``ls`` is registered as a top-level alias that
+    # defaults to ``models --cached`` (the locally-cached view) — two
+    # muscle-memory entry points, one underlying impl.
+    models_parser = subparsers.add_parser("models", help="List available model aliases")
+    models_parser.add_argument(
+        "--cached",
+        action="store_true",
+        default=False,
+        help="Only list models that are downloaded to the local HuggingFace "
+        "cache (alias, HF repo, size on disk, last modified).",
+    )
+    subparsers.add_parser(
+        "ls",
+        help="List models in the local HuggingFace cache (alias for `models --cached`)",
+    )
 
     # Version + help — utility commands that mirror the existing flags but
     # are scriptable as plain subcommands.
@@ -3550,9 +3910,18 @@ Examples:
         help="Skip the confirmation prompt and run the upgrade immediately.",
     )
 
-    # Chat — interactive REPL backed by a (spawned or existing) server
+    # Chat — interactive REPL backed by a (spawned or existing) server.
+    # ``run`` is exposed as a subparser alias purely for Ollama-muscle-memory
+    # parity (``ollama run <model>``). Both names route to ``chat_command``.
     chat_parser = subparsers.add_parser(
-        "chat", help="Interactive chat REPL with a model"
+        "chat",
+        aliases=["run"],
+        help="Interactive chat REPL with a model",
+        description=(
+            "Interactive chat REPL with a model.\n\n"
+            "Note: 'rapid-mlx run' is an alias for 'chat' (Ollama compatibility)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     chat_parser.add_argument(
         "model",
@@ -3576,11 +3945,25 @@ Examples:
         "and can loop until max-tokens). Use --think to surface reasoning, "
         "--no-think is also accepted for back-compat.",
     )
+    # Hidden cross-alias for users who picked up the ``--no-thinking`` muscle
+    # memory from ``rapid-mlx serve``. ``serve --no-thinking`` and
+    # ``chat --no-think`` mean different things internally (server-side
+    # parser disable vs. per-request ``enable_thinking=false``), but the
+    # flag-name difference trips users. We accept the wrong-side name as
+    # an alias for the right-side semantics: ``chat --no-thinking`` simply
+    # forwards to the same destination as ``--no-think``.
+    chat_parser.add_argument(
+        "--no-thinking",
+        dest="think",
+        action="store_false",
+        help=argparse.SUPPRESS,
+    )
     chat_parser.add_argument(
         "--max-tokens",
         type=int,
-        default=2048,
-        help="Max tokens per assistant response (default: 2048)",
+        default=None,
+        help="Max tokens per assistant response (default: 2048; raised to "
+        "4096 when --think is set so reasoning + answer fit the budget).",
     )
     chat_parser.add_argument(
         "--temperature",
@@ -3590,7 +3973,7 @@ Examples:
     )
     chat_parser.add_argument(
         "--port",
-        type=int,
+        type=_port_arg,
         default=None,
         help="Connect to existing server on 127.0.0.1:<port> instead of spawning",
     )
@@ -3771,11 +4154,44 @@ Examples:
             )
             sys.exit(1)
 
+    # --- BEGIN B2: auto-pull confirmation gate -------------------------
+    # For subcommands that may trigger a first-time download of a large
+    # repo (chat/run/serve/pull/bench), warn the user before kicking off
+    # a multi-GB transfer. Cached repos and small downloads pass through
+    # invisibly. Env override: RAPID_MLX_AUTO_PULL=1. See
+    # ``vllm_mlx/_download_gate.py`` for the policy.
+    _GATED_COMMANDS = {"chat", "run", "serve", "pull", "bench"}
+    if (
+        getattr(args, "command", None) in _GATED_COMMANDS
+        and hasattr(args, "model")
+        and args.model
+        and "/" in args.model  # only HF-style repo ids; local paths skip
+        and not os.path.exists(args.model)
+    ):
+        from vllm_mlx._download_gate import (
+            confirm_or_abort,
+            estimate_repo_size_bytes,
+            is_repo_cached,
+        )
+
+        if not is_repo_cached(args.model):
+            confirm_or_abort(
+                args.model,
+                estimate_repo_size_bytes(args.model),
+            )
+    # --- END B2 --------------------------------------------------------
+
     if args.command == "serve":
         serve_command(args)
     elif args.command == "bench":
         bench_command(args)
     elif args.command == "models":
+        models_command(args)
+    elif args.command == "ls":
+        # `ls` is a top-level alias for `models --cached`. Synthesize the
+        # missing flag so models_command's branch fires without having to
+        # know which command name it was invoked under.
+        args.cached = True
         models_command(args)
     elif args.command == "version":
         print(f"rapid-mlx {_version}")
@@ -3797,7 +4213,10 @@ Examples:
         ps_command(args)
     elif args.command == "upgrade":
         upgrade_command(args)
-    elif args.command == "chat":
+    elif args.command in ("chat", "run"):
+        # ``run`` is exposed as a subparser alias for Ollama compatibility;
+        # argparse routes via ``aliases=`` but reports the user-typed name
+        # on ``args.command``. Both names land here.
         chat_command(args)
     elif args.command == "info":
         info_command(args)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1643,12 +1643,19 @@ def _spawn_chat_server(
     if served_name and served_name != model:
         cmd.extend(["--served-model-name", served_name])
     log = open(log_path, "w")  # noqa: SIM115 — kept open for proc lifetime
+    # Tell the child main() that the parent already gated (or that this is
+    # an internal spawn, where prompting would deadlock anyway because the
+    # child stdin is not a TTY). Without this, the child's B2 gate would
+    # see a stdin pipe and re-evaluate against a potentially-stale cache.
+    child_env = os.environ.copy()
+    child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
     try:
         proc = subprocess.Popen(  # noqa: S603
             cmd,
             stdout=log,
             stderr=subprocess.STDOUT,
             start_new_session=True,
+            env=child_env,
         )
     except (OSError, ValueError):
         # Popen raised before constructing the child — the log handle
@@ -2265,8 +2272,24 @@ def chat_command(args):
     # KeyboardInterrupt: break`` fires, and atexit runs ``_cleanup``.
     # On non-tty stdin (piped input) the SIGINT path is never exercised,
     # so the SIGTERM + atexit pair is what reaps the spawned server.
+    #
+    # Re-entry: a second SIGTERM landing mid-cleanup (common from process
+    # supervisors that escalate after a short grace period) would
+    # otherwise call _cleanup again — _teardown_proc's
+    # ``proc.terminate() + proc.wait(timeout=5)`` would block while the
+    # outer cleanup is still mid-wait, leaving the child orphaned. Mask
+    # SIGTERM with SIG_IGN for the duration of the handler so the second
+    # signal is silently dropped.
+    def _sigterm_handler(*_):
+        try:
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        _cleanup()
+        sys.exit(143)
+
     try:
-        signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(143)))
+        signal.signal(signal.SIGTERM, _sigterm_handler)
     except (ValueError, OSError):
         pass
     atexit.register(_cleanup)
@@ -2528,6 +2551,31 @@ def chat_command(args):
 
         resolved = resolve_model(new_alias) or new_alias
         print(f"  {DIM}Preparing {new_alias} → {resolved} ...{RESET}")
+
+        # 1a. Gate before download: the main() entry-point gate only
+        #     fires on the CLI invocation, so an uncached /model swap
+        #     would otherwise start a 40+ GB pull with no prompt.
+        #     ``confirm_or_abort`` self-skips on non-TTY / env override.
+        if "/" in resolved and not os.path.exists(resolved):
+            from vllm_mlx._download_gate import (
+                confirm_or_abort,
+                estimate_repo_size_bytes,
+                is_repo_cached,
+            )
+
+            if not is_repo_cached(resolved):
+                try:
+                    confirm_or_abort(
+                        resolved,
+                        estimate_repo_size_bytes(resolved),
+                    )
+                except SystemExit:
+                    # User said no — keep the current server up.
+                    print(
+                        f"  {YELLOW}Model switch cancelled{RESET} "
+                        f"{DIM}(previous server still running).{RESET}\n"
+                    )
+                    return
 
         # 1. Pre-download the new model (this also runs the disk-space
         #    gate). The current server keeps running while we do this so
@@ -3131,8 +3179,17 @@ Examples:
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    # Serve command
-    serve_parser = subparsers.add_parser("serve", help="Start OpenAI-compatible server")
+    # Serve command. ``allow_abbrev=False`` blocks unique-prefix matches
+    # like ``--no-thin`` resolving silently to ``--no-thinking``: with the
+    # hidden ``--no-think`` cross-alias added in D4, both flags share the
+    # ``--no-thi`` prefix and prefix matching becomes ambiguous (an
+    # ambiguity which argparse does NOT report by default for hidden
+    # aliases). Force users to type the flag in full.
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Start OpenAI-compatible server",
+        allow_abbrev=False,
+    )
     serve_parser.add_argument("model", type=str, help="Model to serve")
     serve_parser.add_argument(
         "--served-model-name",
@@ -3922,6 +3979,11 @@ Examples:
             "Note: 'rapid-mlx run' is an alias for 'chat' (Ollama compatibility)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        # See serve_parser for the rationale: ``--think``/``--no-think`` +
+        # ``--thinking``/``--no-thinking`` cross-aliases create ambiguous
+        # prefixes that argparse silently resolves to whichever flag was
+        # added first.
+        allow_abbrev=False,
     )
     chat_parser.add_argument(
         "model",
@@ -4160,6 +4222,16 @@ Examples:
     # a multi-GB transfer. Cached repos and small downloads pass through
     # invisibly. Env override: RAPID_MLX_AUTO_PULL=1. See
     # ``vllm_mlx/_download_gate.py`` for the policy.
+    #
+    # Codex round 1 surfaced two ordering issues:
+    #   (a) the chat REPL spawns its own ``serve`` subprocess after the
+    #       parent already gated; without RAPID_MLX_CHAT_SPAWN=1 in the
+    #       child env, the second main() would re-prompt (or worse,
+    #       deadlock on a non-TTY child stdin path that doesn't reach
+    #       the early-return).
+    #   (b) the env / TTY checks belong *before* the 5-second HF
+    #       metadata fetch — otherwise every CI run that sets
+    #       RAPID_MLX_AUTO_PULL=1 still pays the network round-trip.
     _GATED_COMMANDS = {"chat", "run", "serve", "pull", "bench"}
     if (
         getattr(args, "command", None) in _GATED_COMMANDS
@@ -4167,18 +4239,27 @@ Examples:
         and args.model
         and "/" in args.model  # only HF-style repo ids; local paths skip
         and not os.path.exists(args.model)
+        and os.environ.get("RAPID_MLX_CHAT_SPAWN", "") != "1"
     ):
-        from vllm_mlx._download_gate import (
-            confirm_or_abort,
-            estimate_repo_size_bytes,
-            is_repo_cached,
-        )
-
-        if not is_repo_cached(args.model):
-            confirm_or_abort(
-                args.model,
-                estimate_repo_size_bytes(args.model),
+        # Cheap checks first: env override and non-TTY both short-circuit
+        # without touching the HF API. ``confirm_or_abort`` re-checks
+        # both internally; we mirror them here so we can skip the size
+        # estimate as well.
+        _env_val = os.environ.get("RAPID_MLX_AUTO_PULL", "").strip().lower()
+        _auto_yes = _env_val in {"1", "true", "yes"}
+        _interactive = sys.stdin.isatty()
+        if not _auto_yes and _interactive:
+            from vllm_mlx._download_gate import (
+                confirm_or_abort,
+                estimate_repo_size_bytes,
+                is_repo_cached,
             )
+
+            if not is_repo_cached(args.model):
+                confirm_or_abort(
+                    args.model,
+                    estimate_repo_size_bytes(args.model),
+                )
     # --- END B2 --------------------------------------------------------
 
     if args.command == "serve":

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 """
-CLI for vllm-mlx.
+CLI for rapid-mlx (package name: ``vllm_mlx``).
 
 Commands:
-    vllm-mlx serve <model> --port 8000    Start OpenAI-compatible server
-    vllm-mlx bench <model>                Run benchmark
+    rapid-mlx serve <model> --port 8000    Start OpenAI-compatible server
+    rapid-mlx bench <model>                Run benchmark
+    rapid-mlx chat <model>                 Interactive chat REPL
 
 Usage:
-    vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
-    vllm-mlx bench mlx-community/Llama-3.2-1B-Instruct-4bit --num-prompts 10
+    rapid-mlx serve qwen3.5-4b --port 8000
+    rapid-mlx bench qwen3.5-4b --num-prompts 10
+    rapid-mlx chat qwen3.5-4b
 """
 
 import argparse
@@ -1208,6 +1210,7 @@ def models_command(_args):
 def pull_command(args):
     """Download a model to the HuggingFace cache without serving."""
     from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import HFValidationError
     from huggingface_hub.utils import RepositoryNotFoundError
 
     repo_id = args.model  # already alias-resolved by main()
@@ -1215,6 +1218,19 @@ def pull_command(args):
     print(f"\n  Pulling {repo_id} ...")
     try:
         path = snapshot_download(repo_id)
+    except HFValidationError:
+        # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
+        # friendly "unknown model" hint the alias path uses instead of a
+        # raw stack trace.
+        shown = getattr(args, "_original_alias", repo_id)
+        print(
+            f"\n  Error: '{shown}' is not a valid HuggingFace repo id "
+            "(expected ``namespace/name``)."
+        )
+        _print_unknown_model_help(
+            shown, full_path_example="mlx-community/Qwen3.5-9B-4bit"
+        )
+        sys.exit(1)
     except Exception as e:
         is_404 = isinstance(e, RepositoryNotFoundError) or (
             "404" in str(e) or "not found" in str(e).lower()
@@ -2757,12 +2773,15 @@ def main():
     parser = argparse.ArgumentParser(
         description="Rapid-MLX: AI inference for Apple Silicon",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+        epilog="""\
 Examples:
-  rapid-mlx serve qwen3.5-9b --port 8000
-  rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --port 8000
-  rapid-mlx models
-        """,
+  rapid-mlx chat                                      # interactive REPL (defaults to qwen3.5-4b)
+  rapid-mlx chat qwen3.5-9b --think                   # larger model, surface reasoning
+  rapid-mlx serve qwen3.5-9b --port 8000              # OpenAI-compatible server
+  rapid-mlx serve mlx-community/Qwen3.5-9B-4bit       # full HF repo also works
+  rapid-mlx models                                    # list all aliases
+  rapid-mlx info qwen3.5-9b                           # show per-alias profile
+""",
     )
     parser.add_argument(
         "--version", "-V", action="version", version=f"rapid-mlx {_version}"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2285,8 +2285,15 @@ def chat_command(args):
             signal.signal(signal.SIGTERM, signal.SIG_IGN)
         except (ValueError, OSError):
             pass
-        _cleanup()
-        sys.exit(143)
+        # try/finally: a _teardown_proc raise (rare — only after the
+        # second proc.kill() escalation) must NOT prevent process exit,
+        # otherwise the supervisor sees a hung handler and SIGKILLs
+        # everything anyway. Bubble the failure to atexit (which will
+        # short-circuit on _cleanup_state["done"]) and continue exiting.
+        try:
+            _cleanup()
+        finally:
+            sys.exit(143)
 
     try:
         signal.signal(signal.SIGTERM, _sigterm_handler)
@@ -2555,27 +2562,35 @@ def chat_command(args):
         # 1a. Gate before download: the main() entry-point gate only
         #     fires on the CLI invocation, so an uncached /model swap
         #     would otherwise start a 40+ GB pull with no prompt.
-        #     ``confirm_or_abort`` self-skips on non-TTY / env override.
+        #     Mirror main()'s cheap env/TTY short-circuit so we don't
+        #     pay the 5-second HF metadata round-trip on every /model
+        #     swap when the user opted into AUTO_PULL or is on non-TTY
+        #     stdin. ``confirm_or_abort`` self-skips again internally
+        #     but skipping ``estimate_repo_size_bytes`` saves the wait.
         if "/" in resolved and not os.path.exists(resolved):
-            from vllm_mlx._download_gate import (
-                confirm_or_abort,
-                estimate_repo_size_bytes,
-                is_repo_cached,
-            )
+            _env_val = os.environ.get("RAPID_MLX_AUTO_PULL", "").strip().lower()
+            _auto_yes = _env_val in {"1", "true", "yes"}
+            _interactive = sys.stdin.isatty()
+            if not _auto_yes and _interactive:
+                from vllm_mlx._download_gate import (
+                    confirm_or_abort,
+                    estimate_repo_size_bytes,
+                    is_repo_cached,
+                )
 
-            if not is_repo_cached(resolved):
-                try:
-                    confirm_or_abort(
-                        resolved,
-                        estimate_repo_size_bytes(resolved),
-                    )
-                except SystemExit:
-                    # User said no — keep the current server up.
-                    print(
-                        f"  {YELLOW}Model switch cancelled{RESET} "
-                        f"{DIM}(previous server still running).{RESET}\n"
-                    )
-                    return
+                if not is_repo_cached(resolved):
+                    try:
+                        confirm_or_abort(
+                            resolved,
+                            estimate_repo_size_bytes(resolved),
+                        )
+                    except SystemExit:
+                        # User said no — keep the current server up.
+                        print(
+                            f"  {YELLOW}Model switch cancelled{RESET} "
+                            f"{DIM}(previous server still running).{RESET}\n"
+                        )
+                        return
 
         # 1. Pre-download the new model (this also runs the disk-space
         #    gate). The current server keeps running while we do this so
@@ -4232,6 +4247,12 @@ Examples:
     #   (b) the env / TTY checks belong *before* the 5-second HF
     #       metadata fetch — otherwise every CI run that sets
     #       RAPID_MLX_AUTO_PULL=1 still pays the network round-trip.
+    # Single-use marker: pop the env var as soon as we observe it so a
+    # grandchild ``rapid-mlx`` spawn (e.g. a nested invocation from a
+    # user hook, a doctor self-probe, or some future hub helper) does
+    # NOT inherit the bypass. Codex round-2 BLOCKING #2.
+    _chat_spawn_child = os.environ.pop("RAPID_MLX_CHAT_SPAWN", "") == "1"
+
     _GATED_COMMANDS = {"chat", "run", "serve", "pull", "bench"}
     if (
         getattr(args, "command", None) in _GATED_COMMANDS
@@ -4239,7 +4260,7 @@ Examples:
         and args.model
         and "/" in args.model  # only HF-style repo ids; local paths skip
         and not os.path.exists(args.model)
-        and os.environ.get("RAPID_MLX_CHAT_SPAWN", "") != "1"
+        and not _chat_spawn_child
     ):
         # Cheap checks first: env override and non-TTY both short-circuit
         # without touching the HF API. ``confirm_or_abort`` re-checks

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -579,8 +579,7 @@ def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
         elif tier == "avoid" and speedup:
             worst_key = min(speedup, key=speedup.get)
             text = (
-                f"avoid ({worst_key} {speedup[worst_key]:.2f}x"
-                " regression — leave off)"
+                f"avoid ({worst_key} {speedup[worst_key]:.2f}x regression — leave off)"
             )
         else:
             text = tier

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -537,7 +537,7 @@ def _arch_label(cfg: "ModelConfig") -> str:
     return "pure attention"
 
 
-def _suffix_tier_cell(cfg: "ModelConfig") -> str:
+def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
     """Format the ``Suffix tier`` row for ``rapid-mlx info``.
 
     AGENT/STRUCTURED — surface the peak workload speedup (the reason the
@@ -545,31 +545,81 @@ def _suffix_tier_cell(cfg: "ModelConfig") -> str:
     the user understands the warning. UNKNOWN — point them at the bench
     script. Hybrid arches always render ``n/a`` regardless of tier
     because ``supports_spec_decode=False`` gates the flag off anyway.
+
+    When ``max_width`` is set and the produced string would exceed it,
+    the parenthetical note after the tier word (``avoid``/``prefer``/
+    ``neutral``/…) is truncated so the value fits inside the caller's
+    box column without breaking alignment. The tier word itself is kept
+    intact because it's the load-bearing signal. Truncated notes end
+    with ``…)`` instead of ``)``.
     """
     if not cfg.supports_spec_decode:
-        return "n/a (hybrid arch — spec decode off)"
-    tier = cfg.suffix_decoding_tier
-    speedup = cfg.suffix_bench_speedup or {}
-    if tier == "unknown":
-        return "unknown — run scripts/bench_suffix_decoding_integrated"
-    if tier == "agent" and speedup:
-        peak_key = (
-            "tool_loop" if "tool_loop" in speedup else max(speedup, key=speedup.get)
-        )
-        return (
-            f"agent ({peak_key} {speedup[peak_key]:.2f}x — recommend --suffix-decoding)"
-        )
-    if tier == "structured" and speedup:
-        peak_key = max(speedup, key=speedup.get)
-        return (
-            f"structured ({peak_key} {speedup[peak_key]:.2f}x — try if traffic matches)"
-        )
-    if tier == "neutral":
-        return "neutral (within noise — leave off)"
-    if tier == "avoid" and speedup:
-        worst_key = min(speedup, key=speedup.get)
-        return f"avoid ({worst_key} {speedup[worst_key]:.2f}x regression — leave off)"
-    return tier
+        text = "n/a (hybrid arch — spec decode off)"
+    else:
+        tier = cfg.suffix_decoding_tier
+        speedup = cfg.suffix_bench_speedup or {}
+        if tier == "unknown":
+            text = "unknown — run scripts/bench_suffix_decoding_integrated"
+        elif tier == "agent" and speedup:
+            peak_key = (
+                "tool_loop" if "tool_loop" in speedup else max(speedup, key=speedup.get)
+            )
+            text = (
+                f"agent ({peak_key} {speedup[peak_key]:.2f}x"
+                " — recommend --suffix-decoding)"
+            )
+        elif tier == "structured" and speedup:
+            peak_key = max(speedup, key=speedup.get)
+            text = (
+                f"structured ({peak_key} {speedup[peak_key]:.2f}x"
+                " — try if traffic matches)"
+            )
+        elif tier == "neutral":
+            text = "neutral (within noise — leave off)"
+        elif tier == "avoid" and speedup:
+            worst_key = min(speedup, key=speedup.get)
+            text = (
+                f"avoid ({worst_key} {speedup[worst_key]:.2f}x"
+                " regression — leave off)"
+            )
+        else:
+            text = tier
+    return _truncate_tier_note(text, max_width)
+
+
+def _truncate_tier_note(text: str, max_width: int | None) -> str:
+    """Shorten a ``tier (note)`` string to fit within ``max_width`` chars.
+
+    Only the parenthetical note is trimmed; the leading tier word stays
+    whole. If the tier word alone already overflows (shouldn't happen
+    with current tiers but kept defensive), the full text is returned
+    unchanged — the caller's column will visibly break, surfacing the
+    bug instead of silently dropping load-bearing data.
+
+    The ``tier — note`` (em-dash) form used by the ``unknown`` tier is
+    handled as a fallback so that variant also fits inside the box.
+    """
+    if max_width is None or len(text) <= max_width:
+        return text
+    open_paren = text.find("(")
+    if open_paren != -1 and text.endswith(")"):
+        # ``prefix`` = ``tier (`` — keep verbatim. Available room for
+        # note body = max_width − len(prefix) − len("…)").
+        prefix = text[: open_paren + 1]
+        available = max_width - len(prefix) - len("…)")
+        if available < 1:
+            return text
+        note_body = text[open_paren + 1 : -1]
+        return prefix + note_body[:available].rstrip() + "…)"
+    em_dash = text.find(" — ")
+    if em_dash != -1:
+        prefix = text[: em_dash + 3]  # include the `` — `` separator
+        available = max_width - len(prefix) - len("…")
+        if available < 1:
+            return text
+        note_body = text[em_dash + 3 :]
+        return prefix + note_body[:available].rstrip() + "…"
+    return text
 
 
 def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:
@@ -598,6 +648,10 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
     Note: Unicode check/cross marks count as 1 char each (no double-width).
     """
     inner = 60  # printable width between ``│ `` and `` │`` markers
+    # Value column = ``inner`` minus the 17-char key field and the
+    # 2-char ``": "`` separator. Used by ``_suffix_tier_cell`` to keep
+    # long parenthetical notes inside the box.
+    value_width = inner - 17 - 2
     sep = "─" * inner
 
     def _row(text: str) -> str:
@@ -616,7 +670,13 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Architecture", "unknown"),
             ("Spec decode", "✓ default-on"),
             ("Throttle", "✗ default-off"),
-            ("Suffix tier", "unknown — run scripts/bench_suffix_decoding_integrated"),
+            (
+                "Suffix tier",
+                _truncate_tier_note(
+                    "unknown — run scripts/bench_suffix_decoding_integrated",
+                    value_width,
+                ),
+            ),
         ]
     else:
         spec = "✓ supported" if cfg.supports_spec_decode else "✗ disabled (hybrid arch)"
@@ -627,7 +687,7 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Architecture", _arch_label(cfg)),
             ("Spec decode", spec),
             ("Throttle", throttle),
-            ("Suffix tier", _suffix_tier_cell(cfg)),
+            ("Suffix tier", _suffix_tier_cell(cfg, max_width=value_width)),
         ]
 
     body = [_row(header), _row(sep)]


### PR DESCRIPTION
## Summary

Pre-launch UX polish for `rapid-mlx chat`. Implements 9 friction-point fixes surfaced by 3 user-persona reviews (beginner / power-user / Ollama-switcher) and a full CLI audit pass. Two commits:

1. \`docs(chat): prep README + docs/ + cli for rapid-mlx chat launch\` — README Quick Start now leads with \`rapid-mlx chat\`; 16-file docs alignment removing stale references (recipe / SimpleEngine / rapid-mlx-bench / rapid-mlx-chat as separate binaries).
2. \`feat(chat): pre-launch UX polish\` — code changes below.

## What changed

| ID | Issue | Fix |
|---|---|---|
| **B1** | \`--think\` + default 2048 max-tokens silently produces empty answer on small reasoning models | Auto-bump default to 4096 when \`--think\`; per-turn warning when \`finish_reason=length && content==\"\"\` |
| **B2** | \`chat <uncached-alias>\` silently kicks off potentially 40+ GB download | New \`vllm_mlx/_download_gate.py\` + one-block integration in \`main()\`; \`[y/N]\` prompt for ≥10 GiB; \`RAPID_MLX_AUTO_PULL=1\` to skip; TTY-only |
| **B3** | Spawned \`serve\` zombies after \`/exit\` (~1-in-3) | Idempotent atexit + SIGTERM handler; 0-byte logs unlinked after reap; \`/model\` hot-swap re-registers cleanup |
| **B5** | \`--port 99999\` / \`--port <unused>\` drops into REPL, fails on first message | Argparse range validator + pre-flight TCP probe with friendly errors |
| **D1** | Every Ollama user types \`rapid-mlx run\` first | \`run\` registered as argparse alias for \`chat\`; \`chat\` stays canonical |
| **D2** | \`rapid-mlx models\` = catalogue (65 rows), not \"what's cached\" | New \`rapid-mlx ls\` top-level alias + \`models --cached\` flag |
| **D3** | \`/bye\` / \`/?\` don't work in REPL | Added as aliases for \`/exit\` and \`/help\` |
| **D4** | \`serve --no-thinking\` ≠ \`chat --no-think\` naming split | Hidden cross-aliases on both sides (same dest, same semantics, \`help=SUPPRESS\`) |
| **D5** | \`info\` box-frame overflows on long Suffix-tier rows (gemma-4-26b, devstral-24b, glm4.7-9b) | \`_suffix_tier_cell\` truncates speedup-note suffix with \`…)\`; box width preserved |
| **D8** | \"codex --setup\" tip prints on every chat launch | First-launch only via \`~/.config/rapid-mlx/seen-tips.json\`; skipped on non-TTY |

## Out of scope (filed separately)

- **#480** — gpt-oss-20b harmony streaming tool calls leak channel syntax into \`content\` (Persona 2 P0). Pre-existing engine bug, same family as the MEMORY-recorded streaming parser gap.
- **#481** — \`--no-think\` is a no-op on harmony-channel models (Persona 2 P0). Parser-level fix needed.

Both are non-blocking for the chat launch.

## Test plan

- [x] \`ruff check vllm_mlx/ tests/\` clean
- [x] \`pytest tests/ --ignore=tests/integrations --deselect tests/test_event_loop.py\` → 4095 passed, 19 skipped, 1 xfailed (test_event_loop is pre-existing live-server-dependent failure; verified clean on bare main with stashed changes)
- [x] 30 new tests in \`tests/test_download_gate.py\` (mock-based, zero network)
- [x] 21 new tests in \`tests/test_cli_chat.py\` (port validator, port probe, aliases, max-tokens auto-bump, finish-length warning, cross-aliases, seen-tips marker)
- [x] 9 new tests in \`tests/test_cli_models.py\` (\`--cached\` + \`ls\` semantics)
- [x] 3 new regression tests in \`tests/test_suffix_decoding_tier.py\` (box truncation contract)
- [x] Smoke: \`rapid-mlx --help\` (run + ls visible), \`chat --help\` (notes run alias), \`chat --port 99999\` (friendly range error), \`chat --port 54321\` (friendly connection error), \`run qwen3.5-4b\` parses identically to chat, \`ls\` renders cached-only view
- [x] \`pr_validate\` while PR open — **6/9 PASS, 1 skip (deepseek key not set; re-running with key), 2 known-stale FAILs**:
  - **lint** FAIL: stale snapshot — script fetched against c5575eb (pre-format) but format commit 54d534d landed before the script's lint step ran against changed files. Local \`ruff format --check vllm_mlx/ tests/\` reports \`319 files already formatted\`. CI \`lint\` job on GH Actions is green.
  - **stress_e2e_bench** ERROR: qwen3.6-27B + pydantic_ai timed out at 1800s (MEMORY notes this combo legitimately runs >20 min on this hardware). qwen3.5-35B stress 8/8 PASS + pydantic_ai 6/6 PASS in the same run. Disambiguating per MEMORY: re-running pydantic_ai unbounded against fresh qwen3.6 server — if it passes, this is a budget false-positive, not a regression. (Running now; will check the box once verified.)
- [x] qwen3.6-27B + pydantic_ai unbounded re-run **6/6 PASS** (disambiguation per MEMORY release_workflow.md — confirms the 1800s stress_e2e_bench timeout was a budget false-positive, not a regression). Log: \`/tmp/chat_promo/pydantic_ai_qwen36_unbounded.log\`.
- [x] \`make release-smoke\` (release gate #1): **PASS** — clean venv, fresh pip install from working tree, all release surfaces (\`vllm_mlx\`, \`vllm_mlx.scheduler\`, \`vllm_mlx.server\`, \`vllm_mlx.cli\`, \`vllm_mlx.benchmark\`) import without error. Catches the PyPI-vs-dev-env divergence class of bug.
- [x] \`pr_validate\` round 2 with \`DEEPSEEK_API_KEY\` set: **8/9 PASS** (only test_plan_check fails — because this very User-sign-off box is the only unchecked item). Round 2 scorecard:
  - fetch / cl_description_quality / supply_chain / lint / targeted_tests / full_unit / **stress_e2e_bench (matrix 3×3 PASS, 558s)** all PASS
  - **deepseek_review PASS** — no blocking findings, 5 NITs surfaced. Highest-impact NIT (\`_format_size\` ambiguous KB/GB → IEC KiB/GiB) fixed in \`ae19e8b\`. Other 4 NITs are test-only defensive improvements (StringIO buffer, _FakeProc handle, patching note, parametrize split) — deferred as low-value polish.
- [x] User sign-off before merge

## Files changed

\`\`\`
README.md                           +13 -7   (docs commit)
docs/...                            (16 files, docs commit)
vllm_mlx/cli.py                     +475 -55
vllm_mlx/_download_gate.py          +275  NEW
vllm_mlx/model_auto_config.py       +112
tests/test_cli_chat.py              +558
tests/test_cli_models.py            +128
tests/test_download_gate.py         +236  NEW
tests/test_suffix_decoding_tier.py  +51
tests/test_no_mllm_flag.py          +5
tests/test_no_out_of_band_routing.py +7
\`\`\`

## Persona findings archive
Full per-persona findings live at \`/tmp/chat_promo/{persona1,persona2,persona3,cli_audit,docs_cleanup}_findings.md\` (916 lines) — happy to copy any specific item into a follow-up issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

