### PR TITLE
fix: install M5 compat shim before mlx_lm import in mllm_batch_generator

### DIFF
--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -24,6 +24,11 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 from mlx_lm.sample_utils import make_sampler
 
 from .multimodal_processor import MultimodalProcessor


### PR DESCRIPTION
## Problem

On **M5** (single-stream GPU), the server crashes immediately on first request:

```
RuntimeError: There is no Stream(gpu, 1) in current thread.
[generation_error_recovery] aborted N running requests, batch generator closed, Metal cache cleared
```

The `_mlx_compat` shim (#404) correctly patches `mx.new_thread_local_stream` to handle M5's single-stream limitation, but it only takes effect if installed **before** `mlx_lm.generate` is imported — because that module captures the stream at module level.

## Root cause

`mllm_batch_generator.py` does a top-level import:

```python
from mlx_lm.sample_utils import make_sampler
```

This triggers `mlx_lm/__init__.py → from .generate import ...`, which captures `new_thread_local_stream` **before** `scheduler.py` calls `_mlx_compat.install()`.

## Fix

Add `_mlx_compat.install()` to `mllm_batch_generator.py` before the `mlx_lm` import, mirroring the existing pattern in `scheduler.py`.