### PR TITLE
fix(mlx-compat): install shim before any top-level mlx_lm.* import (#485)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.68"
+version = "0.6.69"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -211,16 +211,23 @@ def test_every_mlx_lm_consumer_installs_shim():
         a deferred (function/lambda) scope. The walk descends into
         ``If``/``Try``/``With``/``For``/``While``/``ClassDef`` bodies —
         all of which run at module load time when the enclosing module
-        is imported. ``if TYPE_CHECKING:`` is treated as deferred since
-        its body never runs at import time."""
+        is imported. For ``if TYPE_CHECKING:`` the ``body`` is treated
+        as deferred (runs only under static analysis) but the ``orelse``
+        IS walked: ``TYPE_CHECKING`` is False at runtime so ``else:`` runs
+        at module load and any ``import mlx_lm`` there must still install
+        the shim first."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
                 continue
             if _is_type_checking_guard(child):
-                # Yield the If node itself (for parent-tracking) but DO NOT
-                # descend into its body / orelse — the imports there only
-                # run under static analysis, never at module load.
+                # Yield the If node itself (for parent-tracking). Skip the
+                # body (dead at module load) but descend into orelse —
+                # ``else:`` of an ``if TYPE_CHECKING:`` block runs at
+                # import time on every Python interpreter.
                 yield child, parents
+                for sub in child.orelse:
+                    yield sub, parents + (child,)
+                    yield from _walk_module_level(sub, parents + (child,))
                 continue
             yield child, parents
             yield from _walk_module_level(child, parents + (child,))

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -60,8 +60,8 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
 
     Pure source-text audit; no module manipulation so the test is safe
     in a shared pytest process. The shim must be installed lazily at
-    the top of every module that imports `mlx_lm.generate` instead
-    (verified by `test_every_mlx_lm_generate_consumer_installs_shim`)."""
+    the top of every module that imports `mlx_lm.*` instead
+    (verified by `test_every_mlx_lm_consumer_installs_shim`)."""
     init_source = (
         importlib.resources.files("vllm_mlx").joinpath("__init__.py").read_text()
     )
@@ -76,17 +76,31 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
     )
 
 
-def test_every_mlx_lm_generate_consumer_installs_shim():
-    """Any vllm_mlx file that imports `mlx_lm.generate` (either via
-    `from mlx_lm.generate import ...` or `importlib.import_module(
-    "mlx_lm.generate")`) MUST also call `_mlx_compat.install()` in the
-    same file. Otherwise that import path triggers `mlx_lm/generate.py`
-    module-level `mx.new_thread_local_stream` capture on M5 before our
-    shim runs, and the bug from #404 returns.
+def test_every_mlx_lm_consumer_installs_shim():
+    """Any vllm_mlx file with a *top-level* ``from mlx_lm…`` / ``import
+    mlx_lm…`` MUST also call ``_mlx_compat.install()`` in the same file.
 
-    This is a structural audit: a new file that adds the import without
-    the install will fail here at unit-test time, catching the slip
-    before any M5 user does.
+    Why ANY ``mlx_lm`` submodule, not just ``mlx_lm.generate``: importing
+    e.g. ``mlx_lm.sample_utils`` or ``mlx_lm.models.base`` still triggers
+    ``mlx_lm/__init__.py`` execution, which does ``from .generate import
+    batch_generate, generate, stream_generate`` and therefore runs
+    ``mlx_lm/generate.py:226`` ``generation_stream =
+    mx.new_thread_local_stream(mx.default_device())`` at module-import
+    time. The #404 single-stream crash on M5 happens on the same code
+    path regardless of which submodule the import statement names.
+
+    Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
+    ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
+    ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
+    without the shim; the prior version of this guard (which matched
+    only ``mlx_lm.generate``) missed all three. Indented / function-local
+    imports are out of scope here — by the time they run, scheduler.py's
+    install is usually already in effect.
+
+    This is a structural audit: a new file that adds a top-level
+    ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
+    fail here at unit-test time, catching the slip before any M5 user
+    does.
     """
     import pathlib
 
@@ -98,16 +112,18 @@ def test_every_mlx_lm_generate_consumer_installs_shim():
         if path.name == "_mlx_compat.py":
             continue  # the shim itself; nothing to install
         source = path.read_text()
-        imports_generate = (
-            "from mlx_lm.generate" in source
-            or 'import_module("mlx_lm.generate")' in source
-            or "import_module('mlx_lm.generate')" in source
+        has_top_level_mlx_lm_import = any(
+            line.startswith(("from mlx_lm", "import mlx_lm"))
+            for line in source.splitlines()
         )
-        if imports_generate and "_mlx_compat.install()" not in source:
+        if has_top_level_mlx_lm_import and "_mlx_compat.install()" not in source:
             offenders.append(str(path.relative_to(pkg_root)))
     assert not offenders, (
-        "Files import mlx_lm.generate without calling _mlx_compat.install() "
-        "first — #404 M5 regression risk:\n  " + "\n  ".join(offenders)
+        "Files have top-level `from mlx_lm` / `import mlx_lm` without "
+        "calling `_mlx_compat.install()` first — #404 M5 regression "
+        "risk (any mlx_lm submodule triggers mlx_lm/__init__.py which "
+        "loads mlx_lm.generate which captures the GPU stream):\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -152,17 +152,28 @@ def test_every_mlx_lm_consumer_installs_shim():
         return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
 
     def _is_type_checking_guard(node: ast.AST) -> bool:
-        """``True`` for ``if TYPE_CHECKING:`` and ``if typing.TYPE_CHECKING:``
-        — both evaluate to ``False`` at runtime, so the body never executes
-        at module load and isn't a stream-capture hazard. Flagged by
-        DeepSeek pr_validate review on PR #487 as a future-proofing nit."""
+        """``True`` for ``if TYPE_CHECKING:`` and
+        ``if {typing,typing_extensions}.TYPE_CHECKING:`` — both evaluate
+        to ``False`` at runtime, so the body never executes at module
+        load and isn't a stream-capture hazard.
+
+        Narrowed to those two attribute owners specifically so an
+        unrelated ``if config.TYPE_CHECKING:`` (where the attribute is a
+        real runtime flag) is NOT skipped — DeepSeek pr_validate round
+        3 flagged the un-narrowed version as [BLOCKING]: a real
+        ``True`` flag named ``TYPE_CHECKING`` on some other namespace
+        would have hidden an unprotected ``mlx_lm`` import."""
         if not isinstance(node, ast.If):
             return False
         test = node.test
         if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
             return True
         if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
-            return True
+            owner = test.value
+            return isinstance(owner, ast.Name) and owner.id in (
+                "typing",
+                "typing_extensions",
+            )
         return False
 
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -95,17 +95,20 @@ def test_every_mlx_lm_consumer_installs_shim():
     load time. ``vllm_mlx/utils/mamba_cache.py`` and ``vllm_mlx/api/
     guided.py`` both use that pattern for optional-dep guards, and a
     line-prefix check misses them. We walk the AST and accept any
-    ``Import`` / ``ImportFrom`` whose parent chain contains only ``If``,
-    ``Try``, or ``With`` — i.e. unconditionally-executed at module load
-    — while excluding ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef``
-    (those are deferred to call time).
+    ``Import`` / ``ImportFrom`` whose parent chain stays inside
+    module-load-time scopes (``If`` / ``Try`` / ``With`` / ``For`` /
+    ``While`` bodies, plus ``ClassDef`` bodies — class statements run
+    at definition time), while excluding ``FunctionDef`` /
+    ``AsyncFunctionDef`` / ``Lambda`` (deferred to call time).
 
     Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
     ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
     ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
     without the shim; the prior version of this guard (which matched
     only literal ``mlx_lm.generate``) missed all three. Codex round 1
-    review against this PR then surfaced the indented-import gap above.
+    review against this PR then surfaced the indented-import gap above,
+    and DeepSeek pr_validate round 2 added the ``ClassDef``-descent
+    requirement (class bodies execute at module load).
 
     This is a structural audit: a new file that adds a module-load-time
     ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
@@ -117,10 +120,15 @@ def test_every_mlx_lm_consumer_installs_shim():
 
     # AST node types that defer execution — an mlx_lm import nested under
     # any of these does NOT run at module load, so it's out of scope.
+    # NB: ``ClassDef`` is *not* deferred. A class body runs at the class's
+    # definition site; for a module-level class that's still at module
+    # load time, so an ``import mlx_lm`` at class scope captures the
+    # GPU stream exactly as a top-level import would. Method bodies
+    # inside the class are still skipped via ``FunctionDef``. Flagged
+    # as [BLOCKING] by DeepSeek pr_validate round 2 on PR #487.
     DEFERRED_SCOPES = (
         ast.FunctionDef,
         ast.AsyncFunctionDef,
-        ast.ClassDef,
         ast.Lambda,
     )
 
@@ -159,10 +167,11 @@ def test_every_mlx_lm_consumer_installs_shim():
 
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
         """Yield (node, parents) for every descendant that is NOT inside
-        a deferred (function/class/lambda) scope. The walk descends into
-        ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
-        at module load time. ``if TYPE_CHECKING:`` is treated as deferred
-        since its body never runs at import time."""
+        a deferred (function/lambda) scope. The walk descends into
+        ``If``/``Try``/``With``/``For``/``While``/``ClassDef`` bodies —
+        all of which run at module load time when the enclosing module
+        is imported. ``if TYPE_CHECKING:`` is treated as deferred since
+        its body never runs at import time."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
                 continue

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -141,6 +141,28 @@ def test_every_mlx_lm_consumer_installs_shim():
         if isinstance(node, ast.ImportFrom):
             mod = node.module or ""
             return mod == "mlx_lm" or mod.startswith("mlx_lm.")
+        # ``importlib.import_module("mlx_lm…")`` — dynamic import with
+        # the same module-load effect as a static one. DeepSeek
+        # pr_validate round 4 flagged that the AST-only walk silently
+        # dropped this shape, which the prior text-based guard caught
+        # via a literal `import_module("mlx_lm.generate")` substring.
+        # We also accept the keyword-arg form
+        # ``import_module(name="mlx_lm.…")``.
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "import_module":
+                if isinstance(func.value, ast.Name) and func.value.id == "importlib":
+                    arg = None
+                    if node.args:
+                        arg = node.args[0]
+                    else:
+                        for kw in node.keywords:
+                            if kw.arg == "name":
+                                arg = kw.value
+                                break
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        s = arg.value
+                        return s == "mlx_lm" or s.startswith("mlx_lm.")
         return False
 
     def _is_install_call(node: ast.AST) -> bool:
@@ -162,7 +184,15 @@ def test_every_mlx_lm_consumer_installs_shim():
         real runtime flag) is NOT skipped — DeepSeek pr_validate round
         3 flagged the un-narrowed version as [BLOCKING]: a real
         ``True`` flag named ``TYPE_CHECKING`` on some other namespace
-        would have hidden an unprotected ``mlx_lm`` import."""
+        would have hidden an unprotected ``mlx_lm`` import.
+
+        Known limitation (DeepSeek round 4 NIT): aliased typing imports
+        like ``import typing as t; if t.TYPE_CHECKING: import mlx_lm``
+        get the false-positive treatment (the test would flag the
+        ``mlx_lm`` import as unshielded). Convention in this codebase
+        is ``from typing import TYPE_CHECKING`` — don't alias the
+        ``typing`` module in files that import ``mlx_lm`` under a
+        ``TYPE_CHECKING`` guard."""
         if not isinstance(node, ast.If):
             return False
         test = node.test

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -77,8 +77,9 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
 
 
 def test_every_mlx_lm_consumer_installs_shim():
-    """Any vllm_mlx file with a *top-level* ``from mlx_lm…`` / ``import
-    mlx_lm…`` MUST also call ``_mlx_compat.install()`` in the same file.
+    """Any vllm_mlx file that runs a ``from mlx_lm…`` / ``import mlx_lm…``
+    *at module load time* MUST also call ``_mlx_compat.install()`` before
+    the first such import.
 
     Why ANY ``mlx_lm`` submodule, not just ``mlx_lm.generate``: importing
     e.g. ``mlx_lm.sample_utils`` or ``mlx_lm.models.base`` still triggers
@@ -89,20 +90,69 @@ def test_every_mlx_lm_consumer_installs_shim():
     time. The #404 single-stream crash on M5 happens on the same code
     path regardless of which submodule the import statement names.
 
+    Why AST-based and not text-based: imports inside top-level ``try /
+    except ImportError`` blocks are indented but still execute at module
+    load time. ``vllm_mlx/utils/mamba_cache.py`` and ``vllm_mlx/api/
+    guided.py`` both use that pattern for optional-dep guards, and a
+    line-prefix check misses them. We walk the AST and accept any
+    ``Import`` / ``ImportFrom`` whose parent chain contains only ``If``,
+    ``Try``, or ``With`` — i.e. unconditionally-executed at module load
+    — while excluding ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef``
+    (those are deferred to call time).
+
     Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
     ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
     ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
     without the shim; the prior version of this guard (which matched
-    only ``mlx_lm.generate``) missed all three. Indented / function-local
-    imports are out of scope here — by the time they run, scheduler.py's
-    install is usually already in effect.
+    only literal ``mlx_lm.generate``) missed all three. Codex round 1
+    review against this PR then surfaced the indented-import gap above.
 
-    This is a structural audit: a new file that adds a top-level
+    This is a structural audit: a new file that adds a module-load-time
     ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
     fail here at unit-test time, catching the slip before any M5 user
     does.
     """
+    import ast
     import pathlib
+
+    # AST node types that defer execution — an mlx_lm import nested under
+    # any of these does NOT run at module load, so it's out of scope.
+    DEFERRED_SCOPES = (
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Lambda,
+    )
+
+    def _is_mlx_lm_node(node: ast.AST) -> bool:
+        if isinstance(node, ast.Import):
+            return any(
+                alias.name == "mlx_lm" or alias.name.startswith("mlx_lm.")
+                for alias in node.names
+            )
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            return mod == "mlx_lm" or mod.startswith("mlx_lm.")
+        return False
+
+    def _is_install_call(node: ast.AST) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "install":
+            return False
+        return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
+
+    def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
+        """Yield (node, parents) for every descendant that is NOT inside
+        a deferred (function/class/lambda) scope. The walk descends into
+        ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
+        at module load time."""
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, DEFERRED_SCOPES):
+                continue
+            yield child, parents
+            yield from _walk_module_level(child, parents + (child,))
 
     pkg_root = pathlib.Path(
         str(importlib.resources.files("vllm_mlx").joinpath(""))
@@ -112,18 +162,31 @@ def test_every_mlx_lm_consumer_installs_shim():
         if path.name == "_mlx_compat.py":
             continue  # the shim itself; nothing to install
         source = path.read_text()
-        has_top_level_mlx_lm_import = any(
-            line.startswith(("from mlx_lm", "import mlx_lm"))
-            for line in source.splitlines()
-        )
-        if has_top_level_mlx_lm_import and "_mlx_compat.install()" not in source:
-            offenders.append(str(path.relative_to(pkg_root)))
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue  # not our problem here
+        first_mlx_lm_line = None
+        first_install_line = None
+        for node, _parents in _walk_module_level(tree):
+            if first_mlx_lm_line is None and _is_mlx_lm_node(node):
+                first_mlx_lm_line = node.lineno
+            if first_install_line is None and _is_install_call(node):
+                first_install_line = node.lineno
+        if first_mlx_lm_line is None:
+            continue
+        if first_install_line is None or first_install_line > first_mlx_lm_line:
+            rel = str(path.relative_to(pkg_root))
+            offenders.append(
+                f"{rel} (mlx_lm import @ line {first_mlx_lm_line}, "
+                f"install @ line {first_install_line})"
+            )
     assert not offenders, (
-        "Files have top-level `from mlx_lm` / `import mlx_lm` without "
-        "calling `_mlx_compat.install()` first — #404 M5 regression "
-        "risk (any mlx_lm submodule triggers mlx_lm/__init__.py which "
-        "loads mlx_lm.generate which captures the GPU stream):\n  "
-        + "\n  ".join(offenders)
+        "Files run a module-load-time `from mlx_lm` / `import mlx_lm` "
+        "without calling `_mlx_compat.install()` first — #404 M5 "
+        "regression risk (any mlx_lm submodule triggers "
+        "mlx_lm/__init__.py which loads mlx_lm.generate which captures "
+        "the GPU stream):\n  " + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -143,13 +143,34 @@ def test_every_mlx_lm_consumer_installs_shim():
             return False
         return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
 
+    def _is_type_checking_guard(node: ast.AST) -> bool:
+        """``True`` for ``if TYPE_CHECKING:`` and ``if typing.TYPE_CHECKING:``
+        — both evaluate to ``False`` at runtime, so the body never executes
+        at module load and isn't a stream-capture hazard. Flagged by
+        DeepSeek pr_validate review on PR #487 as a future-proofing nit."""
+        if not isinstance(node, ast.If):
+            return False
+        test = node.test
+        if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+            return True
+        if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+            return True
+        return False
+
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
         """Yield (node, parents) for every descendant that is NOT inside
         a deferred (function/class/lambda) scope. The walk descends into
         ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
-        at module load time."""
+        at module load time. ``if TYPE_CHECKING:`` is treated as deferred
+        since its body never runs at import time."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
+                continue
+            if _is_type_checking_guard(child):
+                # Yield the If node itself (for parent-tracking) but DO NOT
+                # descend into its body / orelse — the imports there only
+                # run under static analysis, never at module load.
+                yield child, parents
                 continue
             yield child, parents
             yield from _walk_module_level(child, parents + (child,))

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -11,6 +11,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# MUST install the MLX hardware-compat shim BEFORE the `mlx_lm` import below.
+# Even though the import is inside a `try`, the body still runs at module
+# load time; on success it triggers `mlx_lm/__init__.py` → `mlx_lm.generate`
+# → `mx.new_thread_local_stream(...)` capture, which on M5 single-stream
+# GPUs would be unusable (#404). The shim is idempotent and a no-op on
+# hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 # Check for outlines availability
 try:
     import mlx_lm

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1088,6 +1088,17 @@ def bench_command(args):
     import asyncio
     import time
 
+    # Install the MLX hardware-compat shim BEFORE `from mlx_lm import load`.
+    # `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+    # `mx.new_thread_local_stream(mx.default_device())` at module-import time;
+    # on M5 single-stream GPUs that stream is unusable (#404). Bench is a
+    # separate entry point from `serve` so it doesn't inherit the
+    # scheduler-side install — wire the shim here directly. Idempotent, no-op
+    # on hardware where the original API works.
+    from . import _mlx_compat as _mlx_compat
+
+    _mlx_compat.install()
+
     from mlx_lm import load
 
     from .engine_core import AsyncEngineCore, EngineConfig

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -24,10 +24,20 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.sample_utils import make_sampler
 
-from .multimodal_processor import MultimodalProcessor
-from .vision_embedding_cache import VisionEmbeddingCache
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.sample_utils import make_sampler  # noqa: E402
+
+from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .vision_embedding_cache import VisionEmbeddingCache  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -28,16 +28,26 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import mlx.core as mx
-from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
-from .mllm_batch_generator import (
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer  # noqa: E402
+
+from .mllm_batch_generator import (  # noqa: E402
     MLLMBatchGenerator,
     MLLMBatchRequest,
     MLLMBatchResponse,
 )
-from .mllm_cache import MLLMCacheManager
-from .multimodal_processor import MultimodalProcessor
-from .request import RequestOutput, RequestStatus, SamplingParams
+from .mllm_cache import MLLMCacheManager  # noqa: E402
+from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .request import RequestOutput, RequestStatus, SamplingParams  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -9,11 +9,24 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from mlx.utils import tree_flatten
 
-from mlx_lm.models.base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache
-from mlx_lm.models.mla import MultiLinear
-from mlx_lm.models.pipeline import PipelineMixin
-from mlx_lm.models.switch_layers import SwitchGLU
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)  # noqa: E402
+from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache  # noqa: E402
+from mlx_lm.models.mla import MultiLinear  # noqa: E402
+from mlx_lm.models.pipeline import PipelineMixin  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
 
 @dataclass
@@ -1453,7 +1466,6 @@ class DeepseekV4Cache:
 
 
 class Compressor(nn.Module):
-
     def __init__(self, config: ModelArgs, compress_ratio: int, head_dim: int):
         super().__init__()
         self.compress_ratio = compress_ratio

--- a/vllm_mlx/utils/mamba_cache.py
+++ b/vllm_mlx/utils/mamba_cache.py
@@ -11,6 +11,16 @@ import logging
 
 import mlx.core as mx
 
+# MUST install the MLX hardware-compat shim BEFORE the `mlx_lm` import below.
+# Even though the import is inside a `try`, the body still runs at module
+# load time; on success it triggers `mlx_lm/__init__.py` → `mlx_lm.generate`
+# → `mx.new_thread_local_stream(...)` capture, which on M5 single-stream
+# GPUs would be unusable (#404). The shim is idempotent and a no-op on
+# hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 # MambaCache was removed in mlx-lm 0.30.6, fall back to ArraysCache
 try:
     from mlx_lm.models.cache import MambaCache


### PR DESCRIPTION
## Summary

- `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures `mx.new_thread_local_stream(mx.default_device())` at module-import time. Three files imported top-level `mlx_lm.<sub>` (`sample_utils`, `tokenizer_utils`, `models.*`) without calling `_mlx_compat.install()` first → on M5 single-stream GPUs the captured stream is un-patched and `with mx.stream(...)` raises `RuntimeError: There is no Stream(gpu, 1) in current thread`.
- Two further files (`vllm_mlx/utils/mamba_cache.py`, `vllm_mlx/api/guided.py`) had the same defect with the import nested inside a top-level `try/except` block; the prior line-prefix guard missed them. Surfaced by Codex round 1 review against this PR.
- The prior SOP guard test only matched `from mlx_lm.generate`. Broadened first to any top-level `from mlx_lm` / `import mlx_lm` (round 0), then rewritten as an AST walk that descends only into module-load-time bodies and explicitly skips `if TYPE_CHECKING:` (DeepSeek pr_validate round nit).
- Also adds the shim install at the top of `bench_command` — that entry point does `from mlx_lm import load` before `from .engine_core`, so on a cold `rapid-mlx bench …` invocation the shim hadn't run yet.

## Background

Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29). His PR self-closed citing an M5/M1-Max misdiagnosis, but the architectural defect he identified is real — the prior SOP guard would have caught the regression at PR-time if it had matched the right pattern.

The original #404 shim (added in PR #408) was wired correctly into `vllm_mlx/scheduler.py` and `vllm_mlx/pipeline/decode.py`, which both do `from mlx_lm.generate import …`. Newer MLLM / DeepSeek-V4 / mamba-cache / guided-generation code paths added top-level `mlx_lm.<sub>` imports that landed without realising they hit the same module-load cascade. Because the guard test matched the literal string `mlx_lm.generate`, these files were never flagged.

## Behavior

- **M1–M4 (multi-stream)**: unchanged. Shim's probe succeeds and the original `new_thread_local_stream` is returned.
- **M5 (single-stream)**: shim now runs before stream capture, so `generation_stream` is wrapped to fall back to `default_stream`.
- **M3 Ultra repro (our hardware)**: `rapid-mlx serve gemma-4-26b` + single chat-completion request → HTTP 200, 16 tokens, 29.8 tok/s, no Stream error.

## Files

- `vllm_mlx/mllm_batch_generator.py` — install shim before `from mlx_lm.sample_utils import make_sampler`
- `vllm_mlx/mllm_scheduler.py` — install shim before `from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer`
- `vllm_mlx/models/deepseek_v4.py` — install shim before the five `from mlx_lm.models.*` imports
- `vllm_mlx/utils/mamba_cache.py` — install shim before the `try/except` `from mlx_lm.models.cache` block
- `vllm_mlx/api/guided.py` — install shim before the optional-`outlines` `try/except` `import mlx_lm` block
- `vllm_mlx/cli.py` (`bench_command`) — install shim before `from mlx_lm import load`
- `tests/test_mlx_compat.py` — rename `test_every_mlx_lm_consumer_installs_shim` (was `…_generate_consumer…`); AST walk over module-load-time scope; skips `if TYPE_CHECKING:`. Docstring credits PR #485 + Codex round 1 + DeepSeek round.
- `pyproject.toml` — bump version to 0.6.69

## Release SOP (11 gates, walked manually)

- **G1** `make release-smoke` — OK (every release surface imports cleanly in fresh venv)
- **G2** Codex review — converged at round 3 (2 consecutive clean rounds)
- **G3** CLI ↔ Config fidelity audit — OK
- **G4** `make smoke` — lint + audit + unit (1933 tests) PASS
- **G5** `make stress` / pr_validate stress_e2e_bench 3×3 matrix — PASSED
- **G6** Server fix-path E2E (gemma-4-26b serve + single chat-completion) — HTTP 200
- **G7** Integrations — anthropic_sdk 5/5, smolagents 4/4, pydantic_ai 5/6 (1 token-limit fail unrelated to shim per SOP tolerance)
- **G8** Microbenchmark — N/A (import-order shim install only; no per-token path touched)
- **G9** Server-level latency (10 sequential, qwen3.5-4b) — mean 57.2 tok/s, CV 8.6% (well under 30% threshold)
- **G10** MLX-version-bump cross-chip — N/A (`mlx` / `mlx-lm` / `mlx-vlm` unchanged)
- **G11** Auto-detection escape-hatch — N/A (no auto-routing change)

## Test plan

- [x] `pytest tests/test_mlx_compat.py` — 8/8 pass (AST-based audit + TYPE_CHECKING skip)
- [x] `pytest tests/test_mllm_batch_generator.py` — 5/5 pass
- [x] `pytest tests/test_deepseek_v4_vendored.py` — 4/4 pass
- [x] `pytest tests/test_mllm.py tests/test_mllm_cache.py tests/test_mllm_hybrid_probe.py` — 47/47 pass
- [x] Full unit suite via pr_validate — 4133 passed, 19 skipped, 16 deselected, 1 xfailed
- [x] `rapid-mlx serve gemma-4-26b` + single `POST /v1/chat/completions` → HTTP 200, no Stream(gpu,1) error
- [x] `ruff check` + `ruff format --check` on all touched files clean
- [x] CI green

## Notes for #486 reviewers

mxl's other PR (#486) proposed adding `gemma-4`/`gemma4` to `MLLM_PATTERNS`. We do **not** want that: Gemma 4 text variants are intentionally routed through the LLM path via `vllm_mlx/models/gemma4_text.py` (mlx-vlm `LanguageModel` wrapped for mlx-lm compatibility). `is_mllm_model('mlx-community/gemma-4-31b-it-4bit')` returns False by design. The Stream(gpu,1) crash he saw on M1 Max was almost certainly the #485 root cause, not the MLLM_PATTERNS gap. This PR addresses that root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)