### PR TITLE
feat(parser): unified Parser orchestrator + opt-in route migration (port from vllm)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.68"
+version = "0.6.69"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -211,16 +211,23 @@ def test_every_mlx_lm_consumer_installs_shim():
         a deferred (function/lambda) scope. The walk descends into
         ``If``/``Try``/``With``/``For``/``While``/``ClassDef`` bodies —
         all of which run at module load time when the enclosing module
-        is imported. ``if TYPE_CHECKING:`` is treated as deferred since
-        its body never runs at import time."""
+        is imported. For ``if TYPE_CHECKING:`` the ``body`` is treated
+        as deferred (runs only under static analysis) but the ``orelse``
+        IS walked: ``TYPE_CHECKING`` is False at runtime so ``else:`` runs
+        at module load and any ``import mlx_lm`` there must still install
+        the shim first."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
                 continue
             if _is_type_checking_guard(child):
-                # Yield the If node itself (for parent-tracking) but DO NOT
-                # descend into its body / orelse — the imports there only
-                # run under static analysis, never at module load.
+                # Yield the If node itself (for parent-tracking). Skip the
+                # body (dead at module load) but descend into orelse —
+                # ``else:`` of an ``if TYPE_CHECKING:`` block runs at
+                # import time on every Python interpreter.
                 yield child, parents
+                for sub in child.orelse:
+                    yield sub, parents + (child,)
+                    yield from _walk_module_level(sub, parents + (child,))
                 continue
             yield child, parents
             yield from _walk_module_level(child, parents + (child,))

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -60,8 +60,8 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
 
     Pure source-text audit; no module manipulation so the test is safe
     in a shared pytest process. The shim must be installed lazily at
-    the top of every module that imports `mlx_lm.generate` instead
-    (verified by `test_every_mlx_lm_generate_consumer_installs_shim`)."""
+    the top of every module that imports `mlx_lm.*` instead
+    (verified by `test_every_mlx_lm_consumer_installs_shim`)."""
     init_source = (
         importlib.resources.files("vllm_mlx").joinpath("__init__.py").read_text()
     )
@@ -76,17 +76,31 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
     )
 
 
-def test_every_mlx_lm_generate_consumer_installs_shim():
-    """Any vllm_mlx file that imports `mlx_lm.generate` (either via
-    `from mlx_lm.generate import ...` or `importlib.import_module(
-    "mlx_lm.generate")`) MUST also call `_mlx_compat.install()` in the
-    same file. Otherwise that import path triggers `mlx_lm/generate.py`
-    module-level `mx.new_thread_local_stream` capture on M5 before our
-    shim runs, and the bug from #404 returns.
+def test_every_mlx_lm_consumer_installs_shim():
+    """Any vllm_mlx file with a *top-level* ``from mlx_lm…`` / ``import
+    mlx_lm…`` MUST also call ``_mlx_compat.install()`` in the same file.
 
-    This is a structural audit: a new file that adds the import without
-    the install will fail here at unit-test time, catching the slip
-    before any M5 user does.
+    Why ANY ``mlx_lm`` submodule, not just ``mlx_lm.generate``: importing
+    e.g. ``mlx_lm.sample_utils`` or ``mlx_lm.models.base`` still triggers
+    ``mlx_lm/__init__.py`` execution, which does ``from .generate import
+    batch_generate, generate, stream_generate`` and therefore runs
+    ``mlx_lm/generate.py:226`` ``generation_stream =
+    mx.new_thread_local_stream(mx.default_device())`` at module-import
+    time. The #404 single-stream crash on M5 happens on the same code
+    path regardless of which submodule the import statement names.
+
+    Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
+    ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
+    ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
+    without the shim; the prior version of this guard (which matched
+    only ``mlx_lm.generate``) missed all three. Indented / function-local
+    imports are out of scope here — by the time they run, scheduler.py's
+    install is usually already in effect.
+
+    This is a structural audit: a new file that adds a top-level
+    ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
+    fail here at unit-test time, catching the slip before any M5 user
+    does.
     """
     import pathlib
 
@@ -98,16 +112,18 @@ def test_every_mlx_lm_generate_consumer_installs_shim():
         if path.name == "_mlx_compat.py":
             continue  # the shim itself; nothing to install
         source = path.read_text()
-        imports_generate = (
-            "from mlx_lm.generate" in source
-            or 'import_module("mlx_lm.generate")' in source
-            or "import_module('mlx_lm.generate')" in source
+        has_top_level_mlx_lm_import = any(
+            line.startswith(("from mlx_lm", "import mlx_lm"))
+            for line in source.splitlines()
         )
-        if imports_generate and "_mlx_compat.install()" not in source:
+        if has_top_level_mlx_lm_import and "_mlx_compat.install()" not in source:
             offenders.append(str(path.relative_to(pkg_root)))
     assert not offenders, (
-        "Files import mlx_lm.generate without calling _mlx_compat.install() "
-        "first — #404 M5 regression risk:\n  " + "\n  ".join(offenders)
+        "Files have top-level `from mlx_lm` / `import mlx_lm` without "
+        "calling `_mlx_compat.install()` first — #404 M5 regression "
+        "risk (any mlx_lm submodule triggers mlx_lm/__init__.py which "
+        "loads mlx_lm.generate which captures the GPU stream):\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -152,17 +152,28 @@ def test_every_mlx_lm_consumer_installs_shim():
         return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
 
     def _is_type_checking_guard(node: ast.AST) -> bool:
-        """``True`` for ``if TYPE_CHECKING:`` and ``if typing.TYPE_CHECKING:``
-        — both evaluate to ``False`` at runtime, so the body never executes
-        at module load and isn't a stream-capture hazard. Flagged by
-        DeepSeek pr_validate review on PR #487 as a future-proofing nit."""
+        """``True`` for ``if TYPE_CHECKING:`` and
+        ``if {typing,typing_extensions}.TYPE_CHECKING:`` — both evaluate
+        to ``False`` at runtime, so the body never executes at module
+        load and isn't a stream-capture hazard.
+
+        Narrowed to those two attribute owners specifically so an
+        unrelated ``if config.TYPE_CHECKING:`` (where the attribute is a
+        real runtime flag) is NOT skipped — DeepSeek pr_validate round
+        3 flagged the un-narrowed version as [BLOCKING]: a real
+        ``True`` flag named ``TYPE_CHECKING`` on some other namespace
+        would have hidden an unprotected ``mlx_lm`` import."""
         if not isinstance(node, ast.If):
             return False
         test = node.test
         if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
             return True
         if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
-            return True
+            owner = test.value
+            return isinstance(owner, ast.Name) and owner.id in (
+                "typing",
+                "typing_extensions",
+            )
         return False
 
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -95,17 +95,20 @@ def test_every_mlx_lm_consumer_installs_shim():
     load time. ``vllm_mlx/utils/mamba_cache.py`` and ``vllm_mlx/api/
     guided.py`` both use that pattern for optional-dep guards, and a
     line-prefix check misses them. We walk the AST and accept any
-    ``Import`` / ``ImportFrom`` whose parent chain contains only ``If``,
-    ``Try``, or ``With`` — i.e. unconditionally-executed at module load
-    — while excluding ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef``
-    (those are deferred to call time).
+    ``Import`` / ``ImportFrom`` whose parent chain stays inside
+    module-load-time scopes (``If`` / ``Try`` / ``With`` / ``For`` /
+    ``While`` bodies, plus ``ClassDef`` bodies — class statements run
+    at definition time), while excluding ``FunctionDef`` /
+    ``AsyncFunctionDef`` / ``Lambda`` (deferred to call time).
 
     Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
     ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
     ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
     without the shim; the prior version of this guard (which matched
     only literal ``mlx_lm.generate``) missed all three. Codex round 1
-    review against this PR then surfaced the indented-import gap above.
+    review against this PR then surfaced the indented-import gap above,
+    and DeepSeek pr_validate round 2 added the ``ClassDef``-descent
+    requirement (class bodies execute at module load).
 
     This is a structural audit: a new file that adds a module-load-time
     ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
@@ -117,10 +120,15 @@ def test_every_mlx_lm_consumer_installs_shim():
 
     # AST node types that defer execution — an mlx_lm import nested under
     # any of these does NOT run at module load, so it's out of scope.
+    # NB: ``ClassDef`` is *not* deferred. A class body runs at the class's
+    # definition site; for a module-level class that's still at module
+    # load time, so an ``import mlx_lm`` at class scope captures the
+    # GPU stream exactly as a top-level import would. Method bodies
+    # inside the class are still skipped via ``FunctionDef``. Flagged
+    # as [BLOCKING] by DeepSeek pr_validate round 2 on PR #487.
     DEFERRED_SCOPES = (
         ast.FunctionDef,
         ast.AsyncFunctionDef,
-        ast.ClassDef,
         ast.Lambda,
     )
 
@@ -159,10 +167,11 @@ def test_every_mlx_lm_consumer_installs_shim():
 
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
         """Yield (node, parents) for every descendant that is NOT inside
-        a deferred (function/class/lambda) scope. The walk descends into
-        ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
-        at module load time. ``if TYPE_CHECKING:`` is treated as deferred
-        since its body never runs at import time."""
+        a deferred (function/lambda) scope. The walk descends into
+        ``If``/``Try``/``With``/``For``/``While``/``ClassDef`` bodies —
+        all of which run at module load time when the enclosing module
+        is imported. ``if TYPE_CHECKING:`` is treated as deferred since
+        its body never runs at import time."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
                 continue

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -141,6 +141,28 @@ def test_every_mlx_lm_consumer_installs_shim():
         if isinstance(node, ast.ImportFrom):
             mod = node.module or ""
             return mod == "mlx_lm" or mod.startswith("mlx_lm.")
+        # ``importlib.import_module("mlx_lm…")`` — dynamic import with
+        # the same module-load effect as a static one. DeepSeek
+        # pr_validate round 4 flagged that the AST-only walk silently
+        # dropped this shape, which the prior text-based guard caught
+        # via a literal `import_module("mlx_lm.generate")` substring.
+        # We also accept the keyword-arg form
+        # ``import_module(name="mlx_lm.…")``.
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "import_module":
+                if isinstance(func.value, ast.Name) and func.value.id == "importlib":
+                    arg = None
+                    if node.args:
+                        arg = node.args[0]
+                    else:
+                        for kw in node.keywords:
+                            if kw.arg == "name":
+                                arg = kw.value
+                                break
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        s = arg.value
+                        return s == "mlx_lm" or s.startswith("mlx_lm.")
         return False
 
     def _is_install_call(node: ast.AST) -> bool:
@@ -162,7 +184,15 @@ def test_every_mlx_lm_consumer_installs_shim():
         real runtime flag) is NOT skipped — DeepSeek pr_validate round
         3 flagged the un-narrowed version as [BLOCKING]: a real
         ``True`` flag named ``TYPE_CHECKING`` on some other namespace
-        would have hidden an unprotected ``mlx_lm`` import."""
+        would have hidden an unprotected ``mlx_lm`` import.
+
+        Known limitation (DeepSeek round 4 NIT): aliased typing imports
+        like ``import typing as t; if t.TYPE_CHECKING: import mlx_lm``
+        get the false-positive treatment (the test would flag the
+        ``mlx_lm`` import as unshielded). Convention in this codebase
+        is ``from typing import TYPE_CHECKING`` — don't alias the
+        ``typing`` module in files that import ``mlx_lm`` under a
+        ``TYPE_CHECKING`` guard."""
         if not isinstance(node, ast.If):
             return False
         test = node.test

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -77,8 +77,9 @@ def test_vllm_mlx_init_does_not_install_shim_or_import_mlx():
 
 
 def test_every_mlx_lm_consumer_installs_shim():
-    """Any vllm_mlx file with a *top-level* ``from mlx_lm…`` / ``import
-    mlx_lm…`` MUST also call ``_mlx_compat.install()`` in the same file.
+    """Any vllm_mlx file that runs a ``from mlx_lm…`` / ``import mlx_lm…``
+    *at module load time* MUST also call ``_mlx_compat.install()`` before
+    the first such import.
 
     Why ANY ``mlx_lm`` submodule, not just ``mlx_lm.generate``: importing
     e.g. ``mlx_lm.sample_utils`` or ``mlx_lm.models.base`` still triggers
@@ -89,20 +90,69 @@ def test_every_mlx_lm_consumer_installs_shim():
     time. The #404 single-stream crash on M5 happens on the same code
     path regardless of which submodule the import statement names.
 
+    Why AST-based and not text-based: imports inside top-level ``try /
+    except ImportError`` blocks are indented but still execute at module
+    load time. ``vllm_mlx/utils/mamba_cache.py`` and ``vllm_mlx/api/
+    guided.py`` both use that pattern for optional-dep guards, and a
+    line-prefix check misses them. We walk the AST and accept any
+    ``Import`` / ``ImportFrom`` whose parent chain contains only ``If``,
+    ``Try``, or ``With`` — i.e. unconditionally-executed at module load
+    — while excluding ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef``
+    (those are deferred to call time).
+
     Surfaced by community PR #485 (Michael Ledin / @mxl, 2026-05-29):
     ``mllm_batch_generator.py``, ``mllm_scheduler.py``, and
     ``models/deepseek_v4.py`` all had top-level ``mlx_lm.<sub>`` imports
     without the shim; the prior version of this guard (which matched
-    only ``mlx_lm.generate``) missed all three. Indented / function-local
-    imports are out of scope here — by the time they run, scheduler.py's
-    install is usually already in effect.
+    only literal ``mlx_lm.generate``) missed all three. Codex round 1
+    review against this PR then surfaced the indented-import gap above.
 
-    This is a structural audit: a new file that adds a top-level
+    This is a structural audit: a new file that adds a module-load-time
     ``mlx_lm.*`` import without ``_mlx_compat.install()`` first will
     fail here at unit-test time, catching the slip before any M5 user
     does.
     """
+    import ast
     import pathlib
+
+    # AST node types that defer execution — an mlx_lm import nested under
+    # any of these does NOT run at module load, so it's out of scope.
+    DEFERRED_SCOPES = (
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Lambda,
+    )
+
+    def _is_mlx_lm_node(node: ast.AST) -> bool:
+        if isinstance(node, ast.Import):
+            return any(
+                alias.name == "mlx_lm" or alias.name.startswith("mlx_lm.")
+                for alias in node.names
+            )
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            return mod == "mlx_lm" or mod.startswith("mlx_lm.")
+        return False
+
+    def _is_install_call(node: ast.AST) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "install":
+            return False
+        return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
+
+    def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
+        """Yield (node, parents) for every descendant that is NOT inside
+        a deferred (function/class/lambda) scope. The walk descends into
+        ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
+        at module load time."""
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, DEFERRED_SCOPES):
+                continue
+            yield child, parents
+            yield from _walk_module_level(child, parents + (child,))
 
     pkg_root = pathlib.Path(
         str(importlib.resources.files("vllm_mlx").joinpath(""))
@@ -112,18 +162,31 @@ def test_every_mlx_lm_consumer_installs_shim():
         if path.name == "_mlx_compat.py":
             continue  # the shim itself; nothing to install
         source = path.read_text()
-        has_top_level_mlx_lm_import = any(
-            line.startswith(("from mlx_lm", "import mlx_lm"))
-            for line in source.splitlines()
-        )
-        if has_top_level_mlx_lm_import and "_mlx_compat.install()" not in source:
-            offenders.append(str(path.relative_to(pkg_root)))
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue  # not our problem here
+        first_mlx_lm_line = None
+        first_install_line = None
+        for node, _parents in _walk_module_level(tree):
+            if first_mlx_lm_line is None and _is_mlx_lm_node(node):
+                first_mlx_lm_line = node.lineno
+            if first_install_line is None and _is_install_call(node):
+                first_install_line = node.lineno
+        if first_mlx_lm_line is None:
+            continue
+        if first_install_line is None or first_install_line > first_mlx_lm_line:
+            rel = str(path.relative_to(pkg_root))
+            offenders.append(
+                f"{rel} (mlx_lm import @ line {first_mlx_lm_line}, "
+                f"install @ line {first_install_line})"
+            )
     assert not offenders, (
-        "Files have top-level `from mlx_lm` / `import mlx_lm` without "
-        "calling `_mlx_compat.install()` first — #404 M5 regression "
-        "risk (any mlx_lm submodule triggers mlx_lm/__init__.py which "
-        "loads mlx_lm.generate which captures the GPU stream):\n  "
-        + "\n  ".join(offenders)
+        "Files run a module-load-time `from mlx_lm` / `import mlx_lm` "
+        "without calling `_mlx_compat.install()` first — #404 M5 "
+        "regression risk (any mlx_lm submodule triggers "
+        "mlx_lm/__init__.py which loads mlx_lm.generate which captures "
+        "the GPU stream):\n  " + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_mlx_compat.py
+++ b/tests/test_mlx_compat.py
@@ -143,13 +143,34 @@ def test_every_mlx_lm_consumer_installs_shim():
             return False
         return isinstance(func.value, ast.Name) and func.value.id == "_mlx_compat"
 
+    def _is_type_checking_guard(node: ast.AST) -> bool:
+        """``True`` for ``if TYPE_CHECKING:`` and ``if typing.TYPE_CHECKING:``
+        — both evaluate to ``False`` at runtime, so the body never executes
+        at module load and isn't a stream-capture hazard. Flagged by
+        DeepSeek pr_validate review on PR #487 as a future-proofing nit."""
+        if not isinstance(node, ast.If):
+            return False
+        test = node.test
+        if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+            return True
+        if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+            return True
+        return False
+
     def _walk_module_level(node: ast.AST, parents: tuple[ast.AST, ...] = ()):
         """Yield (node, parents) for every descendant that is NOT inside
         a deferred (function/class/lambda) scope. The walk descends into
         ``If``/``Try``/``With``/``For``/``While`` bodies, which all run
-        at module load time."""
+        at module load time. ``if TYPE_CHECKING:`` is treated as deferred
+        since its body never runs at import time."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, DEFERRED_SCOPES):
+                continue
+            if _is_type_checking_guard(child):
+                # Yield the If node itself (for parent-tracking) but DO NOT
+                # descend into its body / orelse — the imports there only
+                # run under static analysis, never at module load.
+                yield child, parents
                 continue
             yield child, parents
             yield from _walk_module_level(child, parents + (child,))

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -126,6 +126,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # so the child's B2 download gate no-ops (parent already gated).
         # Pure UX flag — never read by the engine or scheduler.
         "RAPID_MLX_CHAT_SPAWN",
+        # Opt-in to the unified Parser orchestrator path in
+        # StreamingPostProcessor (PR #488). Default OFF; ON re-routes the
+        # exact same reasoning+tool parser instances through a single
+        # ``parse_delta`` seam. Not a model/route/engine selector — purely
+        # a code-path A/B for the parser layer. Sole reader:
+        # ``vllm_mlx/service/postprocessor.py``.
+        "RAPID_MLX_UNIFIED_PARSER",
     }
 )
 

--- a/tests/test_parser_orchestrator.py
+++ b/tests/test_parser_orchestrator.py
@@ -230,6 +230,46 @@ def test_no_reasoning_parser_means_tool_phase_from_start():
     assert d_final.tool_calls is not None
 
 
+def test_mixed_reasoning_plus_content_delta_flips_reasoning_ended():
+    """Codex round-8 regression. Some reasoning parsers (Gemma 4 on a
+    thought→content transition) emit BOTH ``reasoning`` and
+    ``content`` on the same boundary delta. The orchestrator must
+    flip ``reasoning_ended`` on that delta so the tool parser sees
+    the content side this same chunk — otherwise a boundary chunk
+    carrying ``<tool_call>...</tool_call>`` would skip the tool
+    phase and leak as raw content."""
+
+    class _MixedReasoningParser(_FakeReasoningParser):
+        def __init__(self, tokenizer=None):
+            super().__init__(tokenizer)
+            self._emitted = False
+
+        def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
+            # On the first chunk emit BOTH reasoning and content (a
+            # Gemma 4-style mixed boundary delta).
+            if not self._emitted:
+                self._emitted = True
+                return DeltaMessage(reasoning="r", content=delta_text)
+            return DeltaMessage(content=delta_text)
+
+        def is_reasoning_end_streaming(self, previous_text, current_text):
+            # Never reports via the canonical end-token signal — the
+            # orchestrator must flip via the content-set fallback.
+            return False
+
+    _WrappedParser.reasoning_parser_cls = _MixedReasoningParser
+    _WrappedParser.tool_parser_cls = _FakeToolParser
+    p = _WrappedParser()
+
+    # Boundary chunk: parser emits reasoning AND content
+    # (content = the tool-call markup that follows).
+    p.parse_delta("<tool_call>{}</tool_call>")
+    assert p._stream_state.reasoning_ended is True, (
+        "mixed reasoning+content delta must flip reasoning_ended so "
+        "the tool parser sees boundary content this same chunk"
+    )
+
+
 def test_content_only_reasoning_delta_flips_reasoning_ended():
     """Codex round-3 regression: parsers that decide a delta is
     content-only (no reasoning text) must hand off to the tool parser

--- a/tests/test_parser_orchestrator.py
+++ b/tests/test_parser_orchestrator.py
@@ -202,16 +202,74 @@ def test_boundary_delta_preserves_reasoning_when_tool_starts_in_same_chunk():
 
 
 def test_no_reasoning_parser_means_tool_phase_from_start():
+    """Codex round-3 regression: tool-only parser must enter tool phase
+    from chunk 0. Without this, reasoning_ended starts False and never
+    flips (no reasoning parser to consult), so the orchestrator would
+    suppress every chunk and the tool call would never surface."""
     p = _build_parser(with_reasoning=False)
-    assert p._in_reasoning_phase(p._stream_state) is False
-    # Without reasoning parser, _is_reasoning_end_streaming defaults to
-    # True so we're immediately in the tool-call phase (or content if
-    # tool parser is also absent).
-    p.parse_delta("<tool_call>{")
-    p.parse_delta('"x":1}</tool_call>')
-    # FakeToolParser only emits on </tool_call>; last delta carries it.
     state = p._stream_state
-    assert state.reasoning_ended is True or p._reasoning_parser is None
+    # Tool phase active from the very first chunk.
+    assert p._in_reasoning_phase(state) is False
+    assert p._in_tool_call_phase(state) is True
+
+    p.parse_delta("<tool_call>{")
+    d_final = p.parse_delta('"x":1}</tool_call>')
+    # FakeToolParser emits on </tool_call> — must materialize.
+    assert d_final is not None
+    assert d_final.tool_calls is not None
+
+
+def test_content_only_reasoning_delta_flips_reasoning_ended():
+    """Codex round-3 regression: parsers that decide a delta is
+    content-only (no reasoning text) must hand off to the tool parser
+    even without seeing ``</think>``. Otherwise the next chunk's
+    ``<tool_call>`` markup leaks as content."""
+
+    class _ContentOnlyReasoningParser(_FakeReasoningParser):
+        def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
+            # Pretend we decided no reasoning is happening — return
+            # content-only directly. No </think> in the stream.
+            return DeltaMessage(content=delta_text, reasoning=None)
+
+        def is_reasoning_end_streaming(self, previous_text, current_text):
+            # Never flips through the canonical end-token signal.
+            return False
+
+    _WrappedParser.reasoning_parser_cls = _ContentOnlyReasoningParser
+    _WrappedParser.tool_parser_cls = _FakeToolParser
+    p = _WrappedParser()
+
+    p.parse_delta("hi")
+    assert p._stream_state.reasoning_ended is True, (
+        "content-only reasoning delta must flip reasoning_ended so the "
+        "tool parser starts seeing subsequent chunks"
+    )
+    # Subsequent tool call should now be parsed.
+    d_final = p.parse_delta("<tool_call>{}</tool_call>")
+    assert d_final is not None
+    assert d_final.tool_calls is not None
+
+
+def test_boundary_chunk_prefers_reasoning_parser_content_over_tool_passthrough():
+    """Codex round-3 regression: on a boundary chunk like
+    ``final thought</think>Answer`` with no tool call, the reasoning
+    parser splits content as ``Answer`` while the tool parser's
+    pass-through content is the raw delta. Orchestrator must surface
+    the reasoning parser's stripped version, not the raw markup."""
+    p = _build_parser()
+    # Prime: open reasoning
+    p.parse_delta("<think>")
+    p.parse_delta("step 1")
+    # Boundary chunk: reasoning text, end token, then plain content
+    d = p.parse_delta("final thought</think>Answer")
+    assert d is not None
+    # The content side must be "Answer" (reasoning parser's stripped
+    # split), not "final thought</think>Answer" (raw passthrough).
+    assert d.content == "Answer", (
+        f"expected reasoning parser's stripped content 'Answer', "
+        f"got {d.content!r} (likely raw tool passthrough including "
+        f"</think>)"
+    )
 
 
 def test_reset_state_clears_stream_and_subparsers():

--- a/tests/test_parser_orchestrator.py
+++ b/tests/test_parser_orchestrator.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the unified ``Parser`` orchestrator.
+
+Pins the contract that closes the "stream and non-stream silently
+diverge" bug class (PRs #436 / #443 / #454 / #456 / #460 / #462 and
+their vLLM analogues #39446 / #41876 / #42691). The orchestrator runs
+reasoning extraction first, then tool-call extraction on the same
+delta, merging boundary chunks where a single token flush spans both
+phases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_mlx.parser import (
+    DelegatingParser,
+    Parser,
+    ParserManager,
+    StreamState,
+    _WrappedParser,
+)
+from vllm_mlx.reasoning.base import DeltaMessage, ReasoningParser
+from vllm_mlx.tool_parsers.abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+)
+
+# ----------------------------- fakes -----------------------------
+
+
+class _FakeReasoningParser(ReasoningParser):
+    """Detects ``<think>...</think>`` purely by text inspection."""
+
+    def __init__(self, tokenizer: Any | None = None) -> None:
+        super().__init__(tokenizer)
+        self.reasoning_ended = False
+
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
+        if "</think>" not in model_output:
+            return (
+                (model_output, None)
+                if "<think>" in model_output
+                else (None, model_output)
+            )
+        reasoning, _, content = model_output.partition("</think>")
+        reasoning = reasoning.replace("<think>", "").strip() or None
+        return reasoning, content.strip() or None
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        if "</think>" in current_text:
+            self.reasoning_ended = True
+            # Boundary delta: emit any post-</think> remainder as content
+            _, _, post = current_text.partition("</think>")
+            prev_post = ""
+            if "</think>" in previous_text:
+                _, _, prev_post = previous_text.partition("</think>")
+            new_content = post[len(prev_post) :] if post.startswith(prev_post) else post
+            return DeltaMessage(content=new_content or None)
+        return DeltaMessage(reasoning=delta_text)
+
+    def is_reasoning_end_streaming(self, previous_text: str, current_text: str) -> bool:
+        return "</think>" in current_text
+
+    def reset_state(self) -> None:
+        self.reasoning_ended = False
+
+
+class _FakeToolParser(ToolParser):
+    """Emits a single tool_call when ``</tool_call>`` is seen."""
+
+    EXPECTED_WIRE_FORMATS = ("tool_call_json",)
+
+    def __init__(self, tokenizer: Any | None = None) -> None:
+        super().__init__(tokenizer)
+        self.emitted = False
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        if "</tool_call>" not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+        return ExtractedToolCallInformation(
+            tools_called=True,
+            tool_calls=[{"name": "x", "arguments": "{}", "index": 0, "id": "call_1"}],
+            content=None,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Any = None,
+        current_token_ids: Any = None,
+        delta_token_ids: Any = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if "</tool_call>" in current_text and not self.emitted:
+            self.emitted = True
+            return {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "x", "arguments": "{}"},
+                    }
+                ]
+            }
+        return None
+
+    def reset(self) -> None:
+        self.emitted = False
+        super().reset() if hasattr(super(), "reset") else None
+
+
+# ----------------------------- helpers -----------------------------
+
+
+def _build_parser(
+    *, with_reasoning: bool = True, with_tool: bool = True
+) -> DelegatingParser:
+    _WrappedParser.reasoning_parser_cls = (
+        _FakeReasoningParser if with_reasoning else None
+    )
+    _WrappedParser.tool_parser_cls = _FakeToolParser if with_tool else None
+    return _WrappedParser()
+
+
+# ----------------------------- tests: state machine -----------------------------
+
+
+def test_pure_content_passthrough_no_parsers():
+    p = _build_parser(with_reasoning=False, with_tool=False)
+    delta = p.parse_delta("hello")
+    assert delta is not None
+    assert delta.content == "hello"
+    assert delta.reasoning is None
+    assert delta.tool_calls is None
+
+
+def test_reasoning_phase_routes_to_reasoning_field():
+    p = _build_parser(with_tool=False)
+    delta = p.parse_delta("<think>thinking")
+    assert delta is not None
+    assert delta.reasoning == "<think>thinking"
+    assert delta.content is None
+
+
+def test_boundary_transitions_to_tool_phase_after_end_token():
+    p = _build_parser()
+
+    # Phase 1 — reasoning
+    p.parse_delta("<think>")
+    p.parse_delta("planning")
+    assert p._stream_state.reasoning_ended is False
+
+    # Boundary — </think> seen, state flips
+    p.parse_delta("</think>")
+    assert p._stream_state.reasoning_ended is True
+
+    # Phase 2 — tool call
+    p.parse_delta('<tool_call>{"name":"x"')
+    delta_final = p.parse_delta("}</tool_call>")
+    assert delta_final is not None
+    assert delta_final.tool_calls is not None
+    assert delta_final.tool_calls[0]["function"]["name"] == "x"
+
+
+def test_boundary_delta_preserves_reasoning_when_tool_starts_in_same_chunk():
+    """vLLM PR #42691 / rapid-mlx PR #436 regression coverage.
+
+    A single delta carrying both ``...</think>`` AND ``<tool_call>...`` must
+    not drop the reasoning side when the orchestrator hands off to the
+    tool parser. The fake reasoning parser emits a content chunk on
+    boundary; the orchestrator's preserve-reasoning step keeps any
+    pre-boundary reasoning attached.
+    """
+    p = _build_parser()
+    # Open thinking
+    d1 = p.parse_delta("<think>step 1")
+    assert d1 is not None and d1.reasoning == "<think>step 1"
+
+    # Combined boundary delta: closes think AND opens tool call in one
+    # streamed chunk
+    d2 = p.parse_delta("</think><tool_call>")
+    # After this delta, the boundary state should be ended
+    assert p._stream_state.reasoning_ended is True
+    # Reasoning parser emitted post-</think> content (the "<tool_call>"
+    # prefix); tool parser hasn't seen </tool_call> yet, so it returns
+    # None and the post-boundary content flows through.
+    assert d2 is not None
+
+
+def test_no_reasoning_parser_means_tool_phase_from_start():
+    p = _build_parser(with_reasoning=False)
+    assert p._in_reasoning_phase(p._stream_state) is False
+    # Without reasoning parser, _is_reasoning_end_streaming defaults to
+    # True so we're immediately in the tool-call phase (or content if
+    # tool parser is also absent).
+    p.parse_delta("<tool_call>{")
+    p.parse_delta('"x":1}</tool_call>')
+    # FakeToolParser only emits on </tool_call>; last delta carries it.
+    state = p._stream_state
+    assert state.reasoning_ended is True or p._reasoning_parser is None
+
+
+def test_reset_state_clears_stream_and_subparsers():
+    p = _build_parser()
+    p.parse_delta("<think>halfway")
+    p.parse_delta("</think>boundary")
+    assert p._stream_state.reasoning_ended is True
+
+    p.reset_state()
+    assert isinstance(p._stream_state, StreamState)
+    assert p._stream_state.reasoning_ended is False
+    assert p._stream_state.previous_text == ""
+    assert p._reasoning_parser.reasoning_ended is False  # type: ignore[union-attr]
+
+
+def test_non_stream_extract_reasoning_delegates():
+    p = _build_parser()
+    reasoning, content = p.extract_reasoning("<think>x</think>answer")
+    assert reasoning == "x"
+    assert content == "answer"
+
+
+def test_non_stream_extract_tool_calls_delegates():
+    p = _build_parser()
+    info = p.extract_tool_calls("<tool_call>...</tool_call>")
+    assert info.tools_called is True
+    assert info.tool_calls[0]["name"] == "x"
+
+
+# ----------------------------- tests: ParserManager -----------------------------
+
+
+def test_manager_returns_none_when_no_names_given():
+    assert ParserManager.get_parser(None, None) is None
+
+
+def test_manager_strategy_3_wraps_individual_parsers():
+    cls = ParserManager.get_parser(
+        tool_parser_name="hermes",
+        reasoning_parser_name="qwen3",
+        enable_auto_tools=True,
+    )
+    assert cls is _WrappedParser
+    inst = cls()
+    # Real parsers wired in
+    assert type(inst.reasoning_parser).__name__ == "Qwen3ReasoningParser"
+    assert type(inst.tool_parser).__name__ == "HermesToolParser"
+
+
+def test_manager_strategy_3_only_reasoning_when_tool_disabled():
+    cls = ParserManager.get_parser(
+        tool_parser_name="hermes",
+        reasoning_parser_name="qwen3",
+        enable_auto_tools=False,  # disables tool parser resolution
+    )
+    assert cls is _WrappedParser
+    inst = cls()
+    assert inst.tool_parser is None
+    assert inst.reasoning_parser is not None
+
+
+def test_manager_list_registered_empty_without_unified_parsers():
+    # No model-specific unified Parsers registered in Phase 1
+    assert isinstance(ParserManager.list_registered(), list)
+
+
+def test_manager_unknown_tool_parser_raises_helpful_error():
+    import pytest
+
+    with pytest.raises(TypeError, match="not registered"):
+        ParserManager.get_parser(
+            tool_parser_name="does_not_exist",
+            reasoning_parser_name=None,
+            enable_auto_tools=True,
+        )
+
+
+# ----------------------------- tests: protocol -----------------------------
+
+
+def test_parser_abc_is_abstract():
+    import pytest
+
+    with pytest.raises(TypeError):
+        Parser()  # type: ignore[abstract]
+
+
+def test_delegating_parser_is_concrete():
+    p = DelegatingParser()
+    assert isinstance(p, Parser)
+    assert isinstance(p._stream_state, StreamState)

--- a/tests/test_parser_orchestrator.py
+++ b/tests/test_parser_orchestrator.py
@@ -104,6 +104,10 @@ class _FakeToolParser(ToolParser):
         delta_token_ids: Any = None,
         request: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
+        # Mirror real hermes-style tristate:
+        # - {"tool_calls": [...]} when a complete tool call is parsed
+        # - None when buffering (saw <tool_call> but not </tool_call> yet)
+        # - {"content": delta_text} for plain-text passthrough
         if "</tool_call>" in current_text and not self.emitted:
             self.emitted = True
             return {
@@ -116,7 +120,9 @@ class _FakeToolParser(ToolParser):
                     }
                 ]
             }
-        return None
+        if "<tool_call>" in current_text and "</tool_call>" not in current_text:
+            return None  # buffering
+        return {"content": delta_text}
 
     def reset(self) -> None:
         self.emitted = False
@@ -195,10 +201,15 @@ def test_boundary_delta_preserves_reasoning_when_tool_starts_in_same_chunk():
     d2 = p.parse_delta("</think><tool_call>")
     # After this delta, the boundary state should be ended
     assert p._stream_state.reasoning_ended is True
-    # Reasoning parser emitted post-</think> content (the "<tool_call>"
-    # prefix); tool parser hasn't seen </tool_call> yet, so it returns
-    # None and the post-boundary content flows through.
-    assert d2 is not None
+    # The reasoning parser surfaces ``<tool_call>`` as
+    # ``content_to_preserve`` but the tool parser is now buffering
+    # (sees ``<tool_call>`` without ``</tool_call>``). Orchestrator
+    # MUST suppress the raw markup — d2 is either None or carries no
+    # ``<tool_call>`` text. This is the codex R6 contract.
+    if d2 is not None:
+        assert (d2.content or "") == "" or "<tool_call" not in (d2.content or ""), (
+            f"raw <tool_call> prefix leaked: {d2}"
+        )
 
 
 def test_no_reasoning_parser_means_tool_phase_from_start():

--- a/tests/test_parser_orchestrator.py
+++ b/tests/test_parser_orchestrator.py
@@ -250,6 +250,35 @@ def test_content_only_reasoning_delta_flips_reasoning_ended():
     assert d_final.tool_calls is not None
 
 
+def test_coalesced_boundary_with_full_tool_call_drops_raw_markup():
+    """Codex round-4 regression: when a single chunk carries the
+    reasoning end-token plus a complete tool call
+    (e.g. ``</think><tool_call>{...}</tool_call>``), ``content_to_preserve``
+    is the raw tool markup the reasoning parser surfaced as the
+    post-``</think>`` remainder. With ``tool_delta.tool_calls`` set the
+    tool parser has already consumed that text — the orchestrator must
+    NOT attach it as content, or clients would see the raw tool JSON
+    alongside the structured tool_calls emission."""
+    p = _build_parser()
+
+    # Open the reasoning block first.
+    p.parse_delta("<think>")
+    p.parse_delta("plan")
+
+    # Coalesced boundary: closing tag + full tool call in one chunk.
+    d = p.parse_delta("</think><tool_call>{}</tool_call>")
+    assert d is not None
+    assert d.tool_calls is not None, f"expected tool_calls, got {d}"
+
+    # Hard contract: content must NOT contain raw tool markup.
+    assert (d.content or "") == "" or (
+        "<tool_call" not in d.content and "</tool_call>" not in d.content
+    ), (
+        f"raw tool markup leaked as content on coalesced boundary: "
+        f"content={d.content!r} tool_calls={d.tool_calls!r}"
+    )
+
+
 def test_boundary_chunk_prefers_reasoning_parser_content_over_tool_passthrough():
     """Codex round-3 regression: on a boundary chunk like
     ``final thought</think>Answer`` with no tool call, the reasoning
@@ -312,11 +341,45 @@ def test_manager_strategy_3_wraps_individual_parsers():
         reasoning_parser_name="qwen3",
         enable_auto_tools=True,
     )
-    assert cls is _WrappedParser
+    # Strategy 3 returns a fresh subclass per resolve (not the shared
+    # ``_WrappedParser`` base — codex round-4 regression).
+    assert issubclass(cls, _WrappedParser)
+    assert cls is not _WrappedParser
     inst = cls()
     # Real parsers wired in
     assert type(inst.reasoning_parser).__name__ == "Qwen3ReasoningParser"
     assert type(inst.tool_parser).__name__ == "HermesToolParser"
+
+
+def test_manager_strategy_3_returns_distinct_classes_per_pair():
+    """Codex round-4 regression: each resolve must produce a fresh
+    subclass so concurrent / interleaved resolves don't collide on the
+    shared ``_WrappedParser`` class attributes. Without this, the
+    second ``get_parser`` call would overwrite the first's
+    ``reasoning_parser_cls`` and both instances would pick up
+    whichever pair was assigned last."""
+    cls_qwen_hermes = ParserManager.get_parser(
+        tool_parser_name="hermes",
+        reasoning_parser_name="qwen3",
+        enable_auto_tools=True,
+    )
+    cls_minimax = ParserManager.get_parser(
+        tool_parser_name="minimax",
+        reasoning_parser_name="minimax",
+        enable_auto_tools=True,
+    )
+    # If they're the same class, the assignment ran on the shared base
+    # and the first resolve was clobbered.
+    assert cls_qwen_hermes is not cls_minimax
+    assert cls_qwen_hermes.reasoning_parser_cls.__name__ == "Qwen3ReasoningParser"
+    assert cls_minimax.reasoning_parser_cls.__name__ == "MiniMaxReasoningParser"
+
+    # Instantiating the first resolve AFTER the second resolve must
+    # still pick up the first's wiring — proving the class isn't
+    # shared.
+    inst_qwen_hermes = cls_qwen_hermes()
+    assert type(inst_qwen_hermes.reasoning_parser).__name__ == "Qwen3ReasoningParser"
+    assert type(inst_qwen_hermes.tool_parser).__name__ == "HermesToolParser"
 
 
 def test_manager_strategy_3_only_reasoning_when_tool_disabled():
@@ -325,7 +388,7 @@ def test_manager_strategy_3_only_reasoning_when_tool_disabled():
         reasoning_parser_name="qwen3",
         enable_auto_tools=False,  # disables tool parser resolution
     )
-    assert cls is _WrappedParser
+    assert issubclass(cls, _WrappedParser)
     inst = cls()
     assert inst.tool_parser is None
     assert inst.reasoning_parser is not None

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -539,6 +539,43 @@ def test_channel_routed_bypasses_unified_path(monkeypatch):
     )
 
 
+def test_channel_routed_finalize_uses_accumulated_text_fallback(monkeypatch):
+    """DeepSeek review BLOCKING regression.
+
+    When the env flag is on but the entire stream is channel-routed
+    (OutputRouter — Gemma 4, harmony), ``_process_with_unified_parser``
+    never runs and ``_unified_tool_scope_active`` must stay False. If it
+    were latched to True at construction (the pre-fix behavior), finalize
+    would short-circuit the legacy ``or self.accumulated_text`` fallback
+    and lose any tool_call that the channel-routed path accumulated only
+    in ``accumulated_text``.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    # Sanity: parser exists but scope flag is OFF until a delta consumed.
+    assert pp.unified_parser is not None
+    assert pp._unified_tool_scope_active is False
+
+    # Drive ONLY channel-routed chunks (output.channel set). These
+    # bypass the unified path entirely.
+    for chunk in ["<tool_call>", '{"name":"x","arguments":{}}', "</tool_call>"]:
+        pp.process_chunk(_make_output(chunk, channel="content"))
+
+    # Flag must STILL be False — channel-routed path never latched it.
+    assert pp._unified_tool_scope_active is False, (
+        "Channel-routed stream must not latch _unified_tool_scope_active; "
+        "doing so would suppress finalize()'s accumulated_text fallback "
+        "and lose tool calls accumulated by the channel path."
+    )
+
+
 # ----------------------- reset clears orchestrator state -----------------------
 
 

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phase 2 parity tests for the unified ``Parser.parse_delta`` path in
+``StreamingPostProcessor``.
+
+When ``RAPID_MLX_UNIFIED_PARSER=1`` the post-processor takes its
+text-based reasoning + tool flow through the new orchestrator instead of
+the legacy two-call (``extract_reasoning_streaming`` →
+``_detect_tool_calls``) sequence. These tests pin:
+
+1. The opt-in is a no-op when the env flag is unset.
+2. With the flag set, a Qwen3-style ``<think>...</think>...<tool_call>...``
+   stream produces the same StreamEvent shapes the legacy path would
+   have produced (reasoning → content boundary, tool_call emission).
+3. The flag does NOT activate for channel-routed (Gemma 4 / harmony)
+   outputs — those still route through ``_process_channel_routed`` since
+   OutputRouter is token-level and the orchestrator is text-level.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+
+def _make_cfg(**overrides):
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = False
+    cfg.tool_call_parser = None
+    cfg.tool_parser_instance = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _make_output(text="", finished=False, channel=None, finish_reason=None):
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = channel
+    out.finish_reason = finish_reason or ("stop" if finished else None)
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    return out
+
+
+# ----------------------- opt-in is no-op by default -----------------------
+
+
+def test_unified_parser_is_none_without_env_flag(monkeypatch):
+    """Default OFF: ``unified_parser`` stays None so the legacy path is
+    used. This is the Phase 1→2 safety contract — landing the new code
+    must not change existing behavior for any deployed install."""
+    monkeypatch.delenv("RAPID_MLX_UNIFIED_PARSER", raising=False)
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    assert pp.unified_parser is None
+
+
+def test_unified_parser_not_built_without_reasoning_parser(monkeypatch):
+    """The unified path is only an improvement over the legacy
+    ``_process_with_reasoning``. With no reasoning parser the standard
+    path is correct and the orchestrator gives nothing — don't pay the
+    construction cost."""
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(tool_call_parser="hermes", enable_auto_tool_choice=True)
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    assert pp.unified_parser is None
+
+
+# ----------------------- unified path activation -----------------------
+
+
+def test_unified_parser_built_when_env_and_reasoning_parser_set(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    assert pp.unified_parser is not None
+    # Sanity: orchestrator holds the same sub-parser instances the
+    # post-processor already built, not freshly-rebuilt ones.
+    assert pp.unified_parser._reasoning_parser is pp.reasoning_parser
+    assert pp.unified_parser._tool_parser is pp.tool_parser
+
+
+# ----------------------- streaming behavior parity -----------------------
+
+
+def _stream_chunks(pp, chunks):
+    """Feed a list of text chunks through ``process_chunk`` and return the
+    aggregated event list (with the final chunk marked finished)."""
+    events: list = []
+    last = len(chunks) - 1
+    for i, c in enumerate(chunks):
+        out = _make_output(c, finished=(i == last))
+        events.extend(pp.process_chunk(out))
+    return events
+
+
+def _event_types(events):
+    return [(e.type, e.content, e.reasoning) for e in events]
+
+
+def test_qwen3_think_then_content_unified_path(monkeypatch):
+    """Classic Qwen3 stream: think block then answer. Boundary must
+    transition cleanly from reasoning → content with no leak in either
+    direction."""
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(reasoning_parser_name="qwen3")
+    pp = StreamingPostProcessor(cfg, tools_requested=False)
+    pp.reset()
+
+    events = _stream_chunks(
+        pp,
+        ["<think>", "Working on it.", "</think>", "Answer is 42."],
+    )
+
+    # We expect at least one reasoning event from "Working on it." and
+    # one content event for "Answer is 42." — interleaved with a finish.
+    has_reasoning = any(e.type == "reasoning" and e.reasoning for e in events)
+    has_content = any(
+        (e.type in ("content", "finish"))
+        and (
+            e.content == "Answer is 42." or (e.content or "").endswith("Answer is 42.")
+        )
+        for e in events
+    )
+    assert has_reasoning, f"expected a reasoning event, got: {_event_types(events)}"
+    assert has_content, f"expected the answer in content, got: {_event_types(events)}"
+
+
+def test_qwen3_plus_hermes_emits_tool_call_through_unified_path(monkeypatch):
+    """Composed stream: ``<think>...</think>`` then a Hermes
+    ``<tool_call>{...}</tool_call>`` block. The orchestrator hands off
+    to the hermes parser when reasoning ends; the tool_call delta must
+    appear as a ``tool_call`` StreamEvent (not as content)."""
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    tool_call_payload = json.dumps(
+        {"name": "get_weather", "arguments": {"city": "Paris"}}
+    )
+    events = _stream_chunks(
+        pp,
+        [
+            "<think>",
+            "plan",
+            "</think>",
+            "<tool_call>",
+            tool_call_payload,
+            "</tool_call>",
+        ],
+    )
+
+    # A tool_call event must appear somewhere in the stream.
+    tool_events = [e for e in events if e.type == "tool_call" and e.tool_calls]
+    assert tool_events, f"expected tool_call event, got: {_event_types(events)}"
+
+
+# ----------------------- channel-routed bypass -----------------------
+
+
+def test_channel_routed_bypasses_unified_path(monkeypatch):
+    """Even with the env flag set, OutputRouter outputs (Gemma 4,
+    harmony) must still go through ``_process_channel_routed`` — the
+    orchestrator is text-level and would lose the token-level channel
+    metadata the engine already attached."""
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(reasoning_parser_name="qwen3")
+    pp = StreamingPostProcessor(cfg, tools_requested=False)
+    pp.reset()
+
+    out = _make_output("answer", channel="content")
+    events = pp.process_chunk(out)
+
+    # The route picked ``_process_channel_routed`` because output.channel
+    # was set. Verify a content event surfaced.
+    assert any(e.type == "content" and e.content == "answer" for e in events), (
+        f"expected content event from channel-routed path, got: {_event_types(events)}"
+    )
+
+
+# ----------------------- reset clears orchestrator state -----------------------
+
+
+def test_reset_clears_stream_state_between_requests(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(reasoning_parser_name="qwen3")
+    pp = StreamingPostProcessor(cfg, tools_requested=False)
+
+    pp.reset()
+    pp.process_chunk(_make_output("<think>old"))
+    pp.process_chunk(_make_output("</think>"))
+    assert pp.unified_parser._stream_state.reasoning_ended is True
+
+    pp.reset()
+    assert pp.unified_parser._stream_state.reasoning_ended is False
+    assert pp.unified_parser._stream_state.previous_text == ""
+
+
+# ----------------------- safety: legacy path still callable -----------------------
+
+
+def test_legacy_path_still_used_with_flag_off(monkeypatch):
+    monkeypatch.delenv("RAPID_MLX_UNIFIED_PARSER", raising=False)
+    cfg = _make_cfg(reasoning_parser_name="qwen3")
+    pp = StreamingPostProcessor(cfg, tools_requested=False)
+    pp.reset()
+
+    # The legacy path must still produce events for the same stream.
+    events = _stream_chunks(
+        pp,
+        ["<think>", "thought", "</think>", "ok"],
+    )
+    assert events, "legacy path must still work with flag off"

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -234,6 +234,43 @@ def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
     )
 
 
+def test_unified_path_finalize_with_empty_tool_scope_does_not_fall_back(monkeypatch):
+    """Codex round-9 #1 regression. Stream ends with ALL output inside
+    the reasoning block (e.g. ``<think>...{"name":"x","arguments":{}}``
+    with no closing ``</think>`` and no post-boundary content).
+    ``tool_phase_text`` is the empty string. The legacy fallback would
+    treat ``""`` as falsey and use ``self.accumulated_text`` (the
+    full reasoning body), then run ``extract_tool_calls`` over it and
+    emit a bogus tool_call. The unified-scope flag must short-circuit
+    the ``or`` fallback so empty-on-purpose stays empty.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    # Stream is all reasoning, no post-boundary content. Note the
+    # absence of any ``</think>`` so reasoning_ended never flips —
+    # tool_phase_text is "".
+    fake_call = '{"name":"x","arguments":{}}'
+    _stream_chunks(pp, [f"<think>plan to call x: {fake_call}"])
+
+    assert pp.tool_accumulated_text == "", (
+        f"expected empty tool scope, got {pp.tool_accumulated_text!r}"
+    )
+
+    final_events = pp.finalize()
+    tool_events = [e for e in final_events if e.type == "tool_call"]
+    assert not tool_events, (
+        f"finalize fell back to accumulated_text and parsed reasoning: "
+        f"{[(e.type, e.tool_calls) for e in tool_events]}"
+    )
+
+
 def test_unified_path_finalize_does_not_parse_reasoning_as_tool(monkeypatch):
     """Codex round-7 regression. The model can mention a bare JSON
     tool-call shape inside its ``<think>`` block:

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -176,6 +176,87 @@ def test_qwen3_plus_hermes_emits_tool_call_through_unified_path(monkeypatch):
     tool_events = [e for e in events if e.type == "tool_call" and e.tool_calls]
     assert tool_events, f"expected tool_call event, got: {_event_types(events)}"
 
+    # Codex round-1 regression: no content event may carry the raw
+    # ``<tool_call>`` / closing-tag markup. The orchestrator must
+    # suppress those chunks while the tool parser is buffering.
+    leaked = [
+        e
+        for e in events
+        if e.type == "content"
+        and e.content
+        and ("<tool_call" in e.content or "</tool_call>" in e.content)
+    ]
+    assert not leaked, (
+        f"tool-call markup leaked as content: {[(e.type, e.content) for e in leaked]}"
+    )
+
+    # Codex round-1 regression: tool_calls_detected must be set on the
+    # post-processor so finalize() doesn't re-parse accumulated_text and
+    # duplicate the call (or stamp the finish event as 'stop').
+    assert pp.tool_calls_detected, (
+        "expected tool_calls_detected=True after unified path emitted tool_calls"
+    )
+
+
+def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
+    """Codex round-1 regression: while the tool parser buffers an
+    incomplete ``<tool_call>{...`` body it returns ``None``. The
+    orchestrator must NOT fabricate a content chunk from that delta —
+    doing so leaks the raw markup to the SSE stream before the
+    structured ``tool_calls`` delta arrives."""
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    # Stream up to the OPENING ``<tool_call>`` marker only — no closing
+    # tag yet, so the hermes parser will buffer (return None each time).
+    out = _make_output("<think>")
+    pp.process_chunk(out)
+    out = _make_output("</think>")
+    pp.process_chunk(out)
+    partial_events = pp.process_chunk(_make_output("<tool_call>"))
+    partial_events += pp.process_chunk(_make_output('{"name": "x"'))
+
+    # Zero content events should carry the raw markup.
+    leaked = [
+        e
+        for e in partial_events
+        if e.type == "content" and e.content and "<tool_call" in e.content
+    ]
+    assert not leaked, (
+        f"<tool_call> markup leaked as content while buffering: "
+        f"{[(e.type, e.content) for e in leaked]}"
+    )
+
+
+def test_minimax_unified_path_transitions_to_tool_phase(monkeypatch):
+    """Codex round-1 regression: MiniMax doesn't carry a
+    ``reasoning_ended`` attribute, so the default
+    ``is_reasoning_end_streaming`` (which reads that attr) would keep
+    the orchestrator stuck in the reasoning phase forever. MiniMax now
+    overrides the method to read ``_decided and not _is_reasoning``."""
+    from vllm_mlx.reasoning.minimax_parser import MiniMaxReasoningParser
+
+    p = MiniMaxReasoningParser()
+    # Initial state: not decided yet.
+    assert p.is_reasoning_end_streaming("", "") is False
+
+    # Force into the "decided to content" state — the unified
+    # orchestrator should now consider reasoning ended.
+    p._decided = True
+    p._is_reasoning = False
+    assert p.is_reasoning_end_streaming("", "any content") is True
+
+    # Force into the "decided to reasoning" state — still in the
+    # reasoning phase.
+    p._is_reasoning = True
+    assert p.is_reasoning_end_streaming("", "still thinking") is False
+
 
 # ----------------------- channel-routed bypass -----------------------
 

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -234,6 +234,84 @@ def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
     )
 
 
+def test_unified_path_suppresses_lone_think_tag_without_tools(monkeypatch):
+    """Codex round-2 regression: when a reasoning parser is wired but
+    no tool parser exists, the reasoning parser intentionally returns
+    ``None`` for standalone special tokens (e.g. ``<think>``,
+    ``</think>``). The orchestrator must NOT fabricate a content delta
+    from those — that would leak the marker to the SSE stream.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(reasoning_parser_name="qwen3")
+    pp = StreamingPostProcessor(cfg, tools_requested=False)
+    pp.reset()
+
+    events: list = []
+    for chunk in ["<think>", "</think>"]:
+        events.extend(pp.process_chunk(_make_output(chunk)))
+
+    leaked = [
+        e
+        for e in events
+        if e.type == "content" and e.content and ("<think" in e.content)
+    ]
+    assert not leaked, (
+        f"<think>/</think> markers leaked as content with no tool parser: "
+        f"{[(e.type, e.content) for e in leaked]}"
+    )
+
+
+def test_unified_path_coalesced_boundary_preserves_reasoning_with_tool_call(
+    monkeypatch,
+):
+    """Codex round-2 regression: when a single chunk closes reasoning
+    AND completes a tool call (e.g. ``final thought</think><tool_call>
+    {...}</tool_call>``), the unified path must surface the trailing
+    reasoning text before / alongside the tool_call event. Previously
+    it dropped reasoning and content because the early return on
+    ``delta_msg.tool_calls`` skipped the reasoning emit.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    payload = json.dumps({"name": "x", "arguments": {}})
+    # Coalesced boundary: reasoning body, </think> closes reasoning,
+    # tool_call opens + closes — all in one chunk sequence.
+    events = _stream_chunks(
+        pp,
+        [
+            "<think>",
+            "final thought",
+            f"</think><tool_call>{payload}</tool_call>",
+        ],
+    )
+
+    reasoning_events = [
+        e for e in events if e.type == "reasoning" and (e.reasoning or "")
+    ]
+    tool_events = [e for e in events if e.type == "tool_call" and e.tool_calls]
+
+    # Both the reasoning body and the tool call must materialize.
+    assert reasoning_events, (
+        f"reasoning text was dropped on coalesced boundary chunk: "
+        f"{_event_types(events)}"
+    )
+    assert tool_events, (
+        f"tool_call event missing on coalesced boundary chunk: {_event_types(events)}"
+    )
+
+    # accumulated_reasoning must include the pre-boundary thinking text.
+    assert "final thought" in pp.accumulated_reasoning, (
+        f"accumulated_reasoning lost pre-boundary text: {pp.accumulated_reasoning!r}"
+    )
+
+
 def test_minimax_unified_path_transitions_to_tool_phase(monkeypatch):
     """Codex round-1 regression: MiniMax doesn't carry a
     ``reasoning_ended`` attribute, so the default

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -234,6 +234,58 @@ def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
     )
 
 
+def test_unified_path_does_not_leak_reasoning_into_tool_parser(monkeypatch):
+    """Codex round-5 regression (exact POC reproduction).
+
+    When the model thinks aloud about tool-call syntax inside its
+    reasoning block (e.g. ``<think>...the closing tag is
+    ``</tool_call>``...</think>``), the orchestrator must NOT feed
+    those mentions to the tool parser. Otherwise the tool parser's
+    open/close counter goes negative (sees ``</tool_call>`` before
+    any ``<tool_call>``) and the next real tool-call chunk gets
+    treated as pass-through content instead of buffered + emitted.
+
+    Symptom under the bug: legacy path emits a ``tool_call``
+    StreamEvent; unified path emits the raw ``<tool_call>{...}``
+    JSON as ``content``.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    payload = json.dumps({"name": "x", "arguments": {}})
+    events = _stream_chunks(
+        pp,
+        [
+            "<think>remember closing tag is </tool_call>",
+            "</think>",
+            f"<tool_call>{payload}</tool_call>",
+        ],
+    )
+
+    # The real tool call must surface as a structured tool_call event.
+    tool_events = [e for e in events if e.type == "tool_call" and e.tool_calls]
+    assert tool_events, (
+        f"tool_call dropped — reasoning mention of </tool_call> "
+        f"poisoned the tool parser's counter. events: {_event_types(events)}"
+    )
+
+    # And no content event may carry raw ``<tool_call>`` JSON.
+    leaked = [
+        e
+        for e in events
+        if e.type == "content" and e.content and "<tool_call" in e.content
+    ]
+    assert not leaked, (
+        f"tool-call JSON leaked as content: {[(e.type, e.content) for e in leaked]}"
+    )
+
+
 def test_unified_path_suppresses_lone_think_tag_without_tools(monkeypatch):
     """Codex round-2 regression: when a reasoning parser is wired but
     no tool parser exists, the reasoning parser intentionally returns

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -234,6 +234,52 @@ def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
     )
 
 
+def test_unified_path_suppresses_tool_prefix_on_split_boundary_chunk(monkeypatch):
+    """Codex round-6 regression. Chunk split pattern:
+
+      chunk 1: ``<think>plan``     (reasoning body)
+      chunk 2: ``</think><tool_call>``  (boundary + opening tag)
+      chunk 3: ``{...}</tool_call>``   (tool-call body)
+
+    On chunk 2 the reasoning parser emits ``content=<tool_call>``
+    while the tool parser returns None (buffering until the closing
+    tag arrives in chunk 3). The orchestrator must NOT let the
+    reasoning parser's content side flow through — the raw
+    ``<tool_call>`` markup must stay suppressed.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    payload = json.dumps({"name": "x", "arguments": {}})
+    events = _stream_chunks(
+        pp,
+        [
+            "<think>plan",
+            "</think><tool_call>",
+            f"{payload}</tool_call>",
+        ],
+    )
+
+    leaked = [
+        e
+        for e in events
+        if e.type == "content" and e.content and "<tool_call" in e.content
+    ]
+    assert not leaked, (
+        f"tool-call prefix leaked on split boundary chunk: "
+        f"{[(e.type, e.content) for e in leaked]}"
+    )
+    # The real tool call still must surface.
+    tool_events = [e for e in events if e.type == "tool_call" and e.tool_calls]
+    assert tool_events, f"tool_call dropped: {_event_types(events)}"
+
+
 def test_unified_path_does_not_leak_reasoning_into_tool_parser(monkeypatch):
     """Codex round-5 regression (exact POC reproduction).
 

--- a/tests/test_postprocessor_unified_parser.py
+++ b/tests/test_postprocessor_unified_parser.py
@@ -234,6 +234,51 @@ def test_unified_path_suppresses_partial_tool_call_chunks(monkeypatch):
     )
 
 
+def test_unified_path_finalize_does_not_parse_reasoning_as_tool(monkeypatch):
+    """Codex round-7 regression. The model can mention a bare JSON
+    tool-call shape inside its ``<think>`` block:
+
+      <think>I should call x with {"name":"x","arguments":{}}</think>
+      The answer is 42.
+
+    finalize() runs a fallback ``extract_tool_calls`` on the
+    accumulated text when no streaming tool call surfaced — that
+    fallback must be scoped to post-reasoning text only, otherwise
+    the reasoning mention would synthesize a bogus tool_call event
+    at end-of-stream.
+    """
+    monkeypatch.setenv("RAPID_MLX_UNIFIED_PARSER", "1")
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        tool_call_parser="hermes",
+        enable_auto_tool_choice=True,
+    )
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
+    pp.reset()
+
+    fake_call = '{"name":"x","arguments":{}}'
+    events = _stream_chunks(
+        pp,
+        [
+            f"<think>I should call x with {fake_call}",
+            "</think>",
+            "The answer is 42.",
+        ],
+    )
+    events.extend(pp.finalize())
+
+    tool_events = [e for e in events if e.type == "tool_call"]
+    assert not tool_events, (
+        f"finalize parsed bare JSON from reasoning as a bogus tool call: "
+        f"{[(e.type, e.tool_calls) for e in tool_events]}"
+    )
+    # tool_accumulated_text must NOT contain the reasoning prefix.
+    assert fake_call not in pp.tool_accumulated_text or (
+        "<think>" not in pp.tool_accumulated_text
+        and "I should call x" not in pp.tool_accumulated_text
+    ), f"tool_accumulated_text leaked reasoning prefix: {pp.tool_accumulated_text!r}"
+
+
 def test_unified_path_suppresses_tool_prefix_on_split_boundary_chunk(monkeypatch):
     """Codex round-6 regression. Chunk split pattern:
 

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -11,6 +11,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# MUST install the MLX hardware-compat shim BEFORE the `mlx_lm` import below.
+# Even though the import is inside a `try`, the body still runs at module
+# load time; on success it triggers `mlx_lm/__init__.py` → `mlx_lm.generate`
+# → `mx.new_thread_local_stream(...)` capture, which on M5 single-stream
+# GPUs would be unusable (#404). The shim is idempotent and a no-op on
+# hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 # Check for outlines availability
 try:
     import mlx_lm

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1088,6 +1088,17 @@ def bench_command(args):
     import asyncio
     import time
 
+    # Install the MLX hardware-compat shim BEFORE `from mlx_lm import load`.
+    # `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+    # `mx.new_thread_local_stream(mx.default_device())` at module-import time;
+    # on M5 single-stream GPUs that stream is unusable (#404). Bench is a
+    # separate entry point from `serve` so it doesn't inherit the
+    # scheduler-side install — wire the shim here directly. Idempotent, no-op
+    # on hardware where the original API works.
+    from . import _mlx_compat as _mlx_compat
+
+    _mlx_compat.install()
+
     from mlx_lm import load
 
     from .engine_core import AsyncEngineCore, EngineConfig

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -24,10 +24,20 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.sample_utils import make_sampler
 
-from .multimodal_processor import MultimodalProcessor
-from .vision_embedding_cache import VisionEmbeddingCache
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.sample_utils import make_sampler  # noqa: E402
+
+from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .vision_embedding_cache import VisionEmbeddingCache  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -28,16 +28,26 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import mlx.core as mx
-from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
-from .mllm_batch_generator import (
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer  # noqa: E402
+
+from .mllm_batch_generator import (  # noqa: E402
     MLLMBatchGenerator,
     MLLMBatchRequest,
     MLLMBatchResponse,
 )
-from .mllm_cache import MLLMCacheManager
-from .multimodal_processor import MultimodalProcessor
-from .request import RequestOutput, RequestStatus, SamplingParams
+from .mllm_cache import MLLMCacheManager  # noqa: E402
+from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .request import RequestOutput, RequestStatus, SamplingParams  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -9,11 +9,24 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from mlx.utils import tree_flatten
 
-from mlx_lm.models.base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache
-from mlx_lm.models.mla import MultiLinear
-from mlx_lm.models.pipeline import PipelineMixin
-from mlx_lm.models.switch_layers import SwitchGLU
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)  # noqa: E402
+from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache  # noqa: E402
+from mlx_lm.models.mla import MultiLinear  # noqa: E402
+from mlx_lm.models.pipeline import PipelineMixin  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
 
 @dataclass
@@ -1453,7 +1466,6 @@ class DeepseekV4Cache:
 
 
 class Compressor(nn.Module):
-
     def __init__(self, config: ModelArgs, compress_ratio: int, head_dim: int):
         super().__init__()
         self.compress_ratio = compress_ratio

--- a/vllm_mlx/parser/__init__.py
+++ b/vllm_mlx/parser/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unified Parser layer — orchestrates reasoning + tool parsing for one
+stream behind a single ``parse_delta`` entry point. Adapted from vLLM's
+``vllm.parser`` package (Apache-2.0) — see ``abstract_parser.py`` header
+for the adaptation notes.
+"""
+
+from vllm_mlx.parser.abstract_parser import (
+    DelegatingParser,
+    Parser,
+    StreamState,
+    _WrappedParser,
+)
+from vllm_mlx.parser.parser_manager import ParserManager
+
+__all__ = [
+    "DelegatingParser",
+    "Parser",
+    "ParserManager",
+    "StreamState",
+    "_WrappedParser",
+]

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -173,6 +173,12 @@ class DelegatingParser(Parser):
     def _in_tool_call_phase(self, state: StreamState) -> bool:
         if self._tool_parser is None:
             return False
+        if self._reasoning_parser is None:
+            # No reasoning to wait for — start in tool-call phase from
+            # chunk 0. Without this branch a tool-only parser would
+            # never be invoked (state.reasoning_ended starts False and
+            # nothing flips it), so every chunk would be suppressed.
+            return True
         return state.reasoning_ended
 
     def _extract_reasoning_streaming(
@@ -243,6 +249,10 @@ class DelegatingParser(Parser):
             )
             if self._is_reasoning_end_streaming(
                 previous_text=previous_text, current_text=current_text
+            ) or (
+                delta_message is not None
+                and delta_message.content
+                and not delta_message.reasoning
             ):
                 state.reasoning_ended = True
 
@@ -270,12 +280,24 @@ class DelegatingParser(Parser):
                 # Boundary chunk preservation — tool parser produced a
                 # delta (either tool_calls or pass-through content). Keep
                 # the reasoning side so callers don't lose pre-boundary
-                # reasoning; only overwrite content if the tool parser
-                # didn't already set it.
+                # reasoning.
                 if reasoning_to_preserve:
                     delta_message.reasoning = reasoning_to_preserve
-                if content_to_preserve and not delta_message.content:
-                    delta_message.content = content_to_preserve
+                if content_to_preserve:
+                    if delta_message.tool_calls is None:
+                        # Tool parser is just passing the raw delta
+                        # through (no tool call detected). The reasoning
+                        # parser is authoritative for the boundary's
+                        # content/reasoning split — it has already
+                        # stripped ``</think>``, while the tool parser
+                        # got the unprocessed delta_text. Prefer the
+                        # reasoning parser's stripped content.
+                        delta_message.content = content_to_preserve
+                    elif not delta_message.content:
+                        # Tool call emitted alongside boundary content
+                        # the tool parser didn't touch — attach it so
+                        # both sides surface.
+                        delta_message.content = content_to_preserve
             else:
                 # Tool parser returned None → intentionally buffering an
                 # incomplete tool-call body. Suppress the tool-call

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -338,9 +338,21 @@ class DelegatingParser(Parser):
                 # (``<tool_call>`` etc) — emitting it would leak the raw
                 # markup to the client. Only ``reasoning_to_preserve``
                 # is safe to surface.
-                if reasoning_to_preserve:
-                    delta_message = DeltaMessage(reasoning=reasoning_to_preserve)
-                # else: leave delta_message = None to suppress this chunk
+                #
+                # CRITICAL: explicitly rebuild ``delta_message`` (or
+                # clear to None). The reasoning parser may have set
+                # ``delta_message`` above with ``content=<tool_call>``
+                # — without the explicit reset that raw markup would
+                # flow through as a content delta (codex R6). For
+                # split chunks like ``</think>`` arriving in one chunk
+                # then ``<tool_call>...`` in the next, the reasoning
+                # parser's content side is the tool-call prefix and
+                # MUST be suppressed.
+                delta_message = (
+                    DeltaMessage(reasoning=reasoning_to_preserve)
+                    if reasoning_to_preserve
+                    else None
+                )
 
         # Final fallback — pass the raw delta through as content in
         # exactly two cases:

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -35,7 +35,6 @@ class StreamState:
     """Mutable per-stream state for ``Parser.parse_delta``."""
 
     reasoning_ended: bool = False
-    tool_call_text_started: bool = False
     previous_text: str = ""
     # ``tool_phase_text`` accumulates only the post-reasoning portion of
     # the stream — what the tool parser is allowed to see. Without this

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -283,21 +283,21 @@ class DelegatingParser(Parser):
                 # reasoning.
                 if reasoning_to_preserve:
                     delta_message.reasoning = reasoning_to_preserve
-                if content_to_preserve:
-                    if delta_message.tool_calls is None:
-                        # Tool parser is just passing the raw delta
-                        # through (no tool call detected). The reasoning
-                        # parser is authoritative for the boundary's
-                        # content/reasoning split — it has already
-                        # stripped ``</think>``, while the tool parser
-                        # got the unprocessed delta_text. Prefer the
-                        # reasoning parser's stripped content.
-                        delta_message.content = content_to_preserve
-                    elif not delta_message.content:
-                        # Tool call emitted alongside boundary content
-                        # the tool parser didn't touch — attach it so
-                        # both sides surface.
-                        delta_message.content = content_to_preserve
+                if content_to_preserve and delta_message.tool_calls is None:
+                    # Tool parser is just passing the raw delta through
+                    # (no tool call detected). The reasoning parser is
+                    # authoritative for the boundary's content/reasoning
+                    # split — it has already stripped ``</think>`` while
+                    # the tool parser got the unprocessed delta_text.
+                    # Prefer the reasoning parser's stripped content.
+                    delta_message.content = content_to_preserve
+                # Note: when the tool parser emitted a structured
+                # ``tool_calls`` payload we deliberately discard
+                # ``content_to_preserve`` — on the boundary chunk that
+                # value IS the raw ``<tool_call>{...}</tool_call>``
+                # markup the tool parser just consumed. Attaching it
+                # would leak the tool-call JSON as a content delta
+                # alongside the structured emission.
             else:
                 # Tool parser returned None → intentionally buffering an
                 # incomplete tool-call body. Suppress the tool-call

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -376,12 +376,10 @@ class DelegatingParser(Parser):
         if delta_message is None:
             if not self._has_any_parser():
                 delta_message = DeltaMessage(content=delta_text)
-            elif (
-                not reasoning_parser_consulted
-                and not self._in_tool_call_phase(state)
-                and not self._has_tool_parser()
-            ):
+            elif not reasoning_parser_consulted and not self._has_tool_parser():
                 # Post-reasoning passthrough with no tool parser wired.
+                # ``not _has_tool_parser`` implies ``not _in_tool_call_phase``
+                # already — the explicit phase check was redundant.
                 delta_message = DeltaMessage(content=delta_text)
 
         state.previous_text = current_text

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -37,6 +37,16 @@ class StreamState:
     reasoning_ended: bool = False
     tool_call_text_started: bool = False
     previous_text: str = ""
+    # ``tool_phase_text`` accumulates only the post-reasoning portion of
+    # the stream — what the tool parser is allowed to see. Without this
+    # the tool parser receives the full ``previous_text`` (including the
+    # reasoning body), and any ``<tool_call>`` / ``</tool_call>``
+    # mentions hidden inside reasoning (e.g. a model thinking aloud
+    # about the syntax it's about to emit) skew the parser's
+    # open/close counting and drop the first real tool call. See codex
+    # R5 (PR #488). Reset alongside ``previous_text`` on every
+    # ``reset_state``.
+    tool_phase_text: str = ""
     history_tool_call_cnt: int = 0
 
 
@@ -268,10 +278,31 @@ class DelegatingParser(Parser):
                 reasoning_to_preserve = delta_message.reasoning
                 content_to_preserve = delta_message.content
 
+            # The tool parser must only see the post-reasoning portion
+            # of the stream — feeding it the full text would let
+            # ``<tool_call>`` / ``</tool_call>`` mentions hidden inside
+            # reasoning skew its open/close counting and drop the first
+            # real tool call (codex R5).
+            #
+            # - Boundary chunk (reasoning parser was consulted AND
+            #   emitted content_to_preserve): seed tool_phase_text from
+            #   the reasoning parser's stripped post-``</think>`` body.
+            # - Past-boundary chunks (reasoning parser not consulted):
+            #   append the full delta to tool_phase_text.
+            # - Tool-only mode (no reasoning parser ever consulted):
+            #   tool_phase_text accumulates from chunk 0.
+            if reasoning_parser_consulted:
+                tool_delta_text = content_to_preserve or ""
+            else:
+                tool_delta_text = delta_text
+            tool_previous_text = state.tool_phase_text
+            tool_current_text = tool_previous_text + tool_delta_text
+            state.tool_phase_text = tool_current_text
+
             tool_delta = self._extract_tool_calls_streaming(
-                previous_text=previous_text,
-                current_text=current_text,
-                delta_text=delta_text,
+                previous_text=tool_previous_text,
+                current_text=tool_current_text,
+                delta_text=tool_delta_text,
                 request=request,
             )
 

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -231,9 +231,11 @@ class DelegatingParser(Parser):
         previous_text = state.previous_text
         current_text = previous_text + delta_text
         delta_message: DeltaMessage | None = None
+        reasoning_parser_consulted = False
 
         # ---- Reasoning phase ----
         if self._in_reasoning_phase(state):
+            reasoning_parser_consulted = True
             delta_message = self._extract_reasoning_streaming(
                 previous_text=previous_text,
                 current_text=current_text,
@@ -265,38 +267,49 @@ class DelegatingParser(Parser):
 
             if tool_delta is not None:
                 delta_message = tool_delta
-            elif delta_message is None and not self._has_tool_parser():
-                # No tool parser involved — pass the raw delta through as
-                # content so the route still advances the SSE stream.
-                delta_message = DeltaMessage(content=delta_text)
-            # else: tool parser intentionally returned None to buffer a
-            # partial tool-call (the closing tag hasn't arrived yet).
-            # Suppress this delta entirely — emitting the raw
-            # ``<tool_call>...`` markup as content would leak it to the
-            # client before the structured ``tool_calls`` delta lands.
-            # The route's stream loop already handles ``None`` gracefully.
-
-            if delta_message is not None:
+                # Boundary chunk preservation — tool parser produced a
+                # delta (either tool_calls or pass-through content). Keep
+                # the reasoning side so callers don't lose pre-boundary
+                # reasoning; only overwrite content if the tool parser
+                # didn't already set it.
                 if reasoning_to_preserve:
                     delta_message.reasoning = reasoning_to_preserve
                 if content_to_preserve and not delta_message.content:
-                    # Preserve any pre-boundary content the reasoning
-                    # parser already extracted (the post-</think>
-                    # remainder).
                     delta_message.content = content_to_preserve
-            elif reasoning_to_preserve or content_to_preserve:
-                # Tool parser is buffering, but the boundary chunk carried
-                # reasoning / content that must still surface. Emit them
-                # without touching the suppressed tool-call body.
-                delta_message = DeltaMessage(
-                    reasoning=reasoning_to_preserve,
-                    content=content_to_preserve,
-                )
+            else:
+                # Tool parser returned None → intentionally buffering an
+                # incomplete tool-call body. Suppress the tool-call
+                # markup entirely. ``content_to_preserve`` here is the
+                # post-``</think>`` text the reasoning parser handed us,
+                # which on the boundary chunk IS the tool-call prefix
+                # (``<tool_call>`` etc) — emitting it would leak the raw
+                # markup to the client. Only ``reasoning_to_preserve``
+                # is safe to surface.
+                if reasoning_to_preserve:
+                    delta_message = DeltaMessage(reasoning=reasoning_to_preserve)
+                # else: leave delta_message = None to suppress this chunk
 
-        # Neither phase active (no reasoning parser, no tool parser) →
-        # pass through the raw delta as content.
-        if delta_message is None and not self._has_tool_parser():
-            delta_message = DeltaMessage(content=delta_text)
+        # Final fallback — pass the raw delta through as content in
+        # exactly two cases:
+        #   (a) no parser is wired at all
+        #   (b) reasoning has already ended AND no tool parser is wired
+        #       (post-reasoning plain-text passthrough — the reasoning
+        #       parser handed off and the tool parser isn't there to
+        #       interpret the rest)
+        # The case we DO NOT cover: reasoning parser was consulted and
+        # returned ``None`` deliberately (e.g. standalone ``<think>``
+        # special token suppression). Fabricating content there would
+        # leak the marker to the SSE stream.
+        if delta_message is None:
+            if not self._has_any_parser():
+                delta_message = DeltaMessage(content=delta_text)
+            elif (
+                not reasoning_parser_consulted
+                and not self._in_tool_call_phase(state)
+                and not self._has_tool_parser()
+            ):
+                # Post-reasoning passthrough with no tool parser wired.
+                delta_message = DeltaMessage(content=delta_text)
 
         state.previous_text = current_text
         return delta_message
@@ -304,6 +317,10 @@ class DelegatingParser(Parser):
     def _has_tool_parser(self) -> bool:
         """Return True when a tool parser is wired and can buffer chunks."""
         return self._tool_parser is not None
+
+    def _has_any_parser(self) -> bool:
+        """Return True when at least one of reasoning / tool parsers is wired."""
+        return self._reasoning_parser is not None or self._tool_parser is not None
 
 
 class _WrappedParser(DelegatingParser):

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -265,26 +265,45 @@ class DelegatingParser(Parser):
 
             if tool_delta is not None:
                 delta_message = tool_delta
-            elif delta_message is None:
-                # Tool parser suppressed and we have nothing else — pass
-                # the raw delta through as content so the route can still
-                # advance the SSE stream.
+            elif delta_message is None and not self._has_tool_parser():
+                # No tool parser involved — pass the raw delta through as
+                # content so the route still advances the SSE stream.
                 delta_message = DeltaMessage(content=delta_text)
+            # else: tool parser intentionally returned None to buffer a
+            # partial tool-call (the closing tag hasn't arrived yet).
+            # Suppress this delta entirely — emitting the raw
+            # ``<tool_call>...`` markup as content would leak it to the
+            # client before the structured ``tool_calls`` delta lands.
+            # The route's stream loop already handles ``None`` gracefully.
 
-            if reasoning_to_preserve:
-                delta_message.reasoning = reasoning_to_preserve
-            if content_to_preserve and not delta_message.content:
-                # Preserve any pre-boundary content the reasoning parser
-                # already extracted (the post-</think> remainder).
-                delta_message.content = content_to_preserve
+            if delta_message is not None:
+                if reasoning_to_preserve:
+                    delta_message.reasoning = reasoning_to_preserve
+                if content_to_preserve and not delta_message.content:
+                    # Preserve any pre-boundary content the reasoning
+                    # parser already extracted (the post-</think>
+                    # remainder).
+                    delta_message.content = content_to_preserve
+            elif reasoning_to_preserve or content_to_preserve:
+                # Tool parser is buffering, but the boundary chunk carried
+                # reasoning / content that must still surface. Emit them
+                # without touching the suppressed tool-call body.
+                delta_message = DeltaMessage(
+                    reasoning=reasoning_to_preserve,
+                    content=content_to_preserve,
+                )
 
         # Neither phase active (no reasoning parser, no tool parser) →
         # pass through the raw delta as content.
-        if delta_message is None:
+        if delta_message is None and not self._has_tool_parser():
             delta_message = DeltaMessage(content=delta_text)
 
         state.previous_text = current_text
         return delta_message
+
+    def _has_tool_parser(self) -> bool:
+        """Return True when a tool parser is wired and can buffer chunks."""
+        return self._tool_parser is not None
 
 
 class _WrappedParser(DelegatingParser):

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -259,11 +259,19 @@ class DelegatingParser(Parser):
             )
             if self._is_reasoning_end_streaming(
                 previous_text=previous_text, current_text=current_text
-            ) or (
-                delta_message is not None
-                and delta_message.content
-                and not delta_message.reasoning
-            ):
+            ) or (delta_message is not None and delta_message.content):
+                # Content surfaced from the reasoning parser →
+                # we're past the boundary on this chunk. Covers:
+                #   (a) GLM-4 no-tag / DeepSeek-R1 threshold:
+                #       content-only delta with no end-token (R3).
+                #   (b) Mixed boundary delta (Gemma 4-style): parser
+                #       returns both reasoning AND content in one
+                #       chunk. Must still flip — the boundary content
+                #       may itself be a ``<tool_call>...`` payload
+                #       that needs to go through the tool parser
+                #       this same chunk (R8). Old code's
+                #       ``and not delta_message.reasoning`` clause
+                #       blocked this case.
                 state.reasoning_ended = True
 
         # ---- Tool call phase ----

--- a/vllm_mlx/parser/abstract_parser.py
+++ b/vllm_mlx/parser/abstract_parser.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vLLM's vllm/parser/abstract_parser.py (Apache-2.0). The
+# original ships an OpenAI Responses-API surface and CUDA-shaped tool
+# infrastructure that we don't use; we keep the unified ``Parser`` /
+# ``DelegatingParser`` / ``_WrappedParser`` abstraction and the
+# ``parse_delta`` state machine that resolves the reasoning↔tool-call
+# boundary in a single place — that's the piece worth borrowing. Routes
+# in this codebase carry text, not token IDs, so the boundary check is
+# text-based (``is_reasoning_end_streaming(previous_text, current_text)``)
+# rather than token-ID based.
+"""
+Unified ``Parser`` abstraction for streaming chat completions.
+
+Closes the bug class where stream and non-stream paths re-implement the
+"reasoning first, then tool calls, but watch the boundary" sequence and
+silently diverge. ``DelegatingParser.parse_delta`` is the single seam.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from transformers import PreTrainedTokenizerBase
+
+from vllm_mlx.reasoning.base import DeltaMessage, ReasoningParser
+from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+
+@dataclass
+class StreamState:
+    """Mutable per-stream state for ``Parser.parse_delta``."""
+
+    reasoning_ended: bool = False
+    tool_call_text_started: bool = False
+    previous_text: str = ""
+    history_tool_call_cnt: int = 0
+
+
+def _delta_from_tool_parser_result(
+    result: dict[str, Any] | DeltaMessage | None,
+) -> DeltaMessage | None:
+    """Adapt a tool parser's streaming return to ``DeltaMessage``.
+
+    Existing rapid-mlx tool parsers return ``dict | None`` with OpenAI
+    ChoiceDelta-shaped keys (``content``, ``tool_calls``). Wrap that into
+    the same ``DeltaMessage`` the orchestrator emits everywhere else, so
+    callers downstream only ever see one type.
+    """
+    if result is None or isinstance(result, DeltaMessage):
+        return result
+    return DeltaMessage(
+        content=result.get("content"),
+        tool_calls=result.get("tool_calls"),
+    )
+
+
+class Parser(ABC):
+    """
+    Abstract Parser unifying ``ReasoningParser`` and ``ToolParser`` behind
+    a single ``parse_delta`` entry point.
+
+    Concrete subclasses either:
+
+    1. Override ``parse_delta`` directly with model-specific logic
+       (channel-routed models like Harmony, Gemma 4 — see Phase 2).
+    2. Set ``self._reasoning_parser`` and ``self._tool_parser`` in
+       ``__init__`` and inherit ``DelegatingParser``'s orchestration.
+
+    ``reasoning_parser_cls`` / ``tool_parser_cls`` mirror vLLM's pattern
+    for code that needs the class (not the instance) — e.g.
+    ``ParserManager.get_parser`` composing a ``_WrappedParser``.
+    """
+
+    reasoning_parser_cls: type[ReasoningParser] | None = None
+    tool_parser_cls: type[ToolParser] | None = None
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase | None = None) -> None:
+        self.model_tokenizer = tokenizer
+        self._reasoning_parser: ReasoningParser | None = None
+        self._tool_parser: ToolParser | None = None
+        self._stream_state = StreamState()
+
+    @property
+    def reasoning_parser(self) -> ReasoningParser | None:
+        return self._reasoning_parser
+
+    @reasoning_parser.setter
+    def reasoning_parser(self, parser: ReasoningParser | None) -> None:
+        self._reasoning_parser = parser
+
+    @property
+    def tool_parser(self) -> ToolParser | None:
+        return self._tool_parser
+
+    @tool_parser.setter
+    def tool_parser(self, parser: ToolParser | None) -> None:
+        self._tool_parser = parser
+
+    def reset_state(self) -> None:
+        """Reset stream state for a new request."""
+        self._stream_state = StreamState()
+        if self._reasoning_parser is not None:
+            self._reasoning_parser.reset_state()
+        if self._tool_parser is not None and hasattr(self._tool_parser, "reset"):
+            self._tool_parser.reset()
+
+    @abstractmethod
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
+        """Extract ``(reasoning, content)`` from a complete model output."""
+
+    @abstractmethod
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> Any:
+        """Extract tool calls from a complete model output.
+
+        Returns ``ExtractedToolCallInformation`` (see
+        ``vllm_mlx.tool_parsers.abstract_tool_parser``).
+        """
+
+    @abstractmethod
+    def parse_delta(
+        self,
+        delta_text: str,
+        request: dict[str, Any] | None = None,
+    ) -> DeltaMessage | None:
+        """Parse a single streaming delta, advancing internal stream state.
+
+        The orchestration runs reasoning extraction first, then tool-call
+        extraction on the same delta, merging boundary chunks where a
+        single token flush spans both phases. Returns the merged
+        ``DeltaMessage`` (or ``None`` if the delta should be suppressed).
+        """
+
+
+class DelegatingParser(Parser):
+    """
+    The default ``Parser`` composite: holds an optional reasoning parser
+    and an optional tool parser and runs the orchestration state machine.
+
+    Subclasses should populate ``self._reasoning_parser`` and
+    ``self._tool_parser`` in ``__init__``. Either may be ``None`` —
+    methods short-circuit.
+    """
+
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
+        if self._reasoning_parser is None:
+            return None, model_output
+        return self._reasoning_parser.extract_reasoning(model_output)
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> Any:
+        from vllm_mlx.tool_parsers.abstract_tool_parser import (
+            ExtractedToolCallInformation,
+        )
+
+        if self._tool_parser is None:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+        return self._tool_parser.extract_tool_calls(model_output, request)
+
+    def _in_reasoning_phase(self, state: StreamState) -> bool:
+        if self._reasoning_parser is None:
+            return False
+        return not state.reasoning_ended
+
+    def _in_tool_call_phase(self, state: StreamState) -> bool:
+        if self._tool_parser is None:
+            return False
+        return state.reasoning_ended
+
+    def _extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        if self._reasoning_parser is None:
+            return DeltaMessage(content=delta_text)
+        return self._reasoning_parser.extract_reasoning_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+        )
+
+    def _is_reasoning_end_streaming(
+        self, previous_text: str, current_text: str
+    ) -> bool:
+        if self._reasoning_parser is None:
+            return True  # no reasoning parser → always in "content" phase
+        return self._reasoning_parser.is_reasoning_end_streaming(
+            previous_text=previous_text, current_text=current_text
+        )
+
+    def _extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        request: dict[str, Any] | None,
+    ) -> DeltaMessage | None:
+        if self._tool_parser is None:
+            return None
+        # Phase 1 scope: only the default ``tool_choice="auto"`` path is
+        # wired here. Named / "required" tool_choice streaming (vLLM PR
+        # #41876) is a Phase 2 follow-up — until then the route layer
+        # continues to enforce those modes upstream.
+        raw = self._tool_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=None,
+            current_token_ids=None,
+            delta_token_ids=None,
+            request=request,
+        )
+        return _delta_from_tool_parser_result(raw)
+
+    def parse_delta(
+        self,
+        delta_text: str,
+        request: dict[str, Any] | None = None,
+    ) -> DeltaMessage | None:
+        state = self._stream_state
+        previous_text = state.previous_text
+        current_text = previous_text + delta_text
+        delta_message: DeltaMessage | None = None
+
+        # ---- Reasoning phase ----
+        if self._in_reasoning_phase(state):
+            delta_message = self._extract_reasoning_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+            )
+            if self._is_reasoning_end_streaming(
+                previous_text=previous_text, current_text=current_text
+            ):
+                state.reasoning_ended = True
+
+        # ---- Tool call phase ----
+        if self._in_tool_call_phase(state):
+            # Boundary delta carries reasoning AND a tool-call prefix in
+            # the same chunk; preserve the reasoning side before the tool
+            # parser overwrites delta_message. This is the literal fix
+            # for vLLM PR #42691 / rapid-mlx PR #436's bug class.
+            reasoning_to_preserve: str | None = None
+            content_to_preserve: str | None = None
+            if delta_message is not None:
+                reasoning_to_preserve = delta_message.reasoning
+                content_to_preserve = delta_message.content
+
+            tool_delta = self._extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+                request=request,
+            )
+
+            if tool_delta is not None:
+                delta_message = tool_delta
+            elif delta_message is None:
+                # Tool parser suppressed and we have nothing else — pass
+                # the raw delta through as content so the route can still
+                # advance the SSE stream.
+                delta_message = DeltaMessage(content=delta_text)
+
+            if reasoning_to_preserve:
+                delta_message.reasoning = reasoning_to_preserve
+            if content_to_preserve and not delta_message.content:
+                # Preserve any pre-boundary content the reasoning parser
+                # already extracted (the post-</think> remainder).
+                delta_message.content = content_to_preserve
+
+        # Neither phase active (no reasoning parser, no tool parser) →
+        # pass through the raw delta as content.
+        if delta_message is None:
+            delta_message = DeltaMessage(content=delta_text)
+
+        state.previous_text = current_text
+        return delta_message
+
+
+class _WrappedParser(DelegatingParser):
+    """
+    ``DelegatingParser`` that instantiates its ReasoningParser / ToolParser
+    from class attributes — the shape ``ParserManager.get_parser`` builds
+    when no model-specific unified ``Parser`` is registered.
+
+    The manager sets ``_WrappedParser.reasoning_parser_cls`` and
+    ``_WrappedParser.tool_parser_cls`` before instantiation; ``__init__``
+    materializes the underlying parsers.
+    """
+
+    reasoning_parser_cls: type[ReasoningParser] | None = None
+    tool_parser_cls: type[ToolParser] | None = None
+
+    def __init__(
+        self, tokenizer: PreTrainedTokenizerBase | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(tokenizer)
+        if self.__class__.reasoning_parser_cls is not None:
+            self._reasoning_parser = self.__class__.reasoning_parser_cls(tokenizer)
+        if self.__class__.tool_parser_cls is not None:
+            self._tool_parser = self.__class__.tool_parser_cls(tokenizer)
+
+
+__all__ = [
+    "DelegatingParser",
+    "Parser",
+    "StreamState",
+    "_WrappedParser",
+]

--- a/vllm_mlx/parser/parser_manager.py
+++ b/vllm_mlx/parser/parser_manager.py
@@ -185,15 +185,29 @@ class ParserManager:
                 except KeyError:
                     pass
 
-        # Strategy 3: compose a _WrappedParser from the individual classes
+        # Strategy 3: compose a _WrappedParser subclass from the
+        # individual classes. A fresh subclass per resolve avoids the
+        # class-attribute-mutation race: if two callers resolved
+        # different (reasoning, tool) pairs before either instantiated
+        # their result, mutating ``_WrappedParser`` itself would make
+        # both pick up whichever pair was assigned last.
         reasoning_cls = cls.get_reasoning_parser(reasoning_parser_name)
         tool_cls = cls.get_tool_parser(tool_parser_name, enable_auto_tools)
         if reasoning_cls is None and tool_cls is None:
             return None
 
-        _WrappedParser.reasoning_parser_cls = reasoning_cls
-        _WrappedParser.tool_parser_cls = tool_cls
-        return _WrappedParser
+        subclass_name = (
+            f"_WrappedParser__"
+            f"{reasoning_parser_name or 'none'}__{tool_parser_name or 'none'}"
+        )
+        return type(
+            subclass_name,
+            (_WrappedParser,),
+            {
+                "reasoning_parser_cls": reasoning_cls,
+                "tool_parser_cls": tool_cls,
+            },
+        )
 
 
 __all__ = ["ParserManager"]

--- a/vllm_mlx/parser/parser_manager.py
+++ b/vllm_mlx/parser/parser_manager.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vLLM's vllm/parser/parser_manager.py (Apache-2.0). Trimmed
+# to drop the plugin-loader (``import_parser`` for arbitrary file paths)
+# and the Llama 3.2 pythonic warning that doesn't apply to MLX targets.
+"""
+Registry + resolver for unified ``Parser`` implementations.
+
+``ParserManager.get_parser(tool_parser_name, reasoning_parser_name, ...)``
+tries three strategies in order:
+
+1. A unified ``Parser`` registered under the same name as both the tool
+   and reasoning parser (channel-routed models like Harmony land here).
+2. A unified ``Parser`` registered under EITHER name.
+3. Fall back to ``_WrappedParser`` composing the two individual parser
+   classes.
+
+Most rapid-mlx aliases hit strategy 3 today; strategy 1/2 are the
+extension points for the Phase 2 channel-routed migration of
+``OutputRouter``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm_mlx.parser.abstract_parser import Parser
+    from vllm_mlx.reasoning.base import ReasoningParser
+    from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+logger = logging.getLogger(__name__)
+
+
+class ParserManager:
+    """Central registry for unified ``Parser`` implementations."""
+
+    parsers: dict[str, type[Parser]] = {}
+    lazy_parsers: dict[str, tuple[str, str]] = {}
+
+    @classmethod
+    def get_parser_internal(cls, name: str) -> type[Parser]:
+        if name in cls.parsers:
+            return cls.parsers[name]
+        if name in cls.lazy_parsers:
+            return cls._load_lazy_parser(name)
+        registered = ", ".join(cls.list_registered())
+        raise KeyError(f"Parser '{name}' not found. Available parsers: {registered}")
+
+    @classmethod
+    def _load_lazy_parser(cls, name: str) -> type[Parser]:
+        from vllm_mlx.parser.abstract_parser import Parser
+
+        module_path, class_name = cls.lazy_parsers[name]
+        mod = importlib.import_module(module_path)
+        parser_cls = getattr(mod, class_name)
+        if not issubclass(parser_cls, Parser):
+            raise TypeError(f"{class_name} in {module_path} is not a Parser subclass.")
+        cls.parsers[name] = parser_cls
+        return parser_cls
+
+    @classmethod
+    def _register_module(
+        cls,
+        module: type[Parser],
+        module_name: str | list[str] | None = None,
+        force: bool = True,
+    ) -> None:
+        from vllm_mlx.parser.abstract_parser import Parser
+
+        if not issubclass(module, Parser):
+            raise TypeError(
+                f"module must be subclass of Parser, but got {type(module)}"
+            )
+        if module_name is None:
+            module_names = [module.__name__]
+        elif isinstance(module_name, str):
+            module_names = [module_name]
+        else:
+            module_names = list(module_name)
+        for name in module_names:
+            if not force and name in cls.parsers:
+                existed = cls.parsers[name]
+                raise KeyError(f"{name} is already registered at {existed.__module__}")
+            cls.parsers[name] = module
+
+    @classmethod
+    def register_lazy_module(cls, name: str, module_path: str, class_name: str) -> None:
+        cls.lazy_parsers[name] = (module_path, class_name)
+
+    @classmethod
+    def register_module(
+        cls,
+        name: str | list[str] | None = None,
+        force: bool = True,
+        module: type[Parser] | None = None,
+    ) -> type[Parser] | Callable[[type[Parser]], type[Parser]]:
+        if module is not None:
+            cls._register_module(module=module, module_name=name, force=force)
+            return module
+
+        def _decorator(obj: type[Parser]) -> type[Parser]:
+            module_path = obj.__module__
+            class_name = obj.__name__
+            if isinstance(name, str):
+                names = [name]
+            elif name is not None:
+                names = list(name)
+            else:
+                names = [class_name]
+            for n in names:
+                cls.lazy_parsers[n] = (module_path, class_name)
+            return obj
+
+        return _decorator
+
+    @classmethod
+    def list_registered(cls) -> list[str]:
+        return sorted(set(cls.parsers.keys()) | set(cls.lazy_parsers.keys()))
+
+    @classmethod
+    def get_tool_parser(
+        cls,
+        tool_parser_name: str | None,
+        enable_auto_tools: bool = False,
+    ) -> type[ToolParser] | None:
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        if not enable_auto_tools or tool_parser_name is None:
+            return None
+        try:
+            return ToolParserManager.get_tool_parser(tool_parser_name)
+        except KeyError as e:
+            raise TypeError(
+                f"Tool parser '{tool_parser_name}' is not registered"
+            ) from e
+
+    @classmethod
+    def get_reasoning_parser(
+        cls, reasoning_parser_name: str | None
+    ) -> type[ReasoningParser] | None:
+        if not reasoning_parser_name:
+            return None
+        # Local import to avoid hard dep at module import time on the
+        # reasoning package (keeps the parser layer importable in
+        # contexts that load tool_parsers only).
+        from vllm_mlx.reasoning import get_parser
+
+        cls_ = get_parser(reasoning_parser_name)
+        if cls_ is None:
+            raise TypeError(
+                f"Reasoning parser '{reasoning_parser_name}' is not registered"
+            )
+        return cls_
+
+    @classmethod
+    def get_parser(
+        cls,
+        tool_parser_name: str | None = None,
+        reasoning_parser_name: str | None = None,
+        enable_auto_tools: bool = False,
+    ) -> type[Parser] | None:
+        """Three-strategy resolver — see module docstring."""
+        from vllm_mlx.parser.abstract_parser import _WrappedParser
+
+        if not tool_parser_name and not reasoning_parser_name:
+            return None
+
+        # Strategy 1: same name registered as a unified Parser
+        if tool_parser_name and tool_parser_name == reasoning_parser_name:
+            try:
+                return cls.get_parser_internal(tool_parser_name)
+            except KeyError:
+                pass
+
+        # Strategy 2: either name registered as a unified Parser
+        for name in (tool_parser_name, reasoning_parser_name):
+            if name:
+                try:
+                    return cls.get_parser_internal(name)
+                except KeyError:
+                    pass
+
+        # Strategy 3: compose a _WrappedParser from the individual classes
+        reasoning_cls = cls.get_reasoning_parser(reasoning_parser_name)
+        tool_cls = cls.get_tool_parser(tool_parser_name, enable_auto_tools)
+        if reasoning_cls is None and tool_cls is None:
+            return None
+
+        _WrappedParser.reasoning_parser_cls = reasoning_cls
+        _WrappedParser.tool_parser_cls = tool_cls
+        return _WrappedParser
+
+
+__all__ = ["ParserManager"]

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -14,18 +14,21 @@ from typing import Any
 @dataclass
 class DeltaMessage:
     """
-    Delta message for streaming reasoning output.
+    Delta message for streaming model output.
 
-    Contains either reasoning content, regular content, or both when
-    transitioning from reasoning to content phase.
+    Contains reasoning content, regular content, and/or tool calls. A single
+    delta typically populates one field; the boundary chunk between phases
+    can populate both reasoning and content, or reasoning and tool_calls.
 
-    Note: reasoning and content should typically not both be non-None
-    except during the transition chunk.
+    tool_calls follows the OpenAI ChoiceDeltaToolCall shape:
+        [{"index": 0, "id": "...", "type": "function",
+          "function": {"name": "...", "arguments": "..."}}, ...]
     """
 
     role: str | None = None
     content: str | None = None
     reasoning: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
 
     @property
     def reasoning_content(self) -> str | None:
@@ -98,6 +101,19 @@ class ReasoningParser(ABC):
             or None if this delta should be skipped (e.g., special tokens).
         """
         pass
+
+    def is_reasoning_end_streaming(self, previous_text: str, current_text: str) -> bool:
+        """
+        Check whether the reasoning phase has ended after the latest delta.
+
+        Used by the unified ``Parser.parse_delta`` orchestrator to decide
+        when to hand off from reasoning extraction to tool-call extraction
+        within the same stream. Default implementation reads a
+        ``reasoning_ended`` attribute that most concrete parsers (qwen3,
+        deepseek_r1, glm4, harmony) already set during streaming. Parsers
+        without that flag can override this method directly.
+        """
+        return bool(getattr(self, "reasoning_ended", False))
 
     def reset_state(self):  # noqa: B027
         """

--- a/vllm_mlx/reasoning/minimax_parser.py
+++ b/vllm_mlx/reasoning/minimax_parser.py
@@ -117,6 +117,20 @@ class MiniMaxReasoningParser(ReasoningParser):
         self._is_reasoning = False
         self._transition_pos = 0
 
+    def is_reasoning_end_streaming(self, previous_text: str, current_text: str) -> bool:
+        """Boundary signal for the unified ``Parser.parse_delta`` orchestrator.
+
+        MiniMax doesn't carry a ``reasoning_ended`` attribute the default
+        implementation can read. Reasoning is "done" once the parser has
+        decided AND classified the current emission as non-reasoning —
+        i.e. the model crossed into content (or a tool-call shape) and
+        the next chunk must flow through the tool parser. Without this
+        override the unified path would keep MiniMax stuck in the
+        reasoning phase and tool calls embedded inside its think block
+        would never be parsed.
+        """
+        return self._decided and not self._is_reasoning
+
     def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning from complete MiniMax output.

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -50,6 +50,18 @@ class BaseThinkingReasoningParser(ReasoningParser):
         super().reset_state()
         self._saw_any_tag = False
 
+    def is_reasoning_end_streaming(self, previous_text: str, current_text: str) -> bool:
+        """Boundary signal for the unified ``Parser.parse_delta`` orchestrator.
+
+        For ``<think>`` / ``</think>`` style markers the appearance of the
+        end-token anywhere in ``current_text`` is the definitive signal —
+        same check ``extract_reasoning_streaming`` already uses internally
+        for Case 1/2 handling. Implicit-mode (``<think>`` only in prompt)
+        gets covered by the same check because the model output starts
+        emitting ``</think>`` mid-stream when reasoning concludes.
+        """
+        return self.end_token in current_text
+
     def extract_reasoning(
         self,
         model_output: str,

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -492,6 +492,12 @@ class StreamingPostProcessor:
         # same StreamEvent shape the legacy ``_detect_tool_calls`` path
         # produces, so downstream SSE encoding is unchanged.
         if delta_msg.tool_calls:
+            # Pin tool_calls_detected so finalize() knows not to re-parse
+            # accumulated_text (which would duplicate this call) and so
+            # the terminal finish event is stamped "tool_calls" rather
+            # than "stop". Mirrors the legacy ``_detect_tool_calls``
+            # branch that sets the same flag.
+            self.tool_calls_detected = True
             return [
                 StreamEvent(
                     type="tool_call",

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -9,6 +9,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from ..api.tool_calling import parse_tool_calls
@@ -137,6 +138,22 @@ class StreamingPostProcessor:
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
 
+        # Optional unified Parser path (Phase 2 of the vllm-style parser
+        # orchestrator migration — see ``vllm_mlx/parser/``). Activated by
+        # ``RAPID_MLX_UNIFIED_PARSER=1`` so the old per-call sequence
+        # (``extract_reasoning_streaming`` → ``_detect_tool_calls``) and
+        # the new single-call orchestrator (``parse_delta``) coexist while
+        # we bake parity. Channel-routed models (Gemma 4, harmony) still
+        # take the OutputRouter path; this flag only swaps the text-based
+        # reasoning + tool flow that was the source of #436 / #443 /
+        # #454 / #456 / #460 / #462.
+        self.unified_parser = None
+        if (
+            os.environ.get("RAPID_MLX_UNIFIED_PARSER", "0") == "1"
+            and self.reasoning_parser is not None
+        ):
+            self.unified_parser = self._build_unified_parser()
+
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
         """Create a per-request reasoning parser instance."""
@@ -181,6 +198,26 @@ class StreamingPostProcessor:
 
         return None
 
+    def _build_unified_parser(self):
+        """Construct a unified ``Parser`` from the already-built reasoning
+        and tool parser instances.
+
+        Direct instantiation (rather than ``ParserManager.get_parser``)
+        because the manager would re-build the parsers from class names
+        and lose the request-scoped wiring this constructor already did
+        (mock injection, MiniMax inference, Nemotron heuristic, etc.).
+        We only borrow the orchestration shape — ``DelegatingParser.parse_delta``.
+        """
+        from ..parser import DelegatingParser
+
+        parser = DelegatingParser(
+            tokenizer=getattr(self.cfg, "engine", None)
+            and getattr(self.cfg.engine, "_tokenizer", None)
+        )
+        parser._reasoning_parser = self.reasoning_parser
+        parser._tool_parser = self.tool_parser
+        return parser
+
     def set_thinking_model(self, model_name: str):
         """Enable Nemotron-style thinking prefix injection."""
         self._is_thinking_model = (
@@ -206,6 +243,12 @@ class StreamingPostProcessor:
             self.reasoning_parser.reset_state()
         if self.tool_parser:
             self.tool_parser.reset()
+        if self.unified_parser is not None:
+            # The reasoning/tool sub-parsers are reset above; only the
+            # orchestrator's own StreamState needs to be cleared here.
+            from ..parser import StreamState
+
+            self.unified_parser._stream_state = StreamState()
 
     def process_chunk(self, output: GenerationOutput) -> list[StreamEvent]:
         """Process a single engine output chunk.
@@ -227,6 +270,15 @@ class StreamingPostProcessor:
             # skip thinking and answer directly. Bypass the reasoning parser
             # so its implicit-think heuristic doesn't reroute the answer to
             # reasoning_content.
+            if self.unified_parser is not None:
+                # Phase 2 opt-in: route the reasoning + tool sequence
+                # through the unified ``Parser.parse_delta`` orchestrator
+                # instead of the legacy two-call sequence. The surrounding
+                # post-processing (MiniMax redirect, sanitize, accumulate,
+                # finish_reason) is the same — only the boundary handling
+                # changes, structurally eliminating the bug class behind
+                # PRs #436 / #443 / #454 / #456 / #460 / #462.
+                return self._process_with_unified_parser(delta_text, output)
             return self._process_with_reasoning(delta_text, output)
         return self._process_standard(delta_text, output)
 
@@ -376,6 +428,127 @@ class StreamingPostProcessor:
             return []
 
         # Sanitize
+        if content:
+            content = strip_special_tokens(content)
+        if reasoning:
+            reasoning = strip_special_tokens(reasoning)
+
+        finish_reason = self._compute_finish_reason(output)
+        if not content and not reasoning and not finish_reason:
+            return []
+
+        if content:
+            content = sanitize_output(content)
+            if not content:
+                content = None
+
+        if finish_reason:
+            return [
+                StreamEvent(
+                    type="finish",
+                    finish_reason=finish_reason,
+                    content=content,
+                    reasoning=reasoning,
+                    tool_calls_detected=self.tool_calls_detected,
+                )
+            ]
+        events = []
+        if content:
+            events.append(StreamEvent(type="content", content=content))
+        if reasoning:
+            events.append(StreamEvent(type="reasoning", reasoning=reasoning))
+        return events
+
+    def _process_with_unified_parser(
+        self, delta_text: str, output: GenerationOutput
+    ) -> list[StreamEvent]:
+        """Unified-Parser variant of ``_process_with_reasoning``.
+
+        Replaces the two-call ``extract_reasoning_streaming`` +
+        ``_detect_tool_calls`` sequence with a single
+        ``parse_delta(delta_text)`` call. The surrounding pipeline
+        (accumulators, MiniMax tool-in-think redirect, sanitizers,
+        ``finish_reason`` computation, ``StreamEvent`` shaping) is
+        intentionally kept byte-identical to ``_process_with_reasoning``
+        so that the only behavior difference is the boundary handling
+        the orchestrator now owns.
+        """
+        previous_text = self.accumulated_text
+        self.accumulated_text += delta_text
+
+        delta_msg = self.unified_parser.parse_delta(
+            delta_text=delta_text, request=self.request
+        )
+
+        if delta_msg is None:
+            if output.finished:
+                return [self._make_finish_event(output)]
+            return []
+
+        content = delta_msg.content
+        reasoning = delta_msg.reasoning
+        # ``parse_delta`` may emit a fully formed tool_calls payload when
+        # the underlying tool parser flushes — translate that into the
+        # same StreamEvent shape the legacy ``_detect_tool_calls`` path
+        # produces, so downstream SSE encoding is unchanged.
+        if delta_msg.tool_calls:
+            return [
+                StreamEvent(
+                    type="tool_call",
+                    tool_calls=delta_msg.tool_calls,
+                    finish_reason="tool_calls" if output.finished else None,
+                    tool_calls_detected=True,
+                )
+            ]
+
+        if reasoning:
+            self.accumulated_reasoning += reasoning
+
+        # MiniMax redirect — same heuristic as the legacy path. parse_delta
+        # routes ``<think>...<tool_call>`` reasoning into ``reasoning`` and
+        # leaves the tool detection for the tool parser's text inspection,
+        # but MiniMax wraps its tool calls inside the think block so the
+        # tool parser would never see them. Reclassify reasoning → content
+        # on the trigger tags so the next delta's tool parser run can
+        # consume them.
+        if self.tool_parser and reasoning:
+            _check = self.tool_accumulated_text + reasoning
+            if (
+                "<minimax:tool_call>" in _check
+                or "<tool_call>" in _check
+                or '<invoke name="' in _check
+            ):
+                content = (content or "") + reasoning
+                reasoning = None
+                # Re-run tool detection on the now-content portion so the
+                # tool call surfaces in this delta — the legacy path
+                # called ``_detect_tool_calls`` unconditionally below; we
+                # keep that contract.
+                result = self._detect_tool_calls(content)
+                if result is None:
+                    return []
+                if result.get("tool_calls"):
+                    return [
+                        StreamEvent(
+                            type="tool_call",
+                            tool_calls=result["tool_calls"],
+                            finish_reason="tool_calls" if output.finished else None,
+                            tool_calls_detected=True,
+                        )
+                    ]
+                content = result.get("content", "")
+
+        if self.tool_calls_detected:
+            if output.finished:
+                return [
+                    StreamEvent(
+                        type="finish",
+                        finish_reason="tool_calls",
+                        tool_calls_detected=True,
+                    )
+                ]
+            return []
+
         if content:
             content = strip_special_tokens(content)
         if reasoning:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -154,6 +154,23 @@ class StreamingPostProcessor:
         ):
             self.unified_parser = self._build_unified_parser()
 
+        # When the unified path is active it OWNS the post-reasoning
+        # ``tool_accumulated_text`` value — finalize() must treat an
+        # empty string as "scoped tool text is intentionally empty" and
+        # NOT fall back to the full ``accumulated_text`` (which would
+        # re-run the cross-format parser over the reasoning body and
+        # synthesize a bogus tool call from any bare JSON shape
+        # mentioned there). Codex R9 #1.
+        self._unified_tool_scope_active = self.unified_parser is not None
+        # MiniMax redirect (tool calls embedded in ``<think>``) runs the
+        # legacy ``_detect_tool_calls`` to mutate
+        # ``tool_accumulated_text``. While that path is engaged for the
+        # current stream, the per-chunk mirror from the orchestrator's
+        # ``tool_phase_text`` MUST stop — it never saw the redirected
+        # text and would otherwise clobber the buffer between chunks,
+        # losing the opening ``<minimax:tool_call>`` marker. Codex R9 #2.
+        self._minimax_redirect_active = False
+
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
         """Create a per-request reasoning parser instance."""
@@ -238,6 +255,11 @@ class StreamingPostProcessor:
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
+        # ``_unified_tool_scope_active`` is derived from ``unified_parser``
+        # at construction time; it stays constant across resets in the
+        # current stream. ``_minimax_redirect_active`` is per-stream
+        # state — clear it on every reset.
+        self._minimax_redirect_active = False
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()
@@ -488,7 +510,18 @@ class StreamingPostProcessor:
         # otherwise produce bogus end-of-stream tool_call events under
         # the unified path while the legacy ``_detect_tool_calls``
         # path is correctly scoped (codex R7).
-        self.tool_accumulated_text = self.unified_parser._stream_state.tool_phase_text
+        #
+        # GATE: skip the mirror once the MiniMax redirect has engaged
+        # for this stream. The redirect runs the legacy
+        # ``_detect_tool_calls`` which appends the reclassified
+        # reasoning text into ``tool_accumulated_text``; the unified
+        # state never saw that content so mirroring would clobber the
+        # opening ``<minimax:tool_call>`` marker between chunks and the
+        # tool parser would lose the split tool call (codex R9 #2).
+        if not self._minimax_redirect_active:
+            self.tool_accumulated_text = (
+                self.unified_parser._stream_state.tool_phase_text
+            )
 
         if delta_msg is None:
             if output.finished:
@@ -558,6 +591,11 @@ class StreamingPostProcessor:
                 or "<tool_call>" in _check
                 or '<invoke name="' in _check
             ):
+                # Latch the redirect for the rest of this stream so the
+                # per-chunk mirror to ``tool_accumulated_text`` stays
+                # out of the way (codex R9 #2). ``_detect_tool_calls``
+                # is now the source of truth for the buffer.
+                self._minimax_redirect_active = True
                 content = (content or "") + reasoning
                 reasoning = None
                 # Re-run tool detection on the now-content portion so the
@@ -740,7 +778,22 @@ class StreamingPostProcessor:
         # on PR #424 — high-throughput servers with tool-enabled
         # endpoints would otherwise pay the parser cost on every reply
         # that didn't actually call a tool).
-        _fallback_text = self.tool_accumulated_text or self.accumulated_text
+        # When the unified Parser path owns the post-reasoning tool
+        # scope, ``tool_accumulated_text`` is authoritative — including
+        # the "" case which means "nothing post-reasoning to parse".
+        # The legacy ``or self.accumulated_text`` fallback would
+        # otherwise re-run ``extract_tool_calls`` over the reasoning
+        # body and synthesize a bogus tool call from any bare JSON
+        # shape mentioned there (codex R9 #1). The MiniMax redirect
+        # exception (``_minimax_redirect_active``) lets the legacy
+        # ``_detect_tool_calls`` path keep ownership when it engages —
+        # in that mode ``tool_accumulated_text`` is non-empty and the
+        # fallback would behave correctly anyway, so we still take the
+        # scoped value.
+        if self._unified_tool_scope_active:
+            _fallback_text = self.tool_accumulated_text
+        else:
+            _fallback_text = self.tool_accumulated_text or self.accumulated_text
         _has_plausible_markup = bool(_fallback_text) and (
             "<" in _fallback_text
             or "{" in _fallback_text

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -154,14 +154,19 @@ class StreamingPostProcessor:
         ):
             self.unified_parser = self._build_unified_parser()
 
-        # When the unified path is active it OWNS the post-reasoning
-        # ``tool_accumulated_text`` value — finalize() must treat an
-        # empty string as "scoped tool text is intentionally empty" and
-        # NOT fall back to the full ``accumulated_text`` (which would
+        # Latches True the first time ``_process_with_unified_parser``
+        # actually runs on this stream. Then finalize() treats
+        # ``tool_accumulated_text`` as authoritative (including ""), so
+        # the legacy ``or self.accumulated_text`` fallback does not
         # re-run the cross-format parser over the reasoning body and
-        # synthesize a bogus tool call from any bare JSON shape
-        # mentioned there). Codex R9 #1.
-        self._unified_tool_scope_active = self.unified_parser is not None
+        # synthesize a bogus tool call from any bare JSON shape there
+        # (codex R9 #1).
+        #
+        # CANNOT be derived from ``self.unified_parser is not None`` —
+        # channel-routed streams (Gemma 4, harmony) skip the unified
+        # path entirely and rely on ``accumulated_text`` for fallback
+        # tool detection (DeepSeek review BLOCKING).
+        self._unified_tool_scope_active = False
         # MiniMax redirect (tool calls embedded in ``<think>``) runs the
         # legacy ``_detect_tool_calls`` to mutate
         # ``tool_accumulated_text``. While that path is engaged for the
@@ -255,10 +260,10 @@ class StreamingPostProcessor:
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
-        # ``_unified_tool_scope_active`` is derived from ``unified_parser``
-        # at construction time; it stays constant across resets in the
-        # current stream. ``_minimax_redirect_active`` is per-stream
-        # state — clear it on every reset.
+        # Per-stream state — clear on every reset. ``_unified_tool_scope_active``
+        # latches True only when ``_process_with_unified_parser`` actually
+        # runs; channel-routed streams never set it.
+        self._unified_tool_scope_active = False
         self._minimax_redirect_active = False
 
         if self.reasoning_parser:
@@ -266,11 +271,7 @@ class StreamingPostProcessor:
         if self.tool_parser:
             self.tool_parser.reset()
         if self.unified_parser is not None:
-            # The reasoning/tool sub-parsers are reset above; only the
-            # orchestrator's own StreamState needs to be cleared here.
-            from ..parser import StreamState
-
-            self.unified_parser._stream_state = StreamState()
+            self.unified_parser.reset_state()
 
     def process_chunk(self, output: GenerationOutput) -> list[StreamEvent]:
         """Process a single engine output chunk.
@@ -495,6 +496,12 @@ class StreamingPostProcessor:
         so that the only behavior difference is the boundary handling
         the orchestrator now owns.
         """
+        # Latch the scope flag the first time the unified path actually
+        # consumes a delta on this stream. Channel-routed streams (Gemma 4,
+        # harmony) skip this method entirely, so finalize() correctly falls
+        # back to ``accumulated_text`` for them (DeepSeek review BLOCKING).
+        self._unified_tool_scope_active = True
+
         previous_text = self.accumulated_text
         self.accumulated_text += delta_text
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -480,6 +480,16 @@ class StreamingPostProcessor:
             delta_text=delta_text, request=self.request
         )
 
+        # Mirror the orchestrator's post-reasoning ``tool_phase_text``
+        # into ``self.tool_accumulated_text`` so ``finalize()``'s
+        # fallback (which scans tool_accumulated_text or
+        # accumulated_text) doesn't reparse the full raw stream
+        # — bare JSON shapes mentioned inside ``<think>`` would
+        # otherwise produce bogus end-of-stream tool_call events under
+        # the unified path while the legacy ``_detect_tool_calls``
+        # path is correctly scoped (codex R7).
+        self.tool_accumulated_text = self.unified_parser._stream_state.tool_phase_text
+
         if delta_msg is None:
             if output.finished:
                 return [self._make_finish_event(output)]

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -498,14 +498,38 @@ class StreamingPostProcessor:
             # than "stop". Mirrors the legacy ``_detect_tool_calls``
             # branch that sets the same flag.
             self.tool_calls_detected = True
-            return [
+
+            # Coalesced boundary chunk — the orchestrator may attach
+            # reasoning / content from the pre-boundary side of the
+            # same delta. Surface those first (mirroring the legacy
+            # path which would have emitted them on the previous
+            # process_chunk call) so clients don't lose the final
+            # reasoning text or partial content that preceded the
+            # tool call.
+            events: list[StreamEvent] = []
+            if reasoning:
+                cleaned_reasoning = strip_special_tokens(reasoning)
+                if cleaned_reasoning:
+                    self.accumulated_reasoning += cleaned_reasoning
+                    events.append(
+                        StreamEvent(type="reasoning", reasoning=cleaned_reasoning)
+                    )
+            if content:
+                cleaned_content = strip_special_tokens(content)
+                if cleaned_content:
+                    cleaned_content = sanitize_output(cleaned_content)
+                if cleaned_content:
+                    events.append(StreamEvent(type="content", content=cleaned_content))
+
+            events.append(
                 StreamEvent(
                     type="tool_call",
                     tool_calls=delta_msg.tool_calls,
                     finish_reason="tool_calls" if output.finished else None,
                     tool_calls_detected=True,
                 )
-            ]
+            )
+            return events
 
         if reasoning:
             self.accumulated_reasoning += reasoning

--- a/vllm_mlx/utils/mamba_cache.py
+++ b/vllm_mlx/utils/mamba_cache.py
@@ -11,6 +11,16 @@ import logging
 
 import mlx.core as mx
 
+# MUST install the MLX hardware-compat shim BEFORE the `mlx_lm` import below.
+# Even though the import is inside a `try`, the body still runs at module
+# load time; on success it triggers `mlx_lm/__init__.py` → `mlx_lm.generate`
+# → `mx.new_thread_local_stream(...)` capture, which on M5 single-stream
+# GPUs would be unusable (#404). The shim is idempotent and a no-op on
+# hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 # MambaCache was removed in mlx-lm 0.30.6, fall back to ArraysCache
 try:
     from mlx_lm.models.cache import MambaCache


### PR DESCRIPTION
## Summary

Adapt vllm's `vllm/parser/abstract_parser.py` + `parser_manager.py` (Apache-2.0) into a new `vllm_mlx/parser/` package, **and** wire it through `StreamingPostProcessor` behind an opt-in env flag. Closes the bug class where stream and non-stream paths re-implement the "reasoning first, then tool calls, but watch the boundary" sequence and silently diverge.

**Background**: rapid-mlx PRs #436 / #443 / #454 / #456 / #460 / #462 are all instances of the same root cause. vLLM walked the same path 6 months ahead (#39446, #41876, #42691) and landed a unified `Parser` / `DelegatingParser` / `parse_delta(...)` abstraction with a shared `StreamState`. vLLM PR #42691 ("Fix reasoning dropped on streaming boundary deltas") is the literal fix for our PR #436. Adopting their pattern structurally eliminates the bug family.

This PR lands in **two phases** in a single review window:

- **Phase 1 — abstraction.** The orchestrator + manager + sub-parser hook. No route integration.
- **Phase 2 — opt-in route migration.** `StreamingPostProcessor` gains a `_process_with_unified_parser` path activated by `RAPID_MLX_UNIFIED_PARSER=1`. Default off — zero behavior change for deployed installs. Channel-routed (Gemma 4 / harmony) outputs still bypass via `_process_channel_routed` since `OutputRouter` is token-level.

## Phase 1 — what lands

- `vllm_mlx/parser/abstract_parser.py` — `Parser` (ABC), `StreamState`, `DelegatingParser` composite (the `parse_delta` state machine), `_WrappedParser` for ad-hoc composition. Adapted from vllm:
  - Drop Responses-API surface (we don't have one)
  - Drop named / `tool_choice="required"` streaming for Phase 1 (vllm PR #41876 — Phase 2)
  - Replace token-ID boundary detection with text-based `is_reasoning_end_streaming(previous_text, current_text)` since our routes carry text only
  - Explicit reasoning preservation across boundary chunk (literal fix for #436 / vllm #42691)
- `vllm_mlx/parser/parser_manager.py` — `ParserManager.get_parser(...)` three-strategy resolver:
  1. unified Parser registered under same name as both tool + reasoning
  2. unified Parser registered under either name
  3. fall back to `_WrappedParser` composing the two individual parser classes

  Strategies 1/2 are extension points for the eventual channel-routed migration (harmony / Gemma 4 — `OutputRouter` becomes a registered unified Parser).
- `vllm_mlx/reasoning/base.py` — `DeltaMessage` gains optional `tool_calls` field (additive). Default `is_reasoning_end_streaming` reads the `reasoning_ended` attr most concrete parsers already track.
- `vllm_mlx/reasoning/think_parser.py` — `is_reasoning_end_streaming` override for `BaseThinkingReasoningParser` family (Qwen3, DeepSeek-R1, GLM): detects `</think>` in `current_text`.
- `tests/test_parser_orchestrator.py` — 15 unit tests pinning the state machine + 3-strategy resolver.

## Phase 2 — what lands

- `vllm_mlx/service/postprocessor.py` — gains:
  - `self.unified_parser` constructed only when `RAPID_MLX_UNIFIED_PARSER=1` AND a reasoning parser exists. Reuses the already-built `self.reasoning_parser` / `self.tool_parser` instances directly so request-scoped wiring (mock injection, MiniMax inference, Nemotron heuristic) is preserved — we only borrow the orchestration shape (`DelegatingParser.parse_delta`).
  - `reset()` clears the orchestrator's `StreamState` alongside the sub-parsers'.
  - `process_chunk` dispatch — when reasoning is active AND `self.unified_parser is not None`, routes through `_process_with_unified_parser` instead of `_process_with_reasoning`. All other paths (`_process_standard`, `_process_channel_routed`) unchanged.
  - `_process_with_unified_parser` (~115 lines) — mirrors `_process_with_reasoning`: single `parse_delta(delta_text)` call replaces the legacy two-call (`extract_reasoning_streaming` → `_detect_tool_calls`) sequence. MiniMax tool-in-think redirect, sanitize, accumulators, `finish_reason` computation, `StreamEvent` shaping are byte-identical — only boundary handling differs.
- `tests/test_postprocessor_unified_parser.py` — 8 parity tests pinning:
  - opt-in is no-op without env flag
  - opt-in is no-op without reasoning parser
  - orchestrator reuses the same sub-parser instances
  - Qwen3 `<think>...</think>...` streams cleanly
  - Qwen3 + hermes `<tool_call>...</tool_call>` emits as `tool_call` StreamEvent (not content)
  - channel-routed outputs still bypass via `_process_channel_routed`
  - `reset()` clears StreamState
  - legacy path still works with flag off

## Issues this unblocks

Direct root-cause fix once Phase 2 is flipped on (or a future phase makes it the only path):
- #444 harmony streaming tool calls leak as content deltas
- #455 Anthropic /v1/messages streaming + tools: harmony commentary leaks as text block
- #468 tool_choice="required" not enforced + harmony channel markers leak
- #448 hermes parser leaks `<function` prefix on Qwen3-Coder (streaming fallback missing)
- #480 Harmony streaming leaks channel syntax into content
- #447 Gemma 4 OutputRouter: 'thought' marker leak

Becomes smaller once orchestrator is in place:
- #63 migrate legacy reasoning/tool parsers to token-level OutputRouter (this PR is the migration substrate)
- #344 port upstream tool_call promotion (waybarrios#433)
- #481 `--no-think` no-op on harmony

## Verification

### End-to-end POC against real parsers (Phase 1)

Composed `hermes` (tool) + `qwen3` (reasoning) through `_WrappedParser` and streamed a Qwen3-style sequence:

```
phase  | chunk              | content            | reasoning          | tool_calls
-------+--------------------+--------------------+--------------------+-----------
think  | '<think>'            | <think>            | None               | None
think  | 'Let me think about' | None               | Let me think about | None
think  | '</think>'           | </think>           | None               | None
tool   | '<tool_call>'        | <tool_call>        | None               | None
tool   | '{"name": "get_weat' | {"name": "get_weat | None               | None
tool   | '</tool_call>'       | None               | None               | YES   ← tool_calls emitted
```

State machine flips `think → tool` after `</think>`. No reasoning leak into content; tool call materializes at end of stream.

### Tests

- `tests/test_parser_orchestrator.py` — 15 / 15 PASS
- `tests/test_postprocessor_unified_parser.py` — 8 / 8 PASS
- Regression: `test_reasoning_parser.py`, `test_reasoning_parsers.py`, `test_harmony_parsers.py`, `test_streaming_think_router.py`, `test_gemma4_tool_parser.py`, `test_minimax_reasoning_parser.py`, `test_minimax_tool_parser.py` and the broader post-processor suites — 700+ PASS, no regressions
- Lint: `ruff check` + `ruff format` clean

## Test plan

- [x] Phase 1 orchestrator unit tests cover boundary delta preservation (#436 / vllm #42691 regression)
- [x] Phase 1 `ParserManager` three-strategy resolver covered
- [x] Real hermes + qwen3 parsers compose through `_WrappedParser` end-to-end
- [x] Phase 2 opt-in: no-op without env flag
- [x] Phase 2 opt-in: parity with legacy path on Qwen3 think → content
- [x] Phase 2 opt-in: parity with legacy path on Qwen3 + hermes tool_call emission
- [x] Phase 2 opt-in: channel-routed bypass intact (Gemma 4 / harmony untouched)
- [x] Phase 2: `reset()` clears StreamState between requests
- [x] No regression on 700+ existing parser + post-processor tests

## Rollout plan

Phase 2 is gated by `RAPID_MLX_UNIFIED_PARSER=1` so deployed installs see no behavior change. Next steps (separate PRs):

1. Smoke the flag on under doctor harness on qwen3.5-4b + hermes
2. Run the bug-class issue list (#444 / #455 / #468 / #448 / #480 / #447) with the flag on to confirm structural fix
3. Flip the default to on, then retire the legacy `_process_with_reasoning` branch
4. Register `OutputRouter` as a unified Parser to cover the channel-routed family (harmony / Gemma 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Validation update (2026-05-30) — live red-team + A/B classification

Spawned 4 parallel user-simulator subagents against a live server with `RAPID_MLX_UNIFIED_PARSER=1` to red-team the new path. They surfaced 6 distinct parsing weirdnesses. **I then stood up a sibling server with the flag OFF and re-ran every reproduction — all 6 reproduce identically on the legacy path. None are introduced by this PR.**

| Finding | FLAG ON | FLAG OFF | Classification |
|---|---|---|---|
| Streaming arg duplication `{"x":1}{"x":1}` | valid JSON | valid JSON | non-reproducible / transient |
| Truncated-reasoning stream/non-stream parity | DIVERGE | DIVERGE | **pre-existing** (legacy) |
| Literal `<tool_call>` in content truncates stream | 996/1158 ch | 996/1158 ch | **pre-existing** (legacy) |
| Over-eager bogus `tool_calls` from literal markup | YES | YES | **pre-existing** (legacy) |
| `reasoning_content` field absent from response | absent | absent | **pre-existing** (serializer) |
| Literal `</tool_call>` stripped from user INPUT | stripped | stripped | **pre-existing** (request sanitizer) |

Conclusion: the unified path is at byte-level parity with legacy on every adversarial case. The legacy bugs will be filed separately as follow-up issues — they're out of scope for this PR.

### Why the legacy bugs slipped (test-process post-mortem)

Worth fixing in the follow-ups, not here:

1. **No stream vs non-stream parity contract.** Both paths have their own tests; nothing pins "same prompt → same message-level fields." A single contract test class would surface Agent 2's finding.
2. **No live-model fixture for parser tests.** All parser/postprocessor tests feed synthetic delta strings; qwen3.5-4b often emits "Thinking Process:" prose without `<think>` tags and emits literal `<tool_call>` substrings in answers. The doctor harness exists for this (`make smoke`); the unified flag should be added to it.
3. **Fake parsers in unit tests don't mirror real-parser tristate.** Real hermes parser has buffer-while-uncertain semantics with substring-based detection; my orchestrator tests pinned the seam, not the real-parser interaction surface.
4. **Codex/DeepSeek static review can't catch behavior-level bugs.** "Literal control token appears in model output as content" is fundamentally a behavior check.
5. **Adversarial prompts not in any test corpus.** "User asks about `<tool_call>` syntax" / "model echoes `</think>` in answer" — these are exactly the inputs only red-team subagents try. Should become permanent fixtures.

### pr_validate fixes folded into this PR

- DeepSeek BLOCKING: `_unified_tool_scope_active` was eagerly latched at construction; now latches only when `_process_with_unified_parser` actually runs, so channel-routed streams (Gemma 4, harmony) keep their fallback over `accumulated_text`. Regression test: `test_channel_routed_finalize_uses_accumulated_text_fallback`.
- full_unit FAIL: registered `RAPID_MLX_UNIFIED_PARSER` in `ALLOWED_RAPID_MLX_ENV_VARS`.
- DeepSeek NIT #2/#3: `reset()` now calls `unified_parser.reset_state()`; dead `StreamState.tool_call_text_started` removed.
