### PR TITLE
refactor(routes): systematic fix for engine silent-skip bug-class (post-#500/v0.6.70)

### DIFF
--- a/tests/test_cloud_router.py
+++ b/tests/test_cloud_router.py
@@ -520,3 +520,253 @@ class TestEngineCloudRoutingContract:
             "deleted in #155). Use `engine.estimate_new_tokens(prompt)` — the "
             "method is now part of the engine contract."
         )
+
+
+# ---------------------------------------------------------------------------
+# Live cloud-routing repro — would have caught #500 + the v0.6.70 hotfix
+# ---------------------------------------------------------------------------
+
+
+from vllm_mlx.engine.base import BaseEngine, GenerationOutput
+
+
+class _ContractEngine(BaseEngine):
+    """Real ``BaseEngine`` subclass — instantiation enforces the abstract
+    contract, so a missing route-layer method (``build_prompt``,
+    ``estimate_new_tokens``) raises ``TypeError`` at construction instead of
+    a silent runtime degradation.
+
+    This is the property the previous regression tests lacked: every
+    existing route test mocks the engine with ``MagicMock``, which
+    auto-satisfies any attribute access and so let #500 and the v0.6.70
+    hotfix ship green. Subclassing ``BaseEngine`` here means a future PR
+    can't remove ``build_prompt`` without this file failing to import.
+
+    Only the slice the cloud-routing branch needs is wired up; the
+    remaining abstracts return placeholders so the ABC check passes.
+    """
+
+    preserve_native_tool_format = False
+
+    def __init__(self, *, prompt_tokens: int):
+        self._prompt_tokens = prompt_tokens
+        self.build_prompt_calls: list[dict] = []
+        self.estimate_calls: list[str] = []
+        self.chat_calls: list[dict] = []
+
+    @property
+    def model_name(self) -> str:
+        return "test-model"
+
+    @property
+    def is_mllm(self) -> bool:
+        return False
+
+    @property
+    def tokenizer(self):
+        return None
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    def build_prompt(
+        self,
+        messages,
+        tools=None,
+        enable_thinking=None,
+    ) -> str:
+        self.build_prompt_calls.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "enable_thinking": enable_thinking,
+            }
+        )
+        return "RENDERED_PROMPT"
+
+    def estimate_new_tokens(self, prompt: str) -> tuple[int, int]:
+        self.estimate_calls.append(prompt)
+        return self._prompt_tokens, self._prompt_tokens
+
+    async def generate(self, prompt, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    async def stream_generate(self, prompt, **kwargs):  # pragma: no cover
+        if False:
+            yield None
+
+    async def chat(self, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text="local",
+            new_text="local",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):  # pragma: no cover
+        if False:
+            yield None
+
+
+def _make_cloud_routed_client(
+    *,
+    prompt_tokens: int,
+    threshold: int,
+    cloud_response: dict | None = None,
+):
+    """Wire ``routes/chat.py`` against a ``_ContractEngine`` + a stubbed
+    ``CloudRouter`` whose ``completion()`` returns ``cloud_response``.
+
+    Returns ``(client, engine, cloud_router)`` so tests can inspect both the
+    HTTP response AND whether the engine methods were actually called (the
+    silent-skip bug signature).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.cloud_router import CloudRouter
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    engine = _ContractEngine(prompt_tokens=prompt_tokens)
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.reasoning_parser = None
+    cfg.tool_parser = None
+    cfg.no_thinking = True
+
+    cloud_router = CloudRouter(cloud_model="test/cloud", threshold=threshold)
+    if cloud_response is not None:
+        mock_litellm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.model_dump.return_value = cloud_response
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+        cloud_router._litellm = mock_litellm
+    cfg.cloud_router = cloud_router
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app), engine, cloud_router
+
+
+@pytest.fixture
+def _reset_after():
+    yield
+    from vllm_mlx.config import reset_config
+
+    reset_config()
+
+
+class TestCloudRoutingFiresEndToEnd:
+    """Repro for #500 + the v0.6.70 hotfix.
+
+    Before the fixes, this class of test would have failed in two ways:
+
+    * #500 / pre-v0.6.69: ``hasattr(engine, "build_prompt")`` returned False
+      → cloud branch skipped, response came from the local engine.
+    * v0.6.70 hotfix / pre-3839a1b: route called ``engine.model.estimate_
+      new_tokens`` → AttributeError, try/except logged
+      ``[CLOUD ROUTE] Error during routing check ... falling back to local``,
+      response came from the local engine.
+
+    Both failure modes produce the same observable: the response payload
+    comes from the LOCAL engine instead of the cloud stub. This test
+    asserts the cloud branch is reached, the methods are called in order,
+    and the cloud response is returned.
+    """
+
+    def test_above_threshold_routes_to_cloud(self, _reset_after):
+        client, engine, _ = _make_cloud_routed_client(
+            prompt_tokens=500,
+            threshold=10,
+            cloud_response={
+                "id": "cloud-resp-1",
+                "model": "test/cloud",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "ROUTED_TO_CLOUD",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 500,
+                    "completion_tokens": 3,
+                    "total_tokens": 503,
+                },
+            },
+        )
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "doesn't matter"}],
+                "max_tokens": 16,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # The cloud branch fired → response carries the cloud content,
+        # not the local "local" string.
+        assert body["choices"][0]["message"]["content"] == "ROUTED_TO_CLOUD", (
+            "cloud-routing branch did not return the cloud response — "
+            "the route silently fell back to local (see #500, v0.6.70 hotfix). "
+            f"got: {body['choices'][0]['message']}"
+        )
+        # The contract methods were actually called.
+        assert engine.build_prompt_calls, (
+            "engine.build_prompt was NOT called — the cloud branch was skipped "
+            "before reaching the body (the #500 silent-skip shape)."
+        )
+        assert engine.estimate_calls == ["RENDERED_PROMPT"], (
+            "engine.estimate_new_tokens was NOT called with the rendered prompt "
+            "— the cloud branch crashed silently before reaching this line "
+            "(the v0.6.70 hotfix shape)."
+        )
+        # And the local chat() path was NOT exercised.
+        assert engine.chat_calls == [], (
+            "engine.chat was called even though the request should have routed "
+            "to cloud — the cloud branch fell through to local."
+        )
+
+    def test_below_threshold_stays_local(self, _reset_after):
+        client, engine, _ = _make_cloud_routed_client(
+            prompt_tokens=5,
+            threshold=10,
+            cloud_response=None,
+        )
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 16,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        # Local path → content is "local" from the stub.
+        assert resp.json()["choices"][0]["message"]["content"] == "local"
+        # estimate_new_tokens still ran (the route always evaluates the
+        # threshold before deciding), but the cloud branch chose local.
+        assert engine.estimate_calls == ["RENDERED_PROMPT"]
+        assert engine.chat_calls, "local engine.chat was not called"

--- a/tests/test_cloud_router.py
+++ b/tests/test_cloud_router.py
@@ -688,7 +688,7 @@ class TestCloudRoutingFiresEndToEnd:
     """
 
     def test_above_threshold_routes_to_cloud(self, _reset_after):
-        client, engine, _ = _make_cloud_routed_client(
+        client, engine, cloud_router = _make_cloud_routed_client(
             prompt_tokens=500,
             threshold=10,
             cloud_response={
@@ -745,6 +745,14 @@ class TestCloudRoutingFiresEndToEnd:
         assert engine.chat_calls == [], (
             "engine.chat was called even though the request should have routed "
             "to cloud — the cloud branch fell through to local."
+        )
+        # Positive evidence the cloud call itself fired — guards against a
+        # future refactor where the response payload happens to match
+        # ``ROUTED_TO_CLOUD`` via the local path (codex round-1 review:
+        # asserting response content alone is necessary-but-not-sufficient).
+        assert cloud_router._litellm.acompletion.called, (
+            "cloud_router.completion was never invoked — the response "
+            "matched 'ROUTED_TO_CLOUD' for the wrong reason."
         )
 
     def test_below_threshold_stays_local(self, _reset_after):

--- a/tests/test_route_engine_contract.py
+++ b/tests/test_route_engine_contract.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bug-class AST gates for ``vllm_mlx/routes/*.py`` engine access.
+
+Two regressions back-to-back (``#500`` + the ``v0.6.70`` hotfix) shipped the
+same shape: a route accessed an engine attribute / method that didn't exist
+on the production engine, and the failure was silently swallowed.
+
+* ``#500`` — ``hasattr(engine, "build_prompt")`` guarded the cloud-routing
+  branch. When ``#155`` deleted ``SimpleEngine`` (which hosted the method),
+  the guard turned ``False`` against ``BatchedEngine`` and the whole branch
+  was skipped without a log line.
+* ``v0.6.70 hotfix`` — same branch, deeper in the body: ``engine.model.
+  estimate_new_tokens(...)``. ``BatchedEngine`` has no ``.model`` attribute
+  (that was a ``SimpleEngine`` convention). The broad ``except Exception``
+  around the cloud block caught the ``AttributeError`` and the warning
+  ``"falling back to local"`` was the only signal.
+
+Neither was caught by ``pr_validate``, ``make smoke``, ``make stress``, or
+the three integration suites. They all passed because the existing route
+tests used ``MagicMock`` engines that auto-satisfy any attribute access.
+The bugs surfaced only at the release SOP's Gate 6 (real-server live
+repro).
+
+These gates exist so the bug-class is structurally impossible to
+reintroduce. They are intentionally AST-based (not string ``in`` checks)
+so refactors don't accidentally bypass them.
+
+Pattern A — ``hasattr(engine, X)`` is banned unless ``X`` is on an
+explicit allowlist of "genuinely optional" methods. The methods used by
+cloud routing and guided generation are on the ``BaseEngine`` contract;
+guarding them with ``hasattr`` re-creates the silent-skip shape.
+
+Pattern B — ``engine.X.Y`` (two-level access) is banned unless ``X`` is
+explicitly declared on ``BaseEngine``. The only ``X`` that qualifies
+today is ``tokenizer``. Anything else (``engine.model``, ``engine.scheduler``,
+…) is reaching into private engine internals from the route layer.
+
+Pattern C — every method called as ``engine.METHOD(...)`` from a route
+must exist on ``BaseEngine``. Catches "I added a new route helper that
+calls a method only one engine implements" before it ships.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+ROUTES_DIR = pathlib.Path(__file__).parent.parent / "vllm_mlx" / "routes"
+
+
+# Methods/properties the routes may legitimately ``hasattr``-guard. Keep
+# this list small. Anything that warrants a real conditional code path
+# belongs on ``BaseEngine`` with a sensible default instead.
+HASATTR_ENGINE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # No entries today. The cloud-routing methods (#500) and guided-
+        # generation methods are on BaseEngine now; the hasattr guards
+        # that used to live in routes/chat.py have all been removed.
+    }
+)
+
+# Two-level engine accesses (``engine.X.Y``) that are sanctioned because
+# ``X`` is on the BaseEngine contract.
+TWO_LEVEL_ENGINE_ROOT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "tokenizer",  # declared abstract on BaseEngine
+    }
+)
+
+
+def _route_files() -> list[pathlib.Path]:
+    return sorted(p for p in ROUTES_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+def _parse(file: pathlib.Path) -> ast.AST:
+    return ast.parse(file.read_text(), filename=str(file))
+
+
+def _base_engine_public_attrs() -> set[str]:
+    """Names declared on ``BaseEngine`` that routes may legitimately use.
+
+    Includes ``@abstractmethod`` methods, ``@property`` declarations, and
+    concrete methods with default implementations.
+    """
+    from vllm_mlx.engine import base as base_mod
+
+    base = base_mod.BaseEngine
+    # Walk the MRO so concrete defaults declared on ``BaseEngine`` (not
+    # only on subclasses) are picked up.
+    names = set()
+    for cls in base.__mro__:
+        if cls is object:
+            continue
+        for name, value in vars(cls).items():
+            if name.startswith("_"):
+                continue
+            names.add(name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Pattern A — hasattr(engine, X) guards
+# ---------------------------------------------------------------------------
+
+
+class _HasattrEngineVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.findings: list[tuple[int, str]] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "hasattr"
+            and len(node.args) == 2
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "engine"
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            self.findings.append((node.lineno, node.args[1].value))
+        self.generic_visit(node)
+
+
+@pytest.mark.parametrize("route_file", _route_files(), ids=lambda p: p.name)
+def test_no_hasattr_engine_guard(route_file: pathlib.Path) -> None:
+    """``hasattr(engine, "X")`` is banned unless ``X`` is on the
+    allowlist. The guard is the same shape that silently disabled cloud
+    routing in #500 — when the engine class evolves and the method goes
+    away, the guard turns False and the feature is dead with no signal.
+
+    If a future engine genuinely doesn't support some optional feature,
+    declare it on ``BaseEngine`` with a sensible default (e.g.
+    ``supports_X = False``) and branch on the value, not on attribute
+    existence.
+    """
+    visitor = _HasattrEngineVisitor()
+    visitor.visit(_parse(route_file))
+    illegal = [
+        (line, name)
+        for line, name in visitor.findings
+        if name not in HASATTR_ENGINE_ALLOWLIST
+    ]
+    assert not illegal, (
+        f"{route_file.name} has hasattr(engine, ...) guards on non-"
+        f"allowlisted methods (silent-skip shape of #500):\n"
+        + "\n".join(f"  line {ln}: hasattr(engine, {name!r})" for ln, name in illegal)
+        + f"\nAllowlist: {sorted(HASATTR_ENGINE_ALLOWLIST) or '(empty)'}."
+        " Hoist the method onto BaseEngine with a default and remove the"
+        " guard, or add to the allowlist with a documented justification."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern B — engine.X.Y (two-level engine access)
+# ---------------------------------------------------------------------------
+
+
+class _TwoLevelEngineVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.findings: list[tuple[int, str, str]] = []  # (line, X, full)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # match ``engine.X.Y`` — i.e. an Attribute whose ``value`` is itself
+        # an Attribute whose ``value`` is a Name("engine").
+        inner = node.value
+        if (
+            isinstance(inner, ast.Attribute)
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id == "engine"
+        ):
+            self.findings.append(
+                (
+                    node.lineno,
+                    inner.attr,
+                    f"engine.{inner.attr}.{node.attr}",
+                )
+            )
+        self.generic_visit(node)
+
+
+@pytest.mark.parametrize("route_file", _route_files(), ids=lambda p: p.name)
+def test_no_two_level_engine_access(route_file: pathlib.Path) -> None:
+    """``engine.X.Y`` is banned unless ``X`` is declared on
+    ``BaseEngine``. ``engine.model.estimate_new_tokens`` (v0.6.70 hotfix)
+    is the canonical bad case: ``BatchedEngine`` has no ``.model``
+    attribute, so the access raises ``AttributeError`` and the cloud
+    branch's try/except silently logs ``"falling back to local"``.
+
+    If you genuinely need ``engine.X.Y``, declare ``X`` on
+    ``BaseEngine`` as an abstract property so every engine that ships
+    has it.
+    """
+    visitor = _TwoLevelEngineVisitor()
+    visitor.visit(_parse(route_file))
+    illegal = [
+        (line, x, full)
+        for line, x, full in visitor.findings
+        if x not in TWO_LEVEL_ENGINE_ROOT_ALLOWLIST
+    ]
+    assert not illegal, (
+        f"{route_file.name} reaches into engine internals via two-level"
+        f" attribute access (shape of v0.6.70 hotfix):\n"
+        + "\n".join(f"  line {ln}: {full}" for ln, _, full in illegal)
+        + f"\nAllowed roots: {sorted(TWO_LEVEL_ENGINE_ROOT_ALLOWLIST)}."
+        " Hoist the helper onto BaseEngine as ``engine.Y(...)`` so every"
+        " engine that ships implements it (and a missing one fails at"
+        " instantiation, not at request time)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern C — engine.METHOD(...) must be on BaseEngine
+# ---------------------------------------------------------------------------
+
+
+class _DirectEngineMethodVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.findings: list[tuple[int, str]] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # match ``engine.METHOD(...)``
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "engine"
+        ):
+            self.findings.append((node.lineno, func.attr))
+        self.generic_visit(node)
+
+
+@pytest.mark.parametrize("route_file", _route_files(), ids=lambda p: p.name)
+def test_route_engine_method_calls_are_on_base_contract(
+    route_file: pathlib.Path,
+) -> None:
+    """Every ``engine.METHOD(...)`` call in a route file must resolve to
+    a name declared on ``BaseEngine``. Catches the "new route helper
+    calls a BatchedEngine-only method" failure mode at PR time, before
+    the missing method ships as a silent route-level skip.
+    """
+    base_names = _base_engine_public_attrs()
+    visitor = _DirectEngineMethodVisitor()
+    visitor.visit(_parse(route_file))
+    illegal = [
+        (line, name) for line, name in visitor.findings if name not in base_names
+    ]
+    assert not illegal, (
+        f"{route_file.name} calls engine methods that are NOT on the"
+        f" BaseEngine contract:\n"
+        + "\n".join(f"  line {ln}: engine.{name}(...)" for ln, name in illegal)
+        + "\nAdd the method to vllm_mlx/engine/base.py — either as"
+        " @abstractmethod (every engine must implement) or with a default"
+        " body (engines opt in by overriding)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke — confirm the gate works against the original buggy shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_gates_catch_pre_fix_shapes(tmp_path: pathlib.Path) -> None:
+    """Synthesize the two original bug shapes in a temp file and assert
+    each gate's AST visitor flags them. Without this, a future refactor
+    could silently weaken the visitors and we'd never know."""
+    src = (
+        "def f(engine):\n"
+        '    if hasattr(engine, "build_prompt"):\n'
+        '        engine.build_prompt("x")\n'
+        "    return engine.model.estimate_new_tokens('x')\n"
+    )
+    tree = ast.parse(src)
+
+    a = _HasattrEngineVisitor()
+    a.visit(tree)
+    assert a.findings == [(2, "build_prompt")]
+
+    b = _TwoLevelEngineVisitor()
+    b.visit(tree)
+    assert b.findings == [(4, "model", "engine.model.estimate_new_tokens")]
+
+    c = _DirectEngineMethodVisitor()
+    c.visit(tree)
+    assert c.findings == [(3, "build_prompt")]

--- a/tests/test_route_engine_contract.py
+++ b/tests/test_route_engine_contract.py
@@ -79,25 +79,19 @@ def _parse(file: pathlib.Path) -> ast.AST:
 
 
 def _base_engine_public_attrs() -> set[str]:
-    """Names declared on ``BaseEngine`` that routes may legitimately use.
+    """Names declared **on** ``BaseEngine`` itself that routes may use.
+
+    Reads only ``vars(BaseEngine)`` — not the MRO — so inherited names
+    from ``ABC`` (``__subclasshook__``, etc.) and ``object`` (``__init__``,
+    ``__repr__``, etc.) don't accidentally become part of the "contract"
+    and let route-layer typos through (codex round-1 review on PR #502).
 
     Includes ``@abstractmethod`` methods, ``@property`` declarations, and
-    concrete methods with default implementations.
+    concrete methods with default implementations declared in this class.
     """
     from vllm_mlx.engine import base as base_mod
 
-    base = base_mod.BaseEngine
-    # Walk the MRO so concrete defaults declared on ``BaseEngine`` (not
-    # only on subclasses) are picked up.
-    names = set()
-    for cls in base.__mro__:
-        if cls is object:
-            continue
-        for name, value in vars(cls).items():
-            if name.startswith("_"):
-                continue
-            names.add(name)
-    return names
+    return {name for name in vars(base_mod.BaseEngine) if not name.startswith("_")}
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -238,3 +238,78 @@ class BaseEngine(ABC):
     async def abort_request(self, request_id: str) -> bool:
         """Abort an active or queued request when the engine supports it."""
         return False
+
+    # ------------------------------------------------------------------
+    # Route-layer contract
+    #
+    # The OpenAI / Anthropic routes call these directly on the engine —
+    # they're declared here so a missing implementation fails at
+    # instantiation (ABC enforcement) instead of silently degrading at
+    # request time under a ``hasattr`` guard or broad ``try/except``.
+    #
+    # Bug history this contract closes: #500 (``hasattr(engine,
+    # "build_prompt")`` silently disabled cloud routing for ~6 weeks
+    # after #155 deleted SimpleEngine which hosted the method) and the
+    # v0.6.70 hotfix (``engine.model.estimate_new_tokens`` AttributeError
+    # was swallowed by the cloud branch's broad try/except → silent
+    # fallback). Both regressions surfaced only via Gate 6 (real-server
+    # live repro); none of the unit/integration suites caught them
+    # because every test mocked the engine with a MagicMock that
+    # auto-satisfies any attribute access.
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def build_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        enable_thinking: bool | None = None,
+    ) -> str:
+        """Render the chat prompt for ``messages`` + ``tools`` without
+        starting generation.
+
+        Called by ``routes/chat.py`` for cloud-routing token estimation
+        and for eager streaming chat-template validation (so template
+        errors surface as HTTP 400 instead of mid-stream failures).
+        """
+
+    @abstractmethod
+    def estimate_new_tokens(self, prompt: str) -> tuple[int, int]:
+        """Return ``(total_tokens, new_tokens)`` for ``prompt``.
+
+        Called by ``routes/chat.py`` cloud routing to decide whether the
+        request crosses ``--cloud-threshold`` and should be offloaded.
+        ``new_tokens`` is the count that would need fresh prefill — i.e.
+        total minus the prefix already warm in cache. A conservative
+        ``(total, total)`` is acceptable; correctness only requires that
+        the threshold semantics hold.
+        """
+
+    @property
+    def supports_guided_generation(self) -> bool:
+        """Whether the engine can constrain output to a JSON schema.
+
+        Default ``False``; override to return ``True`` only when
+        ``generate_with_schema`` is also implemented (the route checks
+        this flag before calling). Allows engines without ``outlines`` /
+        guided decoding to participate in the contract without
+        implementing the optional schema path.
+        """
+        return False
+
+    async def generate_with_schema(
+        self,
+        messages: list[dict[str, Any]],
+        json_schema: dict[str, Any],
+        **kwargs,
+    ) -> "GenerationOutput":
+        """Generate output constrained to ``json_schema``.
+
+        Default raises ``NotImplementedError``. The route only calls this
+        when ``supports_guided_generation`` is ``True``, so engines that
+        leave that flag at the default ``False`` need not override.
+        """
+        raise NotImplementedError(
+            "generate_with_schema is not implemented for this engine. "
+            "Override supports_guided_generation to advertise capability."
+        )

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -439,7 +439,12 @@ async def _stream_anthropic_messages(
     accumulated_text = ""
     accumulated_raw = ""
     tool_filter = StreamingToolCallFilter()
-    _tokenizer = engine.tokenizer if hasattr(engine, "tokenizer") else None
+    # ``tokenizer`` is on the BaseEngine contract; the old ``hasattr``
+    # guard predated the abstract declaration and is the same silent-skip
+    # shape that produced #500. The inner ``chat_template`` guard stays
+    # because that attribute is HF-tokenizer-specific, not part of our
+    # contract.
+    _tokenizer = engine.tokenizer
     _chat_template = ""
     if _tokenizer and hasattr(_tokenizer, "chat_template"):
         _chat_template = _tokenizer.chat_template or ""

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -85,13 +85,28 @@ router = APIRouter()
 def _cloud_call_recoverable_exceptions() -> tuple[type[BaseException], ...]:
     """Build the allowlist of exception types we treat as recoverable from
     the cloud call. Lazy so cloud routing being disabled doesn't pay the
-    litellm import cost."""
+    litellm import cost.
+
+    Covered failure shapes (codex round-1 review on PR #502 — broaden
+    beyond ``httpx.HTTPError`` to catch real production cases):
+      * ``asyncio.TimeoutError`` / ``TimeoutError`` — request budget hit
+      * ``ConnectionError`` — TCP/UDP transport down
+      * ``ssl.SSLError`` — certificate / handshake — common w/ corp MITM
+      * ``json.JSONDecodeError`` — provider returned malformed body
+      * ``httpx.HTTPError`` — covers ``HTTPStatusError``, ``RequestError``,
+        ``ConnectError``, ``ProxyError``, ``ReadTimeout``, etc.
+      * ``litellm.exceptions.APIError`` — provider-side surface
+    """
     import asyncio
+    import json
+    import ssl
 
     exc_types: list[type[BaseException]] = [
         asyncio.TimeoutError,
         ConnectionError,
         TimeoutError,
+        ssl.SSLError,
+        json.JSONDecodeError,
     ]
     try:
         import httpx

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -70,6 +70,47 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Exceptions worth catching around the cloud call so the local engine can
+# take over: provider/network/auth/quota — transient or out-of-our-control.
+# Anything outside this allowlist (AttributeError, TypeError,
+# NotImplementedError, …) is an engine-contract violation or programming
+# bug and MUST surface as 500. The original ``except Exception`` here hid
+# both #500 (missing ``build_prompt``) and the v0.6.70 hotfix (missing
+# the token-estimation helper on the engine) as silent fallback warnings.
+#
+# ``litellm.exceptions`` is imported lazily — its presence depends on
+# whether cloud routing was configured at startup. ``httpx`` and the
+# stdlib timeout/connection set are always available, so we fall back
+# to those when litellm isn't importable.
+def _cloud_call_recoverable_exceptions() -> tuple[type[BaseException], ...]:
+    """Build the allowlist of exception types we treat as recoverable from
+    the cloud call. Lazy so cloud routing being disabled doesn't pay the
+    litellm import cost."""
+    import asyncio
+
+    exc_types: list[type[BaseException]] = [
+        asyncio.TimeoutError,
+        ConnectionError,
+        TimeoutError,
+    ]
+    try:
+        import httpx
+
+        exc_types.append(httpx.HTTPError)
+    except ImportError:
+        pass
+    try:
+        from litellm import exceptions as _litellm_exc
+
+        exc_types.append(_litellm_exc.APIError)
+    except (ImportError, AttributeError):
+        pass
+    return tuple(exc_types)
+
+
+_CLOUD_CALL_RECOVERABLE_EXCEPTIONS = _cloud_call_recoverable_exceptions()
+
+
 # Matches a single backslash directly followed by a non-ASCII codepoint.
 # ``lm-format-enforcer``'s grammar permits ``\\`` followed by any codepoint
 # as a valid JSON escape, so a model emitting JSON with CJK / emoji content
@@ -532,46 +573,57 @@ async def _create_chat_completion_impl(
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
 
-    # Cloud routing: offload large-context requests to cloud LLM
+    # Cloud routing: offload large-context requests to cloud LLM.
+    #
+    # The token-budget computation (``build_prompt`` + ``estimate_new_
+    # tokens``) is part of the BaseEngine contract — any exception there
+    # is a real bug and must surface, NOT be silently swallowed as
+    # "falling back to local". The two regressions this scope-narrowing
+    # closes (#500 + the v0.6.70 hotfix) both hid behind a broad
+    # ``except Exception`` that turned engine-contract violations into
+    # warning logs while cloud routing silently never fired.
+    #
+    # Only the cloud call itself is wrapped, and only "expected,
+    # transient" failure shapes (network, auth, provider) are caught.
     if cfg.cloud_router and not engine.is_mllm:
-        try:
-            prompt = engine.build_prompt(messages, tools=request.tools)
-            total_tokens, new_tokens = engine.estimate_new_tokens(prompt)
-            if cfg.cloud_router.should_route_to_cloud(new_tokens):
-                logger.info(
-                    f"[CLOUD ROUTE] {new_tokens} new tokens (total {total_tokens}) "
-                    f"> threshold {cfg.cloud_router.threshold}, "
-                    f"routing to {cfg.cloud_router.cloud_model}"
+        prompt = engine.build_prompt(messages, tools=request.tools)
+        total_tokens, new_tokens = engine.estimate_new_tokens(prompt)
+        if cfg.cloud_router.should_route_to_cloud(new_tokens):
+            logger.info(
+                f"[CLOUD ROUTE] {new_tokens} new tokens (total {total_tokens}) "
+                f"> threshold {cfg.cloud_router.threshold}, "
+                f"routing to {cfg.cloud_router.cloud_model}"
+            )
+            cloud_messages = _cloud_original_messages
+            cloud_kwargs = {
+                "temperature": chat_kwargs.get("temperature"),
+                "max_tokens": chat_kwargs.get("max_tokens"),
+                "top_p": chat_kwargs.get("top_p"),
+            }
+            if request.stop:
+                cloud_kwargs["stop"] = request.stop
+            if request.tool_choice is not None:
+                cloud_kwargs["tool_choice"] = request.tool_choice
+            if request.response_format:
+                rf = request.response_format
+                cloud_kwargs["response_format"] = (
+                    rf.model_dump() if hasattr(rf, "model_dump") else rf
                 )
-                cloud_messages = _cloud_original_messages
-                cloud_kwargs = {
-                    "temperature": chat_kwargs.get("temperature"),
-                    "max_tokens": chat_kwargs.get("max_tokens"),
-                    "top_p": chat_kwargs.get("top_p"),
-                }
-                if request.stop:
-                    cloud_kwargs["stop"] = request.stop
-                if request.tool_choice is not None:
-                    cloud_kwargs["tool_choice"] = request.tool_choice
-                if request.response_format:
-                    rf = request.response_format
-                    cloud_kwargs["response_format"] = (
-                        rf.model_dump() if hasattr(rf, "model_dump") else rf
-                    )
-                if request.tools:
-                    cloud_kwargs["tools"] = [
-                        t.model_dump() if hasattr(t, "model_dump") else t
-                        for t in request.tools
-                    ]
-                # Cloud-routed request: the local scheduler/Metal path
-                # is bypassed entirely, so admission is not acquired
-                # for cloud paths. The wrapper's ``finally`` checks
-                # ``_admission_acquired[0]`` (still False here) and
-                # skips the release. Without this ordering (admission
-                # check moved BELOW the cloud routing block), a burst
-                # of local requests filling the cap would 503
-                # cloud-routable requests that never touch the local
-                # engine (codex R9).
+            if request.tools:
+                cloud_kwargs["tools"] = [
+                    t.model_dump() if hasattr(t, "model_dump") else t
+                    for t in request.tools
+                ]
+            # Cloud-routed request: the local scheduler/Metal path
+            # is bypassed entirely, so admission is not acquired
+            # for cloud paths. The wrapper's ``finally`` checks
+            # ``_admission_acquired[0]`` (still False here) and
+            # skips the release. Without this ordering (admission
+            # check moved BELOW the cloud routing block), a burst
+            # of local requests filling the cap would 503
+            # cloud-routable requests that never touch the local
+            # engine (codex R9).
+            try:
                 if request.stream:
                     return StreamingResponse(
                         _disconnect_guard(
@@ -596,14 +648,19 @@ async def _create_chat_completion_impl(
                         content=json.dumps(result),
                         media_type="application/json",
                     )
-            else:
-                logger.info(
-                    f"[LOCAL] {new_tokens} new tokens (total {total_tokens}) "
-                    f"<= threshold {cfg.cloud_router.threshold}, using local inference"
+            except _CLOUD_CALL_RECOVERABLE_EXCEPTIONS as e:
+                # Provider/network failures are transient and the local
+                # engine is a reasonable fallback. Engine-contract
+                # violations (AttributeError, TypeError, …) are NOT in
+                # this allowlist on purpose — they must surface as 500.
+                logger.warning(
+                    f"[CLOUD ROUTE] Cloud call failed ({type(e).__name__}: {e}), "
+                    "falling back to local"
                 )
-        except Exception as e:
-            logger.warning(
-                f"[CLOUD ROUTE] Error during routing check: {e}, falling back to local"
+        else:
+            logger.info(
+                f"[LOCAL] {new_tokens} new tokens (total {total_tokens}) "
+                f"<= threshold {cfg.cloud_router.threshold}, using local inference"
             )
 
     # Local-path admission gate: reserve a slot before kicking the
@@ -628,21 +685,16 @@ async def _create_chat_completion_impl(
     json_schema = None
     if response_format and not request.tools:
         json_schema = extract_json_schema_for_guided(response_format)
-        if json_schema and hasattr(engine, "supports_guided_generation"):
+        if json_schema:
+            # ``supports_guided_generation`` and ``generate_with_schema``
+            # are on the BaseEngine contract — defaults are False /
+            # NotImplementedError, so engines without guided decoding
+            # opt out by leaving the property at False. The previous
+            # ``hasattr`` guards were artifacts of the engine API being
+            # informal; they're the same silent-skip shape that produced
+            # #500 and the v0.6.70 hotfix and have no role now that the
+            # contract is explicit.
             use_guided = engine.supports_guided_generation
-            # Belt-and-suspenders: a future custom engine could advertise
-            # ``supports_guided_generation=True`` yet not implement
-            # ``generate_with_schema``. Without this guard the streaming
-            # path would 500 with AttributeError on the first guided
-            # request; the non-stream branch would do the same. Match
-            # the contract surface that ``stream_chat_completion_guided``
-            # and the non-stream guided dispatch actually call.
-            if use_guided and not hasattr(engine, "generate_with_schema"):
-                logger.warning(
-                    "Engine advertises supports_guided_generation=True but "
-                    "is missing generate_with_schema; disabling guided path"
-                )
-                use_guided = False
             if use_guided:
                 logger.info("Using guided generation for JSON schema enforcement")
             else:


### PR DESCRIPTION
## Why

Two regressions back-to-back (#500 + v0.6.70 hotfix) shipped the same shape: a route accessed an engine attribute/method that didn't exist on the production engine, and the failure was silently swallowed. Neither was caught by `pr_validate`, `make smoke`, `make stress`, or any of the three integration suites — every existing route test used `MagicMock` engines that auto-satisfy any attribute access. **Both surfaced only at the release SOP's Gate 6 (real-server live repro).**

This PR closes the bug-class structurally so a third instance can't ship.

## What

### 1. Engine contract — `vllm_mlx/engine/base.py`

Hoist 4 methods onto `BaseEngine` so missing implementations fail at instantiation (ABC enforcement) instead of at request time:

| name | shape | rationale |
|---|---|---|
| `build_prompt` | `@abstractmethod` | every engine that serves chat needs it |
| `estimate_new_tokens` | `@abstractmethod` | every engine that can be the local arm of cloud routing needs it |
| `supports_guided_generation` | property, default `False` | engines opt in by overriding |
| `generate_with_schema` | default `NotImplementedError` | optional path, route checks the flag first |

`BatchedEngine` already implements all 4; ABC check stays empty (`frozenset()`). Verified.

### 2. Narrow try/except — `vllm_mlx/routes/chat.py`

The cloud-routing branch used `except Exception` which swallowed both regressions silently. Replaced with an explicit allowlist of recoverable failure modes (`asyncio.TimeoutError`, `ConnectionError`, `TimeoutError`, `ssl.SSLError`, `json.JSONDecodeError`, `httpx.HTTPError`, `litellm.exceptions.APIError`). Engine-contract violations (`AttributeError`, `TypeError`, `NotImplementedError`) now surface as 500.

### 3. Remove dead `hasattr` guards

`routes/chat.py` (`supports_guided_generation`, `generate_with_schema`) and `routes/anthropic.py` (`tokenizer`) — all three are on the BaseEngine contract; the guards were the same silent-skip shape and have no role anymore.

### 4. Repro tests — `tests/test_cloud_router.py::TestCloudRoutingFiresEndToEnd`

Two tests using a real `BaseEngine` subclass (not `MagicMock`). The subclass forces the contract: if `BaseEngine` later loses `build_prompt`, the test file fails to import.

**Inverse-verified** locally: synthesizing either the original #500 hasattr guard or the v0.6.70 `engine.model.estimate_new_tokens` shape in `routes/chat.py` flips `test_above_threshold_routes_to_cloud` to fail immediately (`"local"` instead of `"ROUTED_TO_CLOUD"`).

### 5. AST gate file — `tests/test_route_engine_contract.py`

Parametrized across every route file with 3 patterns:

| pattern | banned shape | exemption |
|---|---|---|
| A | `hasattr(engine, X)` | empty allowlist (intentional) |
| B | `engine.X.Y` (two-level access) | `X` must be on BaseEngine; only `tokenizer` qualifies today |
| C | `engine.METHOD(...)` | METHOD must be declared on BaseEngine |

Plus a self-test that synthesizes the two original bug shapes and asserts each AST visitor flags them — ensures future refactors of the visitors don't accidentally weaken the gates.

### 6. DeepSeek round-1 adversarial review (commit `931782c`)

10 findings raised, 3 actionable addressed:
- broaden cloud exception allowlist (`ssl.SSLError`, `json.JSONDecodeError`)
- positive assertion on `cloud_router._litellm.acompletion.called` in repro test
- tighten `_base_engine_public_attrs` to read only `vars(BaseEngine)` (not MRO)

The 7 not acted on were either invalid (no other BaseEngine subclasses exist in repo since #155) or design-intent (restoring belt-and-suspenders hasattr IS the silent-skip pattern this PR removes).

## Test plan

- [x] `pytest tests/test_cloud_router.py` → 27 passed (including 2 new live-repro tests)
- [x] `pytest tests/test_route_engine_contract.py` → 25 passed (8 routes × 3 patterns + 1 self-test)
- [x] Inverse check on chat.py: re-introducing either bug shape fails Pattern A or B gate with clear error message naming bug history (#500 / v0.6.70 hotfix)
- [x] 161 adjacent route tests pass (cloud_router, route_engine_contract, paired_compat, chat_streaming_*, chat_route_*, anthropic_*, chat_logprobs_*, embeddings_timeout_admission, no_out_of_band_routing, parallel_tool_calls, text_only_media_gate)
- [x] `make smoke` → lint + audit + 1933 unit tests, 3/3 PASS
- [x] `ruff check` + `ruff format --check` on changed files
- [x] `pr_validate 502` — `targeted_tests` 327/327, `full_unit` 4164/4164, Qwen3.6-27B-8bit stress 8/8 + 6/6 langchain
- [x] CI 8/8 green on commit `931782c` (lint, type-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, tests)

### pr_validate residuals (environmental, none touch this diff)

1. **`stress_e2e_bench` qwen3.5-35B-A3B-8bit boot timeout** — same HF `xet_get` first-download issue as the v0.6.70 release. Disk free, 180s server-boot probe < download time. Family has no smaller fallback.
2. **`stress_e2e_bench` qwen3.6-27B pydantic_ai_full subprocess timeout** — 1800s pr_validate subprocess cap; documented in memory as known slow-but-passing on this model. Sanity check unbounded on qwen3.5-4b: 5/6 (one client-config failure, not regression). Diff touches no pydantic_ai code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)