### PR TITLE
feat(mvp): single-Mac dogfood launcher + minimax-m2.7 alias

### DIFF
--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -11,17 +11,36 @@
 #     scripts/run_dogfood_mvp.sh status
 #
 #   Env vars:
-#     MODEL    alias to serve (default: qwen3.5-35b)
-#     PORT     local port (default: 8765)
-#     API_KEY  bearer token (default: random 24 hex bytes)
+#     MODEL            alias to serve (default: qwen3.5-35b)
+#     PORT             local port (default: 8765)
+#     API_KEY          bearer token (default: random 24 hex bytes)
+#     TUNNEL_MODE      quick | named (default: auto — named iff ~/.cloudflared/config.yml exists)
+#     TUNNEL_NAME      named tunnel name (default: rapid-mlx-mvp)
+#     TUNNEL_HOSTNAME  named tunnel hostname (default: parsed from config.yml)
 #
-# Designed to be re-runnable: `stop` then `start` gives a fresh URL.
+# Designed to be re-runnable: `stop` then `start` gives a fresh URL in
+# quick mode and the same persistent URL in named mode.
 
 set -euo pipefail
 
 MODEL="${MODEL:-qwen3.5-35b}"
 PORT="${PORT:-8765}"
 API_KEY="${API_KEY:-$(openssl rand -hex 24)}"
+# Extra args appended to `rapid-mlx serve`. Defaults tuned for chat-UX dogfood:
+#   --no-thinking         skip <think> reasoning so Open WebUI sees content
+#                         immediately (cuts perceived TTFT 10-15s on qwen3.5)
+#   --cors-origins "*"    allow browser-based chat UIs (LobeChat, Big-AGI, …)
+EXTRA_SERVE_ARGS="${EXTRA_SERVE_ARGS:---no-thinking --cors-origins *}"
+
+# Tunnel mode auto-detect: if a cloudflared config exists, default to named.
+TUNNEL_NAME="${TUNNEL_NAME:-rapid-mlx-mvp}"
+CF_CONFIG="$HOME/.cloudflared/config.yml"
+if [ -z "${TUNNEL_MODE:-}" ]; then
+  if [ -f "$CF_CONFIG" ]; then TUNNEL_MODE="named"; else TUNNEL_MODE="quick"; fi
+fi
+if [ -z "${TUNNEL_HOSTNAME:-}" ] && [ -f "$CF_CONFIG" ]; then
+  TUNNEL_HOSTNAME="$(awk '/^\s*-\s*hostname:/ {print $NF; exit}' "$CF_CONFIG")"
+fi
 
 LOG_DIR="$HOME/.cache/rapid-mlx/dogfood"
 mkdir -p "$LOG_DIR"
@@ -91,9 +110,10 @@ if ! command -v cloudflared >/dev/null; then
   echo "cloudflared not found — brew install cloudflared" >&2; exit 1
 fi
 
-echo "Starting rapid-mlx ($MODEL on :$PORT) …"
+echo "Starting rapid-mlx ($MODEL on :$PORT) [extra: $EXTRA_SERVE_ARGS] …"
+# shellcheck disable=SC2086  # intentional word splitting on EXTRA_SERVE_ARGS
 nohup rapid-mlx serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
-  --log-level INFO >"$SERVER_LOG" 2>&1 &
+  --log-level INFO $EXTRA_SERVE_ARGS >"$SERVER_LOG" 2>&1 &
 echo $! > "$SERVER_PID"
 
 # Wait for /healthz — model load can take 60-90s for a 30B MoE from cache.
@@ -113,22 +133,47 @@ if [ "$ok" -ne 1 ]; then
   exit 1
 fi
 
-echo "Starting cloudflared quick tunnel …"
-nohup cloudflared tunnel --url "http://localhost:$PORT" >"$TUNNEL_LOG" 2>&1 &
-echo $! > "$TUNNEL_PID"
-
-echo -n "Waiting for tunnel URL "
-URL=""
-for _ in $(seq 1 60); do
-  URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$TUNNEL_LOG" | head -1 || true)
-  if [ -n "$URL" ]; then echo " $URL"; break; fi
-  echo -n "."
-  sleep 1
-done
-if [ -z "$URL" ]; then
-  echo " FAIL — see $TUNNEL_LOG"
-  do_stop
-  exit 1
+if [ "$TUNNEL_MODE" = "named" ]; then
+  if [ -z "${TUNNEL_HOSTNAME:-}" ]; then
+    echo "TUNNEL_MODE=named but no hostname (set TUNNEL_HOSTNAME or add ingress to $CF_CONFIG)" >&2
+    do_stop
+    exit 1
+  fi
+  echo "Starting cloudflared named tunnel ($TUNNEL_NAME → $TUNNEL_HOSTNAME) …"
+  nohup cloudflared tunnel run "$TUNNEL_NAME" >"$TUNNEL_LOG" 2>&1 &
+  echo $! > "$TUNNEL_PID"
+  echo -n "Waiting for tunnel registration "
+  ok=0
+  for _ in $(seq 1 60); do
+    if grep -q "Registered tunnel connection" "$TUNNEL_LOG" 2>/dev/null; then
+      echo " ok"; ok=1; break
+    fi
+    echo -n "."
+    sleep 1
+  done
+  if [ "$ok" -ne 1 ]; then
+    echo " FAIL — see $TUNNEL_LOG"
+    do_stop
+    exit 1
+  fi
+  URL="https://$TUNNEL_HOSTNAME"
+else
+  echo "Starting cloudflared quick tunnel …"
+  nohup cloudflared tunnel --url "http://localhost:$PORT" >"$TUNNEL_LOG" 2>&1 &
+  echo $! > "$TUNNEL_PID"
+  echo -n "Waiting for tunnel URL "
+  URL=""
+  for _ in $(seq 1 60); do
+    URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$TUNNEL_LOG" | head -1 || true)
+    if [ -n "$URL" ]; then echo " $URL"; break; fi
+    echo -n "."
+    sleep 1
+  done
+  if [ -z "$URL" ]; then
+    echo " FAIL — see $TUNNEL_LOG"
+    do_stop
+    exit 1
+  fi
 fi
 
 echo "$URL" > "$URL_FILE"

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Minimal "single-Mac behind Cloudflare" dogfood MVP.
+#
+# Starts rapid-mlx serving an alias on localhost, then exposes that port
+# as a public *.trycloudflare.com endpoint gated by an API key (Bearer
+# token). Quick tunnel is ephemeral — URL resets on each run.
+#
+#   Usage:
+#     scripts/run_dogfood_mvp.sh [start]   # default
+#     scripts/run_dogfood_mvp.sh stop
+#     scripts/run_dogfood_mvp.sh status
+#
+#   Env vars:
+#     MODEL    alias to serve (default: qwen3.5-35b)
+#     PORT     local port (default: 8765)
+#     API_KEY  bearer token (default: random 24 hex bytes)
+#
+# Designed to be re-runnable: `stop` then `start` gives a fresh URL.
+
+set -euo pipefail
+
+MODEL="${MODEL:-qwen3.5-35b}"
+PORT="${PORT:-8765}"
+API_KEY="${API_KEY:-$(openssl rand -hex 24)}"
+
+LOG_DIR="$HOME/.cache/rapid-mlx/dogfood"
+mkdir -p "$LOG_DIR"
+SERVER_LOG="$LOG_DIR/server.log"
+TUNNEL_LOG="$LOG_DIR/tunnel.log"
+STATE_DIR="$LOG_DIR/state"
+mkdir -p "$STATE_DIR"
+SERVER_PID="$STATE_DIR/server.pid"
+TUNNEL_PID="$STATE_DIR/tunnel.pid"
+URL_FILE="$STATE_DIR/url"
+KEY_FILE="$STATE_DIR/api_key"
+
+cmd="${1:-start}"
+
+is_alive() {
+  local f="$1"
+  [ -f "$f" ] && kill -0 "$(cat "$f")" 2>/dev/null
+}
+
+do_stop() {
+  for f in "$TUNNEL_PID" "$SERVER_PID"; do
+    if is_alive "$f"; then
+      kill "$(cat "$f")" 2>/dev/null || true
+    fi
+    rm -f "$f"
+  done
+  rm -f "$URL_FILE" "$KEY_FILE"
+  echo "stopped."
+}
+
+do_status() {
+  if is_alive "$SERVER_PID"; then
+    echo "server: up (pid $(cat "$SERVER_PID"))"
+  else
+    echo "server: down"
+  fi
+  if is_alive "$TUNNEL_PID"; then
+    echo "tunnel: up (pid $(cat "$TUNNEL_PID"))"
+  else
+    echo "tunnel: down"
+  fi
+  if [ -f "$URL_FILE" ]; then
+    echo "url:    $(cat "$URL_FILE")"
+  fi
+  if [ -f "$KEY_FILE" ]; then
+    echo "key:    $(cat "$KEY_FILE")"
+  fi
+}
+
+case "$cmd" in
+  stop)   do_stop;   exit 0 ;;
+  status) do_status; exit 0 ;;
+  start)  ;;
+  *) echo "usage: $0 [start|stop|status]" >&2; exit 2 ;;
+esac
+
+if is_alive "$SERVER_PID" || is_alive "$TUNNEL_PID"; then
+  echo "already running — run '$0 stop' first." >&2
+  do_status
+  exit 1
+fi
+
+if ! command -v rapid-mlx >/dev/null; then
+  echo "rapid-mlx not found in PATH" >&2; exit 1
+fi
+if ! command -v cloudflared >/dev/null; then
+  echo "cloudflared not found — brew install cloudflared" >&2; exit 1
+fi
+
+echo "Starting rapid-mlx ($MODEL on :$PORT) …"
+nohup rapid-mlx serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
+  --log-level INFO >"$SERVER_LOG" 2>&1 &
+echo $! > "$SERVER_PID"
+
+# Wait for /healthz — model load can take 60-90s for a 30B MoE from cache.
+echo -n "Waiting for /healthz "
+ok=0
+for _ in $(seq 1 180); do
+  if curl -s -f "http://localhost:$PORT/healthz" >/dev/null 2>&1; then
+    echo " ok"
+    ok=1; break
+  fi
+  echo -n "."
+  sleep 2
+done
+if [ "$ok" -ne 1 ]; then
+  echo " FAIL — see $SERVER_LOG"
+  do_stop
+  exit 1
+fi
+
+echo "Starting cloudflared quick tunnel …"
+nohup cloudflared tunnel --url "http://localhost:$PORT" >"$TUNNEL_LOG" 2>&1 &
+echo $! > "$TUNNEL_PID"
+
+echo -n "Waiting for tunnel URL "
+URL=""
+for _ in $(seq 1 60); do
+  URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$TUNNEL_LOG" | head -1 || true)
+  if [ -n "$URL" ]; then echo " $URL"; break; fi
+  echo -n "."
+  sleep 1
+done
+if [ -z "$URL" ]; then
+  echo " FAIL — see $TUNNEL_LOG"
+  do_stop
+  exit 1
+fi
+
+echo "$URL" > "$URL_FILE"
+echo "$API_KEY" > "$KEY_FILE"
+
+cat <<EOF
+
+==================================================================
+  Dogfood MVP up
+==================================================================
+  Endpoint:  $URL
+  Model:     $MODEL
+  API key:   $API_KEY
+
+  Probe:
+    curl $URL/healthz
+
+  Chat:
+    curl -sS $URL/v1/chat/completions \\
+      -H "Authorization: Bearer $API_KEY" \\
+      -H "Content-Type: application/json" \\
+      -d '{"model":"$MODEL","stream":false,"messages":[{"role":"user","content":"hi"}]}'
+
+  Logs:
+    tail -f $SERVER_LOG
+    tail -f $TUNNEL_LOG
+
+  Stop:
+    $0 stop
+==================================================================
+EOF

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -14,6 +14,11 @@
 #     MODEL            alias to serve (default: qwen3.5-35b)
 #     PORT             local port (default: 8765)
 #     API_KEY          bearer token (default: random 24 hex bytes)
+#     RAPID_MLX_CMD    serve command (default: auto — editable `python3.12 -m
+#                      vllm_mlx.cli` if we're inside the vllm-mlx repo,
+#                      else system `rapid-mlx`). The editable path sees
+#                      newly-added aliases.json entries; the brew-installed
+#                      binary only knows the aliases bundled at install time.
 #     TUNNEL_MODE      quick | named (default: auto — named iff ~/.cloudflared/config.yml exists)
 #     TUNNEL_NAME      named tunnel name (default: rapid-mlx-mvp)
 #     TUNNEL_HOSTNAME  named tunnel hostname (default: parsed from config.yml)
@@ -39,7 +44,8 @@ if [ -z "${TUNNEL_MODE:-}" ]; then
   if [ -f "$CF_CONFIG" ]; then TUNNEL_MODE="named"; else TUNNEL_MODE="quick"; fi
 fi
 if [ -z "${TUNNEL_HOSTNAME:-}" ] && [ -f "$CF_CONFIG" ]; then
-  TUNNEL_HOSTNAME="$(awk '/^\s*-\s*hostname:/ {print $NF; exit}' "$CF_CONFIG")"
+  # POSIX bracket class — macOS BSD awk doesn't support \s.
+  TUNNEL_HOSTNAME="$(awk '/^[[:space:]]*-[[:space:]]*hostname:/ {print $NF; exit}' "$CF_CONFIG")"
 fi
 
 LOG_DIR="$HOME/.cache/rapid-mlx/dogfood"
@@ -103,16 +109,27 @@ if is_alive "$SERVER_PID" || is_alive "$TUNNEL_PID"; then
   exit 1
 fi
 
-if ! command -v rapid-mlx >/dev/null; then
-  echo "rapid-mlx not found in PATH" >&2; exit 1
+# Pick the serve command. Prefer the editable repo CLI when we're inside
+# vllm-mlx — the brew-installed `rapid-mlx` ships an older aliases.json
+# and won't see recent additions like `minimax-m2.7`.
+if [ -z "${RAPID_MLX_CMD:-}" ]; then
+  if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/vllm_mlx/cli.py" ] \
+       && python3.12 -c "import vllm_mlx" >/dev/null 2>&1; then
+    RAPID_MLX_CMD="python3.12 -m vllm_mlx.cli"
+  else
+    RAPID_MLX_CMD="rapid-mlx"
+  fi
+fi
+if ! $RAPID_MLX_CMD --help >/dev/null 2>&1; then
+  echo "RAPID_MLX_CMD=$RAPID_MLX_CMD not runnable" >&2; exit 1
 fi
 if ! command -v cloudflared >/dev/null; then
   echo "cloudflared not found — brew install cloudflared" >&2; exit 1
 fi
 
-echo "Starting rapid-mlx ($MODEL on :$PORT) [extra: $EXTRA_SERVE_ARGS] …"
-# shellcheck disable=SC2086  # intentional word splitting on EXTRA_SERVE_ARGS
-nohup rapid-mlx serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
+echo "Starting $RAPID_MLX_CMD ($MODEL on :$PORT) [extra: $EXTRA_SERVE_ARGS] …"
+# shellcheck disable=SC2086  # intentional word splitting on CMD + EXTRA args
+nohup $RAPID_MLX_CMD serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
   --log-level INFO $EXTRA_SERVE_ARGS >"$SERVER_LOG" 2>&1 &
 echo $! > "$SERVER_PID"
 

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -205,14 +205,21 @@ chmod 600 "$KEY_FILE"
 # below the cloudflared registration timeout (60s loop above) but enough
 # to weed out "URL was printed but 502s for 10 seconds" races.
 echo -n "Probing $URL/healthz "
+probe_ok=0
 for _ in $(seq 1 30); do
   if curl -sSf -m 3 "$URL/healthz" >/dev/null 2>&1; then
     echo " ok"
+    probe_ok=1
     break
   fi
   echo -n "."
   sleep 1
 done
+if [ "$probe_ok" -ne 1 ]; then
+  echo " FAIL — tunnel did not become reachable; see $TUNNEL_LOG"
+  do_stop
+  exit 1
+fi
 
 cat <<EOF
 

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -54,6 +54,9 @@ SERVER_LOG="$LOG_DIR/server.log"
 TUNNEL_LOG="$LOG_DIR/tunnel.log"
 STATE_DIR="$LOG_DIR/state"
 mkdir -p "$STATE_DIR"
+# State dir holds the API key — keep it owner-only so a shared host doesn't
+# leak the bearer token used by the public tunnel.
+chmod 700 "$STATE_DIR"
 SERVER_PID="$STATE_DIR/server.pid"
 TUNNEL_PID="$STATE_DIR/tunnel.pid"
 URL_FILE="$STATE_DIR/url"
@@ -195,6 +198,21 @@ fi
 
 echo "$URL" > "$URL_FILE"
 echo "$API_KEY" > "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Probe the tunnel itself — quick mode often surfaces the URL before the
+# tunnel is actually forwarding traffic. We allow up to 30s; that's well
+# below the cloudflared registration timeout (60s loop above) but enough
+# to weed out "URL was printed but 502s for 10 seconds" races.
+echo -n "Probing $URL/healthz "
+for _ in $(seq 1 30); do
+  if curl -sSf -m 3 "$URL/healthz" >/dev/null 2>&1; then
+    echo " ok"
+    break
+  fi
+  echo -n "."
+  sleep 1
+done
 
 cat <<EOF
 

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -132,8 +132,13 @@ fi
 
 echo "Starting $RAPID_MLX_CMD ($MODEL on :$PORT) [extra: $EXTRA_SERVE_ARGS] …"
 # shellcheck disable=SC2086  # intentional word splitting on CMD + EXTRA args
+# `set -f` disables pathname expansion so a literal `*` in EXTRA_SERVE_ARGS
+# (e.g. `--cors-origins *`) survives the unquoted expansion instead of
+# globbing against $PWD. Restore right after.
+set -f
 nohup $RAPID_MLX_CMD serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
   --log-level INFO $EXTRA_SERVE_ARGS >"$SERVER_LOG" 2>&1 &
+set +f
 echo $! > "$SERVER_PID"
 
 # Wait for /healthz — model load can take 60-90s for a 30B MoE from cache.

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -407,6 +407,13 @@
     "is_hybrid": false,
     "supports_spec_decode": true
   },
+  "minimax-m2.7": {
+    "hf_path": "mlx-community/MiniMax-M2.7-4bit-mxfp4",
+    "tool_call_parser": "minimax",
+    "reasoning_parser": "minimax",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
   "deepseek-r1-8b": {
     "hf_path": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
     "tool_call_parser": "deepseek_v31",


### PR DESCRIPTION
## Summary
- New launcher `scripts/run_dogfood_mvp.sh` that brings up `rapid-mlx serve` behind a Cloudflare tunnel (quick or named) for hands-on dogfood. Defaults to `--no-thinking --cors-origins *` so browser-based chat UIs (Open WebUI, LobeChat, Big-AGI) get content immediately without a 500-1000 token `<think>` prelude.
- New alias `minimax-m2.7` → `mlx-community/MiniMax-M2.7-4bit-mxfp4`, mirroring the structure of `minimax-m2.5` (parser/reasoning = `minimax`, dense, spec-decode supported).
- Two small startup fixes the dogfood script hit on macOS: (a) prefer editable `python3.12 -m vllm_mlx.cli` when run inside the repo so newly-added aliases are visible (brew-installed binary bundles a frozen `aliases.json`); (b) POSIX bracket class in awk because macOS BSD awk doesn't grok `\s`.
- Three hardening fixes from review: `chmod 600`/`700` on key+state dir, tunnel `/healthz` fail-stop probe (not just sniff), `set -f` around the nohup so `--cors-origins *` doesn't glob against `$PWD`.

## What it is (and isn't)
- The script is a dogfood tool, not production deployment. It writes pids/URL/key to `~/.cache/rapid-mlx/dogfood/state/` and exposes `start|stop|status`.
- The `minimax-m2.7` entry follows the *existing* convention for MoE aliases in the repo (`is_moe` is not set on `kimi-48b`, `kimi-k2.5`, `deepseek-v4-flash`, `minimax-m2.5` either — that gap is pre-existing and out of scope here).
- Suffix-decoding tier is `unknown` for this alias — `scripts/bench_suffix_decoding_integrated.py` can promote it later; not required to ship.

## Validation
- `make lint` PASS
- `make audit` (CLI ↔ config fidelity) PASS
- `python3.12 scripts/dev_test.py unit` — 4039 passed, 19 skipped (60s)
- `python3.12 -m vllm_mlx.cli info minimax-m2.7` resolves cleanly: parser=minimax, reasoning=minimax, dense pure-attention, DFlash correctly marked ineligible (4-bit/mxfp4 floor)
- `make check` (doctor) — PASS (6/6 + 1 informational skip; baseline_diff has no baseline for qwen3.5-35b)
- Manually dogfooded end-to-end via `mvp.goodwillclaw.com` named tunnel (Open WebUI + curl): TTFT acceptable with `--no-thinking`, 47 tok/s/stream at 2 concurrent users

## Test plan
- [x] `make lint` clean
- [x] `python3.12 scripts/dev_test.py unit` clean (4039 passed)
- [x] `make check` (doctor gated tier) clean
- [x] `python3.12 -m scripts.pr_validate.pr_validate 503` runs (3 review rounds converged; only test_plan_check + nits remaining)