### PR TITLE
feat(aliases): add gemma-4-12b + gemma-4-12b-8bit (gemma4_unified)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.72"
+version = "0.6.73"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 # Required for any model with vision input. Text-only models work without this.
 # 0.5.0+ also unlocks DFlash speculative decoding (see [dflash] extras).
 vision = [
-    "mlx-vlm>=0.5.0",  # 0.5.0: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
+    "mlx-vlm>=0.6.1",  # 0.6.1: gemma4_unified architecture (gemma-4-12b/12b-8bit aliases require it). 0.5.0 baseline: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -68,7 +68,7 @@ vision = [
 # the vision extras do. Only enable if you serve a DFlash-eligible alias
 # (e.g. qwen3.5-27b-8bit) with --enable-dflash.
 dflash = [
-    "mlx-vlm>=0.5.0",
+    "mlx-vlm>=0.6.1",
 ]
 # Embedding endpoint
 embeddings = [
@@ -84,7 +84,7 @@ chat = [
 # pip install .[all] and editable installs.
 all = [
     # vision
-    "mlx-vlm>=0.5.0",
+    "mlx-vlm>=0.6.1",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -261,6 +261,32 @@
       "code_edit": 0.584
     }
   },
+  "gemma-4-12b": {
+    "hf_path": "mlx-community/gemma-4-12B-it-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-12b-8bit": {
+    "hf_path": "mlx-community/gemma-4-12B-it-8bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
   "gemma-4-26b": {
     "hf_path": "mlx-community/gemma-4-26b-a4b-it-4bit",
     "tool_call_parser": "gemma4",


### PR DESCRIPTION
## Summary

- Adds two new aliases for Google's freshly-released Gemma 4 12B:
  - `gemma-4-12b` → `mlx-community/gemma-4-12B-it-4bit` (~7 GB)
  - `gemma-4-12b-8bit` → `mlx-community/gemma-4-12B-it-8bit` (~13 GB)
- Bumps `mlx-vlm>=0.5.0` → `>=0.6.1` (3 locations: `vision`, `dflash`, `all` extras). v0.6.1 ships the `gemma4_unified` model backend required by this architecture.
- Version bump 0.6.72 → 0.6.73.

## Why this isn't just another Gemma 4 alias

Gemma 4 12B uses a **different model_type than 26B/31B** that already live in `aliases.json`:

| Variant | model_type | Architecture string |
| --- | --- | --- |
| 26b (a4b sparse) | `gemma4` | `Gemma4ForConditionalGeneration` |
| 31b dense | `gemma4` | `Gemma4ForConditionalGeneration` |
| **12b dense (this PR)** | **`gemma4_unified`** | **`Gemma4UnifiedForConditionalGeneration`** |

mlx-vlm 0.5.0 (our current pin) does NOT register `gemma4_unified`; loading would fail with `AttributeError` on architecture lookup. mlx-vlm 0.6.1 (PR Blaizzy/mlx-vlm#1267, commit `608ce455`, tagged 2026-06-03T17:26Z) adds the backend.

## Alias shape rationale

Cloned from `gemma-4-31b-8bit`:

- `tool_call_parser: gemma4` — reuses existing parser; 12B emits the same channel tokens as 26B/31B (audio/vision channels are extra but the gemma4 parser already allowlists the text channel).
- `reasoning_parser: gemma4`
- `is_hybrid: false` — `Gemma4UnifiedForConditionalGeneration` is dense; sliding+full attention mix is not "hybrid" in our (GDN/Mamba) sense.
- `is_moe: false` — config has `enable_moe_block: false`, `num_experts: null`. The MoE knobs exist but are disabled at this size class.
- `supports_spec_decode: true`
- `recommended_sampling: {temperature: 1.0, top_p: 0.95, top_k: 64}` — Gemma canonical.

## Test plan

- [x] Both aliases resolve via `resolve_profile()` with correct parser / reasoning / flags
- [x] `rapid-mlx info gemma-4-12b` renders the expected metadata card
- [x] `tests/test_aliases_contract.py` + `test_model_aliases.py` + `test_model_profiles_ssot.py` + `test_alias_recommended_sampling.py` — 751 passed
- [x] Live `rapid-mlx serve gemma-4-12b` non-stream + stream chat round-trip — content=`"4"` for `"2+2?"`, 200 SSE chunks + `[DONE]`, `reasoning_content` separated from `content`
- [x] Live tool-call round-trip via `gemma4` parser — `{"name":"get_weather","arguments":"{\"city\":\"Tokyo\"}"}`, `finish_reason="tool_calls"`
- [x] `scripts/pr_validate` — codex review PASS, supply_chain PASS (pip-audit clean for mlx-vlm bump), full_unit 4348/4348 PASS. stress_e2e_bench surfaced a single `pydantic_ai test 6 multi_tool` failure on `Qwen3.6-27B-MLX-8bit` (5/6 instead of 6/6). A/B classified as pre-existing flake — re-ran the test twice on this exact server build and both replays were 6/6, and the failure mode (model emitting `<tool_name>...</tool_name>` XML on round-2 of multi-tool) is independent of the alias / mlx-vlm changes in this PR.
- [ ] CI all green

## Risks

- mlx-vlm 0.6.0→0.6.1 changelog is additive (Gemma 4 MTP rollback fix, Cohere2 MoE, Locate-3B). No documented breaks for our existing aliases. CI test-apple-silicon will catch regressions.
- 12B is a brand-new release (uploaded today). The chat template lives in `chat_template.jinja` (a separate file in the repo, NOT inside `tokenizer_config.json`'s `chat_template` field — that field is empty); transformers picks this up automatically. Worth double-checking on a clean checkout.