### PR TITLE
test(aliases): pin curated sampling for gemma-4-12b + 31b-8bit

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -621,8 +621,11 @@ _CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
     # Gemma 4 — official Google sampling guidance hasn't been
     # published yet at the time of writing; we extrapolate from the
     # Gemma 3 family card. Revisit when an official Gemma 4 doc lands.
+    "gemma-4-12b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-12b-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-26b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-31b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-31b-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     # GLM-4.5-Air — THUDM publishes two recommendations: temperature=0.6
     # for *thinking* mode, ~1.0 for non-thinking. The alias has
     # reasoning_parser=glm4 → thinking IS the default response path,


### PR DESCRIPTION
## Summary

Follow-up to PR #507 (v0.6.73, gemma-4-12b alias addition). Codex review round 2 (G2 SOP gate retroactively) surfaced that the new aliases were not pinned in `_CURATED_RECOMMENDED_SAMPLING` — a future drift would have slipped through.

Also adds the pre-existing `gemma-4-31b-8bit` which was missing the pin even though `gemma-4-31b` (its 4-bit sibling) had one.

## Test plan

- [x] `tests/test_aliases_contract.py` — 695 passed (was 692; +3 new pins enforced)
- [x] Test-only change, no version bump

## Deferred

Codex round 2 also raised a [BLOCKING] about `is_mllm_model()` routing — empirically disproved (the `is_gemma4_model` substring match catches `gemma4_unified`, and mlx-vlm's gemma4 and gemma4_unified `TextConfig` dataclasses have identical 37-field shapes, so the legacy text loader works for both). Filed as follow-up issue for explicit `gemma4_unified` routing cleanup.