### PR TITLE
fix(scheduler): bump OpenAI penalty context_size 20 → 4096

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.73"
+version = "0.6.74"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_sampling_params_passthrough.py
+++ b/tests/test_sampling_params_passthrough.py
@@ -440,3 +440,67 @@ def test_make_logits_processors_signature_supports_three_penalties():
             f"mlx-lm make_logits_processors no longer accepts {name!r}; "
             f"scheduler wiring is broken — see #355."
         )
+
+
+def test_scheduler_overrides_openai_penalty_context_size():
+    """#470 regression guard. mlx-lm's ``make_logits_processors`` defaults
+    ``presence_context_size`` and ``frequency_context_size`` to 20 — only
+    the last 20 generated tokens count toward the penalty. OpenAI's spec
+    defines these penalties over the *entire* generated sequence, so the
+    default makes the penalty feel like a no-op on chat-length outputs
+    (#470 reported "zero observable effect" at ``frequency_penalty=2.0``).
+
+    The scheduler must explicitly pass a much larger context size so the
+    penalty actually covers a realistic chat response. We pin 4096 as the
+    minimum; raising it is fine, lowering reverts #470.
+    """
+    from pathlib import Path
+
+    src = Path("vllm_mlx/scheduler.py").read_text()
+
+    # Find the `make_logits_processors(` call in the penalty wiring block
+    # and capture its parenthesised arg list intact.
+    import re
+
+    match = re.search(r"make_logits_processors\(", src)
+    assert match, "make_logits_processors() call not found in scheduler.py"
+
+    start = match.end()
+    depth = 1
+    i = start
+    while i < len(src) and depth > 0:
+        if src[i] == "(":
+            depth += 1
+        elif src[i] == ")":
+            depth -= 1
+        i += 1
+    call_args = src[start : i - 1]
+
+    # Each OpenAI-spec penalty must override the upstream default of 20.
+    # We require an integer literal ≥ 4096 — the file-level constant
+    # makes review easy if someone tries to "just bump" it later.
+    for kw in ("presence_context_size", "frequency_context_size"):
+        m = re.search(rf"{kw}\s*=\s*(\d+)", call_args)
+        assert m, (
+            f"scheduler.py make_logits_processors call is missing {kw}=. "
+            f"Without it, mlx-lm uses its 20-token default and the penalty "
+            f"feels like a no-op on chat-length output — regresses #470."
+        )
+        value = int(m.group(1))
+        assert value >= 4096, (
+            f"scheduler.py passes {kw}={value} to mlx-lm. That's too small "
+            f"to cover a typical chat response; OpenAI semantics apply the "
+            f"penalty over the entire generated sequence. Use ≥ 4096."
+        )
+
+    # Repetition penalty is a rapid-mlx extension (not OpenAI-spec) and
+    # is documented as multiplicative over a rolling window — leaving it
+    # at mlx-lm's default 20 is intentional. Assert we don't accidentally
+    # bump it (which would silently change semantics for existing users).
+    assert "repetition_context_size" not in call_args, (
+        "repetition_context_size should NOT be overridden in the scheduler. "
+        "repetition_penalty is rapid-mlx's multiplicative rolling-window "
+        "extension; only the OpenAI-spec frequency/presence penalties need "
+        "the larger window. If you're intentionally changing this, update "
+        "the test and document the semantic change."
+    )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2772,6 +2772,17 @@ class Scheduler:
             # returns an empty list when all knobs are at defaults, but
             # constructing it unconditionally would still allocate the
             # context-tracking arrays for every request.
+            #
+            # OpenAI-spec penalties (frequency/presence) are defined over
+            # the entire generated sequence, not a sliding window. mlx-lm's
+            # default context_size of 20 truncates the visibility window so
+            # aggressively that callers report the penalty "feels like a
+            # no-op" on chat-length outputs (#470). We bump the OpenAI-spec
+            # ones to 4096 — enough to cover the vast majority of chat
+            # responses without bloating per-request arrays. Repetition
+            # penalty stays at mlx-lm's default 20 since it's a rapid-mlx
+            # extension (not OpenAI-spec) and is documented as multiplicative
+            # over a rolling window.
             sp = request.sampling_params
             if (
                 sp.repetition_penalty != 1.0
@@ -2788,11 +2799,13 @@ class Scheduler:
                         presence_penalty=(
                             sp.presence_penalty if sp.presence_penalty != 0.0 else None
                         ),
+                        presence_context_size=4096,
                         frequency_penalty=(
                             sp.frequency_penalty
                             if sp.frequency_penalty != 0.0
                             else None
                         ),
+                        frequency_context_size=4096,
                     )
                 )
             request_logits_processors = (


### PR DESCRIPTION
## Summary

Fixes #470. `frequency_penalty` and `presence_penalty` were already plumbed to mlx-lm's `make_logits_processors` (#357), but mlx-lm's default `frequency_context_size` / `presence_context_size` is **20** — meaning the penalty only sees the last 20 generated tokens. OpenAI's spec applies these penalties over the *entire* generated sequence, so the default window made the parameter feel like a no-op on chat-length responses.

This PR passes `presence_context_size=4096` + `frequency_context_size=4096` so a realistic chat answer (~500-2000 tokens) is fully visible to the penalty.

## Empirical before/after

On `gemma-4-12b` (M3 Ultra, prompt: "Write 80 words about the color blue, vary your vocabulary"):

| ctx_size | fp=1.5 diversity | fp=2.0 diversity | top word |
|---|---|---|---|
| 20 (before) | 0.753 | 0.756 | `the` × 6-8 |
| 4096 (after) | 0.887 | 0.952 | `the` gone from top-3 |

Diversity 0.75 → 0.95; the previously-dominant function word `the` drops out of the top-3 entirely. Penalty is now visibly effective.

## Why not bump `repetition_context_size` too?

`repetition_penalty` is a rapid-mlx extension with multiplicative rolling-window semantics — explicitly NOT OpenAI-spec. The regression test pins this asymmetry so a future refactor that "just bumps everything to match" doesn't silently change repetition semantics.

## Test plan

- [x] Regression test `test_scheduler_overrides_openai_penalty_context_size` source-greps scheduler.py for >=4096 on both fields + asserts repetition_context_size is NOT overridden (13/13 pass)
- [x] G1: `make release-smoke` — clean venv import OK
- [x] G2: codex review x 2 rounds — round 1 via pr_validate OK; round 2 manual returned 0 BLOCKING + 3 NITs (tracked as follow-ups)
- [x] G3: `python3.12 scripts/audit_cli_config_fidelity.py` — OK
- [x] G4: pr_validate full_unit — 4349 passed
- [x] G5/G7: pr_validate stress_e2e_bench — see A/B classification below
- [x] G6: Live server real repro — see diversity table above
- [x] G8: Microbench overhead (ctx=20 vs ctx=4096) — -9.4% (within noise, well under 5% bar)
- [x] G9: 10-req sequential latency — CV 7.3%, no anomalies
- G10: n/a (no MLX dep bump)
- G11: n/a (no auto-routing change)

## Stress findings + A/B classification

Two BLOCKING-shaped failures on first stress run; classified as pre-existing flakes after analysis:

1. `anthropic_sdk Test 4 (stream count)` on Qwen3.5-35B: model returned "1, 2" instead of 10. Non-deterministic small-model output; payload uses default penalty=0.
2. `pydantic_ai Test 6 (multi-tool)` on gpt-oss-20b: hit pydantic-AI's 50-request safety limit (harmony tool-loop pattern). Payload uses default penalty=0.

Rerun timed out at 30 min on `pydantic_ai+qwen3.6-27B` — matches documented gotcha "qwen3.6-27B + pydantic_ai legitimately takes >20 min".

**Why these are not regressions from this PR**: the change adds two kwargs inside `if sp.presence_penalty != 0.0 or sp.frequency_penalty != 0.0 or sp.repetition_penalty != 1.0` — all three failing test paths use defaults (penalty=0), so the conditional branch is never entered and the new kwargs are unreached.

## Round-2 codex NITs (follow-ups, not blockers)

1. Lift `4096` to a module-level constant and consider `max(4096, sp.max_tokens)` for callers using `max_tokens > 4096` (tracked as task #690).
2. Document the `repetition_context_size=20` footgun on `repetition_penalty` field doc (task #691).
3. File issue: `MLLMScheduler` has zero penalty wiring — vision models silently ignore all three penalty params (task #692).

Closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)