### PR TITLE
feat(router): openai-harmony bypass for gpt-oss tool calls (closes #444 #455 #468 #480, #513)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ dependencies = [
     # rapidserver Worker as the reverse-tunnel transport. Pure Python,
     # ~200 KB. Replaces the prior frpc Go binary download.
     "websockets>=12.0",
+    # openai-harmony — official harmony-protocol streaming parser. Used
+    # by ``HarmonyStreamingRouter`` (output_router_harmony.py) to route
+    # gpt-oss tool calls correctly (issue #513 / cluster #444 #455
+    # #468 #480). Same library vLLM and SGLang delegate to for gpt-oss
+    # tool calling. Soft-imported at runtime; the legacy custom state
+    # machine remains the fallback if the dep is unavailable.
+    "openai-harmony>=0.0.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -597,6 +597,72 @@ def test_compat_gate_rejects_mismatched_body_vocab():
     assert is_openai_harmony_compatible(tm, _MismatchedBodyVocabTokenizer()) is False
 
 
+def test_compat_gate_rejects_non_int_encode_result():
+    """Codex round-8 BLOCKING (PR #515): some HF tokenizer
+    configurations (``return_tensors`` defaults, wrapped Fast
+    tokenizers) make ``encode()`` return a ``BatchEncoding`` / tensor
+    rather than a flat ``list[int]``. ``list(...)`` on those either
+    raises or yields opaque objects whose equality check against the
+    harmony reference list returns False but in a way that would crash
+    later consumers (``StreamableParser.process``). The gate must
+    return False on anything that isn't a flat int sequence so the
+    engine falls back cleanly to the legacy router.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    class _BatchEncodingShape:
+        """Pretends to be a BatchEncoding — ``list(self)`` returns
+        dict-style keys (``"input_ids"``, ``"attention_mask"``), not
+        the integer token IDs the gate expects.
+        """
+
+        def __iter__(self):
+            return iter(("input_ids", "attention_mask"))
+
+    class _BatchEncodingTokenizer:
+        name_or_path = "mlx-community/gpt-oss-BATCH-ENCODING-VARIANT"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return _BatchEncodingShape()
+
+    assert is_openai_harmony_compatible(tm, _BatchEncodingTokenizer()) is False
+
+    # And a flat tuple of non-int items (an even more degenerate
+    # tokenizer config) must also fall back to False rather than
+    # surface a TypeError.
+    class _StringTokenIdsTokenizer:
+        name_or_path = "mlx-community/gpt-oss-STRING-IDS-VARIANT"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return ("Hello", "world")
+
+    assert is_openai_harmony_compatible(tm, _StringTokenIdsTokenizer()) is False
+
+
 def test_finalize_never_synthesizes_truncated_commentary(router, encoding):
     """Codex round-6 BLOCKING resolution (PR #515): finalize() adopts
     the vLLM / SGLang safer-default — a commentary message cut off

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -309,18 +309,23 @@ def test_reconstruct_tool_call_rejects_malformed_recipient(router):
     assert "to=functions.get_weather" in out
 
 
-def test_reconstruct_tool_call_rejects_body_carrying_harmony_sentinel(router):
-    """Codex round-7 BLOCKING (PR #515): the reconstructed wire text is
-    a delimiter-based format the downstream HarmonyToolParser parses by
-    regex on literal sentinel strings (``<|call|>``, ``<|message|>``,
-    etc.). If the body contains any of those literals — even though
-    gpt-oss normally emits them as single special tokens, an
-    adversarial prompt could echo the raw characters back through body
-    vocab — the downstream parser would anchor on the embedded
-    sentinel and truncate the JSON arguments. Reject (raise) rather
-    than escape, so the engine's outer try/except falls back to the
-    legacy text-based parser instead of feeding corrupt args downstream.
-    Consistent with the recipient-validation BLOCKING from round-1.
+def test_reconstruct_tool_call_abstains_on_body_carrying_harmony_sentinel(router):
+    """Codex round-7 BLOCKING (don't emit corrupt structured event) +
+    round-9 BLOCKING (don't raise on legitimate JSON containing
+    ``<|...|>`` substrings): when the body or content_type carries a
+    harmony structural sentinel that would corrupt the downstream
+    HarmonyToolParser regex parse, ``_reconstruct_tool_call_text``
+    must ABSTAIN — return ``None`` — instead of raising.
+
+    The caller (``feed()``) then emits no router event for this
+    message; the engine's outer plumbing leaves the model's raw
+    ``fallback_text`` untouched, and the legacy text-based parser
+    handles the call (with the same parse limitation that the
+    text-based path imposes universally — no worse than baseline).
+    Matches the recipient-validation pattern's intent (don't emit a
+    bogus structured event) without the round-9 cost (dropping
+    legitimate OpenAI tool calls whose JSON values happen to contain
+    those characters).
     """
 
     class _Content:
@@ -333,7 +338,7 @@ def test_reconstruct_tool_call_rejects_body_carrying_harmony_sentinel(router):
             self.content = [_Content(body)]
             self.content_type = ctype
 
-    bad_bodies = (
+    abstain_bodies = (
         '{"text":"use <|call|>"}',
         '{"text":"<|message|>injected"}',
         '{"x":"<|channel|>commentary"}',
@@ -342,33 +347,32 @@ def test_reconstruct_tool_call_rejects_body_carrying_harmony_sentinel(router):
         '{"a":"<|start|>"}',
         '{"b":"<|constrain|>json"}',
     )
-    for bad in bad_bodies:
-        with pytest.raises(ValueError, match="sentinel"):
-            router._reconstruct_tool_call_text(_FakeMessage(bad))
+    for bad in abstain_bodies:
+        out = router._reconstruct_tool_call_text(_FakeMessage(bad))
+        assert out is None, f"body carrying sentinel must abstain (None); got {out!r}"
 
-    # Sanity: clean JSON must NOT raise — and the bodies that contain
-    # the substring as a property name ALSO trip the gate (intentional
-    # — we cannot distinguish key vs value in raw text and must err on
-    # the safe side).
+    # Sanity: clean JSON must reconstruct normally.
     clean = _FakeMessage('{"city":"NYC"}')
     out = router._reconstruct_tool_call_text(clean)
+    assert out is not None
     assert '{"city":"NYC"}' in out
     assert "<|message|>" in out  # legitimate framing must remain
     assert out.endswith("<|call|>")  # legitimate trailing sentinel
 
     # A content_type that smuggles a sentinel past the
-    # ``<|constrain|>`` prefix must also be rejected.
-    with pytest.raises(ValueError, match="sentinel"):
-        router._reconstruct_tool_call_text(
-            _FakeMessage(
-                '{"city":"NYC"}',
-                ctype="<|constrain|>json<|call|>injected",
-            )
+    # ``<|constrain|>`` prefix must also abstain.
+    out = router._reconstruct_tool_call_text(
+        _FakeMessage(
+            '{"city":"NYC"}',
+            ctype="<|constrain|>json<|call|>injected",
         )
+    )
+    assert out is None, f"content_type smuggling a sentinel must abstain; got {out!r}"
 
-    # A normal ``<|constrain|>json`` content_type must NOT raise.
+    # A normal ``<|constrain|>json`` content_type must NOT abstain.
     ok = _FakeMessage('{"city":"NYC"}', ctype="<|constrain|>json")
     out = router._reconstruct_tool_call_text(ok)
+    assert out is not None
     assert "<|constrain|>json<|message|>" in out
 
 

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -697,12 +697,17 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
         def encode(self, text, add_special_tokens=False):
             return enc.encode(text, allowed_special="none")
 
-    # Tail-substring fakes (must be rejected).
+    # Tail-substring fakes AND non-allowlisted owner prefixes (codex
+    # round-12 BLOCKING — even an anchored basename allowlist let
+    # arbitrary owners pass; restrict to known owner prefixes).
     rejected_names = (
         "my-not-gpt-oss/whatever",
         "foo/bar-gpt-oss-malicious",
         "my-not-gpt-oss-20b",  # no slash, tail substring
         "notgpt-oss-fake",
+        "some-user/gpt-oss-remapped",  # unknown owner with valid basename
+        "evil-org/gpt-oss-20b",
+        "anonymous/gpt-oss",
     )
     for name in rejected_names:
 
@@ -715,10 +720,13 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
             f"anchored allowlist failed"
         )
 
-    # Canonical names (must still pass — sanity).
+    # Canonical names — known owner prefixes (openai, mlx-community,
+    # unsloth) plus bare basename. Sanity check that the allowlist
+    # tightening didn't accidentally over-reject.
     accepted_names = (
         "openai/gpt-oss-20b",
         "mlx-community/gpt-oss-20b-MXFP4-Q8",
+        "unsloth/gpt-oss-20b-MLX-8bit",
         "gpt-oss-20b",  # bare, anchored at ^
         "gpt-oss",  # bare exact
     )
@@ -1065,11 +1073,11 @@ def test_compat_gate_rejects_missing_marker_ids():
 
 
 def test_compat_gate_cache_segregates_by_marker_ids():
-    """Codex round-4 NIT (PR #515): two tokenizer instances with the
-    same ``name_or_path`` but different marker IDs must NOT share a
-    cached compatibility result. The cache key includes the marker
-    tuple so a mock tokenizer changing its vocab between calls won't
-    leak a stale True/False.
+    """Codex round-4 NIT (PR #515): a SINGLE tokenizer instance probed
+    with two different ``TokenMap`` marker-ID tuples must NOT share a
+    cached compatibility result — the inner per-tokenizer cache keys
+    on the ``(name_lc, marker_ids)`` tuple, so distinct marker tuples
+    segregate into distinct entries even on the same tokenizer.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import (
@@ -1077,9 +1085,6 @@ def test_compat_gate_cache_segregates_by_marker_ids():
         is_openai_harmony_compatible,
     )
 
-    # Identity passes the allowlist; markers differ between the two
-    # TokenMap instances — gate must run twice and may return
-    # different results.
     class _T:
         name_or_path = "mlx-community/gpt-oss-CACHE-KEY-SEGREGATION"
 
@@ -1095,18 +1100,15 @@ def test_compat_gate_cache_segregates_by_marker_ids():
     tm_a = TokenMap(format_tag="harmony", harmony_channel=200005)
     tm_b = TokenMap(format_tag="harmony", harmony_channel=999999)
 
-    # Clear cache for hygiene.
-    for k in list(_COMPAT_RESULT_CACHE.keys()):
-        if "cache-key-segregation" in str(k):
-            _COMPAT_RESULT_CACHE.pop(k, None)
+    t = _T()  # one instance — keep alive for the WeakKeyDictionary
+    is_openai_harmony_compatible(tm_a, t)
+    is_openai_harmony_compatible(tm_b, t)
 
-    is_openai_harmony_compatible(tm_a, _T())
-    is_openai_harmony_compatible(tm_b, _T())
-
-    seg_keys = [k for k in _COMPAT_RESULT_CACHE if "cache-key-segregation" in str(k)]
-    assert len(seg_keys) == 2, (
-        f"cache must keep separate entries per marker-ID tuple; "
-        f"got {len(seg_keys)} entries: {seg_keys!r}"
+    inner = _COMPAT_RESULT_CACHE.get(t)
+    assert inner is not None, "tokenizer must have a cache slot after probes"
+    assert len(inner) == 2, (
+        f"cache must keep separate inner entries per marker-ID tuple; "
+        f"got {len(inner)} entries: {list(inner.keys())!r}"
     )
 
 
@@ -1124,10 +1126,7 @@ def test_compat_gate_caches_per_tokenizer_identity():
     result, and the second call MUST be short-circuited by the cache.
     """
     from vllm_mlx.output_router import TokenMap
-    from vllm_mlx.output_router_harmony import (
-        _COMPAT_RESULT_CACHE,
-        is_openai_harmony_compatible,
-    )
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
 
     enc = openai_harmony.load_harmony_encoding(
         openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
@@ -1166,12 +1165,9 @@ def test_compat_gate_caches_per_tokenizer_identity():
             call_count["n"] += 1
             return [0]  # nonsense — guaranteed mismatch → False
 
-    # Clear any stale cache entry from prior runs (key now includes
-    # the marker tuple per round-4 NIT).
-    for k in list(_COMPAT_RESULT_CACHE.keys()):
-        if "cache-probe-invocation" in str(k):
-            _COMPAT_RESULT_CACHE.pop(k, None)
-
+    # Fresh tokenizer instance — the WeakKeyDictionary cache is keyed
+    # on the instance object, so a new instance is guaranteed to start
+    # with no stale entry regardless of prior test state.
     t = _CountingTokenizer()
     # First call reaches the body-vocab probe and increments
     # call_count — that's the work the cache must save on subsequent

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -317,15 +317,17 @@ def test_reconstruct_tool_call_abstains_on_body_carrying_harmony_sentinel(router
     HarmonyToolParser regex parse, ``_reconstruct_tool_call_text``
     must ABSTAIN — return ``None`` — instead of raising.
 
-    The caller (``feed()``) then emits no router event for this
-    message; the engine's outer plumbing leaves the model's raw
-    ``fallback_text`` untouched, and the legacy text-based parser
-    handles the call (with the same parse limitation that the
-    text-based path imposes universally — no worse than baseline).
+    The caller (``feed()``) then emits a CONTENT event with the body
+    bytes (codex round-10 BLOCKING — streaming visibility) so the
+    user still sees the tool call's intent verbatim, matching baseline
+    behavior where the legacy router leaked commentary body into
+    CONTENT. The engine non-stream path is unaffected: it relies on
+    ``fallback_text``, which still carries the model's raw emit.
     Matches the recipient-validation pattern's intent (don't emit a
     bogus structured event) without the round-9 cost (dropping
     legitimate OpenAI tool calls whose JSON values happen to contain
-    those characters).
+    those characters) and without the round-10 cost (silent streaming
+    drop).
     """
 
     class _Content:
@@ -374,6 +376,50 @@ def test_reconstruct_tool_call_abstains_on_body_carrying_harmony_sentinel(router
     out = router._reconstruct_tool_call_text(ok)
     assert out is not None
     assert "<|constrain|>json<|message|>" in out
+
+
+def test_sentinel_body_emits_content_event_for_streaming_visibility(
+    router, encoding, monkeypatch
+):
+    """Codex round-10 BLOCKING (PR #515): when ``_reconstruct_tool_call_text``
+    abstains for a sentinel-laden body, ``feed()`` must NOT silently
+    swallow the streaming output. The body was buffered during the
+    commentary deltas (we suppress per-token emission until close), so
+    a silent drop would make the entire tool call invisible to the
+    streaming consumer. Surface the body bytes as a CONTENT event so
+    the user still sees what the model emitted — matches baseline
+    behavior where the legacy router leaked commentary body into
+    CONTENT verbatim.
+
+    Force the abstain path by monkeypatching the static reconstructor
+    to return None (which is what would happen on a sentinel-laden
+    body for a real call); replay a normal commentary tool call and
+    assert ``feed_sequence`` surfaces the body bytes via CONTENT.
+    """
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NYC"}<|call|>'
+    )
+    tokens = _encode(encoding, text)
+
+    monkeypatch.setattr(
+        HarmonyStreamingRouter,
+        "_reconstruct_tool_call_text",
+        staticmethod(lambda _msg: None),
+    )
+
+    router.reset()
+    result = router.feed_sequence(tokens)
+
+    # No TOOL_CALL surfaces (abstained).
+    assert result["tool_calls"] is None, (
+        f"abstain path must not emit TOOL_CALL; got {result['tool_calls']!r}"
+    )
+    # But the body IS visible to streaming consumers via CONTENT.
+    assert result["content"] is not None and '{"city":"NYC"}' in result["content"], (
+        f"abstain path must surface body bytes via CONTENT; got {result['content']!r}"
+    )
 
 
 def test_compat_gate_rejects_unknown_tokenizer_identity():

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -309,6 +309,69 @@ def test_reconstruct_tool_call_rejects_malformed_recipient(router):
     assert "to=functions.get_weather" in out
 
 
+def test_reconstruct_tool_call_rejects_body_carrying_harmony_sentinel(router):
+    """Codex round-7 BLOCKING (PR #515): the reconstructed wire text is
+    a delimiter-based format the downstream HarmonyToolParser parses by
+    regex on literal sentinel strings (``<|call|>``, ``<|message|>``,
+    etc.). If the body contains any of those literals — even though
+    gpt-oss normally emits them as single special tokens, an
+    adversarial prompt could echo the raw characters back through body
+    vocab — the downstream parser would anchor on the embedded
+    sentinel and truncate the JSON arguments. Reject (raise) rather
+    than escape, so the engine's outer try/except falls back to the
+    legacy text-based parser instead of feeding corrupt args downstream.
+    Consistent with the recipient-validation BLOCKING from round-1.
+    """
+
+    class _Content:
+        def __init__(self, text):
+            self.text = text
+
+    class _FakeMessage:
+        def __init__(self, body, recipient="functions.get_weather", ctype=None):
+            self.recipient = recipient
+            self.content = [_Content(body)]
+            self.content_type = ctype
+
+    bad_bodies = (
+        '{"text":"use <|call|>"}',
+        '{"text":"<|message|>injected"}',
+        '{"x":"<|channel|>commentary"}',
+        '{"y":"<|end|>"}',
+        '{"z":"<|return|>"}',
+        '{"a":"<|start|>"}',
+        '{"b":"<|constrain|>json"}',
+    )
+    for bad in bad_bodies:
+        with pytest.raises(ValueError, match="sentinel"):
+            router._reconstruct_tool_call_text(_FakeMessage(bad))
+
+    # Sanity: clean JSON must NOT raise — and the bodies that contain
+    # the substring as a property name ALSO trip the gate (intentional
+    # — we cannot distinguish key vs value in raw text and must err on
+    # the safe side).
+    clean = _FakeMessage('{"city":"NYC"}')
+    out = router._reconstruct_tool_call_text(clean)
+    assert '{"city":"NYC"}' in out
+    assert "<|message|>" in out  # legitimate framing must remain
+    assert out.endswith("<|call|>")  # legitimate trailing sentinel
+
+    # A content_type that smuggles a sentinel past the
+    # ``<|constrain|>`` prefix must also be rejected.
+    with pytest.raises(ValueError, match="sentinel"):
+        router._reconstruct_tool_call_text(
+            _FakeMessage(
+                '{"city":"NYC"}',
+                ctype="<|constrain|>json<|call|>injected",
+            )
+        )
+
+    # A normal ``<|constrain|>json`` content_type must NOT raise.
+    ok = _FakeMessage('{"city":"NYC"}', ctype="<|constrain|>json")
+    out = router._reconstruct_tool_call_text(ok)
+    assert "<|constrain|>json<|message|>" in out
+
+
 def test_compat_gate_rejects_unknown_tokenizer_identity():
     """Codex round-2 BLOCKING (PR #515): a 3-string probe set cannot
     prove full-vocab parity. The gate must ALSO require the

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -609,6 +609,181 @@ def test_finalize_drops_truncated_commentary_with_empty_body(router, encoding):
     )
 
 
+def test_finalize_does_not_double_emit_completed_final(router, encoding):
+    """Codex round-4 BLOCKING (PR #515): for a NORMALLY-completed
+    final channel (model emitted ``<|return|>``), the per-token feed
+    has already produced every body delta. ``finalize()`` must NOT
+    re-emit those bytes as a second routed event — that would
+    duplicate the final response.
+    """
+    text = "<|channel|>final<|message|>Hi there.<|return|>"
+    tokens = _encode(encoding, text)
+    router.reset()
+    streamed = []
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is not None:
+            streamed.append(ev)
+    drained = router.finalize()
+
+    assert drained is None, (
+        f"completed final must not re-emit on finalize; got {drained!r}"
+    )
+    # The per-token stream already produced the full body.
+    assert (
+        "".join(e.text for e in streamed if e.channel == Channel.CONTENT) == "Hi there."
+    )
+
+
+def test_finalize_drains_truncated_final_buffered_delta(router, encoding):
+    """Codex round-4 BLOCKING (PR #515): when an EOS / process_eos
+    surfaces a ``last_content_delta`` from a truncated final or
+    analysis message, ``finalize()`` must route it to CONTENT /
+    REASONING respectively rather than dropping it. Empirically the
+    current openai-harmony build emits everything during ``feed()``,
+    but the contract pins the behavior in case a future build flushes
+    a buffered tail on EOS.
+    """
+    # Construct a router whose underlying StreamableParser is forced
+    # into a state where process_eos produces a synthetic delta.
+
+    class _StubMessage:
+        def __init__(self, channel):
+            self.channel = channel
+            self.recipient = None
+            self.content = []
+            self.content_type = None
+
+    class _StubParser:
+        def __init__(self, channel, delta):
+            self._channel = channel
+            self._delta = delta
+            self.tokens = [1]
+            self.messages: list[_StubMessage] = []
+
+        @property
+        def current_channel(self):
+            return self._channel
+
+        @property
+        def last_content_delta(self):
+            return self._delta
+
+        def process_eos(self):
+            # Simulate EOS appending a closed final-channel message
+            # AND flushing a buffered tail delta — the codex-flagged
+            # corner case my finalize must handle.
+            self.messages.append(_StubMessage(self._channel))
+            self._delta = " tail"
+
+    router.reset()
+    router._parser = _StubParser("final", "")
+    drained = router.finalize()
+    assert drained is not None
+    assert drained.channel == Channel.CONTENT, (
+        f"truncated final delta must drain to CONTENT; got {drained!r}"
+    )
+    assert drained.text == " tail"
+
+    # Symmetric: analysis channel routes to REASONING.
+    router.reset()
+    router._parser = _StubParser("analysis", "")
+    drained = router.finalize()
+    assert drained is not None
+    assert drained.channel == Channel.REASONING
+    assert drained.text == " tail"
+
+
+def test_compat_gate_rejects_missing_marker_ids():
+    """Codex round-4 BLOCKING (PR #515): the gate must require ALL
+    seven harmony markers to be present in the tokenizer's TokenMap.
+    Previously a tokenizer with only ``<|channel|>`` / ``<|message|>``
+    plus matching probe IDs could pass — StreamableParser would then
+    crash when the model emitted a ``<|call|>`` the gate never checked.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    def _id(s):
+        return enc.encode(s, allowed_special="all")[0]
+
+    # Missing ``harmony_call`` — gate must reject.
+    tm_missing_call = TokenMap(
+        format_tag="harmony",
+        harmony_channel=_id("<|channel|>"),
+        harmony_message=_id("<|message|>"),
+        # harmony_call=None (left out)
+        harmony_end=_id("<|end|>"),
+        harmony_return=_id("<|return|>"),
+        harmony_start=_id("<|start|>"),
+        harmony_constrain=_id("<|constrain|>"),
+    )
+
+    class _GptOssTokenizer:
+        name_or_path = "mlx-community/gpt-oss-MISSING-CALL-VARIANT"
+
+        def encode(self, text, add_special_tokens=False):
+            return enc.encode(text, allowed_special="none")
+
+        def decode(self, ids):
+            return enc.decode(ids)
+
+        def get_vocab(self):
+            return {}
+
+    assert is_openai_harmony_compatible(tm_missing_call, _GptOssTokenizer()) is False
+
+
+def test_compat_gate_cache_segregates_by_marker_ids():
+    """Codex round-4 NIT (PR #515): two tokenizer instances with the
+    same ``name_or_path`` but different marker IDs must NOT share a
+    cached compatibility result. The cache key includes the marker
+    tuple so a mock tokenizer changing its vocab between calls won't
+    leak a stale True/False.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import (
+        _COMPAT_RESULT_CACHE,
+        is_openai_harmony_compatible,
+    )
+
+    # Identity passes the allowlist; markers differ between the two
+    # TokenMap instances — gate must run twice and may return
+    # different results.
+    class _T:
+        name_or_path = "mlx-community/gpt-oss-CACHE-KEY-SEGREGATION"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return [0]  # always rejected by body-vocab probe
+
+    tm_a = TokenMap(format_tag="harmony", harmony_channel=200005)
+    tm_b = TokenMap(format_tag="harmony", harmony_channel=999999)
+
+    # Clear cache for hygiene.
+    for k in list(_COMPAT_RESULT_CACHE.keys()):
+        if "cache-key-segregation" in str(k):
+            _COMPAT_RESULT_CACHE.pop(k, None)
+
+    is_openai_harmony_compatible(tm_a, _T())
+    is_openai_harmony_compatible(tm_b, _T())
+
+    seg_keys = [k for k in _COMPAT_RESULT_CACHE if "cache-key-segregation" in str(k)]
+    assert len(seg_keys) == 2, (
+        f"cache must keep separate entries per marker-ID tuple; "
+        f"got {len(seg_keys)} entries: {seg_keys!r}"
+    )
+
+
 def test_compat_gate_caches_per_tokenizer_identity():
     """Codex round-3 NIT (PR #515): the compatibility probe is called
     on every request from the engine's streaming factory; the marker

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Closure regressions for issues #444 / #455 / #468 / #480 via the
+openai-harmony bypass (PR #515 landing #513).
+
+PR #514 partially fixed these at the parser layer (prefix-hold +
+count-based ``<|call|>`` detection) but their END-TO-END production
+fix required the router to understand harmony's tool-call protocol:
+``commentary`` + ``to=functions.<name>`` + optional
+``<|constrain|>json`` + body + ``<|call|>``. PR #514 confirmed
+``commentary`` is multi-token (``comment``+``ary``) on production
+gpt-oss-20b, which the custom token-ID-match state machine could
+never identify.
+
+PR #515 lands the SOTA fix: delegate harmony state tracking to
+``openai-harmony.StreamableParser`` (same library vLLM and SGLang
+delegate to). The new ``HarmonyStreamingRouter`` shim exposes the
+existing ``OutputRouter`` surface so the engine streaming path is
+unchanged; only the harmony format gets the new backend.
+
+This file pins the closure of #444 / #455 / #468 / #480 by replaying
+production-shape token sequences (encoded via the real harmony
+encoding, NOT the synthetic test vocab used by the partial-closure
+regressions in the sibling files) and asserting NO marker leak +
+correct channel routing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip the whole module when the optional ``openai-harmony`` dep is
+# missing — without it, the legacy router runs and leaks (#444 etc.
+# remain xfail-strict in the sibling regression files).
+openai_harmony = pytest.importorskip("openai_harmony")
+
+from openai_harmony import (  # noqa: E402
+    HarmonyEncodingName,
+    load_harmony_encoding,
+)
+
+from vllm_mlx.output_router import Channel, TokenMap  # noqa: E402
+from vllm_mlx.output_router_harmony import HarmonyStreamingRouter  # noqa: E402
+
+from .._harmony_markers import HARMONY_LEAK_MARKERS  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def encoding():
+    return load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+
+
+class _HarmonyDecodeAdapter:
+    """Minimal tokenizer surface for ``HarmonyStreamingRouter``.
+
+    The router uses ``tokenizer.decode`` only for the legacy router
+    fallback paths (not on the openai-harmony path), so a thin
+    adapter over the harmony encoding suffices.
+    """
+
+    def __init__(self, enc):
+        self._enc = enc
+
+    def decode(self, ids):
+        return self._enc.decode(ids)
+
+    def get_vocab(self):
+        return {}
+
+
+@pytest.fixture
+def router(encoding):
+    tm = TokenMap(format_tag="harmony")
+    return HarmonyStreamingRouter(tm, _HarmonyDecodeAdapter(encoding))
+
+
+def _encode(encoding, text: str) -> list[int]:
+    """Wrap encode with allowed_special=all so structural markers
+    (``<|channel|>`` etc.) round-trip as single token IDs the way
+    a real gpt-oss-20b would emit them.
+    """
+    return encoding.encode(text, allowed_special="all")
+
+
+# Production-shape emit sequences. ``StreamableParser`` is initialized
+# with ``role=ASSISTANT`` so the FIRST message starts directly with
+# ``<|channel|>`` (the pre-set role consumes the header). Subsequent
+# messages within the same assistant turn use the explicit
+# ``<|start|>assistant<|channel|>...`` form.
+
+
+# ----- #444 / #480 — Harmony streaming tool call leak ------------------
+
+
+def test_issue_444_480_commentary_tool_call_no_marker_leak(router, encoding):
+    """#444 / #480: streaming a harmony tool call MUST NOT leak
+    structural markers or channel labels into ``content`` / ``reasoning``,
+    and the tool call MUST surface in ``tool_calls`` with the recipient
+    + body intact.
+
+    Pre-PR #515: the custom router state machine recognized ``analysis``
+    / ``final`` channel-type words by single-token ID match. Production
+    ``commentary`` is two tokens (``comment``+``ary``); the router fell
+    through to CONTENT and leaked the entire markered tool-call sequence
+    as content text.
+    """
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NYC"}<|call|>'
+    )
+    tokens = _encode(encoding, text)
+    result = router.feed_sequence(tokens)
+
+    assert result["content"] is None, (
+        f"#444/#480: tool-call commentary stream must NOT leak into "
+        f"content; got content={result['content']!r}"
+    )
+    assert result["reasoning"] is None, (
+        f"#444/#480: no analysis channel in this sequence — reasoning "
+        f"must stay empty; got reasoning={result['reasoning']!r}"
+    )
+    assert result["tool_calls"] is not None and len(result["tool_calls"]) == 1, (
+        f"#444/#480: tool call must surface; got tool_calls={result['tool_calls']!r}"
+    )
+    tc_text = result["tool_calls"][0]
+    # Tool call event carries the reconstructed wire text the
+    # downstream HarmonyToolParser consumes — must include recipient
+    # and body.
+    assert "functions.get_weather" in tc_text, (
+        f"#444/#480: tool call must carry recipient; got {tc_text!r}"
+    )
+    assert '{"city":"NYC"}' in tc_text, (
+        f"#444/#480: tool call must carry body; got {tc_text!r}"
+    )
+
+
+# ----- #455 — Harmony commentary channel routing -----------------------
+
+
+def test_issue_455_analysis_then_commentary_separates_channels(router, encoding):
+    """#455: analysis (reasoning) + commentary (tool call) in one
+    assistant turn must route to reasoning and tool_calls respectively,
+    with no leak between them and no markers in either.
+
+    Pre-PR #515: the analysis body landed in reasoning correctly, but
+    the commentary tool call leaked into content (router couldn't
+    transition state on multi-token ``commentary``).
+    """
+    text = (
+        "<|channel|>analysis<|message|>"
+        "I'll fetch the weather.<|end|>"
+        "<|start|>assistant<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"Paris"}<|call|>'
+    )
+    tokens = _encode(encoding, text)
+    result = router.feed_sequence(tokens)
+
+    assert result["content"] is None, (
+        f"#455: content must stay empty; got {result['content']!r}"
+    )
+    assert result["reasoning"] == "I'll fetch the weather.", (
+        f"#455: reasoning must carry analysis body; got {result['reasoning']!r}"
+    )
+    assert result["tool_calls"] is not None and len(result["tool_calls"]) == 1, (
+        f"#455: tool call must surface; got tool_calls={result['tool_calls']!r}"
+    )
+
+    # Universal leak check — no harmony marker may appear in user-
+    # facing channels regardless of how the route runs.
+    for ch_name in ("content", "reasoning"):
+        val = result.get(ch_name) or ""
+        for marker in HARMONY_LEAK_MARKERS:
+            assert marker not in val, (
+                f"#455: marker {marker!r} leaked into {ch_name}; got {val!r}"
+            )
+
+
+# ----- #468 — tool_choice="required" + commentary compound -----------
+
+
+def test_issue_468_compound_analysis_commentary_final_separates(router, encoding):
+    """#468: assistant turn with analysis → tool call (commentary) →
+    final response. All three channels must route independently with
+    no cross-leak.
+    """
+    text = (
+        "<|channel|>analysis<|message|>"
+        "Need to compute the sum.<|end|>"
+        "<|start|>assistant<|channel|>commentary "
+        "to=functions.add <|constrain|>json<|message|>"
+        '{"a":1,"b":2}<|call|>'
+        "<|start|>assistant<|channel|>final<|message|>"
+        "The answer is 3.<|return|>"
+    )
+    tokens = _encode(encoding, text)
+    result = router.feed_sequence(tokens)
+
+    assert result["reasoning"] == "Need to compute the sum.", (
+        f"#468: reasoning must carry analysis; got {result['reasoning']!r}"
+    )
+    assert result["content"] == "The answer is 3.", (
+        f"#468: content must carry final body; got {result['content']!r}"
+    )
+    assert result["tool_calls"] is not None and len(result["tool_calls"]) == 1, (
+        f"#468: one tool call must surface; got {result['tool_calls']!r}"
+    )
+
+    # Reconstructed tool call must include name + args.
+    tc_text = result["tool_calls"][0]
+    assert "functions.add" in tc_text
+    assert '{"a":1,"b":2}' in tc_text
+
+    # Universal leak check.
+    for ch_name in ("content", "reasoning"):
+        val = result.get(ch_name) or ""
+        for marker in HARMONY_LEAK_MARKERS:
+            assert marker not in val, (
+                f"#468: marker {marker!r} leaked into {ch_name}; got {val!r}"
+            )
+
+
+# ----- General invariants ----------------------------------------------
+
+
+def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
+    """Pin per-token streaming behavior — analysis/final body tokens
+    produce ONE routed event each (matching the engine streaming
+    contract). Commentary body tokens are suppressed during streaming
+    (the tool call is emitted as a single aggregated event on
+    ``<|call|>``), matching the existing Channel.TOOL_CALL contract.
+    """
+    text = "<|channel|>final<|message|>Hi there.<|return|>"
+    tokens = _encode(encoding, text)
+    # Reset router for explicit per-token feed.
+    router.reset()
+    events_per_channel: dict[Channel, list[str]] = {
+        Channel.CONTENT: [],
+        Channel.REASONING: [],
+        Channel.TOOL_CALL: [],
+    }
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is None:
+            continue
+        events_per_channel[ev.channel].append(ev.text)
+
+    assert events_per_channel[Channel.TOOL_CALL] == []
+    assert events_per_channel[Channel.REASONING] == []
+    # Joined content matches the body, and at least one event per body
+    # token surfaced.
+    assert "".join(events_per_channel[Channel.CONTENT]) == "Hi there."
+    assert len(events_per_channel[Channel.CONTENT]) >= 2, (
+        f"per-token body deltas expected; got {events_per_channel[Channel.CONTENT]!r}"
+    )
+
+
+def test_finalize_drains_truncated_commentary_message(router, encoding):
+    """End-of-stream drain: a commentary message that was cut off mid-
+    body (no ``<|call|>``) must still surface as a TOOL_CALL event when
+    finalize() runs ``process_eos`` — otherwise truncated generations
+    silently drop tool calls.
+    """
+    # Truncate right before <|call|>.
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NYC"}'  # NO <|call|>
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    routed_during_stream = []
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is not None:
+            routed_during_stream.append(ev)
+    drained = router.finalize()
+
+    # No tool call during the truncated stream — final drain surfaces it.
+    assert all(ev.channel != Channel.TOOL_CALL for ev in routed_during_stream)
+    assert drained is not None and drained.channel == Channel.TOOL_CALL, (
+        f"truncated commentary must drain on finalize; "
+        f"got {drained!r} (stream events: {len(routed_during_stream)})"
+    )
+    assert "functions.get_weather" in drained.text

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -255,6 +255,135 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
     )
 
 
+def test_feed_sequence_preserves_leading_and_trailing_whitespace(router, encoding):
+    """Codex round-1 BLOCKING (PR #515): ``feed_sequence`` must NOT
+    ``.strip()`` accumulated content / reasoning — harmony bodies can
+    legitimately begin or end with whitespace (markdown blocks, code
+    fences, formatted output) and stripping silently mutates the
+    response. Only the exact empty string maps to ``None``.
+    """
+    # Final-channel body starts with a newline and ends with two
+    # spaces — both must survive.
+    text = (
+        "<|channel|>final<|message|>"
+        "\n```py\nprint('hi')\n```  "
+        "<|return|>"
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    result = router.feed_sequence(tokens)
+
+    assert result["content"] == "\n```py\nprint('hi')\n```  ", (
+        f"feed_sequence must preserve surrounding whitespace; "
+        f"got {result['content']!r}"
+    )
+
+
+def test_reconstruct_tool_call_rejects_malformed_recipient(router):
+    """Codex round-1 BLOCKING (PR #515): the recipient string is
+    interpolated into the reconstructed ``to=<recipient>`` wire text
+    consumed by ``HarmonyToolParser``. A recipient with whitespace,
+    marker-like characters, or unexpected shape would break the
+    downstream parser. The router must reject it loudly.
+    """
+
+    class _FakeMessage:
+        def __init__(self, recipient):
+            self.recipient = recipient
+            self.content = []
+            self.content_type = None
+
+    # ``feed()`` only calls ``_reconstruct_tool_call_text`` when
+    # ``closed.recipient`` is truthy, so empty / None recipients are
+    # filtered upstream — only test the cases where reconstruction
+    # actually runs (recipient is a non-empty string of unexpected
+    # shape).
+    bad_recipients = (
+        "functions.bad name",  # whitespace
+        "functions.<|call|>",  # marker
+        "not_functions.x",  # wrong namespace
+        "functions.",  # empty name
+    )
+    for bad in bad_recipients:
+        with pytest.raises(ValueError, match="malformed recipient"):
+            router._reconstruct_tool_call_text(_FakeMessage(bad))
+
+    # Sanity: a well-formed recipient must NOT raise.
+    good = _FakeMessage("functions.get_weather")
+    out = router._reconstruct_tool_call_text(good)
+    assert "to=functions.get_weather" in out
+
+
+def test_compat_gate_rejects_tokenizer_without_encode():
+    """Codex round-1 BLOCKING (PR #515): the compatibility gate must
+    require body-vocab parity, not just marker IDs. A tokenizer that
+    lacks ``.encode`` (e.g. ``_FakeTokenizer`` in
+    ``tests/test_engine_router_non_stream.py`` — only exposes
+    ``decode`` + ``get_vocab``) cannot prove vocab parity → gate must
+    return False so the legacy router runs.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    # Realistic harmony marker IDs (same as production gpt-oss-20b).
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    class _NoEncodeTokenizer:
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+    assert is_openai_harmony_compatible(tm, _NoEncodeTokenizer()) is False
+
+
+def test_compat_gate_rejects_mismatched_body_vocab():
+    """Codex round-1 BLOCKING (PR #515): when markers match but body
+    tokens do not, the gate must REJECT — otherwise body tokens are
+    decoded through harmony's vocabulary and corrupt content / tool
+    arguments. This is the 7-unit-regression smoking gun from
+    pr_validate round-1: synthetic test tokenizers had ``Reason=1``
+    / ``ing=2`` matching harmony's markers but had completely
+    different body IDs, decoded to ``"#`` under harmony encoding.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    class _MismatchedBodyVocabTokenizer:
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            # Wrong vocab — every body string is two arbitrary IDs.
+            return [99001, 99002]
+
+    assert is_openai_harmony_compatible(tm, _MismatchedBodyVocabTokenizer()) is False
+
+
 def test_finalize_drains_truncated_commentary_message(router, encoding):
     """End-of-stream drain: a commentary message that was cut off mid-
     body (no ``<|call|>``) must still surface as a TOOL_CALL event when

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -534,17 +534,21 @@ def test_compat_gate_rejects_mismatched_body_vocab():
     assert is_openai_harmony_compatible(tm, _MismatchedBodyVocabTokenizer()) is False
 
 
-def test_finalize_drains_truncated_commentary_message(router, encoding):
-    """End-of-stream drain: a commentary message that was cut off mid-
-    body (no ``<|call|>``) must still surface as a TOOL_CALL event when
-    finalize() runs ``process_eos`` — otherwise truncated generations
-    silently drop tool calls.
+def test_finalize_never_synthesizes_truncated_commentary(router, encoding):
+    """Codex round-6 BLOCKING resolution (PR #515): finalize() adopts
+    the vLLM / SGLang safer-default — a commentary message cut off
+    before ``<|call|>`` must NEVER be surfaced as a tool call, even
+    when the body is syntactically valid JSON. A ``max_tokens`` /
+    ``stop`` truncation must not be executed as if the model had
+    emitted ``<|call|>``; the upside of rescuing a rare recoverable
+    case is dwarfed by the cost of one wrongly-invoked tool. Per-token
+    ``feed()`` already produced every body byte (as buffered
+    commentary, never routed) — finalize only flushes parser state.
     """
-    # Truncate right before <|call|>.
     text = (
         "<|channel|>commentary "
         "to=functions.get_weather <|constrain|>json<|message|>"
-        '{"city":"NYC"}'  # NO <|call|>
+        '{"city":"NYC"}'  # NO <|call|> — truncated right before it
     )
     tokens = _encode(encoding, text)
     router.reset()
@@ -555,25 +559,20 @@ def test_finalize_drains_truncated_commentary_message(router, encoding):
             routed_during_stream.append(ev)
     drained = router.finalize()
 
-    # No tool call during the truncated stream — final drain surfaces it.
     assert all(ev.channel != Channel.TOOL_CALL for ev in routed_during_stream)
-    assert drained is not None and drained.channel == Channel.TOOL_CALL, (
-        f"truncated commentary must drain on finalize; "
-        f"got {drained!r} (stream events: {len(routed_during_stream)})"
+    assert drained is None, (
+        f"truncated commentary must NEVER surface as a tool call; got {drained!r} "
+        f"(stream events: {len(routed_during_stream)})"
     )
-    assert "functions.get_weather" in drained.text
 
 
 def test_finalize_drops_mid_json_truncation(router, encoding):
-    """Codex round-3 BLOCKING (PR #515): when ``process_eos`` closes a
-    commentary message whose body was cut off mid-JSON
-    (e.g. ``{"city":"NY``), the synthesized TOOL_CALL must be DROPPED.
-    Surfacing it would feed corrupt JSON arguments to the downstream
-    parser and the model would be treated as having ``completed`` a
-    malformed tool call. Sibling regression to
-    ``test_finalize_drains_truncated_commentary_message`` — both pin
-    the contract that ``finalize()`` only emits when the closed
-    message body validates against its declared ``content_type``.
+    """Sibling pin to ``test_finalize_never_synthesizes_truncated_commentary``:
+    a commentary message whose body was cut off mid-JSON (e.g.
+    ``{"city":"NY``) must also be dropped. Covered by the same
+    safer-default rule (codex round-6 resolution, PR #515) — finalize()
+    never synthesizes a tool call from a truncated commentary message,
+    so any partial-JSON body is dropped by construction.
     """
     # Commentary header + truncated mid-string body.
     text = (
@@ -593,9 +592,11 @@ def test_finalize_drops_mid_json_truncation(router, encoding):
 
 
 def test_finalize_drops_truncated_commentary_with_empty_body(router, encoding):
-    """Codex round-3 BLOCKING (PR #515): a commentary message with no
-    body whatsoever (truncated right after ``<|message|>``) must also
-    be dropped — empty arguments are never the intended output.
+    """Sibling pin: a commentary message with no body whatsoever
+    (truncated right after ``<|message|>``) must also be dropped.
+    Covered by the same safer-default rule (codex round-6 resolution,
+    PR #515) — finalize() never synthesizes a tool call regardless of
+    body shape.
     """
     text = "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>"
     tokens = _encode(encoding, text)
@@ -635,14 +636,16 @@ def test_finalize_does_not_double_emit_completed_final(router, encoding):
     )
 
 
-def test_finalize_drains_truncated_final_buffered_delta(router, encoding):
-    """Codex round-4 BLOCKING (PR #515): when an EOS / process_eos
-    surfaces a ``last_content_delta`` from a truncated final or
-    analysis message, ``finalize()`` must route it to CONTENT /
-    REASONING respectively rather than dropping it. Empirically the
-    current openai-harmony build emits everything during ``feed()``,
-    but the contract pins the behavior in case a future build flushes
-    a buffered tail on EOS.
+def test_finalize_does_not_drain_post_eos_buffered_delta(router, encoding):
+    """Codex round-6 BLOCKING resolution (PR #515): even if a future
+    openai-harmony build flushes a buffered tail via
+    ``last_content_delta`` during ``process_eos()``, ``finalize()``
+    must NOT route it as a CONTENT / REASONING event. Per-token
+    ``feed()`` already produced every body byte the model emitted;
+    emitting a post-EOS delta risks duplicating the last token (if the
+    build does not clear ``last_content_delta`` between the per-token
+    flush and the EOS flush). The safer default matches vLLM / SGLang:
+    finalize is a parser-state flush only.
     """
     # Construct a router whose underlying StreamableParser is forced
     # into a state where process_eos produces a synthetic delta.
@@ -670,28 +673,18 @@ def test_finalize_drains_truncated_final_buffered_delta(router, encoding):
             return self._delta
 
         def process_eos(self):
-            # Simulate EOS appending a closed final-channel message
-            # AND flushing a buffered tail delta — the codex-flagged
-            # corner case my finalize must handle.
             self.messages.append(_StubMessage(self._channel))
             self._delta = " tail"
 
     router.reset()
     router._parser = _StubParser("final", "")
     drained = router.finalize()
-    assert drained is not None
-    assert drained.channel == Channel.CONTENT, (
-        f"truncated final delta must drain to CONTENT; got {drained!r}"
-    )
-    assert drained.text == " tail"
+    assert drained is None, f"post-EOS final delta must NOT drain; got {drained!r}"
 
-    # Symmetric: analysis channel routes to REASONING.
     router.reset()
     router._parser = _StubParser("analysis", "")
     drained = router.finalize()
-    assert drained is not None
-    assert drained.channel == Channel.REASONING
-    assert drained.text == " tail"
+    assert drained is None, f"post-EOS analysis delta must NOT drain; got {drained!r}"
 
 
 def test_compat_gate_rejects_missing_marker_ids():

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -13,15 +13,19 @@ never identify.
 
 PR #515 lands the SOTA fix: delegate harmony state tracking to
 ``openai-harmony.StreamableParser`` (same library vLLM and SGLang
-delegate to). The new ``HarmonyStreamingRouter`` shim exposes the
-existing ``OutputRouter`` surface so the engine streaming path is
-unchanged; only the harmony format gets the new backend.
+delegate to). The ``HarmonyStreamingRouter`` shim exposes the existing
+``OutputRouter`` surface so the engine streaming path is unchanged;
+only the harmony format gets the new backend.
 
-This file pins the closure of #444 / #455 / #468 / #480 by replaying
-production-shape token sequences (encoded via the real harmony
-encoding, NOT the synthetic test vocab used by the partial-closure
-regressions in the sibling files) and asserting NO marker leak +
-correct channel routing.
+Round-15 architectural refactor (codex round-12 / round-14 BLOCKING
+closure): tool-call events surface a STRUCTURED ``{"name", "arguments"}``
+payload on ``RouterEvent.tool_call`` and flow through the engine via
+``GenerationOutput.tool_calls``. The previous design reconstructed
+sentinel-delimited wire text and let downstream text-based
+``HarmonyToolParser`` regex-parse it again, which lost tool calls
+whose JSON arguments contained literal harmony marker substrings
+(e.g. ``{"text":"<|call|>"}``). Bytes-faithful structured passthrough
+matches vLLM and SGLang and eliminates that loss path entirely.
 """
 
 from __future__ import annotations
@@ -94,8 +98,8 @@ def _encode(encoding, text: str) -> list[int]:
 def test_issue_444_480_commentary_tool_call_no_marker_leak(router, encoding):
     """#444 / #480: streaming a harmony tool call MUST NOT leak
     structural markers or channel labels into ``content`` / ``reasoning``,
-    and the tool call MUST surface in ``tool_calls`` with the recipient
-    + body intact.
+    and the tool call MUST surface in ``tool_calls`` as a structured
+    ``{"name", "arguments"}`` dict.
 
     Pre-PR #515: the custom router state machine recognized ``analysis``
     / ``final`` channel-type words by single-token ID match. Production
@@ -122,16 +126,19 @@ def test_issue_444_480_commentary_tool_call_no_marker_leak(router, encoding):
     assert result["tool_calls"] is not None and len(result["tool_calls"]) == 1, (
         f"#444/#480: tool call must surface; got tool_calls={result['tool_calls']!r}"
     )
-    tc_text = result["tool_calls"][0]
-    # Tool call event carries the reconstructed wire text the
-    # downstream HarmonyToolParser consumes — must include recipient
-    # and body.
-    assert "functions.get_weather" in tc_text, (
-        f"#444/#480: tool call must carry recipient; got {tc_text!r}"
+    tc = result["tool_calls"][0]
+    # Round-15 refactor: structured ``{"name", "arguments"}`` shape.
+    assert isinstance(tc, dict), f"#444/#480: tool_call must be dict; got {type(tc)}"
+    assert tc["name"] == "get_weather", (
+        f"#444/#480: tool call must carry recipient name; got {tc!r}"
     )
-    assert '{"city":"NYC"}' in tc_text, (
-        f"#444/#480: tool call must carry body; got {tc_text!r}"
+    assert tc["arguments"] == '{"city":"NYC"}', (
+        f"#444/#480: tool call arguments must be verbatim body bytes; got {tc!r}"
     )
+    # And the structured payload MUST NOT carry harmony wire markers.
+    assert "<|channel|>" not in tc["arguments"]
+    assert "<|message|>" not in tc["arguments"]
+    assert "<|call|>" not in tc["arguments"]
 
 
 # ----- #455 — Harmony commentary channel routing -----------------------
@@ -164,6 +171,10 @@ def test_issue_455_analysis_then_commentary_separates_channels(router, encoding)
     )
     assert result["tool_calls"] is not None and len(result["tool_calls"]) == 1, (
         f"#455: tool call must surface; got tool_calls={result['tool_calls']!r}"
+    )
+    tc = result["tool_calls"][0]
+    assert tc == {"name": "get_weather", "arguments": '{"city":"Paris"}'}, (
+        f"#455: structured payload mismatch; got {tc!r}"
     )
 
     # Universal leak check — no harmony marker may appear in user-
@@ -206,10 +217,10 @@ def test_issue_468_compound_analysis_commentary_final_separates(router, encoding
         f"#468: one tool call must surface; got {result['tool_calls']!r}"
     )
 
-    # Reconstructed tool call must include name + args.
-    tc_text = result["tool_calls"][0]
-    assert "functions.add" in tc_text
-    assert '{"a":1,"b":2}' in tc_text
+    tc = result["tool_calls"][0]
+    assert tc == {"name": "add", "arguments": '{"a":1,"b":2}'}, (
+        f"#468: structured payload mismatch; got {tc!r}"
+    )
 
     # Universal leak check.
     for ch_name in ("content", "reasoning"):
@@ -218,6 +229,149 @@ def test_issue_468_compound_analysis_commentary_final_separates(router, encoding
             assert marker not in val, (
                 f"#468: marker {marker!r} leaked into {ch_name}; got {val!r}"
             )
+
+
+# ----- Round-15 architectural refactor — sentinel-in-body passthrough --
+
+
+def test_structured_payload_preserves_body_with_harmony_sentinels(router, encoding):
+    """Round-15 refactor closure for codex round-12 / round-14
+    BLOCKING (PR #515): a tool call whose JSON arguments contain a
+    literal harmony sentinel substring (``{"text":"<|call|>"}``,
+    ``{"x":"<|message|>"}`` etc.) MUST be surfaced intact via the
+    structured ``{"name", "arguments"}`` payload. The previous
+    wire-text round-trip lost these calls — the downstream regex
+    parser anchored on the embedded sentinel and truncated the JSON,
+    silently dropping a legitimate tool invocation.
+
+    Bytes-faithful structured passthrough eliminates the failure mode
+    by construction: arguments are the verbatim concatenated body
+    text the parser surfaced, no marker handling required.
+    """
+    sentinel_bearing_bodies = (
+        '{"text":"use <|call|>"}',
+        '{"text":"<|message|>injected"}',
+        '{"x":"<|channel|>commentary"}',
+        '{"y":"<|end|>"}',
+        '{"z":"<|return|>"}',
+        '{"a":"<|start|>"}',
+        '{"b":"<|constrain|>json"}',
+    )
+    # Encode the structural prefix / suffix with allowed_special="all"
+    # so harmony markers round-trip as single token IDs, but encode the
+    # body with allowed_special="none" so literal harmony-marker text
+    # INSIDE the JSON body remains plain body bytes — matches how a
+    # real gpt-oss model would tokenize a tool call whose JSON value
+    # happens to contain a marker substring (the model's tokenizer
+    # would not promote inside-JSON text to special-token IDs).
+    prefix_ids = encoding.encode(
+        "<|channel|>commentary to=functions.echo <|constrain|>json<|message|>",
+        allowed_special="all",
+    )
+    suffix_ids = encoding.encode("<|call|>", allowed_special="all")
+    for body in sentinel_bearing_bodies:
+        # ``disallowed_special=()`` tells the harmony encoder to treat
+        # marker-shaped substrings inside the body as plain text bytes
+        # (default behavior raises to prevent accidental special-token
+        # injection). That's exactly the production model behavior we
+        # want to simulate: the model's tokenizer would surface these
+        # bytes via normal body vocab IDs, not as the special marker.
+        body_ids = encoding.encode(body, allowed_special="none", disallowed_special=())
+        tokens = prefix_ids + body_ids + suffix_ids
+        router.reset()
+        result = router.feed_sequence(tokens)
+
+        assert result["tool_calls"] is not None, (
+            f"body {body!r}: tool call MUST surface (round-15 "
+            f"bytes-faithful refactor); got tool_calls=None"
+        )
+        assert len(result["tool_calls"]) == 1, (
+            f"body {body!r}: exactly one tool call expected; "
+            f"got {result['tool_calls']!r}"
+        )
+        tc = result["tool_calls"][0]
+        assert tc == {"name": "echo", "arguments": body}, (
+            f"body {body!r}: structured payload must preserve bytes; got {tc!r}"
+        )
+        # And the body must NOT leak into content (the abstain path
+        # in earlier revisions surfaced sentinel bodies via CONTENT
+        # to keep streaming visible; bytes-faithful passthrough makes
+        # that workaround obsolete).
+        assert result["content"] is None, (
+            f"body {body!r}: must NOT leak into content under "
+            f"bytes-faithful refactor; got {result['content']!r}"
+        )
+
+
+def test_structured_payload_carries_truncated_recipient_namespace(router):
+    """The router strips the harmony ``functions.`` namespace prefix
+    from the recipient before surfacing it. OpenAI's spec carries the
+    bare tool name in ``function.name``; the namespace is transport
+    metadata only.
+    """
+
+    class _C:
+        def __init__(self, t):
+            self.text = t
+
+    class _Msg:
+        recipient = "functions.my-tool-with-dash_and_under"
+        content = [_C('{"k":"v"}')]
+        content_type = None
+
+    out = router._extract_structured_tool_call(_Msg())
+    assert out is not None
+    assert out["name"] == "my-tool-with-dash_and_under"
+    assert out["arguments"] == '{"k":"v"}'
+
+
+def test_structured_payload_drops_malformed_recipient(router):
+    """A recipient that doesn't match ``functions.<safe-name>`` is
+    treated as structural corruption — the router drops the frame
+    rather than surfacing a half-parsed call. Strictly stronger than
+    the legacy wire-text path which would have produced a garbled
+    call.
+    """
+
+    class _C:
+        def __init__(self, t):
+            self.text = t
+
+    class _Msg:
+        def __init__(self, recipient):
+            self.recipient = recipient
+            self.content = [_C('{"x":1}')]
+            self.content_type = None
+
+    bad_recipients = (
+        "functions.bad name",  # whitespace
+        "functions.<|call|>",  # marker
+        "not_functions.x",  # wrong namespace
+        "functions.",  # empty name
+    )
+    for bad in bad_recipients:
+        out = router._extract_structured_tool_call(_Msg(bad))
+        assert out is None, (
+            f"malformed recipient {bad!r} must drop (return None); got {out!r}"
+        )
+
+
+def test_structured_payload_drops_empty_recipient(router):
+    """A commentary message with no recipient at all is not a tool
+    call — the router skips structured emission so the caller knows
+    to fall through.
+    """
+
+    class _C:
+        def __init__(self, t):
+            self.text = t
+
+    class _Msg:
+        recipient = None
+        content = [_C("x")]
+        content_type = None
+
+    assert router._extract_structured_tool_call(_Msg()) is None
 
 
 # ----- General invariants ----------------------------------------------
@@ -237,19 +391,12 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
     """
     text = "<|channel|>final<|message|>Hi there.<|return|>"
     tokens = _encode(encoding, text)
-    # Identify which token IDs belong to the body (between
-    # ``<|message|>`` and ``<|return|>``) — those are the ones we
-    # expect to produce a CONTENT event each. Markers are
-    # ``<|channel|>``, ``final``, ``<|message|>``, ``<|return|>``;
-    # everything between the ``<|message|>`` and ``<|return|>`` markers
-    # is body.
     message_id = encoding.encode("<|message|>", allowed_special="all")[0]
     return_id = encoding.encode("<|return|>", allowed_special="all")[0]
     body_start = tokens.index(message_id) + 1
     body_end = tokens.index(return_id)
     body_token_count = body_end - body_start
 
-    # Reset router for explicit per-token feed.
     router.reset()
     events_per_channel: dict[Channel, list[str]] = {
         Channel.CONTENT: [],
@@ -264,8 +411,6 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
 
     assert events_per_channel[Channel.TOOL_CALL] == []
     assert events_per_channel[Channel.REASONING] == []
-    # Joined content matches the body, and emit count EQUALS body
-    # token count — coalescing / dropped deltas would now fail.
     assert "".join(events_per_channel[Channel.CONTENT]) == "Hi there."
     assert len(events_per_channel[Channel.CONTENT]) == body_token_count, (
         f"per-token body deltas must be 1-to-1 with body tokens; "
@@ -275,6 +420,31 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
     )
 
 
+def test_tool_call_event_carries_structured_payload(router, encoding):
+    """Per-token feed produces a SINGLE TOOL_CALL event on ``<|call|>``
+    whose ``RouterEvent.tool_call`` field carries the structured
+    payload. Engine plumbs this through ``GenerationOutput.tool_calls``
+    so routes bypass the text-based parser entirely.
+    """
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NYC"}<|call|>'
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    tool_call_events = []
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is not None and ev.channel == Channel.TOOL_CALL:
+            tool_call_events.append(ev)
+    assert len(tool_call_events) == 1
+    ev = tool_call_events[0]
+    assert ev.tool_call is not None
+    assert ev.tool_call["name"] == "get_weather"
+    assert ev.tool_call["arguments"] == '{"city":"NYC"}'
+
+
 def test_feed_sequence_preserves_leading_and_trailing_whitespace(router, encoding):
     """Codex round-1 BLOCKING (PR #515): ``feed_sequence`` must NOT
     ``.strip()`` accumulated content / reasoning — harmony bodies can
@@ -282,8 +452,6 @@ def test_feed_sequence_preserves_leading_and_trailing_whitespace(router, encodin
     fences, formatted output) and stripping silently mutates the
     response. Only the exact empty string maps to ``None``.
     """
-    # Final-channel body starts with a newline and ends with two
-    # spaces — both must survive.
     text = "<|channel|>final<|message|>\n```py\nprint('hi')\n```  <|return|>"
     tokens = _encode(encoding, text)
     router.reset()
@@ -294,165 +462,35 @@ def test_feed_sequence_preserves_leading_and_trailing_whitespace(router, encodin
     )
 
 
-def test_reconstruct_tool_call_rejects_malformed_recipient(router):
-    """Codex round-1 BLOCKING (PR #515): the recipient string is
-    interpolated into the reconstructed ``to=<recipient>`` wire text
-    consumed by ``HarmonyToolParser``. A recipient with whitespace,
-    marker-like characters, or unexpected shape would break the
-    downstream parser. The router must reject it loudly.
+def test_recipient_shape_accepts_digit_start_names(router):
+    """Codex round-2 BLOCKING (PR #515): the original recipient
+    shape regex ``^functions\\.[A-Za-z_]...`` rejected valid OpenAI
+    tool names whose first character is a digit (e.g. ``2fa_lookup``).
+    Widen to match the OpenAI spec ``[A-Za-z0-9_-]{1,64}``.
     """
 
-    class _FakeMessage:
+    class _C:
+        def __init__(self, t):
+            self.text = t
+
+    class _Msg:
         def __init__(self, recipient):
             self.recipient = recipient
-            self.content = []
+            self.content = [_C('{"x":1}')]
             self.content_type = None
 
-    # ``feed()`` only calls ``_reconstruct_tool_call_text`` when
-    # ``closed.recipient`` is truthy, so empty / None recipients are
-    # filtered upstream — only test the cases where reconstruction
-    # actually runs (recipient is a non-empty string of unexpected
-    # shape).
-    bad_recipients = (
-        "functions.bad name",  # whitespace
-        "functions.<|call|>",  # marker
-        "not_functions.x",  # wrong namespace
-        "functions.",  # empty name
-    )
-    for bad in bad_recipients:
-        with pytest.raises(ValueError, match="malformed recipient"):
-            router._reconstruct_tool_call_text(_FakeMessage(bad))
-
-    # Sanity: a well-formed recipient must NOT raise.
-    good = _FakeMessage("functions.get_weather")
-    out = router._reconstruct_tool_call_text(good)
-    assert "to=functions.get_weather" in out
+    for good in (
+        "functions.2fa_lookup",
+        "functions.0_index",
+        "functions.123",
+        "functions.tool-with-dash",
+    ):
+        out = router._extract_structured_tool_call(_Msg(good))
+        assert out is not None, f"good recipient {good!r} dropped; got None"
+        assert out["name"] == good.split(".", 1)[1]
 
 
-def test_reconstruct_tool_call_abstains_on_body_carrying_harmony_sentinel(router):
-    """Codex round-7 BLOCKING (don't emit corrupt structured event) +
-    round-9 BLOCKING (don't raise on legitimate JSON containing
-    ``<|...|>`` substrings): when the body or content_type carries a
-    harmony structural sentinel that would corrupt the downstream
-    HarmonyToolParser regex parse, ``_reconstruct_tool_call_text``
-    must ABSTAIN — return ``None`` — instead of raising.
-
-    The caller (``feed()``) then emits a CONTENT event with the body
-    bytes (codex round-10 BLOCKING — streaming visibility) so the
-    user still sees the tool call's intent verbatim, matching baseline
-    behavior where the legacy router leaked commentary body into
-    CONTENT. The engine non-stream path is unaffected: it relies on
-    ``fallback_text``, which still carries the model's raw emit.
-    Matches the recipient-validation pattern's intent (don't emit a
-    bogus structured event) without the round-9 cost (dropping
-    legitimate OpenAI tool calls whose JSON values happen to contain
-    those characters) and without the round-10 cost (silent streaming
-    drop).
-    """
-
-    class _Content:
-        def __init__(self, text):
-            self.text = text
-
-    class _FakeMessage:
-        def __init__(self, body, recipient="functions.get_weather", ctype=None):
-            self.recipient = recipient
-            self.content = [_Content(body)]
-            self.content_type = ctype
-
-    abstain_bodies = (
-        '{"text":"use <|call|>"}',
-        '{"text":"<|message|>injected"}',
-        '{"x":"<|channel|>commentary"}',
-        '{"y":"<|end|>"}',
-        '{"z":"<|return|>"}',
-        '{"a":"<|start|>"}',
-        '{"b":"<|constrain|>json"}',
-    )
-    for bad in abstain_bodies:
-        out = router._reconstruct_tool_call_text(_FakeMessage(bad))
-        assert out is None, f"body carrying sentinel must abstain (None); got {out!r}"
-
-    # Sanity: clean JSON must reconstruct normally.
-    clean = _FakeMessage('{"city":"NYC"}')
-    out = router._reconstruct_tool_call_text(clean)
-    assert out is not None
-    assert '{"city":"NYC"}' in out
-    assert "<|message|>" in out  # legitimate framing must remain
-    assert out.endswith("<|call|>")  # legitimate trailing sentinel
-
-    # A content_type that smuggles a sentinel past the
-    # ``<|constrain|>`` prefix must also abstain.
-    out = router._reconstruct_tool_call_text(
-        _FakeMessage(
-            '{"city":"NYC"}',
-            ctype="<|constrain|>json<|call|>injected",
-        )
-    )
-    assert out is None, f"content_type smuggling a sentinel must abstain; got {out!r}"
-
-    # A normal ``<|constrain|>json`` content_type must NOT abstain.
-    ok = _FakeMessage('{"city":"NYC"}', ctype="<|constrain|>json")
-    out = router._reconstruct_tool_call_text(ok)
-    assert out is not None
-    assert "<|constrain|>json<|message|>" in out
-
-    # Codex round-11 NIT: a bare enum like ``"json"`` (missing the
-    # ``<|constrain|>`` prefix) would reconstruct non-canonical wire
-    # text the downstream parser can't recognise — must abstain.
-    bare_ctype = _FakeMessage('{"city":"NYC"}', ctype="json")
-    assert router._reconstruct_tool_call_text(bare_ctype) is None, (
-        "bare content_type missing <|constrain|> prefix must abstain"
-    )
-    # And a content_type with disallowed characters must also abstain.
-    bad_chars_ctype = _FakeMessage('{"city":"NYC"}', ctype="<|constrain|>has space")
-    assert router._reconstruct_tool_call_text(bad_chars_ctype) is None, (
-        "content_type with non-safe characters must abstain"
-    )
-
-
-def test_sentinel_body_emits_content_event_for_streaming_visibility(
-    router, encoding, monkeypatch
-):
-    """Codex round-10 BLOCKING (PR #515): when ``_reconstruct_tool_call_text``
-    abstains for a sentinel-laden body, ``feed()`` must NOT silently
-    swallow the streaming output. The body was buffered during the
-    commentary deltas (we suppress per-token emission until close), so
-    a silent drop would make the entire tool call invisible to the
-    streaming consumer. Surface the body bytes as a CONTENT event so
-    the user still sees what the model emitted — matches baseline
-    behavior where the legacy router leaked commentary body into
-    CONTENT verbatim.
-
-    Force the abstain path by monkeypatching the static reconstructor
-    to return None (which is what would happen on a sentinel-laden
-    body for a real call); replay a normal commentary tool call and
-    assert ``feed_sequence`` surfaces the body bytes via CONTENT.
-    """
-    text = (
-        "<|channel|>commentary "
-        "to=functions.get_weather <|constrain|>json<|message|>"
-        '{"city":"NYC"}<|call|>'
-    )
-    tokens = _encode(encoding, text)
-
-    monkeypatch.setattr(
-        HarmonyStreamingRouter,
-        "_reconstruct_tool_call_text",
-        staticmethod(lambda _msg: None),
-    )
-
-    router.reset()
-    result = router.feed_sequence(tokens)
-
-    # No TOOL_CALL surfaces (abstained).
-    assert result["tool_calls"] is None, (
-        f"abstain path must not emit TOOL_CALL; got {result['tool_calls']!r}"
-    )
-    # But the body IS visible to streaming consumers via CONTENT.
-    assert result["content"] is not None and '{"city":"NYC"}' in result["content"], (
-        f"abstain path must surface body bytes via CONTENT; got {result['content']!r}"
-    )
+# ----- Identity allowlist ---------------------------------------------
 
 
 def test_compat_gate_rejects_unknown_tokenizer_identity():
@@ -487,8 +525,6 @@ def test_compat_gate_rejects_unknown_tokenizer_identity():
             return {}
 
         def encode(self, text, add_special_tokens=False):
-            # Even if the tokenizer SOMEHOW produced matching probe IDs,
-            # the identity gate must short-circuit.
             return [99001, 99002]
 
     assert is_openai_harmony_compatible(tm, _NotGptOssTokenizer()) is False
@@ -498,9 +534,7 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
     """Codex round-2 BLOCKING (PR #515): the identity allowlist must
     tolerate the org-prefix + quant-suffix renames the mlx-community
     publishes (``mlx-community/gpt-oss-20b-MXFP4-Q8``,
-    ``mlx-community/gpt-oss-120b-MXFP4-Q4`` etc.) — case-insensitive
-    substring match on ``gpt-oss`` covers all of them while still
-    rejecting random model names.
+    ``mlx-community/gpt-oss-120b-MXFP4-Q4`` etc.).
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -509,7 +543,6 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
         openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
     )
 
-    # Real markers from harmony encoding.
     def _id(s):
         return enc.encode(s, allowed_special="all")[0]
 
@@ -525,11 +558,6 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
     )
 
     class _GptOssLike:
-        """A tokenizer whose ``encode`` actually delegates to the
-        harmony encoding — so the marker + probe checks pass; only the
-        identity check decides accept vs reject for these cases.
-        """
-
         def __init__(self, name):
             self.name_or_path = name
             self._enc = enc
@@ -543,7 +571,6 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
         def get_vocab(self):
             return {}
 
-    # Accepted identities.
     for name in (
         "mlx-community/gpt-oss-20b-MXFP4-Q8",
         "openai/gpt-oss-120b",
@@ -553,7 +580,6 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
             f"identity {name!r} must be accepted"
         )
 
-    # Rejected identities even with matching encoder.
     for name in (
         "mistralai/Mistral-7B-Instruct-v0.3",
         "Qwen/Qwen3-0.6B",
@@ -564,55 +590,14 @@ def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
         )
 
 
-def test_recipient_shape_accepts_digit_start_names():
-    """Codex round-2 BLOCKING (PR #515): the original recipient
-    shape regex ``^functions\\.[A-Za-z_]...`` rejected valid OpenAI
-    tool names whose first character is a digit (e.g. ``2fa_lookup``).
-    Widen to match the OpenAI spec ``[A-Za-z0-9_-]{1,64}``.
-    """
-    from vllm_mlx.output_router import TokenMap
-    from vllm_mlx.output_router_harmony import HarmonyStreamingRouter
-
-    class _Adapter:
-        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
-
-        def decode(self, ids):
-            return ""
-
-        def get_vocab(self):
-            return {}
-
-    r = HarmonyStreamingRouter(TokenMap(format_tag="harmony"), _Adapter())
-
-    class _Msg:
-        def __init__(self, recipient):
-            self.recipient = recipient
-            self.content = []
-            self.content_type = None
-
-    # These were broken on round-1; must pass on round-2.
-    for good in (
-        "functions.2fa_lookup",
-        "functions.0_index",
-        "functions.123",
-        "functions.tool-with-dash",
-    ):
-        out = r._reconstruct_tool_call_text(_Msg(good))
-        assert f"to={good}" in out, f"good recipient {good!r} got: {out!r}"
-
-
 def test_compat_gate_rejects_tokenizer_without_encode():
-    """Codex round-1 BLOCKING (PR #515): the compatibility gate must
-    require body-vocab parity, not just marker IDs. A tokenizer that
-    lacks ``.encode`` (e.g. ``_FakeTokenizer`` in
-    ``tests/test_engine_router_non_stream.py`` — only exposes
-    ``decode`` + ``get_vocab``) cannot prove vocab parity → gate must
-    return False so the legacy router runs.
+    """Codex round-1 BLOCKING (PR #515): a tokenizer that lacks
+    ``.encode`` cannot prove vocab parity → gate must return False so
+    the legacy router runs.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
 
-    # Realistic harmony marker IDs (same as production gpt-oss-20b).
     tm = TokenMap(
         format_tag="harmony",
         harmony_channel=200005,
@@ -624,9 +609,6 @@ def test_compat_gate_rejects_tokenizer_without_encode():
         harmony_constrain=200003,
     )
 
-    # Use a unique identity so the result cache from earlier tests
-    # doesn't short-circuit this one (codex round-3 NIT: cache is keyed
-    # by lowercased ``name_or_path``).
     class _NoEncodeTokenizer:
         name_or_path = "mlx-community/gpt-oss-NO-ENCODE-VARIANT"
 
@@ -643,10 +625,7 @@ def test_compat_gate_rejects_mismatched_body_vocab():
     """Codex round-1 BLOCKING (PR #515): when markers match but body
     tokens do not, the gate must REJECT — otherwise body tokens are
     decoded through harmony's vocabulary and corrupt content / tool
-    arguments. This is the 7-unit-regression smoking gun from
-    pr_validate round-1: synthetic test tokenizers had ``Reason=1``
-    / ``ing=2`` matching harmony's markers but had completely
-    different body IDs, decoded to ``"#`` under harmony encoding.
+    arguments.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -662,8 +641,6 @@ def test_compat_gate_rejects_mismatched_body_vocab():
         harmony_constrain=200003,
     )
 
-    # Use a unique identity so the result cache doesn't return a
-    # stale True from the sibling accepted-variant test.
     class _MismatchedBodyVocabTokenizer:
         name_or_path = "mlx-community/gpt-oss-MISMATCHED-BODY-VARIANT"
 
@@ -674,20 +651,19 @@ def test_compat_gate_rejects_mismatched_body_vocab():
             return {}
 
         def encode(self, text, add_special_tokens=False):
-            # Wrong vocab — every body string is two arbitrary IDs.
             return [99001, 99002]
 
     assert is_openai_harmony_compatible(tm, _MismatchedBodyVocabTokenizer()) is False
 
 
 def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
-    """Codex round-11 BLOCKING (PR #515): the tokenizer-identity
-    allowlist used naive ``in`` substring matching, so an identity
-    like ``my-not-gpt-oss/whatever`` (or ``foo-gpt-oss-bar`` with no
-    ``/`` separator) would pass while clearly not being a real
-    gpt-oss family member. Anchored match
-    (``(?:^|/)gpt-oss(?:-|$)``) accepts canonical names and rejects
-    tail-substring fakes.
+    """Codex round-11 / round-12 / round-13 BLOCKING (PR #515): the
+    tokenizer-identity allowlist used naive ``in`` substring matching,
+    so an identity like ``my-not-gpt-oss/whatever`` (or
+    ``foo-gpt-oss-bar`` with no ``/`` separator) would pass. Anchored
+    match accepts canonical names and rejects tail-substring fakes;
+    remote IDs require an allowlisted owner; local paths trust the
+    basename.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -717,15 +693,12 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
         def encode(self, text, add_special_tokens=False):
             return enc.encode(text, allowed_special="none")
 
-    # Tail-substring fakes AND non-allowlisted owner prefixes (codex
-    # round-12 BLOCKING — even an anchored basename allowlist let
-    # arbitrary owners pass; restrict to known owner prefixes).
     rejected_names = (
         "my-not-gpt-oss/whatever",
         "foo/bar-gpt-oss-malicious",
-        "my-not-gpt-oss-20b",  # no slash, tail substring
+        "my-not-gpt-oss-20b",
         "notgpt-oss-fake",
-        "some-user/gpt-oss-remapped",  # unknown owner with valid basename
+        "some-user/gpt-oss-remapped",
         "evil-org/gpt-oss-20b",
         "anonymous/gpt-oss",
     )
@@ -736,25 +709,19 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
 
         _Fake.name_or_path = name
         assert is_openai_harmony_compatible(tm, _Fake()) is False, (
-            f"tail-substring identity {name!r} must be rejected; "
-            f"anchored allowlist failed"
+            f"tail-substring identity {name!r} must be rejected"
         )
 
-    # Canonical names — known owner prefixes (openai, mlx-community,
-    # unsloth), bare basename, AND local filesystem paths (codex
-    # round-13 BLOCKING — production loads models by absolute path
-    # from local caches; rejecting them broke real deployments).
     accepted_names = (
         "openai/gpt-oss-20b",
         "mlx-community/gpt-oss-20b-MXFP4-Q8",
         "unsloth/gpt-oss-20b-MLX-8bit",
-        "gpt-oss-20b",  # bare, anchored at ^
-        "gpt-oss",  # bare exact
-        "/models/gpt-oss-20b",  # absolute local path
-        "/Users/me/.cache/huggingface/hub/models--openai--gpt-oss-20b/gpt-oss-20b",
-        "~/lmstudio-models/gpt-oss-20b",  # tilde-prefixed local path
-        "./gpt-oss-20b-quantized",  # relative local path
-        "../models/gpt-oss-20b",  # parent-relative local path
+        "gpt-oss-20b",
+        "gpt-oss",
+        "/models/gpt-oss-20b",
+        "~/lmstudio-models/gpt-oss-20b",
+        "./gpt-oss-20b-quantized",
+        "../models/gpt-oss-20b",
     )
     for name in accepted_names:
 
@@ -763,22 +730,99 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
 
         _Real.name_or_path = name
         assert is_openai_harmony_compatible(tm, _Real()) is True, (
-            f"canonical identity {name!r} must pass; anchored regex over-rejected"
+            f"canonical identity {name!r} must pass"
         )
 
 
-def test_compat_cache_key_segregates_by_tokenizer_instance():
-    """Codex round-11 BLOCKING (PR #515): the per-identity cache used
-    ``(name_or_path, marker_ids)`` only, so two distinct tokenizer
-    instances with the same name + marker IDs but a remapped body
-    vocab shared a single cached decision. A previous ``True`` would
-    then upgrade an incompatible tokenizer and corrupt
-    ``StreamableParser`` body decoding.
+def test_compat_gate_accepts_hf_cache_snapshot_path():
+    """Round-15 fix for codex round-14 BLOCKING #1 (PR #515): the HF
+    hub cache snapshot layout is
+    ``~/.cache/huggingface/hub/models--<owner>--<name>/snapshots/<sha>/``.
+    The snapshot basename is an opaque SHA, not the model name, so the
+    basename-only allowlist (round-13) rejected this path and made
+    every HF-cache-loaded gpt-oss model fall back to the leaking
+    legacy router.
 
-    Fix folded ``id(tokenizer)`` into the cache key — distinct
-    instances now segregate naturally, each instance gets an
-    authoritative ``_compute_compat`` pass; same-instance reuses
-    cleanly (zero-encode cache hit).
+    Fix: search the full path for ``models--<owner>--<name>`` and
+    treat it as the remote id ``<owner>/<name>`` (subject to the
+    remote-owner allowlist), so cache-loaded models route through the
+    openai-harmony bypass like their HF-id-loaded siblings.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    def _id(s):
+        return enc.encode(s, allowed_special="all")[0]
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=_id("<|channel|>"),
+        harmony_message=_id("<|message|>"),
+        harmony_call=_id("<|call|>"),
+        harmony_end=_id("<|end|>"),
+        harmony_return=_id("<|return|>"),
+        harmony_start=_id("<|start|>"),
+        harmony_constrain=_id("<|constrain|>"),
+    )
+
+    class _CompatTokenizerBase:
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return enc.encode(text, allowed_special="none")
+
+    accepted_cache_paths = (
+        "/Users/me/.cache/huggingface/hub/models--openai--gpt-oss-20b/snapshots/abc123def/",
+        "/home/user/.cache/huggingface/hub/models--mlx-community--gpt-oss-20b-MXFP4-Q8/snapshots/0f1e2d3c/",
+        "/var/lib/hf-cache/models--unsloth--gpt-oss-20b-MLX-8bit/snapshots/fedcba9876/",
+    )
+    for path in accepted_cache_paths:
+
+        class _CachePath(_CompatTokenizerBase):
+            pass
+
+        _CachePath.name_or_path = path
+        assert is_openai_harmony_compatible(tm, _CachePath()) is True, (
+            f"HF cache snapshot {path!r} must pass (round-14 BLOCKING fix)"
+        )
+
+    # An HF cache path with an UNALLOWLISTED owner must still be rejected.
+    class _BadCachePath(_CompatTokenizerBase):
+        pass
+
+    _BadCachePath.name_or_path = (
+        "/home/x/.cache/huggingface/hub/models--evil-org--gpt-oss-20b/snapshots/xyz/"
+    )
+    assert is_openai_harmony_compatible(tm, _BadCachePath()) is False, (
+        "HF cache path with non-allowlisted owner must NOT pass"
+    )
+
+    # An HF cache path for a non-gpt-oss model must also be rejected.
+    class _NonGptOssCachePath(_CompatTokenizerBase):
+        pass
+
+    _NonGptOssCachePath.name_or_path = (
+        "/home/x/.cache/huggingface/hub/models--openai--whisper-large/snapshots/xyz/"
+    )
+    assert is_openai_harmony_compatible(tm, _NonGptOssCachePath()) is False, (
+        "HF cache path for non-gpt-oss model must NOT pass"
+    )
+
+
+def test_compat_cache_key_segregates_by_tokenizer_instance():
+    """Codex round-11/12 BLOCKING (PR #515): two distinct tokenizer
+    instances with the same name + marker IDs but a remapped body
+    vocab must NOT share a cached decision (id-reuse hazard). The
+    ``WeakKeyDictionary`` keyed on the tokenizer instance segregates
+    naturally.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -798,7 +842,6 @@ def test_compat_cache_key_segregates_by_tokenizer_instance():
         openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
     )
 
-    # Instance #1: real harmony body vocab → True.
     class _RealHarmony:
         name_or_path = "mlx-community/gpt-oss-CACHE-INSTANCE-VARIANT"
 
@@ -813,10 +856,6 @@ def test_compat_cache_key_segregates_by_tokenizer_instance():
 
     assert is_openai_harmony_compatible(tm, _RealHarmony()) is True
 
-    # Instance #2: SAME name_or_path + SAME marker IDs but a
-    # MISMATCHED body vocab. Must NOT reuse instance #1's True (the
-    # cache key now includes ``id(tokenizer)`` so #2 gets a fresh
-    # authoritative probe).
     class _RemappedBody:
         name_or_path = "mlx-community/gpt-oss-CACHE-INSTANCE-VARIANT"
 
@@ -830,7 +869,7 @@ def test_compat_cache_key_segregates_by_tokenizer_instance():
             return [99001, 99002]
 
     assert is_openai_harmony_compatible(tm, _RemappedBody()) is False, (
-        "round-11: cache must segregate by tokenizer instance; "
+        "cache must segregate by tokenizer instance; "
         "remapped tokenizer shared instance #1's stale True decision"
     )
 
@@ -839,12 +878,8 @@ def test_compat_gate_rejects_non_int_encode_result():
     """Codex round-8 BLOCKING (PR #515): some HF tokenizer
     configurations (``return_tensors`` defaults, wrapped Fast
     tokenizers) make ``encode()`` return a ``BatchEncoding`` / tensor
-    rather than a flat ``list[int]``. ``list(...)`` on those either
-    raises or yields opaque objects whose equality check against the
-    harmony reference list returns False but in a way that would crash
-    later consumers (``StreamableParser.process``). The gate must
-    return False on anything that isn't a flat int sequence so the
-    engine falls back cleanly to the legacy router.
+    rather than a flat ``list[int]``. The gate must return False on
+    anything that isn't a flat int sequence.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -861,11 +896,6 @@ def test_compat_gate_rejects_non_int_encode_result():
     )
 
     class _BatchEncodingShape:
-        """Pretends to be a BatchEncoding — ``list(self)`` returns
-        dict-style keys (``"input_ids"``, ``"attention_mask"``), not
-        the integer token IDs the gate expects.
-        """
-
         def __iter__(self):
             return iter(("input_ids", "attention_mask"))
 
@@ -883,9 +913,6 @@ def test_compat_gate_rejects_non_int_encode_result():
 
     assert is_openai_harmony_compatible(tm, _BatchEncodingTokenizer()) is False
 
-    # And a flat tuple of non-int items (an even more degenerate
-    # tokenizer config) must also fall back to False rather than
-    # surface a TypeError.
     class _StringTokenIdsTokenizer:
         name_or_path = "mlx-community/gpt-oss-STRING-IDS-VARIANT"
 
@@ -901,165 +928,9 @@ def test_compat_gate_rejects_non_int_encode_result():
     assert is_openai_harmony_compatible(tm, _StringTokenIdsTokenizer()) is False
 
 
-def test_finalize_never_synthesizes_truncated_commentary(router, encoding):
-    """Codex round-6 BLOCKING resolution (PR #515): finalize() adopts
-    the vLLM / SGLang safer-default — a commentary message cut off
-    before ``<|call|>`` must NEVER be surfaced as a tool call, even
-    when the body is syntactically valid JSON. A ``max_tokens`` /
-    ``stop`` truncation must not be executed as if the model had
-    emitted ``<|call|>``; the upside of rescuing a rare recoverable
-    case is dwarfed by the cost of one wrongly-invoked tool. Per-token
-    ``feed()`` already produced every body byte (as buffered
-    commentary, never routed) — finalize only flushes parser state.
-    """
-    text = (
-        "<|channel|>commentary "
-        "to=functions.get_weather <|constrain|>json<|message|>"
-        '{"city":"NYC"}'  # NO <|call|> — truncated right before it
-    )
-    tokens = _encode(encoding, text)
-    router.reset()
-    routed_during_stream = []
-    for tid in tokens:
-        ev = router.feed(tid)
-        if ev is not None:
-            routed_during_stream.append(ev)
-    drained = router.finalize()
-
-    assert all(ev.channel != Channel.TOOL_CALL for ev in routed_during_stream)
-    assert drained is None, (
-        f"truncated commentary must NEVER surface as a tool call; got {drained!r} "
-        f"(stream events: {len(routed_during_stream)})"
-    )
-
-
-def test_finalize_drops_mid_json_truncation(router, encoding):
-    """Sibling pin to ``test_finalize_never_synthesizes_truncated_commentary``:
-    a commentary message whose body was cut off mid-JSON (e.g.
-    ``{"city":"NY``) must also be dropped. Covered by the same
-    safer-default rule (codex round-6 resolution, PR #515) — finalize()
-    never synthesizes a tool call from a truncated commentary message,
-    so any partial-JSON body is dropped by construction.
-    """
-    # Commentary header + truncated mid-string body.
-    text = (
-        "<|channel|>commentary "
-        "to=functions.get_weather <|constrain|>json<|message|>"
-        '{"city":"NY'  # cut off mid-JSON
-    )
-    tokens = _encode(encoding, text)
-    router.reset()
-    for tid in tokens:
-        router.feed(tid)
-    drained = router.finalize()
-
-    assert drained is None, (
-        f"mid-JSON truncation must NOT surface as a tool call; got {drained!r}"
-    )
-
-
-def test_finalize_drops_truncated_commentary_with_empty_body(router, encoding):
-    """Sibling pin: a commentary message with no body whatsoever
-    (truncated right after ``<|message|>``) must also be dropped.
-    Covered by the same safer-default rule (codex round-6 resolution,
-    PR #515) — finalize() never synthesizes a tool call regardless of
-    body shape.
-    """
-    text = "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>"
-    tokens = _encode(encoding, text)
-    router.reset()
-    for tid in tokens:
-        router.feed(tid)
-    drained = router.finalize()
-
-    assert drained is None, (
-        f"empty-body truncated commentary must be dropped; got {drained!r}"
-    )
-
-
-def test_finalize_does_not_double_emit_completed_final(router, encoding):
-    """Codex round-4 BLOCKING (PR #515): for a NORMALLY-completed
-    final channel (model emitted ``<|return|>``), the per-token feed
-    has already produced every body delta. ``finalize()`` must NOT
-    re-emit those bytes as a second routed event — that would
-    duplicate the final response.
-    """
-    text = "<|channel|>final<|message|>Hi there.<|return|>"
-    tokens = _encode(encoding, text)
-    router.reset()
-    streamed = []
-    for tid in tokens:
-        ev = router.feed(tid)
-        if ev is not None:
-            streamed.append(ev)
-    drained = router.finalize()
-
-    assert drained is None, (
-        f"completed final must not re-emit on finalize; got {drained!r}"
-    )
-    # The per-token stream already produced the full body.
-    assert (
-        "".join(e.text for e in streamed if e.channel == Channel.CONTENT) == "Hi there."
-    )
-
-
-def test_finalize_does_not_drain_post_eos_buffered_delta(router, encoding):
-    """Codex round-6 BLOCKING resolution (PR #515): even if a future
-    openai-harmony build flushes a buffered tail via
-    ``last_content_delta`` during ``process_eos()``, ``finalize()``
-    must NOT route it as a CONTENT / REASONING event. Per-token
-    ``feed()`` already produced every body byte the model emitted;
-    emitting a post-EOS delta risks duplicating the last token (if the
-    build does not clear ``last_content_delta`` between the per-token
-    flush and the EOS flush). The safer default matches vLLM / SGLang:
-    finalize is a parser-state flush only.
-    """
-    # Construct a router whose underlying StreamableParser is forced
-    # into a state where process_eos produces a synthetic delta.
-
-    class _StubMessage:
-        def __init__(self, channel):
-            self.channel = channel
-            self.recipient = None
-            self.content = []
-            self.content_type = None
-
-    class _StubParser:
-        def __init__(self, channel, delta):
-            self._channel = channel
-            self._delta = delta
-            self.tokens = [1]
-            self.messages: list[_StubMessage] = []
-
-        @property
-        def current_channel(self):
-            return self._channel
-
-        @property
-        def last_content_delta(self):
-            return self._delta
-
-        def process_eos(self):
-            self.messages.append(_StubMessage(self._channel))
-            self._delta = " tail"
-
-    router.reset()
-    router._parser = _StubParser("final", "")
-    drained = router.finalize()
-    assert drained is None, f"post-EOS final delta must NOT drain; got {drained!r}"
-
-    router.reset()
-    router._parser = _StubParser("analysis", "")
-    drained = router.finalize()
-    assert drained is None, f"post-EOS analysis delta must NOT drain; got {drained!r}"
-
-
 def test_compat_gate_rejects_missing_marker_ids():
     """Codex round-4 BLOCKING (PR #515): the gate must require ALL
     seven harmony markers to be present in the tokenizer's TokenMap.
-    Previously a tokenizer with only ``<|channel|>`` / ``<|message|>``
-    plus matching probe IDs could pass — StreamableParser would then
-    crash when the model emitted a ``<|call|>`` the gate never checked.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -1071,7 +942,6 @@ def test_compat_gate_rejects_missing_marker_ids():
     def _id(s):
         return enc.encode(s, allowed_special="all")[0]
 
-    # Missing ``harmony_call`` — gate must reject.
     tm_missing_call = TokenMap(
         format_tag="harmony",
         harmony_channel=_id("<|channel|>"),
@@ -1101,9 +971,7 @@ def test_compat_gate_rejects_missing_marker_ids():
 def test_compat_gate_cache_segregates_by_marker_ids():
     """Codex round-4 NIT (PR #515): a SINGLE tokenizer instance probed
     with two different ``TokenMap`` marker-ID tuples must NOT share a
-    cached compatibility result — the inner per-tokenizer cache keys
-    on the ``(name_lc, marker_ids)`` tuple, so distinct marker tuples
-    segregate into distinct entries even on the same tokenizer.
+    cached compatibility result.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import (
@@ -1121,12 +989,12 @@ def test_compat_gate_cache_segregates_by_marker_ids():
             return {}
 
         def encode(self, text, add_special_tokens=False):
-            return [0]  # always rejected by body-vocab probe
+            return [0]
 
     tm_a = TokenMap(format_tag="harmony", harmony_channel=200005)
     tm_b = TokenMap(format_tag="harmony", harmony_channel=999999)
 
-    t = _T()  # one instance — keep alive for the WeakKeyDictionary
+    t = _T()
     is_openai_harmony_compatible(tm_a, t)
     is_openai_harmony_compatible(tm_b, t)
 
@@ -1142,14 +1010,6 @@ def test_compat_gate_caches_per_tokenizer_identity():
     """Codex round-3 NIT (PR #515): the compatibility probe is called
     on every request from the engine's streaming factory; the marker
     + body-vocab checks should only run once per tokenizer identity.
-
-    Codex round-5 BLOCKING redesign: the previous version used an
-    identity that failed the allowlist gate up-front, so ``encode``
-    was never invoked even without caching — the test would pass even
-    if the cache were removed. This version uses a legal gpt-oss
-    identity with real marker IDs so the gate reaches the body-vocab
-    probe step; only a mismatching probe response causes the False
-    result, and the second call MUST be short-circuited by the cache.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
@@ -1161,9 +1021,6 @@ def test_compat_gate_caches_per_tokenizer_identity():
     def _id(s):
         return enc.encode(s, allowed_special="all")[0]
 
-    # Real marker IDs so steps (1) identity allowlist and (2) marker
-    # parity both pass; the body-vocab probe at step (3) is what
-    # rejects this tokenizer (mismatching encode).
     tm = TokenMap(
         format_tag="harmony",
         harmony_channel=_id("<|channel|>"),
@@ -1178,7 +1035,6 @@ def test_compat_gate_caches_per_tokenizer_identity():
     call_count = {"n": 0}
 
     class _CountingTokenizer:
-        # Allowlisted identity — substring match on "gpt-oss".
         name_or_path = "mlx-community/gpt-oss-CACHE-PROBE-INVOCATION"
 
         def decode(self, ids):
@@ -1189,30 +1045,137 @@ def test_compat_gate_caches_per_tokenizer_identity():
 
         def encode(self, text, add_special_tokens=False):
             call_count["n"] += 1
-            return [0]  # nonsense — guaranteed mismatch → False
+            return [0]
 
-    # Fresh tokenizer instance — the WeakKeyDictionary cache is keyed
-    # on the instance object, so a new instance is guaranteed to start
-    # with no stale entry regardless of prior test state.
     t = _CountingTokenizer()
-    # First call reaches the body-vocab probe and increments
-    # call_count — that's the work the cache must save on subsequent
-    # calls.
     result1 = is_openai_harmony_compatible(tm, t)
     assert result1 is False
     first_call_count = call_count["n"]
-    assert first_call_count > 0, (
-        "test setup error: first call must reach the encode probe — "
-        f"expected >0 encode invocations, got {first_call_count}"
-    )
+    assert first_call_count > 0
 
-    # Second call must return the cached False without re-invoking
-    # encode. If the cache were removed, call_count would double on
-    # this call.
     result2 = is_openai_harmony_compatible(tm, t)
     assert result2 is False
     assert call_count["n"] == first_call_count, (
-        "compat gate must cache False results per identity; "
-        f"saw {call_count['n']} encode calls (expected {first_call_count} "
-        "— second call should have hit the cache and not re-probed)"
+        "compat gate must cache False results per identity"
     )
+
+
+# ----- finalize() safer-default pins ----------------------------------
+
+
+def test_finalize_never_synthesizes_truncated_commentary(router, encoding):
+    """Codex round-6 BLOCKING resolution (PR #515): finalize() adopts
+    the vLLM / SGLang safer-default — a commentary message cut off
+    before ``<|call|>`` must NEVER be surfaced as a tool call.
+    """
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NYC"}'  # NO <|call|>
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    routed_during_stream = []
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is not None:
+            routed_during_stream.append(ev)
+    drained = router.finalize()
+
+    assert all(ev.channel != Channel.TOOL_CALL for ev in routed_during_stream)
+    assert drained is None, (
+        f"truncated commentary must NEVER surface as a tool call; got {drained!r} "
+        f"(stream events: {len(routed_during_stream)})"
+    )
+
+
+def test_finalize_drops_mid_json_truncation(router, encoding):
+    """A commentary message whose body was cut off mid-JSON must also
+    be dropped — same safer-default rule as the canonical truncation
+    test.
+    """
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NY'
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    for tid in tokens:
+        router.feed(tid)
+    drained = router.finalize()
+
+    assert drained is None
+
+
+def test_finalize_drops_truncated_commentary_with_empty_body(router, encoding):
+    """A commentary message with no body whatsoever must be dropped."""
+    text = "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>"
+    tokens = _encode(encoding, text)
+    router.reset()
+    for tid in tokens:
+        router.feed(tid)
+    drained = router.finalize()
+
+    assert drained is None
+
+
+def test_finalize_does_not_double_emit_completed_final(router, encoding):
+    """Codex round-4 BLOCKING (PR #515): for a NORMALLY-completed
+    final channel (model emitted ``<|return|>``), ``finalize()`` must
+    NOT re-emit body bytes as a second routed event.
+    """
+    text = "<|channel|>final<|message|>Hi there.<|return|>"
+    tokens = _encode(encoding, text)
+    router.reset()
+    streamed = []
+    for tid in tokens:
+        ev = router.feed(tid)
+        if ev is not None:
+            streamed.append(ev)
+    drained = router.finalize()
+
+    assert drained is None
+    assert (
+        "".join(e.text for e in streamed if e.channel == Channel.CONTENT) == "Hi there."
+    )
+
+
+def test_finalize_does_not_drain_post_eos_buffered_delta(router, encoding):
+    """Codex round-6 BLOCKING resolution (PR #515): finalize must NOT
+    route post-EOS deltas.
+    """
+
+    class _StubMessage:
+        def __init__(self, channel):
+            self.channel = channel
+            self.recipient = None
+            self.content = []
+            self.content_type = None
+
+    class _StubParser:
+        def __init__(self, channel, delta):
+            self._channel = channel
+            self._delta = delta
+            self.tokens = [1]
+            self.messages: list[_StubMessage] = []
+
+        @property
+        def current_channel(self):
+            return self._channel
+
+        @property
+        def last_content_delta(self):
+            return self._delta
+
+        def process_eos(self):
+            self.messages.append(_StubMessage(self._channel))
+            self._delta = " tail"
+
+    router.reset()
+    router._parser = _StubParser("final", "")
+    assert router.finalize() is None
+
+    router.reset()
+    router._parser = _StubParser("analysis", "")
+    assert router.finalize() is None

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -788,6 +788,14 @@ def test_compat_gate_caches_per_tokenizer_identity():
     """Codex round-3 NIT (PR #515): the compatibility probe is called
     on every request from the engine's streaming factory; the marker
     + body-vocab checks should only run once per tokenizer identity.
+
+    Codex round-5 BLOCKING redesign: the previous version used an
+    identity that failed the allowlist gate up-front, so ``encode``
+    was never invoked even without caching — the test would pass even
+    if the cache were removed. This version uses a legal gpt-oss
+    identity with real marker IDs so the gate reaches the body-vocab
+    probe step; only a mismatching probe response causes the False
+    result, and the second call MUST be short-circuited by the cache.
     """
     from vllm_mlx.output_router import TokenMap
     from vllm_mlx.output_router_harmony import (
@@ -795,21 +803,32 @@ def test_compat_gate_caches_per_tokenizer_identity():
         is_openai_harmony_compatible,
     )
 
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    def _id(s):
+        return enc.encode(s, allowed_special="all")[0]
+
+    # Real marker IDs so steps (1) identity allowlist and (2) marker
+    # parity both pass; the body-vocab probe at step (3) is what
+    # rejects this tokenizer (mismatching encode).
     tm = TokenMap(
         format_tag="harmony",
-        harmony_channel=200005,
-        harmony_message=200008,
-        harmony_call=200012,
-        harmony_end=200007,
-        harmony_return=200002,
-        harmony_start=200006,
-        harmony_constrain=200003,
+        harmony_channel=_id("<|channel|>"),
+        harmony_message=_id("<|message|>"),
+        harmony_call=_id("<|call|>"),
+        harmony_end=_id("<|end|>"),
+        harmony_return=_id("<|return|>"),
+        harmony_start=_id("<|start|>"),
+        harmony_constrain=_id("<|constrain|>"),
     )
 
     call_count = {"n": 0}
 
     class _CountingTokenizer:
-        name_or_path = "test-identity-cache-key"
+        # Allowlisted identity — substring match on "gpt-oss".
+        name_or_path = "mlx-community/gpt-oss-CACHE-PROBE-INVOCATION"
 
         def decode(self, ids):
             return ""
@@ -821,21 +840,31 @@ def test_compat_gate_caches_per_tokenizer_identity():
             call_count["n"] += 1
             return [0]  # nonsense — guaranteed mismatch → False
 
-    # Clear any stale cache entry from prior runs.
-    _COMPAT_RESULT_CACHE.pop("test-identity-cache-key", None)
+    # Clear any stale cache entry from prior runs (key now includes
+    # the marker tuple per round-4 NIT).
+    for k in list(_COMPAT_RESULT_CACHE.keys()):
+        if "cache-probe-invocation" in str(k):
+            _COMPAT_RESULT_CACHE.pop(k, None)
 
     t = _CountingTokenizer()
-    # First call runs the probe — `name_or_path` is not in the allowlist
-    # so it fails fast, BEFORE the encode probes — call_count stays 0
-    # for the first call. The cache should still record the False.
+    # First call reaches the body-vocab probe and increments
+    # call_count — that's the work the cache must save on subsequent
+    # calls.
     result1 = is_openai_harmony_compatible(tm, t)
     assert result1 is False
-    cached_calls = call_count["n"]
+    first_call_count = call_count["n"]
+    assert first_call_count > 0, (
+        "test setup error: first call must reach the encode probe — "
+        f"expected >0 encode invocations, got {first_call_count}"
+    )
 
-    # Second call returns the cached False; never re-runs probes.
+    # Second call must return the cached False without re-invoking
+    # encode. If the cache were removed, call_count would double on
+    # this call.
     result2 = is_openai_harmony_compatible(tm, t)
     assert result2 is False
-    assert call_count["n"] == cached_calls, (
+    assert call_count["n"] == first_call_count, (
         "compat gate must cache False results per identity; "
-        f"saw {call_count['n']} encode calls"
+        f"saw {call_count['n']} encode calls (expected {first_call_count} "
+        "— second call should have hit the cache and not re-probed)"
     )

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -377,6 +377,19 @@ def test_reconstruct_tool_call_abstains_on_body_carrying_harmony_sentinel(router
     assert out is not None
     assert "<|constrain|>json<|message|>" in out
 
+    # Codex round-11 NIT: a bare enum like ``"json"`` (missing the
+    # ``<|constrain|>`` prefix) would reconstruct non-canonical wire
+    # text the downstream parser can't recognise — must abstain.
+    bare_ctype = _FakeMessage('{"city":"NYC"}', ctype="json")
+    assert router._reconstruct_tool_call_text(bare_ctype) is None, (
+        "bare content_type missing <|constrain|> prefix must abstain"
+    )
+    # And a content_type with disallowed characters must also abstain.
+    bad_chars_ctype = _FakeMessage('{"city":"NYC"}', ctype="<|constrain|>has space")
+    assert router._reconstruct_tool_call_text(bad_chars_ctype) is None, (
+        "content_type with non-safe characters must abstain"
+    )
+
 
 def test_sentinel_body_emits_content_event_for_streaming_visibility(
     router, encoding, monkeypatch
@@ -645,6 +658,147 @@ def test_compat_gate_rejects_mismatched_body_vocab():
             return [99001, 99002]
 
     assert is_openai_harmony_compatible(tm, _MismatchedBodyVocabTokenizer()) is False
+
+
+def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
+    """Codex round-11 BLOCKING (PR #515): the tokenizer-identity
+    allowlist used naive ``in`` substring matching, so an identity
+    like ``my-not-gpt-oss/whatever`` (or ``foo-gpt-oss-bar`` with no
+    ``/`` separator) would pass while clearly not being a real
+    gpt-oss family member. Anchored match
+    (``(?:^|/)gpt-oss(?:-|$)``) accepts canonical names and rejects
+    tail-substring fakes.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    class _CompatTokenizerBase:
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return enc.encode(text, allowed_special="none")
+
+    # Tail-substring fakes (must be rejected).
+    rejected_names = (
+        "my-not-gpt-oss/whatever",
+        "foo/bar-gpt-oss-malicious",
+        "my-not-gpt-oss-20b",  # no slash, tail substring
+        "notgpt-oss-fake",
+    )
+    for name in rejected_names:
+
+        class _Fake(_CompatTokenizerBase):
+            pass
+
+        _Fake.name_or_path = name
+        assert is_openai_harmony_compatible(tm, _Fake()) is False, (
+            f"tail-substring identity {name!r} must be rejected; "
+            f"anchored allowlist failed"
+        )
+
+    # Canonical names (must still pass — sanity).
+    accepted_names = (
+        "openai/gpt-oss-20b",
+        "mlx-community/gpt-oss-20b-MXFP4-Q8",
+        "gpt-oss-20b",  # bare, anchored at ^
+        "gpt-oss",  # bare exact
+    )
+    for name in accepted_names:
+
+        class _Real(_CompatTokenizerBase):
+            pass
+
+        _Real.name_or_path = name
+        assert is_openai_harmony_compatible(tm, _Real()) is True, (
+            f"canonical identity {name!r} must pass; anchored regex over-rejected"
+        )
+
+
+def test_compat_cache_key_segregates_by_tokenizer_instance():
+    """Codex round-11 BLOCKING (PR #515): the per-identity cache used
+    ``(name_or_path, marker_ids)`` only, so two distinct tokenizer
+    instances with the same name + marker IDs but a remapped body
+    vocab shared a single cached decision. A previous ``True`` would
+    then upgrade an incompatible tokenizer and corrupt
+    ``StreamableParser`` body decoding.
+
+    Fix folded ``id(tokenizer)`` into the cache key — distinct
+    instances now segregate naturally, each instance gets an
+    authoritative ``_compute_compat`` pass; same-instance reuses
+    cleanly (zero-encode cache hit).
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    # Instance #1: real harmony body vocab → True.
+    class _RealHarmony:
+        name_or_path = "mlx-community/gpt-oss-CACHE-INSTANCE-VARIANT"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return enc.encode(text, allowed_special="none")
+
+    assert is_openai_harmony_compatible(tm, _RealHarmony()) is True
+
+    # Instance #2: SAME name_or_path + SAME marker IDs but a
+    # MISMATCHED body vocab. Must NOT reuse instance #1's True (the
+    # cache key now includes ``id(tokenizer)`` so #2 gets a fresh
+    # authoritative probe).
+    class _RemappedBody:
+        name_or_path = "mlx-community/gpt-oss-CACHE-INSTANCE-VARIANT"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            return [99001, 99002]
+
+    assert is_openai_harmony_compatible(tm, _RemappedBody()) is False, (
+        "round-11: cache must segregate by tokenizer instance; "
+        "remapped tokenizer shared instance #1's stale True decision"
+    )
 
 
 def test_compat_gate_rejects_non_int_encode_result():

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -478,9 +478,11 @@ def test_compat_gate_rejects_tokenizer_without_encode():
         harmony_constrain=200003,
     )
 
+    # Use a unique identity so the result cache from earlier tests
+    # doesn't short-circuit this one (codex round-3 NIT: cache is keyed
+    # by lowercased ``name_or_path``).
     class _NoEncodeTokenizer:
-        # Pass the identity gate so we exercise the no-encode path.
-        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+        name_or_path = "mlx-community/gpt-oss-NO-ENCODE-VARIANT"
 
         def decode(self, ids):
             return ""
@@ -514,10 +516,10 @@ def test_compat_gate_rejects_mismatched_body_vocab():
         harmony_constrain=200003,
     )
 
+    # Use a unique identity so the result cache doesn't return a
+    # stale True from the sibling accepted-variant test.
     class _MismatchedBodyVocabTokenizer:
-        # Pass the identity gate so the body-vocab probe step actually
-        # runs and is what rejects.
-        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+        name_or_path = "mlx-community/gpt-oss-MISMATCHED-BODY-VARIANT"
 
         def decode(self, ids):
             return ""
@@ -560,3 +562,105 @@ def test_finalize_drains_truncated_commentary_message(router, encoding):
         f"got {drained!r} (stream events: {len(routed_during_stream)})"
     )
     assert "functions.get_weather" in drained.text
+
+
+def test_finalize_drops_mid_json_truncation(router, encoding):
+    """Codex round-3 BLOCKING (PR #515): when ``process_eos`` closes a
+    commentary message whose body was cut off mid-JSON
+    (e.g. ``{"city":"NY``), the synthesized TOOL_CALL must be DROPPED.
+    Surfacing it would feed corrupt JSON arguments to the downstream
+    parser and the model would be treated as having ``completed`` a
+    malformed tool call. Sibling regression to
+    ``test_finalize_drains_truncated_commentary_message`` — both pin
+    the contract that ``finalize()`` only emits when the closed
+    message body validates against its declared ``content_type``.
+    """
+    # Commentary header + truncated mid-string body.
+    text = (
+        "<|channel|>commentary "
+        "to=functions.get_weather <|constrain|>json<|message|>"
+        '{"city":"NY'  # cut off mid-JSON
+    )
+    tokens = _encode(encoding, text)
+    router.reset()
+    for tid in tokens:
+        router.feed(tid)
+    drained = router.finalize()
+
+    assert drained is None, (
+        f"mid-JSON truncation must NOT surface as a tool call; got {drained!r}"
+    )
+
+
+def test_finalize_drops_truncated_commentary_with_empty_body(router, encoding):
+    """Codex round-3 BLOCKING (PR #515): a commentary message with no
+    body whatsoever (truncated right after ``<|message|>``) must also
+    be dropped — empty arguments are never the intended output.
+    """
+    text = "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>"
+    tokens = _encode(encoding, text)
+    router.reset()
+    for tid in tokens:
+        router.feed(tid)
+    drained = router.finalize()
+
+    assert drained is None, (
+        f"empty-body truncated commentary must be dropped; got {drained!r}"
+    )
+
+
+def test_compat_gate_caches_per_tokenizer_identity():
+    """Codex round-3 NIT (PR #515): the compatibility probe is called
+    on every request from the engine's streaming factory; the marker
+    + body-vocab checks should only run once per tokenizer identity.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import (
+        _COMPAT_RESULT_CACHE,
+        is_openai_harmony_compatible,
+    )
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    call_count = {"n": 0}
+
+    class _CountingTokenizer:
+        name_or_path = "test-identity-cache-key"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            call_count["n"] += 1
+            return [0]  # nonsense — guaranteed mismatch → False
+
+    # Clear any stale cache entry from prior runs.
+    _COMPAT_RESULT_CACHE.pop("test-identity-cache-key", None)
+
+    t = _CountingTokenizer()
+    # First call runs the probe — `name_or_path` is not in the allowlist
+    # so it fails fast, BEFORE the encode probes — call_count stays 0
+    # for the first call. The cache should still record the False.
+    result1 = is_openai_harmony_compatible(tm, t)
+    assert result1 is False
+    cached_calls = call_count["n"]
+
+    # Second call returns the cached False; never re-runs probes.
+    result2 = is_openai_harmony_compatible(tm, t)
+    assert result2 is False
+    assert call_count["n"] == cached_calls, (
+        "compat gate must cache False results per identity; "
+        f"saw {call_count['n']} encode calls"
+    )

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -229,9 +229,26 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
     contract). Commentary body tokens are suppressed during streaming
     (the tool call is emitted as a single aggregated event on
     ``<|call|>``), matching the existing Channel.TOOL_CALL contract.
+
+    Codex round-13 NIT: assert the EXACT event count equals the body-
+    token count (not merely ``>= 2``) — coalesced / dropped per-token
+    deltas would otherwise pass silently and degrade streaming
+    behavior on the engine side.
     """
     text = "<|channel|>final<|message|>Hi there.<|return|>"
     tokens = _encode(encoding, text)
+    # Identify which token IDs belong to the body (between
+    # ``<|message|>`` and ``<|return|>``) — those are the ones we
+    # expect to produce a CONTENT event each. Markers are
+    # ``<|channel|>``, ``final``, ``<|message|>``, ``<|return|>``;
+    # everything between the ``<|message|>`` and ``<|return|>`` markers
+    # is body.
+    message_id = encoding.encode("<|message|>", allowed_special="all")[0]
+    return_id = encoding.encode("<|return|>", allowed_special="all")[0]
+    body_start = tokens.index(message_id) + 1
+    body_end = tokens.index(return_id)
+    body_token_count = body_end - body_start
+
     # Reset router for explicit per-token feed.
     router.reset()
     events_per_channel: dict[Channel, list[str]] = {
@@ -247,11 +264,14 @@ def test_per_token_streaming_routes_one_event_per_body_token(router, encoding):
 
     assert events_per_channel[Channel.TOOL_CALL] == []
     assert events_per_channel[Channel.REASONING] == []
-    # Joined content matches the body, and at least one event per body
-    # token surfaced.
+    # Joined content matches the body, and emit count EQUALS body
+    # token count — coalescing / dropped deltas would now fail.
     assert "".join(events_per_channel[Channel.CONTENT]) == "Hi there."
-    assert len(events_per_channel[Channel.CONTENT]) >= 2, (
-        f"per-token body deltas expected; got {events_per_channel[Channel.CONTENT]!r}"
+    assert len(events_per_channel[Channel.CONTENT]) == body_token_count, (
+        f"per-token body deltas must be 1-to-1 with body tokens; "
+        f"got {len(events_per_channel[Channel.CONTENT])} events for "
+        f"{body_token_count} body tokens: "
+        f"{events_per_channel[Channel.CONTENT]!r}"
     )
 
 
@@ -721,14 +741,20 @@ def test_compat_gate_anchored_allowlist_rejects_tail_substring_fake():
         )
 
     # Canonical names — known owner prefixes (openai, mlx-community,
-    # unsloth) plus bare basename. Sanity check that the allowlist
-    # tightening didn't accidentally over-reject.
+    # unsloth), bare basename, AND local filesystem paths (codex
+    # round-13 BLOCKING — production loads models by absolute path
+    # from local caches; rejecting them broke real deployments).
     accepted_names = (
         "openai/gpt-oss-20b",
         "mlx-community/gpt-oss-20b-MXFP4-Q8",
         "unsloth/gpt-oss-20b-MLX-8bit",
         "gpt-oss-20b",  # bare, anchored at ^
         "gpt-oss",  # bare exact
+        "/models/gpt-oss-20b",  # absolute local path
+        "/Users/me/.cache/huggingface/hub/models--openai--gpt-oss-20b/gpt-oss-20b",
+        "~/lmstudio-models/gpt-oss-20b",  # tilde-prefixed local path
+        "./gpt-oss-20b-quantized",  # relative local path
+        "../models/gpt-oss-20b",  # parent-relative local path
     )
     for name in accepted_names:
 

--- a/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
+++ b/tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py
@@ -264,18 +264,13 @@ def test_feed_sequence_preserves_leading_and_trailing_whitespace(router, encodin
     """
     # Final-channel body starts with a newline and ends with two
     # spaces — both must survive.
-    text = (
-        "<|channel|>final<|message|>"
-        "\n```py\nprint('hi')\n```  "
-        "<|return|>"
-    )
+    text = "<|channel|>final<|message|>\n```py\nprint('hi')\n```  <|return|>"
     tokens = _encode(encoding, text)
     router.reset()
     result = router.feed_sequence(tokens)
 
     assert result["content"] == "\n```py\nprint('hi')\n```  ", (
-        f"feed_sequence must preserve surrounding whitespace; "
-        f"got {result['content']!r}"
+        f"feed_sequence must preserve surrounding whitespace; got {result['content']!r}"
     )
 
 
@@ -314,6 +309,152 @@ def test_reconstruct_tool_call_rejects_malformed_recipient(router):
     assert "to=functions.get_weather" in out
 
 
+def test_compat_gate_rejects_unknown_tokenizer_identity():
+    """Codex round-2 BLOCKING (PR #515): a 3-string probe set cannot
+    prove full-vocab parity. The gate must ALSO require the
+    tokenizer's reported identity to be a known gpt-oss family
+    member; a tokenizer named ``mistralai/Mistral-...`` that happened
+    to match the markers and probes would otherwise be wrongly
+    upgraded and might corrupt uncommon body tokens.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=200005,
+        harmony_message=200008,
+        harmony_call=200012,
+        harmony_end=200007,
+        harmony_return=200002,
+        harmony_start=200006,
+        harmony_constrain=200003,
+    )
+
+    class _NotGptOssTokenizer:
+        name_or_path = "mistralai/Mistral-7B-Instruct-v0.3"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+        def encode(self, text, add_special_tokens=False):
+            # Even if the tokenizer SOMEHOW produced matching probe IDs,
+            # the identity gate must short-circuit.
+            return [99001, 99002]
+
+    assert is_openai_harmony_compatible(tm, _NotGptOssTokenizer()) is False
+
+
+def test_compat_gate_accepts_gpt_oss_quant_suffix_variants():
+    """Codex round-2 BLOCKING (PR #515): the identity allowlist must
+    tolerate the org-prefix + quant-suffix renames the mlx-community
+    publishes (``mlx-community/gpt-oss-20b-MXFP4-Q8``,
+    ``mlx-community/gpt-oss-120b-MXFP4-Q4`` etc.) — case-insensitive
+    substring match on ``gpt-oss`` covers all of them while still
+    rejecting random model names.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import is_openai_harmony_compatible
+
+    enc = openai_harmony.load_harmony_encoding(
+        openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+    )
+
+    # Real markers from harmony encoding.
+    def _id(s):
+        return enc.encode(s, allowed_special="all")[0]
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=_id("<|channel|>"),
+        harmony_message=_id("<|message|>"),
+        harmony_call=_id("<|call|>"),
+        harmony_end=_id("<|end|>"),
+        harmony_return=_id("<|return|>"),
+        harmony_start=_id("<|start|>"),
+        harmony_constrain=_id("<|constrain|>"),
+    )
+
+    class _GptOssLike:
+        """A tokenizer whose ``encode`` actually delegates to the
+        harmony encoding — so the marker + probe checks pass; only the
+        identity check decides accept vs reject for these cases.
+        """
+
+        def __init__(self, name):
+            self.name_or_path = name
+            self._enc = enc
+
+        def encode(self, text, add_special_tokens=False):
+            return self._enc.encode(text, allowed_special="none")
+
+        def decode(self, ids):
+            return self._enc.decode(ids)
+
+        def get_vocab(self):
+            return {}
+
+    # Accepted identities.
+    for name in (
+        "mlx-community/gpt-oss-20b-MXFP4-Q8",
+        "openai/gpt-oss-120b",
+        "mlx-community/GPT-OSS-20b",  # case-insensitive
+    ):
+        assert is_openai_harmony_compatible(tm, _GptOssLike(name)) is True, (
+            f"identity {name!r} must be accepted"
+        )
+
+    # Rejected identities even with matching encoder.
+    for name in (
+        "mistralai/Mistral-7B-Instruct-v0.3",
+        "Qwen/Qwen3-0.6B",
+        "",  # missing name
+    ):
+        assert is_openai_harmony_compatible(tm, _GptOssLike(name)) is False, (
+            f"identity {name!r} must be rejected"
+        )
+
+
+def test_recipient_shape_accepts_digit_start_names():
+    """Codex round-2 BLOCKING (PR #515): the original recipient
+    shape regex ``^functions\\.[A-Za-z_]...`` rejected valid OpenAI
+    tool names whose first character is a digit (e.g. ``2fa_lookup``).
+    Widen to match the OpenAI spec ``[A-Za-z0-9_-]{1,64}``.
+    """
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import HarmonyStreamingRouter
+
+    class _Adapter:
+        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+
+        def decode(self, ids):
+            return ""
+
+        def get_vocab(self):
+            return {}
+
+    r = HarmonyStreamingRouter(TokenMap(format_tag="harmony"), _Adapter())
+
+    class _Msg:
+        def __init__(self, recipient):
+            self.recipient = recipient
+            self.content = []
+            self.content_type = None
+
+    # These were broken on round-1; must pass on round-2.
+    for good in (
+        "functions.2fa_lookup",
+        "functions.0_index",
+        "functions.123",
+        "functions.tool-with-dash",
+    ):
+        out = r._reconstruct_tool_call_text(_Msg(good))
+        assert f"to={good}" in out, f"good recipient {good!r} got: {out!r}"
+
+
 def test_compat_gate_rejects_tokenizer_without_encode():
     """Codex round-1 BLOCKING (PR #515): the compatibility gate must
     require body-vocab parity, not just marker IDs. A tokenizer that
@@ -338,6 +479,9 @@ def test_compat_gate_rejects_tokenizer_without_encode():
     )
 
     class _NoEncodeTokenizer:
+        # Pass the identity gate so we exercise the no-encode path.
+        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+
         def decode(self, ids):
             return ""
 
@@ -371,6 +515,10 @@ def test_compat_gate_rejects_mismatched_body_vocab():
     )
 
     class _MismatchedBodyVocabTokenizer:
+        # Pass the identity gate so the body-vocab probe step actually
+        # runs and is what rejects.
+        name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+
         def decode(self, ids):
             return ""
 

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -229,6 +229,65 @@ def test_tool_call_routing_preserves_fallback_text(engine, monkeypatch):
     assert '{"city":"NYC"}' in content
 
 
+def test_finalize_drained_tool_call_supplements_fallback_text(engine, monkeypatch):
+    """PR #515 round-3 BLOCKING: when ``HarmonyStreamingRouter.finalize()``
+    synthesizes a tool-call event from a truncated commentary (no
+    ``<|call|>`` in the raw text), ``_clean_gpt_oss_output``'s
+    bail-out may not match — the strip regex then removes the
+    commentary header from ``fallback_text``, and the route's
+    ``HarmonyToolParser`` sees no tool call at all. The engine must
+    pipe ``routed["tool_calls"]`` through by appending the
+    reconstructed wire text so the downstream parser can extract it.
+    Idempotent: when the raw text already carries ``<|channel|>commentary``,
+    don't append (avoids double-parsing).
+    """
+
+    class _DrainedToolCallRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": "Calling the tool",
+                "tool_calls": [
+                    "<|channel|>commentary to=functions.get_weather "
+                    '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+                ],
+            }
+
+    monkeypatch.setattr(
+        engine, "_create_output_router", lambda: _DrainedToolCallRouter()
+    )
+
+    # Case A: fallback_text was already stripped — must be supplemented.
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005, 12606, 815, 200008, 1],
+        fallback_text="",  # stripped because clean_output_text didn't bail
+    )
+    assert reasoning == "Calling the tool"
+    assert "functions.get_weather" in content, (
+        f"finalize-drained tool call must be appended to empty fallback_text; "
+        f"got {content!r}"
+    )
+    assert '{"city":"NYC"}' in content
+
+    # Case B: fallback_text already has commentary markers — don't append
+    # (idempotent; avoids the downstream parser seeing the same call twice).
+    pre_existing = (
+        "<|channel|>commentary to=functions.add <|constrain|>json"
+        '<|message|>{"a":1,"b":2}<|call|>'
+    )
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005, 12606, 815, 200008, 1], fallback_text=pre_existing
+    )
+    assert reasoning == "Calling the tool"
+    assert content == pre_existing, (
+        f"fallback_text with existing commentary must not be double-appended; "
+        f"got {content!r}"
+    )
+
+
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):
     """If the router blows up mid-sequence (e.g. token id outside the
     vocab causes a decode failure), the engine must not propagate the

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -348,6 +348,78 @@ def test_multi_tool_fallback_with_existing_marker_still_appends_new(
     assert '{"topic":"tech"}' in content
 
 
+def test_fallback_dedup_normalizes_whitespace_variance(engine, monkeypatch):
+    """Codex round-7 NIT (PR #515): the previous verbatim substring
+    check ``tc_text not in fallback_text`` doubled tool calls when the
+    model's emit and the router's canonical reconstruction differ only
+    by whitespace runs (e.g. one space vs two between ``to=...`` and
+    ``<|constrain|>``). The dedup must compare by the structural
+    ``(recipient, normalized_body)`` tuple instead so the same call
+    matches across spacing variants.
+    """
+    # Model emitted the call with double-space between recipient and
+    # constrain (a plausible variance — gpt-oss tokenizer roundtrips
+    # may decode trailing whitespace before the special token). Router
+    # reconstructs the canonical single-space form. Body bytes are
+    # identical (both come from the same body-token decode).
+    model_emit = (
+        "<|channel|>commentary to=functions.get_weather  <|constrain|>json"
+        '<|message|>{"city":"NYC"}<|call|>'
+    )
+    router_reconstructs = (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
+        '<|message|>{"city":"NYC"}<|call|>'
+    )
+
+    class _SpacingVariantRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [router_reconstructs],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _SpacingVariantRouter())
+
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=model_emit
+    )
+    # Spacing-variant of the same call must NOT double-append.
+    assert content.count("functions.get_weather") == 1, (
+        f"spacing-variant duplicate of same call must not double-append; "
+        f"got {content!r}"
+    )
+    # And a DIFFERENT call (different body, even if same recipient)
+    # still gets appended.
+    different_body_call = (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
+        '<|message|>{"city":"Paris"}<|call|>'
+    )
+
+    class _DifferentBodyRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [different_body_call],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _DifferentBodyRouter())
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=model_emit
+    )
+    assert content.count("functions.get_weather") == 2, (
+        f"same recipient with different body must append; got {content!r}"
+    )
+    assert '{"city":"Paris"}' in content
+
+
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):
     """If the router blows up mid-sequence (e.g. token id outside the
     vocab causes a decode failure), the engine must not propagate the

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -272,20 +272,80 @@ def test_finalize_drained_tool_call_supplements_fallback_text(engine, monkeypatc
     )
     assert '{"city":"NYC"}' in content
 
-    # Case B: fallback_text already has commentary markers — don't append
-    # (idempotent; avoids the downstream parser seeing the same call twice).
-    pre_existing = (
-        "<|channel|>commentary to=functions.add <|constrain|>json"
-        '<|message|>{"a":1,"b":2}<|call|>'
+    # PR #515 round-5 BLOCKING refinement: idempotency must be per
+    # wire-text, not "any commentary marker present" — the multi-tool
+    # case is covered in
+    # ``test_multi_tool_fallback_with_existing_marker_still_appends_new``.
+
+    # Case B: fallback_text already contains THIS exact tool call —
+    # don't double-append.
+    tc_wire = (
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
     )
     reasoning, content = engine._route_tokens_for_channels(
-        [200005, 12606, 815, 200008, 1], fallback_text=pre_existing
+        [200005, 12606, 815, 200008, 1], fallback_text=tc_wire
     )
     assert reasoning == "Calling the tool"
-    assert content == pre_existing, (
-        f"fallback_text with existing commentary must not be double-appended; "
+    assert content == tc_wire, (
+        f"fallback_text already carrying THIS tool call must not be doubled; "
         f"got {content!r}"
     )
+    assert content.count("functions.get_weather") == 1
+
+
+def test_multi_tool_fallback_with_existing_marker_still_appends_new(
+    engine, monkeypatch
+):
+    """PR #515 round-5 BLOCKING: in a multi-tool turn (model emits
+    tool call #1 cleanly with ``<|call|>``, then is truncated mid-tool
+    call #2), ``fallback_text`` already carries call #1's commentary
+    marker. The previous bulk guard ``"<|channel|>commentary" not in
+    fallback_text`` then suppressed appending ALL reconstructed tool
+    calls, dropping call #2. The fix checks each reconstructed wire
+    text individually so call #1 isn't doubled and call #2 still
+    reaches ``HarmonyToolParser``.
+    """
+    call1_text = (
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+    )
+    call2_text = (
+        "<|channel|>commentary to=functions.get_news "
+        '<|constrain|>json<|message|>{"topic":"tech"}<|call|>'
+    )
+
+    class _MultiToolRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            # Router surfaces BOTH tool calls.
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [call1_text, call2_text],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _MultiToolRouter())
+
+    # fallback_text has call #1 already (from raw text bail-out) but
+    # NOT call #2 (finalize() synthesized it because raw was truncated
+    # before <|call|>).
+    fallback_in = call1_text
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=fallback_in
+    )
+
+    # Call #1 must not be doubled.
+    assert content.count("functions.get_weather") == 1, (
+        f"call #1 must not be doubled; got {content!r}"
+    )
+    # Call #2 must be appended.
+    assert "functions.get_news" in content, (
+        f"finalize-synthesized call #2 must be appended; got {content!r}"
+    )
+    assert '{"topic":"tech"}' in content
 
 
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -502,6 +502,113 @@ def test_non_canonical_router_wire_text_is_dropped(engine, monkeypatch):
     )
 
 
+def test_identical_calls_twice_in_turn_both_survive_dedup(engine, monkeypatch):
+    """Codex round-9 BLOCKING (PR #515): when the model legitimately
+    emits the SAME tool call twice in one turn (user asked for the
+    weather twice in one prompt), the model's raw fallback_text
+    carries two wire-text instances AND the router structures both.
+    The round-7/8 ``set`` dedup collapsed identical signatures to one
+    and silently dropped the second; the fix uses ``Counter``
+    multiplicity so each existing match consumes ONE routed call and
+    the duplicates both survive.
+    """
+    same_call = (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
+        '<|message|>{"city":"NYC"}<|call|>'
+    )
+    fallback_two_calls = same_call + same_call
+
+    class _TwoIdenticalRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [same_call, same_call],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _TwoIdenticalRouter())
+
+    # Two in fallback, two in routed → two existing matches consume
+    # both routed calls → nothing appended → final count stays at 2.
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=fallback_two_calls
+    )
+    assert content.count("functions.get_weather") == 2, (
+        f"identical-twice (model+router both saw both) must dedup to 2; got {content!r}"
+    )
+
+    # And if the model emitted ONE but the router structured TWO
+    # (truncation rescued one), the second must be appended.
+    fallback_one_call = same_call
+
+    class _OneInFallbackTwoRouted:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [same_call, same_call],
+            }
+
+    monkeypatch.setattr(
+        engine, "_create_output_router", lambda: _OneInFallbackTwoRouted()
+    )
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=fallback_one_call
+    )
+    assert content.count("functions.get_weather") == 2, (
+        f"one-in-fallback + two-routed must merge to 2; got {content!r}"
+    )
+
+
+def test_signature_regex_requires_commentary_frame(engine, monkeypatch):
+    """Codex round-9 BLOCKING (PR #515): the previous signature regex
+    matched a BARE ``to=functions.X<|message|>...<|call|>`` shape
+    without requiring the ``<|channel|>commentary`` prefix. A
+    fallback_text where ``clean_output_text`` stripped the commentary
+    header but left the tail (or ordinary content happening to contain
+    those substrings) then false-matched as an existing tool call,
+    suppressing the router's real reconstructed wire text. The fix
+    anchors the regex on the full commentary frame.
+    """
+    tc_wire = (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
+        '<|message|>{"city":"NYC"}<|call|>'
+    )
+    # Stripped fallback_text — the commentary header is gone, only the
+    # tail survives. This must NOT register as an existing signature.
+    stripped_fallback = (
+        'to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+    )
+
+    class _OneCallRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [tc_wire],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _OneCallRouter())
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=stripped_fallback
+    )
+    # Router's canonical wire text must be appended — the stripped
+    # fallback's bare tail does NOT count as an existing signature.
+    assert content.count("<|channel|>commentary") == 1, (
+        f"stripped fallback must not false-suppress; got {content!r}"
+    )
+    assert "<|channel|>commentary to=functions.get_weather" in content
+
+
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):
     """If the router blows up mid-sequence (e.g. token id outside the
     vocab causes a decode failure), the engine must not propagate the

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -191,6 +191,44 @@ def test_empty_token_list_returns_fallback(engine):
     assert content == "whatever"
 
 
+def test_tool_call_routing_preserves_fallback_text(engine, monkeypatch):
+    """PR #515 round-1: when the router emits a TOOL_CALL channel
+    (commentary tool call) the override MUST NOT fire — fallback_text
+    has to survive intact so the route's ``_parse_tool_calls_with_parser``
+    can extract the call from the harmony wire format. Verified via a
+    live diff against the pre-PR baseline; this test pins the
+    invariant so a future override-condition change doesn't silently
+    regress non-stream tool calls.
+    """
+
+    class _ToolCallRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": "Need to call the function",
+                "tool_calls": [
+                    "<|channel|>commentary to=functions.get_weather "
+                    '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+                ],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _ToolCallRouter())
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005, 12606, 815, 200008, 1],
+        fallback_text='<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|>',
+    )
+    assert reasoning == "Need to call the function"
+    # The override must NOT clobber fallback_text — tool-call commentary
+    # MUST survive to the route's HarmonyToolParser.
+    assert "functions.get_weather" in content, (
+        f"tool-call fallback_text clobbered; got {content!r}"
+    )
+    assert '{"city":"NYC"}' in content
+
+
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):
     """If the router blows up mid-sequence (e.g. token id outside the
     vocab causes a decode failure), the engine must not propagate the

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -18,17 +18,19 @@ terminators the model didn't emit":
      ``_stream_with_output_router`` — non-streaming silently diverged.
 
 The fix routes the completed token sequence through the same
-``OutputRouter`` state machine the streaming path trusts. The router
-tracks channel state at the token level (it doesn't care about ``<|end|>``
-markers — it knows it's in analysis the moment the analysis word token
-fires), so truncated output is handled identically to terminated.
+``OutputRouter`` state machine the streaming path trusts.
 
-The engine's ``_route_tokens_for_channels`` returns
-``(reasoning_text, content_text)``; the content override only fires
-when the router authoritatively says "no content, only reasoning" so
-tool-call paths (where harmony commentary needs to survive intact for
-the route's tool parser) keep their existing behavior. These tests pin
-each branch of that override decision.
+Round-15 refactor (PR #515 codex round-12 / round-14 BLOCKING
+closure): ``_route_tokens_for_channels`` returns
+``(reasoning_text, content_text, structured_tool_calls)``. The third
+value is the engine's structured tool-call passthrough — when the
+router natively parses tool calls (currently
+``HarmonyStreamingRouter`` via openai-harmony's ``StreamableParser``),
+the bytes-faithful ``[{"name", "arguments"}]`` payload flows through
+``GenerationOutput.tool_calls`` so the route layer bypasses text-based
+regex extraction entirely. This eliminates the wire-text round-trip
+that previously corrupted tool calls whose JSON arguments contained
+literal harmony sentinel substrings.
 """
 
 from __future__ import annotations
@@ -96,13 +98,14 @@ def test_truncated_analysis_drops_content_and_recovers_reasoning(engine):
     """
     # <|channel|> analysis <|message|> Reason ing  (no <|end|>)
     token_ids = [200005, 35644, 200008, 1, 2]
-    reasoning, content = engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
         token_ids, fallback_text="Reasoning"
     )
     assert reasoning == "Reasoning", (
         f"#442: router did not recover reasoning from truncated analysis: {reasoning!r}"
     )
     assert content == "", f"#442: analysis body leaked into content: {content!r}"
+    assert tool_calls is None
 
 
 def test_terminated_analysis_only_also_drops_content(engine):
@@ -112,11 +115,12 @@ def test_terminated_analysis_only_also_drops_content(engine):
     reproduces both with and without ``<|end|>``).
     """
     token_ids = [200005, 35644, 200008, 1, 2, 200007]
-    reasoning, content = engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
         token_ids, fallback_text="anything"
     )
     assert reasoning == "Reasoning"
     assert content == ""
+    assert tool_calls is None
 
 
 def test_analysis_then_final_keeps_fallback_content(engine):
@@ -124,8 +128,7 @@ def test_analysis_then_final_keeps_fallback_content(engine):
     BOTH a CONTENT event (final-channel "Answer") and a REASONING event
     (analysis-channel "Reasoning"). Override condition (content is None
     AND reasoning exists) is FALSE → keep the fallback text from
-    ``clean_output_text``. This pins the existing PR #436 / #440
-    behavior so the new override doesn't regress the common case.
+    ``clean_output_text``.
     """
     token_ids = [
         200005,
@@ -135,73 +138,76 @@ def test_analysis_then_final_keeps_fallback_content(engine):
         2,  # Reasoning
         200007,  # <|end|>
         200006,
-        173781,  # <|start|>assistant  (PR #441 swallows the role)
+        173781,  # <|start|>assistant
         200005,
         17196,
         200008,  # <|channel|>final<|message|>
         3,  # Answer
         200002,  # <|return|>
     ]
-    reasoning, content = engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
         token_ids, fallback_text="Answer"
     )
     assert reasoning == "Reasoning"
     assert content == "Answer", "happy path must not clobber the text-cleaning result"
+    assert tool_calls is None
 
 
 def test_pure_content_no_thinking_keeps_fallback(engine):
     """``<|channel|>final<|message|>Plain<|return|>`` — content-only,
     no analysis. Router emits CONTENT and no REASONING. Override
     condition is FALSE (reasoning empty) → fallback content preserved.
-    Without this guard the engine would clobber pure-content responses
-    with ``text=""`` on every non-reasoning model.
     """
     token_ids = [200005, 17196, 200008, 4, 200002]
-    reasoning, content = engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
         token_ids, fallback_text="Plain"
     )
     assert reasoning == ""
     assert content == "Plain"
+    assert tool_calls is None
 
 
 def test_no_router_returns_fallback_untouched(engine):
     """If ``_create_output_router`` returns ``None`` (tokenizer doesn't
     have channel tokens — e.g. plain Llama), the engine must NOT try
-    to do anything channel-aware. Returns empty reasoning + the
-    original ``fallback_text`` so routes' ReasoningParser path keeps
-    handling extraction for older formats.
+    to do anything channel-aware.
     """
     plain_engine = BatchedEngine("test-model")
     plain_engine._loaded = True
     plain_engine._is_mllm = False
     plain_engine._tokenizer = _FakeTokenizer({"plain": 100})
-    reasoning, content = plain_engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = plain_engine._route_tokens_for_channels(
         [100, 100], fallback_text="plain text"
     )
     assert reasoning == ""
     assert content == "plain text"
+    assert tool_calls is None
 
 
 def test_empty_token_list_returns_fallback(engine):
     """Defensive: empty token IDs (race during error paths) must not
-    crash. Returns empty reasoning + the fallback text.
+    crash.
     """
-    reasoning, content = engine._route_tokens_for_channels([], fallback_text="whatever")
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [], fallback_text="whatever"
+    )
     assert reasoning == ""
     assert content == "whatever"
+    assert tool_calls is None
 
 
-def test_tool_call_routing_preserves_fallback_text(engine, monkeypatch):
-    """PR #515 round-1: when the router emits a TOOL_CALL channel
-    (commentary tool call) the override MUST NOT fire — fallback_text
-    has to survive intact so the route's ``_parse_tool_calls_with_parser``
-    can extract the call from the harmony wire format. Verified via a
-    live diff against the pre-PR baseline; this test pins the
-    invariant so a future override-condition change doesn't silently
-    regress non-stream tool calls.
+def test_structured_tool_call_passthrough_drops_fallback_text(engine, monkeypatch):
+    """Round-15 refactor: when the router natively surfaces structured
+    tool calls (HarmonyStreamingRouter), the engine MUST surface them
+    via ``structured_tool_calls`` and force ``content`` to the
+    router's CONTENT-channel result. The ``fallback_text`` from
+    ``clean_output_text`` may still carry un-cleaned commentary
+    headers that would otherwise bleed into the user-facing
+    ``content`` field. The route layer then bypasses text-based
+    extraction entirely.
     """
 
-    class _ToolCallRouter:
+    class _StructuredToolCallRouter:
         def reset(self):
             pass
 
@@ -210,172 +216,76 @@ def test_tool_call_routing_preserves_fallback_text(engine, monkeypatch):
                 "content": None,
                 "reasoning": "Need to call the function",
                 "tool_calls": [
-                    "<|channel|>commentary to=functions.get_weather "
-                    '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+                    {"name": "get_weather", "arguments": '{"city":"NYC"}'},
                 ],
             }
 
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _ToolCallRouter())
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005, 12606, 815, 200008, 1],
-        fallback_text='<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|>',
+    monkeypatch.setattr(
+        engine, "_create_output_router", lambda: _StructuredToolCallRouter()
+    )
+    fallback = (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
+        '<|message|>{"city":"NYC"}<|call|>'
+    )
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005, 12606, 815, 200008, 1], fallback_text=fallback
     )
     assert reasoning == "Need to call the function"
-    # The override must NOT clobber fallback_text — tool-call commentary
-    # MUST survive to the route's HarmonyToolParser.
-    assert "functions.get_weather" in content, (
-        f"tool-call fallback_text clobbered; got {content!r}"
+    # Structured passthrough — fallback_text's commentary residue MUST
+    # NOT leak into content. The route layer reads tool_calls instead.
+    assert content == "", (
+        f"structured passthrough must clear content of commentary residue; "
+        f"got {content!r}"
     )
-    assert '{"city":"NYC"}' in content
+    assert tool_calls == [{"name": "get_weather", "arguments": '{"city":"NYC"}'}]
 
 
-def test_routed_tool_call_supplements_fallback_text(engine, monkeypatch):
-    """PR #515 (codex round-3 BLOCKING origin / round-11 NIT retarget):
-    when ``OutputRouter.feed_sequence`` surfaces a structured tool call
-    in ``routed["tool_calls"]`` but ``_clean_gpt_oss_output`` has
-    stripped the commentary wire text from ``fallback_text``, the
-    engine must pipe each routed call through by appending its
-    reconstructed wire text so the route's ``HarmonyToolParser`` can
-    extract it. Idempotent: when ``fallback_text`` already carries
-    the SAME canonical signature, don't double-append.
-
-    (Round-6 flipped ``HarmonyStreamingRouter.finalize()`` to the
-    vLLM / SGLang safer-default — finalize now always returns None;
-    tool calls only surface via ``feed()`` on a fully closed
-    ``<|call|>``-terminated commentary message. The fake-router stub
-    below stands in for that ``feed_sequence`` path, not finalize.)
+def test_structured_tool_call_passthrough_preserves_final_content(engine, monkeypatch):
+    """When the model emits BOTH a tool call AND a final-channel
+    response (compound assistant turn), structured passthrough must
+    preserve the final-channel CONTENT alongside the tool_calls. The
+    router's CONTENT result is the user-facing text; the tool_calls
+    are surfaced separately for the route layer.
     """
 
-    class _DrainedToolCallRouter:
+    class _CompoundRouter:
         def reset(self):
             pass
 
         def feed_sequence(self, _ids):
             return {
-                "content": None,
-                "reasoning": "Calling the tool",
+                "content": "The answer is 42.",
+                "reasoning": None,
                 "tool_calls": [
-                    "<|channel|>commentary to=functions.get_weather "
-                    '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
+                    {"name": "lookup", "arguments": '{"q":"meaning"}'},
                 ],
             }
 
-    monkeypatch.setattr(
-        engine, "_create_output_router", lambda: _DrainedToolCallRouter()
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _CompoundRouter())
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005], fallback_text="any fallback"
     )
-
-    # Case A: fallback_text was already stripped — must be supplemented.
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005, 12606, 815, 200008, 1],
-        fallback_text="",  # stripped because clean_output_text didn't bail
-    )
-    assert reasoning == "Calling the tool"
-    assert "functions.get_weather" in content, (
-        f"finalize-drained tool call must be appended to empty fallback_text; "
+    assert reasoning == ""
+    assert content == "The answer is 42.", (
+        f"final-channel content must survive alongside structured tool calls; "
         f"got {content!r}"
     )
-    assert '{"city":"NYC"}' in content
-
-    # PR #515 round-5 BLOCKING refinement: idempotency must be per
-    # wire-text, not "any commentary marker present" — the multi-tool
-    # case is covered in
-    # ``test_multi_tool_fallback_with_existing_marker_still_appends_new``.
-
-    # Case B: fallback_text already contains THIS exact tool call —
-    # don't double-append.
-    tc_wire = (
-        "<|channel|>commentary to=functions.get_weather "
-        '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
-    )
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005, 12606, 815, 200008, 1], fallback_text=tc_wire
-    )
-    assert reasoning == "Calling the tool"
-    assert content == tc_wire, (
-        f"fallback_text already carrying THIS tool call must not be doubled; "
-        f"got {content!r}"
-    )
-    assert content.count("functions.get_weather") == 1
+    assert tool_calls == [{"name": "lookup", "arguments": '{"q":"meaning"}'}]
 
 
-def test_multi_tool_fallback_with_existing_marker_still_appends_new(
+def test_structured_tool_call_passthrough_preserves_sentinel_bearing_arguments(
     engine, monkeypatch
 ):
-    """PR #515 round-5 BLOCKING: in a multi-tool turn (model emits
-    tool call #1 cleanly with ``<|call|>``, then is truncated mid-tool
-    call #2), ``fallback_text`` already carries call #1's commentary
-    marker. The previous bulk guard ``"<|channel|>commentary" not in
-    fallback_text`` then suppressed appending ALL reconstructed tool
-    calls, dropping call #2. The fix checks each reconstructed wire
-    text individually so call #1 isn't doubled and call #2 still
-    reaches ``HarmonyToolParser``.
+    """Round-15 closure for codex round-12 / round-14 BLOCKING: a tool
+    call whose JSON arguments contain a literal harmony sentinel
+    substring (``{"text":"<|call|>"}``) MUST flow through bytes-
+    faithfully via the structured payload. The previous wire-text
+    round-trip lost these calls — the downstream regex parser
+    anchored on the embedded sentinel and truncated the JSON.
     """
-    call1_text = (
-        "<|channel|>commentary to=functions.get_weather "
-        '<|constrain|>json<|message|>{"city":"NYC"}<|call|>'
-    )
-    call2_text = (
-        "<|channel|>commentary to=functions.get_news "
-        '<|constrain|>json<|message|>{"topic":"tech"}<|call|>'
-    )
+    sentinel_bearing_args = '{"text":"use <|call|>"}'
 
-    class _MultiToolRouter:
-        def reset(self):
-            pass
-
-        def feed_sequence(self, _ids):
-            # Router surfaces BOTH tool calls.
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [call1_text, call2_text],
-            }
-
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _MultiToolRouter())
-
-    # fallback_text has call #1 already (from raw text bail-out) but
-    # NOT call #2 (finalize() synthesized it because raw was truncated
-    # before <|call|>).
-    fallback_in = call1_text
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=fallback_in
-    )
-
-    # Call #1 must not be doubled.
-    assert content.count("functions.get_weather") == 1, (
-        f"call #1 must not be doubled; got {content!r}"
-    )
-    # Call #2 must be appended.
-    assert "functions.get_news" in content, (
-        f"finalize-synthesized call #2 must be appended; got {content!r}"
-    )
-    assert '{"topic":"tech"}' in content
-
-
-def test_fallback_dedup_normalizes_whitespace_variance(engine, monkeypatch):
-    """Codex round-7 NIT (PR #515): the previous verbatim substring
-    check ``tc_text not in fallback_text`` doubled tool calls when the
-    model's emit and the router's canonical reconstruction differ only
-    by whitespace runs (e.g. one space vs two between ``to=...`` and
-    ``<|constrain|>``). The dedup must compare by the structural
-    ``(recipient, normalized_body)`` tuple instead so the same call
-    matches across spacing variants.
-    """
-    # Model emitted the call with double-space between recipient and
-    # constrain (a plausible variance — gpt-oss tokenizer roundtrips
-    # may decode trailing whitespace before the special token). Router
-    # reconstructs the canonical single-space form. Body bytes are
-    # identical (both come from the same body-token decode).
-    model_emit = (
-        "<|channel|>commentary to=functions.get_weather  <|constrain|>json"
-        '<|message|>{"city":"NYC"}<|call|>'
-    )
-    router_reconstructs = (
-        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
-        '<|message|>{"city":"NYC"}<|call|>'
-    )
-
-    class _SpacingVariantRouter:
+    class _SentinelBodyRouter:
         def reset(self):
             pass
 
@@ -383,144 +293,55 @@ def test_fallback_dedup_normalizes_whitespace_variance(engine, monkeypatch):
             return {
                 "content": None,
                 "reasoning": None,
-                "tool_calls": [router_reconstructs],
+                "tool_calls": [
+                    {"name": "echo", "arguments": sentinel_bearing_args},
+                ],
             }
 
-    monkeypatch.setattr(
-        engine, "_create_output_router", lambda: _SpacingVariantRouter()
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _SentinelBodyRouter())
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005], fallback_text=""
     )
+    assert tool_calls is not None and len(tool_calls) == 1
+    # Bytes-faithful: the sentinel substring inside the JSON body is
+    # preserved exactly. Pre-refactor this was lost because the wire-
+    # text reconstruction abstained (rounds 7/9) or because regex
+    # extraction anchored on the embedded sentinel (rounds 12/14).
+    assert tool_calls[0] == {"name": "echo", "arguments": sentinel_bearing_args}
 
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=model_emit
-    )
-    # Spacing-variant of the same call must NOT double-append.
-    assert content.count("functions.get_weather") == 1, (
-        f"spacing-variant duplicate of same call must not double-append; "
-        f"got {content!r}"
-    )
-    # And a DIFFERENT call (different body, even if same recipient)
-    # still gets appended.
-    different_body_call = (
-        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
-        '<|message|>{"city":"Paris"}<|call|>'
-    )
 
-    class _DifferentBodyRouter:
+def test_multiple_structured_tool_calls_pass_through_in_order(engine, monkeypatch):
+    """A multi-tool turn must surface all tool calls in emission
+    order. Distinct calls (same recipient with different args, or
+    different recipients) MUST NOT be deduped — multiplicity is part
+    of the model's intent.
+    """
+    calls = [
+        {"name": "get_weather", "arguments": '{"city":"NYC"}'},
+        {"name": "get_news", "arguments": '{"topic":"tech"}'},
+        {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+    ]
+
+    class _MultiRouter:
         def reset(self):
             pass
 
         def feed_sequence(self, _ids):
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [different_body_call],
-            }
+            return {"content": None, "reasoning": None, "tool_calls": list(calls)}
 
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _DifferentBodyRouter())
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=model_emit
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _MultiRouter())
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005], fallback_text=""
     )
-    assert content.count("functions.get_weather") == 2, (
-        f"same recipient with different body must append; got {content!r}"
-    )
-    assert '{"city":"Paris"}' in content
+    assert tool_calls == calls, "multi-tool turn must preserve order and multiplicity"
 
 
-def test_fallback_dedup_preserves_internal_body_whitespace(engine, monkeypatch):
-    """Codex round-8 BLOCKING (PR #515): two legitimate calls
-    ``{"q":"a b"}`` and ``{"q":"a  b"}`` carry semantically distinct
-    arguments and must dedup to DIFFERENT signatures. The round-7
-    body-whitespace-collapse path made them collide and could drop the
-    later call. Signature now uses the exact body bytes — distinct
-    internal whitespace ⇒ distinct signature ⇒ both calls survive.
+def test_identical_structured_calls_twice_both_survive(engine, monkeypatch):
+    """When the model legitimately emits the SAME tool call twice in
+    one turn, BOTH must surface — multiplicity carries semantic intent
+    (user asked the same question twice, model called the tool twice).
     """
-    call_a_one_space = (
-        "<|channel|>commentary to=functions.search <|constrain|>json"
-        '<|message|>{"q":"a b"}<|call|>'
-    )
-    call_a_two_space = (
-        "<|channel|>commentary to=functions.search <|constrain|>json"
-        '<|message|>{"q":"a  b"}<|call|>'
-    )
-
-    class _DistinctBodyRouter:
-        def reset(self):
-            pass
-
-        def feed_sequence(self, _ids):
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [call_a_two_space],
-            }
-
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _DistinctBodyRouter())
-
-    # fallback_text already has the single-space-body variant from the
-    # model's clean emit. The router separately reconstructed the
-    # double-space-body call (different tool turn). Dedup must NOT
-    # collapse them.
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=call_a_one_space
-    )
-    assert content.count("functions.search") == 2, (
-        f"distinct internal-whitespace bodies must NOT dedup; got {content!r}"
-    )
-    assert '{"q":"a b"}' in content
-    assert '{"q":"a  b"}' in content
-
-
-def test_non_canonical_router_wire_text_is_dropped(engine, monkeypatch):
-    """Codex round-8 BLOCKING (PR #515): when the router emits a wire
-    text that doesn't match the canonical
-    ``to=functions.<name>...<|message|>...<|call|>`` shape (e.g.
-    truncated header, missing ``<|call|>`` terminator, or a malformed
-    recipient that nonetheless survived router-side validation), the
-    engine must NOT append it to fallback_text — feeding malformed wire
-    text to HarmonyToolParser either fails to parse or anchors on the
-    wrong markers and surfaces a corrupt tool call. Drop instead.
-    """
-    malformed = "<|channel|>commentary to=functions.broken<|message|>{}"
-    # NOTE: no <|call|> terminator → signature regex won't match.
-
-    class _MalformedRouter:
-        def reset(self):
-            pass
-
-        def feed_sequence(self, _ids):
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [malformed],
-            }
-
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _MalformedRouter())
-
-    fallback = "raw fallback text without any tool call"
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=fallback
-    )
-    # Non-canonical wire text must not be appended — fallback stays.
-    assert content == fallback, (
-        f"non-canonical wire text must be dropped, not appended; got {content!r}"
-    )
-
-
-def test_identical_calls_twice_in_turn_both_survive_dedup(engine, monkeypatch):
-    """Codex round-9 BLOCKING (PR #515): when the model legitimately
-    emits the SAME tool call twice in one turn (user asked for the
-    weather twice in one prompt), the model's raw fallback_text
-    carries two wire-text instances AND the router structures both.
-    The round-7/8 ``set`` dedup collapsed identical signatures to one
-    and silently dropped the second; the fix uses ``Counter``
-    multiplicity so each existing match consumes ONE routed call and
-    the duplicates both survive.
-    """
-    same_call = (
-        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
-        '<|message|>{"city":"NYC"}<|call|>'
-    )
-    fallback_two_calls = same_call + same_call
+    same_call = {"name": "get_weather", "arguments": '{"city":"NYC"}'}
 
     class _TwoIdenticalRouter:
         def reset(self):
@@ -530,94 +351,22 @@ def test_identical_calls_twice_in_turn_both_survive_dedup(engine, monkeypatch):
             return {
                 "content": None,
                 "reasoning": None,
-                "tool_calls": [same_call, same_call],
+                "tool_calls": [dict(same_call), dict(same_call)],
             }
 
     monkeypatch.setattr(engine, "_create_output_router", lambda: _TwoIdenticalRouter())
-
-    # Two in fallback, two in routed → two existing matches consume
-    # both routed calls → nothing appended → final count stays at 2.
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=fallback_two_calls
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005], fallback_text=""
     )
-    assert content.count("functions.get_weather") == 2, (
-        f"identical-twice (model+router both saw both) must dedup to 2; got {content!r}"
+    assert tool_calls == [same_call, same_call], (
+        f"identical-twice calls must both survive; got {tool_calls!r}"
     )
-
-    # And if the model emitted ONE but the router structured TWO
-    # (truncation rescued one), the second must be appended.
-    fallback_one_call = same_call
-
-    class _OneInFallbackTwoRouted:
-        def reset(self):
-            pass
-
-        def feed_sequence(self, _ids):
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [same_call, same_call],
-            }
-
-    monkeypatch.setattr(
-        engine, "_create_output_router", lambda: _OneInFallbackTwoRouted()
-    )
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=fallback_one_call
-    )
-    assert content.count("functions.get_weather") == 2, (
-        f"one-in-fallback + two-routed must merge to 2; got {content!r}"
-    )
-
-
-def test_signature_regex_requires_commentary_frame(engine, monkeypatch):
-    """Codex round-9 BLOCKING (PR #515): the previous signature regex
-    matched a BARE ``to=functions.X<|message|>...<|call|>`` shape
-    without requiring the ``<|channel|>commentary`` prefix. A
-    fallback_text where ``clean_output_text`` stripped the commentary
-    header but left the tail (or ordinary content happening to contain
-    those substrings) then false-matched as an existing tool call,
-    suppressing the router's real reconstructed wire text. The fix
-    anchors the regex on the full commentary frame.
-    """
-    tc_wire = (
-        "<|channel|>commentary to=functions.get_weather <|constrain|>json"
-        '<|message|>{"city":"NYC"}<|call|>'
-    )
-    # Stripped fallback_text — the commentary header is gone, only the
-    # tail survives. This must NOT register as an existing signature.
-    stripped_fallback = (
-        'to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|>'
-    )
-
-    class _OneCallRouter:
-        def reset(self):
-            pass
-
-        def feed_sequence(self, _ids):
-            return {
-                "content": None,
-                "reasoning": None,
-                "tool_calls": [tc_wire],
-            }
-
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _OneCallRouter())
-    reasoning, content = engine._route_tokens_for_channels(
-        [200005], fallback_text=stripped_fallback
-    )
-    # Router's canonical wire text must be appended — the stripped
-    # fallback's bare tail does NOT count as an existing signature.
-    assert content.count("<|channel|>commentary") == 1, (
-        f"stripped fallback must not false-suppress; got {content!r}"
-    )
-    assert "<|channel|>commentary to=functions.get_weather" in content
 
 
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):
     """If the router blows up mid-sequence (e.g. token id outside the
     vocab causes a decode failure), the engine must not propagate the
-    exception — fall back to text-based cleaning. The streaming router
-    handles this the same way; symmetry matters.
+    exception — fall back to text-based cleaning.
     """
 
     def _exploding_router():
@@ -631,8 +380,43 @@ def test_router_exception_falls_back_cleanly(engine, monkeypatch):
         return _BoomRouter()
 
     monkeypatch.setattr(engine, "_create_output_router", _exploding_router)
-    reasoning, content = engine._route_tokens_for_channels(
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
         [1, 2, 3], fallback_text="fallback"
     )
     assert reasoning == ""
     assert content == "fallback"
+    assert tool_calls is None
+
+
+def test_legacy_router_emitting_wire_text_strings_routes_through_fallback(
+    engine, monkeypatch
+):
+    """Backwards compatibility: the legacy ``OutputRouter`` (gemma4 /
+    think-tag) emits TOOL_CALL events whose ``text`` is wire-format
+    string (single tool_call sentinel block decoded into one string).
+    The engine MUST treat those as non-structured — leave
+    ``fallback_text`` intact for the legacy text-based parser path.
+    Only HarmonyStreamingRouter currently emits dicts.
+    """
+
+    class _LegacyRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": "Some content",
+                "reasoning": None,
+                "tool_calls": ["<some_legacy_wire_text>"],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _LegacyRouter())
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [200005], fallback_text="raw fallback"
+    )
+    assert tool_calls is None, (
+        f"legacy wire-text tool calls must not surface as structured; "
+        f"got {tool_calls!r}"
+    )
+    # And fallback_text is preserved since the structured path didn't fire.
+    assert content == "raw fallback"

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -229,17 +229,21 @@ def test_tool_call_routing_preserves_fallback_text(engine, monkeypatch):
     assert '{"city":"NYC"}' in content
 
 
-def test_finalize_drained_tool_call_supplements_fallback_text(engine, monkeypatch):
-    """PR #515 round-3 BLOCKING: when ``HarmonyStreamingRouter.finalize()``
-    synthesizes a tool-call event from a truncated commentary (no
-    ``<|call|>`` in the raw text), ``_clean_gpt_oss_output``'s
-    bail-out may not match — the strip regex then removes the
-    commentary header from ``fallback_text``, and the route's
-    ``HarmonyToolParser`` sees no tool call at all. The engine must
-    pipe ``routed["tool_calls"]`` through by appending the
-    reconstructed wire text so the downstream parser can extract it.
-    Idempotent: when the raw text already carries ``<|channel|>commentary``,
-    don't append (avoids double-parsing).
+def test_routed_tool_call_supplements_fallback_text(engine, monkeypatch):
+    """PR #515 (codex round-3 BLOCKING origin / round-11 NIT retarget):
+    when ``OutputRouter.feed_sequence`` surfaces a structured tool call
+    in ``routed["tool_calls"]`` but ``_clean_gpt_oss_output`` has
+    stripped the commentary wire text from ``fallback_text``, the
+    engine must pipe each routed call through by appending its
+    reconstructed wire text so the route's ``HarmonyToolParser`` can
+    extract it. Idempotent: when ``fallback_text`` already carries
+    the SAME canonical signature, don't double-append.
+
+    (Round-6 flipped ``HarmonyStreamingRouter.finalize()`` to the
+    vLLM / SGLang safer-default — finalize now always returns None;
+    tool calls only surface via ``feed()`` on a fully closed
+    ``<|call|>``-terminated commentary message. The fake-router stub
+    below stands in for that ``feed_sequence`` path, not finalize.)
     """
 
     class _DrainedToolCallRouter:

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -382,7 +382,9 @@ def test_fallback_dedup_normalizes_whitespace_variance(engine, monkeypatch):
                 "tool_calls": [router_reconstructs],
             }
 
-    monkeypatch.setattr(engine, "_create_output_router", lambda: _SpacingVariantRouter())
+    monkeypatch.setattr(
+        engine, "_create_output_router", lambda: _SpacingVariantRouter()
+    )
 
     reasoning, content = engine._route_tokens_for_channels(
         [200005], fallback_text=model_emit
@@ -418,6 +420,86 @@ def test_fallback_dedup_normalizes_whitespace_variance(engine, monkeypatch):
         f"same recipient with different body must append; got {content!r}"
     )
     assert '{"city":"Paris"}' in content
+
+
+def test_fallback_dedup_preserves_internal_body_whitespace(engine, monkeypatch):
+    """Codex round-8 BLOCKING (PR #515): two legitimate calls
+    ``{"q":"a b"}`` and ``{"q":"a  b"}`` carry semantically distinct
+    arguments and must dedup to DIFFERENT signatures. The round-7
+    body-whitespace-collapse path made them collide and could drop the
+    later call. Signature now uses the exact body bytes — distinct
+    internal whitespace ⇒ distinct signature ⇒ both calls survive.
+    """
+    call_a_one_space = (
+        "<|channel|>commentary to=functions.search <|constrain|>json"
+        '<|message|>{"q":"a b"}<|call|>'
+    )
+    call_a_two_space = (
+        "<|channel|>commentary to=functions.search <|constrain|>json"
+        '<|message|>{"q":"a  b"}<|call|>'
+    )
+
+    class _DistinctBodyRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [call_a_two_space],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _DistinctBodyRouter())
+
+    # fallback_text already has the single-space-body variant from the
+    # model's clean emit. The router separately reconstructed the
+    # double-space-body call (different tool turn). Dedup must NOT
+    # collapse them.
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=call_a_one_space
+    )
+    assert content.count("functions.search") == 2, (
+        f"distinct internal-whitespace bodies must NOT dedup; got {content!r}"
+    )
+    assert '{"q":"a b"}' in content
+    assert '{"q":"a  b"}' in content
+
+
+def test_non_canonical_router_wire_text_is_dropped(engine, monkeypatch):
+    """Codex round-8 BLOCKING (PR #515): when the router emits a wire
+    text that doesn't match the canonical
+    ``to=functions.<name>...<|message|>...<|call|>`` shape (e.g.
+    truncated header, missing ``<|call|>`` terminator, or a malformed
+    recipient that nonetheless survived router-side validation), the
+    engine must NOT append it to fallback_text — feeding malformed wire
+    text to HarmonyToolParser either fails to parse or anchors on the
+    wrong markers and surfaces a corrupt tool call. Drop instead.
+    """
+    malformed = "<|channel|>commentary to=functions.broken<|message|>{}"
+    # NOTE: no <|call|> terminator → signature regex won't match.
+
+    class _MalformedRouter:
+        def reset(self):
+            pass
+
+        def feed_sequence(self, _ids):
+            return {
+                "content": None,
+                "reasoning": None,
+                "tool_calls": [malformed],
+            }
+
+    monkeypatch.setattr(engine, "_create_output_router", lambda: _MalformedRouter())
+
+    fallback = "raw fallback text without any tool call"
+    reasoning, content = engine._route_tokens_for_channels(
+        [200005], fallback_text=fallback
+    )
+    # Non-canonical wire text must not be appended — fallback stays.
+    assert content == fallback, (
+        f"non-canonical wire text must be dropped, not appended; got {content!r}"
+    )
 
 
 def test_router_exception_falls_back_cleanly(engine, monkeypatch):

--- a/tests/test_parallel_tool_calls.py
+++ b/tests/test_parallel_tool_calls.py
@@ -136,7 +136,7 @@ class TestRouteIntegration:
         from vllm_mlx.engine.base import GenerationOutput
         from vllm_mlx.routes.chat import router as chat_router
 
-        def _fake_parse(text, request):
+        def _fake_parse(text, request, *, structured_tool_calls=None):
             return (
                 "",
                 [

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -21,8 +21,15 @@ def _make_cfg(**overrides):
     return cfg
 
 
-def _make_output(text="", finished=False, channel=None, finish_reason=None):
-    """Create a mock GenerationOutput."""
+def _make_output(
+    text="", finished=False, channel=None, finish_reason=None, tool_calls=None
+):
+    """Create a mock GenerationOutput.
+
+    ``tool_calls`` defaults to None so the postprocessor's structured
+    fast-path (PR #515) stays inert in tests that don't opt in. Tests
+    exercising HarmonyStreamingRouter passthrough must set this explicitly.
+    """
     out = MagicMock()
     out.new_text = text
     out.finished = finished
@@ -32,6 +39,7 @@ def _make_output(text="", finished=False, channel=None, finish_reason=None):
     out.completion_tokens = 5
     out.tokens = []
     out.logprobs = None
+    out.tool_calls = tool_calls
     return out
 
 
@@ -725,6 +733,217 @@ class TestStreamingPostProcessorToolCallChannel:
         assert len(events) == 1
         assert events[0].type == "finish"
         assert events[0].reasoning == "final thought"
+
+
+class TestStructuredToolCallStreaming:
+    """Tests for the engine-surfaced structured tool-call fast-path
+    introduced by PR #515 (HarmonyStreamingRouter bypass).
+
+    Two invariants the legacy text-parser path enforced must be
+    preserved on the structured path — codex round-15 BLOCKINGs:
+
+    1. ``tool_calls[*].index`` is monotonically increasing across
+       distinct router chunks (clients merge deltas on ``index``;
+       colliding indices silently overwrite).
+    2. ``parallel_tool_calls=false`` caps the response at one call
+       (matching the post-parse trim in ``routes/chat.py``).
+    """
+
+    def test_index_monotonic_across_chunks(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        first = pp.process_chunk(
+            _make_output(
+                "search(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "search", "arguments": '{"q":"a"}'}],
+            )
+        )
+        second = pp.process_chunk(
+            _make_output(
+                "lookup(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "lookup", "arguments": '{"q":"b"}'}],
+            )
+        )
+
+        assert len(first) == 1 and first[0].type == "tool_call"
+        assert len(second) == 1 and second[0].type == "tool_call"
+        assert first[0].tool_calls[0]["index"] == 0
+        assert second[0].tool_calls[0]["index"] == 1
+
+    def test_index_monotonic_within_single_chunk(self):
+        """Multiple calls in one router event still receive distinct indices."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                "two(...)",
+                channel="tool_call",
+                tool_calls=[
+                    {"name": "a", "arguments": "{}"},
+                    {"name": "b", "arguments": "{}"},
+                ],
+            )
+        )
+        assert len(events) == 1
+        indices = [tc["index"] for tc in events[0].tool_calls]
+        assert indices == [0, 1]
+
+    def test_parallel_tool_calls_false_caps_across_chunks(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(
+            _make_output(
+                "search(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "search", "arguments": '{"q":"a"}'}],
+            )
+        )
+        second = pp.process_chunk(
+            _make_output(
+                "lookup(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "lookup", "arguments": '{"q":"b"}'}],
+            )
+        )
+
+        assert len(first) == 1
+        assert first[0].type == "tool_call"
+        assert first[0].tool_calls[0]["function"]["name"] == "search"
+        # Second chunk is suppressed entirely (no finish marker since
+        # the engine output isn't ``finished``).
+        assert second == []
+        assert pp.tool_calls_detected is True
+
+    def test_parallel_tool_calls_false_caps_within_single_chunk(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                "two(...)",
+                channel="tool_call",
+                tool_calls=[
+                    {"name": "a", "arguments": "{}"},
+                    {"name": "b", "arguments": "{}"},
+                ],
+            )
+        )
+        assert len(events) == 1
+        assert len(events[0].tool_calls) == 1
+        assert events[0].tool_calls[0]["function"]["name"] == "a"
+
+    def test_parallel_tool_calls_true_does_not_cap(self):
+        """Explicit ``True`` must behave like unset (no cap)."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": True})
+        pp.reset()
+
+        first = pp.process_chunk(
+            _make_output(
+                "search(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "search", "arguments": "{}"}],
+            )
+        )
+        second = pp.process_chunk(
+            _make_output(
+                "lookup(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "lookup", "arguments": "{}"}],
+            )
+        )
+        assert len(first) == 1 and len(second) == 1
+        assert second[0].tool_calls[0]["index"] == 1
+
+    def test_cap_suppression_preserves_finish_semantics(self):
+        """When the suppressed chunk is also the finished chunk we must
+        still emit a finish event so the route's buffered_finish gate
+        fires.
+        """
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        pp.process_chunk(
+            _make_output(
+                "first(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "first", "arguments": "{}"}],
+            )
+        )
+        events = pp.process_chunk(
+            _make_output(
+                "second(...)",
+                channel="tool_call",
+                finished=True,
+                finish_reason="stop",
+                tool_calls=[{"name": "second", "arguments": "{}"}],
+            )
+        )
+        assert len(events) == 1
+        assert events[0].type == "finish"
+        assert events[0].finish_reason == "tool_calls"
+
+    def test_structured_event_assigns_id_when_missing(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                "search(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "search", "arguments": "{}"}],
+            )
+        )
+        assert events[0].tool_calls[0]["id"].startswith("call_")
+        assert events[0].tool_calls[0]["type"] == "function"
+
+    def test_structured_event_preserves_caller_id(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        events = pp.process_chunk(
+            _make_output(
+                "search(...)",
+                channel="tool_call",
+                tool_calls=[{"id": "call_abc", "name": "search", "arguments": "{}"}],
+            )
+        )
+        assert events[0].tool_calls[0]["id"] == "call_abc"
+
+    def test_reset_clears_structured_counter(self):
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg)
+        pp.reset()
+
+        pp.process_chunk(
+            _make_output(
+                "first(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "a", "arguments": "{}"}],
+            )
+        )
+        pp.reset()
+        events = pp.process_chunk(
+            _make_output(
+                "second(...)",
+                channel="tool_call",
+                tool_calls=[{"name": "b", "arguments": "{}"}],
+            )
+        )
+        # New stream → index restarts at 0.
+        assert events[0].tool_calls[0]["index"] == 0
 
 
 # ======================================================================

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1201,16 +1201,25 @@ class TestGenerationOutputFieldOrder:
         assert out.reasoning_text == ""
 
     def test_field_order_appends_new_fields_at_end(self):
-        """Make the rule machine-checkable: ``raw_text`` and
-        ``reasoning_text`` must be the LAST two fields. If a refactor
-        ever reorders them back into the middle, this test fails loud
-        instead of producing silent positional-bind regressions.
+        """Make the rule machine-checkable: new fields added after
+        v0.6.65 (``raw_text``, ``reasoning_text``, ``tool_calls``) must
+        be APPENDED in chronological order at the end of the dataclass.
+        If a refactor ever reorders them back into the middle, this
+        test fails loud instead of producing silent positional-bind
+        regressions for downstream callers that still construct
+        GenerationOutput positionally.
         """
         from dataclasses import fields
 
         names = [f.name for f in fields(GenerationOutput)]
-        assert names[-2:] == ["raw_text", "reasoning_text"], (
-            f"raw_text and reasoning_text must remain the LAST two fields "
-            f"of GenerationOutput to preserve positional-arg compatibility "
-            f"for the v0.6.65 surface. Current order: {names}"
+        # The original v0.6.65-and-earlier surface ends at ``channel``.
+        # ``raw_text``, ``reasoning_text``, and ``tool_calls`` were
+        # appended in order and must stay in their append positions.
+        legacy_tail_idx = names.index("channel")
+        appended = names[legacy_tail_idx + 1 :]
+        assert appended == ["raw_text", "reasoning_text", "tool_calls"], (
+            f"new GenerationOutput fields must be APPENDED in order "
+            f"(raw_text → reasoning_text → tool_calls) to preserve "
+            f"positional-arg compatibility for the pre-v0.6.65 surface. "
+            f"Current trailing fields after ``channel``: {appended}"
         )

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -54,6 +54,22 @@ class GenerationOutput:
     # (no router, or router failed) — routes fall back to the
     # text-based ``ReasoningParser`` in that case. Issue #442.
     reasoning_text: str = ""
+    # Pre-parsed structured tool calls surfaced by routers that already
+    # speak the model's native tool-call protocol natively (currently
+    # ``HarmonyStreamingRouter`` via ``openai-harmony.StreamableParser``).
+    # Each entry is ``{"name": str, "arguments": str}`` where
+    # ``arguments`` is the JSON string the model produced (verbatim body
+    # bytes — no escaping, no normalisation).
+    #
+    # When present, the route layer SKIPS text-based tool-call
+    # extraction (``_parse_tool_calls_with_parser``) and uses these
+    # entries directly. This bypasses the wire-text round-trip that
+    # previously corrupted tool calls whose JSON arguments happened to
+    # contain harmony sentinel substrings (e.g. ``{"text":"<|call|>"}``)
+    # — see PR #515 codex round-12/14 BLOCKING. ``None`` means the
+    # router did not surface structured calls; the route falls back to
+    # the legacy regex-based parser path.
+    tool_calls: list[dict] | None = None
 
 
 class BaseEngine(ABC):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1362,11 +1362,24 @@ class BatchedEngine(BaseEngine):
         # regex removes the header — the downstream parser then sees
         # no tool call at all. Append the reconstructed wire text from
         # ``routed["tool_calls"]`` so the parser can extract it.
-        # Suppressed when fallback_text already contains a commentary
-        # marker to avoid double-parsing the same call.
+        #
+        # PR #515 round-5 BLOCKING: the previous bulk guard
+        # ``"<|channel|>commentary" not in fallback_text`` was too
+        # broad — in a multi-tool turn (model emits tool call #1
+        # cleanly with ``<|call|>``, then is truncated mid-tool call
+        # #2), the fallback_text already carries call #1's commentary
+        # marker so the entire append was suppressed and call #2 was
+        # lost. Check each reconstructed wire text individually and
+        # only append the ones that aren't already present (verbatim
+        # substring match), so call #1 isn't doubled and call #2
+        # gets through.
         tool_calls = routed.get("tool_calls") or []
-        if tool_calls and "<|channel|>commentary" not in fallback_text:
-            fallback_text = fallback_text + "".join(tool_calls)
+        appended_parts: list[str] = []
+        for tc_text in tool_calls:
+            if tc_text and tc_text not in fallback_text:
+                appended_parts.append(tc_text)
+        if appended_parts:
+            fallback_text = fallback_text + "".join(appended_parts)
 
         return reasoning, fallback_text
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1339,12 +1339,19 @@ class BatchedEngine(BaseEngine):
         return reasoning, fallback_text
 
     def _create_output_router(self) -> OutputRouter | None:
-        """Create a per-request token router for supported tokenizer formats."""
+        """Create a per-request token router for supported tokenizer formats.
+
+        Uses ``from_tokenizer_for_streaming`` so harmony models (gpt-oss)
+        get routed through ``HarmonyStreamingRouter`` backed by
+        openai-harmony's ``StreamableParser`` (issue #513). Falls back to
+        the legacy custom state machine for non-harmony models and for
+        harmony tokenizers whose IDs don't match the official encoding.
+        """
         try:
             tokenizer = self.tokenizer
             if tokenizer is None:
                 return None
-            router = OutputRouter.from_tokenizer(tokenizer)
+            router = OutputRouter.from_tokenizer_for_streaming(tokenizer)
             if router is None:
                 return None
             if router.map.format_tag not in _OUTPUT_ROUTER_ALLOWLIST:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1296,8 +1296,15 @@ class BatchedEngine(BaseEngine):
     # may emit ``to=functions.foo  <|constrain|>`` (double space) while
     # the router reconstructs with a single space. The previous check
     # then mis-classifies the call as "new" and double-appends. Match
-    # by the structural pair ``(recipient, body)`` instead, with
-    # whitespace-runs in the body collapsed for comparison.
+    # by the structural pair ``(recipient, body)`` instead.
+    #
+    # Codex round-8 BLOCKING: do NOT collapse whitespace runs inside
+    # the body — two legitimate calls ``{"q":"a b"}`` and ``{"q":"a  b"}``
+    # have semantically distinct arguments and must dedup to DIFFERENT
+    # signatures. Use the exact body bytes captured between
+    # ``<|message|>`` and ``<|call|>``. Spacing variance only meaningfully
+    # appears in the structural wrapper (between ``to=`` and
+    # ``<|constrain|>``), which the regex's ``\s*`` already absorbs.
     _HARMONY_TC_SIGNATURE_RE: re.Pattern[str] = re.compile(
         r"to=(functions\.[A-Za-z0-9_\-]{1,64})\s*"
         r"(?:<\|constrain\|>[A-Za-z0-9_\-]{1,32})?"
@@ -1307,15 +1314,22 @@ class BatchedEngine(BaseEngine):
 
     @classmethod
     def _harmony_tool_call_signature(cls, wire_text: str) -> tuple[str, str] | None:
-        """Extract ``(recipient, normalized_body)`` from a tool-call
-        wire text for spacing-invariant dedup. ``None`` if the text
-        doesn't match the canonical commentary-tool-call shape.
+        """Extract ``(recipient, exact_body)`` from a tool-call wire
+        text for structural dedup. ``None`` if the text doesn't match
+        the canonical commentary-tool-call shape.
+
+        Body bytes are returned VERBATIM — any whitespace inside the
+        body is part of the tool argument and must NOT be normalized
+        away. The structural wrapper already tolerates spacing variance
+        via the ``\\s*`` in the regex; that is the only place spacing
+        can legitimately differ between a model emit and the router's
+        canonical reconstruction.
         """
         m = cls._HARMONY_TC_SIGNATURE_RE.search(wire_text)
         if not m:
             return None
         recipient, body = m.group(1), m.group(2)
-        return (recipient, " ".join(body.split()))
+        return (recipient, body)
 
     def _route_tokens_for_channels(
         self, token_ids: list[int] | None, *, fallback_text: str
@@ -1408,9 +1422,8 @@ class BatchedEngine(BaseEngine):
         # different arguments for the same recipient.
         tool_calls = routed.get("tool_calls") or []
         existing_sigs: set[tuple[str, str]] = {
-            sig
+            (m.group(1), m.group(2))
             for m in self._HARMONY_TC_SIGNATURE_RE.finditer(fallback_text)
-            if (sig := (m.group(1), " ".join(m.group(2).split())))
         }
         appended_parts: list[str] = []
         for tc_text in tool_calls:
@@ -1418,13 +1431,20 @@ class BatchedEngine(BaseEngine):
                 continue
             sig = self._harmony_tool_call_signature(tc_text)
             if sig is None:
-                # Non-canonical reconstruction (e.g. router emitted a
-                # malformed wire text). Fall back to verbatim match so
-                # we still dedup against a literally identical
-                # fallback_text snippet, but otherwise append — better
-                # to risk a duplicate than to silently drop.
-                if tc_text not in fallback_text:
-                    appended_parts.append(tc_text)
+                # Codex round-8 BLOCKING: non-canonical reconstruction
+                # means the wire text doesn't match the
+                # ``to=functions.<name>...<|message|>...<|call|>`` shape
+                # — feeding it to HarmonyToolParser would either fail
+                # to parse (best case) or anchor on the wrong markers
+                # and produce a corrupt tool call (worst case). Drop
+                # with a debug log; the router has already lost the
+                # tool-call signal and there is nothing safe to recover.
+                logger.debug(
+                    "BatchedEngine._route_tokens_for_channels: skipping "
+                    "non-canonical reconstructed tool-call text "
+                    "(length=%d)",
+                    len(tc_text),
+                )
                 continue
             if sig in existing_sigs:
                 continue

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1351,6 +1351,23 @@ class BatchedEngine(BaseEngine):
         # routed.content non-None.
         if routed.get("content") is None and reasoning and not routed.get("tool_calls"):
             return reasoning, ""
+
+        # PR #515 round-3 BLOCKING: when the router synthesized a
+        # tool-call event via ``finalize()`` (truncated commentary
+        # without ``<|call|>``), the raw text-based ``fallback_text``
+        # may lack the wire markers ``HarmonyToolParser`` needs.
+        # Specifically, if the model emitted a commentary header but
+        # was cut off before the ``<|message|>`` token, the bail-out
+        # in ``_clean_gpt_oss_output`` doesn't trigger and the strip
+        # regex removes the header — the downstream parser then sees
+        # no tool call at all. Append the reconstructed wire text from
+        # ``routed["tool_calls"]`` so the parser can extract it.
+        # Suppressed when fallback_text already contains a commentary
+        # marker to avoid double-parsing the same call.
+        tool_calls = routed.get("tool_calls") or []
+        if tool_calls and "<|channel|>commentary" not in fallback_text:
+            fallback_text = fallback_text + "".join(tool_calls)
+
         return reasoning, fallback_text
 
     def _create_output_router(self) -> OutputRouter | None:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -16,6 +16,7 @@ import json
 import logging
 import re
 import threading
+from collections import Counter
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -1291,22 +1292,20 @@ class BatchedEngine(BaseEngine):
         except Exception:
             return 0
 
-    # Codex round-7 NIT: verbatim substring dedup of reconstructed
-    # tool-call wire text is brittle to spacing variance — the model
-    # may emit ``to=functions.foo  <|constrain|>`` (double space) while
-    # the router reconstructs with a single space. The previous check
-    # then mis-classifies the call as "new" and double-appends. Match
-    # by the structural pair ``(recipient, body)`` instead.
-    #
-    # Codex round-8 BLOCKING: do NOT collapse whitespace runs inside
-    # the body — two legitimate calls ``{"q":"a b"}`` and ``{"q":"a  b"}``
-    # have semantically distinct arguments and must dedup to DIFFERENT
-    # signatures. Use the exact body bytes captured between
-    # ``<|message|>`` and ``<|call|>``. Spacing variance only meaningfully
-    # appears in the structural wrapper (between ``to=`` and
-    # ``<|constrain|>``), which the regex's ``\s*`` already absorbs.
+    # Codex round-7 NIT / round-8 BLOCKING / round-9 BLOCKING:
+    # verbatim substring dedup is brittle to spacing variance, but
+    # collapsing whitespace inside the body merges semantically
+    # distinct calls; and a regex matching the bare
+    # ``to=functions.X<|message|>...<|call|>`` shape false-suppresses
+    # the real call when ``clean_output_text`` strips the
+    # ``<|channel|>commentary`` header but leaves the tail. The
+    # signature must anchor on the FULL commentary frame so a
+    # stripped fallback_text doesn't look like an existing tool call,
+    # and the body must be matched VERBATIM. Spacing variance is
+    # confined to the wrapper (``\s+`` / ``\s*``); the body capture
+    # uses exact bytes.
     _HARMONY_TC_SIGNATURE_RE: re.Pattern[str] = re.compile(
-        r"to=(functions\.[A-Za-z0-9_\-]{1,64})\s*"
+        r"<\|channel\|>commentary\s+to=(functions\.[A-Za-z0-9_\-]{1,64})\s*"
         r"(?:<\|constrain\|>[A-Za-z0-9_\-]{1,32})?"
         r"<\|message\|>(.*?)<\|call\|>",
         re.DOTALL,
@@ -1420,11 +1419,20 @@ class BatchedEngine(BaseEngine):
         # ``(recipient, normalized_body)`` tuple instead — robust to
         # any spacing the model picks while still distinguishing
         # different arguments for the same recipient.
+        # Codex round-9 BLOCKING: dedup by SIGNATURE COUNT, not set
+        # membership. If the model legitimately emits the same tool
+        # call twice in one turn (e.g. user asked the same question
+        # twice, both produce ``get_weather("NYC")``), the model's
+        # raw fallback_text carries both wire-text instances AND the
+        # router structures both. Set dedup collapsed them to one and
+        # silently dropped the second; multiplicity counting consumes
+        # ONE existing match per routed call so identical-twice
+        # survives.
         tool_calls = routed.get("tool_calls") or []
-        existing_sigs: set[tuple[str, str]] = {
+        existing_counts: Counter[tuple[str, str]] = Counter(
             (m.group(1), m.group(2))
             for m in self._HARMONY_TC_SIGNATURE_RE.finditer(fallback_text)
-        }
+        )
         appended_parts: list[str] = []
         for tc_text in tool_calls:
             if not tc_text:
@@ -1432,13 +1440,13 @@ class BatchedEngine(BaseEngine):
             sig = self._harmony_tool_call_signature(tc_text)
             if sig is None:
                 # Codex round-8 BLOCKING: non-canonical reconstruction
-                # means the wire text doesn't match the
-                # ``to=functions.<name>...<|message|>...<|call|>`` shape
-                # — feeding it to HarmonyToolParser would either fail
-                # to parse (best case) or anchor on the wrong markers
-                # and produce a corrupt tool call (worst case). Drop
-                # with a debug log; the router has already lost the
-                # tool-call signal and there is nothing safe to recover.
+                # means the wire text doesn't match the canonical
+                # ``<|channel|>commentary to=...<|message|>...<|call|>``
+                # shape — feeding it to HarmonyToolParser would either
+                # fail to parse or anchor on the wrong markers and
+                # produce a corrupt tool call. Drop with a debug log;
+                # the router has lost the tool-call signal and there
+                # is nothing safe to recover.
                 logger.debug(
                     "BatchedEngine._route_tokens_for_channels: skipping "
                     "non-canonical reconstructed tool-call text "
@@ -1446,10 +1454,10 @@ class BatchedEngine(BaseEngine):
                     len(tc_text),
                 )
                 continue
-            if sig in existing_sigs:
+            if existing_counts[sig] > 0:
+                existing_counts[sig] -= 1
                 continue
             appended_parts.append(tc_text)
-            existing_sigs.add(sig)
         if appended_parts:
             fallback_text = fallback_text + "".join(appended_parts)
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -14,6 +14,7 @@ LLM engine), so text-only requests must also be routed through it.
 import functools
 import json
 import logging
+import re
 import threading
 from collections.abc import AsyncIterator
 from dataclasses import replace
@@ -1290,6 +1291,32 @@ class BatchedEngine(BaseEngine):
         except Exception:
             return 0
 
+    # Codex round-7 NIT: verbatim substring dedup of reconstructed
+    # tool-call wire text is brittle to spacing variance — the model
+    # may emit ``to=functions.foo  <|constrain|>`` (double space) while
+    # the router reconstructs with a single space. The previous check
+    # then mis-classifies the call as "new" and double-appends. Match
+    # by the structural pair ``(recipient, body)`` instead, with
+    # whitespace-runs in the body collapsed for comparison.
+    _HARMONY_TC_SIGNATURE_RE: re.Pattern[str] = re.compile(
+        r"to=(functions\.[A-Za-z0-9_\-]{1,64})\s*"
+        r"(?:<\|constrain\|>[A-Za-z0-9_\-]{1,32})?"
+        r"<\|message\|>(.*?)<\|call\|>",
+        re.DOTALL,
+    )
+
+    @classmethod
+    def _harmony_tool_call_signature(cls, wire_text: str) -> tuple[str, str] | None:
+        """Extract ``(recipient, normalized_body)`` from a tool-call
+        wire text for spacing-invariant dedup. ``None`` if the text
+        doesn't match the canonical commentary-tool-call shape.
+        """
+        m = cls._HARMONY_TC_SIGNATURE_RE.search(wire_text)
+        if not m:
+            return None
+        recipient, body = m.group(1), m.group(2)
+        return (recipient, " ".join(body.split()))
+
     def _route_tokens_for_channels(
         self, token_ids: list[int] | None, *, fallback_text: str
     ) -> tuple[str, str]:
@@ -1369,15 +1396,40 @@ class BatchedEngine(BaseEngine):
         # cleanly with ``<|call|>``, then is truncated mid-tool call
         # #2), the fallback_text already carries call #1's commentary
         # marker so the entire append was suppressed and call #2 was
-        # lost. Check each reconstructed wire text individually and
-        # only append the ones that aren't already present (verbatim
-        # substring match), so call #1 isn't doubled and call #2
-        # gets through.
+        # lost. Check each reconstructed wire text individually so
+        # call #1 isn't doubled and call #2 gets through.
+        #
+        # PR #515 round-7 NIT: verbatim substring match is brittle to
+        # whitespace variance between the model's emit and the router's
+        # canonical reconstruction (e.g. ``to=functions.foo  <|...``
+        # vs ``to=functions.foo <|...``). Compare by the structural
+        # ``(recipient, normalized_body)`` tuple instead — robust to
+        # any spacing the model picks while still distinguishing
+        # different arguments for the same recipient.
         tool_calls = routed.get("tool_calls") or []
+        existing_sigs: set[tuple[str, str]] = {
+            sig
+            for m in self._HARMONY_TC_SIGNATURE_RE.finditer(fallback_text)
+            if (sig := (m.group(1), " ".join(m.group(2).split())))
+        }
         appended_parts: list[str] = []
         for tc_text in tool_calls:
-            if tc_text and tc_text not in fallback_text:
-                appended_parts.append(tc_text)
+            if not tc_text:
+                continue
+            sig = self._harmony_tool_call_signature(tc_text)
+            if sig is None:
+                # Non-canonical reconstruction (e.g. router emitted a
+                # malformed wire text). Fall back to verbatim match so
+                # we still dedup against a literally identical
+                # fallback_text snippet, but otherwise append — better
+                # to risk a duplicate than to silently drop.
+                if tc_text not in fallback_text:
+                    appended_parts.append(tc_text)
+                continue
+            if sig in existing_sigs:
+                continue
+            appended_parts.append(tc_text)
+            existing_sigs.add(sig)
         if appended_parts:
             fallback_text = fallback_text + "".join(appended_parts)
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1329,12 +1329,31 @@ class BatchedEngine(BaseEngine):
 
         reasoning = routed.get("reasoning") or ""
         # Override content ONLY when the router authoritatively says
-        # there is no content channel AND there is reasoning. In every
-        # other case we keep ``fallback_text`` so tool-call commentary
-        # text reaches the route's tool parser unchanged, and so non-
-        # reasoning models (router emits CONTENT only) keep their
-        # text-cleaning result.
-        if routed.get("content") is None and reasoning:
+        # there is no content channel AND there is reasoning AND no
+        # tool-call channel was emitted. In every other case we keep
+        # ``fallback_text`` so tool-call commentary text reaches the
+        # route's tool parser unchanged, and so non-reasoning models
+        # (router emits CONTENT only) keep their text-cleaning result.
+        #
+        # PR #515 round-1: the harmony bypass router correctly
+        # classifies commentary tool calls as TOOL_CALL events
+        # (instead of leaking them into CONTENT), so a harmony tool
+        # call now produces ``content=None`` from ``feed_sequence``
+        # even though the model DID emit a structural sequence the
+        # downstream ``HarmonyToolParser`` needs to parse. Without the
+        # ``not tool_calls`` guard, the override clobbers
+        # ``fallback_text`` (which still carries the commentary wire
+        # text — ``_clean_gpt_oss_output`` bails on commentary), and
+        # ``_parse_tool_calls_with_parser`` in the route receives an
+        # empty string. Verified against the baseline pre-#515:
+        # baseline preserved fallback_text because the legacy router
+        # couldn't classify multi-token ``commentary``, leaving
+        # routed.content non-None.
+        if (
+            routed.get("content") is None
+            and reasoning
+            and not routed.get("tool_calls")
+        ):
             return reasoning, ""
         return reasoning, fallback_text
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1349,11 +1349,7 @@ class BatchedEngine(BaseEngine):
         # baseline preserved fallback_text because the legacy router
         # couldn't classify multi-token ``commentary``, leaving
         # routed.content non-None.
-        if (
-            routed.get("content") is None
-            and reasoning
-            and not routed.get("tool_calls")
-        ):
+        if routed.get("content") is None and reasoning and not routed.get("tool_calls"):
             return reasoning, ""
         return reasoning, fallback_text
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -14,9 +14,7 @@ LLM engine), so text-only requests must also be routed through it.
 import functools
 import json
 import logging
-import re
 import threading
-from collections import Counter
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -1016,7 +1014,7 @@ class BatchedEngine(BaseEngine):
         # (issue #442). The router doesn't care about ``<|end|>``
         # terminators so it also recovers reasoning from truncated
         # output (``finish_reason=length`` mid-thinking).
-        reasoning_text, text = self._route_tokens_for_channels(
+        reasoning_text, text, structured_tool_calls = self._route_tokens_for_channels(
             output.output_token_ids, fallback_text=text
         )
 
@@ -1027,6 +1025,7 @@ class BatchedEngine(BaseEngine):
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
+            tool_calls=structured_tool_calls,
         )
 
     async def stream_generate(
@@ -1292,176 +1291,89 @@ class BatchedEngine(BaseEngine):
         except Exception:
             return 0
 
-    # Codex round-7 NIT / round-8 BLOCKING / round-9 BLOCKING:
-    # verbatim substring dedup is brittle to spacing variance, but
-    # collapsing whitespace inside the body merges semantically
-    # distinct calls; and a regex matching the bare
-    # ``to=functions.X<|message|>...<|call|>`` shape false-suppresses
-    # the real call when ``clean_output_text`` strips the
-    # ``<|channel|>commentary`` header but leaves the tail. The
-    # signature must anchor on the FULL commentary frame so a
-    # stripped fallback_text doesn't look like an existing tool call,
-    # and the body must be matched VERBATIM. Spacing variance is
-    # confined to the wrapper (``\s+`` / ``\s*``); the body capture
-    # uses exact bytes.
-    _HARMONY_TC_SIGNATURE_RE: re.Pattern[str] = re.compile(
-        r"<\|channel\|>commentary\s+to=(functions\.[A-Za-z0-9_\-]{1,64})\s*"
-        r"(?:<\|constrain\|>[A-Za-z0-9_\-]{1,32})?"
-        r"<\|message\|>(.*?)<\|call\|>",
-        re.DOTALL,
-    )
-
-    @classmethod
-    def _harmony_tool_call_signature(cls, wire_text: str) -> tuple[str, str] | None:
-        """Extract ``(recipient, exact_body)`` from a tool-call wire
-        text for structural dedup. ``None`` if the text doesn't match
-        the canonical commentary-tool-call shape.
-
-        Body bytes are returned VERBATIM — any whitespace inside the
-        body is part of the tool argument and must NOT be normalized
-        away. The structural wrapper already tolerates spacing variance
-        via the ``\\s*`` in the regex; that is the only place spacing
-        can legitimately differ between a model emit and the router's
-        canonical reconstruction.
-        """
-        m = cls._HARMONY_TC_SIGNATURE_RE.search(wire_text)
-        if not m:
-            return None
-        recipient, body = m.group(1), m.group(2)
-        return (recipient, body)
-
     def _route_tokens_for_channels(
         self, token_ids: list[int] | None, *, fallback_text: str
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list[dict] | None]:
         """Run ``OutputRouter.feed_sequence`` on a completed token list.
 
-        Returns ``(reasoning_text, content_text)`` for the non-streaming
-        path. The router is the token-level state machine that the
-        streaming path already trusts (``_stream_with_output_router``);
-        using it here closes a long-standing gap where non-streaming
-        relied on text-based ``clean_output_text`` regex parsing and
-        leaked analysis-channel content into ``content`` when the
-        model finished mid-thinking (``finish_reason=length`` — issue
-        #442) or otherwise emitted no ``final`` channel.
+        Returns ``(reasoning_text, content_text, structured_tool_calls)``
+        for the non-streaming path. The router is the token-level state
+        machine that the streaming path already trusts
+        (``_stream_with_output_router``); using it here closes a long-
+        standing gap where non-streaming relied on text-based
+        ``clean_output_text`` regex parsing and leaked analysis-channel
+        content into ``content`` when the model finished mid-thinking
+        (``finish_reason=length`` — issue #442) or otherwise emitted no
+        ``final`` channel.
 
-        ``fallback_text`` is the result of ``clean_output_text`` —
-        we keep it as ``content`` for cases the router doesn't override
-        (e.g. tool-call paths where harmony commentary text needs to
-        survive intact for the route's tool parser; the router only
-        knows about ``analysis`` and ``final`` for harmony, so we don't
-        clobber its decisions). The override fires only when the router
-        is authoritative AND text-based cleaning is known wrong —
-        specifically when the router sees REASONING tokens but no
-        CONTENT tokens, which means there was no ``final`` channel and
-        ``message.content`` should be empty.
+        ``fallback_text`` is the result of ``clean_output_text`` — we
+        keep it as ``content`` for cases the router doesn't override.
+        The override fires when the router is authoritative AND
+        text-based cleaning is known wrong — specifically when the
+        router sees REASONING tokens but no CONTENT tokens (no
+        ``final`` channel emitted), or when the router surfaced
+        structured tool calls (their bodies must NOT bleed into
+        content text via the un-cleaned commentary header).
+
+        ``structured_tool_calls`` carries ``[{"name", "arguments"}]``
+        entries from routers that natively parse the model's tool-call
+        protocol (currently ``HarmonyStreamingRouter`` via
+        openai-harmony's ``StreamableParser``). When non-None, the
+        route layer bypasses text-based extraction entirely (see
+        ``GenerationOutput.tool_calls`` plumbing). This eliminates the
+        sentinel-delimited wire-text round-trip that previously lost
+        tool calls whose JSON arguments contained literal harmony
+        marker substrings — PR #515 codex round-12 / round-14 BLOCKING.
         """
         if not token_ids:
-            return "", fallback_text
+            return "", fallback_text, None
         router = self._create_output_router()
         if router is None:
-            return "", fallback_text
+            return "", fallback_text, None
         try:
             router.reset()
             routed = router.feed_sequence(token_ids)
         except Exception as e:
             logger.debug("OutputRouter sequence routing failed: %s", e)
-            return "", fallback_text
+            return "", fallback_text, None
 
         reasoning = routed.get("reasoning") or ""
+        raw_tool_calls = routed.get("tool_calls") or []
+        # Normalise to the structured ``{"name", "arguments"}`` shape
+        # the route layer expects. The HarmonyStreamingRouter already
+        # produces dicts; the legacy ``OutputRouter`` emits wire-text
+        # strings (gemma4 / qwen / deepseek) which we leave to the
+        # legacy text-based parser path — those models don't surface
+        # structured payloads yet, so structured_tool_calls is None
+        # for them and the existing fallback_text + regex extraction
+        # flow continues unchanged.
+        structured_tool_calls: list[dict] | None
+        if raw_tool_calls and all(isinstance(tc, dict) for tc in raw_tool_calls):
+            structured_tool_calls = list(raw_tool_calls)
+        else:
+            structured_tool_calls = None
+
+        # When the router surfaces structured tool calls, the text-
+        # based fallback path is dead weight — and worse, the
+        # un-cleaned harmony commentary header still embedded in
+        # ``fallback_text`` would bleed into the route's user-facing
+        # ``content`` field. Force content to the router's CONTENT
+        # channel result (final-channel text only) and drop the
+        # commentary residue. Reasoning is also taken from the router
+        # because the harmony reasoning parser cannot find an
+        # ``<|end|>`` terminator on the analysis channel after the
+        # tool call has consumed the commentary block.
+        if structured_tool_calls is not None:
+            return reasoning, routed.get("content") or "", structured_tool_calls
+
         # Override content ONLY when the router authoritatively says
-        # there is no content channel AND there is reasoning AND no
-        # tool-call channel was emitted. In every other case we keep
-        # ``fallback_text`` so tool-call commentary text reaches the
-        # route's tool parser unchanged, and so non-reasoning models
+        # there is no content channel AND there is reasoning. In every
+        # other case we keep ``fallback_text`` so non-reasoning models
         # (router emits CONTENT only) keep their text-cleaning result.
-        #
-        # PR #515 round-1: the harmony bypass router correctly
-        # classifies commentary tool calls as TOOL_CALL events
-        # (instead of leaking them into CONTENT), so a harmony tool
-        # call now produces ``content=None`` from ``feed_sequence``
-        # even though the model DID emit a structural sequence the
-        # downstream ``HarmonyToolParser`` needs to parse. Without the
-        # ``not tool_calls`` guard, the override clobbers
-        # ``fallback_text`` (which still carries the commentary wire
-        # text — ``_clean_gpt_oss_output`` bails on commentary), and
-        # ``_parse_tool_calls_with_parser`` in the route receives an
-        # empty string. Verified against the baseline pre-#515:
-        # baseline preserved fallback_text because the legacy router
-        # couldn't classify multi-token ``commentary``, leaving
-        # routed.content non-None.
-        if routed.get("content") is None and reasoning and not routed.get("tool_calls"):
-            return reasoning, ""
+        if routed.get("content") is None and reasoning:
+            return reasoning, "", None
 
-        # PR #515 round-3 BLOCKING: when the router synthesized a
-        # tool-call event via ``finalize()`` (truncated commentary
-        # without ``<|call|>``), the raw text-based ``fallback_text``
-        # may lack the wire markers ``HarmonyToolParser`` needs.
-        # Specifically, if the model emitted a commentary header but
-        # was cut off before the ``<|message|>`` token, the bail-out
-        # in ``_clean_gpt_oss_output`` doesn't trigger and the strip
-        # regex removes the header — the downstream parser then sees
-        # no tool call at all. Append the reconstructed wire text from
-        # ``routed["tool_calls"]`` so the parser can extract it.
-        #
-        # PR #515 round-5 BLOCKING: the previous bulk guard
-        # ``"<|channel|>commentary" not in fallback_text`` was too
-        # broad — in a multi-tool turn (model emits tool call #1
-        # cleanly with ``<|call|>``, then is truncated mid-tool call
-        # #2), the fallback_text already carries call #1's commentary
-        # marker so the entire append was suppressed and call #2 was
-        # lost. Check each reconstructed wire text individually so
-        # call #1 isn't doubled and call #2 gets through.
-        #
-        # PR #515 round-7 NIT: verbatim substring match is brittle to
-        # whitespace variance between the model's emit and the router's
-        # canonical reconstruction (e.g. ``to=functions.foo  <|...``
-        # vs ``to=functions.foo <|...``). Compare by the structural
-        # ``(recipient, normalized_body)`` tuple instead — robust to
-        # any spacing the model picks while still distinguishing
-        # different arguments for the same recipient.
-        # Codex round-9 BLOCKING: dedup by SIGNATURE COUNT, not set
-        # membership. If the model legitimately emits the same tool
-        # call twice in one turn (e.g. user asked the same question
-        # twice, both produce ``get_weather("NYC")``), the model's
-        # raw fallback_text carries both wire-text instances AND the
-        # router structures both. Set dedup collapsed them to one and
-        # silently dropped the second; multiplicity counting consumes
-        # ONE existing match per routed call so identical-twice
-        # survives.
-        tool_calls = routed.get("tool_calls") or []
-        existing_counts: Counter[tuple[str, str]] = Counter(
-            (m.group(1), m.group(2))
-            for m in self._HARMONY_TC_SIGNATURE_RE.finditer(fallback_text)
-        )
-        appended_parts: list[str] = []
-        for tc_text in tool_calls:
-            if not tc_text:
-                continue
-            sig = self._harmony_tool_call_signature(tc_text)
-            if sig is None:
-                # Codex round-8 BLOCKING: non-canonical reconstruction
-                # means the wire text doesn't match the canonical
-                # ``<|channel|>commentary to=...<|message|>...<|call|>``
-                # shape — feeding it to HarmonyToolParser would either
-                # fail to parse or anchor on the wrong markers and
-                # produce a corrupt tool call. Drop with a debug log;
-                # the router has lost the tool-call signal and there
-                # is nothing safe to recover.
-                logger.debug(
-                    "BatchedEngine._route_tokens_for_channels: skipping "
-                    "non-canonical reconstructed tool-call text "
-                    "(length=%d)",
-                    len(tc_text),
-                )
-                continue
-            if existing_counts[sig] > 0:
-                existing_counts[sig] -= 1
-                continue
-            appended_parts.append(tc_text)
-        if appended_parts:
-            fallback_text = fallback_text + "".join(appended_parts)
-
-        return reasoning, fallback_text
+        return reasoning, fallback_text, None
 
     def _create_output_router(self) -> OutputRouter | None:
         """Create a per-request token router for supported tokenizer formats.
@@ -1498,6 +1410,17 @@ class BatchedEngine(BaseEngine):
         finish_reason: str | None = None,
         logprobs=None,
     ) -> GenerationOutput:
+        # Propagate structured tool-call payload from the router event
+        # when present (HarmonyStreamingRouter on TOOL_CALL channel
+        # close). Carrying it on the per-token streaming output lets
+        # the postprocessor emit a structured ``tool_call`` StreamEvent
+        # directly instead of round-tripping through text-based
+        # extraction — the same bypass the non-streaming path uses via
+        # ``GenerationOutput.tool_calls``.
+        tool_calls = None
+        event_tc = getattr(event, "tool_call", None)
+        if event_tc is not None:
+            tool_calls = [event_tc]
         return GenerationOutput(
             text=source.text,
             new_text=event.text if new_text is None else new_text,
@@ -1508,6 +1431,7 @@ class BatchedEngine(BaseEngine):
             finish_reason=finish_reason,
             logprobs=logprobs,
             channel=_channel_name(event.channel),
+            tool_calls=tool_calls,
         )
 
     def _routed_finish_sentinel(self, source: GenerationOutput) -> GenerationOutput:

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -584,6 +584,14 @@ class OutputRouter:
             return cls(token_map, tokenizer)
 
         # GPT-OSS/Harmony detection: channel/message special tokens.
+        # ``from_tokenizer`` returns the legacy custom state machine
+        # for backwards compatibility (existing tests pin its
+        # transitions on a synthetic vocab). Production code that
+        # wants the openai-harmony SOTA path uses
+        # ``OutputRouter.from_tokenizer_for_streaming`` which prefers
+        # ``HarmonyStreamingRouter`` for matched-vocab harmony models.
+        # See vllm_mlx/output_router_harmony.py and issue #513 /
+        # cluster #444/#455/#468/#480.
         if "<|channel|>" in vocab and "<|message|>" in vocab:
             token_map = TokenMap(
                 format_tag="harmony",
@@ -627,3 +635,35 @@ class OutputRouter:
             return cls(token_map, tokenizer)
 
         return None  # unsupported model format
+
+    @classmethod
+    def from_tokenizer_for_streaming(cls, tokenizer: Any):
+        """Production streaming factory — prefers ``HarmonyStreamingRouter``
+        for harmony-format models whose vocab IDs match the openai-harmony
+        encoding (verified at PR-time for upstream gpt-oss). Falls back to
+        the legacy ``OutputRouter`` state machine for everything else
+        (Gemma 4, think-tag, harmony with mismatched IDs, etc.).
+
+        Separate from ``from_tokenizer`` so the legacy harmony test suite
+        (synthetic vocab in ``tests/test_output_router.py``) continues to
+        exercise the custom state machine without the openai-harmony shim
+        being forced on it. Engine code
+        (``BatchedEngine._create_output_router``) uses THIS factory.
+        """
+        from .output_router_harmony import (
+            HarmonyStreamingRouter,
+            is_openai_harmony_compatible,
+        )
+
+        legacy = cls.from_tokenizer(tokenizer)
+        if legacy is None:
+            return None
+        if legacy.map.format_tag == "harmony" and is_openai_harmony_compatible(
+            legacy.map
+        ):
+            logger.info(
+                "[OutputRouter] Streaming factory upgraded harmony "
+                "router to openai-harmony StreamableParser"
+            )
+            return HarmonyStreamingRouter(legacy.map, tokenizer)
+        return legacy

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -659,7 +659,7 @@ class OutputRouter:
         if legacy is None:
             return None
         if legacy.map.format_tag == "harmony" and is_openai_harmony_compatible(
-            legacy.map
+            legacy.map, tokenizer
         ):
             logger.info(
                 "[OutputRouter] Streaming factory upgraded harmony "

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -53,6 +53,15 @@ class RouterEvent:
     channel: Channel
     token_id: int
     text: str  # decoded text for this token
+    # Optional structured payload for ``Channel.TOOL_CALL`` events.
+    # Populated by routers that natively parse the model's tool-call
+    # protocol (``HarmonyStreamingRouter`` via openai-harmony's
+    # ``StreamableParser``) so the downstream pipeline can consume
+    # ``{"name", "arguments"}`` directly instead of round-tripping
+    # through sentinel-delimited wire text. ``None`` means the consumer
+    # should fall back to text-based extraction on ``text`` (legacy
+    # ``OutputRouter`` path for Gemma 4 / Qwen3 / DeepSeek R1).
+    tool_call: dict | None = None
 
 
 @dataclass

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -661,7 +661,13 @@ class OutputRouter:
         if legacy.map.format_tag == "harmony" and is_openai_harmony_compatible(
             legacy.map, tokenizer
         ):
-            logger.info(
+            # Codex round-2 NIT: emit at DEBUG level. The streaming
+            # factory is called per request in the engine path; an
+            # INFO-level log would spam production logs once per
+            # /v1/chat/completions call. Operators who want to confirm
+            # the upgrade is active should enable router DEBUG once
+            # at startup rather than read it from every request log.
+            logger.debug(
                 "[OutputRouter] Streaming factory upgraded harmony "
                 "router to openai-harmony StreamableParser"
             )

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Harmony-format streaming router backed by ``openai-harmony.StreamableParser``.
+
+Issue #513 / cluster #444/#455/#468/#480: the custom Gemma 4–style
+``OutputRouter`` state machine cannot model the harmony protocol's
+tool-call channel reliably. Production ``commentary`` is two tokens
+(``comment`` + ``ary``) so a single-token channel-type match never
+fires; the recipient string (``functions.<name>``) and constrain
+directive (``<|constrain|>json``) are multi-token literals that the
+naive router state machine swallows or leaks. The marker-preserving
+redesign discussed in PR #514 / #513 is exactly the behavior
+``openai-harmony``'s ``StreamableParser`` already implements — and is
+the same library vLLM and SGLang delegate to for gpt-oss tool calls.
+
+This module exposes ``HarmonyStreamingRouter``, a shim that exposes the
+same ``feed`` / ``finalize`` / ``reset`` / ``feed_sequence`` / ``map``
+surface as ``OutputRouter`` so the engine streaming path
+(``BatchedEngine._stream_with_output_router``) and the non-stream
+sequence path (``_finalize_with_router_sequence``) can pick it up
+without changes. The underlying state, channel transitions, recipient
+parsing, and constraint-type detection all come from
+``StreamableParser`` — we do not maintain a parallel state machine.
+
+Token ID compatibility: ``mlx-community/gpt-oss-20b-MXFP4-Q8`` (and the
+upstream gpt-oss family) use exactly the harmony encoding's IDs for
+the structural markers and for body tokens — verified at PR-time by
+encoding ``<|channel|>``, ``<|message|>``, ``<|call|>``, ``<|end|>``,
+``<|return|>``, ``<|start|>``, ``<|constrain|>`` and a multi-token body
+string through both the model's HF tokenizer and the harmony encoding
+and asserting set equality. So we can feed model-emitted token IDs
+directly to ``StreamableParser`` without re-encoding.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .output_router import Channel, RouterEvent, TokenMap
+
+logger = logging.getLogger(__name__)
+
+# Channel name strings emitted by openai-harmony StreamableParser.
+_HARMONY_CHANNEL_ANALYSIS = "analysis"
+_HARMONY_CHANNEL_FINAL = "final"
+_HARMONY_CHANNEL_COMMENTARY = "commentary"
+
+
+class HarmonyStreamingRouter:
+    """Duck-typed replacement for ``OutputRouter`` on harmony-format
+    models. Delegates state tracking to ``openai-harmony.StreamableParser``.
+
+    The class deliberately mirrors ``OutputRouter``'s public API:
+    ``feed(tid) -> RouterEvent | None``,
+    ``finalize() -> RouterEvent | None``,
+    ``reset() -> None``,
+    ``feed_sequence(token_ids) -> dict``, and a ``.map`` attribute
+    containing a ``TokenMap`` so callers that read
+    ``router.map.format_tag`` (e.g. allowlist filtering in
+    ``BatchedEngine._create_output_router``) work unchanged.
+    """
+
+    def __init__(self, token_map: TokenMap, tokenizer: Any):
+        # Import inside __init__ so module import is cheap even when
+        # the optional dep is missing — discovery code can decide whether
+        # to construct this class or fall back to a different router.
+        from openai_harmony import (
+            HarmonyEncodingName,
+            Role,
+            StreamableParser,
+            load_harmony_encoding,
+        )
+
+        self.map = token_map
+        self.tokenizer = tokenizer
+        self._enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        self._role = Role.ASSISTANT
+        self._StreamableParser = StreamableParser
+        self._parser = StreamableParser(self._enc, role=self._role)
+        # Index of the last message we already surfaced as a TOOL_CALL
+        # event — used to detect freshly-closed commentary messages.
+        self._emitted_msg_count = 0
+
+    def reset(self) -> None:
+        """Reset state for a new request — re-create the parser."""
+        self._parser = self._StreamableParser(self._enc, role=self._role)
+        self._emitted_msg_count = 0
+
+    @staticmethod
+    def _reconstruct_tool_call_text(message: Any) -> str:
+        """Render a commentary ``Message`` back into the text form the
+        downstream ``HarmonyToolParser`` expects.
+
+        ``StreamableParser.messages[i]`` gives us a structured
+        ``Message`` with channel / recipient / content_type / content,
+        but the rest of the route pipeline (postprocessor + chat route
+        + ``HarmonyToolParser.extract_tool_calls``) is text-based. To
+        avoid changing that contract for one router, we reconstruct
+        the canonical wire format:
+        ``<|channel|>commentary to=functions.<name>
+        [<|constrain|>json]<|message|>{body}<|call|>``
+        and hand it through as a single TOOL_CALL channel event. The
+        text parser then extracts the structured call.
+        """
+        body = ""
+        for c in message.content:
+            t = getattr(c, "text", None)
+            if t:
+                body += t
+        parts: list[str] = ["<|channel|>commentary"]
+        recipient = getattr(message, "recipient", None)
+        if recipient:
+            parts.append(f" to={recipient}")
+        ctype = getattr(message, "content_type", None)
+        if ctype:
+            # ``content_type`` from StreamableParser is e.g.
+            # ``"<|constrain|>json"``; emit verbatim.
+            parts.append(f" {ctype}")
+        parts.append("<|message|>")
+        parts.append(body)
+        parts.append("<|call|>")
+        return "".join(parts)
+
+    def feed(self, token_id: int) -> RouterEvent | None:
+        """Feed one token and emit the routed event, if any.
+
+        Routing rules:
+          * Channel ``analysis`` → Channel.REASONING with the
+            parser's ``last_content_delta`` for this token.
+          * Channel ``final`` → Channel.CONTENT with the
+            ``last_content_delta``.
+          * Channel ``commentary`` (tool call): suppress per-token
+            deltas during the body. When the message closes (parser
+            transitions out of CONTENT to EXPECT_START and adds an
+            entry to ``messages``), emit a single Channel.TOOL_CALL
+            event carrying the reconstructed wire-format text so the
+            downstream HarmonyToolParser can extract the structured
+            call.
+          * Anything else (control tokens, headers, transitions) →
+            None.
+        """
+        try:
+            self._parser.process(token_id)
+        except Exception as e:
+            # The model emitted a token sequence the harmony parser
+            # can't follow (e.g. corrupted output, mid-stream
+            # truncation). Surface as a router failure so the engine
+            # falls back to the legacy text-based parsers — see
+            # ``BatchedEngine._stream_with_output_router``'s
+            # ``except Exception`` handler at the call site.
+            raise RuntimeError(
+                f"HarmonyStreamableParser rejected token_id={token_id}: {e}"
+            ) from e
+
+        # Did a message just close? StreamableParser appends to
+        # ``messages`` when it sees ``<|end|>`` / ``<|return|>`` /
+        # ``<|call|>``. A freshly-closed commentary message with a
+        # recipient is a tool call ready to surface.
+        new_msg_count = len(self._parser.messages)
+        if new_msg_count > self._emitted_msg_count:
+            closed = self._parser.messages[-1]
+            self._emitted_msg_count = new_msg_count
+            if getattr(
+                closed, "channel", None
+            ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
+                text = self._reconstruct_tool_call_text(closed)
+                return RouterEvent(Channel.TOOL_CALL, token_id, text)
+
+        # Per-token body delta routing for analysis / final.
+        ch = self._parser.current_channel
+        delta = self._parser.last_content_delta
+        if delta is None or delta == "":
+            return None
+        if ch == _HARMONY_CHANNEL_ANALYSIS:
+            return RouterEvent(Channel.REASONING, token_id, delta)
+        if ch == _HARMONY_CHANNEL_FINAL:
+            return RouterEvent(Channel.CONTENT, token_id, delta)
+        # commentary body deltas are buffered; emission happens on
+        # message close above. Any other channel ID (None during
+        # headers, unknown future channels) → no emission.
+        return None
+
+    def finalize(self) -> RouterEvent | None:
+        """End-of-stream drain.
+
+        ``StreamableParser`` may have an in-progress message that never
+        reached ``<|end|>`` / ``<|return|>`` / ``<|call|>`` (truncated
+        generation). Force-close via ``process_eos`` so any buffered
+        commentary message surfaces as a TOOL_CALL event.
+        """
+        try:
+            self._parser.process_eos()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("StreamableParser.process_eos failed: %s", e)
+            return None
+
+        new_msg_count = len(self._parser.messages)
+        if new_msg_count > self._emitted_msg_count:
+            closed = self._parser.messages[-1]
+            self._emitted_msg_count = new_msg_count
+            if getattr(
+                closed, "channel", None
+            ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
+                text = self._reconstruct_tool_call_text(closed)
+                # No "current" token id at finalize — pick the parser's
+                # last processed token if available, else 0.
+                token_id = self._parser.tokens[-1] if self._parser.tokens else 0
+                return RouterEvent(Channel.TOOL_CALL, token_id, text)
+        return None
+
+    def feed_sequence(self, token_ids: list[int]) -> dict[str, Any]:
+        """Batch path: route a complete token sequence and return
+        the same separated-channels dict as ``OutputRouter.feed_sequence``.
+
+        Returns:
+            ``{"content": str|None, "reasoning": str|None,
+               "tool_calls": list[str]|None}``
+        """
+        content = ""
+        reasoning = ""
+        tool_calls: list[str] = []
+
+        def _accumulate(event: RouterEvent | None) -> None:
+            nonlocal content, reasoning
+            if event is None:
+                return
+            if event.channel == Channel.CONTENT:
+                content += event.text
+            elif event.channel == Channel.REASONING:
+                reasoning += event.text
+            elif event.channel == Channel.TOOL_CALL:
+                tool_calls.append(event.text)
+
+        for tid in token_ids:
+            _accumulate(self.feed(tid))
+        # Drain end-of-stream (truncated messages, etc.).
+        _accumulate(self.finalize())
+
+        return {
+            "content": content.strip() or None,
+            "reasoning": reasoning.strip() or None,
+            "tool_calls": tool_calls or None,
+        }
+
+
+def is_openai_harmony_available() -> bool:
+    """Return True iff the optional ``openai-harmony`` dep can be
+    imported. The detection caller (``OutputRouter.from_tokenizer``)
+    uses this to decide whether to construct the new harmony router
+    or fall back to the legacy custom state machine.
+    """
+    try:
+        import openai_harmony  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def is_openai_harmony_compatible(token_map: TokenMap) -> bool:
+    """Return True iff the model's harmony special-token IDs match the
+    ``openai-harmony`` encoding's IDs AND the optional dep is present.
+
+    Why the gate exists: ``StreamableParser`` consumes integer token
+    IDs from its own encoding's vocabulary. Production upstream
+    ``mlx-community/gpt-oss-20b-MXFP4-Q8`` (and the gpt-oss family in
+    general) emit the SAME IDs the harmony encoding uses for
+    ``<|channel|>`` / ``<|message|>`` / ``<|call|>`` / ``<|end|>`` /
+    ``<|return|>`` / ``<|start|>`` / ``<|constrain|>``, so we can
+    forward model token IDs directly without re-encoding (verified
+    PR-time). Synthetic test vocabs that map ``<|channel|>`` to a
+    different ID would feed ``StreamableParser`` IDs it doesn't
+    recognize as control tokens, producing garbled output. This
+    gate short-circuits to the legacy state machine in that case.
+    """
+    if not is_openai_harmony_available():
+        return False
+    try:
+        from openai_harmony import HarmonyEncodingName, load_harmony_encoding
+
+        enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+    except Exception:  # noqa: BLE001
+        return False
+    # Verify each known harmony marker the TokenMap recorded matches
+    # what the harmony encoder produces. Any miss → not compatible.
+    pairs = (
+        (token_map.harmony_channel, "<|channel|>"),
+        (token_map.harmony_message, "<|message|>"),
+        (token_map.harmony_call, "<|call|>"),
+        (token_map.harmony_end, "<|end|>"),
+        (token_map.harmony_return, "<|return|>"),
+        (token_map.harmony_start, "<|start|>"),
+        (token_map.harmony_constrain, "<|constrain|>"),
+    )
+    for model_id, marker in pairs:
+        if model_id is None:
+            continue
+        try:
+            harmony_ids = enc.encode(marker, allowed_special="all")
+        except Exception:  # noqa: BLE001
+            return False
+        if harmony_ids != [model_id]:
+            return False
+    return True

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -99,22 +99,60 @@ _CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
 # require the tokenizer's reported identity to be a known gpt-oss
 # family member.
 #
-# Codex round-11 BLOCKING: ``known in name_lc`` substring matching let
-# an arbitrary ``not-gpt-oss`` identity pass. Codex round-12 BLOCKING:
-# even an anchored ``(?:^|/)gpt-oss(?:-|$)`` accepted arbitrary owners
-# (``some-user/gpt-oss-remapped``). Restrict to known-good owner
-# prefixes only — the upstream ``openai`` org, the canonical MLX
-# repackagers (``mlx-community``, ``unsloth``), and the bare basename
-# form. Anything else (`some-user/gpt-oss-…`) is rejected even though
-# its basename starts with ``gpt-oss-``; an artifact under a non-
-# allowlisted owner cannot prove the vocab is the harmony encoding's
-# vocab regardless of how its body-probe responses align.
-_KNOWN_HARMONY_TOKENIZER_PATTERNS = (
-    re.compile(r"^openai/gpt-oss(?:-|$)"),
-    re.compile(r"^mlx-community/gpt-oss(?:-|$)"),
-    re.compile(r"^unsloth/gpt-oss(?:-|$)"),
-    re.compile(r"^gpt-oss(?:-|$)"),
+# Codex round-11 BLOCKING / round-12 BLOCKING / round-13 BLOCKING —
+# the tokenizer-identity gate has had three rounds of tightening:
+#   * round-11: naive ``known in name_lc`` substring → anchored basename
+#     regex (rejected tail-substring fakes).
+#   * round-12: anchored basename still let arbitrary owners through
+#     (``some-user/gpt-oss-remapped``) → restrict to known owners.
+#   * round-13: pure remote-id-prefix matching rejected legitimate
+#     LOCAL paths (``/models/gpt-oss-20b``, ``~/.cache/.../gpt-oss-20b``)
+#     and made production fall back to the leaking legacy router.
+# Final shape (two-tier):
+#   * Local filesystem paths (``/``, ``~``, ``./``, ``../`` prefixes)
+#     trust the basename — the user explicitly loaded that artifact,
+#     and the body-probe set is the authoritative vocab check.
+#   * Remote HF IDs (``owner/name`` shape with no leading separator)
+#     require an allowlisted owner; this defense-in-depth catches the
+#     ``some-user/gpt-oss-remapped`` shape codex flagged.
+# The basename regex itself is the same anchored
+# ``^gpt-oss(?:-|$)`` shape from round-11.
+_BASENAME_GPT_OSS_RE = re.compile(r"^gpt-oss(?:-|$)")
+_KNOWN_HARMONY_REMOTE_OWNERS = frozenset(
+    {
+        "openai",
+        "mlx-community",
+        "unsloth",
+    }
 )
+
+
+def _is_known_harmony_identity(name_or_path: str) -> bool:
+    """Two-tier allowlist: local paths trust the basename, remote
+    HF IDs require an allowlisted owner. Returns True iff the
+    identity names a known gpt-oss family member.
+    """
+    name_lc = name_or_path.lower().rstrip("/")
+    if not name_lc:
+        return False
+    basename = name_lc.rsplit("/", 1)[-1]
+    if not _BASENAME_GPT_OSS_RE.match(basename):
+        return False
+    # Bare basename (no path separator at all) — accept.
+    if "/" not in name_lc:
+        return True
+    # Local filesystem path — accept (user-controlled artifact).
+    if (
+        name_lc.startswith("/")
+        or name_lc.startswith("~")
+        or name_lc.startswith("./")
+        or name_lc.startswith("../")
+    ):
+        return True
+    # Remote HF ID (``owner/name`` shape) — owner must be allowlisted.
+    owner = name_lc.split("/", 1)[0]
+    return owner in _KNOWN_HARMONY_REMOTE_OWNERS
+
 
 # Probe strings used by ``is_openai_harmony_compatible`` to verify
 # that the model's body-token vocabulary matches the openai-harmony
@@ -208,11 +246,16 @@ class HarmonyStreamingRouter:
             Malformed-recipient still ``raise``s; recipient corruption
             is structural, not body-content-dependent.
         """
-        body = ""
+        # Codex round-13 NIT: avoid O(n^2) ``+=`` string accumulation
+        # for large JSON tool arguments — collect text chunks in a
+        # list and ``"".join`` once. Same pattern as the round-2 NIT
+        # fix in ``feed_sequence``.
+        body_parts: list[str] = []
         for c in message.content:
             t = getattr(c, "text", None)
             if t:
-                body += t
+                body_parts.append(t)
+        body = "".join(body_parts)
         parts: list[str] = ["<|channel|>commentary"]
         recipient = getattr(message, "recipient", None)
         # Codex round-1 BLOCKING: validate recipient against the
@@ -584,16 +627,11 @@ def _compute_compat(
     out from ``is_openai_harmony_compatible`` so the cache-write logic
     lives in one place around a single return value (codex round-3 NIT).
     """
-    # (1) Tokenizer-identity allowlist. ``name_or_path`` is set by HF /
-    # mlx-lm tokenizers to the model id passed at load time. We do a
-    # case-insensitive ANCHORED match (codex round-11 BLOCKING — naive
-    # substring let ``not-gpt-oss`` pass) so quant-suffix renames
-    # (``-MXFP4-Q8``) and org prefixes (``mlx-community/`` vs
-    # ``openai/``) all resolve to the same family while tail-substring
-    # fakes (``my-not-gpt-oss``) are rejected. Missing or empty
-    # name_or_path → can't prove identity → reject.
-    name_lc = str(name_or_path).lower()
-    if not any(p.search(name_lc) for p in _KNOWN_HARMONY_TOKENIZER_PATTERNS):
+    # (1) Tokenizer-identity allowlist (codex round-11 / round-12 /
+    # round-13). Two-tier: local filesystem paths trust the basename
+    # gpt-oss match; remote HF IDs require an allowlisted owner. See
+    # ``_is_known_harmony_identity`` docstring for the full algorithm.
+    if not _is_known_harmony_identity(str(name_or_path)):
         return False
 
     # (2) Marker-ID parity. Codex round-4 BLOCKING: ALL seven harmony

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -80,6 +80,15 @@ _HARMONY_BODY_FORBIDDEN_SENTINELS = (
     "<|constrain|>",
 )
 
+# Allowed shape for the StreamableParser-surfaced ``content_type``
+# field on a commentary tool call. The only canonical form harmony
+# uses is ``<|constrain|><safe-type>``; codex round-11 NIT — a bare
+# enum value like ``"json"`` would otherwise reconstruct non-canonical
+# wire text (``to=functions.x json<|message|>...``) that downstream
+# HarmonyToolParser does not recognise. Anything outside this shape
+# triggers abstain (return None) from ``_reconstruct_tool_call_text``.
+_CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
+
 # Tokenizer-identity allowlist — known-compatible HF / mlx-community
 # names whose vocab is the harmony encoding. Codex round-2 BLOCKING:
 # matching a 3-string probe set against the harmony encoding is not
@@ -87,11 +96,15 @@ _HARMONY_BODY_FORBIDDEN_SENTINELS = (
 # markers and the right probes but a remapped uncommon token could
 # silently corrupt later content. The cleanest defense is to ALSO
 # require the tokenizer's reported identity to be a known gpt-oss
-# family member. ``in`` substring match keeps the gate robust to MLX
-# quant-suffix renames (``-MXFP4-Q8`` etc.).
-_KNOWN_HARMONY_TOKENIZERS = (
-    "gpt-oss",  # openai/gpt-oss-* and any mlx-community/gpt-oss-*-MXFP4-Q8 variant
-)
+# family member.
+#
+# Codex round-11 BLOCKING: ``known in name_lc`` substring matching let
+# an arbitrary ``not-gpt-oss`` identity pass. Switch to anchored
+# patterns that require either a path-segment boundary (``/gpt-oss-``,
+# ``/gpt-oss$``) or the bare basename at start (``gpt-oss-...``).
+# This still admits ``openai/gpt-oss-*`` and ``mlx-community/gpt-oss-*-MXFP4-Q8``
+# while rejecting ``not-gpt-oss`` and similar tail-substring fakes.
+_KNOWN_HARMONY_TOKENIZER_PATTERNS = (re.compile(r"(?:^|/)gpt-oss(?:-|$)"),)
 
 # Probe strings used by ``is_openai_harmony_compatible`` to verify
 # that the model's body-token vocabulary matches the openai-harmony
@@ -207,22 +220,24 @@ class HarmonyStreamingRouter:
             parts.append(f" to={recipient}")
         ctype = getattr(message, "content_type", None)
         if ctype:
-            # ``content_type`` from StreamableParser is e.g.
-            # ``"<|constrain|>json"``; emit verbatim. Strip the
-            # leading ``<|constrain|>`` sentinel literal before
-            # forbidden-substring scanning (it's the legitimate
-            # framing carrier, not body content).
-            ctype_body = (
-                ctype.removeprefix("<|constrain|>") if isinstance(ctype, str) else ""
-            )
-            for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
-                if bad in ctype_body:
-                    logger.debug(
-                        "HarmonyStreamingRouter: abstaining from tool-call "
-                        "reconstruction — content_type carries sentinel %r",
-                        bad,
-                    )
-                    return None
+            # Codex round-11 NIT: validate ``content_type`` against the
+            # canonical ``<|constrain|><safe-type>`` shape before
+            # interpolating. A bare enum value like ``"json"`` would
+            # reconstruct non-canonical wire text the downstream
+            # HarmonyToolParser does not recognise. The shape regex
+            # also implicitly rejects any embedded sentinel substring
+            # (matches only safe alphanumerics + underscore / dash
+            # after the legit ``<|constrain|>`` prefix), so the
+            # round-7-era smuggled-sentinel scan is subsumed — abstain
+            # on any mismatch.
+            if not isinstance(ctype, str) or not _CONTENT_TYPE_SHAPE.match(ctype):
+                logger.debug(
+                    "HarmonyStreamingRouter: abstaining from tool-call "
+                    "reconstruction — content_type %r does not match the "
+                    "canonical <|constrain|><safe-type> shape",
+                    ctype,
+                )
+                return None
             parts.append(f" {ctype}")
         # Codex round-7 BLOCKING / round-9 BLOCKING: a body containing
         # any harmony structural sentinel substring would corrupt the
@@ -486,10 +501,16 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     # path below collapses cleanly to ``False`` in that case.
 
     # Cache lookup (codex round-3 NIT). Codex round-4 NIT: include the
-    # marker-ID tuple in the key — two tokenizer instances with the
-    # same ``name_or_path`` but different marker IDs (e.g. test mocks,
-    # or a model loaded with a vocab override) must NOT share a
-    # cached compatibility decision.
+    # marker-ID tuple in the key. Codex round-11 BLOCKING: also include
+    # the tokenizer instance identity (``id(tokenizer)``) so two
+    # distinct tokenizer objects with the same ``name_or_path`` +
+    # marker IDs but a remapped body vocabulary cannot reuse a stale
+    # ``True`` decision and feed incompatible IDs to
+    # ``StreamableParser``. ``id()`` segregates by Python object
+    # identity — same instance reuses (the engine reuses one tokenizer
+    # per model across requests), distinct instances re-probe
+    # authoritatively. Zero per-lookup encode cost (vs a fingerprint
+    # probe), which keeps the cache hot path free.
     name_or_path = getattr(tokenizer, "name_or_path", "") or ""
     marker_ids = (
         token_map.harmony_channel,
@@ -500,7 +521,7 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
         token_map.harmony_start,
         token_map.harmony_constrain,
     )
-    cache_key = (str(name_or_path).lower(), marker_ids)
+    cache_key = (str(name_or_path).lower(), marker_ids, id(tokenizer))
     cached = _COMPAT_RESULT_CACHE.get(cache_key)
     if cached is not None:
         return cached
@@ -524,12 +545,14 @@ def _compute_compat(
     """
     # (1) Tokenizer-identity allowlist. ``name_or_path`` is set by HF /
     # mlx-lm tokenizers to the model id passed at load time. We do a
-    # case-insensitive substring match so quant-suffix renames
+    # case-insensitive ANCHORED match (codex round-11 BLOCKING — naive
+    # substring let ``not-gpt-oss`` pass) so quant-suffix renames
     # (``-MXFP4-Q8``) and org prefixes (``mlx-community/`` vs
-    # ``openai/``) all resolve to the same family. Missing or empty
+    # ``openai/``) all resolve to the same family while tail-substring
+    # fakes (``my-not-gpt-oss``) are rejected. Missing or empty
     # name_or_path → can't prove identity → reject.
     name_lc = str(name_or_path).lower()
-    if not any(known in name_lc for known in _KNOWN_HARMONY_TOKENIZERS):
+    if not any(p.search(name_lc) for p in _KNOWN_HARMONY_TOKENIZER_PATTERNS):
         return False
 
     # (2) Marker-ID parity. Codex round-4 BLOCKING: ALL seven harmony

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -256,6 +256,10 @@ class HarmonyStreamingRouter:
         before emitting; if validation fails, drop the synthesized
         call rather than passing garbage to the downstream parser.
         """
+        # Snapshot pre-EOS state so we can detect deltas process_eos
+        # surfaces but the per-token streaming path didn't already
+        # emit (codex round-4 BLOCKING).
+        pre_eos_channel = self._parser.current_channel
         try:
             self._parser.process_eos()
         except Exception as e:  # noqa: BLE001
@@ -266,9 +270,10 @@ class HarmonyStreamingRouter:
         if new_msg_count > self._emitted_msg_count:
             closed = self._parser.messages[-1]
             self._emitted_msg_count = new_msg_count
-            if getattr(
-                closed, "channel", None
-            ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
+            channel = getattr(closed, "channel", None)
+            if channel == _HARMONY_CHANNEL_COMMENTARY and getattr(
+                closed, "recipient", None
+            ):
                 if not self._tool_call_body_is_valid(closed):
                     logger.debug(
                         "HarmonyStreamingRouter.finalize: dropping truncated "
@@ -280,6 +285,30 @@ class HarmonyStreamingRouter:
                 # last processed token if available, else 0.
                 token_id = self._parser.tokens[-1] if self._parser.tokens else 0
                 return RouterEvent(Channel.TOOL_CALL, token_id, text)
+
+            # Codex round-4 BLOCKING: ``process_eos`` may surface a
+            # final / analysis delta that was buffered inside
+            # StreamableParser and not yet emitted via per-token
+            # ``last_content_delta``. Empirically the current
+            # openai-harmony build emits everything during ``feed()``
+            # and process_eos only appends the closed Message, but
+            # downstream library changes could change that — be
+            # defensive and drain any new delta as the appropriate
+            # channel event. Use ``pre_eos_channel`` rather than the
+            # post-EOS channel (which becomes ``None``) so we route
+            # based on the channel that was active at truncation.
+            delta = self._parser.last_content_delta
+            if delta:
+                target = (
+                    Channel.REASONING
+                    if pre_eos_channel == _HARMONY_CHANNEL_ANALYSIS
+                    else Channel.CONTENT
+                    if pre_eos_channel == _HARMONY_CHANNEL_FINAL
+                    else None
+                )
+                if target is not None:
+                    token_id = self._parser.tokens[-1] if self._parser.tokens else 0
+                    return RouterEvent(target, token_id, delta)
         return None
 
     @staticmethod
@@ -386,11 +415,12 @@ def is_openai_harmony_available() -> bool:
 # ``/v1/chat/completions`` and the marker / probe checks call into
 # ``enc.encode`` six times — measurable when serving high QPS.
 #
-# Keyed by the same case-insensitive ``name_or_path`` substring the
-# identity allowlist uses; entries whose identity doesn't match the
-# allowlist also get cached as False so subsequent rejected models
-# don't re-run the probe.
-_COMPAT_RESULT_CACHE: dict[str, bool] = {}
+# Codex round-4 NIT: the key must include the marker-ID tuple too —
+# two tokenizer instances with the same ``name_or_path`` but distinct
+# marker IDs (e.g. mock tokenizers in tests, or a model loaded with
+# a custom vocab override) would otherwise share a stale entry. The
+# marker IDs uniquely identify a (model, harmony-format) pair.
+_COMPAT_RESULT_CACHE: dict[tuple, bool] = {}
 _HARMONY_ENCODING_CACHE: dict[str, Any] = {}
 
 
@@ -452,12 +482,22 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     if not is_openai_harmony_available():
         return False
 
-    # Cache lookup (codex round-3 NIT). The cache key is the same
-    # identity string the allowlist matches against, so the cache
-    # also short-circuits the marker + probe checks for repeated
-    # rejected identities.
+    # Cache lookup (codex round-3 NIT). Codex round-4 NIT: include the
+    # marker-ID tuple in the key — two tokenizer instances with the
+    # same ``name_or_path`` but different marker IDs (e.g. test mocks,
+    # or a model loaded with a vocab override) must NOT share a
+    # cached compatibility decision.
     name_or_path = getattr(tokenizer, "name_or_path", "") or ""
-    cache_key = str(name_or_path).lower()
+    marker_ids = (
+        token_map.harmony_channel,
+        token_map.harmony_message,
+        token_map.harmony_call,
+        token_map.harmony_end,
+        token_map.harmony_return,
+        token_map.harmony_start,
+        token_map.harmony_constrain,
+    )
+    cache_key = (str(name_or_path).lower(), marker_ids)
     cached = _COMPAT_RESULT_CACHE.get(cache_key)
     if cached is not None:
         return cached
@@ -489,7 +529,15 @@ def _compute_compat(
     if not any(known in name_lc for known in _KNOWN_HARMONY_TOKENIZERS):
         return False
 
-    # (2) Marker-ID parity.
+    # (2) Marker-ID parity. Codex round-4 BLOCKING: ALL seven harmony
+    # markers must be present in the tokenizer's vocab AND match the
+    # harmony encoding's IDs — a tokenizer with only ``<|channel|>``
+    # and ``<|message|>`` (but missing ``<|call|>`` / ``<|end|>`` etc.)
+    # could otherwise be upgraded and then crash inside
+    # ``StreamableParser`` when the model emits a marker the parser
+    # expects but the gate didn't verify. Requiring all seven is the
+    # documented invariant of the harmony encoding; any production
+    # gpt-oss tokenizer has them all.
     pairs = (
         (token_map.harmony_channel, "<|channel|>"),
         (token_map.harmony_message, "<|message|>"),
@@ -501,7 +549,7 @@ def _compute_compat(
     )
     for model_id, marker in pairs:
         if model_id is None:
-            continue
+            return False
         try:
             harmony_ids = enc.encode(marker, allowed_special="all")
         except Exception:  # noqa: BLE001

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -295,13 +295,28 @@ class HarmonyStreamingRouter:
                 text = self._reconstruct_tool_call_text(closed)
                 if text is not None:
                     return RouterEvent(Channel.TOOL_CALL, token_id, text)
-                # Codex round-9 BLOCKING: ``_reconstruct_tool_call_text``
-                # abstains (returns None) when the body / content_type
-                # carries a sentinel substring that would corrupt the
-                # downstream regex parse. Fall through — no router
-                # event is emitted, the engine's outer plumbing keeps
-                # the model's raw fallback_text intact, and the legacy
-                # text-based HarmonyToolParser handles the call.
+                # Codex round-9 BLOCKING + round-10 BLOCKING:
+                # ``_reconstruct_tool_call_text`` abstains (returns
+                # None) when the body / content_type carries a sentinel
+                # substring that would corrupt downstream regex parse.
+                # Emitting no event at all (round-9 behavior) regressed
+                # streaming relative to baseline — the per-token loop
+                # had already suppressed commentary body deltas (we
+                # buffer until close), so the streaming user saw
+                # nothing. Surface the accumulated body bytes as a
+                # single CONTENT event so the user still sees the tool
+                # call's intent — this matches baseline behavior, in
+                # which the legacy router leaked commentary body into
+                # CONTENT verbatim. The engine non-stream path is
+                # unaffected: it relies on ``fallback_text``, which
+                # still carries the model's raw emit.
+                body = "".join(
+                    c.text
+                    for c in closed.content
+                    if getattr(c, "text", None) is not None
+                )
+                if body:
+                    return RouterEvent(Channel.CONTENT, token_id, body)
 
         # Per-token body delta routing for analysis / final.
         ch = self._parser.current_channel

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -34,7 +34,6 @@ directly to ``StreamableParser`` without re-encoding.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
@@ -240,113 +239,21 @@ class HarmonyStreamingRouter:
         return None
 
     def finalize(self) -> RouterEvent | None:
-        """End-of-stream drain.
+        """End-of-stream flush.
 
-        ``StreamableParser`` may have an in-progress message that never
-        reached ``<|end|>`` / ``<|return|>`` / ``<|call|>`` (truncated
-        generation). Force-close via ``process_eos`` so any buffered
-        commentary message surfaces as a TOOL_CALL event — BUT only
-        if the body validates as JSON when the content_type says so.
-
-        Codex round-3 BLOCKING: ``process_eos`` synthesizes a closed
-        Message for any partially-emitted commentary, so a
-        max_tokens/length truncation in the middle of the JSON body
-        (e.g. ``{"city":"NY``) would otherwise be surfaced as a
-        completed tool call with corrupt arguments. Validate the body
-        before emitting; if validation fails, drop the synthesized
-        call rather than passing garbage to the downstream parser.
+        Matches vLLM / SGLang safer-default: only flush the parser
+        state via ``process_eos`` so its internal buffers are released.
+        Do NOT synthesize a tool call from a truncated commentary
+        message — a ``max_tokens`` cutoff mid-body must not be executed
+        as if the model had emitted ``<|call|>`` — and do NOT re-emit
+        any post-EOS ``last_content_delta``; per-token ``feed()`` has
+        already streamed every body byte the model produced.
         """
-        # Snapshot pre-EOS state so we can detect deltas process_eos
-        # surfaces but the per-token streaming path didn't already
-        # emit (codex round-4 BLOCKING).
-        pre_eos_channel = self._parser.current_channel
         try:
             self._parser.process_eos()
         except Exception as e:  # noqa: BLE001
             logger.debug("StreamableParser.process_eos failed: %s", e)
-            return None
-
-        new_msg_count = len(self._parser.messages)
-        if new_msg_count > self._emitted_msg_count:
-            closed = self._parser.messages[-1]
-            self._emitted_msg_count = new_msg_count
-            channel = getattr(closed, "channel", None)
-            if channel == _HARMONY_CHANNEL_COMMENTARY and getattr(
-                closed, "recipient", None
-            ):
-                if not self._tool_call_body_is_valid(closed):
-                    logger.debug(
-                        "HarmonyStreamingRouter.finalize: dropping truncated "
-                        "commentary — body fails content_type validation"
-                    )
-                    return None
-                text = self._reconstruct_tool_call_text(closed)
-                # No "current" token id at finalize — pick the parser's
-                # last processed token if available, else 0.
-                token_id = self._parser.tokens[-1] if self._parser.tokens else 0
-                return RouterEvent(Channel.TOOL_CALL, token_id, text)
-
-            # Codex round-4 BLOCKING: ``process_eos`` may surface a
-            # final / analysis delta that was buffered inside
-            # StreamableParser and not yet emitted via per-token
-            # ``last_content_delta``. Empirically the current
-            # openai-harmony build emits everything during ``feed()``
-            # and process_eos only appends the closed Message, but
-            # downstream library changes could change that — be
-            # defensive and drain any new delta as the appropriate
-            # channel event. Use ``pre_eos_channel`` rather than the
-            # post-EOS channel (which becomes ``None``) so we route
-            # based on the channel that was active at truncation.
-            delta = self._parser.last_content_delta
-            if delta:
-                target = (
-                    Channel.REASONING
-                    if pre_eos_channel == _HARMONY_CHANNEL_ANALYSIS
-                    else Channel.CONTENT
-                    if pre_eos_channel == _HARMONY_CHANNEL_FINAL
-                    else None
-                )
-                if target is not None:
-                    token_id = self._parser.tokens[-1] if self._parser.tokens else 0
-                    return RouterEvent(target, token_id, delta)
         return None
-
-    @staticmethod
-    def _tool_call_body_is_valid(message: Any) -> bool:
-        """Validate the synthesized tool-call body before emitting.
-
-        Codex round-3 BLOCKING: ``process_eos`` appends the message to
-        ``self._parser.messages`` even when the body was cut off
-        mid-stream (max_tokens truncation in the middle of JSON). The
-        ``content_type`` field on the closed Message tells us what
-        shape the body should have:
-
-        * ``<|constrain|>json`` — body must round-trip through
-          ``json.loads``. Catches mid-JSON truncation
-          (``{"city":"NY``).
-        * any other / missing content_type — accept any non-empty
-          body (matches the pre-bypass behavior where the regex parser
-          extracted whatever was emitted).
-        """
-        body_parts: list[str] = []
-        for c in message.content:
-            t = getattr(c, "text", None)
-            if t:
-                body_parts.append(t)
-        body = "".join(body_parts).strip()
-        if not body:
-            # Empty body — nothing to surface, definitely truncated.
-            return False
-        ctype = getattr(message, "content_type", None) or ""
-        # ``content_type`` is e.g. ``"<|constrain|>json"`` from
-        # StreamableParser. JSON is the only constraint gpt-oss emits
-        # in practice for tool calls; check it explicitly.
-        if "json" in ctype.lower():
-            try:
-                json.loads(body)
-            except (json.JSONDecodeError, ValueError):
-                return False
-        return True
 
     def feed_sequence(self, token_ids: list[int]) -> dict[str, Any]:
         """Batch path: route a complete token sequence and return

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -60,6 +60,26 @@ _HARMONY_CHANNEL_COMMENTARY = "commentary"
 # upstream API accepts also round-trips through the router.
 _RECIPIENT_SHAPE = re.compile(r"^functions\.[A-Za-z0-9_\-]{1,64}$")
 
+# Harmony structural sentinels. The reconstructed tool-call wire text is
+# a delimited format that downstream ``HarmonyToolParser`` parses via
+# regex on the literal sentinel strings; a body containing any of these
+# substrings would corrupt that parse (e.g. ``body == '{"x":"<|call|>"}'``
+# would let the parser anchor on the embedded sentinel and truncate the
+# JSON). On gpt-oss these sentinels are single special tokens never
+# emitted as body text, but a defensive substring check is still
+# required because (a) future tokenizers may differ and (b) an
+# adversarial prompt could echo the literal characters through normal
+# body vocabulary. Codex round-7 BLOCKING (PR #515).
+_HARMONY_BODY_FORBIDDEN_SENTINELS = (
+    "<|channel|>",
+    "<|message|>",
+    "<|call|>",
+    "<|end|>",
+    "<|return|>",
+    "<|start|>",
+    "<|constrain|>",
+)
+
 # Tokenizer-identity allowlist — known-compatible HF / mlx-community
 # names whose vocab is the harmony encoding. Codex round-2 BLOCKING:
 # matching a 3-string probe set against the harmony encoding is not
@@ -172,8 +192,36 @@ class HarmonyStreamingRouter:
         ctype = getattr(message, "content_type", None)
         if ctype:
             # ``content_type`` from StreamableParser is e.g.
-            # ``"<|constrain|>json"``; emit verbatim.
+            # ``"<|constrain|>json"``; emit verbatim. Strip the
+            # leading ``<|constrain|>`` sentinel literal before
+            # forbidden-substring scanning (it's the legitimate
+            # framing carrier, not body content).
+            ctype_body = (
+                ctype.removeprefix("<|constrain|>") if isinstance(ctype, str) else ""
+            )
+            for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
+                if bad in ctype_body:
+                    raise ValueError(
+                        f"HarmonyStreamingRouter: refusing to reconstruct "
+                        f"tool-call wire text for content_type carrying "
+                        f"sentinel {bad!r}; got {ctype!r}"
+                    )
             parts.append(f" {ctype}")
+        # Codex round-7 BLOCKING: a body literal containing any harmony
+        # structural sentinel (``<|call|>``, ``<|message|>``, etc.)
+        # would corrupt the downstream HarmonyToolParser's regex parse
+        # of the reconstructed wire text — the parser would anchor on
+        # the embedded sentinel and truncate the JSON arguments. Reject
+        # rather than escape so the failure surfaces as a router error
+        # and the engine falls back to the legacy text-based parser
+        # (consistent with the recipient validation above).
+        for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
+            if bad in body:
+                raise ValueError(
+                    f"HarmonyStreamingRouter: refusing to reconstruct "
+                    f"tool-call wire text for body carrying harmony "
+                    f"sentinel {bad!r}; body length={len(body)}"
+                )
         parts.append("<|message|>")
         parts.append(body)
         parts.append("<|call|>")

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -34,6 +34,7 @@ directly to ``StreamableParser`` without re-encoding.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import Any
@@ -107,16 +108,20 @@ class HarmonyStreamingRouter:
         # Import inside __init__ so module import is cheap even when
         # the optional dep is missing — discovery code can decide whether
         # to construct this class or fall back to a different router.
-        from openai_harmony import (
-            HarmonyEncodingName,
-            Role,
-            StreamableParser,
-            load_harmony_encoding,
-        )
+        from openai_harmony import Role, StreamableParser
 
         self.map = token_map
         self.tokenizer = tokenizer
-        self._enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        # Codex round-3 NIT: reuse the module-level cached encoding so
+        # the relatively expensive ``load_harmony_encoding`` only runs
+        # once per process instead of once per request.
+        self._enc = _get_harmony_encoding()
+        if self._enc is None:
+            raise RuntimeError(
+                "HarmonyStreamingRouter: openai_harmony.load_harmony_encoding "
+                "is unavailable; the gate is_openai_harmony_compatible should "
+                "have rejected this tokenizer before construction."
+            )
         self._role = Role.ASSISTANT
         self._StreamableParser = StreamableParser
         self._parser = StreamableParser(self._enc, role=self._role)
@@ -240,7 +245,16 @@ class HarmonyStreamingRouter:
         ``StreamableParser`` may have an in-progress message that never
         reached ``<|end|>`` / ``<|return|>`` / ``<|call|>`` (truncated
         generation). Force-close via ``process_eos`` so any buffered
-        commentary message surfaces as a TOOL_CALL event.
+        commentary message surfaces as a TOOL_CALL event — BUT only
+        if the body validates as JSON when the content_type says so.
+
+        Codex round-3 BLOCKING: ``process_eos`` synthesizes a closed
+        Message for any partially-emitted commentary, so a
+        max_tokens/length truncation in the middle of the JSON body
+        (e.g. ``{"city":"NY``) would otherwise be surfaced as a
+        completed tool call with corrupt arguments. Validate the body
+        before emitting; if validation fails, drop the synthesized
+        call rather than passing garbage to the downstream parser.
         """
         try:
             self._parser.process_eos()
@@ -255,12 +269,55 @@ class HarmonyStreamingRouter:
             if getattr(
                 closed, "channel", None
             ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
+                if not self._tool_call_body_is_valid(closed):
+                    logger.debug(
+                        "HarmonyStreamingRouter.finalize: dropping truncated "
+                        "commentary — body fails content_type validation"
+                    )
+                    return None
                 text = self._reconstruct_tool_call_text(closed)
                 # No "current" token id at finalize — pick the parser's
                 # last processed token if available, else 0.
                 token_id = self._parser.tokens[-1] if self._parser.tokens else 0
                 return RouterEvent(Channel.TOOL_CALL, token_id, text)
         return None
+
+    @staticmethod
+    def _tool_call_body_is_valid(message: Any) -> bool:
+        """Validate the synthesized tool-call body before emitting.
+
+        Codex round-3 BLOCKING: ``process_eos`` appends the message to
+        ``self._parser.messages`` even when the body was cut off
+        mid-stream (max_tokens truncation in the middle of JSON). The
+        ``content_type`` field on the closed Message tells us what
+        shape the body should have:
+
+        * ``<|constrain|>json`` — body must round-trip through
+          ``json.loads``. Catches mid-JSON truncation
+          (``{"city":"NY``).
+        * any other / missing content_type — accept any non-empty
+          body (matches the pre-bypass behavior where the regex parser
+          extracted whatever was emitted).
+        """
+        body_parts: list[str] = []
+        for c in message.content:
+            t = getattr(c, "text", None)
+            if t:
+                body_parts.append(t)
+        body = "".join(body_parts).strip()
+        if not body:
+            # Empty body — nothing to surface, definitely truncated.
+            return False
+        ctype = getattr(message, "content_type", None) or ""
+        # ``content_type`` is e.g. ``"<|constrain|>json"`` from
+        # StreamableParser. JSON is the only constraint gpt-oss emits
+        # in practice for tool calls; check it explicitly.
+        if "json" in ctype.lower():
+            try:
+                json.loads(body)
+            except (json.JSONDecodeError, ValueError):
+                return False
+        return True
 
     def feed_sequence(self, token_ids: list[int]) -> dict[str, Any]:
         """Batch path: route a complete token sequence and return
@@ -323,6 +380,41 @@ def is_openai_harmony_available() -> bool:
         return False
 
 
+# Codex round-3 NIT: cache by tokenizer identity so the compatibility
+# probe + harmony encoding load only happen once per model identity,
+# not once per request. The streaming factory runs per
+# ``/v1/chat/completions`` and the marker / probe checks call into
+# ``enc.encode`` six times — measurable when serving high QPS.
+#
+# Keyed by the same case-insensitive ``name_or_path`` substring the
+# identity allowlist uses; entries whose identity doesn't match the
+# allowlist also get cached as False so subsequent rejected models
+# don't re-run the probe.
+_COMPAT_RESULT_CACHE: dict[str, bool] = {}
+_HARMONY_ENCODING_CACHE: dict[str, Any] = {}
+
+
+def _get_harmony_encoding() -> Any | None:
+    """Load (and cache) the ``HARMONY_GPT_OSS`` encoding.
+
+    The harmony encoding load is relatively expensive on first call
+    (loads tiktoken-style merges); cache the instance so every
+    compatibility probe and ``HarmonyStreamingRouter.__init__`` reuses
+    the same object instead of re-loading.
+    """
+    cached = _HARMONY_ENCODING_CACHE.get("gpt_oss")
+    if cached is not None:
+        return cached
+    try:
+        from openai_harmony import HarmonyEncodingName, load_harmony_encoding
+
+        enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+    except Exception:  # noqa: BLE001
+        return None
+    _HARMONY_ENCODING_CACHE["gpt_oss"] = enc
+    return enc
+
+
 def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     """Return True iff the model's vocabulary matches the
     ``openai-harmony`` encoding's vocabulary AND the optional dep is
@@ -354,24 +446,45 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
        set of plain / JSON / multi-token strings must round-trip
        through both encoders to identical IDs.
 
-    All three must pass.
+    All three must pass. Result is cached per tokenizer identity
+    (codex round-3 NIT) so the probe runs at most once per model.
     """
     if not is_openai_harmony_available():
         return False
-    try:
-        from openai_harmony import HarmonyEncodingName, load_harmony_encoding
 
-        enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
-    except Exception:  # noqa: BLE001
+    # Cache lookup (codex round-3 NIT). The cache key is the same
+    # identity string the allowlist matches against, so the cache
+    # also short-circuits the marker + probe checks for repeated
+    # rejected identities.
+    name_or_path = getattr(tokenizer, "name_or_path", "") or ""
+    cache_key = str(name_or_path).lower()
+    cached = _COMPAT_RESULT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    enc = _get_harmony_encoding()
+    if enc is None:
+        _COMPAT_RESULT_CACHE[cache_key] = False
         return False
 
+    result = _compute_compat(token_map, tokenizer, enc, name_or_path)
+    _COMPAT_RESULT_CACHE[cache_key] = result
+    return result
+
+
+def _compute_compat(
+    token_map: TokenMap, tokenizer: Any, enc: Any, name_or_path: str
+) -> bool:
+    """Helper that runs the three-layer compatibility check. Split
+    out from ``is_openai_harmony_compatible`` so the cache-write logic
+    lives in one place around a single return value (codex round-3 NIT).
+    """
     # (1) Tokenizer-identity allowlist. ``name_or_path`` is set by HF /
     # mlx-lm tokenizers to the model id passed at load time. We do a
     # case-insensitive substring match so quant-suffix renames
     # (``-MXFP4-Q8``) and org prefixes (``mlx-community/`` vs
     # ``openai/``) all resolve to the same family. Missing or empty
     # name_or_path → can't prove identity → reject.
-    name_or_path = getattr(tokenizer, "name_or_path", "") or ""
     name_lc = str(name_or_path).lower()
     if not any(known in name_lc for known in _KNOWN_HARMONY_TOKENIZERS):
         return False

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -35,6 +35,7 @@ directly to ``StreamableParser`` without re-encoding.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from .output_router import Channel, RouterEvent, TokenMap
@@ -45,6 +46,28 @@ logger = logging.getLogger(__name__)
 _HARMONY_CHANNEL_ANALYSIS = "analysis"
 _HARMONY_CHANNEL_FINAL = "final"
 _HARMONY_CHANNEL_COMMENTARY = "commentary"
+
+# Tool-call recipient shape: ``functions.<safe-name>``. The downstream
+# ``HarmonyToolParser`` does its own parsing of this field but reads
+# it verbatim from the reconstructed wire text — a recipient with
+# whitespace, marker-like characters, or newlines could break the
+# parser's regex or leak content. Codex round-1 BLOCKING (PR #515).
+_RECIPIENT_SHAPE = re.compile(r"^functions\.[A-Za-z_][A-Za-z0-9_\-.]*$")
+
+# Probe strings used by ``is_openai_harmony_compatible`` to verify
+# that the model's body-token vocabulary matches the openai-harmony
+# encoding's vocabulary. If any probe round-trips to a different ID
+# list, the gate falls back to the legacy router — feeding mismatched
+# IDs to ``StreamableParser`` decodes bodies through the wrong vocab
+# and corrupts content / tool-call arguments (codex round-1 BLOCKING).
+# Pick short strings that exercise common body-vocab regions: plain
+# English, JSON-shaped text, and the smoking-gun multi-token word
+# ``commentary`` from PR #514 (``comment``+``ary`` on gpt-oss-20b).
+_BODY_VOCAB_PROBES = (
+    "Hello world",
+    'functions.get_weather {"a":1}',
+    "commentary",
+)
 
 
 class HarmonyStreamingRouter:
@@ -110,7 +133,20 @@ class HarmonyStreamingRouter:
                 body += t
         parts: list[str] = ["<|channel|>commentary"]
         recipient = getattr(message, "recipient", None)
+        # Codex round-1 BLOCKING: validate recipient against the
+        # canonical ``functions.<name>`` shape before interpolating —
+        # whitespace, marker-like text, or a name containing
+        # ``<|...|>`` literals in the recipient would produce wire
+        # text the downstream HarmonyToolParser cannot parse.
         if recipient:
+            if not isinstance(recipient, str) or not _RECIPIENT_SHAPE.match(
+                recipient
+            ):
+                raise ValueError(
+                    f"HarmonyStreamingRouter: refusing to reconstruct "
+                    f"tool-call wire text for malformed recipient "
+                    f"{recipient!r}; expected 'functions.<name>'"
+                )
             parts.append(f" to={recipient}")
         ctype = getattr(message, "content_type", None)
         if ctype:
@@ -237,9 +273,15 @@ class HarmonyStreamingRouter:
         # Drain end-of-stream (truncated messages, etc.).
         _accumulate(self.finalize())
 
+        # Codex round-1 BLOCKING: do NOT ``.strip()`` accumulated
+        # content / reasoning — harmony bodies can legitimately begin
+        # or end with whitespace / newlines (e.g. markdown blocks,
+        # code fences) and stripping silently mutates them. Only
+        # convert the exact empty string to ``None`` so non-emitting
+        # channels still surface as missing.
         return {
-            "content": content.strip() or None,
-            "reasoning": reasoning.strip() or None,
+            "content": content if content != "" else None,
+            "reasoning": reasoning if reasoning != "" else None,
             "tool_calls": tool_calls or None,
         }
 
@@ -258,21 +300,27 @@ def is_openai_harmony_available() -> bool:
         return False
 
 
-def is_openai_harmony_compatible(token_map: TokenMap) -> bool:
-    """Return True iff the model's harmony special-token IDs match the
-    ``openai-harmony`` encoding's IDs AND the optional dep is present.
+def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
+    """Return True iff the model's vocabulary matches the
+    ``openai-harmony`` encoding's vocabulary AND the optional dep is
+    present.
 
     Why the gate exists: ``StreamableParser`` consumes integer token
     IDs from its own encoding's vocabulary. Production upstream
     ``mlx-community/gpt-oss-20b-MXFP4-Q8`` (and the gpt-oss family in
-    general) emit the SAME IDs the harmony encoding uses for
-    ``<|channel|>`` / ``<|message|>`` / ``<|call|>`` / ``<|end|>`` /
-    ``<|return|>`` / ``<|start|>`` / ``<|constrain|>``, so we can
-    forward model token IDs directly without re-encoding (verified
-    PR-time). Synthetic test vocabs that map ``<|channel|>`` to a
-    different ID would feed ``StreamableParser`` IDs it doesn't
-    recognize as control tokens, producing garbled output. This
-    gate short-circuits to the legacy state machine in that case.
+    general) share the harmony encoding's vocabulary for BOTH special
+    markers AND body tokens — so we can forward model token IDs
+    directly without re-encoding. A model whose markers happen to
+    match but whose body-token IDs differ would feed
+    ``StreamableParser`` IDs that decode through the wrong vocabulary,
+    corrupting streamed content and tool-call arguments (e.g.
+    synthetic test vocabs in ``tests/test_engine_router_non_stream.py``
+    where ``"Reason"=1`` and ``"ing"=2`` decode to garbage under
+    harmony's encoding).
+
+    Codex round-1 BLOCKING (PR #515): the original gate only verified
+    marker IDs. We now also probe representative body strings through
+    BOTH encoders and require ID equality on every probe.
     """
     if not is_openai_harmony_available():
         return False
@@ -301,5 +349,35 @@ def is_openai_harmony_compatible(token_map: TokenMap) -> bool:
         except Exception:  # noqa: BLE001
             return False
         if harmony_ids != [model_id]:
+            return False
+
+    # Codex round-1 BLOCKING: also verify body-token vocab parity. A
+    # tokenizer that lacks ``.encode`` (e.g. ``_FakeTokenizer`` used in
+    # the legacy harmony test suite — only exposes ``decode`` +
+    # ``get_vocab``) → not compatible; the legacy router runs instead.
+    encode = getattr(tokenizer, "encode", None)
+    if not callable(encode):
+        return False
+    for probe in _BODY_VOCAB_PROBES:
+        try:
+            harmony_ids = enc.encode(probe, allowed_special="none")
+        except Exception:  # noqa: BLE001
+            return False
+        try:
+            # ``add_special_tokens=False`` keeps the probe pure-body —
+            # HF tokenizers wrap with BOS/EOS otherwise. Pass it as a
+            # kwarg the tokenizer may or may not accept; some
+            # tokenizers raise TypeError on unknown kwargs, in which
+            # case we fall back to a positional call. Either way, a
+            # raise means we can't prove compatibility → return False.
+            try:
+                model_ids = encode(probe, add_special_tokens=False)
+            except TypeError:
+                model_ids = encode(probe)
+        except Exception:  # noqa: BLE001
+            return False
+        # ``encode`` returns ``list[int]`` for HF / mlx_lm tokenizers;
+        # convert to list for comparison robustness.
+        if list(model_ids) != list(harmony_ids):
             return False
     return True

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -154,7 +154,7 @@ class HarmonyStreamingRouter:
         self._emitted_msg_count = 0
 
     @staticmethod
-    def _reconstruct_tool_call_text(message: Any) -> str:
+    def _reconstruct_tool_call_text(message: Any) -> str | None:
         """Render a commentary ``Message`` back into the text form the
         downstream ``HarmonyToolParser`` expects.
 
@@ -166,8 +166,24 @@ class HarmonyStreamingRouter:
         the canonical wire format:
         ``<|channel|>commentary to=functions.<name>
         [<|constrain|>json]<|message|>{body}<|call|>``
-        and hand it through as a single TOOL_CALL channel event. The
-        text parser then extracts the structured call.
+        and hand it through as a single TOOL_CALL channel event.
+
+        Returns:
+            The reconstructed wire text on success, or ``None`` if the
+            body or content_type carries a harmony structural sentinel
+            substring (which would corrupt the downstream regex
+            extraction in HarmonyToolParser — codex round-7 BLOCKING).
+            Codex round-9 BLOCKING flipped the contract from ``raise``
+            to ``return None`` so the caller can ABSTAIN cleanly from
+            emitting a structured tool-call event: the engine's
+            ``_route_tokens_for_channels`` then leaves the model's raw
+            ``fallback_text`` untouched, and the legacy text-based
+            HarmonyToolParser path handles the same call (with the
+            same baseline limitation OpenAI tool-call JSON values
+            containing literal ``<|...|>`` substrings impose on every
+            text-based harmony consumer — not specific to this router).
+            Malformed-recipient still ``raise``s; recipient corruption
+            is structural, not body-content-dependent.
         """
         body = ""
         for c in message.content:
@@ -201,27 +217,34 @@ class HarmonyStreamingRouter:
             )
             for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
                 if bad in ctype_body:
-                    raise ValueError(
-                        f"HarmonyStreamingRouter: refusing to reconstruct "
-                        f"tool-call wire text for content_type carrying "
-                        f"sentinel {bad!r}; got {ctype!r}"
+                    logger.debug(
+                        "HarmonyStreamingRouter: abstaining from tool-call "
+                        "reconstruction — content_type carries sentinel %r",
+                        bad,
                     )
+                    return None
             parts.append(f" {ctype}")
-        # Codex round-7 BLOCKING: a body literal containing any harmony
-        # structural sentinel (``<|call|>``, ``<|message|>``, etc.)
-        # would corrupt the downstream HarmonyToolParser's regex parse
-        # of the reconstructed wire text — the parser would anchor on
-        # the embedded sentinel and truncate the JSON arguments. Reject
-        # rather than escape so the failure surfaces as a router error
-        # and the engine falls back to the legacy text-based parser
-        # (consistent with the recipient validation above).
+        # Codex round-7 BLOCKING / round-9 BLOCKING: a body containing
+        # any harmony structural sentinel substring would corrupt the
+        # downstream HarmonyToolParser's regex parse (the parser would
+        # anchor on the embedded sentinel and truncate the JSON
+        # arguments). Round-9 noted that legitimate OpenAI JSON CAN
+        # contain those characters, so a hard raise drops legitimate
+        # calls. Abstain (return None) instead — the engine's
+        # ``_route_tokens_for_channels`` then leaves the model's raw
+        # ``fallback_text`` untouched and the legacy text-based path
+        # handles the call (with the same parse limitation; no worse
+        # than baseline).
         for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
             if bad in body:
-                raise ValueError(
-                    f"HarmonyStreamingRouter: refusing to reconstruct "
-                    f"tool-call wire text for body carrying harmony "
-                    f"sentinel {bad!r}; body length={len(body)}"
+                logger.debug(
+                    "HarmonyStreamingRouter: abstaining from tool-call "
+                    "reconstruction — body carries sentinel %r "
+                    "(body length=%d)",
+                    bad,
+                    len(body),
                 )
+                return None
         parts.append("<|message|>")
         parts.append(body)
         parts.append("<|call|>")
@@ -270,7 +293,15 @@ class HarmonyStreamingRouter:
                 closed, "channel", None
             ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
                 text = self._reconstruct_tool_call_text(closed)
-                return RouterEvent(Channel.TOOL_CALL, token_id, text)
+                if text is not None:
+                    return RouterEvent(Channel.TOOL_CALL, token_id, text)
+                # Codex round-9 BLOCKING: ``_reconstruct_tool_call_text``
+                # abstains (returns None) when the body / content_type
+                # carries a sentinel substring that would corrupt the
+                # downstream regex parse. Fall through — no router
+                # event is emitted, the engine's outer plumbing keeps
+                # the model's raw fallback_text intact, and the legacy
+                # text-based HarmonyToolParser handles the call.
 
         # Per-token body delta routing for analysis / final.
         ch = self._parser.current_channel

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import re
+import weakref
 from typing import Any
 
 from .output_router import Channel, RouterEvent, TokenMap
@@ -99,12 +100,21 @@ _CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
 # family member.
 #
 # Codex round-11 BLOCKING: ``known in name_lc`` substring matching let
-# an arbitrary ``not-gpt-oss`` identity pass. Switch to anchored
-# patterns that require either a path-segment boundary (``/gpt-oss-``,
-# ``/gpt-oss$``) or the bare basename at start (``gpt-oss-...``).
-# This still admits ``openai/gpt-oss-*`` and ``mlx-community/gpt-oss-*-MXFP4-Q8``
-# while rejecting ``not-gpt-oss`` and similar tail-substring fakes.
-_KNOWN_HARMONY_TOKENIZER_PATTERNS = (re.compile(r"(?:^|/)gpt-oss(?:-|$)"),)
+# an arbitrary ``not-gpt-oss`` identity pass. Codex round-12 BLOCKING:
+# even an anchored ``(?:^|/)gpt-oss(?:-|$)`` accepted arbitrary owners
+# (``some-user/gpt-oss-remapped``). Restrict to known-good owner
+# prefixes only — the upstream ``openai`` org, the canonical MLX
+# repackagers (``mlx-community``, ``unsloth``), and the bare basename
+# form. Anything else (`some-user/gpt-oss-…`) is rejected even though
+# its basename starts with ``gpt-oss-``; an artifact under a non-
+# allowlisted owner cannot prove the vocab is the harmony encoding's
+# vocab regardless of how its body-probe responses align.
+_KNOWN_HARMONY_TOKENIZER_PATTERNS = (
+    re.compile(r"^openai/gpt-oss(?:-|$)"),
+    re.compile(r"^mlx-community/gpt-oss(?:-|$)"),
+    re.compile(r"^unsloth/gpt-oss(?:-|$)"),
+    re.compile(r"^gpt-oss(?:-|$)"),
+)
 
 # Probe strings used by ``is_openai_harmony_compatible`` to verify
 # that the model's body-token vocabulary matches the openai-harmony
@@ -436,7 +446,26 @@ def is_openai_harmony_available() -> bool:
 # marker IDs (e.g. mock tokenizers in tests, or a model loaded with
 # a custom vocab override) would otherwise share a stale entry. The
 # marker IDs uniquely identify a (model, harmony-format) pair.
-_COMPAT_RESULT_CACHE: dict[tuple, bool] = {}
+#
+# Codex round-12 BLOCKING / NIT: the previous key
+# ``(name_or_path_lc, marker_ids, id(tokenizer))`` was vulnerable to
+# Python's ``id()`` reuse after garbage collection — a tokenizer freed
+# between requests could have its memory address reused by a brand-new
+# (potentially incompatible) tokenizer, which then hit the stale True
+# entry and was upgraded incorrectly. Switch to a
+# ``WeakKeyDictionary`` keyed on the tokenizer object itself; when the
+# tokenizer is garbage-collected the entry is automatically reaped,
+# eliminating the id-reuse hazard and bounding cache growth across
+# model reloads. The inner per-tokenizer dict is keyed on
+# ``(name_or_path_lc, marker_ids)`` so distinct ``TokenMap`` overrides
+# on a single tokenizer still segregate.
+#
+# Fallback: a few tokenizer mocks (and any tokenizer whose class
+# disables ``__weakref__``) are not weak-referenceable. For those we
+# fall back to recomputing on every call — cheap, no correctness risk.
+_COMPAT_RESULT_CACHE: weakref.WeakKeyDictionary[Any, dict[tuple, bool]] = (
+    weakref.WeakKeyDictionary()
+)
 _HARMONY_ENCODING_CACHE: dict[str, Any] = {}
 
 
@@ -500,17 +529,12 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     # and returns ``None`` if the import fails. The pre-cache return
     # path below collapses cleanly to ``False`` in that case.
 
-    # Cache lookup (codex round-3 NIT). Codex round-4 NIT: include the
-    # marker-ID tuple in the key. Codex round-11 BLOCKING: also include
-    # the tokenizer instance identity (``id(tokenizer)``) so two
-    # distinct tokenizer objects with the same ``name_or_path`` +
-    # marker IDs but a remapped body vocabulary cannot reuse a stale
-    # ``True`` decision and feed incompatible IDs to
-    # ``StreamableParser``. ``id()`` segregates by Python object
-    # identity — same instance reuses (the engine reuses one tokenizer
-    # per model across requests), distinct instances re-probe
-    # authoritatively. Zero per-lookup encode cost (vs a fingerprint
-    # probe), which keeps the cache hot path free.
+    # Cache lookup (codex round-3 NIT / round-4 NIT / round-11 BLOCKING
+    # / round-12 BLOCKING+NIT). The cache is now a
+    # ``WeakKeyDictionary[tokenizer] -> dict[(name_lc, marker_ids), bool]``
+    # — distinct tokenizer instances naturally segregate, and entries
+    # auto-clear when the tokenizer is garbage-collected (no ``id()``
+    # reuse hazard, bounded growth across model reloads).
     name_or_path = getattr(tokenizer, "name_or_path", "") or ""
     marker_ids = (
         token_map.harmony_channel,
@@ -521,18 +545,35 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
         token_map.harmony_start,
         token_map.harmony_constrain,
     )
-    cache_key = (str(name_or_path).lower(), marker_ids, id(tokenizer))
-    cached = _COMPAT_RESULT_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
+    inner_key = (str(name_or_path).lower(), marker_ids)
+    try:
+        tk_cache = _COMPAT_RESULT_CACHE.get(tokenizer)
+    except TypeError:
+        # Tokenizer class is not weak-referenceable (e.g. some test
+        # mocks). Skip caching for this call; correctness is preserved
+        # at the cost of a recompute per request.
+        tk_cache = None
+        cacheable = False
+    else:
+        cacheable = True
+    if tk_cache is not None:
+        cached = tk_cache.get(inner_key)
+        if cached is not None:
+            return cached
 
     enc = _get_harmony_encoding()
     if enc is None:
-        _COMPAT_RESULT_CACHE[cache_key] = False
-        return False
+        result = False
+    else:
+        result = _compute_compat(token_map, tokenizer, enc, name_or_path)
 
-    result = _compute_compat(token_map, tokenizer, enc, name_or_path)
-    _COMPAT_RESULT_CACHE[cache_key] = result
+    if cacheable:
+        try:
+            slot = _COMPAT_RESULT_CACHE.setdefault(tokenizer, {})
+        except TypeError:
+            pass
+        else:
+            slot[inner_key] = result
     return result
 
 

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -22,6 +22,20 @@ without changes. The underlying state, channel transitions, recipient
 parsing, and constraint-type detection all come from
 ``StreamableParser`` — we do not maintain a parallel state machine.
 
+Codex round-12/14 BLOCKING (PR #515): earlier revisions reconstructed
+the parsed ``Message`` back into harmony wire text
+(``<|channel|>commentary to=functions.X<|message|>{body}<|call|>``)
+so the downstream text-based ``HarmonyToolParser`` could re-parse it.
+That round-trip was lossy — any tool-call body containing a literal
+harmony sentinel substring (e.g. ``{"text":"<|call|>"}``) corrupted
+the downstream regex parse and silently dropped the call. The current
+design eliminates the round-trip: TOOL_CALL events surface a
+structured ``{"name", "arguments"}`` payload on
+``RouterEvent.tool_call``, the engine plumbs it through
+``GenerationOutput.tool_calls``, and the route layer bypasses the
+text-based parser entirely when the structured field is populated.
+This matches vLLM and SGLang exactly.
+
 Token ID compatibility: ``mlx-community/gpt-oss-20b-MXFP4-Q8`` (and the
 upstream gpt-oss family) use exactly the harmony encoding's IDs for
 the structural markers and for body tokens — verified at PR-time by
@@ -48,47 +62,25 @@ _HARMONY_CHANNEL_ANALYSIS = "analysis"
 _HARMONY_CHANNEL_FINAL = "final"
 _HARMONY_CHANNEL_COMMENTARY = "commentary"
 
-# Tool-call recipient shape: ``functions.<safe-name>``. The downstream
-# ``HarmonyToolParser`` does its own parsing of this field but reads
-# it verbatim from the reconstructed wire text — a recipient with
-# whitespace, marker-like characters, or newlines could break the
-# parser's regex or leak content. Codex round-1 BLOCKING (PR #515).
-#
-# Codex round-2 BLOCKING: original ``^functions\.[A-Za-z_]...`` rejected
-# OpenAI-spec valid tool names that start with a digit
-# (e.g. ``functions.2fa_lookup``). OpenAI's documented function-name
-# regex is ``[a-zA-Z0-9_-]{1,64}`` — match that exactly so any tool the
-# upstream API accepts also round-trips through the router.
+# Tool-call recipient shape: ``functions.<safe-name>``. OpenAI's
+# documented function-name regex is ``[a-zA-Z0-9_-]{1,64}`` — match
+# that exactly so any tool the upstream API accepts also round-trips
+# through the router. A recipient that doesn't match (whitespace,
+# marker-like characters, newlines, leading digit beyond the allowed
+# set) is treated as structural corruption: the router abstains rather
+# than surfacing a half-parsed call.
 _RECIPIENT_SHAPE = re.compile(r"^functions\.[A-Za-z0-9_\-]{1,64}$")
 
-# Harmony structural sentinels. The reconstructed tool-call wire text is
-# a delimited format that downstream ``HarmonyToolParser`` parses via
-# regex on the literal sentinel strings; a body containing any of these
-# substrings would corrupt that parse (e.g. ``body == '{"x":"<|call|>"}'``
-# would let the parser anchor on the embedded sentinel and truncate the
-# JSON). On gpt-oss these sentinels are single special tokens never
-# emitted as body text, but a defensive substring check is still
-# required because (a) future tokenizers may differ and (b) an
-# adversarial prompt could echo the literal characters through normal
-# body vocabulary. Codex round-7 BLOCKING (PR #515).
-_HARMONY_BODY_FORBIDDEN_SENTINELS = (
-    "<|channel|>",
-    "<|message|>",
-    "<|call|>",
-    "<|end|>",
-    "<|return|>",
-    "<|start|>",
-    "<|constrain|>",
-)
-
-# Allowed shape for the StreamableParser-surfaced ``content_type``
-# field on a commentary tool call. The only canonical form harmony
-# uses is ``<|constrain|><safe-type>``; codex round-11 NIT — a bare
-# enum value like ``"json"`` would otherwise reconstruct non-canonical
-# wire text (``to=functions.x json<|message|>...``) that downstream
-# HarmonyToolParser does not recognise. Anything outside this shape
-# triggers abstain (return None) from ``_reconstruct_tool_call_text``.
-_CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
+# HuggingFace hub cache snapshot dir pattern. Path components have the
+# form ``models--<owner>--<name>`` so ``/.../models--openai--gpt-oss-20b
+# /snapshots/<sha>/`` resolves to the identity ``openai/gpt-oss-20b``
+# (the basename is the snapshot SHA, which on its own gives no hint
+# that this is a gpt-oss tokenizer). Codex round-14 BLOCKING — the
+# previous basename-only check rejected this path shape and the gate
+# fell back to the leaking legacy router for any model loaded straight
+# from the HF cache. Pattern is tolerant of either dir separator since
+# the path may be normalised before reaching us.
+_HF_CACHE_MODEL_DIR_RE = re.compile(r"models--([^-/\\]+(?:-[^-/\\]+)*)--([^/\\]+)")
 
 # Tokenizer-identity allowlist — known-compatible HF / mlx-community
 # names whose vocab is the harmony encoding. Codex round-2 BLOCKING:
@@ -99,8 +91,9 @@ _CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
 # require the tokenizer's reported identity to be a known gpt-oss
 # family member.
 #
-# Codex round-11 BLOCKING / round-12 BLOCKING / round-13 BLOCKING —
-# the tokenizer-identity gate has had three rounds of tightening:
+# Codex round-11 BLOCKING / round-12 BLOCKING / round-13 BLOCKING /
+# round-14 BLOCKING — the tokenizer-identity gate has had four rounds
+# of tightening:
 #   * round-11: naive ``known in name_lc`` substring → anchored basename
 #     regex (rejected tail-substring fakes).
 #   * round-12: anchored basename still let arbitrary owners through
@@ -108,10 +101,18 @@ _CONTENT_TYPE_SHAPE = re.compile(r"^<\|constrain\|>[A-Za-z0-9_\-]{1,32}$")
 #   * round-13: pure remote-id-prefix matching rejected legitimate
 #     LOCAL paths (``/models/gpt-oss-20b``, ``~/.cache/.../gpt-oss-20b``)
 #     and made production fall back to the leaking legacy router.
-# Final shape (two-tier):
+#   * round-14: HF cache snapshot dir ``models--openai--gpt-oss-20b
+#     /snapshots/<sha>`` has SHA basename → recognise the ``models--
+#     owner--name`` segment anywhere in the path and treat it as a
+#     remote id for the owner check.
+# Final shape (three-tier):
 #   * Local filesystem paths (``/``, ``~``, ``./``, ``../`` prefixes)
-#     trust the basename — the user explicitly loaded that artifact,
-#     and the body-probe set is the authoritative vocab check.
+#     that DO NOT carry an HF cache marker trust the basename — the
+#     user explicitly loaded that artifact, and the body-probe set is
+#     the authoritative vocab check.
+#   * Paths that contain ``models--<owner>--<name>`` (HF hub cache
+#     layout) are treated as the remote id ``<owner>/<name>`` and run
+#     through the remote-owner allowlist below.
 #   * Remote HF IDs (``owner/name`` shape with no leading separator)
 #     require an allowlisted owner; this defense-in-depth catches the
 #     ``some-user/gpt-oss-remapped`` shape codex flagged.
@@ -128,13 +129,27 @@ _KNOWN_HARMONY_REMOTE_OWNERS = frozenset(
 
 
 def _is_known_harmony_identity(name_or_path: str) -> bool:
-    """Two-tier allowlist: local paths trust the basename, remote
-    HF IDs require an allowlisted owner. Returns True iff the
+    """Three-tier allowlist: HF cache snapshot paths resolve to their
+    ``owner/name`` segment, plain local paths trust the basename, and
+    remote HF IDs require an allowlisted owner. Returns True iff the
     identity names a known gpt-oss family member.
     """
     name_lc = name_or_path.lower().rstrip("/")
     if not name_lc:
         return False
+
+    # HF cache snapshot layout. ``~/.cache/huggingface/hub/models--<owner>
+    # --<name>/snapshots/<sha>/`` — the basename is opaque, so search the
+    # full path for the canonical ``models--<owner>--<name>`` directory
+    # segment and use the embedded owner/name pair. Tolerant of either
+    # ``/`` or ``\`` separators so HF hub paths on either OS work.
+    cache_match = _HF_CACHE_MODEL_DIR_RE.search(name_lc)
+    if cache_match is not None:
+        owner, name = cache_match.group(1), cache_match.group(2)
+        if not _BASENAME_GPT_OSS_RE.match(name):
+            return False
+        return owner in _KNOWN_HARMONY_REMOTE_OWNERS
+
     basename = name_lc.rsplit("/", 1)[-1]
     if not _BASENAME_GPT_OSS_RE.match(basename):
         return False
@@ -182,6 +197,14 @@ class HarmonyStreamingRouter:
     containing a ``TokenMap`` so callers that read
     ``router.map.format_tag`` (e.g. allowlist filtering in
     ``BatchedEngine._create_output_router``) work unchanged.
+
+    TOOL_CALL events carry the parsed ``{"name", "arguments"}``
+    payload on ``RouterEvent.tool_call`` (set on closed commentary
+    messages with a valid ``functions.<name>`` recipient). The engine
+    plumbs this through ``GenerationOutput.tool_calls`` and routes
+    consume it directly — bypassing the legacy wire-text → regex
+    round-trip that lost calls whose JSON arguments contained literal
+    harmony sentinel substrings (PR #515 codex round-12/14 BLOCKING).
     """
 
     def __init__(self, token_map: TokenMap, tokenizer: Any):
@@ -215,108 +238,48 @@ class HarmonyStreamingRouter:
         self._emitted_msg_count = 0
 
     @staticmethod
-    def _reconstruct_tool_call_text(message: Any) -> str | None:
-        """Render a commentary ``Message`` back into the text form the
-        downstream ``HarmonyToolParser`` expects.
+    def _extract_structured_tool_call(message: Any) -> dict | None:
+        """Pull a structured ``{"name", "arguments"}`` payload out of a
+        closed harmony commentary ``Message``.
 
-        ``StreamableParser.messages[i]`` gives us a structured
-        ``Message`` with channel / recipient / content_type / content,
-        but the rest of the route pipeline (postprocessor + chat route
-        + ``HarmonyToolParser.extract_tool_calls``) is text-based. To
-        avoid changing that contract for one router, we reconstruct
-        the canonical wire format:
-        ``<|channel|>commentary to=functions.<name>
-        [<|constrain|>json]<|message|>{body}<|call|>``
-        and hand it through as a single TOOL_CALL channel event.
+        Returns ``None`` if the recipient shape is malformed — the
+        upstream pipeline treats that as "no tool call surfaced here"
+        and the corrupt frame is dropped. This is a strictly stronger
+        gate than the legacy wire-text path which would have produced
+        a garbled call.
 
-        Returns:
-            The reconstructed wire text on success, or ``None`` if the
-            body or content_type carries a harmony structural sentinel
-            substring (which would corrupt the downstream regex
-            extraction in HarmonyToolParser — codex round-7 BLOCKING).
-            Codex round-9 BLOCKING flipped the contract from ``raise``
-            to ``return None`` so the caller can ABSTAIN cleanly from
-            emitting a structured tool-call event: the engine's
-            ``_route_tokens_for_channels`` then leaves the model's raw
-            ``fallback_text`` untouched, and the legacy text-based
-            HarmonyToolParser path handles the same call (with the
-            same baseline limitation OpenAI tool-call JSON values
-            containing literal ``<|...|>`` substrings impose on every
-            text-based harmony consumer — not specific to this router).
-            Malformed-recipient still ``raise``s; recipient corruption
-            is structural, not body-content-dependent.
+        ``arguments`` is the verbatim concatenated body bytes — no
+        normalisation, no sentinel scrubbing, no JSON re-encoding.
+        That bytes-faithful surface is the entire point of the
+        round-trip elimination: a tool call whose JSON arguments
+        contain a literal ``<|call|>`` substring (the documented PR
+        #515 codex round-12/14 BLOCKING scenario) is now preserved
+        intact instead of being corrupted by sentinel-anchored regex
+        parsing.
         """
-        # Codex round-13 NIT: avoid O(n^2) ``+=`` string accumulation
-        # for large JSON tool arguments — collect text chunks in a
-        # list and ``"".join`` once. Same pattern as the round-2 NIT
-        # fix in ``feed_sequence``.
+        recipient = getattr(message, "recipient", None)
+        if not recipient:
+            return None
+        if not isinstance(recipient, str) or not _RECIPIENT_SHAPE.match(recipient):
+            logger.debug(
+                "HarmonyStreamingRouter: dropping tool call with "
+                "malformed recipient %r (expected functions.<name>)",
+                recipient,
+            )
+            return None
+        # ``functions.get_weather`` → ``get_weather``. The OpenAI
+        # tool-call schema's ``function.name`` field carries the bare
+        # name; the ``functions.`` namespace prefix is harmony-specific
+        # transport metadata.
+        name = recipient.split(".", 1)[1]
+        # Codex round-13 NIT: list-build + join (avoid quadratic ``+=``).
         body_parts: list[str] = []
         for c in message.content:
             t = getattr(c, "text", None)
             if t:
                 body_parts.append(t)
-        body = "".join(body_parts)
-        parts: list[str] = ["<|channel|>commentary"]
-        recipient = getattr(message, "recipient", None)
-        # Codex round-1 BLOCKING: validate recipient against the
-        # canonical ``functions.<name>`` shape before interpolating —
-        # whitespace, marker-like text, or a name containing
-        # ``<|...|>`` literals in the recipient would produce wire
-        # text the downstream HarmonyToolParser cannot parse.
-        if recipient:
-            if not isinstance(recipient, str) or not _RECIPIENT_SHAPE.match(recipient):
-                raise ValueError(
-                    f"HarmonyStreamingRouter: refusing to reconstruct "
-                    f"tool-call wire text for malformed recipient "
-                    f"{recipient!r}; expected 'functions.<name>'"
-                )
-            parts.append(f" to={recipient}")
-        ctype = getattr(message, "content_type", None)
-        if ctype:
-            # Codex round-11 NIT: validate ``content_type`` against the
-            # canonical ``<|constrain|><safe-type>`` shape before
-            # interpolating. A bare enum value like ``"json"`` would
-            # reconstruct non-canonical wire text the downstream
-            # HarmonyToolParser does not recognise. The shape regex
-            # also implicitly rejects any embedded sentinel substring
-            # (matches only safe alphanumerics + underscore / dash
-            # after the legit ``<|constrain|>`` prefix), so the
-            # round-7-era smuggled-sentinel scan is subsumed — abstain
-            # on any mismatch.
-            if not isinstance(ctype, str) or not _CONTENT_TYPE_SHAPE.match(ctype):
-                logger.debug(
-                    "HarmonyStreamingRouter: abstaining from tool-call "
-                    "reconstruction — content_type %r does not match the "
-                    "canonical <|constrain|><safe-type> shape",
-                    ctype,
-                )
-                return None
-            parts.append(f" {ctype}")
-        # Codex round-7 BLOCKING / round-9 BLOCKING: a body containing
-        # any harmony structural sentinel substring would corrupt the
-        # downstream HarmonyToolParser's regex parse (the parser would
-        # anchor on the embedded sentinel and truncate the JSON
-        # arguments). Round-9 noted that legitimate OpenAI JSON CAN
-        # contain those characters, so a hard raise drops legitimate
-        # calls. Abstain (return None) instead — the engine's
-        # ``_route_tokens_for_channels`` then leaves the model's raw
-        # ``fallback_text`` untouched and the legacy text-based path
-        # handles the call (with the same parse limitation; no worse
-        # than baseline).
-        for bad in _HARMONY_BODY_FORBIDDEN_SENTINELS:
-            if bad in body:
-                logger.debug(
-                    "HarmonyStreamingRouter: abstaining from tool-call "
-                    "reconstruction — body carries sentinel %r "
-                    "(body length=%d)",
-                    bad,
-                    len(body),
-                )
-                return None
-        parts.append("<|message|>")
-        parts.append(body)
-        parts.append("<|call|>")
-        return "".join(parts)
+        arguments = "".join(body_parts)
+        return {"name": name, "arguments": arguments}
 
     def feed(self, token_id: int) -> RouterEvent | None:
         """Feed one token and emit the routed event, if any.
@@ -330,9 +293,8 @@ class HarmonyStreamingRouter:
             deltas during the body. When the message closes (parser
             transitions out of CONTENT to EXPECT_START and adds an
             entry to ``messages``), emit a single Channel.TOOL_CALL
-            event carrying the reconstructed wire-format text so the
-            downstream HarmonyToolParser can extract the structured
-            call.
+            event with the structured ``{"name", "arguments"}``
+            payload on ``RouterEvent.tool_call``.
           * Anything else (control tokens, headers, transitions) →
             None.
         """
@@ -360,31 +322,19 @@ class HarmonyStreamingRouter:
             if getattr(
                 closed, "channel", None
             ) == _HARMONY_CHANNEL_COMMENTARY and getattr(closed, "recipient", None):
-                text = self._reconstruct_tool_call_text(closed)
-                if text is not None:
-                    return RouterEvent(Channel.TOOL_CALL, token_id, text)
-                # Codex round-9 BLOCKING + round-10 BLOCKING:
-                # ``_reconstruct_tool_call_text`` abstains (returns
-                # None) when the body / content_type carries a sentinel
-                # substring that would corrupt downstream regex parse.
-                # Emitting no event at all (round-9 behavior) regressed
-                # streaming relative to baseline — the per-token loop
-                # had already suppressed commentary body deltas (we
-                # buffer until close), so the streaming user saw
-                # nothing. Surface the accumulated body bytes as a
-                # single CONTENT event so the user still sees the tool
-                # call's intent — this matches baseline behavior, in
-                # which the legacy router leaked commentary body into
-                # CONTENT verbatim. The engine non-stream path is
-                # unaffected: it relies on ``fallback_text``, which
-                # still carries the model's raw emit.
-                body = "".join(
-                    c.text
-                    for c in closed.content
-                    if getattr(c, "text", None) is not None
-                )
-                if body:
-                    return RouterEvent(Channel.CONTENT, token_id, body)
+                structured = self._extract_structured_tool_call(closed)
+                if structured is not None:
+                    return RouterEvent(
+                        channel=Channel.TOOL_CALL,
+                        token_id=token_id,
+                        # ``text`` carries the JSON args as a human-
+                        # readable summary for legacy consumers that
+                        # may peek at the field. The structured payload
+                        # below is the authoritative source for
+                        # downstream processing.
+                        text=structured["arguments"],
+                        tool_call=structured,
+                    )
 
         # Per-token body delta routing for analysis / final.
         ch = self._parser.current_channel
@@ -419,11 +369,18 @@ class HarmonyStreamingRouter:
 
     def feed_sequence(self, token_ids: list[int]) -> dict[str, Any]:
         """Batch path: route a complete token sequence and return
-        the same separated-channels dict as ``OutputRouter.feed_sequence``.
+        the separated-channels dict.
 
         Returns:
             ``{"content": str|None, "reasoning": str|None,
-               "tool_calls": list[str]|None}``
+               "tool_calls": list[dict]|None}``
+
+        ``tool_calls`` entries are structured ``{"name", "arguments"}``
+        dicts — the engine plumbs them through
+        ``GenerationOutput.tool_calls`` and routes bypass text-based
+        extraction when this field is populated. The shape matches
+        ``HarmonyToolParser.extract_tool_calls`` so downstream
+        consumers can treat both sources uniformly.
 
         Codex round-2 NIT: accumulate per-token deltas in lists and
         ``"".join`` once at return — Python string ``+=`` is O(n²) for
@@ -432,7 +389,7 @@ class HarmonyStreamingRouter:
         """
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
-        tool_calls: list[str] = []
+        tool_calls: list[dict] = []
 
         def _accumulate(event: RouterEvent | None) -> None:
             if event is None:
@@ -441,8 +398,8 @@ class HarmonyStreamingRouter:
                 content_parts.append(event.text)
             elif event.channel == Channel.REASONING:
                 reasoning_parts.append(event.text)
-            elif event.channel == Channel.TOOL_CALL:
-                tool_calls.append(event.text)
+            elif event.channel == Channel.TOOL_CALL and event.tool_call is not None:
+                tool_calls.append(event.tool_call)
 
         for tid in token_ids:
             _accumulate(self.feed(tid))
@@ -628,8 +585,9 @@ def _compute_compat(
     lives in one place around a single return value (codex round-3 NIT).
     """
     # (1) Tokenizer-identity allowlist (codex round-11 / round-12 /
-    # round-13). Two-tier: local filesystem paths trust the basename
-    # gpt-oss match; remote HF IDs require an allowlisted owner. See
+    # round-13 / round-14). Three-tier: HF cache snapshot dirs resolve
+    # via ``models--<owner>--<name>`` segment, plain local paths trust
+    # the basename, remote HF IDs require an allowlisted owner. See
     # ``_is_known_harmony_identity`` docstring for the full algorithm.
     if not _is_known_harmony_identity(str(name_or_path)):
         return False

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -52,7 +52,26 @@ _HARMONY_CHANNEL_COMMENTARY = "commentary"
 # it verbatim from the reconstructed wire text — a recipient with
 # whitespace, marker-like characters, or newlines could break the
 # parser's regex or leak content. Codex round-1 BLOCKING (PR #515).
-_RECIPIENT_SHAPE = re.compile(r"^functions\.[A-Za-z_][A-Za-z0-9_\-.]*$")
+#
+# Codex round-2 BLOCKING: original ``^functions\.[A-Za-z_]...`` rejected
+# OpenAI-spec valid tool names that start with a digit
+# (e.g. ``functions.2fa_lookup``). OpenAI's documented function-name
+# regex is ``[a-zA-Z0-9_-]{1,64}`` — match that exactly so any tool the
+# upstream API accepts also round-trips through the router.
+_RECIPIENT_SHAPE = re.compile(r"^functions\.[A-Za-z0-9_\-]{1,64}$")
+
+# Tokenizer-identity allowlist — known-compatible HF / mlx-community
+# names whose vocab is the harmony encoding. Codex round-2 BLOCKING:
+# matching a 3-string probe set against the harmony encoding is not
+# enough to prove full-vocab parity — a tokenizer with the right
+# markers and the right probes but a remapped uncommon token could
+# silently corrupt later content. The cleanest defense is to ALSO
+# require the tokenizer's reported identity to be a known gpt-oss
+# family member. ``in`` substring match keeps the gate robust to MLX
+# quant-suffix renames (``-MXFP4-Q8`` etc.).
+_KNOWN_HARMONY_TOKENIZERS = (
+    "gpt-oss",  # openai/gpt-oss-* and any mlx-community/gpt-oss-*-MXFP4-Q8 variant
+)
 
 # Probe strings used by ``is_openai_harmony_compatible`` to verify
 # that the model's body-token vocabulary matches the openai-harmony
@@ -139,9 +158,7 @@ class HarmonyStreamingRouter:
         # ``<|...|>`` literals in the recipient would produce wire
         # text the downstream HarmonyToolParser cannot parse.
         if recipient:
-            if not isinstance(recipient, str) or not _RECIPIENT_SHAPE.match(
-                recipient
-            ):
+            if not isinstance(recipient, str) or not _RECIPIENT_SHAPE.match(recipient):
                 raise ValueError(
                     f"HarmonyStreamingRouter: refusing to reconstruct "
                     f"tool-call wire text for malformed recipient "
@@ -252,19 +269,23 @@ class HarmonyStreamingRouter:
         Returns:
             ``{"content": str|None, "reasoning": str|None,
                "tool_calls": list[str]|None}``
+
+        Codex round-2 NIT: accumulate per-token deltas in lists and
+        ``"".join`` once at return — Python string ``+=`` is O(n²) for
+        long non-stream generations and a 4k-token reply would spend
+        most of its time copying the accumulator.
         """
-        content = ""
-        reasoning = ""
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
         tool_calls: list[str] = []
 
         def _accumulate(event: RouterEvent | None) -> None:
-            nonlocal content, reasoning
             if event is None:
                 return
             if event.channel == Channel.CONTENT:
-                content += event.text
+                content_parts.append(event.text)
             elif event.channel == Channel.REASONING:
-                reasoning += event.text
+                reasoning_parts.append(event.text)
             elif event.channel == Channel.TOOL_CALL:
                 tool_calls.append(event.text)
 
@@ -273,6 +294,8 @@ class HarmonyStreamingRouter:
         # Drain end-of-stream (truncated messages, etc.).
         _accumulate(self.finalize())
 
+        content = "".join(content_parts)
+        reasoning = "".join(reasoning_parts)
         # Codex round-1 BLOCKING: do NOT ``.strip()`` accumulated
         # content / reasoning — harmony bodies can legitimately begin
         # or end with whitespace / newlines (e.g. markdown blocks,
@@ -318,9 +341,20 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     where ``"Reason"=1`` and ``"ing"=2`` decode to garbage under
     harmony's encoding).
 
-    Codex round-1 BLOCKING (PR #515): the original gate only verified
-    marker IDs. We now also probe representative body strings through
-    BOTH encoders and require ID equality on every probe.
+    Three layers of defense:
+
+    1. Tokenizer-identity allowlist (codex round-2 BLOCKING). A
+       tokenizer whose ``name_or_path`` does not name a known gpt-oss
+       family member is rejected even if markers and probes pass —
+       this guards against the case where matching markers and three
+       probe strings coincide but uncommon body tokens are remapped.
+    2. Marker-ID parity. Each known harmony marker the ``TokenMap``
+       recorded must encode to the same ID under the harmony encoding.
+    3. Body-vocab probe set (codex round-1 BLOCKING). A representative
+       set of plain / JSON / multi-token strings must round-trip
+       through both encoders to identical IDs.
+
+    All three must pass.
     """
     if not is_openai_harmony_available():
         return False
@@ -330,8 +364,19 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
         enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
     except Exception:  # noqa: BLE001
         return False
-    # Verify each known harmony marker the TokenMap recorded matches
-    # what the harmony encoder produces. Any miss → not compatible.
+
+    # (1) Tokenizer-identity allowlist. ``name_or_path`` is set by HF /
+    # mlx-lm tokenizers to the model id passed at load time. We do a
+    # case-insensitive substring match so quant-suffix renames
+    # (``-MXFP4-Q8``) and org prefixes (``mlx-community/`` vs
+    # ``openai/``) all resolve to the same family. Missing or empty
+    # name_or_path → can't prove identity → reject.
+    name_or_path = getattr(tokenizer, "name_or_path", "") or ""
+    name_lc = str(name_or_path).lower()
+    if not any(known in name_lc for known in _KNOWN_HARMONY_TOKENIZERS):
+        return False
+
+    # (2) Marker-ID parity.
     pairs = (
         (token_map.harmony_channel, "<|channel|>"),
         (token_map.harmony_message, "<|message|>"),
@@ -351,10 +396,9 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
         if harmony_ids != [model_id]:
             return False
 
-    # Codex round-1 BLOCKING: also verify body-token vocab parity. A
-    # tokenizer that lacks ``.encode`` (e.g. ``_FakeTokenizer`` used in
-    # the legacy harmony test suite — only exposes ``decode`` +
-    # ``get_vocab``) → not compatible; the legacy router runs instead.
+    # (3) Body-vocab probe set. A tokenizer that lacks ``.encode`` is
+    # likewise rejected (e.g. ``_FakeTokenizer`` in the legacy harmony
+    # test suite — only exposes ``decode`` + ``get_vocab``).
     encode = getattr(tokenizer, "encode", None)
     if not callable(encode):
         return False

--- a/vllm_mlx/output_router_harmony.py
+++ b/vllm_mlx/output_router_harmony.py
@@ -434,8 +434,10 @@ def is_openai_harmony_compatible(token_map: TokenMap, tokenizer: Any) -> bool:
     All three must pass. Result is cached per tokenizer identity
     (codex round-3 NIT) so the probe runs at most once per model.
     """
-    if not is_openai_harmony_available():
-        return False
+    # Codex round-8 NIT: skip the redundant ``is_openai_harmony_available``
+    # call — ``_get_harmony_encoding`` is the single dependency probe
+    # and returns ``None`` if the import fails. The pre-cache return
+    # path below collapses cleanly to ``False`` in that case.
 
     # Cache lookup (codex round-3 NIT). Codex round-4 NIT: include the
     # marker-ID tuple in the key — two tokenizer instances with the
@@ -536,8 +538,19 @@ def _compute_compat(
                 model_ids = encode(probe)
         except Exception:  # noqa: BLE001
             return False
-        # ``encode`` returns ``list[int]`` for HF / mlx_lm tokenizers;
-        # convert to list for comparison robustness.
-        if list(model_ids) != list(harmony_ids):
+        # Codex round-8 BLOCKING: ``encode`` is expected to return a
+        # flat list[int] for HF / mlx_lm tokenizers, but some HF
+        # tokenizer configurations (e.g. ``return_tensors`` defaults
+        # or wrapped Fast tokenizers) yield ``BatchEncoding`` /
+        # tensor-like objects whose ``list(...)`` is either a column
+        # vector or raises. Defensively coerce to a flat int sequence
+        # and fall back to False on anything we cannot interpret.
+        try:
+            model_ids_list = list(model_ids)
+        except TypeError:
+            return False
+        if not all(isinstance(x, int) for x in model_ids_list):
+            return False
+        if model_ids_list != list(harmony_ids):
             return False
     return True

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -227,9 +227,15 @@ async def create_anthropic_message(
             f"Anthropic messages: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
-        # Parse tool calls
+        # Parse tool calls — prefer the engine's structured payload
+        # (HarmonyStreamingRouter via openai-harmony's StreamableParser)
+        # over text-based extraction when present. See routes/chat.py
+        # for the rationale (PR #515 codex round-12 / round-14 BLOCKING
+        # — wire-text round-trip lost calls whose JSON args contained
+        # harmony sentinels).
+        engine_tool_calls = getattr(output, "tool_calls", None)
         cleaned_text, tool_calls = _parse_tool_calls_with_parser(
-            output.text, openai_request
+            output.text, openai_request, structured_tool_calls=engine_tool_calls
         )
 
         # Extract reasoning content via the same orchestration the OpenAI route
@@ -438,6 +444,14 @@ async def _stream_anthropic_messages(
 
     accumulated_text = ""
     accumulated_raw = ""
+    # Structured tool calls surfaced by the engine's OutputRouter
+    # (currently HarmonyStreamingRouter via openai-harmony's
+    # StreamableParser). When non-empty at end-of-stream the final
+    # ``_parse_tool_calls_with_parser`` call uses these directly,
+    # bypassing the regex round-trip — same bytes-faithful path the
+    # non-streaming branch uses (PR #515 codex round-12/14 BLOCKING
+    # closure).
+    accumulated_structured_tool_calls: list[dict] = []
     tool_filter = StreamingToolCallFilter()
     # ``tokenizer`` is on the BaseEngine contract; the old ``hasattr``
     # guard predated the abstract declaration and is the same silent-skip
@@ -488,6 +502,17 @@ async def _stream_anthropic_messages(
             prompt_tokens = output.prompt_tokens
         if hasattr(output, "completion_tokens") and output.completion_tokens:
             completion_tokens = output.completion_tokens
+
+        # Capture engine-surfaced structured tool calls (HarmonyStreamingRouter
+        # via openai-harmony's StreamableParser). The delta_text on these
+        # events is the JSON args summary; we DO NOT want to feed it into
+        # the text-based tool_filter / accumulator because that would re-
+        # introduce the round-trip lossy path the refactor exists to
+        # eliminate (PR #515 codex round-12/14 BLOCKING).
+        engine_tool_calls = getattr(output, "tool_calls", None) or []
+        if engine_tool_calls:
+            accumulated_structured_tool_calls.extend(engine_tool_calls)
+            continue
 
         if delta_text:
             accumulated_text += delta_text
@@ -665,8 +690,15 @@ async def _stream_anthropic_messages(
                 yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
                 block_index += 1
 
-    # Check for tool calls in accumulated text
-    _, tool_calls = _parse_tool_calls_with_parser(accumulated_text, openai_request)
+    # Check for tool calls — prefer engine-surfaced structured payload
+    # (HarmonyStreamingRouter via openai-harmony's StreamableParser)
+    # over text-based extraction. Same fall-through contract the
+    # non-streaming branch uses.
+    _, tool_calls = _parse_tool_calls_with_parser(
+        accumulated_text,
+        openai_request,
+        structured_tool_calls=accumulated_structured_tool_calls or None,
+    )
 
     if tool_calls:
         for i, tc in enumerate(tool_calls):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -913,8 +913,19 @@ async def _create_chat_completion_impl(
         f"Chat completion: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
-    # Parse tool calls from output using configured parser
-    cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
+    # Parse tool calls from output using configured parser.
+    # ``output.tool_calls`` is non-None when the engine's
+    # ``OutputRouter`` already produced structured ``[{"name",
+    # "arguments"}]`` entries (currently HarmonyStreamingRouter via
+    # openai-harmony's StreamableParser). In that case the text-based
+    # parser is bypassed — the structured pass is bytes-faithful
+    # whereas the regex round-trip lost calls whose JSON arguments
+    # contained literal harmony sentinel substrings (PR #515 codex
+    # round-12 / round-14 BLOCKING).
+    engine_tool_calls = getattr(output, "tool_calls", None)
+    cleaned_text, tool_calls = _parse_tool_calls_with_parser(
+        output.text, request, structured_tool_calls=engine_tool_calls
+    )
 
     # Honor ``parallel_tool_calls=false`` by capping the parsed list at one.
     # No decoder-level enforcement exists, so this is a post-parse trim — the

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -659,13 +659,40 @@ def _validate_model_name(request_model: str) -> None:
 
 
 def _parse_tool_calls_with_parser(
-    output_text: str, request=None
+    output_text: str,
+    request=None,
+    *,
+    structured_tool_calls: list[dict] | None = None,
 ) -> tuple[str, list | None]:
     """Parse tool calls from model output using the configured parser.
 
     Creates a per-call parser instance to avoid state corruption under
     concurrent BatchedEngine requests.
+
+    ``structured_tool_calls`` is the engine-surfaced ``[{"name",
+    "arguments"}]`` list (populated by ``HarmonyStreamingRouter`` via
+    openai-harmony's ``StreamableParser``). When present, the text-
+    based parser is bypassed entirely — the router has already done
+    the structural parse and returning to a regex pass would re-
+    introduce the wire-text round-trip that lost tool calls whose
+    JSON arguments contained literal harmony sentinel substrings (PR
+    #515 codex round-12 / round-14 BLOCKING). ``output_text`` becomes
+    the user-facing content directly in that case.
     """
+    if structured_tool_calls:
+        tool_calls = [
+            ToolCall(
+                id=tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                type="function",
+                function=FunctionCall(
+                    name=tc["name"],
+                    arguments=tc["arguments"],
+                ),
+            )
+            for tc in structured_tool_calls
+        ]
+        return output_text or "", tool_calls
+
     cfg = get_config()
     request_dict = request.model_dump() if request else None
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -127,6 +127,14 @@ class StreamingPostProcessor:
         self.accumulated_reasoning = ""
         self.tool_calls_detected = False
         self.tool_markup_possible = False
+        # Monotonic counter for structured tool-call indices across the
+        # whole response. Each TOOL_CALL channel ``GenerationOutput`` may
+        # carry a single structured call; if multiple chunks fire
+        # separately (router emits one per ``<|call|>``) the index field
+        # must keep counting up so clients can disambiguate them
+        # (OpenAI spec: tool_calls deltas merge on ``index``). Codex
+        # round-15 BLOCKING #1.
+        self._structured_tool_call_count = 0
 
         # Nemotron thinking prefix
         self._is_thinking_model = False
@@ -188,6 +196,25 @@ class StreamingPostProcessor:
             "nemotron" in model_name.lower() and not self.reasoning_parser
         )
 
+    def _parallel_tool_calls_allowed(self) -> bool:
+        """Return False iff the request explicitly opted out of
+        parallel tool calls via ``parallel_tool_calls=false``.
+
+        OpenAI spec: ``True`` and unset both mean "no cap". Only the
+        explicit ``false`` triggers single-call enforcement (matches
+        the non-streaming trim in ``routes/chat.py`` post-parse). The
+        request may arrive as a pydantic model (production) or a dict
+        (test fixtures, lifted bench scaffolds); accept both.
+        """
+        req = self.request
+        if req is None:
+            return True
+        if isinstance(req, dict):
+            val = req.get("parallel_tool_calls")
+        else:
+            val = getattr(req, "parallel_tool_calls", None)
+        return val is not False
+
     def reset(self):
         """Reset all parser states for a new stream.
 
@@ -202,6 +229,7 @@ class StreamingPostProcessor:
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
+        self._structured_tool_call_count = 0
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()
@@ -246,18 +274,53 @@ class StreamingPostProcessor:
         # anchored regex parsing).
         engine_tool_calls = getattr(output, "tool_calls", None) or []
         if output.channel == "tool_call" and engine_tool_calls:
-            structured = [
-                {
-                    "index": i,
-                    "id": tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
-                    "type": "function",
-                    "function": {
-                        "name": tc["name"],
-                        "arguments": tc["arguments"],
-                    },
-                }
-                for i, tc in enumerate(engine_tool_calls)
-            ]
+            # ``parallel_tool_calls=false`` is a hard external contract:
+            # the non-streaming path caps the parsed list at one
+            # (routes/chat.py); the streaming path must do the same or
+            # clients with the flag set get extra calls they explicitly
+            # opted out of. Drop everything past the cap on this chunk
+            # AND mark ``tool_calls_detected`` so subsequent chunks
+            # short-circuit before emission. Codex round-15 BLOCKING #2.
+            parallel_allowed = self._parallel_tool_calls_allowed()
+            allowed_calls: list[dict] = []
+            for tc in engine_tool_calls:
+                if not parallel_allowed and self._structured_tool_call_count >= 1:
+                    break
+                allowed_calls.append(tc)
+                self._structured_tool_call_count += 1
+            if not allowed_calls:
+                # Cap exhausted — preserve finish semantics but skip
+                # emission. The buffered_finish gate fires through the
+                # existing tool_calls_detected branch below.
+                self.tool_calls_detected = True
+                if output.finished:
+                    return [
+                        StreamEvent(
+                            type="finish",
+                            finish_reason="tool_calls",
+                            tool_calls_detected=True,
+                        )
+                    ]
+                return []
+            # Monotonic indices across the whole response so clients
+            # can disambiguate calls that arrive in separate router
+            # chunks. ``OpenAI`` clients merge ``tool_calls`` deltas
+            # on ``index`` — colliding indices cause one call to
+            # overwrite another. Codex round-15 BLOCKING #1.
+            structured = []
+            for offset, tc in enumerate(allowed_calls):
+                idx = self._structured_tool_call_count - len(allowed_calls) + offset
+                structured.append(
+                    {
+                        "index": idx,
+                        "id": tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                        "type": "function",
+                        "function": {
+                            "name": tc["name"],
+                            "arguments": tc["arguments"],
+                        },
+                    }
+                )
             self.tool_calls_detected = True
             return [
                 StreamEvent(

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -9,6 +9,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 from ..api.tool_calling import parse_tool_calls
@@ -234,6 +235,39 @@ class StreamingPostProcessor:
         self, delta_text: str, output: GenerationOutput
     ) -> list[StreamEvent]:
         """Handle OutputRouter models (Gemma 4 etc.) with token-level routing."""
+        # Engine-surfaced structured tool calls (HarmonyStreamingRouter
+        # via openai-harmony's StreamableParser). Emit a structured
+        # StreamEvent directly — the router has already done the
+        # parse and re-running text-based extraction over the wire
+        # representation would re-introduce the round-trip lossy path
+        # this refactor exists to eliminate (PR #515 codex round-12 /
+        # round-14 BLOCKING — tool calls whose JSON args contain
+        # literal harmony sentinels were corrupted by sentinel-
+        # anchored regex parsing).
+        engine_tool_calls = getattr(output, "tool_calls", None) or []
+        if output.channel == "tool_call" and engine_tool_calls:
+            structured = [
+                {
+                    "index": i,
+                    "id": tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["arguments"],
+                    },
+                }
+                for i, tc in enumerate(engine_tool_calls)
+            ]
+            self.tool_calls_detected = True
+            return [
+                StreamEvent(
+                    type="tool_call",
+                    tool_calls=structured,
+                    finish_reason="tool_calls" if output.finished else None,
+                    tool_calls_detected=True,
+                )
+            ]
+
         if output.channel == "reasoning":
             content, reasoning = None, delta_text
         elif output.channel == "tool_call":


### PR DESCRIPTION
## Summary

Replace the custom harmony state machine in OutputRouter with a thin shim over [openai-harmony](https://github.com/openai/harmony)'s ``StreamableParser`` — the same library vLLM and SGLang delegate to for gpt-oss tool calling — and surface structured tool-call data through the engine and routes (no more sentinel-delimited wire-text round-trip).

Closes #444 / #480 (harmony streaming tool call leak).
Closes #455 (commentary channel routing).
Closes #468 (tool_choice=required compound).
Lands #513.

## Why

PR #514 partially fixed #444/#480 at the parser layer (prefix-hold + count-based ``<|call|>`` detection) but explicitly deferred the END-TO-END production fix because the router can't model harmony's tool-call protocol with a single-token state machine.

Live verification on ``mlx-community/gpt-oss-20b-MXFP4-Q8`` confirmed that ``commentary`` tokenizes as ``comment``(12606) + ``ary``(815) — TWO tokens. The custom router's AWAITING_CHANNEL_TYPE branch only recognizes ``analysis`` and ``final`` as single-token channel words. ``commentary`` falls through to CONTENT and leaks the whole markered tool-call sequence into the content stream.

The proper fix is what vLLM and SGLang already do: delegate to the official harmony streaming parser. ``StreamableParser`` handles multi-token channel/recipient/constrain parsing, message boundaries, and state transitions natively.

## Architecture (round-15 — bytes-faithful structured passthrough)

Earlier revisions of this PR reconstructed parsed harmony messages back into sentinel-delimited wire text so the downstream text-based ``HarmonyToolParser`` could regex-parse them again. That round-trip lost tool calls whose JSON arguments contained literal harmony marker substrings (e.g. ``{"text":"<|call|>"}``) — the regex anchored on the embedded sentinel and silently truncated the call. Round-15 eliminates the round-trip; ``HarmonyStreamingRouter`` surfaces structured ``{"name", "arguments"}`` payloads that flow through the engine via a new ``GenerationOutput.tool_calls`` field. Routes consume the structured data directly, bypassing the regex pass for the router-fed path. This matches vLLM and SGLang exactly.

- **New ``HarmonyStreamingRouter``** (``vllm_mlx/output_router_harmony.py``) — duck-typed replacement for ``OutputRouter`` on harmony format. Internally wraps ``StreamableParser``. Same ``feed``/``finalize``/``reset``/``feed_sequence`` surface so engine streaming + non-stream sequence paths pick it up without changes.
- **Structured event payload** — TOOL_CALL ``RouterEvent`` instances carry the parsed ``{"name", "arguments"}`` dict on a new ``RouterEvent.tool_call`` field; ``feed_sequence`` returns the same shape via ``routed["tool_calls"]``.
- **Engine plumbing** — ``GenerationOutput.tool_calls: list[dict] | None`` carries the structured payload through both streaming and non-streaming paths. ``_route_tokens_for_channels`` returns a ``(reasoning, content, structured_tool_calls)`` triple; the wire-text dedup machinery is gone.
- **Route bypass** — ``_parse_tool_calls_with_parser(..., structured_tool_calls=...)`` short-circuits the regex extraction when the engine surfaced structured calls. The text-based parser stays for legacy paths (gemma4 + non-harmony) which still produce wire-text TOOL_CALL events.
- **Compatibility gate** — selected only when the model's harmony special-token IDs AND a representative set of body-vocab probe strings round-trip to the same IDs through both the model tokenizer and the harmony encoding. Tokenizer-identity allowlist accepts known-owner remote IDs, local filesystem paths, AND HuggingFace cache snapshot dirs (``models--<owner>--<name>/snapshots/<sha>``). Mismatched body vocabs / unknown owners fall back to the legacy router.
- **finalize() safer-default** — only flushes ``process_eos``; never synthesizes a tool call from truncated commentary (vLLM / SGLang behavior).
- **Whitespace preservation** — ``feed_sequence`` returns accumulated text verbatim; only the exact empty string maps to ``None``.

## Test coverage

- ``tests/parsers/regressions/test_issue_513_harmony_streamable_parser.py`` (27 tests):
  - Closes #444 / #455 / #468 / #480 by replaying production-shape token sequences through the real harmony encoding and asserting structured tool-call surfacing + zero marker leak.
  - ``test_structured_payload_preserves_body_with_harmony_sentinels`` — pins the round-15 architectural fix: 7 sentinel-bearing JSON bodies (``{"text":"<|call|>"}`` etc.) each surface intact via the structured payload.
  - ``test_compat_gate_accepts_hf_cache_snapshot_path`` — pins HF cache snapshot dir acceptance.
  - Identity-allowlist, marker-parity, body-vocab probe, weak-key cache, ``finalize`` safer-default, recipient-shape, per-token streaming contract all covered.
- ``tests/test_engine_router_non_stream.py`` (13 tests) — pins the new ``(reasoning, content, structured_tool_calls)`` triple. ``test_structured_tool_call_passthrough_preserves_sentinel_bearing_arguments`` mirrors the BLOCKING #2 scenario at the engine layer.
- ``tests/test_anthropic_*`` (122 tests) — anthropic streaming + non-streaming flows green.
- Full unit suite: 4475 passed, 19 skipped, 16 deselected, 7 xfailed.

Skips gracefully when ``openai-harmony`` is missing.

## What was verified live (gpt-oss-20b)

- ✅ Streaming tool call: ``finish_reason=tool_calls``, content empty, tool surfaced w/ correct args
- ✅ Non-stream tool call: same shape
- ✅ Analysis + final (no tools): reasoning and content split, zero marker leak
- ✅ pydantic_ai_full: 6/6 pass
- ✅ anthropic_sdk: 5/5 pass
- ✅ langchain: 6/6 pass

## Dependency

Adds ``openai-harmony>=0.0.6`` to project deps. Pure Python + small Rust extension, ~600 KB. Soft-imported at runtime — missing dep / mismatched vocab gracefully falls back to legacy state machine.

## Test plan
- [x] CI green
- [x] Live verify gpt-oss-20b commentary tool call surfaces with no content leak
- [x] Live verify gpt-oss-20b analysis + final still route correctly post-bypass
- [x] Regression: gpt-oss-20b agent tests pass (pydantic_ai / anthropic_sdk / langchain)
- [x] Round-15: sentinel-in-JSON-args bodies preserved bytes-faithfully (codex round-12 / round-14 BLOCKING closure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
