### PR TITLE
fix(streaming): tool_choice=required enforcement + parallel_tool_calls cap symmetry + harmony escape hatch (closes #468 #516 #517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,9 @@ Also: logprobs API, structured JSON output (`response_format`), continuous batch
 | `--api-key` | API key for authentication | *(no auth)* |
 | `--rate-limit` | Requests per minute per client | *(unlimited)* |
 | `--timeout` | Request timeout in seconds | `1800` |
-| `--mllm` | Force multimodal (vision) mode | auto-detect |
+| `--mllm` / `--no-mllm` | Force / disable multimodal (vision) mode | auto-detect |
+| `--force-openai-harmony-streaming` | Force the openai-harmony streaming router on (escape hatch — debug-only, raises on non-harmony tokenizers) | auto-detect |
+| `--no-openai-harmony-streaming` | Disable the openai-harmony streaming router; fall back to the legacy state machine | auto-detect |
 | `--mcp-config` | MCP configuration file for tool integration | *(none)* |
 | `--embedding-model` | Pre-load embedding model at startup | *(none)* |
 

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -472,6 +472,55 @@ def test_tool_choice_named_function_wrong_call_returns_422():
     assert "get_weather" in resp.text
 
 
+class _MultiCallEngine(_RecordingEngine):
+    """Mock engine that emits TWO tool_calls: the target plus an
+    extra. Used to verify the round-4 BLOCKING #2 ``all(...)`` gate.
+    """
+
+    def __init__(self, *, target_name: str, extra_name: str):
+        super().__init__()
+        self._target = target_name
+        self._extra = extra_name
+
+    async def chat(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_chat_kwargs = kwargs
+        return GenerationOutput(
+            text="",
+            raw_text="",
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="tool_calls",
+            tool_calls=[
+                {"name": self._target, "arguments": "{}"},
+                {"name": self._extra, "arguments": "{}"},
+            ],
+        )
+
+
+def test_tool_choice_named_function_extra_call_returns_422():
+    """PR #518 round-4 codex BLOCKING #2: ``tool_choice`` with
+    ``function.name = X`` allows ONLY X. A response carrying X PLUS
+    an extra call (e.g. ``[X, Y]``) is a contract violation — the
+    prior ``any(...)`` gate accepted it silently.
+    """
+    engine = _MultiCallEngine(target_name="get_weather", extra_name="get_time")
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "get_time" in resp.text
+
+
 def test_tool_choice_named_function_injects_named_suffix():
     """The named-function form must inject a suffix that names the
     target tool explicitly — without this, the model may still pick

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -75,12 +75,19 @@ class _RecordingEngine:
         )
 
 
-def _make_client(engine: _RecordingEngine) -> TestClient:
+def _make_client(
+    engine: _RecordingEngine, tool_call_parser: str | None = "hermes"
+) -> TestClient:
     cfg = reset_config()
     cfg.engine = engine
     cfg.model_name = "test-model"
     cfg.model_registry = None
     cfg.no_thinking = True
+    # Suffix injection at chat.py is gated on ``cfg.tool_call_parser`` being
+    # set; default to ``"hermes"`` so the ``tool_choice`` enforcement tests
+    # exercise the injection branch. Pass ``None`` explicitly to assert the
+    # alternate path.
+    cfg.tool_call_parser = tool_call_parser
     app = FastAPI()
     app.include_router(chat_router)
     return TestClient(app)
@@ -143,8 +150,14 @@ def test_tool_choice_specific_function_filters_to_named_only():
     filter ``tools`` to a single entry — the named function. Without
     this the model sees both candidates and picks the one it prefers,
     silently ignoring the user's force choice.
+
+    Uses ``_ToolCallingEngine`` (returns matching tool_call) so the
+    post-parse #468 enforcement gate (added in the same change) does
+    not fire — the engine HAS to return the right call for this test
+    to isolate the tools-filter behavior; a separate test covers the
+    enforcement gate failure mode.
     """
-    engine = _RecordingEngine()
+    engine = _ToolCallingEngine(fn_name="get_time")
     client = _make_client(engine)
     resp = client.post(
         "/v1/chat/completions",
@@ -217,15 +230,12 @@ def test_tool_choice_function_missing_name_returns_400():
     assert resp.status_code == 400
 
 
-@pytest.mark.parametrize("choice", ["auto", "required", None])
-def test_tool_choice_auto_required_none_field_leave_tools_untouched(choice):
-    """``"auto"``, ``"required"``, and unset ``tool_choice`` must NOT
-    mutate ``request.tools``. ``"required"`` enforcement is tracked
-    separately (#442 needs FSM constraints); for now it falls through
-    to model behavior — same as ``"auto"``. This test pins that the
-    normalization layer is precisely scoped to ``"none"`` and the
-    specific-function form and doesn't accidentally rewrite the other
-    paths.
+@pytest.mark.parametrize("choice", ["auto", None])
+def test_tool_choice_auto_and_unset_leave_tools_untouched(choice):
+    """``"auto"`` and unset ``tool_choice`` must NOT mutate
+    ``request.tools``. ``"required"`` has its own enforcement path
+    (post-parse 422 / suffix injection — see #468 tests below) and is
+    excluded from this parametrize.
     """
     engine = _RecordingEngine()
     client = _make_client(engine)
@@ -320,3 +330,207 @@ def test_tool_choice_function_missing_name_with_no_tools_returns_400():
         },
     )
     assert resp.status_code == 400
+
+
+# ──────────────────────────────────────────────────────────────────
+# ``tool_choice="required"`` enforcement (#468)
+# ──────────────────────────────────────────────────────────────────
+
+
+class _ToolCallingEngine(_RecordingEngine):
+    """Mock engine that injects an engine-surfaced structured tool_call
+    so the route's parse path emits a real ``tool_calls`` field.
+
+    The route consumes ``GenerationOutput.tool_calls`` via the PR #515
+    structured passthrough (``_parse_tool_calls_with_parser`` honors
+    ``structured_tool_calls=...``), so we can simulate a model that
+    actually called a tool without standing up a full parser fixture.
+    """
+
+    def __init__(
+        self, fn_name: str = "get_weather", arguments: str = '{"city":"Tokyo"}'
+    ):
+        super().__init__()
+        self._fn_name = fn_name
+        self._arguments = arguments
+
+    async def chat(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_chat_kwargs = kwargs
+        return GenerationOutput(
+            text="",
+            raw_text="",
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="tool_calls",
+            tool_calls=[{"name": self._fn_name, "arguments": self._arguments}],
+        )
+
+
+def test_tool_choice_required_empty_response_returns_422():
+    """``tool_choice="required"`` with a model that returned text-only
+    output (zero tool_calls) must surface as 422, not a silent
+    content-bearing 200 (#468). The OpenAI spec guarantees a tool_call
+    is present in the response when ``required`` is set.
+    """
+    engine = _RecordingEngine()  # default: text="ok", tool_calls=None
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "required" in resp.text.lower()
+
+
+def test_tool_choice_required_with_tool_call_returns_200():
+    """When the model DID emit a tool_call, ``tool_choice="required"``
+    must succeed cleanly and forward the call to the client. Pins the
+    happy path so the 422 gate doesn't accidentally fire on success.
+    """
+    engine = _ToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    tcs = body["choices"][0]["message"].get("tool_calls") or []
+    assert len(tcs) == 1
+    assert tcs[0]["function"]["name"] == "get_weather"
+
+
+def test_tool_choice_required_injects_strict_system_suffix():
+    """The ``required`` mode must inject the strict suffix
+    (``_TOOL_USE_REQUIRED_SUFFIX``) into the system prompt — this is
+    the strongest enforcement lever in the absence of FSM-constrained
+    decoding (#132). Verify the suffix lands by inspecting what the
+    engine receives in ``last_messages``.
+    """
+    engine = _ToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    sys_msgs = [
+        m
+        for m in engine.last_messages
+        if (m.get("role") if isinstance(m, dict) else m.role) == "system"
+    ]
+    assert sys_msgs, "expected an auto-injected system message"
+    content = (
+        sys_msgs[0]["content"] if isinstance(sys_msgs[0], dict) else sys_msgs[0].content
+    )
+    assert "MUST call one of the provided tools" in content
+
+
+def test_tool_choice_named_function_wrong_call_returns_422():
+    """``tool_choice={"type":"function","function":{"name":X}}`` with a
+    model that called a DIFFERENT tool must 422. The non-stream path
+    filters ``request.tools`` to the named function pre-flight (so the
+    model only sees that one), but a malicious / drifted parser could
+    still surface a different call from the engine — the route must
+    refuse to forward a contract-violating response.
+    """
+    # Engine returns get_time even though tool_choice pins get_weather.
+    engine = _ToolCallingEngine(fn_name="get_time", arguments='{"city":"Tokyo"}')
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Pick a function"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "get_weather" in resp.text
+
+
+def test_tool_choice_named_function_injects_named_suffix():
+    """The named-function form must inject a suffix that names the
+    target tool explicitly — without this, the model may still pick
+    a different tool from the (now-filtered) singleton list.
+    """
+    engine = _ToolCallingEngine()  # returns get_weather
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    sys_msgs = [
+        m
+        for m in engine.last_messages
+        if (m.get("role") if isinstance(m, dict) else m.role) == "system"
+    ]
+    assert sys_msgs
+    content = (
+        sys_msgs[0]["content"] if isinstance(sys_msgs[0], dict) else sys_msgs[0].content
+    )
+    assert "'get_weather'" in content
+    assert "MUST call the tool named" in content
+
+
+def test_tool_choice_auto_keeps_loose_suffix():
+    """``tool_choice="auto"`` (and unset) must keep the original
+    ``_TOOL_USE_SYSTEM_SUFFIX`` (loose) — NOT the strict required
+    variant. This pins the gate so the strict suffix doesn't bleed
+    into auto-mode requests where the model is allowed to opt out.
+    """
+    engine = _ToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "auto",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    sys_msgs = [
+        m
+        for m in engine.last_messages
+        if (m.get("role") if isinstance(m, dict) else m.role) == "system"
+    ]
+    assert sys_msgs
+    content = (
+        sys_msgs[0]["content"] if isinstance(sys_msgs[0], dict) else sys_msgs[0].content
+    )
+    # The loose suffix says "When the user's request can be answered ..."
+    assert "When the user's request can be answered" in content
+    # The strict suffix would say "MUST call one of the provided tools" — verify absent.
+    assert "MUST call one of the provided tools" not in content

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -472,6 +472,79 @@ def test_tool_choice_named_function_wrong_call_returns_422():
     assert "get_weather" in resp.text
 
 
+def test_tool_choice_required_with_stream_returns_422():
+    """PR #518 round-7 codex BLOCKING: ``tool_choice="required"`` with
+    ``stream=true`` cannot be enforced — non-stream 422s on text-only
+    output, but in streaming we'd commit to ``200 OK`` before knowing.
+    Reject upfront with a clear message pointing at the workarounds.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "stream": True,
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "stream=false" in resp.text
+    # Verify the engine was never invoked — we rejected before the
+    # streaming handler opened.
+    assert engine.last_chat_kwargs is None
+
+
+def test_tool_choice_required_without_stream_still_works():
+    """Symmetric pin: ``required`` + ``stream=false`` must still
+    succeed (covered by the existing happy-path test, restated here
+    so the 422 above doesn't accidentally regress the non-stream
+    path during future refactors).
+    """
+    engine = _ToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "stream": False,
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_tool_choice_named_with_stream_passes_through():
+    """The named-function form is still allowed under streaming —
+    the filtered tools list makes the wrong-tool case much rarer
+    (the model only sees one tool), even though we can't 422
+    mid-stream if it still produces text. Documented limitation
+    in the 422 message for ``required``.
+    """
+    engine = _ToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "stream": True,
+            "max_tokens": 32,
+        },
+    )
+    # Streaming response: 200 OK + SSE body. Test passes if we got
+    # past the upfront-reject gate.
+    assert resp.status_code == 200, resp.text
+
+
 class _MultiCallEngine(_RecordingEngine):
     """Mock engine that emits TWO tool_calls: the target plus an
     extra. Used to verify the round-4 BLOCKING #2 ``all(...)`` gate.

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -39,6 +39,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import _tool_call_name
 from vllm_mlx.routes.chat import router as chat_router
 
 
@@ -534,3 +535,60 @@ def test_tool_choice_auto_keeps_loose_suffix():
     assert "When the user's request can be answered" in content
     # The strict suffix would say "MUST call one of the provided tools" — verify absent.
     assert "MUST call one of the provided tools" not in content
+
+
+# ======================================================================
+# _tool_call_name shape-agnostic extraction (PR #518 round-2 BLOCKING)
+# ======================================================================
+
+
+class _AttrFunction:
+    def __init__(self, name):
+        self.name = name
+
+
+class _AttrToolCall:
+    def __init__(self, name):
+        self.function = _AttrFunction(name)
+
+
+def test_tool_call_name_handles_attr_shape():
+    """Pydantic ``ToolCall`` instances expose ``function.name`` as
+    attribute access — text-parser path output.
+    """
+    assert _tool_call_name(_AttrToolCall("get_weather")) == "get_weather"
+
+
+def test_tool_call_name_handles_dict_shape():
+    """Raw dict from engine structured passthrough — both outer and
+    inner are dicts. Pure-attr access used to return None here and
+    silently 422 matching named-function calls.
+    """
+    tc = {
+        "id": "call_a",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": "{}"},
+    }
+    assert _tool_call_name(tc) == "get_weather"
+
+
+def test_tool_call_name_handles_mixed_shape():
+    """Outer attr-object whose ``function`` is a dict (or vice versa)
+    — the helper must walk both layers independently.
+    """
+
+    class _OuterAttr:
+        function = {"name": "get_time"}
+
+    assert _tool_call_name(_OuterAttr()) == "get_time"
+
+    outer_dict = {"function": _AttrFunction("get_date")}
+    assert _tool_call_name(outer_dict) == "get_date"
+
+
+def test_tool_call_name_returns_none_when_function_missing():
+    """Defensive guard: a tool_call lacking ``function`` returns None
+    instead of raising AttributeError mid-422-check.
+    """
+    assert _tool_call_name({}) is None
+    assert _tool_call_name(_AttrFunction("ignored")) is None  # no .function

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -472,6 +472,63 @@ def test_tool_choice_named_function_wrong_call_returns_422():
     assert "get_weather" in resp.text
 
 
+def test_tool_choice_required_with_stream_passes_through_cloud_routing():
+    """PR #518 round-8 codex BLOCKING #1: the streaming-required 422
+    guard must NOT fire when the cloud router is configured to handle
+    the request — cloud backends (e.g. GPT-4o) DO support
+    ``required`` with streaming via decoder-side constraints. The
+    guard now lives below the cloud routing block.
+
+    Verifies the guard's PRE-cloud placement was wrong by simulating
+    a cloud-routed request and asserting we don't 422 before cloud
+    routing decides.
+    """
+
+    # Minimal cloud router stub that always claims it would route.
+    class _FakeCloudRouter:
+        threshold = 0
+        cloud_model = "gpt-4o"
+
+        def should_route_to_cloud(self, _new_tokens):
+            return True
+
+        async def stream_completion(self, *args, **kwargs):
+            # Emit one SSE chunk then close — proves we reached cloud,
+            # not the local-side 422.
+            yield b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'
+            yield b"data: [DONE]\n\n"
+
+        async def completion(self, *args, **kwargs):
+            return {"choices": [{"message": {"content": "x"}}]}
+
+    engine = _RecordingEngine()
+    engine.estimate_new_tokens = lambda prompt: (10, 5)  # noqa: E731
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.cloud_router = _FakeCloudRouter()
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "stream": True,
+            "max_tokens": 32,
+        },
+    )
+    # Must NOT 422 — cloud-routed requests are forwarded; cloud
+    # handles ``required`` correctly.
+    assert resp.status_code != 422, resp.text
+
+
 def test_tool_choice_required_with_stream_returns_422():
     """PR #518 round-7 codex BLOCKING: ``tool_choice="required"`` with
     ``stream=true`` cannot be enforced — non-stream 422s on text-only

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -485,6 +485,13 @@ def test_tool_choice_required_with_stream_passes_through_cloud_routing():
     """
 
     # Minimal cloud router stub that always claims it would route.
+    # Sets ``stream_completion_called`` on first invocation so the
+    # test can prove the cloud path actually executed (not just that
+    # the local 422 didn't fire — round-9 codex NIT).
+    cloud_called = {"stream": False}
+
+    _CLOUD_SENTINEL_CONTENT = "CLOUD_SENTINEL_X"
+
     class _FakeCloudRouter:
         threshold = 0
         cloud_model = "gpt-4o"
@@ -493,9 +500,12 @@ def test_tool_choice_required_with_stream_passes_through_cloud_routing():
             return True
 
         async def stream_completion(self, *args, **kwargs):
-            # Emit one SSE chunk then close — proves we reached cloud,
-            # not the local-side 422.
-            yield b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'
+            cloud_called["stream"] = True
+            yield (
+                'data: {"choices":[{"delta":{"content":"'
+                + _CLOUD_SENTINEL_CONTENT
+                + '"}}]}\n\n'
+            ).encode()
             yield b"data: [DONE]\n\n"
 
         async def completion(self, *args, **kwargs):
@@ -524,19 +534,27 @@ def test_tool_choice_required_with_stream_passes_through_cloud_routing():
             "max_tokens": 32,
         },
     )
-    # Must NOT 422 — cloud-routed requests are forwarded; cloud
-    # handles ``required`` correctly.
-    assert resp.status_code != 422, resp.text
+    # Must reach the cloud path: 200 OK + cloud's sentinel content in
+    # the body + the cloud router's stream_completion was invoked.
+    assert resp.status_code == 200, resp.text
+    assert _CLOUD_SENTINEL_CONTENT in resp.text, (
+        f"cloud sentinel missing — local path was hit instead: {resp.text[:300]}"
+    )
+    assert cloud_called["stream"], (
+        "cloud router's stream_completion was never called — local 422 fired "
+        "or the request silently fell back to local inference"
+    )
 
 
-def test_tool_choice_required_with_stream_returns_422():
-    """PR #518 round-7 codex BLOCKING: ``tool_choice="required"`` with
-    ``stream=true`` cannot be enforced — non-stream 422s on text-only
-    output, but in streaming we'd commit to ``200 OK`` before knowing.
-    Reject upfront with a clear message pointing at the workarounds.
+def test_tool_choice_required_with_stream_no_parser_returns_422():
+    """PR #518 round-9 codex BLOCKING: the streaming-required 422 now
+    fires ONLY when no streaming tool-call parser is configured.
+    Without a parser the server has no path to emit tool_calls in SSE,
+    so the OpenAI ``tool_call guaranteed`` contract can never be met.
     """
     engine = _RecordingEngine()
-    client = _make_client(engine)
+    # tool_call_parser=None explicitly — no streaming tool-call path.
+    client = _make_client(engine, tool_call_parser=None)
     resp = client.post(
         "/v1/chat/completions",
         json={
@@ -549,10 +567,37 @@ def test_tool_choice_required_with_stream_returns_422():
         },
     )
     assert resp.status_code == 422, resp.text
-    assert "stream=false" in resp.text
+    assert "tool-call parser" in resp.text
     # Verify the engine was never invoked — we rejected before the
     # streaming handler opened.
     assert engine.last_chat_kwargs is None
+
+
+def test_tool_choice_required_with_stream_and_parser_passes():
+    """PR #518 round-9 codex BLOCKING: when a streaming tool-call
+    parser IS configured (e.g. hermes), the streaming path CAN emit
+    tool_calls and the 422 must NOT fire. Local inference still
+    can't decoder-enforce, but prompt injection + parser is the
+    best lever we have and was the documented behavior pre-PR.
+    """
+    engine = _RecordingEngine()
+    # ``_make_client`` defaults tool_call_parser="hermes".
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "stream": True,
+            "max_tokens": 32,
+        },
+    )
+    # The stream may emit text-only output (model didn't comply with
+    # prompt injection) — but the server must NOT block the request
+    # upfront; the parser path is the agreed enforcement mechanism.
+    assert resp.status_code == 200, resp.text
 
 
 def test_tool_choice_required_without_stream_still_works():

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -586,9 +586,28 @@ def test_tool_call_name_handles_mixed_shape():
     assert _tool_call_name(outer_dict) == "get_date"
 
 
-def test_tool_call_name_returns_none_when_function_missing():
-    """Defensive guard: a tool_call lacking ``function`` returns None
-    instead of raising AttributeError mid-422-check.
+def test_tool_call_name_handles_flat_dict_shape():
+    """PR #518 round-3 codex BLOCKING: raw engine
+    ``GenerationOutput.tool_calls`` is ``[{"name": ..., "arguments":
+    ...}]`` — no ``function`` wrapper. ``_ToolCallingEngine`` in this
+    file emits exactly that shape, so the helper must extract the
+    name directly from the top-level dict.
+    """
+    tc = {"name": "get_weather", "arguments": '{"city":"Tokyo"}'}
+    assert _tool_call_name(tc) == "get_weather"
+
+
+def test_tool_call_name_handles_flat_attr_shape():
+    """Symmetric attr-shape: outer object exposes ``.name`` directly
+    (no ``.function``). Future passthrough surfaces may use this.
+    """
+    obj = _AttrFunction("get_weather")
+    assert _tool_call_name(obj) == "get_weather"
+
+
+def test_tool_call_name_returns_none_when_no_name_anywhere():
+    """Defensive guard: a tool_call lacking ``function`` AND
+    ``name`` returns None instead of raising mid-422-check.
     """
     assert _tool_call_name({}) is None
-    assert _tool_call_name(_AttrFunction("ignored")) is None  # no .function
+    assert _tool_call_name(object()) is None

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -573,6 +573,103 @@ def test_tool_choice_required_with_stream_no_parser_returns_422():
     assert engine.last_chat_kwargs is None
 
 
+def test_tool_choice_required_with_stream_channel_routed_bypasses_422(monkeypatch):
+    """PR #518 round-10 codex BLOCKING #1: when no text parser is set
+    but the engine has channel-routed tool-call capability (harmony /
+    Gemma 4), the streaming-required 422 must NOT fire — the
+    OutputRouter's tool channel is the production path that emits
+    structured tool_calls for those models. Monkeypatch the capability
+    probe to True so we exercise the bypass deterministically without
+    needing a real harmony tokenizer in the test fixture.
+    """
+    from vllm_mlx.routes import chat as chat_module
+
+    engine = _RecordingEngine()
+    monkeypatch.setattr(
+        chat_module,
+        "_engine_supports_channel_routed_tool_calls",
+        lambda _e: True,
+    )
+    # No text parser — pre-round-10 this combination always 422'd.
+    client = _make_client(engine, tool_call_parser=None)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "stream": True,
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_engine_supports_channel_routed_helper_returns_false_on_no_tokenizer():
+    """The capability probe must return ``False`` (not raise) when the
+    engine has no tokenizer attribute or it is ``None`` — the gate
+    must fall back to the parser-only path safely.
+    """
+    from vllm_mlx.routes.chat import _engine_supports_channel_routed_tool_calls
+
+    class _NoTokenizerEngine:
+        tokenizer = None
+
+    assert _engine_supports_channel_routed_tool_calls(_NoTokenizerEngine()) is False
+
+
+def test_engine_supports_channel_routed_helper_returns_true_for_harmony_router(
+    monkeypatch,
+):
+    """When ``OutputRouter.from_tokenizer_for_streaming`` returns a
+    router whose ``format_tag`` is in the engine allowlist (harmony /
+    gemma4), the helper returns True so the streaming-required gate
+    lets the request through.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.output_router import OutputRouter
+    from vllm_mlx.routes.chat import _engine_supports_channel_routed_tool_calls
+
+    fake_router = SimpleNamespace(map=SimpleNamespace(format_tag="harmony"))
+    monkeypatch.setattr(
+        OutputRouter,
+        "from_tokenizer_for_streaming",
+        classmethod(lambda cls, tokenizer, **kw: fake_router),
+    )
+
+    class _HarmonyEngine:
+        tokenizer = object()
+
+    assert _engine_supports_channel_routed_tool_calls(_HarmonyEngine()) is True
+
+
+def test_engine_supports_channel_routed_helper_returns_false_for_unsupported_format(
+    monkeypatch,
+):
+    """Format tags outside the engine allowlist (e.g. ``think_tag``)
+    must NOT trip the bypass — those routers don't emit structured
+    tool calls, so the streaming-required 422 still needs to fire.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.output_router import OutputRouter
+    from vllm_mlx.routes.chat import _engine_supports_channel_routed_tool_calls
+
+    fake_router = SimpleNamespace(map=SimpleNamespace(format_tag="think_tag"))
+    monkeypatch.setattr(
+        OutputRouter,
+        "from_tokenizer_for_streaming",
+        classmethod(lambda cls, tokenizer, **kw: fake_router),
+    )
+
+    class _ThinkTagEngine:
+        tokenizer = object()
+
+    assert _engine_supports_channel_routed_tool_calls(_ThinkTagEngine()) is False
+
+
 def test_tool_choice_required_with_stream_and_parser_passes():
     """PR #518 round-9 codex BLOCKING: when a streaming tool-call
     parser IS configured (e.g. hermes), the streaming path CAN emit

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -126,6 +126,25 @@ AUTO_ROUTING_FLAG_PAIRS: tuple[RoutingFlagPair, ...] = (
         forwarded_kwargs=("force_spec_decode", "no_spec_decode"),
         model_config_field="supports_spec_decode",
     ),
+    RoutingFlagPair(
+        force_on="--force-openai-harmony-streaming",
+        force_off="--no-openai-harmony-streaming",
+        desc=(
+            "HarmonyStreamingRouter auto-upgrade gate (#516, PR #515 "
+            "follow-up). Auto-detection upgrades the legacy custom "
+            "harmony state machine to openai-harmony's StreamableParser "
+            "for matched-vocab gpt-oss tokenizers; the pair lets users "
+            "override either way without code changes."
+        ),
+        required_files=("cli.py", "server.py"),
+        forwarded_kwargs=(
+            "force_openai_harmony_streaming",
+            "no_openai_harmony_streaming",
+        ),
+        # Override acts on the streaming OutputRouter factory, NOT on
+        # ModelConfig — same shape as --mllm / --no-mllm.
+        model_config_field=None,
+    ),
 )
 
 
@@ -1010,6 +1029,14 @@ def test_registry_invariants():
             # not ModelConfig. Verified by test_force_text_overrides_auto_detection.
             "force_mllm",
             "force_text",
+            # --force-openai-harmony-streaming / --no-openai-harmony-streaming
+            # act on the streaming OutputRouter factory at request time
+            # (BatchedEngine._create_output_router →
+            # OutputRouter.from_tokenizer_for_streaming), NOT on ModelConfig.
+            # The override has no static field to mutate; it gates a runtime
+            # constructor branch. #516 / PR #515 follow-up.
+            "force_openai_harmony_streaming",
+            "no_openai_harmony_streaming",
         }
     )
     for pair in AUTO_ROUTING_FLAG_PAIRS:

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -920,3 +920,20 @@ class TestStreamingFactoryEscapeHatches:
             )
             is None
         )
+
+    def test_both_flags_true_raises(self, monkeypatch):
+        """PR #518 round-2 codex NIT: setting BOTH force-on and force-off
+        is incoherent — the CLI layer enforces mutual exclusion, but
+        direct API callers (third-party engines, tests) deserve the
+        same guardrail. Factory must raise instead of silently honoring
+        one over the other.
+        """
+        self._patch_factory(monkeypatch, gate_returns=True)
+        self._harmony_legacy(monkeypatch)
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            OutputRouter.from_tokenizer_for_streaming(
+                object(),
+                force_harmony_streaming=True,
+                no_harmony_streaming=True,
+            )

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -776,3 +776,147 @@ class TestStateReset:
         router.reset()
         e2 = router.feed(9259)  # "Hello"
         assert e2.channel == Channel.CONTENT
+
+
+# ============================================================================
+# #516 — HarmonyStreamingRouter auto-upgrade escape hatches (release-SOP G11)
+# ============================================================================
+
+
+class TestStreamingFactoryEscapeHatches:
+    """The streaming-factory auto-upgrade from the legacy custom harmony
+    state machine to ``HarmonyStreamingRouter`` (PR #515) is a binary
+    auto-routing decision. The SOP requires both a force-on and a
+    force-off CLI flag plumbed to the factory; these tests pin the
+    branches at the factory level.
+
+    We monkey-patch the two dependencies (``is_openai_harmony_compatible``
+    and ``HarmonyStreamingRouter``) so we don't need a real harmony
+    tokenizer — only the dispatch tree is under test here.
+    """
+
+    def _patch_factory(self, monkeypatch, *, gate_returns: bool):
+        """Substitute the harmony compat probe + constructor with stubs
+        so the test exercises the factory branches without needing a
+        real tokenizer.
+        """
+        import vllm_mlx.output_router_harmony as orh
+
+        def fake_is_compat(_token_map, _tokenizer):
+            return gate_returns
+
+        class FakeHarmonyRouter:
+            map = None  # populated in __init__
+
+            def __init__(self, token_map, _tokenizer):
+                self.map = token_map
+                self.format_tag = "harmony"
+
+        monkeypatch.setattr(orh, "is_openai_harmony_compatible", fake_is_compat)
+        monkeypatch.setattr(orh, "HarmonyStreamingRouter", FakeHarmonyRouter)
+        return FakeHarmonyRouter
+
+    def _harmony_legacy(self, monkeypatch):
+        """Stub ``from_tokenizer`` to return a legacy router whose
+        ``format_tag`` is 'harmony'. Returns the stub instance.
+        """
+
+        class _LegacyStub:
+            class _Map:
+                format_tag = "harmony"
+
+            map = _Map()
+
+        monkeypatch.setattr(
+            OutputRouter, "from_tokenizer", classmethod(lambda cls, tok: _LegacyStub())
+        )
+        return _LegacyStub
+
+    def _non_harmony_legacy(self, monkeypatch):
+        class _LegacyStub:
+            class _Map:
+                format_tag = "gemma4"
+
+            map = _Map()
+
+        monkeypatch.setattr(
+            OutputRouter, "from_tokenizer", classmethod(lambda cls, tok: _LegacyStub())
+        )
+        return _LegacyStub
+
+    def test_default_returns_harmony_when_gate_accepts(self, monkeypatch):
+        FakeHarmony = self._patch_factory(monkeypatch, gate_returns=True)
+        self._harmony_legacy(monkeypatch)
+
+        router = OutputRouter.from_tokenizer_for_streaming(object())
+        assert isinstance(router, FakeHarmony)
+
+    def test_default_returns_legacy_when_gate_rejects(self, monkeypatch):
+        FakeHarmony = self._patch_factory(monkeypatch, gate_returns=False)
+        legacy_cls = self._harmony_legacy(monkeypatch)
+
+        router = OutputRouter.from_tokenizer_for_streaming(object())
+        assert not isinstance(router, FakeHarmony)
+        assert isinstance(router, legacy_cls)
+
+    def test_no_harmony_streaming_forces_legacy_even_when_gate_accepts(
+        self, monkeypatch
+    ):
+        FakeHarmony = self._patch_factory(monkeypatch, gate_returns=True)
+        legacy_cls = self._harmony_legacy(monkeypatch)
+
+        router = OutputRouter.from_tokenizer_for_streaming(
+            object(), no_harmony_streaming=True
+        )
+        assert not isinstance(router, FakeHarmony)
+        assert isinstance(router, legacy_cls)
+
+    def test_force_harmony_streaming_bypasses_gate(self, monkeypatch):
+        """Force-on must construct HarmonyStreamingRouter even when the
+        compat probe returns False — debug-only path. The constructor
+        will surface real failures on its own.
+        """
+        FakeHarmony = self._patch_factory(monkeypatch, gate_returns=False)
+        self._harmony_legacy(monkeypatch)
+
+        router = OutputRouter.from_tokenizer_for_streaming(
+            object(), force_harmony_streaming=True
+        )
+        assert isinstance(router, FakeHarmony)
+
+    def test_force_harmony_streaming_rejects_non_harmony_format(self, monkeypatch):
+        """If the tokenizer isn't even harmony-shaped, --force-on must
+        raise pointing at the right escape hatch — silently constructing
+        a harmony router on a non-harmony tokenizer would crash later
+        with an opaque error.
+        """
+        self._patch_factory(monkeypatch, gate_returns=True)
+        self._non_harmony_legacy(monkeypatch)
+
+        with pytest.raises(ValueError, match="not 'harmony'"):
+            OutputRouter.from_tokenizer_for_streaming(
+                object(), force_harmony_streaming=True
+            )
+
+    def test_returns_none_when_legacy_returns_none(self, monkeypatch):
+        """If the legacy factory returns None (unsupported tokenizer),
+        the override flags must NOT manufacture a router — that would
+        crash downstream.
+        """
+        monkeypatch.setattr(
+            OutputRouter, "from_tokenizer", classmethod(lambda cls, tok: None)
+        )
+
+        assert OutputRouter.from_tokenizer_for_streaming(object()) is None
+        assert (
+            OutputRouter.from_tokenizer_for_streaming(
+                object(), no_harmony_streaming=True
+            )
+            is None
+        )
+        assert (
+            OutputRouter.from_tokenizer_for_streaming(
+                object(), force_harmony_streaming=True
+            )
+            is None
+        )

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -942,6 +942,39 @@ class TestStreamingFactoryEscapeHatches:
             is None
         )
 
+    def test_no_harmony_streaming_does_not_import_harmony_shim(self, monkeypatch):
+        """PR #518 round-10 codex NIT: force-off must short-circuit
+        BEFORE importing ``output_router_harmony``. Operators who
+        explicitly opt out shouldn't pay the import cost, and the
+        legacy path must work on environments that don't ship
+        openai-harmony at all.
+
+        Simulate the latter by making the harmony module raise on
+        import — force-off must still return the legacy router; only
+        the default + force-on paths should hit the import.
+        """
+        import sys
+
+        # Make sure the no-import branch is exercised cleanly even if
+        # the module is already cached from another test.
+        monkeypatch.setitem(sys.modules, "vllm_mlx.output_router_harmony", None)
+        # Stage a legacy router so the function has something non-None
+        # to return on the force-off branch.
+        self._harmony_legacy(monkeypatch)
+
+        # Default path would hit the (broken) import → blows up with
+        # ImportError as expected.
+        with pytest.raises(Exception):
+            OutputRouter.from_tokenizer_for_streaming(object())
+
+        # Force-off path must NOT import the shim — must return legacy
+        # without raising.
+        router = OutputRouter.from_tokenizer_for_streaming(
+            object(), no_harmony_streaming=True
+        )
+        assert router is not None
+        assert getattr(router, "map", None) is not None
+
     def test_both_flags_true_raises(self, monkeypatch):
         """PR #518 round-2 codex NIT: setting BOTH force-on and force-off
         is incoherent — the CLI layer enforces mutual exclusion, but

--- a/tests/test_output_router.py
+++ b/tests/test_output_router.py
@@ -900,8 +900,9 @@ class TestStreamingFactoryEscapeHatches:
 
     def test_returns_none_when_legacy_returns_none(self, monkeypatch):
         """If the legacy factory returns None (unsupported tokenizer),
-        the override flags must NOT manufacture a router — that would
-        crash downstream.
+        the default + force-off paths return None (no override flags
+        manufacture a router). Force-on raises instead — see
+        ``test_force_on_with_unsupported_tokenizer_raises``.
         """
         monkeypatch.setattr(
             OutputRouter, "from_tokenizer", classmethod(lambda cls, tok: None)
@@ -914,9 +915,29 @@ class TestStreamingFactoryEscapeHatches:
             )
             is None
         )
-        assert (
+
+    def test_force_on_with_unsupported_tokenizer_raises(self, monkeypatch):
+        """PR #518 round-4 codex BLOCKING #3: when ``from_tokenizer``
+        returns None (unsupported tokenizer) and force-on is set,
+        silently returning None lets the public escape hatch no-op —
+        the operator never learns their tokenizer is unsupported.
+        Must raise so the misuse is visible.
+        """
+        monkeypatch.setattr(
+            OutputRouter, "from_tokenizer", classmethod(lambda cls, tok: None)
+        )
+
+        with pytest.raises(ValueError, match="not recognized"):
             OutputRouter.from_tokenizer_for_streaming(
                 object(), force_harmony_streaming=True
+            )
+
+        # Default and no-streaming paths must STILL return None — only
+        # force-on raises, since only it is making a positive claim.
+        assert OutputRouter.from_tokenizer_for_streaming(object()) is None
+        assert (
+            OutputRouter.from_tokenizer_for_streaming(
+                object(), no_harmony_streaming=True
             )
             is None
         )

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1112,6 +1112,122 @@ class TestTextParserParallelCap:
         assert events[0].type == "finish"
         assert events[0].finish_reason == "tool_calls"
 
+    def test_continuation_deltas_pass_through_admit_by_index(self):
+        """PR #518 round-1 codex BLOCKING regression: qwen3_coder-style
+        parsers emit one incremental ``arguments`` fragment per delta,
+        each sharing the same ``index``. Under
+        ``parallel_tool_calls=false`` the cap must admit the call by
+        ``index`` ONCE and let every continuation through, otherwise
+        the JSON arguments are silently truncated mid-string.
+        """
+        tool_parser = MagicMock()
+        # Header delta: name + first argument fragment, index 0.
+        # Two follow-up deltas: same index 0, only argument fragments.
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q": "'},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "function": {"arguments": "weather"},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "function": {"arguments": '"}'},
+                    }
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        second = pp.process_chunk(_make_output("frag1"))
+        third = pp.process_chunk(_make_output("frag2"))
+
+        # All three deltas must forward — admit-by-index lets the
+        # continuation fragments through after the first admit.
+        assert len(first) == 1 and first[0].type == "tool_call"
+        assert first[0].tool_calls[0]["function"]["arguments"] == '{"q": "'
+        assert len(second) == 1 and second[0].type == "tool_call"
+        assert second[0].tool_calls[0]["function"]["arguments"] == "weather"
+        assert len(third) == 1 and third[0].type == "tool_call"
+        assert third[0].tool_calls[0]["function"]["arguments"] == '"}'
+        # Only ONE distinct call admitted across the three deltas.
+        assert pp._admitted_tool_call_indices == {0}
+
+    def test_continuation_after_new_call_past_cap_is_dropped(self):
+        """A new call (unseen ``index``) past the cap is dropped, AND
+        any subsequent continuations of that dropped index are dropped
+        too — otherwise a half-admitted call would leak arguments.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": '{"x": '},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        second = pp.process_chunk(_make_output("<tool_call>b</tool_call>"))
+        third = pp.process_chunk(_make_output("frag"))
+
+        assert len(first) == 1 and first[0].tool_calls[0]["function"]["name"] == "a"
+        # Index 1 never admitted — second AND third are suppressed.
+        assert second == []
+        assert third == []
+        assert pp._admitted_tool_call_indices == {0}
+
 
 # ======================================================================
 # Coverage gap tests — model-specific edge cases + error paths

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1223,18 +1223,10 @@ class TestTextParserParallelCap:
         assert third[0].tool_calls[0]["function"]["arguments"] == '"}'
         assert pp._no_index_call_admitted is True
 
-    def test_no_index_deltas_treated_as_single_in_flight_call(self):
-        """When the parser emits deltas without ``index``, the cap
-        admits the FIRST delta and treats every subsequent no-index
-        delta as a continuation of that call (the only safe choice —
-        without ``index`` the cap can't distinguish "new call" from
-        "next fragment of the admitted call"). Documented design
-        tradeoff in ``_apply_parallel_cap`` docstring.
-
-        Two-distinct-no-index-calls is unobservable from delta shape
-        alone; well-behaved parsers either emit ``index`` everywhere
-        or share the no-index slot across all their continuation
-        fragments. Anything else is a parser bug.
+    def test_no_index_arg_fragment_passes_through_as_continuation(self):
+        """No-index argument-only fragments are continuations of the
+        in-flight no-index call — forward so the JSON arguments are
+        complete.
         """
         tool_parser = MagicMock()
         tool_parser.extract_tool_calls_streaming.side_effect = [
@@ -1266,6 +1258,79 @@ class TestTextParserParallelCap:
         assert len(first) == 1
         assert len(second) == 1
         assert second[0].tool_calls[0]["function"]["arguments"] == "rest"
+
+    def test_no_index_second_full_call_dropped_under_cap(self):
+        """PR #518 round-3 codex BLOCKING: a second no-index delta
+        carrying a fresh ``id`` or function ``name`` is a NEW call,
+        not a continuation. Under ``parallel_tool_calls=false`` the
+        first slot is taken by call_a; the second full call leaks
+        past the cap if every no-index delta is treated as a
+        continuation. Verify the cap holds.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    }
+                ]
+            },
+            {
+                # Fresh id + name — distinct call. Must be dropped.
+                "tool_calls": [
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    }
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        second = pp.process_chunk(_make_output("<tool_call>b</tool_call>"))
+        assert len(first) == 1
+        assert first[0].tool_calls[0]["function"]["name"] == "a"
+        assert second == []
+
+    def test_uncapped_path_does_not_set_no_index_admitted(self):
+        """PR #518 round-3 codex NIT: the uncapped path used to set
+        ``_no_index_call_admitted=True`` for every no-index delta.
+        That state is cap-only — leaking it into the uncapped path
+        would corrupt cap accounting if a request's flag changed
+        mid-stream (or the same processor were reused). Verify the
+        uncapped path leaves the flag alone.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.return_value = {
+            "tool_calls": [
+                {
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {"name": "a", "arguments": "{}"},
+                }
+            ]
+        }
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": True})
+        pp.reset()
+
+        pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        assert pp._no_index_call_admitted is False
 
     def test_continuation_after_new_call_past_cap_is_dropped(self):
         """A new call (unseen ``index``) past the cap is dropped, AND

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1368,6 +1368,64 @@ class TestTextParserParallelCap:
             "_no_index_last_dropped should have routed it to drop."
         )
 
+    def test_dropped_indexed_anchor_blocks_no_index_arg_leak(self):
+        """PR #518 round-6 codex BLOCKING: when an INDEXED anchor is
+        dropped past the cap, subsequent no-index argument-only
+        fragments must NOT leak into the admitted call's payload.
+
+        Sequence:
+          1. call_a anchor (index=0, name=a, args='{}')      → admit
+          2. call_b anchor (index=1, name=b, args='{"x":1') → cap full → DROP
+          3. call_b frag (no index, args='}')                → must DROP
+
+        Prior to round-6 fix, step 2's drop did not set
+        ``_no_index_last_dropped`` (only no-index drops did), so
+        step 3 was routed to the unified continuation branch and
+        appended call_b's args to call_a's payload.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": '{"x":1'},
+                    }
+                ]
+            },
+            {"tool_calls": [{"function": {"arguments": "}"}}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>b</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>f</tool_call>"))
+
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["function"]["name"] == "a"
+        assert e2 == []
+        # The continuation fragment must NOT leak — last anchor was
+        # dropped and the flag should suppress it.
+        assert e3 == [], f"no-index fragment leaked after dropped indexed anchor: {e3}"
+
     def test_indexed_anchor_then_no_index_arg_fragment_continues(self):
         """PR #518 round-5 codex BLOCKING #2: when the FIRST delta
         admits an indexed call (e.g. ``index=0`` with name + arg

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1368,6 +1368,35 @@ class TestTextParserParallelCap:
             "_no_index_last_dropped should have routed it to drop."
         )
 
+    def test_flat_shape_second_call_dropped_under_cap(self):
+        """PR #518 round-8 codex BLOCKING #2: parsers can emit FLAT
+        no-index calls (``{"name": "X", "arguments": "..."}`` — no
+        ``function`` wrapper). Anchor detection used to look only at
+        ``function.name`` or ``id``, so a second flat call leaked
+        past the cap as a "continuation" of the first.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            # First flat call — admitted.
+            {"tool_calls": [{"name": "a", "arguments": "{}"}]},
+            # Second flat call — distinct ``name``, should be dropped.
+            {"tool_calls": [{"name": "b", "arguments": "{}"}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>b</tool_call>"))
+
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["name"] == "a"
+        assert e2 == [], f"flat-shape second call leaked past cap as continuation: {e2}"
+
     def test_dropped_indexed_anchor_blocks_no_index_arg_leak(self):
         """PR #518 round-6 codex BLOCKING: when an INDEXED anchor is
         dropped past the cap, subsequent no-index argument-only

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1645,6 +1645,117 @@ class TestTextParserParallelCap:
         assert third == []
         assert pp._admitted_tool_call_indices == {0}
 
+    def test_no_index_cumulative_anchor_passes_as_continuation(self):
+        """PR #518 round-10 codex BLOCKING #2: cumulative-update parsers
+        re-emit the SAME ``id``/``name`` on every delta (carrying the
+        full arguments string grown so far) rather than emitting one
+        anchor and bare-argument continuations. Without identity
+        tracking the second+ anchor was misclassified as a NEW call
+        and dropped under ``parallel_tool_calls=false``, truncating
+        the arguments JSON to whatever shipped on the first delta.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {"id": "call_a", "function": {"name": "f", "arguments": "{"}}
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"id": "call_a", "function": {"name": "f", "arguments": '{"x":'}}
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"id": "call_a", "function": {"name": "f", "arguments": '{"x":1}'}}
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>2</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>3</tool_call>"))
+
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["function"]["name"] == "f"
+        assert len(e2) == 1, (
+            "same-identity no-index re-emit must pass through as continuation"
+        )
+        assert e2[0].tool_calls[0]["function"]["arguments"] == '{"x":'
+        assert len(e3) == 1
+        assert e3[0].tool_calls[0]["function"]["arguments"] == '{"x":1}'
+
+    def test_no_index_different_identity_dropped_under_cap(self):
+        """Identity tracking must NOT silently accept a DIFFERENT
+        no-index anchor as continuation — a second logical call still
+        gets dropped under ``parallel_tool_calls=false``. Companion to
+        ``test_no_index_cumulative_anchor_passes_as_continuation`` —
+        proves the match is identity-strict, not anchor-shape-only.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {"id": "call_a", "function": {"name": "f", "arguments": "{}"}}
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"id": "call_b", "function": {"name": "g", "arguments": "{}"}}
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>2</tool_call>"))
+
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["function"]["name"] == "f"
+        assert e2 == [], f"different-identity no-index call leaked past cap: {e2}"
+
+    def test_no_index_name_only_cumulative_anchor_passes_as_continuation(self):
+        """Cumulative parsers that omit ``id`` and only re-emit
+        ``function.name`` still benefit from identity tracking — same
+        name = continuation, different name = new call (dropped).
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {"tool_calls": [{"function": {"name": "f", "arguments": "{"}}]},
+            {"tool_calls": [{"function": {"name": "f", "arguments": '{"x":1}'}}]},
+            {"tool_calls": [{"function": {"name": "g", "arguments": "{}"}}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>2</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>3</tool_call>"))
+
+        assert len(e1) == 1
+        assert len(e2) == 1, "same-name no-index anchor must continue"
+        assert e2[0].tool_calls[0]["function"]["arguments"] == '{"x":1}'
+        assert e3 == [], f"different-name new call leaked past cap: {e3}"
+
 
 # ======================================================================
 # Coverage gap tests — model-specific edge cases + error paths

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1303,6 +1303,71 @@ class TestTextParserParallelCap:
         assert first[0].tool_calls[0]["function"]["name"] == "a"
         assert second == []
 
+    def test_dropped_no_index_call_args_do_not_leak_to_admitted(self):
+        """PR #518 round-4 codex BLOCKING #1: after a second no-index
+        call gets dropped past the cap, its later argument-only
+        fragments would still satisfy the continuation branch and
+        leak into the admitted call's payload, corrupting its JSON.
+
+        Sequence (one delta per chunk):
+          1. call_a anchor (id=a, name=a, args='{')      → admit
+          2. call_a frag (args='}'  )                    → continuation, forward
+          3. call_b anchor (id=b, name=b, args='{"x":1') → cap full → DROP
+          4. call_b frag (args='}'  )                    → must DROP (was sliding into call_a)
+
+        The fix routes (4) to the dropped path via
+        ``_no_index_last_dropped`` so call_a's arguments stay '{}'.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{"},
+                    }
+                ]
+            },
+            {"tool_calls": [{"function": {"arguments": "}"}}]},
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": '{"x":1'},
+                    }
+                ]
+            },
+            {"tool_calls": [{"function": {"arguments": "}"}}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>a_anchor</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>a_frag</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>b_anchor</tool_call>"))
+        e4 = pp.process_chunk(_make_output("<tool_call>b_frag</tool_call>"))
+
+        # call_a's two deltas both pass.
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["function"]["arguments"] == "{"
+        assert len(e2) == 1
+        assert e2[0].tool_calls[0]["function"]["arguments"] == "}"
+        # call_b's anchor dropped (cap full).
+        assert e3 == []
+        # call_b's continuation MUST be dropped — not forwarded as a
+        # continuation of call_a.
+        assert e4 == [], (
+            f"dropped no-index call's args leaked: {e4}. "
+            "_no_index_last_dropped should have routed it to drop."
+        )
+
     def test_uncapped_path_does_not_set_no_index_admitted(self):
         """PR #518 round-3 codex NIT: the uncapped path used to set
         ``_no_index_call_admitted=True`` for every no-index delta.

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1174,6 +1174,99 @@ class TestTextParserParallelCap:
         # Only ONE distinct call admitted across the three deltas.
         assert pp._admitted_tool_call_indices == {0}
 
+    def test_no_index_continuation_deltas_pass_through(self):
+        """PR #518 round-2 codex BLOCKING: parsers that omit ``index``
+        from continuation deltas were treated as a stream of NEW calls;
+        the first admitted the synthetic marker, every subsequent
+        no-index delta was re-classified "new", saw the cap as full
+        and dropped. Now an in-flight no-index call has explicit state.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q":"'},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"function": {"arguments": "weather"}},
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"function": {"arguments": '"}'}},
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        second = pp.process_chunk(_make_output("frag1"))
+        third = pp.process_chunk(_make_output("frag2"))
+
+        assert len(first) == 1 and first[0].type == "tool_call"
+        assert first[0].tool_calls[0]["function"]["arguments"] == '{"q":"'
+        assert len(second) == 1 and second[0].type == "tool_call"
+        assert second[0].tool_calls[0]["function"]["arguments"] == "weather"
+        assert len(third) == 1 and third[0].type == "tool_call"
+        assert third[0].tool_calls[0]["function"]["arguments"] == '"}'
+        assert pp._no_index_call_admitted is True
+
+    def test_no_index_deltas_treated_as_single_in_flight_call(self):
+        """When the parser emits deltas without ``index``, the cap
+        admits the FIRST delta and treats every subsequent no-index
+        delta as a continuation of that call (the only safe choice —
+        without ``index`` the cap can't distinguish "new call" from
+        "next fragment of the admitted call"). Documented design
+        tradeoff in ``_apply_parallel_cap`` docstring.
+
+        Two-distinct-no-index-calls is unobservable from delta shape
+        alone; well-behaved parsers either emit ``index`` everywhere
+        or share the no-index slot across all their continuation
+        fragments. Anything else is a parser bug.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": '{"q":"'},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"function": {"arguments": "rest"}},
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        second = pp.process_chunk(_make_output("frag"))
+        assert len(first) == 1
+        assert len(second) == 1
+        assert second[0].tool_calls[0]["function"]["arguments"] == "rest"
+
     def test_continuation_after_new_call_past_cap_is_dropped(self):
         """A new call (unseen ``index``) past the cap is dropped, AND
         any subsequent continuations of that dropped index are dropped

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -946,6 +946,173 @@ class TestStructuredToolCallStreaming:
         assert events[0].tool_calls[0]["index"] == 0
 
 
+class TestTextParserParallelCap:
+    """Tests for issue #517 — text-parser streaming paths
+    (``_process_standard``, ``_process_reasoning``) must honor
+    ``parallel_tool_calls=false`` symmetrically to the channel-routed
+    path PR #515 already covered.
+    """
+
+    def _make_pp_with_parser(self, returns: list[dict], **req_kwargs):
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.return_value = {"tool_calls": returns}
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        request = req_kwargs or None
+        pp = StreamingPostProcessor(cfg, request=request)
+        pp.reset()
+        return pp
+
+    def test_standard_path_caps_two_calls_in_single_delta(self):
+        """When the parser emits two calls in one delta and the request
+        has ``parallel_tool_calls=false``, only the first is forwarded.
+        """
+        pp = self._make_pp_with_parser(
+            [
+                {
+                    "index": 0,
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {"name": "a", "arguments": "{}"},
+                },
+                {
+                    "index": 1,
+                    "id": "call_b",
+                    "type": "function",
+                    "function": {"name": "b", "arguments": "{}"},
+                },
+            ],
+            parallel_tool_calls=False,
+        )
+
+        events = pp.process_chunk(_make_output("<tool_call>x</tool_call>"))
+        assert len(events) == 1
+        assert len(events[0].tool_calls) == 1
+        assert events[0].tool_calls[0]["function"]["name"] == "a"
+
+    def test_standard_path_caps_calls_across_deltas(self):
+        """When the parser emits one call per delta and the request has
+        ``parallel_tool_calls=false``, the second delta's call is
+        suppressed entirely (parser may still see the tokens but
+        nothing reaches the client).
+        """
+        # First delta: parser returns call_a
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    }
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        first = pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        second = pp.process_chunk(_make_output("<tool_call>b</tool_call>"))
+
+        assert len(first) == 1
+        assert first[0].type == "tool_call"
+        assert first[0].tool_calls[0]["function"]["name"] == "a"
+        # Second delta suppressed — tool_calls_detected branch fires.
+        assert second == []
+        assert pp.tool_calls_detected is True
+
+    def test_standard_path_passes_through_when_parallel_allowed(self):
+        """``parallel_tool_calls=true`` (or unset) must NOT cap."""
+        pp = self._make_pp_with_parser(
+            [
+                {
+                    "index": 0,
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {"name": "a", "arguments": "{}"},
+                },
+                {
+                    "index": 1,
+                    "id": "call_b",
+                    "type": "function",
+                    "function": {"name": "b", "arguments": "{}"},
+                },
+            ],
+            parallel_tool_calls=True,
+        )
+
+        events = pp.process_chunk(_make_output("<tool_call>both</tool_call>"))
+        assert len(events) == 1
+        assert len(events[0].tool_calls) == 2
+
+    def test_standard_path_cap_preserves_finish_semantics(self):
+        """Suppressed second delta that is ALSO finished must still emit
+        a finish event so the route's buffered_finish gate fires.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    }
+                ]
+            },
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        pp.process_chunk(_make_output("<tool_call>a</tool_call>"))
+        events = pp.process_chunk(
+            _make_output(
+                "<tool_call>b</tool_call>",
+                finished=True,
+                finish_reason="stop",
+            )
+        )
+        assert len(events) == 1
+        assert events[0].type == "finish"
+        assert events[0].finish_reason == "tool_calls"
+
+
 # ======================================================================
 # Coverage gap tests — model-specific edge cases + error paths
 # ======================================================================

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1368,6 +1368,66 @@ class TestTextParserParallelCap:
             "_no_index_last_dropped should have routed it to drop."
         )
 
+    def test_indexed_continuation_resets_dropped_flag(self):
+        """PR #518 round-9 codex BLOCKING #2: after a second indexed
+        anchor is dropped (cap full), an admitted call's MIXED
+        continuation (indexed first, then no-index argument fragment)
+        was being suppressed because the dropped flag was still set.
+
+        Sequence:
+          1. call_a anchor (index=0, name=a, args='{"q":"')   → admit
+          2. call_b anchor (index=1, name=b, args='{}')        → DROP, set flag
+          3. call_a continuation (index=0, args='weather')     → forward + RESET flag
+          4. call_a continuation (no-index, args='"}')         → forward (flag reset)
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": '{"q":"'},
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    }
+                ]
+            },
+            {"tool_calls": [{"index": 0, "function": {"arguments": "weather"}}]},
+            {"tool_calls": [{"function": {"arguments": '"}'}}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>1</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>2</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>3</tool_call>"))
+        e4 = pp.process_chunk(_make_output("<tool_call>4</tool_call>"))
+
+        assert len(e1) == 1 and e1[0].tool_calls[0]["function"]["name"] == "a"
+        assert e2 == []
+        assert len(e3) == 1, "indexed continuation of admitted call must forward"
+        assert e3[0].tool_calls[0]["function"]["arguments"] == "weather"
+        assert len(e4) == 1, (
+            "no-index arg following indexed continuation must forward "
+            "(dropped flag reset by the indexed continuation)"
+        )
+        assert e4[0].tool_calls[0]["function"]["arguments"] == '"}'
+
     def test_flat_shape_second_call_dropped_under_cap(self):
         """PR #518 round-8 codex BLOCKING #2: parsers can emit FLAT
         no-index calls (``{"name": "X", "arguments": "..."}`` — no

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1368,6 +1368,53 @@ class TestTextParserParallelCap:
             "_no_index_last_dropped should have routed it to drop."
         )
 
+    def test_indexed_anchor_then_no_index_arg_fragment_continues(self):
+        """PR #518 round-5 codex BLOCKING #2: when the FIRST delta
+        admits an indexed call (e.g. ``index=0`` with name + arg
+        prefix), subsequent argument-only no-index fragments would
+        previously fall through the indexed-continuation branch and
+        the no-index-continuation branch (since
+        ``_no_index_call_admitted=False``), then hit the new-call
+        cap check and be dropped — truncating the JSON.
+
+        Now the no-index argument-only fragment matches the unified
+        "any-admitted-call" continuation branch.
+        """
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls_streaming.side_effect = [
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q":"'},
+                    }
+                ]
+            },
+            {"tool_calls": [{"function": {"arguments": "weather"}}]},
+            {"tool_calls": [{"function": {"arguments": '"}'}}]},
+        ]
+        tool_parser.has_pending_tool_call.return_value = False
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=tool_parser,
+        )
+        pp = StreamingPostProcessor(cfg, request={"parallel_tool_calls": False})
+        pp.reset()
+
+        e1 = pp.process_chunk(_make_output("<tool_call>anchor</tool_call>"))
+        e2 = pp.process_chunk(_make_output("<tool_call>f1</tool_call>"))
+        e3 = pp.process_chunk(_make_output("<tool_call>f2</tool_call>"))
+
+        # All three pass — the indexed admit covers the no-index args.
+        assert len(e1) == 1
+        assert e1[0].tool_calls[0]["function"]["arguments"] == '{"q":"'
+        assert len(e2) == 1
+        assert e2[0].tool_calls[0]["function"]["arguments"] == "weather"
+        assert len(e3) == 1
+        assert e3[0].tool_calls[0]["function"]["arguments"] == '"}'
+
     def test_uncapped_path_does_not_set_no_index_admitted(self):
         """PR #518 round-3 codex NIT: the uncapped path used to set
         ``_no_index_call_admitted=True`` for every no-index delta.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1025,6 +1025,16 @@ def serve_command(args):
             file=sys.stderr,
         )
         sys.exit(2)
+    if getattr(args, "force_openai_harmony_streaming", False) and getattr(
+        args, "no_openai_harmony_streaming", False
+    ):
+        print(
+            "error: --force-openai-harmony-streaming and "
+            "--no-openai-harmony-streaming are mutually exclusive — pick one "
+            "to override the HarmonyStreamingRouter auto-upgrade gate (#516).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     try:
         load_model(
             args.model,
@@ -1044,6 +1054,12 @@ def serve_command(args):
             no_hybrid=getattr(args, "no_hybrid", False),
             force_spec_decode=getattr(args, "force_spec_decode", False),
             no_spec_decode=getattr(args, "no_spec_decode", False),
+            force_openai_harmony_streaming=getattr(
+                args, "force_openai_harmony_streaming", False
+            ),
+            no_openai_harmony_streaming=getattr(
+                args, "no_openai_harmony_streaming", False
+            ),
         )
     except Exception as e:
         # Show clean error instead of raw traceback. Catch the typed
@@ -3788,6 +3804,37 @@ Examples:
             "Force-disable speculative-decode eligibility (suffix / MTP / "
             "DFlash) even when AliasProfile says the model supports it. "
             "Mutually exclusive with --force-spec-decode."
+        ),
+    )
+    # #516 — HarmonyStreamingRouter auto-upgrade escape hatches (G11).
+    # PR #515 introduced an auto-upgrade from the legacy harmony state
+    # machine to openai-harmony's StreamableParser for matched-vocab
+    # gpt-oss tokenizers. The auto-detection is conservative (three-layer
+    # compat check) but the SOP requires every binary auto-routing
+    # decision expose both force-on and force-off CLI flags.
+    serve_parser.add_argument(
+        "--force-openai-harmony-streaming",
+        dest="force_openai_harmony_streaming",
+        action="store_true",
+        default=False,
+        help=(
+            "Force-on: construct HarmonyStreamingRouter even when the "
+            "compat gate would reject. Use to debug a regression in the "
+            "gate itself; production should leave this off. Mutually "
+            "exclusive with --no-openai-harmony-streaming."
+        ),
+    )
+    serve_parser.add_argument(
+        "--no-openai-harmony-streaming",
+        dest="no_openai_harmony_streaming",
+        action="store_true",
+        default=False,
+        help=(
+            "Force-off: skip the HarmonyStreamingRouter upgrade and use "
+            "the legacy custom harmony state machine even on matched-vocab "
+            "gpt-oss tokenizers. Escape hatch for a hypothetical false "
+            "positive in the compat gate. Mutually exclusive with "
+            "--force-openai-harmony-streaming."
         ),
     )
     # GC control (Tier 0 optimization)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -267,6 +267,8 @@ class BatchedEngine(BaseEngine):
         no_hybrid: bool = False,
         force_spec_decode: bool = False,
         no_spec_decode: bool = False,
+        force_openai_harmony_streaming: bool = False,
+        no_openai_harmony_streaming: bool = False,
     ):
         """
         Initialize the batched engine.
@@ -301,6 +303,11 @@ class BatchedEngine(BaseEngine):
         self._no_hybrid = no_hybrid
         self._force_spec_decode = force_spec_decode
         self._no_spec_decode = no_spec_decode
+        # #516 — auto-routing escape hatches for the HarmonyStreamingRouter
+        # auto-upgrade introduced in PR #515. Mutually exclusive (CLI
+        # enforces; engine accepts and asserts defensively at use time).
+        self._force_openai_harmony_streaming = force_openai_harmony_streaming
+        self._no_openai_harmony_streaming = no_openai_harmony_streaming
         if force_text:
             # User explicitly opted out of MLLM routing. Skip the probe
             # entirely so a False from auto-detection can't be overridden
@@ -1388,7 +1395,11 @@ class BatchedEngine(BaseEngine):
             tokenizer = self.tokenizer
             if tokenizer is None:
                 return None
-            router = OutputRouter.from_tokenizer_for_streaming(tokenizer)
+            router = OutputRouter.from_tokenizer_for_streaming(
+                tokenizer,
+                force_harmony_streaming=self._force_openai_harmony_streaming,
+                no_harmony_streaming=self._no_openai_harmony_streaming,
+            )
             if router is None:
                 return None
             if router.map.format_tag not in _OUTPUT_ROUTER_ALLOWLIST:

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -697,6 +697,19 @@ class OutputRouter:
 
         legacy = cls.from_tokenizer(tokenizer)
         if legacy is None:
+            if force_harmony_streaming:
+                # Round-4 codex BLOCKING #3: silently returning ``None``
+                # under force-on lets the public escape hatch no-op —
+                # the operator who set the flag never learns the
+                # tokenizer is unsupported. Surface it.
+                raise ValueError(
+                    "--force-openai-harmony-streaming requested but the "
+                    "tokenizer is not recognized by OutputRouter "
+                    "(no format detected). The harmony streaming router "
+                    "only works with harmony-shape tokenizers (gpt-oss "
+                    "family). Drop the flag to let the auto-router pick "
+                    "the right path."
+                )
             return None
 
         # Honor force-off before any compat check fires — the explicit

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -678,13 +678,22 @@ class OutputRouter:
           rejects the tokenizer/marker map. Use to debug a regression in
           the gate itself, NOT for general production override.
 
-          Mutually exclusive with ``no_harmony_streaming``; the caller is
-          responsible for not setting both (CLI layer enforces this).
+          Mutually exclusive with ``no_harmony_streaming``; the factory
+          raises ``ValueError`` if both are set so direct API callers
+          (tests, third-party engines) get the same enforcement the CLI
+          layer applies. PR #518 round-2 codex NIT.
         """
         from .output_router_harmony import (
             HarmonyStreamingRouter,
             is_openai_harmony_compatible,
         )
+
+        if force_harmony_streaming and no_harmony_streaming:
+            raise ValueError(
+                "force_harmony_streaming and no_harmony_streaming are "
+                "mutually exclusive — they describe opposite escape "
+                "hatches over the auto-router. Pass at most one."
+            )
 
         legacy = cls.from_tokenizer(tokenizer)
         if legacy is None:

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -683,11 +683,6 @@ class OutputRouter:
           (tests, third-party engines) get the same enforcement the CLI
           layer applies. PR #518 round-2 codex NIT.
         """
-        from .output_router_harmony import (
-            HarmonyStreamingRouter,
-            is_openai_harmony_compatible,
-        )
-
         if force_harmony_streaming and no_harmony_streaming:
             raise ValueError(
                 "force_harmony_streaming and no_harmony_streaming are "
@@ -696,6 +691,24 @@ class OutputRouter:
             )
 
         legacy = cls.from_tokenizer(tokenizer)
+        # Honor force-off BEFORE importing the harmony shim — operators
+        # who explicitly opt out shouldn't pay the import cost (or hit
+        # an unrelated harmony-module import failure on environments
+        # that don't ship openai-harmony). PR #518 round-10 codex NIT.
+        if no_harmony_streaming:
+            if legacy is None:
+                return None
+            logger.debug(
+                "[OutputRouter] Streaming factory honoring "
+                "--no-openai-harmony-streaming; using legacy router"
+            )
+            return legacy
+
+        from .output_router_harmony import (
+            HarmonyStreamingRouter,
+            is_openai_harmony_compatible,
+        )
+
         if legacy is None:
             if force_harmony_streaming:
                 # Round-4 codex BLOCKING #3: silently returning ``None``
@@ -711,15 +724,6 @@ class OutputRouter:
                     "the right path."
                 )
             return None
-
-        # Honor force-off before any compat check fires — the explicit
-        # opt-out short-circuits regardless of harmony-shape detection.
-        if no_harmony_streaming:
-            logger.debug(
-                "[OutputRouter] Streaming factory honoring "
-                "--no-openai-harmony-streaming; using legacy router"
-            )
-            return legacy
 
         is_harmony = legacy.map.format_tag == "harmony"
         if force_harmony_streaming:

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -646,7 +646,13 @@ class OutputRouter:
         return None  # unsupported model format
 
     @classmethod
-    def from_tokenizer_for_streaming(cls, tokenizer: Any):
+    def from_tokenizer_for_streaming(
+        cls,
+        tokenizer: Any,
+        *,
+        force_harmony_streaming: bool = False,
+        no_harmony_streaming: bool = False,
+    ):
         """Production streaming factory — prefers ``HarmonyStreamingRouter``
         for harmony-format models whose vocab IDs match the openai-harmony
         encoding (verified at PR-time for upstream gpt-oss). Falls back to
@@ -658,6 +664,22 @@ class OutputRouter:
         exercise the custom state machine without the openai-harmony shim
         being forced on it. Engine code
         (``BatchedEngine._create_output_router``) uses THIS factory.
+
+        Auto-routing escape hatches (#516, release-SOP G11):
+
+        - ``no_harmony_streaming=True`` — force-off. Always return the
+          legacy router even if the compat gate would accept. Use when an
+          environment exposes a false positive in the gate (impossible by
+          construction with the current three-layer check, but the SOP
+          requires the escape hatch exist regardless).
+        - ``force_harmony_streaming=True`` — force-on. Bypass the compat
+          gate and construct ``HarmonyStreamingRouter`` unconditionally,
+          raising if the underlying ``HarmonyStreamingRouter`` constructor
+          rejects the tokenizer/marker map. Use to debug a regression in
+          the gate itself, NOT for general production override.
+
+          Mutually exclusive with ``no_harmony_streaming``; the caller is
+          responsible for not setting both (CLI layer enforces this).
         """
         from .output_router_harmony import (
             HarmonyStreamingRouter,
@@ -667,9 +689,36 @@ class OutputRouter:
         legacy = cls.from_tokenizer(tokenizer)
         if legacy is None:
             return None
-        if legacy.map.format_tag == "harmony" and is_openai_harmony_compatible(
-            legacy.map, tokenizer
-        ):
+
+        # Honor force-off before any compat check fires — the explicit
+        # opt-out short-circuits regardless of harmony-shape detection.
+        if no_harmony_streaming:
+            logger.debug(
+                "[OutputRouter] Streaming factory honoring "
+                "--no-openai-harmony-streaming; using legacy router"
+            )
+            return legacy
+
+        is_harmony = legacy.map.format_tag == "harmony"
+        if force_harmony_streaming:
+            if not is_harmony:
+                raise ValueError(
+                    "--force-openai-harmony-streaming requested but the "
+                    "tokenizer's detected format is "
+                    f"{legacy.map.format_tag!r}, not 'harmony'. The "
+                    "harmony streaming router only works with harmony-shape "
+                    "tokenizers (gpt-oss family). Drop the flag to let the "
+                    "auto-router pick the right path."
+                )
+            # Bypass compat probe; HarmonyStreamingRouter will surface a
+            # real failure (e.g. missing marker IDs) at construction time.
+            logger.debug(
+                "[OutputRouter] Streaming factory force-on via "
+                "--force-openai-harmony-streaming (compat probe bypassed)"
+            )
+            return HarmonyStreamingRouter(legacy.map, tokenizer)
+
+        if is_harmony and is_openai_harmony_compatible(legacy.map, tokenizer):
             # Codex round-2 NIT: emit at DEBUG level. The streaming
             # factory is called per request in the engine path; an
             # INFO-level log would spam production logs once per

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -85,21 +85,37 @@ router = APIRouter()
 # stdlib timeout/connection set are always available, so we fall back
 # to those when litellm isn't importable.
 def _tool_call_name(tc) -> str | None:
-    """Extract ``function.name`` from a tool_call entry regardless of
-    shape — pydantic ``ToolCall`` (the text-parser path's output) or
-    raw dict (engine structured passthrough). PR #518 round-2 codex
-    BLOCKING: pure-attr access mis-treated dict-shaped entries as
-    nameless, spuriously 422'ing matching named-function calls.
+    """Extract the function name from a tool_call entry regardless of
+    shape. Three real shapes seen in production:
+
+    1. Pydantic ``ToolCall`` — ``tc.function.name``. Text-parser path.
+    2. Wrapped dict — ``{"function": {"name": ...}}``. Anthropic
+       passthrough and engine structured passthrough through
+       ``_parse_tool_calls_with_parser``.
+    3. Flat dict — ``{"name": ..., "arguments": ...}``. Raw engine
+       ``GenerationOutput.tool_calls`` shape (Harmony StreamableParser
+       output before wrapping). Surfaces in tests/fixtures and any
+       downstream that forwards engine output directly.
+
+    PR #518 round-2 codex BLOCKING added shapes 1+2; round-3 BLOCKING
+    added shape 3 (the round-2 widening missed it, even though the
+    same PR's test fixture emits exactly that shape).
     """
     if isinstance(tc, dict):
         fn = tc.get("function")
         if isinstance(fn, dict):
             return fn.get("name")
-        return getattr(fn, "name", None) if fn else None
+        if fn is not None:
+            return getattr(fn, "name", None)
+        # Flat shape — no ``function`` wrapper.
+        return tc.get("name")
     fn = getattr(tc, "function", None)
     if isinstance(fn, dict):
         return fn.get("name")
-    return getattr(fn, "name", None) if fn else None
+    if fn is not None:
+        return getattr(fn, "name", None)
+    # Flat attr-shape — no ``function`` attribute.
+    return getattr(tc, "name", None)
 
 
 def _cloud_call_recoverable_exceptions() -> tuple[type[BaseException], ...]:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -118,6 +118,40 @@ def _tool_call_name(tc) -> str | None:
     return getattr(tc, "name", None)
 
 
+def _engine_supports_channel_routed_tool_calls(engine) -> bool:
+    """Probe whether the engine's tokenizer yields a channel-routed
+    streaming path that can emit structured tool calls without a text
+    parser. Harmony (gpt-oss) and Gemma 4 publish tool calls via the
+    OutputRouter's tool-call channel, so a stream=true tool_choice=
+    required request CAN satisfy the contract for those models even
+    when ``cfg.tool_call_parser`` is unset.
+
+    PR #518 round-10 codex BLOCKING #1: the prior gate rejected every
+    parser-less streaming-required request and blocked legitimate
+    harmony/gemma4 traffic. The capability probe relies on the same
+    detection the engine itself uses
+    (``OutputRouter.from_tokenizer_for_streaming`` + the engine's
+    format allowlist), so a positive answer here means the actual
+    engine path WILL produce structured tool_call deltas.
+    """
+    try:
+        from ..engine.batched import _OUTPUT_ROUTER_ALLOWLIST
+        from ..output_router import OutputRouter
+
+        tokenizer = getattr(engine, "tokenizer", None)
+        if tokenizer is None:
+            return False
+        router = OutputRouter.from_tokenizer_for_streaming(tokenizer)
+        if router is None:
+            return False
+        return router.map.format_tag in _OUTPUT_ROUTER_ALLOWLIST
+    except Exception:
+        # Capability probe is best-effort — any failure means we
+        # cannot prove channel-routed support, so the gate falls
+        # back to the parser-only path (which 422s without one).
+        return False
+
+
 def _cloud_call_recoverable_exceptions() -> tuple[type[BaseException], ...]:
     """Build the allowlist of exception types we treat as recoverable from
     the cloud call. Lazy so cloud routing being disabled doesn't pay the
@@ -730,38 +764,41 @@ async def _create_chat_completion_impl(
                 f"<= threshold {cfg.cloud_router.threshold}, using local inference"
             )
 
-    # ``tool_choice="required"`` + ``stream=true`` is enforceable IF
-    # a streaming tool-call parser is configured: the model usually
-    # complies with the strict-suffix prompt injection (#468), the
-    # parser emits a structured tool_call SSE chunk, and the rare
-    # text-only outcome is a known limitation of local inference
-    # without decoder-side constraints (FSM, #132). When no parser
-    # is configured we have NO path to produce a streaming tool_call
-    # at all — the request can never satisfy the contract, so reject
+    # ``tool_choice="required"`` + ``stream=true`` is enforceable IF the
+    # engine has SOME path to produce a streaming tool_call:
+    #   (a) a text-parser path — ``cfg.tool_call_parser`` set; or
+    #   (b) a channel-routed path — harmony (gpt-oss) / Gemma 4 emit
+    #       structured tool_calls via the OutputRouter's tool channel
+    #       without needing a text parser.
+    # The request can satisfy the contract iff EITHER path is available.
+    # When neither is available we have NO mechanism at all, so reject
     # upfront with a clear error.
     #
     # Round-7 codex BLOCKING surfaced the silent text-only finish_reason
-    # case; round-8 moved the guard below cloud routing; round-9 codex
-    # BLOCKING narrowed the guard to the truly-unenforceable case
-    # (no parser) so configurations that CAN emit streaming tool calls
-    # aren't blocked.
+    # case; round-8 moved the guard below cloud routing; round-9 narrowed
+    # to the truly-unenforceable case (no parser); round-10 codex BLOCKING
+    # #1 widened "enforceable" to include channel-routed capability so
+    # harmony/gemma4 streaming requests aren't blocked by the gate.
     if (
         request.stream
         and tc == "required"
         and request.tools
         and not cfg.tool_call_parser
+        and not _engine_supports_channel_routed_tool_calls(engine)
     ):
         raise HTTPException(
             status_code=422,
             detail=(
-                'tool_choice="required" with stream=true requires a streaming '
-                "tool-call parser to be configured (--tool-call-parser); without "
-                "one this server has no path to emit tool_calls in the response "
-                "and the OpenAI 'tool_call guaranteed' contract cannot be met. "
-                "Either set --tool-call-parser=hermes (or your model's parser), "
-                "retry with stream=false (non-stream path 422s text-only output), "
-                "or pin a specific function via tool_choice="
-                '{"type":"function","function":{"name":...}}.'
+                'tool_choice="required" with stream=true requires either a '
+                "streaming tool-call parser (--tool-call-parser) or a "
+                "channel-routed model (harmony / Gemma 4) so the server has "
+                "a path to emit structured tool_calls. Neither is available "
+                "for this request — the OpenAI 'tool_call guaranteed' "
+                "contract cannot be met. Either set --tool-call-parser=hermes "
+                "(or your model's parser), retry with stream=false "
+                "(non-stream path 422s text-only output), or pin a specific "
+                'function via tool_choice={"type":"function",'
+                '"function":{"name":...}}.'
             ),
         )
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -84,6 +84,24 @@ router = APIRouter()
 # whether cloud routing was configured at startup. ``httpx`` and the
 # stdlib timeout/connection set are always available, so we fall back
 # to those when litellm isn't importable.
+def _tool_call_name(tc) -> str | None:
+    """Extract ``function.name`` from a tool_call entry regardless of
+    shape — pydantic ``ToolCall`` (the text-parser path's output) or
+    raw dict (engine structured passthrough). PR #518 round-2 codex
+    BLOCKING: pure-attr access mis-treated dict-shaped entries as
+    nameless, spuriously 422'ing matching named-function calls.
+    """
+    if isinstance(tc, dict):
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            return fn.get("name")
+        return getattr(fn, "name", None) if fn else None
+    fn = getattr(tc, "function", None)
+    if isinstance(fn, dict):
+        return fn.get("name")
+    return getattr(fn, "name", None) if fn else None
+
+
 def _cloud_call_recoverable_exceptions() -> tuple[type[BaseException], ...]:
     """Build the allowlist of exception types we treat as recoverable from
     the cloud call. Lazy so cloud routing being disabled doesn't pay the
@@ -980,15 +998,9 @@ async def _create_chat_completion_impl(
         ):
             _target = (request.tool_choice.get("function") or {}).get("name")
 
-            # ``tool_calls`` carries pydantic ``ToolCall`` objects, not raw
-            # dicts (built by ``_parse_tool_calls_with_parser`` from either
-            # the engine's structured passthrough or the text-parser layer).
-            # Attribute access via ``getattr`` survives both shapes.
-            def _tc_name(tc):
-                fn = getattr(tc, "function", None)
-                return getattr(fn, "name", None) if fn else None
-
-            if _target and not any(_tc_name(tc) == _target for tc in tool_calls or []):
+            if _target and not any(
+                _tool_call_name(tc) == _target for tc in tool_calls or []
+            ):
                 raise HTTPException(
                     status_code=422,
                     detail=(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -730,32 +730,38 @@ async def _create_chat_completion_impl(
                 f"<= threshold {cfg.cloud_router.threshold}, using local inference"
             )
 
-    # ``tool_choice="required"`` + ``stream=true`` is unenforceable on
-    # local inference: the non-stream path 422s if the model returns
-    # text-only output, but in streaming mode we'd have already sent
-    # ``200 OK`` and emitted content chunks before discovering the
-    # contract violation. Mid-stream SSE-error events aren't a
-    # standard OpenAI client capability, so reject upfront with a
-    # clear error pointing at the workarounds. PR #518 round-7 codex
-    # BLOCKING: streaming ``required`` silently returned text-only
-    # ``finish_reason=stop``, violating the OpenAI guarantee.
+    # ``tool_choice="required"`` + ``stream=true`` is enforceable IF
+    # a streaming tool-call parser is configured: the model usually
+    # complies with the strict-suffix prompt injection (#468), the
+    # parser emits a structured tool_call SSE chunk, and the rare
+    # text-only outcome is a known limitation of local inference
+    # without decoder-side constraints (FSM, #132). When no parser
+    # is configured we have NO path to produce a streaming tool_call
+    # at all — the request can never satisfy the contract, so reject
+    # upfront with a clear error.
     #
-    # Round-8 codex BLOCKING #1: placed AFTER the cloud-routing block
-    # so cloud-routable requests aren't spuriously rejected — the
-    # cloud backend (e.g. GPT-4o) DOES support ``required`` with
-    # streaming via decoder-side constraints. Only requests that
-    # reach this point are committed to local inference.
-    if request.stream and tc == "required" and request.tools:
+    # Round-7 codex BLOCKING surfaced the silent text-only finish_reason
+    # case; round-8 moved the guard below cloud routing; round-9 codex
+    # BLOCKING narrowed the guard to the truly-unenforceable case
+    # (no parser) so configurations that CAN emit streaming tool calls
+    # aren't blocked.
+    if (
+        request.stream
+        and tc == "required"
+        and request.tools
+        and not cfg.tool_call_parser
+    ):
         raise HTTPException(
             status_code=422,
             detail=(
-                'tool_choice="required" cannot be enforced when stream=true on '
-                "local inference (no decoder-level constraint, and SSE has no "
-                "standard mid-stream error event). Either retry with stream=false, "
+                'tool_choice="required" with stream=true requires a streaming '
+                "tool-call parser to be configured (--tool-call-parser); without "
+                "one this server has no path to emit tool_calls in the response "
+                "and the OpenAI 'tool_call guaranteed' contract cannot be met. "
+                "Either set --tool-call-parser=hermes (or your model's parser), "
+                "retry with stream=false (non-stream path 422s text-only output), "
                 "or pin a specific function via tool_choice="
-                '{"type":"function","function":{"name":...}} '
-                "— named choice still relies on prompt injection but the "
-                "filtered tools list makes the wrong-tool case much rarer."
+                '{"type":"function","function":{"name":...}}.'
             ),
         )
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -441,29 +441,6 @@ async def _create_chat_completion_impl(
         elif tc == "none" and request.tools:
             request.tools = None
 
-    # ``tool_choice="required"`` + ``stream=true`` is unenforceable on
-    # local inference: the non-stream path 422s if the model returns
-    # text-only output, but in streaming mode we'd have already sent
-    # ``200 OK`` and emitted content chunks before discovering the
-    # contract violation. Mid-stream SSE-error events aren't a
-    # standard OpenAI client capability, so reject upfront with a
-    # clear error pointing at the workarounds. PR #518 round-7 codex
-    # BLOCKING: streaming ``required`` silently returned text-only
-    # ``finish_reason=stop``, violating the OpenAI guarantee.
-    if request.stream and tc == "required" and request.tools:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                'tool_choice="required" cannot be enforced when stream=true on '
-                "local inference (no decoder-level constraint, and SSE has no "
-                "standard mid-stream error event). Either retry with stream=false, "
-                "or pin a specific function via tool_choice="
-                '{"type":"function","function":{"name":...}} '
-                "— named choice still relies on prompt injection but the "
-                "filtered tools list makes the wrong-tool case much rarer."
-            ),
-        )
-
     # Save original messages (clean dicts) for cloud routing BEFORE
     # local mutations (extract_multimodal_content, developer→system, suffix injection).
     if cfg.cloud_router:
@@ -752,6 +729,35 @@ async def _create_chat_completion_impl(
                 f"[LOCAL] {new_tokens} new tokens (total {total_tokens}) "
                 f"<= threshold {cfg.cloud_router.threshold}, using local inference"
             )
+
+    # ``tool_choice="required"`` + ``stream=true`` is unenforceable on
+    # local inference: the non-stream path 422s if the model returns
+    # text-only output, but in streaming mode we'd have already sent
+    # ``200 OK`` and emitted content chunks before discovering the
+    # contract violation. Mid-stream SSE-error events aren't a
+    # standard OpenAI client capability, so reject upfront with a
+    # clear error pointing at the workarounds. PR #518 round-7 codex
+    # BLOCKING: streaming ``required`` silently returned text-only
+    # ``finish_reason=stop``, violating the OpenAI guarantee.
+    #
+    # Round-8 codex BLOCKING #1: placed AFTER the cloud-routing block
+    # so cloud-routable requests aren't spuriously rejected — the
+    # cloud backend (e.g. GPT-4o) DOES support ``required`` with
+    # streaming via decoder-side constraints. Only requests that
+    # reach this point are committed to local inference.
+    if request.stream and tc == "required" and request.tools:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                'tool_choice="required" cannot be enforced when stream=true on '
+                "local inference (no decoder-level constraint, and SSE has no "
+                "standard mid-stream error event). Either retry with stream=false, "
+                "or pin a specific function via tool_choice="
+                '{"type":"function","function":{"name":...}} '
+                "— named choice still relies on prompt injection but the "
+                "filtered tools list makes the wrong-tool case much rarer."
+            ),
+        )
 
     # Local-path admission gate: reserve a slot before kicking the
     # engine. Placed AFTER cloud routing so cloud-routable requests

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -441,6 +441,29 @@ async def _create_chat_completion_impl(
         elif tc == "none" and request.tools:
             request.tools = None
 
+    # ``tool_choice="required"`` + ``stream=true`` is unenforceable on
+    # local inference: the non-stream path 422s if the model returns
+    # text-only output, but in streaming mode we'd have already sent
+    # ``200 OK`` and emitted content chunks before discovering the
+    # contract violation. Mid-stream SSE-error events aren't a
+    # standard OpenAI client capability, so reject upfront with a
+    # clear error pointing at the workarounds. PR #518 round-7 codex
+    # BLOCKING: streaming ``required`` silently returned text-only
+    # ``finish_reason=stop``, violating the OpenAI guarantee.
+    if request.stream and tc == "required" and request.tools:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                'tool_choice="required" cannot be enforced when stream=true on '
+                "local inference (no decoder-level constraint, and SSE has no "
+                "standard mid-stream error event). Either retry with stream=false, "
+                "or pin a specific function via tool_choice="
+                '{"type":"function","function":{"name":...}} '
+                "— named choice still relies on prompt injection but the "
+                "filtered tools list makes the wrong-tool case much rarer."
+            ),
+        )
+
     # Save original messages (clean dicts) for cloud routing BEFORE
     # local mutations (extract_multimodal_content, developer→system, suffix injection).
     if cfg.cloud_router:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1014,17 +1014,26 @@ async def _create_chat_completion_impl(
         ):
             _target = (request.tool_choice.get("function") or {}).get("name")
 
-            if _target and not any(
-                _tool_call_name(tc) == _target for tc in tool_calls or []
-            ):
-                raise HTTPException(
-                    status_code=422,
-                    detail=(
-                        f"tool_choice pinned function {_target!r} but the model did not "
-                        "call it. Local inference cannot decoder-enforce a specific "
-                        "function; retry with a more direct user message."
-                    ),
-                )
+            # OpenAI spec: a named ``tool_choice`` allows ONLY the named
+            # function. A response that includes the target plus any
+            # other call violates the contract — refuse to forward.
+            # Round-4 codex BLOCKING #2: prior ``any(...)`` accepted
+            # ``[target, wrong]`` and shipped the extra call to the
+            # client. Now require: at least one match AND every emitted
+            # call matches.
+            if _target:
+                _names = [_tool_call_name(tc) for tc in tool_calls or []]
+                _mismatched = [n for n in _names if n != _target]
+                if not _names or _mismatched:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"tool_choice pinned function {_target!r} but the model "
+                            f"emitted calls to {_mismatched or 'no tool'}. Local "
+                            "inference cannot decoder-enforce a specific function; "
+                            "retry with a more direct user message."
+                        ),
+                    )
 
     # Validate tool call parameter values against schemas
     if tool_calls and request.tools:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -42,6 +42,7 @@ from ..config import get_config
 from ..engine import GenerationOutput
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
+    _TOOL_USE_REQUIRED_SUFFIX,
     _TOOL_USE_SYSTEM_SUFFIX,
     _build_usage,
     _check_admission_or_503,
@@ -57,6 +58,7 @@ from ..service.helpers import (
     _resolve_model_name,
     _resolve_temperature,
     _resolve_top_p,
+    _tool_use_required_named_suffix,
     _validate_model_name,
     _validate_tool_call_params,
     _wait_with_disconnect,
@@ -504,10 +506,26 @@ async def _create_chat_completion_impl(
             else:
                 m.role = "system"
 
-    # Auto-inject system prompt suffix for tool use and/or reasoning control
+    # Auto-inject system prompt suffix for tool use and/or reasoning control.
+    # ``tool_choice="required"`` (and the specific-function form) gets a
+    # stricter suffix than the default tool-use one — the OpenAI spec
+    # guarantees a tool_call when ``required`` is set, but local inference
+    # has no decoder-level enforcement (FSM constraint tracked in #132).
+    # Prompt injection + post-parse 422 are the strongest levers we have
+    # (#468). Strictness shape: explicit ``required`` > named function >
+    # the default ``auto``/unset suffix.
     _inject_suffix = None
     if request.tools and cfg.tool_call_parser:
-        _inject_suffix = _TOOL_USE_SYSTEM_SUFFIX
+        if tc == "required":
+            _inject_suffix = _TOOL_USE_REQUIRED_SUFFIX
+        elif isinstance(tc, dict) and tc.get("type") == "function":
+            _named = (tc.get("function") or {}).get("name")
+            if _named:
+                _inject_suffix = _tool_use_required_named_suffix(_named)
+            else:
+                _inject_suffix = _TOOL_USE_SYSTEM_SUFFIX
+        else:
+            _inject_suffix = _TOOL_USE_SYSTEM_SUFFIX
     elif cfg.reasoning_parser_name == "minimax":
         _inject_suffix = (
             "\n\nDo NOT think out loud or show your reasoning process. "
@@ -933,6 +951,52 @@ async def _create_chat_completion_impl(
     # single tool call (see PR #132 for the longer-term FSM-constrained path).
     if tool_calls and len(tool_calls) > 1 and request.parallel_tool_calls is False:
         tool_calls = tool_calls[:1]
+
+    # ``tool_choice="required"`` post-parse enforcement (#468). The system
+    # suffix injected above (``_TOOL_USE_REQUIRED_SUFFIX``) makes the model
+    # overwhelmingly likely to comply, but local inference has no
+    # decoder-level guarantee. When the parser comes back empty we 422
+    # rather than ship a contract-violating response (OpenAI spec: a
+    # tool_call is GUARANTEED present in the response when ``required``
+    # is set). For the named-function form we also verify the right tool
+    # fired. Streaming path is best-effort prompt-injection only; once
+    # SSE chunks are out we can't 422 mid-flight.
+    if request.tool_choice is not None and request.tools:
+        if request.tool_choice == "required" and not tool_calls:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    'tool_choice="required" but the model returned a text response '
+                    "with no tool_calls. Local inference has no decoder-level "
+                    "constraint; the system-prompt enforcement was insufficient "
+                    "for this prompt. Retry with a more concrete user message or "
+                    'use tool_choice={"type":"function","function":{"name":...}} '
+                    "to pin a specific tool."
+                ),
+            )
+        if (
+            isinstance(request.tool_choice, dict)
+            and request.tool_choice.get("type") == "function"
+        ):
+            _target = (request.tool_choice.get("function") or {}).get("name")
+
+            # ``tool_calls`` carries pydantic ``ToolCall`` objects, not raw
+            # dicts (built by ``_parse_tool_calls_with_parser`` from either
+            # the engine's structured passthrough or the text-parser layer).
+            # Attribute access via ``getattr`` survives both shapes.
+            def _tc_name(tc):
+                fn = getattr(tc, "function", None)
+                return getattr(fn, "name", None) if fn else None
+
+            if _target and not any(_tc_name(tc) == _target for tc in tool_calls or []):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"tool_choice pinned function {_target!r} but the model did not "
+                        "call it. Local inference cannot decoder-enforce a specific "
+                        "function; retry with a more direct user message."
+                    ),
+                )
 
     # Validate tool call parameter values against schemas
     if tool_calls and request.tools:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -528,6 +528,8 @@ def load_model(
     no_hybrid: bool = False,
     force_spec_decode: bool = False,
     no_spec_decode: bool = False,
+    force_openai_harmony_streaming: bool = False,
+    no_openai_harmony_streaming: bool = False,
 ):
     """
     Load a model (auto-detects MLLM vs LLM).
@@ -643,6 +645,12 @@ def load_model(
             "force_spec_decode and no_spec_decode are mutually exclusive — "
             "pick at most one to override auto-detection."
         )
+    if force_openai_harmony_streaming and no_openai_harmony_streaming:
+        raise ValueError(
+            "force_openai_harmony_streaming and no_openai_harmony_streaming "
+            "are mutually exclusive — pick at most one to override the "
+            "HarmonyStreamingRouter auto-upgrade gate (#516)."
+        )
     if force_mllm:
         logger.info("Force MLLM mode enabled via --mllm flag")
     if force_text:
@@ -663,6 +671,8 @@ def load_model(
         no_hybrid=no_hybrid,
         force_spec_decode=force_spec_decode,
         no_spec_decode=no_spec_decode,
+        force_openai_harmony_streaming=force_openai_harmony_streaming,
+        no_openai_harmony_streaming=no_openai_harmony_streaming,
     )
     logger.info(f"Model loaded: {model_name}")
 
@@ -963,6 +973,21 @@ Examples:
         default=False,
         help="Force-disable speculative-decode eligibility (suffix/MTP/DFlash). Mutually exclusive with --force-spec-decode.",
     )
+    # #516 — HarmonyStreamingRouter auto-upgrade escape hatches (SOP G11).
+    parser.add_argument(
+        "--force-openai-harmony-streaming",
+        dest="force_openai_harmony_streaming",
+        action="store_true",
+        default=False,
+        help="Force-on HarmonyStreamingRouter (bypass compat gate). Debug only. Mutually exclusive with --no-openai-harmony-streaming.",
+    )
+    parser.add_argument(
+        "--no-openai-harmony-streaming",
+        dest="no_openai_harmony_streaming",
+        action="store_true",
+        default=False,
+        help="Force-off HarmonyStreamingRouter upgrade; use legacy state machine. Mutually exclusive with --force-openai-harmony-streaming.",
+    )
     parser.add_argument(
         "--continuous-batching",
         action="store_true",
@@ -1238,6 +1263,13 @@ Examples:
         args, "no_spec_decode", False
     ):
         parser.error("--force-spec-decode and --no-spec-decode are mutually exclusive")
+    if getattr(args, "force_openai_harmony_streaming", False) and getattr(
+        args, "no_openai_harmony_streaming", False
+    ):
+        parser.error(
+            "--force-openai-harmony-streaming and "
+            "--no-openai-harmony-streaming are mutually exclusive"
+        )
     load_model(
         args.model,
         scheduler_config=scheduler_config,
@@ -1252,6 +1284,10 @@ Examples:
         no_hybrid=getattr(args, "no_hybrid", False),
         force_spec_decode=getattr(args, "force_spec_decode", False),
         no_spec_decode=getattr(args, "no_spec_decode", False),
+        force_openai_harmony_streaming=getattr(
+            args, "force_openai_harmony_streaming", False
+        ),
+        no_openai_harmony_streaming=getattr(args, "no_openai_harmony_streaming", False),
     )
 
     # Start server

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -256,6 +256,31 @@ _TOOL_USE_SYSTEM_SUFFIX = (
     "Give direct answers only — no preamble like 'The user asks...' or 'Let me think...'."
 )
 
+# Tool-use system prompt for ``tool_choice="required"`` (#468). Strict
+# variant of the default suffix — the OpenAI spec guarantees a tool_call
+# will be present in the response when ``required`` is set, but local
+# inference has no decoder-level enforcement (no FSM constraint yet,
+# tracked under PR #132). Prompt injection is the strongest tool we
+# have until then; the route also applies a post-parse 422 on the
+# non-stream path to surface failures clearly.
+_TOOL_USE_REQUIRED_SUFFIX = (
+    "\n\nCRITICAL: You MUST call one of the provided tools to answer this request. "
+    "Do NOT respond with text content. Do NOT explain. Do NOT ask for clarification. "
+    "Pick the most appropriate tool and call it immediately. If no tool fits the "
+    "user's request exactly, pick the closest match and call it with your best guess "
+    "of the arguments. A text-only response is INVALID for this request."
+)
+
+
+def _tool_use_required_named_suffix(name: str) -> str:
+    """Variant used when ``tool_choice={'type':'function','function':{'name':X}}``."""
+    return (
+        f"\n\nCRITICAL: You MUST call the tool named {name!r} to answer this "
+        "request. Do NOT respond with text content. Do NOT explain. Do NOT call "
+        "any other tool. Call this exact tool immediately with your best guess "
+        "of the arguments. A text-only response is INVALID for this request."
+    )
+
 
 # ── Resolution helpers ─────────────────────────────────────────────
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -152,6 +152,19 @@ class StreamingPostProcessor:
         # continuations were re-classified as new calls and dropped
         # once the cap was full, silently truncating arguments.
         self._no_index_call_admitted: bool = False
+        # Tracks whether the MOST RECENT no-index "anchor" delta (one
+        # carrying a fresh ``id`` or function ``name``) was DROPPED
+        # because the cap was full. Subsequent argument-only no-index
+        # fragments belong to whichever anchor came last — so if the
+        # last anchor was dropped, the fragments must be dropped too,
+        # not silently appended to the admitted call's arguments.
+        # PR #518 round-3 codex BLOCKING fix surfaced this leak; this
+        # closes it. Assumes sequential parser emission (one call
+        # completes before the next starts) — interleaved no-index
+        # calls without ``id`` are indistinguishable from delta shape
+        # alone; well-behaved parsers either disambiguate via
+        # ``index``/``id`` or emit sequentially.
+        self._no_index_last_dropped: bool = False
 
         # Nemotron thinking prefix
         self._is_thinking_model = False
@@ -314,6 +327,15 @@ class StreamingPostProcessor:
                     and tc.get("id")
                 )
                 if not (has_name or has_id):
+                    # Continuation fragment — route to whichever
+                    # anchor was last seen. If the last anchor was a
+                    # dropped new call (cap-full new-call branch
+                    # below set ``_no_index_last_dropped``), suppress
+                    # so the dropped call's arguments don't leak
+                    # into the admitted call's payload (round-4 codex
+                    # BLOCKING #1).
+                    if self._no_index_last_dropped:
+                        continue
                     allowed.append(tc)
                     continue
             # New call (unseen index, fresh no-index call with id/name,
@@ -324,13 +346,22 @@ class StreamingPostProcessor:
             if already_admitted >= 1:
                 # Cap full — drop this new call AND any further
                 # continuations of its index, since we never admit it.
+                if idx is None:
+                    # Mark so subsequent no-index argument fragments
+                    # are routed to "dropped" rather than silently
+                    # appended to the admitted call.
+                    self._no_index_last_dropped = True
                 continue
             if isinstance(idx, int):
                 self._admitted_tool_call_indices.add(idx)
             else:
                 # Mark the no-index slot as taken; subsequent no-index
-                # deltas hit the continuation branch above.
+                # deltas hit the continuation branch above. Reset the
+                # dropped-anchor flag — this delta is the most recent
+                # anchor and it was admitted, so its fragments belong
+                # here.
                 self._no_index_call_admitted = True
+                self._no_index_last_dropped = False
             self._structured_tool_call_count = max(
                 self._structured_tool_call_count,
                 len(self._admitted_tool_call_indices)
@@ -356,6 +387,7 @@ class StreamingPostProcessor:
         self._structured_tool_call_count = 0
         self._admitted_tool_call_indices = set()
         self._no_index_call_admitted = False
+        self._no_index_last_dropped = False
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -152,6 +152,17 @@ class StreamingPostProcessor:
         # continuations were re-classified as new calls and dropped
         # once the cap was full, silently truncating arguments.
         self._no_index_call_admitted: bool = False
+        # Identity of the admitted no-index call. Some parsers re-emit
+        # the same ``id`` / function ``name`` on every cumulative
+        # argument-update delta (rather than emitting an anchor once
+        # and bare-argument continuations after). Round-10 codex
+        # BLOCKING: without remembering the admitted identity, the
+        # repeated anchor was misclassified as a NEW call and dropped
+        # under ``parallel_tool_calls=false``, truncating the JSON.
+        # Set together with ``_no_index_call_admitted`` on admit;
+        # cleared on ``reset()``.
+        self._no_index_admitted_id: str | None = None
+        self._no_index_admitted_name: str | None = None
         # Tracks whether the MOST RECENT anchor delta (one carrying a
         # fresh ``id`` / function ``name`` / new ``index``) was DROPPED
         # because the cap was full. Subsequent argument-only no-index
@@ -345,6 +356,41 @@ class StreamingPostProcessor:
                 allowed.append(tc)
                 continue
 
+            # No-index anchor matching the admitted no-index call's
+            # identity: cumulative argument-update parsers re-emit
+            # ``{"id": "<same>", "function": {"name": "<same>",
+            # "arguments": "<grew>"}}`` on every delta rather than
+            # emitting a single anchor and bare-argument continuations.
+            # Without this branch, every such re-emission would be
+            # mis-classified as a new call and dropped under
+            # ``parallel_tool_calls=false`` (round-10 codex BLOCKING #2).
+            # Match if BOTH the delta and the admitted call carry id
+            # AND ids match, OR if id is absent on the delta and the
+            # function names match — never silently accept a different
+            # call identity as continuation.
+            if idx is None and is_anchor and self._no_index_call_admitted:
+                delta_id = tc.get("id") if has_id else None
+                delta_name = (
+                    fn.get("name")
+                    if has_wrapped_name
+                    else (tc.get("name") if has_flat_name else None)
+                )
+                id_matches = (
+                    delta_id is not None
+                    and self._no_index_admitted_id is not None
+                    and delta_id == self._no_index_admitted_id
+                )
+                name_matches_no_id_conflict = (
+                    delta_id is None
+                    and delta_name is not None
+                    and self._no_index_admitted_name is not None
+                    and delta_name == self._no_index_admitted_name
+                )
+                if id_matches or name_matches_no_id_conflict:
+                    self._no_index_last_dropped = False
+                    allowed.append(tc)
+                    continue
+
             # Argument-only no-index fragment: routes to whichever
             # anchor was most recently seen. Any admitted call (indexed
             # OR no-index slot) keeps the fragment unless the most
@@ -404,9 +450,19 @@ class StreamingPostProcessor:
                 # deltas hit the continuation branch above. Reset the
                 # dropped-anchor flag — this delta is the most recent
                 # anchor and it was admitted, so its fragments belong
-                # here.
+                # here. Capture the admitted identity (id + name) so a
+                # later anchor delta carrying the SAME id/name (parsers
+                # that re-emit the anchor with cumulative arguments) is
+                # matched as a continuation rather than misclassified
+                # as a new call. PR #518 round-10 codex BLOCKING #2.
                 self._no_index_call_admitted = True
                 self._no_index_last_dropped = False
+                if has_id:
+                    self._no_index_admitted_id = tc.get("id")
+                if has_wrapped_name:
+                    self._no_index_admitted_name = fn.get("name")
+                elif has_flat_name:
+                    self._no_index_admitted_name = tc.get("name")
             self._structured_tool_call_count = max(
                 self._structured_tool_call_count,
                 len(self._admitted_tool_call_indices)
@@ -432,6 +488,8 @@ class StreamingPostProcessor:
         self._structured_tool_call_count = 0
         self._admitted_tool_call_indices = set()
         self._no_index_call_admitted = False
+        self._no_index_admitted_id = None
+        self._no_index_admitted_name = None
         self._no_index_last_dropped = False
 
         if self.reasoning_parser:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -215,6 +215,22 @@ class StreamingPostProcessor:
             val = getattr(req, "parallel_tool_calls", None)
         return val is not False
 
+    def _cap_remaining(self) -> int | None:
+        """Slots remaining under ``parallel_tool_calls=false`` cap. None
+        means uncapped (default / explicit ``parallel_tool_calls=true``).
+
+        Issue #517: PR #515 added the cap to ``_process_channel_routed``
+        only; the text-parser streaming paths (``_process_standard``,
+        ``_process_reasoning``) emitted ``result['tool_calls']`` raw,
+        letting hermes/qwen3 streaming responses exceed the cap the
+        non-stream path enforces at ``routes/chat.py:934``. Shared
+        helper so all three streaming branches honor the same external
+        contract; the counter is per-request via __init__/reset().
+        """
+        if self._parallel_tool_calls_allowed():
+            return None
+        return max(0, 1 - self._structured_tool_call_count)
+
     def reset(self):
         """Reset all parser states for a new stream.
 
@@ -359,10 +375,27 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                # Issue #517 — apply ``parallel_tool_calls=false`` cap
+                # uniformly across all streaming paths.
+                raw_tcs = result["tool_calls"]
+                cap = self._cap_remaining()
+                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
+                self._structured_tool_call_count += len(allowed_tcs)
+                if not allowed_tcs:
+                    self.tool_calls_detected = True
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason="tool_calls",
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return []
                 return [
                     StreamEvent(
                         type="tool_call",
-                        tool_calls=result["tool_calls"],
+                        tool_calls=allowed_tcs,
                         finish_reason="tool_calls" if output.finished else None,
                         tool_calls_detected=True,
                     )
@@ -478,10 +511,27 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                # Issue #517 — apply ``parallel_tool_calls=false`` cap
+                # uniformly across all streaming paths.
+                raw_tcs = result["tool_calls"]
+                cap = self._cap_remaining()
+                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
+                self._structured_tool_call_count += len(allowed_tcs)
+                if not allowed_tcs:
+                    self.tool_calls_detected = True
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason="tool_calls",
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return []
                 return [
                     StreamEvent(
                         type="tool_call",
-                        tool_calls=result["tool_calls"],
+                        tool_calls=allowed_tcs,
                         finish_reason="tool_calls" if output.finished else None,
                         tool_calls_detected=True,
                     )
@@ -577,10 +627,29 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                # Apply ``parallel_tool_calls=false`` cap before emission
+                # (issue #517) — the parser may produce N calls in one
+                # delta or trickle them across deltas; the counter tracks
+                # cross-delta cumulative emissions.
+                raw_tcs = result["tool_calls"]
+                cap = self._cap_remaining()
+                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
+                self._structured_tool_call_count += len(allowed_tcs)
+                if not allowed_tcs:
+                    self.tool_calls_detected = True
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason="tool_calls",
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return []
                 return [
                     StreamEvent(
                         type="tool_call",
-                        tool_calls=result["tool_calls"],
+                        tool_calls=allowed_tcs,
                         finish_reason="tool_calls" if output.finished else None,
                         tool_calls_detected=True,
                     )

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -303,43 +303,55 @@ class StreamingPostProcessor:
         allowed: list[dict] = []
         for tc in tool_calls:
             idx = tc.get("index") if isinstance(tc, dict) else None
+            fn = tc.get("function") if isinstance(tc, dict) else None
+            has_name = (
+                isinstance(fn, dict)
+                and isinstance(fn.get("name"), str)
+                and fn.get("name")
+            )
+            has_id = (
+                isinstance(tc, dict) and isinstance(tc.get("id"), str) and tc.get("id")
+            )
+            is_anchor = bool(has_name or has_id)
+
             if isinstance(idx, int) and idx in self._admitted_tool_call_indices:
                 # Continuation of an already-admitted indexed call —
                 # always forward so the client's arguments JSON is
                 # complete.
                 allowed.append(tc)
                 continue
-            if idx is None and self._no_index_call_admitted:
-                # Only argument-fragment deltas (no fresh ``id`` /
-                # ``name``) count as continuations of the in-flight
-                # no-index call. A delta carrying a new ``id`` or
-                # function ``name`` is a distinct new call and must
-                # run the cap check (round-3 codex BLOCKING #2).
-                fn = tc.get("function") if isinstance(tc, dict) else None
-                has_name = (
-                    isinstance(fn, dict)
-                    and isinstance(fn.get("name"), str)
-                    and fn.get("name")
+
+            # Argument-only no-index fragment: routes to whichever
+            # anchor was most recently seen. Any admitted call (indexed
+            # OR no-index slot) keeps the fragment unless the most
+            # recent anchor was dropped.
+            #
+            # Round-5 codex BLOCKING #2: previously this branch only
+            # fired when ``_no_index_call_admitted`` was True. An
+            # indexed FIRST delta (e.g. ``{"index": 0, "id": "a",
+            # "function": {"name": "a", "arguments": "{"}}``) followed
+            # by argument-only no-index deltas (``{"function":
+            # {"arguments": "}"}}``) routed the fragments to the
+            # new-call cap-check and dropped them as cap-full —
+            # truncating the JSON. Now any admitted call (indexed
+            # or no-index) absorbs no-index argument fragments.
+            if idx is None and not is_anchor:
+                has_admitted_call = bool(self._admitted_tool_call_indices) or (
+                    self._no_index_call_admitted
                 )
-                has_id = (
-                    isinstance(tc, dict)
-                    and isinstance(tc.get("id"), str)
-                    and tc.get("id")
-                )
-                if not (has_name or has_id):
-                    # Continuation fragment — route to whichever
-                    # anchor was last seen. If the last anchor was a
-                    # dropped new call (cap-full new-call branch
-                    # below set ``_no_index_last_dropped``), suppress
-                    # so the dropped call's arguments don't leak
-                    # into the admitted call's payload (round-4 codex
-                    # BLOCKING #1).
+                if has_admitted_call:
                     if self._no_index_last_dropped:
+                        # Most recent anchor was dropped; suppress so
+                        # the dropped call's args don't leak into the
+                        # admitted call's payload.
                         continue
                     allowed.append(tc)
                     continue
-            # New call (unseen index, fresh no-index call with id/name,
-            # or first no-index delta).
+                # Falls through to new-call branch (first delta of the
+                # stream has no index AND no anchor — treat as new).
+
+            # New call: unseen index, fresh no-index call with id/name,
+            # or first no-index delta with no admitted call yet.
             already_admitted = len(self._admitted_tool_call_indices) + (
                 1 if self._no_index_call_admitted else 0
             )
@@ -354,6 +366,11 @@ class StreamingPostProcessor:
                 continue
             if isinstance(idx, int):
                 self._admitted_tool_call_indices.add(idx)
+                # Indexed admit: subsequent no-index argument fragments
+                # belong to the in-flight admitted call. Reset the
+                # dropped-anchor flag (the cap-full branch above is
+                # the only writer).
+                self._no_index_last_dropped = False
             else:
                 # Mark the no-index slot as taken; subsequent no-index
                 # deltas hit the continuation branch above. Reset the
@@ -451,7 +468,17 @@ class StreamingPostProcessor:
             parallel_allowed = self._parallel_tool_calls_allowed()
             allowed_calls: list[dict] = []
             for tc in engine_tool_calls:
-                if not parallel_allowed and len(self._admitted_tool_call_indices) >= 1:
+                # Defense in depth: include the no-index slot in the
+                # cap total even though a single stream rarely hits
+                # both the channel-routed AND text-parser paths
+                # (channel-routed is gated on ``output.channel`` being
+                # set, which only happens for OutputRouter models).
+                # Round-5 codex BLOCKING #1: if any future flow lets
+                # cross-pollination happen, the cap would leak.
+                already_admitted = len(self._admitted_tool_call_indices) + (
+                    1 if self._no_index_call_admitted else 0
+                )
+                if not parallel_allowed and already_admitted >= 1:
                     break
                 new_idx = self._structured_tool_call_count
                 self._admitted_tool_call_indices.add(new_idx)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -144,6 +144,14 @@ class StreamingPostProcessor:
         # index are continuations and must pass through so the client
         # can reassemble the JSON. PR #518 codex round-1 BLOCKING.
         self._admitted_tool_call_indices: set[int] = set()
+        # Parallel to the indexed-set above, but for parsers that emit
+        # continuation deltas without an ``index`` field. Treated as a
+        # single in-flight call: first no-index delta admits, every
+        # subsequent no-index delta is forwarded as a continuation.
+        # PR #518 round-2 codex BLOCKING: without this, no-index
+        # continuations were re-classified as new calls and dropped
+        # once the cap was full, silently truncating arguments.
+        self._no_index_call_admitted: bool = False
 
         # Nemotron thinking prefix
         self._is_thinking_model = False
@@ -247,8 +255,13 @@ class StreamingPostProcessor:
           - Capped (parallel=false): for each delta, if its ``index``
             is already admitted, pass through (continuation). If it's
             new, only admit if we haven't filled the slot yet.
-          - A delta with no ``index`` field falls through unchanged —
-            we can't disambiguate, so don't apply the cap to it.
+          - A delta with no ``index`` field is treated as belonging to
+            the single in-flight "no-index" call: first such delta is
+            the admit, every subsequent no-index delta is a
+            continuation. PR #518 round-2 codex BLOCKING: previously
+            each no-index delta after the first was re-classified as
+            "new" and dropped, silently truncating arguments for
+            parsers that omit ``index`` from continuation fragments.
 
         Returns the filtered list (possibly empty if every delta in
         the batch is a new call past the cap).
@@ -261,6 +274,8 @@ class StreamingPostProcessor:
                 idx = tc.get("index") if isinstance(tc, dict) else None
                 if isinstance(idx, int):
                     self._admitted_tool_call_indices.add(idx)
+                else:
+                    self._no_index_call_admitted = True
             self._structured_tool_call_count = max(
                 self._structured_tool_call_count,
                 len(self._admitted_tool_call_indices),
@@ -271,27 +286,33 @@ class StreamingPostProcessor:
         for tc in tool_calls:
             idx = tc.get("index") if isinstance(tc, dict) else None
             if isinstance(idx, int) and idx in self._admitted_tool_call_indices:
-                # Continuation of an already-admitted call — always
-                # forward so the client's arguments JSON is complete.
+                # Continuation of an already-admitted indexed call —
+                # always forward so the client's arguments JSON is
+                # complete.
                 allowed.append(tc)
                 continue
-            # New call (unseen index, or index field absent — treat as
-            # new since we can't prove otherwise).
-            if len(self._admitted_tool_call_indices) >= 1:
+            if idx is None and self._no_index_call_admitted:
+                # Continuation of the in-flight no-index call.
+                allowed.append(tc)
+                continue
+            # New call (unseen index, or first no-index delta).
+            already_admitted = len(self._admitted_tool_call_indices) + (
+                1 if self._no_index_call_admitted else 0
+            )
+            if already_admitted >= 1:
                 # Cap full — drop this new call AND any further
                 # continuations of its index, since we never admit it.
                 continue
             if isinstance(idx, int):
                 self._admitted_tool_call_indices.add(idx)
             else:
-                # Synthesize a placeholder index so subsequent
-                # continuations of THIS no-index call would have been
-                # admitted too. Use ``_structured_tool_call_count`` as
-                # the synthetic marker.
-                self._admitted_tool_call_indices.add(self._structured_tool_call_count)
+                # Mark the no-index slot as taken; subsequent no-index
+                # deltas hit the continuation branch above.
+                self._no_index_call_admitted = True
             self._structured_tool_call_count = max(
                 self._structured_tool_call_count,
-                len(self._admitted_tool_call_indices),
+                len(self._admitted_tool_call_indices)
+                + (1 if self._no_index_call_admitted else 0),
             )
             allowed.append(tc)
         return allowed
@@ -312,6 +333,7 @@ class StreamingPostProcessor:
         self._json_preamble_buffer = ""
         self._structured_tool_call_count = 0
         self._admitted_tool_call_indices = set()
+        self._no_index_call_admitted = False
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -249,19 +249,26 @@ class StreamingPostProcessor:
         dropped — silently truncating the JSON arguments mid-string.
 
         New rule:
-          - Uncapped (parallel=true / unset): pass everything; mark
-            every seen index as admitted so callers can disambiguate
-            new vs continuation when they need to.
+          - Uncapped (parallel=true / unset): pass everything; ONLY
+            track ``index`` admits (for the channel-routed branch's
+            monotonic-counter math). Do NOT touch
+            ``_no_index_call_admitted`` here — that field is cap-only
+            state, and mutating it in the uncapped path could
+            pollute cap accounting if request flags change mid-stream
+            (PR #518 round-3 codex NIT).
           - Capped (parallel=false): for each delta, if its ``index``
-            is already admitted, pass through (continuation). If it's
-            new, only admit if we haven't filled the slot yet.
-          - A delta with no ``index`` field is treated as belonging to
-            the single in-flight "no-index" call: first such delta is
-            the admit, every subsequent no-index delta is a
-            continuation. PR #518 round-2 codex BLOCKING: previously
-            each no-index delta after the first was re-classified as
-            "new" and dropped, silently truncating arguments for
-            parsers that omit ``index`` from continuation fragments.
+            is already admitted, pass through (continuation). If
+            ``index`` is absent AND the delta carries ONLY argument
+            fragments (no new ``id`` / ``name``), treat it as a
+            continuation of the in-flight no-index call. A no-index
+            delta carrying a fresh ``id`` or function ``name`` is a
+            NEW call — admit only if the cap allows. PR #518 round-3
+            codex BLOCKING: previously, every subsequent no-index
+            delta was treated as a continuation, leaking a second
+            full call past the cap.
+          - Cap-full new calls are dropped, AND their later
+            continuations are dropped too (no admit ever fired, so
+            the index/no-index slot was never taken).
 
         Returns the filtered list (possibly empty if every delta in
         the batch is a new call past the cap).
@@ -274,8 +281,6 @@ class StreamingPostProcessor:
                 idx = tc.get("index") if isinstance(tc, dict) else None
                 if isinstance(idx, int):
                     self._admitted_tool_call_indices.add(idx)
-                else:
-                    self._no_index_call_admitted = True
             self._structured_tool_call_count = max(
                 self._structured_tool_call_count,
                 len(self._admitted_tool_call_indices),
@@ -292,10 +297,27 @@ class StreamingPostProcessor:
                 allowed.append(tc)
                 continue
             if idx is None and self._no_index_call_admitted:
-                # Continuation of the in-flight no-index call.
-                allowed.append(tc)
-                continue
-            # New call (unseen index, or first no-index delta).
+                # Only argument-fragment deltas (no fresh ``id`` /
+                # ``name``) count as continuations of the in-flight
+                # no-index call. A delta carrying a new ``id`` or
+                # function ``name`` is a distinct new call and must
+                # run the cap check (round-3 codex BLOCKING #2).
+                fn = tc.get("function") if isinstance(tc, dict) else None
+                has_name = (
+                    isinstance(fn, dict)
+                    and isinstance(fn.get("name"), str)
+                    and fn.get("name")
+                )
+                has_id = (
+                    isinstance(tc, dict)
+                    and isinstance(tc.get("id"), str)
+                    and tc.get("id")
+                )
+                if not (has_name or has_id):
+                    allowed.append(tc)
+                    continue
+            # New call (unseen index, fresh no-index call with id/name,
+            # or first no-index delta).
             already_admitted = len(self._admitted_tool_call_indices) + (
                 1 if self._no_index_call_admitted else 0
             )

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -333,7 +333,15 @@ class StreamingPostProcessor:
             if isinstance(idx, int) and idx in self._admitted_tool_call_indices:
                 # Continuation of an already-admitted indexed call —
                 # always forward so the client's arguments JSON is
-                # complete.
+                # complete. Round-9 codex BLOCKING #2: seeing a fresh
+                # continuation of an admitted indexed call signals
+                # that the in-flight call is still alive, so reset
+                # the dropped-anchor flag — otherwise a NO-INDEX
+                # argument fragment immediately following this
+                # indexed continuation would be wrongly dropped as
+                # "belongs to a dropped call" when it really belongs
+                # to THIS admitted call.
+                self._no_index_last_dropped = False
                 allowed.append(tc)
                 continue
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -152,18 +152,22 @@ class StreamingPostProcessor:
         # continuations were re-classified as new calls and dropped
         # once the cap was full, silently truncating arguments.
         self._no_index_call_admitted: bool = False
-        # Tracks whether the MOST RECENT no-index "anchor" delta (one
-        # carrying a fresh ``id`` or function ``name``) was DROPPED
+        # Tracks whether the MOST RECENT anchor delta (one carrying a
+        # fresh ``id`` / function ``name`` / new ``index``) was DROPPED
         # because the cap was full. Subsequent argument-only no-index
         # fragments belong to whichever anchor came last — so if the
         # last anchor was dropped, the fragments must be dropped too,
         # not silently appended to the admitted call's arguments.
-        # PR #518 round-3 codex BLOCKING fix surfaced this leak; this
-        # closes it. Assumes sequential parser emission (one call
-        # completes before the next starts) — interleaved no-index
-        # calls without ``id`` are indistinguishable from delta shape
-        # alone; well-behaved parsers either disambiguate via
-        # ``index``/``id`` or emit sequentially.
+        # Reset on every admit (indexed or no-index). Set on every
+        # cap-full drop (indexed or no-index). PR #518 round-3 first
+        # surfaced the leak; round-6 codex widened the set to also
+        # cover indexed dropped anchors (name kept ``no_index`` for
+        # backwards refs, but semantically tracks "last anchor was
+        # dropped"). Assumes sequential parser emission — interleaved
+        # no-index continuations of distinct admitted indexed calls
+        # are indistinguishable from delta shape alone; well-behaved
+        # parsers either disambiguate via ``index``/``id`` or emit
+        # sequentially.
         self._no_index_last_dropped: bool = False
 
         # Nemotron thinking prefix
@@ -358,11 +362,15 @@ class StreamingPostProcessor:
             if already_admitted >= 1:
                 # Cap full — drop this new call AND any further
                 # continuations of its index, since we never admit it.
-                if idx is None:
-                    # Mark so subsequent no-index argument fragments
-                    # are routed to "dropped" rather than silently
-                    # appended to the admitted call.
-                    self._no_index_last_dropped = True
+                # Mark so subsequent no-index argument-only fragments
+                # are routed to "dropped" rather than silently
+                # appended to the admitted call. Round-6 codex
+                # BLOCKING: previously this flag was only set when
+                # the dropped anchor was no-index, so an INDEXED
+                # dropped anchor would leave the flag clear and the
+                # next no-index argument fragment would leak into
+                # the admitted call's payload.
+                self._no_index_last_dropped = True
                 continue
             if isinstance(idx, int):
                 self._admitted_tool_call_indices.add(idx)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -135,6 +135,15 @@ class StreamingPostProcessor:
         # (OpenAI spec: tool_calls deltas merge on ``index``). Codex
         # round-15 BLOCKING #1.
         self._structured_tool_call_count = 0
+        # Set of tool_call indices we've already admitted under the
+        # ``parallel_tool_calls`` cap. Text-parser streaming paths
+        # (hermes, qwen3_coder, etc.) emit MANY deltas per logical call:
+        # name first, then argument fragments, all with the same
+        # ``index``. The cap consumes a slot only on the FIRST sighting
+        # of a new index; subsequent deltas for an already-admitted
+        # index are continuations and must pass through so the client
+        # can reassemble the JSON. PR #518 codex round-1 BLOCKING.
+        self._admitted_tool_call_indices: set[int] = set()
 
         # Nemotron thinking prefix
         self._is_thinking_model = False
@@ -215,21 +224,77 @@ class StreamingPostProcessor:
             val = getattr(req, "parallel_tool_calls", None)
         return val is not False
 
-    def _cap_remaining(self) -> int | None:
-        """Slots remaining under ``parallel_tool_calls=false`` cap. None
-        means uncapped (default / explicit ``parallel_tool_calls=true``).
+    def _apply_parallel_cap(self, tool_calls: list[dict]) -> list[dict]:
+        """Filter a streaming tool_calls delta list under the
+        ``parallel_tool_calls=false`` cap, distinguishing NEW tool
+        calls (unseen ``index``) from CONTINUATION deltas (seen
+        ``index`` — name + incremental argument fragments for an
+        already-admitted call).
 
-        Issue #517: PR #515 added the cap to ``_process_channel_routed``
-        only; the text-parser streaming paths (``_process_standard``,
-        ``_process_reasoning``) emitted ``result['tool_calls']`` raw,
-        letting hermes/qwen3 streaming responses exceed the cap the
-        non-stream path enforces at ``routes/chat.py:934``. Shared
-        helper so all three streaming branches honor the same external
-        contract; the counter is per-request via __init__/reset().
+        Text-parser streaming paths (hermes, qwen3_coder, etc.) emit
+        many deltas per logical call: a header carrying ``{index, id,
+        function: {name}}``, then a sequence of deltas carrying only
+        ``{index, function: {arguments: "<fragment>"}}``. PR #518 round-1
+        codex BLOCKING: the prior implementation consumed a cap slot
+        per delta, so the first argument fragment for index 0 took the
+        only slot and every subsequent fragment of THE SAME CALL was
+        dropped — silently truncating the JSON arguments mid-string.
+
+        New rule:
+          - Uncapped (parallel=true / unset): pass everything; mark
+            every seen index as admitted so callers can disambiguate
+            new vs continuation when they need to.
+          - Capped (parallel=false): for each delta, if its ``index``
+            is already admitted, pass through (continuation). If it's
+            new, only admit if we haven't filled the slot yet.
+          - A delta with no ``index`` field falls through unchanged —
+            we can't disambiguate, so don't apply the cap to it.
+
+        Returns the filtered list (possibly empty if every delta in
+        the batch is a new call past the cap).
         """
         if self._parallel_tool_calls_allowed():
-            return None
-        return max(0, 1 - self._structured_tool_call_count)
+            # Still track admitted indices so the channel-routed branch
+            # can use the same set when assigning its own monotonic
+            # ``index`` values from the count.
+            for tc in tool_calls:
+                idx = tc.get("index") if isinstance(tc, dict) else None
+                if isinstance(idx, int):
+                    self._admitted_tool_call_indices.add(idx)
+            self._structured_tool_call_count = max(
+                self._structured_tool_call_count,
+                len(self._admitted_tool_call_indices),
+            )
+            return list(tool_calls)
+
+        allowed: list[dict] = []
+        for tc in tool_calls:
+            idx = tc.get("index") if isinstance(tc, dict) else None
+            if isinstance(idx, int) and idx in self._admitted_tool_call_indices:
+                # Continuation of an already-admitted call — always
+                # forward so the client's arguments JSON is complete.
+                allowed.append(tc)
+                continue
+            # New call (unseen index, or index field absent — treat as
+            # new since we can't prove otherwise).
+            if len(self._admitted_tool_call_indices) >= 1:
+                # Cap full — drop this new call AND any further
+                # continuations of its index, since we never admit it.
+                continue
+            if isinstance(idx, int):
+                self._admitted_tool_call_indices.add(idx)
+            else:
+                # Synthesize a placeholder index so subsequent
+                # continuations of THIS no-index call would have been
+                # admitted too. Use ``_structured_tool_call_count`` as
+                # the synthetic marker.
+                self._admitted_tool_call_indices.add(self._structured_tool_call_count)
+            self._structured_tool_call_count = max(
+                self._structured_tool_call_count,
+                len(self._admitted_tool_call_indices),
+            )
+            allowed.append(tc)
+        return allowed
 
     def reset(self):
         """Reset all parser states for a new stream.
@@ -246,6 +311,7 @@ class StreamingPostProcessor:
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
         self._structured_tool_call_count = 0
+        self._admitted_tool_call_indices = set()
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()
@@ -297,13 +363,24 @@ class StreamingPostProcessor:
             # opted out of. Drop everything past the cap on this chunk
             # AND mark ``tool_calls_detected`` so subsequent chunks
             # short-circuit before emission. Codex round-15 BLOCKING #2.
+            #
+            # Engine surfaces ONE complete structured call per
+            # ``<|call|>`` boundary (openai-harmony StreamableParser),
+            # so each entry here is a distinct logical call — no
+            # continuation-delta concern (that's the text-parser path,
+            # see ``_apply_parallel_cap``). PR #518 round-1: keep this
+            # branch's per-entry counting but share the admitted-set
+            # with the text-parser path so the response-wide counter
+            # stays consistent.
             parallel_allowed = self._parallel_tool_calls_allowed()
             allowed_calls: list[dict] = []
             for tc in engine_tool_calls:
-                if not parallel_allowed and self._structured_tool_call_count >= 1:
+                if not parallel_allowed and len(self._admitted_tool_call_indices) >= 1:
                     break
+                new_idx = self._structured_tool_call_count
+                self._admitted_tool_call_indices.add(new_idx)
+                self._structured_tool_call_count = new_idx + 1
                 allowed_calls.append(tc)
-                self._structured_tool_call_count += 1
             if not allowed_calls:
                 # Cap exhausted — preserve finish semantics but skip
                 # emission. The buffered_finish gate fires through the
@@ -376,11 +453,11 @@ class StreamingPostProcessor:
                 return []
             if result.get("tool_calls"):
                 # Issue #517 — apply ``parallel_tool_calls=false`` cap
-                # uniformly across all streaming paths.
-                raw_tcs = result["tool_calls"]
-                cap = self._cap_remaining()
-                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
-                self._structured_tool_call_count += len(allowed_tcs)
+                # uniformly across all streaming paths. Round-1 codex
+                # BLOCKING: admit by ``index`` so continuation deltas
+                # (incremental argument fragments for the same call)
+                # don't each consume a slot.
+                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -392,6 +469,7 @@ class StreamingPostProcessor:
                             )
                         ]
                     return []
+                self.tool_calls_detected = True
                 return [
                     StreamEvent(
                         type="tool_call",
@@ -512,11 +590,11 @@ class StreamingPostProcessor:
                 return []
             if result.get("tool_calls"):
                 # Issue #517 — apply ``parallel_tool_calls=false`` cap
-                # uniformly across all streaming paths.
-                raw_tcs = result["tool_calls"]
-                cap = self._cap_remaining()
-                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
-                self._structured_tool_call_count += len(allowed_tcs)
+                # uniformly across all streaming paths. Round-1 codex
+                # BLOCKING: admit by ``index`` so continuation deltas
+                # (incremental argument fragments for the same call)
+                # don't each consume a slot.
+                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -528,6 +606,7 @@ class StreamingPostProcessor:
                             )
                         ]
                     return []
+                self.tool_calls_detected = True
                 return [
                     StreamEvent(
                         type="tool_call",
@@ -627,14 +706,12 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
-                # Apply ``parallel_tool_calls=false`` cap before emission
-                # (issue #517) — the parser may produce N calls in one
-                # delta or trickle them across deltas; the counter tracks
-                # cross-delta cumulative emissions.
-                raw_tcs = result["tool_calls"]
-                cap = self._cap_remaining()
-                allowed_tcs = raw_tcs if cap is None else raw_tcs[:cap]
-                self._structured_tool_call_count += len(allowed_tcs)
+                # Apply ``parallel_tool_calls=false`` cap (issue #517).
+                # Round-1 codex BLOCKING: admit by ``index`` so
+                # incremental argument fragments don't each consume a
+                # cap slot (qwen3_coder pattern — header delta + N
+                # argument-fragment deltas all share the same index).
+                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -646,6 +723,7 @@ class StreamingPostProcessor:
                             )
                         ]
                     return []
+                self.tool_calls_detected = True
                 return [
                     StreamEvent(
                         type="tool_call",

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -308,15 +308,27 @@ class StreamingPostProcessor:
         for tc in tool_calls:
             idx = tc.get("index") if isinstance(tc, dict) else None
             fn = tc.get("function") if isinstance(tc, dict) else None
-            has_name = (
+            has_wrapped_name = (
                 isinstance(fn, dict)
                 and isinstance(fn.get("name"), str)
                 and fn.get("name")
             )
+            # Round-8 codex BLOCKING #2: parsers can emit FLAT-shape
+            # tool calls (``{"name": "X", "arguments": ...}`` — no
+            # ``function`` wrapper, mirrored from raw engine output
+            # via ``_tool_call_name`` shape #3 in chat.py). Without
+            # the top-level ``name`` check, a flat-shape second call
+            # was misclassified as a continuation and leaked past
+            # the ``parallel_tool_calls=false`` cap.
+            has_flat_name = (
+                isinstance(tc, dict)
+                and isinstance(tc.get("name"), str)
+                and tc.get("name")
+            )
             has_id = (
                 isinstance(tc, dict) and isinstance(tc.get("id"), str) and tc.get("id")
             )
-            is_anchor = bool(has_name or has_id)
+            is_anchor = bool(has_wrapped_name or has_flat_name or has_id)
 
             if isinstance(idx, int) and idx in self._admitted_tool_call_indices:
                 # Continuation of an already-admitted indexed call —


### PR DESCRIPTION
Three follow-ups to PR #515, batched per user request, targeting v0.6.76.

## Closes #468 — `tool_choice="required"` enforcement

PR #515 fixed the channel-marker leak half of #468 but the enforcement half (model returning text + `finish_reason=stop` on a non-tool prompt) was still broken — confirmed against v0.6.75 + gpt-oss-20b by post-release subagent UX probe.

This change adds two reinforcing levers:

- **Strict system-prompt injection** — `_TOOL_USE_REQUIRED_SUFFIX` selected at chat.py:518 when `tool_choice="required"`. Named-function form uses a dedicated variant that names the target tool. Same injection mechanism the loose tool-use suffix already uses.
- **Post-parse 422** — non-stream path refuses to ship a contract-violating response if the parser comes back empty. Named-function form additionally verifies the matching call fired (defense-in-depth — pre-flight tools-filter is the primary, this catches a malicious / drifted parser).
- **Streaming path is best-effort** prompt-injection only (once SSE chunks are out we can't 422 mid-flight). Documented in the suffix docstring as the FSM-decoder gap tracked by #132.

## Closes #517 — streaming parallel_tool_calls=false cap symmetry

PR #515 added the cap to `_process_channel_routed` (gpt-oss / Gemma 4 structured path) but the text-parser streaming paths (`_process_standard`, `_process_reasoning`) emitted `result['tool_calls']` raw, letting hermes/qwen3 streaming responses exceed the cap the non-stream path enforces at `routes/chat.py:934`. Confirmed by qwen3.5-35b 3-city weather probe (returned 3 calls despite `parallel_tool_calls=false`).

Factored `_cap_remaining()` helper. All three streaming paths now `raw_tcs[:cap]` before emission and bump the shared counter so cross-chunk emissions respect the cap across the whole response.

## Closes #516 — HarmonyStreamingRouter auto-upgrade escape hatch (release-SOP G11)

Per release-SOP G11 + `tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS`, every binary auto-routing decision must expose both a force-on AND force-off CLI flag. PR #515 introduced the HarmonyStreamingRouter auto-upgrade gate without these.

- `--force-openai-harmony-streaming` — bypass compat probe (debug-only)
- `--no-openai-harmony-streaming` — pin legacy custom state machine

Plumbed cli.py → server.load_model → BatchedEngine.__init__ → `_create_output_router` → `OutputRouter.from_tokenizer_for_streaming`. Force-on raises actionable `ValueError` pointing at `--no-openai-harmony-streaming` when the underlying tokenizer isn't even harmony-shaped. Registered in `AUTO_ROUTING_FLAG_PAIRS` + `KWARGS_FORWARDED_BUT_NOT_VIA_MODEL_CONFIG`.

## Test plan

- [x] `tests/test_postprocessor.py::TestTextParserParallelCap` — 4 cases covering text-parser cap (#517)
- [x] `tests/test_chat_route_tool_choice_enforcement.py` — 5 new cases for #468 (empty→422, success, strict suffix injection, named-function wrong-call→422, named-function suffix injection)
- [x] `tests/test_output_router.py::TestStreamingFactoryEscapeHatches` — 6 cases monkey-patching the compat probe + harmony constructor to assert each branch of the factory (#516)
- [x] `tests/test_no_mllm_flag.py` registry gate green with new pair
- [x] Full unit suite: 4499 passed (+15 vs main), lint clean

## Why one PR

User explicitly requested batching all three v0.6.76 follow-ups in one PR. The three changes touch overlapping infrastructure (chat route, postprocessor, output router factory) so splitting would mean three rebases plus three rounds of pr_validate — one combined PR is faster and gives codex a single architectural view of the whole follow-up scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)