### PR TITLE
chore: bump version to 0.6.76

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.75"
+version = "0.6.76"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release headline

**perf(mllm)**: batched-sampler fast path in `MLLMBatchGenerator` collapses the per-row Python loop into one MLX kernel when requests share `(temperature, top_p)`.

| Metric | v0.6.75 | v0.6.76 | Δ |
|---|---:|---:|---:|
| HTTP concurrent @ B=8 | 94.7 tok/s | **119.5** | **+26%** |
| In-proc step time @ B=8 | 73.1 ms | 52.1 ms | -29% |
| Scaling @ B=8 | 1.62× | **2.21×** | |
| B=1 | 60.5 | 60.1 | flat |

Gemma 3 12B 4bit @ M3 Ultra 256GB. First time rapid-mlx matches mlx-vlm at B=8 concurrent.

## Release SOP

All 9 applicable gates green ([release_workflow.md](https://github.com/raullenchai/Rapid-MLX/blob/main/docs/release_workflow.md)):

- ✅ G1 release-smoke (clean-venv install + import)
- ✅ G2 codex review × 2 rounds — APPROVE
- ✅ G3 CLI ↔ Config fidelity audit
- ✅ G4 make smoke 3/3 (lint + audit + 1933 units)
- ✅ G5 stress 8/8 (incl tool storm + disconnect + memory)
- ✅ G6 e2e live server: B=8 = 120.2 tok/s reproduces
- ✅ G7 anthropic_sdk 4/5 (1 pre-existing tool-parser gap, not perf-related)
- ✅ G8 microbenchmark: `perf_batch_scaling.py` B=1/2/4/8 evidence
- ✅ G9 sequential latency stable: median 58.5 tok/s, stddev 1.00
- N/A G10 (no mlx version bump)
- N/A G11 (no new auto-detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)