### PR TITLE
perf(scheduler): dense-LLM batched-sampler fast path (Qwen 3.6 27B B=8 +31%)

### DIFF
--- a/tests/test_dense_sampler_fastpath.py
+++ b/tests/test_dense_sampler_fastpath.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the dense-LLM batched-sampler fast path.
+
+Mirrors ``test_mllm_batch_generator``'s shape on the dense path. The MLLM
+fast path lives inside our ``MLLMBatchGenerator._step``; the dense path
+lives inside mlx-lm's ``GenerationBatch._step`` which we cannot edit, so
+we monkey-patch the bound ``_step`` to swap ``samplers`` to all-None +
+``fallback_sampler`` to the shared sampler when the running batch is
+homogeneous.
+
+The tests stub a minimal ``GenerationBatch``-shaped object so we don't
+have to load a model. They lock in the four behaviors that matter:
+
+1. Homogeneous batch (all samplers identity-equal) → swaps to fast path
+   (``self.samplers`` is observed as all-None inside the wrapped call;
+   ``self.fallback_sampler`` is the shared sampler).
+2. Heterogeneous batch → leaves ``self.samplers`` untouched.
+3. B=1 → no swap (degenerate case; identity-equality with empty rest is
+   true but the patch must NOT engage since the fast-path savings only
+   exist for B ≥ 2).
+4. Swap is reversed after the call returns — even on exception — so the
+   per-request samplers are restored for the NEXT step.
+"""
+
+from __future__ import annotations
+
+import types
+
+from vllm_mlx.scheduler import _install_dense_sampler_fastpath
+
+
+class _FakeGenBatch:
+    """Stub matching mlx-lm ``GenerationBatch`` attributes the fast path touches."""
+
+    def __init__(self, samplers, fallback):
+        self.samplers = samplers
+        self.fallback_sampler = fallback
+        self.observed_samplers = None
+        self.observed_fallback = None
+        self.step_calls = 0
+        self.raise_in_step: Exception | None = None
+
+    def _step(self):
+        self.step_calls += 1
+        self.observed_samplers = list(self.samplers)
+        self.observed_fallback = self.fallback_sampler
+        if self.raise_in_step is not None:
+            raise self.raise_in_step
+        return ([0] * len(self.samplers), [None] * len(self.samplers))
+
+
+class _FakeBatchGen:
+    def __init__(self, gen_batch):
+        self._generation_batch = gen_batch
+
+
+def _install(gen_batch):
+    _install_dense_sampler_fastpath(_FakeBatchGen(gen_batch))
+
+
+def test_homogeneous_batch_swaps_to_fast_path():
+    """All samplers are the same callable → ``self.samplers`` is all-None
+    inside the wrapped step and ``self.fallback_sampler`` is the shared one."""
+    shared = lambda x: x  # noqa: E731 — stand-in for make_sampler closure
+    original_fallback = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[shared, shared, shared, shared], fallback=original_fallback)
+    _install(gb)
+
+    gb._step()
+
+    assert gb.observed_samplers == [None, None, None, None]
+    assert gb.observed_fallback is shared
+    # Restoration: outside the call, the per-request samplers are back.
+    assert gb.samplers == [shared, shared, shared, shared]
+    assert gb.fallback_sampler is original_fallback
+
+
+def test_heterogeneous_batch_keeps_per_request_samplers():
+    """Mixed sampler identities → patch is a no-op; mlx-lm's per-row loop runs."""
+    s1 = lambda x: x  # noqa: E731
+    s2 = lambda x: x  # noqa: E731
+    original_fallback = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[s1, s2, s1, s2], fallback=original_fallback)
+    _install(gb)
+
+    gb._step()
+
+    # Slow path observed: samplers and fallback unchanged inside the call.
+    assert gb.observed_samplers == [s1, s2, s1, s2]
+    assert gb.observed_fallback is original_fallback
+
+
+def test_b1_does_not_engage_fast_path():
+    """B=1 is degenerate — patch must NOT swap (no perf upside, and
+    swapping just adds attribute writes per step)."""
+    sampler = lambda x: x  # noqa: E731
+    original_fallback = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[sampler], fallback=original_fallback)
+    _install(gb)
+
+    gb._step()
+
+    assert gb.observed_samplers == [sampler]
+    assert gb.observed_fallback is original_fallback
+
+
+def test_homogeneous_with_first_none_does_not_engage():
+    """If samplers[0] is None we cannot share — even if the rest match,
+    ``None`` means mlx-lm will reach for ``fallback_sampler`` per row.
+    The patch's identity-equality check is gated on ``first is not None``."""
+    original_fallback = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[None, None], fallback=original_fallback)
+    _install(gb)
+
+    gb._step()
+
+    # mlx-lm's slow-path branch is `any(self.samplers)` — all-None already
+    # takes the fast path naturally; we just must not synthesize a swap.
+    assert gb.observed_samplers == [None, None]
+    assert gb.observed_fallback is original_fallback
+
+
+def test_swap_is_reversed_on_exception():
+    """If ``_step`` raises, the per-request samplers MUST still be
+    restored. Otherwise the next step would silently see the wrong
+    sampling distribution for those requests."""
+    shared = lambda x: x  # noqa: E731
+    original_fallback = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[shared, shared], fallback=original_fallback)
+    boom = RuntimeError("metal blew up")
+    gb.raise_in_step = boom
+    _install(gb)
+
+    try:
+        gb._step()
+    except RuntimeError as exc:
+        assert exc is boom
+
+    # After the exception, swap must be reverted.
+    assert gb.samplers == [shared, shared]
+    assert gb.fallback_sampler is original_fallback
+
+
+def test_install_is_safe_when_step_already_a_plain_closure():
+    """SuffixDecoding writes ``gb._step = _suffix_step`` (a plain closure,
+    not a bound method). The fast-path installer must wrap it without
+    requiring ``__func__``."""
+    shared = lambda x: x  # noqa: E731
+    captured = {"called": False}
+
+    def suffix_like_step():  # zero-arg closure, mimics _install_suffix_decoding
+        captured["called"] = True
+        return ([0, 0], [None, None])
+
+    gb = _FakeGenBatch(samplers=[shared, shared], fallback=lambda x: x)
+    gb._step = suffix_like_step  # type: ignore[method-assign]
+    _install(gb)
+
+    gb._step()
+
+    assert captured["called"]
+    # Outside the wrapped call samplers are restored to the per-request list.
+    assert gb.samplers == [shared, shared]
+
+
+def test_install_no_op_when_generation_batch_missing():
+    """Defensive: older mlx-lm shapes without ``_generation_batch`` must
+    not crash the installer — they just skip the fast path."""
+
+    class _BareBatchGen:
+        _generation_batch = None
+
+    # Should not raise.
+    _install_dense_sampler_fastpath(_BareBatchGen())
+
+    class _NoStepBatch:
+        pass
+
+    class _BareBatchGen2:
+        _generation_batch = _NoStepBatch()
+
+    _install_dense_sampler_fastpath(_BareBatchGen2())
+
+
+def test_sampler_cache_interns_by_param_tuple():
+    """``Scheduler._get_request_sampler`` must return the SAME callable
+    for identical params — that's what lets the fast-path detector
+    short-circuit via ``is`` comparison."""
+    from vllm_mlx.scheduler import Scheduler
+
+    # We need a Scheduler instance to exercise _get_request_sampler, but
+    # we don't want the heavy __init__ (loads model). Construct via
+    # __new__ + manual init of just the attributes the method reads.
+    sched = Scheduler.__new__(Scheduler)
+    sched._sampler_cache = {}
+
+    class _SP:
+        temperature = 0.7
+        top_p = 0.95
+        min_p = 0.0
+        top_k = 20
+
+    class _SP_same:
+        temperature = 0.7
+        top_p = 0.95
+        min_p = 0.0
+        top_k = 20
+
+    class _SP_diff:
+        temperature = 1.0
+        top_p = 0.95
+        min_p = 0.0
+        top_k = 20
+
+    a = sched._get_request_sampler(_SP())
+    b = sched._get_request_sampler(_SP_same())
+    c = sched._get_request_sampler(_SP_diff())
+
+    assert a is b, "identical params must reuse cached sampler — required for fast path"
+    assert a is not c, "different temperature must produce a distinct sampler"
+    assert len(sched._sampler_cache) == 2
+
+
+def test_method_type_wrapper_sees_correct_self():
+    """The installed patch is bound via ``types.MethodType`` — ``self``
+    inside the wrapper must be the actual generation_batch instance
+    (not whatever was passed at install time)."""
+    shared = lambda x: x  # noqa: E731
+    gb = _FakeGenBatch(samplers=[shared, shared], fallback=lambda x: x)
+    _install(gb)
+
+    assert isinstance(gb._step, types.MethodType)
+    assert gb._step.__self__ is gb

--- a/tests/test_dense_sampler_fastpath.py
+++ b/tests/test_dense_sampler_fastpath.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 from vllm_mlx.scheduler import _install_dense_sampler_fastpath
 
 
@@ -63,7 +65,9 @@ def test_homogeneous_batch_swaps_to_fast_path():
     inside the wrapped step and ``self.fallback_sampler`` is the shared one."""
     shared = lambda x: x  # noqa: E731 — stand-in for make_sampler closure
     original_fallback = lambda x: x  # noqa: E731
-    gb = _FakeGenBatch(samplers=[shared, shared, shared, shared], fallback=original_fallback)
+    gb = _FakeGenBatch(
+        samplers=[shared, shared, shared, shared], fallback=original_fallback
+    )
     _install(gb)
 
     gb._step()
@@ -123,7 +127,10 @@ def test_homogeneous_with_first_none_does_not_engage():
 def test_swap_is_reversed_on_exception():
     """If ``_step`` raises, the per-request samplers MUST still be
     restored. Otherwise the next step would silently see the wrong
-    sampling distribution for those requests."""
+    sampling distribution for those requests.
+
+    Uses ``pytest.raises`` so a regression that stops raising is caught —
+    a bare ``try/except`` would let the test silently pass."""
     shared = lambda x: x  # noqa: E731
     original_fallback = lambda x: x  # noqa: E731
     gb = _FakeGenBatch(samplers=[shared, shared], fallback=original_fallback)
@@ -131,10 +138,9 @@ def test_swap_is_reversed_on_exception():
     gb.raise_in_step = boom
     _install(gb)
 
-    try:
+    with pytest.raises(RuntimeError) as excinfo:
         gb._step()
-    except RuntimeError as exc:
-        assert exc is boom
+    assert excinfo.value is boom
 
     # After the exception, swap must be reverted.
     assert gb.samplers == [shared, shared]
@@ -186,13 +192,16 @@ def test_sampler_cache_interns_by_param_tuple():
     """``Scheduler._get_request_sampler`` must return the SAME callable
     for identical params — that's what lets the fast-path detector
     short-circuit via ``is`` comparison."""
+    from collections import OrderedDict
+
     from vllm_mlx.scheduler import Scheduler
 
     # We need a Scheduler instance to exercise _get_request_sampler, but
     # we don't want the heavy __init__ (loads model). Construct via
     # __new__ + manual init of just the attributes the method reads.
     sched = Scheduler.__new__(Scheduler)
-    sched._sampler_cache = {}
+    sched._sampler_cache = OrderedDict()
+    sched._sampler_cache_max = 32
 
     class _SP:
         temperature = 0.7
@@ -219,6 +228,42 @@ def test_sampler_cache_interns_by_param_tuple():
     assert a is b, "identical params must reuse cached sampler — required for fast path"
     assert a is not c, "different temperature must produce a distinct sampler"
     assert len(sched._sampler_cache) == 2
+
+
+def test_sampler_cache_is_bounded_lru():
+    """The cache key is request-controlled (clients pick temp/top_p), so
+    the cache MUST be bounded. Without a cap, an adversarial client
+    streaming unique floats grows ``_sampler_cache`` without bound for
+    the process lifetime."""
+    from collections import OrderedDict
+
+    from vllm_mlx.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)
+    sched._sampler_cache = OrderedDict()
+    sched._sampler_cache_max = 4  # small cap for test legibility
+
+    class _SP:
+        def __init__(self, temp):
+            self.temperature = temp
+            self.top_p = 0.95
+            self.min_p = 0.0
+            self.top_k = 20
+
+    # Fill past the cap.
+    samplers = [sched._get_request_sampler(_SP(0.1 * i)) for i in range(6)]
+    assert len(sched._sampler_cache) == 4, "cap must hold even under churn"
+
+    # Oldest entries (temp=0.0, 0.1) are evicted.
+    keys = list(sched._sampler_cache.keys())
+    assert (0.0, 0.95, 0.0, 20) not in keys
+    assert (0.1, 0.95, 0.0, 20) not in keys
+    # Newest entry is at the LRU tail.
+    assert keys[-1] == (0.5, 0.95, 0.0, 20)
+
+    # Hot-key LRU bookkeeping: hitting an existing key bumps it to MRU.
+    sched._get_request_sampler(_SP(0.2))  # was middle of the LRU
+    assert list(sched._sampler_cache.keys())[-1] == (0.2, 0.95, 0.0, 20)
 
 
 def test_method_type_wrapper_sees_correct_self():

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -648,6 +648,67 @@ def _install_chunked_prefill(
     logger.info(f"[chunked_prefill] installed with budget={budget} tokens per step")
 
 
+def _install_dense_sampler_fastpath(batch_gen: "BatchGenerator") -> None:
+    """Swap to mlx-lm's batched sampler fast path when the running batch
+    is homogeneous in sampling params.
+
+    mlx-lm's ``GenerationBatch._step`` (``mlx_lm/generate.py:1320``) takes
+    a per-row Python loop + ``mx.concatenate`` whenever
+    ``any(self.samplers)`` is True. The Scheduler attaches a per-request
+    sampler on every ``insert(...)``, so that branch is taken for every
+    multi-request batch — bypassing the fast ``fallback_sampler(logprobs)``
+    path that runs sampling once on ``[B, vocab]``.
+
+    When every entry in ``self.samplers`` is the same callable instance,
+    sampling is mathematically identical to invoking that one callable on
+    the full ``[B, vocab]`` matrix (mlx-lm's ``apply_top_p`` /
+    ``apply_min_p`` / ``apply_top_k`` / ``categorical_sampling`` all
+    operate row-wise along ``axis=-1``). The Scheduler interns samplers
+    via ``_get_request_sampler``, so identity-equality of the entries in
+    ``self.samplers`` already implies value-equality of the sampling
+    params — no separate key check needed.
+
+    Heterogeneous batches (mixed temp/top_p across requests) fall back to
+    mlx-lm's original per-row loop — correctness preserved.
+
+    Companion to ``MLLMBatchGenerator._step`` fast path in
+    ``mllm_batch_generator.py`` (PR #519). This installs the same shape
+    on the dense LLM path that lives inside mlx-lm.
+    """
+    import types
+
+    gen_batch = batch_gen._generation_batch
+    if gen_batch is None or not hasattr(gen_batch, "_step"):
+        return
+
+    # ``gen_batch._step`` may already be a bound method (vanilla mlx-lm)
+    # OR a plain closure replaced by ``_install_suffix_decoding`` (which
+    # writes ``gb._step = _suffix_step`` — see the assignment in that
+    # function). Both shapes accept zero args (the closure closes over
+    # ``gb``; the bound method already carries ``self``), so calling
+    # ``orig_step()`` without args works for either.
+    orig_step = gen_batch._step
+
+    def patched_step(self):
+        samplers = self.samplers
+        if samplers and len(samplers) >= 2:
+            first = samplers[0]
+            if first is not None and all(s is first for s in samplers[1:]):
+                saved_samplers = self.samplers
+                saved_fallback = self.fallback_sampler
+                self.samplers = [None] * len(samplers)
+                self.fallback_sampler = first
+                try:
+                    return orig_step()
+                finally:
+                    self.samplers = saved_samplers
+                    self.fallback_sampler = saved_fallback
+        return orig_step()
+
+    gen_batch._step = types.MethodType(patched_step, gen_batch)
+    logger.info("[dense_sampler_fastpath] installed on BatchGenerator")
+
+
 def _install_mtp(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1667,6 +1728,15 @@ class Scheduler:
         self.batch_generator: BatchGenerator | None = None
         self._current_sampler_params: tuple | None = None
 
+        # Sampler cache: interns ``make_sampler`` results keyed on
+        # ``(temp, top_p, min_p, top_k)``. Homogeneous concurrent
+        # batches end up sharing one callable, which lets
+        # ``_install_dense_sampler_fastpath`` detect them by identity and
+        # swap to mlx-lm's batched fast path. Stores up to ~32 distinct
+        # sampling-param tuples — production traffic almost always
+        # collapses to a single key.
+        self._sampler_cache: dict[tuple, Any] = {}
+
         # Prefix cache for KV state reuse
         self.prefix_cache: PrefixCacheManager | None = None
         self.memory_aware_cache: MemoryAwarePrefixCache | None = None
@@ -1800,6 +1870,41 @@ class Scheduler:
                     # Handle case where eos_token_ids is a single int
                     stop_tokens.add(tok.eos_token_ids)
         return stop_tokens
+
+    def _get_request_sampler(self, sampling_params: SamplingParams) -> Any:
+        """Return a cached sampler for these sampling params.
+
+        Interning samplers by ``(temp, top_p, min_p, top_k)`` is what
+        lets ``_install_dense_sampler_fastpath`` detect homogeneous
+        batches via identity comparison on ``GenerationBatch.samplers``.
+        Without this, every request would carry its own
+        ``make_sampler`` closure even when the params are identical,
+        forcing the slow per-row loop in mlx-lm.
+
+        WARNING: the cache key intentionally covers only the four
+        knobs threaded through to ``make_sampler``. If we ever start
+        forwarding xtc_probability / xtc_threshold / xtc_special_tokens
+        per request, the key MUST grow accordingly — otherwise
+        homogeneous-looking batches would silently share an incorrect
+        sampler.
+        """
+        key = (
+            sampling_params.temperature,
+            sampling_params.top_p,
+            sampling_params.min_p,
+            sampling_params.top_k,
+        )
+        cached = self._sampler_cache.get(key)
+        if cached is not None:
+            return cached
+        sampler = make_sampler(
+            temp=sampling_params.temperature,
+            top_p=sampling_params.top_p,
+            min_p=sampling_params.min_p,
+            top_k=sampling_params.top_k,
+        )
+        self._sampler_cache[key] = sampler
+        return sampler
 
     def _create_batch_generator(
         self, sampling_params: SamplingParams
@@ -1938,6 +2043,15 @@ class Scheduler:
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,
             )
+
+        # Install batched-sampler fast path. Must run AFTER MTP /
+        # SuffixDecoding since they may replace _step on the
+        # GenerationBatch — our wrapper has to sit at the outermost
+        # layer so it can short-circuit the per-row loop wherever the
+        # final _step ends up. SuffixDecoding/MTP wrappers themselves
+        # call into the original ``_step`` and ignore ``self.samplers``,
+        # so this layering is safe.
+        _install_dense_sampler_fastpath(bg)
 
         return bg
 
@@ -2815,12 +2929,10 @@ class Scheduler:
             # Per-request sampler (temperature/top_p/top_k/min_p may differ
             # per request). Without this, all requests use the BatchGenerator's
             # default sampler (argmax), ignoring the requested temperature.
-            request_sampler = make_sampler(
-                temp=request.sampling_params.temperature,
-                top_p=request.sampling_params.top_p,
-                min_p=request.sampling_params.min_p,
-                top_k=request.sampling_params.top_k,
-            )
+            # ``_get_request_sampler`` interns by sampling-param tuple so that
+            # homogeneous batches share one callable — required for
+            # ``_install_dense_sampler_fastpath`` to detect them by identity.
+            request_sampler = self._get_request_sampler(request.sampling_params)
 
             # Issue #427: split the insert at prefix_boundary so the
             # per-message cache snapshot can fire after the prefix

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -12,7 +12,7 @@ The scheduler follows vLLM's design with:
 """
 
 import logging
-from collections import deque
+from collections import OrderedDict, deque
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -677,7 +677,7 @@ def _install_dense_sampler_fastpath(batch_gen: "BatchGenerator") -> None:
     """
     import types
 
-    gen_batch = batch_gen._generation_batch
+    gen_batch = getattr(batch_gen, "_generation_batch", None)
     if gen_batch is None or not hasattr(gen_batch, "_step"):
         return
 
@@ -1732,10 +1732,17 @@ class Scheduler:
         # ``(temp, top_p, min_p, top_k)``. Homogeneous concurrent
         # batches end up sharing one callable, which lets
         # ``_install_dense_sampler_fastpath`` detect them by identity and
-        # swap to mlx-lm's batched fast path. Stores up to ~32 distinct
-        # sampling-param tuples — production traffic almost always
-        # collapses to a single key.
-        self._sampler_cache: dict[tuple, Any] = {}
+        # swap to mlx-lm's batched fast path.
+        #
+        # Bounded LRU (``OrderedDict``) because the cache key is
+        # request-controlled: an adversarial client could otherwise
+        # stream many unique float values for ``(temp, top_p, min_p,
+        # top_k)`` and grow the cache without bound. Production traffic
+        # almost always converges to one or two distinct keys, so a
+        # small cap is more than enough; evicting an entry just costs
+        # one ``make_sampler`` call the next time that key reappears.
+        self._sampler_cache: OrderedDict[tuple, Any] = OrderedDict()
+        self._sampler_cache_max = 32
 
         # Prefix cache for KV state reuse
         self.prefix_cache: PrefixCacheManager | None = None
@@ -1896,6 +1903,8 @@ class Scheduler:
         )
         cached = self._sampler_cache.get(key)
         if cached is not None:
+            # LRU bookkeeping — keep the hot key warm.
+            self._sampler_cache.move_to_end(key)
             return cached
         sampler = make_sampler(
             temp=sampling_params.temperature,
@@ -1904,6 +1913,12 @@ class Scheduler:
             top_k=sampling_params.top_k,
         )
         self._sampler_cache[key] = sampler
+        # Evict the least-recently-used entry once we exceed the cap.
+        # Identity-sharing only matters for live in-flight batches; a
+        # freshly evicted sampler that reappears just costs one
+        # ``make_sampler`` call.
+        if len(self._sampler_cache) > self._sampler_cache_max:
+            self._sampler_cache.popitem(last=False)
         return sampler
 
     def _create_batch_generator(


### PR DESCRIPTION
## Summary

- Dense LLM analogue of PR #519. mlx-lm's `GenerationBatch._step` has the same per-row sampler loop fast-path bypass that MLLM had; this PR ports the fix to the dense path.
- Intern per-request samplers by `(temperature, top_p, min_p, top_k)` so homogeneous batches share one callable, then swap `samplers` to `[None]*N` + `fallback_sampler` to the shared one for the step. Heterogeneous batches keep the per-row loop.
- Qwen 3.6 27B 4-bit, M3 Ultra, HTTP streaming, max_tokens=256, temp=0.7, top_p=0.95:

  | B | rapid-mlx 0.6.76 | this PR | upstream vllm-mlx 0.3.0 |
  | - | - | - | - |
  | 1 | 30.8 | 32.4 | 36.2 |
  | 4 | 61.0 | 65.6 | 68.3 |
  | 8 | 56.7 | **74.4** | 69.6 |

  B=1 +5%, B=4 +8%, **B=8 +31%**. B=4→B=8 throughput inversion eliminated; B=8 now beats the upstream baseline.

## Scope

| Path | Behaviour after this PR |
| - | - |
| Dense LLM, homogeneous batch | Fast path (one MLX kernel on `[B, vocab]`) |
| Dense LLM, heterogeneous batch | Unchanged — mlx-lm's per-row loop |
| Dense LLM, B=1 | Unchanged (patch gated on `len(samplers) >= 2`) |
| MLLM (Gemma 3/4, Qwen-VL …) | Unchanged — PR #519 already covers it |
| Suffix decoding / MTP | Unchanged — wrapper sits outside, both inner wrappers read sampler params from `request.sampling_params` |

## Correctness

`apply_top_p` / `apply_min_p` / `apply_top_k` / `categorical_sampling` all operate row-wise along `axis=-1`. One call on `[B, vocab]` is mathematically identical to B calls on `[1, vocab]` slices — same property PR #519 relied on for the MLLM swap.

The cache key intentionally covers only the four knobs threaded through `make_sampler`. A WARNING comment locks this in: any future per-request sampler knob (xtc, repetition penalty …) must extend the key.

## Test plan

- [x] `tests/test_dense_sampler_fastpath.py` — 9/9 pass
  - [x] Homogeneous swap to fast path
  - [x] Heterogeneous bypass
  - [x] B=1 degenerate
  - [x] All-None samplers (already-fast natural case)
  - [x] Exception-safe restoration
  - [x] Suffix-decoding-style plain-closure compatibility
  - [x] Missing `_generation_batch` defensive paths
  - [x] Sampler cache identity (`a is b` for same params)
  - [x] `MethodType` self binding
- [x] `tests/test_batching{,_deterministic}.py` + `test_mtp_inject_and_install.py` + `test_engine_step_thread.py` — 61/61 pass, 0 regression
- [x] Live HTTP bench on Qwen 3.6 27B (above table), repeated twice for stability — `74.4 tok/s` reproduces exactly
- [x] `[dense_sampler_fastpath] installed on BatchGenerator` log confirms install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

