### PR TITLE
chore: bump version to 0.6.77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.76"
+version = "0.6.77"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release v0.6.77 — dense-LLM batched-sampler fast path (PR #521 merged).

## Bench (Qwen 3.6 27B 4-bit, M3 Ultra, HTTP streaming)

| B | 0.6.76 | 0.6.77 | upstream 0.3.0 |
| - | - | - | - |
| 1 | 30.8 | 32.6 | 36.2 |
| 4 | 61.0 | 65.6 | 68.3 |
| 8 | 56.7 | **75.2** | 69.6 |

B=8 **+33%** vs 0.6.76, exceeds upstream baseline by 8%. The pre-fix B=4 → B=8 throughput inversion is eliminated.

## Release SOP — all 9 applicable gates GREEN

- [x] G1 release-smoke (clean-venv install + 5/5 surface imports OK)
- [x] G2 codex review × 2 rounds (round-1 found 3 BLOCKING all fixed, round-2 APPROVE)
- [x] G3 CLI ↔ Config fidelity audit (exit 0)
- [x] G4 make smoke equivalent (lint clean + 4501 unit tests pass via pr_validate)
- [x] G5 stress + anthropic_sdk matrix 3×3 (qwen3.5-35B + qwen3.6-27B + gpt-oss-20B) PASS
- [x] G6 e2e live server: B=8 75.2 tok/s reproduces on Qwen 3.6 27B
- [x] G7 anthropic_sdk all green in stress matrix
- [x] G8 microbench evidence via G6 (+31% reproducible across two back-to-back runs)
- [x] G9 sequential latency: median 31.6 tok/s, stdev 0.79 (10 runs)
- [x] G10 N/A (no mlx / mlx-lm / mlx-vlm version bump)
- [x] G11 N/A (no new auto-detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)