### PR TITLE
feat(aliases): add Gemma 4 QAT variants (12B/26B/31B at 4/8-bit)

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -626,6 +626,15 @@ _CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
     "gemma-4-26b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-31b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-31b-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    # Gemma 4 QAT variants — same sampling as PTQ siblings. QAT changes
+    # weight distribution (training with simulated quantization) not the
+    # decoding distribution, so Google's chat sampling guidance applies
+    # unchanged.
+    "gemma-4-12b-qat": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-12b-qat-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-26b-qat": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-31b-qat": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-31b-qat-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     # GLM-4.5-Air — THUDM publishes two recommendations: temperature=0.6
     # for *thinking* mode, ~1.0 for non-thinking. The alias has
     # reasoning_parser=glm4 → thinking IS the default response path,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -334,6 +334,71 @@
       "top_k": 64
     }
   },
+  "gemma-4-12b-qat": {
+    "hf_path": "mlx-community/gemma-4-12B-it-qat-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-12b-qat-8bit": {
+    "hf_path": "mlx-community/gemma-4-12B-it-qat-8bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-26b-qat": {
+    "hf_path": "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-31b-qat": {
+    "hf_path": "mlx-community/gemma-4-31B-it-qat-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-31b-qat-8bit": {
+    "hf_path": "mlx-community/gemma-4-31B-it-qat-8bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
   "gemma3-12b": {
     "hf_path": "mlx-community/gemma-3-12b-it-qat-4bit",
     "tool_call_parser": "hermes",


### PR DESCRIPTION
## Summary

Adds 5 new aliases pointing at Google's official **Gemma 4 quantization-aware-training (QAT)** checkpoints, converted to MLX by `mlx-community`. QAT trains the model with simulated low-bit quantization noise so the weights learn to compensate — significantly narrowing the 4-bit-vs-BF16 quality gap (Gemma 3 numbers: 54% reduction in Q4_0 perplexity loss vs PTQ).

New aliases (PTQ siblings unchanged for backwards compat):

| Alias | HF path | Size |
| --- | --- | --- |
| `gemma-4-12b-qat` | `mlx-community/gemma-4-12B-it-qat-4bit` | ~3 GB |
| `gemma-4-12b-qat-8bit` | `mlx-community/gemma-4-12B-it-qat-8bit` | ~6 GB |
| `gemma-4-26b-qat` | `mlx-community/gemma-4-26B-A4B-it-qat-4bit` | ~5 GB |
| `gemma-4-31b-qat` | `mlx-community/gemma-4-31B-it-qat-4bit` | ~8 GB |
| `gemma-4-31b-qat-8bit` | `mlx-community/gemma-4-31B-it-qat-8bit` | ~17 GB |

## Why this is safe

QAT changes weight *values* produced by training, not architecture or quantization scheme. Diffing `config.json` between PTQ and QAT repos confirms:

- Same `model_type: gemma4_unified`
- Same `architectures: ["Gemma4UnifiedForConditionalGeneration"]`
- Same `quantization_config` shape (4-bit base + selective 8-bit on first 48 MLP layers' gate/up/down projections, group_size=64, affine mode)

Therefore all `AliasProfile` fields inherit unchanged from PTQ siblings:
- `tool_call_parser: gemma4`
- `reasoning_parser: gemma4`
- `is_hybrid: false`, `is_moe: false`
- `supports_spec_decode: true`

`recommended_sampling` matches PTQ (Gemma chat sampling guidance applies to the decoding distribution, not the weights).

`suffix_decoding_tier` is intentionally **omitted** (= unknown). Tier must be empirically benched per checkpoint — assuming the PTQ 26B's `avoid` (0.203× speedup on json_array) transfers to QAT 26B would be presumptuous. Tier sweep is a follow-up task.

## Verification

- `python3.12 -m pytest tests/test_aliases_contract.py tests/test_model_aliases.py tests/test_alias_recommended_sampling.py tests/test_model_profiles_ssot.py` → **801/801 pass**
- Smoke against `gemma-4-12b-qat`:
  - `rapid-mlx serve gemma-4-12b-qat` loads the model successfully
  - `auto-config` resolves to `gemma4` tool/reasoning parsers (correct)
  - `POST /v1/chat/completions` returns 200 with valid OpenAI-shape response
  - Reasoning parser correctly splits `reasoning_content` from final `content`
  - QAT-domain answer ("In one sentence: what does QAT mean in ML?") sane and correct
  - Exact-string instruction ("Reply with exactly: HELLO") returns `content='HELLO'`, `finish_reason=stop`

## Test plan

- [ ] CI green on raullenchai/Rapid-MLX
- [ ] Manual: download + smoke `gemma-4-12b-qat` on a fresh checkout
- [ ] Follow-up: QAT vs PTQ quality A/B on a fixed eval set (5 prompts greedy) to decide whether to promote QAT to the default `gemma-4-12b` alias path
- [ ] Follow-up: SuffixDecoding tier bench for the QAT variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)