### PR TITLE
feat(cli): shell tab completion via argcomplete for every subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,22 @@ dependencies = [
     "uvicorn>=0.23.0",
     "mcp>=1.0.0",
     "jsonschema>=4.0.0",
+    # argcomplete — shell tab completion for the `rapid-mlx` CLI. Tiny
+    # pure-Python package (~50 KB) wired into argparse via the magic
+    # `# PYTHON_ARGCOMPLETE_OK` marker in cli.py and a per-arg
+    # `.completer = alias_completer` for model positionals. Required
+    # (not optional) so `rapid-mlx chat gemma-4-<TAB>` works on every
+    # install without an extras step. Activation in the user's shell is
+    # one-time: `eval "$(register-python-argcomplete rapid-mlx)"` in
+    # ~/.zshrc, or `activate-global-python-argcomplete` system-wide.
+    # The Homebrew formula handles activation automatically.
+    #
+    # >=3.6 is required: Python 3.12.6+ added a 4th positional arg
+    # (`intermixed`) to argparse._parse_known_args. argcomplete <3.6
+    # subclasses with only 3 positional args → TypeError mid-handshake
+    # and tab completion silently returns nothing. 3.6 ships the
+    # variadic signature fix.
+    "argcomplete>=3.6",
     # WebSocket client for ``rapid-mlx share`` — connects to the
     # rapidserver Worker as the reverse-tunnel transport. Pure Python,
     # ~200 KB. Replaces the prior frpc Go binary download.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ dependencies = [
     # ~/.zshrc, or `activate-global-python-argcomplete` system-wide.
     # The Homebrew formula handles activation automatically.
     #
-    # >=3.6 is required: Python 3.12.6+ added a 4th positional arg
-    # (`intermixed`) to argparse._parse_known_args. argcomplete <3.6
-    # subclasses with only 3 positional args → TypeError mid-handshake
-    # and tab completion silently returns nothing. 3.6 ships the
-    # variadic signature fix.
+    # >=3.6 is required: a recent Python 3.12 micro release added a 4th
+    # positional `intermixed` argument to argparse._parse_known_args.
+    # argcomplete <3.6 subclasses that hook with only 3 positional args,
+    # so the very first Tab raises TypeError mid-handshake and the shell
+    # silently shows nothing. 3.6.0 ships the variadic signature fix.
     "argcomplete>=3.6",
     # WebSocket client for ``rapid-mlx share`` — connects to the
     # rapidserver Worker as the reverse-tunnel transport. Pure Python,

--- a/tests/test_cli_argcomplete.py
+++ b/tests/test_cli_argcomplete.py
@@ -134,3 +134,157 @@ def test_aliases_path_resolves_to_real_file() -> None:
         f"aliases.json missing at {_ALIASES_PATH}; if the file moved, "
         "_completion.py needs the new location"
     )
+
+
+def test_alias_csv_completer_handles_whitespace_after_comma() -> None:
+    """``--models a, gem<TAB>`` — the runtime alias parser already
+    accepts whitespace around commas (``split + strip``). The completer
+    must match that contract so users who naturally type the
+    human-friendly ``a, b, c`` shape get suggestions instead of an
+    empty list."""
+    spaced = alias_csv_completer("qwen3.5-4b, gemma-4-")
+    tight = alias_csv_completer("qwen3.5-4b,gemma-4-")
+    assert len(spaced) == len(tight), (
+        "csv completer must produce the same number of matches whether "
+        "the user typed `a,b` or `a, b`"
+    )
+
+
+def test_load_alias_names_rejects_oversized_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A hostile multi-megabyte ``aliases.json`` (supply-chain swap, or
+    a dev-machine fat-finger) must not stall every keystroke on a
+    multi-second JSON decode. Cap is hard and fail-closed."""
+    from vllm_mlx import _completion
+
+    huge = tmp_path / "huge.json"
+    payload = "{" + ",".join(f'"{i}":1' for i in range(200_000)) + "}"
+    huge.write_text(payload)
+    assert huge.stat().st_size > _completion._MAX_ALIASES_BYTES
+
+    monkeypatch.setattr(_completion, "_ALIASES_PATH", huge)
+    monkeypatch.setattr(_completion, "_CACHE", None)
+    assert _completion._load_alias_names() == []
+
+
+def test_load_alias_names_strips_unsafe_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A key containing newline / vertical-tab / NUL bytes would split
+    argcomplete's line-oriented stdout IPC into multiple bogus
+    completions or corrupt the user's terminal. The loader filters
+    them out before returning. Legitimate aliases pass through."""
+    from vllm_mlx import _completion
+
+    spiked = tmp_path / "spiked.json"
+    spiked.write_text(
+        '{"good-alias":{}, "evil\\nname":{}, "evil\\u000bname":{}, '
+        '"with space":{}, "":{}}'
+    )
+    monkeypatch.setattr(_completion, "_ALIASES_PATH", spiked)
+    monkeypatch.setattr(_completion, "_CACHE", None)
+
+    assert _completion._load_alias_names() == ["good-alias"]
+
+
+def test_load_alias_names_caches_by_mtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A hot Tab burst must hit the in-memory cache, not re-decode
+    JSON each keystroke. The cache key is ``(mtime, size)`` so a
+    fresh write invalidates automatically."""
+    import os
+
+    from vllm_mlx import _completion
+
+    f = tmp_path / "cached.json"
+    f.write_text('{"alpha":{}}')
+    monkeypatch.setattr(_completion, "_ALIASES_PATH", f)
+    monkeypatch.setattr(_completion, "_CACHE", None)
+
+    first = _completion._load_alias_names()
+    assert first == ["alpha"]
+    cached_id = id(_completion._CACHE)
+
+    second = _completion._load_alias_names()
+    assert second == ["alpha"]
+    assert id(_completion._CACHE) == cached_id, "second call should reuse cache"
+
+    # Edit the file; the mtime+size change must invalidate.
+    f.write_text('{"alpha":{}, "beta":{}}')
+    # Force a measurable mtime delta in case the FS has 1-second
+    # resolution and the writes landed in the same second.
+    future = f.stat().st_mtime + 5
+    os.utime(f, (future, future))
+
+    refreshed = _completion._load_alias_names()
+    assert refreshed == ["alpha", "beta"]
+
+
+def test_cli_lazy_imports_argcomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``vllm_mlx.cli`` must NOT import ``argcomplete`` at module load
+    — the minimal-deps CI lane runs without it. Regression guard for
+    the lazy-import fix in the round-2 of this PR."""
+    import importlib
+    import sys
+
+    # Force-reload cli with argcomplete blocked at import time.
+    monkeypatch.setitem(sys.modules, "argcomplete", None)
+    sys.modules.pop("vllm_mlx.cli", None)
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    # The module imported successfully (no ModuleNotFoundError) and
+    # exports the expected entry point.
+    assert hasattr(cli, "main"), "cli module missing main() entry point"
+
+
+def test_autocomplete_handshake_returns_aliases_on_subprocess() -> None:
+    """End-to-end shell-completion handshake. Spawn ``python -m
+    vllm_mlx.cli`` with the argcomplete env vars and verify fd 8
+    receives the expected alias list — proves the magic marker,
+    the lazy import, and ``argcomplete.autocomplete(parser)`` all
+    line up at runtime, not just in unit tests.
+
+    Skipped when ``argcomplete`` is not importable in the current
+    interpreter (minimal-deps CI lane) — the lazy-import path is
+    covered by ``test_cli_lazy_imports_argcomplete`` instead."""
+    import os
+    import subprocess
+    import sys
+
+    pytest.importorskip("argcomplete")
+
+    env = {
+        **os.environ,
+        "_ARGCOMPLETE": "1",
+        "COMP_LINE": "rapid-mlx serve gemma-4-",
+        "COMP_POINT": "24",
+        "_ARGCOMPLETE_IFS": "\n",
+    }
+    # ``sys.executable`` so the child uses THIS interpreter — relying
+    # on the bare ``python3`` alias would silently route to a Python
+    # without our editable install or without argcomplete.
+    # fd 8 is where argcomplete writes; route it to stdout via the
+    # child shell so subprocess.run can capture it.
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"{sys.executable} -m vllm_mlx.cli 8>&1 1>/dev/null 2>/dev/null",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"argcomplete handshake exit={result.returncode}; "
+        f"stderr={result.stderr!r}; stdout={result.stdout!r}"
+    )
+    completions = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert any(c.startswith("gemma-4-") for c in completions), (
+        f"expected gemma-4-* matches, got: {completions[:5]}"
+    )

--- a/tests/test_cli_argcomplete.py
+++ b/tests/test_cli_argcomplete.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the rapid-mlx CLI shell-completion wiring.
+
+Locks in three things that are easy to break:
+
+1. The ``# PYTHON_ARGCOMPLETE_OK`` magic marker stays in the first 1024
+   bytes of ``cli.py``. ``register-python-argcomplete`` grep-skips
+   scripts without this marker for speed — losing it silently turns
+   off tab completion across every install.
+2. ``alias_completer`` returns aliases filtered by prefix (the actual
+   contract argcomplete invokes per keystroke).
+3. ``alias_csv_completer`` correctly carries the comma-separated
+   prefix forward so ``--models qwen3.5-4b,gem<TAB>`` expands the
+   trailing token only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx._completion import (
+    _ALIASES_PATH,
+    alias_completer,
+    alias_csv_completer,
+)
+
+_CLI_PATH = Path(__file__).parent.parent / "vllm_mlx" / "cli.py"
+
+
+def test_python_argcomplete_ok_marker_present() -> None:
+    """``register-python-argcomplete`` grep-scans the first ~1024 bytes
+    of the script for ``PYTHON_ARGCOMPLETE_OK``. Without it, the shell
+    completion handler refuses to invoke the script entirely — losing
+    the marker would silently break tab completion on every install
+    until a user noticed and reported it."""
+    head = _CLI_PATH.read_bytes()[:1024]
+    assert b"PYTHON_ARGCOMPLETE_OK" in head, (
+        "PYTHON_ARGCOMPLETE_OK magic marker must be in the first 1024 "
+        "bytes of cli.py — argcomplete grep-skips scripts without it."
+    )
+
+
+def test_alias_completer_no_prefix_returns_sorted_list() -> None:
+    """Empty prefix → full sorted alias list (shell collapses to the
+    longest common prefix and re-prompts on second Tab, standard UX)."""
+    result = alias_completer("")
+    assert len(result) > 50, (
+        f"expected the full alias list, got {len(result)}; if the file "
+        "moved or load_alias_names returned [], this regressed"
+    )
+    assert result == sorted(result), "completer must return sorted output"
+
+
+def test_alias_completer_filters_by_prefix() -> None:
+    """``gemma-4-<TAB>`` must surface all gemma-4-* aliases and nothing
+    else. This is the user-visible contract: a startswith filter on the
+    alias name."""
+    result = alias_completer("gemma-4-")
+    assert len(result) >= 5, "should match at least 5 gemma-4 aliases"
+    assert all(n.startswith("gemma-4-") for n in result), (
+        f"completer leaked non-matching aliases: "
+        f"{[n for n in result if not n.startswith('gemma-4-')]}"
+    )
+
+
+def test_alias_completer_unknown_prefix_returns_empty() -> None:
+    """Unknown prefix → []; the shell will then beep/fall back to
+    filename completion. Must not raise or return stale results."""
+    result = alias_completer("this-alias-does-not-exist-xyz")
+    assert result == []
+
+
+def test_alias_completer_handles_missing_aliases_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tab completion must NEVER raise. A missing or corrupt
+    aliases.json should degrade to ``[]`` — anything else propagates
+    as a Python traceback into the user's shell, which is worse than a
+    silent no-match."""
+    missing = tmp_path / "no_such_aliases.json"
+    monkeypatch.setattr("vllm_mlx._completion._ALIASES_PATH", missing)
+
+    assert alias_completer("") == []
+    assert alias_completer("gemma-4-") == []
+
+
+def test_alias_completer_handles_corrupt_aliases_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same robustness contract for a syntactically broken file."""
+    corrupt = tmp_path / "broken.json"
+    corrupt.write_text("not valid json {{")
+    monkeypatch.setattr("vllm_mlx._completion._ALIASES_PATH", corrupt)
+
+    assert alias_completer("") == []
+
+
+def test_alias_csv_completer_first_token() -> None:
+    """``rapid-mlx doctor --models <TAB>`` (no comma yet) behaves
+    exactly like ``alias_completer``."""
+    no_comma = alias_csv_completer("gemma-4-")
+    plain = alias_completer("gemma-4-")
+    assert no_comma == plain
+
+
+def test_alias_csv_completer_appends_to_existing_csv() -> None:
+    """``--models qwen3.5-4b,gem<TAB>`` should expand only the
+    trailing token but emit the full re-assembled value so the shell
+    inserts ``qwen3.5-4b,gemma-4-12b`` rather than dropping the head."""
+    result = alias_csv_completer("qwen3.5-4b,gemma-4-")
+    assert all(m.startswith("qwen3.5-4b,gemma-4-") for m in result), (
+        f"csv completer dropped the head before the comma: "
+        f"{[m for m in result if not m.startswith('qwen3.5-4b,')]}"
+    )
+    assert len(result) >= 5, "should match at least 5 gemma-4-* tokens"
+
+
+def test_alias_csv_completer_multiple_commas() -> None:
+    """``--models a,b,c<TAB>`` only completes ``c``; ``a,b,`` is
+    carried through unchanged. Lock this in because rpartition vs
+    partition is an easy-to-flip bug."""
+    result = alias_csv_completer("qwen3.5-4b,gemma-4-12b,qwen3.6-")
+    assert all(m.startswith("qwen3.5-4b,gemma-4-12b,qwen3.6-") for m in result), (
+        "csv completer must preserve all prior csv tokens"
+    )
+
+
+def test_aliases_path_resolves_to_real_file() -> None:
+    """Sanity check the path we ship resolves to a real file in the
+    installed package — catches a path bug at the module level."""
+    assert _ALIASES_PATH.exists(), (
+        f"aliases.json missing at {_ALIASES_PATH}; if the file moved, "
+        "_completion.py needs the new location"
+    )

--- a/vllm_mlx/_completion.py
+++ b/vllm_mlx/_completion.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shell completion helpers for the rapid-mlx CLI.
+
+Used by ``argcomplete`` to suggest model aliases when the user
+tab-completes on subcommands like ``rapid-mlx chat gemma-4-<TAB>``.
+
+Kept free of heavy imports so the completion handler stays snappy:
+the only file read here is ``aliases.json`` (~10 KB), small enough
+to JSON-decode on every keystroke without measurable lag and small
+enough that re-reading per call means a freshly-edited
+``aliases.json`` tab-completes the same shell session.
+
+Wired in ``vllm_mlx/cli.py`` and ``vllm_mlx/share/cli.py`` via::
+
+    arg = parser.add_argument("model", ...)
+    arg.completer = alias_completer
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_ALIASES_PATH = Path(__file__).parent / "aliases.json"
+
+
+def _load_alias_names() -> list[str]:
+    """Return sorted alias keys from ``aliases.json`` (empty list on error).
+
+    Tab-completion must never raise — a missing or corrupt aliases.json
+    should degrade gracefully to "no suggestions" rather than crashing
+    the user's shell.
+    """
+    try:
+        with _ALIASES_PATH.open("rb") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    return sorted(data.keys())
+
+
+def alias_completer(prefix: str = "", **_: Any) -> list[str]:
+    """Argcomplete callback: aliases matching ``prefix``.
+
+    Returns the full sorted alias list when prefix is empty (user
+    typed nothing yet, hit Tab) — the shell collapses to the longest
+    common prefix and re-prompts on a second Tab, which is the
+    standard behavior.
+    """
+    names = _load_alias_names()
+    if not prefix:
+        return names
+    return [n for n in names if n.startswith(prefix)]
+
+
+def alias_csv_completer(prefix: str = "", **_: Any) -> list[str]:
+    """Comma-separated-list variant for ``doctor --models a,b,c``.
+
+    The user-visible prefix at completion time contains everything
+    typed for this flag — e.g. ``qwen3.5-4b,gem`` when partway through
+    the second entry. We split on the last comma, complete only the
+    trailing token against alias names, and re-attach the prefix so
+    the shell inserts the full value correctly.
+    """
+    head, sep, tail = prefix.rpartition(",")
+    pool = _load_alias_names()
+    matches = [n for n in pool if n.startswith(tail)]
+    if not sep:
+        return matches
+    return [f"{head},{m}" for m in matches]

--- a/vllm_mlx/_completion.py
+++ b/vllm_mlx/_completion.py
@@ -85,7 +85,11 @@ def _load_alias_names() -> list[str]:
         return []
     try:
         data = json.loads(raw)
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
+        # ``json.loads`` recurses on nested objects/arrays. A small but
+        # deeply-nested file (e.g. ``[[[[...]]]]``) raises
+        # ``RecursionError``, which is technically not a ``JSONDecodeError``
+        # and would otherwise leak as a traceback into the user's shell.
         return []
     if not isinstance(data, dict):
         return []

--- a/vllm_mlx/_completion.py
+++ b/vllm_mlx/_completion.py
@@ -4,11 +4,17 @@
 Used by ``argcomplete`` to suggest model aliases when the user
 tab-completes on subcommands like ``rapid-mlx chat gemma-4-<TAB>``.
 
-Kept free of heavy imports so the completion handler stays snappy:
-the only file read here is ``aliases.json`` (~10 KB), small enough
-to JSON-decode on every keystroke without measurable lag and small
-enough that re-reading per call means a freshly-edited
-``aliases.json`` tab-completes the same shell session.
+Two layers of defense for the completion hot path:
+
+1. **mtime-keyed cache** so a hot Tab burst doesn't re-parse the JSON
+   on every keystroke. The cache key is ``(mtime, size)`` so an
+   editor-save re-load is automatic — no manual invalidation needed.
+2. **Size cap + control-char strip** so an oversized or hostile
+   ``aliases.json`` can't (a) stall every Tab on JSON decode or
+   (b) leak protocol-separator bytes into argcomplete's line-oriented
+   stdout IPC. The wheel-shipped file is well under the cap and only
+   uses ASCII identifier characters, so this is purely defense in
+   depth against a supply-chain swap or a hand-edited dev copy.
 
 Wired in ``vllm_mlx/cli.py`` and ``vllm_mlx/share/cli.py`` via::
 
@@ -24,22 +30,68 @@ from typing import Any
 
 _ALIASES_PATH = Path(__file__).parent / "aliases.json"
 
+# Hard cap on the JSON we will parse. The wheel-shipped file is ~10 KB
+# (73 aliases as of 0.6.77). 1 MB is ~100× headroom while still tiny
+# enough to fail closed on a hostile multi-GB file before we burn the
+# user's shell on a JSON decode.
+_MAX_ALIASES_BYTES = 1_000_000
+
+# Cache of (mtime, size, sorted_names). One-entry cache is enough: the
+# completer is invoked from a single shell process per Tab burst.
+_CACHE: tuple[float, int, list[str]] | None = None
+
+
+def _is_safe_alias_name(name: object) -> bool:
+    """Reject names that would corrupt argcomplete's line-oriented IPC.
+
+    Argcomplete writes completions to fd 8 separated by either ``\\v``
+    or ``\\n`` (depending on ``_ARGCOMPLETE_IFS``). A key containing
+    those bytes would split into multiple bogus suggestions; a key
+    containing control characters could mis-render in the user's
+    terminal or corrupt the shell completion buffer. Require printable
+    non-whitespace characters only — every legitimate alias today
+    matches.
+    """
+    if not isinstance(name, str) or not name:
+        return False
+    return all(c.isprintable() and not c.isspace() for c in name)
+
 
 def _load_alias_names() -> list[str]:
-    """Return sorted alias keys from ``aliases.json`` (empty list on error).
+    """Return sorted, safety-filtered alias keys from ``aliases.json``.
 
-    Tab-completion must never raise — a missing or corrupt aliases.json
-    should degrade gracefully to "no suggestions" rather than crashing
-    the user's shell.
+    Tab-completion must never raise — a missing, oversized, or corrupt
+    ``aliases.json`` should degrade gracefully to "no suggestions"
+    rather than crashing the user's shell. The mtime+size cache lets
+    a burst of Tabs hit a hot path instead of re-decoding JSON each
+    time.
     """
+    global _CACHE
+    try:
+        stat = _ALIASES_PATH.stat()
+    except OSError:
+        return []
+    if stat.st_size > _MAX_ALIASES_BYTES:
+        return []
+    cache = _CACHE
+    if cache is not None and cache[0] == stat.st_mtime and cache[1] == stat.st_size:
+        return cache[2]
     try:
         with _ALIASES_PATH.open("rb") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+            raw = f.read(_MAX_ALIASES_BYTES + 1)
+    except OSError:
+        return []
+    if len(raw) > _MAX_ALIASES_BYTES:
+        return []
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return []
     if not isinstance(data, dict):
         return []
-    return sorted(data.keys())
+    names = sorted(k for k in data if _is_safe_alias_name(k))
+    _CACHE = (stat.st_mtime, stat.st_size, names)
+    return names
 
 
 def alias_completer(prefix: str = "", **_: Any) -> list[str]:
@@ -61,11 +113,15 @@ def alias_csv_completer(prefix: str = "", **_: Any) -> list[str]:
 
     The user-visible prefix at completion time contains everything
     typed for this flag — e.g. ``qwen3.5-4b,gem`` when partway through
-    the second entry. We split on the last comma, complete only the
-    trailing token against alias names, and re-attach the prefix so
-    the shell inserts the full value correctly.
+    the second entry. We split on the last comma, strip whitespace
+    around the tail so ``--models a, gem<TAB>`` works the same as
+    ``--models a,gem<TAB>`` (the runtime ``split + strip`` accepts
+    both forms; the completer should match that contract), complete
+    only the stripped tail against alias names, and re-attach the
+    head prefix so the shell inserts the full value correctly.
     """
     head, sep, tail = prefix.rpartition(",")
+    tail = tail.lstrip()
     pool = _load_alias_names()
     matches = [n for n in pool if n.startswith(tail)]
     if not sep:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4297,11 +4297,15 @@ Examples:
     _preinit_argcomplete_state(parser)
     try:
         import argcomplete
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
         # Best-effort: tab completion silently no-ops if argcomplete is
         # missing. Listed as a required dep in ``pyproject.toml`` so
         # this path only fires in minimal test envs or stripped images.
-        pass
+        # Narrow the swallow to the top-level argcomplete package — if a
+        # transitive import inside argcomplete is missing we want that
+        # to surface, not get mistaken for "argcomplete not installed".
+        if exc.name != "argcomplete":
+            raise
     else:
         argcomplete.autocomplete(parser)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 # SPDX-License-Identifier: Apache-2.0
 """
 CLI for rapid-mlx (package name: ``vllm_mlx``).
@@ -17,6 +18,10 @@ Usage:
 import argparse
 import os
 import sys
+
+import argcomplete
+
+from vllm_mlx._completion import alias_completer, alias_csv_completer
 
 
 def _log_level_choice(value: str) -> str:
@@ -3258,7 +3263,9 @@ Examples:
         help="Start OpenAI-compatible server",
         allow_abbrev=False,
     )
-    serve_parser.add_argument("model", type=str, help="Model to serve")
+    serve_parser.add_argument(
+        "model", type=str, help="Model to serve"
+    ).completer = alias_completer
     serve_parser.add_argument(
         "--served-model-name",
         type=str,
@@ -3888,7 +3895,9 @@ Examples:
     )
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")
-    bench_parser.add_argument("model", type=str, help="Model to benchmark")
+    bench_parser.add_argument(
+        "model", type=str, help="Model to benchmark"
+    ).completer = alias_completer
     bench_parser.add_argument(
         "--force-disk-check",
         action="store_true",
@@ -4022,13 +4031,13 @@ Examples:
     )
     pull_parser.add_argument(
         "model", help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name)"
-    )
+    ).completer = alias_completer
     rm_parser = subparsers.add_parser(
         "rm", help="Remove a cached model from the HuggingFace cache"
     )
     rm_parser.add_argument(
         "model", help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name)"
-    )
+    ).completer = alias_completer
     subparsers.add_parser("ps", help="List running rapid-mlx servers")
 
     # Upgrade — detect install method and run the right upgrade command
@@ -4067,7 +4076,7 @@ Examples:
         default="qwen3.5-4b",
         help="Model alias (e.g. qwen3.5-4b) or HF repo (org/name). "
         "Defaults to qwen3.5-4b when omitted.",
-    )
+    ).completer = alias_completer
     chat_parser.add_argument(
         "--system",
         type=str,
@@ -4143,7 +4152,7 @@ Examples:
     info_parser.add_argument(
         "model",
         help="Model alias (e.g. qwen3.5-4b) or HF repo (e.g. mlx-community/SmolLM3-3B-4bit)",
-    )
+    ).completer = alias_completer
 
     # Agents command
     agents_parser = subparsers.add_parser(
@@ -4170,7 +4179,7 @@ Examples:
         type=str,
         default=None,
         help="Model to use (default: auto-detect from running server)",
-    )
+    ).completer = alias_completer
     agents_parser.add_argument(
         "--base-url",
         type=str,
@@ -4201,7 +4210,7 @@ Examples:
         type=str,
         default=None,
         help="Model alias for check tier (default: qwen3.5-35b)",
-    )
+    ).completer = alias_completer
     doctor_parser.add_argument(
         "--models",
         type=str,
@@ -4209,7 +4218,7 @@ Examples:
         help="Comma-separated model aliases for full / benchmark tiers "
         "(full default: qwen3.5-35b,qwen3.6-35b; "
         "benchmark default: auto-discovered from local cache)",
-    )
+    ).completer = alias_csv_completer
     doctor_parser.add_argument(
         "--update-baselines",
         action="store_true",
@@ -4250,6 +4259,37 @@ Examples:
     from vllm_mlx.share.cli import register as _register_share
 
     _register_share(subparsers)
+
+    # Shell tab completion via argcomplete. Must fire before parse_args:
+    # when the shell completion handler invokes us with the
+    # ``_ARGCOMPLETE`` env var set, this function short-circuits before
+    # any heavy import paths or model resolution runs, so the user gets
+    # snappy ``rapid-mlx chat gemma-4-<TAB>`` even on a cold shell.
+    #
+    # ``_action_conflicts`` and ``_seen_non_default_actions`` are
+    # populated by argcomplete inside ``IntrospectiveArgumentParser._
+    # parse_known_args`` — but option completion (``finders.py:_
+    # action_allowed``) reads them before parsing has run on a
+    # subparser, raising ``AttributeError`` on the first Tab. We
+    # pre-walk the parser tree and seed empty containers so completion
+    # works at the very first keystroke. Issue tracked upstream at
+    # kislyuk/argcomplete (no mutex groups → conflict set is just
+    # empty; this is the documented null-init).
+    def _preinit_argcomplete_state(p: argparse.ArgumentParser) -> None:
+        if not hasattr(p, "_action_conflicts"):
+            p._action_conflicts = {}  # type: ignore[attr-defined]
+        if not hasattr(p, "_seen_non_default_actions"):
+            p._seen_non_default_actions = set()  # type: ignore[attr-defined]
+        if not hasattr(p, "active_actions"):
+            p.active_actions = []  # type: ignore[attr-defined]
+        for action in p._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                for sub in action.choices.values():
+                    if isinstance(sub, argparse.ArgumentParser):
+                        _preinit_argcomplete_state(sub)
+
+    _preinit_argcomplete_state(parser)
+    argcomplete.autocomplete(parser)
 
     args = parser.parse_args()
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -19,9 +19,15 @@ import argparse
 import os
 import sys
 
-import argcomplete
-
 from vllm_mlx._completion import alias_completer, alias_csv_completer
+
+# NOTE: ``argcomplete`` is imported lazily inside ``main()`` instead of
+# at module top. Module-level imports of ``vllm_mlx.cli`` (e.g.
+# ``tests/test_harmony_parsers.py::TestServeLogLevelFlags``) run in the
+# minimal-deps CI lane that doesn't pre-install argcomplete; pulling it
+# at top would surface as ``ModuleNotFoundError`` during test collection.
+# argcomplete is still a required runtime dep in ``pyproject.toml`` so
+# real installs get tab completion out of the box.
 
 
 def _log_level_choice(value: str) -> str:
@@ -4289,7 +4295,15 @@ Examples:
                         _preinit_argcomplete_state(sub)
 
     _preinit_argcomplete_state(parser)
-    argcomplete.autocomplete(parser)
+    try:
+        import argcomplete
+    except ModuleNotFoundError:
+        # Best-effort: tab completion silently no-ops if argcomplete is
+        # missing. Listed as a required dep in ``pyproject.toml`` so
+        # this path only fires in minimal test envs or stripped images.
+        pass
+    else:
+        argcomplete.autocomplete(parser)
 
     args = parser.parse_args()
 

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -47,6 +47,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+from .._completion import alias_completer
 from . import warning, ws_tunnel
 
 # Pulled out so the routing-shape audit (tests/test_no_out_of_band_routing.py)
@@ -767,7 +768,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "model",
         help="Alias to serve (same names as `rapid-mlx serve`, e.g. qwen3.5-4b)",
-    )
+    ).completer = alias_completer
     p.add_argument(
         "--port",
         type=int,


### PR DESCRIPTION
## Summary

Adds zsh/bash/fish tab completion for the ``rapid-mlx`` CLI. Hit Tab on a model alias or subcommand and the shell pulls candidates straight from ``aliases.json``:

```
$ rapid-mlx chat gemma-4-<TAB>
gemma-4-12b       gemma-4-12b-8bit  gemma-4-26b
gemma-4-31b       gemma-4-31b-8bit

$ rapid-mlx s<TAB>
serve  share

$ rapid-mlx serve --p<TAB>
--port  --prefill-batch-size  --prefix-cache-size  ...

$ rapid-mlx doctor --models qwen3.5-4b,gem<TAB>
qwen3.5-4b,gemma-4-12b  qwen3.5-4b,gemma-4-26b  ...
```

Covers every subcommand that takes a model alias: ``serve``, ``bench``, ``pull``, ``rm``, ``chat`` (and its ``run`` alias), ``info``, ``share``, ``agents --model``, ``doctor --model``, ``doctor --models`` (CSV). Subparser names and option flags get free completion from argcomplete's introspection.

## Implementation

| File | Change |
| --- | --- |
| `vllm_mlx/_completion.py` | NEW. `alias_completer` (single) + `alias_csv_completer` (CSV) callbacks. Re-reads `aliases.json` per keystroke (~10 KB JSON, unmeasurable). Degrades gracefully (`[]`) on missing/corrupt file. |
| `vllm_mlx/cli.py` | Magic marker `# PYTHON_ARGCOMPLETE_OK` in first 1024 bytes. `argcomplete.autocomplete(parser)` immediately before `parse_args` so the handler short-circuits before any heavy import paths. `.completer = alias_completer` on all model positional args + `--model` flags. `_preinit_argcomplete_state` walks subparsers to defense-in-depth seed `_action_conflicts`/`_seen_non_default_actions`/`active_actions` against older argcomplete versions. |
| `vllm_mlx/share/cli.py` | `.completer = alias_completer` on the share `model` positional. |
| `pyproject.toml` | `argcomplete>=3.6` added to required deps. <3.6 silently breaks on Python 3.12.6+ due to a 4-arg `_parse_known_args` signature change. |
| `tests/test_cli_argcomplete.py` | NEW. 10 unit tests pinning: magic-marker presence, prefix filter, empty/unknown prefix, missing/corrupt file robustness, CSV head-preservation, multi-comma rpartition correctness, aliases.json path resolution. |

## Verification

1. **Unit tests**: `python3.12 -m pytest tests/test_cli_argcomplete.py -v` → **10/10 pass**
2. **Alias contract regression**: `python3.12 -m pytest tests/test_aliases_contract.py tests/test_model_aliases.py tests/test_alias_recommended_sampling.py tests/test_model_profiles_ssot.py -q` → **779/779 pass**
3. **Lint + format**: `ruff check` + `ruff format --check` → **clean**
4. **End-to-end shell handshake** (simulated):
   ```
   _ARGCOMPLETE=1 COMP_LINE='rapid-mlx chat gemma-4-12b-' COMP_POINT=27 \
   _ARGCOMPLETE_IFS=$'\n' python3.12 -m vllm_mlx.cli 8>&1 1>/dev/null
   → gemma-4-12b-8bit  (correct: 1 PTQ match on main)
   ```
   Tested across `chat`, `share`, `serve`, `serve --p<TAB>` (option), `s<TAB>` (subcommand), `doctor --models a,b,<TAB>` (CSV) — all return correct candidates.

## Why argcomplete >= 3.6 is mandatory

Python 3.12.6+ added a 4th positional `intermixed` argument to `argparse._parse_known_args`. argcomplete <3.6 subclasses with only 3 positional args and raises `TypeError` mid-completion-handshake — the shell silently shows nothing. 3.6.x ships the variadic signature fix. The pin guarantees first-Tab works on every supported Python version.

## User activation (one-time)

After install, the user adds one line to their shell rc:

**zsh / bash:**
```bash
eval "$(register-python-argcomplete rapid-mlx)"
```

**system-wide (macOS / Linux):**
```bash
activate-global-python-argcomplete
```

## Follow-ups (not in this PR)

- [ ] Homebrew formula: auto-install `rapid-mlx` completion script into `etc/bash_completion.d/` and `share/zsh/site-functions/` so brew users get completion without the manual eval line.
- [ ] README: add a "Tab completion" subsection under Installation.

## Test plan

- [ ] CI green on raullenchai/Rapid-MLX
- [ ] Manual: install + add eval line + tab-complete each subcommand in zsh / bash
- [ ] Verify QAT aliases (PR #523) tab-complete once both PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)