### PR TITLE
chore: bump version to 0.6.78

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.77"
+version = "0.6.78"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli_argcomplete.py
+++ b/tests/test_cli_argcomplete.py
@@ -63,6 +63,20 @@ def test_alias_completer_filters_by_prefix() -> None:
         f"completer leaked non-matching aliases: "
         f"{[n for n in result if not n.startswith('gemma-4-')]}"
     )
+    # Lock in the five QAT aliases shipped in v0.6.78 (PR #523) — a
+    # ``len >= 5`` floor alone would have passed even before they were
+    # added (pre-#523 there were already 5 gemma-4-* aliases). Explicit
+    # membership catches a silent regression where the QAT entries get
+    # dropped from aliases.json without the test failing.
+    qat_aliases = {
+        "gemma-4-12b-qat",
+        "gemma-4-12b-qat-8bit",
+        "gemma-4-26b-qat",
+        "gemma-4-31b-qat",
+        "gemma-4-31b-qat-8bit",
+    }
+    missing = qat_aliases - set(result)
+    assert not missing, f"QAT aliases missing from completer output: {missing}"
 
 
 def test_alias_completer_unknown_prefix_returns_empty() -> None:


### PR DESCRIPTION
## Summary
- Bumps `version = "0.6.77"` → `"0.6.78"` in `pyproject.toml`
- Picks up release-review NIT: explicit QAT-alias membership assertion in `tests/test_cli_argcomplete.py::test_alias_completer_filters_by_prefix` (the `len >= 5` floor alone passed pre-PR #523, so a silent drop of QAT entries would have escaped the gate)

## Changes in v0.6.78 (since v0.6.77)
- **PR #523** — `feat(aliases)`: Gemma 4 QAT variants `gemma-4-{12b,26b,31b}-qat` + `gemma-4-{12b,31b}-qat-8bit`. Data-only; inherits `gemma4` parser/sampling from PTQ siblings.
- **PR #524** — `feat(cli)`: shell tab completion via `argcomplete` on every subcommand (`chat`/`serve`/`share`/`pull`/`rm`/`info`/`agents`/`doctor`/`bench`/`run`). One-time activation: `eval "$(register-python-argcomplete rapid-mlx)"`.

## Release SOP — all 11 gates walked
| Gate | Status | Notes |
| ---- | ------ | ----- |
| G1  `make release-smoke` | ✅ | clean-room install + 5 release surfaces import |
| G2  codex review | ✅ | 1 expected version BLOCKER (this PR) + 3 NITs (#1 applied here; #2/#3 → follow-up issue) |
| G3  `scripts/audit_cli_config_fidelity.py` | ✅ | exit 0 |
| G4  `make smoke` | ✅ | lint + audit + 1933 unit (65s) |
| G5  `make stress` | ✅ | 8/8 scenarios, 34.4s |
| G6  e2e repro | ✅ | argcomplete returns all 5 new QAT aliases under `chat` + `share`; live `/v1/chat/completions` → 200 |
| G7  integrations | ✅ | anthropic_sdk 5/5, pydantic_ai 6/6, smolagents 4/4 (15/15) |
| G8  microbench sanity | ✅ | no perf-touching diff |
| G9  sequential latency | ✅ | median 203ms, p90 206ms, max 217ms |
| G10 MLX bump gate | n/a | no MLX bumps |
| G11 auto-routing escape-hatch | n/a | no auto-routing changes |

## Test plan
- [x] `python3.12 -m pytest tests/test_cli_argcomplete.py` — 16/16 pass
- [ ] Auto-release workflow tags `v0.6.78`, publishes to PyPI, bumps Homebrew formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)