### PR TITLE
fix(upgrade): correct brew tap path for rapid-mlx upgrade

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -93,7 +93,7 @@ jobs:
               echo "_(no changes recorded)_"
             fi
             echo
-            echo "Install: \`brew upgrade rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\`"
+            echo "Install: \`brew upgrade raullenchai/rapid-mlx/rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."
             echo '__EOF__'
           } >> "$GITHUB_OUTPUT"
 

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -183,7 +183,7 @@ def test_warning_message_recommends_upgrade_subcommand(isolated_cache, monkeypat
     """The banner must point users at our own upgrade subcommand.
 
     Pre-0.6.31 we suggested raw ``brew upgrade rapid-mlx`` — wrong formula
-    path (the tap is ``raullenchai/tap/rapid-mlx``) AND it stranded pip /
+    path (the tap is ``raullenchai/rapid-mlx/rapid-mlx``) AND it stranded pip /
     install.sh users. The new flow centralises the install-method detection
     in ``rapid-mlx upgrade``, so the warning just needs to point there.
     """
@@ -215,8 +215,8 @@ def test_detect_install_method_brew(monkeypatch):
 
     info = vc.detect_install_method()
     assert info.method == "brew"
-    assert info.upgrade_command == "brew upgrade raullenchai/tap/rapid-mlx"
-    assert info.upgrade_argv == ["brew", "upgrade", "raullenchai/tap/rapid-mlx"]
+    assert info.upgrade_command == "brew upgrade raullenchai/rapid-mlx/rapid-mlx"
+    assert info.upgrade_argv == ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"]
     assert info.binary_path == fake_binary
 
 
@@ -409,8 +409,8 @@ def test_prompt_returns_false_when_upgrade_subprocess_fails(monkeypatch, interac
         "detect_install_method",
         lambda: vc.InstallInfo(
             method="brew",
-            upgrade_command="brew upgrade raullenchai/tap/rapid-mlx",
-            upgrade_argv=["brew", "upgrade", "raullenchai/tap/rapid-mlx"],
+            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
         ),
     )
     fake_result = MagicMock(returncode=1)
@@ -460,8 +460,8 @@ def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive
         "detect_install_method",
         lambda: vc.InstallInfo(
             method="brew",
-            upgrade_command="brew upgrade raullenchai/tap/rapid-mlx",
-            upgrade_argv=["brew", "upgrade", "raullenchai/tap/rapid-mlx"],
+            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
         ),
     )
     fake_result = MagicMock(returncode=0)
@@ -472,7 +472,7 @@ def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive
     ):
         assert vc.prompt_upgrade_if_available() is True
         run.assert_called_once_with(
-            ["brew", "upgrade", "raullenchai/tap/rapid-mlx"], check=False
+            ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"], check=False
         )
 
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -14,7 +14,7 @@ non-interactive context (``CI=1``, missing TTY).
 Behaviour matrix:
 
   installed = 0.6.14, latest = 0.6.16 (2 patch behind)
-    → warns, suggests ``brew upgrade``
+    → warns, suggests ``rapid-mlx upgrade``
 
   installed = 0.6.16, latest = 0.6.16 (current)
     → silent

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -329,7 +329,7 @@ def detect_install_method() -> InstallInfo:
     Detection order:
       1. brew — ``rapid-mlx`` realpath under ``/Cellar/rapid-mlx``,
          ``/opt/homebrew/`` (macOS) or ``/home/linuxbrew/`` (Linux brew)
-         triggers ``brew upgrade raullenchai/tap/rapid-mlx``.
+         triggers ``brew upgrade raullenchai/rapid-mlx/rapid-mlx``.
       2. install.sh — binary under ``~/.local/bin`` (or realpath under
          the install.sh venv at ``~/.rapid-mlx/``) triggers a re-run of
          the install.sh script.
@@ -346,8 +346,8 @@ def detect_install_method() -> InstallInfo:
         if any(m in normalized for m in brew_markers):
             return InstallInfo(
                 method="brew",
-                upgrade_command="brew upgrade raullenchai/tap/rapid-mlx",
-                upgrade_argv=["brew", "upgrade", "raullenchai/tap/rapid-mlx"],
+                upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
+                upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
                 binary_path=binary,
             )
         # install.sh creates ``~/.rapid-mlx`` (venv) and symlinks the


### PR DESCRIPTION
## Summary
- `vllm_mlx/_version_check.py` hard-coded the brew tap as `raullenchai/tap/rapid-mlx`, but the real tap is `raullenchai/rapid-mlx` (GitHub repo `homebrew-rapid-mlx`, with the `homebrew-` prefix stripped by Homebrew). The fully qualified formula reference is `raullenchai/rapid-mlx/rapid-mlx`.
- Every brew user hits a hard error from `rapid-mlx upgrade` on the v0.6.78 release:
  > `Error: No available formula or cask with the name "raullenchai/tap/rapid-mlx". Did you mean raullenchai/rapid-mlx/rapid-mlx?`
- Unit tests in `tests/test_version_check.py` pinned the wrong string (catching nothing). Updated in lockstep.

## User repro (caught by user on 0.6.77 → 0.6.78 upgrade)
```
> rapid-mlx upgrade
Current:  rapid-mlx 0.6.77
Latest:   rapid-mlx 0.6.78
Install:  brew (/opt/homebrew/Cellar/rapid-mlx/0.6.77/libexec/bin/rapid-mlx)
Command:  brew upgrade raullenchai/tap/rapid-mlx
Run now? [y/N] Y
...
Error: No available formula or cask with the name "raullenchai/tap/rapid-mlx".
       Did you mean raullenchai/rapid-mlx/rapid-mlx?
```

## Test plan
- [x] `python3.12 -m pytest tests/test_version_check.py` → 44/44 pass
- [x] Manual `brew search rapid-mlx` confirms `raullenchai/rapid-mlx/rapid-mlx` is the resolvable formula
- [ ] After merge + v0.6.79 release: `rapid-mlx upgrade` from 0.6.78 → 0.6.79 should complete cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)