### PR TITLE
chore: bump version to 0.6.80

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.79"
+version = "0.6.80"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release v0.6.80 — Gemma 4 family no longer crashes on bare ``pip install rapid-mlx``.

Bundles the merged code-side fix:
- PR #529 — ``vllm_mlx.models.gemma4_text.load_gemma4_text`` wraps the ``mlx_vlm.models.gemma4`` imports in ``try / except ImportError`` and re-raises with an actionable install hint (``pip install --no-deps 'mlx-vlm>=0.6.1'`` or ``pip install 'rapid-mlx[vision]'``).

Companion tap PR (raullenchai/homebrew-rapid-mlx #11) already installs mlx-vlm ``--no-deps`` so brew users no longer hit the failure path; the code-side guard catches PyPI users on a bare install and survives any future packaging change.

## Release SOP

All 11 gates walked per ``release_workflow.md``:

| # | gate | status |
|---|---|---|
| 1 | release-smoke (clean-room install/import) | PASS |
| 2 | codex review × 2 rounds | PASS (0 BLOCKING, 4 NIT across rounds) |
| 3 | CLI ↔ config fidelity audit | PASS |
| 4 | make smoke (lint + audit + unit) | PASS 3/3 |
| 5 | make stress | PASS 8/8 |
| 6 | real-server fix-path repro | PASS (alias resolves, server up) |
| 7 | integration SDKs | Anthropic 5/5, smolagents 4/4, pydantic_ai 4/6 (2 unrelated max_tokens) |
| 8 | microbench | N/A (load-time guard only) |
| 9 | server latency 10×sequential | PASS stable |
| 10 | MLX bump cross-chip-family | N/A (no mlx/mlx-lm/mlx-vlm bump) |
| 11 | escape-hatch + actionable error | PASS (``--no-mllm`` pair, msg) |

## Test plan

- [x] All 11 release gates walked
- [x] No CJK in any release artifact
- [x] pyproject.toml version pinned to 0.6.80

🤖 Generated with [Claude Code](https://claude.com/claude-code)