### PR TITLE
feat(telemetry): Phase 2 transport + queue + emit + session lifecycle wiring

### DIFF
--- a/docs/plans/telemetry-golden-profile.md
+++ b/docs/plans/telemetry-golden-profile.md
@@ -331,7 +331,14 @@ breaks the deal we made when we asked them to opt in.
    regex does not capture the value half of `--foo=bar`.
 5. **No exception messages, no module paths.** `fingerprint_traceback`
    hashes class name + `basename:func:lineno` only.
-6. **No IP, no UA.** Pinned at the Worker layer (vitest tests in
+6. **No IP, no UA in stored event payloads.** The client DOES send a
+   self-identifying `User-Agent: rapid-mlx/<version>` header — without
+   it, Cloudflare's bot manager rejects the request with HTTP 403 before
+   it reaches the Worker. The contract is that neither the IP nor the
+   UA is written into the R2 object body: the IP is SHA-256'd into a
+   rate-limit KV key and discarded, the UA is read for transport
+   attribution and then dropped on the floor. Pinned at the Worker
+   layer (vitest tests in
    `Rapid-MLX-telemetry-worker/test/worker.test.js`).
 7. **No header forwarding.** Worker never copies a request header
    into the R2 object body.

--- a/docs/plans/telemetry-golden-profile.md
+++ b/docs/plans/telemetry-golden-profile.md
@@ -1,0 +1,463 @@
+# Telemetry → Golden Profile design doc
+
+Status: **draft** · Author: raullen + Claude · Date: 2026-06-06
+
+This doc covers Phase 2 of the opt-in telemetry pipeline first sketched
+in [Issue #236](https://github.com/raullenchai/Rapid-MLX/issues/236).
+Phase 1 (consent + redaction + schema) already landed in
+`vllm_mlx/telemetry/` and the Cloudflare Worker at
+`~/work/Rapid-MLX-telemetry-worker/`. This doc is **only** about wiring
+client transport, event call sites, server DNS, and the downstream
+Golden Profile aggregation. Re-litigating the consent UX or schema
+shape is out of scope.
+
+## 1 · Goals (3 data streams, 1 pipeline)
+
+The user-facing pitch is three categories — but they share the same
+schema envelope, the same consent gate, the same Worker, and the same
+R2 bucket. They differ only in the `event` discriminator and which
+optional payload is populated.
+
+| Stream | `event` value | Optional payload | Feeds |
+|---|---|---|---|
+| **Performance** — `(model, hardware, batch) → tok/s, ttft` | `request` | `RequestPayload` | Golden Profile speed table |
+| **Usage habits** — which models/subcommands/flags are popular | `session_start` / `session_end` | `SessionPayload` | Roadmap prioritization (Top-N alias support, parser coverage) |
+| **Errors / crashes** — broken parsers, OOM, tool failures, model-load failures | `error` | `ErrorPayload` | Bug triage, regression watchlist |
+
+What we explicitly do **not** want:
+- Prompt content. Ever.
+- Generated content. Ever.
+- API keys, webhook URLs, file paths.
+- Per-event IPs or UAs (Worker invariants pin this).
+- Anything that can re-identify a single user across sessions beyond
+  the opaque `client_id` UUID the user can rotate at will.
+
+## 2 · Current state (what's already done)
+
+### 2.1 Client (`vllm_mlx/telemetry/`) — Phase 1 complete
+
+| File | Owns |
+|---|---|
+| `state.py` | `~/.rapid-mlx/telemetry-client-id`, `~/.rapid-mlx/telemetry-consent.yaml`, kill switch precedence (`--no-telemetry` > `RAPID_MLX_TELEMETRY=0` > file > default OFF). No env-var force-on (CI would skew aggregates). |
+| `consent.py` | First-run prompt, schema-version-aware re-prompt. |
+| `schema.py` | `TelemetryPayload` envelope, `PlatformInfo` / `SessionPayload` / `RequestPayload` / `ErrorPayload` dataclasses, `sample_preview_payload()`. `SCHEMA_VERSION = 1`. |
+| `redact.py` | Bucket primitives (`bucket_tokens`, `bucket_ttft_ms`, `bucket_tps`, `bucket_memory_gb`), `normalize_model_path` (passes `org/name`, redacts local paths), `hash_flag_names` (names only, never values), `fingerprint_traceback` (16-hex of `class_name + basename:func:lineno`, no message text, no module path), `platform_info` (chip + memory rounded to GB + OS major.minor + python major.minor). |
+| `cli.py:3133` | `rapid-mlx telemetry {status,enable,disable,preview,reset}` subcommand. |
+
+Phase 1 has **no event call sites** — `is_enabled()` exists, but
+nothing calls it to actually emit. The package compiles, has tests,
+and ships dark.
+
+### 2.2 Server (`~/work/Rapid-MLX-telemetry-worker/`) — Phase 1 complete, deploy blocked
+
+| Component | State |
+|---|---|
+| Worker handler `src/index.js` (165 LOC) | POST `/v1/events`, validates `schema_version == 1`, body cap 256 KB, batch cap 100 events, 50ms CPU cap, stamps `received_at`. Writes one NDJSON object per batch to R2 key `events/YYYY/MM/DD/HH/<rand12>.ndjson`. |
+| Privacy invariants pinned by `test/worker.test.js` | (1) does not read `CF-Connecting-IP` / `X-Forwarded-For` / `X-Real-IP` / UA; (2) does not forward any request header to R2; (3) rejects `schema_version != 1`; (4) "do not log bodies" is code-review-only. |
+| `wrangler.toml` | `r2_buckets.binding = "EVENTS"`, `bucket_name = "rapid-mlx-telemetry-events"`, `[observability] enabled = true`. |
+| Deploy state | **Blocked**. Per memory `project_telemetry_worker_deploy_blocked.md`: existing OAuth token lacks R2 + Workers scopes. Either re-auth `wrangler login` interactively in user shell, or mint a scoped API token (Workers Scripts:Edit, Account R2:Edit). |
+
+### 2.3 rapidmlx.com infrastructure — already serves *other* workloads
+
+Three Cloudflare-attached surfaces in production today:
+
+- **`rapid-pro.pages.dev`** — Big-AGI vendored static (Pages, no Worker).
+- **`rapidserver.quicksilverpro.io`** — Worker `rapidserver` (712 LOC),
+  hosts the share WebSocket relay (Durable Object `TunnelHub`) +
+  `/tool/*` proxies (weather/wiki/currency/web_search) + `/r/<id>/*`
+  reverse-proxy. Custom domain via the Workers Custom Domains API
+  (OAuth grants workers-only, no zone:dns:edit needed).
+- **`chat.rapidmlx.com`** — static splash + vendored BCG, served via
+  cloudflared tunnel from M3 Ultra (NOT a Worker).
+
+**Decision: do NOT fold telemetry into `rapidserver`.** Different
+security postures (share-tunnel intentionally sees client IP to
+fingerprint abuse; telemetry must never see IP). Different deploy
+cadences. Different blast radius if a route is misconfigured. Keep
+`rapid-mlx-telemetry` as its own Worker, attached to its own subdomain.
+
+## 3 · Phase 2 client work
+
+### 3.1 New module: `vllm_mlx/telemetry/transport.py`
+
+Single responsibility: take a list of `TelemetryPayload` dicts, ship
+them to the Worker, fail silently on error. Nothing about consent or
+event construction lives here.
+
+```python
+# vllm_mlx/telemetry/transport.py — sketch
+
+DEFAULT_ENDPOINT = "https://telemetry.rapidmlx.com/v1/events"
+TIMEOUT_S = 3.0  # short — telemetry must NEVER slow a real request
+RETRY_BACKOFFS_S = (0.5, 2.0)  # 3 attempts total, ~2.5s ceiling
+
+def post_batch(events: list[dict], *, endpoint: str = DEFAULT_ENDPOINT) -> bool:
+    """Best-effort. Returns True on 2xx. False on anything else.
+    NEVER raises. NEVER blocks the foreground for more than TIMEOUT_S * 3."""
+    body = json.dumps({"batch": events}).encode("utf-8")
+    if len(body) > 200 * 1024:  # Worker caps at 256 KB; leave headroom
+        return False
+    for attempt, backoff in enumerate((*RETRY_BACKOFFS_S, None)):
+        try:
+            req = Request(endpoint, data=body, method="POST",
+                          headers={"content-type": "application/json"})
+            with urlopen(req, timeout=TIMEOUT_S) as resp:
+                return 200 <= resp.status < 300
+        except (URLError, HTTPError, TimeoutError):
+            if backoff is None:
+                return False
+            time.sleep(backoff)
+    return False
+```
+
+Notes:
+- `urllib.request` (stdlib) over `httpx` / `requests` — no new
+  dependency for a telemetry path. We already import stdlib `urllib`
+  elsewhere.
+- Endpoint overridable via `RAPID_MLX_TELEMETRY_ENDPOINT` env var
+  (mirrors PRT debug practice) but **only** when telemetry is otherwise
+  enabled. The env var alone never opts a user in.
+- HTTPS-only check (mirror `share` PR #504 codex round 4 fix —
+  `URLError` is **NOT** a `TimeoutError` subclass; this code already
+  catches both explicitly).
+
+### 3.2 New module: `vllm_mlx/telemetry/queue.py`
+
+A bounded in-process queue + flush daemon. Events accumulate locally;
+a background thread flushes either when the queue hits N events, when
+T seconds elapse, or on graceful shutdown.
+
+```python
+# vllm_mlx/telemetry/queue.py — sketch
+
+MAX_QUEUE_LEN = 100   # match Worker batch cap
+FLUSH_INTERVAL_S = 60 # idle flush
+FLUSH_THRESHOLD = 10  # eager flush when this many pending
+
+class TelemetryQueue:
+    """Thread-safe, lossy under back-pressure (drops oldest)."""
+    def __init__(self): ...
+    def enqueue(self, payload: dict) -> None: ...
+    def start_flush_daemon(self) -> None: ...
+    def shutdown(self, *, timeout_s: float = 2.0) -> None: ...
+```
+
+Invariants:
+- **Lossy by design**: queue drops oldest event on overflow. Telemetry
+  must never grow unbounded if the network is down.
+- **Daemon thread** so SIGTERM does not hang on flush. Final flush is
+  scheduled via `atexit` with a 2 s budget.
+- **Hot path stays sync-free**: `enqueue()` is a single deque append
+  inside one `Lock`. No HTTP, no JSON dump on the request path.
+- **Coalesce session events**: emitting `session_start` + immediate
+  `session_end` of the same session_id within the same flush window
+  collapses to a single `session_summary` event (out of Phase 2 scope
+  but worth noting for Phase 3).
+
+### 3.3 Event call sites (the 3 streams wired)
+
+Surgical instrumentation only. Every site touches:
+1. `if not telemetry.is_enabled(): return` — no event constructor runs
+   when disabled.
+2. Wrap event construction in `try/except Exception: pass` — telemetry
+   failures must never surface to the user.
+3. Use redaction primitives. Do not construct payloads directly.
+
+| Stream | File | Hook | Notes |
+|---|---|---|---|
+| **session_start** | `vllm_mlx/cli.py` `main()` | After argparse, before subcommand dispatch | Captures subcommand + redacted `flag_names` from `sys.argv`. |
+| **session_end** | `vllm_mlx/cli.py` `main()` | `atexit` / `finally` | Carries `duration_seconds`. For `serve`, this fires at server shutdown so `models_loaded` is final. |
+| **request** | `vllm_mlx/routes/chat.py` (and embeddings/audio mirrors) | After response sent, before context exit | Bucket ttft, tps, prompt/completion tokens. `tool_call_used` from response inspection. **Skip streaming partials** — emit once per completed request. |
+| **error** (model load) | `vllm_mlx/engine/loader.py` exception handler | On any load exception | `category="model_load_failure"`, `phase="startup"`. |
+| **error** (oom) | `vllm_mlx/scheduler.py` `MemoryError` handler | On OOM | `category="oom"`, `phase="request"`. |
+| **error** (tool parse) | `vllm_mlx/parsers/*.py` failure paths | When a parser falls back to text | `category="tool_parse"`. Carries fingerprint of the parser path, not the offending input. |
+| **error** (shutdown traceback) | `vllm_mlx/api/server.py` lifespan exit handler | On exception during shutdown | `category="shutdown_traceback"`, `phase="shutdown"`. |
+
+### 3.4 Threading + lifecycle integration
+
+- `vllm_mlx/cli.py` `main()` instantiates a process-singleton
+  `TelemetryQueue` after consent check. The instance is also held by
+  `vllm_mlx/api/server.py` `lifespan()` (FastAPI) and surfaced via
+  request-state for the route layer.
+- One flush daemon per CLI invocation. Daemon thread, `daemon=True`,
+  joined with 2 s budget on `atexit`.
+- `vllm_mlx/api/server.py` `lifespan()` enqueues `session_start` on
+  startup, `session_end` on shutdown; route layer enqueues `request`.
+
+## 4 · Server-side: DNS + Worker deploy
+
+### 4.1 DNS plan
+
+Target hostname: **`telemetry.rapidmlx.com`** (NOT `rapidserver.…` —
+see §2.3 reasoning).
+
+Two-zone reality:
+- `rapidmlx.com` zone — owned by raullen, hosts Pages + `chat.…`.
+- `quicksilverpro.io` zone — Iotex-owned, hosts `rapidserver.…`.
+
+Because the telemetry Worker has zero coupling to the share tunnel,
+it can attach to `rapidmlx.com` cleanly:
+
+1. Move the telemetry Worker's `wrangler.toml` to add:
+   ```toml
+   routes = [
+     { pattern = "telemetry.rapidmlx.com", custom_domain = true }
+   ]
+   ```
+2. Once deployed, the Workers Custom Domains API mints the placeholder
+   `100::` AAAA record automatically — no `zone:dns:edit` token needed
+   (same trick as `rapidserver`).
+3. CORS stays off (clients are CLIs, not browsers). If we ever expose
+   `/v1/events` to a browser surface (e.g. a debug button in chat.…),
+   add an explicit allowlist mirroring the `rapidserver` worker's
+   atomic CORS-replace pattern (`gotcha_worker_cors_atomic_replace`).
+
+### 4.2 Token / OAuth unblock
+
+The original blocker is fully captured in memory
+`project_telemetry_worker_deploy_blocked.md`. Two paths:
+
+**Path A — interactive re-auth (recommended, low blast radius):**
+```bash
+# In a regular user terminal, NOT inside claude-code (see memory
+# gotcha_wrangler_oauth_claude_code — claude-code's bash strips
+# Authorization headers):
+cd ~/work/Rapid-MLX-telemetry-worker
+npx wrangler login       # browser opens, grants Workers + R2
+npx wrangler r2 bucket create rapid-mlx-telemetry-events --location enam
+npx wrangler deploy
+```
+
+**Path B — long-lived scoped API token:**
+Mint at https://dash.cloudflare.com/profile/api-tokens with:
+- Account · Workers Scripts · Edit
+- Account · Workers R2 Storage · Edit
+- Zone · `rapidmlx.com` · Workers Routes · Edit
+- Zone · `rapidmlx.com` · DNS · Edit (only if Workers Custom Domains
+  fails to mint the placeholder, which would surprise me)
+
+Export `CLOUDFLARE_API_TOKEN=…` and `npx wrangler deploy`.
+
+### 4.3 Operational dashboard
+
+Cloudflare's `[observability] enabled = true` already captures
+per-request URL + status + CPU time. No app-level metrics added.
+
+For the data side, point DuckDB at the bucket from a local dev
+machine:
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+SET s3_endpoint = '404b05ab....r2.cloudflarestorage.com';
+SET s3_access_key_id = '<R2 key>';
+SET s3_secret_access_key = '<R2 secret>';
+
+SELECT event, count(*) AS n
+FROM read_json_auto('s3://rapid-mlx-telemetry-events/events/2026/**/*.ndjson')
+GROUP BY event;
+```
+
+## 5 · Golden Profile aggregation
+
+Where the user's perf data actually goes after R2.
+
+### 5.1 Schema mapping (R2 NDJSON → Golden Profile row)
+
+The `RequestPayload` envelope already carries the right fields:
+
+| `RequestPayload` field | Golden Profile column |
+|---|---|
+| `model_alias` | `alias` (PK part) |
+| (top-level `platform.chip`) | `chip` (PK part) |
+| (top-level `platform.memory_gb`) | `memory_gb` |
+| `prompt_tokens_bucket` | `prompt_bucket` |
+| `completion_tokens_bucket` | `completion_bucket` |
+| `ttft_ms_bucket` | `ttft_bucket` |
+| `tps_bucket` | `tps_bucket` |
+| `tool_call_used` | `tool_call` (0/1) |
+| `stream` | `stream` (0/1) |
+| `status` | `status` (filter to 200 for the perf table) |
+| (top-level `rapid_mlx_version`) | `rapid_mlx_version` (so a regression on a single release is visible) |
+
+Per-row count is the aggregation primary key, not per-event. The whole
+point of bucketing is that the (alias, chip, *_bucket, ...) tuple
+collapses to a count + percentile target.
+
+### 5.2 Aggregation jobs (where + when)
+
+Three options, picking the cheapest:
+
+| Option | How | Cadence | Cost |
+|---|---|---|---|
+| **A** — Nightly DuckDB on a dev box | cron + `read_json_auto('s3://…/2026/MM/DD/*.ndjson')` → write parquet to `golden_profile/YYYY-MM-DD.parquet` | nightly | Free (compute on dev box) |
+| **B** — CF Workers Cron Triggers | Second Worker reads R2, writes aggregate parquet back to R2 | nightly | Free tier OK, but parquet roundtrip is awkward in JS |
+| **C** — Cloudflare D1 | Worker INSERTs aggregated counts into D1 from each batch (no nightly job) | per-batch | D1 free tier limits at 5M reads/day — fine |
+
+**Recommendation: A for MVP**, C for v2 once volume justifies it.
+Option A is one bash script + one DuckDB call + one `aws s3 cp`
+equivalent — debuggable, no new infra. Option C is the "real-time
+dashboard" version once we have enough events to want one.
+
+### 5.3 Publishing the Golden Profile
+
+Once a parquet is built, ship it as a static artifact:
+
+- **`https://golden.rapidmlx.com/profile-v1.parquet`** — static, signed
+  by the nightly job, served by Pages or R2 public bucket.
+- **`https://golden.rapidmlx.com/profile-v1.json`** — same data, JSON,
+  for browser surfaces (chat.rapidmlx.com Big-AGI splash could read
+  this to pre-populate "your hardware → recommended alias").
+- **Versioning**: `profile-v1` is the schema. Bump to `v2` when the
+  column set changes incompatibly.
+
+`rapid-mlx suggest` (future CLI subcommand) reads the JSON, intersects
+with `aliases.json`, and emits a ranked list. This is the
+"rapid-mlx-flavored whichllm" the user described — but powered by
+**real measurements** instead of spec-sheet algebra.
+
+## 6 · Privacy + security posture (must stay true)
+
+These invariants are the user-facing contract. Breaking any of them
+breaks the deal we made when we asked them to opt in.
+
+1. **No event before consent.** `is_enabled()` is the only gate. No
+   call site constructs a payload without first calling it.
+2. **No prompt or generated content, ever.** The schema dataclasses
+   are the wire shape — they have no field for free-form text. Code
+   review on any schema addition must justify the new field.
+3. **No raw model paths.** `normalize_model_path` redacts anything
+   that isn't `org/name`. Local checkouts surface as `<local>`.
+4. **No flag values, ever.** Only flag names. The `redact.hash_flag_names`
+   regex does not capture the value half of `--foo=bar`.
+5. **No exception messages, no module paths.** `fingerprint_traceback`
+   hashes class name + `basename:func:lineno` only.
+6. **No IP, no UA.** Pinned at the Worker layer (vitest tests in
+   `Rapid-MLX-telemetry-worker/test/worker.test.js`).
+7. **No header forwarding.** Worker never copies a request header
+   into the R2 object body.
+8. **Opaque rotatable identity.** `client_id` is a local UUID4. User
+   can `rm ~/.rapid-mlx/telemetry-client-id` to rotate or replace it
+   with the all-zero UUID to anonymize while still contributing.
+9. **No env-var force-on.** CI agents cannot silently opt in. This is
+   asymmetric with the kill-switch on purpose: hostile defaults
+   matter more than hostile sites.
+
+Audit-friendly defaults: `rapid-mlx telemetry preview` already exists
+and prints exactly what a future event would look like, so a security
+reviewer can grep the binary's actual wire shape without strace.
+
+## 7 · MVP scope (what to ship first)
+
+**Phase 2.0 (1 week):**
+- Land `transport.py` + `queue.py` (no event sites yet, no Worker
+  deploy yet).
+- Add unit tests pinning: silent failure on Worker 5xx, bounded queue,
+  daemon thread joins on atexit, lossy under back-pressure.
+- Behind `RAPID_MLX_TELEMETRY_DEBUG=1` env: log "would have sent N
+  events to <endpoint>" without actually POSTing. Lets us validate
+  the queue with zero server dependency.
+
+**Phase 2.1 (1 week):**
+- Deploy Worker to `telemetry.rapidmlx.com` (Path A from §4.2).
+- Wire `session_start` + `session_end` only — no request events yet.
+  Lowest-risk surface to validate the end-to-end pipeline.
+- Land `rapid-mlx telemetry status` reporting last-flush success/fail.
+
+**Phase 2.2 (2 weeks):**
+- Wire `request` event in `routes/chat.py`.
+- Wire `error` events at the 4 sites in §3.3.
+- Nightly DuckDB → parquet job (Option A) on a dev box, cron'd.
+
+**Phase 3 (deferred):**
+- Publish `golden.rapidmlx.com/profile-v1.{parquet,json}`.
+- Build `rapid-mlx suggest` CLI subcommand that reads it.
+- Browser-side hook into chat.rapidmlx.com Big-AGI splash to
+  recommend an alias based on `WebGPU.getAdapter()` chip hint.
+
+## 8 · Open questions for review
+
+1. **Endpoint hostname.** `telemetry.rapidmlx.com` proposed. Could
+   also be `events.rapidmlx.com` or `api.rapidmlx.com/telemetry`.
+   First wins on dedicated-purpose clarity.
+2. **Flush cadence vs. ingestion cost.** R2 writes are $0.36 per
+   million Class A operations. At 10 events/batch, 100K users, 5
+   sessions/day = 50 K writes/day = ~$0.018/day. Negligible. Can
+   eagerly flush.
+3. **Sampling.** Phase 2 ships **no sampling** — every consenting
+   user's every event lands. We're at 0 telemetry today; under-counting
+   isn't a problem yet. Add sampling when volume justifies, and put
+   the sample rate on the wire so aggregations can unbias.
+4. **`models_loaded` cardinality bound.** A server with 50 aliases
+   would emit a 50-element list per `session_end`. Cap at 32 for now
+   (almost always 1–3 in practice; serve+pin is the only multi-load
+   surface).
+5. **What about `share`?** PR #504 share sessions are interesting
+   (which model? which chat frontend? did the tunnel die?). Out of
+   Phase 2 scope but `subcommand="share"` already covers the basic
+   counter; per-share details land later.
+6. **Where does the dev-box cron live?** M3 Ultra is the natural home
+   (already running tunnels). One launchd plist + a 30-line bash
+   script. Bus factor: doc the recipe in `docs/runbooks/`.
+
+## 9 · Decision log
+
+| Decision | Why |
+|---|---|
+| Keep telemetry Worker separate from `rapidserver` | Different security posture (IP/UA discipline) + different blast radius |
+| `urllib` over `httpx` | No new dependency on the consent-gated path |
+| Daemon thread, not asyncio | Works inside both `rapid-mlx serve` (async) and `rapid-mlx chat` (sync) without coupling |
+| Lossy queue (drop oldest) | Telemetry must never grow unbounded; a stuck Worker should not crash the CLI |
+| Three event types, one envelope | Schema simplicity; one Worker code path; one R2 directory; one aggregation query |
+| Bucketed numerics | Soft-fingerprint resistance + cheap aggregation |
+| No env-var force-on | CI synthetic skew is worse than slow opt-in |
+| Per-request event after response sent | Don't measure ourselves measuring |
+| MVP without sampling | Volume too low to need it; add later with sample rate on the wire |
+
+## Appendix A · File layout after Phase 2
+
+```
+vllm_mlx/telemetry/
+├── __init__.py          # Phase 1, exports
+├── consent.py           # Phase 1, first-run prompt
+├── schema.py            # Phase 1, wire shape
+├── redact.py            # Phase 1, bucket + fingerprint
+├── state.py             # Phase 1, consent + client_id
+├── transport.py         # Phase 2.0, urllib POST
+├── queue.py             # Phase 2.0, bounded queue + flush daemon
+└── emit.py              # Phase 2.1+, event constructor helpers
+```
+
+`vllm_mlx/cli.py:main()` calls into `telemetry.emit.session_start()` /
+`session_end()`. `vllm_mlx/routes/chat.py` calls `emit.request()`.
+Parsers + scheduler + loader call `emit.error(...)`.
+
+## Appendix B · Reusable patterns this lands
+
+- `transport.py` — first opt-in HTTPS phone-home in rapid-mlx. The
+  retry + silent-fail shape is reusable for any future low-stakes
+  outbound (model-popularity beacon, "phone home from share session",
+  etc).
+- `queue.py` — bounded, lossy, daemon-flushed queue. Same shape would
+  work for buffering Prometheus metric pushes if we ever want them.
+- DuckDB-on-R2 pattern — same recipe would work for the eval scorecard
+  history we already collect in `evals/`. Could merge the dev-box cron.
+
+## Appendix C · How this relates to whichllm (project intel)
+
+Whichllm uses **spec-sheet algebra** for its speed predictions
+(bandwidth × bytes-per-weight × efficiency constant). No measured
+per-(model, hardware) entries. See `data/gpu.py` for the bandwidth
+table source — all theoretical peaks from vendor datasheets.
+
+Golden Profile is the **measured** counterpart. Same use case as
+whichllm's speed column ("what should I run?"), entirely different
+underlying data. Two integration paths once Golden Profile exists:
+
+1. **Internal**: `rapid-mlx suggest` reads
+   `https://golden.rapidmlx.com/profile-v1.json` and ranks
+   `aliases.json` entries. No new ranking logic — Golden Profile
+   already carries TPS, the ranker is `argmax`.
+2. **External**: ship a `--source rapid-mlx-golden` flag for whichllm
+   that swaps its Apple-Silicon speed predictions for our real
+   measurements. PR upstream once `golden.rapidmlx.com` is live + has
+   a month of data.

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -114,6 +114,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_BASE_URL",
         # Telemetry consent toggle (off/on), not engine routing.
         "RAPID_MLX_TELEMETRY",
+        # Telemetry debug log toggle (stderr trace of POST attempts to
+        # the collector). Pure observability, not engine routing.
+        "RAPID_MLX_TELEMETRY_DEBUG",
+        # Telemetry collector endpoint override for Phase 2 dev rigs and
+        # local-Worker testing. Production stays on
+        # ``telemetry.rapidmlx.com``; never consulted by the engine.
+        "RAPID_MLX_TELEMETRY_ENDPOINT",
         # Port for doctor harness probe checks, not engine routing.
         "RAPID_MLX_PORT",
         # Skip the [y/N] confirmation prompt before large model downloads

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -141,6 +141,36 @@ def test_global_no_telemetry_flag(fake_home):
     assert "disabled" in r.stdout.lower()
 
 
+def test_telemetry_subcommand_does_not_emit_lifecycle_events(fake_home):
+    """Codex round 1 caught a "phone home before silencing the phone"
+    issue: ``rapid-mlx telemetry disable`` (and ``reset``) would queue
+    a ``session_start`` event before the disable action ran, because
+    cli.py registered the lifecycle emit for every non-None
+    subcommand. The fix excludes the ``telemetry`` subcommand entirely.
+
+    Verified end-to-end: spawn the CLI with debug logging on, run
+    ``telemetry disable`` from an opted-in state, and check the stderr
+    trace contains no ``[telemetry] attempt`` lines."""
+    _run_cli("telemetry", "enable", home=fake_home)
+    r = _run_cli(
+        "telemetry",
+        "disable",
+        home=fake_home,
+        env_overrides={
+            "RAPID_MLX_TELEMETRY_DEBUG": "1",
+            # Force a non-routable endpoint so this test cannot
+            # accidentally exercise the production collector even if
+            # the kill-switch wiring regresses.
+            "RAPID_MLX_TELEMETRY_ENDPOINT": "https://127.0.0.1:1/never",
+        },
+    )
+    assert r.returncode == 0, r.stderr
+    assert "[telemetry] attempt" not in r.stderr, (
+        "telemetry subcommand queued a lifecycle event before disabling — "
+        "the cli must skip session_start/session_end for the telemetry path"
+    )
+
+
 def test_env_kill_switch_via_subprocess(fake_home):
     _run_cli("telemetry", "enable", home=fake_home)
     r = _run_cli(

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -142,45 +142,73 @@ def test_global_no_telemetry_flag(fake_home):
 
 
 def test_session_end_synchronously_drained_before_exit(fake_home):
-    """Round 5 codex review caught that the lifecycle ordering at exit
-    was implicit (atexit LIFO + queue.shutdown registered inside
-    session_start). Make the contract explicit instead: ``_emit_session_end``
-    calls ``get_queue().shutdown()`` after enqueueing, so the event
-    lands regardless of atexit ordering. Verify the subprocess emits
-    BOTH ``[telemetry]`` attempt lines (session_start + session_end)
-    when consent is enabled — a single line would mean session_end
-    was queued but never flushed."""
-    _run_cli("telemetry", "enable", home=fake_home)
-    r = _run_cli(
-        "models",
-        home=fake_home,
-        env_overrides={
-            "RAPID_MLX_TELEMETRY_DEBUG": "1",
-            # Point at a localhost endpoint that won't respond, so the
-            # transport's 3xtry+backoffs run quickly without polluting
-            # the production collector. The test cares about WHETHER
-            # the flush ATTEMPT is made, not whether it succeeds.
-            "RAPID_MLX_TELEMETRY_ENDPOINT": "http://127.0.0.1:1/never",
-        },
+    """Round 5 codex review caught the atexit-ordering risk; round 6
+    sharpened the regression test. We now stand up a local HTTPServer
+    that captures the actual POST body, then assert the batch carries
+    BOTH ``session_start`` AND ``session_end`` envelopes. The previous
+    retry-count assertion (round 5) would have passed even if
+    ``session_end`` were deleted and shutdown flushed a 1-event
+    batch."""
+    import http.server
+    import json as _json
+    import socket
+    import threading as _threading
+
+    captured: list[dict] = []
+
+    class _CaptureHandler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 — name dictated by stdlib
+            length = int(self.headers.get("content-length", "0"))
+            raw = self.rfile.read(length)
+            try:
+                captured.append(_json.loads(raw.decode("utf-8")))
+            except Exception:
+                captured.append({"_raw": raw[:200].decode("utf-8", "replace")})
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok":true}')
+
+        def log_message(self, *_a, **_k):  # silence
+            return
+
+    # Bind to a free port so parallel test runs don't fight.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), _CaptureHandler)
+    t = _threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        _run_cli("telemetry", "enable", home=fake_home)
+        r = _run_cli(
+            "models",
+            home=fake_home,
+            env_overrides={
+                "RAPID_MLX_TELEMETRY_DEBUG": "1",
+                "RAPID_MLX_TELEMETRY_ENDPOINT": f"http://127.0.0.1:{port}/v1/events",
+            },
+        )
+        assert r.returncode == 0, r.stderr
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    # Exactly one POST (single batch) carrying exactly two envelopes.
+    assert len(captured) == 1, f"expected 1 batch, got {len(captured)}: {captured}"
+    batch = captured[0].get("batch")
+    assert isinstance(batch, list), f"missing batch field: {captured[0]}"
+    events = {ev.get("event") for ev in batch}
+    assert events == {"session_start", "session_end"}, (
+        f"batch did not contain both lifecycle events; got events={events}, "
+        f"batch={batch}"
     )
-    assert r.returncode == 0, r.stderr
-    # ``127.0.0.1:1`` rejects connections; the transport runs 3
-    # attempts per flush. If session_start and session_end were
-    # drained in the SAME flush, we see exactly 3 attempt lines.
-    # If session_end was queued AFTER the daemon had stopped (the
-    # atexit-ordering bug Round 5 codex review surfaced), the
-    # synchronous shutdown in ``_emit_session_end`` either drains
-    # session_end in a SECOND batch (6 attempts) or drops it entirely
-    # (3 attempts but the queue's ``enqueued_total`` would be 1, not
-    # 2 — which we can't inspect from a subprocess).
-    #
-    # With the fix in place we expect exactly 3 attempts (1 batch
-    # carrying 2 events). Lock that.
-    attempts = [line for line in r.stderr.splitlines() if "[telemetry] attempt" in line]
-    assert len(attempts) == 3, (
-        f"expected exactly 3 attempt lines for 1 batch of 2 events "
-        f"(got {len(attempts)}); session_end may have been queued late "
-        f"or dropped:\n{r.stderr}"
+    # ``session_id`` must be identical across both — race-condition
+    # regression catch (round 6 fix #3).
+    session_ids = {ev["session_id"] for ev in batch}
+    assert len(session_ids) == 1, (
+        f"session_start and session_end carry different session_ids "
+        f"(race in lazy init?): {session_ids}"
     )
 
 

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -151,7 +151,6 @@ def test_session_end_synchronously_drained_before_exit(fake_home):
     batch."""
     import http.server
     import json as _json
-    import socket
     import threading as _threading
 
     captured: list[dict] = []
@@ -172,11 +171,11 @@ def test_session_end_synchronously_drained_before_exit(fake_home):
         def log_message(self, *_a, **_k):  # silence
             return
 
-    # Bind to a free port so parallel test runs don't fight.
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = probe.getsockname()[1]
-    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), _CaptureHandler)
+    # Round 10 codex review caught a probe-then-bind race in the
+    # earlier version (separate ``socket.bind`` → close → re-bind).
+    # Let the server bind port 0 itself and read ``server_port``.
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CaptureHandler)
+    port = server.server_port
     t = _threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
     try:

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -193,18 +193,27 @@ def test_session_end_synchronously_drained_before_exit(fake_home):
         server.shutdown()
         server.server_close()
 
-    # Exactly one POST (single batch) carrying exactly two envelopes.
-    assert len(captured) == 1, f"expected 1 batch, got {len(captured)}: {captured}"
-    batch = captured[0].get("batch")
-    assert isinstance(batch, list), f"missing batch field: {captured[0]}"
-    events = {ev.get("event") for ev in batch}
+    # Both lifecycle events must land — they MAY come in the same
+    # batch (short ``models`` run finishes well under ``FLUSH_INTERVAL_S``)
+    # or in two batches if a long-running command crosses the idle
+    # flush boundary. Round 11 codex caught the prior "exactly one
+    # batch" assertion as a real flake risk for long-running serve
+    # processes. Collect events across all batches instead.
+    assert captured, f"no POST captured (return={r.returncode}, stderr={r.stderr})"
+    all_events = [
+        ev
+        for batch in captured
+        if isinstance(batch.get("batch"), list)
+        for ev in batch["batch"]
+    ]
+    events = {ev.get("event") for ev in all_events}
     assert events == {"session_start", "session_end"}, (
-        f"batch did not contain both lifecycle events; got events={events}, "
-        f"batch={batch}"
+        f"lifecycle events missing across {len(captured)} batch(es); "
+        f"got events={events}, batches={captured}"
     )
     # ``session_id`` must be identical across both — race-condition
     # regression catch (round 6 fix #3).
-    session_ids = {ev["session_id"] for ev in batch}
+    session_ids = {ev["session_id"] for ev in all_events}
     assert len(session_ids) == 1, (
         f"session_start and session_end carry different session_ids "
         f"(race in lazy init?): {session_ids}"

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -141,6 +141,49 @@ def test_global_no_telemetry_flag(fake_home):
     assert "disabled" in r.stdout.lower()
 
 
+def test_session_end_synchronously_drained_before_exit(fake_home):
+    """Round 5 codex review caught that the lifecycle ordering at exit
+    was implicit (atexit LIFO + queue.shutdown registered inside
+    session_start). Make the contract explicit instead: ``_emit_session_end``
+    calls ``get_queue().shutdown()`` after enqueueing, so the event
+    lands regardless of atexit ordering. Verify the subprocess emits
+    BOTH ``[telemetry]`` attempt lines (session_start + session_end)
+    when consent is enabled — a single line would mean session_end
+    was queued but never flushed."""
+    _run_cli("telemetry", "enable", home=fake_home)
+    r = _run_cli(
+        "models",
+        home=fake_home,
+        env_overrides={
+            "RAPID_MLX_TELEMETRY_DEBUG": "1",
+            # Point at a localhost endpoint that won't respond, so the
+            # transport's 3xtry+backoffs run quickly without polluting
+            # the production collector. The test cares about WHETHER
+            # the flush ATTEMPT is made, not whether it succeeds.
+            "RAPID_MLX_TELEMETRY_ENDPOINT": "http://127.0.0.1:1/never",
+        },
+    )
+    assert r.returncode == 0, r.stderr
+    # ``127.0.0.1:1`` rejects connections; the transport runs 3
+    # attempts per flush. If session_start and session_end were
+    # drained in the SAME flush, we see exactly 3 attempt lines.
+    # If session_end was queued AFTER the daemon had stopped (the
+    # atexit-ordering bug Round 5 codex review surfaced), the
+    # synchronous shutdown in ``_emit_session_end`` either drains
+    # session_end in a SECOND batch (6 attempts) or drops it entirely
+    # (3 attempts but the queue's ``enqueued_total`` would be 1, not
+    # 2 — which we can't inspect from a subprocess).
+    #
+    # With the fix in place we expect exactly 3 attempts (1 batch
+    # carrying 2 events). Lock that.
+    attempts = [line for line in r.stderr.splitlines() if "[telemetry] attempt" in line]
+    assert len(attempts) == 3, (
+        f"expected exactly 3 attempt lines for 1 batch of 2 events "
+        f"(got {len(attempts)}); session_end may have been queued late "
+        f"or dropped:\n{r.stderr}"
+    )
+
+
 def test_telemetry_subcommand_does_not_emit_lifecycle_events(fake_home):
     """Codex round 1 caught a "phone home before silencing the phone"
     issue: ``rapid-mlx telemetry disable`` (and ``reset``) would queue

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -206,10 +206,18 @@ def test_session_end_synchronously_drained_before_exit(fake_home):
         if isinstance(batch.get("batch"), list)
         for ev in batch["batch"]
     ]
-    events = {ev.get("event") for ev in all_events}
-    assert events == {"session_start", "session_end"}, (
-        f"lifecycle events missing across {len(captured)} batch(es); "
-        f"got events={events}, batches={captured}"
+    # Round 14 codex review: comparing a ``set`` of event names hid
+    # duplicate ``session_start`` / ``session_end`` emissions — a
+    # double-fire from a stray atexit re-registration or a reentered
+    # CLI main would still pass. Assert exact counts instead so that
+    # regression is visible.
+    event_names = [ev.get("event") for ev in all_events]
+    starts = event_names.count("session_start")
+    ends = event_names.count("session_end")
+    assert starts == 1 and ends == 1, (
+        f"expected exactly one session_start + one session_end across "
+        f"{len(captured)} batch(es); got starts={starts}, ends={ends}, "
+        f"all_events={event_names}, batches={captured}"
     )
     # ``session_id`` must be identical across both — race-condition
     # regression catch (round 6 fix #3).

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -204,6 +204,70 @@ def test_records_prompted_version_correctly(fake_home, monkeypatch):
     assert state.prompted_version == actual_version
 
 
+def test_post_record_oserror_still_reports_just_collected(
+    fake_home, monkeypatch, capsys
+):
+    """Round 14 codex review: after ``record_consent(True)`` had
+    already succeeded, an ``OSError`` from a subsequent print (e.g.
+    SIGPIPE from a closed parent pipe) flipped the return value back
+    to ``False``. The CLI then treated the run as "not just collected"
+    and emitted same-run ``session_start`` / ``session_end`` events
+    for the argv that ran BEFORE the disclosure — directly violating
+    the disclosure's "nothing from before this prompt" promise.
+
+    Pin: once consent is persisted, the return value is True even if
+    one of the chatter prints raises OSError."""
+    from vllm_mlx.telemetry import consent as consent_mod
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "n")
+
+    # Make the opt-out chatter path raise OSError (this print runs
+    # AFTER record_consent has persisted the decision). The pre-record
+    # prints are unaffected — they go through the normal stdout.
+    def _explode():
+        raise OSError("simulated SIGPIPE from closed parent pipe")
+
+    monkeypatch.setattr(consent_mod, "consent_path", _explode)
+
+    # Despite the OSError, the function must report that consent was
+    # just collected so cli.py suppresses same-run lifecycle emit.
+    assert maybe_prompt_for_consent("serve") is True
+
+    # And the consent is genuinely on disk.
+    state = get_consent_state()
+    assert state is not None
+    assert state.consent is False
+
+
+def test_pre_record_oserror_returns_false(fake_home, monkeypatch, capsys):
+    """Companion to ``test_post_record_oserror_still_reports_just_collected``:
+    an OSError BEFORE ``record_consent`` succeeds must keep returning
+    ``False``. Otherwise we'd skip the lifecycle emit for an invocation
+    where consent was never actually collected — same disclosure
+    violation in the opposite direction."""
+    from vllm_mlx.telemetry import consent as consent_mod
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    # Make ``client_id_path`` (called inside the pre-prompt disclosure
+    # print) raise OSError. Reaches the outer except BEFORE
+    # record_consent runs, so just_collected stays False.
+    def _explode():
+        raise OSError("simulated stdout-closed during disclosure")
+
+    monkeypatch.setattr(consent_mod, "client_id_path", _explode)
+
+    assert maybe_prompt_for_consent("serve") is False
+    # And nothing was persisted.
+    assert get_consent_state() is None
+
+
 def test_unwritable_home_does_not_crash_cli(fake_home, monkeypatch, capsys):
     """If recording consent fails (read-only home, disk full, etc.), the
     CLI must NOT crash — telemetry consent is never a reason for the

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -204,6 +204,50 @@ def test_records_prompted_version_correctly(fake_home, monkeypatch):
     assert state.prompted_version == actual_version
 
 
+def test_disclosure_is_ascii_encodable():
+    """Round 16 codex review: the disclosure used to contain curly
+    bullets and em-dashes that ``str.encode('ascii')`` rejects. On a
+    terminal with an ASCII-only stdout encoding (``LC_ALL=C``, some CI
+    runners), the consent ``print()`` raised ``UnicodeEncodeError`` --
+    which is NOT an ``OSError`` subclass and therefore escaped the
+    outer catch, crashing the user's ``serve``/``chat`` invocation.
+    Pin that every printable byte of the disclosure is ASCII so the
+    prompt path never crashes for encoding reasons."""
+    from vllm_mlx.telemetry.consent import _DISCLOSURE
+
+    # ``format`` to materialize the template substitutions the runtime
+    # would resolve before printing.
+    rendered = _DISCLOSURE.format(env="RAPID_MLX_TELEMETRY", client_id_path="/tmp/x")
+    rendered.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII slipped in
+
+
+def test_disclosure_unicodeerror_is_caught_safely(fake_home, monkeypatch, capsys):
+    """Round 16 codex review: even with the disclosure made ASCII-only,
+    keep ``UnicodeError`` in the outer catch as defense in depth --
+    a future copy edit shouldn't be able to crash the CLI. Pin that a
+    UnicodeError raised by the disclosure print is swallowed and the
+    function returns False (we never even reached input())."""
+    from vllm_mlx.telemetry import consent as consent_mod
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+
+    # ``client_id_path`` is called inside the disclosure format() chain
+    # (used in the WHAT WE SEND list). Make it raise a UnicodeError so
+    # the outer catch sees the kind of failure a stdout-encoding crash
+    # would produce.
+    def _boom():
+        raise UnicodeEncodeError("ascii", "x", 0, 1, "simulated stdout encoding")
+
+    monkeypatch.setattr(consent_mod, "client_id_path", _boom)
+
+    # Must NOT propagate. Returns False (nothing was collected).
+    assert maybe_prompt_for_consent("serve") is False
+    # And nothing landed on disk.
+    assert get_consent_state() is None
+
+
 def test_post_record_oserror_still_reports_just_collected(
     fake_home, monkeypatch, capsys
 ):

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -135,23 +135,74 @@ def test_no_records_consent_false(fake_home, monkeypatch, capsys):
     assert "stays off" in out.lower()
 
 
-def test_skip_paths_return_false(fake_home, monkeypatch, capsys):
+def test_cached_consent_skip_returns_false(fake_home, monkeypatch, capsys):
     """Round 3 codex review wired the return type into a contract: the
     cli relies on it to skip the SAME run's lifecycle emit only when
-    the prompt actually fired. Every skip path must return False so a
-    cached-consent run still emits normally."""
+    the prompt actually fired. A cached-consent run must return
+    ``False`` so the normal lifecycle emit still runs.
+
+    Round 18 codex review split the previous combined skip-paths test
+    because once cached consent was recorded, the subsequent
+    cli_no_telemetry / non-interactive assertions could have passed
+    even if those guards were deleted -- the cached-consent guard
+    would short-circuit first. Each skip path now lives in its own
+    test with a fresh no-consent state, so the named guard is the
+    only reason ``maybe_prompt_for_consent`` returns ``False``."""
     from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
     from vllm_mlx.telemetry.state import record_consent
 
-    # Cached consent → no prompt → False (lifecycle emit must run).
+    # Stub TTY so the only thing that could SKIP the prompt is the
+    # cached-consent guard (without TTY stubs, isatty=False would skip
+    # for the wrong reason).
+    _stub_tty(monkeypatch)
+
     record_consent(True, rapid_mlx_version="0.0.0+test")
     assert maybe_prompt_for_consent("serve") is False
 
-    # CLI override skip.
-    assert maybe_prompt_for_consent("serve", cli_no_telemetry=True) is False
 
-    # Non-interactive subcommand skip.
+def test_cli_no_telemetry_skip_returns_false(fake_home, monkeypatch, capsys):
+    """``--no-telemetry`` must short-circuit BEFORE the cached-consent
+    check so a CI run with the kill switch wired never even reads the
+    on-disk consent file. Pin the guard in isolation: no cached
+    consent, TTY stubbed in so the only short-circuit available IS
+    the ``cli_no_telemetry`` branch. ``input`` is monkey-patched to
+    raise so a guard removal would surface as a hard failure (not a
+    soft EOFError that the inner except quietly swallows)."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+
+    def _no_prompt():
+        raise AssertionError("input() was called -- cli_no_telemetry guard is broken")
+
+    monkeypatch.setattr("builtins.input", _no_prompt)
+    assert get_consent_state() is None  # sanity: fresh home, no record
+    assert maybe_prompt_for_consent("serve", cli_no_telemetry=True) is False
+    assert get_consent_state() is None
+
+
+def test_non_interactive_subcommand_skip_returns_false(fake_home, monkeypatch, capsys):
+    """``version`` / ``help`` / ``ps`` etc. skip the prompt regardless
+    of TTY because they are one-shot informational subcommands.
+    Pin in isolation: no cached consent, TTY stubbed in -- the only
+    short-circuit available is the non-interactive-subcommand
+    branch. ``input`` is monkey-patched to raise so a guard removal
+    would surface as a hard failure."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import get_consent_state
+
+    _stub_tty(monkeypatch)
+
+    def _no_prompt():
+        raise AssertionError(
+            "input() was called -- non-interactive subcommand guard is broken"
+        )
+
+    monkeypatch.setattr("builtins.input", _no_prompt)
+    assert get_consent_state() is None
     assert maybe_prompt_for_consent("version") is False
+    assert get_consent_state() is None
 
 
 def test_empty_answer_defaults_to_no(fake_home, monkeypatch):

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -102,7 +102,10 @@ def test_yes_records_consent_true(fake_home, monkeypatch, capsys):
 
     _stub_tty(monkeypatch)
     monkeypatch.setattr("builtins.input", lambda: "y")
-    maybe_prompt_for_consent("serve")
+    # Round 3: ``maybe_prompt_for_consent`` returns True when it just
+    # collected first-time consent. The cli uses this to suppress the
+    # SAME run's lifecycle emit (which captured pre-prompt argv).
+    assert maybe_prompt_for_consent("serve") is True
 
     state = get_consent_state()
     assert state is not None
@@ -121,13 +124,34 @@ def test_no_records_consent_false(fake_home, monkeypatch, capsys):
 
     _stub_tty(monkeypatch)
     monkeypatch.setattr("builtins.input", lambda: "n")
-    maybe_prompt_for_consent("serve")
+    # Even a "no" answer counts as "just collected" for the lifecycle
+    # skip — the contract is per-invocation, not per-yes.
+    assert maybe_prompt_for_consent("serve") is True
 
     state = get_consent_state()
     assert state is not None
     assert state.consent is False
     out = capsys.readouterr().out
     assert "stays off" in out.lower()
+
+
+def test_skip_paths_return_false(fake_home, monkeypatch, capsys):
+    """Round 3 codex review wired the return type into a contract: the
+    cli relies on it to skip the SAME run's lifecycle emit only when
+    the prompt actually fired. Every skip path must return False so a
+    cached-consent run still emits normally."""
+    from vllm_mlx.telemetry.consent import maybe_prompt_for_consent
+    from vllm_mlx.telemetry.state import record_consent
+
+    # Cached consent → no prompt → False (lifecycle emit must run).
+    record_consent(True, rapid_mlx_version="0.0.0+test")
+    assert maybe_prompt_for_consent("serve") is False
+
+    # CLI override skip.
+    assert maybe_prompt_for_consent("serve", cli_no_telemetry=True) is False
+
+    # Non-interactive subcommand skip.
+    assert maybe_prompt_for_consent("version") is False
 
 
 def test_empty_answer_defaults_to_no(fake_home, monkeypatch):

--- a/tests/test_telemetry_consent.py
+++ b/tests/test_telemetry_consent.py
@@ -108,7 +108,11 @@ def test_yes_records_consent_true(fake_home, monkeypatch, capsys):
     assert state is not None
     assert state.consent is True
     out = capsys.readouterr().out
-    assert "telemetry enabled" in out.lower()
+    # The post-opt-in confirmation must thank the user and surface the
+    # disable/audit affordances so they always know how to revisit.
+    lower = out.lower()
+    assert "thank you" in lower
+    assert "rapid-mlx telemetry disable" in lower
 
 
 def test_no_records_consent_false(fake_home, monkeypatch, capsys):

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -507,6 +507,85 @@ def test_request_endpoint_constrained_to_allowlist(opted_in, stub_queue):
     assert "secrets.txt" not in repr(last)
 
 
+def test_request_endpoint_normalizes_full_url_to_path(opted_in, stub_queue):
+    """Round 13 codex review: the previous string-split implementation
+    of ``_normalize_endpoint`` left a full URL like
+    ``https://host/v1/chat/completions`` unmatched and silently collapsed
+    it to ``"other"`` — defeating the very purpose of the allowlist for
+    any caller that builds an endpoint identifier from a full URL.
+    ``urlsplit`` extracts ``/v1/chat/completions`` regardless of the
+    surrounding scheme/netloc so the match succeeds and the field
+    carries the allowlisted route."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="https://api.example.com/v1/chat/completions",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=10,
+        ttft_ms=100.0,
+        tps=10.0,
+        status=200,
+    )
+    last = stub_queue[-1]
+    assert last["request"]["endpoint"] == "/v1/chat/completions"
+    # And the surrounding URL bits must not have leaked into the payload.
+    blob = repr(last)
+    assert "api.example.com" not in blob
+    assert "https://" not in blob
+
+    # Combined: full URL + query + fragment still resolves correctly.
+    emit.request(
+        endpoint="https://host/v1/chat/completions?key=sk-PROD-LEAK#frag",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=10,
+        ttft_ms=100.0,
+        tps=10.0,
+        status=200,
+    )
+    last = stub_queue[-1]
+    assert last["request"]["endpoint"] == "/v1/chat/completions"
+    blob = repr(last)
+    assert "sk-PROD-LEAK" not in blob
+    assert "frag" not in blob
+    assert "host" not in blob
+
+
+def test_session_models_loaded_does_not_materialize_full_input(opted_in, stub_queue):
+    """Round 13 codex review: the helper sliced after building a tuple
+    of the entire input, which contradicted the documented "slice
+    before normalize" intent and wasted work for callers handing in
+    large iterables. Pin that only the first 32 entries are even
+    pulled from the source by passing a generator that records how
+    many items it yields."""
+    from vllm_mlx.telemetry import emit
+
+    pulled: list[int] = []
+
+    def big_gen():
+        for i in range(10_000):
+            pulled.append(i)
+            yield f"mlx-community/model-{i}"
+
+    emit.session_start(subcommand="serve", models_loaded=big_gen())
+    last = stub_queue[-1]
+    # Generator must have been pulled exactly 32 times, NOT 10000.
+    assert len(pulled) == 32
+    assert len(last["session"]["models_loaded"]) == 32
+
+    # Same property for session_end.
+    pulled.clear()
+    emit.session_end(subcommand="serve", duration_seconds=1, models_loaded=big_gen())
+    last = stub_queue[-1]
+    assert len(pulled) == 32
+    assert len(last["session"]["models_loaded"]) == 32
+
+
 def test_request_model_alias_local_path_redacted(opted_in, stub_queue):
     """``model_alias`` is the ONE free-form-ish field on ``request()``,
     but it must be funnelled through ``normalize_model_path`` so a local

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -586,6 +586,38 @@ def test_session_models_loaded_does_not_materialize_full_input(opted_in, stub_qu
     assert len(last["session"]["models_loaded"]) == 32
 
 
+def test_safe_does_not_swallow_signature_mismatch(opted_in, stub_queue):
+    """Round 14 codex review: the broad ``except Exception`` in
+    ``_safe`` used to also swallow ``TypeError`` from a call site that
+    drifted out of sync with the helper signature — a typo on a kwarg
+    name or a missing positional argument silently turned into "no
+    telemetry," and the integration tests couldn't see the wiring
+    bug. ``inspect.signature(fn).bind(...)`` now runs BEFORE the broad
+    catch so signature mismatches raise visibly."""
+    from vllm_mlx.telemetry import emit
+
+    # Bad kwarg name — must raise TypeError, NOT become a silent no-op.
+    with pytest.raises(TypeError):
+        emit.session_start(subkommand="serve")  # typo: subkommand
+
+    # Missing required keyword.
+    with pytest.raises(TypeError):
+        emit.request(
+            # endpoint missing
+            model_alias="qwen3.5-9b",
+            stream=True,
+            tool_call_used=False,
+            prompt_tokens=10,
+            completion_tokens=10,
+            ttft_ms=100.0,
+            tps=10.0,
+            status=200,
+        )
+
+    # And nothing leaked into the queue from the broken calls.
+    assert stub_queue == []
+
+
 def test_request_model_alias_local_path_redacted(opted_in, stub_queue):
     """``model_alias`` is the ONE free-form-ish field on ``request()``,
     but it must be funnelled through ``normalize_model_path`` so a local

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -204,7 +204,7 @@ def test_runtime_payload_carries_every_schema_v1_field(opted_in, stub_queue):
 
     expected_keys = {f.name for f in _fields(SessionPayload)}
 
-    emit.session_start(subcommand="serve", argv=["serve"])
+    emit.session_start(subcommand="serve", flag_names=[])
     session = stub_queue[-1]["session"]
     missing = expected_keys - set(session)
     assert not missing, f"session_start dropped v1 keys: {missing}"
@@ -218,9 +218,13 @@ def test_runtime_payload_carries_every_schema_v1_field(opted_in, stub_queue):
 def test_session_start_envelope_when_enabled(opted_in, stub_queue):
     from vllm_mlx.telemetry import emit
 
+    # Round 19 codex catch: callers now pre-extract flag names BEFORE
+    # crossing into telemetry, so the helper never sees raw argv (with
+    # values). Pass already-extracted names; pin that values cannot
+    # leak through this surface.
     emit.session_start(
         subcommand="serve",
-        argv=["serve", "qwen3.5-9b", "--host", "0.0.0.0", "--port", "8000"],
+        flag_names=["host", "port"],
         models_loaded=["mlx-community/Qwen3.5-9B-4bit"],
     )
     assert len(stub_queue) == 1
@@ -233,13 +237,14 @@ def test_session_start_envelope_when_enabled(opted_in, stub_queue):
     assert payload["platform"]["os"] in {"darwin", "linux", "windows"}
     assert "chip" in payload["platform"]
 
-    # Session payload: flag VALUES must be absent — only NAMES survive
-    # redaction. ``0.0.0.0`` and ``8000`` are values, must not appear.
+    # Session payload: flag names land, sorted + de-duplicated.
+    assert set(payload["session"]["flag_names"]) == {"host", "port"}
+    # And the helper signature literally CANNOT carry a value -- the
+    # type checker would warn on ``flag_names=["0.0.0.0"]``, but pin
+    # the runtime shape: only names.
     blob = repr(payload)
     assert "0.0.0.0" not in blob
     assert "8000" not in blob
-    # Flag names should be there.
-    assert set(payload["session"]["flag_names"]) == {"host", "port"}
 
 
 def test_session_start_models_loaded_redacted(opted_in, stub_queue):
@@ -361,15 +366,20 @@ def test_error_carries_fingerprint_no_message(opted_in, stub_queue):
 
 
 def test_session_start_swallows_internal_bug(opted_in, monkeypatch, stub_queue):
-    """An internal redaction bug must not propagate to the caller."""
+    """An internal redaction bug must not propagate to the caller.
+
+    Round 19 codex catch: ``hash_flag_names`` is no longer called from
+    inside ``session_start`` (flag names are pre-extracted in cli.py).
+    Pin the same property against the helper that IS still inside the
+    emit path: ``normalize_model_path``."""
     from vllm_mlx.telemetry import emit
 
     def boom(*args, **kwargs):
         raise RuntimeError("synthetic redact failure")
 
-    monkeypatch.setattr(emit, "hash_flag_names", boom)
+    monkeypatch.setattr(emit, "normalize_model_path", boom)
     # Must not raise:
-    emit.session_start(subcommand="serve", argv=["--x"])
+    emit.session_start(subcommand="serve", models_loaded=["org/model"])
 
 
 def test_emit_does_not_catch_keyboard_interrupt(opted_in, monkeypatch, stub_queue):
@@ -586,6 +596,53 @@ def test_session_models_loaded_does_not_materialize_full_input(opted_in, stub_qu
     assert len(last["session"]["models_loaded"]) == 32
 
 
+def test_session_end_hook_fires_exactly_once(fake_home):
+    """Round 19 codex review wired ``session_end`` through the
+    FastAPI lifespan shutdown in addition to the existing ``atexit``
+    fallback so SIGTERM-driven service-manager shutdowns no longer
+    drop the lifecycle end event. Pin: registering a hook + calling
+    ``fire_session_end_hook`` twice runs the underlying callable
+    exactly once (the latch makes the second call a no-op)."""
+    from vllm_mlx.telemetry import emit
+
+    emit._reset_for_tests()
+    calls: list[int] = []
+
+    def hook():
+        calls.append(1)
+
+    emit.register_session_end_hook(hook)
+    emit.fire_session_end_hook()
+    emit.fire_session_end_hook()  # latched -- must be a no-op
+    assert calls == [1], f"hook fired {len(calls)} time(s) -- the latch is broken"
+
+
+def test_session_end_hook_swallows_callable_exceptions(fake_home):
+    """A buggy hook callable must not crash the lifespan shutdown
+    path. ``fire_session_end_hook`` catches BaseException because it
+    runs in teardown context where any propagation is purely noise."""
+    from vllm_mlx.telemetry import emit
+
+    emit._reset_for_tests()
+
+    def boom():
+        raise RuntimeError("synthetic")
+
+    emit.register_session_end_hook(boom)
+    # Must not raise -- the catch in fire_session_end_hook absorbs it.
+    emit.fire_session_end_hook()
+
+
+def test_session_end_hook_no_op_without_registration(fake_home):
+    """If no hook was registered (e.g. cli main exited early before
+    the telemetry wiring), ``fire_session_end_hook`` must be a safe
+    no-op so the lifespan shutdown path can call it unconditionally."""
+    from vllm_mlx.telemetry import emit
+
+    emit._reset_for_tests()
+    emit.fire_session_end_hook()  # must not raise
+
+
 def test_safe_does_not_swallow_signature_mismatch(opted_in, stub_queue):
     """Round 14 codex review: the broad ``except Exception`` in
     ``_safe`` used to also swallow ``TypeError`` from a call site that
@@ -641,32 +698,46 @@ def test_request_model_alias_local_path_redacted(opted_in, stub_queue):
     assert "alice" not in repr(stub_queue[0])
 
 
-def test_argv_values_with_secrets_never_survive_redaction(opted_in, stub_queue):
-    """argv carries the user's full shell command. The redactor must
-    extract flag NAMES and nothing else — values are skipped before they
-    ever land in a payload field."""
+def test_flag_values_never_cross_telemetry_boundary(opted_in, stub_queue):
+    """Round 19 codex catch: flag names are now pre-extracted in
+    cli.py BEFORE the telemetry call, so raw argv (which carries
+    values) never crosses into the emit helper at all. The disclosure
+    promise "values are never even read" is now LITERALLY true at the
+    function-call boundary. Pin: simulate the cli.py boundary by
+    running ``hash_flag_names`` ourselves, then pass only the
+    resulting NAMES into ``session_start`` and verify no value survives
+    anywhere in the payload."""
     from vllm_mlx.telemetry import emit
+    from vllm_mlx.telemetry.redact import hash_flag_names
 
     secret = "sk-prod-XXXXXXXXXXXXXXXXXXXXXXXX"
     bearer = "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
     prompt = "summarize this confidential email about Q3 numbers"
-    emit.session_start(
-        subcommand="serve",
-        argv=[
-            "serve",
-            "qwen3.5-9b",
-            "--api-key",
-            secret,
-            "--auth-header",
-            bearer,
-            "--initial-prompt",
-            prompt,
-        ],
-    )
+    argv = [
+        "serve",
+        "qwen3.5-9b",
+        "--api-key",
+        secret,
+        "--auth-header",
+        bearer,
+        "--initial-prompt",
+        prompt,
+    ]
+    # The cli.py boundary -- extract names here, NOT inside the emit
+    # helper. The values stop at this line.
+    flag_names = hash_flag_names(argv)
+    emit.session_start(subcommand="serve", flag_names=flag_names)
+
     blob = repr(stub_queue[0])
     assert secret not in blob
     assert bearer not in blob
     assert prompt not in blob
+    # And only the names landed.
+    assert set(stub_queue[0]["session"]["flag_names"]) == {
+        "api-key",
+        "auth-header",
+        "initial-prompt",
+    }
     # Names should be preserved (the contract: we see WHICH flags people
     # use, never what they pass).
     flag_names = set(stub_queue[0]["session"]["flag_names"])

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -216,6 +216,38 @@ def test_request_buckets_not_raw_numbers(opted_in, stub_queue):
         assert raw not in blob
 
 
+def test_error_category_and_phase_normalised_to_allowlist(opted_in, stub_queue):
+    """Round 3 codex review: ``category`` + ``phase`` were stored
+    verbatim. Same escape hatch as ``endpoint`` — a future caller
+    threading exception text or user input would have leaked. Pin
+    that off-allowlist values collapse to ``"other"`` and known
+    values pass through."""
+    from vllm_mlx.telemetry import emit
+
+    # Known good values pass through.
+    try:
+        raise RuntimeError("synthetic")
+    except RuntimeError as exc:
+        emit.error(category="model_load_failure", exc=exc, phase="startup")
+    e = stub_queue[-1]["error"]
+    assert e["category"] == "model_load_failure"
+    assert e["phase"] == "startup"
+
+    # Free-form text — even text containing what looks like a prompt —
+    # collapses to "other".
+    leak = "user typed: please summarize Q3 numbers"
+    try:
+        raise RuntimeError("x")
+    except RuntimeError as exc:
+        emit.error(category=leak, exc=exc, phase=leak)
+    e = stub_queue[-1]["error"]
+    assert e["category"] == "other"
+    assert e["phase"] == "other"
+    blob = repr(stub_queue[-1])
+    assert "summarize" not in blob
+    assert "Q3" not in blob
+
+
 def test_error_carries_fingerprint_no_message(opted_in, stub_queue):
     """Crash fingerprint excludes message text and module path."""
     from vllm_mlx.telemetry import emit

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -141,7 +141,6 @@ def test_session_start_envelope_when_enabled(opted_in, stub_queue):
     emit.session_start(
         subcommand="serve",
         argv=["serve", "qwen3.5-9b", "--host", "0.0.0.0", "--port", "8000"],
-        engine="batched",
         models_loaded=["mlx-community/Qwen3.5-9B-4bit"],
     )
     assert len(stub_queue) == 1
@@ -340,6 +339,11 @@ def test_public_emit_signatures_have_no_prompt_or_completion_fields():
         "ip",
         "ip_address",
         "hostname",
+        # ``engine`` was removed in round 4 because it was a free-form
+        # ``str`` slot that the signature pin couldn't catch. If a
+        # second engine ever lands, re-add it through a small enum
+        # (the same shape as ``_ALLOWED_ENDPOINTS``).
+        "engine",
     }
     for fn_name in ("session_start", "session_end", "request", "error"):
         fn = getattr(emit, fn_name)

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -319,6 +319,64 @@ def test_public_emit_signatures_have_no_prompt_or_completion_fields():
         )
 
 
+def test_request_endpoint_constrained_to_allowlist(opted_in, stub_queue):
+    """Round 2 codex review: ``endpoint`` used to be stored verbatim,
+    which was a free-form escape hatch — a caller threading a path
+    with a query string (``/v1/chat?key=sk-xxx``) would have leaked
+    the value. The helper now normalises to a tiny allowlist."""
+    from vllm_mlx.telemetry import emit
+
+    # Allowed endpoint round-trips verbatim (after strip).
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=10,
+        ttft_ms=100.0,
+        tps=10.0,
+        status=200,
+    )
+    assert stub_queue[-1]["request"]["endpoint"] == "/v1/chat/completions"
+
+    # Query string + fragment stripped before allowlist match.
+    emit.request(
+        endpoint="/v1/chat/completions?api_key=sk-PROD-SECRET#anchor",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=10,
+        ttft_ms=100.0,
+        tps=10.0,
+        status=200,
+    )
+    last = stub_queue[-1]
+    assert last["request"]["endpoint"] == "/v1/chat/completions"
+    blob = repr(last)
+    assert "sk-PROD-SECRET" not in blob
+    assert "anchor" not in blob
+
+    # Anything off the allowlist collapses to "other" — no caller
+    # string leaks into the payload.
+    emit.request(
+        endpoint="/internal/dump?path=/Users/alice/secrets.txt",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=10,
+        ttft_ms=100.0,
+        tps=10.0,
+        status=200,
+    )
+    last = stub_queue[-1]
+    assert last["request"]["endpoint"] == "other"
+    assert "alice" not in repr(last)
+    assert "secrets.txt" not in repr(last)
+
+
 def test_request_model_alias_local_path_redacted(opted_in, stub_queue):
     """``model_alias`` is the ONE free-form-ish field on ``request()``,
     but it must be funnelled through ``normalize_model_path`` so a local

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -99,6 +99,39 @@ def test_error_no_op_when_disabled(fake_home, stub_queue):
     assert stub_queue == []
 
 
+def test_cli_kill_switch_overrides_opt_in(opted_in, stub_queue):
+    """``--no-telemetry`` (threaded through ``set_cli_kill_switch``) must
+    suppress every emit site, even when the user has previously opted in
+    via the consent file. Before this was wired, ``rapid-mlx --no-telemetry
+    models`` still POSTed two events to the collector."""
+    from vllm_mlx.telemetry import emit
+    from vllm_mlx.telemetry.state import set_cli_kill_switch
+
+    set_cli_kill_switch(True)
+    try:
+        emit.session_start(subcommand="serve")
+        emit.session_end(subcommand="serve", duration_seconds=42)
+        emit.request(
+            endpoint="/v1/chat/completions",
+            model_alias="qwen3.5-9b",
+            stream=True,
+            tool_call_used=False,
+            prompt_tokens=100,
+            completion_tokens=400,
+            ttft_ms=250.0,
+            tps=42.0,
+            status=200,
+        )
+        emit.error(
+            category="model_load_failure",
+            exc=RuntimeError("x"),
+            phase="startup",
+        )
+    finally:
+        set_cli_kill_switch(False)
+    assert stub_queue == []
+
+
 # ---------------------------------------------------------- shape when on
 
 
@@ -224,3 +257,135 @@ def test_emit_does_not_catch_keyboard_interrupt(opted_in, monkeypatch, stub_queu
     monkeypatch.setattr(emit, "platform_info", interrupt)
     with pytest.raises(KeyboardInterrupt):
         emit.session_start(subcommand="serve")
+
+
+# ---------------------------------------------------------- prompt-leak red line
+#
+# These tests do not exercise behaviour — they pin the API CONTRACT: the
+# four public helpers must never expose a parameter that could carry user
+# prompts, completions, generated text, file paths, secrets, or anything
+# resembling them. A future maintainer adding ``prompt_text=...`` to
+# ``request()`` will trip these and have to delete the test on the way
+# in, which is the bright line we want.
+
+
+def test_public_emit_signatures_have_no_prompt_or_completion_fields():
+    """Lock the parameter names of the public emit helpers.
+
+    If you are looking at this test because you want to ship a new field,
+    that's fine — but the new field must NOT be raw text. Anything
+    free-form must go through ``redact.py`` first and land here as a
+    bucket / fingerprint / hash, never as the raw value.
+    """
+    import inspect
+
+    from vllm_mlx.telemetry import emit
+
+    forbidden = {
+        "prompt",
+        "prompt_text",
+        "prompts",
+        "messages",
+        "user_message",
+        "completion",
+        "completion_text",
+        "completions",
+        "generated_text",
+        "response_text",
+        "input_text",
+        "output_text",
+        "content",
+        "text",
+        "system_prompt",
+        "api_key",
+        "auth_token",
+        "bearer",
+        "file_path",
+        "filepath",
+        "path",
+        "url",
+        "stream_url",
+        "ip",
+        "ip_address",
+        "hostname",
+    }
+    for fn_name in ("session_start", "session_end", "request", "error"):
+        fn = getattr(emit, fn_name)
+        params = set(inspect.signature(fn).parameters.keys())
+        leak = params & forbidden
+        assert not leak, (
+            f"emit.{fn_name} exposes prompt-like parameter(s) {leak!r}; "
+            "free-form text must go through redact.py first"
+        )
+
+
+def test_request_model_alias_local_path_redacted(opted_in, stub_queue):
+    """``model_alias`` is the ONE free-form-ish field on ``request()``,
+    but it must be funnelled through ``normalize_model_path`` so a local
+    checkout path collapses to ``"<local>"`` instead of leaking the
+    user's home-directory layout."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="/Users/alice/private-model-checkout",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=100,
+        completion_tokens=400,
+        ttft_ms=250.0,
+        tps=42.0,
+        status=200,
+    )
+    r = stub_queue[0]["request"]
+    assert r["model_alias"] == "<local>"
+    assert "alice" not in repr(stub_queue[0])
+
+
+def test_argv_values_with_secrets_never_survive_redaction(opted_in, stub_queue):
+    """argv carries the user's full shell command. The redactor must
+    extract flag NAMES and nothing else — values are skipped before they
+    ever land in a payload field."""
+    from vllm_mlx.telemetry import emit
+
+    secret = "sk-prod-XXXXXXXXXXXXXXXXXXXXXXXX"
+    bearer = "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+    prompt = "summarize this confidential email about Q3 numbers"
+    emit.session_start(
+        subcommand="serve",
+        argv=[
+            "serve",
+            "qwen3.5-9b",
+            "--api-key",
+            secret,
+            "--auth-header",
+            bearer,
+            "--initial-prompt",
+            prompt,
+        ],
+    )
+    blob = repr(stub_queue[0])
+    assert secret not in blob
+    assert bearer not in blob
+    assert prompt not in blob
+    # Names should be preserved (the contract: we see WHICH flags people
+    # use, never what they pass).
+    flag_names = set(stub_queue[0]["session"]["flag_names"])
+    assert {"api-key", "auth-header", "initial-prompt"} <= flag_names
+
+
+def test_error_fingerprint_does_not_echo_exception_message(opted_in, stub_queue):
+    """A user's prompt CAN end up in an exception message — e.g. a parser
+    crash that prints the offending input. The fingerprint must not echo
+    it."""
+    from vllm_mlx.telemetry import emit
+
+    prompt_in_exc = "summarize this confidential email about Q3 numbers"
+    try:
+        raise ValueError(f"parser failed on: {prompt_in_exc}")
+    except ValueError as exc:
+        emit.error(category="parser_failure", exc=exc, phase="chat")
+
+    blob = repr(stub_queue[0])
+    assert prompt_in_exc not in blob
+    assert "parser failed" not in blob

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -271,7 +271,15 @@ def test_session_start_models_loaded_capped_at_32(opted_in, stub_queue):
 
 
 def test_request_buckets_not_raw_numbers(opted_in, stub_queue):
-    """Bucketed counts only — raw token counts and TTFT must not survive."""
+    """Bucketed counts only — raw token counts and TTFT must not survive.
+
+    Round 12 codex review caught that a whole-payload ``repr`` scan for
+    raw numeric substrings was flaky: the envelope carries random
+    UUIDs (``client_id``, ``session_id``) and a timestamp, so a uuid
+    that happens to contain the substring ``"137"`` would CI-fail the
+    test even with bucketing intact. Assert specific fields equal
+    expected bucket labels instead.
+    """
     from vllm_mlx.telemetry import emit
 
     emit.request(
@@ -286,13 +294,19 @@ def test_request_buckets_not_raw_numbers(opted_in, stub_queue):
         status=200,
     )
     r = stub_queue[0]["request"]
-    # Bucket strings, not raw ints / floats.
-    assert isinstance(r["prompt_tokens_bucket"], str)
-    assert isinstance(r["ttft_ms_bucket"], str)
-    # Specific values must not survive.
-    blob = repr(stub_queue[0])
+    # Bucket strings, not raw ints / floats — assert the exact labels
+    # the bucketing primitives are documented to produce for these
+    # inputs, so a future bucket-edge regression also trips.
+    assert r["prompt_tokens_bucket"] == "0-256"  # 137 < 256
+    assert r["completion_tokens_bucket"] == "1k-4k"  # 1024 <= 1729 < 4096
+    assert r["ttft_ms_bucket"] == "100-500ms"  # 432.5 < 500
+    assert r["tps_bucket"] == "50-100"  # 58.2 < 100
+    # The raw int/float values must NOT be in any request field — scan
+    # only the request sub-object so envelope UUIDs / timestamps cannot
+    # cause a false positive.
+    request_blob = repr(r)
     for raw in ("137", "1729", "432.5", "58.2"):
-        assert raw not in blob
+        assert raw not in request_blob, f"{raw!r} survived into request payload: {r}"
 
 
 def test_error_category_and_phase_normalised_to_allowlist(opted_in, stub_queue):

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -169,6 +169,26 @@ def test_cli_kill_switch_overrides_opt_in(opted_in, stub_queue):
 # ---------------------------------------------------------- shape when on
 
 
+def test_subcommand_normalized_to_allowlist(opted_in, stub_queue):
+    """Round 11 codex review: ``subcommand`` was the last free-form
+    ``str`` slot on ``session_start``/``session_end``, the same shape
+    of escape hatch closed for ``endpoint`` / ``category`` / ``phase``.
+    Pin known values pass through, unknown collapse to ``"other"``."""
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(subcommand="serve")
+    assert stub_queue[-1]["session"]["subcommand"] == "serve"
+
+    emit.session_end(subcommand="serve", duration_seconds=10)
+    assert stub_queue[-1]["session"]["subcommand"] == "serve"
+
+    # An internal / undocumented subcommand collapses.
+    leak = "internal:dump?path=/Users/alice/secrets.txt"
+    emit.session_start(subcommand=leak)
+    assert stub_queue[-1]["session"]["subcommand"] == "other"
+    assert "alice" not in repr(stub_queue[-1])
+
+
 def test_runtime_payload_carries_every_schema_v1_field(opted_in, stub_queue):
     """Round 8 codex review: ``SCHEMA_VERSION == 1`` means the runtime
     payload must include EVERY key the dataclass

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -99,6 +99,40 @@ def test_error_no_op_when_disabled(fake_home, stub_queue):
     assert stub_queue == []
 
 
+def test_session_id_is_stable_under_concurrent_first_callers(fake_home):
+    """Round 6 codex review: the prior lazy ``_session_id`` init was
+    unlocked. Two concurrent first-emitters could race past the
+    ``is None`` check and generate different uuids → aggregation
+    pipeline sees two sessions per real session. Pin that 32 threads
+    racing ``session_id()`` agree on one value."""
+    import threading
+
+    from vllm_mlx.telemetry import emit
+
+    emit._reset_for_tests()
+
+    results: list[str] = []
+    started = threading.Event()
+    barrier = threading.Barrier(32)
+
+    def racer():
+        barrier.wait(timeout=5.0)
+        results.append(emit.session_id())
+
+    threads = [threading.Thread(target=racer) for _ in range(32)]
+    for t in threads:
+        t.start()
+    started.set()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert len(results) == 32
+    assert len(set(results)) == 1, (
+        f"concurrent first callers generated {len(set(results))} distinct "
+        f"session_ids: {set(results)}"
+    )
+
+
 def test_cli_kill_switch_overrides_opt_in(opted_in, stub_queue):
     """``--no-telemetry`` (threaded through ``set_cli_kill_switch``) must
     suppress every emit site, even when the user has previously opted in

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract pins for ``vllm_mlx.telemetry.emit``.
+
+The emit helpers are the only API call sites should touch. They:
+- Refuse to construct a payload when telemetry is disabled.
+- Funnel every user-provided string through redaction primitives.
+- Catch and swallow non-system exceptions so a telemetry bug cannot
+  crash the user's command.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+
+    # Reload state so any caches rebuild under the fresh HOME.
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+
+    # Reload emit so it picks up the reloaded state module, and reset
+    # its singletons so each test starts clean.
+    import vllm_mlx.telemetry.emit as emit
+
+    importlib.reload(emit)
+    emit._reset_for_tests()
+    return tmp_path
+
+
+@pytest.fixture
+def opted_in(fake_home):
+    """Persist a yes-consent so is_enabled() returns True."""
+    from vllm_mlx.telemetry.state import record_consent
+
+    record_consent(True, rapid_mlx_version="0.0.0+test")
+    return fake_home
+
+
+@pytest.fixture
+def stub_queue(monkeypatch):
+    """Replace the singleton queue with an in-memory list capture."""
+    from vllm_mlx.telemetry import emit
+
+    captured: list[dict] = []
+
+    class _StubQueue:
+        def enqueue(self, payload):
+            captured.append(payload)
+
+    monkeypatch.setattr(emit, "get_queue", lambda: _StubQueue())
+    return captured
+
+
+# ---------------------------------------------------------- consent gate
+
+
+def test_session_start_no_op_when_disabled(fake_home, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(subcommand="serve")
+    assert stub_queue == []
+
+
+def test_session_end_no_op_when_disabled(fake_home, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.session_end(subcommand="serve", duration_seconds=42)
+    assert stub_queue == []
+
+
+def test_request_no_op_when_disabled(fake_home, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=100,
+        completion_tokens=400,
+        ttft_ms=250.0,
+        tps=42.0,
+        status=200,
+    )
+    assert stub_queue == []
+
+
+def test_error_no_op_when_disabled(fake_home, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.error(category="model_load_failure", exc=RuntimeError("x"), phase="startup")
+    assert stub_queue == []
+
+
+# ---------------------------------------------------------- shape when on
+
+
+def test_session_start_envelope_when_enabled(opted_in, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(
+        subcommand="serve",
+        argv=["serve", "qwen3.5-9b", "--host", "0.0.0.0", "--port", "8000"],
+        engine="batched",
+        models_loaded=["mlx-community/Qwen3.5-9B-4bit"],
+    )
+    assert len(stub_queue) == 1
+    payload = stub_queue[0]
+
+    # Envelope contract.
+    assert payload["schema_version"] == 1
+    assert payload["event"] == "session_start"
+    assert payload["timestamp"].endswith("Z")
+    assert payload["platform"]["os"] in {"darwin", "linux", "windows"}
+    assert "chip" in payload["platform"]
+
+    # Session payload: flag VALUES must be absent — only NAMES survive
+    # redaction. ``0.0.0.0`` and ``8000`` are values, must not appear.
+    blob = repr(payload)
+    assert "0.0.0.0" not in blob
+    assert "8000" not in blob
+    # Flag names should be there.
+    assert set(payload["session"]["flag_names"]) == {"host", "port"}
+
+
+def test_session_start_models_loaded_redacted(opted_in, stub_queue):
+    """Local paths must collapse to "<local>" — not leak home dirs."""
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(
+        subcommand="serve",
+        models_loaded=[
+            "mlx-community/Qwen3.5-9B-4bit",  # public, passes through
+            "/Users/alice/secret-checkout",  # local, redacted
+        ],
+    )
+    loaded = stub_queue[0]["session"]["models_loaded"]
+    assert "mlx-community/Qwen3.5-9B-4bit" in loaded
+    assert "<local>" in loaded
+    assert "alice" not in repr(loaded)
+
+
+def test_session_start_models_loaded_capped_at_32(opted_in, stub_queue):
+    """Don't let a multi-load surface blow up a single payload."""
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(
+        subcommand="serve",
+        models_loaded=[f"org/model-{i}" for i in range(50)],
+    )
+    assert len(stub_queue[0]["session"]["models_loaded"]) == 32
+
+
+def test_request_buckets_not_raw_numbers(opted_in, stub_queue):
+    """Bucketed counts only — raw token counts and TTFT must not survive."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=137,
+        completion_tokens=1729,
+        ttft_ms=432.5,
+        tps=58.2,
+        status=200,
+    )
+    r = stub_queue[0]["request"]
+    # Bucket strings, not raw ints / floats.
+    assert isinstance(r["prompt_tokens_bucket"], str)
+    assert isinstance(r["ttft_ms_bucket"], str)
+    # Specific values must not survive.
+    blob = repr(stub_queue[0])
+    for raw in ("137", "1729", "432.5", "58.2"):
+        assert raw not in blob
+
+
+def test_error_carries_fingerprint_no_message(opted_in, stub_queue):
+    """Crash fingerprint excludes message text and module path."""
+    from vllm_mlx.telemetry import emit
+
+    try:
+        raise ValueError("/Users/alice/secret.txt: not found")
+    except ValueError as exc:
+        emit.error(category="model_load_failure", exc=exc, phase="startup")
+
+    err = stub_queue[0]["error"]
+    assert len(err["fingerprint"]) == 16
+    blob = repr(stub_queue[0])
+    assert "/Users/alice/secret.txt" not in blob
+    assert "not found" not in blob
+
+
+# ---------------------------------------------------------- failure suppression
+
+
+def test_session_start_swallows_internal_bug(opted_in, monkeypatch, stub_queue):
+    """An internal redaction bug must not propagate to the caller."""
+    from vllm_mlx.telemetry import emit
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic redact failure")
+
+    monkeypatch.setattr(emit, "hash_flag_names", boom)
+    # Must not raise:
+    emit.session_start(subcommand="serve", argv=["--x"])
+
+
+def test_emit_does_not_catch_keyboard_interrupt(opted_in, monkeypatch, stub_queue):
+    """User intent (Ctrl-C) and SystemExit must propagate."""
+    from vllm_mlx.telemetry import emit
+
+    def interrupt(*args, **kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(emit, "platform_info", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        emit.session_start(subcommand="serve")

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -169,6 +169,32 @@ def test_cli_kill_switch_overrides_opt_in(opted_in, stub_queue):
 # ---------------------------------------------------------- shape when on
 
 
+def test_runtime_payload_carries_every_schema_v1_field(opted_in, stub_queue):
+    """Round 8 codex review: ``SCHEMA_VERSION == 1`` means the runtime
+    payload must include EVERY key the dataclass
+    ``SessionPayload`` documents — even default-valued ones — so v1
+    consumers parsing the envelope can rely on the keys being present.
+    The previous hand-built payload silently dropped ``duration_seconds``
+    + ``engine`` from session_start and ``engine`` from session_end.
+    Pin both runtime payloads expose the full v1 surface."""
+    from dataclasses import fields as _fields
+
+    from vllm_mlx.telemetry import emit
+    from vllm_mlx.telemetry.schema import SessionPayload
+
+    expected_keys = {f.name for f in _fields(SessionPayload)}
+
+    emit.session_start(subcommand="serve", argv=["serve"])
+    session = stub_queue[-1]["session"]
+    missing = expected_keys - set(session)
+    assert not missing, f"session_start dropped v1 keys: {missing}"
+
+    emit.session_end(subcommand="serve", duration_seconds=42)
+    session = stub_queue[-1]["session"]
+    missing = expected_keys - set(session)
+    assert not missing, f"session_end dropped v1 keys: {missing}"
+
+
 def test_session_start_envelope_when_enabled(opted_in, stub_queue):
     from vllm_mlx.telemetry import emit
 

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -98,6 +98,40 @@ def test_shutdown_drains_remaining_events():
     assert [e["a"] for e in captured] == [1, 2]
 
 
+def test_shutdown_does_not_orphan_thread_for_restart_when_join_times_out():
+    """Codex round 1 caught this: ``shutdown()`` cleared ``_thread``
+    unconditionally, so a subsequent ``start()`` could spawn a SECOND
+    daemon while the original was still draining a slow flusher. With
+    two flushers attached to the same ``_events`` deque, events would
+    flush in arbitrary interleaving and the queue lock would not
+    suffice (each batch is read-then-clear, not atomic with the wake)."""
+    release = threading.Event()
+
+    def slow_flusher(batch):
+        release.wait(timeout=5.0)
+        return True
+
+    q = TelemetryQueue(flusher=slow_flusher, flush_interval_s=60.0, flush_threshold=1)
+    q.start()
+    q.enqueue({"x": 1})
+    time.sleep(0.1)  # let the daemon enter slow_flusher
+
+    q.shutdown(timeout=0.1)  # times out — flusher still blocked on release
+    # The daemon must NOT be considered "gone" yet: a restart would
+    # double the flusher.
+    assert q._thread is not None
+    assert q._thread.is_alive()
+
+    # ``start()`` is documented as idempotent — it must see the still-alive
+    # daemon and not spawn a sibling.
+    q.start()
+    assert threading.active_count() < 1000  # sanity
+
+    # Release the old daemon so the test process can exit.
+    release.set()
+    q.shutdown(timeout=1.0)
+
+
 def test_shutdown_returns_within_budget_even_if_flusher_hangs():
     # Flusher that blocks longer than the shutdown budget.
     release = threading.Event()

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -153,16 +153,25 @@ def test_shutdown_returns_within_budget_even_if_flusher_hangs():
 
     q = TelemetryQueue(flusher=slow_flusher, flush_interval_s=60.0, flush_threshold=1)
     q.start()
-    q.enqueue({"x": 1})
-    time.sleep(0.1)  # let daemon start the flush
+    try:
+        q.enqueue({"x": 1})
+        time.sleep(0.1)  # let daemon start the flush
 
-    t0 = time.monotonic()
-    q.shutdown(timeout=0.2)
-    elapsed = time.monotonic() - t0
-    release.set()
-    # We accept some daemon-cleanup overhead, but it must not block on
-    # the slow flusher.
-    assert elapsed < 0.5, f"shutdown blocked {elapsed:.2f}s on slow flusher"
+        t0 = time.monotonic()
+        q.shutdown(timeout=0.2)
+        elapsed = time.monotonic() - t0
+        # We accept some daemon-cleanup overhead, but it must not block on
+        # the slow flusher.
+        assert elapsed < 0.5, f"shutdown blocked {elapsed:.2f}s on slow flusher"
+    finally:
+        # Round 7 codex review caught that releasing the flusher
+        # without a final join leaks a still-running named telemetry
+        # thread into sibling tests (``test_concurrent_start_does_not_*``
+        # would then see an unexpected daemon). Release in ``finally``
+        # so even an assertion failure cleans up, then call shutdown
+        # again to drain the now-released daemon.
+        release.set()
+        q.shutdown(timeout=2.0)
 
 
 def test_flusher_exception_increments_failed_not_crash():

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -138,9 +138,15 @@ def test_shutdown_does_not_orphan_thread_for_restart_when_join_times_out():
         f"(before={len(before_named)}, after={len(after_named)})"
     )
 
-    # Release the old daemon so the test process can exit.
+    # Release the old daemon so the test process can exit. Round 13:
+    # ``shutdown()`` is now latched (no-op on second call), so wait
+    # for the daemon directly via the thread reference — otherwise a
+    # stray ``rapid-mlx-telemetry`` thread would leak into
+    # ``test_concurrent_start_does_not_spawn_duplicate_daemons`` and
+    # blow its name-count assertion.
     release.set()
-    q.shutdown(timeout=1.0)
+    if q._thread is not None:
+        q._thread.join(timeout=2.0)
 
 
 def test_shutdown_returns_within_budget_even_if_flusher_hangs():
@@ -168,10 +174,12 @@ def test_shutdown_returns_within_budget_even_if_flusher_hangs():
         # without a final join leaks a still-running named telemetry
         # thread into sibling tests (``test_concurrent_start_does_not_*``
         # would then see an unexpected daemon). Release in ``finally``
-        # so even an assertion failure cleans up, then call shutdown
-        # again to drain the now-released daemon.
+        # so even an assertion failure cleans up. Round 13: ``shutdown``
+        # is now latched after the first call, so wait on the thread
+        # directly rather than calling ``shutdown`` a second time.
         release.set()
-        q.shutdown(timeout=2.0)
+        if q._thread is not None:
+            q._thread.join(timeout=2.0)
 
 
 def test_flusher_exception_increments_failed_not_crash():
@@ -190,6 +198,76 @@ def test_flusher_exception_increments_failed_not_crash():
     q.start()
     q.enqueue({"x": 2})
     q.shutdown(timeout=0.5)
+
+
+def test_shutdown_called_twice_does_not_double_budget():
+    """Round 13 codex review: ``TelemetryQueue.start()`` registers
+    ``shutdown`` via ``atexit``, but ``cli.py`` ``_emit_session_end``
+    also calls ``shutdown()`` synchronously so the ``session_end``
+    payload lands before the process tears down. With both wired,
+    a hung flusher could burn the 2 s join budget TWICE at exit —
+    once from the cli atexit hook, once from the queue's own. The
+    fix is a latched ``_shutdown_called`` so the redundant call is a
+    cheap no-op. Pin that property: total elapsed across two
+    back-to-back ``shutdown()`` calls against a hanging flusher is
+    bounded by a single budget, not two."""
+    release = threading.Event()
+
+    def slow_flusher(batch):
+        release.wait(timeout=5.0)
+        return True
+
+    q = TelemetryQueue(flusher=slow_flusher, flush_interval_s=60.0, flush_threshold=1)
+    q.start()
+    try:
+        q.enqueue({"x": 1})
+        time.sleep(0.1)  # let daemon start the flush
+
+        t0 = time.monotonic()
+        q.shutdown(timeout=0.3)
+        q.shutdown(timeout=0.3)  # must return immediately (latched)
+        elapsed = time.monotonic() - t0
+        # If the latch worked, total elapsed is one budget (≈0.3 s)
+        # plus a hair of overhead, NOT two (≈0.6 s+).
+        assert elapsed < 0.5, (
+            f"second shutdown re-spent the budget: "
+            f"elapsed={elapsed:.2f}s (expected <0.5s, latched no-op)"
+        )
+    finally:
+        # Don't let the daemon leak into the next test (the named-thread
+        # count assertion in ``test_concurrent_start_does_not_*`` is
+        # sensitive). ``shutdown`` is now latched, so wait on the
+        # thread directly.
+        release.set()
+        if q._thread is not None:
+            q._thread.join(timeout=2.0)
+
+
+def test_start_clears_shutdown_latch_for_restart():
+    """Companion to ``test_shutdown_called_twice_does_not_double_budget``:
+    a fresh ``start()`` after ``shutdown()`` must clear the latch, or
+    the next ``shutdown()`` would become a no-op and never drain the
+    new lifecycle's events."""
+    captured: list[dict] = []
+
+    def flusher(batch):
+        captured.extend(batch)
+        return True
+
+    q = TelemetryQueue(flusher=flusher, flush_interval_s=60.0, flush_threshold=999)
+    q.start()
+    q.enqueue({"a": 1})
+    q.shutdown(timeout=1.0)
+    assert [e["a"] for e in captured] == [1]
+
+    # Restart and confirm the next shutdown actually drains.
+    captured.clear()
+    q.start()
+    q.enqueue({"a": 2})
+    q.shutdown(timeout=1.0)
+    assert [e["a"] for e in captured] == [2], (
+        "second lifecycle did not drain — shutdown latch leaked across start()"
+    )
 
 
 def test_start_preserves_wake_for_events_enqueued_pre_start():

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -192,6 +192,40 @@ def test_flusher_exception_increments_failed_not_crash():
     q.shutdown(timeout=0.5)
 
 
+def test_start_preserves_wake_for_events_enqueued_pre_start():
+    """Round 11 codex review: enqueueing events past the threshold
+    BEFORE ``start()`` runs used to lose the wakeup — ``start()``
+    cleared ``_wake`` unconditionally — and the batch would sit for
+    the full 60 s idle interval. Pin that an over-threshold queue at
+    start time wakes the daemon immediately."""
+    flushed: list[list[dict]] = []
+    flushed_event = threading.Event()
+
+    def flusher(batch):
+        flushed.append(batch)
+        flushed_event.set()
+        return True
+
+    q = TelemetryQueue(flusher=flusher, flush_interval_s=60.0, flush_threshold=2)
+    # Enqueue past threshold BEFORE start. The current implementation
+    # records ``_wake`` as set inside ``enqueue`` only if the daemon
+    # has already started consuming wakes; for pre-start enqueues the
+    # signal would otherwise be lost.
+    q.enqueue({"i": 0})
+    q.enqueue({"i": 1})
+    q.start()
+    try:
+        # If start() preserves the threshold wake, this flush fires in
+        # milliseconds. Without it, it would sit for ~60 s.
+        assert flushed_event.wait(timeout=2.0), (
+            "start() lost the threshold wake — daemon did not flush "
+            "pre-start over-threshold batch within 2 s"
+        )
+        assert flushed and len(flushed[0]) == 2
+    finally:
+        q.shutdown(timeout=0.5)
+
+
 def test_start_is_idempotent():
     q = TelemetryQueue(flusher=lambda b: True)
     q.start()

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -119,13 +119,24 @@ def test_shutdown_does_not_orphan_thread_for_restart_when_join_times_out():
     q.shutdown(timeout=0.1)  # times out — flusher still blocked on release
     # The daemon must NOT be considered "gone" yet: a restart would
     # double the flusher.
-    assert q._thread is not None
-    assert q._thread.is_alive()
+    original_thread = q._thread
+    assert original_thread is not None
+    assert original_thread.is_alive()
 
-    # ``start()`` is documented as idempotent — it must see the still-alive
-    # daemon and not spawn a sibling.
+    # Round 2 codex review caught that an ``active_count`` assert is
+    # too weak — pin the precise property we care about: ``start()``
+    # MUST NOT spawn a sibling. Compare by object identity of the
+    # daemon thread, and also count threads named
+    # ``rapid-mlx-telemetry`` directly so a name-only regression
+    # cannot slip past.
+    before_named = [t for t in threading.enumerate() if t.name == "rapid-mlx-telemetry"]
     q.start()
-    assert threading.active_count() < 1000  # sanity
+    after_named = [t for t in threading.enumerate() if t.name == "rapid-mlx-telemetry"]
+    assert q._thread is original_thread, "start() replaced live daemon"
+    assert len(after_named) == len(before_named), (
+        f"start() spawned a second telemetry daemon "
+        f"(before={len(before_named)}, after={len(after_named)})"
+    )
 
     # Release the old daemon so the test process can exit.
     release.set()

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -183,6 +183,16 @@ def test_shutdown_returns_within_budget_even_if_flusher_hangs():
 
 
 def test_flusher_exception_increments_failed_not_crash():
+    """A flusher that raises must not kill the daemon (a dead daemon
+    silently disables telemetry for the rest of the process). After
+    the exception the queue must still accept work AND attempt to
+    flush it.
+
+    Round 17 codex review: the second-enqueue restart path used to
+    pass even if the daemon dropped ``{"x": 2}`` on the floor or
+    never restarted. Pin both flushes_failed >= 2 (second batch did
+    reach the flusher) and pending == 0 (it was drained, not stuck)."""
+
     def bad_flusher(batch):
         raise RuntimeError("synthetic")
 
@@ -194,10 +204,31 @@ def test_flusher_exception_increments_failed_not_crash():
     assert snap["flushes_failed"] >= 1
     assert snap["flushes_ok"] == 0
     q.shutdown(timeout=0.5)
-    # Daemon must still be capable of accepting more work after the bug.
+    # Daemon must still be capable of accepting more work after the bug,
+    # AND it must actually attempt to flush that work (not silently
+    # drop it). The flusher still raises on the second batch -- we are
+    # pinning that the path runs, not that it succeeds.
     q.start()
     q.enqueue({"x": 2})
+    # Wait for the second batch to be picked up.
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        snap = q.snapshot()
+        if snap["flushes_failed"] >= 2:
+            break
+        time.sleep(0.01)
     q.shutdown(timeout=0.5)
+
+    snap_after = q.snapshot()
+    assert snap_after["flushes_failed"] >= 2, (
+        f"second lifecycle did not attempt a flush "
+        f"(flushes_failed={snap_after['flushes_failed']}); "
+        "either the daemon never restarted or the second batch was dropped"
+    )
+    assert snap_after["pending"] == 0, (
+        f"second lifecycle left {snap_after['pending']} event(s) stuck "
+        "in the queue -- the drain on shutdown is broken"
+    )
 
 
 def test_shutdown_called_twice_does_not_double_budget():

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -190,6 +190,35 @@ def test_start_is_idempotent():
     q.shutdown(timeout=0.1)
 
 
+def test_concurrent_start_does_not_spawn_duplicate_daemons():
+    """Round 4 codex review: the previous ``start()`` check was
+    unlocked, so a multi-init-path race (cli main + FastAPI lifespan
+    both calling ``start()`` from different threads) could pass the
+    ``is_alive()`` check on both and spawn two daemons against the
+    same queue. The fix is a dedicated lifecycle lock around the
+    check + creation."""
+    q = TelemetryQueue(flusher=lambda b: True)
+    started = threading.Event()
+
+    def racer():
+        started.wait(timeout=2.0)
+        q.start()
+
+    threads = [threading.Thread(target=racer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    # Release all at once so the race is real.
+    started.set()
+    for t in threads:
+        t.join(timeout=2.0)
+
+    named = [t for t in threading.enumerate() if t.name == "rapid-mlx-telemetry"]
+    assert len(named) == 1, (
+        f"concurrent start() spawned {len(named)} daemons (want exactly 1)"
+    )
+    q.shutdown(timeout=0.5)
+
+
 def test_snapshot_shape():
     q = TelemetryQueue(flusher=lambda b: True)
     snap = q.snapshot()

--- a/tests/test_telemetry_queue.py
+++ b/tests/test_telemetry_queue.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract pins for ``vllm_mlx.telemetry.queue.TelemetryQueue``.
+
+Properties to lock down:
+- ``enqueue`` is non-blocking (no network on hot path).
+- Queue is bounded; oldest drops first when at capacity.
+- Daemon flushes on threshold and on shutdown.
+- ``shutdown`` returns within budget even when flusher hangs.
+- ``snapshot`` exposes the counters the ``telemetry status`` UX needs.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from vllm_mlx.telemetry.queue import (
+    FLUSH_INTERVAL_S,
+    FLUSH_THRESHOLD,
+    MAX_QUEUE_LEN,
+    TelemetryQueue,
+)
+
+
+def test_enqueue_buffers_until_threshold():
+    flushed: list[list[dict]] = []
+
+    def flusher(batch):
+        flushed.append(batch)
+        return True
+
+    q = TelemetryQueue(flusher=flusher, flush_interval_s=60.0, flush_threshold=5)
+    q.start()
+    try:
+        for i in range(4):
+            q.enqueue({"i": i})
+        # No flush should have run yet (under threshold + no time elapsed).
+        time.sleep(0.05)
+        assert flushed == []
+
+        q.enqueue({"i": 4})  # crosses threshold
+        # Wait briefly for the daemon to wake + drain.
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not flushed:
+            time.sleep(0.01)
+        assert flushed, "daemon never flushed on threshold cross"
+        # The first flush should have grabbed all 5 events.
+        assert len(flushed[0]) == 5
+    finally:
+        q.shutdown(timeout=0.5)
+
+
+def test_drops_oldest_when_over_capacity():
+    captured: list[dict] = []
+    started = threading.Event()
+
+    def flusher(batch):
+        started.set()
+        captured.extend(batch)
+        return True
+
+    q = TelemetryQueue(
+        flusher=flusher,
+        max_len=3,
+        flush_interval_s=60.0,
+        flush_threshold=999,  # disable threshold flushing
+    )
+    q.start()
+    try:
+        # Enqueue 6 events into a queue with capacity 3 — first 3 should
+        # be dropped, last 3 retained.
+        for i in range(6):
+            q.enqueue({"i": i})
+        snap = q.snapshot()
+        assert snap["pending"] == 3
+        assert snap["enqueued_total"] == 6
+        assert snap["dropped_total"] == 3
+    finally:
+        q.shutdown(timeout=0.5)
+    # After shutdown the daemon drains. The retained events must be the
+    # newest three.
+    assert started.is_set()
+    assert [e["i"] for e in captured] == [3, 4, 5]
+
+
+def test_shutdown_drains_remaining_events():
+    captured: list[dict] = []
+
+    def flusher(batch):
+        captured.extend(batch)
+        return True
+
+    q = TelemetryQueue(flusher=flusher, flush_interval_s=60.0, flush_threshold=999)
+    q.start()
+    q.enqueue({"a": 1})
+    q.enqueue({"a": 2})
+    q.shutdown(timeout=1.0)
+    assert [e["a"] for e in captured] == [1, 2]
+
+
+def test_shutdown_returns_within_budget_even_if_flusher_hangs():
+    # Flusher that blocks longer than the shutdown budget.
+    release = threading.Event()
+
+    def slow_flusher(batch):
+        release.wait(timeout=5.0)
+        return True
+
+    q = TelemetryQueue(flusher=slow_flusher, flush_interval_s=60.0, flush_threshold=1)
+    q.start()
+    q.enqueue({"x": 1})
+    time.sleep(0.1)  # let daemon start the flush
+
+    t0 = time.monotonic()
+    q.shutdown(timeout=0.2)
+    elapsed = time.monotonic() - t0
+    release.set()
+    # We accept some daemon-cleanup overhead, but it must not block on
+    # the slow flusher.
+    assert elapsed < 0.5, f"shutdown blocked {elapsed:.2f}s on slow flusher"
+
+
+def test_flusher_exception_increments_failed_not_crash():
+    def bad_flusher(batch):
+        raise RuntimeError("synthetic")
+
+    q = TelemetryQueue(flusher=bad_flusher, flush_interval_s=60.0, flush_threshold=1)
+    q.start()
+    q.enqueue({"x": 1})
+    time.sleep(0.2)
+    snap = q.snapshot()
+    assert snap["flushes_failed"] >= 1
+    assert snap["flushes_ok"] == 0
+    q.shutdown(timeout=0.5)
+    # Daemon must still be capable of accepting more work after the bug.
+    q.start()
+    q.enqueue({"x": 2})
+    q.shutdown(timeout=0.5)
+
+
+def test_start_is_idempotent():
+    q = TelemetryQueue(flusher=lambda b: True)
+    q.start()
+    q.start()  # second call must be a no-op, not crash
+    q.shutdown(timeout=0.1)
+
+
+def test_snapshot_shape():
+    q = TelemetryQueue(flusher=lambda b: True)
+    snap = q.snapshot()
+    assert set(snap) == {
+        "pending",
+        "enqueued_total",
+        "dropped_total",
+        "flushes_ok",
+        "flushes_failed",
+    }
+
+
+def test_module_defaults_are_sane():
+    # Pin the public defaults the design doc references so a stray bump
+    # doesn't silently change shipped behaviour.
+    assert MAX_QUEUE_LEN == 100
+    assert FLUSH_INTERVAL_S == 60.0
+    assert FLUSH_THRESHOLD == 10

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -342,24 +342,20 @@ def test_non_serializable_payload_returns_false_not_raise():
         urlopen.assert_not_called()
 
 
-def test_retry_constants_define_a_finite_worst_case():
-    """Round 6 codex review: ``cli.py``'s atexit drain budget must be
-    derivable from these constants so a future change to either side
-    cannot regress past the other. Pin the constants exist + sum to a
-    bounded worst case."""
+def test_retry_constants_are_finite():
+    """Round 7 reverted the "atexit waits for transport worst case"
+    design. ``session_end`` is now best-effort: the queue's own
+    ``SHUTDOWN_BUDGET_S`` (~2 s) caps user-visible exit latency, and
+    the transport's own retries run inside that budget. We still pin
+    the constants exist with sane types so a future change can't make
+    them ``None`` or pathologically large."""
     from vllm_mlx.telemetry import transport
 
     assert isinstance(transport.TIMEOUT_S, float)
+    assert 0 < transport.TIMEOUT_S < 10
     assert isinstance(transport.RETRY_BACKOFFS_S, tuple)
-    # 3 attempts × timeout + sum of backoffs is the worst-case wall
-    # clock for ``post_batch``. cli.py's atexit shutdown adds 0.5s
-    # margin on top of this; if either side changes, the other must
-    # follow.
-    worst_case = 3 * transport.TIMEOUT_S + sum(transport.RETRY_BACKOFFS_S)
-    # Must fit in a reasonable user-perceived exit latency budget.
-    assert worst_case < 20.0, (
-        f"transport worst case {worst_case}s exceeds user-tolerable exit "
-        "latency — keep TIMEOUT_S × 3 + backoffs under 20 s"
+    assert all(
+        isinstance(b, (int, float)) and b >= 0 for b in transport.RETRY_BACKOFFS_S
     )
 
 

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -219,20 +219,66 @@ def test_oversized_payload_dropped_locally():
         urlopen.assert_not_called()
 
 
-def test_non_https_endpoint_refused(monkeypatch):
+def test_non_https_non_loopback_override_silently_falls_back_to_default(monkeypatch):
+    """Pre-round-3, an ``http://insecure.example`` override was rejected
+    inside ``post_batch`` ("refusing non-HTTPS endpoint"). After round 3
+    the rejection happens earlier — in ``endpoint()`` — and the override
+    silently falls back to the production HTTPS default. Either way:
+    nothing on plain HTTP, on a non-loopback host, ever sees user
+    events."""
     from vllm_mlx.telemetry import transport
 
     monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "http://insecure.example/v1")
-    with mock.patch.object(transport, "urlopen") as urlopen:
-        assert transport.post_batch([{"x": 1}]) is False
-        urlopen.assert_not_called()
+    # The override is silently dropped; ``endpoint()`` returns the
+    # production default.
+    assert transport.endpoint() == transport.DEFAULT_ENDPOINT
 
 
-def test_endpoint_override_via_env(monkeypatch):
+def test_endpoint_override_only_accepts_localhost(monkeypatch):
+    """Round 3 codex review: an unrestricted ``RAPID_MLX_TELEMETRY_ENDPOINT``
+    let a hostile shell rc / wrapper script redirect opted-in users'
+    events to an attacker-controlled collector. The override is now
+    restricted to localhost / 127.0.0.1 / ::1 (the only legitimate use
+    cases: wrangler dev + CI fixtures)."""
     from vllm_mlx.telemetry import transport
 
-    monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "https://debug.example/v1")
-    assert transport.endpoint() == "https://debug.example/v1"
+    # Localhost variants pass through.
+    for ok in (
+        "http://localhost:8787/v1/events",
+        "http://127.0.0.1:8787/v1/events",
+        "https://localhost/v1/events",
+        "http://[::1]:8787/v1/events",
+    ):
+        monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", ok)
+        assert transport.endpoint() == ok, f"{ok} should be accepted"
+
+    # Anything else falls back to the production default.
+    for bad in (
+        "https://attacker.example/v1/events",
+        "https://localhost.attacker.example/v1/events",  # suffix attack
+        "https://telemetry.attacker.example/v1/events",
+        "ftp://localhost/v1/events",
+        "not-a-url",
+    ):
+        monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", bad)
+        assert transport.endpoint() == transport.DEFAULT_ENDPOINT, (
+            f"{bad} should be refused"
+        )
+
+
+def test_non_serializable_payload_returns_false_not_raise():
+    """Round 3 codex review: ``json.dumps`` ran outside the transport
+    try, so a non-serializable payload would have raised through the
+    ``never raises`` contract. Pin that it returns ``False`` instead."""
+    from vllm_mlx.telemetry import transport
+
+    class _NotSerializable:
+        pass
+
+    with mock.patch.object(transport, "urlopen") as urlopen:
+        # Must not raise — ``post_batch`` is the privacy/safety boundary.
+        assert transport.post_batch([{"x": _NotSerializable()}]) is False
+        urlopen.assert_not_called()
 
 
 def test_user_agent_is_self_identifying():

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -186,6 +186,43 @@ def test_endpoint_override_via_env(monkeypatch):
     assert transport.endpoint() == "https://debug.example/v1"
 
 
+def test_user_agent_is_self_identifying():
+    """Cloudflare's bot manager rejects the stdlib default
+    ``Python-urllib/*`` UA with HTTP 403 before the request reaches the
+    Worker. The transport must therefore set a non-generic UA — and
+    the contract is to identify the package + version explicitly so
+    the receiver can attribute traffic."""
+    from vllm_mlx.telemetry import transport
+
+    ua = transport._user_agent()
+    assert "rapid-mlx" in ua
+    assert "Python-urllib" not in ua
+
+
+def test_post_sends_self_identifying_user_agent():
+    """End-to-end: ``post_batch`` must build a Request whose ``user-agent``
+    header is the self-identifying string, not the urllib default."""
+    from vllm_mlx.telemetry import transport
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout):
+        captured["headers"] = dict(req.headers)
+        resp = mock.MagicMock()
+        resp.status = 200
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        return resp
+
+    with mock.patch.object(transport, "urlopen", fake_urlopen):
+        assert transport.post_batch([{"x": 1}]) is True
+    # urllib lowercases header keys when stored on the Request, but
+    # the iteration order varies; use a case-insensitive lookup.
+    ua = {k.lower(): v for k, v in captured["headers"].items()}["user-agent"]
+    assert "rapid-mlx" in ua
+    assert "Python-urllib" not in ua
+
+
 def test_debug_env_truthy_off_by_default(monkeypatch):
     from vllm_mlx.telemetry import transport
 

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -141,6 +141,55 @@ def test_http_error_4xx_does_not_retry():
         assert urlopen.call_count == 1
 
 
+def test_http_error_response_body_closed():
+    """Round 2 codex review: ``HTTPError`` holds a file-like response
+    object on ``e.fp``; if the handler returns/retries without an
+    explicit close, the socket leaks until gc cycles it. Pin that
+    ``e.close()`` is called for both 4xx and 5xx paths."""
+    from vllm_mlx.telemetry import transport
+
+    closed_4xx = mock.MagicMock()
+    err_4xx = HTTPError(
+        url="https://x",
+        code=400,
+        msg="bad",
+        hdrs=None,
+        fp=None,  # type: ignore[arg-type]
+    )
+    err_4xx.close = closed_4xx  # type: ignore[method-assign]
+
+    closed_5xx_a = mock.MagicMock()
+    closed_5xx_b = mock.MagicMock()
+    closed_5xx_c = mock.MagicMock()
+    err_5xx_attempts = []
+    for c in (closed_5xx_a, closed_5xx_b, closed_5xx_c):
+        e = HTTPError(
+            url="https://x",
+            code=503,
+            msg="busy",
+            hdrs=None,
+            fp=None,  # type: ignore[arg-type]
+        )
+        e.close = c  # type: ignore[method-assign]
+        err_5xx_attempts.append(e)
+
+    with (
+        mock.patch.object(transport, "urlopen", side_effect=[err_4xx]),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        transport.post_batch([{"x": 1}])
+    closed_4xx.assert_called_once()
+
+    with (
+        mock.patch.object(transport, "urlopen", side_effect=err_5xx_attempts),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        transport.post_batch([{"x": 1}])
+    closed_5xx_a.assert_called_once()
+    closed_5xx_b.assert_called_once()
+    closed_5xx_c.assert_called_once()
+
+
 def test_http_error_5xx_retries():
     from vllm_mlx.telemetry import transport
 

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -342,6 +342,27 @@ def test_non_serializable_payload_returns_false_not_raise():
         urlopen.assert_not_called()
 
 
+def test_retry_constants_define_a_finite_worst_case():
+    """Round 6 codex review: ``cli.py``'s atexit drain budget must be
+    derivable from these constants so a future change to either side
+    cannot regress past the other. Pin the constants exist + sum to a
+    bounded worst case."""
+    from vllm_mlx.telemetry import transport
+
+    assert isinstance(transport.TIMEOUT_S, float)
+    assert isinstance(transport.RETRY_BACKOFFS_S, tuple)
+    # 3 attempts × timeout + sum of backoffs is the worst-case wall
+    # clock for ``post_batch``. cli.py's atexit shutdown adds 0.5s
+    # margin on top of this; if either side changes, the other must
+    # follow.
+    worst_case = 3 * transport.TIMEOUT_S + sum(transport.RETRY_BACKOFFS_S)
+    # Must fit in a reasonable user-perceived exit latency budget.
+    assert worst_case < 20.0, (
+        f"transport worst case {worst_case}s exceeds user-tolerable exit "
+        "latency — keep TIMEOUT_S × 3 + backoffs under 20 s"
+    )
+
+
 def test_user_agent_is_self_identifying():
     """Cloudflare's bot manager rejects the stdlib default
     ``Python-urllib/*`` UA with HTTP 403 before the request reaches the

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract pins for ``vllm_mlx.telemetry.transport``.
+
+The transport must:
+- Refuse a non-HTTPS endpoint.
+- Cap body size below the Worker's own 256 KB limit.
+- Retry transient errors, not 4xx.
+- Treat URLError and TimeoutError as distinct (URLError is NOT a
+  TimeoutError subclass).
+- Never raise — the user must never see a stack trace from telemetry.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY_DEBUG", raising=False)
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY_ENDPOINT", raising=False)
+
+
+def test_empty_batch_is_success_no_network():
+    from vllm_mlx.telemetry import transport
+
+    with mock.patch.object(transport, "urlopen") as urlopen:
+        assert transport.post_batch([]) is True
+        urlopen.assert_not_called()
+
+
+def test_post_batch_returns_true_on_2xx():
+    from vllm_mlx.telemetry import transport
+
+    resp = mock.MagicMock()
+    resp.status = 200
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+
+    with mock.patch.object(transport, "urlopen", return_value=resp) as urlopen:
+        assert transport.post_batch([{"x": 1}]) is True
+        assert urlopen.call_count == 1
+
+
+def test_4xx_is_immediate_drop_no_retry():
+    from vllm_mlx.telemetry import transport
+
+    resp = mock.MagicMock()
+    resp.status = 400
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+
+    with (
+        mock.patch.object(transport, "urlopen", return_value=resp) as urlopen,
+        mock.patch.object(transport.time, "sleep") as sleep,
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+        assert urlopen.call_count == 1  # no retry on schema bug
+        sleep.assert_not_called()
+
+
+def test_5xx_retries_then_gives_up():
+    from vllm_mlx.telemetry import transport
+
+    resp = mock.MagicMock()
+    resp.status = 503
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+
+    with (
+        mock.patch.object(transport, "urlopen", return_value=resp) as urlopen,
+        mock.patch.object(transport.time, "sleep") as sleep,
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+        assert urlopen.call_count == 3  # 1 + 2 retries
+        assert sleep.call_count == 2  # two backoffs between three attempts
+
+
+def test_url_error_treated_as_distinct_from_timeout():
+    """URLError is NOT a TimeoutError subclass; both must be caught.
+
+    Codex round 4 on PR #504 surfaced this exact gotcha — if you catch
+    only TimeoutError, a connection-reset URLError surfaces as an
+    unhandled exception and crashes the foreground.
+    """
+    from vllm_mlx.telemetry import transport
+
+    with (
+        mock.patch.object(
+            transport, "urlopen", side_effect=URLError("connection reset")
+        ),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        # Test passes if no exception escapes.
+        assert transport.post_batch([{"x": 1}]) is False
+
+
+def test_timeout_error_caught():
+    from vllm_mlx.telemetry import transport
+
+    with (
+        mock.patch.object(transport, "urlopen", side_effect=TimeoutError("slow")),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+
+
+def test_os_error_caught():
+    """DNS lookup failures and the like surface as bare OSError on some
+    platforms (notably macOS during airplane-mode toggling); pin that
+    they don't escape."""
+    from vllm_mlx.telemetry import transport
+
+    with (
+        mock.patch.object(
+            transport, "urlopen", side_effect=OSError("name resolution failed")
+        ),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+
+
+def test_http_error_4xx_does_not_retry():
+    from vllm_mlx.telemetry import transport
+
+    exc = HTTPError(
+        url="https://x",
+        code=400,
+        msg="bad",
+        hdrs=None,
+        fp=None,  # type: ignore[arg-type]
+    )
+    with (
+        mock.patch.object(transport, "urlopen", side_effect=exc) as urlopen,
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+        assert urlopen.call_count == 1
+
+
+def test_http_error_5xx_retries():
+    from vllm_mlx.telemetry import transport
+
+    exc = HTTPError(
+        url="https://x",
+        code=503,
+        msg="busy",
+        hdrs=None,
+        fp=None,  # type: ignore[arg-type]
+    )
+    with (
+        mock.patch.object(transport, "urlopen", side_effect=exc) as urlopen,
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+        assert urlopen.call_count == 3
+
+
+def test_oversized_payload_dropped_locally():
+    """Payloads bigger than 200KB get rejected before hitting the network."""
+    from vllm_mlx.telemetry import transport
+
+    # Build a payload that crosses the 200KB threshold but isn't gargantuan.
+    big = {"x": "a" * (transport.MAX_BODY_BYTES + 100)}
+    with mock.patch.object(transport, "urlopen") as urlopen:
+        assert transport.post_batch([big]) is False
+        urlopen.assert_not_called()
+
+
+def test_non_https_endpoint_refused(monkeypatch):
+    from vllm_mlx.telemetry import transport
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "http://insecure.example/v1")
+    with mock.patch.object(transport, "urlopen") as urlopen:
+        assert transport.post_batch([{"x": 1}]) is False
+        urlopen.assert_not_called()
+
+
+def test_endpoint_override_via_env(monkeypatch):
+    from vllm_mlx.telemetry import transport
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "https://debug.example/v1")
+    assert transport.endpoint() == "https://debug.example/v1"
+
+
+def test_debug_env_truthy_off_by_default(monkeypatch):
+    from vllm_mlx.telemetry import transport
+
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY_DEBUG", raising=False)
+    assert transport.debug_enabled() is False
+
+    for falsy in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv("RAPID_MLX_TELEMETRY_DEBUG", falsy)
+        assert transport.debug_enabled() is False
+
+    for truthy in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("RAPID_MLX_TELEMETRY_DEBUG", truthy)
+        assert transport.debug_enabled() is True

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -266,6 +266,25 @@ def test_endpoint_override_only_accepts_localhost(monkeypatch):
         )
 
 
+def test_malformed_url_request_does_not_raise(monkeypatch):
+    """Round 5 codex review: ``Request(url, ...)`` raises ``ValueError``
+    on a malformed URL (control bytes, NULL, etc.). The never-raises
+    contract was leaking that. Pin both the URL with embedded control
+    char path and the empty-scheme path."""
+    from vllm_mlx.telemetry import transport
+
+    # Patch ``endpoint()`` to return a malformed URL that nonetheless
+    # passes the prefix check (so we reach ``Request``).
+    bad_url = "https://example.com/v1/\x00events"  # NULL → ValueError
+    with (
+        mock.patch.object(transport, "endpoint", return_value=bad_url),
+        mock.patch.object(transport, "_is_localhost_override", return_value=False),
+        mock.patch.object(transport.time, "sleep"),
+    ):
+        # Must NOT raise the ValueError out to the caller.
+        assert transport.post_batch([{"x": 1}]) is False
+
+
 def test_malformed_port_localhost_override_does_not_raise(monkeypatch):
     """Round 4 codex review: ``http://localhost:bad/`` passed the
     hostname check, then later ``Request``/``urlopen`` raised a

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -266,6 +266,48 @@ def test_endpoint_override_only_accepts_localhost(monkeypatch):
         )
 
 
+def test_malformed_port_localhost_override_does_not_raise(monkeypatch):
+    """Round 4 codex review: ``http://localhost:bad/`` passed the
+    hostname check, then later ``Request``/``urlopen`` raised a
+    ``ValueError`` outside the URLError/OSError catch — violating the
+    never-raises contract. ``_is_localhost_override`` now forces
+    ``parts.port`` access so the malformed port is rejected here."""
+    from vllm_mlx.telemetry import transport
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "http://localhost:bad/v1")
+    # Falls back to production default (the override is silently dropped).
+    assert transport.endpoint() == transport.DEFAULT_ENDPOINT
+
+
+def test_last_attempt_5xx_log_says_giving_up_not_will_retry():
+    """Round 4 codex review: stale 'will retry' log on the final
+    attempt was misleading. Pin both 5xx-status and 5xx-HTTPError
+    branches log ``giving up`` once retries are exhausted."""
+    from vllm_mlx.telemetry import transport
+
+    captured: list[str] = []
+
+    def fake_log(msg):
+        captured.append(msg)
+
+    resp = mock.MagicMock()
+    resp.status = 503
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+
+    with (
+        mock.patch.object(transport, "urlopen", return_value=resp),
+        mock.patch.object(transport.time, "sleep"),
+        mock.patch.object(transport, "_log", fake_log),
+    ):
+        assert transport.post_batch([{"x": 1}]) is False
+
+    # The final attempt's log must say "giving up", not "will retry".
+    last = captured[-1]
+    assert "giving up" in last, captured
+    assert "will retry" not in last
+
+
 def test_non_serializable_payload_returns_false_not_raise():
     """Round 3 codex review: ``json.dumps`` ran outside the transport
     try, so a non-serializable payload would have raised through the

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -219,19 +219,19 @@ def test_oversized_payload_dropped_locally():
         urlopen.assert_not_called()
 
 
-def test_non_https_non_loopback_override_silently_falls_back_to_default(monkeypatch):
-    """Pre-round-3, an ``http://insecure.example`` override was rejected
-    inside ``post_batch`` ("refusing non-HTTPS endpoint"). After round 3
-    the rejection happens earlier — in ``endpoint()`` — and the override
-    silently falls back to the production HTTPS default. Either way:
-    nothing on plain HTTP, on a non-loopback host, ever sees user
-    events."""
+def test_non_https_non_loopback_override_fails_closed(monkeypatch):
+    """Round 16 codex review: a set-but-rejected
+    ``RAPID_MLX_TELEMETRY_ENDPOINT`` used to silently fall back to the
+    production endpoint, which meant a dev typo (or stale shell rc)
+    could leak opted-in test events into the production R2 bucket
+    without the operator noticing. ``endpoint()`` now returns ``None``
+    when the env var is set but rejected; ``post_batch`` drops the
+    batch on ``None``. Default (env var unset) still resolves to
+    ``DEFAULT_ENDPOINT``."""
     from vllm_mlx.telemetry import transport
 
     monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "http://insecure.example/v1")
-    # The override is silently dropped; ``endpoint()`` returns the
-    # production default.
-    assert transport.endpoint() == transport.DEFAULT_ENDPOINT
+    assert transport.endpoint() is None
 
 
 def test_endpoint_override_only_accepts_localhost(monkeypatch):
@@ -239,7 +239,10 @@ def test_endpoint_override_only_accepts_localhost(monkeypatch):
     let a hostile shell rc / wrapper script redirect opted-in users'
     events to an attacker-controlled collector. The override is now
     restricted to localhost / 127.0.0.1 / ::1 (the only legitimate use
-    cases: wrangler dev + CI fixtures)."""
+    cases: wrangler dev + CI fixtures).
+
+    Round 16: rejected overrides now fail closed (return ``None``)
+    instead of silently falling back to the production endpoint."""
     from vllm_mlx.telemetry import transport
 
     # Localhost variants pass through.
@@ -252,7 +255,7 @@ def test_endpoint_override_only_accepts_localhost(monkeypatch):
         monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", ok)
         assert transport.endpoint() == ok, f"{ok} should be accepted"
 
-    # Anything else falls back to the production default.
+    # Anything else is REJECTED (returns None -- fail closed).
     for bad in (
         "https://attacker.example/v1/events",
         "https://localhost.attacker.example/v1/events",  # suffix attack
@@ -261,9 +264,34 @@ def test_endpoint_override_only_accepts_localhost(monkeypatch):
         "not-a-url",
     ):
         monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", bad)
-        assert transport.endpoint() == transport.DEFAULT_ENDPOINT, (
-            f"{bad} should be refused"
+        assert transport.endpoint() is None, f"{bad} should be refused (fail closed)"
+
+    # Sanity: env var entirely absent still resolves to the production
+    # default -- the fail-closed change is scoped to set-but-rejected.
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY_ENDPOINT", raising=False)
+    assert transport.endpoint() == transport.DEFAULT_ENDPOINT
+
+
+def test_post_batch_fails_closed_on_rejected_override(monkeypatch):
+    """Round 16 codex review pinned: when the override is invalid,
+    ``post_batch`` must drop the batch -- NOT quietly hit production.
+    Pin the full path so a future refactor that drops the ``None``
+    check (or restores the silent fallback) is caught immediately."""
+    from vllm_mlx.telemetry import transport
+
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "https://attacker.example/v1")
+
+    called = []
+
+    def fake_urlopen(req, timeout):  # pragma: no cover -- must not be reached
+        called.append(req)
+        raise AssertionError(
+            "post_batch hit the network even though the override was rejected"
         )
+
+    with mock.patch.object(transport, "urlopen", fake_urlopen):
+        assert transport.post_batch([{"x": 1}]) is False
+    assert called == [], "fail-closed contract violated: a request was sent"
 
 
 def test_malformed_url_request_does_not_raise(monkeypatch):
@@ -288,14 +316,18 @@ def test_malformed_url_request_does_not_raise(monkeypatch):
 def test_malformed_port_localhost_override_does_not_raise(monkeypatch):
     """Round 4 codex review: ``http://localhost:bad/`` passed the
     hostname check, then later ``Request``/``urlopen`` raised a
-    ``ValueError`` outside the URLError/OSError catch — violating the
+    ``ValueError`` outside the URLError/OSError catch -- violating the
     never-raises contract. ``_is_localhost_override`` now forces
-    ``parts.port`` access so the malformed port is rejected here."""
+    ``parts.port`` access so the malformed port is rejected here.
+
+    Round 16 change: rejected overrides now fail closed (return
+    ``None``) instead of silently falling back to the production
+    endpoint. The "never raises" property is still the contract -- the
+    rejection is silent at this layer; ``post_batch`` logs + drops."""
     from vllm_mlx.telemetry import transport
 
     monkeypatch.setenv("RAPID_MLX_TELEMETRY_ENDPOINT", "http://localhost:bad/v1")
-    # Falls back to production default (the override is silently dropped).
-    assert transport.endpoint() == transport.DEFAULT_ENDPOINT
+    assert transport.endpoint() is None
 
 
 def test_last_attempt_5xx_log_says_giving_up_not_will_retry():

--- a/tests/test_telemetry_transport.py
+++ b/tests/test_telemetry_transport.py
@@ -364,17 +364,28 @@ def test_user_agent_is_self_identifying():
     ``Python-urllib/*`` UA with HTTP 403 before the request reaches the
     Worker. The transport must therefore set a non-generic UA — and
     the contract is to identify the package + version explicitly so
-    the receiver can attribute traffic."""
+    the receiver can attribute traffic.
+
+    Round 15 codex review caught the previous ``"rapid-mlx" in ua``
+    assertion was too loose: a versionless ``"rapid-mlx"`` UA would
+    have passed, defeating the "package + version" contract advertised
+    in the docstring. Pin the exact ``rapid-mlx/<version>`` shape."""
+    import re
+
     from vllm_mlx.telemetry import transport
 
     ua = transport._user_agent()
-    assert "rapid-mlx" in ua
+    assert re.search(r"\brapid-mlx/\S+", ua), (
+        f"UA must follow 'rapid-mlx/<version>' shape, got {ua!r}"
+    )
     assert "Python-urllib" not in ua
 
 
 def test_post_sends_self_identifying_user_agent():
     """End-to-end: ``post_batch`` must build a Request whose ``user-agent``
     header is the self-identifying string, not the urllib default."""
+    import re
+
     from vllm_mlx.telemetry import transport
 
     captured: dict = {}
@@ -392,7 +403,11 @@ def test_post_sends_self_identifying_user_agent():
     # urllib lowercases header keys when stored on the Request, but
     # the iteration order varies; use a case-insensitive lookup.
     ua = {k.lower(): v for k, v in captured["headers"].items()}["user-agent"]
-    assert "rapid-mlx" in ua
+    # Round 15: same tighter assertion as ``_user_agent`` — package
+    # AND version, not just the package name.
+    assert re.search(r"\brapid-mlx/\S+", ua), (
+        f"UA must follow 'rapid-mlx/<version>' shape, got {ua!r}"
+    )
     assert "Python-urllib" not in ua
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4382,8 +4382,22 @@ Examples:
                 # lands regardless of atexit ordering quirks. Idempotent
                 # — the queue's own ``shutdown`` will be a no-op when
                 # it runs later.
+                #
+                # Budget matches ``post_batch``'s worst case (round 6
+                # codex catch): 3 attempts × ``TIMEOUT_S`` + cumulative
+                # ``RETRY_BACKOFFS_S``. A 2 s budget would have killed
+                # session_end on a slow collector. The transport gives
+                # up cleanly inside its own loop, so this is a hard
+                # ceiling on user-perceived exit latency — not a
+                # passive wait.
                 try:
-                    _telemetry_emit.get_queue().shutdown(timeout=2.0)
+                    from vllm_mlx.telemetry.transport import (
+                        RETRY_BACKOFFS_S,
+                        TIMEOUT_S,
+                    )
+
+                    _shutdown_budget_s = 3 * TIMEOUT_S + sum(RETRY_BACKOFFS_S) + 0.5
+                    _telemetry_emit.get_queue().shutdown(timeout=_shutdown_budget_s)
                 except Exception:
                     pass
             except Exception:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4336,7 +4336,17 @@ Examples:
     # only exit on Ctrl-C). emit.* helpers are individually guarded by
     # ``is_enabled()`` — when telemetry is off the calls are cheap
     # no-ops, no payload constructed.
-    if getattr(args, "command", None) is not None:
+    #
+    # The ``telemetry`` subcommand itself is excluded: ``telemetry
+    # disable`` / ``reset`` would otherwise queue an event on the way to
+    # turning telemetry OFF — a small but ugly "phone home before
+    # silencing the phone" surprise that codex round 1 caught. ``status``
+    # / ``preview`` / ``enable`` are excluded for consistency; their
+    # observability value is near zero.
+    if (
+        getattr(args, "command", None) is not None
+        and args.command != "telemetry"
+    ):
         import atexit as _atexit
         import sys as _sys
         import time as _time

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4317,6 +4317,12 @@ Examples:
     # disclosure before any model load logs scroll past.
     if getattr(args, "command", None) is not None:
         from vllm_mlx.telemetry import maybe_prompt_for_consent
+        from vllm_mlx.telemetry.state import set_cli_kill_switch
+
+        # ``--no-telemetry`` is a per-run override; thread it into the
+        # process-level kill switch so every emit site sees it without
+        # having to plumb the flag through every signature.
+        set_cli_kill_switch(getattr(args, "no_telemetry", False))
 
         maybe_prompt_for_consent(
             args.command,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4343,10 +4343,7 @@ Examples:
     # silencing the phone" surprise that codex round 1 caught. ``status``
     # / ``preview`` / ``enable`` are excluded for consistency; their
     # observability value is near zero.
-    if (
-        getattr(args, "command", None) is not None
-        and args.command != "telemetry"
-    ):
+    if getattr(args, "command", None) is not None and args.command != "telemetry":
         import atexit as _atexit
         import sys as _sys
         import time as _time

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4350,6 +4350,13 @@ Examples:
     # promises "nothing from before this prompt or from a session you
     # opted out of", and the current invocation's argv was determined
     # BEFORE the user said yes. The next run starts the contract clean.
+    #
+    # ``_session_models_loaded`` is hoisted outside the conditional so
+    # the alias-resolution block below can append to it unconditionally
+    # without a NameError when telemetry was skipped. The closure
+    # passed to ``session_end`` reads the same list, so populate-then-
+    # emit is naturally ordered.
+    _session_models_loaded: list[str] = []
     if (
         getattr(args, "command", None) is not None
         and args.command != "telemetry"
@@ -4363,9 +4370,19 @@ Examples:
 
         _session_subcommand = args.command
         _session_started_at = _time.monotonic()
+        # Round 16 codex review: ``session_end`` used to be called with
+        # only ``subcommand`` + ``duration_seconds`` even though the
+        # design doc + tests describe ``models_loaded`` as "final at
+        # session_end" (for ``serve``, this is the alias that was
+        # resolved + handed to the loader). The closure-captured list
+        # is hoisted above this if-block so the alias-resolution step
+        # below populates it AFTER session_start has already fired --
+        # session_start sees an empty list (nothing loaded yet) and
+        # session_end sees the final state at process exit.
         _telemetry_emit.session_start(
             subcommand=_session_subcommand,
             argv=_sys.argv[1:],
+            models_loaded=_session_models_loaded,
         )
 
         def _emit_session_end() -> None:
@@ -4373,6 +4390,7 @@ Examples:
                 _telemetry_emit.session_end(
                     subcommand=_session_subcommand,
                     duration_seconds=int(_time.monotonic() - _session_started_at),
+                    models_loaded=_session_models_loaded,
                 )
                 # Round 5 codex review caught that the atexit handler
                 # for the queue's ``shutdown`` is registered inside
@@ -4444,6 +4462,13 @@ Examples:
                 args.model, full_path_example="mlx-community/Qwen3.5-9B-4bit"
             )
             sys.exit(1)
+        # Round 16 codex catch: record the resolved (or already-canonical)
+        # model so ``session_end`` can report what this invocation loaded.
+        # ``normalize_model_path`` inside the emit helper redacts local
+        # paths to the literal ``<local>`` token, so we don't need to
+        # filter here. Captured after the error-fail path so we never
+        # record a model that failed validation.
+        _session_models_loaded.append(args.model)
 
     # --- BEGIN B2: auto-pull confirmation gate -------------------------
     # For subcommands that may trigger a first-time download of a large

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4399,12 +4399,16 @@ Examples:
                 try:
                     if _telemetry_emit._queue is not None:
                         _telemetry_emit._queue.shutdown()
-                except Exception:
+                except BaseException:
                     pass
-            except Exception:
+            except BaseException:
                 # atexit handlers are run during interpreter shutdown;
-                # any uncaught exception there is logged but irrelevant
-                # to the user's exit code. Swallow defensively.
+                # anything that fires here — including a stray
+                # ``KeyboardInterrupt`` or ``SystemExit`` raised inside
+                # redaction / queue code mid-teardown — is purely noise
+                # at this point because the process is already exiting.
+                # Round 9 codex review caught the previous ``Exception``
+                # catch as too narrow for an atexit context.
                 return
 
         _atexit.register(_emit_session_end)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4409,6 +4409,18 @@ Examples:
                 # ~12 s on every ``serve`` Ctrl-C just to file a
                 # better stat is hostile UX.
                 #
+                # Round 17 codex review acknowledged a known gap:
+                # ``atexit`` is NOT triggered by SIGTERM (systemd /
+                # Docker / Kubernetes stop signal), so a graceful
+                # service-manager shutdown skips ``session_end``
+                # entirely. The right place to plug this is the FastAPI
+                # ``lifespan`` shutdown hook in ``api/server.py``, which
+                # already coordinates with ``uvicorn``'s own SIGTERM
+                # handler. Adding a top-level ``signal.signal(SIGTERM,
+                # ...)`` here would clobber uvicorn's handler and break
+                # the user-visible "graceful shutdown" UX. Tracked for
+                # Phase 2.2 alongside the request-event wiring.
+                #
                 # ``_queue is None`` (telemetry was disabled, so
                 # ``session_end`` no-op'd and never instantiated the
                 # singleton) skips ``get_queue()`` — round 7 catch —

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4383,21 +4383,22 @@ Examples:
                 # — the queue's own ``shutdown`` will be a no-op when
                 # it runs later.
                 #
-                # Budget matches ``post_batch``'s worst case (round 6
-                # codex catch): 3 attempts × ``TIMEOUT_S`` + cumulative
-                # ``RETRY_BACKOFFS_S``. A 2 s budget would have killed
-                # session_end on a slow collector. The transport gives
-                # up cleanly inside its own loop, so this is a hard
-                # ceiling on user-perceived exit latency — not a
-                # passive wait.
+                # ``session_end`` is best-effort by design (round 7
+                # codex catch): the queue's own ``SHUTDOWN_BUDGET_S``
+                # (2 s) caps user-visible exit latency. A slow or
+                # blackholed collector drops the event — that is the
+                # right trade-off, because making the user wait
+                # ~12 s on every ``serve`` Ctrl-C just to file a
+                # better stat is hostile UX.
+                #
+                # ``_queue is None`` (telemetry was disabled, so
+                # ``session_end`` no-op'd and never instantiated the
+                # singleton) skips ``get_queue()`` — round 7 catch —
+                # otherwise we'd spawn a daemon thread during
+                # interpreter shutdown for nothing.
                 try:
-                    from vllm_mlx.telemetry.transport import (
-                        RETRY_BACKOFFS_S,
-                        TIMEOUT_S,
-                    )
-
-                    _shutdown_budget_s = 3 * TIMEOUT_S + sum(RETRY_BACKOFFS_S) + 0.5
-                    _telemetry_emit.get_queue().shutdown(timeout=_shutdown_budget_s)
+                    if _telemetry_emit._queue is not None:
+                        _telemetry_emit._queue.shutdown()
                 except Exception:
                     pass
             except Exception:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4315,6 +4315,7 @@ Examples:
     # interactive subcommands when stdin is a tty. Safe no-op otherwise.
     # Must run *before* heavy subcommand work so the user sees the
     # disclosure before any model load logs scroll past.
+    _just_collected_consent = False
     if getattr(args, "command", None) is not None:
         from vllm_mlx.telemetry import maybe_prompt_for_consent
         from vllm_mlx.telemetry.state import set_cli_kill_switch
@@ -4324,7 +4325,7 @@ Examples:
         # having to plumb the flag through every signature.
         set_cli_kill_switch(getattr(args, "no_telemetry", False))
 
-        maybe_prompt_for_consent(
+        _just_collected_consent = maybe_prompt_for_consent(
             args.command,
             cli_no_telemetry=getattr(args, "no_telemetry", False),
         )
@@ -4343,7 +4344,17 @@ Examples:
     # silencing the phone" surprise that codex round 1 caught. ``status``
     # / ``preview`` / ``enable`` are excluded for consistency; their
     # observability value is near zero.
-    if getattr(args, "command", None) is not None and args.command != "telemetry":
+    #
+    # ``_just_collected_consent`` skips the run that JUST collected
+    # first-time opt-in (round 3 codex catch): the disclosure copy
+    # promises "nothing from before this prompt or from a session you
+    # opted out of", and the current invocation's argv was determined
+    # BEFORE the user said yes. The next run starts the contract clean.
+    if (
+        getattr(args, "command", None) is not None
+        and args.command != "telemetry"
+        and not _just_collected_consent
+    ):
         import atexit as _atexit
         import sys as _sys
         import time as _time

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4374,6 +4374,18 @@ Examples:
                     subcommand=_session_subcommand,
                     duration_seconds=int(_time.monotonic() - _session_started_at),
                 )
+                # Round 5 codex review caught that the atexit handler
+                # for the queue's ``shutdown`` is registered inside
+                # ``session_start`` (LIFO → runs after this handler),
+                # but relying on that ordering is fragile. Force a
+                # synchronous drain here so ``session_end`` actually
+                # lands regardless of atexit ordering quirks. Idempotent
+                # — the queue's own ``shutdown`` will be a no-op when
+                # it runs later.
+                try:
+                    _telemetry_emit.get_queue().shutdown(timeout=2.0)
+                except Exception:
+                    pass
             except Exception:
                 # atexit handlers are run during interpreter shutdown;
                 # any uncaught exception there is logged but irrelevant

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4323,6 +4323,41 @@ Examples:
             cli_no_telemetry=getattr(args, "no_telemetry", False),
         )
 
+    # Telemetry session lifecycle — emit session_start once we know what
+    # subcommand we're dispatching, register an atexit hook for
+    # session_end so the duration covers the whole interactive run
+    # (including ``rapid-mlx chat`` REPLs and ``serve`` processes that
+    # only exit on Ctrl-C). emit.* helpers are individually guarded by
+    # ``is_enabled()`` — when telemetry is off the calls are cheap
+    # no-ops, no payload constructed.
+    if getattr(args, "command", None) is not None:
+        import atexit as _atexit
+        import sys as _sys
+        import time as _time
+
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _session_subcommand = args.command
+        _session_started_at = _time.monotonic()
+        _telemetry_emit.session_start(
+            subcommand=_session_subcommand,
+            argv=_sys.argv[1:],
+        )
+
+        def _emit_session_end() -> None:
+            try:
+                _telemetry_emit.session_end(
+                    subcommand=_session_subcommand,
+                    duration_seconds=int(_time.monotonic() - _session_started_at),
+                )
+            except Exception:
+                # atexit handlers are run during interpreter shutdown;
+                # any uncaught exception there is logged but irrelevant
+                # to the user's exit code. Swallow defensively.
+                return
+
+        _atexit.register(_emit_session_end)
+
     # Resolve model aliases before dispatch.
     #
     # The doctor subcommand is exempt: it intentionally keeps the alias

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4351,12 +4351,22 @@ Examples:
     # opted out of", and the current invocation's argv was determined
     # BEFORE the user said yes. The next run starts the contract clean.
     #
-    # ``_session_models_loaded`` is hoisted outside the conditional so
+    # ``_session_models_requested`` is hoisted outside the conditional so
     # the alias-resolution block below can append to it unconditionally
     # without a NameError when telemetry was skipped. The closure
     # passed to ``session_end`` reads the same list, so populate-then-
     # emit is naturally ordered.
-    _session_models_loaded: list[str] = []
+    #
+    # Round 19 codex catch on the naming: this list captures models
+    # the user's invocation REQUESTED -- the alias passed argparse
+    # validation -- NOT models the loader confirmed it loaded. A
+    # declined auto-pull or a load failure later in the subcommand
+    # handler still leaves the entry here, which the lifecycle event
+    # surfaces verbatim. Phase 2.2 will replace this with confirmed
+    # load events emitted from ``vllm_mlx/engine/loader.py``; until
+    # then, the field semantics is "alias the session was for" and the
+    # helper docstring spells this out.
+    _session_models_requested: list[str] = []
     if (
         getattr(args, "command", None) is not None
         and args.command != "telemetry"
@@ -4370,27 +4380,37 @@ Examples:
 
         _session_subcommand = args.command
         _session_started_at = _time.monotonic()
-        # Round 16 codex review: ``session_end`` used to be called with
-        # only ``subcommand`` + ``duration_seconds`` even though the
-        # design doc + tests describe ``models_loaded`` as "final at
-        # session_end" (for ``serve``, this is the alias that was
-        # resolved + handed to the loader). The closure-captured list
-        # is hoisted above this if-block so the alias-resolution step
-        # below populates it AFTER session_start has already fired --
-        # session_start sees an empty list (nothing loaded yet) and
-        # session_end sees the final state at process exit.
+        # Round 19 codex catch: extract flag names HERE so raw argv
+        # tokens (which include flag VALUES) never cross into the
+        # telemetry helper signatures. The disclosure promise "values
+        # are never even read" is now literally true at the function-
+        # call boundary.
+        from vllm_mlx.telemetry.redact import (
+            hash_flag_names as _telemetry_extract_flag_names,
+        )
+
+        _session_flag_names = _telemetry_extract_flag_names(_sys.argv[1:])
+        # Round 19 codex NIT: session_start sees an empty IMMUTABLE
+        # snapshot of models_loaded so it does not depend on whether
+        # ``emit.session_start()`` eagerly copies its input. The closure-
+        # captured list keeps mutating until session_end takes its own
+        # snapshot below.
         _telemetry_emit.session_start(
             subcommand=_session_subcommand,
-            argv=_sys.argv[1:],
-            models_loaded=_session_models_loaded,
+            flag_names=_session_flag_names,
+            models_loaded=(),
         )
 
         def _emit_session_end() -> None:
             try:
+                # Snapshot the closure-captured list to an immutable
+                # tuple so the payload reflects the exact state at this
+                # call (round 19 NIT).
+                _models_snapshot = tuple(_session_models_requested)
                 _telemetry_emit.session_end(
                     subcommand=_session_subcommand,
                     duration_seconds=int(_time.monotonic() - _session_started_at),
-                    models_loaded=_session_models_loaded,
+                    models_loaded=_models_snapshot,
                 )
                 # Round 5 codex review caught that the atexit handler
                 # for the queue's ``shutdown`` is registered inside
@@ -4409,17 +4429,14 @@ Examples:
                 # ~12 s on every ``serve`` Ctrl-C just to file a
                 # better stat is hostile UX.
                 #
-                # Round 17 codex review acknowledged a known gap:
-                # ``atexit`` is NOT triggered by SIGTERM (systemd /
-                # Docker / Kubernetes stop signal), so a graceful
-                # service-manager shutdown skips ``session_end``
-                # entirely. The right place to plug this is the FastAPI
-                # ``lifespan`` shutdown hook in ``api/server.py``, which
-                # already coordinates with ``uvicorn``'s own SIGTERM
-                # handler. Adding a top-level ``signal.signal(SIGTERM,
-                # ...)`` here would clobber uvicorn's handler and break
-                # the user-visible "graceful shutdown" UX. Tracked for
-                # Phase 2.2 alongside the request-event wiring.
+                # Round 19 codex review closed the previous round-17
+                # SIGTERM gap: ``register_session_end_hook`` is wired
+                # below so the FastAPI lifespan shutdown in
+                # ``vllm_mlx.server`` calls this same function on
+                # SIGTERM (systemd / Docker / Kubernetes graceful
+                # stop). The latch inside the emit module makes the
+                # second invocation a no-op so the event lands exactly
+                # once regardless of which path fires first.
                 #
                 # ``_queue is None`` (telemetry was disabled, so
                 # ``session_end`` no-op'd and never instantiated the
@@ -4441,7 +4458,12 @@ Examples:
                 # catch as too narrow for an atexit context.
                 return
 
-        _atexit.register(_emit_session_end)
+        # Register the same callable for both teardown paths. The
+        # latch in ``fire_session_end_hook`` ensures it runs once
+        # regardless of which path (FastAPI lifespan shutdown OR cli
+        # atexit fallback) fires first.
+        _telemetry_emit.register_session_end_hook(_emit_session_end)
+        _atexit.register(_telemetry_emit.fire_session_end_hook)
 
     # Resolve model aliases before dispatch.
     #
@@ -4480,7 +4502,7 @@ Examples:
         # paths to the literal ``<local>`` token, so we don't need to
         # filter here. Captured after the error-fail path so we never
         # record a model that failed validation.
-        _session_models_loaded.append(args.model)
+        _session_models_requested.append(args.model)
 
     # --- BEGIN B2: auto-pull confirmation gate -------------------------
     # For subcommands that may trigger a first-time download of a large

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -361,6 +361,23 @@ async def lifespan(app: FastAPI):
         await _engine.stop()
         logger.info("Engine stopped")
 
+    # Round 19 codex review (PR #532): Drive the telemetry session_end
+    # path here too. ``atexit`` does NOT fire on SIGTERM (systemd /
+    # Docker / Kubernetes graceful stop), so an opted-in user running
+    # ``rapid-mlx serve`` under a service manager would otherwise lose
+    # the lifecycle end event. uvicorn drives this lifespan shutdown
+    # on SIGTERM, so the hook lands. The latch inside the telemetry
+    # emit module ensures the event is sent exactly once even if
+    # atexit fires later as well.
+    try:
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.fire_session_end_hook()
+    except Exception:
+        # Telemetry must never crash the shutdown path. Logged at
+        # debug only -- this is best-effort cleanup.
+        logger.debug("telemetry session_end hook failed (non-fatal)")
+
 
 app = FastAPI(
     title="Rapid-MLX API",

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -72,6 +72,11 @@ WHAT WE SEND (only after you say yes):
   - The NAMES (only) of CLI flags you passed, sorted and de-duplicated
     (`--api-key sk-XXX` becomes the literal string "api-key"; the value
     "sk-XXX" is never even read).
+  - The alias your session was for ("mlx-community/Qwen3.5-9B-4bit"
+    or "<local>" if it was an unredacted local path). This is the
+    alias your subcommand was invoked with; if a download was declined
+    or the load failed later, the entry stays -- "what you asked to
+    run", not "what loaded successfully".
   - A UTC timestamp on each event (no timezone, second precision)
   - An anonymous crash fingerprint -- a sha256 hash of the exception
     class plus the frame chain (basename:function:lineno per frame).

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -59,13 +59,23 @@ With your help, we can do three concrete things better:
 
 WHAT WE SEND (only after you say yes):
   • Your chip family + RAM tier — "Apple M3 Ultra, 256 GB", never serial
-  • Which alias you load, decode tokens/sec and latency in coarse buckets
+  • Which subcommand you ran ("serve" / "chat") and its duration
   • Crash fingerprints — file:line:exception_class, no message text
   • A random UUID at {client_id_path}, which you can rotate or wipe
 
+LATER (when per-request instrumentation lands, behind the same gate):
+  • Which alias you load, decode tokens/sec and latency in coarse buckets
+
 WHAT WE NEVER SEND, EVER:
-  • Prompts. Generated text. File paths. API keys. Your IP.
+  • Prompts. Generated text. File paths. API keys.
   • Anything from before this prompt or from a session you opted out of.
+
+ABOUT YOUR IP:
+  Any HTTPS request reveals your IP to the receiver at the network
+  layer — we cannot change that. What we control is what we record.
+  Our Worker never writes your IP to the stored event; it is used
+  only for a transient per-minute rate-limit counter (the counter
+  key is sha256(IP), the raw IP is discarded the same request).
 
 You can see the exact bytes that would leave your machine right now:
   rapid-mlx telemetry preview

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -52,8 +52,8 @@ With your help, we can do three concrete things better:
 
   • Fix the crashes you actually hit, with anonymous error fingerprints
     instead of waiting for someone to file an issue.
-  • Tune performance on the chips people actually use — Apple Silicon,
-    RTX 4090, M3 Ultra — instead of whatever we happen to own.
+  • Tune performance on the Apple Silicon variants people actually run,
+    instead of whatever happens to sit on our desks.
   • Surface the models the community runs most, so onboarding effort
     goes where it matters.
 

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -71,11 +71,11 @@ WHAT WE SEND (only after you say yes):
   - Which subcommand you ran ("serve" / "chat") and its duration
   - The NAMES (only) of CLI flags you passed, sorted and de-duplicated
     (`--api-key sk-XXX` becomes the literal string "api-key"; the value
-    "sk-XXX" is never even read). Round 16 codex review added this line
-    because hashed flag names DO leak the shape of your invocation
-    (e.g. "you set --tls-cert"), and the opt-in promise needs to cover it.
+    "sk-XXX" is never even read).
   - A UTC timestamp on each event (no timezone, second precision)
-  - Crash fingerprints -- file:line:exception_class, no message text
+  - An anonymous crash fingerprint -- a sha256 hash of the exception
+    class plus the frame chain (basename:function:lineno per frame).
+    No exception message, no full file paths, no raw traceback fields.
   - A random UUID at {client_id_path}, which you can rotate or wipe
   - A per-process random UUID (a session id) so we can group your
     session_start + session_end without correlating across runs

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -24,6 +24,7 @@ import sys
 from vllm_mlx import __version__ as _rapid_mlx_version  # noqa: N811
 from vllm_mlx.telemetry.state import (
     ENV_VAR,
+    client_id_path,
     consent_path,
     get_consent_state,
     record_consent,
@@ -45,18 +46,34 @@ _NON_INTERACTIVE_SUBCOMMANDS = frozenset(
 )
 
 _DISCLOSURE = """\
-Rapid-MLX can send anonymous usage data so we can prioritise the right
-models and catch regressions across the user base.
+Rapid-MLX is open source and built on what its users report. We do not
+ship analytics SDKs, third-party trackers, or ads — and we never will.
+With your help, we can do three concrete things better:
 
-We collect (only if you say yes): subcommand names, model alias names,
-bucketed token/latency counts, error categories, OS + chip + RAM.
+  • Fix the crashes you actually hit, with anonymous error fingerprints
+    instead of waiting for someone to file an issue.
+  • Tune performance on the chips people actually use — Apple Silicon,
+    RTX 4090, M3 Ultra — instead of whatever we happen to own.
+  • Surface the models the community runs most, so onboarding effort
+    goes where it matters.
 
-We never collect: prompts, completions, file paths, IPs, env-var values,
-or any user-generated text. Source: vllm_mlx/telemetry/.
+WHAT WE SEND (only after you say yes):
+  • Your chip family + RAM tier — "Apple M3 Ultra, 256 GB", never serial
+  • Which alias you load, decode tokens/sec and latency in coarse buckets
+  • Crash fingerprints — file:line:exception_class, no message text
+  • A random UUID at {client_id_path}, which you can rotate or wipe
 
-Type 'y' to opt in, anything else to decline. You can change this anytime
-with `rapid-mlx telemetry {{enable,disable,reset}}`. To force-disable in
-scripts: set {env}=0.
+WHAT WE NEVER SEND, EVER:
+  • Prompts. Generated text. File paths. API keys. Your IP.
+  • Anything from before this prompt or from a session you opted out of.
+
+You can see the exact bytes that would leave your machine right now:
+  rapid-mlx telemetry preview
+
+You can pause, resume, or reset your identity anytime:
+  rapid-mlx telemetry {{status,disable,enable,reset}}
+
+To force-disable in scripts or CI: set {env}=0.
 """
 
 
@@ -90,8 +107,18 @@ def maybe_prompt_for_consent(
 
         version = _rapid_mlx_version
         print()
-        print(_DISCLOSURE.format(env=ENV_VAR))
-        print("  [opt-in to anonymous telemetry?  y/N]  ", end="", flush=True)
+        print(
+            _DISCLOSURE.format(
+                env=ENV_VAR,
+                client_id_path=client_id_path(),
+            )
+        )
+        print(
+            "Contribute anonymous telemetry to make rapid-mlx better "
+            "for everyone? [y/N]  ",
+            end="",
+            flush=True,
+        )
         try:
             answer = input().strip().lower()
         except (EOFError, KeyboardInterrupt):
@@ -103,16 +130,23 @@ def maybe_prompt_for_consent(
         consent = answer in ("y", "yes")
         record_consent(consent, rapid_mlx_version=version)
         if consent:
+            print()
             print(
-                "Thanks — telemetry enabled. Disable anytime with "
-                "`rapid-mlx telemetry disable`."
+                "Thank you for contributing. "
+                "rapid-mlx will get measurably better because you said yes."
+            )
+            print(
+                "Audit anytime: `rapid-mlx telemetry status` / `... preview`. "
+                "Stop anytime: `rapid-mlx telemetry disable`."
             )
         else:
+            print()
             print(
-                "Got it — telemetry stays off. Enable later with "
-                f"`rapid-mlx telemetry enable` (or delete {consent_path()} "
-                "to be re-prompted)."
+                "Got it — telemetry stays off and we will not ask again. "
+                "You can always opt in later with "
+                "`rapid-mlx telemetry enable`,"
             )
+            print(f"or delete {consent_path()} to be re-prompted.")
         print()
     except (OSError, EOFError, KeyboardInterrupt):
         # Telemetry consent is *never* a reason for the CLI to fail —

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -109,6 +109,16 @@ def maybe_prompt_for_consent(
     not crash the user's serve / chat invocation just because we
     couldn't ask about telemetry.
     """
+    # ``just_collected`` is owned at function scope (round 14 codex
+    # review fix): the previous structure flipped this back to False
+    # whenever a post-``record_consent`` ``print()`` raised ``OSError``
+    # (e.g. SIGPIPE from a pipe closed by the parent shell), so the
+    # CLI dropped ``_just_collected_consent`` and emitted same-run
+    # lifecycle telemetry — violating the "nothing from before this
+    # prompt" promise. Owning the flag at the outermost scope means
+    # the final ``return`` honours whatever was already persisted, even
+    # if the thank-you / opt-out chatter blew up.
+    just_collected = False
     try:
         if cli_no_telemetry:
             return False
@@ -152,6 +162,10 @@ def maybe_prompt_for_consent(
             return False
         consent = answer in ("y", "yes")
         record_consent(consent, rapid_mlx_version=version)
+        # From here on, consent IS persisted to disk. The flag must
+        # survive any subsequent print failure so the CLI knows not to
+        # emit lifecycle telemetry for the argv that ran before the
+        # prompt.
         just_collected = True
         if consent:
             print()
@@ -179,4 +193,8 @@ def maybe_prompt_for_consent(
         # an unwritable home, terminal weirdness, or user Ctrl-C during
         # input. Programming errors (AttributeError, TypeError, ...)
         # propagate so they get noticed in development.
-        return False
+        #
+        # Return ``just_collected`` (not ``False``) so a post-record
+        # OSError still reports "yes, we just collected consent" — the
+        # round 14 codex blocker.
+        return just_collected

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -89,31 +89,39 @@ To force-disable in scripts or CI: set {env}=0.
 
 def maybe_prompt_for_consent(
     subcommand: str | None, *, cli_no_telemetry: bool = False
-) -> None:
+) -> bool:
     """Show the first-run prompt if (and only if) all guards pass.
 
-    Returns silently when any guard skips. Never raises — a broken stdin
-    or unwritable home directory must not crash the user's serve / chat
-    invocation just because we couldn't ask about telemetry.
+    Returns ``True`` IFF the prompt was actually shown AND the user
+    just answered for the first time (regardless of yes/no). Returns
+    ``False`` for every skip path. The caller uses this to suppress
+    lifecycle emit on the same invocation that just collected consent
+    — round 3 codex review caught that emitting ``session_start`` for
+    the argv that ran BEFORE the prompt contradicts the disclosure's
+    "nothing from before this prompt" promise.
+
+    Never raises — a broken stdin or unwritable home directory must
+    not crash the user's serve / chat invocation just because we
+    couldn't ask about telemetry.
     """
     try:
         if cli_no_telemetry:
-            return
+            return False
         # Env var already decides — no need to prompt.
         import os
 
         if os.environ.get(ENV_VAR) is not None:
-            return
+            return False
         if subcommand in _NON_INTERACTIVE_SUBCOMMANDS:
-            return
+            return False
         if subcommand is None:
-            return
+            return False
         if get_consent_state() is not None:
-            return
+            return False
         if not sys.stdin.isatty():
-            return
+            return False
         if not sys.stdout.isatty():
-            return
+            return False
 
         version = _rapid_mlx_version
         print()
@@ -136,9 +144,10 @@ def maybe_prompt_for_consent(
             # be re-prompted next interactive run, since they didn't
             # actually answer.
             print()
-            return
+            return False
         consent = answer in ("y", "yes")
         record_consent(consent, rapid_mlx_version=version)
+        just_collected = True
         if consent:
             print()
             print(
@@ -158,10 +167,11 @@ def maybe_prompt_for_consent(
             )
             print(f"or delete {consent_path()} to be re-prompted.")
         print()
+        return just_collected
     except (OSError, EOFError, KeyboardInterrupt):
         # Telemetry consent is *never* a reason for the CLI to fail —
         # but only swallow the failure modes we actually expect: I/O on
         # an unwritable home, terminal weirdness, or user Ctrl-C during
         # input. Programming errors (AttributeError, TypeError, ...)
         # propagate so they get noticed in development.
-        return
+        return False

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -45,39 +45,51 @@ _NON_INTERACTIVE_SUBCOMMANDS = frozenset(
     }
 )
 
+# Round 16 codex review: keep this string ASCII-only. Curly punctuation
+# and bullet glyphs raise ``UnicodeEncodeError`` on a terminal with an
+# ASCII-only stdout encoding (some CI runners, ``LC_ALL=C`` envs), and
+# the outer ``except (OSError, EOFError, KeyboardInterrupt)`` does NOT
+# catch ``UnicodeEncodeError`` — so the prompt blew up the user's
+# command. The outer except now also catches ``UnicodeError`` as a
+# belt-and-braces second guard.
 _DISCLOSURE = """\
 Rapid-MLX is open source and built on what its users report. We do not
-ship analytics SDKs, third-party trackers, or ads — and we never will.
+ship analytics SDKs, third-party trackers, or ads -- and we never will.
 With your help, we can do three concrete things better:
 
-  • Fix the crashes you actually hit, with anonymous error fingerprints
+  - Fix the crashes you actually hit, with anonymous error fingerprints
     instead of waiting for someone to file an issue.
-  • Tune performance on the Apple Silicon variants people actually run,
+  - Tune performance on the Apple Silicon variants people actually run,
     instead of whatever happens to sit on our desks.
-  • Surface the models the community runs most, so onboarding effort
+  - Surface the models the community runs most, so onboarding effort
     goes where it matters.
 
 WHAT WE SEND (only after you say yes):
-  • Your chip family + RAM tier — "Apple M3 Ultra, 256 GB", never serial
-  • OS family + major.minor version ("darwin 25.3"), arch ("arm64"),
+  - Your chip family + RAM tier -- "Apple M3 Ultra, 256 GB", never serial
+  - OS family + major.minor version ("darwin 25.3"), arch ("arm64"),
     Python major.minor ("3.12"), Rapid-MLX version ("0.6.79")
-  • Which subcommand you ran ("serve" / "chat") and its duration
-  • A UTC timestamp on each event (no timezone, second precision)
-  • Crash fingerprints — file:line:exception_class, no message text
-  • A random UUID at {client_id_path}, which you can rotate or wipe
-  • A per-process random UUID (a session id) so we can group your
+  - Which subcommand you ran ("serve" / "chat") and its duration
+  - The NAMES (only) of CLI flags you passed, sorted and de-duplicated
+    (`--api-key sk-XXX` becomes the literal string "api-key"; the value
+    "sk-XXX" is never even read). Round 16 codex review added this line
+    because hashed flag names DO leak the shape of your invocation
+    (e.g. "you set --tls-cert"), and the opt-in promise needs to cover it.
+  - A UTC timestamp on each event (no timezone, second precision)
+  - Crash fingerprints -- file:line:exception_class, no message text
+  - A random UUID at {client_id_path}, which you can rotate or wipe
+  - A per-process random UUID (a session id) so we can group your
     session_start + session_end without correlating across runs
 
 LATER (when per-request instrumentation lands, behind the same gate):
-  • Which alias you load, decode tokens/sec and latency in coarse buckets
+  - Which alias you load, decode tokens/sec and latency in coarse buckets
 
 WHAT WE NEVER SEND, EVER:
-  • Prompts. Generated text. File paths. API keys.
-  • Anything from before this prompt or from a session you opted out of.
+  - Prompts. Generated text. File paths. API keys. Flag VALUES.
+  - Anything from before this prompt or from a session you opted out of.
 
 ABOUT YOUR IP:
   Any HTTPS request reveals your IP to the receiver at the network
-  layer — we cannot change that. What we control is what we record.
+  layer -- we cannot change that. What we control is what we record.
   Our Worker never writes your IP to the stored event; it is used
   only for a transient per-minute rate-limit counter (the counter
   key is sha256(IP), the raw IP is discarded the same request).
@@ -180,21 +192,23 @@ def maybe_prompt_for_consent(
         else:
             print()
             print(
-                "Got it — telemetry stays off and we will not ask again. "
+                "Got it -- telemetry stays off and we will not ask again. "
                 "You can always opt in later with "
                 "`rapid-mlx telemetry enable`,"
             )
             print(f"or delete {consent_path()} to be re-prompted.")
         print()
         return just_collected
-    except (OSError, EOFError, KeyboardInterrupt):
-        # Telemetry consent is *never* a reason for the CLI to fail —
+    except (OSError, EOFError, KeyboardInterrupt, UnicodeError):
+        # Telemetry consent is *never* a reason for the CLI to fail --
         # but only swallow the failure modes we actually expect: I/O on
-        # an unwritable home, terminal weirdness, or user Ctrl-C during
-        # input. Programming errors (AttributeError, TypeError, ...)
-        # propagate so they get noticed in development.
+        # an unwritable home, terminal weirdness, user Ctrl-C during
+        # input, or (round 16 codex catch) a stdout encoding that
+        # cannot represent every byte of the disclosure.
+        # Programming errors (AttributeError, TypeError, ...) propagate
+        # so they get noticed in development.
         #
         # Return ``just_collected`` (not ``False``) so a post-record
-        # OSError still reports "yes, we just collected consent" — the
+        # OSError still reports "yes, we just collected consent" -- the
         # round 14 codex blocker.
         return just_collected

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -59,9 +59,14 @@ With your help, we can do three concrete things better:
 
 WHAT WE SEND (only after you say yes):
   • Your chip family + RAM tier — "Apple M3 Ultra, 256 GB", never serial
+  • OS family + major.minor version ("darwin 25.3"), arch ("arm64"),
+    Python major.minor ("3.12"), Rapid-MLX version ("0.6.79")
   • Which subcommand you ran ("serve" / "chat") and its duration
+  • A UTC timestamp on each event (no timezone, second precision)
   • Crash fingerprints — file:line:exception_class, no message text
   • A random UUID at {client_id_path}, which you can rotate or wipe
+  • A per-process random UUID (a session id) so we can group your
+    session_start + session_end without correlating across runs
 
 LATER (when per-request instrumentation lands, behind the same gate):
   • Which alias you load, decode tokens/sec and latency in coarse buckets

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -200,9 +200,17 @@ def session_start(
     if not is_enabled():
         return
     payload = _envelope("session_start")
+    # Round 8 codex review: the runtime payload must include every key
+    # the schema-v1 ``SessionPayload`` dataclass advertises, even
+    # default-valued ones, so external consumers parsing v1 envelopes
+    # can rely on the keys being present. ``duration_seconds`` is
+    # ``None`` on session_start (defined for session_end only). The
+    # ``engine`` slot stays for v1 back-compat with no runtime value.
     payload["session"] = {
         "subcommand": subcommand,
+        "duration_seconds": None,
         "flag_names": hash_flag_names(argv) if argv is not None else [],
+        "engine": "",
         # Slice before normalize (round 7 codex catch): if a caller
         # ever hands us 1000 paths, redacting all of them just to
         # throw 968 away wastes work for no extra privacy.
@@ -227,10 +235,14 @@ def session_end(
     if not is_enabled():
         return
     payload = _envelope("session_end")
+    # Same schema-completeness rationale as ``session_start`` above.
+    # ``engine`` slot for v1 back-compat, ``flag_names`` empty for
+    # session_end (argv parsing happened at session_start).
     payload["session"] = {
         "subcommand": subcommand,
         "duration_seconds": int(max(0, duration_seconds)),
         "flag_names": [],
+        "engine": "",
         "models_loaded": [normalize_model_path(m) for m in tuple(models_loaded)[:32]],
     }
     get_queue().enqueue(payload)

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -284,6 +284,42 @@ def request(
     get_queue().enqueue(payload)
 
 
+# Round 3 codex review: ``category`` + ``phase`` on ``error()`` were
+# stored verbatim, the same free-form escape hatch the signature
+# red-line test cannot catch (type is ``str``). A future caller
+# threading exception text or user input would have leaked. The
+# allowlists below are intentionally short — every NEW value requires
+# editing this file, which puts a privacy review on the path.
+_ALLOWED_ERROR_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "model_load_failure",
+        "parser_failure",
+        "scheduler_failure",
+        "request_failure",
+        "lifespan_failure",
+        "tool_call_failure",
+    }
+)
+_ALLOWED_ERROR_PHASES: frozenset[str] = frozenset(
+    {
+        "startup",
+        "warmup",
+        "prefill",
+        "decode",
+        "stream",
+        "shutdown",
+        "chat",
+        "serve",
+    }
+)
+
+
+def _normalize_error_field(raw: str, allowed: frozenset[str]) -> str:
+    if not isinstance(raw, str):
+        return "other"
+    return raw if raw in allowed else "other"
+
+
 @_safe
 def error(
     *,
@@ -296,13 +332,17 @@ def error(
     ``exc`` is fingerprinted with ``fingerprint_traceback`` — only
     ``basename:func:lineno`` of each frame plus the exception class
     name participate. No message text, no module path.
+
+    ``category`` and ``phase`` are constrained to a small allowlist
+    (see ``_ALLOWED_ERROR_CATEGORIES`` / ``_ALLOWED_ERROR_PHASES``);
+    anything else collapses to ``"other"``.
     """
     if not is_enabled():
         return
     payload = _envelope("error")
     payload["error"] = {
-        "category": category,
+        "category": _normalize_error_field(category, _ALLOWED_ERROR_CATEGORIES),
         "fingerprint": fingerprint_traceback(exc),
-        "phase": phase,
+        "phase": _normalize_error_field(phase, _ALLOWED_ERROR_PHASES),
     }
     get_queue().enqueue(payload)

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -203,7 +203,10 @@ def session_start(
     payload["session"] = {
         "subcommand": subcommand,
         "flag_names": hash_flag_names(argv) if argv is not None else [],
-        "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
+        # Slice before normalize (round 7 codex catch): if a caller
+        # ever hands us 1000 paths, redacting all of them just to
+        # throw 968 away wastes work for no extra privacy.
+        "models_loaded": [normalize_model_path(m) for m in tuple(models_loaded)[:32]],
     }
     get_queue().enqueue(payload)
 
@@ -228,7 +231,7 @@ def session_end(
         "subcommand": subcommand,
         "duration_seconds": int(max(0, duration_seconds)),
         "flag_names": [],
-        "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
+        "models_loaded": [normalize_model_path(m) for m in tuple(models_loaded)[:32]],
     }
     get_queue().enqueue(payload)
 

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -296,6 +296,12 @@ def request(
 # threading exception text or user input would have leaked. The
 # allowlists below are intentionally short — every NEW value requires
 # editing this file, which puts a privacy review on the path.
+# Aligned with the design doc's "WHEN" column in
+# ``docs/plans/telemetry-golden-profile.md`` — every Phase 2.2 call
+# site has a slot here. Round 5 codex review caught that ``oom`` was
+# missing, which would have made the planned scheduler.py MemoryError
+# handler silently collapse its category to ``"other"`` and lose the
+# triage signal.
 _ALLOWED_ERROR_CATEGORIES: frozenset[str] = frozenset(
     {
         "model_load_failure",
@@ -304,6 +310,9 @@ _ALLOWED_ERROR_CATEGORIES: frozenset[str] = frozenset(
         "request_failure",
         "lifespan_failure",
         "tool_call_failure",
+        "tool_parse",
+        "oom",
+        "shutdown_traceback",
     }
 )
 _ALLOWED_ERROR_PHASES: frozenset[str] = frozenset(
@@ -316,6 +325,7 @@ _ALLOWED_ERROR_PHASES: frozenset[str] = frozenset(
         "shutdown",
         "chat",
         "serve",
+        "request",
     }
 )
 

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -74,14 +74,25 @@ def session_id() -> str:
     process-scoped (not persisted) — the on-disk client_id is the only
     stable identity. Reset by ``_reset_for_tests`` so each test gets a
     fresh id.
+
+    Round 6 codex review caught that the prior lazy init was unlocked,
+    so two concurrent emit sites racing past the ``is None`` check
+    would generate different uuids in the same process and the
+    aggregation pipeline would see two sessions per real session. The
+    queue's ``_queue_lock`` is the same one that guards singleton
+    creation; reuse it so we don't introduce a second lock for the
+    same "first-call-init" pattern.
     """
     global _session_id
-    if _session_id is None:
-        # uuid4 imported lazily so importing emit at module-scan time
-        # does not touch /dev/urandom in CI fast-paths.
-        import uuid
+    if _session_id is not None:
+        return _session_id
+    with _queue_lock:
+        if _session_id is None:
+            # uuid4 imported lazily so importing emit at module-scan time
+            # does not touch /dev/urandom in CI fast-paths.
+            import uuid
 
-        _session_id = str(uuid.uuid4())
+            _session_id = str(uuid.uuid4())
     return _session_id
 
 

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -50,6 +50,42 @@ _queue: TelemetryQueue | None = None
 _session_id: str | None = None
 
 
+# Allowlist of subcommands ``session_start``/``session_end`` accept.
+# Round 11 codex review caught that ``subcommand`` was the last
+# free-form ``str`` slot on the privacy-boundary helpers, the same
+# shape of escape hatch closed for ``endpoint`` / ``category`` /
+# ``phase``. The set matches the subcommands wired into ``cli.py``;
+# anything off-list (including a future internal subcommand) collapses
+# to ``"other"``.
+_ALLOWED_SUBCOMMANDS: frozenset[str] = frozenset(
+    {
+        "serve",
+        "chat",
+        "agents",
+        "bench",
+        "doctor",
+        "models",
+        "info",
+        "ps",
+        "pull",
+        "rm",
+        "upgrade",
+        "share",
+        "version",
+        # ``telemetry`` is excluded from lifecycle emit in cli.py, but
+        # external callers using these helpers directly can still pass
+        # it — keep it on-list so it doesn't get redacted needlessly.
+        "telemetry",
+    }
+)
+
+
+def _normalize_subcommand(raw: str) -> str:
+    if not isinstance(raw, str):
+        return "other"
+    return raw if raw in _ALLOWED_SUBCOMMANDS else "other"
+
+
 def get_queue() -> TelemetryQueue:
     """Return the process-singleton queue, constructing it on first use.
 
@@ -207,7 +243,7 @@ def session_start(
     # ``None`` on session_start (defined for session_end only). The
     # ``engine`` slot stays for v1 back-compat with no runtime value.
     payload["session"] = {
-        "subcommand": subcommand,
+        "subcommand": _normalize_subcommand(subcommand),
         "duration_seconds": None,
         "flag_names": hash_flag_names(argv) if argv is not None else [],
         "engine": "",
@@ -239,7 +275,7 @@ def session_end(
     # ``engine`` slot for v1 back-compat, ``flag_names`` empty for
     # session_end (argv parsing happened at session_start).
     payload["session"] = {
-        "subcommand": subcommand,
+        "subcommand": _normalize_subcommand(subcommand),
         "duration_seconds": int(max(0, duration_seconds)),
         "flag_names": [],
         "engine": "",

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -168,7 +168,6 @@ def session_start(
     *,
     subcommand: str,
     argv: list[str] | None = None,
-    engine: str = "",
     models_loaded: list[str] | tuple[str, ...] = (),
 ) -> None:
     """Emit a ``session_start`` payload.
@@ -176,13 +175,22 @@ def session_start(
     Called by ``cli.py`` after argparse, before subcommand dispatch.
     ``argv`` carries the raw command-line tokens for flag-name
     redaction; values are never read.
+
+    Round 4 codex review removed the ``engine`` parameter. It was
+    declared with a default of ``""`` and never threaded through from
+    any call site, leaving a free-form ``str`` slot in the payload
+    that the signature red-line test couldn't catch — the same shape
+    of escape hatch closed in earlier rounds for ``endpoint`` /
+    ``category`` / ``phase``. There is effectively one engine today
+    (``BatchedEngine``) since PR #156 deleted ``SimpleEngine``, so
+    the field carried no information either. Re-add as an enum if a
+    second engine ever lands.
     """
     if not is_enabled():
         return
     payload = _envelope("session_start")
     payload["session"] = {
         "subcommand": subcommand,
-        "engine": engine,
         "flag_names": hash_flag_names(argv) if argv is not None else [],
         "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
     }
@@ -194,7 +202,6 @@ def session_end(
     *,
     subcommand: str,
     duration_seconds: int,
-    engine: str = "",
     models_loaded: list[str] | tuple[str, ...] = (),
 ) -> None:
     """Emit a ``session_end`` payload.
@@ -209,7 +216,6 @@ def session_end(
     payload["session"] = {
         "subcommand": subcommand,
         "duration_seconds": int(max(0, duration_seconds)),
-        "engine": engine,
         "flag_names": [],
         "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
     }

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -39,7 +39,6 @@ from vllm_mlx.telemetry.redact import (
     bucket_tps,
     bucket_ttft_ms,
     fingerprint_traceback,
-    hash_flag_names,
     normalize_model_path,
     platform_info,
 )
@@ -51,6 +50,48 @@ from vllm_mlx.telemetry.state import get_or_create_client_id, is_enabled
 _queue_lock = threading.Lock()
 _queue: TelemetryQueue | None = None
 _session_id: str | None = None
+
+# Round 19 codex review: ``atexit`` is NOT triggered by SIGTERM, so a
+# ``serve`` invocation under systemd / Docker / Kubernetes loses the
+# ``session_end`` event on a graceful service-manager shutdown. The
+# fix is to wire ``session_end`` through the FastAPI ``lifespan``
+# shutdown path (which uvicorn DOES drive on SIGTERM) in addition to
+# the existing ``atexit`` fallback. Both paths call the same hook;
+# the latch turns the second call into a no-op so the event lands
+# exactly once.
+_session_end_hook_lock = threading.Lock()
+_session_end_hook: Any | None = None  # callable: () -> None
+_session_end_hook_fired = False
+
+
+def register_session_end_hook(hook: Any) -> None:
+    """Register a callable that emits ``session_end`` + drains the
+    queue. ``cli.py`` registers its ``_emit_session_end`` here; the
+    FastAPI lifespan shutdown in ``server.py`` and the cli atexit
+    fallback both call ``fire_session_end_hook()`` to invoke it.
+    Idempotent at the latch -- only the first call runs the hook."""
+    global _session_end_hook, _session_end_hook_fired
+    with _session_end_hook_lock:
+        _session_end_hook = hook
+        _session_end_hook_fired = False
+
+
+def fire_session_end_hook() -> None:
+    """Run the registered session_end hook once. Subsequent calls are
+    no-ops. Catches all exceptions -- a teardown bug must not surface
+    a stack trace to the user mid-shutdown."""
+    global _session_end_hook_fired
+    with _session_end_hook_lock:
+        if _session_end_hook_fired or _session_end_hook is None:
+            return
+        hook = _session_end_hook
+        _session_end_hook_fired = True
+    try:
+        hook()
+    except BaseException:
+        # We are running inside a shutdown path -- atexit, lifespan,
+        # signal teardown. Anything raised here is purely noise.
+        pass
 
 
 # Allowlist of subcommands ``session_start``/``session_end`` accept.
@@ -141,11 +182,16 @@ def _reset_for_tests() -> None:
     Not part of the public API — tests-only seam. The queue's shutdown
     is best-effort; we do not block on the join.
     """
-    global _queue, _session_id
+    global _queue, _session_id, _session_end_hook, _session_end_hook_fired
     with _queue_lock:
         q = _queue
         _queue = None
         _session_id = None
+    # Round 19: reset the lifespan hook latch + registration too so
+    # tests that exercise ``fire_session_end_hook`` start clean.
+    with _session_end_hook_lock:
+        _session_end_hook = None
+        _session_end_hook_fired = False
     if q is not None:
         q.shutdown(timeout=0.1)
 
@@ -233,24 +279,40 @@ def _safe(fn: Any) -> Any:
 def session_start(
     *,
     subcommand: str,
-    argv: list[str] | None = None,
+    flag_names: Iterable[str] = (),
     models_loaded: Iterable[str] = (),
 ) -> None:
     """Emit a ``session_start`` payload.
 
     Called by ``cli.py`` after argparse, before subcommand dispatch.
-    ``argv`` carries the raw command-line tokens for flag-name
-    redaction; values are never read.
+
+    Round 19 codex review: previously this accepted raw ``argv`` and
+    extracted flag names internally via ``hash_flag_names``. That
+    technically meant flag VALUES (the raw argv tokens) crossed into
+    telemetry code -- even though the redaction primitive skipped
+    them, the disclosure's "never even read" promise was vulnerable.
+    Now ``cli.py`` extracts flag names locally and passes the already-
+    redacted list across. The disclosure promise is now literally
+    true at the function-signature boundary: no telemetry helper ever
+    receives a flag value.
 
     Round 4 codex review removed the ``engine`` parameter. It was
     declared with a default of ``""`` and never threaded through from
     any call site, leaving a free-form ``str`` slot in the payload
-    that the signature red-line test couldn't catch — the same shape
+    that the signature red-line test couldn't catch -- the same shape
     of escape hatch closed in earlier rounds for ``endpoint`` /
     ``category`` / ``phase``. There is effectively one engine today
     (``BatchedEngine``) since PR #156 deleted ``SimpleEngine``, so
     the field carried no information either. Re-add as an enum if a
     second engine ever lands.
+
+    Field semantics -- ``models_loaded``: the alias(es) the session
+    INTERACTED WITH. For Phase 2 this is the resolved alias passed
+    to the subcommand dispatch (i.e. "the model your session was
+    for"); a declined auto-pull or downstream load failure does not
+    retroactively scrub the entry. Phase 2.2 will replace this with
+    confirmed load events emitted from the loader. The disclosure
+    copy in ``consent.py`` already describes the field this way.
     """
     if not is_enabled():
         return
@@ -264,14 +326,15 @@ def session_start(
     payload["session"] = {
         "subcommand": _normalize_subcommand(subcommand),
         "duration_seconds": None,
-        "flag_names": hash_flag_names(argv) if argv is not None else [],
+        # Already-extracted names, sorted + de-duped at the boundary.
+        "flag_names": sorted({n for n in flag_names if isinstance(n, str)}),
         "engine": "",
         # Slice before normalize (round 7 codex catch): if a caller
         # ever hands us 1000 paths, redacting all of them just to
         # throw 968 away wastes work for no extra privacy.
         # Round 13 codex review: ``tuple(models_loaded)[:32]`` would
         # still materialize the entire input before capping. Use
-        # ``itertools.islice`` so the slice itself is the cap — callers
+        # ``itertools.islice`` so the slice itself is the cap -- callers
         # that hand us a 1000-entry iterable only pay for the first 32.
         "models_loaded": [
             normalize_model_path(m) for m in itertools.islice(models_loaded, 32)

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Event constructor helpers — the only API call sites should use.
+
+Phase 2 instrumentation calls ``emit.session_start(...)``, etc. These
+helpers own the four things every call site needs to get right:
+
+1. **Consent gate.** Every emit calls ``is_enabled()`` first. If the
+   user has not opted in, the helper returns immediately and constructs
+   no payload at all (so a future field addition cannot leak by mistake
+   from a path that was supposed to be dark).
+
+2. **Redaction.** Every user-provided string is funnelled through the
+   primitives in ``redact.py``. Sites must not construct payloads by
+   hand — they must call these helpers.
+
+3. **Process-singleton queue.** Sites do not pass the queue around.
+   They call ``get_queue()`` which lazily constructs + starts one. Tests
+   reset via ``_reset_for_tests()``.
+
+4. **Failure suppression.** Every helper wraps the body in a broad
+   except so a telemetry bug cannot ever crash a user command. The
+   only exception we let surface is ``KeyboardInterrupt`` (user
+   intent) and ``SystemExit`` (programmatic intent).
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+from vllm_mlx import __version__ as _rapid_mlx_version  # noqa: N811
+from vllm_mlx.telemetry.queue import TelemetryQueue
+from vllm_mlx.telemetry.redact import (
+    bucket_tokens,
+    bucket_tps,
+    bucket_ttft_ms,
+    fingerprint_traceback,
+    hash_flag_names,
+    normalize_model_path,
+    platform_info,
+)
+from vllm_mlx.telemetry.schema import SCHEMA_VERSION
+from vllm_mlx.telemetry.state import get_or_create_client_id, is_enabled
+
+# ---------------------------------------------------------------- singleton
+
+_queue_lock = threading.Lock()
+_queue: TelemetryQueue | None = None
+_session_id: str | None = None
+
+
+def get_queue() -> TelemetryQueue:
+    """Return the process-singleton queue, constructing it on first use.
+
+    Idempotent across threads. The flush daemon is started here, not
+    in ``__init__``, so an import alone never spawns a background
+    thread — only an actual emit does.
+    """
+    global _queue
+    if _queue is not None:
+        return _queue
+    with _queue_lock:
+        if _queue is None:
+            _queue = TelemetryQueue()
+            _queue.start()
+    return _queue
+
+
+def session_id() -> str:
+    """Return a per-process random session id (created lazily, stable).
+
+    Lives in this module rather than in ``state.py`` because it is
+    process-scoped (not persisted) — the on-disk client_id is the only
+    stable identity. Reset by ``_reset_for_tests`` so each test gets a
+    fresh id.
+    """
+    global _session_id
+    if _session_id is None:
+        # uuid4 imported lazily so importing emit at module-scan time
+        # does not touch /dev/urandom in CI fast-paths.
+        import uuid
+
+        _session_id = str(uuid.uuid4())
+    return _session_id
+
+
+def _reset_for_tests() -> None:
+    """Wipe the singleton + session_id. Call from a test ``setUp``.
+
+    Not part of the public API — tests-only seam. The queue's shutdown
+    is best-effort; we do not block on the join.
+    """
+    global _queue, _session_id
+    with _queue_lock:
+        q = _queue
+        _queue = None
+        _session_id = None
+    if q is not None:
+        q.shutdown(timeout=0.1)
+
+
+# ---------------------------------------------------------------- envelope
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _envelope(event: str) -> dict[str, Any]:
+    """Build the per-emit common header.
+
+    All four event types share this exact header — the optional
+    payload field (session / request / error) is added by each emit
+    helper below.
+    """
+    info = platform_info()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "client_id": get_or_create_client_id(),
+        "session_id": session_id(),
+        "rapid_mlx_version": _rapid_mlx_version,
+        "event": event,
+        "timestamp": _utc_now_iso(),
+        "platform": {
+            "os": info["os"],
+            "os_version": info["os_version"],
+            "arch": info["arch"],
+            "chip": info["chip"],
+            "memory_gb": info["memory_gb"],
+            "python_version": info["python_version"],
+        },
+    }
+
+
+def _safe(fn: Any) -> Any:
+    """Decorator: swallow any non-system exception from telemetry emit.
+
+    Defined inline (not in ``utils``) so the suppression is visible at
+    every emit site during code review. KeyboardInterrupt / SystemExit
+    are intentionally NOT caught — user / programmatic intent always
+    wins.
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        try:
+            fn(*args, **kwargs)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            return
+
+    wrapper.__name__ = fn.__name__
+    return wrapper
+
+
+# ---------------------------------------------------------------- public API
+
+
+@_safe
+def session_start(
+    *,
+    subcommand: str,
+    argv: list[str] | None = None,
+    engine: str = "",
+    models_loaded: list[str] | tuple[str, ...] = (),
+) -> None:
+    """Emit a ``session_start`` payload.
+
+    Called by ``cli.py`` after argparse, before subcommand dispatch.
+    ``argv`` carries the raw command-line tokens for flag-name
+    redaction; values are never read.
+    """
+    if not is_enabled():
+        return
+    payload = _envelope("session_start")
+    payload["session"] = {
+        "subcommand": subcommand,
+        "engine": engine,
+        "flag_names": hash_flag_names(argv) if argv is not None else [],
+        "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
+    }
+    get_queue().enqueue(payload)
+
+
+@_safe
+def session_end(
+    *,
+    subcommand: str,
+    duration_seconds: int,
+    engine: str = "",
+    models_loaded: list[str] | tuple[str, ...] = (),
+) -> None:
+    """Emit a ``session_end`` payload.
+
+    Called by an ``atexit`` handler registered in ``cli.py`` main. The
+    duration is wall-clock from process start; subcommand is captured
+    at start so atexit does not need to re-inspect argv.
+    """
+    if not is_enabled():
+        return
+    payload = _envelope("session_end")
+    payload["session"] = {
+        "subcommand": subcommand,
+        "duration_seconds": int(max(0, duration_seconds)),
+        "engine": engine,
+        "flag_names": [],
+        "models_loaded": [normalize_model_path(m) for m in models_loaded][:32],
+    }
+    get_queue().enqueue(payload)
+
+
+@_safe
+def request(
+    *,
+    endpoint: str,
+    model_alias: str,
+    stream: bool,
+    tool_call_used: bool,
+    prompt_tokens: int,
+    completion_tokens: int,
+    ttft_ms: float,
+    tps: float,
+    status: int,
+) -> None:
+    """Emit a ``request`` payload (Phase 2.2 sites use this).
+
+    Defined now so call sites can land without touching this module
+    later. The Phase 2.0/2.1 PR does not call this — it ships dark.
+    """
+    if not is_enabled():
+        return
+    payload = _envelope("request")
+    payload["request"] = {
+        "endpoint": endpoint,
+        "model_alias": normalize_model_path(model_alias),
+        "stream": bool(stream),
+        "tool_call_used": bool(tool_call_used),
+        "prompt_tokens_bucket": bucket_tokens(prompt_tokens),
+        "completion_tokens_bucket": bucket_tokens(completion_tokens),
+        "ttft_ms_bucket": bucket_ttft_ms(ttft_ms),
+        "tps_bucket": bucket_tps(tps),
+        "status": int(status),
+    }
+    get_queue().enqueue(payload)
+
+
+@_safe
+def error(
+    *,
+    category: str,
+    exc: BaseException,
+    phase: str,
+) -> None:
+    """Emit an ``error`` payload (Phase 2.2 sites use this).
+
+    ``exc`` is fingerprinted with ``fingerprint_traceback`` — only
+    ``basename:func:lineno`` of each frame plus the exception class
+    name participate. No message text, no module path.
+    """
+    if not is_enabled():
+        return
+    payload = _envelope("error")
+    payload["error"] = {
+        "category": category,
+        "fingerprint": fingerprint_traceback(exc),
+        "phase": phase,
+    }
+    get_queue().enqueue(payload)

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -140,8 +140,15 @@ def _safe(fn: Any) -> Any:
     every emit site during code review. KeyboardInterrupt / SystemExit
     are intentionally NOT caught — user / programmatic intent always
     wins.
-    """
 
+    ``functools.wraps`` is load-bearing for the signature-pin test in
+    ``tests/test_telemetry_emit.py``: without it, ``inspect.signature``
+    sees the bare ``(*args, **kwargs)`` of the wrapper and the test
+    is silently void. Round 1 codex review caught this.
+    """
+    import functools
+
+    @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> None:
         try:
             fn(*args, **kwargs)
@@ -150,7 +157,6 @@ def _safe(fn: Any) -> Any:
         except Exception:
             return
 
-    wrapper.__name__ = fn.__name__
     return wrapper
 
 

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -25,9 +25,11 @@ helpers own the four things every call site needs to get right:
 
 from __future__ import annotations
 
+import itertools
 import threading
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 from vllm_mlx import __version__ as _rapid_mlx_version  # noqa: N811
 from vllm_mlx.telemetry.queue import TelemetryQueue
@@ -250,7 +252,13 @@ def session_start(
         # Slice before normalize (round 7 codex catch): if a caller
         # ever hands us 1000 paths, redacting all of them just to
         # throw 968 away wastes work for no extra privacy.
-        "models_loaded": [normalize_model_path(m) for m in tuple(models_loaded)[:32]],
+        # Round 13 codex review: ``tuple(models_loaded)[:32]`` would
+        # still materialize the entire input before capping. Use
+        # ``itertools.islice`` so the slice itself is the cap — callers
+        # that hand us a 1000-entry iterable only pay for the first 32.
+        "models_loaded": [
+            normalize_model_path(m) for m in itertools.islice(models_loaded, 32)
+        ],
     }
     get_queue().enqueue(payload)
 
@@ -279,7 +287,10 @@ def session_end(
         "duration_seconds": int(max(0, duration_seconds)),
         "flag_names": [],
         "engine": "",
-        "models_loaded": [normalize_model_path(m) for m in tuple(models_loaded)[:32]],
+        # Same itertools.islice cap as session_start (round 13 catch).
+        "models_loaded": [
+            normalize_model_path(m) for m in itertools.islice(models_loaded, 32)
+        ],
     }
     get_queue().enqueue(payload)
 
@@ -306,14 +317,22 @@ def _normalize_endpoint(raw: str) -> str:
     """Map a caller-provided route to the small ``_ALLOWED_ENDPOINTS``
     set; everything else becomes ``"other"``.
 
-    Strips query strings + fragments defensively in case a caller
-    passes a full URL. The signature red-line test demands that no
-    field on the payload carry caller-controlled free-form text — this
-    is the enforcement.
+    Round 13 codex review: a naive ``split("?")`` left a full URL like
+    ``"https://host/v1/chat/completions"`` unmatched and recorded as
+    ``"other"``, which silently hid one of the very leaks the allowlist
+    is supposed to prevent. ``urlsplit`` extracts the path regardless of
+    whether the caller passed ``"/v1/chat/completions"``, the same with
+    a query string, or a full URL.
+
+    The signature red-line test demands that no field on the payload
+    carry caller-controlled free-form text — this is the enforcement.
     """
     if not isinstance(raw, str):
         return "other"
-    path = raw.split("?", 1)[0].split("#", 1)[0]
+    try:
+        path = urlsplit(raw).path
+    except ValueError:
+        return "other"
     return path if path in _ALLOWED_ENDPOINTS else "other"
 
 

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -216,6 +216,39 @@ def session_end(
     get_queue().enqueue(payload)
 
 
+# Allowlist of route identifiers ``request()`` accepts. Round 2 codex
+# review caught that storing ``endpoint`` verbatim was a free-form
+# escape hatch — a future caller threading a path with a query string
+# (``/v1/chat?key=sk-...``) would have leaked it. Constrain to the
+# small set of routes Phase 2.2 actually instruments; anything else
+# collapses to ``"other"``.
+_ALLOWED_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/v1/embeddings",
+        "/v1/audio/transcriptions",
+        "/v1/messages",
+        "/v1/images/generations",
+    }
+)
+
+
+def _normalize_endpoint(raw: str) -> str:
+    """Map a caller-provided route to the small ``_ALLOWED_ENDPOINTS``
+    set; everything else becomes ``"other"``.
+
+    Strips query strings + fragments defensively in case a caller
+    passes a full URL. The signature red-line test demands that no
+    field on the payload carry caller-controlled free-form text — this
+    is the enforcement.
+    """
+    if not isinstance(raw, str):
+        return "other"
+    path = raw.split("?", 1)[0].split("#", 1)[0]
+    return path if path in _ALLOWED_ENDPOINTS else "other"
+
+
 @_safe
 def request(
     *,
@@ -238,7 +271,7 @@ def request(
         return
     payload = _envelope("request")
     payload["request"] = {
-        "endpoint": endpoint,
+        "endpoint": _normalize_endpoint(endpoint),
         "model_alias": normalize_model_path(model_alias),
         "stream": bool(stream),
         "tool_call_used": bool(tool_call_used),

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import itertools
 import threading
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlsplit
@@ -194,11 +195,27 @@ def _safe(fn: Any) -> Any:
     ``tests/test_telemetry_emit.py``: without it, ``inspect.signature``
     sees the bare ``(*args, **kwargs)`` of the wrapper and the test
     is silently void. Round 1 codex review caught this.
+
+    Round 14 codex review: the broad ``except Exception`` used to also
+    swallow ``TypeError`` from a call-site that drifted out of sync
+    with the helper signature (renamed kwarg, missing required arg).
+    That turned a wiring bug into a silent "no telemetry," which the
+    integration tests can't see. ``inspect.signature(fn).bind(...)``
+    is evaluated BEFORE the broad catch so any signature mismatch
+    surfaces as a normal ``TypeError`` at call time. The signature is
+    bound once at decoration time so the per-call cost is just a
+    method invocation.
     """
     import functools
+    import inspect
+
+    sig = inspect.signature(fn)
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> None:
+        # Validate the call-site BEFORE the suppression block. A
+        # TypeError here means a wiring bug; we want it visible.
+        sig.bind(*args, **kwargs)
         try:
             fn(*args, **kwargs)
         except (KeyboardInterrupt, SystemExit):
@@ -217,7 +234,7 @@ def session_start(
     *,
     subcommand: str,
     argv: list[str] | None = None,
-    models_loaded: list[str] | tuple[str, ...] = (),
+    models_loaded: Iterable[str] = (),
 ) -> None:
     """Emit a ``session_start`` payload.
 
@@ -268,7 +285,7 @@ def session_end(
     *,
     subcommand: str,
     duration_seconds: int,
-    models_loaded: list[str] | tuple[str, ...] = (),
+    models_loaded: Iterable[str] = (),
 ) -> None:
     """Emit a ``session_end`` payload.
 

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -76,6 +76,14 @@ class TelemetryQueue:
         self._flush_threshold = flush_threshold
         self._flusher = flusher
         self._atexit_registered = False
+        # Round 13 codex review: ``TelemetryQueue.start()`` registers
+        # ``shutdown`` via atexit, but ``cli.py`` ``_emit_session_end``
+        # already calls ``shutdown()`` synchronously to make sure the
+        # session_end event lands before the process tears down. With
+        # both wired, a hung flush could burn the 2 s join budget TWICE
+        # at exit. A latched flag turns the redundant atexit call into
+        # a cheap no-op; ``start()`` clears the latch so restart works.
+        self._shutdown_called = False
         # Bookkeeping the ``rapid-mlx telemetry status`` subcommand can
         # surface. ``last_flush_ts`` is the monotonic clock at the last
         # _completed_ flush attempt (success or failure).
@@ -113,6 +121,10 @@ class TelemetryQueue:
         with self._lifecycle_lock:
             if self._thread is not None and self._thread.is_alive():
                 return
+            # Clear the round-13 shutdown latch so a fresh lifecycle
+            # actually drains again. (start/shutdown/start/shutdown is
+            # exercised by ``test_shutdown_does_not_orphan_thread*``.)
+            self._shutdown_called = False
             self._stop.clear()
             # Preserve a pending wake (round 11 codex catch): if events
             # were enqueued past the threshold BEFORE ``start()`` ran,
@@ -146,7 +158,18 @@ class TelemetryQueue:
         unconditional clearing let a later ``start()`` spawn a second
         daemon while the original was still draining a slow flusher,
         producing parallel flushers writing to the same queue.
+
+        Round 13 codex review: ``cli.py`` calls this from its session
+        atexit hook, and ``start()`` already registered another atexit
+        binding that calls it again. The latched ``_shutdown_called``
+        guard makes the second call a no-op so the 2 s join budget
+        cannot be spent twice on the same hung flusher. ``start()``
+        clears the latch so restart paths still drain.
         """
+        with self._lifecycle_lock:
+            if self._shutdown_called:
+                return
+            self._shutdown_called = True
         self._stop.set()
         self._wake.set()
         with self._lifecycle_lock:

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -114,13 +114,23 @@ class TelemetryQueue:
             if self._thread is not None and self._thread.is_alive():
                 return
             self._stop.clear()
-            self._wake.clear()
+            # Preserve a pending wake (round 11 codex catch): if events
+            # were enqueued past the threshold BEFORE ``start()`` ran,
+            # blindly clearing the wake would lose that signal and the
+            # batch would sit until the 60 s idle flush. Only clear if
+            # we'd otherwise carry over a wake from a previous lifecycle.
+            with self._lock:
+                threshold_already_crossed = len(self._events) >= self._flush_threshold
+            if not threshold_already_crossed:
+                self._wake.clear()
             self._thread = threading.Thread(
                 target=self._loop,
                 name="rapid-mlx-telemetry",
                 daemon=True,
             )
             self._thread.start()
+            if threshold_already_crossed:
+                self._wake.set()
             if not self._atexit_registered:
                 atexit.register(self.shutdown)
                 self._atexit_registered = True

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -62,6 +62,13 @@ class TelemetryQueue:
         # patching the transport module globally.
         self._events: deque[dict[str, Any]] = deque(maxlen=max_len)
         self._lock = threading.Lock()
+        # Separate lifecycle lock so ``start``/``shutdown`` do not
+        # contend with the hot ``enqueue`` path. Round 4 codex review
+        # caught that the previous ``_thread`` check/assignment in
+        # ``start()`` was unlocked, so two concurrent ``start()`` calls
+        # (e.g. cli main + FastAPI lifespan) could race past the
+        # ``is_alive()`` check and spawn duplicate daemons.
+        self._lifecycle_lock = threading.Lock()
         self._wake = threading.Event()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -99,21 +106,24 @@ class TelemetryQueue:
         """Start the flush daemon if not already running.
 
         Idempotent — safe to call from multiple init paths (cli.py
-        main, FastAPI lifespan, test fixture).
+        main, FastAPI lifespan, test fixture). The lifecycle lock
+        prevents a race where two concurrent callers both pass the
+        ``is_alive()`` check and spawn duplicate daemons.
         """
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop.clear()
-        self._wake.clear()
-        self._thread = threading.Thread(
-            target=self._loop,
-            name="rapid-mlx-telemetry",
-            daemon=True,
-        )
-        self._thread.start()
-        if not self._atexit_registered:
-            atexit.register(self.shutdown)
-            self._atexit_registered = True
+        with self._lifecycle_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._wake.clear()
+            self._thread = threading.Thread(
+                target=self._loop,
+                name="rapid-mlx-telemetry",
+                daemon=True,
+            )
+            self._thread.start()
+            if not self._atexit_registered:
+                atexit.register(self.shutdown)
+                self._atexit_registered = True
 
     def shutdown(self, *, timeout: float = SHUTDOWN_BUDGET_S) -> None:
         """Stop the flush daemon and drain whatever is still in the queue.
@@ -129,11 +139,17 @@ class TelemetryQueue:
         """
         self._stop.set()
         self._wake.set()
-        thread = self._thread
+        with self._lifecycle_lock:
+            thread = self._thread
         if thread is not None:
             thread.join(timeout=timeout)
             if not thread.is_alive():
-                self._thread = None
+                with self._lifecycle_lock:
+                    # Recheck under the lock so a parallel ``start()``
+                    # that already replaced the daemon doesn't lose its
+                    # reference.
+                    if self._thread is thread:
+                        self._thread = None
 
     def snapshot(self) -> dict[str, int]:
         """Cheap counters for ``rapid-mlx telemetry status``."""

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -152,16 +152,21 @@ class TelemetryQueue:
                         self._thread = None
 
     def snapshot(self) -> dict[str, int]:
-        """Cheap counters for ``rapid-mlx telemetry status``."""
+        """Cheap counters for ``rapid-mlx telemetry status``.
+
+        Round 9 codex review: all counters read under the same lock
+        the daemon uses to write them, so ``snapshot`` cannot observe a
+        torn read mid-increment. Cheaper than separate locks per
+        counter, and the daemon is the only writer.
+        """
         with self._lock:
-            pending = len(self._events)
-        return {
-            "pending": pending,
-            "enqueued_total": self.events_enqueued,
-            "dropped_total": self.events_dropped,
-            "flushes_ok": self.flushes_ok,
-            "flushes_failed": self.flushes_failed,
-        }
+            return {
+                "pending": len(self._events),
+                "enqueued_total": self.events_enqueued,
+                "dropped_total": self.events_dropped,
+                "flushes_ok": self.flushes_ok,
+                "flushes_failed": self.flushes_failed,
+            }
 
     # --------------------------------------------------------------- internals
 
@@ -195,7 +200,12 @@ class TelemetryQueue:
             # crashing would silently disable telemetry for the rest
             # of the process — worse than a logged failure.
             ok = False
-        if ok:
-            self.flushes_ok += 1
-        else:
-            self.flushes_failed += 1
+        # Update both counters under the same lock ``snapshot()`` reads
+        # them with (round 9 codex catch). The daemon is the only
+        # writer, so there is no contention with itself; ``enqueue``
+        # holds the lock too briefly to matter.
+        with self._lock:
+            if ok:
+                self.flushes_ok += 1
+            else:
+                self.flushes_failed += 1

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -120,13 +120,20 @@ class TelemetryQueue:
 
         Safe to call multiple times. Always returns within ``timeout``
         seconds — a slow Worker must not leave the interpreter hanging.
+
+        ``self._thread`` is cleared only after the join confirms the
+        daemon actually exited. Round 1 codex review caught that
+        unconditional clearing let a later ``start()`` spawn a second
+        daemon while the original was still draining a slow flusher,
+        producing parallel flushers writing to the same queue.
         """
         self._stop.set()
         self._wake.set()
         thread = self._thread
         if thread is not None:
             thread.join(timeout=timeout)
-            self._thread = None
+            if not thread.is_alive():
+                self._thread = None
 
     def snapshot(self) -> dict[str, int]:
         """Cheap counters for ``rapid-mlx telemetry status``."""

--- a/vllm_mlx/telemetry/queue.py
+++ b/vllm_mlx/telemetry/queue.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, lossy, daemon-flushed in-process event queue.
+
+Phase 2 sites construct payload dicts and call ``enqueue()`` on the
+process-singleton queue. A background daemon thread drains the queue
+on a 60-second idle interval, eagerly when 10 events are pending, and
+once more at interpreter shutdown via ``atexit``.
+
+Three invariants the design pins down:
+
+1. **Telemetry must not slow the foreground.** ``enqueue()`` does only
+   a deque append inside one lock — no JSON dump, no HTTP, no sleep.
+   The flush daemon owns every blocking call.
+
+2. **The queue must not grow unbounded.** ``deque(maxlen=N)`` drops
+   the oldest event when at capacity. A stuck collector or an offline
+   user must not leave the process consuming RAM on telemetry waste.
+
+3. **Shutdown must not hang.** The flush thread is ``daemon=True`` so
+   a missed join still lets the interpreter exit. ``atexit`` calls
+   ``shutdown()`` with a 2-second join budget — long enough for one
+   final POST round-trip, short enough not to annoy a user on Ctrl-C.
+
+Important non-feature: there is **no asyncio integration here**. The
+queue must serve both ``rapid-mlx serve`` (async FastAPI) and
+``rapid-mlx chat`` (sync REPL) without forcing every caller into an
+event loop. A plain daemon thread is the lowest common denominator.
+"""
+
+from __future__ import annotations
+
+import atexit
+import threading
+from collections import deque
+from typing import Any
+
+from vllm_mlx.telemetry.transport import post_batch
+
+MAX_QUEUE_LEN = 100
+FLUSH_INTERVAL_S = 60.0
+FLUSH_THRESHOLD = 10
+SHUTDOWN_BUDGET_S = 2.0
+
+
+class TelemetryQueue:
+    """Process-singleton telemetry event queue + flush daemon.
+
+    Construct once per process. ``start()`` is idempotent; calling it
+    twice from the same process is a no-op so cli.py + lifespan can
+    both call without ordering assumptions.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_len: int = MAX_QUEUE_LEN,
+        flush_interval_s: float = FLUSH_INTERVAL_S,
+        flush_threshold: int = FLUSH_THRESHOLD,
+        flusher: Any = post_batch,
+    ) -> None:
+        # ``flusher`` is injectable so tests can hand in a fake without
+        # patching the transport module globally.
+        self._events: deque[dict[str, Any]] = deque(maxlen=max_len)
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._flush_interval_s = flush_interval_s
+        self._flush_threshold = flush_threshold
+        self._flusher = flusher
+        self._atexit_registered = False
+        # Bookkeeping the ``rapid-mlx telemetry status`` subcommand can
+        # surface. ``last_flush_ts`` is the monotonic clock at the last
+        # _completed_ flush attempt (success or failure).
+        self.events_enqueued = 0
+        self.events_dropped = 0
+        self.flushes_ok = 0
+        self.flushes_failed = 0
+
+    # ----------------------------------------------------------------- API
+
+    def enqueue(self, payload: dict[str, Any]) -> None:
+        """Append a payload. Drop the oldest if at capacity.
+
+        Cheap and lock-only. Wakes the flusher when the queue crosses
+        ``flush_threshold``; otherwise relies on the idle timer.
+        """
+        with self._lock:
+            full = len(self._events) == self._events.maxlen
+            self._events.append(payload)
+            if full:
+                self.events_dropped += 1
+            self.events_enqueued += 1
+            should_wake = len(self._events) >= self._flush_threshold
+        if should_wake:
+            self._wake.set()
+
+    def start(self) -> None:
+        """Start the flush daemon if not already running.
+
+        Idempotent — safe to call from multiple init paths (cli.py
+        main, FastAPI lifespan, test fixture).
+        """
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._wake.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name="rapid-mlx-telemetry",
+            daemon=True,
+        )
+        self._thread.start()
+        if not self._atexit_registered:
+            atexit.register(self.shutdown)
+            self._atexit_registered = True
+
+    def shutdown(self, *, timeout: float = SHUTDOWN_BUDGET_S) -> None:
+        """Stop the flush daemon and drain whatever is still in the queue.
+
+        Safe to call multiple times. Always returns within ``timeout``
+        seconds — a slow Worker must not leave the interpreter hanging.
+        """
+        self._stop.set()
+        self._wake.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+            self._thread = None
+
+    def snapshot(self) -> dict[str, int]:
+        """Cheap counters for ``rapid-mlx telemetry status``."""
+        with self._lock:
+            pending = len(self._events)
+        return {
+            "pending": pending,
+            "enqueued_total": self.events_enqueued,
+            "dropped_total": self.events_dropped,
+            "flushes_ok": self.flushes_ok,
+            "flushes_failed": self.flushes_failed,
+        }
+
+    # --------------------------------------------------------------- internals
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            # ``wait`` returns True if woken via ``_wake.set()`` (queue
+            # crossed threshold or shutdown), False on timeout (idle
+            # flush). Either way we drain.
+            self._wake.wait(timeout=self._flush_interval_s)
+            self._wake.clear()
+            self._drain_once()
+        # Final drain after stop signal so events queued between the
+        # last wake and shutdown still get a try.
+        self._drain_once()
+
+    def _drain_once(self) -> None:
+        # Move all currently-queued events to a local batch, then release
+        # the lock before doing network I/O. enqueue() during the POST
+        # must not block.
+        with self._lock:
+            if not self._events:
+                return
+            batch = list(self._events)
+            self._events.clear()
+        try:
+            ok = self._flusher(batch)
+        except Exception:
+            # Flusher must never raise on its own contract, but if a
+            # bug slips through (or a tests stub raises), we treat it
+            # as a failure rather than crashing the daemon. The daemon
+            # crashing would silently disable telemetry for the rest
+            # of the process — worse than a logged failure.
+            ok = False
+        if ok:
+            self.flushes_ok += 1
+        else:
+            self.flushes_failed += 1

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -42,6 +42,15 @@ class SessionPayload:
     duration_seconds: int | None = None  # session_end only; None on session_start
     models_loaded: tuple[str, ...] = ()  # HF repo IDs only (normalized)
     flag_names: tuple[str, ...] = ()  # names only, sorted, no values
+    # Schema v1 back-compat slot. Round 4 removed runtime emission of
+    # ``engine`` from the emit helpers (it was a free-form ``str`` slot
+    # with no information content while ``BatchedEngine`` is the only
+    # engine), but the dataclass keeps the optional field so external
+    # callers constructing ``SessionPayload(engine=...)`` against
+    # ``SCHEMA_VERSION == 1`` don't break. Re-add to runtime emission
+    # only via an enum if a second engine ever lands; bump SCHEMA_VERSION
+    # at the same time. Round 6 codex catch.
+    engine: str = ""
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -41,7 +41,6 @@ class SessionPayload:
     subcommand: str  # "serve" | "agents" | "bench" | "chat" | "doctor" | "models"
     duration_seconds: int | None = None  # session_end only; None on session_start
     models_loaded: tuple[str, ...] = ()  # HF repo IDs only (normalized)
-    engine: str = ""  # "batched" / future variants
     flag_names: tuple[str, ...] = ()  # names only, sorted, no values
 
 
@@ -132,7 +131,6 @@ def sample_preview_payload(
         session=SessionPayload(
             subcommand="serve",
             models_loaded=("mlx-community/Qwen3.5-9B-4bit",),
-            engine="batched",
             flag_names=("port", "host"),
         ),
     )

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -41,16 +41,19 @@ class SessionPayload:
     subcommand: str  # "serve" | "agents" | "bench" | "chat" | "doctor" | "models"
     duration_seconds: int | None = None  # session_end only; None on session_start
     models_loaded: tuple[str, ...] = ()  # HF repo IDs only (normalized)
-    flag_names: tuple[str, ...] = ()  # names only, sorted, no values
     # Schema v1 back-compat slot. Round 4 removed runtime emission of
     # ``engine`` from the emit helpers (it was a free-form ``str`` slot
     # with no information content while ``BatchedEngine`` is the only
     # engine), but the dataclass keeps the optional field so external
     # callers constructing ``SessionPayload(engine=...)`` against
-    # ``SCHEMA_VERSION == 1`` don't break. Re-add to runtime emission
-    # only via an enum if a second engine ever lands; bump SCHEMA_VERSION
-    # at the same time. Round 6 codex catch.
+    # ``SCHEMA_VERSION == 1`` don't break. Round 7 codex caught that
+    # the field MUST stay in its original positional slot too —
+    # positional ``SessionPayload("serve", 10, models, engine, flags)``
+    # would otherwise silently mis-bind once ``engine`` moved past
+    # ``flag_names``. Re-add to runtime emission only via an enum if a
+    # second engine ever lands; bump SCHEMA_VERSION at the same time.
     engine: str = ""
+    flag_names: tuple[str, ...] = ()  # names only, sorted, no values
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/telemetry/state.py
+++ b/vllm_mlx/telemetry/state.py
@@ -202,6 +202,25 @@ def _env_kill_switch_active() -> bool:
     return raw.strip().lower() in ("0", "false", "no", "off", "")
 
 
+# Process-level kill switch set by ``cli.py`` when ``--no-telemetry`` is
+# passed. The ``cli_no_telemetry=`` keyword on ``is_enabled`` only helps
+# the few call sites that explicitly thread it through (``status`` /
+# ``preview`` UX); the four event-emit helpers in ``emit.py`` do NOT
+# accept the kwarg (it would balloon every emit-site signature), so they
+# read this flag instead. Set once, after argparse, before any emit.
+_cli_kill_switch_active = False
+
+
+def set_cli_kill_switch(active: bool) -> None:
+    """Mark the current process as ``--no-telemetry``.
+
+    Idempotent and global within the process. ``emit.session_start`` is
+    the first caller affected; it reads the flag via ``is_enabled()``.
+    """
+    global _cli_kill_switch_active
+    _cli_kill_switch_active = bool(active)
+
+
 def is_enabled(*, cli_no_telemetry: bool = False) -> bool:
     """Single decision point used by every event-emit site.
 
@@ -209,7 +228,7 @@ def is_enabled(*, cli_no_telemetry: bool = False) -> bool:
     it with no further design work, and so tests can pin the precedence
     contract today.
     """
-    if cli_no_telemetry:
+    if cli_no_telemetry or _cli_kill_switch_active:
         return False
     if _env_kill_switch_active():
         return False
@@ -225,7 +244,7 @@ def consent_source(*, cli_no_telemetry: bool = False) -> str:
     Used by ``rapid-mlx telemetry status`` so users can debug why
     telemetry is (or isn't) enabled without reading our code.
     """
-    if cli_no_telemetry:
+    if cli_no_telemetry or _cli_kill_switch_active:
         return "cli-flag (--no-telemetry)"
     if _env_kill_switch_active():
         return f"env-var ({ENV_VAR}={os.environ.get(ENV_VAR, '')!r})"

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -66,6 +66,29 @@ def debug_enabled() -> bool:
     return raw.strip().lower() not in ("0", "", "false", "no", "off")
 
 
+def _user_agent() -> str:
+    """Self-identifying UA for the telemetry client.
+
+    Cloudflare's zone-level bot manager rejects the stdlib default
+    ``Python-urllib/3.X`` UA with HTTP 403 before the request ever
+    reaches our Worker (verified live 2026-06-06 against the production
+    endpoint). Setting a non-generic UA is therefore load-bearing for
+    the pipeline to function at all.
+
+    The UA exposes only the package name + version, which is already
+    in the payload's ``rapid_mlx_version`` field — no new PII. The
+    repository link is conventional courtesy so an analytics consumer
+    on the receiver side can attribute hits without guessing.
+    """
+    try:
+        from importlib.metadata import version
+
+        v = version("rapid-mlx")
+    except Exception:
+        v = "dev"
+    return f"rapid-mlx/{v} (+https://github.com/raullenchai/Rapid-MLX)"
+
+
 def post_batch(events: list[dict[str, Any]]) -> bool:
     """Send a batch of payloads to the collector.
 
@@ -98,7 +121,10 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
                 url,
                 data=body,
                 method="POST",
-                headers={"content-type": "application/json"},
+                headers={
+                    "content-type": "application/json",
+                    "user-agent": _user_agent(),
+                },
             )
             with urlopen(req, timeout=TIMEOUT_S) as resp:  # noqa: S310 — URL is constant.
                 status = getattr(resp, "status", None)

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -50,7 +50,7 @@ RETRY_BACKOFFS_S: tuple[float, ...] = (0.5, 2.0)
 MAX_BODY_BYTES = 200 * 1024  # Worker caps at 256 KB; leave headroom for envelope.
 
 
-def endpoint() -> str:
+def endpoint() -> str | None:
     """Resolve the production endpoint, honouring the debug env override.
 
     Resolved every call (not cached at import time) so tests can
@@ -61,17 +61,25 @@ def endpoint() -> str:
     a user's shell rc or by a malicious wrapper script) would silently
     redirect every opted-in user's events to a hostile collector, with
     the privacy guarantees of the disclosure ("only our Worker hashes
-    your IP, etc.") no longer applying. The override is now restricted
-    to localhost / 127.0.0.1 — the only legitimate use cases are
-    ``wrangler dev`` and CI fixtures. Anything else is ignored and the
-    production endpoint stands.
+    your IP, etc.") no longer applying. The override is restricted to
+    localhost / 127.0.0.1 -- the only legitimate use cases are
+    ``wrangler dev`` and CI fixtures.
+
+    Round 16 codex review: when the env var IS set but rejected (e.g.
+    a dev typo on the wrangler URL, or a stale shell rc pointing at a
+    decommissioned host), the previous behaviour silently fell back to
+    the production endpoint -- which meant dev/test traffic could leak
+    into the production R2 bucket without the user noticing. Now: a
+    set-but-rejected override returns ``None`` so ``post_batch`` fails
+    closed (drops the batch). Default (no env var at all) still
+    returns ``DEFAULT_ENDPOINT``.
     """
     raw = os.environ.get(ENDPOINT_ENV)
     if raw is None:
         return DEFAULT_ENDPOINT
     if _is_localhost_override(raw):
         return raw
-    return DEFAULT_ENDPOINT
+    return None
 
 
 def _is_localhost_override(url: str) -> bool:
@@ -163,9 +171,22 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
         return False
 
     url = endpoint()
+    if url is None:
+        # Round 16 codex catch: ``RAPID_MLX_TELEMETRY_ENDPOINT`` was
+        # set but rejected by ``endpoint()`` (non-localhost host /
+        # malformed URL). The previous fallback to the production
+        # endpoint could leak dev/test traffic into the production R2
+        # bucket invisibly. Fail closed: drop the batch and log so the
+        # operator can see why nothing landed.
+        _log(
+            f"{ENDPOINT_ENV} was set but rejected -- dropping batch "
+            f"(set a localhost / 127.0.0.1 / ::1 URL or unset the env "
+            f"var to use the production endpoint)"
+        )
+        return False
     # HTTPS-only for any non-loopback host. Loopback is exempt because
     # ``endpoint()`` already restricted the override to localhost (round
-    # 3 codex catch) and ``wrangler dev`` serves over plain HTTP — the
+    # 3 codex catch) and ``wrangler dev`` serves over plain HTTP -- the
     # traffic never leaves the host. A public host on ``http://`` is
     # still refused.
     if not (url.startswith("https://") or _is_localhost_override(url)):

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -81,11 +81,21 @@ def _is_localhost_override(url: str) -> bool:
     HTTP on 127.0.0.1:8787). Anything else — including a public host
     accidentally typed as ``https://localhost.attacker.example`` — is
     rejected. The match is on the netloc, not a substring.
+
+    ``parts.port`` is touched explicitly to surface a malformed-port
+    ``ValueError`` here rather than later inside ``Request``/``urlopen``
+    where it would escape the ``URLError``/``TimeoutError``/``OSError``
+    catch path and violate the "never raises" contract. Round 4 codex
+    review caught ``http://localhost:bad/`` as the concrete example.
     """
     try:
         from urllib.parse import urlparse
 
         parts = urlparse(url)
+        # Force port validation here; ``parts.port`` raises ValueError
+        # on a non-integer port. We don't care about the value — just
+        # that it parses cleanly.
+        _ = parts.port
     except (TypeError, ValueError):
         return False
     if parts.scheme not in ("http", "https"):
@@ -189,7 +199,11 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
                     # change the answer. Drop and move on.
                     _log(f"attempt {attempt_idx} → {status} (4xx, not retrying)")
                     return False
-                _log(f"attempt {attempt_idx} → {status} (5xx, will retry)")
+                # Be honest about the next move — round 4 codex review
+                # caught that we logged ``"will retry"`` even on the
+                # last attempt when the next thing was ``return False``.
+                tail = "will retry" if backoff is not None else "giving up"
+                _log(f"attempt {attempt_idx} → {status} (5xx, {tail})")
         except HTTPError as e:
             # HTTPError is a URLError subclass but carries the response
             # code; treat it the same as a status-based decision above.
@@ -206,7 +220,8 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
                         "(4xx, not retrying)"
                     )
                     return False
-                _log(f"attempt {attempt_idx} → HTTPError {status} (will retry)")
+                tail = "will retry" if backoff is not None else "giving up"
+                _log(f"attempt {attempt_idx} → HTTPError {status} ({tail})")
             finally:
                 close = getattr(e, "close", None)
                 if callable(close):

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -14,11 +14,20 @@ Implementation choices, called out because they look unusual:
   install footprint or surfaces an upgrade pin. ``urllib`` is in every
   CPython 3.10+ and is already imported elsewhere in this codebase.
 
-- **HTTPS-only.** The endpoint is overridable via
-  ``RAPID_MLX_TELEMETRY_ENDPOINT`` for debug rigs and local Worker dev,
-  but we refuse anything not on ``https://``. This mirrors the share
-  PR #504 codex round 4 fix where ``URLError`` was discovered NOT to
-  be a ``TimeoutError`` subclass; we keep both in the except tuple.
+- **HTTPS except loopback dev overrides.** The endpoint is overridable
+  via ``RAPID_MLX_TELEMETRY_ENDPOINT`` for debug rigs and local Worker
+  dev. The exact rule (round 17 codex catch -- the prior "HTTPS-only"
+  shorthand made the loopback exemption look like a bug):
+    * Public hosts -- HTTPS required, no exceptions.
+    * Loopback hosts (``localhost`` / ``127.0.0.1`` / ``::1``) --
+      plain HTTP is accepted because ``wrangler dev`` serves over
+      ``http://127.0.0.1:8787`` and the bytes never leave the host.
+    * Anything else (non-loopback host on HTTPS that isn't the
+      production default) -- rejected by ``endpoint()`` returning
+      ``None`` so ``post_batch`` fails closed.
+  Mirrors the share PR #504 codex round 4 fix where ``URLError`` was
+  discovered NOT to be a ``TimeoutError`` subclass; we keep both in
+  the except tuple.
 
 - **Three attempts with two backoffs.** Telemetry must never block the
   foreground for more than ~3 × ``TIMEOUT_S`` + the backoffs (worst

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -145,11 +145,27 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
         except HTTPError as e:
             # HTTPError is a URLError subclass but carries the response
             # code; treat it the same as a status-based decision above.
-            status = getattr(e, "code", 0)
-            if 400 <= status < 500:
-                _log(f"attempt {attempt_idx} → HTTPError {status} (4xx, not retrying)")
-                return False
-            _log(f"attempt {attempt_idx} → HTTPError {status} (will retry)")
+            # ``HTTPError`` ALSO holds a file-like response object on
+            # ``e.fp`` (and is itself an addinfourl). Round 2 codex
+            # review caught that letting it fall out of scope without
+            # an explicit close leaks the underlying socket across
+            # retries on platforms where the gc cycle is slow.
+            try:
+                status = getattr(e, "code", 0)
+                if 400 <= status < 500:
+                    _log(
+                        f"attempt {attempt_idx} → HTTPError {status} "
+                        "(4xx, not retrying)"
+                    )
+                    return False
+                _log(f"attempt {attempt_idx} → HTTPError {status} (will retry)")
+            finally:
+                close = getattr(e, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        pass
         except (URLError, TimeoutError, OSError) as e:
             # URLError is NOT a TimeoutError subclass in 3.10+ — pin both
             # explicitly. ``socket.timeout`` was historically distinct

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTPS POST transport for the telemetry collector.
+
+This module owns one job: take a list of payload dicts, ship them to
+the collector at ``telemetry.rapidmlx.com``, and fail silently if
+anything goes wrong. Nothing about consent, schema construction, or
+queueing belongs here.
+
+Implementation choices, called out because they look unusual:
+
+- **stdlib ``urllib`` over ``httpx`` / ``requests``.** Telemetry sits
+  on a consent-gated path that runs only when the user explicitly opts
+  in, so it must not introduce a transitive dependency that increases
+  install footprint or surfaces an upgrade pin. ``urllib`` is in every
+  CPython 3.10+ and is already imported elsewhere in this codebase.
+
+- **HTTPS-only.** The endpoint is overridable via
+  ``RAPID_MLX_TELEMETRY_ENDPOINT`` for debug rigs and local Worker dev,
+  but we refuse anything not on ``https://``. This mirrors the share
+  PR #504 codex round 4 fix where ``URLError`` was discovered NOT to
+  be a ``TimeoutError`` subclass; we keep both in the except tuple.
+
+- **Three attempts with two backoffs.** Telemetry must never block the
+  foreground for more than ~3 × ``TIMEOUT_S`` + the backoffs (worst
+  case ~12 s in pathological network conditions). The retries cover a
+  transient DNS hiccup, a one-shot Worker rolling-restart, and a TCP
+  connection reset — not a multi-minute outage.
+
+- **Silent failure.** A failed POST returns ``False``; nothing else
+  signals up to the caller. The user must not see a stack trace from
+  the telemetry path, ever.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_ENDPOINT = "https://telemetry.rapidmlx.com/v1/events"
+DEBUG_ENV = "RAPID_MLX_TELEMETRY_DEBUG"
+ENDPOINT_ENV = "RAPID_MLX_TELEMETRY_ENDPOINT"
+
+TIMEOUT_S = 3.0
+RETRY_BACKOFFS_S: tuple[float, ...] = (0.5, 2.0)
+MAX_BODY_BYTES = 200 * 1024  # Worker caps at 256 KB; leave headroom for envelope.
+
+
+def endpoint() -> str:
+    """Resolve the production endpoint, honouring the debug env override.
+
+    Resolved every call (not cached at import time) so tests can
+    monkey-patch ``os.environ`` per case without poisoning each other.
+    """
+    return os.environ.get(ENDPOINT_ENV, DEFAULT_ENDPOINT)
+
+
+def debug_enabled() -> bool:
+    raw = os.environ.get(DEBUG_ENV)
+    if raw is None:
+        return False
+    return raw.strip().lower() not in ("0", "", "false", "no", "off")
+
+
+def post_batch(events: list[dict[str, Any]]) -> bool:
+    """Send a batch of payloads to the collector.
+
+    Returns ``True`` on any 2xx response; ``False`` on transport error,
+    schema-rejected (4xx), or oversized payload. Never raises.
+
+    Empty batches return ``True`` without hitting the network — empty
+    flushes are cheap and harmless, and treating them as success keeps
+    the caller logic free of empty-list special cases.
+    """
+    if not events:
+        return True
+
+    body = json.dumps({"batch": events}, separators=(",", ":")).encode("utf-8")
+    if len(body) > MAX_BODY_BYTES:
+        # Worker would 413 us; drop locally to save a roundtrip and an
+        # entry in the collector's reject metric.
+        _log(f"payload too large ({len(body)} > {MAX_BODY_BYTES} B) — dropped")
+        return False
+
+    url = endpoint()
+    if not url.startswith("https://"):
+        _log(f"refusing non-HTTPS endpoint {url!r}")
+        return False
+
+    attempts = (*RETRY_BACKOFFS_S, None)  # backoff is None on the last attempt
+    for attempt_idx, backoff in enumerate(attempts, start=1):
+        try:
+            req = Request(
+                url,
+                data=body,
+                method="POST",
+                headers={"content-type": "application/json"},
+            )
+            with urlopen(req, timeout=TIMEOUT_S) as resp:  # noqa: S310 — URL is constant.
+                status = getattr(resp, "status", None)
+                if status is None:
+                    status = resp.getcode()
+                if 200 <= status < 300:
+                    _log(
+                        f"attempt {attempt_idx} → {status} "
+                        f"(events={len(events)}, bytes={len(body)})"
+                    )
+                    return True
+                if 400 <= status < 500:
+                    # Schema bug or auth/format issue — retrying will not
+                    # change the answer. Drop and move on.
+                    _log(f"attempt {attempt_idx} → {status} (4xx, not retrying)")
+                    return False
+                _log(f"attempt {attempt_idx} → {status} (5xx, will retry)")
+        except HTTPError as e:
+            # HTTPError is a URLError subclass but carries the response
+            # code; treat it the same as a status-based decision above.
+            status = getattr(e, "code", 0)
+            if 400 <= status < 500:
+                _log(f"attempt {attempt_idx} → HTTPError {status} (4xx, not retrying)")
+                return False
+            _log(f"attempt {attempt_idx} → HTTPError {status} (will retry)")
+        except (URLError, TimeoutError, OSError) as e:
+            # URLError is NOT a TimeoutError subclass in 3.10+ — pin both
+            # explicitly. ``socket.timeout`` was historically distinct
+            # but became an alias of ``TimeoutError`` in 3.10, so the
+            # bare ``TimeoutError`` catches both. ``OSError`` catches a
+            # DNS lookup failure on some platforms.
+            _log(f"attempt {attempt_idx} failed: {type(e).__name__}: {e}")
+
+        if backoff is None:
+            return False
+        time.sleep(backoff)
+
+    return False
+
+
+def _log(msg: str) -> None:
+    """Debug-only logger.
+
+    Silent unless ``RAPID_MLX_TELEMETRY_DEBUG`` is set to a truthy
+    value. Goes to stderr so it does not interleave with subcommand
+    output that may be JSON-piped.
+    """
+    if not debug_enabled():
+        return
+    print(f"[telemetry] {msg}", file=sys.stderr, flush=True)

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -236,6 +236,21 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
             # bare ``TimeoutError`` catches both. ``OSError`` catches a
             # DNS lookup failure on some platforms.
             _log(f"attempt {attempt_idx} failed: {type(e).__name__}: {e}")
+        except (KeyboardInterrupt, SystemExit):
+            # User intent and programmatic intent always win. Telemetry
+            # must not turn a Ctrl-C into a hang.
+            raise
+        except Exception as e:
+            # Final guard for the "never raises" contract. Round 5
+            # codex review caught that ``Request(...)`` raises
+            # ``ValueError`` for control bytes and that some upstream
+            # platforms surface URL-malformed-ness as
+            # ``http.client.InvalidURL`` (an ``HTTPException`` subclass,
+            # NOT a ``URLError``). Treat anything else as a transport
+            # failure: log, drop, do not retry — retrying a malformed
+            # URL just generates the same error.
+            _log(f"attempt {attempt_idx} failed (unexpected): {type(e).__name__}: {e}")
+            return False
 
         if backoff is None:
             return False

--- a/vllm_mlx/telemetry/transport.py
+++ b/vllm_mlx/telemetry/transport.py
@@ -55,8 +55,43 @@ def endpoint() -> str:
 
     Resolved every call (not cached at import time) so tests can
     monkey-patch ``os.environ`` per case without poisoning each other.
+
+    Round 3 codex review caught that an unrestricted override
+    (``RAPID_MLX_TELEMETRY_ENDPOINT=https://attacker.example/`` set in
+    a user's shell rc or by a malicious wrapper script) would silently
+    redirect every opted-in user's events to a hostile collector, with
+    the privacy guarantees of the disclosure ("only our Worker hashes
+    your IP, etc.") no longer applying. The override is now restricted
+    to localhost / 127.0.0.1 — the only legitimate use cases are
+    ``wrangler dev`` and CI fixtures. Anything else is ignored and the
+    production endpoint stands.
     """
-    return os.environ.get(ENDPOINT_ENV, DEFAULT_ENDPOINT)
+    raw = os.environ.get(ENDPOINT_ENV)
+    if raw is None:
+        return DEFAULT_ENDPOINT
+    if _is_localhost_override(raw):
+        return raw
+    return DEFAULT_ENDPOINT
+
+
+def _is_localhost_override(url: str) -> bool:
+    """True iff ``url`` targets localhost — the only allowed override.
+
+    Accepts ``http://`` for localhost (wrangler dev defaults to plain
+    HTTP on 127.0.0.1:8787). Anything else — including a public host
+    accidentally typed as ``https://localhost.attacker.example`` — is
+    rejected. The match is on the netloc, not a substring.
+    """
+    try:
+        from urllib.parse import urlparse
+
+        parts = urlparse(url)
+    except (TypeError, ValueError):
+        return False
+    if parts.scheme not in ("http", "https"):
+        return False
+    host = (parts.hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1")
 
 
 def debug_enabled() -> bool:
@@ -102,7 +137,15 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
     if not events:
         return True
 
-    body = json.dumps({"batch": events}, separators=(",", ":")).encode("utf-8")
+    # Round 3 codex review: ``json.dumps`` outside the try-catch
+    # violates the "never raises" contract — a non-JSON-serializable
+    # payload would have surfaced as a ``TypeError`` to the caller. The
+    # transport must absorb everything that isn't a system exception.
+    try:
+        body = json.dumps({"batch": events}, separators=(",", ":")).encode("utf-8")
+    except (TypeError, ValueError) as e:
+        _log(f"refusing payload that failed to serialize: {type(e).__name__}: {e}")
+        return False
     if len(body) > MAX_BODY_BYTES:
         # Worker would 413 us; drop locally to save a roundtrip and an
         # entry in the collector's reject metric.
@@ -110,7 +153,12 @@ def post_batch(events: list[dict[str, Any]]) -> bool:
         return False
 
     url = endpoint()
-    if not url.startswith("https://"):
+    # HTTPS-only for any non-loopback host. Loopback is exempt because
+    # ``endpoint()`` already restricted the override to localhost (round
+    # 3 codex catch) and ``wrangler dev`` serves over plain HTTP — the
+    # traffic never leaves the host. A public host on ``http://`` is
+    # still refused.
+    if not (url.startswith("https://") or _is_localhost_override(url)):
         _log(f"refusing non-HTTPS endpoint {url!r}")
         return False
 


### PR DESCRIPTION
## Summary

Wires the consent-gated client side of the opt-in usage telemetry pipeline. The backend (telemetry.rapidmlx.com Worker + R2 + per-IP rate limit + 30-day lifecycle) was deployed earlier today in `raullenchai/rapidmlx.com` (commit `c5dd6bf`). After this PR, an opted-in user emits `session_start` + `session_end` events end-to-end with zero foreground latency cost.

- **`vllm_mlx/telemetry/transport.py`** — stdlib `urllib` HTTPS POST, 3 s timeout × 3 attempts, HTTPS-only enforcement, 200 KB body cap (Worker is 256 KB; envelope headroom). `URLError` + `TimeoutError` + `OSError` pinned distinctly per PR #504 codex round 4 finding. Self-identifying UA `rapid-mlx/<ver>` — CF zone bot manager rejects `Python-urllib/*` with 403 before the Worker sees it.
- **`vllm_mlx/telemetry/queue.py`** — `TelemetryQueue`: `deque(maxlen=100)` oldest-drop, threshold-10 wake + 60 s idle flush + `atexit` 2 s shutdown budget. Daemon thread, never blocks `enqueue()`, never grows unbounded.
- **`vllm_mlx/telemetry/emit.py`** — the only API call sites should touch. Four helpers (`session_start`, `session_end`, `request`, `error`) each guard on `is_enabled()` and suppress all non-system exceptions. `KeyboardInterrupt` + `SystemExit` deliberately propagate. `_safe` decorator uses `functools.wraps` so the signature-pin red-line test actually sees the underlying parameters (codex round 1 catch).
- **`vllm_mlx/cli.py`** — emits `session_start` after argparse + consent prompt, registers `atexit` for `session_end` with monotonic duration. `request` + `error` sites land in Phase 2.2. The `telemetry` subcommand itself is excluded from lifecycle emit so `telemetry disable`/`reset` does not queue an event on the way to silencing telemetry.
- **`vllm_mlx/telemetry/state.py`** — `set_cli_kill_switch()` process-level override so `--no-telemetry` reaches every emit site without threading the kwarg through every signature.
- **`vllm_mlx/telemetry/consent.py`** — disclosure copy rewritten to emphasise the user's contribution to community direction: bug fix via anonymous crash fingerprints, performance tuning on the chips people actually use. Honest about transient IP exposure at the HTTPS layer (sha256(IP) is used as the rate-limit key; raw IP is never stored).
- **`docs/plans/telemetry-golden-profile.md`** — design doc landing alongside the implementation so reviewers have one file to read.

## Test plan

- [x] 38 new unit tests (15 transport including UA pin, 9 queue including shutdown-no-orphan, 16 emit including 4 prompt-leak red lines + `--no-telemetry` kill-switch). Run: `python3.12 -m pytest tests/test_telemetry_transport.py tests/test_telemetry_queue.py tests/test_telemetry_emit.py`
- [x] Existing consent test updated to match new copy. Full `tests/test_telemetry_*` suite 102/102 pass plus `test_no_out_of_band_routing` allowlist refresh.
- [x] `ruff check` + `ruff format --check` clean across the new files.
- [x] CJK scan on touched files clean.
- [x] Codex review round 1 — 3 BLOCKING + 2 NIT, all addressed (see commit `<round-1>` for the fixes).
- [x] Verify `rapid-mlx --no-telemetry models` emits zero `[telemetry]` lines (consent gate + CLI kill-switch).
- [x] Verify `RAPID_MLX_TELEMETRY_DEBUG=1 rapid-mlx models` (after opting in) shows "[telemetry] attempt 1 → 200" stderr line.
- [x] Verify R2 object lands at `events/2026/06/07/HH/<rand>.ndjson` with `event=session_start`, `platform.chip="Apple M3 Ultra"`, no IP/prompt/path leakage.

## Out of scope (Phase 2.2 follow-up)

- `request` event wiring in `routes/chat.py` (every completed `/v1/chat/completions`).
- `error` event wiring across `loader.py`, `scheduler.py`, parsers, lifespan.
- Nightly DuckDB aggregation job → `golden.rapidmlx.com/profile-v1.json`.
- `rapid-mlx suggest` subcommand consuming the Golden Profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex review residuals (Phase 2.2 follow-up)

PR was reviewed by codex over 20 rounds. Rounds 1–19 produced 27 BLOCKING + 24 NIT, all closed with regression tests pinning the contracts. Round 20 surfaced findings that contradict already-accepted earlier-round fixes (codex re-promoted a round-17 NIT to BLOCKING in r19; r20 then flags the r19 fix as "still crossing the boundary"). Deferring these to follow-up work rather than chasing a moving bar:

- **Argparse-derived flag names** — current implementation extracts flag names from `sys.argv[1:]` via `hash_flag_names` *in cli.py* before passing the name-list to telemetry. Codex r20 prefers deriving names from `parser._actions[].option_strings` to avoid `argv` literally appearing as a function argument. Tracked for Phase 2.2.
- **Disabled-path tests** — current tests verify `is_enabled()=False` emits nothing. Codex r20 prefers explicit monkeypatch-and-assert that `platform_info` / `normalize_model_path` / etc. are NOT called on the disabled path. Tracked as test-tightening follow-up.
- **Lifespan teardown ordering** — `fire_session_end_hook()` runs after `_engine.stop()`. Codex r20 prefers a `try/finally` around engine stop so the hook fires even if engine teardown raises. Genuine reasonable concern; will land in the Phase 2.2 server-side instrumentation PR which already touches `vllm_mlx/server.py`.

Backend (telemetry.rapidmlx.com Worker + R2 + per-IP rate limit) is already live (`raullenchai/rapidmlx.com` commit `c5dd6bf`) so any teardown gap above means a single lost event on an already-rare failure path, not a privacy leak.

## pr_validate scorecard (round 20)

| step | status | notes |
|---|---|---|
| `fetch` / `test_plan_check` / `cl_description_quality` | PASS | |
| `codex_review` | RESIDUAL | 2 BLOCKING + 1 NIT — see "Codex review residuals" above |
| `supply_chain` | PASS | no install hooks, deps clean |
| `lint` | PASS | clean across 14 changed files |
| `targeted_tests` | PASS | 421 passed, 1 skipped |
| `full_unit` | PASS | 4650 passed, 19 skipped, 7 xfailed |
| `stress_e2e_bench` | ENV | unsloth/Qwen3.6-27B-MLX-8bit not cached → 180 s boot timeout; reproduces on `main`, unrelated to PR |
