### PR TITLE
chore: bump version to 0.6.81

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.80"
+version = "0.6.81"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Ship Phase 2 opt-in telemetry pipeline.

- PR #532 (telemetry Phase 2) — landed earlier today; 20 rounds codex review (27 BLOCKING + 24 NIT closed)
- bd0b36a (README benchmark refresh) — already on main

Backend (telemetry.rapidmlx.com Worker + R2 + KV per-IP rate limit) is already live. This release puts the client wiring in users' hands. Default is OFF — users must explicitly opt in at the first-run disclosure prompt.

## Release gates

- [x] pr_validate (20 rounds codex review on #532) — round-20 residuals deferred to Phase 2.2 (see #532 body)
- [x] `make release-smoke` — clean venv install + 5 surface imports
- [x] `python3.12 -m pytest tests/ --ignore=tests/integrations --ignore=tests/stress` — 4651 passed, 19 skipped, 7 xfailed
- [x] `ruff check` + `ruff format --check` — clean
- [x] supply_chain — no install hooks, deps clean
- [x] CJK scan on touched files — clean

## Test plan

- [ ] CI green (lint + test-matrix 3.10/3.11/3.12 + test-apple-silicon)
- [ ] Auto-release tag fires on merge → PyPI 0.6.81 published
- [ ] Homebrew formula auto-bump PR opened
- [ ] Fresh install onboarding test (subagent): `pipx install rapid-mlx==0.6.81 && rapid-mlx serve qwen3.5-9b` → see disclosure prompt → answer "y" → verify `session_start` event lands in telemetry.rapidmlx.com R2 within ~60 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)