### PR TITLE
chore: bump version to 0.6.82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.81"
+version = "0.6.82"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bumps 0.6.81 → 0.6.82. Ships PR #518 (merged `0010866`):

- **#468** `tool_choice="required"` enforcement: strict system-prompt injection (named + freeform) + post-parse 422 if the parser comes back empty
- **#517** Streaming `parallel_tool_calls=false` cap symmetry across text-parser paths (hermes/qwen3) — non-streaming path's cap was already enforced; streaming was bypassing
- **#516** HarmonyStreamingRouter G11 escape hatches: `--force-openai-harmony-streaming` / `--no-openai-harmony-streaming`

Real chat-surface bugs surfaced by the v0.6.75 subagent UX probe; users on gpt-oss-20b and qwen3.5-35b were seeing garbled tool-call output / silent cap bypass.

## Test plan

- [x] PR #518 unit suite: 4499 passed (+15 vs main), lint clean — see `0010866`
- [ ] Post-merge: PyPI shows 0.6.82 within ~5 min via `auto-release.yml`
- [ ] Post-merge: Homebrew tap formula updates within ~10 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)