### PR TITLE
chore(ci): push PR-validation + release SOP gates to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,18 @@ jobs:
       - name: CLI ↔ Config fidelity audit
         run: python scripts/audit_cli_config_fidelity.py
 
+      # PF-3 — supply-chain hardening. Third-party GitHub Actions must
+      # pin to a 40-char commit SHA, not a mutable tag/branch. The repo
+      # currently has known pre-existing violations (codecov-action,
+      # peaceiris/gh-pages, pypa/gh-action-pypi-publish, peter-evans/
+      # repository-dispatch) tracked for follow-up — advisory mode
+      # (continue-on-error) until those are pinned in a separate
+      # hardening PR. Once clean, drop continue-on-error to make this
+      # a hard gate.
+      - name: GitHub Actions SHA pinning (advisory)
+        continue-on-error: true
+        run: python scripts/check_gha_pinning.py
+
   type-check:
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +110,9 @@ jobs:
             tests/test_minimax_reasoning_parser.py \
             tests/test_pr_validate_runner.py \
             tests/test_pr_validate_codex.py \
+            tests/test_validate_release_subject.py \
+            tests/test_check_gha_pinning.py \
+            tests/test_check_mlx_upstream_calls.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \
@@ -152,6 +167,7 @@ jobs:
             tests/test_streaming_simulator.py \
             tests/test_streaming_detokenizer.py \
             tests/test_tool_logits.py \
+            tests/test_no_mllm_flag.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,180 @@
+name: Release pre-flight
+
+# Runs SOP gates that block a release if they fail. Triggered on PRs
+# whose title matches the strict bump subject ``chore: bump version to
+# X.Y.Z`` — the same regex the auto-release.yml workflow watches post-
+# merge.
+#
+# Gate coverage (see docs/development/release_workflow.md for the
+# canonical list):
+#
+#   G1   clean-room install + import smoke     macOS-14
+#   G2   codex review presence assertion       advisory comment
+#   G3   CLI ↔ Config fidelity audit           covered by ci.yml lint
+#   G10  MLX upstream cross-chip-family scan   advisory
+#   G11  auto-routing escape-hatch registry    macOS-14 (needs MLX)
+#   PF-1 squash subject regex pre-check        ubuntu-latest
+#
+# What this workflow does NOT cover (M3-only, runs locally — see
+# release_workflow.md):
+#   G4 full make smoke (covered by ci.yml test-apple-silicon subset)
+#   G5 make stress      — needs cached weights + live server
+#   G6 fix-path repro   — needs live server
+#   G7 SDK integration  — needs cached weights + network
+#   G8 microbench       — needs perf-baseline infra (#TBD)
+#   G9 latency 10-seq   — needs live server
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect-bump-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      is_bump: ${{ steps.check.outputs.is_bump }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - id: check
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Match the auto-release.yml regex EXACTLY. If the PR title
+          # doesn't match, every job below is skipped — non-bump PRs
+          # pay zero CI cost.
+          if echo "$TITLE" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+$'; then
+            VERSION=$(echo "$TITLE" | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+            echo "is_bump=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Detected bump PR for v$VERSION"
+          else
+            echo "is_bump=false" >> "$GITHUB_OUTPUT"
+            echo "Not a bump PR — skipping all preflight gates"
+          fi
+
+  pf1-subject-regex:
+    # PF-1 — verifies the PR title would auto-release cleanly. Catches
+    # the `(#NN)` squash-suffix trap upfront instead of after a botched
+    # merge to main. Pure structural; runs on every PR opened/edited.
+    needs: detect-bump-pr
+    if: needs.detect-bump-pr.outputs.is_bump == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: PF-1 — validate bump PR title matches auto-release regex
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: python scripts/validate_release_subject.py --subject "$TITLE"
+      - name: Verify pyproject.toml version matches title
+        env:
+          TITLE_VER: ${{ needs.detect-bump-pr.outputs.version }}
+        run: |
+          PYPROJECT_VER=$(grep -m1 '^version *=' pyproject.toml | awk -F'"' '{print $2}')
+          echo "title: $TITLE_VER"
+          echo "pyproject.toml: $PYPROJECT_VER"
+          if [ "$TITLE_VER" != "$PYPROJECT_VER" ]; then
+            echo "::error::PR title says v$TITLE_VER but pyproject.toml is $PYPROJECT_VER. Bump pyproject.toml or rename the PR."
+            exit 1
+          fi
+
+  g1-release-smoke:
+    # G1 — clean-room install + import smoke on macOS-14. Catches the
+    # #408 class where dev mlx has a symbol PyPI mlx doesn't.
+    needs: detect-bump-pr
+    if: needs.detect-bump-pr.outputs.is_bump == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: G1 — clean-room install + import smoke
+        run: make release-smoke
+
+  g10-upstream-mlx-scan:
+    # G10 — advisory scan of installed mlx-lm/mlx-vlm for module-scope
+    # calls into chip-family-sensitive APIs. Surfaces, does not block.
+    # The release-er must cite "audited" in the PR description if any
+    # finding lands in a code path our compat shim doesn't already cover.
+    needs: detect-bump-pr
+    if: needs.detect-bump-pr.outputs.is_bump == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install mlx-lm + mlx-vlm at pyproject-pinned versions
+        # The scan must run against the EXACT version range the bump
+        # ships. Install in user-site so we don't disturb the runner's
+        # default python.
+        run: |
+          python -m pip install --upgrade pip
+          # Install only mlx-* (skip the rest — we just need the wheel
+          # tree on disk to scan).
+          MLX_LM_PIN=$(grep -m1 'mlx-lm' pyproject.toml | grep -oE '>=[0-9.]+|==[0-9.]+|~=[0-9.]+' | head -1 || true)
+          MLX_VLM_PIN=$(grep -m1 'mlx-vlm' pyproject.toml | grep -oE '>=[0-9.]+|==[0-9.]+|~=[0-9.]+' | head -1 || true)
+          pip install "mlx-lm${MLX_LM_PIN}" "mlx-vlm${MLX_VLM_PIN}"
+      - name: G10 — surface module-scope dangerous MLX calls
+        # Advisory only (no --strict). The release reviewer reads the
+        # output and decides whether each finding needs a compat shim.
+        run: python scripts/check_mlx_upstream_calls.py
+
+  g11-escape-hatch:
+    # G11 — auto-routing escape-hatch registry. Catches the class of
+    # bugs in #393 (no --no-mllm), #400 (silent flag drop), #404 (no
+    # user override for hardware probe). Requires MLX because the test
+    # introspects vllm_mlx.engine / vllm_mlx.server signatures.
+    needs: detect-bump-pr
+    if: needs.detect-bump-pr.outputs.is_bump == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install project (vision extras for full surface coverage)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[vision]"
+          pip install pytest pytest-asyncio
+      - name: G11 — escape-hatch registry test
+        run: pytest tests/test_no_mllm_flag.py -v --tb=short
+
+  preflight-summary:
+    # Roll-up so the bump PR has a single "Release pre-flight" required
+    # check to gate merge on, instead of N independent jobs.
+    needs:
+      - detect-bump-pr
+      - pf1-subject-regex
+      - g1-release-smoke
+      - g10-upstream-mlx-scan
+      - g11-escape-hatch
+    if: always() && needs.detect-bump-pr.outputs.is_bump == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate gate results
+        env:
+          PF1: ${{ needs.pf1-subject-regex.result }}
+          G1: ${{ needs.g1-release-smoke.result }}
+          G10: ${{ needs.g10-upstream-mlx-scan.result }}
+          G11: ${{ needs.g11-escape-hatch.result }}
+        run: |
+          echo "PF-1 subject regex:   $PF1"
+          echo "G1   release-smoke:   $G1"
+          echo "G10  upstream MLX:    $G10  (advisory — never fails)"
+          echo "G11  escape-hatch:    $G11"
+          # G10 is advisory — never blocks. Others must pass.
+          if [ "$PF1" != "success" ] || [ "$G1" != "success" ] || [ "$G11" != "success" ]; then
+            echo "::error::One or more release pre-flight gates failed. See docs/development/release_workflow.md for the gate definitions."
+            exit 1
+          fi
+          echo "All blocking gates passed. M3-only gates (G4-G9) must be run locally."

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -222,6 +222,28 @@ Before merge, the PR description must accurately reflect actual current state:
 - If the squash subject contains `(#NN)` GitHub auto-suffix on a `chore: bump version to X.Y.Z` commit, override with `--subject` — the regex in `auto-release.yml` is strict.
 - After merge, verify `git log raullenchai/main --oneline -1` shows your squash commit.
 
+## CI coverage of these steps
+
+The CI runs a subset of the gauntlet automatically. The table maps each step to where it actually executes — when CI is green, only the local-only rows still require human action:
+
+| Step | CI coverage | M3-local-only | Notes |
+|---|---|---|---|
+| 0 — necessity | — | local | judgment call, can't automate |
+| 1 — pre-flight | partial (`version-check.yml` blast-radius detection) | local | PR description quality is automated in `pr_validate.steps.cl_description_quality` |
+| 2 — codex review | — | local | codex-bot runs on PR push events; convergence is human-judged |
+| 3 — test coverage | `ci.yml` (existence of `tests/test_<scope>*.py` files) | local mutation spot-check | mutation testing is the local part |
+| 4 — lint + format | `ci.yml` lint job (ruff, ruff format, audit_cli_config_fidelity, gha-pinning advisory) | — | full coverage |
+| 5 — broader unit suite | `ci.yml` test-matrix (linux subset) + test-apple-silicon (mlx-dependent) | full `make smoke` | linux runs ~20 curated test files; macOS runs the mlx-importing tests |
+| 6 — pr_validate | partial (test_plan_check + cl_description_quality auto-run by `ci.yml` test-matrix) | full pipeline including deepseek + stress | DeepSeek + stress_e2e_bench are local-only |
+| 7 — supply chain | partial (`pr_validate.supply_chain` step, gha-pinning advisory) | local pip-audit + license review | license drift + transitive deps still local |
+| 8 — doctor `make check` | — | **local** (needs MLX + cached weights) | inference-touching PRs only |
+| 9 — Anthropic-compat | — | **local** (needs MLX + live server) | parser/router PRs only |
+| 10 — CI gate | `ci.yml` aggregation step | — | full coverage |
+| 11 — PR description audit | `pr_validate.cl_description_quality` (auto) | local final read | automated rejects empty bodies and bad titles |
+| 12 — merge | `auto-release.yml` regex match + `release-preflight.yml` PF-1 subject pre-check | — | strict subject enforced both PR-time and post-merge |
+
+For release-time gates (the 11-gate gauntlet that fires on bump PRs), see [`releasing.md` § "Pre-release validation gauntlet"](releasing.md#pre-release-validation-gauntlet-11-gates).
+
 ## Common pitfalls
 
 - **"Tests pass on my branch" ≠ "no regression"** — always confirm pre-existing flakes on clean main, never assume.
@@ -230,6 +252,11 @@ Before merge, the PR description must accurately reflect actual current state:
 - **Hybrid models** (`is_hybrid=True`: Qwen3.5/3.6, Qwopus, Nemotron, Granite4) cannot use spec-decode / suffix-decode. Trust the gate.
 - **Background processes block GPU** — orphaned `rapid-mlx serve` from prior sessions can hang pytest. `pkill -f "vllm_mlx.cli serve"` before benches.
 - **Auto-deploy blast radius** — merging to main with version bump = instant PyPI + Homebrew release. External PR review must include the Step 7 supply-chain audit before merge.
+- **Squash-suffix trap** — GitHub's default squash-merge appends `(#NN)` to the subject, breaking `auto-release.yml`'s regex. Always pass `--subject` to `gh pr merge` for bump PRs. `release-preflight.yml` PF-1 catches this pre-merge.
+- **`skip-version-bump` label refire** — adding the label after `version-check.yml` has already failed does NOT auto-re-run the workflow (the label-add event isn't a `pull_request` event the bypass step listens to). Either close+reopen the PR or push a commit to refire. Memory: `gotcha_skip_version_bump_label_after_run`.
+- **A/B classify validation-surfaced bugs** — when `pr_validate` or codex surfaces a bug, replay against base/main before deciding it's PR-introduced. Pre-existing bugs are follow-up issues, not PR scope creep. Memory: `feedback_pr_scope_ab_classify_first`.
+- **Codex+DeepSeek convergence asymmetry** — codex converges in ~9 rounds, DeepSeek is asymptotic. Run codex to convergence, then ONE DeepSeek round. Memory: `codex_deepseek_convergence_asymmetry`.
+- **Pre-existing pre-existing flake confirmation** — use a worktree, not `git stash`. The stash pattern leaves work stashed if pytest crashes mid-run.
 
 ## Tracked SOP improvements
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -120,3 +120,82 @@ chore: bump version to X.Y.Z
 ```
 
 — where `X.Y.Z` is three numeric components matching the new `pyproject.toml` version. Anything else (extra words, different prefix, dev suffixes) is silently ignored.
+
+> **Squash-suffix trap.** GitHub's default squash-merge appends `(#NN)` to the subject. That suffix breaks the regex match and strands the version between commit-on-main and PyPI/Homebrew publish (recurring footgun — see `release_squash_subject` memory). Always pass `--subject` to `gh pr merge`:
+>
+> ```bash
+> gh pr merge <PR#> --repo raullenchai/Rapid-MLX --squash \
+>   --subject "chore: bump version to X.Y.Z" --delete-branch
+> ```
+>
+> The `release-preflight.yml` workflow checks bump-PR titles against the same regex up-front; `scripts/validate_release_subject.py` is the structural belt-and-suspenders.
+
+## Pre-release validation gauntlet (11 gates)
+
+The full set of gates that block a release. Some run automatically in CI, others must be run locally on an M-series machine before pushing the bump commit.
+
+| # | Gate | CI runner | M3-only | Catches |
+|---|---|---|---|---|
+| G1 | `make release-smoke` — clean-room install + import | `release-preflight.yml` (macOS-14) | — | dev mlx symbol drift (#408) |
+| G2 | Codex review × 2 rounds on the PR | local | local | every PR-author bug class |
+| G3 | CLI ↔ Config fidelity audit | `ci.yml` lint (ubuntu) | — | silent CLI flag drop (#400) |
+| G4 | `make smoke` — lint + 4500+ unit tests | `ci.yml` test-matrix (linux subset) + `test-apple-silicon` (macOS-14) | full `make smoke` on local | parser/router regressions |
+| G5 | `make stress` — 8 scenarios incl. tool storm | — | **M3** (needs cached model + live server) | concurrent-batching regressions |
+| G6 | Live-server fix-path repro | — | **M3** (needs live server) | fix doesn't ship to the user-visible path |
+| G7 | SDK integration (anthropic / pydantic_ai / smolagents) | — | **M3** (needs cached weights + PyPI deps) | router-level breakage that unit tests miss |
+| G8 | Microbench changed code path | — | **M3** (needs perf baseline DB) | silent perf regressions |
+| G9 | 10-sequential latency check | — | **M3** (needs live server) | KV-cache / hot-path regressions |
+| G10 | MLX upstream cross-chip-family audit | `release-preflight.yml` advisory (macOS-14) | review the warnings | M5-style #404 landmines |
+| G11 | Auto-routing escape-hatch registry | `release-preflight.yml` (macOS-14) + `ci.yml` test-apple-silicon | — | silent auto-detection failures (#393/#400/#404) |
+
+### What CI covers automatically on the bump PR
+
+When you open a PR titled `chore: bump version to X.Y.Z`, `release-preflight.yml` runs:
+
+- **PF-1** — `scripts/validate_release_subject.py` checks the title matches the auto-release regex (catches the `(#NN)` trap).
+- **Version coherence** — `pyproject.toml` version line must equal the version in the title.
+- **G1** — `make release-smoke` on macOS-14.
+- **G10** — `scripts/check_mlx_upstream_calls.py` scans the installed mlx-lm/mlx-vlm tree for module-scope calls into chip-family-sensitive APIs; **advisory only**, the release-er decides per finding.
+- **G11** — `tests/test_no_mllm_flag.py` 33-test registry asserts every auto-routing helper exposes both force-on and force-off CLI flags.
+
+The `preflight-summary` job aggregates them so the bump PR has a single required check.
+
+### What you must run locally on M3 before pushing the bump commit
+
+These need cached model weights and live MLX inference — they can't run on GitHub-hosted runners:
+
+```bash
+# In one shell — start the server with the alias the fix targets:
+python3.12 -m vllm_mlx.cli serve qwen3.5-4b --port 8000
+
+# In another shell, run all four:
+make stress                          # G5 — 8-scenario stress test
+# G6 — boot the fix-path-specific curl repro; see PR description
+python3.12 tests/integrations/test_anthropic_sdk.py    # G7
+python3.12 tests/integrations/test_pydantic_ai_full.py # G7
+python3.12 tests/integrations/test_smolagents_full.py  # G7
+# G8 — microbench the changed code path against the prior version
+# G9 — 10 sequential requests, watch tok/s stability
+```
+
+Document each result in the bump PR description. If any M3-only gate is skipped, explain why (e.g. "G7: smolagents failures pre-existing on main, see <ref>").
+
+### Gates with known pitfalls
+
+| Pitfall | Memory ref | Mitigation |
+|---|---|---|
+| `(#NN)` squash suffix breaks regex | `release_squash_subject` | PF-1 + doc note above |
+| `skip-version-bump` label needs PR close+reopen to refire | `gotcha_skip_version_bump_label` | Doc note in `version-check.yml`; user must close+reopen or push to refire `pull_request` event |
+| Mutable GitHub Actions tags as supply-chain vector | `pr_merge_sop` §7 | `scripts/check_gha_pinning.py` (advisory in `ci.yml` lint pending pinning cleanup) |
+| MLX upstream new module-scope calls (M5 #404) | `release_workflow` G10 | `scripts/check_mlx_upstream_calls.py` runs in `release-preflight.yml` G10 |
+| Codex-skip rationalization on bump PRs ("feels like just a version bump") | `feedback_release_sop_third_offense` | G2 stays local — the 11-gate table above is the explicit override of "feels small" |
+
+### Adding a new gate
+
+When a release-time bug class recurs:
+
+1. Write the gate as a pure-Python script under `scripts/` if it doesn't need MLX.
+2. Add it to `release-preflight.yml` (a new job + the `preflight-summary` aggregator).
+3. Add unit tests under `tests/test_<gate>.py` covering pass + fail + edge cases.
+4. Append a row to the 11-gate table above with the catches/CI columns.
+5. If the gate is M3-only, add it to the "must run locally" list with the exact command.

--- a/scripts/check_gha_pinning.py
+++ b/scripts/check_gha_pinning.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Enforce 40-char SHA pinning on third-party GitHub Actions.
+
+Mutable tags (``actions/checkout@v4``) are a supply-chain compromise
+vector: if the action's repo is taken over, every workflow that pins by
+tag automatically picks up the malicious version on the next CI run.
+This bit Trivy in 2026 and is the recurring class of attack against
+auto-publishing release pipelines (which Rapid-MLX is).
+
+Allowlist: official ``actions/*`` and ``github/*`` org actions are
+permitted at tag refs because GitHub backs their immutability via a
+separate guarantee. Everything else must be a 40-char commit SHA, with
+the human-readable version comment on the same line:
+
+    uses: codecov/codecov-action@1234567890abcdef1234567890abcdef12345678  # v4.5.0
+
+Run on every PR touching ``.github/workflows/`` (gate in ci.yml).
+Standalone: ``python3 scripts/check_gha_pinning.py``.
+
+Exit 0 = all good, exit 1 = violations (printed to stderr).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Owners whose tags we trust as immutable (per GitHub's own guarantee).
+TRUSTED_OWNERS = {"actions", "github"}
+
+# uses: <owner>/<repo>[/path]@<ref>
+USES_RE = re.compile(
+    r"^\s*-?\s*uses:\s*([^@\s]+)@([^\s#]+)",
+    re.MULTILINE,
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def violations_in_file(path: Path) -> list[str]:
+    """Return a list of human-readable violations for one workflow file."""
+    out: list[str] = []
+    text = path.read_text()
+    for m in USES_RE.finditer(text):
+        action, ref = m.group(1), m.group(2)
+        owner = action.split("/", 1)[0]
+        if owner in TRUSTED_OWNERS:
+            continue
+        if SHA_RE.fullmatch(ref):
+            continue
+        line_no = text[: m.start()].count("\n") + 1
+        out.append(
+            f"{path}:{line_no}: uses: {action}@{ref} — non-allowlisted "
+            "third-party action must pin to a 40-char SHA, not a tag/branch"
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--workflows-dir",
+        default=".github/workflows",
+        help="Directory of GitHub Actions workflow YAML files",
+    )
+    args = p.parse_args(argv)
+
+    root = Path(args.workflows_dir)
+    if not root.is_dir():
+        print(f"FAIL: {root} is not a directory", file=sys.stderr)
+        return 1
+
+    workflows = sorted(p for p in root.iterdir() if p.suffix in {".yml", ".yaml"})
+    if not workflows:
+        print(f"OK: no workflows in {root}")
+        return 0
+
+    all_violations: list[str] = []
+    for wf in workflows:
+        all_violations.extend(violations_in_file(wf))
+
+    if not all_violations:
+        print(
+            f"OK: {len(workflows)} workflows clean — every third-party "
+            "`uses:` is a 40-char SHA or an allowlisted owner."
+        )
+        return 0
+
+    print(
+        f"FAIL: {len(all_violations)} GitHub Actions SHA-pinning violation(s):",
+        file=sys.stderr,
+    )
+    for v in all_violations:
+        print(f"  {v}", file=sys.stderr)
+    print(
+        "\nFix: replace the tag/branch with the commit SHA from the action's "
+        "GitHub release page, keeping the tag as a trailing comment:\n"
+        "  - uses: foo/bar@<40-char-sha>  # v1.2.3",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_mlx_upstream_calls.py
+++ b/scripts/check_mlx_upstream_calls.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Surface dangerous module-scope MLX API calls in installed mlx-*.
+
+Release SOP Gate 10 catches the class of bug that #404 shipped: a new
+top-level ``mx.new_thread_local_stream(mx.default_device())`` lands at
+module-load time in ``mlx_lm/generate.py``, works on M1-M4, crashes on
+M5. The dev env's MLX is whatever's checked out; the release wheel
+might pull a newer mlx-lm that has the new call, and the dev gates run
+green while production users on the wrong chip family ``ImportError``.
+
+This script does NOT diff against an "old" version — it scans the
+currently-installed mlx-lm / mlx-vlm tree for ALL module-scope (i.e.
+import-time) calls to a known-dangerous API set, and emits a warning
+list. The CI gate fires only when ``pyproject.toml``'s mlx-* deps
+change in the PR; the release-er must read the list and either:
+
+  (a) explicitly clear it in the PR description ("audited for #404
+      class — none of these call into hardware-specific paths"), or
+  (b) add a ``vllm_mlx/_mlx_compat.py``-style probe-and-cache shim for
+      the affected call before merging.
+
+The script does NOT auto-fail — it surfaces. Hard-failing on every
+new mx.* import-time call would block legitimate releases on
+upstream's cleanup PRs. The human decision is the gate; this is the
+information feed to that decision.
+
+Usage:
+    python3 scripts/check_mlx_upstream_calls.py
+        # scans installed mlx_lm + mlx_vlm; prints findings + exits 0
+
+    python3 scripts/check_mlx_upstream_calls.py --strict
+        # exits 1 if any findings — for CI runs where the bump must be
+        # human-reviewed before merge
+
+Exit 0 = scan complete (or no findings in --strict).
+Exit 1 = scan error (or findings in --strict).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+# API surface that has historically caused chip-family-specific failures
+# at module load time. Add to this list when a new landmine is found.
+#
+# Format: ("<attribute path>", "<rationale>"). The attribute path is the
+# AST-rendered dotted form (``mx.metal.foo``, ``mlx.core.default_device``)
+# we match against any Call's func chain.
+DANGEROUS_CALLS = [
+    ("mx.metal", "device-introspection / chip-family-specific"),
+    ("mlx.core.metal", "device-introspection / chip-family-specific"),
+    ("mx.new_thread_local_stream", "single-stream M5 #404 root cause"),
+    ("mlx.core.new_thread_local_stream", "single-stream M5 #404 root cause"),
+    ("mx.default_device", "device-introspection at import time"),
+    ("mlx.core.default_device", "device-introspection at import time"),
+    ("mx.set_default_device", "mutates global device state at import"),
+    ("mlx.core.set_default_device", "mutates global device state at import"),
+]
+
+
+def _attr_chain(node: ast.AST) -> str:
+    """Render ``mx.metal.foo`` from the nested Attribute/Name AST."""
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    return ".".join(reversed(parts))
+
+
+def _is_module_scope(parents: list[ast.AST]) -> bool:
+    """A call is module-scope if no enclosing FunctionDef/ClassDef."""
+    return not any(
+        isinstance(p, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        for p in parents
+    )
+
+
+def _walk_with_parents(node: ast.AST, parents: list[ast.AST] | None = None):
+    if parents is None:
+        parents = []
+    yield node, parents
+    for child in ast.iter_child_nodes(node):
+        yield from _walk_with_parents(child, parents + [node])
+
+
+def scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return list of ``(line_no, dangerous_chain, rationale)`` for path."""
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    findings: list[tuple[int, str, str]] = []
+    for node, parents in _walk_with_parents(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_module_scope(parents):
+            continue
+        chain = _attr_chain(node.func)
+        for needle, rationale in DANGEROUS_CALLS:
+            if chain == needle or chain.startswith(needle + "."):
+                findings.append((node.lineno, chain, rationale))
+                break
+    return findings
+
+
+def scan_package(pkg_name: str) -> list[tuple[Path, int, str, str]]:
+    """Scan an installed package by name; return [(path, lineno, chain, why)]."""
+    spec = importlib.util.find_spec(pkg_name)
+    if spec is None or spec.origin is None:
+        return []
+    root = Path(spec.origin).parent
+    out: list[tuple[Path, int, str, str]] = []
+    for py in sorted(root.rglob("*.py")):
+        for line_no, chain, why in scan_file(py):
+            out.append((py, line_no, chain, why))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--packages",
+        nargs="+",
+        default=["mlx_lm", "mlx_vlm"],
+        help="Packages to scan (default: mlx_lm mlx_vlm).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 if any dangerous module-scope calls found.",
+    )
+    args = p.parse_args(argv)
+
+    total = 0
+    for pkg in args.packages:
+        findings = scan_package(pkg)
+        if not findings:
+            print(f"OK: {pkg}: no module-scope calls into known-dangerous MLX API.")
+            continue
+        print(
+            f"⚠  {pkg}: {len(findings)} module-scope call(s) into known-dangerous MLX API:"
+        )
+        for path, line_no, chain, why in findings:
+            print(f"    {path}:{line_no}: {chain}()  — {why}")
+        total += len(findings)
+
+    if total == 0:
+        return 0
+
+    print(
+        "\nThese are CANDIDATES for cross-chip-family review — see release "
+        "workflow Gate 10. For each finding, decide:\n"
+        "  (a) add an `_mlx_compat.py`-style probe-and-cache shim if it's a "
+        "real landmine on M3/M4/M5, or\n"
+        "  (b) explicitly clear in the PR description: '#404-audited — "
+        "<file>:<line> is OK because <reason>'."
+    )
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_release_subject.py
+++ b/scripts/validate_release_subject.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate a candidate commit subject would auto-release cleanly.
+
+The ``auto-release.yml`` workflow watches for a strict subject:
+
+    chore: bump version to X.Y.Z
+
+GitHub's default squash-merge appends ``(#NN)`` to the subject unless
+the merger passes ``--subject``. That suffix breaks the regex match and
+strands the version between commit-to-main and PyPI/Homebrew publish.
+
+This script is the structural belt-and-suspenders: run it on the bump
+PR's title at PR-time, and the workflow refuses to merge until the
+title is auto-release-compatible.
+
+Usage:
+    python3 scripts/validate_release_subject.py --subject "<text>"
+
+Exit 0 = OK, exit 1 = would not auto-release (with reason on stderr).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# Mirror auto-release.yml's regex EXACTLY. If you tweak one, tweak both.
+SUBJECT_RE = re.compile(r"^chore: bump version to \d+\.\d+\.\d+$")
+
+
+def diagnose(subject: str) -> list[str]:
+    """Return a list of human-readable problems with the subject.
+
+    Empty list means the subject would auto-release.
+    """
+    problems: list[str] = []
+    if not subject:
+        problems.append("subject is empty")
+        return problems
+    if SUBJECT_RE.fullmatch(subject):
+        return problems
+
+    if re.search(r"\(#\d+\)\s*$", subject):
+        problems.append(
+            "subject has a `(#NN)` PR-number suffix — GitHub's default "
+            'squash-merge added it. Pass `--subject "chore: bump version '
+            'to X.Y.Z"` to `gh pr merge` to strip it.'
+        )
+    if not subject.startswith("chore: bump version to "):
+        problems.append(
+            "subject does not start with the literal `chore: bump version to ` prefix"
+        )
+    if not re.search(r"\b\d+\.\d+\.\d+\b", subject):
+        problems.append("subject contains no X.Y.Z version number")
+    if "\n" in subject:
+        problems.append(
+            "subject contains a newline — only the first line is the subject"
+        )
+    if subject != subject.strip():
+        problems.append("subject has leading/trailing whitespace")
+    if not problems:
+        problems.append(
+            "subject doesn't match the auto-release regex "
+            f"`{SUBJECT_RE.pattern}` for an unknown reason"
+        )
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--subject",
+        required=True,
+        help="The candidate commit subject (typically the bump PR title).",
+    )
+    args = p.parse_args(argv)
+
+    problems = diagnose(args.subject)
+    if not problems:
+        print(f"OK: subject would auto-release: {args.subject!r}")
+        return 0
+    print(f"FAIL: subject would NOT auto-release: {args.subject!r}", file=sys.stderr)
+    for prob in problems:
+        print(f"  - {prob}", file=sys.stderr)
+    print(
+        "\nFix: rename the PR to exactly `chore: bump version to X.Y.Z` and, "
+        "at merge time, use:\n"
+        "  gh pr merge <PR#> --repo raullenchai/Rapid-MLX --squash "
+        '--subject "chore: bump version to X.Y.Z" --delete-branch',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_gha_pinning.py
+++ b/tests/test_check_gha_pinning.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``scripts/check_gha_pinning.py``.
+
+Pure stdlib — runs on Linux CI without MLX. Tests synthesize tiny
+workflow YAMLs in tmp dirs so the production workflow files don't
+affect the assertions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import textwrap
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_gha_pinning.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_gha_pinning", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cgp():
+    return _load_module()
+
+
+def _make_workflow(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    wf = tmp_path / "test.yml"
+    wf.write_text(textwrap.dedent(body))
+    return wf
+
+
+# ---------- allowlisted owners pass ----------------------------------
+
+
+def test_actions_owner_tag_is_allowed(cgp, tmp_path):
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: actions/checkout@v4
+              - uses: actions/setup-python@v5
+        """,
+    )
+    assert cgp.violations_in_file(wf) == []
+
+
+def test_github_owner_tag_is_allowed(cgp, tmp_path):
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: github/codeql-action@v3
+        """,
+    )
+    assert cgp.violations_in_file(wf) == []
+
+
+# ---------- third-party tag refs are violations ----------------------
+
+
+def test_third_party_tag_is_violation(cgp, tmp_path):
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: codecov/codecov-action@v4
+        """,
+    )
+    violations = cgp.violations_in_file(wf)
+    assert len(violations) == 1
+    assert "codecov/codecov-action" in violations[0]
+    assert "@v4" in violations[0]
+
+
+def test_third_party_branch_is_violation(cgp, tmp_path):
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: pypa/gh-action-pypi-publish@release/v1
+        """,
+    )
+    assert len(cgp.violations_in_file(wf)) == 1
+
+
+def test_third_party_short_sha_is_violation(cgp, tmp_path):
+    # Short SHAs (7 chars) are NOT acceptable — must be 40-char.
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: codecov/codecov-action@abc1234
+        """,
+    )
+    assert len(cgp.violations_in_file(wf)) == 1
+
+
+# ---------- 40-char SHAs are accepted --------------------------------
+
+
+def test_third_party_40_char_sha_is_accepted(cgp, tmp_path):
+    sha = "0" * 40
+    wf = _make_workflow(
+        tmp_path,
+        f"""
+        jobs:
+          x:
+            steps:
+              - uses: codecov/codecov-action@{sha}  # v4.5.0
+        """,
+    )
+    assert cgp.violations_in_file(wf) == []
+
+
+def test_third_party_40_char_sha_uppercase_is_rejected(cgp, tmp_path):
+    # Be strict: lowercase hex only. Uppercase shouldn't happen but is
+    # an easy typo to introduce silently.
+    sha = "A" * 40
+    wf = _make_workflow(
+        tmp_path,
+        f"""
+        jobs:
+          x:
+            steps:
+              - uses: codecov/codecov-action@{sha}
+        """,
+    )
+    assert len(cgp.violations_in_file(wf)) == 1
+
+
+# ---------- entry point ----------------------------------------------
+
+
+def test_main_clean_dir_exits_0(cgp, tmp_path):
+    _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: actions/checkout@v4
+        """,
+    )
+    assert cgp.main(["--workflows-dir", str(tmp_path)]) == 0
+
+
+def test_main_violation_dir_exits_1(cgp, tmp_path):
+    _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: codecov/codecov-action@v4
+        """,
+    )
+    assert cgp.main(["--workflows-dir", str(tmp_path)]) == 1
+
+
+def test_main_empty_dir_exits_0(cgp, tmp_path):
+    assert cgp.main(["--workflows-dir", str(tmp_path)]) == 0
+
+
+def test_main_missing_dir_exits_1(cgp, tmp_path):
+    assert cgp.main(["--workflows-dir", str(tmp_path / "nope")]) == 1

--- a/tests/test_check_mlx_upstream_calls.py
+++ b/tests/test_check_mlx_upstream_calls.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``scripts/check_mlx_upstream_calls.py``.
+
+Pure stdlib AST testing — synthesize tiny Python files and assert the
+scanner classifies them correctly. No real mlx-lm install needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import textwrap
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_mlx_upstream_calls.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_mlx_upstream_calls", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cmu():
+    return _load_module()
+
+
+def _write(tmp_path: pathlib.Path, name: str, body: str) -> pathlib.Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(body))
+    return p
+
+
+# ---------- module-scope dangerous calls flagged --------------------
+
+
+def test_module_scope_new_thread_local_stream_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        _stream = mx.new_thread_local_stream(mx.default_device())
+        """,
+    )
+    findings = cmu.scan_file(f)
+    chains = [chain for _, chain, _ in findings]
+    assert "mx.new_thread_local_stream" in chains
+    assert "mx.default_device" in chains
+
+
+def test_module_scope_mx_metal_is_available_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        HAS_METAL = mx.metal.is_available()
+        """,
+    )
+    findings = cmu.scan_file(f)
+    assert any("mx.metal" in chain for _, chain, _ in findings)
+
+
+def test_set_default_device_at_module_scope_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        mx.set_default_device(mx.gpu)
+        """,
+    )
+    findings = cmu.scan_file(f)
+    chains = [chain for _, chain, _ in findings]
+    assert "mx.set_default_device" in chains
+
+
+# ---------- inside-function calls are NOT flagged -------------------
+
+
+def test_dangerous_call_inside_function_not_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        def get_stream():
+            return mx.new_thread_local_stream(mx.default_device())
+        """,
+    )
+    assert cmu.scan_file(f) == []
+
+
+def test_dangerous_call_inside_class_method_not_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        class Foo:
+            def __init__(self):
+                self.stream = mx.new_thread_local_stream(mx.default_device())
+        """,
+    )
+    assert cmu.scan_file(f) == []
+
+
+def test_dangerous_call_inside_class_body_is_known_gap(cmu, tmp_path):
+    # Class body executes at import — same risk as module top-level.
+    # AST-wise it's inside ClassDef, so per the strict reading of
+    # _is_module_scope (no enclosing FunctionDef/ClassDef) this is
+    # currently NOT flagged. Document the behavior so the reader
+    # knows the limit — class-body initializers should be rare in
+    # mlx-lm anyway.
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        class Foo:
+            stream = mx.new_thread_local_stream(mx.default_device())
+        """,
+    )
+    # Known-gap: scanner only catches top-of-module right now.
+    assert cmu.scan_file(f) == []
+
+
+# ---------- non-dangerous calls not flagged -------------------------
+
+
+def test_mlx_array_call_not_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core as mx
+        ZERO = mx.array([0])
+        """,
+    )
+    assert cmu.scan_file(f) == []
+
+
+def test_non_mlx_call_not_flagged(cmu, tmp_path):
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import os
+        _ = os.environ.get("FOO")
+        """,
+    )
+    assert cmu.scan_file(f) == []
+
+
+# ---------- robustness ----------------------------------------------
+
+
+def test_invalid_python_returns_empty(cmu, tmp_path):
+    f = _write(tmp_path, "a.py", "this is not python code }}\n")
+    assert cmu.scan_file(f) == []
+
+
+def test_full_mlx_core_path_also_matched(cmu, tmp_path):
+    # Some files import as ``from mlx.core import ...`` and write
+    # ``mlx.core.default_device()`` explicitly.
+    f = _write(
+        tmp_path,
+        "a.py",
+        """
+        import mlx.core
+        DEV = mlx.core.default_device()
+        """,
+    )
+    chains = [chain for _, chain, _ in cmu.scan_file(f)]
+    assert "mlx.core.default_device" in chains

--- a/tests/test_validate_release_subject.py
+++ b/tests/test_validate_release_subject.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``scripts/validate_release_subject.py``.
+
+Pure stdlib + the subject script — runs on Linux CI without MLX.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "validate_release_subject.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("validate_release_subject", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def vrs():
+    return _load_module()
+
+
+# ---------- happy path ------------------------------------------------
+
+
+def test_canonical_bump_subject_is_accepted(vrs):
+    assert vrs.diagnose("chore: bump version to 0.6.82") == []
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["0.1.0", "1.0.0", "99.99.99", "0.6.100"],
+)
+def test_any_three_part_semver_is_accepted(vrs, version):
+    assert vrs.diagnose(f"chore: bump version to {version}") == []
+
+
+# ---------- the suffix trap (PF-1, primary class of bug) -------------
+
+
+def test_pr_number_suffix_is_rejected(vrs):
+    probs = vrs.diagnose("chore: bump version to 0.6.82 (#518)")
+    assert probs
+    assert any("#NN" in p or "(#" in p for p in probs), probs
+
+
+def test_pr_number_suffix_with_extra_space(vrs):
+    probs = vrs.diagnose("chore: bump version to 0.6.82  (#518)")
+    assert probs
+
+
+# ---------- prefix violations ----------------------------------------
+
+
+def test_wrong_prefix(vrs):
+    assert vrs.diagnose("Release 0.6.82") != []
+
+
+def test_missing_colon(vrs):
+    assert vrs.diagnose("chore bump version to 0.6.82") != []
+
+
+def test_two_digit_version_rejected(vrs):
+    # Versioning is X.Y.Z, not X.Y.
+    assert vrs.diagnose("chore: bump version to 0.6") != []
+
+
+# ---------- whitespace / structure -----------------------------------
+
+
+def test_empty_is_rejected(vrs):
+    probs = vrs.diagnose("")
+    assert probs
+    assert "empty" in probs[0]
+
+
+def test_leading_whitespace_rejected(vrs):
+    assert vrs.diagnose(" chore: bump version to 0.6.82") != []
+
+
+def test_trailing_whitespace_rejected(vrs):
+    assert vrs.diagnose("chore: bump version to 0.6.82 ") != []
+
+
+def test_newline_in_subject_rejected(vrs):
+    assert vrs.diagnose("chore: bump version to 0.6.82\nbody") != []
+
+
+# ---------- CLI entry point ------------------------------------------
+
+
+def test_main_exit_0_on_valid(vrs):
+    assert vrs.main(["--subject", "chore: bump version to 0.6.82"]) == 0
+
+
+def test_main_exit_1_on_invalid(vrs):
+    assert vrs.main(["--subject", "wrong"]) == 1


### PR DESCRIPTION
## Why

We've shipped four releases (v0.6.73, v0.6.76, v0.6.78, v0.6.82) where the release SOP was either fully or partially skipped at PR time and only run retroactively. The pattern is consistent: small-feeling diff → "feels safe" rationalization → bump-PR opens → publish.yml fires before the gates have all run.

Push every gate that doesn't need MLX + cached model weights + a live server into CI so skipping is no longer an option for those classes.

## What this PR does

### New `release-preflight.yml` (fires on bump PRs only)

Triggered when a PR title matches `chore: bump version to X.Y.Z`. Six jobs:

| Job | Gate | Runner | Hard-blocks merge |
|---|---|---|---|
| `pf1-subject-regex` | PF-1 squash-suffix trap | ubuntu | ✅ |
| `pf1-subject-regex` (step 2) | pyproject ↔ title version match | ubuntu | ✅ |
| `g1-release-smoke` | G1 clean-room install + import | macOS-14 | ✅ |
| `g10-upstream-mlx-scan` | G10 MLX upstream cross-chip-family scan | macOS-14 | ⚠ advisory (informational) |
| `g11-escape-hatch` | G11 auto-routing escape-hatch registry | macOS-14 | ✅ |
| `preflight-summary` | aggregator | ubuntu | ✅ |

### Extend `ci.yml`

- Add `scripts/check_gha_pinning.py` to lint job — advisory mode (4 pre-existing tag refs tracked for separate hardening PR).
- Add `tests/test_validate_release_subject.py`, `tests/test_check_gha_pinning.py`, `tests/test_check_mlx_upstream_calls.py` to test-matrix (pure stdlib, run on Linux).
- Add `tests/test_no_mllm_flag.py` to test-apple-silicon (G11 escape-hatch registry — introspects `vllm_mlx.server`).

### New pure-stdlib scripts (each with meta-tests)

- `scripts/validate_release_subject.py` — regex+structural check on a candidate squash subject. Diagnoses `(#NN)` suffix, missing prefix, wrong version shape, whitespace, newlines.
- `scripts/check_gha_pinning.py` — every third-party `uses:` must be a 40-char SHA. `actions/*` and `github/*` are allowlisted.
- `scripts/check_mlx_upstream_calls.py` — AST-walks installed mlx-lm/mlx-vlm for module-scope calls into chip-family-sensitive APIs. Already surfaces the M5 #404 root cause (`mlx_lm/generate.py:226: mx.new_thread_local_stream(mx.default_device())`).

### Docs

- `docs/development/releasing.md` — append 11-gate canonical gauntlet table with CI/M3 split, pitfalls table, "Adding a new gate" runbook.
- `docs/development/pr_merge_sop.md` — append "CI coverage of these steps" table (maps step 0-12 to which workflow runs it) + expand Common pitfalls with squash-suffix trap, skip-version-bump refire, A/B classify, codex/DeepSeek convergence asymmetry.

## What stays M3-local

G5 stress / G6 fix-path repro / G7 SDK integration / G8 microbench / G9 latency 10-seq. All need cached weights + live MLX inference. The 11-gate table in `releasing.md` lists each with the exact local command.

## SOP enhancements baked in from past pitfalls

| Pitfall (memory ref) | New CI artifact |
|---|---|
| `release_squash_subject` — `(#NN)` breaks auto-release regex | PF-1 + `validate_release_subject.py` + doc note |
| `gotcha_skip_version_bump_label_after_run` | doc note in `releasing.md` |
| `pr_merge_sop` §7 — mutable GHA tags as supply-chain vector | `check_gha_pinning.py` |
| `release_workflow` G10 — MLX upstream `mx.metal.*` landmines | `check_mlx_upstream_calls.py` |
| `feedback_release_sop_third_offense` — "feels small" rationalization | 11-gate canonical table + CI mapping |

## Test plan

- [x] `pytest tests/test_validate_release_subject.py tests/test_check_gha_pinning.py tests/test_check_mlx_upstream_calls.py` — 37/37 pass
- [x] `make smoke` — 4563 unit tests + lint + audit, all green
- [x] `actionlint` on both workflow files — clean
- [x] `ruff check` + `ruff format --check` on all new files — clean
- [x] `python3 scripts/validate_release_subject.py --subject "chore: bump version to 0.6.82"` exits 0
- [x] `python3 scripts/validate_release_subject.py --subject "chore: bump version to 0.6.82 (#518)"` exits 1
- [x] `python3 scripts/check_gha_pinning.py` correctly reports 4 pre-existing violations
- [x] `python3 scripts/check_mlx_upstream_calls.py` correctly surfaces M5 #404 trigger

The new `release-preflight.yml` is title-gated so this PR's CI won't fire it; the next bump PR (v0.6.83+) will be the live trial.

## Why this is `skip-version-bump`

Pure CI + scripts + docs addition. No `pyproject.toml`/`aliases.json`/`cli.py` changes, no user-visible behavior change. `version-check.yml` shouldn't fire, but the bypass label is here as belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)