### PR TITLE
fix(ci): comment-post on external-fork PRs must not block merge

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -148,6 +148,19 @@ jobs:
 
       - name: Post scorecard as PR comment
         if: github.event_name == 'pull_request'
+        # External-fork PRs run with a read-only GITHUB_TOKEN by
+        # design (GitHub's security model — the fork could otherwise
+        # abuse write access via a malicious workflow change). The
+        # comment-post will then fail with
+        # ``GraphQL: Resource not accessible by integration``.
+        # That's expected and must not block merge: the scorecard is
+        # still uploaded as an artifact in the previous step, and the
+        # ``Block merge on pipeline failure`` step below is what
+        # actually gates merge on the pipeline verdict. Marking this
+        # step best-effort keeps the comment for the common
+        # (internal-PR) path without turning every external-fork PR
+        # red — the actual verdict is already enforced separately.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.prnum.outputs.pr }}


### PR DESCRIPTION
## Summary

External-fork PRs (#491 surfaced this) run with a **read-only** `GITHUB_TOKEN` by GitHub's security design — even when the workflow's `permissions:` block requests `pull-requests: write`. The "Post scorecard as PR comment" step then fails with:

```
GraphQL: Resource not accessible by integration (addComment)
```

…and the entire `validate` job goes red, even when the underlying `pr_validate` pipeline returned `Verdict: MERGE-SAFE`.

## Fix

Mark the post-comment step `continue-on-error: true`. The actual merge gate is the separate `Block merge on pipeline failure` step (which reads `steps.validate.outputs.exit_code`); the comment is just a UI convenience that can safely be best-effort. The scorecard is still uploaded as an artifact.

Alternatives considered and rejected:
- **`pull_request_target`**: would give write token but runs in *base-repo* context with fork-controlled code — security tradeoff not worth a scorecard comment.
- **Custom GitHub App with broader scopes**: more infrastructure for the same end result.

## Test plan
- [x] actionlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
