### PR TITLE
fix(test): embeddings model-lock test asserts OpenAI error envelope

### DIFF
--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -264,8 +264,11 @@ class TestEmbeddingsEndpoint:
             )
             assert resp.status_code == 400
             body = resp.json()
-            assert "locked-model" in body["detail"]
-            assert "other-model" in body["detail"]
+            # OpenAI-style error envelope, per the server-wide
+            # StarletteHTTPException handler installed by PR #491.
+            message = body["error"]["message"]
+            assert "locked-model" in message
+            assert "other-model" in message
         finally:
             srv._embedding_engine = original_engine
             srv._embedding_model_locked = original_locked


### PR DESCRIPTION
## Summary
- Pre-existing test regression introduced by PR #491 (StarletteHTTPException → OpenAI envelope handler).
- `tests/test_embeddings.py::TestEmbeddingsEndpoint::test_model_locked_rejects_different_model` asserted on `body["detail"]` (FastAPI default) but the production response is now `body["error"]["message"]`.
- Surfaced when running `full_unit` step of pr_validate against PR #478.

Pure test fix; no production change.

## Test plan
- [x] `python3.12 -m pytest tests/test_embeddings.py -q` — 9 passed