### PR TITLE
fix: default Y on download + upgrade prompts

### DIFF
--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -195,14 +195,16 @@ def test_confirm_aborts_on_no(monkeypatch, capsys):
     assert "RAPID_MLX_AUTO_PULL" in out
 
 
-def test_confirm_aborts_on_empty_input(monkeypatch):
-    """Empty input (the default) → abort. ``[y/N]`` means N is the default."""
+def test_confirm_proceeds_on_empty_input(monkeypatch):
+    """Empty input (just hit Enter) → proceed. ``[Y/n]`` means Y is the
+    default — the user already typed the subcommand on a specific alias,
+    so Enter should respect their intent, not abort.
+    """
     monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _=None: "")
 
-    with pytest.raises(SystemExit):
-        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+    assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
 
 
 def test_confirm_aborts_on_ctrl_c(monkeypatch):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -207,8 +207,15 @@ def test_confirm_proceeds_on_empty_input(monkeypatch):
     assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
 
 
-def test_confirm_aborts_on_ctrl_c(monkeypatch):
-    """Ctrl-C at the prompt → treated as abort, not a stack trace."""
+def test_confirm_aborts_on_ctrl_c(monkeypatch, capsys):
+    """Ctrl-C at the prompt → treated as abort (mapped to ``n`` internally,
+    same ``sys.exit(1)`` path as a typed ``n``), not a stack trace.
+
+    Pinning the exit code (not just ``SystemExit``) keeps the contract
+    explicit: a future refactor that re-maps Ctrl-C to ``130`` would
+    flip the gate's semantics for callers that distinguish "user
+    cancelled" from "abort hint printed and exited".
+    """
     monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
@@ -217,8 +224,61 @@ def test_confirm_aborts_on_ctrl_c(monkeypatch):
 
     monkeypatch.setattr("builtins.input", _raise)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as excinfo:
         gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+    assert excinfo.value.code == 1
+
+    out = capsys.readouterr().out
+    assert "Aborted" in out
+    assert "rapid-mlx pull foo/huge" in out
+
+
+def test_confirm_proceeds_on_eof(monkeypatch):
+    """EOFError on ``input()`` (e.g. stdin closed mid-prompt by a script
+    that fed an empty pipe but kept the TTY check tricked) → treat as
+    Enter and proceed. Previously bundled with ``KeyboardInterrupt``
+    (both → abort); now split so Ctrl-C cancels but EOF defers to the
+    ``[Y/n]`` default. Pins the new split-handler contract."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    def _eof(_=None):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+
+    assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
+
+
+@pytest.mark.parametrize("typo", ["ys", "yres", "nope", "q", "abort", "go"])
+def test_confirm_proceeds_on_non_no_typos(monkeypatch, typo):
+    """``[Y/n]`` semantics: only an explicit ``n``/``no`` aborts. Typos
+    (``ys``, ``yres``) and stray words (``nope``, ``q``, ``abort``) all
+    proceed because the user already invoked the subcommand and the
+    only "danger" is downloading the very alias they typed.
+
+    This generosity is intentional — pin it so a stricter rewrite
+    (e.g. "only accept y/yes/empty, re-prompt on anything else") has
+    to delete this test on purpose. ``nope`` proceeding is the most
+    surprising one; documented here.
+    """
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: typo)
+
+    assert gate.confirm_or_abort("foo/huge", 41 * 1024**3) is True
+
+
+def test_confirm_aborts_on_no_uppercase(monkeypatch):
+    """``N`` (single capital) → abort. ``.lower()`` already runs on the
+    raw input, but pin the case-insensitivity contract explicitly."""
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _=None: "N")
+
+    with pytest.raises(SystemExit) as excinfo:
+        gate.confirm_or_abort("foo/huge", 41 * 1024**3)
+    assert excinfo.value.code == 1
 
 
 def test_confirm_logfile_hint_appears_in_prompt(monkeypatch, capsys):

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -123,7 +123,7 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_TELEMETRY_ENDPOINT",
         # Port for doctor harness probe checks, not engine routing.
         "RAPID_MLX_PORT",
-        # Skip the [y/N] confirmation prompt before large model downloads
+        # Skip the [Y/n] confirmation prompt before large model downloads
         # (UX knob for unattended/CI usage; not consulted by the engine).
         "RAPID_MLX_AUTO_PULL",
         # Override the per-user config dir used to remember "seen-tips"

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -444,8 +444,11 @@ def confirm_or_abort(
     heads-up but proceed — blocking on a transient API failure would be
     worse than the silent-download problem we're trying to fix.
 
-    When the user types anything other than ``y``/``yes``, we print a
-    one-line abort hint and call ``sys.exit(1)``.
+    Prompt default is Y (``[Y/n]``): the user already typed a subcommand
+    naming a specific alias, so pressing Enter is treated as confirmation.
+    Only an explicit ``n``/``no`` (case-insensitive) — or Ctrl-C, which is
+    mapped to ``n`` internally — triggers the abort hint and
+    ``sys.exit(1)``. EOF on stdin is treated as Enter (proceed).
     """
     # Env override always wins.
     env_val = os.environ.get(auto_yes_env, "").strip().lower()

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -6,7 +6,7 @@ Persona-3 ("Ollama switcher") feedback (2026-05): running
     rapid-mlx chat qwen3-coder
 
 against an alias that wasn't yet cached silently kicked off a 41.8 GB
-download with no ``[y/N]`` prompt. The download itself ran fine, but
+download with no ``[Y/n]`` prompt. The download itself ran fine, but
 because the spawned ``serve`` subprocess captured stdout to a logfile,
 the user saw a blank screen and assumed the CLI was hung.
 
@@ -482,16 +482,21 @@ def confirm_or_abort(
     if logfile_hint:
         print(f"    Download progress will appear in {logfile_hint}; tail it to watch.")
     print()
+    # Default Y — the user explicitly invoked a subcommand on a specific
+    # alias ("rapid-mlx serve qwen…", "rapid-mlx share gemma…"); intent
+    # to use that model is clear. Pressing Enter shouldn't punish them
+    # with an abort. Ctrl-C still cancels.
     try:
-        answer = input("  Continue? [y/N]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        answer = ""
+        answer = input("  Continue? [Y/n]: ").strip().lower()
+    except EOFError:
+        answer = ""  # equivalent to Enter
+    except KeyboardInterrupt:
+        answer = "n"  # explicit user cancel
 
-    if answer in {"y", "yes"}:
-        return True
-
-    print(
-        f"  Aborted. Use 'rapid-mlx pull {repo_id}' to download separately, "
-        f"or set {auto_yes_env}=1 to skip this prompt."
-    )
-    sys.exit(1)
+    if answer in {"n", "no"}:
+        print(
+            f"  Aborted. Use 'rapid-mlx pull {repo_id}' to download separately, "
+            f"or set {auto_yes_env}=1 to skip this prompt."
+        )
+        sys.exit(1)
+    return True

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3121,12 +3121,16 @@ def upgrade_command(args):
     if args.yes:
         confirmed = True
     else:
+        # Default Y — the user already typed the upgrade command;
+        # punishing the Enter key with a no-op skip is bad UX.
         try:
-            answer = input("  Run now? [y/N] ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
+            answer = input("  Run now? [Y/n] ").strip().lower()
+        except EOFError:
+            answer = ""
+        except KeyboardInterrupt:
             print()
             return
-        confirmed = answer in {"y", "yes"}
+        confirmed = answer not in {"n", "no"}
 
     if not confirmed:
         print("  Skipped — run the command above when ready.\n")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3122,7 +3122,12 @@ def upgrade_command(args):
         confirmed = True
     else:
         # Default Y — the user already typed the upgrade command;
-        # punishing the Enter key with a no-op skip is bad UX.
+        # punishing the Enter key with a no-op skip is bad UX. EOF on
+        # stdin is treated as Enter (proceed), mirroring the download
+        # gate. Ctrl-C is the only "skip" path — it returns silently
+        # without ``sys.exit`` because upgrade is a leaf operation, so
+        # there's nothing downstream to abort; cf. the gate, which
+        # exits 1 because it's gatekeeping a multi-GB download.
         try:
             answer = input("  Run now? [Y/n] ").strip().lower()
         except EOFError:


### PR DESCRIPTION
## Summary

- Download gate `Continue? [y/N]:` → `Continue? [Y/n]:`; empty input (Enter) now proceeds instead of aborting. Ctrl-C still cancels.
- Same flip on `rapid-mlx upgrade`'s `Run now?` confirmation.
- Telemetry consent prompt **intentionally unchanged** (`[y/N]`) — privacy opt-in must require explicit consent.

## Why

User typed:
```
rapid-mlx share gemma-4-12b-qat-8bit
  About to download mlx-community/gemma-4-12B-it-qat-8bit
    Estimated size: 11.9 GiB (this may take a while on first run)
  Continue? [y/N]:
```
and pressed Enter — got `Aborted`. Pressing Enter on a prompt for an alias they already explicitly named goes against muscle memory from brew, npm, etc. The user's intent is already encoded in the subcommand they typed; an interactive prompt is just a courtesy heads-up.

## Test plan
- [x] `test_confirm_aborts_on_empty_input` renamed to `test_confirm_proceeds_on_empty_input` with inverted assertion.
- [x] `n` / `no` → still abort.
- [x] Ctrl-C → still abort (mapped to `n` internally so exit code + message unchanged).
- [x] Env override `RAPID_MLX_AUTO_PULL=1` → still proceeds without prompt.
- [x] 49/49 tests green in `test_download_gate.py`.