### PR TITLE
chore: bump version to 0.6.83

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.6.82"
+version = "0.6.83"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cuts release **v0.6.83** containing the fused top-p/top-k/temperature sampler fast path (PR #542).

## Highlights

- **+39% B=1 tok/s on Qwen 3.6 35B-A3B** (66.3 → 92.2 tok/s, 5-run median on M3 Ultra).
- Distributionally equivalent to mlx-lm on the active eligibility window (``0 < top_p < 1``, optional ``top_k > 0``).
- Tightly hardened: 7 codex review rounds. 2 real BLOCKER classes fixed (fp16 promotion + test-rigor). 3 hypothetical/falsified BLOCKERs refuted with mlx-lm source-pin regression tests.
- Operator escape hatch: ``RAPID_MLX_DISABLE_FUSED_SAMPLER=1|true|yes|on`` (case-insensitive).

## Test plan

- [x] make release-smoke (clean-room install+import smoke)
- [x] make smoke (lint + audit + 4668 unit tests)
- [x] make check (doctor harness: regression + smoke matrix + stress + autoresearch on qwen3.5-35b)
- [x] pr_validate (full_unit 4803 + stress matrix 3×3 + targeted 44 + lint + supply-chain)
- [x] CLI ↔ Config fidelity audit (must exit 0)
- [x] Microbench (5-run A/B on qwen3.6-35b: 92.20 vs 66.29 tok/s = +39.1%)
- [x] Cross-model sweep (qwen3.6-27b-8bit, hermes3-8b, qwen3.5-4b, gemma3-12b — no regressions)
- [x] codex_review × 7 rounds converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)