### PR TITLE
chore(gitignore): ignore .webui_secret_key generated by Open WebUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Local secrets that must never be committed
+.webui_secret_key
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

The OpenWebUI session-secret file lives at the repo root (``.webui_secret_key``, 16 bytes) but wasn't in ``.gitignore``. A previous ``git add -A`` on the perf/sampler PR briefly included it before the staging was reverted via ``git reset --mixed HEAD~1`` + force-push.

Three-line addition under "Local secrets that must never be committed". Key rotated locally on 2026-06-09; the file is now properly ignored, so future ``git add -A`` sweeps can't re-include it.

## Test plan

- [x] ``git check-ignore -v .webui_secret_key`` reports ``.gitignore:71``
- [x] No new tracked files; only ``.gitignore`` modified