### PR TITLE
feat(brand): cheetah glyph in serve/chat/share startup banners

### DIFF
--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -929,6 +929,28 @@ def test_banner_does_not_inline_key_in_curl_command():
     assert "Bearer SUPER_SECRET_KEY" not in out
 
 
+def test_banner_has_cheetah_brand_line():
+    """Cheetah brand mark sits above the warning box so the share output
+    leads with the friendly ``rapid-mlx`` identity before the harsh
+    security warning. Mirrors the cheetah glyph the desktop app's
+    AppIcon ships."""
+    from vllm_mlx.share import warning
+
+    out = warning.render(
+        "https://rapidserver.quicksilverpro.io/r/abc",
+        "deadbeef",
+        "mlx-community/Qwen3.5-4B",
+        "abc",
+        "https://chat.example.com",
+    )
+    assert "🐆" in out
+    # Brand line must appear BEFORE the warning box (the leading edge of
+    # the security warning is the top-left of the box).
+    cheetah_pos = out.index("🐆")
+    warning_pos = out.index("PUBLIC INTERNET")
+    assert cheetah_pos < warning_pos
+
+
 def test_banner_includes_one_click_chat_link():
     from vllm_mlx.share import warning
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -949,7 +949,7 @@ def serve_command(args):
 
     # Startup summary
     print()
-    print("  Rapid-MLX")
+    print("  🐆 Rapid-MLX")
     print("  ─────────")
     features = []
     if args.enable_auto_tool_choice:
@@ -3165,7 +3165,7 @@ def chat_command(args):
         )
 
     print(
-        f"  {BOLD}Chat{RESET} — "
+        f"  🐆 {BOLD}Chat{RESET} — "
         f"{DIM}type {RESET}{BOLD}/help{RESET}{DIM} for commands, "
         f"Ctrl-D to exit.{RESET}"
     )

--- a/vllm_mlx/share/warning.py
+++ b/vllm_mlx/share/warning.py
@@ -67,6 +67,7 @@ def render(
         chat_line = ""
 
     return (
+        f"\n  🐆 {bold}Rapid-MLX share{reset}\n"
         f"\n{red}╔══════════════════════════════════════════════════════════════════╗{reset}\n"
         f"{red}║  ⚠  PUBLIC INTERNET — read this before sharing                   ║{reset}\n"
         f"{red}╠══════════════════════════════════════════════════════════════════╣{reset}\n"


### PR DESCRIPTION
## Summary
- Adds a 🐆 cheetah glyph to the startup banners of `rapid-mlx serve`, `rapid-mlx chat`, and `rapid-mlx share`
- Mirrors the cheetah AppIcon the rapid-desktop app ships, carrying the brand across the terminal surface
- Pure additive — every existing banner assertion stays unchanged

## Sites touched
| Command | Before | After |
|---|---|---|
| `serve` | `  Rapid-MLX` | `  🐆 Rapid-MLX` |
| `chat`  | `  Chat — type /help …` | `  🐆 Chat — type /help …` |
| `share` | (security warning box first) | `🐆 Rapid-MLX share` line above the warning box |

## Why above the share warning, not below
The friendly identity reads first; the harsh `⚠ PUBLIC INTERNET` warning still owns the dominant visual space immediately below. Mixing the cheetah INTO the warning would dilute the security signal.

## No semver delta
Output-only branding change. No public API, schema, or behavior touched — `skip-version-bump` label applied.

## Test plan
- [x] `pytest tests/test_share_cli.py -k banner` — 7/7 pass
- [x] New `test_banner_has_cheetah_brand_line` pins the cheetah + ordering vs. the `PUBLIC INTERNET` line so a future warning-template refactor can't silently drop it

🤖 Generated with [Claude Code](https://claude.com/claude-code)