### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.0"
+version = "0.7.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cut v0.7.1. Single non-text release: ship `Modality` field + DiffusionEngine lane (PR #551 / commit `8c8a20e`).

## Release notes

- **feat(alias)**: add `Modality` field + diffusion-lane skeleton (#551)
  - First non-text modality lane: `AliasProfile.modality` is now `"text" | "text-diffusion"` (default `"text"`); `"vision"` and `"image-gen"` reserved.
  - `DiffusionEngine` (`vllm_mlx/runtime/diffusion_lane.py`) wraps mlx-vlm 0.6.3 `stream_diffusion_generate` behind the BaseEngine ABC. Persistent GPU worker thread + asyncio.Queue bridge; per-job cancel events; stop-sequence post-processing with lookback buffer; tools silent-drop with logged warning.
  - `diffusion-gemma-26b-it-4bit` alias points at `mlx-community/diffusion-gemma-2-26b-it-4bit`. Route via `server.load_model` modality branch (`vllm_mlx/server.py:702`).
  - `mlx-vlm` pin: `>=0.6.1` → `>=0.6.3` (`stream_diffusion_generate` requires 0.6.3).

## 11-gate release SOP — full walk

| Gate | Status | Evidence |
|---|---|---|
| G1 release-smoke | PASS | clean venv install + 5 release surfaces import OK |
| G2 codex × 2 (PR #551) | PASS | 11 pr_validate rounds; r11 codex 0 BLOCKING / 0 NIT |
| G3 CLI ↔ Config fidelity | PASS | `audit_cli_config_fidelity.py` exit 0 |
| G4 make smoke | COVERED | pr_validate r11 `full_unit` 4889 passed |
| G5 make stress | COVERED | pr_validate r11 `stress_e2e_bench` 3×3 matrix 543s PASS |
| G6 live server repro | COVERED | DiffusionEngine live smoke during 0.7.0 dev (task #964) |
| G7 integration tests | PASS | pydantic-ai 6/6 + anthropic SDK 5/5 on qwen3.5-35b-8bit |
| G8 microbenchmark | N/A | New lane only — text-path perf unchanged |
| G9 server latency | COVERED | stress_e2e_bench 3×3 matrix |
| G10 mlx-vlm bump scan | PASS | 0.6.1→0.6.3 introduces 0 new module-level `mx.*` calls; new modules (`image.py`, `edit_image.py`, `diffusion.py`) all clean |
| G11 auto-detect escape hatch | N/A | `modality` is profile-driven (aliases.json), not auto-detected |

## Test plan

- [x] Local `make check` PASS (6 pass / 0 regression / 0 fail / 1 skip on qwen3.5-35b-8bit)
- [x] pr_validate r11 on PR #551 = MERGE-SAFE
- [x] G1 release-smoke green in clean venv
- [x] G3 CLI fidelity audit green
- [x] G10 mlx-vlm upgrade scan clean
- [x] G7 integration tests (pydantic-ai 6/6 + anthropic SDK 5/5) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
