### PR TITLE
feat(diffusion): in-house generation loop for DiffusionGemma (P1)

### DIFF
--- a/tests/test_alias_diffusion_knobs.py
+++ b/tests/test_alias_diffusion_knobs.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Schema tests for AliasProfile diffusion knobs.
+
+Three knobs added with the in-house diffusion loop (see
+``runtime/diffusion_loop.py``):
+
+- ``diffusion_backend``: ``"rapid"`` (default, in-house) | ``"mlx-vlm"``
+  (escape hatch). Routing decision — typo silently swaps generation
+  loops, so the loader must reject unknown values.
+- ``diffusion_fixed_steps`` (default 8): number of denoising passes per
+  canvas in the rapid backend. Must be a positive JSON int — silently
+  truncating ``8.5`` would hide a hand-edit typo.
+- ``diffusion_sc_every`` (default 1): self-conditioning matmul cadence.
+  Empirical: only ``1`` keeps quality on DiffusionGemma 26B-A4B 4-bit;
+  ``>=2`` collapses output to ``"the the the…"`` (see quality eval
+  ``research/diffusion-gemma/quality/eval-20260611-1001.md``). Kept as
+  a knob for future diffusion families.
+
+These tests pin the contract so a future schema edit can't silently
+flip routing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import (
+    AliasProfile,
+    _coerce,
+    list_profiles,
+    resolve_profile,
+)
+
+
+def test_defaults_match_diffusion_gemma_empirical_optimum():
+    """Code-level defaults must match what we found is optimal for the
+    only shipped diffusion alias today. If a future change moves the
+    default away from these, the diff is review-visible."""
+    prof = AliasProfile(hf_path="x/y")
+    assert prof.diffusion_backend == "rapid"
+    assert prof.diffusion_fixed_steps == 8
+    assert prof.diffusion_sc_every == 1
+
+
+def test_text_alias_inherits_defaults_silently():
+    """An existing text-modality alias (no diffusion_* fields in JSON)
+    must keep loading — the new fields default to no-ops for AR."""
+    qwen = resolve_profile("qwen3.5-4b-4bit")
+    assert qwen is not None
+    assert qwen.modality == "text"
+    assert qwen.diffusion_backend == "rapid"
+    assert qwen.diffusion_fixed_steps == 8
+    assert qwen.diffusion_sc_every == 1
+
+
+def test_diffusion_gemma_alias_picks_up_defaults():
+    """The shipped DiffusionGemma alias today does not set the fields
+    explicitly — they must come from the AliasProfile defaults."""
+    diff = resolve_profile("diffusion-gemma-26b")
+    assert diff is not None
+    assert diff.modality == "text-diffusion"
+    assert diff.diffusion_backend == "rapid"
+    assert diff.diffusion_fixed_steps == 8
+    assert diff.diffusion_sc_every == 1
+
+
+# =============================================================================
+# Validation — typos must fail loud at load
+# =============================================================================
+
+
+def test_backend_typo_fails_loud():
+    """Routing decision — typo silently swaps loops. Fail at load."""
+    with pytest.raises(ValueError, match="diffusion_backend must be one of"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_backend": "rappid",
+        })
+
+
+def test_fixed_steps_must_be_positive_int():
+    with pytest.raises(ValueError, match="diffusion_fixed_steps must be a JSON integer"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_fixed_steps": 8.5,
+        })
+    with pytest.raises(ValueError, match="diffusion_fixed_steps must be >= 1"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_fixed_steps": 0,
+        })
+
+
+def test_sc_every_must_be_positive_int():
+    with pytest.raises(ValueError, match="diffusion_sc_every must be a JSON integer"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_sc_every": True,  # bool subclass of int — rejected
+        })
+    with pytest.raises(ValueError, match="diffusion_sc_every must be >= 1"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_sc_every": -1,
+        })
+
+
+# =============================================================================
+# Modality gate — diffusion_* on a text alias is a configuration error
+# =============================================================================
+
+
+def test_diffusion_field_on_text_alias_fails_loud():
+    """Setting any diffusion knob on a text-modality alias is a typo
+    (the AR runtime ignores it). Mirror the DFlash/spec-decode gate
+    pattern — fail at load, not at request time."""
+    for field, val in [
+        ("diffusion_backend", "rapid"),
+        ("diffusion_fixed_steps", 8),
+        ("diffusion_sc_every", 1),
+    ]:
+        with pytest.raises(ValueError, match=f"{field} is only meaningful when"):
+            _coerce("x", {
+                "hf_path": "a/b",
+                "modality": "text",
+                **{field: val},
+            })
+
+
+def test_diffusion_field_accepted_on_text_diffusion_alias():
+    """Same fields, modality=text-diffusion → must accept."""
+    prof = _coerce("x", {
+        "hf_path": "a/b",
+        "modality": "text-diffusion",
+        "supports_spec_decode": False,
+        "diffusion_backend": "mlx-vlm",
+        "diffusion_fixed_steps": 16,
+        "diffusion_sc_every": 1,
+    })
+    assert prof.diffusion_backend == "mlx-vlm"
+    assert prof.diffusion_fixed_steps == 16
+    assert prof.diffusion_sc_every == 1
+
+
+# =============================================================================
+# Closed-key schema — unknown key under diffusion_* still rejected
+# =============================================================================
+
+
+def test_unknown_diffusion_key_still_rejected():
+    """The closed-key gate at _ALLOWED_PROFILE_KEYS protects against a
+    contributor typoing a NEW field. Verify a plausible typo is caught."""
+    with pytest.raises(ValueError, match="unknown key"):
+        _coerce("x", {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_step_count": 8,  # typo — should be diffusion_fixed_steps
+        })
+
+
+# =============================================================================
+# Every alias still loads — drift sentinel
+# =============================================================================
+
+
+def test_all_existing_aliases_still_load():
+    """A schema edit that crashes existing alias loads is the worst
+    regression class. Pin it here."""
+    profs = list_profiles()
+    assert len(profs) >= 50  # rough sanity bound; real count is 73 at 2026-06-11
+    for name, prof in profs.items():
+        assert prof.diffusion_backend in ("rapid", "mlx-vlm"), name
+        assert prof.diffusion_fixed_steps >= 1, name
+        assert prof.diffusion_sc_every >= 1, name

--- a/tests/test_alias_diffusion_knobs.py
+++ b/tests/test_alias_diffusion_knobs.py
@@ -7,14 +7,16 @@ Three knobs added with the in-house diffusion loop (see
 - ``diffusion_backend``: ``"rapid"`` (default, in-house) | ``"mlx-vlm"``
   (escape hatch). Routing decision — typo silently swaps generation
   loops, so the loader must reject unknown values.
-- ``diffusion_fixed_steps`` (default ``None``): number of denoising
-  passes per canvas in the rapid backend. ``None`` enables adaptive
-  early-stop via ``_stable_and_confident`` (mlx-vlm parity); int
-  caps the per-canvas budget and disables adaptive stop (operator
-  opt-in for either deterministic step counts or the ~1.7× longform
-  perf win that ``fixed_steps=8`` provides at the cost of some short-
-  prompt quality drift). When set, must be a positive JSON int —
-  silently truncating ``8.5`` would hide a hand-edit typo.
+- ``diffusion_fixed_steps`` (default ``8``): number of denoising
+  passes per canvas in the rapid backend. ``8`` is the empirical
+  optimum on DiffusionGemma 26B-A4B 4-bit — 1.76x speedup on long-
+  form vs mlx-vlm at byte-comparable quality (valid JSON, working
+  code, coherent prose). Setting ``null`` in JSON opts into the
+  ``_stable_and_confident`` adaptive-stop predicate for bit-for-bit
+  step-count parity with upstream (slightly slower, useful for
+  spec-decode draft-budget accounting). Any int value must be a
+  positive JSON int — silently truncating ``8.5`` would hide a
+  hand-edit typo.
 - ``diffusion_sc_every`` (default 1): self-conditioning matmul cadence.
   Empirical: only ``1`` keeps quality on DiffusionGemma 26B-A4B 4-bit;
   ``>=2`` collapses output to ``"the the the…"`` (see quality eval
@@ -43,7 +45,7 @@ def test_defaults_match_diffusion_gemma_empirical_optimum():
     default away from these, the diff is review-visible."""
     prof = AliasProfile(hf_path="x/y")
     assert prof.diffusion_backend == "rapid"
-    assert prof.diffusion_fixed_steps is None  # adaptive stop
+    assert prof.diffusion_fixed_steps == 8  # empirical optimum
     assert prof.diffusion_sc_every == 1
 
 
@@ -54,7 +56,7 @@ def test_text_alias_inherits_defaults_silently():
     assert qwen is not None
     assert qwen.modality == "text"
     assert qwen.diffusion_backend == "rapid"
-    assert qwen.diffusion_fixed_steps is None
+    assert qwen.diffusion_fixed_steps == 8
     assert qwen.diffusion_sc_every == 1
 
 
@@ -65,24 +67,41 @@ def test_diffusion_gemma_alias_picks_up_defaults():
     assert diff is not None
     assert diff.modality == "text-diffusion"
     assert diff.diffusion_backend == "rapid"
-    assert diff.diffusion_fixed_steps is None  # adaptive stop
+    assert diff.diffusion_fixed_steps == 8  # empirical optimum
     assert diff.diffusion_sc_every == 1
 
 
-def test_fixed_steps_explicit_int_is_honored():
-    """Operators can opt into a fixed step budget for the longform
-    perf win or deterministic step accounting. The loader must accept
-    an int and the same strict-positive-int validation must apply."""
+def test_fixed_steps_explicit_null_opts_into_adaptive_mode():
+    """Operators can opt into the vendored ``_stable_and_confident``
+    adaptive-stop predicate by setting ``"diffusion_fixed_steps": null``
+    in the alias JSON. The loader must propagate ``None`` to the
+    AliasProfile (which the lane translates into "omit the kwarg" so
+    the rapid loop's signature default enables adaptive)."""
     prof = _coerce(
         "x",
         {
             "hf_path": "a/b",
             "modality": "text-diffusion",
             "supports_spec_decode": False,
-            "diffusion_fixed_steps": 8,
+            "diffusion_fixed_steps": None,
         },
     )
-    assert prof.diffusion_fixed_steps == 8
+    assert prof.diffusion_fixed_steps is None
+
+
+def test_fixed_steps_explicit_int_overrides_default():
+    """Explicit ints override the ``8`` default. ``16`` is plausible
+    if a future diffusion model converges slower than DiffusionGemma."""
+    prof = _coerce(
+        "x",
+        {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_fixed_steps": 16,
+        },
+    )
+    assert prof.diffusion_fixed_steps == 16
 
 
 # =============================================================================

--- a/tests/test_alias_diffusion_knobs.py
+++ b/tests/test_alias_diffusion_knobs.py
@@ -7,9 +7,14 @@ Three knobs added with the in-house diffusion loop (see
 - ``diffusion_backend``: ``"rapid"`` (default, in-house) | ``"mlx-vlm"``
   (escape hatch). Routing decision — typo silently swaps generation
   loops, so the loader must reject unknown values.
-- ``diffusion_fixed_steps`` (default 8): number of denoising passes per
-  canvas in the rapid backend. Must be a positive JSON int — silently
-  truncating ``8.5`` would hide a hand-edit typo.
+- ``diffusion_fixed_steps`` (default ``None``): number of denoising
+  passes per canvas in the rapid backend. ``None`` enables adaptive
+  early-stop via ``_stable_and_confident`` (mlx-vlm parity); int
+  caps the per-canvas budget and disables adaptive stop (operator
+  opt-in for either deterministic step counts or the ~1.7× longform
+  perf win that ``fixed_steps=8`` provides at the cost of some short-
+  prompt quality drift). When set, must be a positive JSON int —
+  silently truncating ``8.5`` would hide a hand-edit typo.
 - ``diffusion_sc_every`` (default 1): self-conditioning matmul cadence.
   Empirical: only ``1`` keeps quality on DiffusionGemma 26B-A4B 4-bit;
   ``>=2`` collapses output to ``"the the the…"`` (see quality eval
@@ -38,7 +43,7 @@ def test_defaults_match_diffusion_gemma_empirical_optimum():
     default away from these, the diff is review-visible."""
     prof = AliasProfile(hf_path="x/y")
     assert prof.diffusion_backend == "rapid"
-    assert prof.diffusion_fixed_steps == 8
+    assert prof.diffusion_fixed_steps is None  # adaptive stop
     assert prof.diffusion_sc_every == 1
 
 
@@ -49,7 +54,7 @@ def test_text_alias_inherits_defaults_silently():
     assert qwen is not None
     assert qwen.modality == "text"
     assert qwen.diffusion_backend == "rapid"
-    assert qwen.diffusion_fixed_steps == 8
+    assert qwen.diffusion_fixed_steps is None
     assert qwen.diffusion_sc_every == 1
 
 
@@ -60,8 +65,24 @@ def test_diffusion_gemma_alias_picks_up_defaults():
     assert diff is not None
     assert diff.modality == "text-diffusion"
     assert diff.diffusion_backend == "rapid"
-    assert diff.diffusion_fixed_steps == 8
+    assert diff.diffusion_fixed_steps is None  # adaptive stop
     assert diff.diffusion_sc_every == 1
+
+
+def test_fixed_steps_explicit_int_is_honored():
+    """Operators can opt into a fixed step budget for the longform
+    perf win or deterministic step accounting. The loader must accept
+    an int and the same strict-positive-int validation must apply."""
+    prof = _coerce(
+        "x",
+        {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_fixed_steps": 8,
+        },
+    )
+    assert prof.diffusion_fixed_steps == 8
 
 
 # =============================================================================
@@ -72,46 +93,63 @@ def test_diffusion_gemma_alias_picks_up_defaults():
 def test_backend_typo_fails_loud():
     """Routing decision — typo silently swaps loops. Fail at load."""
     with pytest.raises(ValueError, match="diffusion_backend must be one of"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_backend": "rappid",
-        })
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_backend": "rappid",
+            },
+        )
 
 
 def test_fixed_steps_must_be_positive_int():
-    with pytest.raises(ValueError, match="diffusion_fixed_steps must be a JSON integer"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_fixed_steps": 8.5,
-        })
+    with pytest.raises(
+        ValueError, match="diffusion_fixed_steps must be a JSON integer"
+    ):
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_fixed_steps": 8.5,
+            },
+        )
     with pytest.raises(ValueError, match="diffusion_fixed_steps must be >= 1"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_fixed_steps": 0,
-        })
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_fixed_steps": 0,
+            },
+        )
 
 
 def test_sc_every_must_be_positive_int():
     with pytest.raises(ValueError, match="diffusion_sc_every must be a JSON integer"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_sc_every": True,  # bool subclass of int — rejected
-        })
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_sc_every": True,  # bool subclass of int — rejected
+            },
+        )
     with pytest.raises(ValueError, match="diffusion_sc_every must be >= 1"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_sc_every": -1,
-        })
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_sc_every": -1,
+            },
+        )
 
 
 # =============================================================================
@@ -129,23 +167,29 @@ def test_diffusion_field_on_text_alias_fails_loud():
         ("diffusion_sc_every", 1),
     ]:
         with pytest.raises(ValueError, match=f"{field} is only meaningful when"):
-            _coerce("x", {
-                "hf_path": "a/b",
-                "modality": "text",
-                **{field: val},
-            })
+            _coerce(
+                "x",
+                {
+                    "hf_path": "a/b",
+                    "modality": "text",
+                    **{field: val},
+                },
+            )
 
 
 def test_diffusion_field_accepted_on_text_diffusion_alias():
     """Same fields, modality=text-diffusion → must accept."""
-    prof = _coerce("x", {
-        "hf_path": "a/b",
-        "modality": "text-diffusion",
-        "supports_spec_decode": False,
-        "diffusion_backend": "mlx-vlm",
-        "diffusion_fixed_steps": 16,
-        "diffusion_sc_every": 1,
-    })
+    prof = _coerce(
+        "x",
+        {
+            "hf_path": "a/b",
+            "modality": "text-diffusion",
+            "supports_spec_decode": False,
+            "diffusion_backend": "mlx-vlm",
+            "diffusion_fixed_steps": 16,
+            "diffusion_sc_every": 1,
+        },
+    )
     assert prof.diffusion_backend == "mlx-vlm"
     assert prof.diffusion_fixed_steps == 16
     assert prof.diffusion_sc_every == 1
@@ -160,12 +204,15 @@ def test_unknown_diffusion_key_still_rejected():
     """The closed-key gate at _ALLOWED_PROFILE_KEYS protects against a
     contributor typoing a NEW field. Verify a plausible typo is caught."""
     with pytest.raises(ValueError, match="unknown key"):
-        _coerce("x", {
-            "hf_path": "a/b",
-            "modality": "text-diffusion",
-            "supports_spec_decode": False,
-            "diffusion_step_count": 8,  # typo — should be diffusion_fixed_steps
-        })
+        _coerce(
+            "x",
+            {
+                "hf_path": "a/b",
+                "modality": "text-diffusion",
+                "supports_spec_decode": False,
+                "diffusion_step_count": 8,  # typo — should be diffusion_fixed_steps
+            },
+        )
 
 
 # =============================================================================
@@ -180,5 +227,7 @@ def test_all_existing_aliases_still_load():
     assert len(profs) >= 50  # rough sanity bound; real count is 73 at 2026-06-11
     for name, prof in profs.items():
         assert prof.diffusion_backend in ("rapid", "mlx-vlm"), name
-        assert prof.diffusion_fixed_steps >= 1, name
+        # fixed_steps is either None (adaptive) or a positive int.
+        if prof.diffusion_fixed_steps is not None:
+            assert prof.diffusion_fixed_steps >= 1, name
         assert prof.diffusion_sc_every >= 1, name

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -55,6 +55,9 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "supports_dflash",
         "dflash_draft_model",
         "recommended_sampling",
+        "diffusion_backend",
+        "diffusion_fixed_steps",
+        "diffusion_sc_every",
     }
 )
 

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -165,6 +165,28 @@ def _install_mlx_vlm_mock(
     monkeypatch.setitem(sys.modules, "mlx_vlm.generate.diffusion", mlx_vlm_diffusion)
     monkeypatch.setitem(sys.modules, "mlx_vlm.generate.common", mlx_vlm_common)
 
+    # Since the AliasProfile default for ``diffusion-gemma``-shape aliases
+    # is ``diffusion_backend="rapid"``, ``_run_mlxvlm_generator`` lazy-imports
+    # ``vllm_mlx.runtime.diffusion_loop.rapid_stream_diffusion_generate`` and
+    # calls IT, not the upstream ``stream_diffusion_generate`` stubbed
+    # above. Stub the rapid entry-point to delegate to the SAME stream
+    # so existing tests (which expect ``_stream``'s yields to appear in
+    # the SSE output) keep working regardless of which backend the lane
+    # picked. Routing tests that care about WHICH backend was called live
+    # in ``test_diffusion_lane_routing.py``.
+    import vllm_mlx.runtime.diffusion_loop as _loop_mod
+
+    def _rapid_stub(model, processor, tokenizer, input_ids,
+                    pixel_values, attention_mask, **kw):
+        current = sys.modules["mlx_vlm.generate.diffusion"].stream_diffusion_generate
+        return current(model, processor, tokenizer, input_ids,
+                       pixel_values, attention_mask, **{
+                           k: v for k, v in kw.items()
+                           if k not in {"fixed_steps", "sc_every"}
+                       })
+
+    monkeypatch.setattr(_loop_mod, "rapid_stream_diffusion_generate", _rapid_stub)
+
 
 # ----------------------------------------------------------------------
 # Tests

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -176,14 +176,19 @@ def _install_mlx_vlm_mock(
     # in ``test_diffusion_lane_routing.py``.
     import vllm_mlx.runtime.diffusion_loop as _loop_mod
 
-    def _rapid_stub(model, processor, tokenizer, input_ids,
-                    pixel_values, attention_mask, **kw):
+    def _rapid_stub(
+        model, processor, tokenizer, input_ids, pixel_values, attention_mask, **kw
+    ):
         current = sys.modules["mlx_vlm.generate.diffusion"].stream_diffusion_generate
-        return current(model, processor, tokenizer, input_ids,
-                       pixel_values, attention_mask, **{
-                           k: v for k, v in kw.items()
-                           if k not in {"fixed_steps", "sc_every"}
-                       })
+        return current(
+            model,
+            processor,
+            tokenizer,
+            input_ids,
+            pixel_values,
+            attention_mask,
+            **{k: v for k, v in kw.items() if k not in {"fixed_steps", "sc_every"}},
+        )
 
     monkeypatch.setattr(_loop_mod, "rapid_stream_diffusion_generate", _rapid_stub)
 

--- a/tests/test_diffusion_gemma_parity.py
+++ b/tests/test_diffusion_gemma_parity.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end parity test — the rapid backend must produce coherent
+DiffusionGemma output that's at least as good as mlx-vlm's upstream
+loop on the canonical eval prompts.
+
+Marked ``slow`` because it loads the real ~1.2 GB checkpoint and
+exercises the GPU. CI skips by default; run on M3 Ultra with:
+
+    python3.12 -m pytest tests/test_diffusion_gemma_parity.py -m slow -v
+
+The 8-prompt set mirrors ``research/diffusion-gemma/scripts/quality_eval.py``
+so the bench data on disk stays comparable with what CI/SOP asserts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+MODEL_ID = "mlx-community/diffusiongemma-26B-A4B-it-4bit"
+
+CANONICAL_PROMPTS: list[tuple[str, str, int, list[str]]] = [
+    (
+        "longform-coherence",
+        "Explain what a diffusion language model is and how it differs from an "
+        "autoregressive language model. Cover: token emission order, parallelism, "
+        "training objective, and one concrete strength + one concrete weakness.",
+        256,
+        ["diffusion", "autoregressive"],
+    ),
+    (
+        "code-python",
+        "Write a Python function `quicksort(arr)` that sorts a list of integers in "
+        "ascending order, in place. Include a 1-line docstring. Just the code, no "
+        "surrounding explanation.",
+        256,
+        # ``pivot`` is the only word every quicksort variant emits (in-place
+        # vs out-of-place differ on whether they ``return arr``; some
+        # implementations emit ``mid`` instead of ``pivot`` only when
+        # using merge sort, not quicksort).
+        ["def quicksort", "pivot"],
+    ),
+    (
+        "structured-json",
+        "Return ONLY a JSON object (no markdown, no prose) describing a book "
+        "with: title (string), author (string), year (int), tags (array of "
+        "strings, 3 tags), in_stock (bool).",
+        256,
+        ['"title"', '"author"'],
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def loaded_model():
+    """Load DiffusionGemma once for the whole module — the checkpoint
+    is 1.2 GB and warmup costs ~5s; sharing across the 3 prompts is
+    necessary for the suite to finish under 30s."""
+    import mlx.core as mx
+    from mlx_vlm.utils import load
+
+    model, processor = load(MODEL_ID)
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+
+    # Warmup once so the first measured generation isn't cold-shaded.
+    from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
+    warm_chat = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        add_generation_prompt=True, tokenize=False,
+    )
+    warm_ids = mx.array([tokenizer.encode(warm_chat)])
+    for _ in rapid_stream_diffusion_generate(
+        model, processor, tokenizer, warm_ids,
+        max_tokens=8, fixed_steps=4, sc_every=1, temperature=0.0,
+    ):
+        pass
+
+    return model, processor, tokenizer
+
+
+@pytest.mark.parametrize(
+    "prompt_id,prompt,max_tokens,expected_keywords",
+    CANONICAL_PROMPTS,
+    ids=[p[0] for p in CANONICAL_PROMPTS],
+)
+def test_rapid_backend_keyword_quality(
+    loaded_model, prompt_id: str, prompt: str,
+    max_tokens: int, expected_keywords: list[str],
+) -> None:
+    """Rapid backend at ``fixed_steps=8, sc_every=1, temperature=0`` must
+    contain every expected keyword in the decoded output. This is the
+    same gate the hand-graded quality eval uses (see
+    ``research/diffusion-gemma/quality/eval-20260611-1001.md``)."""
+    import mlx.core as mx
+
+    from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
+
+    model, processor, tokenizer = loaded_model
+    chat = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        add_generation_prompt=True, tokenize=False,
+    )
+    input_ids = mx.array([tokenizer.encode(chat)])
+
+    pieces: list[str] = []
+    terminated = False
+    for r in rapid_stream_diffusion_generate(
+        model, processor, tokenizer, input_ids,
+        max_tokens=max_tokens, fixed_steps=8, sc_every=1, temperature=0.0,
+    ):
+        if r.text:
+            pieces.append(r.text)
+        if r.finish_reason is not None:
+            terminated = True
+    text = "".join(pieces).strip()
+
+    assert terminated, "rapid loop must end with a finish_reason"
+    assert text, f"{prompt_id}: rapid backend produced empty output"
+    text_lc = text.lower()
+    missing = [k for k in expected_keywords if k.lower() not in text_lc]
+    assert not missing, (
+        f"{prompt_id}: rapid output missing expected keywords {missing}. "
+        f"Output head: {text[:200]!r}"
+    )
+
+
+def test_rapid_backend_throughput_floor(loaded_model) -> None:
+    """Rapid backend on the canonical long-form prompt must do at
+    least 80 tok/s on M3 Ultra. The hand-measured number is ~127 tok/s
+    (see quality eval 2026-06-11); 80 is the regression floor — if
+    we drop below this, somebody changed something that broke the
+    fast path (e.g. removed precise=True softmax, lost dequantize
+    optimization, made a fixed_steps default change)."""
+    import time
+
+    import mlx.core as mx
+
+    from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
+
+    model, processor, tokenizer = loaded_model
+    prompt = CANONICAL_PROMPTS[0][1]  # longform-coherence
+    chat = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        add_generation_prompt=True, tokenize=False,
+    )
+    input_ids = mx.array([tokenizer.encode(chat)])
+
+    t0 = time.perf_counter()
+    last = None
+    for r in rapid_stream_diffusion_generate(
+        model, processor, tokenizer, input_ids,
+        max_tokens=256, fixed_steps=8, sc_every=1, temperature=0.0,
+    ):
+        last = r
+    e2e = time.perf_counter() - t0
+
+    assert last is not None
+    assert last.generation_tokens >= 200, (
+        f"rapid backend generated only {last.generation_tokens} tokens "
+        "for max_tokens=256 — early stop hides a bug if no EOS was hit"
+    )
+    tps = last.generation_tokens / e2e
+    assert tps >= 80.0, (
+        f"rapid backend throughput regressed: {tps:.1f} tok/s "
+        f"(floor: 80 tok/s, hand-measured: ~127 tok/s on M3 Ultra)"
+    )

--- a/tests/test_diffusion_gemma_parity.py
+++ b/tests/test_diffusion_gemma_parity.py
@@ -99,10 +99,16 @@ def test_rapid_backend_keyword_quality(
     max_tokens: int,
     expected_keywords: list[str],
 ) -> None:
-    """Rapid backend at adaptive-stop (``fixed_steps=None``, default for
-    the AliasProfile) + ``sc_every=1`` + ``temperature=0`` must contain
-    every expected keyword in the decoded output. Same gate as the
-    hand-graded quality eval (``research/diffusion-gemma/quality/``)."""
+    """Rapid backend at production config — ``fixed_steps=8`` (the
+    AliasProfile default that ``diffusion_lane.py:_run_mlxvlm_generator``
+    forwards) + ``sc_every=1`` + ``temperature=0`` — must contain every
+    expected keyword in the decoded output. Same gate as the hand-graded
+    quality eval (``research/diffusion-gemma/quality/``).
+
+    Codex round 5 [P1]: prior version omitted ``fixed_steps`` and tested
+    the adaptive-only path, leaving the production ceiling path
+    untested. Pin both the user-visible quality contract AND the
+    production config simultaneously."""
     import mlx.core as mx
 
     from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
@@ -125,6 +131,7 @@ def test_rapid_backend_keyword_quality(
         max_tokens=max_tokens,
         sc_every=1,
         temperature=0.0,
+        fixed_steps=8,  # production default; AliasProfile.diffusion_fixed_steps
     ):
         if r.text:
             pieces.append(r.text)
@@ -166,14 +173,16 @@ def test_rapid_backend_keyword_quality(
 
 
 def test_rapid_backend_throughput_floor(loaded_model) -> None:
-    """Rapid backend on the canonical long-form prompt at adaptive-stop
-    (default ``fixed_steps=None``) must do at least 60 tok/s on M3
-    Ultra. Hand-measured: ~90-100 tok/s adaptive, ~135 tok/s with
-    ``fixed_steps=8`` (operator opt-in). 60 is the regression floor —
-    drops below this signal a real algorithm regression (lost
-    precise=True softmax, broken dequantize fast path, bad SC cadence).
-    Concurrent GPU contention (e.g. a parallel bench run) can also drag
-    this down; treat 60-80 as "investigate", not "definitely a bug"."""
+    """Rapid backend on the canonical long-form prompt at PRODUCTION
+    config (``fixed_steps=8``, the AliasProfile default the lane
+    forwards) must do at least 90 tok/s on M3 Ultra. Hand-measured
+    median: ~126 tok/s on the 2026-06-11 PR #555 bench. 90 is the
+    regression floor — 30% slack absorbs GPU contention (parallel bench
+    runs, background load). Drops below 90 signal a real algorithm
+    regression (lost precise=True softmax, broken dequantize fast path,
+    bad SC cadence). Codex round 5 [P1]: prior version omitted
+    ``fixed_steps=8`` so it benchmarked adaptive-only mode instead of
+    the production path the lane actually takes."""
     import time
 
     import mlx.core as mx
@@ -199,6 +208,7 @@ def test_rapid_backend_throughput_floor(loaded_model) -> None:
         max_tokens=256,
         sc_every=1,
         temperature=0.0,
+        fixed_steps=8,  # production default
     ):
         last = r
     e2e = time.perf_counter() - t0
@@ -209,8 +219,8 @@ def test_rapid_backend_throughput_floor(loaded_model) -> None:
         "for max_tokens=256 — early stop hides a bug if no EOS was hit"
     )
     tps = last.generation_tokens / e2e
-    assert tps >= 60.0, (
+    assert tps >= 90.0, (
         f"rapid backend throughput regressed: {tps:.1f} tok/s "
-        f"(floor: 60 tok/s, hand-measured: ~90-100 tok/s adaptive "
-        f"on M3 Ultra)"
+        f"(floor: 90 tok/s, hand-measured: ~126 tok/s production "
+        f"fixed_steps=8 on M3 Ultra)"
     )

--- a/tests/test_diffusion_gemma_parity.py
+++ b/tests/test_diffusion_gemma_parity.py
@@ -65,14 +65,22 @@ def loaded_model():
 
     # Warmup once so the first measured generation isn't cold-shaded.
     from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
+
     warm_chat = tokenizer.apply_chat_template(
         [{"role": "user", "content": "hi"}],
-        add_generation_prompt=True, tokenize=False,
+        add_generation_prompt=True,
+        tokenize=False,
     )
     warm_ids = mx.array([tokenizer.encode(warm_chat)])
     for _ in rapid_stream_diffusion_generate(
-        model, processor, tokenizer, warm_ids,
-        max_tokens=8, fixed_steps=4, sc_every=1, temperature=0.0,
+        model,
+        processor,
+        tokenizer,
+        warm_ids,
+        max_tokens=8,
+        fixed_steps=4,
+        sc_every=1,
+        temperature=0.0,
     ):
         pass
 
@@ -85,13 +93,16 @@ def loaded_model():
     ids=[p[0] for p in CANONICAL_PROMPTS],
 )
 def test_rapid_backend_keyword_quality(
-    loaded_model, prompt_id: str, prompt: str,
-    max_tokens: int, expected_keywords: list[str],
+    loaded_model,
+    prompt_id: str,
+    prompt: str,
+    max_tokens: int,
+    expected_keywords: list[str],
 ) -> None:
-    """Rapid backend at ``fixed_steps=8, sc_every=1, temperature=0`` must
-    contain every expected keyword in the decoded output. This is the
-    same gate the hand-graded quality eval uses (see
-    ``research/diffusion-gemma/quality/eval-20260611-1001.md``)."""
+    """Rapid backend at adaptive-stop (``fixed_steps=None``, default for
+    the AliasProfile) + ``sc_every=1`` + ``temperature=0`` must contain
+    every expected keyword in the decoded output. Same gate as the
+    hand-graded quality eval (``research/diffusion-gemma/quality/``)."""
     import mlx.core as mx
 
     from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
@@ -99,15 +110,21 @@ def test_rapid_backend_keyword_quality(
     model, processor, tokenizer = loaded_model
     chat = tokenizer.apply_chat_template(
         [{"role": "user", "content": prompt}],
-        add_generation_prompt=True, tokenize=False,
+        add_generation_prompt=True,
+        tokenize=False,
     )
     input_ids = mx.array([tokenizer.encode(chat)])
 
     pieces: list[str] = []
     terminated = False
     for r in rapid_stream_diffusion_generate(
-        model, processor, tokenizer, input_ids,
-        max_tokens=max_tokens, fixed_steps=8, sc_every=1, temperature=0.0,
+        model,
+        processor,
+        tokenizer,
+        input_ids,
+        max_tokens=max_tokens,
+        sc_every=1,
+        temperature=0.0,
     ):
         if r.text:
             pieces.append(r.text)
@@ -124,14 +141,39 @@ def test_rapid_backend_keyword_quality(
         f"Output head: {text[:200]!r}"
     )
 
+    # Structured-JSON quality gate: PR #555 round 1 surfaced a bug
+    # where the canvas-overwrite-every-step algorithm produced broken
+    # JSON like ``{\n  title": ...`` (missing opening quote on the
+    # first key). Keyword-matching missed it because ``"title"`` was
+    # still present further along. Vendoring the upstream progressive-
+    # reveal acceptance mask fixed it; this assertion pins the fix.
+    if prompt_id == "structured-json":
+        import json
+        import re
+
+        # The model often wraps in markdown fences ("```json … ```")
+        # or prefixes with prose despite "no markdown"; extract the
+        # outermost {…} block.
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        assert match, f"{prompt_id}: no JSON object found in output: {text!r}"
+        try:
+            json.loads(match.group(0))
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"{prompt_id}: rapid output is not valid JSON ({exc}). "
+                f"Extracted: {match.group(0)!r}"
+            ) from exc
+
 
 def test_rapid_backend_throughput_floor(loaded_model) -> None:
-    """Rapid backend on the canonical long-form prompt must do at
-    least 80 tok/s on M3 Ultra. The hand-measured number is ~127 tok/s
-    (see quality eval 2026-06-11); 80 is the regression floor — if
-    we drop below this, somebody changed something that broke the
-    fast path (e.g. removed precise=True softmax, lost dequantize
-    optimization, made a fixed_steps default change)."""
+    """Rapid backend on the canonical long-form prompt at adaptive-stop
+    (default ``fixed_steps=None``) must do at least 60 tok/s on M3
+    Ultra. Hand-measured: ~90-100 tok/s adaptive, ~135 tok/s with
+    ``fixed_steps=8`` (operator opt-in). 60 is the regression floor —
+    drops below this signal a real algorithm regression (lost
+    precise=True softmax, broken dequantize fast path, bad SC cadence).
+    Concurrent GPU contention (e.g. a parallel bench run) can also drag
+    this down; treat 60-80 as "investigate", not "definitely a bug"."""
     import time
 
     import mlx.core as mx
@@ -142,15 +184,21 @@ def test_rapid_backend_throughput_floor(loaded_model) -> None:
     prompt = CANONICAL_PROMPTS[0][1]  # longform-coherence
     chat = tokenizer.apply_chat_template(
         [{"role": "user", "content": prompt}],
-        add_generation_prompt=True, tokenize=False,
+        add_generation_prompt=True,
+        tokenize=False,
     )
     input_ids = mx.array([tokenizer.encode(chat)])
 
     t0 = time.perf_counter()
     last = None
     for r in rapid_stream_diffusion_generate(
-        model, processor, tokenizer, input_ids,
-        max_tokens=256, fixed_steps=8, sc_every=1, temperature=0.0,
+        model,
+        processor,
+        tokenizer,
+        input_ids,
+        max_tokens=256,
+        sc_every=1,
+        temperature=0.0,
     ):
         last = r
     e2e = time.perf_counter() - t0
@@ -161,7 +209,8 @@ def test_rapid_backend_throughput_floor(loaded_model) -> None:
         "for max_tokens=256 — early stop hides a bug if no EOS was hit"
     )
     tps = last.generation_tokens / e2e
-    assert tps >= 80.0, (
+    assert tps >= 60.0, (
         f"rapid backend throughput regressed: {tps:.1f} tok/s "
-        f"(floor: 80 tok/s, hand-measured: ~127 tok/s on M3 Ultra)"
+        f"(floor: 60 tok/s, hand-measured: ~90-100 tok/s adaptive "
+        f"on M3 Ultra)"
     )

--- a/tests/test_diffusion_lane_routing.py
+++ b/tests/test_diffusion_lane_routing.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Routing tests for ``runtime/diffusion_lane.py`` — backend selection
+between in-house rapid loop and upstream mlx-vlm.
+
+Backend choice is driven entirely by ``profile.diffusion_backend``
+(AliasProfile is the SSOT for every per-model routing decision —
+``test_no_out_of_band_routing.py`` forbids env-var routing). Default is
+``"rapid"``; ``"mlx-vlm"`` falls through to upstream verbatim.
+
+(``cfg.temperature`` is NOT a gate — both rapid and mlx-vlm honor the
+same temperature semantics; rapid extends greedy → categorical via
+``_sample_canvas``.)
+
+We spy on which generator was invoked by patching both
+``mlx_vlm.generate.diffusion.stream_diffusion_generate`` AND
+``vllm_mlx.runtime.diffusion_loop.rapid_stream_diffusion_generate``
+to set sentinels. The actual model never has to run.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class _FakeResult:
+    text: str = ""
+    token: int = 0
+    prompt_tokens: int = 0
+    generation_tokens: int = 0
+    finish_reason: str | None = None
+    is_draft: bool = False
+    diffusion_block_complete: bool = False
+
+
+class _FakeTokenizer:
+    all_special_ids = [0, 1, 2]
+
+    class _SC:
+        def reset(self, *_a: Any) -> None:
+            pass
+
+    stopping_criteria = _SC()
+
+    def apply_chat_template(self, messages: list[dict], tokenize: bool = False,
+                            add_generation_prompt: bool = True) -> str:
+        rendered = "\n".join(m.get("content", "") for m in messages)
+        if add_generation_prompt:
+            rendered += "\n<model>\n"
+        return rendered
+
+    def encode(self, text: str) -> list[int]:
+        return [ord(c) % 256 for c in text]
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.tokenizer = _FakeTokenizer()
+
+
+class _FakeModelConfig:
+    eos_token_id = 7
+    canvas_length = 256
+
+
+class _FakeModel:
+    config = _FakeModelConfig()
+
+
+def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
+    """Wire fakes for both backends. Return a dict whose keys flip True
+    when the corresponding generator is invoked. This is the
+    spy mechanism — neither generator actually does any math; they
+    both yield two ``_FakeResult`` items so the consumer at
+    ``diffusion_lane.py:1229`` runs to completion."""
+
+    called: dict[str, bool] = {"rapid": False, "mlx_vlm": False}
+    captured_kwargs: dict[str, dict[str, Any]] = {}
+
+    # ----------- mlx-vlm side ----------------------------------------
+    mlx_vlm = sys.modules.get("mlx_vlm") or types.ModuleType("mlx_vlm")
+    mlx_vlm_utils = types.ModuleType("mlx_vlm.utils")
+    mlx_vlm_utils.load = lambda _: (_FakeModel(), _FakeProc())  # type: ignore[attr-defined]
+    mlx_vlm_generate = types.ModuleType("mlx_vlm.generate")
+    mlx_vlm_diffusion = types.ModuleType("mlx_vlm.generate.diffusion")
+    mlx_vlm_diffusion.diffusion_generation_family = lambda _: "block"  # type: ignore[attr-defined]
+
+    def _stream_upstream(model, processor, tokenizer, input_ids,
+                         pixel_values, attention_mask, **kw):
+        called["mlx_vlm"] = True
+        captured_kwargs["mlx_vlm"] = kw
+        yield _FakeResult(text="UP", diffusion_block_complete=True)
+        yield _FakeResult(text="", finish_reason="stop", generation_tokens=1)
+
+    mlx_vlm_diffusion.stream_diffusion_generate = _stream_upstream  # type: ignore[attr-defined]
+
+    mlx_vlm_common = types.ModuleType("mlx_vlm.generate.common")
+
+    class _WL:
+        def __init__(self, *_a: Any, **_k: Any) -> None: ...
+        def __enter__(self) -> _WL: return self
+        def __exit__(self, *_a: Any) -> None: ...
+
+    mlx_vlm_common.wired_limit = _WL  # type: ignore[attr-defined]
+    mlx_vlm_common.generation_stream = object()  # type: ignore[attr-defined]
+
+    for n, mod in [
+        ("mlx_vlm", mlx_vlm),
+        ("mlx_vlm.utils", mlx_vlm_utils),
+        ("mlx_vlm.generate", mlx_vlm_generate),
+        ("mlx_vlm.generate.diffusion", mlx_vlm_diffusion),
+        ("mlx_vlm.generate.common", mlx_vlm_common),
+    ]:
+        monkeypatch.setitem(sys.modules, n, mod)
+
+    # ----------- Rapid loop side --------------------------------------
+    # The lane does ``from .diffusion_loop import rapid_stream_diffusion_generate``
+    # INSIDE _run_mlxvlm_generator (lazy import). Patch the attribute on
+    # the already-imported module so the lazy import sees our spy.
+    import vllm_mlx.runtime.diffusion_loop as loop_mod
+
+    def _stream_rapid(model, processor, tokenizer, input_ids,
+                      pixel_values, attention_mask, **kw):
+        called["rapid"] = True
+        captured_kwargs["rapid"] = kw
+        yield _FakeResult(text="RA", diffusion_block_complete=True)
+        yield _FakeResult(text="", finish_reason="stop", generation_tokens=1)
+
+    monkeypatch.setattr(loop_mod, "rapid_stream_diffusion_generate", _stream_rapid)
+
+    # Stash captured_kwargs on the result so tests can introspect
+    # what the lane forwarded to the chosen backend.
+    called["_kwargs"] = captured_kwargs  # type: ignore[assignment]
+    return called
+
+
+@pytest.mark.asyncio
+async def test_default_alias_uses_rapid_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default profile (no JSON overrides) → diffusion_backend='rapid'
+    → rapid path. This is the production path most users hit."""
+    spy = _install_backend_spies(monkeypatch)
+
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+    engine = DiffusionEngine(model_name="x/y")
+    engine._load_blocking()
+    assert engine._profile.diffusion_backend == "rapid"
+
+    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
+                                      max_tokens=8):
+        pass
+
+    assert spy["rapid"] is True, "rapid backend should have fired"
+    assert spy["mlx_vlm"] is False, "mlx-vlm should NOT have been called"
+    # Profile knobs threaded through:
+    rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
+    assert rapid_kw["fixed_steps"] == 8
+    assert rapid_kw["sc_every"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mlx_vlm_backend_when_profile_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting ``"diffusion_backend": "mlx-vlm"`` on an alias falls
+    through to upstream verbatim. Emergency rollback path: edit
+    aliases.json + restart."""
+    spy = _install_backend_spies(monkeypatch)
+
+    # Hand-build a profile with diffusion_backend="mlx-vlm" and bind
+    # it to the engine post-init (resolve_profile would only return
+    # "rapid" for any real alias today).
+    from vllm_mlx.model_aliases import AliasProfile
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
+    engine = DiffusionEngine(model_name="x/y")
+    engine._profile = AliasProfile(
+        hf_path="x/y", modality="text-diffusion",
+        supports_spec_decode=False,
+        diffusion_backend="mlx-vlm",
+    )
+    engine._load_blocking()
+
+    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
+                                      max_tokens=8):
+        pass
+
+    assert spy["mlx_vlm"] is True
+    assert spy["rapid"] is False
+    # Rapid-only kwargs must NOT leak into the mlx-vlm call (would
+    # raise TypeError upstream — defense in depth).
+    mlx_kw = spy["_kwargs"]["mlx_vlm"]  # type: ignore[index]
+    assert "fixed_steps" not in mlx_kw
+    assert "sc_every" not in mlx_kw
+
+
+@pytest.mark.asyncio
+async def test_temperature_does_not_gate_rapid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``temperature>0`` must still take the rapid path. The lane
+    used to gate on ``temperature==0`` (rapid was greedy-only); with
+    ``_sample_canvas`` honoring temperature, that gate is gone — the
+    default ``_FALLBACK_TEMPERATURE=0.7`` flows through cleanly."""
+    spy = _install_backend_spies(monkeypatch)
+    monkeypatch.delenv("RAPID_MLX_DIFFUSION_BACKEND", raising=False)
+
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+    engine = DiffusionEngine(model_name="x/y")
+    engine._load_blocking()
+    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
+                                      max_tokens=8, temperature=0.7):
+        pass
+
+    assert spy["rapid"] is True
+    rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
+    assert rapid_kw["temperature"] == pytest.approx(0.7)
+
+
+# =============================================================================
+# Profile resolution — alias name vs HF path vs unknown
+# =============================================================================
+
+
+def test_profile_resolves_for_known_alias_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_backend_spies(monkeypatch)
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
+    engine = DiffusionEngine(model_name="diffusion-gemma-26b")
+    assert engine._profile.modality == "text-diffusion"
+    assert engine._profile.diffusion_backend == "rapid"
+    assert engine._profile.diffusion_fixed_steps == 8
+    assert engine._profile.diffusion_sc_every == 1
+
+
+def test_profile_falls_back_for_unknown_hf_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare HF paths that no alias references get a throwaway profile
+    with safe diffusion defaults so the engine still has knobs to
+    pass into the rapid loop."""
+    _install_backend_spies(monkeypatch)
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
+    engine = DiffusionEngine(model_name="some-org/no-such-alias")
+    assert engine._profile is not None
+    assert engine._profile.modality == "text-diffusion"
+    assert engine._profile.diffusion_backend == "rapid"  # default
+    assert engine._profile.diffusion_fixed_steps == 8    # default
+    assert engine._profile.diffusion_sc_every == 1       # default

--- a/tests/test_diffusion_lane_routing.py
+++ b/tests/test_diffusion_lane_routing.py
@@ -47,8 +47,12 @@ class _FakeTokenizer:
 
     stopping_criteria = _SC()
 
-    def apply_chat_template(self, messages: list[dict], tokenize: bool = False,
-                            add_generation_prompt: bool = True) -> str:
+    def apply_chat_template(
+        self,
+        messages: list[dict],
+        tokenize: bool = False,
+        add_generation_prompt: bool = True,
+    ) -> str:
         rendered = "\n".join(m.get("content", "") for m in messages)
         if add_generation_prompt:
             rendered += "\n<model>\n"
@@ -90,8 +94,9 @@ def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
     mlx_vlm_diffusion = types.ModuleType("mlx_vlm.generate.diffusion")
     mlx_vlm_diffusion.diffusion_generation_family = lambda _: "block"  # type: ignore[attr-defined]
 
-    def _stream_upstream(model, processor, tokenizer, input_ids,
-                         pixel_values, attention_mask, **kw):
+    def _stream_upstream(
+        model, processor, tokenizer, input_ids, pixel_values, attention_mask, **kw
+    ):
         called["mlx_vlm"] = True
         captured_kwargs["mlx_vlm"] = kw
         yield _FakeResult(text="UP", diffusion_block_complete=True)
@@ -103,7 +108,9 @@ def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
 
     class _WL:
         def __init__(self, *_a: Any, **_k: Any) -> None: ...
-        def __enter__(self) -> _WL: return self
+        def __enter__(self) -> _WL:
+            return self
+
         def __exit__(self, *_a: Any) -> None: ...
 
     mlx_vlm_common.wired_limit = _WL  # type: ignore[attr-defined]
@@ -124,8 +131,9 @@ def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
     # the already-imported module so the lazy import sees our spy.
     import vllm_mlx.runtime.diffusion_loop as loop_mod
 
-    def _stream_rapid(model, processor, tokenizer, input_ids,
-                      pixel_values, attention_mask, **kw):
+    def _stream_rapid(
+        model, processor, tokenizer, input_ids, pixel_values, attention_mask, **kw
+    ):
         called["rapid"] = True
         captured_kwargs["rapid"] = kw
         yield _FakeResult(text="RA", diffusion_block_complete=True)
@@ -140,25 +148,36 @@ def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
 
 
 @pytest.mark.asyncio
-async def test_default_alias_uses_rapid_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_default_alias_uses_rapid_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Default profile (no JSON overrides) → diffusion_backend='rapid'
     → rapid path. This is the production path most users hit."""
     spy = _install_backend_spies(monkeypatch)
 
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
     engine = DiffusionEngine(model_name="x/y")
     engine._load_blocking()
     assert engine._profile.diffusion_backend == "rapid"
 
-    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
-                                      max_tokens=8):
+    async for _ in engine.stream_chat(
+        [{"role": "user", "content": "hi"}], max_tokens=8
+    ):
         pass
 
     assert spy["rapid"] is True, "rapid backend should have fired"
     assert spy["mlx_vlm"] is False, "mlx-vlm should NOT have been called"
-    # Profile knobs threaded through:
+    # Profile knobs threaded through. Default profile has
+    # ``diffusion_fixed_steps=None`` → ``fixed_steps`` is OMITTED
+    # entirely (lane only forwards when non-None) so the rapid loop's
+    # own ``fixed_steps=None`` default enables adaptive stop.
+    # ``sc_every`` is always forwarded.
     rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
-    assert rapid_kw["fixed_steps"] == 8
+    assert "fixed_steps" not in rapid_kw, (
+        "default profile uses adaptive stop; fixed_steps must NOT be "
+        f"forwarded, got {rapid_kw.get('fixed_steps')!r}"
+    )
     assert rapid_kw["sc_every"] == 1
 
 
@@ -179,14 +198,16 @@ async def test_mlx_vlm_backend_when_profile_says_so(
 
     engine = DiffusionEngine(model_name="x/y")
     engine._profile = AliasProfile(
-        hf_path="x/y", modality="text-diffusion",
+        hf_path="x/y",
+        modality="text-diffusion",
         supports_spec_decode=False,
         diffusion_backend="mlx-vlm",
     )
     engine._load_blocking()
 
-    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
-                                      max_tokens=8):
+    async for _ in engine.stream_chat(
+        [{"role": "user", "content": "hi"}], max_tokens=8
+    ):
         pass
 
     assert spy["mlx_vlm"] is True
@@ -210,10 +231,12 @@ async def test_temperature_does_not_gate_rapid(
     monkeypatch.delenv("RAPID_MLX_DIFFUSION_BACKEND", raising=False)
 
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
     engine = DiffusionEngine(model_name="x/y")
     engine._load_blocking()
-    async for _ in engine.stream_chat([{"role": "user", "content": "hi"}],
-                                      max_tokens=8, temperature=0.7):
+    async for _ in engine.stream_chat(
+        [{"role": "user", "content": "hi"}], max_tokens=8, temperature=0.7
+    ):
         pass
 
     assert spy["rapid"] is True
@@ -233,11 +256,13 @@ def test_profile_resolves_for_known_alias_name(monkeypatch: pytest.MonkeyPatch) 
     engine = DiffusionEngine(model_name="diffusion-gemma-26b")
     assert engine._profile.modality == "text-diffusion"
     assert engine._profile.diffusion_backend == "rapid"
-    assert engine._profile.diffusion_fixed_steps == 8
+    assert engine._profile.diffusion_fixed_steps is None  # adaptive stop
     assert engine._profile.diffusion_sc_every == 1
 
 
-def test_profile_falls_back_for_unknown_hf_path(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_profile_falls_back_for_unknown_hf_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Bare HF paths that no alias references get a throwaway profile
     with safe diffusion defaults so the engine still has knobs to
     pass into the rapid loop."""
@@ -248,5 +273,33 @@ def test_profile_falls_back_for_unknown_hf_path(monkeypatch: pytest.MonkeyPatch)
     assert engine._profile is not None
     assert engine._profile.modality == "text-diffusion"
     assert engine._profile.diffusion_backend == "rapid"  # default
-    assert engine._profile.diffusion_fixed_steps == 8    # default
-    assert engine._profile.diffusion_sc_every == 1       # default
+    assert engine._profile.diffusion_fixed_steps is None  # adaptive stop
+    assert engine._profile.diffusion_sc_every == 1  # default
+
+
+@pytest.mark.asyncio
+async def test_alias_with_explicit_fixed_steps_forwards_int(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operators can opt into a fixed step budget; when set, the lane
+    MUST forward ``fixed_steps=<int>`` so the rapid loop honors it and
+    disables adaptive stop."""
+    spy = _install_backend_spies(monkeypatch)
+    from vllm_mlx.model_aliases import AliasProfile
+    from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
+    engine = DiffusionEngine(model_name="x/y")
+    engine._profile = AliasProfile(
+        hf_path="x/y",
+        modality="text-diffusion",
+        supports_spec_decode=False,
+        diffusion_fixed_steps=8,
+    )
+    engine._load_blocking()
+    async for _ in engine.stream_chat(
+        [{"role": "user", "content": "hi"}],
+        max_tokens=8,
+    ):
+        pass
+    rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
+    assert rapid_kw["fixed_steps"] == 8

--- a/tests/test_diffusion_lane_routing.py
+++ b/tests/test_diffusion_lane_routing.py
@@ -168,16 +168,13 @@ async def test_default_alias_uses_rapid_backend(
 
     assert spy["rapid"] is True, "rapid backend should have fired"
     assert spy["mlx_vlm"] is False, "mlx-vlm should NOT have been called"
-    # Profile knobs threaded through. Default profile has
-    # ``diffusion_fixed_steps=None`` → ``fixed_steps`` is OMITTED
-    # entirely (lane only forwards when non-None) so the rapid loop's
-    # own ``fixed_steps=None`` default enables adaptive stop.
-    # ``sc_every`` is always forwarded.
+    # Default profile is ``diffusion_fixed_steps=8`` — the empirical
+    # optimum that delivers the 1.76x longform speedup over mlx-vlm.
+    # Lane forwards ``fixed_steps=8`` AND ``sc_every=1`` so the rapid
+    # loop runs with deterministic step counts (disabling the
+    # adaptive-stop predicate).
     rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
-    assert "fixed_steps" not in rapid_kw, (
-        "default profile uses adaptive stop; fixed_steps must NOT be "
-        f"forwarded, got {rapid_kw.get('fixed_steps')!r}"
-    )
+    assert rapid_kw["fixed_steps"] == 8
     assert rapid_kw["sc_every"] == 1
 
 
@@ -256,7 +253,7 @@ def test_profile_resolves_for_known_alias_name(monkeypatch: pytest.MonkeyPatch) 
     engine = DiffusionEngine(model_name="diffusion-gemma-26b")
     assert engine._profile.modality == "text-diffusion"
     assert engine._profile.diffusion_backend == "rapid"
-    assert engine._profile.diffusion_fixed_steps is None  # adaptive stop
+    assert engine._profile.diffusion_fixed_steps == 8  # empirical optimum
     assert engine._profile.diffusion_sc_every == 1
 
 
@@ -273,17 +270,18 @@ def test_profile_falls_back_for_unknown_hf_path(
     assert engine._profile is not None
     assert engine._profile.modality == "text-diffusion"
     assert engine._profile.diffusion_backend == "rapid"  # default
-    assert engine._profile.diffusion_fixed_steps is None  # adaptive stop
+    assert engine._profile.diffusion_fixed_steps == 8  # empirical optimum
     assert engine._profile.diffusion_sc_every == 1  # default
 
 
 @pytest.mark.asyncio
-async def test_alias_with_explicit_fixed_steps_forwards_int(
+async def test_alias_with_null_fixed_steps_opts_into_adaptive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Operators can opt into a fixed step budget; when set, the lane
-    MUST forward ``fixed_steps=<int>`` so the rapid loop honors it and
-    disables adaptive stop."""
+    """Setting ``"diffusion_fixed_steps": null`` in the alias JSON
+    opts into adaptive-stop. The lane MUST OMIT ``fixed_steps`` from
+    the kwargs so the rapid loop's signature default (``None``)
+    enables the ``_stable_and_confident`` predicate."""
     spy = _install_backend_spies(monkeypatch)
     from vllm_mlx.model_aliases import AliasProfile
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
@@ -293,7 +291,7 @@ async def test_alias_with_explicit_fixed_steps_forwards_int(
         hf_path="x/y",
         modality="text-diffusion",
         supports_spec_decode=False,
-        diffusion_fixed_steps=8,
+        diffusion_fixed_steps=None,
     )
     engine._load_blocking()
     async for _ in engine.stream_chat(
@@ -302,4 +300,6 @@ async def test_alias_with_explicit_fixed_steps_forwards_int(
     ):
         pass
     rapid_kw = spy["_kwargs"]["rapid"]  # type: ignore[index]
-    assert rapid_kw["fixed_steps"] == 8
+    assert "fixed_steps" not in rapid_kw, (
+        f"null fixed_steps must NOT be forwarded; got {rapid_kw.get('fixed_steps')!r}"
+    )

--- a/tests/test_diffusion_lane_routing.py
+++ b/tests/test_diffusion_lane_routing.py
@@ -151,13 +151,15 @@ def _install_backend_spies(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
 async def test_default_alias_uses_rapid_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Default profile (no JSON overrides) → diffusion_backend='rapid'
-    → rapid path. This is the production path most users hit."""
+    """The shipped ``diffusion-gemma-26b`` alias resolves to
+    ``diffusion_backend='rapid'`` → rapid path. This is the production
+    path most users hit. (Bare unresolvable HF paths now fall back to
+    mlx-vlm — see ``test_profile_falls_back_for_unknown_hf_path``.)"""
     spy = _install_backend_spies(monkeypatch)
 
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
 
-    engine = DiffusionEngine(model_name="x/y")
+    engine = DiffusionEngine(model_name="diffusion-gemma-26b")
     engine._load_blocking()
     assert engine._profile.diffusion_backend == "rapid"
 
@@ -229,7 +231,10 @@ async def test_temperature_does_not_gate_rapid(
 
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
 
-    engine = DiffusionEngine(model_name="x/y")
+    # Use the real ``diffusion-gemma-26b`` alias so the resolved
+    # profile carries ``diffusion_backend='rapid'``. (Bare unresolvable
+    # HF paths now fall back to mlx-vlm — see Finding 1 in codex round 2.)
+    engine = DiffusionEngine(model_name="diffusion-gemma-26b")
     engine._load_blocking()
     async for _ in engine.stream_chat(
         [{"role": "user", "content": "hi"}], max_tokens=8, temperature=0.7
@@ -261,17 +266,17 @@ def test_profile_falls_back_for_unknown_hf_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Bare HF paths that no alias references get a throwaway profile
-    with safe diffusion defaults so the engine still has knobs to
-    pass into the rapid loop."""
+    that points at upstream ``mlx-vlm``. The rapid loop is hand-tuned
+    for DiffusionGemma specifically — unknown diffusion families take
+    the conservative upstream path until an operator adds an alias
+    entry that opts them into rapid. codex round 2 [P1]."""
     _install_backend_spies(monkeypatch)
     from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
 
     engine = DiffusionEngine(model_name="some-org/no-such-alias")
     assert engine._profile is not None
     assert engine._profile.modality == "text-diffusion"
-    assert engine._profile.diffusion_backend == "rapid"  # default
-    assert engine._profile.diffusion_fixed_steps == 8  # empirical optimum
-    assert engine._profile.diffusion_sc_every == 1  # default
+    assert engine._profile.diffusion_backend == "mlx-vlm"  # safe fallback
 
 
 @pytest.mark.asyncio

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -356,9 +356,13 @@ def test_rejects_pixel_values():
 
 def test_accepts_explicit_zero_temperature():
     """``temperature=0.0`` → greedy argmax path inside ``_sample_canvas``.
-    Generator is constructed without error. (Iteration calls model()
-    which is None and crashes; that's fine — the test only verifies the
-    upfront guard logic doesn't reject the legal value.)"""
+    Codex round 2 [P1]: generator BODIES don't execute until iteration,
+    so the previous version was a false-green — a future regression that
+    added an upfront ``raise ValueError("temperature must be > 0")`` would
+    silently pass. Drive the generator with ``next()`` so the body runs.
+    ``model=None`` crashes downstream with some other error class once we
+    reach the forward pass — that's fine; what matters is that the upfront
+    validation does NOT reject the legal ``temperature=0.0`` value."""
     fake_input_ids = mx.array([[1, 2, 3]])
     gen = rapid_stream_diffusion_generate(
         model=None,
@@ -367,7 +371,14 @@ def test_accepts_explicit_zero_temperature():
         input_ids=fake_input_ids,
         temperature=0.0,
     )
-    assert gen is not None
+    with pytest.raises(Exception) as exc_info:
+        next(gen)
+    # Body executed and crashed downstream (model=None); the upfront
+    # validation did NOT raise ``ValueError`` against the legal value.
+    assert not (
+        isinstance(exc_info.value, ValueError)
+        and "temperature" in str(exc_info.value).lower()
+    ), f"Upfront validation rejected legal temperature=0.0: {exc_info.value}"
 
 
 def test_rejects_zero_or_negative_prefill_step_size():
@@ -404,7 +415,10 @@ def test_accepts_nonzero_temperature():
     """``temperature>0`` is now legal: per-step argmax switches to
     ``mx.random.categorical`` inside ``_sample_canvas`` to match
     mlx-vlm's sampling semantics. Chat clients defaulting to
-    ``temperature=0.7`` must reach the rapid path."""
+    ``temperature=0.7`` must reach the rapid path. Codex round 2 [P1]:
+    same false-green class as ``test_accepts_explicit_zero_temperature``
+    — drive ``next()`` so the generator body runs and we can assert the
+    upfront guard does NOT reject ``temperature=0.7``."""
     fake_input_ids = mx.array([[1, 2, 3]])
     gen = rapid_stream_diffusion_generate(
         model=None,
@@ -413,7 +427,12 @@ def test_accepts_nonzero_temperature():
         input_ids=fake_input_ids,
         temperature=0.7,
     )
-    assert gen is not None
+    with pytest.raises(Exception) as exc_info:
+        next(gen)
+    assert not (
+        isinstance(exc_info.value, ValueError)
+        and "temperature" in str(exc_info.value).lower()
+    ), f"Upfront validation rejected legal temperature=0.7: {exc_info.value}"
 
 
 # =============================================================================

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``runtime/diffusion_loop.py``.
+
+Covers the math helpers + EOS extraction + greedy-only / vision guards.
+Does NOT load DiffusionGemma — those live in
+``test_diffusion_gemma_parity.py`` behind ``@pytest.mark.gpu_heavy``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from vllm_mlx.runtime.diffusion_loop import (
+    RapidDiffusionResult,
+    _extract_eos_ids,
+    _initialize_canvas,
+    _sample_canvas,
+    _soft_embedding_weight,
+    _soft_embeddings,
+    rapid_stream_diffusion_generate,
+)
+
+# =============================================================================
+# RapidDiffusionResult — getattr contract with diffusion_lane.py consumer
+# =============================================================================
+
+
+def test_result_dataclass_is_frozen():
+    """The lane reads via ``getattr(result, …, default)``; mutation here
+    would break the implicit immutability assumption at
+    ``diffusion_lane.py:1241``."""
+    r = RapidDiffusionResult(text="x", token=1, prompt_tokens=2,
+                             generation_tokens=3, diffusion_block_complete=True,
+                             finish_reason=None)
+    with pytest.raises(Exception):
+        r.text = "mutated"  # type: ignore[misc]
+
+
+def test_result_getattr_defaults_match_mlx_vlm_shape():
+    """The lane uses ``getattr(result, 'is_draft', False)`` etc.; verify
+    our dataclass returns the same defaults the upstream
+    ``GenerationResult`` would surface."""
+    r = RapidDiffusionResult(text="hi", token=42, prompt_tokens=10,
+                             generation_tokens=1, diffusion_block_complete=True,
+                             finish_reason=None)
+    assert getattr(r, "is_draft", "MISSING") is False
+    assert getattr(r, "prompt_tokens", 0) == 10
+    assert getattr(r, "generation_tokens", 0) == 1
+    assert getattr(r, "token", None) == 42
+    assert getattr(r, "diffusion_block_complete", False) is True
+    assert getattr(r, "finish_reason", None) is None
+
+
+# =============================================================================
+# _initialize_canvas — shape + dtype + value range
+# =============================================================================
+
+
+def test_initialize_canvas_shape_and_dtype():
+    canvas = _initialize_canvas(batch_size=1, canvas_length=64,
+                                vocab_size=1000, dtype=mx.int32)
+    assert canvas.shape == (1, 64)
+    assert canvas.dtype == mx.int32
+
+
+def test_initialize_canvas_values_in_vocab():
+    """Upstream uses mx.random.randint(0, vocab_size, …) — values must
+    stay in ``[0, vocab_size)``. Off-by-one here lands the mask token
+    in the canvas and breaks the first denoising pass."""
+    canvas = _initialize_canvas(1, 256, 1000, mx.int32)
+    vals = canvas.tolist()
+    flat = vals[0]
+    assert min(flat) >= 0
+    assert max(flat) < 1000
+
+
+def test_initialize_canvas_int8_canvas_dtype():
+    """DiffusionGemma's input_ids are int8 in some quantization configs;
+    the helper must respect the requested dtype."""
+    canvas = _initialize_canvas(1, 32, 256, mx.int16)
+    assert canvas.dtype == mx.int16
+
+
+# =============================================================================
+# _soft_embedding_weight — handles regular nn.Embedding + QuantizedEmbedding
+# =============================================================================
+
+
+def test_soft_embedding_weight_regular_embedding():
+    """Plain ``nn.Embedding`` returns its weight directly (no dequant)."""
+    embed = nn.Embedding(num_embeddings=100, dims=32)
+    w = _soft_embedding_weight(embed)
+    assert w.shape == (100, 32)
+    # Identity check — no copy, no dequant.
+    assert w is embed.weight or mx.array_equal(w, embed.weight)
+
+
+def test_soft_embedding_weight_quantized_embedding():
+    """Quantized embeddings must be dequantized before matmul — the
+    packed weight has a different shape and ``probs @ packed_weight``
+    silently produces garbage. This is the bug that surfaced in B3's
+    first smoke test."""
+    # nn.QuantizedEmbedding requires an existing embedding to quantize.
+    base = nn.Embedding(num_embeddings=128, dims=64)
+    q = nn.QuantizedEmbedding.from_embedding(base, bits=4, group_size=64)
+
+    w = _soft_embedding_weight(q)
+    # After dequant, shape must be ``[num_embeddings, dims]`` —
+    # otherwise the @ embedding_weight matmul in _soft_embeddings will
+    # produce wrong-shape activations.
+    assert w.shape == (128, 64)
+
+
+# =============================================================================
+# _soft_embeddings — math sanity
+# =============================================================================
+
+
+def test_soft_embeddings_output_shape_and_dtype():
+    """Shape ``[B, L, V]`` @ ``[V, H]`` → ``[B, L, H]``, scaled, same
+    dtype as embedding_weight. Wrong shape here is what crashed the
+    first B3 smoke run before the dequant fix."""
+    logits = mx.random.normal((1, 8, 32))  # [B=1, L=8, V=32]
+    embedding_weight = mx.random.normal((32, 16))  # [V=32, H=16]
+    embed_scale = mx.array(2.5)
+
+    out = _soft_embeddings(logits, embedding_weight, embed_scale)
+    assert out.shape == (1, 8, 16)
+    assert out.dtype == embedding_weight.dtype
+
+
+def test_soft_embeddings_scale_factor_applied():
+    """``embed_scale`` must multiply the result — DiffusionGemma's
+    decoder.embed_scale is non-1.0; dropping it silently degrades
+    self-conditioning input magnitude on every step."""
+    logits = mx.zeros((1, 4, 8))  # uniform softmax → 1/8 per vocab slot
+    embedding_weight = mx.ones((8, 4))  # each col = 8 → softmax @ weight = 1.0
+    embed_scale = mx.array(3.0)
+    out = _soft_embeddings(logits, embedding_weight, embed_scale)
+    # softmax(zeros) = uniform 1/8, @ ones(8,4) = ones(B,L,4), * 3 = 3
+    expected = mx.full(out.shape, 3.0, dtype=embedding_weight.dtype)
+    assert mx.allclose(out, expected, atol=1e-5)
+
+
+# =============================================================================
+# _sample_canvas — greedy vs categorical, temperature semantics
+# =============================================================================
+
+
+def test_sample_canvas_greedy_at_temp_zero():
+    """``temperature=0`` → deterministic argmax. One-hot logits land on
+    the corresponding token id every time."""
+    # Build logits where each [B, L] position has a unique max
+    logits = mx.array([[
+        [-100.0, 5.0, -100.0, -100.0],  # → 1
+        [-100.0, -100.0, 7.0, -100.0],  # → 2
+        [3.0, -100.0, -100.0, -100.0],  # → 0
+    ]])  # shape [1, 3, 4]
+    out = _sample_canvas(logits, mx.int32, temperature=0.0)
+    assert out.shape == (1, 3)
+    assert out.tolist() == [[1, 2, 0]]
+
+
+def test_sample_canvas_greedy_at_negative_temp():
+    """``temperature<0`` also routes to argmax (defensive — upstream
+    treats anything <= 0 as greedy)."""
+    logits = mx.array([[[1.0, 9.0, 2.0]]])
+    assert _sample_canvas(logits, mx.int32, temperature=-1.0).tolist() == [[1]]
+
+
+def test_sample_canvas_categorical_at_temp_one():
+    """``temperature=1`` → categorical sample. Sharp logits should
+    still pick the dominant token most of the time; verify the picked
+    id is at least valid."""
+    logits = mx.array([[[10.0, -10.0, -10.0, -10.0]]])  # token 0 totally dominant
+    # Even with sampling, this should always pick 0 (others have ~0 prob).
+    for _ in range(5):
+        out = _sample_canvas(logits, mx.int32, temperature=1.0)
+        assert out.tolist() == [[0]]
+
+
+def test_sample_canvas_temperature_rescales_logits():
+    """``temperature != 1`` scales logits before softmax. Lower temp
+    → sharper distribution. We can't bit-check randomness, but we can
+    verify the path runs and produces in-vocab tokens for diverse
+    temps."""
+    logits = mx.random.normal((1, 4, 32))
+    for t in [0.1, 0.5, 0.7, 1.0, 2.0]:
+        out = _sample_canvas(logits, mx.int32, temperature=t)
+        assert out.shape == (1, 4)
+        vals = out.tolist()[0]
+        assert min(vals) >= 0
+        assert max(vals) < 32
+
+
+def test_sample_canvas_dtype_preserved():
+    """The canvas dtype must match the input ids dtype — mlx-vlm
+    uses int32 / int16 depending on quantization."""
+    logits = mx.array([[[1.0, 2.0]]])
+    assert _sample_canvas(logits, mx.int32, 0.0).dtype == mx.int32
+    assert _sample_canvas(logits, mx.int16, 1.0).dtype == mx.int16
+
+
+# =============================================================================
+# _extract_eos_ids — union of generation_config + tokenizer EOS
+# =============================================================================
+
+
+class _StubConfig:
+    def __init__(self, generation_config: Any = None, eos_token_id: Any = None):
+        self.generation_config = generation_config
+        if eos_token_id is not None:
+            self.eos_token_id = eos_token_id
+
+
+class _StubTokenizer:
+    def __init__(self, eos: Any = None):
+        if eos is not None:
+            self.eos_token_id = eos
+
+
+def test_extract_eos_unions_generation_config_list():
+    cfg = _StubConfig(generation_config={"eos_token_id": [1, 2, 3]})
+    tok = _StubTokenizer(eos=99)
+    assert _extract_eos_ids(cfg, tok) == {1, 2, 3, 99}
+
+
+def test_extract_eos_unions_int_and_list():
+    """DiffusionGemma's actual checkpoint splits the EOS set between
+    ``config.eos_token_id`` (single int) and
+    ``generation_config.eos_token_id`` (list incl. <end_of_turn>).
+    Missing this union silently turns <end_of_turn> into normal text
+    and the model rambles past the natural stop."""
+    cfg = _StubConfig(generation_config={"eos_token_id": [106]},
+                      eos_token_id=1)
+    tok = _StubTokenizer()
+    assert _extract_eos_ids(cfg, tok) == {1, 106}
+
+
+def test_extract_eos_empty_when_nothing_set():
+    cfg = _StubConfig()
+    tok = _StubTokenizer()
+    assert _extract_eos_ids(cfg, tok) == set()
+
+
+def test_extract_eos_handles_missing_generation_config():
+    cfg = _StubConfig(generation_config=None, eos_token_id=42)
+    tok = _StubTokenizer(eos=42)
+    # Set union → single element
+    assert _extract_eos_ids(cfg, tok) == {42}
+
+
+# =============================================================================
+# Guards — vision input + non-zero temperature
+# =============================================================================
+
+
+def test_rejects_pixel_values():
+    """Vision input should fail loud — the text-diffusion lane never
+    routes pixels and silently ignoring would hide a routing bug."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="text-only"):
+        next(rapid_stream_diffusion_generate(
+            model=None, processor=None, tokenizer=None,
+            input_ids=fake_input_ids,
+            pixel_values=mx.zeros((1, 3, 224, 224)),
+        ))
+
+
+def test_accepts_explicit_zero_temperature():
+    """``temperature=0.0`` → greedy argmax path inside ``_sample_canvas``.
+    Generator is constructed without error. (Iteration calls model()
+    which is None and crashes; that's fine — the test only verifies the
+    upfront guard logic doesn't reject the legal value.)"""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    gen = rapid_stream_diffusion_generate(
+        model=None, processor=None, tokenizer=None,
+        input_ids=fake_input_ids,
+        temperature=0.0,
+    )
+    assert gen is not None
+
+
+def test_accepts_nonzero_temperature():
+    """``temperature>0`` is now legal: per-step argmax switches to
+    ``mx.random.categorical`` inside ``_sample_canvas`` to match
+    mlx-vlm's sampling semantics. Chat clients defaulting to
+    ``temperature=0.7`` must reach the rapid path."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    gen = rapid_stream_diffusion_generate(
+        model=None, processor=None, tokenizer=None,
+        input_ids=fake_input_ids,
+        temperature=0.7,
+    )
+    assert gen is not None

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -411,6 +411,65 @@ def test_rejects_zero_or_negative_prefill_step_size():
         )
 
 
+def test_rejects_zero_or_negative_fixed_steps():
+    """Codex round 4 [P1]: programmatic callers (not just JSON loaders)
+    can pass ``fixed_steps=0``. Without entry validation,
+    ``denoise_budget`` resolves to ``0``, the for-loop body never runs,
+    and ``_initialize_canvas`` random ids are emitted as model output.
+    AliasProfile's loader already enforces ``>= 1`` on the JSON surface
+    (``test_fixed_steps_must_be_positive_int``); this test pins the
+    same contract on the runtime entry."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="fixed_steps must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                fixed_steps=0,
+            )
+        )
+    with pytest.raises(ValueError, match="fixed_steps must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                fixed_steps=-3,
+            )
+        )
+
+
+def test_rejects_zero_or_negative_max_denoising_steps():
+    """Codex round 4 [P1]: see ``test_rejects_zero_or_negative_fixed_steps``
+    — same bug class on the ``max_denoising_steps`` knob, which is the
+    accept-and-honor mirror of mlx-vlm's upstream signature. Per-request
+    overrides also need entry validation."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="max_denoising_steps must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                max_denoising_steps=0,
+            )
+        )
+    with pytest.raises(ValueError, match="max_denoising_steps must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                max_denoising_steps=-2,
+            )
+        )
+
+
 def test_accepts_nonzero_temperature():
     """``temperature>0`` is now legal: per-step argmax switches to
     ``mx.random.categorical`` inside ``_sample_canvas`` to match

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -33,9 +33,14 @@ def test_result_dataclass_is_frozen():
     """The lane reads via ``getattr(result, …, default)``; mutation here
     would break the implicit immutability assumption at
     ``diffusion_lane.py:1241``."""
-    r = RapidDiffusionResult(text="x", token=1, prompt_tokens=2,
-                             generation_tokens=3, diffusion_block_complete=True,
-                             finish_reason=None)
+    r = RapidDiffusionResult(
+        text="x",
+        token=1,
+        prompt_tokens=2,
+        generation_tokens=3,
+        diffusion_block_complete=True,
+        finish_reason=None,
+    )
     with pytest.raises(Exception):
         r.text = "mutated"  # type: ignore[misc]
 
@@ -44,9 +49,14 @@ def test_result_getattr_defaults_match_mlx_vlm_shape():
     """The lane uses ``getattr(result, 'is_draft', False)`` etc.; verify
     our dataclass returns the same defaults the upstream
     ``GenerationResult`` would surface."""
-    r = RapidDiffusionResult(text="hi", token=42, prompt_tokens=10,
-                             generation_tokens=1, diffusion_block_complete=True,
-                             finish_reason=None)
+    r = RapidDiffusionResult(
+        text="hi",
+        token=42,
+        prompt_tokens=10,
+        generation_tokens=1,
+        diffusion_block_complete=True,
+        finish_reason=None,
+    )
     assert getattr(r, "is_draft", "MISSING") is False
     assert getattr(r, "prompt_tokens", 0) == 10
     assert getattr(r, "generation_tokens", 0) == 1
@@ -61,8 +71,9 @@ def test_result_getattr_defaults_match_mlx_vlm_shape():
 
 
 def test_initialize_canvas_shape_and_dtype():
-    canvas = _initialize_canvas(batch_size=1, canvas_length=64,
-                                vocab_size=1000, dtype=mx.int32)
+    canvas = _initialize_canvas(
+        batch_size=1, canvas_length=64, vocab_size=1000, dtype=mx.int32
+    )
     assert canvas.shape == (1, 64)
     assert canvas.dtype == mx.int32
 
@@ -155,11 +166,15 @@ def test_sample_canvas_greedy_at_temp_zero():
     """``temperature=0`` → deterministic argmax. One-hot logits land on
     the corresponding token id every time."""
     # Build logits where each [B, L] position has a unique max
-    logits = mx.array([[
-        [-100.0, 5.0, -100.0, -100.0],  # → 1
-        [-100.0, -100.0, 7.0, -100.0],  # → 2
-        [3.0, -100.0, -100.0, -100.0],  # → 0
-    ]])  # shape [1, 3, 4]
+    logits = mx.array(
+        [
+            [
+                [-100.0, 5.0, -100.0, -100.0],  # → 1
+                [-100.0, -100.0, 7.0, -100.0],  # → 2
+                [3.0, -100.0, -100.0, -100.0],  # → 0
+            ]
+        ]
+    )  # shape [1, 3, 4]
     out = _sample_canvas(logits, mx.int32, temperature=0.0)
     assert out.shape == (1, 3)
     assert out.tolist() == [[1, 2, 0]]
@@ -235,8 +250,7 @@ def test_extract_eos_unions_int_and_list():
     ``generation_config.eos_token_id`` (list incl. <end_of_turn>).
     Missing this union silently turns <end_of_turn> into normal text
     and the model rambles past the natural stop."""
-    cfg = _StubConfig(generation_config={"eos_token_id": [106]},
-                      eos_token_id=1)
+    cfg = _StubConfig(generation_config={"eos_token_id": [106]}, eos_token_id=1)
     tok = _StubTokenizer()
     assert _extract_eos_ids(cfg, tok) == {1, 106}
 
@@ -254,6 +268,71 @@ def test_extract_eos_handles_missing_generation_config():
     assert _extract_eos_ids(cfg, tok) == {42}
 
 
+class _StubFullTok:
+    """Tokenizer/processor surface covering all 4 EOS shapes
+    ``Scheduler._get_stop_tokens`` reads."""
+
+    def __init__(self, eos=None, eos_plural=None, wrapper_set=None, rapid_extras=None):
+        if eos is not None:
+            self.eos_token_id = eos
+        if eos_plural is not None:
+            self.eos_token_ids = eos_plural
+        if wrapper_set is not None:
+            self._eos_token_ids = wrapper_set
+        if rapid_extras is not None:
+            self._rapid_extra_eos_token_ids = rapid_extras
+
+
+def test_extract_eos_unions_all_tokenizer_surfaces():
+    """Codex r1 P1: my original ``_extract_eos_ids`` read only
+    ``tokenizer.eos_token_id`` and silently missed three other surfaces
+    (``eos_token_ids`` plural, mlx-lm ``_eos_token_ids`` set,
+    ``_rapid_extra_eos_token_ids`` stash). For models whose chat
+    terminator only lands on one of those (Gemma 3 VL processors,
+    augmented HF tokenizers), the rapid loop would generate up to
+    ``max_tokens`` instead of stopping at the natural turn boundary."""
+    cfg = _StubConfig()
+    tok = _StubFullTok(
+        eos=1,
+        eos_plural=[2, 3],
+        wrapper_set={4, 5},
+        rapid_extras={6},
+    )
+    assert _extract_eos_ids(cfg, tok) == {1, 2, 3, 4, 5, 6}
+
+
+def test_extract_eos_reads_processor_surface_when_tokenizer_bare():
+    """mlx-vlm processors carry EOS on ``processor.tokenizer`` AND on
+    ``processor`` itself depending on the loader. The rapid loop must
+    union both — otherwise rapid would miss the EOS that mlx-vlm's
+    own augmenter stashed on the processor (most common shape for
+    DiffusionGemma's HF tokenizer wrapper)."""
+    cfg = _StubConfig()
+    tok = _StubFullTok()  # bare — nothing
+    proc = _StubFullTok(rapid_extras={106})  # the augmented stash
+    assert _extract_eos_ids(cfg, tok, proc) == {106}
+
+
+def test_extract_eos_handles_tuple_and_set_shapes():
+    """``eos_token_ids`` can be a list, set, or tuple depending on the
+    tokenizer flavor — all three must work."""
+    cfg = _StubConfig()
+    tok = _StubFullTok(eos_plural=(7, 8))
+    assert _extract_eos_ids(cfg, tok) == {7, 8}
+    tok = _StubFullTok(wrapper_set={9, 10, 11})
+    assert _extract_eos_ids(cfg, tok) == {9, 10, 11}
+
+
+def test_extract_eos_skips_none_and_non_int_entries():
+    """``getattr`` defaults must not blow up on ``None``, and bogus
+    string entries in a list must be silently skipped (defensive —
+    HF generation configs sometimes carry mixed lists during loader
+    upgrades)."""
+    cfg = _StubConfig(generation_config={"eos_token_id": [1, "bogus", 2]})
+    tok = _StubFullTok()
+    assert _extract_eos_ids(cfg, tok) == {1, 2}
+
+
 # =============================================================================
 # Guards — vision input + non-zero temperature
 # =============================================================================
@@ -264,11 +343,15 @@ def test_rejects_pixel_values():
     routes pixels and silently ignoring would hide a routing bug."""
     fake_input_ids = mx.array([[1, 2, 3]])
     with pytest.raises(ValueError, match="text-only"):
-        next(rapid_stream_diffusion_generate(
-            model=None, processor=None, tokenizer=None,
-            input_ids=fake_input_ids,
-            pixel_values=mx.zeros((1, 3, 224, 224)),
-        ))
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                pixel_values=mx.zeros((1, 3, 224, 224)),
+            )
+        )
 
 
 def test_accepts_explicit_zero_temperature():
@@ -278,11 +361,43 @@ def test_accepts_explicit_zero_temperature():
     upfront guard logic doesn't reject the legal value.)"""
     fake_input_ids = mx.array([[1, 2, 3]])
     gen = rapid_stream_diffusion_generate(
-        model=None, processor=None, tokenizer=None,
+        model=None,
+        processor=None,
+        tokenizer=None,
         input_ids=fake_input_ids,
         temperature=0.0,
     )
     assert gen is not None
+
+
+def test_rejects_zero_or_negative_prefill_step_size():
+    """Codex r1 P0 fix: ``prefill_step_size`` is honored now. A
+    non-positive value is a caller-side bug (operator typo in
+    ``--prefill-step-size`` or SchedulerConfig); silently treating it
+    as ``None`` would mask the misconfig. Mirror upstream's loud
+    raise at mlx-vlm diffusion.py:655. Validation runs BEFORE any
+    model state is touched so this test can pass ``model=None``."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="prefill_step_size must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                prefill_step_size=0,
+            )
+        )
+    with pytest.raises(ValueError, match="prefill_step_size must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                prefill_step_size=-1,
+            )
+        )
 
 
 def test_accepts_nonzero_temperature():
@@ -292,7 +407,9 @@ def test_accepts_nonzero_temperature():
     ``temperature=0.7`` must reach the rapid path."""
     fake_input_ids = mx.array([[1, 2, 3]])
     gen = rapid_stream_diffusion_generate(
-        model=None, processor=None, tokenizer=None,
+        model=None,
+        processor=None,
+        tokenizer=None,
         input_ids=fake_input_ids,
         temperature=0.7,
     )

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -440,29 +440,146 @@ def test_accepts_nonzero_temperature():
 # =============================================================================
 
 
-def test_fixed_steps_and_adaptive_stop_are_not_mutually_exclusive():
-    """Round-3 fix: PR #555 v2 logic treated ``fixed_steps != None`` as
-    "disable adaptive stop", which forced 8 steps on structured-json
-    prompts that converged at 6 (the canvas was stable but we kept
-    re-running the same forward pass). Without this test, a future
-    refactor could re-introduce the mutual-exclusive code path and
-    silently bring back the ~25% regression on EOS-bound short outputs.
+class _StableLogitsFakeModel:
+    """Minimal fake model: every per-step forward returns peaky logits
+    where token ``5`` dominates. argmax_canvas is the same on every
+    step from step 1, so ``_stable_and_confident`` MUST fire on step 2
+    (history has 1 entry from step 1, current matches). Counts forward
+    calls so the test can assert the loop exited well before consuming
+    the ``fixed_steps`` ceiling.
 
-    We can't easily probe the internal ``adaptive_stop`` flag without
-    leaking implementation detail, so this test pins the OBSERVABLE
-    contract via the function docstring: ``fixed_steps`` is described
-    as a CEILING, and the live PR #555 bench (commit on this branch)
-    confirms structured-json runs 41.2 tok/s (rapid) vs 37.1 tok/s
-    (mlx-vlm) — only possible if adaptive stop is firing inside the
-    cap. If somebody flips this back to mutually-exclusive, this
-    docstring-pin assertion makes the regression visible at review."""
+    Codex round 3 [P1]: this replaces the prior docstring-pin assertion
+    which would have silently passed if production code re-introduced
+    the v1/v2 mutually-exclusive ``adaptive_stop = (fixed_steps is None)``
+    logic. With the fake model, that regression makes ``forward_calls``
+    jump from ~2 to the full ceiling and the test fails loud.
+    """
+
+    class _TC:
+        vocab_size = 16
+
+    class _C:
+        text_config: Any
+        canvas_length = 4
+        generation_config: dict[str, Any] = {
+            # diffusion_stopping_config with low thresholds so
+            # _stable_and_confident fires aggressively on peaky logits.
+            "diffusion_stopping_config": {
+                "stability_threshold": 1,
+                "confidence_threshold": 0.5,
+            },
+            "sampler_config": {"entropy_bound": 1.0},
+        }
+        eos_token_id = None
+
+    class _ET:
+        # Regular (non-quantized) weight — _soft_embedding_weight returns
+        # the .weight attribute directly. (vocab=16, dim=4)
+        weight: mx.array
+
+    class _Decoder:
+        embed_scale = 1.0
+        embed_tokens: Any
+
+        @staticmethod
+        def _make_decoder_masks(canvas_ids, kv_cache, decoder_attention_mask):
+            # The loop only forwards this opaquely into model() as
+            # ``decoder_attention_mask`` — our fake ignores it.
+            return None
+
+    class _Inner:
+        decoder: Any
+
+        @staticmethod
+        def encoder(input_ids, attention_mask=None, cache=None):
+            return None, cache or []
+
+    def __init__(self) -> None:
+        self.forward_calls = 0
+        # Peaky logits — one-hot at token 5 with a huge spike so entropy
+        # is ~0. Broadcast to (batch=1, canvas_length=4, vocab=16).
+        spike = mx.where(
+            mx.arange(16) == 5,
+            mx.array(1000.0),
+            mx.array(0.0),
+        )
+        self._logits = mx.broadcast_to(spike[None, None, :], (1, 4, 16))
+        # Build the nested config/embed_tokens/decoder shape the loop
+        # reads. Done in __init__ so the fake has stable per-instance
+        # state (rather than class-level mutable defaults).
+        tc = self._TC()
+        cfg = self._C()
+        cfg.text_config = tc
+        et = self._ET()
+        et.weight = mx.zeros((16, 4))
+        dec = self._Decoder()
+        dec.embed_tokens = et
+        inner = self._Inner()
+        inner.decoder = dec
+        self.config = cfg
+        self.model = inner
+
+    def make_cache(self) -> list:
+        class _Cache:
+            state = mx.zeros((1,))
+
+        return [_Cache()]
+
+    def __call__(self, cache=None, canvas_ids=None, **kw):
+        self.forward_calls += 1
+
+        class _R:
+            pass
+
+        r = _R()
+        r.logits = self._logits
+        return r
+
+
+class _FakeTokenizerForLoopTest:
+    all_special_ids: list[int] = []
+    eos_token_id = None
+
+    def decode(self, ids):  # type: ignore[no-untyped-def]
+        return "".join(chr(0x41 + (int(i) % 26)) for i in ids)
+
+
+def test_fixed_steps_and_adaptive_stop_are_not_mutually_exclusive():
+    """Codex round 3 [P1]: pin that adaptive early-stop fires INSIDE a
+    large ``fixed_steps`` ceiling. With a fake model whose canvas
+    stabilizes on step 1 (peaky logits → argmax is deterministic and
+    identical every step), ``_stable_and_confident`` MUST fire on step 2
+    of the denoising loop, regardless of how large ``fixed_steps`` is.
+
+    If a future refactor re-introduces the v1/v2 mutually-exclusive
+    behavior (``adaptive_stop = fixed_steps is None``), ``forward_calls``
+    will balloon from ~2 to the full ceiling and this test fails loud.
+    This is the structured-json regression the round-3 hybrid mode
+    closed."""
     from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
 
-    doc = rapid_stream_diffusion_generate.__doc__ or ""
-    # The docstring MUST advertise fixed_steps as a ceiling — this
-    # is the user-visible contract the AliasProfile default depends on.
-    assert "ceiling, not a floor" in doc.lower() or "caps" in doc.lower(), (
-        "rapid_stream_diffusion_generate docstring must describe "
-        "fixed_steps as a budget cap (not a mutually-exclusive override) "
-        "so future contributors don't re-introduce the v2 perf regression"
+    model = _StableLogitsFakeModel()
+    tok = _FakeTokenizerForLoopTest()
+    input_ids = mx.array([[1, 2, 3]])
+
+    # ``fixed_steps=64`` is the ceiling; if adaptive stop is disabled
+    # the loop will burn all 64 forward passes per canvas. With it on,
+    # the stable-logits fake exits at step 2.
+    gen = rapid_stream_diffusion_generate(
+        model=model,
+        processor=None,
+        tokenizer=tok,
+        input_ids=input_ids,
+        fixed_steps=64,
+        max_tokens=4,  # one canvas-worth — single denoising pass
+        temperature=0.0,
+    )
+    # Drain the generator so the loop runs to completion.
+    list(gen)
+
+    assert model.forward_calls < 10, (
+        f"adaptive_stop should have fired ~step 2 of the ``fixed_steps=64`` "
+        f"ceiling on stable peaky logits, but the loop made "
+        f"{model.forward_calls} forward calls — the v1/v2 mutually-exclusive "
+        f"regression (``adaptive_stop = fixed_steps is None``) is back."
     )

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -3,7 +3,8 @@
 
 Covers the math helpers + EOS extraction + greedy-only / vision guards.
 Does NOT load DiffusionGemma — those live in
-``test_diffusion_gemma_parity.py`` behind ``@pytest.mark.gpu_heavy``.
+``test_diffusion_gemma_parity.py`` behind ``@pytest.mark.slow`` (run
+with ``pytest --run-slow``).
 """
 
 from __future__ import annotations
@@ -464,6 +465,49 @@ def test_strict_int_validation_rejects_float_and_bool():
                     tokenizer=None,
                     input_ids=fake_input_ids,
                     **knob_kwargs,  # type: ignore[arg-type]
+                )
+            )
+
+
+def test_rejects_padded_inputs():
+    """Codex round 6 [P1]: the per-canvas re-prefill grows the KV cache
+    by ``current_canvas`` each iteration, but ``decoder_attention_mask``
+    was only built from ``prompt + current_canvas`` lengths. On padded
+    inputs the mask would diverge from cache length on canvas 2+, so
+    attention silently looks at the wrong slots. The lane never pads
+    today (B=1, no padding), so reject at entry until a multi-canvas
+    + padding implementation lands."""
+    fake_input_ids = mx.array([[1, 2, 3, 4]])
+    # Mask with at least one False slot → has_padding = True → reject.
+    padded_mask = mx.array([[True, True, False, False]])
+    with pytest.raises(ValueError, match="padded inputs"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                attention_mask=padded_mask,
+            )
+        )
+
+
+def test_rejects_invalid_sc_every():
+    """Codex round 6 [P1]: ``sc_every`` gates
+    ``cur_step % max(sc_every, 1)`` mid-loop. A float raises
+    ``TypeError`` 32 steps into generation; ``0``/negative silently
+    coerce to ``1`` via the ``max(...)`` guard. Mirror the same strict
+    validation as the budget knobs."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    for bad_val in (None, 1.5, True, 0, -1):
+        with pytest.raises(ValueError, match="sc_every must be"):
+            next(
+                rapid_stream_diffusion_generate(
+                    model=None,
+                    processor=None,
+                    tokenizer=None,
+                    input_ids=fake_input_ids,
+                    sc_every=bad_val,  # type: ignore[arg-type]
                 )
             )
 

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -531,6 +531,139 @@ def test_stop_string_validation_rejects_non_string_list():
         )
 
 
+def test_stop_string_validation_rejects_non_string_list_element():
+    """codex round 8 [P1]: ``stop=[123]`` MUST raise — previously
+    ``[s for s in stop if isinstance(s, str) and s]`` silently dropped
+    the non-string element and the resulting empty list made the
+    caller's stop request a no-op. Raise loud rather than coerce."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="stop list elements must be strings"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                stop=[123],  # type: ignore[list-item]
+            )
+        )
+    # Mixed list: even one bad element → raise (don't silently filter).
+    with pytest.raises(ValueError, match="stop list elements must be strings"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                stop=["</answer>", 42, "</done>"],  # type: ignore[list-item]
+            )
+        )
+
+
+def test_stop_string_wins_over_length_when_earlier():
+    """codex round 8 [P1]: when a canvas decodes to text that BOTH
+    contains a stop string AND hits the max_tokens cap on the same
+    canvas, the earlier cut must win. Previously the ``if not
+    canvas_stop`` guard let length-from-max_tokens win unconditionally,
+    leaving the stop string un-trimmed in the emitted text."""
+
+    class _StopTok:
+        all_special_ids: list[int] = []
+        eos_token_id = None
+
+        def decode(self, ids):  # type: ignore[no-untyped-def]
+            # Each token 5 → "STOPHERE"; canvas of [5,5,5,5] decodes to
+            # "STOPHERESTOPHERESTOPHERESTOPHERE" — stop at index 0.
+            return "".join("STOPHERE" if int(i) == 5 else "?" for i in ids)
+
+    model = _StableLogitsFakeModel()
+    tok = _StopTok()
+    input_ids = mx.array([[1, 2, 3]])
+
+    # max_tokens=4 matches canvas_length exactly, so the length cap fires
+    # on the same canvas as the stop match. Without the r8 fix, length
+    # wins and "STOPHERESTOPHERESTOPHERESTOPHERE" leaks out unfiltered.
+    last = None
+    full_text = ""
+    for r in rapid_stream_diffusion_generate(
+        model=model,
+        processor=None,
+        tokenizer=tok,
+        input_ids=input_ids,
+        fixed_steps=8,
+        max_tokens=4,
+        temperature=0.0,
+        stop=["STOPHERE"],
+    ):
+        full_text += r.text
+        last = r
+    assert last is not None
+    assert last.finish_reason == "stop", (
+        f"stop should win over length when earlier; got {last.finish_reason!r}"
+    )
+    assert "STOPHERE" not in full_text, (
+        f"stop string leaked into emitted text (got {full_text!r})"
+    )
+
+
+def test_stop_string_cross_canvas_holdback():
+    """codex round 8 [P1]: a stop string that straddles a canvas
+    boundary must still be enforced — we hold back ``max_stop_len - 1``
+    chars from each non-terminal canvas so the next canvas can complete
+    the match. Without the holdback, the first canvas's tail leaks
+    verbatim and the consumer sees the stop string un-trimmed."""
+
+    class _AlternatingTok:
+        """Decode canvas N: first call returns ``"AAAA"``, every
+        subsequent call returns ``"BBBB"``. The stop string ``"AB"``
+        straddles the canvas boundary at position 3-4 of the full
+        emitted prefix."""
+
+        all_special_ids: list[int] = []
+        eos_token_id = None
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def decode(self, ids):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            return "AAAA" if self.calls == 1 else "BBBB"
+
+    model = _StableLogitsFakeModel()
+    tok = _AlternatingTok()
+    input_ids = mx.array([[1, 2, 3]])
+
+    full_text = ""
+    last = None
+    for r in rapid_stream_diffusion_generate(
+        model=model,
+        processor=None,
+        tokenizer=tok,
+        input_ids=input_ids,
+        fixed_steps=8,
+        max_tokens=8,
+        temperature=0.0,
+        stop=["AB"],
+    ):
+        full_text += r.text
+        last = r
+
+    assert last is not None
+    assert last.finish_reason == "stop", (
+        f"cross-canvas stop should terminate with finish_reason='stop'; "
+        f"got {last.finish_reason!r}"
+    )
+    # Full emit should cut at position 3 ("AAA"), NOT leak the 'A' that
+    # would have shipped with canvas 1 absent the holdback.
+    assert full_text == "AAA", (
+        f"cross-canvas stop should cut at position 3 (got {full_text!r}); "
+        "an 'AAAA' or longer prefix means the holdback didn't fire."
+    )
+    assert "AB" not in full_text, (
+        f"stop string 'AB' leaked into emitted text (got {full_text!r})"
+    )
+
+
 def test_stop_string_none_and_empty_are_noop():
     """``stop=None``, ``stop=""``, ``stop=[]``, ``stop=["", ""]`` must
     all behave as "no stop strings" — exercise the entry validation

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -442,6 +442,49 @@ def test_rejects_zero_or_negative_fixed_steps():
         )
 
 
+def test_strict_int_validation_rejects_float_and_bool():
+    """Codex round 5 [NIT]: ``int(x)`` silently truncates ``1.5`` and
+    accepts ``True`` (bool is an int subclass). Strict validation mirrors
+    ``model_aliases._coerce`` so the runtime entry refuses what the JSON
+    loader refuses."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    for knob_name, knob_kwargs in [
+        ("fixed_steps", {"fixed_steps": 1.5}),
+        ("fixed_steps", {"fixed_steps": True}),
+        ("max_denoising_steps", {"max_denoising_steps": 1.5}),
+        ("max_denoising_steps", {"max_denoising_steps": True}),
+        ("prefill_step_size", {"prefill_step_size": 1.5}),
+        ("prefill_step_size", {"prefill_step_size": False}),
+    ]:
+        with pytest.raises(ValueError, match=f"{knob_name} must be"):
+            next(
+                rapid_stream_diffusion_generate(
+                    model=None,
+                    processor=None,
+                    tokenizer=None,
+                    input_ids=fake_input_ids,
+                    **knob_kwargs,  # type: ignore[arg-type]
+                )
+            )
+
+
+def test_rejects_batch_size_greater_than_one():
+    """Codex round 5 [NIT]: the canvas decode step reads
+    ``current_canvas[0]`` only — B>1 inputs would silently drop all but
+    the first row's output. Reject at entry until per-row streaming
+    is implemented."""
+    fake_input_ids_b2 = mx.array([[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(ValueError, match="B=1 only"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids_b2,
+            )
+        )
+
+
 def test_rejects_zero_or_negative_max_denoising_steps():
     """Codex round 4 [P1]: see ``test_rejects_zero_or_negative_fixed_steps``
     — same bug class on the ``max_denoising_steps`` knob, which is the

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -469,6 +469,91 @@ def test_strict_int_validation_rejects_float_and_bool():
             )
 
 
+def test_stop_string_truncates_block_text():
+    """Codex round 7 [P1]: rapid backend must honor request-level
+    string stops. Use the fake-model framework from
+    ``test_fixed_steps_and_adaptive_stop_are_not_mutually_exclusive``
+    — stable peaky logits make the canvas predictable; we override
+    the tokenizer to decode token ``5`` as the string ``"STOPHERE"``
+    so the entire canvas decodes to ``"STOPHEREE...STOPHEREE"``.
+    With ``stop=["STOPHERE"]`` the very first canvas should yield
+    ``""`` (cut at position 0) and ``finish_reason="stop"``."""
+
+    class _StopTok:
+        all_special_ids: list[int] = []
+        eos_token_id = None
+
+        def decode(self, ids):  # type: ignore[no-untyped-def]
+            # Each token 5 → "STOPHERE"; any other id → "?"
+            return "".join("STOPHERE" if int(i) == 5 else "?" for i in ids)
+
+    model = _StableLogitsFakeModel()
+    tok = _StopTok()
+    input_ids = mx.array([[1, 2, 3]])
+
+    last = None
+    for r in rapid_stream_diffusion_generate(
+        model=model,
+        processor=None,
+        tokenizer=tok,
+        input_ids=input_ids,
+        fixed_steps=8,
+        max_tokens=8,
+        temperature=0.0,
+        stop=["STOPHERE"],
+    ):
+        last = r
+    assert last is not None
+    assert last.finish_reason == "stop", (
+        f"stop string should have terminated; got finish_reason={last.finish_reason!r}"
+    )
+    # The first canvas's block_text starts with "STOPHERE..." so the
+    # cut is at index 0; emitted text should be empty.
+    assert last.text == "", (
+        f"text should be truncated at the stop position (got {last.text!r})"
+    )
+
+
+def test_stop_string_validation_rejects_non_string_list():
+    """codex round 7 [P1]: invalid ``stop`` shape must fail loud, not
+    silently no-op. Mirror the lane's ``_normalize_stops`` permissive
+    contract (str / list[str] / None) but raise on other types."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="stop must be"):
+        next(
+            rapid_stream_diffusion_generate(
+                model=None,
+                processor=None,
+                tokenizer=None,
+                input_ids=fake_input_ids,
+                stop=42,  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_stop_string_none_and_empty_are_noop():
+    """``stop=None``, ``stop=""``, ``stop=[]``, ``stop=["", ""]`` must
+    all behave as "no stop strings" — exercise the entry validation
+    drops empty strings silently like the lane does."""
+    fake_input_ids = mx.array([[1, 2, 3]])
+    for empty_stop in (None, "", [], ["", ""]):
+        # Should validate cleanly; downstream model=None crash is
+        # expected and verifies entry validation passed.
+        gen = rapid_stream_diffusion_generate(
+            model=None,
+            processor=None,
+            tokenizer=None,
+            input_ids=fake_input_ids,
+            stop=empty_stop,  # type: ignore[arg-type]
+        )
+        with pytest.raises(Exception) as exc_info:
+            next(gen)
+        # The downstream crash must NOT be a stop-related ValueError.
+        assert not (
+            isinstance(exc_info.value, ValueError) and "stop" in str(exc_info.value)
+        ), f"empty-stop variant {empty_stop!r} rejected at entry: {exc_info.value}"
+
+
 def test_rejects_padded_inputs():
     """Codex round 6 [P1]: the per-canvas re-prefill grows the KV cache
     by ``current_canvas`` each iteration, but ``decoder_attention_mask``

--- a/tests/test_diffusion_loop.py
+++ b/tests/test_diffusion_loop.py
@@ -414,3 +414,36 @@ def test_accepts_nonzero_temperature():
         temperature=0.7,
     )
     assert gen is not None
+
+
+# =============================================================================
+# Hybrid mode — fixed_steps caps the budget, adaptive stop fires on top.
+# =============================================================================
+
+
+def test_fixed_steps_and_adaptive_stop_are_not_mutually_exclusive():
+    """Round-3 fix: PR #555 v2 logic treated ``fixed_steps != None`` as
+    "disable adaptive stop", which forced 8 steps on structured-json
+    prompts that converged at 6 (the canvas was stable but we kept
+    re-running the same forward pass). Without this test, a future
+    refactor could re-introduce the mutual-exclusive code path and
+    silently bring back the ~25% regression on EOS-bound short outputs.
+
+    We can't easily probe the internal ``adaptive_stop`` flag without
+    leaking implementation detail, so this test pins the OBSERVABLE
+    contract via the function docstring: ``fixed_steps`` is described
+    as a CEILING, and the live PR #555 bench (commit on this branch)
+    confirms structured-json runs 41.2 tok/s (rapid) vs 37.1 tok/s
+    (mlx-vlm) — only possible if adaptive stop is firing inside the
+    cap. If somebody flips this back to mutually-exclusive, this
+    docstring-pin assertion makes the regression visible at review."""
+    from vllm_mlx.runtime.diffusion_loop import rapid_stream_diffusion_generate
+
+    doc = rapid_stream_diffusion_generate.__doc__ or ""
+    # The docstring MUST advertise fixed_steps as a ceiling — this
+    # is the user-visible contract the AliasProfile default depends on.
+    assert "ceiling, not a floor" in doc.lower() or "caps" in doc.lower(), (
+        "rapid_stream_diffusion_generate docstring must describe "
+        "fixed_steps as a budget cap (not a mutually-exclusive override) "
+        "so future contributors don't re-introduce the v2 perf regression"
+    )

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -151,17 +151,24 @@ class AliasProfile:
     # to set them on a non-``text-diffusion`` modality — a typo there is
     # a routing decision, not a stray field.
     diffusion_backend: DiffusionBackend = "rapid"
-    # ``None`` enables the vendored adaptive-stop predicate
-    # (_stable_and_confident) which mirrors mlx-vlm; runs as many
-    # denoising steps as the canvas needs to converge. Setting an int
-    # caps the per-canvas step budget AND disables adaptive stop —
-    # operator opt-in for "I want deterministic step counts" or "I want
-    # the long-form perf win at the cost of some short-prompt quality
-    # drift". Empirical optimum on DiffusionGemma:
-    #   - adaptive (None): mlx-vlm-grade quality, ~parity speed
-    #   - fixed_steps=8:   ~1.7x speedup on longform fill-to-max_tokens,
-    #                       on-par on EOS-bound short outputs
-    diffusion_fixed_steps: int | None = None
+    # Empirical optimum on DiffusionGemma 26B-A4B 4-bit from the
+    # hand-graded quality eval (see ``research/diffusion-gemma/quality/``)
+    # AND the PR #555 live bench:
+    #   - ``8`` (default): 1.76x speedup on longform fill-to-max_tokens
+    #     vs mlx-vlm, 1.09x on code, on-par on JSON. Quality byte-
+    #     comparable on all 3 canonical prompts (valid JSON, working
+    #     code, coherent prose).
+    #   - ``None``: enables the vendored ``_stable_and_confident``
+    #     adaptive-stop predicate. Tracks mlx-vlm's algorithm 1:1 —
+    #     slightly slower than ``8`` on long-form, mlx-vlm-parity
+    #     elsewhere. Opt-in for operators who want bit-for-bit step
+    #     counts to match upstream (e.g. for spec-decode draft-budget
+    #     accounting or reproducibility experiments).
+    # We default to ``8`` because the entire value-add of the rapid
+    # backend over the ``"mlx-vlm"`` backend is the perf delta; an
+    # adaptive default would just re-implement upstream in our tree
+    # at upstream's speed.
+    diffusion_fixed_steps: int | None = 8
     diffusion_sc_every: int = 1
 
 
@@ -395,15 +402,20 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             raise ValueError(f"alias {alias!r}: {key} must be >= 1, got {raw}")
         return raw
 
-    raw_fixed_steps = value.get("diffusion_fixed_steps", None)
-    if raw_fixed_steps is None:
-        diffusion_fixed_steps: int | None = None
+    # JSON ``"diffusion_fixed_steps": null`` opts into adaptive mode;
+    # missing key inherits the AliasProfile default (``8``); any int
+    # value runs through the strict positive-int validator.
+    if "diffusion_fixed_steps" in value:
+        raw_fixed_steps = value["diffusion_fixed_steps"]
+        if raw_fixed_steps is None:
+            diffusion_fixed_steps: int | None = None
+        else:
+            diffusion_fixed_steps = _strict_positive_int(
+                "diffusion_fixed_steps",
+                raw_fixed_steps,
+            )
     else:
-        # Re-use the strict validator path for non-None values.
-        diffusion_fixed_steps = _strict_positive_int(
-            "diffusion_fixed_steps",
-            raw_fixed_steps,
-        )
+        diffusion_fixed_steps = 8  # mirrors the dataclass default
     diffusion_sc_every = _strict_positive_int("diffusion_sc_every", 1)
 
     return AliasProfile(

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -28,6 +28,15 @@ from typing import Literal
 # routes/models.py so the surface-level UX (info, ls, chat) doesn't
 # silently expose LLM-only columns on a non-LLM alias.
 Modality = Literal["text", "text-diffusion", "vision", "image-gen"]
+
+# Generation backend for ``text-diffusion`` aliases. ``"rapid"`` runs the
+# in-house loop at ``runtime/diffusion_loop.py`` (deterministic
+# fixed-steps, ~3× upstream throughput, default); ``"mlx-vlm"`` falls
+# through to upstream ``stream_diffusion_generate`` (escape hatch for
+# A/B + bisection). New diffusion backends append here, then update the
+# dispatch table in ``runtime/diffusion_lane.py``.
+DiffusionBackend = Literal["rapid", "mlx-vlm"]
+_VALID_DIFFUSION_BACKENDS: frozenset[str] = frozenset({"rapid", "mlx-vlm"})
 # Implemented lanes — what ``load_model`` can actually dispatch to today.
 # ``vision`` and ``image-gen`` are RESERVED in the type alias so that
 # routing code can pattern-match on them once their dispatch paths land,
@@ -132,6 +141,18 @@ class AliasProfile:
     # modality slot and broke construction without raising. Keep new
     # fields at the tail.
     modality: Modality = "text"
+    # Diffusion-only knobs. All three default to the empirical optimum
+    # measured for DiffusionGemma 26B-A4B 4-bit on M3 Ultra (see quality
+    # eval ``research/diffusion-gemma/quality/eval-20260611-1001.md`` —
+    # ``fixed_steps=8`` + ``sc_every=1`` shipped at 127 tok/s with
+    # coherence on par with upstream's 71-95 tok/s ``max_denoising_steps=16``).
+    # The defaults are NO-OPS for non-diffusion aliases (the AR runtime
+    # never reads them), but ``_coerce`` rejects JSON entries that try
+    # to set them on a non-``text-diffusion`` modality — a typo there is
+    # a routing decision, not a stray field.
+    diffusion_backend: DiffusionBackend = "rapid"
+    diffusion_fixed_steps: int = 8
+    diffusion_sc_every: int = 1
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -175,6 +196,9 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "supports_dflash",
             "dflash_draft_model",
             "recommended_sampling",
+            "diffusion_backend",
+            "diffusion_fixed_steps",
+            "diffusion_sc_every",
         }
     )
     unknown_keys = set(value.keys()) - _ALLOWED_PROFILE_KEYS
@@ -323,6 +347,45 @@ def _coerce(alias: str, value: object) -> AliasProfile:
                 f"modality={modality!r} (DFlash is AR-only)"
             )
 
+    # Diffusion-only knobs. Reject any text-modality alias that tries to
+    # set them — the AR runtime ignores the field silently, so a typo
+    # there would be invisible at request time. Better to fail loud at
+    # load. Defaults still apply silently to existing text aliases (no
+    # JSON change required) because the AR lane never reads them.
+    _DIFFUSION_KEYS = ("diffusion_backend", "diffusion_fixed_steps", "diffusion_sc_every")
+    if modality != "text-diffusion":
+        for k in _DIFFUSION_KEYS:
+            if k in value:
+                raise ValueError(
+                    f"alias {alias!r}: {k} is only meaningful when "
+                    f"modality='text-diffusion', got modality={modality!r}"
+                )
+    raw_backend = value.get("diffusion_backend", "rapid")
+    if raw_backend not in _VALID_DIFFUSION_BACKENDS:
+        raise ValueError(
+            f"alias {alias!r}: diffusion_backend must be one of "
+            f"{sorted(_VALID_DIFFUSION_BACKENDS)}, got {raw_backend!r}"
+        )
+    diffusion_backend: DiffusionBackend = raw_backend  # type: ignore[assignment]
+
+    def _strict_positive_int(key: str, default: int) -> int:
+        raw = value.get(key, default)
+        # Reject bool (subclass of int) and floats — silently truncating
+        # ``fixed_steps=8.5`` would hide a hand-edit typo.
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a JSON integer, "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        if raw < 1:
+            raise ValueError(
+                f"alias {alias!r}: {key} must be >= 1, got {raw}"
+            )
+        return raw
+
+    diffusion_fixed_steps = _strict_positive_int("diffusion_fixed_steps", 8)
+    diffusion_sc_every = _strict_positive_int("diffusion_sc_every", 1)
+
     return AliasProfile(
         hf_path=hf_path,
         modality=modality,
@@ -337,6 +400,9 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         supports_dflash=supports_dflash,
         dflash_draft_model=dflash_draft_model,
         recommended_sampling=recommended_sampling,
+        diffusion_backend=diffusion_backend,
+        diffusion_fixed_steps=diffusion_fixed_steps,
+        diffusion_sc_every=diffusion_sc_every,
     )
 
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -151,7 +151,17 @@ class AliasProfile:
     # to set them on a non-``text-diffusion`` modality — a typo there is
     # a routing decision, not a stray field.
     diffusion_backend: DiffusionBackend = "rapid"
-    diffusion_fixed_steps: int = 8
+    # ``None`` enables the vendored adaptive-stop predicate
+    # (_stable_and_confident) which mirrors mlx-vlm; runs as many
+    # denoising steps as the canvas needs to converge. Setting an int
+    # caps the per-canvas step budget AND disables adaptive stop —
+    # operator opt-in for "I want deterministic step counts" or "I want
+    # the long-form perf win at the cost of some short-prompt quality
+    # drift". Empirical optimum on DiffusionGemma:
+    #   - adaptive (None): mlx-vlm-grade quality, ~parity speed
+    #   - fixed_steps=8:   ~1.7x speedup on longform fill-to-max_tokens,
+    #                       on-par on EOS-bound short outputs
+    diffusion_fixed_steps: int | None = None
     diffusion_sc_every: int = 1
 
 
@@ -352,7 +362,11 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     # there would be invisible at request time. Better to fail loud at
     # load. Defaults still apply silently to existing text aliases (no
     # JSON change required) because the AR lane never reads them.
-    _DIFFUSION_KEYS = ("diffusion_backend", "diffusion_fixed_steps", "diffusion_sc_every")
+    _DIFFUSION_KEYS = (
+        "diffusion_backend",
+        "diffusion_fixed_steps",
+        "diffusion_sc_every",
+    )
     if modality != "text-diffusion":
         for k in _DIFFUSION_KEYS:
             if k in value:
@@ -378,12 +392,18 @@ def _coerce(alias: str, value: object) -> AliasProfile:
                 f"got {type(raw).__name__}={raw!r}"
             )
         if raw < 1:
-            raise ValueError(
-                f"alias {alias!r}: {key} must be >= 1, got {raw}"
-            )
+            raise ValueError(f"alias {alias!r}: {key} must be >= 1, got {raw}")
         return raw
 
-    diffusion_fixed_steps = _strict_positive_int("diffusion_fixed_steps", 8)
+    raw_fixed_steps = value.get("diffusion_fixed_steps", None)
+    if raw_fixed_steps is None:
+        diffusion_fixed_steps: int | None = None
+    else:
+        # Re-use the strict validator path for non-None values.
+        diffusion_fixed_steps = _strict_positive_int(
+            "diffusion_fixed_steps",
+            raw_fixed_steps,
+        )
     diffusion_sc_every = _strict_positive_int("diffusion_sc_every", 1)
 
     return AliasProfile(

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -213,11 +213,18 @@ class DiffusionEngine(BaseEngine):
         # HF paths (``mlx-community/diffusiongemma-26B-A4B-it-4bit``) —
         # the reverse-index built by ``model_aliases._load`` covers both.
         # ``None`` only when the user pointed at an HF path that no
-        # alias references, in which case we fall back to the
-        # AliasProfile defaults (rapid backend + fixed_steps=8 +
-        # sc_every=1) by constructing a throwaway profile below.
+        # alias references. In that case fall back to upstream ``mlx-vlm``
+        # — the rapid loop is hand-tuned for DiffusionGemma 26B-A4B-4bit
+        # specifically (sampler choice, denoising-step budget, EOS surfaces)
+        # and may crash or misgenerate on an unknown diffusion family. The
+        # mlx-vlm backend is the conservative, well-tested default; opting
+        # into rapid is something an operator does explicitly via an alias
+        # entry. codex round 2 [P1].
         self._profile: AliasProfile = resolve_profile(model_name) or AliasProfile(
-            hf_path=model_name, modality="text-diffusion", supports_spec_decode=False
+            hf_path=model_name,
+            modality="text-diffusion",
+            supports_spec_decode=False,
+            diffusion_backend="mlx-vlm",
         )
         # Admission control mirrors BatchedEngine.check_admission —
         # reservations counter under a lock, BackpressureError raised

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..engine.base import BaseEngine, GenerationOutput
+from ..model_aliases import AliasProfile, resolve_profile
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,19 @@ class DiffusionEngine(BaseEngine):
         self._processor: Any = None
         self._loaded = False
         self._load_error: BaseException | None = None
+        # Resolve the AliasProfile once at construction. ``resolve_profile``
+        # works for both alias names (``diffusion-gemma-26b``) and bare
+        # HF paths (``mlx-community/diffusiongemma-26B-A4B-it-4bit``) —
+        # the reverse-index built by ``model_aliases._load`` covers both.
+        # ``None`` only when the user pointed at an HF path that no
+        # alias references, in which case we fall back to the
+        # AliasProfile defaults (rapid backend + fixed_steps=8 +
+        # sc_every=1) by constructing a throwaway profile below.
+        self._profile: AliasProfile = (
+            resolve_profile(model_name)
+            or AliasProfile(hf_path=model_name, modality="text-diffusion",
+                            supports_spec_decode=False)
+        )
         # Admission control mirrors BatchedEngine.check_admission —
         # reservations counter under a lock, BackpressureError raised
         # when the configured ``max_concurrent_requests`` is reached.
@@ -1138,6 +1152,47 @@ class DiffusionEngine(BaseEngine):
         import mlx.core as mx  # noqa: F401 — kept for symmetry with mlx_vlm
         from mlx_vlm.generate.diffusion import stream_diffusion_generate
 
+        # Backend selection lives entirely on the AliasProfile (the
+        # SSOT for every per-model routing decision; see
+        # ``test_no_out_of_band_routing.py`` for why env-var routing is
+        # forbidden). ``profile.diffusion_backend`` defaults to
+        # ``"rapid"`` so DiffusionGemma takes the in-house loop
+        # (``runtime/diffusion_loop.py``) out of the box; setting
+        # ``"diffusion_backend": "mlx-vlm"`` in ``aliases.json`` falls
+        # through to upstream ``stream_diffusion_generate`` verbatim,
+        # making the change a zero-risk additive feature on the
+        # mlx-vlm path.
+        #
+        # Emergency rollback: edit ``aliases.json`` to flip the value,
+        # restart the server. ~30s round-trip for a kill switch is
+        # acceptable; the alternative (an env var) would create an
+        # out-of-band routing channel that bypasses CLI/alias review.
+        #
+        # ``temperature`` is NOT a gate — the rapid loop honors the
+        # same greedy/sampled semantics as mlx-vlm's
+        # ``_diffusion_sample_canvas`` (see ``diffusion_loop.py``
+        # ``_sample_canvas``). Chat clients defaulting to
+        # ``temperature=0.7`` (``service/helpers.py``
+        # ``_FALLBACK_TEMPERATURE``) reach the rapid path too, so the
+        # perf win lands for users who don't explicitly request greedy.
+        use_rapid = self._profile.diffusion_backend == "rapid"
+        if use_rapid:
+            from .diffusion_loop import rapid_stream_diffusion_generate
+
+            _diffusion_gen_fn = rapid_stream_diffusion_generate
+            logger.debug(
+                "diffusion_lane: rapid backend "
+                f"(fixed_steps={self._profile.diffusion_fixed_steps}, "
+                f"sc_every={self._profile.diffusion_sc_every}, "
+                f"temperature={cfg.temperature})"
+            )
+        else:
+            _diffusion_gen_fn = stream_diffusion_generate
+            logger.debug(
+                "diffusion_lane: mlx-vlm backend "
+                f"(profile_backend={self._profile.diffusion_backend})"
+            )
+
         # NOTE: this method ALWAYS runs on the persistent worker
         # thread (see ``_worker_loop``), so the model weights, the
         # tokenizer-managed kv_cache, and the default GPU stream are
@@ -1189,6 +1244,15 @@ class DiffusionEngine(BaseEngine):
             # kwarg is non-None — forward only when the operator opted
             # in via --prefill-step-size / SchedulerConfig (codex r5).
             kwargs["prefill_step_size"] = int(cfg.prefill_step_size)
+        if use_rapid:
+            # Rapid loop ignores the mlx-vlm-flavored knobs
+            # (``diffusion_sampler``, ``max_denoising_steps``,
+            # ``prefill_step_size``) — see ``diffusion_loop.py``'s
+            # accept-and-ignore docstring. It DOES honor
+            # ``temperature`` (raises on >0; we already gated that
+            # above) and reads its own knobs from the profile:
+            kwargs["fixed_steps"] = int(self._profile.diffusion_fixed_steps)
+            kwargs["sc_every"] = int(self._profile.diffusion_sc_every)
 
         block_parts: list[str] = []
         last_prompt_tokens = 0
@@ -1208,7 +1272,7 @@ class DiffusionEngine(BaseEngine):
         if cancel_event.is_set():
             return
 
-        for result in stream_diffusion_generate(
+        for result in _diffusion_gen_fn(
             self._model,
             self._processor,
             tokenizer,

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -1254,9 +1254,13 @@ class DiffusionEngine(BaseEngine):
             # ``prefill_step_size``, ``diffusion_threshold`` via the
             # accept-and-honor signature (codex r2). It reads its own
             # per-alias knobs from the profile:
-            #   - ``fixed_steps``: ``None`` → adaptive stop via
-            #     ``_stable_and_confident`` (default); int → fixed budget,
-            #     disables adaptive stop (operator opt-in).
+            #   - ``fixed_steps``: when set, a CEILING on the denoising
+            #     budget; adaptive early-stop via ``_stable_and_confident``
+            #     STILL fires inside the ceiling. ``None`` → adaptive-only
+            #     (alias opt-in by setting ``"diffusion_fixed_steps": null``
+            #     in JSON). codex round 3 [NIT]: prior comment claimed int
+            #     disabled adaptive stop, which was the v1/v2 behavior the
+            #     hybrid mode replaced (see diffusion_loop.py round-3 fix).
             #   - ``sc_every``: confidence-threshold-path SC cadence.
             if self._profile.diffusion_fixed_steps is not None:
                 kwargs["fixed_steps"] = int(self._profile.diffusion_fixed_steps)

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -216,10 +216,8 @@ class DiffusionEngine(BaseEngine):
         # alias references, in which case we fall back to the
         # AliasProfile defaults (rapid backend + fixed_steps=8 +
         # sc_every=1) by constructing a throwaway profile below.
-        self._profile: AliasProfile = (
-            resolve_profile(model_name)
-            or AliasProfile(hf_path=model_name, modality="text-diffusion",
-                            supports_spec_decode=False)
+        self._profile: AliasProfile = resolve_profile(model_name) or AliasProfile(
+            hf_path=model_name, modality="text-diffusion", supports_spec_decode=False
         )
         # Admission control mirrors BatchedEngine.check_admission —
         # reservations counter under a lock, BackpressureError raised
@@ -1245,13 +1243,16 @@ class DiffusionEngine(BaseEngine):
             # in via --prefill-step-size / SchedulerConfig (codex r5).
             kwargs["prefill_step_size"] = int(cfg.prefill_step_size)
         if use_rapid:
-            # Rapid loop ignores the mlx-vlm-flavored knobs
-            # (``diffusion_sampler``, ``max_denoising_steps``,
-            # ``prefill_step_size``) — see ``diffusion_loop.py``'s
-            # accept-and-ignore docstring. It DOES honor
-            # ``temperature`` (raises on >0; we already gated that
-            # above) and reads its own knobs from the profile:
-            kwargs["fixed_steps"] = int(self._profile.diffusion_fixed_steps)
+            # Rapid honors ``diffusion_sampler``, ``max_denoising_steps``,
+            # ``prefill_step_size``, ``diffusion_threshold`` via the
+            # accept-and-honor signature (codex r2). It reads its own
+            # per-alias knobs from the profile:
+            #   - ``fixed_steps``: ``None`` → adaptive stop via
+            #     ``_stable_and_confident`` (default); int → fixed budget,
+            #     disables adaptive stop (operator opt-in).
+            #   - ``sc_every``: confidence-threshold-path SC cadence.
+            if self._profile.diffusion_fixed_steps is not None:
+                kwargs["fixed_steps"] = int(self._profile.diffusion_fixed_steps)
             kwargs["sc_every"] = int(self._profile.diffusion_sc_every)
 
         block_parts: list[str] = []

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -361,12 +361,17 @@ def rapid_stream_diffusion_generate(
     short EOS-bound outputs.
 
     Knobs:
-      * ``fixed_steps``: if set, overrides ``max_denoising_steps``
-        and disables early-stop. Empirically the prior rapid-mlx loop
-        used ``fixed_steps=8``; with the now-faithful adaptive-stop
-        port that knob is functionally redundant but is honored for
-        operator opt-in to deterministic step counts (e.g. for
-        speculative-decode draft-budget accounting).
+      * ``fixed_steps``: caps the per-canvas step budget. Adaptive
+        early-stop via ``_stable_and_confident`` STILL FIRES — the
+        budget is a ceiling, not a floor. This is the production
+        default (``8``) and gives the rapid backend its perf win:
+          - long-form: budget caps below mlx-vlm's ~11-15 adaptive
+            count → 1.76x speedup
+          - short EOS-bound (JSON, structured): early-stop fires
+            before the cap → on-par with mlx-vlm's own step count
+        Set to ``None`` to remove the ceiling (default upstream
+        ``max_denoising_steps`` budget; useful for reproducibility
+        experiments).
       * ``sc_every``: cadence for explicit (non-entropy-bound) self-
         conditioning. ``1`` = every step (DiffusionGemma optimum from
         the 2026-06-11 hand-graded eval). The entropy-bound path
@@ -402,10 +407,15 @@ def rapid_stream_diffusion_generate(
     sampler_config = _config_dict(generation_config.get("sampler_config"))
     entropy_bound = float(sampler_config.get("entropy_bound", 0.1))
 
-    # Resolve denoising-step budget.
+    # Resolve denoising-step budget. ``fixed_steps`` caps the budget
+    # (a CEILING, not a floor) — adaptive early-stop via
+    # ``_stable_and_confident`` always runs on top so EOS-bound short
+    # outputs (JSON, code) stop at ~6 steps even when ceiling is 8.
+    # This is the round-3 fix for the structured-json regression
+    # surfaced on PR #555: the v1/v2 mutual-exclusive logic forced 8
+    # steps on prompts that converge at 6, paying 33% extra compute.
     if fixed_steps is not None:
         denoise_budget = int(fixed_steps)
-        adaptive_stop = False
     else:
         if max_denoising_steps is None:
             max_denoising_steps = int(
@@ -413,7 +423,7 @@ def rapid_stream_diffusion_generate(
                 or _DEFAULT_MAX_DENOISING_STEPS,
             )
         denoise_budget = int(max_denoising_steps)
-        adaptive_stop = True
+    adaptive_stop = True
 
     # Temperature schedule (linear ramp during denoising). Upstream
     # falls back to {0.4, 0.8} when no config is present.

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -413,22 +413,29 @@ def rapid_stream_diffusion_generate(
     sampler_config = _config_dict(generation_config.get("sampler_config"))
     entropy_bound = float(sampler_config.get("entropy_bound", 0.1))
 
-    # Resolve denoising-step budget. ``fixed_steps`` caps the budget
-    # (a CEILING, not a floor) — adaptive early-stop via
+    # Resolve denoising-step budget — codex round 3 [P1] precedence:
+    # explicit ``max_denoising_steps`` from the caller wins over the
+    # alias default ``fixed_steps``, otherwise ``fixed_steps`` wins
+    # over the generation_config default. Without this, an alias
+    # default ``fixed_steps=8`` silently swallows a per-request
+    # ``max_denoising_steps=32`` override and the existing knob has
+    # no observable effect on the rapid backend.
+    #
+    # Whichever wins, it is a CEILING — adaptive early-stop via
     # ``_stable_and_confident`` always runs on top so EOS-bound short
     # outputs (JSON, code) stop at ~6 steps even when ceiling is 8.
     # This is the round-3 fix for the structured-json regression
     # surfaced on PR #555: the v1/v2 mutual-exclusive logic forced 8
     # steps on prompts that converge at 6, paying 33% extra compute.
-    if fixed_steps is not None:
+    if max_denoising_steps is not None:
+        denoise_budget = int(max_denoising_steps)
+    elif fixed_steps is not None:
         denoise_budget = int(fixed_steps)
     else:
-        if max_denoising_steps is None:
-            max_denoising_steps = int(
-                generation_config.get("max_denoising_steps")
-                or _DEFAULT_MAX_DENOISING_STEPS,
-            )
-        denoise_budget = int(max_denoising_steps)
+        denoise_budget = int(
+            generation_config.get("max_denoising_steps")
+            or _DEFAULT_MAX_DENOISING_STEPS,
+        )
     adaptive_stop = True
 
     # Temperature schedule (linear ramp during denoising). Upstream
@@ -695,12 +702,31 @@ def rapid_stream_diffusion_generate(
                     )
                 self_conditioning_embeddings = next_sc
 
-        current_canvas = argmax_canvas
+        # codex round 3 [P1]: pick the correct readout canvas per sampler.
+        # entropy-bound uses the last argmax (lowest schedule_temperature
+        # at step==1 → sharpest argmax). confidence-threshold accumulates
+        # the actually-revealed tokens into ``draft_canvas`` across steps;
+        # using ``argmax_canvas`` there would discard the temperature-
+        # sampled tokens chosen on the confidence early-exit path
+        # (line ~672 sets ``accepted_canvas = draft_canvas`` then breaks,
+        # but the post-loop assignment used to clobber that with the
+        # last argmax — silently flipping ``temperature > 0`` back to
+        # deterministic on that exit path).
+        if diffusion_sampler == "confidence-threshold":
+            current_canvas = draft_canvas
+        else:
+            current_canvas = argmax_canvas
         mx.eval(current_canvas)
 
-        # Emit canvas tokens one by one — stop on EOS or max_tokens.
+        # Emit canvas tokens — stop on EOS or max_tokens.
+        # codex round 3 [P1]: collect the kept ids and call
+        # ``tokenizer.decode(ids)`` ONCE per canvas. Per-token decode +
+        # concat corrupts output on tokenizers where byte pieces or
+        # merge-dependent tokens only round-trip correctly as a sequence
+        # (BPE byte-fallback, SentencePiece sub-word merges). Mirrors
+        # upstream's incremental detokenizer pattern at the canvas grain.
         canvas_tokens = [int(t) for t in current_canvas[0].tolist()]
-        emitted_text_pieces: list[str] = []
+        ids_to_decode: list[int] = []
         canvas_stop = False
         for tok in canvas_tokens:
             if len(generated) >= max_tokens:
@@ -714,7 +740,7 @@ def rapid_stream_diffusion_generate(
             generated.append(tok)
             last_token = tok
             if tok not in skip_ids:
-                emitted_text_pieces.append(tokenizer.decode([tok]))
+                ids_to_decode.append(tok)
 
         # Edge case: canvas exactly filled the remaining budget. The
         # for-loop above only stamps ``finish_reason='length'`` when the
@@ -726,7 +752,7 @@ def rapid_stream_diffusion_generate(
             finish_reason = "length"
             canvas_stop = True
 
-        block_text = "".join(emitted_text_pieces)
+        block_text = tokenizer.decode(ids_to_decode) if ids_to_decode else ""
         yield RapidDiffusionResult(
             text=block_text,
             token=last_token,

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -416,6 +416,17 @@ def rapid_stream_diffusion_generate(
     # caller still gets through.
     _require_positive_int("fixed_steps", fixed_steps)
     _require_positive_int("max_denoising_steps", max_denoising_steps)
+    # codex round 6 [P1]: ``sc_every`` gates ``cur_step % max(sc_every, 1)``
+    # mid-loop. A float raises ``TypeError`` 32 steps into generation
+    # (worst-failure-mode-money-can-buy); ``0`` or negative gets silently
+    # coerced to ``1`` by the ``max(...)`` guard, defeating the operator's
+    # intent. Mirror the same strict validation as the budget knobs.
+    if sc_every is None or isinstance(sc_every, bool) or not isinstance(sc_every, int):
+        raise ValueError(
+            f"sc_every must be a positive integer (got {type(sc_every).__name__})."
+        )
+    if sc_every <= 0:
+        raise ValueError("sc_every must be a positive integer.")
     if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
         raise ValueError(
             f"Unsupported diffusion sampler: {diffusion_sampler!r}.",
@@ -435,6 +446,23 @@ def rapid_stream_diffusion_generate(
             f"(got batch_size={batch_size}); the diffusion lane "
             "never batches today."
         )
+    # codex round 6 [P1]: ``decoder_attention_mask`` only covers
+    # ``prompt + current_canvas`` lengths, but the per-iteration
+    # encoder re-prefill grows the KV cache by each prior canvas. On
+    # padded inputs the mask would diverge from cache length on
+    # canvas 2+, so attention silently looks at the wrong slots. The
+    # diffusion lane never feeds padded inputs today (B=1, no padding),
+    # but a programmatic caller passing a mask with False slots would
+    # hit this. Reject loud here — BEFORE ``model.config`` so a unit
+    # test can exercise this guard with ``model=None``.
+    if attention_mask is not None:
+        am = attention_mask.astype(mx.bool_)
+        if not bool(mx.all(am).item()):
+            raise ValueError(
+                "rapid_stream_diffusion_generate does not support padded "
+                "inputs across multi-canvas generation; pass an attention "
+                "mask with all True or omit it."
+            )
 
     config = model.config
     text_config = config.text_config
@@ -508,12 +536,14 @@ def rapid_stream_diffusion_generate(
     embed_scale = decoder.embed_scale
 
     # Attention mask defaults to "all real tokens" — matches upstream.
+    # Padded inputs are rejected at entry above (codex round 6 [P1]),
+    # so we only need the all-ones default here for the unpadded path.
     if attention_mask is None:
         attention_mask = mx.ones((batch_size, prompt_length), dtype=mx.bool_)
     else:
         attention_mask = attention_mask.astype(mx.bool_)
-    has_padding = not bool(mx.all(attention_mask).item())
-    decoder_attention_mask = attention_mask if has_padding else None
+    has_padding = False
+    decoder_attention_mask = None
 
     # Prefill — chunked if the operator opted in and the prompt is long
     # enough to benefit. Mirrors ``_diffusion_prefill_cache``.

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -347,11 +347,13 @@ def rapid_stream_diffusion_generate(
     # rapid-mlx knobs (forwarded by AliasProfile via diffusion_lane.py)
     fixed_steps: int | None = None,
     sc_every: int = 1,
-    # Request-level stop strings. codex round 7 [P1]: previously only
-    # ``eos_ids`` token-id matches stopped the loop, so a caller passing
-    # ``stop=["</answer>"]`` would receive text past their requested
-    # boundary. We now check ``emitted_text + new_block_text`` for the
-    # earliest stop match per canvas and truncate.
+    # Request-level stop strings. codex round 7 [P1] + round 8 [P1]:
+    # previously only ``eos_ids`` token-id matches stopped the loop, so
+    # a caller passing ``stop=["</answer>"]`` would receive text past
+    # their requested boundary. We now prepend a per-canvas holdback of
+    # ``max(len(stop)) - 1`` chars and search ``holdback + new_block``
+    # for the earliest stop match — cross-canvas stops match without
+    # leak.
     stop: list[str] | None = None,
     # Accept-and-honor knobs that mirror upstream's signature so the
     # lane can hand the same kwargs to either backend. Empty defaults
@@ -604,11 +606,6 @@ def rapid_stream_diffusion_generate(
         mx.eval([c.state for c in kv_cache])
 
     generated: list[int] = []
-    # codex round 7 [P1]: emitted-text accumulator drives stop-string
-    # detection. We keep the full string (not just a tail buffer) so
-    # cross-canvas stops still match — at long generation lengths this
-    # is at most a few KB of memory, negligible vs the canvas tensors.
-    emitted_text: str = ""
     # codex round 8 [P1]: hold back ``max(len(stop)) - 1`` chars from the
     # tail of each canvas so a stop string that straddles a canvas
     # boundary still gets matched on the NEXT canvas before any text
@@ -909,8 +906,6 @@ def rapid_stream_diffusion_generate(
             else:
                 block_text = ""
                 holdback = combined
-
-        emitted_text += block_text
 
         yield RapidDiffusionResult(
             text=block_text,

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-house diffusion generation loop for DiffusionGemma 26B-A4B.
+
+Drop-in replacement for ``mlx_vlm.generate.diffusion.stream_diffusion_generate``.
+Produces an iterator yielding ``RapidDiffusionResult`` instances whose
+attribute shape matches what ``runtime/diffusion_lane.py`` expects from
+mlx-vlm's own ``DiffusionGenerationResult`` (``getattr(result, 'X', …)``
+sites at ``diffusion_lane.py:1229-1252``).
+
+Why we wrote this:
+  - mlx-vlm's loop uses entropy-bound adaptive stopping (median ~23
+    denoising steps per canvas) which is conservative by ~3× on
+    M3 Ultra and non-deterministic at temperature=0 (filed as
+    mlx-vlm#1351).
+  - With a fixed-step + per-step self-conditioning policy we hit
+    127 tok/s on the canonical DiffusionGemma benchmark prompt (vs
+    upstream's 30-46 tok/s baseline), at quality on par with
+    upstream's ``max_denoising_steps=16`` setting — see quality eval
+    ``research/diffusion-gemma/quality/eval-20260611-1001.md``.
+
+Scope:
+  - **Generation loop only.** We re-use mlx-vlm's loaded model — same
+    weights, same transformer arch (``model.model.encoder`` for prefill,
+    ``model.model.decoder._make_decoder_masks`` for attention masks,
+    ``model(canvas_ids=…, self_conditioning_embeddings=…)`` for the
+    denoising forward pass), same KV cache class. Only the loop body
+    (canvas init, fixed-step denoising, self-conditioning cadence,
+    EOS-aware multi-canvas advancement) is ours.
+
+The handful of small generation utilities that live in mlx-vlm's
+``generate/diffusion.py`` as ``_diffusion_initialize_canvas`` /
+``_diffusion_soft_embedding_weight`` / ``_diffusion_soft_embeddings``
+are inlined below — they're a few lines of mx math each, and importing
+them under their ``_`` private name would couple us to mlx-vlm
+internals (their loop calls them; ours is parallel). When mlx-vlm
+refactors their loop we don't care, because we don't share the loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RapidDiffusionResult:
+    """Per-canvas yield record. Attribute names + semantics match what
+    ``diffusion_lane.py``'s ``stream_diffusion_generate`` consumer reads
+    via ``getattr(result, …, default)``. New consumers should use this
+    dataclass directly so the typing is explicit."""
+
+    text: str
+    token: int | None
+    prompt_tokens: int
+    generation_tokens: int
+    diffusion_block_complete: bool
+    finish_reason: str | None
+    # ``is_draft`` is False for every yield we produce — we don't emit
+    # mid-canvas previews. Kept for ``getattr(result, "is_draft", False)``
+    # call-site symmetry with mlx-vlm's draft results.
+    is_draft: bool = False
+
+
+# =============================================================================
+# Math helpers — vendored equivalents of mlx-vlm's diffusion utilities
+# =============================================================================
+
+
+def _initialize_canvas(batch_size: int, canvas_length: int, vocab_size: int,
+                       dtype: Any) -> mx.array:
+    """Start a denoising canvas as uniform random token ids in
+    ``[0, vocab_size)`` — same convention as
+    ``mlx_vlm.generate.diffusion._diffusion_initialize_canvas`` at
+    mlx-vlm 0.6.3. DiffusionGemma's first denoising pass overwrites the
+    whole canvas via self-attention on the prompt KV cache, so the
+    initial values are noise, not zeros."""
+    return mx.random.randint(0, vocab_size, (batch_size, canvas_length)).astype(dtype)
+
+
+def _soft_embedding_weight(embed_layer: nn.Module) -> mx.array:
+    """Return a float weight matrix usable as ``probs @ weight``.
+
+    For 4-bit / quantized DiffusionGemma checkpoints the packed
+    ``embed_layer.weight`` can't feed a regular matmul — we have to
+    dequantize once. mlx-vlm does the same at
+    ``_diffusion_soft_embedding_weight`` (mlx-vlm 0.6.3); their note:
+    ``mx.quantized_matmul(..., transpose=False)`` is several times
+    slower at this shape, so dequant-once is the cheaper path."""
+    if isinstance(embed_layer, nn.QuantizedEmbedding):
+        return mx.dequantize(
+            embed_layer.weight,
+            embed_layer.scales,
+            embed_layer.biases,
+            group_size=embed_layer.group_size,
+            bits=embed_layer.bits,
+        )
+    return embed_layer.weight
+
+
+def _sample_canvas(logits: mx.array, dtype: Any, temperature: float) -> mx.array:
+    """Per-position argmax (greedy) or categorical sample (sampled).
+
+    Vendored from ``mlx_vlm.generate.diffusion._diffusion_sample_canvas``
+    at mlx-vlm 0.6.3. The semantics are:
+      - ``temperature <= 0``: greedy argmax (deterministic at given seed).
+      - ``temperature == 1.0``: categorical sample without rescaling.
+      - ``temperature in (0, 1) or (1, inf)``: rescale logits then sample.
+
+    Shape: ``[B, L, V]`` → ``[B, L]`` token ids in ``dtype``.
+
+    Keeping this matched to upstream's behavior is important — chat
+    clients (BCG, Big-AGI, etc.) default to ``temperature=0.7`` if the
+    user hasn't overridden it. Diverging here would silently change
+    sampled outputs vs. the mlx-vlm baseline."""
+    logits_f32 = logits.astype(mx.float32)
+    if temperature <= 0:
+        return mx.argmax(logits_f32, axis=-1).astype(dtype)
+    if temperature != 1.0:
+        logits_f32 = logits_f32 / temperature
+    return mx.random.categorical(logits_f32).astype(dtype)
+
+
+def _soft_embeddings(logits: mx.array, embedding_weight: mx.array,
+                     embed_scale: float) -> mx.array:
+    """``softmax(logits) @ embedding_weight * embed_scale`` — feeds the
+    next denoising pass as self-conditioning context.
+
+    Mirrors ``_diffusion_soft_embeddings`` at mlx-vlm 0.6.3 (uses
+    ``precise=True`` softmax to match upstream's numerics on the
+    ``[B, canvas, vocab=262144]`` reduction; ordinary softmax produces
+    visibly different self-conditioning input for the next step on
+    DiffusionGemma).
+
+    Shape: ``[B, canvas, vocab]`` @ ``[vocab, hidden]`` →
+    ``[B, canvas, hidden]``, scaled."""
+    probs = mx.softmax(logits, axis=-1, precise=True)
+    return (
+        probs.astype(embedding_weight.dtype) @ embedding_weight
+    ).astype(embedding_weight.dtype) * embed_scale
+
+
+# =============================================================================
+# Main loop
+# =============================================================================
+
+
+def _extract_eos_ids(model_config: Any, tokenizer: Any) -> set[int]:
+    """Collect EOS token ids from the model's ``generation_config`` and
+    the tokenizer's ``eos_token_id`` field. We union both because
+    DiffusionGemma's checkpoint splits the two between
+    ``config.json::eos_token_id`` (single id) and
+    ``generation_config.json::eos_token_id`` (list incl. ``<end_of_turn>``)."""
+    ids: set[int] = set()
+
+    gc = getattr(model_config, "generation_config", None)
+    if isinstance(gc, dict):
+        raw = gc.get("eos_token_id")
+        if isinstance(raw, list):
+            ids.update(int(x) for x in raw)
+        elif isinstance(raw, int):
+            ids.add(int(raw))
+
+    cfg_eos = getattr(model_config, "eos_token_id", None)
+    if isinstance(cfg_eos, list):
+        ids.update(int(x) for x in cfg_eos)
+    elif isinstance(cfg_eos, int):
+        ids.add(int(cfg_eos))
+
+    tok_eos = getattr(tokenizer, "eos_token_id", None)
+    if isinstance(tok_eos, int):
+        ids.add(int(tok_eos))
+
+    return ids
+
+
+def rapid_stream_diffusion_generate(
+    model,
+    processor,
+    tokenizer,
+    input_ids: mx.array,
+    pixel_values=None,
+    attention_mask=None,
+    *,
+    max_tokens: int = 256,
+    skip_special_token_ids: set[int] | None = None,
+    fixed_steps: int = 8,
+    sc_every: int = 1,
+    # Accept-and-ignore parameters that ``stream_diffusion_generate``
+    # also takes — keeps the call site at ``diffusion_lane.py:1211`` from
+    # having to discriminate between backends. Anything we don't honor:
+    #   - ``temperature``: the rapid loop is greedy-only by design.
+    #     ``diffusion_lane.py`` is responsible for routing non-zero
+    #     temperature to the mlx-vlm backend before we get here.
+    #   - ``diffusion_sampler``: argmax only; same routing rule.
+    #   - ``max_denoising_steps``: ``fixed_steps`` is the source of truth.
+    #   - ``prefill_step_size``: full prefill always (DiffusionGemma's
+    #     prompts are short relative to the 4-bit prefill cost).
+    temperature: float = 0.0,
+    diffusion_sampler=None,
+    max_denoising_steps: int | None = None,
+    prefill_step_size: int | None = None,
+) -> Iterator[RapidDiffusionResult]:
+    """Yield one ``RapidDiffusionResult`` per completed canvas plus a
+    final result with ``finish_reason='stop'`` or ``'length'``.
+
+    Caller contract is the same as mlx-vlm's
+    ``stream_diffusion_generate``: results with
+    ``diffusion_block_complete=True`` carry the canvas's joined text;
+    the terminal result carries ``finish_reason``."""
+
+    if pixel_values is not None:
+        # The text-diffusion lane is not supposed to land any
+        # vision input. Fail loud rather than silently ignore — caller
+        # has a bug.
+        raise ValueError(
+            "rapid_stream_diffusion_generate is text-only; "
+            "pixel_values must be None"
+        )
+    # Note: ``temperature`` is honored per-step via ``_sample_canvas``.
+    # 0.0 → greedy argmax (deterministic), >0 → categorical sample.
+    # Matches mlx-vlm's ``_diffusion_sample_canvas`` semantics so chat
+    # clients defaulting to temperature=0.7 (BCG, Big-AGI) get the same
+    # output distribution as the upstream loop, at rapid-loop speed.
+
+    config = model.config
+    canvas_length = int(config.canvas_length)
+    vocab_size = int(config.text_config.vocab_size)
+    batch_size, prompt_length = input_ids.shape
+
+    skip_ids = skip_special_token_ids if skip_special_token_ids is not None else set()
+    eos_ids = _extract_eos_ids(config, tokenizer)
+
+    decoder = model.model.decoder
+    soft_emb_weight = _soft_embedding_weight(decoder.embed_tokens)
+    embed_scale = decoder.embed_scale
+
+    # Prefill — sets up KV cache as if the prompt had been seen.
+    kv_cache = model.make_cache()
+    _, kv_cache = model.model.encoder(input_ids, attention_mask=None, cache=kv_cache)
+    mx.eval([c.state for c in kv_cache])
+
+    generated: list[int] = []
+    last_emitted_idx = 0  # length of ``generated`` already streamed out
+    finish_reason: str | None = None
+    last_token_id: int = 0
+
+    while len(generated) < max_tokens:
+        if finish_reason is not None:
+            break
+
+        remaining = max_tokens - len(generated)
+        # Sized to the canvas (mask tokens that lap past the request
+        # cap are clipped at emit time). Floor at 64 so a tiny
+        # ``max_tokens`` doesn't shrink the canvas below DiffusionGemma's
+        # minimum useful denoising width — short canvases under-denoise
+        # (see quality eval: shortform 'scat shorter' token corruption).
+        cur_canvas_len = min(canvas_length, max(remaining, 64))
+
+        canvas = _initialize_canvas(batch_size, cur_canvas_len, vocab_size,
+                                    input_ids.dtype)
+        mask_mapping = decoder._make_decoder_masks(canvas[..., None], kv_cache, None)
+
+        # Denoising loop — fixed_steps passes over the canvas. Each pass:
+        #   1. Forward(canvas, sc_emb) -> logits [B, L, V]
+        #   2. canvas = argmax(logits)
+        #   3. Maybe recompute soft-embedding for next pass
+        sc_emb: mx.array | None = None
+        last_logits: mx.array | None = None
+        for step in range(fixed_steps):
+            if sc_emb is None:
+                out = model(
+                    cache=kv_cache,
+                    canvas_ids=canvas,
+                    self_conditioning_logits=None,
+                    decoder_attention_mask=mask_mapping,
+                )
+            else:
+                out = model(
+                    cache=kv_cache,
+                    canvas_ids=canvas,
+                    self_conditioning_embeddings=sc_emb,
+                    decoder_attention_mask=mask_mapping,
+                )
+            last_logits = out.logits
+            canvas = _sample_canvas(last_logits, input_ids.dtype, float(temperature))
+            mx.eval(canvas)
+
+            # Compute self-conditioning for the NEXT step on the
+            # configured cadence. The empirical optimum on
+            # DiffusionGemma is sc_every=1 (every step); values >=2
+            # collapse output quality (eval 2026-06-11).
+            if step < fixed_steps - 1 and (step + 1) % sc_every == 0:
+                sc_emb = _soft_embeddings(last_logits, soft_emb_weight, embed_scale)
+                mx.eval(sc_emb)
+
+        # Walk the finished canvas tokens, append to running buffer,
+        # stop at EOS / max_tokens.
+        canvas_tokens = [int(t) for t in canvas[0].tolist()]
+        canvas_stop = False
+        for tok in canvas_tokens:
+            if len(generated) >= max_tokens:
+                finish_reason = "length"
+                canvas_stop = True
+                break
+            if tok in eos_ids:
+                finish_reason = "stop"
+                canvas_stop = True
+                break
+            generated.append(tok)
+            last_token_id = tok
+
+        # Emit one result per completed canvas (or terminal piece).
+        new_token_ids = [
+            t for t in generated[last_emitted_idx:]
+            if t not in skip_ids
+        ]
+        last_emitted_idx = len(generated)
+        block_text = tokenizer.decode(new_token_ids) if new_token_ids else ""
+
+        yield RapidDiffusionResult(
+            text=block_text,
+            token=last_token_id if generated else None,
+            prompt_tokens=int(prompt_length),
+            generation_tokens=len(generated),
+            diffusion_block_complete=True,
+            finish_reason=finish_reason,
+            is_draft=False,
+        )
+
+        if canvas_stop:
+            break
+
+        # Extend KV cache with the accepted canvas tokens for the next
+        # canvas — same call shape as mlx-vlm's loop does between
+        # canvases. We pass the ORIGINAL canvas (not the skip-id
+        # filtered view) so the cache state matches what the next
+        # canvas's decoder mask expects.
+        _, kv_cache = model.model.encoder(canvas, attention_mask=None, cache=kv_cache)
+        mx.eval([c.state for c in kv_cache])
+
+    # If we ran out of the while-loop without setting finish_reason
+    # (e.g. exact max_tokens hit between canvases), emit a terminal
+    # result so the consumer's "no finish_reason → synthetic stop"
+    # branch at ``diffusion_lane.py:1290`` doesn't fire on top of our
+    # already-terminal yield.
+    if finish_reason is None:
+        yield RapidDiffusionResult(
+            text="",
+            token=last_token_id if generated else None,
+            prompt_tokens=int(prompt_length),
+            generation_tokens=len(generated),
+            diffusion_block_complete=True,
+            finish_reason="length",
+            is_draft=False,
+        )
+
+
+__all__ = [
+    "RapidDiffusionResult",
+    "rapid_stream_diffusion_generate",
+]

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -433,20 +433,31 @@ def rapid_stream_diffusion_generate(
         )
     if sc_every <= 0:
         raise ValueError("sc_every must be a positive integer.")
-    # codex round 7 [P1]: normalize stop into a non-empty list of strings.
-    # Mirror ``vllm_mlx/runtime/diffusion_lane.py:_normalize_stops`` —
-    # empty strings would match everywhere, drop them silently. None or
-    # empty list disables stop-string handling (token-id EOS still applies).
+    # codex round 7 [P1] + round 8 [P1]: normalize stop into a list of
+    # non-empty strings. Empty strings (``""``) match everywhere so we
+    # drop them. ANY non-string element (``stop=[123]``) is a programmer
+    # bug — raise loud rather than silently coerce to an empty list,
+    # which would make a misconfigured caller's stop request a no-op.
     if stop is None:
         stop_list: list[str] = []
     elif isinstance(stop, str):
         stop_list = [stop] if stop else []
     elif isinstance(stop, list):
-        stop_list = [s for s in stop if isinstance(s, str) and s]
+        for s in stop:
+            if not isinstance(s, str):
+                raise ValueError(
+                    f"stop list elements must be strings (got {type(s).__name__})."
+                )
+        stop_list = [s for s in stop if s]
     else:
         raise ValueError(
             f"stop must be None, str, or list[str] (got {type(stop).__name__})."
         )
+    # Pre-compute the holdback tail size — the longest stop string minus
+    # one char is the max that could overlap a canvas boundary and start
+    # a stop match on the next canvas.
+    _max_stop_len = max((len(s) for s in stop_list), default=0)
+    _stop_holdback_chars = max(0, _max_stop_len - 1)
     if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
         raise ValueError(
             f"Unsupported diffusion sampler: {diffusion_sampler!r}.",
@@ -598,6 +609,11 @@ def rapid_stream_diffusion_generate(
     # cross-canvas stops still match — at long generation lengths this
     # is at most a few KB of memory, negligible vs the canvas tensors.
     emitted_text: str = ""
+    # codex round 8 [P1]: hold back ``max(len(stop)) - 1`` chars from the
+    # tail of each canvas so a stop string that straddles a canvas
+    # boundary still gets matched on the NEXT canvas before any text
+    # leaks to the consumer. Flushed verbatim on the terminal canvas.
+    holdback: str = ""
     finish_reason: str | None = None
     last_token: int | None = None
     is_prefill_done = True  # we just did the initial prefill
@@ -854,31 +870,45 @@ def rapid_stream_diffusion_generate(
 
         block_text = tokenizer.decode(ids_to_decode) if ids_to_decode else ""
 
-        # codex round 7 [P1]: request-level stop-string enforcement.
-        # Check ``emitted_text + block_text`` for the earliest stop
-        # match — covers stops that span a canvas boundary (lookback =
-        # entire emitted prefix). When found, truncate ``block_text`` at
-        # the cut point and stamp ``finish_reason="stop"``.
-        if stop_list and not canvas_stop:
-            combined = emitted_text + block_text
+        # codex round 7 [P1] + round 8 [P1] + [P1]: request-level
+        # stop-string enforcement with a cross-canvas holdback.
+        #
+        # (a) The check runs unconditionally — even if ``canvas_stop`` is
+        #     already True from EOS / max_tokens — because a stop string
+        #     can land EARLIER in the decoded block than the length
+        #     boundary. The earlier cut wins; ``finish_reason`` flips to
+        #     ``"stop"`` when stop is earlier or equal.
+        # (b) ``holdback`` carries up to ``_stop_holdback_chars`` from the
+        #     tail of the previous canvas. We prepend it here so a stop
+        #     string that started in canvas N-1 and finishes in canvas N
+        #     still matches (covers the cross-boundary leak case).
+        # (c) On non-terminal canvases we re-stash the new tail into
+        #     ``holdback`` and only emit ``combined[:-tail]``. On the
+        #     terminal canvas (``canvas_stop=True`` from EOS / length /
+        #     stop) we flush everything — no leak.
+        combined = holdback + block_text
+        holdback = ""
+        if stop_list:
             earliest = -1
             for s in stop_list:
                 idx = combined.find(s)
                 if idx != -1 and (earliest == -1 or idx < earliest):
                     earliest = idx
             if earliest >= 0:
-                cut_in_block = earliest - len(emitted_text)
-                # Boundary case: stop straddles the previous canvas. The
-                # previous canvas already shipped; defensive truncate
-                # this canvas to "" and rely on the caller (typically
-                # ``diffusion_lane.py``) to truncate the already-emitted
-                # text via its own _earliest_stop_index buffer. For
-                # direct callers the practical effect is that
-                # ``max_stop_len - 1`` chars may have leaked past the
-                # boundary — documented in the rapid loop contract.
-                block_text = block_text[: max(0, cut_in_block)]
+                combined = combined[:earliest]
                 finish_reason = "stop"
                 canvas_stop = True
+
+        if canvas_stop or _stop_holdback_chars == 0:
+            block_text = combined
+        else:
+            tail = _stop_holdback_chars
+            if len(combined) > tail:
+                block_text = combined[:-tail]
+                holdback = combined[-tail:]
+            else:
+                block_text = ""
+                holdback = combined
 
         emitted_text += block_text
 

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -347,6 +347,12 @@ def rapid_stream_diffusion_generate(
     # rapid-mlx knobs (forwarded by AliasProfile via diffusion_lane.py)
     fixed_steps: int | None = None,
     sc_every: int = 1,
+    # Request-level stop strings. codex round 7 [P1]: previously only
+    # ``eos_ids`` token-id matches stopped the loop, so a caller passing
+    # ``stop=["</answer>"]`` would receive text past their requested
+    # boundary. We now check ``emitted_text + new_block_text`` for the
+    # earliest stop match per canvas and truncate.
+    stop: list[str] | None = None,
     # Accept-and-honor knobs that mirror upstream's signature so the
     # lane can hand the same kwargs to either backend. Empty defaults
     # match mlx-vlm's behavior.
@@ -427,6 +433,20 @@ def rapid_stream_diffusion_generate(
         )
     if sc_every <= 0:
         raise ValueError("sc_every must be a positive integer.")
+    # codex round 7 [P1]: normalize stop into a non-empty list of strings.
+    # Mirror ``vllm_mlx/runtime/diffusion_lane.py:_normalize_stops`` —
+    # empty strings would match everywhere, drop them silently. None or
+    # empty list disables stop-string handling (token-id EOS still applies).
+    if stop is None:
+        stop_list: list[str] = []
+    elif isinstance(stop, str):
+        stop_list = [stop] if stop else []
+    elif isinstance(stop, list):
+        stop_list = [s for s in stop if isinstance(s, str) and s]
+    else:
+        raise ValueError(
+            f"stop must be None, str, or list[str] (got {type(stop).__name__})."
+        )
     if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
         raise ValueError(
             f"Unsupported diffusion sampler: {diffusion_sampler!r}.",
@@ -573,6 +593,11 @@ def rapid_stream_diffusion_generate(
         mx.eval([c.state for c in kv_cache])
 
     generated: list[int] = []
+    # codex round 7 [P1]: emitted-text accumulator drives stop-string
+    # detection. We keep the full string (not just a tail buffer) so
+    # cross-canvas stops still match — at long generation lengths this
+    # is at most a few KB of memory, negligible vs the canvas tensors.
+    emitted_text: str = ""
     finish_reason: str | None = None
     last_token: int | None = None
     is_prefill_done = True  # we just did the initial prefill
@@ -828,6 +853,35 @@ def rapid_stream_diffusion_generate(
             canvas_stop = True
 
         block_text = tokenizer.decode(ids_to_decode) if ids_to_decode else ""
+
+        # codex round 7 [P1]: request-level stop-string enforcement.
+        # Check ``emitted_text + block_text`` for the earliest stop
+        # match — covers stops that span a canvas boundary (lookback =
+        # entire emitted prefix). When found, truncate ``block_text`` at
+        # the cut point and stamp ``finish_reason="stop"``.
+        if stop_list and not canvas_stop:
+            combined = emitted_text + block_text
+            earliest = -1
+            for s in stop_list:
+                idx = combined.find(s)
+                if idx != -1 and (earliest == -1 or idx < earliest):
+                    earliest = idx
+            if earliest >= 0:
+                cut_in_block = earliest - len(emitted_text)
+                # Boundary case: stop straddles the previous canvas. The
+                # previous canvas already shipped; defensive truncate
+                # this canvas to "" and rely on the caller (typically
+                # ``diffusion_lane.py``) to truncate the already-emitted
+                # text via its own _earliest_stop_index buffer. For
+                # direct callers the practical effect is that
+                # ``max_stop_len - 1`` chars may have leaked past the
+                # boundary — documented in the rapid loop contract.
+                block_text = block_text[: max(0, cut_in_block)]
+                finish_reason = "stop"
+                canvas_stop = True
+
+        emitted_text += block_text
+
         yield RapidDiffusionResult(
             text=block_text,
             token=last_token,

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -303,9 +303,15 @@ def _extract_eos_ids(
         if isinstance(value, int):
             ids.add(int(value))
 
-    gc = getattr(model_config, "generation_config", None)
-    if isinstance(gc, dict):
-        _add(gc.get("eos_token_id"))
+    # codex round 2 [P1]: ``generation_config`` is a dict on some loaders
+    # and a typed config object on others (HF ``GenerationConfig``-style).
+    # ``_config_dict`` normalizes both shapes so we never silently drop the
+    # chat terminator when the loader hands us an attribute-bearing object.
+    gc_dict = _config_dict(getattr(model_config, "generation_config", None))
+    _add(gc_dict.get("eos_token_id"))
+    _add(
+        getattr(getattr(model_config, "generation_config", None), "eos_token_id", None)
+    )
     _add(getattr(model_config, "eos_token_id", None))
     for src in (tokenizer, processor):
         if src is None:

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -393,31 +393,53 @@ def rapid_stream_diffusion_generate(
         raise ValueError(
             "rapid_stream_diffusion_generate is text-only; pixel_values must be None"
         )
-    if prefill_step_size is not None and int(prefill_step_size) <= 0:
-        raise ValueError("prefill_step_size must be a positive integer.")
+
+    # codex round 5 [NIT]: strict positive-int validation. ``int(...)``
+    # silently truncates ``1.5`` → 1, and ``bool`` is an ``int`` subclass
+    # so ``True`` would slip past a naive ``isinstance(x, int)`` check.
+    # AliasProfile's ``_coerce`` enforces non-bool JSON int on the load
+    # surface; mirror that here so the runtime entry is consistent.
+    def _require_positive_int(name: str, val: Any) -> None:
+        if val is None:
+            return
+        if isinstance(val, bool) or not isinstance(val, int):
+            raise ValueError(f"{name} must be an integer (got {type(val).__name__}).")
+        if val <= 0:
+            raise ValueError(f"{name} must be a positive integer.")
+
+    _require_positive_int("prefill_step_size", prefill_step_size)
     # codex round 4 [P1]: ``denoise_budget`` resolves from these two
     # caller knobs; ``<= 0`` would skip the for-loop and yield the
     # random ``_initialize_canvas`` output verbatim as "model output".
     # The AliasProfile loader already enforces ``>= 1`` on the JSON
     # surface (test_fixed_steps_must_be_positive_int) but a programmatic
-    # caller still gets through. Reject at entry to mirror the
-    # ``prefill_step_size`` validation directly above.
-    if fixed_steps is not None and int(fixed_steps) <= 0:
-        raise ValueError("fixed_steps must be a positive integer.")
-    if max_denoising_steps is not None and int(max_denoising_steps) <= 0:
-        raise ValueError("max_denoising_steps must be a positive integer.")
+    # caller still gets through.
+    _require_positive_int("fixed_steps", fixed_steps)
+    _require_positive_int("max_denoising_steps", max_denoising_steps)
     if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
         raise ValueError(
             f"Unsupported diffusion sampler: {diffusion_sampler!r}.",
         )
     if not 0.0 <= diffusion_threshold <= 1.0:
         raise ValueError("diffusion_threshold must be between 0 and 1.")
+    # codex round 5 [NIT]: the canvas decode step only reads
+    # ``current_canvas[0]``, silently dropping outputs for B > 1. The
+    # lane only ever feeds us B=1 today, but a programmatic caller
+    # batching two prompts would get one back. Reject loud rather than
+    # under-deliver — done BEFORE touching ``model.config`` so the test
+    # can pass ``model=None`` and exercise this guard in isolation.
+    batch_size, prompt_length = input_ids.shape
+    if batch_size != 1:
+        raise ValueError(
+            f"rapid_stream_diffusion_generate is B=1 only "
+            f"(got batch_size={batch_size}); the diffusion lane "
+            "never batches today."
+        )
 
     config = model.config
     text_config = config.text_config
     model_canvas_length = int(config.canvas_length)
     vocab_size = int(text_config.vocab_size)
-    batch_size, prompt_length = input_ids.shape
     prompt_tokens = int(input_ids.size)
 
     generation_config = _config_dict(getattr(config, "generation_config", None))
@@ -723,8 +745,20 @@ def rapid_stream_diffusion_generate(
         # but the post-loop assignment used to clobber that with the
         # last argmax — silently flipping ``temperature > 0`` back to
         # deterministic on that exit path).
+        #
+        # codex round 5 [P1]: the confidence-threshold path additionally
+        # needs to backfill unrevealed positions from ``argmax_canvas``.
+        # The ``cur_step == 1`` early break at line ~591 fires BEFORE
+        # the per-step confidence-threshold acceptance pass that would
+        # have run ``force_all=True`` and locked the remaining positions
+        # in. Without the backfill, ``draft_canvas`` still carries the
+        # random ids that ``_initialize_canvas`` planted, and those
+        # leak into the decoded output. entropy-bound is safe because it
+        # reads ``argmax_canvas`` directly. (Default sampler is
+        # entropy-bound; this bug only manifested when an operator
+        # explicitly switched to confidence-threshold.)
         if diffusion_sampler == "confidence-threshold":
-            current_canvas = draft_canvas
+            current_canvas = mx.where(draft_reveal_mask, draft_canvas, argmax_canvas)
         else:
             current_canvas = argmax_canvas
         mx.eval(current_canvas)

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -1,44 +1,62 @@
 # SPDX-License-Identifier: Apache-2.0
-"""In-house diffusion generation loop for DiffusionGemma 26B-A4B.
+"""In-house diffusion generation loop for block-diffusion text models
+(DiffusionGemma family today; extensible to siblings as we add them).
 
-Drop-in replacement for ``mlx_vlm.generate.diffusion.stream_diffusion_generate``.
-Produces an iterator yielding ``RapidDiffusionResult`` instances whose
-attribute shape matches what ``runtime/diffusion_lane.py`` expects from
-mlx-vlm's own ``DiffusionGenerationResult`` (``getattr(result, 'X', …)``
-sites at ``diffusion_lane.py:1229-1252``).
+Phase 1 of the in-source roadmap (``docs/plans/in-source-roadmap.md``) —
+this module owns the generation loop, ``mlx_vlm.models.bonsai`` still
+owns the model architecture (MMDiT forward pass + ``QuantizedEmbedding``
+layers). Phase 2 vendors the model arch and removes the runtime dep on
+mlx-vlm for this model family.
 
-Why we wrote this:
-  - mlx-vlm's loop uses entropy-bound adaptive stopping (median ~23
-    denoising steps per canvas) which is conservative by ~3× on
-    M3 Ultra and non-deterministic at temperature=0 (filed as
-    mlx-vlm#1351).
-  - With a fixed-step + per-step self-conditioning policy we hit
-    127 tok/s on the canonical DiffusionGemma benchmark prompt (vs
-    upstream's 30-46 tok/s baseline), at quality on par with
-    upstream's ``max_denoising_steps=16`` setting — see quality eval
-    ``research/diffusion-gemma/quality/eval-20260611-1001.md``.
+## Vendoring policy
 
-Scope:
-  - **Generation loop only.** We re-use mlx-vlm's loaded model — same
-    weights, same transformer arch (``model.model.encoder`` for prefill,
-    ``model.model.decoder._make_decoder_masks`` for attention masks,
-    ``model(canvas_ids=…, self_conditioning_embeddings=…)`` for the
-    denoising forward pass), same KV cache class. Only the loop body
-    (canvas init, fixed-step denoising, self-conditioning cadence,
-    EOS-aware multi-canvas advancement) is ours.
+The math helpers (`_diffusion_*`) and the core denoising algorithm in
+``rapid_stream_diffusion_generate`` are direct ports of mlx-vlm 0.6.3's
+``mlx_vlm.generate.diffusion`` (Apache 2.0; original code by Lucas
+Newman; commit ``3967c21`` and ancestors). We vendor verbatim where the
+math is load-bearing (entropy/confidence-mask, soft-embedding scaling,
+canvas initialization, stable-and-confident early-stop) so the rapid
+backend produces byte-identical output to the upstream loop at
+``temperature=0`` — verified by ``tests/test_diffusion_gemma_parity.py``
+on 3 canonical prompts.
 
-The handful of small generation utilities that live in mlx-vlm's
-``generate/diffusion.py`` as ``_diffusion_initialize_canvas`` /
-``_diffusion_soft_embedding_weight`` / ``_diffusion_soft_embeddings``
-are inlined below — they're a few lines of mx math each, and importing
-them under their ``_`` private name would couple us to mlx-vlm
-internals (their loop calls them; ours is parallel). When mlx-vlm
-refactors their loop we don't care, because we don't share the loop.
+## What we change vs upstream
+
+1. **Structure**: a single function instead of a 500-line generator
+   with vision / show-unmasking / static-cache branches we don't take
+   on the text-diffusion lane.
+2. **Result shape**: ``RapidDiffusionResult`` mirrors the
+   ``getattr(result, 'X', default)`` contract ``diffusion_lane.py``
+   already expects from ``GenerationResult``, but is frozen and has
+   only the fields we actually consume. The lane never has to
+   discriminate between this and ``GenerationResult``.
+4. **EOS extraction**: union of every shape ``Scheduler._get_stop_tokens``
+   reads (``eos_token_id``, ``eos_token_ids``, ``_eos_token_ids``,
+   ``_rapid_extra_eos_token_ids``) on both tokenizer and processor.
+   Upstream relies on ``tokenizer.stopping_criteria(token)`` which is
+   not present on every loader-shape — the union path is robust.
+5. **No ``tokenizer.stopping_criteria.add_eos_token_ids``** side-effect:
+   we never mutate tokenizer global state.
+
+## What we do NOT change vs upstream
+
+- Helpers (`_diffusion_*`) are verbatim — any deviation here would
+  silently drift output distributions away from mlx-vlm's, and the
+  parity test would no longer hold.
+- The acceptance-mask + draft-canvas progressive reveal pattern is
+  preserved verbatim — overwriting the canvas every step (which the
+  first iteration of this module did) breaks ``structured-json`` and
+  similar deterministic-output prompts because token positions that
+  the model already locked in get re-sampled from a noisier
+  intermediate distribution.
+- ``mx.compile`` of decoder logits is intentionally skipped — the
+  upstream compile path has a fallback for shape changes (we'd inherit
+  the fallback warning logger); we'd rather leave the decision to
+  callers wrapping us in their own ``mx.compile`` layer.
 """
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -46,138 +64,267 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 
-logger = logging.getLogger(__name__)
+# =============================================================================
+# Result — mirrors the getattr contract diffusion_lane.py reads via
+# mlx-vlm's GenerationResult.
+# =============================================================================
 
 
 @dataclass(frozen=True)
 class RapidDiffusionResult:
-    """Per-canvas yield record. Attribute names + semantics match what
-    ``diffusion_lane.py``'s ``stream_diffusion_generate`` consumer reads
-    via ``getattr(result, …, default)``. New consumers should use this
-    dataclass directly so the typing is explicit."""
-
-    text: str
-    token: int | None
-    prompt_tokens: int
-    generation_tokens: int
-    diffusion_block_complete: bool
-    finish_reason: str | None
-    # ``is_draft`` is False for every yield we produce — we don't emit
-    # mid-canvas previews. Kept for ``getattr(result, "is_draft", False)``
-    # call-site symmetry with mlx-vlm's draft results.
+    text: str = ""
+    token: int | None = None
+    prompt_tokens: int = 0
+    generation_tokens: int = 0
+    diffusion_block_complete: bool = False
+    finish_reason: str | None = None
     is_draft: bool = False
 
 
 # =============================================================================
-# Math helpers — vendored equivalents of mlx-vlm's diffusion utilities
+# Vendored helpers — direct port of mlx-vlm 0.6.3 ``mlx_vlm.generate.diffusion``
+# (Apache 2.0). Function names match upstream so a reader cross-referencing
+# the two trees finds the same identifiers.
 # =============================================================================
 
 
-def _initialize_canvas(batch_size: int, canvas_length: int, vocab_size: int,
-                       dtype: Any) -> mx.array:
-    """Start a denoising canvas as uniform random token ids in
-    ``[0, vocab_size)`` — same convention as
-    ``mlx_vlm.generate.diffusion._diffusion_initialize_canvas`` at
-    mlx-vlm 0.6.3. DiffusionGemma's first denoising pass overwrites the
-    whole canvas via self-attention on the prompt KV cache, so the
-    initial values are noise, not zeros."""
-    return mx.random.randint(0, vocab_size, (batch_size, canvas_length)).astype(dtype)
+def _initialize_canvas(
+    batch_size: int,
+    canvas_length: int,
+    vocab_size: int,
+    dtype,
+) -> mx.array:
+    return mx.random.randint(
+        0,
+        vocab_size,
+        (batch_size, canvas_length),
+    ).astype(dtype)
 
 
-def _soft_embedding_weight(embed_layer: nn.Module) -> mx.array:
+def _sample_canvas(
+    processed_logits: mx.array,
+    dtype,
+    temperature: float,
+) -> mx.array:
+    logits = processed_logits.astype(mx.float32)
+    if temperature <= 0:
+        return mx.argmax(logits, axis=-1).astype(dtype)
+    if temperature != 1.0:
+        logits = logits / temperature
+    return mx.random.categorical(logits).astype(dtype)
+
+
+def _token_probability(
+    processed_logits: mx.array,
+    token_ids: mx.array,
+) -> mx.array:
+    logits = processed_logits.astype(mx.float32)
+    token_logits = mx.take_along_axis(
+        logits,
+        token_ids[..., None],
+        axis=-1,
+    ).squeeze(-1)
+    return mx.exp(token_logits - mx.logsumexp(logits, axis=-1))
+
+
+def _token_entropy(processed_logits: mx.array) -> mx.array:
+    logits = processed_logits.astype(mx.float32)
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    probs = mx.exp(log_probs)
+    return -mx.sum(probs * log_probs, axis=-1)
+
+
+def _soft_embedding_weight(embed_tokens: nn.Module) -> mx.array:
     """Return a float weight matrix usable as ``probs @ weight``.
 
-    For 4-bit / quantized DiffusionGemma checkpoints the packed
-    ``embed_layer.weight`` can't feed a regular matmul — we have to
-    dequantize once. mlx-vlm does the same at
-    ``_diffusion_soft_embedding_weight`` (mlx-vlm 0.6.3); their note:
-    ``mx.quantized_matmul(..., transpose=False)`` is several times
-    slower at this shape, so dequant-once is the cheaper path."""
-    if isinstance(embed_layer, nn.QuantizedEmbedding):
+    Quantized embeddings hold a packed weight that can't feed a regular
+    matmul, and ``mx.quantized_matmul(..., transpose=False)`` is several
+    times slower at this shape; dequantize once per call. Mirrors
+    ``_diffusion_soft_embedding_weight`` at mlx-vlm 0.6.3."""
+    if isinstance(embed_tokens, nn.QuantizedEmbedding):
         return mx.dequantize(
-            embed_layer.weight,
-            embed_layer.scales,
-            embed_layer.biases,
-            group_size=embed_layer.group_size,
-            bits=embed_layer.bits,
+            embed_tokens.weight,
+            embed_tokens.scales,
+            embed_tokens.biases,
+            group_size=embed_tokens.group_size,
+            bits=embed_tokens.bits,
         )
-    return embed_layer.weight
+    return embed_tokens.weight
 
 
-def _sample_canvas(logits: mx.array, dtype: Any, temperature: float) -> mx.array:
-    """Per-position argmax (greedy) or categorical sample (sampled).
-
-    Vendored from ``mlx_vlm.generate.diffusion._diffusion_sample_canvas``
-    at mlx-vlm 0.6.3. The semantics are:
-      - ``temperature <= 0``: greedy argmax (deterministic at given seed).
-      - ``temperature == 1.0``: categorical sample without rescaling.
-      - ``temperature in (0, 1) or (1, inf)``: rescale logits then sample.
-
-    Shape: ``[B, L, V]`` → ``[B, L]`` token ids in ``dtype``.
-
-    Keeping this matched to upstream's behavior is important — chat
-    clients (BCG, Big-AGI, etc.) default to ``temperature=0.7`` if the
-    user hasn't overridden it. Diverging here would silently change
-    sampled outputs vs. the mlx-vlm baseline."""
-    logits_f32 = logits.astype(mx.float32)
-    if temperature <= 0:
-        return mx.argmax(logits_f32, axis=-1).astype(dtype)
-    if temperature != 1.0:
-        logits_f32 = logits_f32 / temperature
-    return mx.random.categorical(logits_f32).astype(dtype)
+def _entropy_probs_chain(logits: mx.array) -> tuple[mx.array, mx.array]:
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    probs = mx.exp(log_probs)
+    entropy = -mx.sum(probs * log_probs, axis=-1)
+    return probs, entropy
 
 
-def _soft_embeddings(logits: mx.array, embedding_weight: mx.array,
-                     embed_scale: float) -> mx.array:
+def _entropy_and_soft_embeddings(
+    processed_logits: mx.array,
+    embedding_weight: mx.array,
+    embed_scale: float,
+) -> tuple[mx.array, mx.array]:
+    probs, entropy = _entropy_probs_chain(processed_logits.astype(mx.float32))
+    soft_embeddings = (probs.astype(embedding_weight.dtype) @ embedding_weight).astype(
+        embedding_weight.dtype
+    ) * embed_scale
+    return entropy, soft_embeddings
+
+
+def _soft_embeddings(
+    processed_logits: mx.array,
+    embedding_weight: mx.array,
+    embed_scale: float,
+) -> mx.array:
     """``softmax(logits) @ embedding_weight * embed_scale`` — feeds the
-    next denoising pass as self-conditioning context.
+    next denoising pass as self-conditioning. ``precise=True`` matches
+    upstream's numerics on the ``[B, canvas, vocab=262144]`` reduction;
+    ordinary softmax produces visibly different SC input on DiffusionGemma."""
+    probs = mx.softmax(processed_logits, axis=-1, precise=True)
+    return (probs.astype(embedding_weight.dtype) @ embedding_weight).astype(
+        embedding_weight.dtype
+    ) * embed_scale
 
-    Mirrors ``_diffusion_soft_embeddings`` at mlx-vlm 0.6.3 (uses
-    ``precise=True`` softmax to match upstream's numerics on the
-    ``[B, canvas, vocab=262144]`` reduction; ordinary softmax produces
-    visibly different self-conditioning input for the next step on
-    DiffusionGemma).
 
-    Shape: ``[B, canvas, vocab]`` @ ``[vocab, hidden]`` →
-    ``[B, canvas, hidden]``, scaled."""
-    probs = mx.softmax(logits, axis=-1, precise=True)
-    return (
-        probs.astype(embedding_weight.dtype) @ embedding_weight
-    ).astype(embedding_weight.dtype) * embed_scale
+def _confidence_transfer_mask(
+    confidence: mx.array,
+    unrevealed_mask: mx.array,
+    threshold: float,
+    *,
+    force_all: bool = False,
+) -> mx.array:
+    if force_all:
+        return unrevealed_mask
+    transfer_mask = unrevealed_mask & (confidence >= threshold)
+    has_unrevealed = mx.any(unrevealed_mask, axis=-1)
+    has_transfer = mx.any(transfer_mask, axis=-1)
+    needs_force = has_unrevealed & (~has_transfer)
+    masked_confidence = mx.where(unrevealed_mask, confidence, -mx.inf)
+    best_index = mx.argmax(masked_confidence, axis=-1)
+    positions = mx.arange(confidence.shape[-1])[None, :]
+    forced = (positions == best_index[:, None]) & needs_force[:, None]
+    return transfer_mask | forced
+
+
+def _entropy_transfer_mask(
+    entropy: mx.array,
+    entropy_bound: float,
+) -> mx.array:
+    sorted_indices = mx.argsort(entropy, axis=-1)
+    sorted_entropy = mx.take_along_axis(entropy, sorted_indices, axis=-1)
+    cumulative_entropy = mx.cumsum(sorted_entropy, axis=-1)
+    cumulative_maximum_entropy = mx.cummax(sorted_entropy, axis=-1)
+    sorted_selection_mask = (
+        cumulative_entropy - cumulative_maximum_entropy
+    ) <= entropy_bound
+    selection_mask = mx.zeros_like(sorted_selection_mask)
+    return mx.put_along_axis(
+        selection_mask,
+        sorted_indices,
+        sorted_selection_mask,
+        axis=-1,
+    )
+
+
+def _stable_and_confident(
+    accepted_canvas: mx.array,
+    processed_logits: mx.array,
+    history: list[mx.array],
+    stopping_config: dict[str, Any] | None,
+) -> bool:
+    """Early-stop predicate. Without this, the rapid loop runs the full
+    ``max_denoising_steps`` even when the canvas has already converged —
+    losing the ~2× speedup mlx-vlm gets on short EOS-bound outputs
+    (code, JSON). Reads ``stability_threshold`` and ``confidence_threshold``
+    from ``generation_config.diffusion_stopping_config`` (DiffusionGemma:
+    ``{stability_threshold: 1, confidence_threshold: 0.005}``)."""
+    if stopping_config is None:
+        return False
+    stability_threshold = int(stopping_config.get("stability_threshold", 1))
+    confidence_threshold = float(stopping_config.get("confidence_threshold", 0.005))
+    if len(history) == stability_threshold:
+        stable = all(
+            bool(mx.all(accepted_canvas == canvas).item()) for canvas in history
+        )
+    else:
+        stable = False
+    history.append(accepted_canvas)
+    if len(history) > stability_threshold:
+        history.pop(0)
+    if not stable:
+        return False
+    token_entropy = _token_entropy(processed_logits)
+    confident = bool((mx.mean(token_entropy) < confidence_threshold).item())
+    return stable and confident
+
+
+def _config_dict(maybe_config: Any) -> dict[str, Any]:
+    if isinstance(maybe_config, dict):
+        return maybe_config
+    if maybe_config is None:
+        return {}
+    if hasattr(maybe_config, "to_dict"):
+        return maybe_config.to_dict()
+    return {}
 
 
 # =============================================================================
-# Main loop
+# EOS extraction — rapid-mlx flavor of upstream's
+# ``tokenizer.stopping_criteria`` path. Unions every surface
+# ``Scheduler._get_stop_tokens`` knows about so loader-shape doesn't
+# silently drop the chat terminator.
 # =============================================================================
 
 
-def _extract_eos_ids(model_config: Any, tokenizer: Any) -> set[int]:
-    """Collect EOS token ids from the model's ``generation_config`` and
-    the tokenizer's ``eos_token_id`` field. We union both because
-    DiffusionGemma's checkpoint splits the two between
-    ``config.json::eos_token_id`` (single id) and
-    ``generation_config.json::eos_token_id`` (list incl. ``<end_of_turn>``)."""
+def _extract_eos_ids(
+    model_config: Any,
+    tokenizer: Any,
+    processor: Any = None,
+) -> set[int]:
+    """Collect EOS token ids from every surface rapid-mlx already
+    enumerates in ``Scheduler._get_stop_tokens``. Sources (all unioned):
+      1. ``config.generation_config['eos_token_id']``
+      2. ``config.eos_token_id``
+      3. ``tokenizer.eos_token_id``
+      4. ``tokenizer.eos_token_ids``
+      5. ``tokenizer._eos_token_ids`` (mlx-lm TokenizerWrapper)
+      6. ``tokenizer._rapid_extra_eos_token_ids`` (rapid-mlx stash)
+      7. all 4 tokenizer surfaces also from ``processor``."""
     ids: set[int] = set()
+
+    def _add(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, (list, set, tuple)):
+            for v in value:
+                if isinstance(v, int):
+                    ids.add(int(v))
+            return
+        if isinstance(value, int):
+            ids.add(int(value))
 
     gc = getattr(model_config, "generation_config", None)
     if isinstance(gc, dict):
-        raw = gc.get("eos_token_id")
-        if isinstance(raw, list):
-            ids.update(int(x) for x in raw)
-        elif isinstance(raw, int):
-            ids.add(int(raw))
-
-    cfg_eos = getattr(model_config, "eos_token_id", None)
-    if isinstance(cfg_eos, list):
-        ids.update(int(x) for x in cfg_eos)
-    elif isinstance(cfg_eos, int):
-        ids.add(int(cfg_eos))
-
-    tok_eos = getattr(tokenizer, "eos_token_id", None)
-    if isinstance(tok_eos, int):
-        ids.add(int(tok_eos))
-
+        _add(gc.get("eos_token_id"))
+    _add(getattr(model_config, "eos_token_id", None))
+    for src in (tokenizer, processor):
+        if src is None:
+            continue
+        _add(getattr(src, "eos_token_id", None))
+        _add(getattr(src, "eos_token_ids", None))
+        _add(getattr(src, "_eos_token_ids", None))
+        _add(getattr(src, "_rapid_extra_eos_token_ids", None))
     return ids
+
+
+# =============================================================================
+# Main loop — slim, text-only port of ``stream_diffusion_generate``.
+# =============================================================================
+
+
+_DEFAULT_MIN_CANVAS_LENGTH = 64
+_DEFAULT_MAX_DENOISING_STEPS = 32
+_DEFAULT_THRESHOLD = 0.9
 
 
 def rapid_stream_diffusion_generate(
@@ -190,119 +337,354 @@ def rapid_stream_diffusion_generate(
     *,
     max_tokens: int = 256,
     skip_special_token_ids: set[int] | None = None,
-    fixed_steps: int = 8,
-    sc_every: int = 1,
-    # Accept-and-ignore parameters that ``stream_diffusion_generate``
-    # also takes — keeps the call site at ``diffusion_lane.py:1211`` from
-    # having to discriminate between backends. Anything we don't honor:
-    #   - ``temperature``: the rapid loop is greedy-only by design.
-    #     ``diffusion_lane.py`` is responsible for routing non-zero
-    #     temperature to the mlx-vlm backend before we get here.
-    #   - ``diffusion_sampler``: argmax only; same routing rule.
-    #   - ``max_denoising_steps``: ``fixed_steps`` is the source of truth.
-    #   - ``prefill_step_size``: full prefill always (DiffusionGemma's
-    #     prompts are short relative to the 4-bit prefill cost).
     temperature: float = 0.0,
-    diffusion_sampler=None,
+    # rapid-mlx knobs (forwarded by AliasProfile via diffusion_lane.py)
+    fixed_steps: int | None = None,
+    sc_every: int = 1,
+    # Accept-and-honor knobs that mirror upstream's signature so the
+    # lane can hand the same kwargs to either backend. Empty defaults
+    # match mlx-vlm's behavior.
+    diffusion_sampler: str = "entropy-bound",
+    diffusion_threshold: float = _DEFAULT_THRESHOLD,
     max_denoising_steps: int | None = None,
     prefill_step_size: int | None = None,
 ) -> Iterator[RapidDiffusionResult]:
-    """Yield one ``RapidDiffusionResult`` per completed canvas plus a
-    final result with ``finish_reason='stop'`` or ``'length'``.
+    """Stream ``RapidDiffusionResult``s from the in-house denoising loop.
 
-    Caller contract is the same as mlx-vlm's
-    ``stream_diffusion_generate``: results with
-    ``diffusion_block_complete=True`` carry the canvas's joined text;
-    the terminal result carries ``finish_reason``."""
+    Algorithm mirrors mlx-vlm 0.6.3 ``stream_diffusion_generate`` for the
+    text-only B=1 case (which is the only shape ``diffusion_lane.py``
+    feeds us). Progressive token-reveal via entropy-bound or
+    confidence-threshold acceptance mask. Early-stop via
+    ``_stable_and_confident`` when the canvas converges before the
+    nominal ``max_denoising_steps`` — this is the gap that made the
+    naive "overwrite canvas every step" version slower than upstream on
+    short EOS-bound outputs.
+
+    Knobs:
+      * ``fixed_steps``: if set, overrides ``max_denoising_steps``
+        and disables early-stop. Empirically the prior rapid-mlx loop
+        used ``fixed_steps=8``; with the now-faithful adaptive-stop
+        port that knob is functionally redundant but is honored for
+        operator opt-in to deterministic step counts (e.g. for
+        speculative-decode draft-budget accounting).
+      * ``sc_every``: cadence for explicit (non-entropy-bound) self-
+        conditioning. ``1`` = every step (DiffusionGemma optimum from
+        the 2026-06-11 hand-graded eval). The entropy-bound path
+        computes SC inline as a byproduct of the entropy mask so this
+        knob only gates the confidence-threshold path.
+
+    Yields:
+      * One result per emitted text segment with that segment's text.
+      * One terminal result per canvas with ``diffusion_block_complete=True``.
+      * One final result with ``finish_reason in {'stop','length'}``."""
 
     if pixel_values is not None:
-        # The text-diffusion lane is not supposed to land any
-        # vision input. Fail loud rather than silently ignore — caller
-        # has a bug.
         raise ValueError(
-            "rapid_stream_diffusion_generate is text-only; "
-            "pixel_values must be None"
+            "rapid_stream_diffusion_generate is text-only; pixel_values must be None"
         )
-    # Note: ``temperature`` is honored per-step via ``_sample_canvas``.
-    # 0.0 → greedy argmax (deterministic), >0 → categorical sample.
-    # Matches mlx-vlm's ``_diffusion_sample_canvas`` semantics so chat
-    # clients defaulting to temperature=0.7 (BCG, Big-AGI) get the same
-    # output distribution as the upstream loop, at rapid-loop speed.
+    if prefill_step_size is not None and int(prefill_step_size) <= 0:
+        raise ValueError("prefill_step_size must be a positive integer.")
+    if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
+        raise ValueError(
+            f"Unsupported diffusion sampler: {diffusion_sampler!r}.",
+        )
+    if not 0.0 <= diffusion_threshold <= 1.0:
+        raise ValueError("diffusion_threshold must be between 0 and 1.")
 
     config = model.config
-    canvas_length = int(config.canvas_length)
-    vocab_size = int(config.text_config.vocab_size)
+    text_config = config.text_config
+    model_canvas_length = int(config.canvas_length)
+    vocab_size = int(text_config.vocab_size)
     batch_size, prompt_length = input_ids.shape
+    prompt_tokens = int(input_ids.size)
 
+    generation_config = _config_dict(getattr(config, "generation_config", None))
+    sampler_config = _config_dict(generation_config.get("sampler_config"))
+    entropy_bound = float(sampler_config.get("entropy_bound", 0.1))
+
+    # Resolve denoising-step budget.
+    if fixed_steps is not None:
+        denoise_budget = int(fixed_steps)
+        adaptive_stop = False
+    else:
+        if max_denoising_steps is None:
+            max_denoising_steps = int(
+                generation_config.get("max_denoising_steps")
+                or _DEFAULT_MAX_DENOISING_STEPS,
+            )
+        denoise_budget = int(max_denoising_steps)
+        adaptive_stop = True
+
+    # Temperature schedule (linear ramp during denoising). Upstream
+    # falls back to {0.4, 0.8} when no config is present.
+    temperature_config = generation_config.get(
+        "linear_temperature_schedule_config",
+    )
+    temperature_config = _config_dict(temperature_config)
+    if not temperature_config:
+        if "t_min" in generation_config or "t_max" in generation_config:
+            temperature_config = {
+                "t_min": generation_config.get("t_min", 0.4),
+                "t_max": generation_config.get("t_max", 0.8),
+            }
+        else:
+            temperature_config = {"t_min": 0.4, "t_max": 0.8}
+
+    # Adaptive-stop config (used only when adaptive_stop=True).
+    stopping_config = _config_dict(
+        generation_config.get("diffusion_stopping_config"),
+    )
+    if not stopping_config:
+        stopping_config = {
+            key: generation_config[key]
+            for key in ("confidence_threshold", "stability_threshold")
+            if key in generation_config
+        }
+    if not stopping_config:
+        stopping_config = None
+
+    canvas_dtype = input_ids.dtype
     skip_ids = skip_special_token_ids if skip_special_token_ids is not None else set()
-    eos_ids = _extract_eos_ids(config, tokenizer)
+    eos_ids = _extract_eos_ids(config, tokenizer, processor)
 
     decoder = model.model.decoder
     soft_emb_weight = _soft_embedding_weight(decoder.embed_tokens)
     embed_scale = decoder.embed_scale
 
-    # Prefill — sets up KV cache as if the prompt had been seen.
+    # Attention mask defaults to "all real tokens" — matches upstream.
+    if attention_mask is None:
+        attention_mask = mx.ones((batch_size, prompt_length), dtype=mx.bool_)
+    else:
+        attention_mask = attention_mask.astype(mx.bool_)
+    has_padding = not bool(mx.all(attention_mask).item())
+    decoder_attention_mask = attention_mask if has_padding else None
+
+    # Prefill — chunked if the operator opted in and the prompt is long
+    # enough to benefit. Mirrors ``_diffusion_prefill_cache``.
     kv_cache = model.make_cache()
-    _, kv_cache = model.model.encoder(input_ids, attention_mask=None, cache=kv_cache)
-    mx.eval([c.state for c in kv_cache])
+    chunk_prefill = (
+        prefill_step_size is not None
+        and prompt_length > int(prefill_step_size)
+        and not has_padding
+    )
+    if chunk_prefill:
+        step = int(prefill_step_size)  # type: ignore[arg-type]
+        for start in range(0, prompt_length, step):
+            end = min(start + step, prompt_length)
+            _, kv_cache = model.model.encoder(
+                input_ids[:, start:end],
+                attention_mask=None,
+                cache=kv_cache,
+            )
+            mx.eval([c.state for c in kv_cache])
+            mx.clear_cache()
+    else:
+        _, kv_cache = model.model.encoder(
+            input_ids,
+            attention_mask=(attention_mask if has_padding else None),
+            cache=kv_cache,
+        )
+        mx.eval([c.state for c in kv_cache])
 
     generated: list[int] = []
-    last_emitted_idx = 0  # length of ``generated`` already streamed out
     finish_reason: str | None = None
-    last_token_id: int = 0
+    last_token: int | None = None
+    is_prefill_done = True  # we just did the initial prefill
+    current_canvas: mx.array | None = None
 
     while len(generated) < max_tokens:
         if finish_reason is not None:
             break
 
+        # Re-encode the previous canvas into the KV cache (upstream
+        # line 793-797). Skipping this is the OTHER algorithmic bug
+        # the v1 rapid loop had — subsequent canvases hallucinated
+        # because the KV state was stale.
+        if not is_prefill_done and current_canvas is not None:
+            _, kv_cache = model.model.encoder(
+                current_canvas,
+                attention_mask=None,
+                cache=kv_cache,
+            )
+        is_prefill_done = False
+
         remaining = max_tokens - len(generated)
-        # Sized to the canvas (mask tokens that lap past the request
-        # cap are clipped at emit time). Floor at 64 so a tiny
-        # ``max_tokens`` doesn't shrink the canvas below DiffusionGemma's
-        # minimum useful denoising width — short canvases under-denoise
-        # (see quality eval: shortform 'scat shorter' token corruption).
-        cur_canvas_len = min(canvas_length, max(remaining, 64))
+        canvas_length = min(
+            model_canvas_length,
+            max(remaining, _DEFAULT_MIN_CANVAS_LENGTH),
+        )
+        current_decoder_attention_mask = (
+            mx.concatenate(
+                [
+                    decoder_attention_mask,
+                    mx.ones((batch_size, canvas_length), dtype=mx.bool_),
+                ],
+                axis=-1,
+            )
+            if decoder_attention_mask is not None
+            else None
+        )
 
-        canvas = _initialize_canvas(batch_size, cur_canvas_len, vocab_size,
-                                    input_ids.dtype)
-        mask_mapping = decoder._make_decoder_masks(canvas[..., None], kv_cache, None)
+        current_canvas = _initialize_canvas(
+            batch_size,
+            canvas_length,
+            vocab_size,
+            canvas_dtype,
+        )
+        draft_reveal_mask = mx.zeros(current_canvas.shape, dtype=mx.bool_)
+        draft_canvas = current_canvas
+        accepted_canvas = current_canvas
+        argmax_canvas = current_canvas
+        self_conditioning_embeddings = None
+        mask_mapping = decoder._make_decoder_masks(
+            current_canvas[..., None],
+            kv_cache,
+            current_decoder_attention_mask,
+        )
+        diffusion_history: list[mx.array] = []
 
-        # Denoising loop — fixed_steps passes over the canvas. Each pass:
-        #   1. Forward(canvas, sc_emb) -> logits [B, L, V]
-        #   2. canvas = argmax(logits)
-        #   3. Maybe recompute soft-embedding for next pass
-        sc_emb: mx.array | None = None
-        last_logits: mx.array | None = None
-        for step in range(fixed_steps):
-            if sc_emb is None:
-                out = model(
+        # Denoising loop — counts DOWN like upstream so the linear
+        # temperature schedule matches.
+        for cur_step in reversed(range(1, denoise_budget + 1)):
+            if self_conditioning_embeddings is None:
+                processed_logits = model(
                     cache=kv_cache,
-                    canvas_ids=canvas,
+                    canvas_ids=current_canvas,
                     self_conditioning_logits=None,
                     decoder_attention_mask=mask_mapping,
-                )
+                ).logits
             else:
-                out = model(
+                processed_logits = model(
                     cache=kv_cache,
-                    canvas_ids=canvas,
-                    self_conditioning_embeddings=sc_emb,
+                    canvas_ids=current_canvas,
+                    self_conditioning_embeddings=self_conditioning_embeddings,
                     decoder_attention_mask=mask_mapping,
+                ).logits
+
+            # Linear temperature ramp (mirrors upstream).
+            t_min = float(temperature_config.get("t_min", 0.4))
+            t_max = float(temperature_config.get("t_max", 0.8))
+            schedule_temperature = t_min + (
+                (t_max - t_min) * (cur_step / denoise_budget)
+            )
+            processed_logits = processed_logits / schedule_temperature
+
+            argmax_canvas = mx.argmax(processed_logits, axis=-1).astype(
+                canvas_dtype,
+            )
+            if cur_step == 1:
+                break
+
+            denoiser_canvas = (
+                argmax_canvas
+                if temperature <= 0
+                else _sample_canvas(
+                    processed_logits,
+                    canvas_dtype,
+                    float(temperature),
                 )
-            last_logits = out.logits
-            canvas = _sample_canvas(last_logits, input_ids.dtype, float(temperature))
-            mx.eval(canvas)
+            )
 
-            # Compute self-conditioning for the NEXT step on the
-            # configured cadence. The empirical optimum on
-            # DiffusionGemma is sc_every=1 (every step); values >=2
-            # collapse output quality (eval 2026-06-11).
-            if step < fixed_steps - 1 and (step + 1) % sc_every == 0:
-                sc_emb = _soft_embeddings(last_logits, soft_emb_weight, embed_scale)
-                mx.eval(sc_emb)
+            if diffusion_sampler == "entropy-bound":
+                if cur_step > 1:
+                    token_entropy, next_sc = _entropy_and_soft_embeddings(
+                        processed_logits,
+                        soft_emb_weight,
+                        embed_scale,
+                    )
+                else:
+                    token_entropy = _token_entropy(processed_logits)
+                    next_sc = None
+                acceptance_mask = _entropy_transfer_mask(
+                    token_entropy,
+                    entropy_bound,
+                )
+                accepted_canvas = mx.where(
+                    acceptance_mask,
+                    denoiser_canvas,
+                    current_canvas,
+                )
+                current_canvas = mx.where(
+                    acceptance_mask,
+                    accepted_canvas,
+                    _initialize_canvas(
+                        batch_size,
+                        canvas_length,
+                        vocab_size,
+                        canvas_dtype,
+                    ),
+                )
+                draft_reveal_mask = acceptance_mask
+                draft_canvas = argmax_canvas
+            else:
+                next_sc = None
+                unrevealed_mask = ~draft_reveal_mask
+                confidence = _token_probability(
+                    processed_logits,
+                    denoiser_canvas,
+                )
+                acceptance_mask = _confidence_transfer_mask(
+                    confidence,
+                    unrevealed_mask,
+                    diffusion_threshold,
+                    force_all=cur_step == 1,
+                )
+                accepted_canvas = mx.where(
+                    acceptance_mask,
+                    denoiser_canvas,
+                    draft_canvas,
+                )
+                current_canvas = mx.where(
+                    draft_reveal_mask | acceptance_mask,
+                    accepted_canvas,
+                    _initialize_canvas(
+                        batch_size,
+                        canvas_length,
+                        vocab_size,
+                        canvas_dtype,
+                    ),
+                )
+                draft_reveal_mask = draft_reveal_mask | acceptance_mask
+                draft_canvas = mx.where(
+                    acceptance_mask,
+                    accepted_canvas,
+                    draft_canvas,
+                )
 
-        # Walk the finished canvas tokens, append to running buffer,
-        # stop at EOS / max_tokens.
-        canvas_tokens = [int(t) for t in canvas[0].tolist()]
+            # Confidence-threshold sampler can short-circuit when every
+            # position is revealed.
+            if diffusion_sampler == "confidence-threshold" and bool(
+                mx.all(draft_reveal_mask).item(),
+            ):
+                accepted_canvas = draft_canvas
+                break
+
+            # Adaptive early-stop — the gap that closed the perf cliff
+            # vs upstream on short outputs.
+            if adaptive_stop and _stable_and_confident(
+                argmax_canvas,
+                processed_logits,
+                diffusion_history,
+                stopping_config,
+            ):
+                break
+
+            # Self-conditioning for next step.
+            if cur_step > 1 and (cur_step % max(sc_every, 1) == 0):
+                if next_sc is None:
+                    next_sc = _soft_embeddings(
+                        processed_logits,
+                        soft_emb_weight,
+                        embed_scale,
+                    )
+                self_conditioning_embeddings = next_sc
+
+        current_canvas = argmax_canvas
+        mx.eval(current_canvas)
+
+        # Emit canvas tokens one by one — stop on EOS or max_tokens.
+        canvas_tokens = [int(t) for t in current_canvas[0].tolist()]
+        emitted_text_pieces: list[str] = []
         canvas_stop = False
         for tok in canvas_tokens:
             if len(generated) >= max_tokens:
@@ -314,20 +696,25 @@ def rapid_stream_diffusion_generate(
                 canvas_stop = True
                 break
             generated.append(tok)
-            last_token_id = tok
+            last_token = tok
+            if tok not in skip_ids:
+                emitted_text_pieces.append(tokenizer.decode([tok]))
 
-        # Emit one result per completed canvas (or terminal piece).
-        new_token_ids = [
-            t for t in generated[last_emitted_idx:]
-            if t not in skip_ids
-        ]
-        last_emitted_idx = len(generated)
-        block_text = tokenizer.decode(new_token_ids) if new_token_ids else ""
+        # Edge case: canvas exactly filled the remaining budget. The
+        # for-loop above only stamps ``finish_reason='length'`` when the
+        # cap fires MID-canvas; when ``len(generated)`` rises to exactly
+        # ``max_tokens`` on the final append, the loop exits naturally
+        # with finish_reason=None and the consumer never sees a
+        # terminal SSE event. Catch the boundary explicitly.
+        if not canvas_stop and len(generated) >= max_tokens:
+            finish_reason = "length"
+            canvas_stop = True
 
+        block_text = "".join(emitted_text_pieces)
         yield RapidDiffusionResult(
             text=block_text,
-            token=last_token_id if generated else None,
-            prompt_tokens=int(prompt_length),
+            token=last_token,
+            prompt_tokens=prompt_tokens,
             generation_tokens=len(generated),
             diffusion_block_complete=True,
             finish_reason=finish_reason,
@@ -336,33 +723,3 @@ def rapid_stream_diffusion_generate(
 
         if canvas_stop:
             break
-
-        # Extend KV cache with the accepted canvas tokens for the next
-        # canvas — same call shape as mlx-vlm's loop does between
-        # canvases. We pass the ORIGINAL canvas (not the skip-id
-        # filtered view) so the cache state matches what the next
-        # canvas's decoder mask expects.
-        _, kv_cache = model.model.encoder(canvas, attention_mask=None, cache=kv_cache)
-        mx.eval([c.state for c in kv_cache])
-
-    # If we ran out of the while-loop without setting finish_reason
-    # (e.g. exact max_tokens hit between canvases), emit a terminal
-    # result so the consumer's "no finish_reason → synthetic stop"
-    # branch at ``diffusion_lane.py:1290`` doesn't fire on top of our
-    # already-terminal yield.
-    if finish_reason is None:
-        yield RapidDiffusionResult(
-            text="",
-            token=last_token_id if generated else None,
-            prompt_tokens=int(prompt_length),
-            generation_tokens=len(generated),
-            diffusion_block_complete=True,
-            finish_reason="length",
-            is_draft=False,
-        )
-
-
-__all__ = [
-    "RapidDiffusionResult",
-    "rapid_stream_diffusion_generate",
-]

--- a/vllm_mlx/runtime/diffusion_loop.py
+++ b/vllm_mlx/runtime/diffusion_loop.py
@@ -395,6 +395,17 @@ def rapid_stream_diffusion_generate(
         )
     if prefill_step_size is not None and int(prefill_step_size) <= 0:
         raise ValueError("prefill_step_size must be a positive integer.")
+    # codex round 4 [P1]: ``denoise_budget`` resolves from these two
+    # caller knobs; ``<= 0`` would skip the for-loop and yield the
+    # random ``_initialize_canvas`` output verbatim as "model output".
+    # The AliasProfile loader already enforces ``>= 1`` on the JSON
+    # surface (test_fixed_steps_must_be_positive_int) but a programmatic
+    # caller still gets through. Reject at entry to mirror the
+    # ``prefill_step_size`` validation directly above.
+    if fixed_steps is not None and int(fixed_steps) <= 0:
+        raise ValueError("fixed_steps must be a positive integer.")
+    if max_denoising_steps is not None and int(max_denoising_steps) <= 0:
+        raise ValueError("max_denoising_steps must be a positive integer.")
     if diffusion_sampler not in ("entropy-bound", "confidence-threshold"):
         raise ValueError(
             f"Unsupported diffusion sampler: {diffusion_sampler!r}.",


### PR DESCRIPTION
## Summary

Vendors mlx-vlm's `stream_diffusion_generate` into `vllm_mlx/runtime/diffusion_loop.py` so DiffusionGemma's generation loop lives inside rapid-mlx, while continuing to delegate the model architecture (MMDiT block-diffusion forward pass + `QuantizedEmbedding` layers) to upstream.

This is **Phase P1** of the in-source migration roadmap (see `docs/plans/in-source-roadmap.md`, local-only). Full mlx-vlm removal for this model — vendoring the ~1300 LOC of MMDiT model code — lands as a follow-up PR once P1 has soaked. The goal of the multi-phase split is to keep the user-visible delta small per PR and stage the change of ownership across modules that rapid-mlx already understands first.

## Why

The current `runtime/diffusion_lane.py` routes 100% of DiffusionGemma traffic to `mlx_vlm.generate.diffusion.stream_diffusion_generate`. We have no place to land:
- self-conditioning matmul cadence (`sc_every`) tuning — verified empirically that only `sc_every=1` produces coherent DiffusionGemma output; the upstream-default cadence drops quality
- fixed-step (vs entropy-bound) stopping cadence (`fixed_steps=8` is empirically optimal for the 26B-A4B 4-bit checkpoint at 256 canvas length)
- per-step sampling that respects `temperature > 0` cleanly (mlx-vlm uses `_diffusion_sample_canvas`; mirrored here)

Carrying the loop in-tree lets every diffusion knob ride on the existing `AliasProfile` SSOT.

## What changed

**Backend selection**

3 new `AliasProfile` fields, all defaulting to the empirically optimal values for `diffusion-gemma-26b`:
- `diffusion_backend: Literal["rapid","mlx-vlm"]` — default `"rapid"`
- `diffusion_fixed_steps: int` — default `8`
- `diffusion_sc_every: int` — default `1`

Non-text-diffusion aliases reject all three fields at load time (modality gate). Per the routing SOP (`test_no_out_of_band_routing.py`), there is **no env-var kill switch** — emergency rollback is "edit `aliases.json` to set `diffusion_backend: \"mlx-vlm\"`, restart".

**Runtime**

`DiffusionEngine.__init__` resolves the alias profile (or synthesizes a throwaway `AliasProfile` with safe defaults for bare HF paths that no alias references). At call time `_run_mlxvlm_generator` branches on `profile.diffusion_backend`:
- `rapid` → `rapid_stream_diffusion_generate` (with `fixed_steps`/`sc_every` threaded through)
- `mlx-vlm` → `stream_diffusion_generate` verbatim (rapid-only kwargs stripped to avoid `TypeError` upstream)

The in-house loop is lazy-imported so the mlx-vlm install path stays identical for users who set the backend back to `mlx-vlm`.

**Loop implementation** (`vllm_mlx/runtime/diffusion_loop.py`, 368 LOC)

- `RapidDiffusionResult` is a frozen dataclass mirroring the `getattr(result, …, default)` shape the consumer side (`diffusion_lane.py:1241`) already expects from mlx-vlm's `GenerationResult` — zero consumer-side changes.
- `_initialize_canvas` matches upstream: random ids in `[0, vocab_size)` via `mx.random.randint`. Off-by-one here lands the mask token in the canvas and breaks the first denoising pass.
- `_soft_embedding_weight` dequantizes `nn.QuantizedEmbedding` via `mx.dequantize(...)`. Without this, the packed weight shape leaks into `probs @ embedding_weight` and downstream RMSNorm fires the shape-mismatch crash that surfaced in the first smoke run.
- `_sample_canvas` vendors mlx-vlm's `_diffusion_sample_canvas`: `temperature <= 0` → `argmax` (deterministic), `temperature > 0` → scaled `mx.random.categorical`. The lane used to gate the rapid path on `temperature == 0`, but chat clients default to `_FALLBACK_TEMPERATURE = 0.7`, so 99% of traffic would have missed the rapid path. With `_sample_canvas` honoring temperature, that gate is removed.
- `_extract_eos_ids` unions `generation_config.eos_token_id` + tokenizer EOS. DiffusionGemma splits its EOS set across both (config carries `1`; generation_config adds `<end_of_turn>=106`); missing the union silently turns `<end_of_turn>` into normal text.
- Vision input fails loud (text-only model); the lane never routes pixels here.

## Tests

| Suite | Count | What it pins |
|------|-------|--------------|
| `test_alias_diffusion_knobs.py` | 10 | default knobs, typo/invalid rejection, modality gate, existing aliases unchanged |
| `test_diffusion_loop.py` | 21 | canvas init, soft-embedding scale, sample-canvas dtype+temperature, EOS union, guards |
| `test_diffusion_lane_routing.py` | 5 | default → rapid; profile override → mlx-vlm; temperature doesn't gate; profile fallback for unknown HF path |
| `test_diffusion_gemma_parity.py` | 4 (`@slow`) | loads real 1.2 GB checkpoint; coherent keyword output on 3 canonical prompts; ≥80 tok/s throughput floor (hand-measured ~127 tok/s on M3 Ultra) |
| `test_diffusion_engine.py` | 70 unchanged | extended `_install_mlx_vlm_mock` to also stub `rapid_stream_diffusion_generate`, dynamically dispatching to the current `mlx_vlm.generate.diffusion.stream_diffusion_generate` so stop-race / max-tokens-capture tests keep working regardless of backend |

Diffusion + routing + alias-contract slice: **940 / 940 pass**.
Full repo non-slow sweep: **4935 passed, 0 new regressions** (2 pre-existing `test_event_loop.py` failures require a live `:8000` server, unchanged on `main`).

Run the parity slice with:
```bash
PYTEST_ADDOPTS="-m slow" python3.12 -m pytest \
  tests/test_diffusion_gemma_parity.py --run-slow
```

## Test plan

- [x] `python3.12 -m pytest tests/test_diffusion_loop.py tests/test_diffusion_lane_routing.py tests/test_diffusion_engine.py tests/test_alias_diffusion_knobs.py tests/test_aliases_contract.py tests/test_modality_field.py tests/test_no_out_of_band_routing.py tests/test_no_mllm_flag.py tests/test_model_aliases.py -q` → 940 passed
- [x] Full repo non-slow sweep → 4935 passed, 0 new failures
- [x] `python3.12 -m ruff check vllm_mlx/{model_aliases,runtime/diffusion_lane,runtime/diffusion_loop}.py tests/test_diffusion_*.py tests/test_alias_diffusion_knobs.py` → all checks passed
- [x] Slow parity suite → 4 / 4 pass on M3 Ultra at ~127 tok/s decode
- [x] CJK scan over all 9 touched files → clean (English-only)
- [x] Codex review rounds — round 1 (5 BLOCKING resolved) + round 2 (3 real P1 resolved, 1 false alarm verified; see commits 09be934..02a1697)
- [x] `pr_validate <PR#>` → r10 codex PASS (0 BLOCKING + 3 NIT, NIT 3 fixed); r11 full_unit + stress_e2e_bench PASS
- [x] `make check` (inference-touching gate) → r11 full_unit (4955 passed) covers SOP coverage

## Risk

- Backend default flips from `mlx-vlm` (implicit) → `rapid` (explicit). Routing test pins this; emergency rollback is editing the alias.
- `_run_mlxvlm_generator` consumer side reads via `getattr(..., default)` — `RapidDiffusionResult` mirrors every field the consumer touches and is frozen so the contract is enforceable.
- Existing `test_diffusion_engine.py` tests now hit the rapid path on the FakeModel mock; the dynamic-dispatch stub keeps them transparent.

