### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.1"
+version = "0.7.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bump rapid-mlx to **v0.7.2**.

Headline changes since v0.7.1:
- **feat(diffusion): in-house generation loop for DiffusionGemma** (#555, `6ebebc0`) — vendors the mlx-vlm 0.6.3 `stream_diffusion_generate` denoising algorithm directly into `vllm_mlx/runtime/diffusion_loop.py`. Owns the loop, acceptance mask, `stable_and_confident` early-stop, EOS union, and request-level stop-string enforcement with cross-canvas holdback. Phase 1 of the in-source roadmap.
- **fix(diffusion): strip leaked Gemma channel header from first block** (`307f8a8`) — `thought` / `final` channel markers no longer escape into the diffusion canvas decoded text.

## Release validation (11-gate SOP)

- [x] G1 — `make release-smoke` (clean-room venv import) PASS
- [x] G2 — codex review × 2 (PR #555 r10: 0 BLOCKING; r11 backend-timeout but stress + full_unit PASS)
- [x] G3 — `scripts/audit_cli_config_fidelity.py` PASS
- [x] G4 — `make smoke` (lint + audit + 1933 unit) PASS
- [x] G5 — `make stress` (8 scenarios incl. tool storm) PASS
- [x] G6 — `parallel_tool_calls=false` cap (PR #518 path) PASS
- [x] G7 — SDK integration (anthropic 5/5, pydantic_ai 6/6) PASS
- [x] G8 — parser microbench (4/4 under threshold) PASS
- [x] G9 — 10-seq latency PASS (134 tok/s on qwen3.5-4b-4bit)
- [x] G10 — MLX bump cross-chip gate — **N/A** (no mlx / mlx-lm / mlx-vlm dep bump in this release)
- [x] G11 — escape-hatch + actionable-error grep (47 tests across `test_no_mllm_flag.py` + `test_no_out_of_band_routing.py`) PASS

## Test plan

- [x] `make release-smoke` → "OK — every release surface imports cleanly."
- [x] `make smoke` → 3/3 PASS
- [x] `make release-check-m3 MODEL=qwen3.5-4b-4bit` → ALL gates green
- [x] CJK scan on touched files → clean
