### PR TITLE
Fix Claude Code connectivity with Rapid-MLX server

### DIFF
--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -233,6 +233,57 @@ def test_anthropic_messages_accepts_valid_bearer_api_key(anthropic_client):
     assert len(engine.calls) == 1
 
 
+def test_anthropic_messages_accepts_claude_model_name(anthropic_client):
+    """Claude Code sends its real model name (e.g. 'claude-opus-4-5') in the
+    request body. The Anthropic endpoint must route this to the loaded
+    engine instead of 404-ing on the name mismatch.
+
+    The model name in the response should reflect the *loaded* model, not the
+    client-supplied claude name.
+    """
+    client = anthropic_client.client
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-opus-4-5",
+            "max_tokens": 4,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers={"x-api-key": "test-secret"},
+    )
+
+    assert response.status_code == 200
+    # The response must carry the loaded model name, not the claude alias.
+    assert response.json()["model"] == "test-model"
+
+
+def test_anthropic_messages_accepts_any_claude_variant(anthropic_client):
+    """All claude-* variants (claude-3-haiku-20240307, claude-sonnet-4-5,
+    claude-3-5-sonnet-20241022, etc.) must pass through to the loaded engine."""
+    client = anthropic_client.client
+
+    for model_name in [
+        "claude-3-haiku-20240307",
+        "claude-sonnet-4-5",
+        "claude-opus-4-5",
+        "claude-3-5-sonnet-20241022",
+    ]:
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": model_name,
+                "max_tokens": 4,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            headers={"x-api-key": "test-secret"},
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 for model={model_name!r}, got {response.status_code}: "
+            f"{response.text}"
+        )
+
+
 def test_anthropic_messages_rejects_mixed_invalid_credentials(anthropic_client):
     client = anthropic_client.client
     engine = anthropic_client.engine

--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -64,6 +64,41 @@ class TestValidateModelName:
         # Should not raise.
         _validate_model_name(None)
 
+    def test_mismatch_still_raises_404_via_openai_route(self, patched_config, monkeypatch):
+        """The OpenAI chat route must still reject unknown model names with 404.
+        This confirms that removing _validate_model_name from the Anthropic
+        route did NOT affect the OpenAI route."""
+        from vllm_mlx.routes import chat as chat_route
+
+        engine = MagicMock()
+        engine.is_mllm = False
+        patched_config(
+            engine=engine,
+            model_name="loaded-model",
+            model_alias=None,
+            model_path=None,
+            model_registry=None,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            ready=True,
+            api_key=None,
+        )
+        monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+        app = FastAPI()
+        app.include_router(chat_route.router)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "wrong-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert r.status_code == 404
+        assert "wrong-model" in r.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # Chat completion validation block — top_p, max_tokens cap, logit_bias

--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -64,7 +64,9 @@ class TestValidateModelName:
         # Should not raise.
         _validate_model_name(None)
 
-    def test_mismatch_still_raises_404_via_openai_route(self, patched_config, monkeypatch):
+    def test_mismatch_still_raises_404_via_openai_route(
+        self, patched_config, monkeypatch
+    ):
         """The OpenAI chat route must still reject unknown model names with 404.
         This confirms that removing _validate_model_name from the Anthropic
         route did NOT affect the OpenAI route."""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -180,6 +180,47 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_get_root_returns_200(self):
+        """GET / must return 200 so FastAPI auto-generates HEAD / → 200."""
+        orig = self._patch_config(engine=None, mcp_manager=None, model_name=None)
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+            r = client.get("/")
+            assert r.status_code == 200
+            assert r.json()["status"] == "ok"
+        finally:
+            self._restore_config(orig)
+
+    def test_head_root_returns_200(self):
+        """HEAD / is the Claude Code connectivity probe. FastAPI auto-generates
+        it from GET / — this test pins the contract so a future refactor that
+        moves GET / to `router` (auth-gated) doesn't silently break the probe."""
+        orig = self._patch_config(engine=None, mcp_manager=None, model_name=None)
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+            r = client.head("/")
+            assert r.status_code == 200
+        finally:
+            self._restore_config(orig)
+
+    def test_head_root_bypasses_api_key(self):
+        """HEAD / must return 200 even when --api-key is configured."""
+        orig = self._patch_config(
+            api_key="test-secret",
+            engine=None,
+            mcp_manager=None,
+            model_name=None,
+        )
+        try:
+            app = self._make_app()
+            client = TestClient(app)
+            r = client.head("/")
+            assert r.status_code == 200
+        finally:
+            self._restore_config(orig)
+
     @pytest.mark.parametrize(
         ("method", "path"),
         [

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -193,9 +193,9 @@ class TestHealthRoutes:
             self._restore_config(orig)
 
     def test_head_root_returns_200(self):
-        """HEAD / is the Claude Code connectivity probe. FastAPI auto-generates
-        it from GET / — this test pins the contract so a future refactor that
-        moves GET / to `router` (auth-gated) doesn't silently break the probe."""
+        """HEAD / is explicitly registered on probe_router (no auth) alongside GET /.
+        This test pins the contract so a future refactor that moves the route or
+        changes its methods doesn't silently break the Claude Code connectivity probe."""
         orig = self._patch_config(engine=None, mcp_manager=None, model_name=None)
         try:
             app = self._make_app()

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -42,6 +42,7 @@ from ..service.helpers import (
     _resolve_max_tokens,
     _resolve_temperature,
     _resolve_top_p,
+    _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
     get_engine,
@@ -114,6 +115,8 @@ async def create_anthropic_message(
     body = await request.json()
     anthropic_request = AnthropicRequest(**body)
 
+    if not (anthropic_request.model or "").startswith(("claude-", "gpt-")):
+        _validate_model_name(anthropic_request.model)
     engine = get_engine(anthropic_request.model)
 
     # Pre-flight admission gate (C4) — see routes/chat.py for rationale.
@@ -143,6 +146,14 @@ async def create_anthropic_message(
             f"tools={n_tools}"
         )
         logger.debug(f"[REQUEST] last user message preview: {last_user_preview!r}")
+
+        cfg_for_log = get_config()
+        if anthropic_request.model and cfg_for_log.model_name and anthropic_request.model != cfg_for_log.model_name:
+            logger.info(
+                "Anthropic /v1/messages: request model=%r served by loaded engine=%r",
+                anthropic_request.model,
+                cfg_for_log.model_name,
+            )
 
         # Convert Anthropic request -> OpenAI request
         openai_request = anthropic_to_openai(anthropic_request)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -148,7 +148,11 @@ async def create_anthropic_message(
         logger.debug(f"[REQUEST] last user message preview: {last_user_preview!r}")
 
         cfg_for_log = get_config()
-        if anthropic_request.model and cfg_for_log.model_name and anthropic_request.model != cfg_for_log.model_name:
+        if (
+            anthropic_request.model
+            and cfg_for_log.model_name
+            and anthropic_request.model != cfg_for_log.model_name
+        ):
             logger.info(
                 "Anthropic /v1/messages: request model=%r served by loaded engine=%r",
                 anthropic_request.model,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -42,7 +42,6 @@ from ..service.helpers import (
     _resolve_max_tokens,
     _resolve_temperature,
     _resolve_top_p,
-    _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
     get_engine,
@@ -115,7 +114,6 @@ async def create_anthropic_message(
     body = await request.json()
     anthropic_request = AnthropicRequest(**body)
 
-    _validate_model_name(anthropic_request.model)
     engine = get_engine(anthropic_request.model)
 
     # Pre-flight admission gate (C4) — see routes/chat.py for rationale.

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -23,15 +23,15 @@ router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 @probe_router.api_route("/", methods=["GET", "HEAD"])
 async def root():
-	"""Root path — returns a minimal alive response.
+    """Root path — returns a minimal alive response.
 
-	Claude Code (and other Anthropic SDK clients) send ``HEAD /`` as a
-	connectivity probe before attempting any API call. Without a handler
-	here FastAPI returns 404, which the client interprets as "server
-	unreachable" and aborts. This endpoint lives on ``probe_router``
-	(no-auth) so the probe succeeds regardless of ``--api-key``.
-	"""
-	return {"status": "ok"}
+    Claude Code (and other Anthropic SDK clients) send ``HEAD /`` as a
+    connectivity probe before attempting any API call. Without a handler
+    here FastAPI returns 404, which the client interprets as "server
+    unreachable" and aborts. This endpoint lives on ``probe_router``
+    (no-auth) so the probe succeeds regardless of ``--api-key``.
+    """
+    return {"status": "ok"}
 
 
 @probe_router.get("/health")

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -21,6 +21,19 @@ probe_router = APIRouter()
 router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
+@probe_router.api_route("/", methods=["GET", "HEAD"])
+async def root():
+	"""Root path — returns a minimal alive response.
+
+	Claude Code (and other Anthropic SDK clients) send ``HEAD /`` as a
+	connectivity probe before attempting any API call. Without a handler
+	here FastAPI returns 404, which the client interprets as "server
+	unreachable" and aborts. This endpoint lives on ``probe_router``
+	(no-auth) so the probe succeeds regardless of ``--api-key``.
+	"""
+	return {"status": "ok"}
+
+
 @probe_router.get("/health")
 async def health():
     """Health check endpoint.


### PR DESCRIPTION
## Summary

Fixes two 404 errors that prevent Claude Code from connecting to the local Rapid-MLX inference server:

1. **HEAD / → 404** — Claude Code's connectivity probe fails
2. **POST /v1/messages → 404** — Model name mismatch on Anthropic API endpoint

## Changes

### vllm_mlx/routes/health.py
- Added `@probe_router.api_route("/", methods=["GET", "HEAD"])` handler
- Returns `{"status": "ok"}` 
- Lives on `probe_router` (no-auth) so probe works with `--api-key`

### vllm_mlx/routes/anthropic.py
- Removed `_validate_model_name(anthropic_request.model)` call
- Removed `_validate_model_name` from import list
- `get_engine(anthropic_request.model)` now handles model routing with proper fallback

### Tests (6 new tests)
- `tests/test_routes.py`: 3 root path tests (GET /, HEAD /, HEAD / + api-key)
- `tests/test_anthropic_route_auth.py`: 2 Claude model name tests
- `tests/test_api_validation_bundle.py`: 1 regression test for OpenAI validation

## Test Results

✅ **All 6 new tests passing**
- Root path returns 200 for both GET and HEAD
- Claude model names (claude-opus-4-5, etc.) accepted on /v1/messages
- OpenAI endpoints still strictly validate model names (unchanged behavior)

## How to Test Locally

```bash
# Unit tests
pytest tests/test_routes.py::TestHealthRoutes -k root -v
pytest tests/test_anthropic_route_auth.py -k claude -v

# Manual integration (with server running on http://localhost:8000)
curl -I http://localhost:8000/
# Expected: HTTP/1.1 200 OK

curl -X POST http://localhost:8000/v1/messages \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-opus-4-5","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
# Expected: 200 with message response (not 404)

# Verify OpenAI route unchanged
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"wrong-model","messages":[{"role":"user","content":"hi"}]}'
# Expected: 404 (unchanged)
```

## Context

When Claude Code is configured with `ANTHROPIC_BASE_URL=http://localhost:8000`, it:
1. Sends `HEAD /` as a connectivity probe → was getting 404
2. Sends requests with model names like `"claude-opus-4-5"` → was getting 404 from strict validation

These fixes allow Claude Code to use Rapid-MLX as a local backend while maintaining strict model validation on OpenAI-compatible endpoints.