### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.2"
+version = "0.7.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bump version 0.7.2 → 0.7.3 — ships PR #558 (revert PR #555 in-house diffusion loop; tool calls on mlx-vlm passthrough).

## Release SOP gates (pre-bump)
- G1 release-smoke — PASS
- G3 cli/config fidelity audit — PASS
- G4 make smoke (lint + 1933 unit tests) — PASS 3/3
- G8 parser microbench — PASS (6.78us/call extract, no regression)
- G10 mlx-version-bump scan — SKIP (no mlx-* deps changed since v0.7.2)
- G11 auto-routing escape-hatch tests — PASS 47/47

## Live verification
- ``rapid-mlx share diffusion-gemma-26b-4bit`` boots clean
- Non-stream + SSE tool-call probes return structured ``tool_calls`` (no leaked content)
- Perf parity vs upstream mlx-vlm: 49.5 tok/s (rapid HTTP) vs 53.0 tok/s (mlx-vlm direct) — within HTTP wrapper tax

## Post-merge
- Tag v0.7.3, publish to PyPI, Homebrew formula auto-update
- PyPI yank v0.7.2 + delete v0.7.2 GitHub release (DiffusionGemma quality regression from ``fixed_steps=8`` default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)