### PR TITLE
fix: use hashed token as rate-limit client_id instead of raw header

### DIFF
--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -291,8 +291,7 @@ class TestRateLimitClientId:
         client_id_b = _rate_limit_client_id(Request(scope_b))
 
         assert client_id_a == client_id_b, (
-            f"Same /24 must share a bucket, "
-            f"got {client_id_a!r} != {client_id_b!r}"
+            f"Same /24 must share a bucket, got {client_id_a!r} != {client_id_b!r}"
         )
 
     def test_rate_limit_same_token_via_bearer_and_x_api_key_share_bucket(self):

--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -231,6 +231,100 @@ class TestCheckRateLimit:
 
 
 # ======================================================================
+# _rate_limit_client_id / _anthropic_rate_limit_client_id
+# ======================================================================
+
+
+class TestRateLimitClientId:
+    def test_rate_limit_distinguishes_clients_by_hashed_bearer(self):
+        """Two distinct bearer tokens get separate buckets.
+
+        Pins #192: raw header values used to conflate everyone into one bucket.
+        """
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import _rate_limit_client_id
+
+        scope_1 = {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer sk-token-alpha")],
+            "client": ("192.0.2.1", 12345),
+        }
+        scope_2 = {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer sk-token-beta")],
+            "client": ("192.0.2.1", 12345),
+        }
+
+        client_id_1 = _rate_limit_client_id(Request(scope_1))
+        client_id_2 = _rate_limit_client_id(Request(scope_2))
+
+        assert client_id_1 != client_id_2, (
+            f"Different tokens must produce different client IDs, "
+            f"got {client_id_1!r} == {client_id_2!r}"
+        )
+        assert "sk-token-alpha" not in client_id_1, (
+            "Raw token must not appear in client_id"
+        )
+        assert "sk-token-beta" not in client_id_2, (
+            "Raw token must not appear in client_id"
+        )
+
+    def test_rate_limit_groups_unauth_clients_by_subnet(self):
+        """IPv4 clients in the same /24 share a bucket."""
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import _rate_limit_client_id
+
+        scope_a = {
+            "type": "http",
+            "headers": [],
+            "client": ("192.0.2.10", 12345),
+        }
+        scope_b = {
+            "type": "http",
+            "headers": [],
+            "client": ("192.0.2.99", 54321),
+        }
+
+        client_id_a = _rate_limit_client_id(Request(scope_a))
+        client_id_b = _rate_limit_client_id(Request(scope_b))
+
+        assert client_id_a == client_id_b, (
+            f"Same /24 must share a bucket, "
+            f"got {client_id_a!r} != {client_id_b!r}"
+        )
+
+    def test_rate_limit_same_token_via_bearer_and_x_api_key_share_bucket(self):
+        """Same key value via Bearer and x-api-key maps to same bucket."""
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import (
+            _anthropic_rate_limit_client_id,
+            _rate_limit_client_id,
+        )
+
+        bearer_scope = {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer sk-abc")],
+            "client": ("192.0.2.1", 12345),
+        }
+        x_api_key_scope = {
+            "type": "http",
+            "headers": [(b"x-api-key", b"sk-abc")],
+            "client": ("192.0.2.1", 12345),
+        }
+
+        bearer_id = _rate_limit_client_id(Request(bearer_scope))
+        x_api_id = _anthropic_rate_limit_client_id(Request(x_api_key_scope))
+
+        assert bearer_id == x_api_id, (
+            f"Same key via Bearer and x-api-key must produce same bucket, "
+            f"got {bearer_id!r} != {x_api_id!r}"
+        )
+
+
+# ======================================================================
 # configure_cors — Fetch-spec-compliant defaults (#190)
 # ======================================================================
 

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -2,6 +2,8 @@
 """Authentication and rate limiting middleware."""
 
 import hashlib
+import hmac
+import ipaddress
 import logging
 import secrets
 import threading
@@ -18,6 +20,8 @@ logger = logging.getLogger(__name__)
 security = HTTPBearer(auto_error=False)
 
 _auth_warning_logged: bool = False
+
+_RATE_LIMIT_HMAC_KEY = secrets.token_bytes(32)
 
 
 class RateLimiter:
@@ -88,16 +92,41 @@ def _extract_bearer_token(authorization: str | None) -> str | None:
     return token
 
 
+def _bucket_id(raw: str) -> str:
+    """HMAC-SHA256 with a per-process random key.
+
+    The HMAC key prevents an attacker who knows the SHA-256 of a secret
+    from mapping it back to the secret via a rainbow table of candidate
+    values.  Each process restart also rotates the key, so even if a
+    hash leaks across the wire it becomes useless after the process
+    exits.
+    """
+    return hmac.new(_RATE_LIMIT_HMAC_KEY, raw.encode(), hashlib.sha256).hexdigest()[:16]
+
+
+def _subnet_bucket(host: str) -> str:
+    """Group IPv4 hosts into /24 and IPv6 hosts into /64 subnets."""
+    try:
+        addr = ipaddress.ip_address(host)
+        if isinstance(addr, ipaddress.IPv4Address):
+            network = ipaddress.ip_network(f"{addr}/24", strict=False)
+        else:
+            network = ipaddress.ip_network(f"{addr}/64", strict=False)
+        return str(network.network_address)
+    except ValueError:
+        return host
+
+
 def _rate_limit_client_id(request: Request) -> str:
     """Resolve the default client id for rate limiting."""
     authorization = request.headers.get("Authorization")
     if authorization:
         bearer_key = _extract_bearer_token(authorization)
         raw = bearer_key or authorization
-        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+        return _bucket_id(raw)
 
     if request.client and request.client.host:
-        return request.client.host.rsplit(".", 1)[0]
+        return _subnet_bucket(request.client.host)
     return "unknown"
 
 
@@ -105,14 +134,14 @@ def _anthropic_rate_limit_client_id(request: Request) -> str:
     """Resolve a stable client id for Anthropic-compatible API-key headers."""
     bearer_key = _extract_bearer_token(request.headers.get("Authorization"))
     if bearer_key:
-        return hashlib.sha256(bearer_key.encode()).hexdigest()[:16]
+        return _bucket_id(bearer_key)
 
     x_api_key = request.headers.get("x-api-key")
     if x_api_key:
-        return hashlib.sha256(x_api_key.encode()).hexdigest()[:16]
+        return _bucket_id(x_api_key)
 
     if request.client and request.client.host:
-        return request.client.host.rsplit(".", 1)[0]
+        return _subnet_bucket(request.client.host)
     return "unknown"
 
 

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Authentication and rate limiting middleware."""
 
+import hashlib
 import logging
 import secrets
 import threading
@@ -92,22 +93,27 @@ def _rate_limit_client_id(request: Request) -> str:
     authorization = request.headers.get("Authorization")
     if authorization:
         bearer_key = _extract_bearer_token(authorization)
-        return bearer_key or authorization
+        raw = bearer_key or authorization
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
-    return request.client.host if request.client else "unknown"
+    if request.client and request.client.host:
+        return request.client.host.rsplit(".", 1)[0]
+    return "unknown"
 
 
 def _anthropic_rate_limit_client_id(request: Request) -> str:
     """Resolve a stable client id for Anthropic-compatible API-key headers."""
     bearer_key = _extract_bearer_token(request.headers.get("Authorization"))
     if bearer_key:
-        return bearer_key
+        return hashlib.sha256(bearer_key.encode()).hexdigest()[:16]
 
     x_api_key = request.headers.get("x-api-key")
     if x_api_key:
-        return x_api_key
+        return hashlib.sha256(x_api_key.encode()).hexdigest()[:16]
 
-    return request.client.host if request.client else "unknown"
+    if request.client and request.client.host:
+        return request.client.host.rsplit(".", 1)[0]
+    return "unknown"
 
 
 async def check_rate_limit(request: Request):


### PR DESCRIPTION
## Summary

- Rate limiter previously used the raw Authorization header as client_id
- Fixed by deriving a unique client identifier via HMAC-SHA256 of the token
- Added proper IPv4 /24 and IPv6 /64 subnet grouping for unauthenticated traffic
- This provides forward-compat for multi-tenant tokens, raw-secret hygiene, and NAT-friendly IP grouping

Fixes #192

## Changes

- `_bucket_id()`: HMAC-SHA256 with per-process random key for token hashing
- `_subnet_bucket()`: ipaddress-based subnet masking (IPv4 /24, IPv6 /64)
- 3 new tests pinning the fix behavior

## Test Plan

- [x] `test_rate_limit_distinguishes_clients_by_hashed_bearer` — two tokens → different buckets, raw token not in bucket key
- [x] `test_rate_limit_groups_unauth_clients_by_subnet` — same /24 → same bucket
- [x] `test_rate_limit_same_token_via_bearer_and_x_api_key_share_bucket` — Bearer and x-api-key parity
