### PR TITLE
fix(aliases): disable tool_call_parser for Gemma 3 / 3n family

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -507,6 +507,43 @@ def test_audit_batch_bonsai_tool_call_parser_wired() -> None:
         )
 
 
+def test_gemma3_family_disables_tool_call_parser() -> None:
+    """Gemma 3 / 3n base instruction models were NOT trained for tool
+    calling — their chat templates don't emit ``<tool_call>...`` blocks
+    and the model has no notion of structured function invocation.
+
+    Pre-fix: every Gemma 3 alias inherited ``tool_call_parser="hermes"``
+    from the README's "all Gemma → hermes" shortcut. When a chat surface
+    passed ``tools=[...]``, the model:
+      1. saw tools embedded in the prompt (via ``apply_chat_template``)
+      2. couldn't emit hermes XML markup (never trained for it)
+      3. fell back to plain-text content, often hallucinating about the
+         tool's subject domain (user-reported: "palo alto天气如何" →
+         monologue about "Palo Alto Networks firewall" instead of
+         firing the weather tool)
+
+    Gemma **4** is different — explicitly trained for tools with the
+    ``call:func{...}`` wire format and stays wired to ``gemma4`` parser.
+    This pin guards the Gemma 3 family from a future "let's wire a
+    parser for completeness" regression. If you ever flip these off
+    ``null``, also verify the upstream model card actually claims
+    function-calling support.
+    """
+    profiles = list_profiles()
+    for alias in (
+        "gemma-3n-e4b-4bit",
+        "gemma3-1b-4bit",
+        "gemma3-12b-4bit",
+        "gemma3-27b-4bit",
+    ):
+        assert alias in profiles, f"{alias} missing from aliases.json"
+        assert profiles[alias].tool_call_parser is None, (
+            f"{alias}: tool_call_parser must be None — Gemma 3 family "
+            f"was not trained for tool calling. Got "
+            f"{profiles[alias].tool_call_parser!r}."
+        )
+
+
 def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
     """The DeepSeek-V4-Flash chat template emits ``<think>...</think>``
     blocks (gated by ``thinking_mode``). Without ``reasoning_parser`` set,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -394,7 +394,7 @@
   },
   "gemma3-12b-4bit": {
     "hf_path": "mlx-community/gemma-3-12b-it-qat-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -646,7 +646,7 @@
   },
   "gemma-3n-e4b-4bit": {
     "hf_path": "mlx-community/gemma-3n-E4B-it-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -658,7 +658,7 @@
   },
   "gemma3-1b-4bit": {
     "hf_path": "mlx-community/gemma-3-1b-it-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -676,7 +676,7 @@
   },
   "gemma3-27b-4bit": {
     "hf_path": "mlx-community/gemma-3-27b-it-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,


### PR DESCRIPTION
## Summary

Gemma 3 / 3n instruction models were not trained for function calling. All four aliases inherited `tool_call_parser=\"hermes\"` from the README's \"all Gemma → hermes\" shortcut, which is wrong — hermes is the wire format for Qwen3 / Hermes / Bonsai families.

**User-visible failure** (reported via rapid-desktop chat): asking *\"palo alto天气如何\"* with a weather tool defined on `gemma-3n-e4b-4bit` made the model:
1. see tools embedded in the prompt (via `apply_chat_template`)
2. fail to emit hermes XML markup (never trained for it)
3. hallucinate about Palo Alto Networks firewalls — domain knowledge, no tool intent
4. surface the hallucination as plain content because hermes parser found no markers

## Fix

Set `tool_call_parser: null` on:
- `gemma-3n-e4b-4bit` (user-reported)
- `gemma3-1b-4bit`
- `gemma3-12b-4bit`
- `gemma3-27b-4bit`

With null:
- `routes/chat.py:595` skips the tool-use system suffix injection
- `routes/chat.py:851` rejects forced `tool_choice` (`\"required\"` / named) upfront with a clean 422 instead of running a full generation then failing post-parse
- Downstream chat surfaces (BCG, rapid-desktop) get an honest \"this model can't call tools\" surface

Gemma **4** is unaffected — it ships `tool_call_parser=\"gemma4\"` because it WAS trained for tools with the `call:func{...}` wire format.

## Regression guard

New contract test `test_gemma3_family_disables_tool_call_parser` in `tests/test_aliases_contract.py` pins all four aliases at None. Inverse-style pin matches the existing `test_audit_batch_bonsai_tool_call_parser_wired` (which guarantees bonsai STAYS at hermes).

## Test plan

- [x] `pytest tests/test_aliases_contract.py tests/test_model_aliases.py` — 780 pass
- [x] `pytest tests/test_model_auto_config.py tests/test_server_load_model_order.py` — 76 pass (hermes-parser sites unaffected)
- [ ] E2E smoke: `rapid-mlx serve gemma-3n-e4b-4bit` + chat with weather tool — verify plain content response, no phantom tool_call

🤖 Generated with [Claude Code](https://claude.com/claude-code)