### PR TITLE
chore(deps): move pillow to [vision] extras (−13 MB for text-only installs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",
-    "pillow>=10.0.0",
+    # pillow is opt-in via [vision] extras — only the MLLM paths (mllm.py,
+    # benchmark.py image mode) touch PIL, and mlx-vlm requires it anyway.
     "tqdm>=4.66.0",
     "pyyaml>=6.0",
     "requests>=2.28.0",
@@ -84,6 +85,9 @@ vision = [
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
+    # vllm_mlx imports PIL directly on vision paths (mllm.py, benchmark.py
+    # image mode); mlx-vlm requires it too — listed for explicitness.
+    "pillow>=10.0.0",
 ]
 # DFlash speculative decoding for Qwen3.5/3.6 dense 8-bit models
 # (issue #264). Adds ~1-4 GB at runtime (drafter weights) and depends on
@@ -111,6 +115,7 @@ all = [
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
+    "pillow>=10.0.0",
     # chat
     "gradio>=4.0.0",
     "pytz>=2024.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.3"
+version = "0.7.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/vllm_mlx/benchmark.py
+++ b/vllm_mlx/benchmark.py
@@ -45,9 +45,12 @@ try:
     import cv2
 except ImportError:
     cv2 = None  # Only needed for video benchmarks
+try:
+    from PIL import Image
+except ImportError:
+    Image = None  # Only needed for image benchmarks; ships with rapid-mlx[vision]
 import numpy as np
 import requests
-from PIL import Image
 from tabulate import tabulate
 
 try:
@@ -676,8 +679,15 @@ class MLLMBenchmarkResult:
     mlx_memory_gb: float = 0.0
 
 
-def download_test_image(url: str, timeout: int = 30) -> Image.Image:
+def download_test_image(url: str, timeout: int = 30) -> "Image.Image":
     """Download image from URL and return PIL Image."""
+    if Image is None:
+        raise ImportError(
+            "Image benchmarks require Pillow, which is included in the "
+            "optional vision dependencies.\n"
+            "Install with:\n"
+            "    pip install 'rapid-mlx[vision]'"
+        )
     headers = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
     }
@@ -686,12 +696,12 @@ def download_test_image(url: str, timeout: int = 30) -> Image.Image:
     return Image.open(io.BytesIO(response.content))
 
 
-def resize_image(img: Image.Image, width: int, height: int) -> Image.Image:
+def resize_image(img: "Image.Image", width: int, height: int) -> "Image.Image":
     """Resize image to specified dimensions."""
     return img.resize((width, height), Image.Resampling.LANCZOS)
 
 
-def image_to_base64(img: Image.Image, format: str = "JPEG") -> str:
+def image_to_base64(img: "Image.Image", format: str = "JPEG") -> str:
     """Convert PIL Image to base64 data URL."""
     if img.mode == "RGBA":
         background = Image.new("RGB", img.size, (255, 255, 255))
@@ -711,7 +721,7 @@ def benchmark_mllm_resolution(
     model,
     processor,
     config,
-    base_image: Image.Image,
+    base_image: "Image.Image",
     width: int,
     height: int,
     max_tokens: int = 256,


### PR DESCRIPTION
## What

Removes `pillow` from core dependencies and lists it explicitly under the `[vision]` and `[all]` extras.

## Why

PIL is only touched on vision paths:

- `vllm_mlx/models/mllm.py:659` — already a lazy import, and only reachable after `_require_mlx_vlm()` passes (i.e. `[vision]` is installed)
- `vllm_mlx/benchmark.py` — the MLLM image-benchmark helpers (`download_test_image` / `resize_image` / `image_to_base64`)

Nothing else in the dependency tree pulls pillow unconditionally: `mlx`, `mlx-lm` don't depend on it at all, and `huggingface-hub` / `transformers` only gate it behind their own extras (verified against the installed METADATA). `mlx-vlm` hard-requires `Pillow>=10.3.0`, so vision installs keep working with zero behavior change.

**Result: text-only installs (the default path) shrink by ~13 MB on disk / ~4 MB of download.**

## How

- `benchmark.py`: top-level `from PIL import Image` becomes the same `try/except → None` idiom already used for `cv2` in this file; type annotations quoted; `download_test_image` (the entry point of the image-benchmark flow) raises an actionable error pointing at `pip install 'rapid-mlx[vision]'`
- `pyproject.toml`: pillow dropped from core, added to `vision` and `all` extras for explicitness

## Verified

- `ruff check` + `ruff format --check` pass
- In a venv **without** pillow: `import vllm_mlx.benchmark` succeeds; calling `download_test_image` raises the friendly install hint
- Fresh `uv pip install --dry-run` of this branch resolves **without** pillow; with `[vision]` it resolves with pillow (via both the explicit pin and mlx-vlm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)