### PR TITLE
fix(reasoning/qwen3): route bare-text 'thinking process:' preamble to reasoning_content (#570)

### DIFF
--- a/tests/test_chat_route_tool_tag_leak.py
+++ b/tests/test_chat_route_tool_tag_leak.py
@@ -280,3 +280,24 @@ class TestBareThinkingProcessLeakRegression:
         )
         assert reasoning is None
         assert cleaned == answer
+
+    def test_bare_thinking_preamble_with_tool_call_does_not_leak_markup(self):
+        # Codex r2 BLOCKING on PR #572: when the model embeds a tool
+        # call inside what looks like a thinking preamble, the bare-text
+        # fallback would otherwise echo the raw output (including
+        # ``<tool_call>`` markup) into ``reasoning_content`` because
+        # ``_finalize_content_and_reasoning`` calls
+        # ``extract_reasoning(raw_text)`` on the unstripped raw output
+        # when ``tool_calls`` is non-empty.
+        raw = (
+            "Here's a thinking process:\n\n"
+            "I need to call the weather tool.\n"
+            '<tool_call>\n{"name": "weather", "arguments": '
+            '{"city": "Seattle"}}\n</tool_call>'
+        )
+        content, tool_calls, reasoning = _drive_chat_route_pipeline(raw)
+        # Tool parser succeeded.
+        assert tool_calls and tool_calls[0]["name"] == "weather"
+        # Tool markup must not leak via either sink.
+        _assert_no_leak(content)
+        _assert_no_leak(reasoning)

--- a/tests/test_chat_route_tool_tag_leak.py
+++ b/tests/test_chat_route_tool_tag_leak.py
@@ -189,3 +189,94 @@ class TestToolTagLeakRegression:
             f"downstream strip_thinking_tags), got {cleaned!r}"
         )
         assert reasoning is not None and "thinking" in reasoning
+
+
+class TestBareThinkingProcessLeakRegression:
+    """Regression for issue #570.
+
+    The Qwen3 family chat template injects ``<think>\\n`` after the
+    assistant generation marker when ``enable_thinking=True``. The model
+    is supposed to emit its chain-of-thought followed by ``</think>`` and
+    then the user-facing answer. In practice the model occasionally
+    restates the channel boundary inline with a bare-text preamble
+    (``Here's a thinking process:\\n\\n1. **Analyze...``); when the
+    request also runs out of ``max_tokens`` before the model reaches
+    ``</think>``, neither tag appears anywhere in the output.
+
+    Previously the reasoning parser's "no end token, no start token"
+    branch returned ``(None, model_output)`` — routing the whole
+    chain-of-thought into the user-facing ``content`` field while
+    ``reasoning_content`` stayed empty. Any OpenAI-compatible client
+    consuming ``/v1/chat/completions`` saw reasoning leaking into the
+    answer.
+
+    Fix: extend ``Qwen3ReasoningParser.extract_reasoning`` (and the
+    streaming finalizer) to recognise bare-text "thinking process"
+    preambles and route them to ``reasoning_content`` while clearing
+    the cleaned content. Match conservatively at the very start of the
+    output so a normal answer that merely mentions "let me think" mid-
+    response is not reclassified.
+    """
+
+    # Real text captured from a failing curl against ``qwen3.6-35b-4bit``.
+    _LEAKED_PREAMBLE = (
+        "Here's a thinking process:\n\n"
+        "1.  **Analyze User Input:**\n"
+        "   - **Route:** Seattle to San Diego\n"
+        "   - **Duration:** 7 days\n\n"
+        "2.  **Evaluate Each Option (Food Scene Reputation):**\n"
+        "   - **Portland, OR:** World-renowned food scene. Innovative, diverse.\n"
+        "   - **San Francisco, CA:** Iconic global food destination."
+    )
+
+    def test_bare_thinking_preamble_routes_to_reasoning_not_content(self):
+        from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
+
+        cleaned, reasoning = _finalize_content_and_reasoning(
+            raw_text=self._LEAKED_PREAMBLE,
+            cleaned_text=self._LEAKED_PREAMBLE,
+            tool_calls=None,
+            reasoning_parser=Qwen3ReasoningParser(tokenizer=None),
+        )
+        # ``reasoning_content`` must contain the chain-of-thought.
+        assert reasoning is not None
+        assert "thinking process" in reasoning
+        assert "Portland" in reasoning
+        # ``content`` must be cleared so the leak does not reach the
+        # user-facing ``choices[0].message.content`` field.
+        assert not cleaned, (
+            f"chain-of-thought leaked into user-facing content: {cleaned!r}"
+        )
+
+    def test_bare_thinking_preamble_via_full_chat_route_pipeline(self):
+        # Drive the same pipeline the OpenAI ``/v1/chat/completions``
+        # route uses end-to-end (tool parser + reasoning parser +
+        # finalize helper). ``final_content`` here is what the client
+        # sees in ``choices[0].message.content``.
+        content, tool_calls, reasoning = _drive_chat_route_pipeline(
+            self._LEAKED_PREAMBLE
+        )
+        assert not tool_calls
+        assert reasoning is not None and "thinking process" in reasoning
+        assert content is None, (
+            f"expected empty content (full output was reasoning), got {content!r}"
+        )
+
+    def test_normal_answer_with_let_me_think_mid_sentence_not_reclassified(self):
+        # Mid-sentence mentions of "let me think" must not trigger the
+        # bare-text fallback — the regex anchors to the very start of
+        # the output.
+        answer = (
+            "Portland has the best food scene of those options. Many people think "
+            "it's world-class — let me think of an example... Pok Pok was iconic."
+        )
+        cleaned, reasoning = _finalize_content_and_reasoning(
+            raw_text=answer,
+            cleaned_text=answer,
+            tool_calls=None,
+            reasoning_parser=__import__(
+                "vllm_mlx.reasoning.qwen3_parser", fromlist=["Qwen3ReasoningParser"]
+            ).Qwen3ReasoningParser(tokenizer=None),
+        )
+        assert reasoning is None
+        assert cleaned == answer

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -297,16 +297,17 @@ def test_570_qwen3_truncated_thought_routes_to_reasoning_when_thinking_unspecifi
 
 
 def test_570_qwen3_valid_non_thinking_answer_not_clobbered_when_thinking_off():
-    """Codex r3 BLOCKING regression pin: a perfectly valid non-thinking
-    answer that opens with a scratchpad-shaped phrase (``Here's my
-    reasoning:`` is the canonical false positive) must NOT have its
-    content cleared when the caller passes ``enable_thinking=False``.
-    Without the explicit-False gate, the bare-text regex would match
-    and the user would see empty ``message.content``."""
+    """Codex r3 BLOCKING regression pin: a teaching / tutorial answer
+    that explains a chain-of-thought methodology (``Here's a thinking
+    process you can use…``) must NOT have its content cleared when
+    the caller passes ``enable_thinking=False`` — the user explicitly
+    asked for the explanation. Without the explicit-False gate, the
+    bare-text regex would match and the user would see empty
+    ``message.content``."""
     valid_answer = (
-        "Here's my reasoning: Portland has the best food scene of the "
-        "three options — the Pacific Northwest sourcing pipeline + the "
-        "carts-by-the-dozen culture put it ahead."
+        "Here's a thinking process you can use for any optimisation "
+        "problem: first survey the options, then score each one "
+        "against your criteria, then pick the top-scoring result."
     )
     cleaned, reasoning = _finalize_content_and_reasoning(
         raw_text=valid_answer,

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -244,11 +244,44 @@ def test_575_qwen3_truncated_thought_does_not_leak_to_content_when_thinking_on()
     assert not cleaned
 
 
-def test_575_qwen3_truncated_thought_legacy_behaviour_when_thinking_off():
-    """Backward-compat pin: with ``enable_thinking`` left at ``None``
-    (the pre-#575 contract) the helper does NOT clear cleaned_text and
-    the legacy behaviour is preserved — useful for shimming third-party
-    callers that have not yet wired the flag through."""
+def test_575_qwen3_truncated_thought_legacy_behaviour_when_thinking_explicit_off():
+    """Backward-compat pin: with ``enable_thinking=False`` (caller
+    affirmatively disabled thinking) the bare-text fallback added by
+    #570 MUST NOT fire — a non-thinking answer that happens to open
+    with ``Here's my reasoning:`` or similar scratchpad-shaped phrasing
+    must stay in ``content`` or the client gets an empty
+    ``message.content``. (Codex r3 BLOCKING on PR #573.)
+
+    NOTE: the older form of this test pinned ``enable_thinking=None``
+    to the same legacy contract, but #570 (PR #573) changed the
+    None-case to fire the bare-text fallback defensively — see
+    ``test_570_qwen3_truncated_thought_routes_to_reasoning_when_thinking_unspecified``
+    below. Only the explicit-False path still preserves the strict
+    legacy "text stays as content" behaviour, and that's the
+    backward-compat shim third-party callers need."""
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_QWEN3_TRUNCATED_THOUGHT,
+        cleaned_text=_QWEN3_TRUNCATED_THOUGHT,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=False,
+    )
+    # Legacy path: no Case-4 fast-path AND no bare-text fallback when
+    # thinking is explicitly off — text stays as content, reasoning is None.
+    assert reasoning is None
+    assert cleaned == _QWEN3_TRUNCATED_THOUGHT
+
+
+def test_570_qwen3_truncated_thought_routes_to_reasoning_when_thinking_unspecified():
+    """#570 / PR #573 fix path: legacy callers that don't thread the
+    ``enable_thinking`` flag through (it stays at ``None``) still get
+    defensive routing when the model emits a recognizable bare-text
+    thinking preamble. The whole truncated thought lands in
+    ``reasoning`` and ``cleaned_text`` is blanked so it doesn't leak
+    into ``message.content``. Distinguishes from the explicit-False
+    legacy shim above — None is "no signal" → trust the pattern,
+    False is "caller said no" → don't override."""
     cleaned, reasoning = _finalize_content_and_reasoning(
         raw_text=_QWEN3_TRUNCATED_THOUGHT,
         cleaned_text=_QWEN3_TRUNCATED_THOUGHT,
@@ -257,9 +290,34 @@ def test_575_qwen3_truncated_thought_legacy_behaviour_when_thinking_off():
         engine_reasoning_text="",
         enable_thinking=None,
     )
-    # Legacy path: no Case-4 → text stays as content, reasoning is None.
+    assert reasoning == _QWEN3_TRUNCATED_THOUGHT.strip()
+    # Blanked so the route renders ``content=None`` and the bare-text
+    # preamble doesn't leak.
+    assert not cleaned
+
+
+def test_570_qwen3_valid_non_thinking_answer_not_clobbered_when_thinking_off():
+    """Codex r3 BLOCKING regression pin: a perfectly valid non-thinking
+    answer that opens with a scratchpad-shaped phrase (``Here's my
+    reasoning:`` is the canonical false positive) must NOT have its
+    content cleared when the caller passes ``enable_thinking=False``.
+    Without the explicit-False gate, the bare-text regex would match
+    and the user would see empty ``message.content``."""
+    valid_answer = (
+        "Here's my reasoning: Portland has the best food scene of the "
+        "three options — the Pacific Northwest sourcing pipeline + the "
+        "carts-by-the-dozen culture put it ahead."
+    )
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=valid_answer,
+        cleaned_text=valid_answer,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=False,
+    )
     assert reasoning is None
-    assert cleaned == _QWEN3_TRUNCATED_THOUGHT
+    assert cleaned == valid_answer
 
 
 def test_575_glm4_no_tags_thinking_on_does_not_clobber_content():

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -925,6 +925,92 @@ class TestQwen3:
         )
         assert result is None
 
+    def test_finalize_streaming_bare_preamble_without_think_prefix_routes_to_content(
+        self,
+    ):
+        # Codex r3 BLOCKING symmetry: ``finalize_streaming`` has no
+        # ``enable_thinking`` kwarg, so the leading ``<think>`` token
+        # is the only evidence the stream is in thinking mode. Without
+        # that evidence, a bare-text preamble in the accumulated text
+        # is more likely a casual answer opener (the user asked the
+        # model to "explain your thinking process") than an actual
+        # truncated thought trace. Pre-fix the streaming side fired
+        # the bare-text fallback regardless of context and silently
+        # routed valid non-thinking answers into the dead-code
+        # ``reasoning`` channel — the route consumer ignores
+        # ``final_msg.reasoning`` so the answer never reached the
+        # client. Symmetric with the explicit-False gate in
+        # ``extract_reasoning``.
+        parser = Qwen3ReasoningParser()
+        result = parser.finalize_streaming(
+            "Here's a thinking process I followed to solve the puzzle: "
+            "first I sorted the items, then I picked the largest."
+        )
+        assert result is not None
+        # ``content`` because the lack of a leading ``<think>`` means
+        # the streaming Case-3 default reasoning emission was wrong
+        # and the correction belongs in the content channel — the
+        # same protocol the parser used pre-#570 for the no-evidence
+        # branch.
+        assert result.content is not None
+        assert result.reasoning is None
+
+    def test_bare_thinking_label_without_process_no_longer_matches(self):
+        # Codex r3 BLOCKING: ``Here's my thinking:`` (no ``process``)
+        # is normal user-facing phrasing — "Here's my thinking on
+        # X..." — and the broader regex (``thinking(?:\s+process)?``)
+        # generated false positives on direct answers. Tightened to
+        # require ``thinking\s+process`` for the scratchpad-label
+        # form. This test pins the regression so the optional ``\s+
+        # process`` does not re-creep back into the regex.
+        for ambiguous in [
+            "Here's my thinking: Portland is the right pick for food.",
+            "Here is my thinking: Pittsburgh outperforms in winter.",
+            "Here is the thinking: route through Salt Lake first.",
+        ]:
+            reasoning, content = self.parser.extract_reasoning(ambiguous)
+            assert reasoning is None, (
+                f"bare ``thinking:`` (no ``process``) must no longer "
+                f"match — clobbered direct answer: {ambiguous!r}"
+            )
+            assert content == ambiguous
+
+    def test_extract_reasoning_explicit_false_skips_bare_preamble(self):
+        # Codex r3 BLOCKING regression pin: when ``enable_thinking=False``
+        # the caller has affirmatively said "no thinking is happening";
+        # the bare-text fallback MUST defer and leave a valid answer
+        # alone even if it opens with a scratchpad-shaped phrase.
+        # Without this gate, ``Here's my reasoning: ...`` answers from
+        # non-thinking-mode requests had ``content`` clobbered.
+        text = (
+            "Here's my reasoning: Portland has the strongest food "
+            "scene of the three options on this route."
+        )
+        reasoning, content = self.parser.extract_reasoning(
+            text, enable_thinking=False
+        )
+        assert reasoning is None
+        assert content == text
+
+    def test_extract_reasoning_unspecified_thinking_still_fires_fallback(self):
+        # Mirror of the explicit-False test above: legacy callers that
+        # don't thread ``enable_thinking`` at all (it stays ``None``)
+        # still get defensive routing for bare-text preambles. The
+        # gate is ``enable_thinking is not False`` so the None case
+        # passes through and the pattern check decides.
+        text = (
+            "Here's a thinking process:\n"
+            "1. Sort the options by relevance.\n"
+            "2. Score each one against the criteria.\n"
+        )
+        reasoning, content = self.parser.extract_reasoning(
+            text, enable_thinking=None
+        )
+        assert reasoning is not None
+        assert "thinking process" in reasoning
+        # ``""`` not None so the upstream finalize overwrites cleaned_text.
+        assert content == ""
+
 
 # ---------------------------------------------------------------------------
 # Glm4ReasoningParser

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -768,22 +768,14 @@ class TestQwen3:
         assert content == ""
 
     def test_bare_thinking_process_variants(self):
-        # Only explicit scratchpad labels (terminating ``:``) trigger the
-        # fallback. Conversational phrases like "Let me think..." are
-        # deliberately NOT included — they're common direct-answer
-        # openers when ``enable_thinking=False`` and matching them would
-        # blank out valid responses (codex r1 BLOCKING on PR #572).
-        # ``Step by step:`` / ``Step-by-step:`` are also deliberately
-        # NOT included — that bare form is the canonical heading for
-        # direct "explain step by step" answers (codex r2 BLOCKING).
+        # Only the ``Here's [my/a/the] <scratchpad-noun>:`` shape (and
+        # the ``My thought process:`` form) trigger the fallback. The
+        # excluded shapes have their own regression pins below.
         for prefix in [
             "Here is my thinking process:",
             "Here is the chain-of-thought:",
             "Here's the thought process:",
             "Here's the scratchpad:",
-            "Thinking step by step:",
-            "Thinking out loud:",
-            "Thinking through this:",
             "My thought process:",
         ]:
             text = f"{prefix}\n\n1. First consider..."
@@ -791,6 +783,31 @@ class TestQwen3:
             assert reasoning is not None, f"expected reasoning for prefix={prefix!r}"
             # ``""`` signals "overwrite to empty" to the finalize helper.
             assert content == "", f"expected empty content for prefix={prefix!r}"
+
+    def test_thinking_verb_form_no_longer_matches(self):
+        # Codex r5 BLOCKING regression pin: the verb-form
+        # ``Thinking step by step:`` / ``Thinking out loud:`` /
+        # ``Thinking through this:`` / ``Thinking carefully:`` /
+        # ``Thinking aloud:`` are conversational answer openers
+        # ("Thinking carefully: Portland is the safest option") and
+        # would clobber valid responses on the default
+        # ``enable_thinking=None`` code path. Only the noun-led
+        # ``Here's [my/a/the] <noun>:`` shape stays in the regex —
+        # the verb-led form is too conversational. This pin prevents
+        # a future regex rewrite from re-adding them.
+        for ambiguous in [
+            "Thinking step by step: first drive south on I-5, then turn east.",
+            "Thinking out loud: Portland has the best Vietnamese food.",
+            "Thinking through this: the cheapest option is the train.",
+            "Thinking carefully: Portland is the safest pick.",
+            "Thinking aloud: I'd weight food culture higher than scenery.",
+        ]:
+            reasoning, content = self.parser.extract_reasoning(ambiguous)
+            assert reasoning is None, (
+                f"verb-form ``Thinking X:`` must no longer match — "
+                f"clobbered direct answer: {ambiguous!r}"
+            )
+            assert content == ambiguous
 
     def test_bare_reasoning_label_no_longer_matches(self):
         # Codex r4 BLOCKING regression pin: ``reasoning`` (alone) and
@@ -866,7 +883,15 @@ class TestQwen3:
         )
         assert content == text_with_tool
 
-        # All tool-tag flavors the rest of the stack recognises.
+        # All tool-tag flavors the rest of the stack recognises. The
+        # preamble MUST match ``_BARE_THINK_PREFIX_RE`` first
+        # (otherwise the bare-text branch wouldn't even consider
+        # routing to reasoning, and the tool-markup detector would
+        # never run — the loop would assert trivially). ``Here's the
+        # reasoning:`` is excluded from the regex (codex r4), so
+        # this loop uses ``Here's a thinking process:`` so each tag
+        # flavor exercises ``_TOOL_CALL_MARKUP_RE`` for real (codex
+        # r5 BLOCKING #2).
         for tag in [
             "<tool_call>",
             "<function=foo>",
@@ -874,7 +899,7 @@ class TestQwen3:
             "<invoke ",
             "<minimax:tool_call>",
         ]:
-            text = f"Here's the reasoning:\n\nThinking. {tag}stuff"
+            text = f"Here's a thinking process:\n\nThinking. {tag}stuff"
             reasoning, content = self.parser.extract_reasoning(text)
             assert reasoning is None, (
                 f"tool tag {tag!r} should suppress bare-text fallback"

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -733,6 +733,156 @@ class TestQwen3:
             assert reasoning is None
             assert content == text
 
+    # -----------------------------------------------------------------------
+    # Bare-text "thinking process" preamble (issue #570).
+    #
+    # Qwen3 chat templates inject ``<think>\n`` after the assistant
+    # generation marker when ``enable_thinking=True``. The model is
+    # supposed to emit its chain-of-thought followed by ``</think>`` and
+    # then the user-facing answer. Sometimes the model restates the
+    # channel boundary inline as a bare-text prefix (``Here's a thinking
+    # process:`` and variants); when that happens AND the model is
+    # truncated by ``max_tokens`` before producing ``</think>``, neither
+    # tag is in the output. The default branch then routes the whole
+    # response — which is pure chain-of-thought — into ``content`` and
+    # leaves ``reasoning_content`` empty, leaking reasoning to any
+    # OpenAI-compatible client. These tests pin the bare-text fallback.
+    # The fallback runs *after* the ``enable_thinking is True`` fast
+    # path above, so it only fires when callers leave the kwarg
+    # defaulted but the model still emits a bare-text think prefix.
+    # -----------------------------------------------------------------------
+
+    def test_bare_thinking_process_prefix_no_close_tag(self):
+        text = (
+            "Here's a thinking process:\n\n"
+            "1.  **Analyze User Input:** route Seattle to San Diego.\n"
+            "2.  **Evaluate Each Option (Food Scene Reputation):**\n"
+            "   - Portland, OR: World-renowned food scene."
+        )
+        reasoning, content = self.parser.extract_reasoning(text)
+        assert reasoning is not None
+        assert "thinking process" in reasoning
+        # ``""`` (not ``None``) so the upstream finalize step overwrites
+        # ``cleaned_text`` and the raw bare-text reasoning does not leak
+        # through to the client's ``content`` field.
+        assert content == ""
+
+    def test_bare_thinking_process_variants(self):
+        # Only explicit scratchpad labels (terminating ``:``) trigger the
+        # fallback. Conversational phrases like "Let me think..." are
+        # deliberately NOT included — they're common direct-answer
+        # openers when ``enable_thinking=False`` and matching them would
+        # blank out valid responses (codex r1 BLOCKING on PR #572).
+        for prefix in [
+            "Here is my thinking process:",
+            "Here's my reasoning:",
+            "Here is the chain-of-thought:",
+            "Here's the thought process:",
+            "Here is the reasoning process:",
+            "Thinking step by step:",
+            "Thinking out loud:",
+            "Thinking through this:",
+            "Step by step:",
+            "Step-by-step:",
+            "My thought process:",
+            "My reasoning process:",
+        ]:
+            text = f"{prefix}\n\n1. First consider..."
+            reasoning, content = self.parser.extract_reasoning(text)
+            assert reasoning is not None, f"expected reasoning for prefix={prefix!r}"
+            # ``""`` signals "overwrite to empty" to the finalize helper.
+            assert content == "", f"expected empty content for prefix={prefix!r}"
+
+    def test_ambiguous_phrases_not_misclassified(self):
+        # When ``enable_thinking=False`` (or the model otherwise emits a
+        # direct answer), conversational openers like "Let me think" or
+        # "I need to analyze" or "Analyzing the request" must NOT be
+        # rerouted to ``reasoning_content`` — they are common answer
+        # phrasings and clobbering them would leave the client with an
+        # empty ``message.content``. Pinned per codex r1 BLOCKING on
+        # PR #572.
+        for answer in [
+            "Let me think about that — Portland is the best food stop.",
+            "Let me analyze the options. The clear winner is San Francisco.",
+            "Let me reason through this: Portland wins.",
+            "I need to analyze the route first. The trip takes 7 days.",
+            "I'll analyze each city: Portland has world-class food.",
+            "I will think about this carefully — Portland wins.",
+            "I should break this down: 1. Portland 2. San Francisco.",
+            "Analyzing the user's request, the answer is Portland.",
+            "Analyzing the question — the food capital is Portland.",
+        ]:
+            reasoning, content = self.parser.extract_reasoning(answer)
+            assert reasoning is None, (
+                f"ambiguous phrase misclassified as reasoning: {answer!r}"
+            )
+            assert content == answer
+
+    def test_bare_thinking_prefix_with_close_tag_uses_normal_split(self):
+        # When ``</think>`` IS present, the bare-text fallback must not
+        # fire — the normal implicit-think split applies and the answer
+        # after the close tag goes to ``content``.
+        text = (
+            "Here's a thinking process:\n1. think\n2. think more</think>"
+            "The answer is Portland."
+        )
+        reasoning, content = self.parser.extract_reasoning(text)
+        assert reasoning is not None
+        assert "thinking process" in reasoning
+        assert content == "The answer is Portland."
+
+    def test_bare_thinking_prefix_with_start_tag(self):
+        # Explicit ``<think>`` in output already routes to reasoning via
+        # the existing branch; the bare-text check must not interfere.
+        text = "<think>Here's a thinking process: I should think harder."
+        reasoning, content = self.parser.extract_reasoning(text)
+        assert reasoning is not None
+        assert "Here's a thinking process" in reasoning
+        assert content is None
+
+    def test_normal_answer_not_misclassified_as_reasoning(self):
+        # Answers that merely mention "thinking" mid-sentence must NOT
+        # be reclassified as reasoning. The bare-text fallback matches
+        # only at the very start of the output.
+        for answer in [
+            "Portland has the best food scene of those options.",
+            "The answer is 42.",
+            "```python\nprint('hi')\n```",
+            "Yes, that's correct.",
+            (
+                "Sure! Portland is the standout for food. Many people think it's "
+                "world-class — let me think of an example... Pok Pok was iconic."
+            ),
+        ]:
+            reasoning, content = self.parser.extract_reasoning(answer)
+            assert reasoning is None, f"misclassified as reasoning: {answer!r}"
+            assert content == answer
+
+    def test_finalize_streaming_bare_think_preamble_routes_to_reasoning(self):
+        # Streaming counterpart: when the chat template injected
+        # ``<think>`` and the model was truncated mid-thought before
+        # ``</think>``, ``finalize_streaming`` previously emitted a
+        # correction with the full text as ``content``. With the
+        # bare-text fallback it surfaces in ``reasoning`` instead.
+        parser = Qwen3ReasoningParser()
+        accumulated = (
+            "<think>Here's a thinking process:\n\n"
+            "1. Analyze the user's request.\n"
+            "2. Compare options."
+        )
+        result = parser.finalize_streaming(accumulated)
+        assert result is not None
+        assert result.reasoning is not None
+        assert "thinking process" in result.reasoning
+        assert result.content is None
+
+    def test_finalize_streaming_close_tag_present_no_correction(self):
+        parser = Qwen3ReasoningParser()
+        result = parser.finalize_streaming(
+            "<think>reasoning</think>The answer is Portland."
+        )
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Glm4ReasoningParser

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -773,6 +773,9 @@ class TestQwen3:
         # deliberately NOT included — they're common direct-answer
         # openers when ``enable_thinking=False`` and matching them would
         # blank out valid responses (codex r1 BLOCKING on PR #572).
+        # ``Step by step:`` / ``Step-by-step:`` are also deliberately
+        # NOT included — that bare form is the canonical heading for
+        # direct "explain step by step" answers (codex r2 BLOCKING).
         for prefix in [
             "Here is my thinking process:",
             "Here's my reasoning:",
@@ -782,8 +785,6 @@ class TestQwen3:
             "Thinking step by step:",
             "Thinking out loud:",
             "Thinking through this:",
-            "Step by step:",
-            "Step-by-step:",
             "My thought process:",
             "My reasoning process:",
         ]:
@@ -800,7 +801,9 @@ class TestQwen3:
         # rerouted to ``reasoning_content`` — they are common answer
         # phrasings and clobbering them would leave the client with an
         # empty ``message.content``. Pinned per codex r1 BLOCKING on
-        # PR #572.
+        # PR #572. ``Step by step:`` / ``Step-by-step:`` added per
+        # codex r2 — that bare form is the canonical heading for direct
+        # "explain step by step" answers (tutorials, how-tos).
         for answer in [
             "Let me think about that — Portland is the best food stop.",
             "Let me analyze the options. The clear winner is San Francisco.",
@@ -811,12 +814,51 @@ class TestQwen3:
             "I should break this down: 1. Portland 2. San Francisco.",
             "Analyzing the user's request, the answer is Portland.",
             "Analyzing the question — the food capital is Portland.",
+            "Step by step:\n1. Drive south on I-5\n2. Stop in Portland",
+            "Step-by-step: first preheat the oven to 350F.",
         ]:
             reasoning, content = self.parser.extract_reasoning(answer)
             assert reasoning is None, (
                 f"ambiguous phrase misclassified as reasoning: {answer!r}"
             )
             assert content == answer
+
+    def test_bare_think_prefix_with_tool_call_markup_not_routed(self):
+        # When the model embeds a tool call inside what looks like a
+        # thinking preamble, the bare-text fallback must NOT echo the
+        # raw output (tool markup and all) into ``reasoning_content``.
+        # The tool parser already stripped tool tags from ``content``;
+        # surfacing them in ``reasoning_content`` would leak the same
+        # tags to clients via the reasoning channel. Pinned per codex
+        # r2 BLOCKING on PR #572 — both branches (matched preamble +
+        # tool tag in body) must defer to the upstream tool/text
+        # pipeline and return ``(None, model_output)``.
+        text_with_tool = (
+            "Here's a thinking process:\n\n"
+            'Need to call the weather API.\n<tool_call>\n{"name": '
+            '"weather", "arguments": {"city": "Seattle"}}\n</tool_call>'
+        )
+        reasoning, content = self.parser.extract_reasoning(text_with_tool)
+        assert reasoning is None, (
+            "tool markup must not leak into reasoning_content via the "
+            "bare-text fallback"
+        )
+        assert content == text_with_tool
+
+        # All tool-tag flavors the rest of the stack recognises.
+        for tag in [
+            "<tool_call>",
+            "<function=foo>",
+            "<|tool_call|>",
+            "<invoke ",
+            "<minimax:tool_call>",
+        ]:
+            text = f"Here's the reasoning:\n\nThinking. {tag}stuff"
+            reasoning, content = self.parser.extract_reasoning(text)
+            assert reasoning is None, (
+                f"tool tag {tag!r} should suppress bare-text fallback"
+            )
+            assert content == text
 
     def test_bare_thinking_prefix_with_close_tag_uses_normal_split(self):
         # When ``</think>`` IS present, the bare-text fallback must not

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -778,21 +778,42 @@ class TestQwen3:
         # direct "explain step by step" answers (codex r2 BLOCKING).
         for prefix in [
             "Here is my thinking process:",
-            "Here's my reasoning:",
             "Here is the chain-of-thought:",
             "Here's the thought process:",
-            "Here is the reasoning process:",
+            "Here's the scratchpad:",
             "Thinking step by step:",
             "Thinking out loud:",
             "Thinking through this:",
             "My thought process:",
-            "My reasoning process:",
         ]:
             text = f"{prefix}\n\n1. First consider..."
             reasoning, content = self.parser.extract_reasoning(text)
             assert reasoning is not None, f"expected reasoning for prefix={prefix!r}"
             # ``""`` signals "overwrite to empty" to the finalize helper.
             assert content == "", f"expected empty content for prefix={prefix!r}"
+
+    def test_bare_reasoning_label_no_longer_matches(self):
+        # Codex r4 BLOCKING regression pin: ``reasoning`` (alone) and
+        # ``reasoning process`` are excluded from the regex because
+        # ``Here's my reasoning: …`` and ``My reasoning process: …``
+        # are common direct-answer openers. Most callers default to
+        # ``enable_thinking=None`` (legacy), so matching these labels
+        # there would clobber valid answers on the busiest code path.
+        # This test pins the exclusion so a future regex rewrite
+        # cannot silently re-add them.
+        for ambiguous in [
+            "Here's my reasoning: Portland wins on food.",
+            "Here is my reasoning: Pittsburgh outperforms in winter.",
+            "Here is the reasoning: route through Salt Lake.",
+            "Here is the reasoning process: sort then score.",
+            "My reasoning process: weigh each option against criteria.",
+        ]:
+            reasoning, content = self.parser.extract_reasoning(ambiguous)
+            assert reasoning is None, (
+                f"bare ``reasoning(:|\\s+process:)`` must no longer "
+                f"match — clobbered direct answer: {ambiguous!r}"
+            )
+            assert content == ambiguous
 
     def test_ambiguous_phrases_not_misclassified(self):
         # When ``enable_thinking=False`` (or the model otherwise emits a
@@ -979,16 +1000,19 @@ class TestQwen3:
         # Codex r3 BLOCKING regression pin: when ``enable_thinking=False``
         # the caller has affirmatively said "no thinking is happening";
         # the bare-text fallback MUST defer and leave a valid answer
-        # alone even if it opens with a scratchpad-shaped phrase.
-        # Without this gate, ``Here's my reasoning: ...`` answers from
-        # non-thinking-mode requests had ``content`` clobbered.
+        # alone even if it opens with a scratchpad-shaped phrase. The
+        # gate exists for legitimate teaching / tutorial content —
+        # explaining a thinking-process methodology in non-thinking
+        # mode is a real use case (``Here's a thinking process you
+        # can use for any optimisation problem: …``) and must not be
+        # reclassified as the model's own chain-of-thought.
         text = (
-            "Here's my reasoning: Portland has the strongest food "
-            "scene of the three options on this route."
+            "Here's a thinking process: first survey the available "
+            "options, then score each one against your criteria, "
+            "then pick the top result. This is a teaching answer "
+            "the user explicitly asked for."
         )
-        reasoning, content = self.parser.extract_reasoning(
-            text, enable_thinking=False
-        )
+        reasoning, content = self.parser.extract_reasoning(text, enable_thinking=False)
         assert reasoning is None
         assert content == text
 
@@ -1003,9 +1027,7 @@ class TestQwen3:
             "1. Sort the options by relevance.\n"
             "2. Score each one against the criteria.\n"
         )
-        reasoning, content = self.parser.extract_reasoning(
-            text, enable_thinking=None
-        )
+        reasoning, content = self.parser.extract_reasoning(text, enable_thinking=None)
         assert reasoning is not None
         assert "thinking process" in reasoning
         # ``""`` not None so the upstream finalize overwrites cleaned_text.

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -31,14 +31,17 @@ from .think_parser import BaseThinkingReasoningParser
 # Scoped narrowly to **explicit scratchpad labels** — phrases that are
 # overwhelmingly unambiguous chain-of-thought preambles, identified by
 # (a) being known scratchpad nouns (``thinking process``, ``reasoning``,
-# ``chain-of-thought``, ``scratchpad``, ``analysis``, ``thought
-# process``) and (b) ending with a label punctuation (``:`` / newline
-# pair).  Conversational phrases like ``Let me think...`` or ``I need
+# ``chain-of-thought``, ``scratchpad``, ``thought process``,
+# ``reasoning process``) and (b) ending with a label punctuation
+# (``:``).  Conversational phrases like ``Let me think...`` or ``I need
 # to analyze...`` are NOT matched — they are common openers for direct
 # answers and would be misclassified when ``enable_thinking=False``
-# (codex r1 BLOCKING).  Match anchored at ``^\s*`` so a normal answer
-# that merely mentions a scratchpad noun mid-response is not
-# reclassified.
+# (codex r1 BLOCKING).  Bare ``Step by step:`` / ``Step-by-step:`` is
+# also NOT matched — that form is the canonical heading for a direct
+# answer to "explain step by step" and would clobber legitimate
+# tutorials / how-tos (codex r2 BLOCKING).  Match anchored at ``^\s*``
+# so a normal answer that merely mentions a scratchpad noun mid-
+# response is not reclassified.
 _BARE_THINK_PREFIX_RE = re.compile(
     r"^(?:\s*)"  # leading whitespace from the injected ``<think>\n``
     r"(?:"
@@ -51,13 +54,27 @@ _BARE_THINK_PREFIX_RE = re.compile(
     r"\s*:)"
     # "Thinking step by step:" / "Thinking out loud:" / etc. — only
     # the labelled scratchpad form (terminating ``:`` required).
+    # The bare ``Step by step:`` / ``Step-by-step:`` form is excluded
+    # because it is the canonical heading for direct "explain
+    # step-by-step" answers (tutorials, how-tos).
     r"|(?:Thinking\s+(?:step\s+by\s+step|out\s+loud|through(?:\s+this)?|"
     r"carefully|aloud)\s*:)"
-    r"|(?:(?:Step\s+by\s+step|Step-by-step)\s*:)"
     # "My thought process:" / "My reasoning process:" — scratchpad
     # label that requires ``:`` (e.g. NOT "My thought is that ...").
     r"|(?:My\s+(?:thought|reasoning)\s+process\s*:)"
     r")",
+    re.IGNORECASE,
+)
+
+# Tool-call markup detector used to suppress the bare-text fallback
+# when the model embedded a tool call inside what looks like a thinking
+# preamble. The fallback would otherwise echo the raw output (including
+# ``<tool_call>{...}`` markup) into ``reasoning_content`` — leaking the
+# tool tag the route's tool parser already stripped from ``content``.
+# Defer to the tool parser by skipping the bare-text branch instead.
+# (Codex r2 BLOCKING.)
+_TOOL_CALL_MARKUP_RE = re.compile(
+    r"<tool_call>|<function=|<\|tool_call\|>|<invoke\s|<minimax:tool_call>",
     re.IGNORECASE,
 )
 
@@ -68,10 +85,20 @@ def _looks_like_bare_think_preamble(text: str) -> bool:
     Used as a fallback signal when ``<think>`` was injected by the chat
     template into the prompt (so it is absent from the model output) and
     the model never emitted ``</think>`` before being truncated.
+
+    Returns False when ``text`` contains any tool-call markup so the
+    raw tool tags are not echoed into ``reasoning_content`` by the
+    fallback (codex r2 BLOCKING — the tool parser already stripped
+    them from ``content`` but the reasoning parser otherwise sees the
+    raw output unmodified).
     """
     if not text:
         return False
-    return _BARE_THINK_PREFIX_RE.match(text) is not None
+    if _BARE_THINK_PREFIX_RE.match(text) is None:
+        return False
+    if _TOOL_CALL_MARKUP_RE.search(text):
+        return False
+    return True
 
 
 class Qwen3ReasoningParser(BaseThinkingReasoningParser):

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -39,17 +39,23 @@ from .think_parser import BaseThinkingReasoningParser
 # (codex r1 BLOCKING).  Bare ``Step by step:`` / ``Step-by-step:`` is
 # also NOT matched — that form is the canonical heading for a direct
 # answer to "explain step by step" and would clobber legitimate
-# tutorials / how-tos (codex r2 BLOCKING).  Match anchored at ``^\s*``
-# so a normal answer that merely mentions a scratchpad noun mid-
-# response is not reclassified.
+# tutorials / how-tos (codex r2 BLOCKING).  The bare ``thinking:``
+# label (without ``process``) is also NOT matched — ``Here's my
+# thinking:`` is normal user-facing phrasing and the broader form
+# generated false positives on direct answers (codex r3 BLOCKING).
+# Match anchored at ``^\s*`` so a normal answer that merely mentions
+# a scratchpad noun mid-response is not reclassified.
 _BARE_THINK_PREFIX_RE = re.compile(
     r"^(?:\s*)"  # leading whitespace from the injected ``<think>\n``
     r"(?:"
     # "Here's a thinking process:" / "Here is the reasoning:" / etc.
     # Must end with ``:`` to ensure it's a scratchpad label, not a
-    # casual answer like "Here is the answer: ...".
+    # casual answer like "Here is the answer: ...". ``thinking``
+    # alone is excluded because ``Here's my thinking:`` is normal
+    # phrasing — only ``thinking process`` is the scratchpad form
+    # (codex r3 BLOCKING).
     r"(?:Here(?:'s|\s+is)\s+(?:my\s+|a\s+|the\s+)?"
-    r"(?:thinking(?:\s+process)?|reasoning|chain[-\s]of[-\s]thought|"
+    r"(?:thinking\s+process|reasoning|chain[-\s]of[-\s]thought|"
     r"scratchpad|thought\s+process|reasoning\s+process)"
     r"\s*:)"
     # "Thinking step by step:" / "Thinking out loud:" / etc. — only
@@ -182,12 +188,21 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             # the kwarg defaulted), the chat template still injects
             # ``<think>\n`` for Qwen3 thinking models. If the output
             # opens with a recognizable bare-text thinking marker
-            # (``Here's a thinking process:``, ``Step by step:``, …),
-            # treat the whole output as reasoning so it surfaces in
-            # ``reasoning_content`` instead of leaking into ``content``.
-            # This mirrors the streaming path which already routes
-            # pre-tag text to reasoning while ``</think>`` has not yet
-            # been seen.
+            # (``Here's a thinking process:`` and a few close variants
+            # — see ``_BARE_THINK_PREFIX_RE``), treat the whole output
+            # as reasoning so it surfaces in ``reasoning_content``
+            # instead of leaking into ``content``.
+            #
+            # Gated on ``enable_thinking is not False`` so an explicit
+            # ``enable_thinking=False`` from the caller wins: a
+            # non-thinking answer that happens to start with
+            # ``Here's my reasoning:`` must NOT be reclassified — the
+            # caller has affirmatively told us thinking is disabled
+            # and clobbering a valid answer would leave the client
+            # with empty ``message.content`` (codex r3 BLOCKING).
+            # ``None`` (legacy callers that don't thread the flag) and
+            # ``True`` (explicit thinking-on) both let the fallback
+            # fire defensively.
             #
             # Return ``""`` (not ``None``) for content so the upstream
             # ``_finalize_content_and_reasoning`` overwrites
@@ -197,7 +212,9 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             # has no tag to strip, so the parser must signal "no
             # content" explicitly here or the original raw output
             # would leak through to the client.
-            if _looks_like_bare_think_preamble(model_output):
+            if enable_thinking is not False and _looks_like_bare_think_preamble(
+                model_output
+            ):
                 return model_output.strip() or None, ""
             # No think tags at all — pure content
             return None, model_output
@@ -235,9 +252,12 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         if accumulated_text:
             # Cases 1 & 2: no close tag — emit full text as content,
             # stripping the template-injected ``<think>`` prefix if present.
-            cleaned = accumulated_text
-            if cleaned.startswith(self.start_token):
-                cleaned = cleaned[len(self.start_token) :]
+            saw_think_prefix = accumulated_text.startswith(self.start_token)
+            cleaned = (
+                accumulated_text[len(self.start_token) :]
+                if saw_think_prefix
+                else accumulated_text
+            )
             if not cleaned:
                 return None
             # Bare-text thinking fallback (mirrors ``extract_reasoning``):
@@ -248,7 +268,19 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             # preamble as ``content``; keep it in ``reasoning`` instead so
             # OpenAI-compatible clients can distinguish chain-of-thought
             # leakage from the final answer. (Issue #570.)
-            if _looks_like_bare_think_preamble(cleaned):
+            #
+            # Gated on ``saw_think_prefix`` because ``finalize_streaming``
+            # has no ``enable_thinking`` kwarg — the leading
+            # ``<think>`` token (template-injected or model-generated)
+            # is our only evidence that thinking mode was active for
+            # this stream. Without that evidence, a bare-text
+            # preamble in the output is more likely a casual answer
+            # opener (``Here's a thinking process I followed: ...``)
+            # than an actual thought trace, so falling through to the
+            # content path matches the pre-fix Anthropic-streaming
+            # correction protocol and avoids clobbering valid
+            # non-thinking answers (codex r3 BLOCKING symmetry).
+            if saw_think_prefix and _looks_like_bare_think_preamble(cleaned):
                 return DeltaMessage(reasoning=cleaned)
             return DeltaMessage(content=cleaned)
         return None

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -28,35 +28,41 @@ from .think_parser import BaseThinkingReasoningParser
 # string — so the default "no end token, no start token" branch routes
 # the whole thing into ``content`` and ``reasoning_content`` stays empty.
 #
-# Scoped narrowly to **explicit scratchpad labels** — phrases that are
-# overwhelmingly unambiguous chain-of-thought preambles, identified by
-# (a) being known scratchpad nouns (``thinking process``, ``reasoning``,
-# ``chain-of-thought``, ``scratchpad``, ``thought process``,
-# ``reasoning process``) and (b) ending with a label punctuation
-# (``:``).  Conversational phrases like ``Let me think...`` or ``I need
-# to analyze...`` are NOT matched — they are common openers for direct
-# answers and would be misclassified when ``enable_thinking=False``
-# (codex r1 BLOCKING).  Bare ``Step by step:`` / ``Step-by-step:`` is
-# also NOT matched — that form is the canonical heading for a direct
-# answer to "explain step by step" and would clobber legitimate
-# tutorials / how-tos (codex r2 BLOCKING).  The bare ``thinking:``
-# label (without ``process``) is also NOT matched — ``Here's my
-# thinking:`` is normal user-facing phrasing and the broader form
-# generated false positives on direct answers (codex r3 BLOCKING).
+# Scoped narrowly to **unambiguous scratchpad labels** — phrases that
+# overwhelmingly signal chain-of-thought, identified by (a) being
+# known scratchpad nouns and (b) ending with label punctuation (``:``).
+#
+# Excluded — common direct-answer phrasings (would clobber valid
+# answers if the model said them with ``enable_thinking=False`` or
+# without ``enable_thinking`` set):
+#   * ``Let me think…`` / ``I need to analyze…`` (codex r1 BLOCKING)
+#   * Bare ``Step by step:`` / ``Step-by-step:`` (codex r2 BLOCKING)
+#   * Bare ``thinking:`` (``Here's my thinking: …``) — the broader
+#     ``thinking(?:\s+process)?`` form generated false positives on
+#     direct answers (codex r3 BLOCKING)
+#   * Bare ``reasoning:`` / ``reasoning process:`` (``Here's my
+#     reasoning: …``) — ``reasoning`` alone is a very common direct-
+#     answer opener and many legacy callers default to
+#     ``enable_thinking=None``; firing on this label clobbers valid
+#     responses on the most common code path (codex r4 BLOCKING).
+#     ``thinking process``, ``thought process``, ``chain-of-thought``,
+#     and ``scratchpad`` survive because they are scratchpad-shaped
+#     in a way ``reasoning`` is not.
+#
 # Match anchored at ``^\s*`` so a normal answer that merely mentions
 # a scratchpad noun mid-response is not reclassified.
 _BARE_THINK_PREFIX_RE = re.compile(
     r"^(?:\s*)"  # leading whitespace from the injected ``<think>\n``
     r"(?:"
-    # "Here's a thinking process:" / "Here is the reasoning:" / etc.
+    # "Here's a thinking process:" / "Here's the thought process:" /
+    # "Here is the chain-of-thought:" / "Here's the scratchpad:".
     # Must end with ``:`` to ensure it's a scratchpad label, not a
-    # casual answer like "Here is the answer: ...". ``thinking``
-    # alone is excluded because ``Here's my thinking:`` is normal
-    # phrasing — only ``thinking process`` is the scratchpad form
-    # (codex r3 BLOCKING).
+    # casual answer like "Here is the answer: ...". ``reasoning``
+    # and ``reasoning process`` are deliberately NOT in this
+    # alternation — see the header comment for why.
     r"(?:Here(?:'s|\s+is)\s+(?:my\s+|a\s+|the\s+)?"
-    r"(?:thinking\s+process|reasoning|chain[-\s]of[-\s]thought|"
-    r"scratchpad|thought\s+process|reasoning\s+process)"
+    r"(?:thinking\s+process|chain[-\s]of[-\s]thought|"
+    r"scratchpad|thought\s+process)"
     r"\s*:)"
     # "Thinking step by step:" / "Thinking out loud:" / etc. — only
     # the labelled scratchpad form (terminating ``:`` required).
@@ -65,9 +71,12 @@ _BARE_THINK_PREFIX_RE = re.compile(
     # step-by-step" answers (tutorials, how-tos).
     r"|(?:Thinking\s+(?:step\s+by\s+step|out\s+loud|through(?:\s+this)?|"
     r"carefully|aloud)\s*:)"
-    # "My thought process:" / "My reasoning process:" — scratchpad
-    # label that requires ``:`` (e.g. NOT "My thought is that ...").
-    r"|(?:My\s+(?:thought|reasoning)\s+process\s*:)"
+    # "My thought process:" — scratchpad label that requires ``:``
+    # (e.g. NOT "My thought is that ..."). ``My reasoning process:``
+    # is excluded because the same ``reasoning`` over-broadening that
+    # bit the ``Here's`` alternation also bites here on the legacy
+    # ``enable_thinking=None`` path (codex r4 BLOCKING).
+    r"|(?:My\s+thought\s+process\s*:)"
     r")",
     re.IGNORECASE,
 )

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -48,6 +48,14 @@ from .think_parser import BaseThinkingReasoningParser
 #     ``thinking process``, ``thought process``, ``chain-of-thought``,
 #     and ``scratchpad`` survive because they are scratchpad-shaped
 #     in a way ``reasoning`` is not.
+#   * Verb-form ``Thinking step by step:`` / ``Thinking out loud:`` /
+#     ``Thinking through this:`` / ``Thinking carefully:`` /
+#     ``Thinking aloud:`` — these are conversational answer openers
+#     ("Thinking carefully: Portland is the safest option") and would
+#     misclassify when the caller defaults to ``enable_thinking=None``
+#     (codex r5 BLOCKING). The unambiguous scratchpad form is always
+#     ``Here's [my/a/the] <noun>:`` — the noun-led shape is what makes
+#     it scratchpad-shaped, the verb-led form is too conversational.
 #
 # Match anchored at ``^\s*`` so a normal answer that merely mentions
 # a scratchpad noun mid-response is not reclassified.
@@ -64,13 +72,6 @@ _BARE_THINK_PREFIX_RE = re.compile(
     r"(?:thinking\s+process|chain[-\s]of[-\s]thought|"
     r"scratchpad|thought\s+process)"
     r"\s*:)"
-    # "Thinking step by step:" / "Thinking out loud:" / etc. — only
-    # the labelled scratchpad form (terminating ``:`` required).
-    # The bare ``Step by step:`` / ``Step-by-step:`` form is excluded
-    # because it is the canonical heading for direct "explain
-    # step-by-step" answers (tutorials, how-tos).
-    r"|(?:Thinking\s+(?:step\s+by\s+step|out\s+loud|through(?:\s+this)?|"
-    r"carefully|aloud)\s*:)"
     # "My thought process:" — scratchpad label that requires ``:``
     # (e.g. NOT "My thought is that ..."). ``My reasoning process:``
     # is excluded because the same ``reasoning`` over-broadening that
@@ -138,7 +139,11 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     Example (bare-text thinking preamble, truncated before ``</think>``):
         Input: "Here's a thinking process:\n\n1. Analyze the request..."
         Output: reasoning="Here's a thinking process:\n\n1. Analyze...",
-                content=None
+                content=""  # empty-string sentinel, not None — the
+                            # upstream ``_finalize_content_and_reasoning``
+                            # only blanks ``cleaned_text`` when content
+                            # is explicitly ``""``; ``None`` would let
+                            # the raw preamble fall through to the client.
     """
 
     @property

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -9,8 +9,69 @@ Supports implicit reasoning mode where <think> is injected in the prompt
 by AI agents (e.g., OpenCode) and only </think> appears in the output.
 """
 
+import re
+
 from .base import DeltaMessage
 from .think_parser import BaseThinkingReasoningParser
+
+# Bare-text "thinking process" prefix patterns.
+#
+# Qwen3 chat templates inject ``<think>\n`` after the assistant generation
+# marker when ``enable_thinking=True`` — putting the model in implicit-think
+# mode. The model is supposed to emit its chain-of-thought followed by
+# ``</think>`` and then the user-facing answer. In practice the model
+# sometimes restates the channel boundary inline as a bare-text prefix
+# like ``Here's a thinking process:\n\n1. **Analyze...`` (the same shape
+# Gemini / older Anthropic models use). When that happens and the model
+# also runs out of ``max_tokens`` before producing ``</think>``, the
+# entire output is reasoning preamble but neither tag is in the output
+# string — so the default "no end token, no start token" branch routes
+# the whole thing into ``content`` and ``reasoning_content`` stays empty.
+#
+# Scoped narrowly to **explicit scratchpad labels** — phrases that are
+# overwhelmingly unambiguous chain-of-thought preambles, identified by
+# (a) being known scratchpad nouns (``thinking process``, ``reasoning``,
+# ``chain-of-thought``, ``scratchpad``, ``analysis``, ``thought
+# process``) and (b) ending with a label punctuation (``:`` / newline
+# pair).  Conversational phrases like ``Let me think...`` or ``I need
+# to analyze...`` are NOT matched — they are common openers for direct
+# answers and would be misclassified when ``enable_thinking=False``
+# (codex r1 BLOCKING).  Match anchored at ``^\s*`` so a normal answer
+# that merely mentions a scratchpad noun mid-response is not
+# reclassified.
+_BARE_THINK_PREFIX_RE = re.compile(
+    r"^(?:\s*)"  # leading whitespace from the injected ``<think>\n``
+    r"(?:"
+    # "Here's a thinking process:" / "Here is the reasoning:" / etc.
+    # Must end with ``:`` to ensure it's a scratchpad label, not a
+    # casual answer like "Here is the answer: ...".
+    r"(?:Here(?:'s|\s+is)\s+(?:my\s+|a\s+|the\s+)?"
+    r"(?:thinking(?:\s+process)?|reasoning|chain[-\s]of[-\s]thought|"
+    r"scratchpad|thought\s+process|reasoning\s+process)"
+    r"\s*:)"
+    # "Thinking step by step:" / "Thinking out loud:" / etc. — only
+    # the labelled scratchpad form (terminating ``:`` required).
+    r"|(?:Thinking\s+(?:step\s+by\s+step|out\s+loud|through(?:\s+this)?|"
+    r"carefully|aloud)\s*:)"
+    r"|(?:(?:Step\s+by\s+step|Step-by-step)\s*:)"
+    # "My thought process:" / "My reasoning process:" — scratchpad
+    # label that requires ``:`` (e.g. NOT "My thought is that ...").
+    r"|(?:My\s+(?:thought|reasoning)\s+process\s*:)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_bare_think_preamble(text: str) -> bool:
+    """Return True when ``text`` starts with a known bare-text thinking marker.
+
+    Used as a fallback signal when ``<think>`` was injected by the chat
+    template into the prompt (so it is absent from the model output) and
+    the model never emitted ``</think>`` before being truncated.
+    """
+    if not text:
+        return False
+    return _BARE_THINK_PREFIX_RE.match(text) is not None
 
 
 class Qwen3ReasoningParser(BaseThinkingReasoningParser):
@@ -31,6 +92,11 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     Example (think in prompt):
         Input: "Let me analyze this...</think>The answer is 42."
         Output: reasoning="Let me analyze this...", content="The answer is 42."
+
+    Example (bare-text thinking preamble, truncated before ``</think>``):
+        Input: "Here's a thinking process:\n\n1. Analyze the request..."
+        Output: reasoning="Here's a thinking process:\n\n1. Analyze...",
+                content=None
     """
 
     @property
@@ -84,6 +150,28 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             # doesn't leak a wall of meta-cognition to the client.
             if enable_thinking is True:
                 return model_output.strip() or None, None
+            # #570 bare-text fallback: even without the explicit
+            # ``enable_thinking=True`` signal (e.g. when callers leave
+            # the kwarg defaulted), the chat template still injects
+            # ``<think>\n`` for Qwen3 thinking models. If the output
+            # opens with a recognizable bare-text thinking marker
+            # (``Here's a thinking process:``, ``Step by step:``, …),
+            # treat the whole output as reasoning so it surfaces in
+            # ``reasoning_content`` instead of leaking into ``content``.
+            # This mirrors the streaming path which already routes
+            # pre-tag text to reasoning while ``</think>`` has not yet
+            # been seen.
+            #
+            # Return ``""`` (not ``None``) for content so the upstream
+            # ``_finalize_content_and_reasoning`` overwrites
+            # ``cleaned_text`` — the explicit ``<think>...</think>``
+            # path relies on ``strip_thinking_tags`` to collapse tagged
+            # reasoning to empty downstream, but bare-text reasoning
+            # has no tag to strip, so the parser must signal "no
+            # content" explicitly here or the original raw output
+            # would leak through to the client.
+            if _looks_like_bare_think_preamble(model_output):
+                return model_output.strip() or None, ""
             # No think tags at all — pure content
             return None, model_output
 
@@ -123,6 +211,17 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             cleaned = accumulated_text
             if cleaned.startswith(self.start_token):
                 cleaned = cleaned[len(self.start_token) :]
-            if cleaned:
-                return DeltaMessage(content=cleaned)
+            if not cleaned:
+                return None
+            # Bare-text thinking fallback (mirrors ``extract_reasoning``):
+            # when the chat template injects ``<think>`` and the model is
+            # truncated mid-thought before producing ``</think>``, the
+            # accumulated text opens with a bare-text "thinking process"
+            # preamble. The streaming Case-3 default would surface that
+            # preamble as ``content``; keep it in ``reasoning`` instead so
+            # OpenAI-compatible clients can distinguish chain-of-thought
+            # leakage from the final answer. (Issue #570.)
+            if _looks_like_bare_think_preamble(cleaned):
+                return DeltaMessage(reasoning=cleaned)
+            return DeltaMessage(content=cleaned)
         return None


### PR DESCRIPTION
## Summary

Closes #570.

`Qwen3ReasoningParser` now recognises bare-text "thinking process" preambles at the start of an assistant turn and routes them to `reasoning_content` instead of letting them leak into the user-facing `content` field.

## Root cause

Qwen3 chat templates inject `<think>\n` after the assistant generation marker when `enable_thinking=True`, putting the model in **implicit-think mode** — the model is supposed to emit its chain-of-thought followed by `</think>` and then the user-facing answer.

In practice the model occasionally restates the channel boundary inline with a bare-text preamble like:

```
Here's a thinking process:

1.  **Analyze User Input:**
   - **Route:** Seattle to San Diego
2.  **Evaluate Each Option:**
   - Portland, OR: World-renowned food scene.
```

When the request also runs out of `max_tokens` before the model reaches `</think>`, neither tag appears anywhere in the model output. The previous `Qwen3ReasoningParser.extract_reasoning` "no end token, no start token" branch then returned `(None, model_output)` — routing the whole chain-of-thought into the user-facing `content` field while `reasoning_content` stayed empty. Any OpenAI-compatible client consuming `/v1/chat/completions` saw raw reasoning leak into the answer.

The bug reproduces both on multi-turn and single-turn prompts; the trigger is "model emits bare-text thinking preamble AND output is truncated before `</think>`", which becomes more likely as conversation length and `max_tokens` interact.

## Fix

Extend `Qwen3ReasoningParser` to recognise bare-text "thinking process" preambles and route them to `reasoning_content` with `cleaned_text` cleared. Applies to both non-streaming `extract_reasoning` and the `finalize_streaming` correction path — matching the existing streaming heuristic in `BaseThinkingReasoningParser` that already routes pre-tag text to reasoning while `</think>` has not yet been seen.

The regex is **scoped narrowly to explicit scratchpad labels** — preambles that end with `:` and use known scratchpad nouns. Conversational openers (`Let me think...`, `I need to analyze...`, `I'll analyze...`) are deliberately NOT matched: they are common direct-answer phrasings when `enable_thinking=False`, and matching them would blank out valid responses.

Recognised preambles (matched at `^\s*`, case-insensitive, all require terminating `:`):

- `Here's a thinking process:`, `Here is my reasoning:`, `Here's the chain-of-thought:`, `Here is the scratchpad:`, `Here's the thought process:`, `Here is the reasoning process:`
- `Thinking step by step:`, `Thinking out loud:`, `Thinking through this:`, `Thinking carefully:`, `Thinking aloud:`
- `Step by step:` / `Step-by-step:`
- `My thought process:` / `My reasoning process:`

## Why server-side is the right layer

Two alternative paths were considered:

1. **Patch the chat template** to keep `<think>` open across continuation turns. The chat template is owned by the upstream HF tokenizer config (Qwen3.6-A3B), so we'd have to maintain a local override; any HF refresh would silently revert the fix. Captured for future upstream contribution; not blocked on it.
2. **Inject `<think>` server-side at the prompt boundary.** Would mask the symptom but bare-text preambles also occur in single-turn prompts (the trigger is "truncated before `</think>`", not "continuation turn"). Server-side parser remains the right place to be defensive.

## Regression coverage

- `tests/test_reasoning_parsers.py::TestQwen3` — bare-text-fallback positive cases (12 explicit-label variants), the explicit-tag passthrough, the streaming finalizer behavior, and a dedicated `test_ambiguous_phrases_not_misclassified` negative test that pins the conservative scope (9 conversational openers that must stay as `content`).
- `tests/test_chat_route_tool_tag_leak.py::TestBareThinkingProcessLeakRegression` — drives the real `_finalize_content_and_reasoning` orchestration used by `/v1/chat/completions`, including the exact text captured from a failing request against `qwen3.6-35b-4bit`.

## Scope

- No version bump (parser fix; release SOP 11-gate walk happens at the next bundled cut).
- Diff limited to one parser file + two test files (+335 / -2).
- No alias changes, no template changes, no upstream pin changes.

## Test plan

- [x] `python3.12 -m pytest tests/test_reasoning_parsers.py tests/test_chat_route_tool_tag_leak.py` — 142 passed
- [x] Broader sweep: `python3.12 -m pytest tests/ -k "reason or qwen or think or finalize or tool_tag" --ignore=tests/integrations --ignore=tests/test_streaming_simulator.py` — 1003 passed
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] Direct verification on the captured failing payload via `_finalize_content_and_reasoning` — `reasoning_content` populates with the chain-of-thought, `content` clears