### PR TITLE
chore: bump version to 0.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.5"
+version = "0.7.6"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Two ship-quality fixes since 0.7.5:

- **#575 / PR #576** — Qwen3 thinking-ON non-stream leak (parser Case-4
  fallback). Chat-template-injected `<think>` + truncated mid-thought
  response no longer leaks the entire thought trace into `content`.
  Streaming path was already symmetric; non-streaming now matches.

- **PR #577** — Vendor extensions on `/v1/models`. Curated
  `recommended_sampling`, `is_hybrid`, `is_moe`, `tool_call_parser`,
  `reasoning_parser`, `modality` flow from the `AliasProfile` SSOT to
  any client that asks. OpenAI-only clients ignore the extra keys per
  spec; rapid-desktop 0.5.20 reads them to bootstrap sliders.

## Test plan

- [x] `make smoke` lint + audit pass; unit suite has 5 pre-existing
      `test_tool_call_e2e.py` failures caused by a running auth-on
      Qwen3.5-4B server on localhost:8000 — unrelated to either of the
      merged PRs and verified by repro on PR HEAD pre-changes
      (see codex review note on #576)
- [x] Targeted regression (356 tests):
      `pytest test_reasoning_parsers test_routes test_chat_template_kwargs
      test_chat_route_tool_tag_leak test_chat_route_tool_choice_enforcement
      test_finalize_harmony_raw_text test_anthropic_route_streaming
      test_engine_router_non_stream test_streaming_think_router test_output_router`
- [x] PR #576 + PR #577 CI green individually
- [x] release-preflight.yml gates G1 + G10 + G11 + preflight-summary
      all PASS on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)