### PR TITLE
fix(mistral): stream [ARGS] tool calls without garbling (#579)

### DIFF
--- a/tests/parsers/regressions/test_issue_579_mistral_args_streaming.py
+++ b/tests/parsers/regressions/test_issue_579_mistral_args_streaming.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard for #579 — Mistral ``[ARGS]`` streaming tool-call leak.
+
+Wire format: ``[TOOL_CALLS]<name>[ARGS]{json}`` (Devstral-Small-2 /
+Mistral >= v11). Reported on rapid-mlx 0.7.6, model
+``mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit``, served with
+``--enable-auto-tool-choice --tool-call-parser mistral``.
+
+Symptom: **non-streaming** parsing is correct, but **streaming** garbles
+every tool call. The old ``extract_tool_calls_streaming`` parsed each token
+delta in isolation; the ``[ARGS]`` separator (which starts with ``[``) fell
+into the "arguments continuation" branch and leaked into the body, while the
+name was reconstructed from stray fragments. The assembled stream came out as
+``name='"}'``, ``arguments='[ARGS]{"'``, ``id=''`` — so OpenAI clients
+received ``arguments: []`` and aborted (e.g. agentic coders:
+``Validation failed for tool "read": root: must be object``).
+
+Fix: the streaming path now re-parses the full accumulated text with the
+(working) non-streaming ``extract_tool_calls`` and emits each call once its
+arguments are complete JSON — guaranteeing stream ↔ non-stream parity.
+
+Convention mirrors the other regression guards in this directory: each case
+states the wire format up front and drives the *incremental* streaming entry
+point the way ``service/postprocessor.py`` does (per-delta, with the full
+accumulated text), not just ``finalize()``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers import ToolParserManager
+
+
+def _assemble_stream(parser, chunks: list[str]) -> list[dict]:
+    """Drive ``extract_tool_calls_streaming`` exactly like the postprocessor.
+
+    Feeds ``chunks`` one at a time with (previous_text, current_text,
+    delta_text) and merges the emitted ``tool_calls`` deltas on ``index``
+    (the OpenAI streaming contract), concatenating ``arguments`` fragments.
+    Returns the assembled tool calls as ``{index, id, name, arguments}``.
+    """
+    parser.reset()
+    merged: dict[int, dict] = {}
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        result = parser.extract_tool_calls_streaming(previous, current, chunk)
+        previous = current
+        if not result or "tool_calls" not in result:
+            continue
+        for delta in result["tool_calls"]:
+            idx = delta["index"]
+            slot = merged.setdefault(
+                idx, {"index": idx, "id": "", "name": "", "arguments": ""}
+            )
+            if delta.get("id"):
+                slot["id"] = delta["id"]
+            fn = delta.get("function", {})
+            if fn.get("name"):
+                slot["name"] = fn["name"]
+            if fn.get("arguments"):
+                slot["arguments"] += fn["arguments"]
+    return [merged[i] for i in sorted(merged)]
+
+
+def _norm(calls: list[dict]) -> list[tuple[str, dict]]:
+    return [(c["name"], json.loads(c["arguments"])) for c in calls]
+
+
+@pytest.fixture
+def parser():
+    return ToolParserManager.get_tool_parser("mistral")(None)
+
+
+def test_single_args_call_streams_intact(parser):
+    # [ARGS] arrives as its own chunk and the JSON body is split — the exact
+    # boundary the old per-delta parser mangled.
+    chunks = [
+        "[TOOL_CALLS]",
+        "read",
+        "[ARGS]",
+        '{"file_path":',
+        ' "/tmp/foo',
+        '.txt"}',
+    ]
+    assert _norm(_assemble_stream(parser, chunks)) == [
+        ("read", {"file_path": "/tmp/foo.txt"})
+    ]
+
+
+def test_args_token_never_leaks_into_name_or_arguments(parser):
+    calls = _assemble_stream(
+        parser,
+        ["[TOOL_CALLS]", "get_weather", "[ARGS]", '{"city": "Milan"}'],
+    )
+    assert len(calls) == 1
+    assert calls[0]["name"] == "get_weather"
+    assert "[ARGS]" not in calls[0]["name"]
+    assert "[ARGS]" not in calls[0]["arguments"]
+    assert json.loads(calls[0]["arguments"]) == {"city": "Milan"}
+
+
+def test_multiple_args_calls_stream_intact(parser):
+    chunks = [
+        "[TOOL_CALLS]",
+        "read",
+        "[ARGS]",
+        '{"file_path": "a.txt"}',
+        "[TOOL_CALLS]",
+        "read",
+        "[ARGS]",
+        '{"file_path": ',
+        '"b.txt"}',
+    ]
+    assert _norm(_assemble_stream(parser, chunks)) == [
+        ("read", {"file_path": "a.txt"}),
+        ("read", {"file_path": "b.txt"}),
+    ]
+
+
+def test_leading_content_emitted_before_tool_call(parser):
+    parser.reset()
+    contents, previous = [], ""
+    for chunk in ["Sure!", "[TOOL_CALLS]", "read", "[ARGS]", '{"file_path": "x"}']:
+        current = previous + chunk
+        result = parser.extract_tool_calls_streaming(previous, current, chunk)
+        previous = current
+        if result and result.get("content"):
+            contents.append(result["content"])
+    assert "".join(contents) == "Sure!"
+
+
+def test_stream_matches_nonstream(parser):
+    """The parity invariant this bug violated: streamed == non-streamed."""
+    full = '[TOOL_CALLS]search[ARGS]{"q": "mlx", "k": 5}'
+    # The tokenizer emits [TOOL_CALLS]/[ARGS] as atomic special tokens; feed
+    # them whole and split only the JSON body across deltas.
+    stream = _norm(
+        _assemble_stream(
+            parser, ["[TOOL_CALLS]", "search", "[ARGS]", '{"q": "mlx", ', '"k": 5}']
+        )
+    )
+    ns = parser.extract_tool_calls(full)
+    nonstream = [(tc["name"], json.loads(tc["arguments"])) for tc in ns.tool_calls]
+    assert ns.tools_called is True
+    assert stream == nonstream == [("search", {"q": "mlx", "k": 5})]

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -177,6 +177,14 @@ PARITY_FIXTURES: list = [
         ),
         [("read_file", {"path": "/etc/hostname"})],
     ),
+    # mistral — Devstral / Mistral >= v11 [TOOL_CALLS]name[ARGS]{json} form
+    # (the #579 streaming-leak repro; non-stream already recovered it).
+    (
+        "mistral",
+        "mistral_tool_calls",
+        '[TOOL_CALLS]read_file[ARGS]{"path":"/etc/hostname"}',
+        [("read_file", {"path": "/etc/hostname"})],
+    ),
 ]
 
 
@@ -209,7 +217,6 @@ _PARITY_COVERAGE_EXEMPT: dict[str, str] = {
     "llama4": "alias of llama",
     "minimax": "TODO: add MiniMax M2/M2.5 wire-format fixture",
     "minimax_m2": "alias of minimax",
-    "mistral": "TODO: add Mistral [TOOL_CALLS] wire-format fixture",
     "nemotron": "TODO: add Nemotron wire-format fixture",
     "nemotron3": "alias of nemotron",
     "kimi": "TODO: add Kimi K2 wire-format fixture",

--- a/tests/test_tool_injection.py
+++ b/tests/test_tool_injection.py
@@ -2,6 +2,7 @@
 """Tests for tool injection fallback when chat templates reject tools param."""
 
 import copy
+import json
 
 from vllm_mlx.utils.chat_template import (
     _build_tool_injection_text,
@@ -227,9 +228,16 @@ class TestMistralArgsStripping:
         assert result.tool_calls[0]["name"] == "get_weather"
 
     def test_args_suffix_stripped_streaming(self):
+        # Streaming now re-parses the full accumulated text via
+        # extract_tool_calls (see #579), so [ARGS] is stripped through the
+        # public streaming entry point rather than a per-delta helper.
         parser = MistralToolParser(tokenizer=None)
-        delta = parser._parse_streaming_tool_delta(
-            'get_weather[ARGS]{"location": "Paris"}'
-        )
-        assert delta is not None
-        assert delta["name"] == "get_weather"
+        parser.reset()
+        text = '[TOOL_CALLS]get_weather[ARGS]{"location": "Paris"}'
+        result = parser.extract_tool_calls_streaming("", text, text)
+        assert result is not None
+        assert "tool_calls" in result
+        fn = result["tool_calls"][0]["function"]
+        assert fn["name"] == "get_weather"
+        assert "[ARGS]" not in fn["name"]
+        assert json.loads(fn["arguments"]) == {"location": "Paris"}

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -59,6 +59,13 @@ class MistralToolParser(ToolParser):
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
         self.bot_token_id = self.vocab.get(self.BOT_TOKEN) if self.vocab else None
+        # Number of complete tool calls already emitted on the streaming path.
+        self.streamed_tool_call_count: int = 0
+
+    def reset(self) -> None:
+        """Reset parser state for a new request (streaming counters too)."""
+        super().reset()
+        self.streamed_tool_call_count = 0
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -184,80 +191,58 @@ class MistralToolParser(ToolParser):
         """
         Extract tool calls from streaming Mistral model output.
 
-        For streaming, we detect when [TOOL_CALLS] appears and start
-        accumulating tool call data.
+        Rather than parse each token delta in isolation — which can't
+        reliably reconstruct ``[TOOL_CALLS]name[ARGS]{json}`` once the
+        ``[ARGS]`` separator or the JSON body is split across arbitrary
+        token boundaries (issue #579) — we re-parse the full accumulated
+        text with the non-streaming :meth:`extract_tool_calls` (the single
+        source of truth) and emit each tool call exactly once, the moment
+        its arguments form complete JSON. This guarantees stream ↔
+        non-stream parity by construction.
         """
-        # Check if tool call token is in current output
+        # No tool call marker yet → plain content delta.
         if self.BOT_TOKEN not in current_text:
-            # Not a tool call yet, return content delta
             return {"content": delta_text}
 
-        # Tool call detected
-        if self.BOT_TOKEN in delta_text:
-            # This delta contains the start of tool calls
-            parts = delta_text.split(self.BOT_TOKEN)
-            content_part = parts[0]
-            tool_part = self.BOT_TOKEN.join(parts[1:])
+        result: dict[str, Any] = {}
 
-            result: dict[str, Any] = {}
-            if content_part:
-                result["content"] = content_part
+        # Emit any content that preceded the marker, once, on the delta
+        # where the marker first appears.
+        if self.BOT_TOKEN not in previous_text:
+            leading = delta_text.split(self.BOT_TOKEN, 1)[0]
+            if leading:
+                result["content"] = leading
 
-            # Start tracking tool call
-            self.current_tool_id += 1
+        # Re-parse everything accumulated so far and keep only the tool
+        # calls whose arguments are complete, parseable JSON. A call still
+        # mid-stream has a truncated body and is skipped until it closes.
+        parsed = self.extract_tool_calls(current_text)
+        complete: list[dict[str, Any]] = []
+        for tool_call in parsed.tool_calls:
+            args = tool_call.get("arguments")
+            try:
+                json.loads(args)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            complete.append(tool_call)
 
-            if tool_part:
-                # Try to parse the tool part
-                tool_delta = self._parse_streaming_tool_delta(tool_part)
-                if tool_delta:
-                    result["tool_calls"] = [
-                        {
-                            "index": self.current_tool_id,
-                            "id": generate_mistral_tool_id(),
-                            "type": "function",
-                            "function": tool_delta,
-                        }
-                    ]
+        # Emit only newly completed calls (those past what we've streamed).
+        new_calls = complete[self.streamed_tool_call_count :]
+        if new_calls:
+            deltas = []
+            for offset, tool_call in enumerate(new_calls):
+                deltas.append(
+                    {
+                        "index": self.streamed_tool_call_count + offset,
+                        "id": tool_call.get("id") or generate_mistral_tool_id(),
+                        "type": "function",
+                        "function": {
+                            "name": tool_call["name"],
+                            "arguments": tool_call["arguments"],
+                        },
+                    }
+                )
+            self.streamed_tool_call_count += len(new_calls)
+            result["tool_calls"] = deltas
 
-            return result if result else None
-
-        # We're in the middle of a tool call
-        if self.current_tool_id >= 0:
-            tool_delta = self._parse_streaming_tool_delta(delta_text)
-            if tool_delta:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": self.current_tool_id,
-                            "type": "function",
-                            "function": tool_delta,
-                        }
-                    ]
-                }
-
-        return None
-
-    def _parse_streaming_tool_delta(self, text: str) -> dict[str, str] | None:
-        """Parse a streaming delta for tool call information."""
-        if not text:
-            return None
-
-        result: dict[str, str] = {}
-
-        # Check for function name (before {)
-        # Strip [ARGS] suffix emitted by Devstral models.
-        if "{" in text:
-            name_part = text[: text.find("{")]
-            args_part = text[text.find("{") :]
-            if name_part.strip():
-                result["name"] = name_part.replace("[ARGS]", "").strip()
-            if args_part:
-                result["arguments"] = args_part
-        else:
-            # Could be name or arguments continuation
-            if text.strip() and not text.startswith(("{", "}", "[", "]", ",")):
-                result["name"] = text.strip()
-            else:
-                result["arguments"] = text
-
-        return result if result else None
+        return result or None


### PR DESCRIPTION
## What does this PR do?

Fixes streaming tool-call extraction for the Mistral parser on the
Devstral / Mistral >= v11 wire format `[TOOL_CALLS]<name>[ARGS]{json}`.

`extract_tool_calls_streaming` parsed each token delta in isolation, so once
the `[ARGS]` separator or the JSON body was split across token boundaries the
output garbled: `[ARGS]` (it opens with `[`) fell into the "arguments
continuation" branch and leaked into the body, while the name was rebuilt from
stray fragments — assembled deltas came out as `name='"}'`,
`arguments='[ARGS]{"'`, `id=''`. Non-streaming (`extract_tool_calls`) was
already correct.

The fix makes the streaming path re-parse the **full accumulated text** with
the non-streaming `extract_tool_calls` (single source of truth) and emit each
tool call exactly once, the moment its arguments are complete JSON. This makes
stream ↔ non-stream parity hold by construction. The now-unused
`_parse_streaming_tool_delta` helper is removed.

## Why is this needed?

Fixes #579. On `stream: true`, every Devstral tool call reaches OpenAI-compatible
clients with empty/invalid arguments (`arguments: []`), so they abort — e.g.
agentic coders fail with `Validation failed for tool "read": root: must be
object`. Devstral tool calling is effectively unusable over streaming (which is
the default for most clients). Non-streaming users are unaffected; this restores
parity.

## AI assistance disclosure

AI-assisted (Claude / Opus). The AI diagnosed the bug from a live repro,
wrote the implementation in `vllm_mlx/tool_parsers/mistral_tool_parser.py`, the
new regression test, the parity fixture, and the updated unit test. I verified:

- Reproduced the original bug live against rapid-mlx 0.7.6 + Devstral
  (`mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit`): non-streaming
  returns a correct `{"name":"read","arguments":"{...}"}`; streaming returns
  `name='"}'` / `arguments='[ARGS]{"'`.
- Confirmed the regression test **fails on the pre-fix parser** (4/5 cases) and
  passes on the fix, so it genuinely guards the behavior.
- Ran the targeted parser/tool suites (see test plan) — all green; reviewed the
  diff line by line and can explain the intent, risk, and behavior of every
  change.

## Test plan

- `tests/parsers/regressions/test_issue_579_mistral_args_streaming.py` (new) —
  drives the **incremental** streaming entry point the way
  `service/postprocessor.py` does (per-delta, `[ARGS]` as its own chunk, JSON
  split across deltas); covers single call, multi call, leading content, and
  stream↔non-stream parity. Verified it fails on the old parser.
- `tests/test_tool_call_streaming_parity.py` — added the mistral
  `[TOOL_CALLS]...[ARGS]{...}` fixture and removed the matching
  `_PARITY_COVERAGE_EXEMPT` TODO entry.
- `tests/test_tool_injection.py::TestMistralArgsStripping` — updated
  `test_args_suffix_stripped_streaming` to the public streaming API (the private
  helper it called was removed); class passes.
- `ruff check` + `ruff format --check` clean on all changed files.
- Ran `pytest tests/test_tool_injection.py tests/parsers/regressions/test_issue_579_mistral_args_streaming.py tests/test_tool_call_streaming_parity.py tests/test_tool_parsers.py tests/test_tool_parser_wire_formats.py tests/test_native_tool_format.py tests/test_tool_parser_coverage.py` → **208 passed**.
- Note: I ran on a borrowed venv without `pytest-asyncio` / `aiohttp` / a loaded
  model, so the full suite's async + `test_tool_call_e2e.py` + bench tests error
  on **`main` too** (verified against a clean `HEAD` worktree) — pre-existing /
  environmental, unrelated to this change. Happy for maintainers to run
  `pr_validate` full/stress on merge.

## Checklist

- [x] Tests pass locally (targeted parser/tool suites — 208 passed; see note re: env-only failures)
- [x] Lint passes (`ruff check && ruff format --check`)
- [ ] Self-validated with `scripts.pr_validate.pr_validate` — not run (borrowed env lacks async/bench deps + DeepSeek key; ran the non-negotiable `lint` + targeted tests manually)
- [x] New tests on a critical path (parser) spot-checked to fail when the production line is broken (regression test fails on the pre-fix parser)
- [ ] Updated README/docs if applicable (n/a — no API/behavior surface change beyond the bugfix)
- [x] No breaking changes to existing API
