### PR TITLE
fix(community-bench): unblock bench --submit on M3 Ultra (alias guard + stream + drain)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.7"
+version = "0.7.8"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -1464,3 +1464,90 @@ def test_run_one_round_rejects_eos_early_stop(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="generated 3 tokens"):
         asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# _run_submit_flow alias-key gate
+# ---------------------------------------------------------------------------
+
+
+def test_submit_flow_guard_consults_original_alias(monkeypatch, capsys) -> None:
+    """The CLI dispatcher mutates ``args.model`` to the resolved HF path
+    *before* calling ``_run_submit_flow``, then stashes the user-typed
+    alias on ``args._original_alias``. The whitelist gate must read that
+    stash, not ``args.model`` — otherwise every alias submission fails
+    with a spurious "not the canonical alias key" error even when the
+    contributor did type the canonical alias.
+
+    Regression test for the v0.7.7 bench --submit failure on
+    llama3-1b-4bit (the resolved HF path
+    ``mlx-community/Llama-3.2-1B-Instruct-4bit`` tripped the ``"/" in
+    args.model`` branch).
+    """
+    from argparse import Namespace
+
+    from vllm_mlx import cli as cli_mod
+    from vllm_mlx.community_bench import hardware as hw
+
+    # Pretend we're on Apple Silicon so the gate above this one passes.
+    # ``is_apple_silicon`` is imported inside _run_submit_flow, so we
+    # patch the source module.
+    monkeypatch.setattr(hw, "is_apple_silicon", lambda: True)
+
+    args = Namespace(
+        model="mlx-community/Llama-3.2-1B-Instruct-4bit",
+        _original_alias="llama3-1b-4bit",
+        notes=None,
+        sampled=False,
+        repo_root=None,
+        force_disk_check=False,
+    )
+
+    # We expect the flow to get past the guard and fail later — capture
+    # whatever happens by intercepting the next stage. The simplest probe
+    # is to swap ``_check_disk_space`` with a sentinel that raises a
+    # known marker; if the guard fires first we never see the marker.
+    marker = RuntimeError("__past_guard__")
+
+    def _sentinel(*_a, **_kw):
+        raise marker
+
+    monkeypatch.setattr(cli_mod, "_check_disk_space", _sentinel)
+
+    with pytest.raises(RuntimeError, match="__past_guard__"):
+        cli_mod._run_submit_flow(args)
+
+    out = capsys.readouterr().out
+    # Sanity: the bogus "not the canonical alias key" branch should NOT
+    # have printed.
+    assert "not the resolved HF path" not in out
+    assert "Run `rapid-mlx models`" not in out
+
+
+def test_submit_flow_guard_rejects_hf_path_when_no_original_alias(
+    monkeypatch, capsys
+) -> None:
+    """When the user passes an HF path directly (no alias resolution
+    happens, so ``_original_alias`` is unset), the guard must still
+    reject it — that's the whole point of requiring canonical alias
+    keys."""
+    from argparse import Namespace
+
+    from vllm_mlx import cli as cli_mod
+    from vllm_mlx.community_bench import hardware as hw
+
+    monkeypatch.setattr(hw, "is_apple_silicon", lambda: True)
+
+    args = Namespace(
+        model="mlx-community/Llama-3.2-1B-Instruct-4bit",
+        notes=None,
+        sampled=False,
+        repo_root=None,
+        force_disk_check=False,
+    )
+
+    rc = cli_mod._run_submit_flow(args)
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "requires the canonical alias key" in out
+    assert "mlx-community/Llama-3.2-1B-Instruct-4bit" in out

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1211,11 +1211,32 @@ def _run_submit_flow(args) -> int:
         sampling_modes.append("sampled")
 
     async def _run() -> int:
+        import concurrent.futures
+
+        from .engine_core import _init_mlx_step_thread
+
+        # Load model on the future mlx-step worker thread (#170). mlx-lm
+        # 0.31.3+ binds module-level ``generation_stream`` and any
+        # auto-default stream to the thread that triggers them. If the
+        # model weights or ``mx.compile``-cached graphs are touched on
+        # the asyncio loop thread first, every later eval on the step
+        # worker raises "There is no Stream(gpu, N) in current thread."
+        # Spinning the worker BEFORE load and reusing it for
+        # AsyncEngineCore keeps every MLX op on a single owning thread.
+        # Mirrors the pattern in ``BatchedEngine._start_llm`` (which is
+        # why ``rapid-mlx serve`` works but the unfixed ``bench`` path
+        # doesn't).
         print(f"  Loading model {alias} ({hf_path})…")
+        model_load_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="mlx-step",
+            initializer=_init_mlx_step_thread,
+        )
         try:
-            model, tokenizer = load(hf_path)
+            model, tokenizer = model_load_executor.submit(load, hf_path).result()
         except (RepositoryNotFoundError, OSError) as e:
             print(f"  Error loading model: {e}")
+            model_load_executor.shutdown(wait=False)
             return 2
 
         # Standardized config: B=1, no batching, prefix-cache off so the
@@ -1245,7 +1266,12 @@ def _run_submit_flow(args) -> int:
         )
 
         repo_root = Path(args.repo_root) if args.repo_root else Path.cwd()
-        async with AsyncEngineCore(model, tokenizer, engine_config) as engine:
+        # Pass the EXISTING executor to AsyncEngineCore so the engine
+        # loop, BatchGenerator construction, and every forward pass run
+        # on the same thread that owns the model weights.
+        async with AsyncEngineCore(
+            model, tokenizer, engine_config, executor=model_load_executor
+        ) as engine:
             for mode in sampling_modes:
                 print(
                     f"  Running standardized bench "

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1149,28 +1149,31 @@ def _run_submit_flow(args) -> int:
     # Whitelist gate. ``model.alias`` in the payload is the bucketing
     # key, so we require the user to type the canonical alias *key*
     # rather than a raw HF path — accepting both forms would let a
-    # contributor's typo silently shift their submission into a different
-    # bucket via the reverse-lookup. (Codex PR #582 BLOCKING: silent
-    # alias coercion bypasses the intended "must be a whitelist key"
-    # contract.) The GHA validator re-checks the alias against
-    # aliases.json, so this guard is layered.
-    if "/" in args.model:
+    # contributor's typo silently shift their submission into a
+    # different bucket via the reverse-lookup. (Codex PR #582 BLOCKING:
+    # silent alias coercion bypasses the intended "must be a whitelist
+    # key" contract.) The GHA validator re-checks the alias against
+    # aliases.json, so this guard is layered. ``args._original_alias``
+    # holds the user-typed value before the dispatcher resolves it to
+    # an HF path; if it's None, the user passed an HF path directly.
+    user_typed = getattr(args, "_original_alias", None) or args.model
+    if "/" in user_typed:
         print(
             f"  Error: --submit requires the canonical alias key "
             f"(e.g. 'qwen3.5-9b-4bit'), not the resolved HF path "
-            f"'{args.model}'. Run `rapid-mlx models` for the whitelist."
+            f"'{user_typed}'. Run `rapid-mlx models` for the whitelist."
         )
         return 2
-    profile = resolve_profile(args.model)
+    profile = resolve_profile(user_typed)
     if profile is None:
         print(
-            f"  Error: '{args.model}' is not a registered alias. "
+            f"  Error: '{user_typed}' is not a registered alias. "
             f"Only models listed in vllm_mlx/aliases.json can be submitted "
             f"(this keeps the comparison apples-to-apples)."
         )
         print("  Run `rapid-mlx models` to see the full whitelist.")
         return 2
-    alias = args.model
+    alias = user_typed
     hf_path = profile.hf_path
 
     notes = args.notes or None

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1154,8 +1154,10 @@ def _run_submit_flow(args) -> int:
     # silent alias coercion bypasses the intended "must be a whitelist
     # key" contract.) The GHA validator re-checks the alias against
     # aliases.json, so this guard is layered. ``args._original_alias``
-    # holds the user-typed value before the dispatcher resolves it to
-    # an HF path; if it's None, the user passed an HF path directly.
+    # holds the user-typed value when the dispatcher resolved an alias
+    # to an HF path; if it's absent (HF path passed directly, or any
+    # other no-resolution case) we fall back to ``args.model``, which
+    # this guard then re-checks for the ``/`` HF-path signature.
     user_typed = getattr(args, "_original_alias", None) or args.model
     if "/" in user_typed:
         print(

--- a/vllm_mlx/community_bench/runner.py
+++ b/vllm_mlx/community_bench/runner.py
@@ -182,12 +182,21 @@ async def _run_one_round(
     last_output = None
 
     rid = await engine.add_request(prompt_text, sampling_params)
+    # NOTE: don't ``break`` mid-async-for. Breaking abandons the
+    # ``stream_outputs`` async generator before its ``finally`` block
+    # has a chance to ``_cleanup_request`` (which pops the request
+    # from ``self.scheduler.requests``). The cleanup then runs only at
+    # GC time — by which point ``_run_bucket`` has already looped back
+    # to the next round and ``add_request`` sees the old request still
+    # in-flight, tripping ``BackpressureError`` against the bench's
+    # tight ``max_concurrent_requests=1`` cap. Iterate to completion;
+    # ``stream_outputs`` exits cleanly after yielding the finished
+    # output (its own internal ``break`` on the finished sentinel
+    # routes through ``finally``).
     async for out in engine.stream_outputs(rid, timeout=180):
         if t_first_token is None and out.new_token_ids:
             t_first_token = time.perf_counter()
         last_output = out
-        if out.finished:
-            break
 
     t_end = time.perf_counter()
 


### PR DESCRIPTION
## Summary

Three sequential bugs were blocking `rapid-mlx bench --submit` end-to-end on Apple Silicon. This PR fixes all three so the first wave of self-tests can actually land.

### Bug 1 — alias guard wrong source of truth
`_run_submit_flow`'s whitelist gate was reading `args.model` after the dispatcher had already resolved it to the HF path. The dispatcher stashes the user-typed alias on `args._original_alias` BEFORE mutating `args.model`, so every legitimate alias submission tripped `"/" in args.model` with a spurious "not the canonical alias key" error. Fix reads `_original_alias` first; falls back to `args.model` only when no resolution happened (HF path passed directly, unknown no-slash input, etc.).

### Bug 2 — model loaded on wrong thread (mlx-lm 0.31.3 stream binding)
`_run()` was calling `load(hf_path)` on the asyncio main thread and then handing the model to a fresh `AsyncEngineCore` executor. mlx-lm 0.31.3+ binds module-level `generation_stream` and any auto-default stream to the thread that touched the model first, so every later eval on the engine's mlx-step worker crashed with `RuntimeError: There is no Stream(gpu, 0) in current thread.` Fix mirrors `BatchedEngine._start_llm`: spin a single-worker `ThreadPoolExecutor` with `_init_mlx_step_thread`, submit `load(hf_path)` through it, then pass the same executor to `AsyncEngineCore(..., executor=...)` so every MLX op runs on the thread that owns the weights.

### Bug 3 — backpressure race from generator abandonment
`_run_one_round` did `async for out in stream_outputs(...): if out.finished: break`. The `break` abandoned the async generator before its `finally` block ran — and the `finally` is what calls `_cleanup_request`, which pops the request from `scheduler.requests`. Against the bench's tight `max_concurrent_requests=1` cap, the next round's `add_request` then tripped `BackpressureError` against a request that was finished-but-not-evicted. Fix drops the consumer-side `break` — `stream_outputs` already breaks internally after yielding finished output, so the generator now ends cleanly through its `finally` and the next round gets a free slot.

### Verified

| Model            | Hardware              | Result                                         |
| ---------------- | --------------------- | ---------------------------------------------- |
| llama3-1b-4bit   | Apple M3 Ultra 256 GB | Past alias guard, short bucket runs cleanly; long bucket hits the codex-designed EOS-guard (1B-class models can emit EOS on random-token long prompts — separate, working as intended) |
| phi-4-mini-4bit  | Apple M3 Ultra 256 GB | **PASS**. short: decode=167.93 tok/s, prefill=2197.19 tok/s, ttft=240.3 ms. long: decode=159.76 tok/s, prefill=2278.37 tok/s, ttft=931.8 ms |

Bumps to v0.7.8 — 0.7.7 shipped Bug 1 (and Bugs 2/3 were latent because no one had run `bench --submit` end-to-end on a fresh mlx-lm 0.31.3 install).

## Codex review

Per-file codex review on the original `vllm_mlx/cli.py` diff returned no [BLOCKING] findings; two [NIT]s — comment precision (addressed) and an architectural observation about gate ordering (deferred).

## Test plan

- [x] `tests/test_community_bench.py` — 2 new tests for the alias guard (`test_submit_flow_guard_consults_original_alias`, `test_submit_flow_guard_rejects_hf_path_when_no_original_alias`); 54/54 pass.
- [x] Manual: `rapid-mlx bench llama3-1b-4bit --submit` reaches the engine + bench loop. (Validates Bug 1 + Bug 2; long bucket fails as designed on 1B-class models for a separate reason.)
- [x] Manual: `rapid-mlx bench phi-4-mini-4bit --submit` runs both buckets through to the consent prompt with valid decode/prefill numbers. (Validates Bug 1 + Bug 2 + Bug 3 together.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)