### PR TITLE
feat(routes): #549 POST /v1/responses (OpenAI Responses API) for Codex CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.9"
+version = "0.7.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for Responses-API-to-Chat-Completions adapter.
+
+Pure-logic tests for vllm_mlx/api/responses_adapter.py — no MLX
+dependency. Mirrors the test shape of test_anthropic_adapter.py.
+"""
+
+import json
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    FunctionCall,
+    PromptTokensDetails,
+    ToolCall,
+    Usage,
+)
+from vllm_mlx.api.responses_adapter import (
+    _convert_status,
+    _convert_text_format,
+    _convert_tool_choice,
+    _convert_tools,
+    openai_to_responses,
+    responses_to_openai,
+)
+from vllm_mlx.api.responses_models import (
+    ResponsesContentItem,
+    ResponsesInputItem,
+    ResponsesRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestConvertStatus:
+    def test_length_to_incomplete(self):
+        assert _convert_status("length") == "incomplete"
+
+    def test_stop_to_completed(self):
+        assert _convert_status("stop") == "completed"
+
+    def test_tool_calls_to_completed(self):
+        assert _convert_status("tool_calls") == "completed"
+
+    def test_none_to_completed(self):
+        assert _convert_status(None) == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Tool conversion (Responses-flat → Chat-nested)
+# ---------------------------------------------------------------------------
+
+
+class TestConvertTools:
+    def test_none_returns_none(self):
+        assert _convert_tools(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert _convert_tools([]) is None
+
+    def test_function_tool_flat_to_nested(self):
+        tools = _convert_tools(
+            [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ]
+        )
+        assert tools is not None and len(tools) == 1
+        td = tools[0]
+        assert td.type == "function"
+        assert td.function["name"] == "get_weather"
+        assert td.function["description"] == "Get weather"
+        assert td.function["parameters"]["properties"] == {"city": {"type": "string"}}
+
+    def test_drops_non_function_tools(self):
+        tools = _convert_tools(
+            [
+                {"type": "function", "name": "real_one"},
+                {"type": "web_search"},
+                {"type": "code_interpreter"},
+                {"type": "image_generation"},
+            ]
+        )
+        assert tools is not None and len(tools) == 1
+        assert tools[0].function["name"] == "real_one"
+
+    def test_drops_function_without_name(self):
+        tools = _convert_tools([{"type": "function", "description": "no name"}])
+        assert tools is None
+
+    def test_missing_parameters_defaults_to_empty_object_schema(self):
+        tools = _convert_tools([{"type": "function", "name": "minimal"}])
+        assert tools is not None and len(tools) == 1
+        assert tools[0].function["parameters"] == {"type": "object", "properties": {}}
+
+
+# ---------------------------------------------------------------------------
+# Tool-choice
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToolChoice:
+    def test_none(self):
+        assert _convert_tool_choice(None) is None
+
+    def test_strings_pass_through(self):
+        assert _convert_tool_choice("auto") == "auto"
+        assert _convert_tool_choice("none") == "none"
+        assert _convert_tool_choice("required") == "required"
+
+    def test_function_object_renested(self):
+        result = _convert_tool_choice({"type": "function", "name": "do_thing"})
+        assert result == {"type": "function", "function": {"name": "do_thing"}}
+
+    def test_unknown_object_returns_none(self):
+        assert _convert_tool_choice({"type": "wat"}) is None
+
+
+# ---------------------------------------------------------------------------
+# text.format → response_format
+# ---------------------------------------------------------------------------
+
+
+class TestConvertTextFormat:
+    def test_none_input(self):
+        assert _convert_text_format(None) is None
+
+    def test_no_format_key(self):
+        assert _convert_text_format({"verbosity": "medium"}) is None
+
+    def test_text_type_returns_none(self):
+        # We don't need response_format for plain text output.
+        assert _convert_text_format({"format": {"type": "text"}}) is None
+
+    def test_json_object(self):
+        result = _convert_text_format({"format": {"type": "json_object"}})
+        assert result is not None
+        assert result.type == "json_object"
+
+    def test_json_schema_plumbed_through(self):
+        result = _convert_text_format(
+            {
+                "format": {
+                    "type": "json_schema",
+                    "name": "Movie",
+                    "description": "A movie",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"title": {"type": "string"}},
+                    },
+                    "strict": True,
+                }
+            }
+        )
+        assert result is not None
+        assert result.type == "json_schema"
+        assert result.json_schema is not None
+        assert result.json_schema.name == "Movie"
+        assert result.json_schema.description == "A movie"
+        assert result.json_schema.schema_["properties"] == {"title": {"type": "string"}}
+        assert result.json_schema.strict is True
+
+    def test_json_schema_missing_schema_returns_none(self):
+        result = _convert_text_format(
+            {"format": {"type": "json_schema", "name": "Bad"}}
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# responses_to_openai — full request shape
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesToOpenai:
+    def test_bare_string_input_becomes_user_message(self):
+        req = ResponsesRequest(model="gpt-5", input="Hello world")
+        chat = responses_to_openai(req)
+        assert len(chat.messages) == 1
+        assert chat.messages[0].role == "user"
+        assert chat.messages[0].content == "Hello world"
+
+    def test_instructions_prepended_as_system(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            instructions="You are helpful.",
+            input="Hi",
+        )
+        chat = responses_to_openai(req)
+        assert chat.messages[0].role == "system"
+        assert chat.messages[0].content == "You are helpful."
+        assert chat.messages[1].role == "user"
+        assert chat.messages[1].content == "Hi"
+
+    def test_message_input_item(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[ResponsesContentItem(type="input_text", text="Hello")],
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert len(chat.messages) == 1
+        assert chat.messages[0].role == "user"
+        assert chat.messages[0].content == "Hello"
+
+    def test_message_input_joins_multiple_text_parts(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[
+                        ResponsesContentItem(type="input_text", text="line one"),
+                        ResponsesContentItem(type="input_text", text="line two"),
+                    ],
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert chat.messages[0].content == "line one\nline two"
+
+    def test_output_text_content_replays_assistant(self):
+        # Codex echoes prior assistant turns as type=message role=assistant
+        # with content=[{type:"output_text", text:"..."}].
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="assistant",
+                    content=[
+                        ResponsesContentItem(type="output_text", text="prior reply")
+                    ],
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert chat.messages[0].role == "assistant"
+        assert chat.messages[0].content == "prior reply"
+
+    def test_function_call_input_item_becomes_assistant_with_tool_calls(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="function_call",
+                    call_id="call_42",
+                    name="run_query",
+                    arguments='{"q":"weather"}',
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        msg = chat.messages[0]
+        assert msg.role == "assistant"
+        assert msg.tool_calls is not None and len(msg.tool_calls) == 1
+        tc = msg.tool_calls[0]
+        assert tc["id"] == "call_42"
+        assert tc["function"]["name"] == "run_query"
+        assert tc["function"]["arguments"] == '{"q":"weather"}'
+
+    def test_function_call_output_with_string_becomes_tool_message(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="function_call_output",
+                    call_id="call_42",
+                    output="sunny, 72F",
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        msg = chat.messages[0]
+        assert msg.role == "tool"
+        assert msg.content == "sunny, 72F"
+        assert msg.tool_call_id == "call_42"
+
+    def test_function_call_output_with_dict_serialized_to_json(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="function_call_output",
+                    call_id="call_99",
+                    output={"city": "SF", "temp_f": 64},
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        # Tool message content must be JSON when the original was structured.
+        assert json.loads(chat.messages[0].content) == {"city": "SF", "temp_f": 64}
+
+    def test_reasoning_items_dropped(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="reasoning",
+                    encrypted_content="opaque-blob-from-openai",
+                ),
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[ResponsesContentItem(type="input_text", text="Hi")],
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert len(chat.messages) == 1
+        assert chat.messages[0].content == "Hi"
+
+    def test_unknown_item_types_silently_dropped(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(type="local_shell_call"),
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[ResponsesContentItem(type="input_text", text="Hi")],
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert len(chat.messages) == 1
+
+    def test_sampling_fields_forwarded(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            temperature=0.42,
+            top_p=0.93,
+            max_output_tokens=128,
+            parallel_tool_calls=False,
+            stream=True,
+        )
+        chat = responses_to_openai(req)
+        assert chat.temperature == 0.42
+        assert chat.top_p == 0.93
+        assert chat.max_tokens == 128
+        assert chat.parallel_tool_calls is False
+        assert chat.stream is True
+
+    def test_temperature_omitted_passes_none(self):
+        # The cascade in service/helpers needs to see None so it can
+        # fall through to alias defaults — same contract as Anthropic.
+        req = ResponsesRequest(model="gpt-5", input="x")
+        chat = responses_to_openai(req)
+        assert chat.temperature is None
+        assert chat.top_p is None
+
+    def test_tools_forwarded(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert chat.tools is not None and len(chat.tools) == 1
+        assert chat.tools[0].function["name"] == "search"
+
+    def test_text_format_to_response_format(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "P",
+                    "schema": {"type": "object"},
+                }
+            },
+        )
+        chat = responses_to_openai(req)
+        assert chat.response_format is not None
+        assert chat.response_format.type == "json_schema"
+
+
+# ---------------------------------------------------------------------------
+# openai_to_responses — full response shape
+# ---------------------------------------------------------------------------
+
+
+def _chat_response(
+    *,
+    text: str | None = "",
+    tool_calls: list[ToolCall] | None = None,
+    finish_reason: str = "stop",
+    prompt_tokens: int = 10,
+    completion_tokens: int = 5,
+    cached: int = 0,
+) -> ChatCompletionResponse:
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    if cached:
+        usage.prompt_tokens_details = PromptTokensDetails(cached_tokens=cached)
+    return ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionChoice(
+                message=AssistantMessage(content=text, tool_calls=tool_calls),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=usage,
+    )
+
+
+def _bare_request() -> ResponsesRequest:
+    return ResponsesRequest(model="gpt-5", input="x")
+
+
+class TestOpenaiToResponses:
+    def test_text_only_output(self):
+        chat_resp = _chat_response(text="Hello!")
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) == 1
+        item = resp.output[0]
+        assert item.type == "message"
+        assert item.role == "assistant"
+        assert item.content is not None and len(item.content) == 1
+        assert item.content[0].type == "output_text"
+        assert item.content[0].text == "Hello!"
+        assert resp.status == "completed"
+
+    def test_empty_text_omits_message_item(self):
+        # A pure-tool-call turn should NOT emit a phantom empty message
+        # item — that's what the public Responses API does.
+        chat_resp = _chat_response(
+            text=None,
+            tool_calls=[
+                ToolCall(
+                    id="call_x",
+                    function=FunctionCall(name="run", arguments='{"a":1}'),
+                )
+            ],
+            finish_reason="tool_calls",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) == 1
+        assert resp.output[0].type == "function_call"
+
+    def test_text_then_tool_call_ordering(self):
+        chat_resp = _chat_response(
+            text="Looking that up...",
+            tool_calls=[
+                ToolCall(
+                    id="call_a",
+                    function=FunctionCall(name="search", arguments='{"q":"x"}'),
+                )
+            ],
+            finish_reason="tool_calls",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) == 2
+        # message must come before any function_call — Codex CLI
+        # depends on this ordering when re-rendering turns.
+        assert resp.output[0].type == "message"
+        assert resp.output[1].type == "function_call"
+        assert resp.output[1].name == "search"
+        assert resp.output[1].arguments == '{"q":"x"}'
+        assert resp.output[1].call_id == "call_a"
+
+    def test_length_finish_reason_marks_incomplete(self):
+        chat_resp = _chat_response(text="cut off here", finish_reason="length")
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert resp.status == "incomplete"
+
+    def test_usage_block_populated(self):
+        chat_resp = _chat_response(
+            text="hi", prompt_tokens=100, completion_tokens=50, cached=30
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert resp.usage.input_tokens == 100
+        assert resp.usage.output_tokens == 50
+        assert resp.usage.total_tokens == 150
+        assert resp.usage.input_tokens_details == {"cached_tokens": 30}
+
+    def test_cached_tokens_clamped_to_prompt(self):
+        # Defensive against an over-reported cache count — same clamp
+        # the Anthropic adapter does.
+        chat_resp = _chat_response(
+            text="hi", prompt_tokens=10, completion_tokens=5, cached=999
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert resp.usage.input_tokens_details == {"cached_tokens": 10}
+
+    def test_request_metadata_echoed(self):
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            metadata={"trace_id": "abc"},
+            instructions="be brief",
+        )
+        resp = openai_to_responses(
+            _chat_response(text="hi"), model="m", request=req, created_at=42
+        )
+        assert resp.created_at == 42
+        assert resp.metadata == {"trace_id": "abc"}
+        assert resp.instructions == "be brief"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — request → chat → response keeps Codex's invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_full_codex_turn_roundtrip(self):
+        """A realistic Codex CLI turn: system instructions + replayed
+        user turn + replayed function_call + replayed function_call_output,
+        followed by a new user message. The adapter must produce 5 chat
+        messages in the right order with the right tool_call_id wiring."""
+        req = ResponsesRequest(
+            model="gpt-5-codex",
+            instructions="You are Codex.",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[ResponsesContentItem(type="input_text", text="ls -la")],
+                ),
+                ResponsesInputItem(
+                    type="function_call",
+                    call_id="call_1",
+                    name="run_shell",
+                    arguments='{"cmd":"ls -la"}',
+                ),
+                ResponsesInputItem(
+                    type="function_call_output",
+                    call_id="call_1",
+                    output="total 8\\ndrwxr-xr-x ...",
+                ),
+                ResponsesInputItem(
+                    type="message",
+                    role="user",
+                    content=[
+                        ResponsesContentItem(
+                            type="input_text", text="now show the README"
+                        )
+                    ],
+                ),
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "name": "run_shell",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                }
+            ],
+            stream=True,
+        )
+        chat = responses_to_openai(req)
+        # 1 system + 1 user + 1 assistant (with tool_calls) + 1 tool + 1 user
+        assert [m.role for m in chat.messages] == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "user",
+        ]
+        # Tool wiring: tool message must reference call_1.
+        assert chat.messages[3].tool_call_id == "call_1"
+        # Assistant tool_call must carry call_1 + the original args string.
+        tc = chat.messages[2].tool_calls[0]
+        assert tc["id"] == "call_1"
+        assert tc["function"]["arguments"] == '{"cmd":"ls -la"}'
+        # Tool was forwarded.
+        assert chat.tools is not None
+        assert chat.tools[0].function["name"] == "run_shell"

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level tests for the OpenAI-compatible /v1/responses route.
+
+Same lightweight-engine harness shape as ``test_anthropic_route_auth.py``
+(no MLX import) so the tests stay fast and CI-portable.
+"""
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, text: str) -> list[int]:
+        self.calls.append(text)
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+    tool_calls: list | None = None
+
+
+class _Engine:
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.calls: list[SimpleNamespace] = []
+        self.stream_calls: list[SimpleNamespace] = []
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        return _GenerationOutput(
+            text="hello world",
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason="stop",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        """Emit a tiny synthetic stream: three text chunks then EOS."""
+        self.stream_calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        chunks = ["Hello", " from", " rapid"]
+        for i, c in enumerate(chunks):
+            yield _GenerationOutput(
+                text="".join(chunks[: i + 1]),
+                new_text=c,
+                prompt_tokens=3 if i == 0 else 0,
+                completion_tokens=i + 1,
+                finish_reason=None if i < len(chunks) - 1 else "stop",
+            )
+
+
+def _install_lightweight_engine_modules(monkeypatch):
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.responses",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "responses"),
+)
+_MISSING = object()
+
+
+@pytest.fixture
+def responses_client(monkeypatch):
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.routes.responses import router
+
+    cfg = reset_config()
+    cfg.api_key = "test-secret"
+    cfg.engine = _Engine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    app.include_router(router)
+    yield SimpleNamespace(
+        client=TestClient(app),
+        engine=cfg.engine,
+        rate_limiter=rate_limiter,
+        reset_config=reset_config,
+    )
+
+    reset_config()
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    for name, previous in previous_modules.items():
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+    for (module_name, attr), previous in previous_attrs.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if previous is _MISSING:
+            if hasattr(module, attr):
+                delattr(module, attr)
+        else:
+            setattr(module, attr, previous)
+
+
+def _payload(**overrides) -> dict:
+    base = {
+        "model": "test-model",
+        "input": "Hello, world",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Auth — Bearer token; rapid-mlx Responses route is OpenAI-shape
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesAuth:
+    def test_requires_api_key(self, responses_client):
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post("/v1/responses", json=_payload())
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "API key required"
+        assert engine.calls == []
+
+    def test_rejects_invalid_bearer(self, responses_client):
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(),
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+
+        assert response.status_code == 401
+        assert engine.calls == []
+
+    def test_accepts_valid_bearer(self, responses_client):
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert len(engine.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-stream happy path
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesNonStream:
+    def test_response_shape_matches_codex_expectation(self, responses_client):
+        client = responses_client.client
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["object"] == "response"
+        assert body["status"] == "completed"
+        # One message item; assistant role; output_text content.
+        assert len(body["output"]) == 1
+        item = body["output"][0]
+        assert item["type"] == "message"
+        assert item["role"] == "assistant"
+        assert item["content"][0]["type"] == "output_text"
+        assert item["content"][0]["text"] == "hello world"
+        # Usage is populated.
+        assert body["usage"]["input_tokens"] == 3
+        assert body["usage"]["output_tokens"] == 2
+        assert body["usage"]["total_tokens"] == 5
+
+    def test_response_carries_loaded_model_not_request_alias(self, responses_client):
+        """The response.model field must be the loaded engine's model
+        name, not whatever the client typed — same convention as #557."""
+        client = responses_client.client
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(model="gpt-5"),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200
+        # Loaded model = "test-model" (set in fixture).
+        assert response.json()["model"] == "test-model"
+
+    def test_instructions_become_system_message(self, responses_client):
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(instructions="You are Codex."),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200
+        sent = engine.calls[-1].messages
+        # extract_multimodal_content turns Message → dict on its way to the engine.
+        first = sent[0]
+        first_role = first.role if hasattr(first, "role") else first["role"]
+        first_content = first.content if hasattr(first, "content") else first["content"]
+        assert first_role == "system"
+        assert first_content == "You are Codex."
+
+
+# ---------------------------------------------------------------------------
+# Codex model-name bypass (parallel to #557 claude-* bypass)
+# ---------------------------------------------------------------------------
+
+
+class TestCodexModelBypass:
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "gpt-5",
+            "gpt-5-codex",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "claude-opus-4-5",
+        ],
+    )
+    def test_codex_model_names_route_to_loaded_engine(
+        self, responses_client, model_name
+    ):
+        """Codex CLI sends ``gpt-5`` / ``gpt-5-codex`` etc. The route
+        must route these to the loaded engine without 404'ing on the
+        unknown name — same bypass as #557 for the Anthropic route."""
+        client = responses_client.client
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(model=model_name),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 for model={model_name!r}, got {response.status_code}: "
+            f"{response.text}"
+        )
+        # Response model is the loaded one, regardless of what we asked for.
+        assert response.json()["model"] == "test-model"
+
+
+# ---------------------------------------------------------------------------
+# Statelessness — previous_response_id must 400
+# ---------------------------------------------------------------------------
+
+
+class TestStatelessGate:
+    def test_previous_response_id_returns_400(self, responses_client):
+        """The shim has no response store. A client that sends
+        ``previous_response_id`` would experience silent prompt loss
+        on retries, so 400 loudly with an actionable error message."""
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(previous_response_id="resp_abc123"),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 400
+        assert "previous_response_id" in response.json()["detail"]
+        # Engine must not have been called.
+        assert engine.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Codex-style multi-item input replay
+# ---------------------------------------------------------------------------
+
+
+class TestCodexInputReplay:
+    def test_function_call_and_output_replay_lands_as_assistant_then_tool(
+        self, responses_client
+    ):
+        """A Codex turn carries a prior function_call + function_call_output
+        in input[]. The adapter must produce assistant(tool_calls=...) then
+        a tool message wired by tool_call_id."""
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(
+                model="gpt-5-codex",
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "ls -la"}],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "run_shell",
+                        "arguments": '{"cmd":"ls -la"}',
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_1",
+                        "output": "total 8\ndrwxr-xr-x ...",
+                    },
+                ],
+            ),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 200, response.text
+        sent = engine.calls[-1].messages
+
+        def _role(m):
+            return m.role if hasattr(m, "role") else m["role"]
+
+        def _content(m):
+            return m.content if hasattr(m, "content") else m["content"]
+
+        # extract_multimodal_content (preserve_native_format=False — the
+        # path most local models take) rewrites assistant tool_calls into
+        # "[Calling tool: name(args)]" text and rewrites tool results
+        # into role="user" with a "[Tool Result (call_id)]: ..." prefix.
+        # So we verify the structural invariant — three turns, with the
+        # tool name + tool result text reaching the engine — rather
+        # than the native tool message shape (which is verified in
+        # test_responses_adapter.py).
+        assert len(sent) == 3
+        assert _role(sent[0]) == "user"
+        assert _role(sent[1]) == "assistant"
+        # Assistant content carries the rewritten tool_call signature.
+        assistant_text = _content(sent[1])
+        assert "run_shell" in assistant_text
+        assert "ls -la" in assistant_text
+        # Tool result content surfaces (either as role=tool or as
+        # rewritten user with the [Tool Result (call_id)] prefix).
+        last_role = _role(sent[2])
+        last_content = _content(sent[2])
+        assert last_role in ("tool", "user")
+        if last_role == "user":
+            assert "call_1" in last_content  # the rewrite carries the call_id
+        assert "total 8" in last_content
+
+
+# ---------------------------------------------------------------------------
+# Streaming path — SSE event names Codex CLI parses
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(body_text: str) -> list[tuple[str, dict]]:
+    """Parse SSE response body into [(event, data_obj), ...] pairs."""
+    events: list[tuple[str, dict]] = []
+    blocks = body_text.split("\n\n")
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        event_name = None
+        data_text = None
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event_name = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_text = line[len("data:") :].strip()
+        if event_name and data_text is not None:
+            events.append((event_name, json.loads(data_text)))
+    return events
+
+
+class TestResponsesStream:
+    def test_stream_emits_codex_required_events(self, responses_client):
+        """Codex CLI hard-requires ``response.created`` first and
+        ``response.completed`` last; ``response.output_text.delta``
+        events carry the assistant text."""
+        client = responses_client.client
+
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers={"Authorization": "Bearer test-secret"},
+        ) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        event_names = [e[0] for e in events]
+
+        # First event must be response.created — Codex sets state from it.
+        assert event_names[0] == "response.created"
+        # Last event must be response.completed — Codex treats absence
+        # as a hard failure ("stream closed before response.completed").
+        assert event_names[-1] == "response.completed"
+        # At least one text delta in between.
+        assert "response.output_text.delta" in event_names
+        # Message item opened and closed.
+        assert "response.output_item.added" in event_names
+        assert "response.output_item.done" in event_names
+
+    def test_stream_text_deltas_concatenate_to_full_reply(self, responses_client):
+        client = responses_client.client
+
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers={"Authorization": "Bearer test-secret"},
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        deltas = [
+            d["delta"] for (name, d) in events if name == "response.output_text.delta"
+        ]
+        # The mock engine emits "Hello", " from", " rapid".
+        assert "".join(deltas) == "Hello from rapid"
+
+    def test_stream_completed_event_carries_usage(self, responses_client):
+        client = responses_client.client
+
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers={"Authorization": "Bearer test-secret"},
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        completed = [d for (name, d) in events if name == "response.completed"]
+        assert len(completed) == 1
+        usage = completed[0]["response"]["usage"]
+        # Mock engine returns prompt=3, completion=3 (last chunk).
+        assert usage["input_tokens"] == 3
+        assert usage["output_tokens"] == 3
+        assert usage["total_tokens"] == 6

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Adapter for converting between OpenAI Responses API and OpenAI Chat
+Completions API.
+
+Handles translation of:
+- Requests: Responses (with polymorphic ``input`` items) → Chat
+- Responses: Chat → Responses ``output[]`` (message + function_call items)
+
+This is a stateless conversion — the route layer enforces statelessness
+by 400'ing when ``previous_response_id`` is set. Codex CLI never sends
+that field (openai/codex#3841), so the resulting shim covers the real
+hot path despite the simplification.
+"""
+
+import json
+import uuid
+
+from .models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    Message,
+    ResponseFormat,
+    ResponseFormatJsonSchema,
+    ToolDefinition,
+)
+from .responses_models import (
+    ResponsesContentItem,
+    ResponsesInputItem,
+    ResponsesOutputContent,
+    ResponsesOutputItem,
+    ResponsesRequest,
+    ResponsesResponse,
+    ResponsesUsage,
+)
+
+
+def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
+    """
+    Convert a Responses-API request to an OpenAI Chat Completions request.
+
+    Translation rules:
+    - ``instructions`` → system message (prepended)
+    - ``input`` (bare string) → single user message
+    - ``input[]`` items:
+        - ``message`` → assistant or user message (joined text content)
+        - ``function_call`` → assistant message with ``tool_calls``
+        - ``function_call_output`` → tool-role message with ``tool_call_id``
+        - ``reasoning`` → dropped (encrypted blobs we can't replay)
+    - ``tools`` (Responses-flat) → Chat-nested ``{type, function:{name, ...}}``
+    - ``text.format`` (JSON-schema output) → ``response_format``
+    - ``max_output_tokens`` → ``max_tokens``
+    - ``parallel_tool_calls`` / ``tool_choice`` (string form) carried through
+    """
+    messages: list[Message] = []
+
+    if request.instructions:
+        messages.append(Message(role="system", content=request.instructions))
+
+    if isinstance(request.input, str):
+        messages.append(Message(role="user", content=request.input))
+    else:
+        for item in request.input:
+            converted = _convert_input_item(item)
+            messages.extend(converted)
+
+    tools = _convert_tools(request.tools)
+    tool_choice = _convert_tool_choice(request.tool_choice)
+    response_format = _convert_text_format(request.text)
+
+    return ChatCompletionRequest(
+        model=request.model,
+        messages=messages,
+        # Mirror Anthropic adapter: forward None so the server-side
+        # sampling cascade (request > CLI > alias > generation_config >
+        # fallback) can fire. Hard-coding here would short-circuit it
+        # at the first layer and rob Responses-compat clients of the
+        # model author's curated defaults.
+        temperature=request.temperature,
+        top_p=request.top_p,
+        max_tokens=request.max_output_tokens,
+        stream=request.stream,
+        tools=tools,
+        tool_choice=tool_choice,
+        parallel_tool_calls=request.parallel_tool_calls,
+        response_format=response_format,
+    )
+
+
+def openai_to_responses(
+    response: ChatCompletionResponse,
+    model: str,
+    request: ResponsesRequest,
+    created_at: int,
+) -> ResponsesResponse:
+    """
+    Convert an OpenAI Chat Completions response to a Responses-API
+    response shape.
+
+    The ``output`` array is built in Codex CLI's expected order:
+    first a ``message`` item with the assistant text, then one
+    ``function_call`` item per tool call. An empty assistant turn (only
+    tool calls, no text) emits no ``message`` item — matches the
+    public Responses API.
+    """
+    output: list[ResponsesOutputItem] = []
+    choice = response.choices[0] if response.choices else None
+
+    if choice:
+        text = choice.message.content or ""
+        if text:
+            output.append(
+                ResponsesOutputItem(
+                    type="message",
+                    id=f"msg_{uuid.uuid4().hex[:24]}",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        ResponsesOutputContent(type="output_text", text=text),
+                    ],
+                )
+            )
+
+        for tc in choice.message.tool_calls or []:
+            output.append(
+                ResponsesOutputItem(
+                    type="function_call",
+                    id=f"fc_{uuid.uuid4().hex[:24]}",
+                    call_id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments or "",
+                    status="completed",
+                )
+            )
+
+    status = _convert_status(choice.finish_reason if choice else None)
+
+    usage = _build_responses_usage(response)
+
+    return ResponsesResponse(
+        created_at=created_at,
+        model=model,
+        status=status,
+        output=output,
+        usage=usage,
+        parallel_tool_calls=bool(request.parallel_tool_calls),
+        tool_choice=request.tool_choice or "auto",
+        tools=request.tools or [],
+        metadata=request.metadata,
+        instructions=request.instructions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal: input-item conversion
+# ---------------------------------------------------------------------------
+
+
+def _convert_input_item(item: ResponsesInputItem) -> list[Message]:
+    """Translate one Responses-API input item to 0+ Chat messages."""
+    if item.type == "message":
+        return [_message_item_to_chat(item)]
+    if item.type == "function_call":
+        return [_function_call_to_chat(item)]
+    if item.type == "function_call_output":
+        return [_function_call_output_to_chat(item)]
+    if item.type == "reasoning":
+        # The encrypted_content payload is opaque to non-OpenAI backends;
+        # dropping reasoning items is the documented fallback. Codex
+        # tolerates the absence — it doesn't re-display them anyway.
+        return []
+    # Unknown item types (local_shell_call, tool_search_call, etc.) are
+    # OpenAI-side features Codex won't send to a third-party backend.
+    # Silently drop them rather than 400 — defensive against future
+    # additions on the OpenAI side.
+    return []
+
+
+def _message_item_to_chat(item: ResponsesInputItem) -> Message:
+    role = item.role or "user"
+    content = item.content
+
+    if isinstance(content, str):
+        text = content
+    elif content is None:
+        text = ""
+    else:
+        parts = []
+        for c in content:
+            if isinstance(c, ResponsesContentItem):
+                # input_text and output_text both render as plain text.
+                # input_image is dropped here — vision passthrough is a
+                # follow-up and Codex CLI does not send images today.
+                if c.type in ("input_text", "output_text") and c.text:
+                    parts.append(c.text)
+            elif isinstance(c, dict):
+                # Defensive: client may have sent a raw dict that slipped
+                # past Pydantic if validators are loosened later.
+                ctype = c.get("type")
+                if ctype in ("input_text", "output_text"):
+                    t = c.get("text")
+                    if t:
+                        parts.append(t)
+        text = "\n".join(parts)
+
+    return Message(role=role, content=text)
+
+
+def _function_call_to_chat(item: ResponsesInputItem) -> Message:
+    """Replay a prior assistant tool_call. ``call_id`` becomes the OpenAI
+    tool_call_id, ``name`` + ``arguments`` populate the function payload.
+
+    Arguments are kept as the original JSON string (the engine never
+    re-parses tool_call arguments). Missing args fall back to ``{}``.
+    """
+    return Message(
+        role="assistant",
+        content="",
+        tool_calls=[
+            {
+                "id": item.call_id or f"call_{uuid.uuid4().hex[:8]}",
+                "type": "function",
+                "function": {
+                    "name": item.name or "",
+                    "arguments": item.arguments or "{}",
+                },
+            }
+        ],
+    )
+
+
+def _function_call_output_to_chat(item: ResponsesInputItem) -> Message:
+    """Replay a tool result. Coerce structured output to JSON string."""
+    out = item.output
+    if isinstance(out, (dict, list)):
+        text = json.dumps(out)
+    elif out is None:
+        text = ""
+    else:
+        text = str(out)
+    return Message(
+        role="tool",
+        content=text,
+        tool_call_id=item.call_id or "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal: tools, tool_choice, response_format
+# ---------------------------------------------------------------------------
+
+
+def _convert_tools(tools: list[dict] | None) -> list[ToolDefinition] | None:
+    """Convert Responses-flat tool shape to Chat-nested.
+
+    Responses: ``{type: "function", name, description, parameters}``
+    Chat:      ``{type: "function", function: {name, description, parameters}}``
+
+    Non-function tool types (web_search, image_generation, code_interpreter,
+    file_search, computer_use, etc.) are silently dropped — Codex CLI
+    won't send them to a third-party backend, and they have no analog
+    on a local engine.
+    """
+    if not tools:
+        return None
+    converted: list[ToolDefinition] = []
+    for t in tools:
+        if t.get("type") != "function":
+            continue
+        # OpenAI's Responses-flat shape sometimes nests parameters under
+        # ``parameters`` and sometimes alongside a ``strict`` flag; we
+        # carry both through verbatim — engine layer expects nested.
+        name = t.get("name") or t.get("function", {}).get("name", "")
+        if not name:
+            continue
+        converted.append(
+            ToolDefinition(
+                type="function",
+                function={
+                    "name": name,
+                    "description": t.get("description")
+                    or t.get("function", {}).get("description", ""),
+                    "parameters": t.get("parameters")
+                    or t.get("function", {}).get("parameters")
+                    or {"type": "object", "properties": {}},
+                },
+            )
+        )
+    return converted or None
+
+
+def _convert_tool_choice(tool_choice: str | dict | None) -> str | dict | None:
+    """Carry through string tool_choice; convert object shape to OpenAI's.
+
+    Responses string values: ``"auto"`` | ``"none"`` | ``"required"`` —
+    the same set OpenAI Chat expects, so they pass straight through.
+
+    Object form on Responses is ``{type: "function", name: "..."}``;
+    OpenAI Chat wants ``{type: "function", function: {name: "..."}}``.
+    """
+    if tool_choice is None:
+        return None
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function" and "name" in tool_choice:
+            return {
+                "type": "function",
+                "function": {"name": tool_choice["name"]},
+            }
+    return None
+
+
+def _convert_text_format(text: dict | None) -> ResponseFormat | None:
+    """Map Responses ``text.format`` → Chat ``response_format``.
+
+    ``text.format.type`` values:
+    - ``"text"`` (default) → no response_format needed; return None
+    - ``"json_schema"`` → ResponseFormat with the embedded schema
+    - ``"json_object"`` → ResponseFormat type=json_object
+
+    Anything else is silently passed through as None — the engine then
+    runs unconstrained, matching what Codex would have got from OpenAI
+    if it asked for an unsupported format type.
+    """
+    if not text:
+        return None
+    fmt = text.get("format")
+    if not isinstance(fmt, dict):
+        return None
+    ftype = fmt.get("type")
+    if ftype == "json_object":
+        return ResponseFormat(type="json_object")
+    if ftype == "json_schema":
+        schema = fmt.get("schema") or fmt.get("json_schema")
+        name = fmt.get("name") or "response"
+        if not isinstance(schema, dict):
+            return None
+        return ResponseFormat(
+            type="json_schema",
+            json_schema=ResponseFormatJsonSchema(
+                name=name,
+                description=fmt.get("description"),
+                schema=schema,
+                strict=bool(fmt.get("strict", False)),
+            ),
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal: response building
+# ---------------------------------------------------------------------------
+
+
+def _convert_status(openai_finish_reason: str | None) -> str:
+    """Map OpenAI ``finish_reason`` to Responses ``status``.
+
+    ``"length"`` is the only one Codex CLI reads specially — it
+    surfaces as a follow-up prompt to extend. The rest are folded
+    into ``"completed"``.
+    """
+    if openai_finish_reason == "length":
+        return "incomplete"
+    return "completed"
+
+
+def _build_responses_usage(response: ChatCompletionResponse) -> ResponsesUsage:
+    if not response.usage:
+        return ResponsesUsage()
+    prompt = response.usage.prompt_tokens
+    completion = response.usage.completion_tokens
+    cached = 0
+    if response.usage.prompt_tokens_details is not None:
+        cached = response.usage.prompt_tokens_details.cached_tokens or 0
+    cached = min(cached, prompt)
+    reasoning = 0
+    if response.usage.completion_tokens_details is not None:
+        reasoning = response.usage.completion_tokens_details.reasoning_tokens or 0
+    return ResponsesUsage(
+        input_tokens=prompt,
+        output_tokens=completion,
+        total_tokens=prompt + completion,
+        input_tokens_details=({"cached_tokens": cached} if cached else None),
+        output_tokens_details=({"reasoning_tokens": reasoning} if reasoning else None),
+    )

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Pydantic models for OpenAI Responses API.
+
+These models define the request and response schemas for the
+OpenAI-compatible /v1/responses endpoint, enabling the official Codex CLI
+(and other Responses-API clients) to talk to rapid-mlx as a local backend.
+
+This is a stateless shim: ``previous_response_id`` is not supported and
+the route returns 400 if set. Codex CLI re-sends the full conversation
+history in ``input`` each turn, so statelessness is sufficient
+(openai/codex#3841 confirms ``previous_response_id`` is not used by the
+client).
+"""
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# =============================================================================
+# Request Models
+# =============================================================================
+
+
+class ResponsesContentItem(BaseModel):
+    """A content item inside a Responses-API input message.
+
+    Codex sends ``input_text`` for user/system turns and ``output_text``
+    when echoing back prior assistant turns; ``input_image`` is the
+    vision shape we mirror for future MLLM support.
+    """
+
+    type: str  # "input_text" | "output_text" | "input_image"
+    text: str | None = None
+    image_url: str | None = None
+
+
+class ResponsesInputItem(BaseModel):
+    """A single item in the Responses-API ``input`` array.
+
+    The Responses API unifies user/assistant messages, function calls,
+    function call outputs, and reasoning blocks into one polymorphic
+    list. Codex CLI replays this full list each turn (no
+    ``previous_response_id``).
+    """
+
+    type: (
+        str  # "message" | "function_call" | "function_call_output" | "reasoning" | ...
+    )
+    # message
+    role: str | None = None
+    content: list[ResponsesContentItem] | str | None = None
+    # function_call
+    call_id: str | None = None
+    name: str | None = None
+    arguments: str | None = None
+    # function_call_output — Codex sometimes sends a structured shape,
+    # sometimes a bare string. Both are coerced to str downstream.
+    output: str | dict | list | None = None
+    # reasoning — Codex emits these as ``encrypted_content`` blobs we
+    # cannot decode; the adapter drops them entirely.
+    summary: list[dict] | None = None
+    encrypted_content: str | None = None
+
+
+class ResponsesRequest(BaseModel):
+    """Request body for ``POST /v1/responses``.
+
+    Fields beyond ``model`` / ``input`` are declared so Pydantic does not
+    silently drop them when Codex sends them. ``previous_response_id`` /
+    ``store`` / ``include`` / ``service_tier`` / ``prompt_cache_key`` /
+    ``metadata`` are accepted-but-ignored — same shape Anthropic compat
+    uses for fields we know about but don't act on.
+    """
+
+    model: str
+    # The Responses API allows either a bare prompt string OR an array
+    # of polymorphic ``ResponsesInputItem`` blocks. Codex CLI sends the
+    # array form with the full conversation history each turn.
+    input: str | list[ResponsesInputItem]
+    instructions: str | None = None  # rendered as system message
+    tools: list[dict] | None = None  # Responses-FLAT shape
+    tool_choice: str | dict | None = None
+    parallel_tool_calls: bool | None = None
+    reasoning: dict | None = None  # {"effort": "low|medium|high", "summary": ...}
+    stream: bool = False
+    store: bool | None = None
+    include: list[str] | None = None
+    service_tier: str | None = None
+    prompt_cache_key: str | None = None
+    text: dict | None = None  # {"format": {...}, "verbosity": ...}
+    metadata: dict | None = None
+    previous_response_id: str | None = None  # 400 if set; this shim is stateless
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+
+
+# =============================================================================
+# Response Models
+# =============================================================================
+
+
+class ResponsesUsage(BaseModel):
+    """Token usage block for a Responses-API response."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    # Optional details for prompt cache + reasoning tokens. Codex parses
+    # these fields and they're 1:1 with the OpenAI public spec.
+    input_tokens_details: dict[str, int] | None = None
+    output_tokens_details: dict[str, int] | None = None
+
+
+class ResponsesOutputContent(BaseModel):
+    """A content item inside an output ``message`` block."""
+
+    type: str = "output_text"
+    text: str = ""
+    annotations: list[Any] = Field(default_factory=list)
+
+
+class ResponsesOutputItem(BaseModel):
+    """An item in the ``output`` array of a non-streaming response.
+
+    Two shapes the shim emits:
+    - ``message`` — assistant text reply, content array of output_text
+    - ``function_call`` — one per tool call the model produced
+    """
+
+    type: str  # "message" | "function_call"
+    id: str
+    status: str = "completed"
+    # message
+    role: str | None = None
+    content: list[ResponsesOutputContent] | None = None
+    # function_call
+    call_id: str | None = None
+    name: str | None = None
+    arguments: str | None = None
+
+
+class ResponsesResponse(BaseModel):
+    """Non-streaming response from ``POST /v1/responses``."""
+
+    id: str = Field(default_factory=lambda: f"resp_{uuid.uuid4().hex[:24]}")
+    object: str = "response"
+    created_at: int = 0  # epoch seconds, populated by route
+    model: str
+    status: str = "completed"  # "completed" | "failed" | "incomplete"
+    output: list[ResponsesOutputItem]
+    usage: ResponsesUsage = Field(default_factory=ResponsesUsage)
+    parallel_tool_calls: bool = False
+    tool_choice: str | dict = "auto"
+    tools: list[dict] = Field(default_factory=list)
+    # Echoed back when client supplied them; ignored by Codex but on-spec.
+    metadata: dict | None = None
+    instructions: str | None = None
+    previous_response_id: str | None = None

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1,0 +1,721 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI Responses API endpoint — /v1/responses.
+
+Stateless shim that lets Codex CLI (and any other Responses-API client)
+talk to rapid-mlx as if it were OpenAI. Translates Responses → Chat,
+runs inference through the existing engine, translates back into the
+seven SSE events Codex CLI parses (``response.created``,
+``response.output_item.added``, ``response.output_text.delta``,
+``response.function_call_arguments.delta``, ``response.output_item.done``,
+``response.completed``, ``response.failed``).
+
+Statelessness: ``previous_response_id`` returns 400. Codex CLI doesn't
+use that field (openai/codex#3841) — it re-sends the full conversation
+history every turn in ``input``.
+"""
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
+
+from ..api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+from ..api.responses_adapter import openai_to_responses, responses_to_openai
+from ..api.responses_models import ResponsesRequest
+from ..api.tool_calling import convert_tools_for_template
+from ..api.utils import (
+    StreamingThinkRouter,
+    StreamingToolCallFilter,
+    clean_output_text,
+    extract_multimodal_content,
+    sanitize_output,
+    strip_special_tokens,
+    strip_thinking_tags,
+)
+from ..config import get_config
+from ..engine import BaseEngine
+from ..middleware.auth import check_rate_limit, verify_api_key
+from ..service.helpers import (
+    _build_usage,
+    _check_admission_or_503,
+    _disconnect_guard,
+    _effective_enable_thinking,
+    _finalize_content_and_reasoning,
+    _parse_tool_calls_with_parser,
+    _release_admission_unless_committed,
+    _resolve_enable_thinking,
+    _resolve_max_tokens,
+    _resolve_temperature,
+    _resolve_top_p,
+    _validate_model_name,
+    _wait_with_disconnect,
+    build_extended_sampling_kwargs,
+    get_engine,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _resolved_sampling_kwargs(openai_request: ChatCompletionRequest) -> dict:
+    """Resolve sampling params through the 4-layer cascade.
+
+    Mirrors the helper in routes/anthropic.py so ``/v1/responses`` users
+    get the same alias / generation_config defaults as ``/v1/messages``
+    and ``/v1/chat/completions``.
+    """
+    out = {
+        "temperature": _resolve_temperature(openai_request.temperature),
+        "top_p": _resolve_top_p(openai_request.top_p),
+        "stop": getattr(openai_request, "stop", None),
+    }
+    out.update(build_extended_sampling_kwargs(openai_request))
+    return out
+
+
+def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
+    """Same heuristic as routes/anthropic.py: stream that starts inside an
+    implicit ``<think>`` block should be routed as reasoning until the
+    closing tag. Bypass when thinking is explicitly disabled."""
+    if enable_thinking is False:
+        return False
+    return "<think>" in chat_template and "add_generation_prompt" in chat_template
+
+
+@router.post(
+    "/v1/responses",
+    dependencies=[
+        Depends(verify_api_key),
+        Depends(check_rate_limit),
+    ],
+)
+async def create_response(request: Request):
+    """OpenAI Responses API entry point.
+
+    Codex CLI hardcodes ``stream: true`` and sends the full
+    conversation history in ``input[]`` each turn, so the streaming
+    path is the hot path.
+    """
+    body = await request.json()
+    responses_request = ResponsesRequest(**body)
+
+    # Statelessness gate — see module docstring. Codex CLI does not set
+    # this field; clients that DO use it would get silent prompt loss
+    # on retries because we have no response store, so 400 loudly.
+    if responses_request.previous_response_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "previous_response_id is not supported by this server — "
+                "rapid-mlx is a stateless Responses API shim. Re-send the "
+                "full conversation history in the `input` field each turn."
+            ),
+        )
+
+    # Reuse the Claude-Code / Codex bypass from #557: ``claude-*``,
+    # ``gpt-*`` model names pass through to the loaded engine instead of
+    # 404'ing on _validate_model_name. Codex sends ``gpt-5``,
+    # ``gpt-5-codex``, etc. — none of which match a local alias.
+    if not (responses_request.model or "").startswith(("claude-", "gpt-")):
+        _validate_model_name(responses_request.model)
+    engine = get_engine(responses_request.model)
+
+    # Pre-flight admission — same C4 reservation shape the other two
+    # routes use. ``_admission_committed`` flips to True when the
+    # streaming path takes over so ``_disconnect_guard`` owns release.
+    _check_admission_or_503(engine)
+    _admission_committed = False
+    try:
+        _log_request(responses_request)
+
+        cfg_for_log = get_config()
+        if (
+            responses_request.model
+            and cfg_for_log.model_name
+            and responses_request.model != cfg_for_log.model_name
+        ):
+            logger.info(
+                "Responses /v1/responses: request model=%r served by loaded engine=%r",
+                responses_request.model,
+                cfg_for_log.model_name,
+            )
+
+        openai_request = responses_to_openai(responses_request)
+
+        if responses_request.stream:
+            _admission_committed = True
+            return StreamingResponse(
+                _disconnect_guard(
+                    _stream_responses(engine, openai_request, responses_request),
+                    request,
+                    engine=engine,
+                ),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            )
+
+        return await _non_stream(engine, openai_request, responses_request, request)
+    finally:
+        _release_admission_unless_committed(engine, _admission_committed)
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming path
+# ---------------------------------------------------------------------------
+
+
+async def _non_stream(
+    engine: BaseEngine,
+    openai_request: ChatCompletionRequest,
+    responses_request: ResponsesRequest,
+    request: Request,
+) -> Response:
+    cfg = get_config()
+    created_at = int(time.time())
+
+    messages, _images, _videos = extract_multimodal_content(
+        openai_request.messages,
+        preserve_native_format=engine.preserve_native_tool_format,
+    )
+
+    chat_kwargs = {
+        "max_tokens": _resolve_max_tokens(
+            openai_request.max_tokens,
+            _resolve_enable_thinking(openai_request),
+        ),
+        **_resolved_sampling_kwargs(openai_request),
+    }
+    if openai_request.tools:
+        chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+
+    resolved_thinking = _resolve_enable_thinking(openai_request)
+    if resolved_thinking is not None:
+        chat_kwargs["enable_thinking"] = resolved_thinking
+
+    start_time = time.perf_counter()
+    timeout = cfg.default_timeout
+
+    try:
+        output = await _wait_with_disconnect(
+            engine.chat(messages=messages, **chat_kwargs),
+            request,
+            timeout=timeout,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001 — match other routes' error shape
+        err_msg = str(e)
+        err_type = type(e).__name__
+        if (
+            "TemplateError" in err_type
+            or "template" in err_msg.lower()
+            or ("user" in err_msg.lower() and "found" in err_msg.lower())
+        ):
+            raise HTTPException(
+                status_code=400, detail=f"Chat template error: {err_msg}"
+            )
+        if "Failed to process image" in err_msg or "Failed to process video" in err_msg:
+            raise HTTPException(status_code=400, detail=err_msg)
+        raise
+
+    if output is None:
+        return Response(status_code=499)
+
+    elapsed = time.perf_counter() - start_time
+    tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
+    logger.info(
+        f"Responses: {output.completion_tokens} tokens in {elapsed:.2f}s "
+        f"({tokens_per_sec:.1f} tok/s)"
+    )
+
+    engine_tool_calls = getattr(output, "tool_calls", None)
+    cleaned_text, tool_calls = _parse_tool_calls_with_parser(
+        output.text, openai_request, structured_tool_calls=engine_tool_calls
+    )
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text=output.raw_text or output.text,
+        cleaned_text=cleaned_text,
+        tool_calls=tool_calls,
+        reasoning_parser=cfg.reasoning_parser,
+        engine_reasoning_text=getattr(output, "reasoning_text", "") or "",
+        enable_thinking=_effective_enable_thinking(
+            resolved_thinking, cfg.model_path or cfg.model_name
+        ),
+    )
+
+    final_content = None
+    if cleaned_text:
+        final_content = strip_thinking_tags(clean_output_text(cleaned_text))
+        final_content = sanitize_output(final_content)
+
+    finish_reason = "tool_calls" if tool_calls else output.finish_reason
+
+    openai_response = ChatCompletionResponse(
+        model=cfg.model_name or openai_request.model,
+        choices=[
+            ChatCompletionChoice(
+                message=AssistantMessage(
+                    content=final_content,
+                    reasoning_content=reasoning_text,
+                    tool_calls=tool_calls,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=_build_usage(output, reasoning_text),
+    )
+
+    responses_response = openai_to_responses(
+        openai_response,
+        model=cfg.model_name or responses_request.model,
+        request=responses_request,
+        created_at=created_at,
+    )
+    return Response(
+        content=responses_response.model_dump_json(exclude_none=True),
+        media_type="application/json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming path — emits the 7 SSE events Codex CLI parses
+# ---------------------------------------------------------------------------
+
+
+def _sse(event: str, data: dict) -> str:
+    """Format one Server-Sent Event in Responses-API shape.
+
+    Codex parses ``event: <name>\\ndata: <json>\\n\\n`` framing — same as
+    chat-completions and Anthropic streams. No ``data: [DONE]`` here;
+    that sentinel is chat-completions-only.
+    """
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def _stream_responses(
+    engine: BaseEngine,
+    openai_request: ChatCompletionRequest,
+    responses_request: ResponsesRequest,
+) -> AsyncIterator[str]:
+    """Stream a Responses-API SSE event sequence Codex CLI can parse.
+
+    Event order Codex expects:
+      1. ``response.created`` — once, before any deltas
+      2. ``response.output_item.added`` (message item) — when first text
+         delta arrives
+      3. ``response.output_text.delta`` — each chunk of assistant text
+      4. ``response.output_item.done`` (message item) — when text ends,
+         before any tool_calls
+      5. For each tool call:
+         ``response.output_item.added`` (function_call item) +
+         ``response.function_call_arguments.delta`` (full JSON args) +
+         ``response.output_item.done`` (function_call item)
+      6. ``response.completed`` — terminal event, carries final usage
+
+    Errors emit ``response.failed`` then close. Codex treats
+    stream-close-without-``response.completed`` as a hard failure, so
+    we always finalize.
+    """
+    cfg = get_config()
+    response_id = f"resp_{uuid.uuid4().hex[:24]}"
+    created_at = int(time.time())
+    start_time = time.perf_counter()
+    served_model = cfg.model_name or responses_request.model
+
+    # response.created — Codex needs this before any deltas.
+    yield _sse(
+        "response.created",
+        {
+            "type": "response.created",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": created_at,
+                "status": "in_progress",
+                "model": served_model,
+                "output": [],
+            },
+        },
+    )
+
+    messages, _images, _videos = extract_multimodal_content(
+        openai_request.messages,
+        preserve_native_format=engine.preserve_native_tool_format,
+    )
+
+    chat_kwargs = {
+        "max_tokens": _resolve_max_tokens(
+            openai_request.max_tokens,
+            _resolve_enable_thinking(openai_request),
+        ),
+        **_resolved_sampling_kwargs(openai_request),
+    }
+    if openai_request.tools:
+        chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+    resolved_thinking = _resolve_enable_thinking(openai_request)
+    if resolved_thinking is not None:
+        chat_kwargs["enable_thinking"] = resolved_thinking
+
+    accumulated_text = ""
+    accumulated_raw = ""
+    accumulated_structured_tool_calls: list[dict] = []
+    tool_filter = StreamingToolCallFilter()
+
+    _tokenizer = engine.tokenizer
+    _chat_template = ""
+    if _tokenizer and hasattr(_tokenizer, "chat_template"):
+        _chat_template = _tokenizer.chat_template or ""
+    _starts_thinking = _should_start_in_thinking(
+        _chat_template, chat_kwargs.get("enable_thinking")
+    )
+    think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
+
+    prompt_tokens = 0
+    completion_tokens = 0
+    cached_tokens = 0
+
+    # Lazy message-item state. We do NOT emit the message
+    # output_item.added until we have actual user-facing text to stream
+    # — a turn that is pure tool_calls should not emit a phantom empty
+    # message item.
+    message_item_id: str | None = None
+    message_output_index: int | None = None
+    message_open = False
+
+    # Per-request reasoning parser instance (matches anthropic.py).
+    reasoning_parser = None
+    if cfg.reasoning_parser_name:
+        try:
+            from ..reasoning import get_parser
+
+            reasoning_parser = get_parser(cfg.reasoning_parser_name)()
+        except Exception:
+            pass
+    if chat_kwargs.get("enable_thinking") is False:
+        reasoning_parser = None
+    if reasoning_parser:
+        reasoning_parser.reset_state()
+
+    async def _open_message_item() -> str:
+        """Emit response.output_item.added for the assistant message.
+
+        Returns the event string so callers can yield it; the bookkeeping
+        for ``message_open`` lives here so the open/close pair stays
+        symmetric.
+        """
+        nonlocal message_item_id, message_output_index, message_open
+        message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
+        message_output_index = 0
+        message_open = True
+        return _sse(
+            "response.output_item.added",
+            {
+                "type": "response.output_item.added",
+                "output_index": message_output_index,
+                "item": {
+                    "type": "message",
+                    "id": message_item_id,
+                    "status": "in_progress",
+                    "role": "assistant",
+                    "content": [],
+                },
+            },
+        )
+
+    async def _emit_text_delta(delta: str) -> AsyncIterator[str]:
+        """Yield the message item-added event (lazily) + a text delta."""
+        nonlocal accumulated_text
+        if not delta:
+            return
+        if not message_open:
+            yield await _open_message_item()
+        accumulated_text += delta
+        yield _sse(
+            "response.output_text.delta",
+            {
+                "type": "response.output_text.delta",
+                "item_id": message_item_id,
+                "output_index": message_output_index,
+                "content_index": 0,
+                "delta": delta,
+            },
+        )
+
+    try:
+        async for output in engine.stream_chat(messages=messages, **chat_kwargs):
+            delta_text = output.new_text
+
+            if hasattr(output, "prompt_tokens") and output.prompt_tokens:
+                prompt_tokens = output.prompt_tokens
+            if hasattr(output, "completion_tokens") and output.completion_tokens:
+                completion_tokens = output.completion_tokens
+            if hasattr(output, "cached_tokens") and output.cached_tokens:
+                cached_tokens = output.cached_tokens
+
+            engine_tool_calls = getattr(output, "tool_calls", None) or []
+            if engine_tool_calls:
+                accumulated_structured_tool_calls.extend(engine_tool_calls)
+                continue
+
+            if not delta_text:
+                continue
+
+            # Channel-routed engines (harmony / gemma4) — honor the
+            # channel directly. ``reasoning`` channel drops here
+            # because Responses-API streams don't have a reasoning
+            # delta event Codex parses (Codex maps it from a separate
+            # ``response.reasoning_text.delta`` we omit in v1).
+            output_channel = getattr(output, "channel", None)
+            if output_channel is not None:
+                if output_channel in ("content", "tool_call"):
+                    content = strip_special_tokens(delta_text)
+                    if content:
+                        filtered = tool_filter.process(content)
+                        if filtered:
+                            async for ev in _emit_text_delta(filtered):
+                                yield ev
+                # ``reasoning`` and unknown channels are dropped for v1.
+                continue
+
+            if reasoning_parser:
+                previous_raw = accumulated_raw
+                accumulated_raw += delta_text
+                delta_msg = reasoning_parser.extract_reasoning_streaming(
+                    previous_raw, accumulated_raw, delta_text
+                )
+                if delta_msg is None:
+                    continue
+                if delta_msg.content:
+                    content = strip_special_tokens(delta_msg.content)
+                    if content:
+                        filtered = tool_filter.process(content)
+                        if filtered:
+                            async for ev in _emit_text_delta(filtered):
+                                yield ev
+                # delta_msg.reasoning intentionally dropped — see above.
+                continue
+
+            # Default path: text-only stream with think_router stripping
+            # ``<think>...</think>`` from the text channel.
+            content = strip_special_tokens(delta_text)
+            if not content:
+                continue
+            filtered = tool_filter.process(content)
+            if not filtered:
+                continue
+            pieces = think_router.process(filtered)
+            for block_type, piece in pieces:
+                if block_type == "text" and piece:
+                    async for ev in _emit_text_delta(piece):
+                        yield ev
+                # block_type == "thinking" intentionally dropped.
+
+        # Flush filters
+        remaining = tool_filter.flush()
+        if remaining:
+            if reasoning_parser:
+                async for ev in _emit_text_delta(remaining):
+                    yield ev
+            else:
+                for block_type, piece in think_router.process(remaining):
+                    if block_type == "text" and piece:
+                        async for ev in _emit_text_delta(piece):
+                            yield ev
+
+        if not reasoning_parser:
+            for block_type, piece in think_router.flush():
+                if block_type == "text" and piece:
+                    async for ev in _emit_text_delta(piece):
+                        yield ev
+
+        if reasoning_parser and accumulated_raw:
+            final_msg = (
+                reasoning_parser.finalize_streaming(accumulated_raw)
+                if hasattr(reasoning_parser, "finalize_streaming")
+                else None
+            )
+            if final_msg and final_msg.content:
+                content = strip_special_tokens(final_msg.content)
+                if content:
+                    async for ev in _emit_text_delta(content):
+                        yield ev
+
+        # Close the message item if we ever opened it.
+        if message_open:
+            yield _sse(
+                "response.output_item.done",
+                {
+                    "type": "response.output_item.done",
+                    "output_index": message_output_index,
+                    "item": {
+                        "type": "message",
+                        "id": message_item_id,
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": accumulated_text,
+                                "annotations": [],
+                            }
+                        ],
+                    },
+                },
+            )
+
+        # Emit function_call items for every tool call we saw.
+        _, tool_calls = _parse_tool_calls_with_parser(
+            accumulated_text,
+            openai_request,
+            structured_tool_calls=accumulated_structured_tool_calls or None,
+        )
+
+        tool_output_index = (message_output_index + 1) if message_open else 0
+        for tc in tool_calls or []:
+            fc_id = f"fc_{uuid.uuid4().hex[:24]}"
+            yield _sse(
+                "response.output_item.added",
+                {
+                    "type": "response.output_item.added",
+                    "output_index": tool_output_index,
+                    "item": {
+                        "type": "function_call",
+                        "id": fc_id,
+                        "call_id": tc.id,
+                        "name": tc.function.name,
+                        "arguments": "",
+                        "status": "in_progress",
+                    },
+                },
+            )
+            # Codex CLI accepts the args as a single delta — we don't
+            # have token-by-token streaming for tool_call arguments in
+            # the underlying engine yet, so emit the whole JSON string
+            # at once. Codex concatenates these the same way regardless
+            # of chunk count.
+            yield _sse(
+                "response.function_call_arguments.delta",
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "item_id": fc_id,
+                    "output_index": tool_output_index,
+                    "delta": tc.function.arguments or "",
+                },
+            )
+            yield _sse(
+                "response.output_item.done",
+                {
+                    "type": "response.output_item.done",
+                    "output_index": tool_output_index,
+                    "item": {
+                        "type": "function_call",
+                        "id": fc_id,
+                        "call_id": tc.id,
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments or "",
+                        "status": "completed",
+                    },
+                },
+            )
+            tool_output_index += 1
+
+        # response.completed — terminal event. Codex treats a missing
+        # one as a hard failure (it logs "stream closed before
+        # response.completed").
+        cached_tokens_clamped = min(cached_tokens, prompt_tokens)
+        usage_payload = {
+            "input_tokens": prompt_tokens,
+            "output_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+        if cached_tokens_clamped:
+            usage_payload["input_tokens_details"] = {
+                "cached_tokens": cached_tokens_clamped
+            }
+        yield _sse(
+            "response.completed",
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "object": "response",
+                    "created_at": created_at,
+                    "status": "completed",
+                    "model": served_model,
+                    "usage": usage_payload,
+                },
+            },
+        )
+
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Responses (stream): prompt={prompt_tokens} + "
+            f"completion={completion_tokens} tokens in {elapsed:.2f}s "
+            f"({tokens_per_sec:.1f} tok/s)"
+        )
+
+    except Exception as e:  # noqa: BLE001
+        # response.failed gives Codex a clean shutdown signal instead of
+        # a half-stream-then-EOF; matches how the OpenAI cloud
+        # Responses API closes errored streams.
+        logger.exception("Responses stream failed: %s", e)
+        yield _sse(
+            "response.failed",
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": response_id,
+                    "status": "failed",
+                    "error": {
+                        "code": "internal_error",
+                        "message": str(e),
+                    },
+                },
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_request(req: ResponsesRequest) -> None:
+    """One-line request log mirroring the other route surfaces."""
+    if isinstance(req.input, str):
+        n_items = 1
+        total_chars = len(req.input)
+    else:
+        n_items = len(req.input)
+        total_chars = 0
+        for item in req.input:
+            if isinstance(item.content, str):
+                total_chars += len(item.content)
+            elif item.content:
+                for c in item.content:
+                    if c.text:
+                        total_chars += len(c.text)
+            if item.arguments:
+                total_chars += len(item.arguments)
+    n_tools = len(req.tools) if req.tools else 0
+    instr_chars = len(req.instructions) if req.instructions else 0
+    logger.info(
+        f"[REQUEST] POST /v1/responses (codex) stream={req.stream} "
+        f"model={req.model!r} max_output_tokens={req.max_output_tokens} "
+        f"input_items={n_items} total_chars={total_chars} "
+        f"instructions_chars={instr_chars} tools={n_tools}"
+    )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -350,111 +350,110 @@ async def _stream_responses(
             },
         },
     )
-
-    messages, _images, _videos = extract_multimodal_content(
-        openai_request.messages,
-        preserve_native_format=engine.preserve_native_tool_format,
-    )
-
-    chat_kwargs = {
-        "max_tokens": _resolve_max_tokens(
-            openai_request.max_tokens,
-            _resolve_enable_thinking(openai_request),
-        ),
-        **_resolved_sampling_kwargs(openai_request),
-    }
-    if openai_request.tools:
-        chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
-    resolved_thinking = _resolve_enable_thinking(openai_request)
-    if resolved_thinking is not None:
-        chat_kwargs["enable_thinking"] = resolved_thinking
-
-    accumulated_text = ""
-    accumulated_raw = ""
-    accumulated_structured_tool_calls: list[dict] = []
-    tool_filter = StreamingToolCallFilter()
-
-    _tokenizer = engine.tokenizer
-    _chat_template = ""
-    if _tokenizer and hasattr(_tokenizer, "chat_template"):
-        _chat_template = _tokenizer.chat_template or ""
-    _starts_thinking = _should_start_in_thinking(
-        _chat_template, chat_kwargs.get("enable_thinking")
-    )
-    think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
-
-    prompt_tokens = 0
-    completion_tokens = 0
-    cached_tokens = 0
-
-    # Lazy message-item state. We do NOT emit the message
-    # output_item.added until we have actual user-facing text to stream
-    # — a turn that is pure tool_calls should not emit a phantom empty
-    # message item.
-    message_item_id: str | None = None
-    message_output_index: int | None = None
-    message_open = False
-
-    # Per-request reasoning parser instance (matches anthropic.py).
-    reasoning_parser = None
-    if cfg.reasoning_parser_name:
-        try:
-            from ..reasoning import get_parser
-
-            reasoning_parser = get_parser(cfg.reasoning_parser_name)()
-        except Exception:
-            pass
-    if chat_kwargs.get("enable_thinking") is False:
-        reasoning_parser = None
-    if reasoning_parser:
-        reasoning_parser.reset_state()
-
-    async def _open_message_item() -> str:
-        """Emit response.output_item.added for the assistant message.
-
-        Returns the event string so callers can yield it; the bookkeeping
-        for ``message_open`` lives here so the open/close pair stays
-        symmetric.
-        """
-        nonlocal message_item_id, message_output_index, message_open
-        message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
-        message_output_index = 0
-        message_open = True
-        return _sse(
-            "response.output_item.added",
-            {
-                "type": "response.output_item.added",
-                "output_index": message_output_index,
-                "item": {
-                    "type": "message",
-                    "id": message_item_id,
-                    "status": "in_progress",
-                    "role": "assistant",
-                    "content": [],
-                },
-            },
-        )
-
-    async def _emit_text_delta(delta: str) -> AsyncIterator[str]:
-        """Yield the message item-added event (lazily) + a text delta."""
-        nonlocal accumulated_text
-        if not delta:
-            return
-        if not message_open:
-            yield await _open_message_item()
-        accumulated_text += delta
-        yield _sse(
-            "response.output_text.delta",
-            {
-                "type": "response.output_text.delta",
-                "item_id": message_item_id,
-                "output_index": message_output_index,
-                "content_index": 0,
-                "delta": delta,
-            },
-        )
-
     try:
+        messages, _images, _videos = extract_multimodal_content(
+            openai_request.messages,
+            preserve_native_format=engine.preserve_native_tool_format,
+        )
+
+        chat_kwargs = {
+            "max_tokens": _resolve_max_tokens(
+                openai_request.max_tokens,
+                _resolve_enable_thinking(openai_request),
+            ),
+            **_resolved_sampling_kwargs(openai_request),
+        }
+        if openai_request.tools:
+            chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        resolved_thinking = _resolve_enable_thinking(openai_request)
+        if resolved_thinking is not None:
+            chat_kwargs["enable_thinking"] = resolved_thinking
+
+        accumulated_text = ""
+        accumulated_raw = ""
+        accumulated_structured_tool_calls: list[dict] = []
+        tool_filter = StreamingToolCallFilter()
+
+        _tokenizer = engine.tokenizer
+        _chat_template = ""
+        if _tokenizer and hasattr(_tokenizer, "chat_template"):
+            _chat_template = _tokenizer.chat_template or ""
+        _starts_thinking = _should_start_in_thinking(
+            _chat_template, chat_kwargs.get("enable_thinking")
+        )
+        think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        cached_tokens = 0
+
+        # Lazy message-item state. We do NOT emit the message
+        # output_item.added until we have actual user-facing text to stream
+        # — a turn that is pure tool_calls should not emit a phantom empty
+        # message item.
+        message_item_id: str | None = None
+        message_output_index: int | None = None
+        message_open = False
+
+        # Per-request reasoning parser instance (matches anthropic.py).
+        reasoning_parser = None
+        if cfg.reasoning_parser_name:
+            try:
+                from ..reasoning import get_parser
+
+                reasoning_parser = get_parser(cfg.reasoning_parser_name)()
+            except Exception:
+                pass
+        if chat_kwargs.get("enable_thinking") is False:
+            reasoning_parser = None
+        if reasoning_parser:
+            reasoning_parser.reset_state()
+
+        async def _open_message_item() -> str:
+            """Emit response.output_item.added for the assistant message.
+
+            Returns the event string so callers can yield it; the bookkeeping
+            for ``message_open`` lives here so the open/close pair stays
+            symmetric.
+            """
+            nonlocal message_item_id, message_output_index, message_open
+            message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
+            message_output_index = 0
+            message_open = True
+            return _sse(
+                "response.output_item.added",
+                {
+                    "type": "response.output_item.added",
+                    "output_index": message_output_index,
+                    "item": {
+                        "type": "message",
+                        "id": message_item_id,
+                        "status": "in_progress",
+                        "role": "assistant",
+                        "content": [],
+                    },
+                },
+            )
+
+        async def _emit_text_delta(delta: str) -> AsyncIterator[str]:
+            """Yield the message item-added event (lazily) + a text delta."""
+            nonlocal accumulated_text
+            if not delta:
+                return
+            if not message_open:
+                yield await _open_message_item()
+            accumulated_text += delta
+            yield _sse(
+                "response.output_text.delta",
+                {
+                    "type": "response.output_text.delta",
+                    "item_id": message_item_id,
+                    "output_index": message_output_index,
+                    "content_index": 0,
+                    "delta": delta,
+                },
+            )
+
         async for output in engine.stream_chat(messages=messages, **chat_kwargs):
             delta_text = output.new_text
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -937,6 +937,7 @@ from .routes.health import probe_router as _probe_router
 from .routes.health import router as _health_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.models import router as _models_router
+from .routes.responses import router as _responses_router
 
 app.include_router(_probe_router)
 app.include_router(_health_router)
@@ -944,6 +945,7 @@ app.include_router(_models_router)
 app.include_router(_chat_router)
 app.include_router(_completions_router)
 app.include_router(_anthropic_router)
+app.include_router(_responses_router)
 app.include_router(_embeddings_router)
 app.include_router(_mcp_router)
 app.include_router(_audio_router)


### PR DESCRIPTION
## Summary

Adds a stateless `POST /v1/responses` shim so the official **Codex CLI** (and any other OpenAI Responses-API client) can use rapid-mlx as a local backend. Resolves #549 (@shinrali — M3 Max 48G / Qwen3.6-35B-A3B). This is the protocol layer; PR-B (#590) wires up the harness (codex profile / docs / README).

## Why stateless is enough

- Codex re-sends the **full conversation history in `input[]` every turn** — confirmed by openai/codex#3841 (`previous_response_id` is not used client-side).
- This shim 400s loudly if anyone sets `previous_response_id` — silent prompt loss on retries is worse than a clear error.

## What's in

| File | Role | LOC |
|---|---|---:|
| `vllm_mlx/api/responses_models.py` | Pydantic — request / response / polymorphic input + output items | 161 |
| `vllm_mlx/api/responses_adapter.py` | `responses_to_openai` + `openai_to_responses` | 350 |
| `vllm_mlx/routes/responses.py` | Non-stream + SSE stream route | 520 |
| `vllm_mlx/server.py` | `include_router(_responses_router)` | +2 |
| `tests/test_responses_adapter.py` | 42 pure-logic tests | 491 |
| `tests/test_responses_route.py` | 17 HTTP-level tests (lightweight engine) | 459 |

## SSE event sequence Codex parses

Codex CLI parses exactly 7 event types; the stream emits them in this order:

1. `response.created` — Codex sets state from this; missing = error
2. `response.output_item.added` (message) — when first text delta arrives
3. `response.output_text.delta` — each text chunk
4. `response.output_item.done` (message)
5. For each tool call: `response.output_item.added` (function_call) → `response.function_call_arguments.delta` → `response.output_item.done`
6. `response.completed` — terminal event with usage. **Codex treats stream-close-without-this as a hard failure** ("stream closed before response.completed")
7. `response.failed` — on exception, gives Codex a clean shutdown signal

## Model-name policy

Same `gpt-*` / `claude-*` bypass as #557. Codex sends `gpt-5` / `gpt-5-codex` — would otherwise 404 on `_validate_model_name`. Response carries the loaded model name (consistent with Anthropic route convention).

## v1 scope cuts (Codex still works)

- ✅ `text.format` JSON-schema → `response_format` plumbed through
- ❌ `reasoning.effort` ignored (no `response.reasoning_text.delta` in v1)
- ❌ `previous_response_id` returns 400
- ❌ `input_image` vision dropped (Codex doesn't send it)
- ❌ Non-function tool types (`web_search`, `code_interpreter`, `image_generation`, `file_search`, `computer_use`) dropped — Codex won't send them to a third-party backend

## Test Plan

- [x] `uv run pytest tests/test_responses_adapter.py tests/test_responses_route.py` — 59/59 PASS locally
- [x] `uv run pytest tests/test_anthropic_route_auth.py tests/test_anthropic_adapter.py tests/test_routes.py tests/test_api_validation_bundle.py` — 175/175 PASS (no regression in nearby routes)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Full server import + `POST /v1/responses` reaches the route (returns 503 with no engine loaded — expected)

## Follow-ups (tracked separately, not gated by this PR)

- PR-B (#590) `feat/codex-firstclass-harness` — codex profile, docs/guides/codex-cli.md, README integration. Already up; depends on this PR being released.
- v0.7.11 release after both PRs merge — notify @shinrali in #549.
- #589 codex P2 (IPv4-mapped IPv6 in `_subnet_bucket`) — separate small fix.

Version bump 0.7.9 → 0.7.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
