### PR TITLE
chore(logs): rebrand runtime logger namespace vllm_mlx.* -> rapid_mlx.*

### DIFF
--- a/tests/test_log_namespace_rebrand.py
+++ b/tests/test_log_namespace_rebrand.py
@@ -31,7 +31,7 @@ def isolated_logging_factory():
     leak state into the next test's caplog or into the rest of the suite.
     """
     saved_factory = logging.getLogRecordFactory()
-    saved_sentinel = getattr(logging, _log_namespace._INSTALLED_SENTINEL, False)
+    saved_sentinel = getattr(logging, _log_namespace._INSTALLED_SENTINEL, None)
     if hasattr(logging, _log_namespace._INSTALLED_SENTINEL):
         delattr(logging, _log_namespace._INSTALLED_SENTINEL)
     try:
@@ -40,8 +40,8 @@ def isolated_logging_factory():
         logging.setLogRecordFactory(saved_factory)
         if hasattr(logging, _log_namespace._INSTALLED_SENTINEL):
             delattr(logging, _log_namespace._INSTALLED_SENTINEL)
-        if saved_sentinel:
-            setattr(logging, _log_namespace._INSTALLED_SENTINEL, True)
+        if saved_sentinel is not None:
+            setattr(logging, _log_namespace._INSTALLED_SENTINEL, saved_sentinel)
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +175,80 @@ def test_install_preserves_existing_custom_factory(isolated_logging_factory):
     assert getattr(record, marker_attr, False) is True
     # ...AND our rebrand ran on top.
     assert record.name == "rapid_mlx.scheduler"
+
+
+def test_factory_survives_make_log_record_with_none_name(isolated_logging_factory):
+    """``logging.makeLogRecord(dict)`` (socket / queue handlers reconstructing
+    records from a wire-format dict) calls the active LogRecord factory with
+    ``name=None`` and then patches ``record.__dict__`` afterwards. A naive
+    ``record.name.startswith(...)`` in our wrapper would AttributeError. This
+    test pins the guard so any future refactor that drops the ``isinstance``
+    check fails fast.
+    """
+    install_log_namespace_rebrand()
+    # Equivalent of what SocketHandler / QueueHandler do.
+    record = logging.makeLogRecord(
+        {
+            "name": "vllm_mlx.routes.chat",
+            "levelno": logging.INFO,
+            "levelname": "INFO",
+            "msg": "x",
+        }
+    )
+    # makeLogRecord doesn't go through our factory's rename path (because
+    # name=None at factory time, and the wire dict patches it AFTER our
+    # wrapper has already returned). But the patched name is what handlers
+    # eventually see -- and we must not crash producing the record.
+    assert record.name == "vllm_mlx.routes.chat"
+
+
+def test_install_rewraps_when_external_factory_is_swapped_in(
+    isolated_logging_factory,
+):
+    """If another component (structlog, a test fixture) replaces the global
+    factory AFTER ``install_log_namespace_rebrand`` has run, calling install
+    again must re-wrap on top of the new factory -- not skip with "already
+    installed". A bare-boolean sentinel would have silently left the new
+    foreign factory un-rebranded, which is the bug codex round 1 caught.
+    """
+    install_log_namespace_rebrand()
+    our_wrapper = logging.getLogRecordFactory()
+
+    marker_attr = "_test_external_marker"
+
+    def external_factory(*args, **kwargs):
+        # Simulate structlog-style: ignore the wrapper above us, build a
+        # fresh record from scratch with a custom attribute.
+        record = logging.LogRecord(*args, **kwargs)
+        setattr(record, marker_attr, True)
+        return record
+
+    logging.setLogRecordFactory(external_factory)
+    # The active factory is no longer ours -- subsequent install must
+    # re-wrap, not bail out.
+    install_log_namespace_rebrand()
+    new_wrapper = logging.getLogRecordFactory()
+
+    assert new_wrapper is not our_wrapper, (
+        "install must produce a NEW wrapper when an external factory took over"
+    )
+    assert new_wrapper is not external_factory, (
+        "external factory must be wrapped, not active"
+    )
+
+    # Drive a record through the new chain: external_factory adds its
+    # marker, our wrapper rebrands the name.
+    record = new_wrapper(
+        "vllm_mlx.scheduler",
+        logging.INFO,
+        __file__,
+        0,
+        "x",
+        None,
+        None,
+    )
+    assert record.name == "rapid_mlx.scheduler"
+    assert getattr(record, marker_attr, False) is True
 
 
 def test_factory_does_not_swallow_extra_args(isolated_logging_factory):

--- a/tests/test_log_namespace_rebrand.py
+++ b/tests/test_log_namespace_rebrand.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for ``vllm_mlx/_log_namespace.py`` -- the runtime ``vllm_mlx.*`` ->
+``rapid_mlx.*`` LogRecord-factory rebrand.
+
+We import the module under test directly (not via ``import vllm_mlx``,
+which would install the global factory and pollute every subsequent
+test's caplog). For factory-install verification we save/restore the
+process-wide factory and sentinel.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vllm_mlx import _log_namespace
+from vllm_mlx._log_namespace import (
+    _rewrite_name,
+    install_log_namespace_rebrand,
+)
+
+
+@pytest.fixture
+def isolated_logging_factory():
+    """Save and restore the global LogRecord factory + install sentinel.
+
+    Each test that calls ``install_log_namespace_rebrand`` (or otherwise
+    touches the global factory) must run inside this fixture so it doesn't
+    leak state into the next test's caplog or into the rest of the suite.
+    """
+    saved_factory = logging.getLogRecordFactory()
+    saved_sentinel = getattr(logging, _log_namespace._INSTALLED_SENTINEL, False)
+    if hasattr(logging, _log_namespace._INSTALLED_SENTINEL):
+        delattr(logging, _log_namespace._INSTALLED_SENTINEL)
+    try:
+        yield
+    finally:
+        logging.setLogRecordFactory(saved_factory)
+        if hasattr(logging, _log_namespace._INSTALLED_SENTINEL):
+            delattr(logging, _log_namespace._INSTALLED_SENTINEL)
+        if saved_sentinel:
+            setattr(logging, _log_namespace._INSTALLED_SENTINEL, True)
+
+
+# ---------------------------------------------------------------------------
+# Pure ``_rewrite_name`` -- no side effects, no isolation needed.
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_exact_prefix():
+    assert _rewrite_name("vllm_mlx") == "rapid_mlx"
+
+
+def test_rewrite_dotted_child():
+    assert _rewrite_name("vllm_mlx.server") == "rapid_mlx.server"
+
+
+def test_rewrite_deeply_nested_child():
+    assert _rewrite_name("vllm_mlx.service.helpers") == "rapid_mlx.service.helpers"
+
+
+def test_does_not_rewrite_lookalike_prefix():
+    # ``vllm_mlxfoo`` is not a child of ``vllm_mlx`` (no dot separator).
+    # Defensive: we won't accidentally rebrand a third-party logger that
+    # happens to start with the string.
+    assert _rewrite_name("vllm_mlxfoo") == "vllm_mlxfoo"
+
+
+def test_does_not_rewrite_unrelated_namespaces():
+    for unrelated in (
+        "uvicorn",
+        "uvicorn.access",
+        "fastapi",
+        "asyncio",
+        "httpx",
+        "huggingface_hub",
+        "",
+    ):
+        assert _rewrite_name(unrelated) == unrelated
+
+
+# ---------------------------------------------------------------------------
+# Factory installation -- side-effectful, isolated.
+# ---------------------------------------------------------------------------
+
+
+def test_factory_rewrites_vllm_mlx_records(isolated_logging_factory, caplog):
+    install_log_namespace_rebrand()
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.server"):
+        logging.getLogger("vllm_mlx.server").info("hello from server")
+
+    matching = [r for r in caplog.records if r.message == "hello from server"]
+    assert len(matching) == 1
+    # The factory rewrites the name at record creation time, BEFORE caplog
+    # captures it. So the captured record's name must already be rapid_mlx.*.
+    assert matching[0].name == "rapid_mlx.server"
+
+
+def test_factory_rewrites_deeply_nested_records(isolated_logging_factory, caplog):
+    install_log_namespace_rebrand()
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.service.helpers"):
+        logging.getLogger("vllm_mlx.service.helpers").info("[disconnect_guard] tick")
+
+    matching = [r for r in caplog.records if "disconnect_guard" in r.message]
+    assert len(matching) == 1
+    assert matching[0].name == "rapid_mlx.service.helpers"
+
+
+def test_factory_leaves_third_party_records_alone(isolated_logging_factory, caplog):
+    """uvicorn / asyncio / httpx / etc. log records must NOT be rewritten.
+
+    We have to set ``caplog.at_level`` per-logger because rapid-mlx's
+    ``configure_logging`` (which runs as a side effect of importing
+    ``vllm_mlx.server`` in the broader test session) pins httpx/httpcore/
+    urllib3/huggingface_hub to WARNING. Setting INFO on root alone leaves
+    those at WARNING and an INFO call is dropped before it ever reaches
+    a record.
+    """
+    install_log_namespace_rebrand()
+
+    third_party = ("uvicorn.access", "asyncio", "httpx", "huggingface_hub")
+    with caplog.at_level(logging.INFO):
+        for name in third_party:
+            with caplog.at_level(logging.INFO, logger=name):
+                logging.getLogger(name).info("third-party probe")
+
+    names = {r.name for r in caplog.records if r.message == "third-party probe"}
+    # Every third-party logger must capture its OWN name -- not a rebranded one.
+    for name in third_party:
+        assert name in names, f"third-party logger {name!r} record went missing"
+        # And critically, no rebranded twin appears.
+        assert f"rapid_mlx.{name}" not in names
+
+
+def test_install_is_idempotent(isolated_logging_factory):
+    """Calling install twice must NOT stack factories."""
+    install_log_namespace_rebrand()
+    factory_after_first = logging.getLogRecordFactory()
+
+    install_log_namespace_rebrand()
+    factory_after_second = logging.getLogRecordFactory()
+
+    # Same factory object -- no second wrap.
+    assert factory_after_first is factory_after_second
+
+
+def test_install_preserves_existing_custom_factory(isolated_logging_factory):
+    """If something else (structlog, a test fixture, etc.) has set a custom
+    factory, install_log_namespace_rebrand must wrap it -- not replace it.
+    """
+    marker_attr = "_test_custom_factory_marker"
+
+    def custom_factory(*args, **kwargs):
+        record = logging.LogRecord(*args, **kwargs)
+        setattr(record, marker_attr, True)
+        return record
+
+    logging.setLogRecordFactory(custom_factory)
+    install_log_namespace_rebrand()
+
+    record = logging.getLogRecordFactory()(
+        "vllm_mlx.scheduler",
+        logging.WARNING,
+        __file__,
+        0,
+        "x",
+        None,
+        None,
+    )
+    # Custom factory's marker survived...
+    assert getattr(record, marker_attr, False) is True
+    # ...AND our rebrand ran on top.
+    assert record.name == "rapid_mlx.scheduler"
+
+
+def test_factory_does_not_swallow_extra_args(isolated_logging_factory):
+    """Ensure the factory passes through ``extra``/``stack_info``/etc.
+    correctly -- mirroring what the standard library's default factory does.
+    """
+    install_log_namespace_rebrand()
+    record = logging.getLogRecordFactory()(
+        "vllm_mlx.engine_core",
+        logging.INFO,
+        "/path/to/file.py",
+        42,
+        "msg %s",
+        ("arg",),
+        None,  # exc_info
+        "funcname",
+        "stack info",
+    )
+    assert record.name == "rapid_mlx.engine_core"
+    assert record.pathname == "/path/to/file.py"
+    assert record.lineno == 42
+    assert record.funcName == "funcname"
+    assert record.stack_info == "stack info"
+    assert record.getMessage() == "msg arg"

--- a/vllm_mlx/__init__.py
+++ b/vllm_mlx/__init__.py
@@ -18,6 +18,21 @@ try:
 except Exception:
     __version__ = "0.0.0"  # fallback for editable installs without metadata
 
+# Rebrand runtime logger names from the legacy ``vllm_mlx.*`` namespace to
+# the product-facing ``rapid_mlx.*`` namespace before any submodule has had
+# a chance to create a record. The Python package directory keeps the
+# ``vllm_mlx/`` name (renaming would touch hundreds of imports and break
+# external integrations); only what users see in log output changes. The
+# rebrand is a single ``logging.setLogRecordFactory`` call, idempotent and
+# scoped to the ``vllm_mlx`` prefix -- uvicorn/fastapi/asyncio/httpx
+# namespaces flow through untouched. See ``_log_namespace`` for the
+# rationale (handler-attached filters and logger-attached filters were both
+# rejected; factory is the only path that catches records from descendant
+# loggers without imposing churn on every ``getLogger(__name__)`` site).
+from vllm_mlx._log_namespace import install_log_namespace_rebrand
+
+install_log_namespace_rebrand()
+
 # All imports are lazy to allow usage on non-Apple Silicon platforms
 # (e.g., CI running on Linux) where mlx_lm is not available. The MLX
 # hardware-compat shim (#404 M5 single-stream) lives in `_mlx_compat`

--- a/vllm_mlx/_log_namespace.py
+++ b/vllm_mlx/_log_namespace.py
@@ -36,11 +36,16 @@ import logging
 _OLD_PREFIX = "vllm_mlx"
 _NEW_PREFIX = "rapid_mlx"
 
-# Sentinel so install_log_namespace_rebrand() is idempotent. Repeated calls
-# (test fixtures, in-process restarts, CLI re-entry from a wrapper) MUST NOT
-# stack factories on top of each other -- that would still produce correct
-# output but waste a function call per record forever.
-_INSTALLED_SENTINEL = "_rapid_mlx_log_namespace_rebrand_installed"
+# Sentinel so install_log_namespace_rebrand() can detect "I already wrapped
+# the *currently active* factory". We deliberately store the wrapper
+# callable on the logging module rather than a bare boolean: that way, if
+# some other component (structlog, a test fixture, etc.) calls
+# ``logging.setLogRecordFactory`` AFTER us, the next install_… call sees
+# that the active factory is no longer our wrapper and re-wraps on top of
+# the new one. A bare True/False sentinel would silently leave the new
+# foreign factory un-rebranded -- which is exactly the "wrap, don't
+# replace" promise the docstring makes.
+_INSTALLED_SENTINEL = "_rapid_mlx_log_namespace_rebrand_installed_factory"
 
 
 def _rewrite_name(name: str) -> str:
@@ -62,23 +67,34 @@ def _rewrite_name(name: str) -> str:
 def install_log_namespace_rebrand() -> None:
     """Install a LogRecord factory that rebrands ``vllm_mlx.*`` -> ``rapid_mlx.*``.
 
-    Safe to call multiple times -- subsequent calls are no-ops. Wraps any
-    existing factory so other components (e.g. structlog, third-party
-    libraries) that have set their own factory continue to work; their work
-    runs first, then we rebrand on top.
+    Safe to call multiple times. The idempotency check compares the *currently
+    active* factory against the wrapper we last installed: if they match, do
+    nothing; if they differ (because some other component swapped the factory
+    after us), wrap the new factory so its records get rebranded too.
+
+    Wraps any existing factory so other components (e.g. structlog,
+    third-party libraries) that have set their own factory continue to work;
+    their work runs first, then we rebrand on top.
     """
-    if getattr(logging, _INSTALLED_SENTINEL, False):
+    current_factory = logging.getLogRecordFactory()
+    if getattr(logging, _INSTALLED_SENTINEL, None) is current_factory:
         return
 
-    previous_factory = logging.getLogRecordFactory()
+    previous_factory = current_factory
 
     def _factory(*args, **kwargs):
         record = previous_factory(*args, **kwargs)
-        # Only rewrite when needed -- the prefix check is a fast string op and
-        # avoids touching record.name for every uvicorn/asyncio/httpx record.
-        if record.name.startswith(_OLD_PREFIX):
-            record.name = _rewrite_name(record.name)
+        # ``logging.makeLogRecord(d)`` (used by socket / queue receivers that
+        # reconstruct records from a wire-format dict) calls the factory with
+        # ``name=None`` and patches ``record.__dict__`` afterwards. Touching
+        # ``record.name.startswith(...)`` would AttributeError there. Guard
+        # for any non-string ``name``, then short-circuit on the cheap prefix
+        # check so we don't pay a function call per uvicorn / asyncio /
+        # httpx record.
+        name = record.name
+        if isinstance(name, str) and name.startswith(_OLD_PREFIX):
+            record.name = _rewrite_name(name)
         return record
 
     logging.setLogRecordFactory(_factory)
-    setattr(logging, _INSTALLED_SENTINEL, True)
+    setattr(logging, _INSTALLED_SENTINEL, _factory)

--- a/vllm_mlx/_log_namespace.py
+++ b/vllm_mlx/_log_namespace.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Runtime log namespace rebrand: ``vllm_mlx.*`` -> ``rapid_mlx.*``.
+
+The Python package directory is still ``vllm_mlx/`` (renaming would touch
+every import in the repo and every external integration), but the product,
+PyPI distribution, and CLI are all called ``rapid-mlx``. Without this shim,
+``logging.getLogger(__name__)`` returns ``vllm_mlx.<submodule>`` and every
+log line a user copies into a bug report or LLM reads as a stale, internal
+name.
+
+We use ``logging.setLogRecordFactory`` rather than a logger- or
+handler-attached filter for three reasons:
+
+1. **Logger filters don't propagate to children** -- a filter on the
+   ``vllm_mlx`` logger would NOT see records emitted by ``vllm_mlx.scheduler``
+   etc. (Python docs: "Filters added to a logger are not used by descendant
+   loggers.")
+2. **Handler filters are fragile** -- uvicorn, pytest's caplog, and any
+   library that installs its own handler bypass a filter pinned to the root
+   logger's basicConfig StreamHandler.
+3. **Factory runs once per record at creation time** -- ``record.name`` is
+   already ``vllm_mlx.<sub>`` when the factory runs, so we can rewrite it
+   before any handler (stream, file, caplog) sees it. Third-party namespaces
+   are left untouched because the prefix check filters them out.
+
+This is install-once, idempotent, and removable in one line (revert the
+``setLogRecordFactory`` call). No churn across the 70+ ``getLogger(__name__)``
+sites in the codebase.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_OLD_PREFIX = "vllm_mlx"
+_NEW_PREFIX = "rapid_mlx"
+
+# Sentinel so install_log_namespace_rebrand() is idempotent. Repeated calls
+# (test fixtures, in-process restarts, CLI re-entry from a wrapper) MUST NOT
+# stack factories on top of each other -- that would still produce correct
+# output but waste a function call per record forever.
+_INSTALLED_SENTINEL = "_rapid_mlx_log_namespace_rebrand_installed"
+
+
+def _rewrite_name(name: str) -> str:
+    """Map ``vllm_mlx[.*]`` -> ``rapid_mlx[.*]``; leave everything else alone.
+
+    - Exact ``vllm_mlx`` becomes ``rapid_mlx``.
+    - ``vllm_mlx.server`` becomes ``rapid_mlx.server``.
+    - ``vllm_mlxfoo`` (no separator) is NOT rewritten -- defensive against any
+      future logger naming collision with a different package.
+    - Anything not starting with the prefix is returned as-is.
+    """
+    if name == _OLD_PREFIX:
+        return _NEW_PREFIX
+    if name.startswith(_OLD_PREFIX + "."):
+        return _NEW_PREFIX + name[len(_OLD_PREFIX) :]
+    return name
+
+
+def install_log_namespace_rebrand() -> None:
+    """Install a LogRecord factory that rebrands ``vllm_mlx.*`` -> ``rapid_mlx.*``.
+
+    Safe to call multiple times -- subsequent calls are no-ops. Wraps any
+    existing factory so other components (e.g. structlog, third-party
+    libraries) that have set their own factory continue to work; their work
+    runs first, then we rebrand on top.
+    """
+    if getattr(logging, _INSTALLED_SENTINEL, False):
+        return
+
+    previous_factory = logging.getLogRecordFactory()
+
+    def _factory(*args, **kwargs):
+        record = previous_factory(*args, **kwargs)
+        # Only rewrite when needed -- the prefix check is a fast string op and
+        # avoids touching record.name for every uvicorn/asyncio/httpx record.
+        if record.name.startswith(_OLD_PREFIX):
+            record.name = _rewrite_name(record.name)
+        return record
+
+    logging.setLogRecordFactory(_factory)
+    setattr(logging, _INSTALLED_SENTINEL, True)


### PR DESCRIPTION
## Summary

The Python package directory is still ``vllm_mlx/`` (renaming would touch hundreds of imports and every external integration -- out of scope for this PR), but the product, PyPI distribution, and CLI are all called ``rapid-mlx``. Without this shim, every ``logging.getLogger(__name__)`` call returns ``vllm_mlx.<submodule>`` and log lines users copy into bug reports / LLMs read as a stale, internal name -- e.g. ``INFO:vllm_mlx.service.helpers:[disconnect_guard] poll #90 elapsed=45.1s``.

After this PR, the same line reads ``INFO:rapid_mlx.service.helpers:...``. Third-party namespaces (uvicorn, fastapi, asyncio, httpx, huggingface_hub) flow through untouched.

## Implementation -- why a LogRecord factory and not a filter

A single ``logging.setLogRecordFactory`` call, installed at the top of ``vllm_mlx/__init__.py`` so it runs before any submodule has had a chance to create a record. The factory rewrites ``record.name`` only when it matches ``vllm_mlx`` or ``vllm_mlx.*``.

Other options considered and rejected:

- **Logger-attached filter** -- Python's ``logging`` docs explicitly state "Filters added to a logger are not used by descendant loggers." A filter on the ``vllm_mlx`` logger would NOT see records from ``vllm_mlx.scheduler`` etc.
- **Handler-attached filter** -- Fragile under uvicorn / pytest caplog / any library that installs its own handler bypassing the root logger's basicConfig StreamHandler.
- **Renaming the package** -- High blast radius (hundreds of imports, every external integration, every Python file with a ``from vllm_mlx.foo import bar``). Explicitly out of scope.

The factory approach is single-concern, single attach point, idempotent, and removable in one line.

## Edge cases handled

- ``logging.makeLogRecord(dict)`` (used by ``SocketHandler``/``QueueHandler`` to reconstruct records from a wire-format dict) calls the factory with ``name=None`` and patches ``__dict__`` afterwards. Guarded with ``isinstance(name, str)`` (codex r1 catch).
- External components (structlog, test fixtures) calling ``setLogRecordFactory`` AFTER our install: sentinel stores the wrapper callable, so re-installs re-wrap on top of the new foreign factory instead of silently bailing out (codex r1 catch).
- Pre-existing custom factories: wrapped, not replaced -- their custom record attributes survive the rebrand.

## What's NOT in scope (deliberately)

- Renaming the ``vllm_mlx/`` directory (out of scope; would touch every test, every import, every external integration).
- Renaming the Prometheus metric prefix (``vllm_mlx_*`` in ``vllm_mlx/metrics.py``) -- those are observability identifiers, distinct concern, separate PR.
- Renaming ``import vllm_mlx`` statements throughout the codebase.
- Bumping the version.

## Test plan

- [x] 13 new unit tests in ``tests/test_log_namespace_rebrand.py`` covering pure-rewrite semantics, exact-prefix vs. dotted-child matching, lookalike-prefix safety, factory installation rewriting captured records, third-party namespaces left alone, idempotency, custom-factory composition, ``makeLogRecord(name=None)`` guard, external-swap re-wrap, and ``LogRecord`` extra-arg passthrough.
- [x] Broad existing test sweep: 5098 passed / 0 failed (excluding live-server integration tests that require ``127.0.0.1:8000``).
- [x] Tests that use ``caplog.at_level(logger="vllm_mlx.*")`` (5 files: test_mtp_inject_and_install, test_diffusion_engine, test_dflash_integration, test_prefix_cache_persistence, test_structured_output, test_chat_template_sidecar) all still pass -- those tests check ``record.message``, not ``record.name``.
- [x] Manual smoke test via ``python3.12 -c "import logging; logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(name)s:%(message)s'); import vllm_mlx; logging.getLogger('vllm_mlx.server').info('disconnect_guard poll #1 elapsed=0.1s'); logging.getLogger('uvicorn.access').info('GET /healthz 200')"`` -- confirms ``rapid_mlx.server:...`` output AND ``uvicorn.access`` untouched.
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [x] codex review --base raullenchai/main round 1: 2 P2 findings, both addressed. Round 2: 0 blocking findings.