### PR TITLE
fix(agents): resolve bare-name CLI binaries via PATH for e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ print(response.choices[0].message.content)
 | [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
 | [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
 | [OpenCode](https://github.com/sst/opencode) | TUI Agent | Claude Code-like terminal UX, OpenAI-compat provider |
-| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim ([guide](docs/guides/codex-cli.md)) |
+| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim, **12/12 release-gauntlet E2E on M3** ([guide](docs/guides/codex-cli.md), [G7b](docs/development/releasing.md)) |
 | [Claude Code](https://www.anthropic.com/claude-code) | Agent | Anthropic SDK via `/v1/messages` — `ANTHROPIC_BASE_URL=http://localhost:8000` |
 | [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
 

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import time
+import unittest
 
 import httpx
 
@@ -121,13 +122,20 @@ def hermes_query(query, timeout_sec=120):
         return None, str(e)
 
 
-class HermesSkipError(Exception):
+class HermesSkipError(unittest.SkipTest):
     """Raised by a Hermes test to signal honest unrunnable, not failure.
 
     Hermes refuses to initialize on small-context models, and there's no
     rapid-mlx code to "fix" that — it's the harness asking for more
     context than the served model exposes. The runner maps this to
     SKIP so the gauntlet stays green where it should be.
+
+    Inherits from ``unittest.SkipTest`` so this same exception is honored
+    as SKIP under both code paths:
+      - ``run_test()`` harness (catches ``HermesSkipError`` explicitly)
+      - direct pytest invocation (pytest treats ``unittest.SkipTest``
+        as a skip outcome, not a test failure — which is what
+        pr_validate's targeted_tests step relies on)
     """
 
 

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -81,7 +81,15 @@ def ensure_hermes_config():
 
 
 def hermes_query(query, timeout_sec=120):
-    """Run a single Hermes query in non-interactive mode."""
+    """Run a single Hermes query in non-interactive mode.
+
+    Returns ``(output, error)`` where ``error`` may be prefixed:
+      - ``"SKIP: <reason>"`` — environment can't run this honestly
+        (binary missing; model context too small for Hermes's 62-tool
+        system prompt). Test harnesses should propagate this as a
+        SKIP, not a FAIL.
+      - any other non-None error → genuine failure.
+    """
     if not os.path.exists(HERMES_BIN):
         return None, "SKIP: hermes binary not found"
     try:
@@ -96,11 +104,51 @@ def hermes_query(query, timeout_sec=120):
         # Detect Hermes-level errors
         if "Non-retryable error" in output or "HTTP 404" in output:
             return None, "Hermes error: model mismatch or server down"
+        # Hermes refuses to initialize when the served model's reported
+        # context window is below what Hermes's full tool-rich prompt
+        # needs. Surfacing this as FAIL is dishonest — it isn't a
+        # rapid-mlx regression, it's the served model being too small
+        # for this specific harness setup. Caller should SKIP.
+        if "Failed to initialize agent" in output and "context window" in output:
+            return None, (
+                "SKIP: Hermes requires larger context than served model "
+                "provides (Hermes init refused)"
+            )
         return output, None
     except subprocess.TimeoutExpired:
         return None, "TIMEOUT"
     except Exception as e:
         return None, str(e)
+
+
+class HermesSkipError(Exception):
+    """Raised by a Hermes test to signal honest unrunnable, not failure.
+
+    Hermes refuses to initialize on small-context models, and there's no
+    rapid-mlx code to "fix" that — it's the harness asking for more
+    context than the served model exposes. The runner maps this to
+    SKIP so the gauntlet stays green where it should be.
+    """
+
+
+def skip(reason):
+    """Helper: ``skip(err)`` propagates a ``"SKIP: ..."`` from hermes_query."""
+    msg = reason[len("SKIP:") :].strip() if reason.startswith("SKIP:") else reason
+    raise HermesSkipError(msg)
+
+
+def fail_or_skip(err):
+    """Translate a hermes_query error into FAIL or SKIP based on prefix.
+
+    Replaces the previous ``if err: assert False, err`` pattern so every
+    test propagates the SKIP signal hermes_query started emitting for
+    the small-context init refusal.
+    """
+    if err is None:
+        return
+    if err.startswith("SKIP:"):
+        skip(err)
+    assert False, err
 
 
 def run_test(name, fn):
@@ -112,6 +160,9 @@ def run_test(name, fn):
         fn()
         results[name] = "PASS"
         print("  ✅ PASS")
+    except HermesSkipError as e:
+        results[name] = f"SKIP: {e}"
+        print(f"  ⬜ SKIP: {e}")
     except AssertionError as e:
         results[name] = f"FAIL: {e}"
         print(f"  ❌ FAIL: {e}")
@@ -394,8 +445,7 @@ def test_api_stress_no_leak():
 def test_hermes_chat():
     """Basic Hermes chat (no tool use)."""
     out, err = hermes_query("What is 2+2? Reply with just the number.")
-    if err:
-        assert False, err
+    fail_or_skip(err)
     assert "4" in out, f"Expected 4 in: {out[:100]}"
     print(f"  Hermes output: {out.strip()[:80]}")
 
@@ -403,8 +453,7 @@ def test_hermes_chat():
 def test_hermes_read_file():
     """Hermes reads a file via tool call."""
     out, err = hermes_query("Read the first line of pyproject.toml")
-    if err:
-        assert False, err
+    fail_or_skip(err)
     assert "build" in out.lower() or "project" in out.lower(), (
         f"Unexpected: {out[:100]}"
     )
@@ -414,8 +463,7 @@ def test_hermes_read_file():
 def test_hermes_terminal():
     """Hermes runs a shell command."""
     out, err = hermes_query("Run 'echo rapid_mlx_hermes_test' and show me the output")
-    if err:
-        assert False, err
+    fail_or_skip(err)
     assert "rapid_mlx_hermes_test" in out, f"Command output missing: {out[:100]}"
     print("  Hermes terminal: OK")
 
@@ -423,8 +471,7 @@ def test_hermes_terminal():
 def test_hermes_search():
     """Hermes searches for files."""
     out, err = hermes_query("Search for files named 'aliases.json' in this project")
-    if err:
-        assert False, err
+    fail_or_skip(err)
     assert "aliases" in out.lower(), f"Search failed: {out[:100]}"
     print("  Hermes search: OK")
 
@@ -435,8 +482,7 @@ def test_hermes_multi_step():
         "Find the file aliases.json, read it, and tell me how many entries it has",
         timeout_sec=180,
     )
-    if err:
-        assert False, err
+    fail_or_skip(err)
     # Should mention a number (we have ~22 aliases)
     assert any(str(n) in out for n in range(15, 30)), f"No count found: {out[:200]}"
     print("  Hermes multi-step: OK")
@@ -454,8 +500,7 @@ def test_hermes_write_and_run():
         "10 fibonacci numbers as a comma-separated list, then run it and show output",
         timeout_sec=120,
     )
-    if err:
-        assert False, err
+    fail_or_skip(err)
     # Verify via Hermes output or by checking the file directly
     import subprocess
 
@@ -480,13 +525,15 @@ def test_hermes_code_with_tests():
         "Then run the tests.",
         timeout_sec=180,
     )
-    if err:
-        assert False, err
-    # Verify the files exist and tests pass
-    import subprocess
-
+    fail_or_skip(err)
+    # Verify the files exist and tests pass.
+    # Use sys.executable so we run pytest from the same interpreter that
+    # ran this test (almost always a venv with pytest installed).
+    # Bare ``python3`` resolved to system /Library/Developer/CommandLineTools
+    # on macOS which doesn't carry pytest and made this test FAIL with an
+    # infra issue, not a Hermes issue.
     result = subprocess.run(
-        ["python3", "-m", "pytest", "/tmp/hermes_test_calc.py", "-v"],
+        [sys.executable, "-m", "pytest", "/tmp/hermes_test_calc.py", "-v"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -503,8 +550,7 @@ def test_hermes_code_review():
         "Read vllm_mlx/model_auto_config.py and suggest one specific improvement. Be concise.",
         timeout_sec=120,
     )
-    if err:
-        assert False, err
+    fail_or_skip(err)
     # Should mention something about the code (patterns, config, etc.)
     assert len(out) > 50, f"Response too short for a code review: {out[:100]}"
     assert (
@@ -519,8 +565,7 @@ def test_hermes_git_analysis():
         "Check the git log of this repo and tell me the last 3 commit messages",
         timeout_sec=120,
     )
-    if err:
-        assert False, err
+    fail_or_skip(err)
     assert (
         "commit" in out.lower()
         or "hermes" in out.lower()
@@ -541,8 +586,7 @@ def test_hermes_patch_file():
         f"Add a docstring 'Say hello.' to the hello function in {test_file}",
         timeout_sec=120,
     )
-    if err:
-        assert False, err
+    fail_or_skip(err)
     # Verify the file was modified
     with open(test_file) as f:
         content = f.read()

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -1018,11 +1018,25 @@ class AgentTestRunner:
                     )
                 )
         elif testing.binary:
+            # Two distinct skip reasons land here:
+            #   (a) binary on PATH but profile has `query_cmd: null`
+            #       — interactive-only agent (opencode, openhands,
+            #       openclaude). The runner has no way to drive it
+            #       headlessly, but the binary is installed; saying
+            #       "Binary not found" is actively misleading.
+            #   (b) binary is genuinely missing from PATH / disk.
+            if self._agent_binary_available() and not testing.query_cmd:
+                msg = (
+                    f"Interactive-only profile ({testing.binary} installed "
+                    "but query_cmd=null — no headless driver)"
+                )
+            else:
+                msg = f"Binary not found: {testing.binary}"
             report.results.append(
                 TestResult(
                     "e2e_tests",
                     TestStatus.SKIP,
-                    message=f"Binary not found: {testing.binary}",
+                    message=msg,
                     category="e2e",
                 )
             )
@@ -1162,15 +1176,29 @@ class AgentTestRunner:
                 ]
 
             test_results = []
+            per_test_ms = (time.time() - t0) * 1000 / max(len(results_dict), 1)
             for name, status in results_dict.items():
+                # Test modules report PASS / "FAIL: <reason>" / "SKIP: <reason>".
+                # SKIP exists so deep agentic tests can signal "the environment
+                # can't honestly run this" (e.g. Hermes's 32K-context refusal
+                # on small models) without dirtying the gauntlet with a FAIL
+                # that isn't actionable.
                 if status == "PASS":
                     test_results.append(
                         TestResult(
                             name,
                             TestStatus.PASS,
-                            duration_ms=(time.time() - t0)
-                            * 1000
-                            / max(len(results_dict), 1),
+                            duration_ms=per_test_ms,
+                            category="specific",
+                        )
+                    )
+                elif isinstance(status, str) and status.startswith("SKIP:"):
+                    test_results.append(
+                        TestResult(
+                            name,
+                            TestStatus.SKIP,
+                            duration_ms=per_test_ms,
+                            message=status[len("SKIP:") :].strip()[:120],
                             category="specific",
                         )
                     )
@@ -1184,9 +1212,7 @@ class AgentTestRunner:
                         TestResult(
                             name,
                             TestStatus.FAIL,
-                            duration_ms=(time.time() - t0)
-                            * 1000
-                            / max(len(results_dict), 1),
+                            duration_ms=per_test_ms,
                             message=msg[:120],
                             category="specific",
                         )

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -697,11 +698,26 @@ def _test_tag_suppression(
 def _agent_query(
     binary: str, query_cmd: str, query: str, timeout: int = 120
 ) -> tuple[str | None, str | None]:
-    """Run a single agent query. Returns (output, error)."""
+    """Run a single agent query. Returns (output, error).
+
+    `binary` may be an absolute / ``~``-prefixed path *or* a bare name
+    (e.g. ``codex``, ``opencode``). Bare names are resolved via
+    ``shutil.which`` against ``$PATH``. Mirror of
+    ``AgentTestRunner._agent_binary_available`` — a previous bug here
+    treated bare names as relative paths so every e2e gate silently
+    skipped with "Binary not found" even when the CLI was installed.
+    """
     import shlex
 
-    if not os.path.exists(os.path.expanduser(binary)):
-        return None, f"Binary not found: {binary}"
+    if "/" not in binary and not binary.startswith("~"):
+        resolved = shutil.which(binary)
+        if not resolved:
+            return None, f"Binary not found: {binary}"
+        binary_path = resolved
+    else:
+        binary_path = os.path.expanduser(binary)
+        if not os.path.exists(binary_path):
+            return None, f"Binary not found: {binary}"
 
     # Substitute {query} placeholder and parse with shlex to respect quotes
     cmd_str = query_cmd.replace("{query}", query)
@@ -711,7 +727,7 @@ def _agent_query(
         # Fallback: simple split if shlex can't parse
         cmd_parts = cmd_str.split()
     # Replace first part with full binary path
-    cmd_parts[0] = os.path.expanduser(binary)
+    cmd_parts[0] = binary_path
 
     try:
         proc = subprocess.run(
@@ -867,11 +883,25 @@ class AgentTestRunner:
             return False
 
     def _agent_binary_available(self) -> bool:
-        """Check if the agent binary is installed."""
+        """Check if the agent binary is installed.
+
+        Two forms of `testing.binary` are supported:
+          - **Absolute / ``~``-prefixed path** (e.g. ``~/.hermes/venv/bin/hermes``)
+            — checked with ``os.path.exists`` after ``expanduser``.
+          - **Bare name** (e.g. ``codex``, ``opencode``) — resolved via
+            ``shutil.which`` against the current ``$PATH``. Profiles that
+            ship a homebrew/npm CLI use this form, and a previous bug
+            here treated them as relative paths so the e2e gate never
+            fired even with the binary installed.
+        """
         testing = self.profile.get_testing_for_version(self.agent_version)
         if not testing.binary:
             return False
-        return os.path.exists(os.path.expanduser(testing.binary))
+        binary = testing.binary
+        # Bare name (no `/`, no leading `~`) → look up on $PATH.
+        if "/" not in binary and not binary.startswith("~"):
+            return shutil.which(binary) is not None
+        return os.path.exists(os.path.expanduser(binary))
 
     def build_test_plan(self) -> list[str]:
         """Build the list of test names that will run for this profile."""


### PR DESCRIPTION
## Summary

Three fixes that snowballed from the same e2e codepath:

1. **bare-name CLI binaries** (`codex`, `opencode`, …) were treated as filesystem paths by `_agent_binary_available()` and `_agent_query()` instead of being resolved via `$PATH`. Result: every profile whose CLI is installed via homebrew/npm/cargo silently SKIPped its `e2e_chat` / `e2e_file_read` / `e2e_terminal` tests with a misleading `Binary not found:` message — even when the CLI was on PATH. This was the missing piece for #593's G7b release-gauntlet block.

2. **opencode SKIP message** was actively misleading: profile has `query_cmd: null` (interactive-only, no headless driver), so e2e tests can't fire. The runner reported "Binary not found: opencode" even when the binary was present. Now: detect "binary present + no query_cmd" and surface "Interactive-only profile (… installed but query_cmd=null — no headless driver)".

3. **Hermes deep-test FAILs were dishonest**: Hermes refuses to initialize on small-context models (`"Failed to initialize agent: Model … context window of 32,768 tokens"`). That isn't a rapid-mlx bug — it's Hermes asking for more context than the served model exposes. Previously mapped to FAIL; now `hermes_query()` returns `"SKIP: …"`, the runner's `_run_specific_tests` grew a `SKIP:` prefix recognizer, and `test_hermes_code_with_tests` switched its post-check pytest invocation to `sys.executable` (was bare `python3` which resolved to a system Python without pytest).

## Why two call sites in #1

`_agent_binary_available()` only gates whether the e2e tests appear in the plan; `_agent_query()` is what actually `subprocess.run`s the binary. The original `os.path.exists(expanduser(binary))` check existed in both spots, so fixing only the gate would just promote SKIP→ERROR. Both now share:

- bare name (no `/`, no leading `~`) → `shutil.which(binary)`
- absolute / `~`-prefixed (e.g. `~/.hermes/venv/bin/hermes`) → existing `os.path.exists(expanduser(binary))`

## Verification

Local M3 + `qwen3.5-9b-4bit --no-thinking`:

```
codex --test:
  Before: ✅ 9/12 base, ⬜ e2e_chat / e2e_terminal / e2e_file_read  (Binary not found: codex)
  After:  ✅ 12/12 base, 0 failed, 0 skipped

opencode --test:
  Before: ⬜ e2e_tests — "Binary not found: opencode"  (lie)
  After:  ⬜ e2e_tests — "Interactive-only profile (opencode installed but query_cmd=null …)"

hermes --test specific_tests (the deep agentic block):
  Before: 4 FAIL on "Failed to initialize agent" + 1 FAIL on pytest path
  After:  4 SKIP with accurate "Hermes requires larger context …" + pytest path uses sys.executable
```

## Test plan

- [x] `rapid-mlx agents codex --test` → 12/12 incl. all 3 e2e
- [x] `rapid-mlx agents opencode --test` → SKIP message is accurate (interactive-only, not "binary missing")
- [x] `rapid-mlx agents hermes --test` → Hermes context-window refusals propagate as SKIP, not FAIL
- [x] `ruff check` on changed files → clean
- [x] No new public APIs / no migration impact — purely test-runner correctness fixes