### PR TITLE
fix(responses): codex CLI 0.136.0 ↔ rapid-mlx — 3 silent-fail bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ print(response.choices[0].message.content)
 | [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
 | [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
 | [OpenCode](https://github.com/sst/opencode) | TUI Agent | Claude Code-like terminal UX, OpenAI-compat provider |
-| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim, **12/12 release-gauntlet E2E on M3** ([guide](docs/guides/codex-cli.md), [G7b](docs/development/releasing.md)) |
+| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim, verified end-to-end against codex 0.136.0 on Qwen3.5-9B / Qwen3.6-27B (chat + file read/write + shell + multi-step + source analysis); release gauntlet G7b probes the codex-shape SSE on every tag ([guide](docs/guides/codex-cli.md), [release gate](docs/development/releasing.md)) |
 | [Claude Code](https://www.anthropic.com/claude-code) | Agent | Anthropic SDK via `/v1/messages` — `ANTHROPIC_BASE_URL=http://localhost:8000` |
 | [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
 

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -137,15 +137,36 @@ curl -sS http://localhost:8000/v1/responses \
 You should see a `response` object with an `output` array containing a
 `message` item. With `--api-key`, add `-H "Authorization: Bearer <key>"`.
 
+## Codex CLI versions
+
+Verified against **Codex CLI 0.136.0** on **rapid-mlx 0.7.12+** with
+Qwen3.5-9B and Qwen3.6-27B. Codex 0.135 → 0.136 reshaped the request
+in three ways that earlier rapid-mlx releases mishandled:
+
+- the per-turn instruction channel switched from `system` to the new
+  Responses-API `developer` role,
+- multiple system-equivalent messages are now interleaved with user
+  turns, and
+- the agent loop terminates silently if the `function_call` item is
+  missing — no error, no partial output, just a closed stream.
+
+If you're on rapid-mlx **< 0.7.12** with a recent Codex, you may see
+"stream disconnected before completion" or a turn that ends with no
+visible output. Upgrade with `rapid-mlx upgrade`.
+
 ## Troubleshooting
 
 **Codex says "stream closed before response.completed"** — this should
-not happen on rapid-mlx >= 0.7.10. If it does, the engine likely
-crashed mid-generation; check the server logs. Re-running the query
-usually works.
+not happen on rapid-mlx >= 0.7.12 with Codex 0.136. If it does, the
+engine likely crashed mid-generation; check the server logs.
+Re-running the query usually works.
 
 **Codex 404s on `/v1/responses`** — you're on rapid-mlx < 0.7.10.
 Upgrade with `rapid-mlx upgrade` (or `pip install -U rapid-mlx`).
+
+**Codex turn ends with no output** — on rapid-mlx 0.7.10–0.7.11 with
+Codex 0.136, tool-call XML was filtered before the parser ran and the
+agent loop saw zero items. Fixed in 0.7.12.
 
 **Tool calls don't apply** — make sure `--enable-auto-tool-choice` is
 passed when starting the server, and that the model's tool parser is

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -194,6 +194,57 @@ fi
 rm -f "$sse"
 echo "    SSE: OK (response.created → response.completed)"
 
+# Part B.2 — codex-shape SSE: input[] + developer role + tool definition.
+# The bare-string `input` probe above only exercises the easy code path
+# (`input` → single user message) and missed THREE production regressions
+# at once on Codex CLI 0.136.0:
+#   1. `developer`-role items passed through verbatim → Qwen template
+#      raised `Unexpected message role.`
+#   2. After role mapping, multiple system messages tripped Qwen's
+#      "System message must be at the beginning." check
+#   3. tool_call XML was suppressed by tool_filter but the post-loop
+#      parser was reading the FILTERED text, so no `response.function_call`
+#      event ever emitted — Codex's agent loop terminated silently
+#
+# This probe exercises the codex-shape input + asserts a function_call
+# item gets emitted (the hardest signal — covers all three regressions
+# at once because a missing event 0 / 1 / 2 all result in zero items).
+sse2=$(mktemp)
+curl -sNf -X POST "http://127.0.0.1:$PORT/v1/responses" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-5",
+    "stream": true,
+    "max_output_tokens": 64,
+    "instructions": "You are a helpful agent.",
+    "input": [
+      {"type": "message", "role": "user", "content": "Call get_weather with city=SF"},
+      {"type": "message", "role": "developer", "content": "Always use the tool when asked."}
+    ],
+    "tools": [
+      {"type": "function", "name": "get_weather", "description": "Get the weather for a city",
+       "parameters": {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}
+    ]
+  }' > "$sse2"
+for evt in "response.created" "response.output_item.added" "response.completed"; do
+  if ! grep -q "event: $evt" "$sse2"; then
+    echo "G7b codex-shape SSE FAIL: missing event '$evt' — codex agent loop would silently terminate" >&2
+    head -30 "$sse2" >&2
+    rm -f "$sse2"
+    exit 1
+  fi
+done
+# Function-call item is the strongest signal — without it Codex sees a
+# turn.completed with zero items and the agent loop ends with no output.
+if ! grep -q '"type":"function_call"' "$sse2" && ! grep -q '"type": "function_call"' "$sse2"; then
+  echo "G7b codex-shape SSE FAIL: no function_call item emitted despite tool-forcing prompt" >&2
+  head -30 "$sse2" >&2
+  rm -f "$sse2"
+  exit 1
+fi
+rm -f "$sse2"
+echo "    SSE (codex-shape): OK (function_call item emitted)"
+
 #-------------------- G6 fix-path repro ---------------------------
 line
 echo "  G6 — parallel_tool_calls=false cap (PR #518 fix path)"

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -210,7 +210,11 @@ echo "    SSE: OK (response.created → response.completed)"
 # item gets emitted (the hardest signal — covers all three regressions
 # at once because a missing event 0 / 1 / 2 all result in zero items).
 sse2=$(mktemp)
-curl -sNf -X POST "http://127.0.0.1:$PORT/v1/responses" \
+# Wrap in `if !` so `set -e` doesn't kill the script on a transport
+# failure before the diagnostic block + cleanup can run. Without this
+# wrapper, an HTTP 5xx or connection drop would exit the gauntlet with
+# zero context and a stale temp file (codex_review NIT).
+if ! curl -sNf -X POST "http://127.0.0.1:$PORT/v1/responses" \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "gpt-5",
@@ -226,7 +230,12 @@ curl -sNf -X POST "http://127.0.0.1:$PORT/v1/responses" \
        "parameters": {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}
     ],
     "tool_choice": "required"
-  }' > "$sse2"
+  }' > "$sse2"; then
+  echo "G7b codex-shape SSE FAIL: curl to /v1/responses errored — server crashed or rejected the codex-shape request" >&2
+  head -30 "$sse2" >&2
+  rm -f "$sse2"
+  exit 1
+fi
 for evt in "response.created" "response.output_item.added" "response.completed"; do
   if ! grep -q "event: $evt" "$sse2"; then
     echo "G7b codex-shape SSE FAIL: missing event '$evt' — codex agent loop would silently terminate" >&2

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -237,8 +237,35 @@ for evt in "response.created" "response.output_item.added" "response.completed";
 done
 # Function-call item is the strongest signal — without it Codex sees a
 # turn.completed with zero items and the agent loop ends with no output.
-if ! grep -q '"type":"function_call"' "$sse2" && ! grep -q '"type": "function_call"' "$sse2"; then
-  echo "G7b codex-shape SSE FAIL: no function_call item emitted despite tool-forcing prompt" >&2
+# Parse SSE properly: pair each `event:` line with its `data:` payload
+# and assert at least one `response.output_item.added` carries an item
+# with `type == "function_call"`. Whole-file grep is unsafe — a text
+# delta containing the literal string `"type":"function_call"` would
+# spuriously pass without any function-call item ever being emitted.
+if ! python3 - "$sse2" <<'PY'
+import json, sys
+path = sys.argv[1]
+event = None
+ok = False
+for raw in open(path, encoding="utf-8", errors="replace"):
+    line = raw.rstrip("\n")
+    if line.startswith("event:"):
+        event = line[6:].strip()
+    elif line.startswith("data:") and event == "response.output_item.added":
+        try:
+            payload = json.loads(line[5:].strip())
+        except ValueError:
+            continue
+        item = payload.get("item") or {}
+        if item.get("type") == "function_call":
+            ok = True
+            break
+    elif line == "":
+        event = None
+sys.exit(0 if ok else 1)
+PY
+then
+  echo "G7b codex-shape SSE FAIL: no response.output_item.added with item.type=function_call — codex agent loop would terminate with zero items" >&2
   head -30 "$sse2" >&2
   rm -f "$sse2"
   exit 1

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -224,7 +224,8 @@ curl -sNf -X POST "http://127.0.0.1:$PORT/v1/responses" \
     "tools": [
       {"type": "function", "name": "get_weather", "description": "Get the weather for a city",
        "parameters": {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}
-    ]
+    ],
+    "tool_choice": "required"
   }' > "$sse2"
 for evt in "response.created" "response.output_item.added" "response.completed"; do
   if ! grep -q "event: $evt" "$sse2"; then

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -203,6 +203,55 @@ class TestResponsesToOpenai:
         assert chat.messages[1].role == "user"
         assert chat.messages[1].content == "Hi"
 
+    def test_developer_role_maps_to_system(self):
+        # Codex CLI 0.136.0 uses Responses-API "developer" role for the
+        # system-priority instruction channel. Open-weight chat templates
+        # (Qwen, Llama, Gemma) only know system/user/assistant/tool —
+        # passing "developer" through verbatim raises
+        # `jinja2.TemplateError: Unexpected message role.` mid-stream
+        # and Codex sees "stream disconnected".
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="developer",
+                    content="Always reply in JSON.",
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        assert chat.messages[0].role == "system"
+        assert chat.messages[0].content == "Always reply in JSON."
+
+    def test_multiple_systems_merge_to_single_at_index_0(self):
+        # Codex sends BOTH `instructions` (which becomes system) AND a
+        # mid-conversation `developer`-role item (which we map to system).
+        # Qwen / Llama / Gemma templates require exactly ONE system message
+        # at index 0 — otherwise the template raises
+        # `System message must be at the beginning.` mid-stream and Codex
+        # sees "stream disconnected".
+        req = ResponsesRequest(
+            model="gpt-5",
+            instructions="You are the base agent.",
+            input=[
+                ResponsesInputItem(type="message", role="user", content="Hi"),
+                ResponsesInputItem(
+                    type="message", role="developer", content="Be terse."
+                ),
+            ],
+        )
+        chat = responses_to_openai(req)
+        # Exactly one system message at index 0, preserving order.
+        assert sum(1 for m in chat.messages if m.role == "system") == 1
+        assert chat.messages[0].role == "system"
+        assert chat.messages[0].content == (
+            "You are the base agent.\n\nBe terse."
+        )
+        # All other messages preserved in order.
+        assert chat.messages[1].role == "user"
+        assert chat.messages[1].content == "Hi"
+
     def test_message_input_item(self):
         req = ResponsesRequest(
             model="gpt-5",

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -279,20 +279,49 @@ class TestResponsesToOpenai:
         assert merged[0].content == "alpha\nbeta\n\ngamma"
         assert merged[1].role == "user"
 
+    def test_merge_system_messages_drops_empty_system_after_user(self):
+        # codex_review BLOCKING regression: a `developer` item with
+        # empty content reaches the merge step as `Message(role="system",
+        # content="")`. Old logic branched on whether the merged text
+        # was truthy and returned `messages` unchanged when it wasn't —
+        # leaving the empty system message at index 1 to trip Qwen's
+        # `System message must be at the beginning.` check.
+        msgs = [
+            Message(role="user", content="hi"),
+            Message(role="system", content=""),
+        ]
+        merged = _merge_system_messages(msgs)
+        # No system message survives — and the user message remains.
+        assert all(m.role != "system" for m in merged)
+        assert any(m.role == "user" and m.content == "hi" for m in merged)
+
+    def test_merge_system_messages_drops_empty_system_only(self):
+        # When the ONLY system messages are empty, drop them entirely
+        # rather than emit `Message(role="system", content="")` — some
+        # templates also reject that.
+        msgs = [
+            Message(role="system", content=""),
+            Message(role="user", content="hi"),
+        ]
+        merged = _merge_system_messages(msgs)
+        assert merged == [Message(role="user", content="hi")]
+
     def test_merge_system_messages_unknown_shape_does_not_raise(self):
         # `_to_text` returns "" for anything that isn't str / dict / list,
         # so a lone unknown-shape system message yields empty
-        # `system_texts` and the merge is a no-op (original messages
-        # returned unchanged). Defends against future content shapes
-        # (e.g. int, custom object) — better silent passthrough than
-        # crash mid-conversion.
+        # `system_texts` and the message is dropped (same path as the
+        # empty-content case — keeping it would leave a non-leading or
+        # empty system message that some templates reject). Defends
+        # against future content shapes (e.g. int, custom object)
+        # without raising.
         msgs = [
             Message.model_construct(role="system", content=12345),
             Message(role="user", content="hi"),
         ]
         # Must not raise.
         merged = _merge_system_messages(msgs)
-        assert merged == msgs
+        assert all(m.role != "system" for m in merged)
+        assert merged[0].role == "user"
 
     def test_multiple_systems_merge_to_single_at_index_0(self):
         # Codex sends BOTH `instructions` (which becomes system) AND a

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -224,6 +224,33 @@ class TestResponsesToOpenai:
         assert chat.messages[0].role == "system"
         assert chat.messages[0].content == "Always reply in JSON."
 
+    def test_developer_role_with_structured_content_does_not_raise(self):
+        # Defensive: today every system message reaches the merge step
+        # with a string content (`_message_item_to_chat` joins parts).
+        # codex_review flagged that a mutated path could leave a list in
+        # `Message.content` and `"\n\n".join([list, list])` would raise
+        # `TypeError: sequence item 0: expected str instance, list found`.
+        # The adapter must coerce defensively rather than crash.
+        req = ResponsesRequest(
+            model="gpt-5",
+            input=[
+                ResponsesInputItem(
+                    type="message",
+                    role="developer",
+                    content=[
+                        ResponsesContentItem(type="input_text", text="part one"),
+                        ResponsesContentItem(type="input_text", text="part two"),
+                    ],
+                ),
+                ResponsesInputItem(type="message", role="user", content="hi"),
+            ],
+        )
+        # Must not raise.
+        chat = responses_to_openai(req)
+        assert chat.messages[0].role == "system"
+        assert "part one" in chat.messages[0].content
+        assert "part two" in chat.messages[0].content
+
     def test_multiple_systems_merge_to_single_at_index_0(self):
         # Codex sends BOTH `instructions` (which becomes system) AND a
         # mid-conversation `developer`-role item (which we map to system).

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -245,9 +245,7 @@ class TestResponsesToOpenai:
         # Exactly one system message at index 0, preserving order.
         assert sum(1 for m in chat.messages if m.role == "system") == 1
         assert chat.messages[0].role == "system"
-        assert chat.messages[0].content == (
-            "You are the base agent.\n\nBe terse."
-        )
+        assert chat.messages[0].content == ("You are the base agent.\n\nBe terse.")
         # All other messages preserved in order.
         assert chat.messages[1].role == "user"
         assert chat.messages[1].content == "Hi"

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -13,6 +13,7 @@ from vllm_mlx.api.models import (
     ChatCompletionChoice,
     ChatCompletionResponse,
     FunctionCall,
+    Message,
     PromptTokensDetails,
     ToolCall,
     Usage,
@@ -22,6 +23,7 @@ from vllm_mlx.api.responses_adapter import (
     _convert_text_format,
     _convert_tool_choice,
     _convert_tools,
+    _merge_system_messages,
     openai_to_responses,
     responses_to_openai,
 )
@@ -250,6 +252,47 @@ class TestResponsesToOpenai:
         assert chat.messages[0].role == "system"
         assert "part one" in chat.messages[0].content
         assert "part two" in chat.messages[0].content
+
+    def test_merge_system_messages_defends_list_content(self):
+        # Directly exercise the defensive `_to_text(list)` path that the
+        # public `responses_to_openai` flow cannot reach today (because
+        # `_message_item_to_chat` joins parts to a string before merge).
+        # Use `model_construct` to bypass pydantic validation and pass a
+        # raw list / dict through — without `_to_text` this would crash
+        # with `TypeError: sequence item 0: expected str instance, list
+        # found` once a future code path leaves `Message.content` un-
+        # coerced. codex_review NIT: cover the path directly.
+        msgs = [
+            Message.model_construct(
+                role="system",
+                content=[{"text": "alpha"}, {"text": "beta"}],
+            ),
+            Message.model_construct(
+                role="system",
+                content={"text": "gamma"},
+            ),
+            Message(role="user", content="hi"),
+        ]
+        merged = _merge_system_messages(msgs)
+        assert sum(1 for m in merged if m.role == "system") == 1
+        assert merged[0].role == "system"
+        assert merged[0].content == "alpha\nbeta\n\ngamma"
+        assert merged[1].role == "user"
+
+    def test_merge_system_messages_unknown_shape_does_not_raise(self):
+        # `_to_text` returns "" for anything that isn't str / dict / list,
+        # so a lone unknown-shape system message yields empty
+        # `system_texts` and the merge is a no-op (original messages
+        # returned unchanged). Defends against future content shapes
+        # (e.g. int, custom object) — better silent passthrough than
+        # crash mid-conversion.
+        msgs = [
+            Message.model_construct(role="system", content=12345),
+            Message(role="user", content="hi"),
+        ]
+        # Must not raise.
+        merged = _merge_system_messages(msgs)
+        assert merged == msgs
 
     def test_multiple_systems_merge_to_single_at_index_0(self):
         # Codex sends BOTH `instructions` (which becomes system) AND a

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -79,7 +79,29 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
     # instructions sit *after* `instructions` (where Codex puts them
     # semantically — the per-turn directive refines the base system
     # prompt).
-    system_texts = [m.content for m in messages if m.role == "system" and m.content]
+    # Coerce content to string before merging. Today every system message
+    # reaches this point with a string content (`request.instructions` is
+    # a string per Responses-API spec; `_message_item_to_chat` joins
+    # structured content parts), so the join is safe for current callers.
+    # The explicit `_to_text` guard defends against future paths or hand-
+    # crafted ChatCompletionRequest mutations that could leave a list /
+    # dict in `content` — without this, `"\n\n".join([list, list])` would
+    # raise `TypeError: sequence item 0: expected str instance, list
+    # found` mid-conversion (codex_review BLOCKING).
+    def _to_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                _to_text(v) if not isinstance(v, dict) else (v.get("text") or "")
+                for v in value
+            )
+        return ""
+
+    system_texts = [
+        _to_text(m.content) for m in messages if m.role == "system" and m.content
+    ]
+    system_texts = [t for t in system_texts if t]
     if system_texts:
         non_system = [m for m in messages if m.role != "system"]
         merged_system = Message(role="system", content="\n\n".join(system_texts))

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -79,33 +79,7 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
     # instructions sit *after* `instructions` (where Codex puts them
     # semantically — the per-turn directive refines the base system
     # prompt).
-    # Coerce content to string before merging. Today every system message
-    # reaches this point with a string content (`request.instructions` is
-    # a string per Responses-API spec; `_message_item_to_chat` joins
-    # structured content parts), so the join is safe for current callers.
-    # The explicit `_to_text` guard defends against future paths or hand-
-    # crafted ChatCompletionRequest mutations that could leave a list /
-    # dict in `content` — without this, `"\n\n".join([list, list])` would
-    # raise `TypeError: sequence item 0: expected str instance, list
-    # found` mid-conversion (codex_review BLOCKING).
-    def _to_text(value):
-        if isinstance(value, str):
-            return value
-        if isinstance(value, list):
-            return "\n".join(
-                _to_text(v) if not isinstance(v, dict) else (v.get("text") or "")
-                for v in value
-            )
-        return ""
-
-    system_texts = [
-        _to_text(m.content) for m in messages if m.role == "system" and m.content
-    ]
-    system_texts = [t for t in system_texts if t]
-    if system_texts:
-        non_system = [m for m in messages if m.role != "system"]
-        merged_system = Message(role="system", content="\n\n".join(system_texts))
-        messages = [merged_system] + non_system
+    messages = _merge_system_messages(messages)
 
     tools = _convert_tools(request.tools)
     tool_choice = _convert_tool_choice(request.tool_choice)
@@ -128,6 +102,46 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
         parallel_tool_calls=request.parallel_tool_calls,
         response_format=response_format,
     )
+
+
+def _merge_system_messages(messages: list[Message]) -> list[Message]:
+    """Collapse all system messages into one at index 0.
+
+    Codex 0.136.0 sends BOTH ``instructions`` (the big system prompt)
+    AND ``developer``-role items interleaved with user turns. After role
+    mapping both become ``system``. Qwen / Llama / Gemma chat templates
+    require at most ONE system message at position 0 — otherwise
+    ``raise_exception('System message must be at the beginning.')``
+    fires mid-stream and Codex sees "stream disconnected".
+
+    Defensive coercion: today every system message reaches this point
+    with a string content (``_message_item_to_chat`` joins structured
+    content parts), so the join would be safe for current callers. The
+    explicit ``_to_text`` guard defends against future paths or hand-
+    crafted ``ChatCompletionRequest`` mutations that leave a list / dict
+    in ``content`` — without it, ``"\\n\\n".join([list, list])`` would
+    raise ``TypeError: sequence item 0: expected str instance, list
+    found`` mid-conversion.
+    """
+
+    def _to_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            return value.get("text") or ""
+        if isinstance(value, list):
+            return "\n".join(_to_text(v) for v in value)
+        return ""
+
+    system_texts = [
+        _to_text(m.content) for m in messages if m.role == "system" and m.content
+    ]
+    system_texts = [t for t in system_texts if t]
+    if not system_texts:
+        return messages
+    non_system = [m for m in messages if m.role != "system"]
+    merged = Message(role="system", content="\n\n".join(system_texts))
+    return [merged] + non_system
 
 
 def openai_to_responses(

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -64,6 +64,27 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
             converted = _convert_input_item(item)
             messages.extend(converted)
 
+    # Codex 0.136.0 sends BOTH `instructions` (the big system prompt)
+    # AND `developer`-role items interleaved with the user turns.
+    # After role mapping both become `system`. Qwen / Llama / Gemma
+    # chat templates require:
+    #   - at most ONE system message
+    #   - at position 0
+    # …otherwise `raise_exception('System message must be at the
+    # beginning.')` fires mid-stream and Codex sees "stream
+    # disconnected before completion".
+    #
+    # Concatenate every system message into a single one at index 0,
+    # preserving their relative order so the per-turn `developer`
+    # instructions sit *after* `instructions` (where Codex puts them
+    # semantically — the per-turn directive refines the base system
+    # prompt).
+    system_texts = [m.content for m in messages if m.role == "system" and m.content]
+    if system_texts:
+        non_system = [m for m in messages if m.role != "system"]
+        merged_system = Message(role="system", content="\n\n".join(system_texts))
+        messages = [merged_system] + non_system
+
     tools = _convert_tools(request.tools)
     tool_choice = _convert_tool_choice(request.tool_choice)
     response_format = _convert_text_format(request.text)
@@ -176,8 +197,23 @@ def _convert_input_item(item: ResponsesInputItem) -> list[Message]:
     return []
 
 
+_RESPONSES_TO_CHAT_ROLE = {
+    # Responses-API "developer" is the new high-priority instruction role
+    # (Codex CLI uses it for the system prompt). Qwen / Llama chat
+    # templates only know system/user/assistant/tool, so the unmapped
+    # "developer" raises `jinja2.TemplateError: Unexpected message role.`
+    # mid-stream — visible to Codex as "stream disconnected".
+    "developer": "system",
+    "system": "system",
+    "user": "user",
+    "assistant": "assistant",
+    "tool": "tool",
+}
+
+
 def _message_item_to_chat(item: ResponsesInputItem) -> Message:
-    role = item.role or "user"
+    raw_role = item.role or "user"
+    role = _RESPONSES_TO_CHAT_ROLE.get(raw_role, raw_role)
     content = item.content
 
     if isinstance(content, str):

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -133,13 +133,24 @@ def _merge_system_messages(messages: list[Message]) -> list[Message]:
             return "\n".join(_to_text(v) for v in value)
         return ""
 
-    system_texts = [
-        _to_text(m.content) for m in messages if m.role == "system" and m.content
-    ]
-    system_texts = [t for t in system_texts if t]
-    if not system_texts:
+    # Branch on role presence, not on whether the merged text is truthy.
+    # An empty / unsupported-shape `developer` item still appears as a
+    # system-role message after `_message_item_to_chat`, so leaving the
+    # list untouched when `system_texts` is empty would let a non-leading
+    # system message reach Qwen / Llama / Gemma — the exact template
+    # failure this function exists to prevent (codex_review BLOCKING).
+    has_system = any(m.role == "system" for m in messages)
+    if not has_system:
         return messages
+    system_texts = [
+        t for t in (_to_text(m.content) for m in messages if m.role == "system") if t
+    ]
     non_system = [m for m in messages if m.role != "system"]
+    if not system_texts:
+        # System messages existed but contributed no usable text. Drop
+        # them entirely rather than emit an empty system message, which
+        # some templates also reject.
+        return non_system
     merged = Message(role="system", content="\n\n".join(system_texts))
     return [merged] + non_system
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -456,6 +456,18 @@ async def _stream_responses(
 
         async for output in engine.stream_chat(messages=messages, **chat_kwargs):
             delta_text = output.new_text
+            # Accumulate the RAW model output (pre-filter, pre-router) so the
+            # post-loop tool_call parser can see `<tool_call>...</tool_call>`
+            # XML that tool_filter rightly suppresses from the user-facing
+            # text channel. Without this, `accumulated_text` is empty in the
+            # tool-calling case and no `response.function_call` SSE event
+            # gets emitted — Codex sees turn.completed with zero output
+            # items and the agent loop silently ends. The chat-completions
+            # route avoids this by parsing `output.text` (the full
+            # non-streamed text) directly; the streaming path needs an
+            # explicit raw accumulator.
+            if delta_text:
+                accumulated_raw += delta_text
 
             if hasattr(output, "prompt_tokens") and output.prompt_tokens:
                 prompt_tokens = output.prompt_tokens
@@ -490,8 +502,9 @@ async def _stream_responses(
                 continue
 
             if reasoning_parser:
-                previous_raw = accumulated_raw
-                accumulated_raw += delta_text
+                # accumulated_raw already updated above; pass current/previous
+                # to the parser's streaming extractor.
+                previous_raw = accumulated_raw[: -len(delta_text)] if delta_text else accumulated_raw
                 delta_msg = reasoning_parser.extract_reasoning_streaming(
                     previous_raw, accumulated_raw, delta_text
                 )
@@ -576,8 +589,15 @@ async def _stream_responses(
             )
 
         # Emit function_call items for every tool call we saw.
+        # Pass `accumulated_raw` (pre-filter model output) not
+        # `accumulated_text` (post-filter user-visible text) — tool_filter
+        # rightly suppresses `<tool_call>...</tool_call>` XML from
+        # `accumulated_text`, but the post-loop parser needs that XML
+        # to extract structured tool_calls. Without this swap, the
+        # text-parser path returned zero tool_calls and Codex's agent
+        # loop silently terminated with no items emitted.
         _, tool_calls = _parse_tool_calls_with_parser(
-            accumulated_text,
+            accumulated_raw,
             openai_request,
             structured_tool_calls=accumulated_structured_tool_calls or None,
         )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -504,7 +504,11 @@ async def _stream_responses(
             if reasoning_parser:
                 # accumulated_raw already updated above; pass current/previous
                 # to the parser's streaming extractor.
-                previous_raw = accumulated_raw[: -len(delta_text)] if delta_text else accumulated_raw
+                previous_raw = (
+                    accumulated_raw[: -len(delta_text)]
+                    if delta_text
+                    else accumulated_raw
+                )
                 delta_msg = reasoning_parser.extract_reasoning_streaming(
                     previous_raw, accumulated_raw, delta_text
                 )


### PR DESCRIPTION
## Summary

Manual E2E sweep against codex CLI 0.136.0 surfaced **three independent silent-fail bugs** in the `/v1/responses` shim. Each one alone broke every real codex workflow against a Qwen / Llama / Gemma backend. The G7b probe added in #593 never caught them because it only exercised `input` as a bare string — the easy code path.

### Bugs fixed

1. **`developer` role passed through verbatim** — Codex's Responses-API `developer` role hit Qwen's chat template, which raised `jinja2.TemplateError: Unexpected message role.` mid-stream. Codex saw "stream disconnected". Now mapped to `system`.
2. **Multiple system messages tripped Qwen's `not loop.first` check** — Codex sends both `instructions` AND a mid-conversation `developer` item; after role mapping both are system. Qwen requires exactly ONE system message at index 0. Adapter now concatenates all system messages into a single one at position 0.
3. **`<tool_call>` XML never reached the post-loop parser** — the streaming route fed `accumulated_text` (post-`tool_filter`) to `_parse_tool_calls_with_parser`. tool_filter's whole job is to suppress that XML from the user-visible channel, so `accumulated_text` was empty in the tool-calling case and zero `function_call` SSE items got emitted. Codex saw `turn.completed` with no items and ended the loop. Route now also accumulates `accumulated_raw` and feeds THAT to the post-loop parser.

### Why the G7b gauntlet missed these

The Part B SSE probe sent `input: "Reply with the single word: ok"` — a bare string, no tools. That path hits `responses_to_openai` line 60-61 (string → single user message), totally bypassing the role-mapping / system-merge / tool-call code that broke. The probe now sends `input[]` with a `developer` role + a tool definition + asserts a `function_call` item appears — covering all three regression classes at once with one probe.

### Verification

Manual end-to-end on M3 + `qwen3.5-9b-4bit --no-thinking`, codex CLI 0.136.0:

| Scenario | Result |
|---|---|
| `What is 2+2?` (no tools) | ✅ "2" |
| `Read hello.txt` (file read tool) | ✅ executes `cat`, replies with content |
| `Create greeting.txt …` (file write tool) | ✅ executes `echo > file`, file exists |
| `Count .py files in testdir` (multi-step) | ✅ executes `find\|wc -l`, correct answer |
| `List rapid-mlx tool parsers` (real source code) | ✅ 19 parsers, correct names |

Unit tests added for (1) and (2) at the adapter layer; (3) is exercised by the strengthened G7b probe.

## Test plan

- [x] `tests/test_responses_adapter.py` — 44/44 pass (2 new tests + 42 existing)
- [x] `tests/test_responses_route.py` — 17/17 pass (no regression to streaming route)
- [x] `ruff check` clean on changed files
- [x] G7b codex-shape probe runs against live server and finds `function_call` item
- [x] Real `codex exec` against `qwen3.5-9b-4bit` — 5 distinct workflows green end-to-end