### PR TITLE
docs(readme): point users at rapidmlx.com for the Mac GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 </p>
 
 <p align="center">
+  <sub>Prefer a Mac GUI? Try <a href="https://rapidmlx.com"><b>Rapid-MLX Desktop</b></a> — same engine, no terminal.</sub>
+</p>
+
+<p align="center">
   <img src="https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/docs/assets/demo.gif" alt="Rapid-MLX demo — install, serve Gemma 4, chat, tool calling" width="700">
   <br>
   <em>pip install → serve Gemma 4 26B → chat + tool calling → works with PydanticAI, LangChain, Aider, and more.</em>
@@ -133,6 +137,8 @@ pip install 'rapid-mlx[vision]'
 pip install 'rapid-mlx[audio]'
 ```
 </details>
+
+> **Not into the terminal?** [**Rapid-MLX Desktop**](https://rapidmlx.com) is a Mac app that bundles the same `rapid-mlx` engine inside a one-click GUI — drag to Applications, pick a model, chat. No Python, no `pip`, no `brew`. The CLI here is still the source of truth for serving and scripting; the desktop app is the friendlier on-ramp.
 
 **Try it with Python** (make sure the server is running, then `pip install openai`):
 


### PR DESCRIPTION
## Summary

Soft-sell pointer to https://rapidmlx.com (Rapid-MLX Desktop landing) added to the README in two natural-feeling places — funnels CLI users toward the Mac GUI without shouting.

- **Hero (under the tagline):** one small centered line — `Prefer a Mac GUI? Try Rapid-MLX Desktop — same engine, no terminal.`
- **End of install/serve section (before the Python snippet):** a 1-line blockquote callout — frames the desktop app as a friendlier on-ramp; CLI remains the source of truth for serving and scripting.

## Why

We're starting to gently surface the desktop app to CLI users. Tone is intentionally understated — no badges, no screenshots (desktop is still v0.6.8, screenshots would rot fast), no marketing fluff.

## Scope

- README.md only.
- No version bump, no CHANGELOG, no behavior change, no code touched.
- English-only, matches existing README tone and the `> **Tip:**` / `> **Want a Claude Code-like TUI?**` blockquote pattern already used below in the same section.

## Review note

**Please leave open** — owner wants to eyeball the placement before merging.