### PR TITLE
fix(community-bench): #567 ignore_eos so tg* rounds reach max_tokens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.12"
+version = "0.7.13"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -206,6 +206,81 @@ def test_make_sampling_params_factory() -> None:
         runner._make_sampling_params_factory("bogus")
 
 
+def test_bench_sampling_always_ignores_eos() -> None:
+    """Regression guard for #567 (dineshdb).
+
+    The standardized bench's ``tg128`` / ``tg512`` contract requires every
+    round to generate exactly ``max_tokens`` decode steps for cross-machine
+    comparability. If the synthetic random-token prompt nudges the model
+    toward EOS — qwen3.5-9b-4bit on the locked ``0xC0FFEE`` seed does this
+    — the round aborts early and the guard in ``_run_one_round`` (correctly)
+    rejects the result.
+
+    The fix is to set ``ignore_eos=True`` on the sampling params so the
+    engine suppresses the model's own EOS / chat-terminator tokens. This
+    test pins that contract at the factory boundary: BOTH sampling modes
+    MUST set ``ignore_eos=True``. If a future refactor drops the flag,
+    the bench fails again on the same models that hit it the first time.
+    """
+    from vllm_mlx.community_bench import runner
+
+    for sampling_mode in ("greedy", "sampled"):
+        factory = runner._make_sampling_params_factory(sampling_mode)
+        for max_tokens in (128, 512):
+            params = factory(max_tokens)
+            assert params.ignore_eos is True, (
+                f"_make_sampling_params_factory({sampling_mode!r})({max_tokens}) "
+                f"must set ignore_eos=True — without it the bench fails on any "
+                f"model whose response to the 0xC0FFEE synthetic prompt is to "
+                f"emit EOS early (see issue #567 for the original report)."
+            )
+
+
+def test_scheduler_honours_ignore_eos() -> None:
+    """The other half of the #567 fix: the scheduler must actually act
+    on ``sampling_params.ignore_eos``. The factory above can set the flag
+    all it wants — if the scheduler still merges the model's EOS / chat-
+    terminator tokens into the BatchGenerator's ``stop_tokens``, the bench
+    aborts at token 88 anyway.
+
+    This test inspects the scheduler's stop-token assembly directly (the
+    same logic at ``vllm_mlx/scheduler.py`` near the ``ignore_eos`` branch)
+    by simulating the contract with a stand-in: when ``ignore_eos=True``
+    and no user-supplied stop tokens, the resulting set must be empty.
+    """
+    from vllm_mlx.request import SamplingParams
+
+    # Mirror scheduler.py's stop-token assembly contract. We don't need
+    # the full scheduler — the boundary is small enough to lock with a
+    # tiny re-implementation that future refactors will trip if they
+    # break the contract. The point is: ``ignore_eos=True`` + no caller
+    # stop ids ⇒ empty set, regardless of what the model would have
+    # contributed.
+    model_eos_tokens = {2, 151645, 151643}  # arbitrary stand-in EOS ids
+
+    def assemble_stop_tokens(params: SamplingParams, model_eos: set[int]) -> set[int]:
+        stop = set() if params.ignore_eos else set(model_eos)
+        if params.stop_token_ids:
+            stop.update(params.stop_token_ids)
+        return stop
+
+    # Case A: ignore_eos=True, no extras → empty
+    p = SamplingParams(max_tokens=512, ignore_eos=True)
+    assert assemble_stop_tokens(p, model_eos_tokens) == set()
+
+    # Case B: ignore_eos=True + caller stop ids → only the caller's
+    p = SamplingParams(max_tokens=512, ignore_eos=True, stop_token_ids=[99])
+    assert assemble_stop_tokens(p, model_eos_tokens) == {99}
+
+    # Case C: ignore_eos=False (default) → model EOS preserved
+    p = SamplingParams(max_tokens=512)
+    assert assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens
+
+    # Case D: default + caller stop ids → union
+    p = SamplingParams(max_tokens=512, stop_token_ids=[99])
+    assert assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens | {99}
+
+
 def test_standardized_config_dict_matches_schema_consts() -> None:
     """The hardcoded constants in ``config`` must equal the schema's
     ``const`` values — schema validation depends on this."""

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -244,10 +244,9 @@ def test_scheduler_honours_ignore_eos() -> None:
     aborts at token 88 anyway.
 
     Exercise the **real** production helper that ``_create_batch_generator``
-    calls (codex_review BLOCKING from PR #599: a local stand-in would still
-    pass if the production branch were deleted). Deleting the
-    ``ignore_eos`` branch from ``_assemble_stop_tokens`` now fails this
-    test.
+    calls — a local stand-in would still pass if the production branch
+    were deleted. Deleting the ``ignore_eos`` branch from
+    ``_assemble_stop_tokens`` now fails this test.
     """
     from vllm_mlx.request import SamplingParams
     from vllm_mlx.scheduler import _assemble_stop_tokens

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -243,42 +243,42 @@ def test_scheduler_honours_ignore_eos() -> None:
     terminator tokens into the BatchGenerator's ``stop_tokens``, the bench
     aborts at token 88 anyway.
 
-    This test inspects the scheduler's stop-token assembly directly (the
-    same logic at ``vllm_mlx/scheduler.py`` near the ``ignore_eos`` branch)
-    by simulating the contract with a stand-in: when ``ignore_eos=True``
-    and no user-supplied stop tokens, the resulting set must be empty.
+    Exercise the **real** production helper that ``_create_batch_generator``
+    calls (codex_review BLOCKING from PR #599: a local stand-in would still
+    pass if the production branch were deleted). Deleting the
+    ``ignore_eos`` branch from ``_assemble_stop_tokens`` now fails this
+    test.
     """
     from vllm_mlx.request import SamplingParams
+    from vllm_mlx.scheduler import _assemble_stop_tokens
 
-    # Mirror scheduler.py's stop-token assembly contract. We don't need
-    # the full scheduler — the boundary is small enough to lock with a
-    # tiny re-implementation that future refactors will trip if they
-    # break the contract. The point is: ``ignore_eos=True`` + no caller
-    # stop ids ⇒ empty set, regardless of what the model would have
-    # contributed.
     model_eos_tokens = {2, 151645, 151643}  # arbitrary stand-in EOS ids
-
-    def assemble_stop_tokens(params: SamplingParams, model_eos: set[int]) -> set[int]:
-        stop = set() if params.ignore_eos else set(model_eos)
-        if params.stop_token_ids:
-            stop.update(params.stop_token_ids)
-        return stop
 
     # Case A: ignore_eos=True, no extras → empty
     p = SamplingParams(max_tokens=512, ignore_eos=True)
-    assert assemble_stop_tokens(p, model_eos_tokens) == set()
+    assert _assemble_stop_tokens(p, model_eos_tokens) == set()
 
     # Case B: ignore_eos=True + caller stop ids → only the caller's
     p = SamplingParams(max_tokens=512, ignore_eos=True, stop_token_ids=[99])
-    assert assemble_stop_tokens(p, model_eos_tokens) == {99}
+    assert _assemble_stop_tokens(p, model_eos_tokens) == {99}
 
     # Case C: ignore_eos=False (default) → model EOS preserved
     p = SamplingParams(max_tokens=512)
-    assert assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens
+    assert _assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens
 
     # Case D: default + caller stop ids → union
     p = SamplingParams(max_tokens=512, stop_token_ids=[99])
-    assert assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens | {99}
+    assert _assemble_stop_tokens(p, model_eos_tokens) == model_eos_tokens | {99}
+
+    # Case E: caller-supplied model-stop set must not be mutated. The
+    # previous in-place ``.update()`` on the ``_get_stop_tokens()`` return
+    # value would have poisoned the cached set on subsequent requests if
+    # the helper failed to copy.
+    immutable_model = frozenset({1, 2, 3})
+    p = SamplingParams(max_tokens=512, stop_token_ids=[99])
+    result = _assemble_stop_tokens(p, immutable_model)
+    assert result == {1, 2, 3, 99}
+    assert immutable_model == frozenset({1, 2, 3})  # unchanged
 
 
 def test_standardized_config_dict_matches_schema_consts() -> None:

--- a/tests/test_sampling_params_passthrough.py
+++ b/tests/test_sampling_params_passthrough.py
@@ -289,6 +289,26 @@ def test_sampling_params_accepts_extended_fields():
     assert sp.frequency_penalty == 0.3
 
 
+def test_sampling_params_ignore_eos_field():
+    """``ignore_eos`` is the standardized name (matches llama.cpp
+    ``llama-bench --no-eos`` and vLLM ``SamplingParams.ignore_eos``).
+    Renaming or dropping it breaks ecosystem expectations + reopens
+    issue #567 (the community-bench EOS-early failure on qwen3.5-9b
+    that wasted dineshdb's first contribution attempt).
+
+    Defaults to ``False`` — only opted into by callers that genuinely
+    want decode work measured to ``max_tokens`` regardless of EOS
+    (community-bench, ad-hoc throughput probes).
+    """
+    sp_default = SamplingParams(max_tokens=128)
+    assert sp_default.ignore_eos is False, (
+        "ignore_eos must default to False so serve/chat behave normally"
+    )
+
+    sp_optin = SamplingParams(max_tokens=128, ignore_eos=True)
+    assert sp_optin.ignore_eos is True
+
+
 # =============================================================================
 # Layer 4 — scheduler honours top_k + penalties
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1277,7 +1277,30 @@ def _run_submit_flow(args) -> int:
                     f"  Running standardized bench "
                     f"(sampling={mode}, 2 buckets × 5 rounds + 1 warmup)…"
                 )
-                bench = await run_standardized_bench(engine, tokenizer, sampling=mode)
+                try:
+                    bench = await run_standardized_bench(
+                        engine, tokenizer, sampling=mode
+                    )
+                except RuntimeError as exc:
+                    # Friendly surface for the bench's "exactly N tokens"
+                    # guard. As of #567's fix this branch is engine-bug
+                    # territory (sampling sets ``ignore_eos=True`` so the
+                    # model's EOS shouldn't fire); previously it blamed
+                    # the user's model alias. Print a clear summary so
+                    # contributors aren't dumped into a raw traceback.
+                    msg = str(exc)
+                    if "standardized bench requires exactly" in msg:
+                        print()
+                        print(
+                            "  Bench round aborted (engine bug — NOT your model's fault):"
+                        )
+                        for line in msg.split(". "):
+                            line = line.strip()
+                            if line:
+                                print(f"    {line}")
+                        print()
+                        return 1
+                    raise
 
                 print(
                     f"    short: decode={bench.short.decode_stat['median']:.2f} tok/s, "

--- a/vllm_mlx/community_bench/runner.py
+++ b/vllm_mlx/community_bench/runner.py
@@ -217,7 +217,7 @@ async def _run_one_round(
     # so cross-machine numbers are comparable. ``decode_tps = (N-1)/window``
     # against a shorter ``N`` is NOT a tg128 / tg512 result and silently
     # breaks the comparability contract advertised in the README and
-    # schema. (Codex PR #582 round-6 BLOCKING.)
+    # schema.
     #
     # As of #567's fix, ``_make_sampling_params_factory`` always sets
     # ``ignore_eos=True``, so the engine should suppress the model's

--- a/vllm_mlx/community_bench/runner.py
+++ b/vllm_mlx/community_bench/runner.py
@@ -214,23 +214,30 @@ async def _run_one_round(
 
     # EOS / early-stop guard. The standardized bench depends on every
     # round generating *exactly* ``max_tokens`` (128 short / 512 long)
-    # so cross-machine numbers are comparable. If the model emits an
-    # EOS token early — e.g. because the synthetic random-token prompt
-    # happens to nudge it toward a stop — the round terminates with
-    # fewer tokens but ``decode_tps = (N-1)/window`` still computes
-    # against the shorter N. The reported number is then NOT a
-    # tg128 / tg512 result and silently breaks the comparability
-    # contract advertised in the README and schema. (Codex PR #582
-    # round-6 BLOCKING.) Fail the round instead — the caller can
-    # surface a clear error rather than publishing a wrong number.
+    # so cross-machine numbers are comparable. ``decode_tps = (N-1)/window``
+    # against a shorter ``N`` is NOT a tg128 / tg512 result and silently
+    # breaks the comparability contract advertised in the README and
+    # schema. (Codex PR #582 round-6 BLOCKING.)
+    #
+    # As of #567's fix, ``_make_sampling_params_factory`` always sets
+    # ``ignore_eos=True``, so the engine should suppress the model's
+    # own EOS / chat-terminator tokens and run to ``max_tokens``
+    # regardless of what the model thinks of the synthetic prompt.
+    # If we reach this branch anyway, the engine ignored the flag —
+    # that is an engine-side regression, not a model-suitability issue,
+    # and not a user-recoverable situation. Make the error message say so.
     if completion_tokens != expected_completion_tokens:
         raise RuntimeError(
             f"bench round generated {completion_tokens} tokens but the "
-            f"standardized bench requires exactly {expected_completion_tokens} "
-            f"(model emitted EOS early or hit a stop sequence). Submitting "
-            f"this number would break comparability with other rows in the "
-            f"community DB. Re-run the bench; if the problem reproduces, "
-            f"this model alias is not suitable for the standardized bench."
+            f"standardized bench requires exactly {expected_completion_tokens}. "
+            f"This is an engine bug — sampling was configured with "
+            f"`ignore_eos=True`, so the EOS / chat-terminator path should "
+            f"have been suppressed (see vllm_mlx/scheduler.py near `ignore_eos`). "
+            f"Re-running won't help on greedy sampling with a fixed-seed prompt. "
+            f"Please file a bug at "
+            f"https://github.com/raullenchai/Rapid-MLX/issues/new with the model "
+            f"alias, rapid-mlx version, and this exact error so we can pin the "
+            f"regression. Your hardware row is NOT at fault."
         )
 
     prefill_window_s = max(t_first_token - t_start, 1e-6)
@@ -317,18 +324,37 @@ def _make_sampling_params_factory(sampling: str):
     """Build a callable ``max_tokens -> SamplingParams``."""
     from vllm_mlx.request import SamplingParams
 
+    # ``ignore_eos=True`` is mandatory for the standardized bench: the
+    # ``tg128`` / ``tg512`` contract requires every round to generate
+    # exactly ``max_tokens`` decode steps for cross-machine
+    # comparability. Without it, a model that emits EOS early on the
+    # synthetic random-token prompt (Qwen3.5-9B does on 0xC0FFEE seed
+    # — issue #567) aborts the round and the guard in ``_run_one_round``
+    # rejects the result. Matches ``llama-bench --no-eos`` semantics —
+    # we measure *hardware* decode throughput, not "model decided to
+    # stop here". User-supplied ``stop_token_ids`` / ``stop`` strings
+    # are still honoured if any caller plumbs them through; only the
+    # model's own EOS / chat-terminator is suppressed.
     if sampling == "greedy":
         # temp=0 + top_p=1 ⇒ argmax. Deterministic, matches llama-bench.
         def factory(max_tokens: int):
             return SamplingParams(
-                max_tokens=max_tokens, temperature=0.0, top_p=1.0, top_k=0
+                max_tokens=max_tokens,
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                ignore_eos=True,
             )
     elif sampling == "sampled":
         # Real-world sampling. Matches Rapid-MLX's serve defaults
         # (config.py SamplingParams.temperature=0.7, top_p=0.9).
         def factory(max_tokens: int):
             return SamplingParams(
-                max_tokens=max_tokens, temperature=0.7, top_p=0.9, top_k=0
+                max_tokens=max_tokens,
+                temperature=0.7,
+                top_p=0.9,
+                top_k=0,
+                ignore_eos=True,
             )
     else:
         raise ValueError(f"unknown sampling mode: {sampling!r}")

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -95,6 +95,12 @@ class SamplingParams:
     # there's no way to satisfy it on models that early-stop.
     ignore_eos: bool = False
 
+    def __post_init__(self):
+        if self.stop is None:
+            self.stop = []
+        if self.stop_token_ids is None:
+            self.stop_token_ids = []
+
 
 @dataclass
 class Request:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -77,12 +77,23 @@ class SamplingParams:
     frequency_penalty: float = 0.0
     stop: list[str] | None = None
     stop_token_ids: list[int] | None = None
-
-    def __post_init__(self):
-        if self.stop is None:
-            self.stop = []
-        if self.stop_token_ids is None:
-            self.stop_token_ids = []
+    # Suppress the model's own EOS / chat-terminator tokens so generation
+    # always runs to ``max_tokens``. Matches llama.cpp ``llama-bench
+    # --no-eos`` and vLLM's ``ignore_eos`` semantics — the same standardized
+    # name across the ecosystem. User-supplied ``stop_token_ids`` and
+    # string ``stop`` sequences are still honoured (those are caller
+    # intent, not model intent), so a probe that wants "exactly N tokens
+    # of decode work, regardless of what the model thinks" gets it.
+    #
+    # Why this exists: community-bench's ``tg512`` contract requires every
+    # round to generate exactly 512 tokens for cross-machine comparability.
+    # Without this flag, a model that emits EOS at token 88 on the
+    # synthetic random-token prompt aborts the round and the bench
+    # fails — exactly the failure dineshdb hit in issue #567 on
+    # qwen3.5-9b-4bit. The guard in ``community_bench/runner.py`` is
+    # correct (don't publish wrong numbers), but without ``ignore_eos``
+    # there's no way to satisfy it on models that early-stop.
+    ignore_eos: bool = False
 
 
 @dataclass

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -63,6 +63,39 @@ CACHE_CORRUPTION_PATTERNS = [
 ]
 
 
+def _assemble_stop_tokens(
+    sampling_params: SamplingParams, model_stop_tokens: set[int]
+) -> set[int]:
+    """Build the stop-token set the BatchGenerator should respect for one request.
+
+    Contract (locked by ``tests/test_community_bench.py::test_scheduler_honours_ignore_eos``):
+
+    - ``sampling_params.ignore_eos=True`` → suppress every token in
+      ``model_stop_tokens`` (the model's own EOS + chat-template terminators).
+      Matches llama.cpp ``llama-bench --no-eos`` and vLLM upstream semantics.
+      Used by community-bench's ``tg128`` / ``tg512`` rounds where the
+      contract is "decode exactly N tokens", not "decode until the model
+      decides to stop".
+    - ``sampling_params.stop_token_ids`` is **always** unioned in.
+      Those are *caller intent*, not model intent, so they survive
+      ``ignore_eos=True``.
+    - ``sampling_params.ignore_eos=False`` (default) → return the union
+      of model stop tokens and any caller stop ids. Normal serve / chat
+      behaviour.
+
+    Why this is a free function: extracted from ``_create_batch_generator``
+    so the test exercises the production assembly directly. A local
+    stand-in in the test could pass even if this function deleted the
+    ``ignore_eos`` branch — codex_review BLOCKING from PR #599.
+    """
+    stop_tokens: set[int] = (
+        set() if sampling_params.ignore_eos else set(model_stop_tokens)
+    )
+    if sampling_params.stop_token_ids:
+        stop_tokens.update(sampling_params.stop_token_ids)
+    return stop_tokens
+
+
 class SchedulingPolicy(Enum):
     """Scheduling policy for request ordering."""
 
@@ -2013,18 +2046,7 @@ class Scheduler:
             top_k=sampling_params.top_k,
         )
 
-        # ``ignore_eos`` suppresses the model's own EOS / chat-terminator
-        # tokens (matches llama-bench ``--no-eos`` and vLLM semantics).
-        # User-supplied ``stop_token_ids`` are still honoured below —
-        # those are caller intent, not model intent. Used by community-bench
-        # to guarantee its ``tg512`` rounds always reach exactly 512 tokens
-        # regardless of what the model thinks of the synthetic prompt.
-        stop_tokens: set[int] = (
-            set() if sampling_params.ignore_eos else self._get_stop_tokens()
-        )
-        # Add custom stop token IDs
-        if sampling_params.stop_token_ids:
-            stop_tokens.update(sampling_params.stop_token_ids)
+        stop_tokens = _assemble_stop_tokens(sampling_params, self._get_stop_tokens())
 
         # mlx-lm 0.31.3+: BatchGenerator captures generation_stream at __init__
         # via a thread-local Stream; without an explicit stream= the captured

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2013,7 +2013,15 @@ class Scheduler:
             top_k=sampling_params.top_k,
         )
 
-        stop_tokens = self._get_stop_tokens()
+        # ``ignore_eos`` suppresses the model's own EOS / chat-terminator
+        # tokens (matches llama-bench ``--no-eos`` and vLLM semantics).
+        # User-supplied ``stop_token_ids`` are still honoured below —
+        # those are caller intent, not model intent. Used by community-bench
+        # to guarantee its ``tg512`` rounds always reach exactly 512 tokens
+        # regardless of what the model thinks of the synthetic prompt.
+        stop_tokens: set[int] = (
+            set() if sampling_params.ignore_eos else self._get_stop_tokens()
+        )
         # Add custom stop token IDs
         if sampling_params.stop_token_ids:
             stop_tokens.update(sampling_params.stop_token_ids)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -86,7 +86,7 @@ def _assemble_stop_tokens(
     Why this is a free function: extracted from ``_create_batch_generator``
     so the test exercises the production assembly directly. A local
     stand-in in the test could pass even if this function deleted the
-    ``ignore_eos`` branch — codex_review BLOCKING from PR #599.
+    ``ignore_eos`` branch.
     """
     stop_tokens: set[int] = (
         set() if sampling_params.ignore_eos else set(model_stop_tokens)


### PR DESCRIPTION
## Summary

Closes #567. The documented `rapid-mlx bench <alias> --submit` flow currently fails on Qwen3.5-9B (and any model whose response to the 0xC0FFEE synthetic-token prompt is to emit EOS within 512 tokens) with a hard error that **blames the user's model alias** and suggests "re-run" — which can't recover on greedy + fixed seed.

Root cause: `SamplingParams` had no `ignore_eos` field. The community-bench's tg128/tg512 contract requires every round to generate exactly N tokens for cross-machine comparability, but the engine had no way to be told "suppress this model's EOS / chat-terminator and run to max_tokens" — so when the model decided the random-token prompt looked like it should end, the bench aborted at token 88.

## Three layers

1. **`SamplingParams.ignore_eos: bool = False`** — standardized name (matches `llama-bench --no-eos` and vLLM upstream). User-supplied `stop_token_ids` / `stop` still honoured.
2. **`scheduler.py`** — `ignore_eos=True` skips `_get_stop_tokens()` when assembling the per-request `stop_tokens` set passed to BatchGenerator.
3. **`community_bench/runner.py`** — both factories (`greedy` + `sampled`) set `ignore_eos=True`. The error message in `_run_one_round` is rewritten: pre-fix blamed the user, post-fix correctly identifies it as an engine-side regression and points the contributor at `/issues/new`.

## Hardening — three regression tests

| Test | Pins |
|---|---|
| `test_sampling_params_ignore_eos_field` | Field name + default value |
| `test_bench_sampling_always_ignores_eos` | Both bench factories set `ignore_eos=True` for both bucket sizes |
| `test_scheduler_honours_ignore_eos` | Stop-token assembly contract (ignore_eos=True + no caller ids ⇒ empty set, etc.) |

Plus CLI-level: `_run_submit_flow` now wraps `run_standardized_bench` with a `try/except RuntimeError` that prints a clean error block instead of dumping a traceback on the contributor.

## Test plan

- [x] `pytest tests/test_community_bench.py tests/test_sampling_params_passthrough.py` — 71/72 passed (the 1 failure is `test_validate_rejects_bad_datetime_format` which already fails on main, unrelated to this PR)
- [x] `ruff format` + `ruff check` on all 6 touched files — clean
- [x] `pr_validate` — clean (round 3): codex_review PASS, lint PASS, supply_chain PASS, targeted PASS, full_unit fails are pre-existing on main (verified identical on main: test_validate_rejects_bad_datetime_format, test_dflash_integration, test_platform.py x4 torch ModuleNotFoundError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
