### PR TITLE
fix(community-bench): novice-friction fixes from 0.7.13 UX trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ brew install raullenchai/rapid-mlx/rapid-mlx
 # pip (requires Python 3.10+ — macOS ships 3.9, so install Python first if needed)
 pip install rapid-mlx
 
+# uv (isolated tool env — to refresh later: `uv tool upgrade rapid-mlx`)
+uv tool install rapid-mlx@latest
+
 # Or one-liner with auto-setup (installs Python if needed)
 curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 ```

--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,7 @@ We welcome contributions of all sizes! See [CONTRIBUTING.md](CONTRIBUTING.md) fo
   ```bash
   rapid-mlx bench qwen3.5-9b-4bit --submit
   ```
-  Runs the standardized B=1 bench (greedy, 128 + 512 token buckets, 5 rounds each), shows you the JSON payload, asks for consent, and opens the PR for you via `gh`. If you don't have `gh`, it prints the JSON path + a deep-link to GitHub's compare page so you can open the PR in your browser. Submitted rows land in [community-benchmarks/submissions/](community-benchmarks/) and show up on https://rapidmlx.com once merged.
+  Runs the standardized B=1 bench (greedy, 128 + 512 token buckets, 5 rounds each), shows you the JSON payload, asks for consent, and opens the PR for you via `gh`. If you don't have `gh`, it prints the JSON path + a deep-link to GitHub's compare page so you can open the PR in your browser. Submitted rows land in [community-benchmarks/submissions/](community-benchmarks/submissions/) and show up on https://rapidmlx.com once merged.
 - Test with your favorite AI client (Cursor, Aider, LangChain, etc.)
 - [Report a bug](https://github.com/raullenchai/Rapid-MLX/issues/new?template=bug_report.yml)
 

--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,11 @@ We welcome contributions of all sizes! See [CONTRIBUTING.md](CONTRIBUTING.md) fo
 - [Request model support](https://github.com/raullenchai/Rapid-MLX/issues/new?template=model_support.yml) — tell us which model you want
 
 **Testing contributions** (needs a Mac with Apple Silicon):
-- Benchmark a model and share results
+- **Share your hardware's benchmark numbers** — one command:
+  ```bash
+  rapid-mlx bench qwen3.5-9b-4bit --submit
+  ```
+  Runs the standardized B=1 bench (greedy, 128 + 512 token buckets, 5 rounds each), shows you the JSON payload, asks for consent, and opens the PR for you via `gh`. If you don't have `gh`, it prints the JSON path + a deep-link to GitHub's compare page so you can open the PR in your browser. Submitted rows land in [community-benchmarks/submissions/](community-benchmarks/) and show up on https://rapidmlx.com once merged.
 - Test with your favorite AI client (Cursor, Aider, LangChain, etc.)
 - [Report a bug](https://github.com/raullenchai/Rapid-MLX/issues/new?template=bug_report.yml)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.13"
+version = "0.7.14"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -1531,6 +1531,55 @@ def test_manual_fallback_without_gh_skips_owner_when_origin_is_upstream(
     assert f"compare/main...{upstream_owner}:" not in text
 
 
+def test_manual_fallback_compare_url_quotes_owner_and_branch(
+    tmp_path, monkeypatch
+) -> None:
+    """Regression: the ``main...<owner>:<branch>`` compare URL must
+    URL-quote both halves independently — any owner or branch ref
+    carrying ``#``, ``?``, ``%`` or other URL-reserved chars would
+    otherwise truncate or rewrite the URL silently. Branch is
+    constructed by us (``community-bench/<hex>``) and owner is
+    validated upstream, but pinning the quoting at this layer guards
+    against future loosening. (Codex PR #600 round-2 BLOCKING.)
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {"alias": "x", "hf_path": "y/z"},
+        "hardware": {"chip": "Apple M3 Ultra", "ram_gb": 64},
+        "software": {"rapid_mlx": "0.7.14", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    # Deliberately pathological owner with URL-reserved chars — a real
+    # github.com username can't carry these, but we want the quoting
+    # layer to be load-bearing regardless.
+    monkeypatch.setattr(
+        sub_mod,
+        "_origin_is_safe_github",
+        lambda _repo: (True, "weird?owner#name%"),
+    )
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    # The pathological chars must appear percent-encoded — not raw —
+    # so the URL parses as a single path segment, not as a malformed
+    # query/fragment split.
+    compare_line = next(
+        line for line in text.splitlines() if "/compare/main..." in line
+    ).strip()
+    assert "weird?owner#name%" not in compare_line
+    assert "weird%3Fowner%23name%25" in compare_line
+    # The ``:`` between owner and branch stays literal (GitHub's
+    # syntax requirement).
+    assert ":community-bench/" in compare_line
+
+
 def test_manual_fallback_url_encodes_alias_special_chars(tmp_path, monkeypatch) -> None:
     """Regression: aliases or chip names containing ``&``, ``#``, ``/``,
     ``%``, or spaces must round-trip cleanly through the issue-new

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -1428,6 +1428,8 @@ def test_manual_fallback_without_gh_points_at_web_ui(tmp_path, monkeypatch) -> N
     sub_path.write_text("{}")
 
     monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    # tmp_path has no git remote — _origin_is_safe_github returns
+    # (False, None) so the owner-less compare URL is used.
     out = io.StringIO()
     sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
     text = out.getvalue()
@@ -1443,9 +1445,130 @@ def test_manual_fallback_without_gh_points_at_web_ui(tmp_path, monkeypatch) -> N
     # Must also offer the paste-to-issue escape hatch so users with no
     # git fluency at all still have a way to land their numbers.
     assert (f"https://github.com/{sub_mod.UPSTREAM_REPO_FOR_GH}/issues/new") in text
-    assert "qwen3.5-9b-4bit" in text
-    # Chip name has to be URL-encoded — bare spaces would break the link.
-    assert "Apple%20M3%20Ultra" in text
+    # Title (alias + chip) round-trips through urlencode — verify both
+    # appear unmodified after decoding.
+    import urllib.parse as _up
+
+    issue_line = next(
+        line for line in text.splitlines() if "issues/new" in line
+    ).strip()
+    query = issue_line.split("?", 1)[1]
+    parsed = dict(_up.parse_qsl(query))
+    assert parsed["title"] == "community-bench: qwen3.5-9b-4bit on Apple M3 Ultra"
+
+
+def test_manual_fallback_without_gh_uses_fork_owner_when_origin_is_fork(
+    tmp_path, monkeypatch
+) -> None:
+    """Regression: when origin is a contributor's fork (the normal
+    contribution path), the compare URL must use ``main...<owner>:<branch>``
+    so GitHub can find the head branch on the fork — bare ``main...<branch>``
+    only resolves on the upstream repo. (Codex PR #600 round-1 BLOCKING.)
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {"alias": "qwen3.5-9b-4bit", "hf_path": "y/z"},
+        "hardware": {"chip": "Apple M3 Ultra", "ram_gb": 64},
+        "software": {"rapid_mlx": "0.7.14", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    # Mock origin → contributor's fork on github.com.
+    monkeypatch.setattr(
+        sub_mod,
+        "_origin_is_safe_github",
+        lambda _repo: (True, "some-contributor"),
+    )
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    branch = f"community-bench/{payload['submission_id']}"
+    # Cross-fork compare URL: head is owner-prefixed.
+    assert (f"compare/main...some-contributor:{branch}?expand=1") in text
+    # Must NOT print the bare same-repo form (would 404 for the user).
+    assert f"compare/main...{branch}?expand=1" not in text
+
+
+def test_manual_fallback_without_gh_skips_owner_when_origin_is_upstream(
+    tmp_path, monkeypatch
+) -> None:
+    """Counterpart to the fork case: when origin owner equals the
+    upstream owner (maintainer running locally), the URL must NOT
+    include the ``upstream:`` prefix — that would be redundant and
+    GitHub's compare page redirects it anyway.
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {"alias": "x", "hf_path": "y/z"},
+        "hardware": {"chip": "Apple M4 Pro", "ram_gb": 24},
+        "software": {"rapid_mlx": "0.7.14", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    upstream_owner = sub_mod.UPSTREAM_REPO_FOR_GH.split("/", 1)[0]
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        sub_mod,
+        "_origin_is_safe_github",
+        lambda _repo: (True, upstream_owner),
+    )
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    branch = f"community-bench/{payload['submission_id']}"
+    assert f"compare/main...{branch}?expand=1" in text
+    assert f"compare/main...{upstream_owner}:" not in text
+
+
+def test_manual_fallback_url_encodes_alias_special_chars(tmp_path, monkeypatch) -> None:
+    """Regression: aliases or chip names containing ``&``, ``#``, ``/``,
+    ``%``, or spaces must round-trip cleanly through the issue-new
+    URL. Bare ``.replace(' ', '%20')`` produced malformed URLs for
+    realistic aliases like ``qwen3.6/27b``. (Codex PR #600 round-1 NIT.)
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {
+            "alias": "qwen3.6/27b & friends #beta 50%",
+            "hf_path": "y/z",
+        },
+        "hardware": {"chip": "Apple M3 Ultra", "ram_gb": 64},
+        "software": {"rapid_mlx": "0.7.14", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    # Decode the title param back and assert it round-trips losslessly.
+    import urllib.parse as _up
+
+    issue_line = next(
+        line for line in text.splitlines() if "issues/new" in line
+    ).strip()
+    query = issue_line.split("?", 1)[1]
+    parsed = dict(_up.parse_qsl(query))
+    assert (
+        parsed["title"]
+        == "community-bench: qwen3.6/27b & friends #beta 50% on Apple M3 Ultra"
+    )
 
 
 def test_manual_fallback_with_gh_keeps_gh_command(tmp_path, monkeypatch) -> None:

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -1408,6 +1408,75 @@ def test_state_aware_fallback_skips_already_completed_steps(tmp_path, capsys) ->
     assert "Already completed" in text
 
 
+def test_manual_fallback_without_gh_points_at_web_ui(tmp_path, monkeypatch) -> None:
+    """Regression: when ``gh`` is not on PATH (the common newcomer case),
+    the fallback must not tell the user to run ``gh pr create`` — it
+    has to point them at the GitHub compare page and at the
+    paste-to-issue escape hatch so they can finish the submission
+    without installing extra tooling. (Subagent-friction report, #4.)
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {"alias": "qwen3.5-9b-4bit", "hf_path": "y/z"},
+        "hardware": {"chip": "Apple M3 Ultra", "ram_gb": 64},
+        "software": {"rapid_mlx": "0.7.13", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda _: None)
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    # gh isn't installed — must NOT recommend gh pr create.
+    assert "gh pr create" not in text
+    # Must surface the compare-page URL with the branch ref filled in.
+    branch = f"community-bench/{payload['submission_id']}"
+    assert (
+        f"https://github.com/{sub_mod.UPSTREAM_REPO_FOR_GH}"
+        f"/compare/main...{branch}?expand=1"
+    ) in text
+    # Must also offer the paste-to-issue escape hatch so users with no
+    # git fluency at all still have a way to land their numbers.
+    assert (f"https://github.com/{sub_mod.UPSTREAM_REPO_FOR_GH}/issues/new") in text
+    assert "qwen3.5-9b-4bit" in text
+    # Chip name has to be URL-encoded — bare spaces would break the link.
+    assert "Apple%20M3%20Ultra" in text
+
+
+def test_manual_fallback_with_gh_keeps_gh_command(tmp_path, monkeypatch) -> None:
+    """Counterpart: when ``gh`` IS installed, the fallback should keep
+    surfacing ``gh pr create`` (the original behavior — used when a
+    later git step failed mid-sequence). Pins that we don't drop the
+    gh path while fixing the gh-missing one.
+    """
+    from vllm_mlx.community_bench import submission as sub_mod
+
+    payload = {
+        "submission_id": "abcdef012345",
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "model": {"alias": "x", "hf_path": "y/z"},
+        "hardware": {"chip": "Apple M4 Pro", "ram_gb": 24},
+        "software": {"rapid_mlx": "0.7.13", "mlx": "0.31.2"},
+    }
+    sub_path = tmp_path / "submission.json"
+    sub_path.write_text("{}")
+
+    monkeypatch.setattr(sub_mod.shutil, "which", lambda name: "/opt/homebrew/bin/gh")
+    out = io.StringIO()
+    sub_mod._print_manual_fallback(tmp_path, sub_path, payload, stdout=out)
+    text = out.getvalue()
+
+    assert "gh pr create" in text
+    # Web-UI fallback shouldn't appear when gh is available.
+    assert "compare/main..." not in text
+    assert "/issues/new" not in text
+
+
 def test_decode_tps_formula_uses_n_minus_one(monkeypatch) -> None:
     """Regression: ``decode_tps`` must be computed as ``(N-1)/window``,
     not ``N/window`` — the inter-token window measures N-1 gaps for

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1238,6 +1238,43 @@ def _run_submit_flow(args) -> int:
             print(f"  Error loading model: {e}")
             model_load_executor.shutdown(wait=False)
             return 2
+        except (ValueError, ModuleNotFoundError) as e:
+            # mlx-lm raises ``ValueError: Model type X not supported`` plus an
+            # internal ``ModuleNotFoundError: No module named 'mlx_lm.models.X'``
+            # for any architecture it can't import. The Gemma 4 family lives
+            # in mlx-vlm (the model classes are vision-aware even for the
+            # text-only checkpoints), so a bare ``pip install rapid-mlx``
+            # without the ``[vision]`` extras hits this every time. The
+            # README still recommends ``gemma-4-*`` aliases so newcomers
+            # would otherwise see a raw traceback and conclude the model
+            # is broken — translate to an actionable hint.
+            msg = str(e)
+            needs_vision = (
+                "gemma4_unified" in msg
+                or "gemma4" in msg
+                or "mlx_vlm" in msg
+                or "mlx-vlm" in msg
+            )
+            if needs_vision:
+                print()
+                print(
+                    "  Error: this model needs the vision extras (Gemma 4 "
+                    "architecture classes live in mlx-vlm)."
+                )
+                print("  Install them and re-run:")
+                print()
+                print("    pip install 'rapid-mlx[vision]'")
+                print()
+                print(
+                    "  Or, if you only need text inference (smaller "
+                    "footprint, ~16 MB vs ~450 MB):"
+                )
+                print("    pip install --no-deps 'mlx-vlm>=0.6.1'")
+                print()
+            else:
+                print(f"  Error loading model: {e}")
+            model_load_executor.shutdown(wait=False)
+            return 2
 
         # Standardized config: B=1, no batching, prefix-cache off so the
         # numbers reflect cold prefill on each round (which is what the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1234,10 +1234,6 @@ def _run_submit_flow(args) -> int:
         )
         try:
             model, tokenizer = model_load_executor.submit(load, hf_path).result()
-        except (RepositoryNotFoundError, OSError) as e:
-            print(f"  Error loading model: {e}")
-            model_load_executor.shutdown(wait=False)
-            return 2
         except (ValueError, ModuleNotFoundError) as e:
             # mlx-lm raises ``ValueError: Model type X not supported`` plus an
             # internal ``ModuleNotFoundError: No module named 'mlx_lm.models.X'``
@@ -1247,7 +1243,10 @@ def _run_submit_flow(args) -> int:
             # without the ``[vision]`` extras hits this every time. The
             # README still recommends ``gemma-4-*`` aliases so newcomers
             # would otherwise see a raw traceback and conclude the model
-            # is broken — translate to an actionable hint.
+            # is broken — translate to an actionable hint. Placed BEFORE
+            # the broader ``OSError`` clause so a future maintainer can't
+            # accidentally make the broad branch swallow it (Codex PR
+            # #600 round-1 BLOCKING).
             msg = str(e)
             needs_vision = (
                 "gemma4_unified" in msg
@@ -1273,6 +1272,10 @@ def _run_submit_flow(args) -> int:
                 print()
             else:
                 print(f"  Error loading model: {e}")
+            model_load_executor.shutdown(wait=False)
+            return 2
+        except (RepositoryNotFoundError, OSError) as e:
+            print(f"  Error loading model: {e}")
             model_load_executor.shutdown(wait=False)
             return 2
 

--- a/vllm_mlx/community_bench/submission.py
+++ b/vllm_mlx/community_bench/submission.py
@@ -539,17 +539,51 @@ def _print_manual_fallback(
         )
     if "push" not in done:
         print(f"    git push -u origin {branch}", file=stdout)
-    # If we already pushed but pr_create failed, just retry pr_create —
-    # the user shouldn't re-do the branch ops. ``--repo`` forces the
-    # PR target to upstream regardless of whether origin is a fork.
-    # The owner-prefixed ``--head`` is omitted from the manual line
-    # because the contributor running it locally already has gh's
-    # fork-aware default applied; the explicit prefix only matters
-    # when we shell out non-interactively.
-    print(
-        f"    gh pr create --repo {UPSTREAM_REPO_FOR_GH} --head {branch}",
-        file=stdout,
-    )
+    # The PR-create step has two paths depending on whether ``gh`` is on
+    # PATH. If we got here because gh is missing (the common newcomer
+    # case), recommending ``gh pr create`` is useless — point them at
+    # the GitHub web UI and at the "paste the file into a new issue"
+    # fallback instead. If gh is available (this branch only hits when
+    # git steps failed mid-sequence), surface gh as the resume command.
+    gh_available = shutil.which("gh") is not None
+    if gh_available:
+        # ``--repo`` forces the PR target to upstream regardless of
+        # whether origin is a fork. The owner-prefixed ``--head`` is
+        # omitted because the contributor running it locally already
+        # has gh's fork-aware default applied.
+        print(
+            f"    gh pr create --repo {UPSTREAM_REPO_FOR_GH} --head {branch}",
+            file=stdout,
+        )
+    else:
+        print("", file=stdout)
+        print(
+            "  Then open the PR via the GitHub web UI (no `gh` CLI needed):",
+            file=stdout,
+        )
+        # GitHub auto-detects the just-pushed branch and prefills the
+        # compare-and-PR page when you visit the compare URL with the
+        # branch ref. Works whether origin is the upstream or a fork.
+        print(
+            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/compare/main...{branch}?expand=1",
+            file=stdout,
+        )
+        print("", file=stdout)
+        print(
+            "  If you'd rather skip git entirely, paste the submission JSON",
+            file=stdout,
+        )
+        print(
+            "  contents (above path) into a new issue and we'll convert it",
+            file=stdout,
+        )
+        print("  to a PR for you:", file=stdout)
+        print(
+            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/issues/new"
+            f"?title=community-bench:%20{payload['model']['alias']}"
+            f"%20on%20{payload['hardware']['chip'].replace(' ', '%20')}",
+            file=stdout,
+        )
 
 
 def _print_thanks(payload: dict, *, stdout) -> None:

--- a/vllm_mlx/community_bench/submission.py
+++ b/vllm_mlx/community_bench/submission.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.parse
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -561,11 +562,22 @@ def _print_manual_fallback(
             "  Then open the PR via the GitHub web UI (no `gh` CLI needed):",
             file=stdout,
         )
-        # GitHub auto-detects the just-pushed branch and prefills the
-        # compare-and-PR page when you visit the compare URL with the
-        # branch ref. Works whether origin is the upstream or a fork.
+        # GitHub's "compare across forks" URL uses ``main...<owner>:<branch>``
+        # when the head branch lives on a fork — bare ``main...<branch>``
+        # only works if the branch is on the upstream repo, which most
+        # community contributors don't have write access to. Detect the
+        # origin owner so the printed URL works for the fork workflow
+        # too. (Codex PR #600 round-1 BLOCKING.) Fall back to the
+        # owner-less form when we can't parse origin (covers the
+        # ``no git remote yet`` case where the user hasn't pushed).
+        is_safe, origin_owner = _origin_is_safe_github(repo)
+        upstream_owner = UPSTREAM_REPO_FOR_GH.split("/", 1)[0]
+        if is_safe and origin_owner and origin_owner != upstream_owner:
+            head_ref = f"{origin_owner}:{branch}"
+        else:
+            head_ref = branch
         print(
-            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/compare/main...{branch}?expand=1",
+            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/compare/main...{head_ref}?expand=1",
             file=stdout,
         )
         print("", file=stdout)
@@ -578,10 +590,18 @@ def _print_manual_fallback(
             file=stdout,
         )
         print("  to a PR for you:", file=stdout)
+        # ``urlencode`` over the whole querystring handles spaces, ``&``,
+        # ``#``, ``%``, and any other special chars that might appear
+        # in a model alias or in the chip name. Bare ``.replace(' ', '%20')``
+        # produced malformed URLs for aliases like ``qwen3.6/27b`` where
+        # the slash breaks GitHub's title parser. (Codex PR #600 round-1.)
+        title = (
+            f"community-bench: {payload['model']['alias']} "
+            f"on {payload['hardware']['chip']}"
+        )
+        query = urllib.parse.urlencode({"title": title})
         print(
-            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/issues/new"
-            f"?title=community-bench:%20{payload['model']['alias']}"
-            f"%20on%20{payload['hardware']['chip'].replace(' ', '%20')}",
+            f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/issues/new?{query}",
             file=stdout,
         )
 

--- a/vllm_mlx/community_bench/submission.py
+++ b/vllm_mlx/community_bench/submission.py
@@ -572,10 +572,20 @@ def _print_manual_fallback(
         # ``no git remote yet`` case where the user hasn't pushed).
         is_safe, origin_owner = _origin_is_safe_github(repo)
         upstream_owner = UPSTREAM_REPO_FOR_GH.split("/", 1)[0]
+        # Quote both halves before joining with the literal ``:`` GitHub
+        # expects between owner and branch in the compare path. Owner is
+        # the more constrained piece (GitHub usernames are ``[a-zA-Z0-9-]``
+        # by policy) but we still ``quote(safe="")`` defensively in case
+        # _origin_is_safe_github ever loosens. The branch ref allows ``/``
+        # — that's how we construct ``community-bench/<id>`` to begin with
+        # — so we keep ``/`` unescaped via ``safe="/"``. Without this any
+        # branch ref carrying ``#``, ``?``, or ``%`` would split the URL.
+        # (Codex PR #600 round-2 BLOCKING.)
+        branch_quoted = urllib.parse.quote(branch, safe="/")
         if is_safe and origin_owner and origin_owner != upstream_owner:
-            head_ref = f"{origin_owner}:{branch}"
+            head_ref = f"{urllib.parse.quote(origin_owner, safe='')}:{branch_quoted}"
         else:
-            head_ref = branch
+            head_ref = branch_quoted
         print(
             f"    https://github.com/{UPSTREAM_REPO_FOR_GH}/compare/main...{head_ref}?expand=1",
             file=stdout,


### PR DESCRIPTION
## Summary

Three friction fixes surfaced when 3 novice subagents ran `rapid-mlx bench ... --submit` end-to-end on the freshly-released 0.7.13. All three came back with the same UX gaps:

1. **README discoverability** — "Benchmark a model and share results" was so generic that contributors had no idea what command to run. Replaced with the concrete one-liner (`rapid-mlx bench qwen3.5-9b-4bit --submit`) + a sentence on what it does and where rows land.

2. **Gemma 4 friendly error** — selecting `gemma-4-*` aliases without `[vision]` extras dumped a raw mlx-lm traceback ("Model type gemma4_unified not supported"). The submit flow now catches `ValueError` / `ModuleNotFoundError`, detects the gemma4 / mlx-vlm signature, and prints a `pip install 'rapid-mlx[vision]'` hint (with the `--no-deps` lean-install variant) instead of stack vomit.

3. **`gh` fallback** — when `gh` is not on PATH (typical for first-time contributors), `_print_manual_fallback` was telling them to run `gh pr create` anyway. Now branches on `shutil.which("gh")`: gh-missing path prints a GitHub compare-page deep-link plus a "paste the JSON into a new issue" escape hatch so users without GitHub tooling can still finish the submission.

Two regression tests pin the gh-missing vs gh-available behavior. Version bumped to 0.7.14.

## Test plan

- [x] `pytest tests/test_community_bench.py -k "manual_fallback or state_aware_fallback"` — 3 passed (1 new gh-missing test, 1 new gh-available test, 1 existing state-aware test still green)
- [x] `ruff check` + `ruff format` clean on all touched files
- [x] `pytest tests/test_community_bench.py` — 59 passed, 1 deselected (`test_validate_rejects_bad_datetime_format` is pre-existing main failure, unrelated)
- [x] `pr_validate` gauntlet — round-1: 2 BLOCKING + 2 NIT fixed in 7b00cff
