### PR TITLE
docs(readme): audit + rewrite for clarity and value-prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h1 align="center">Rapid-MLX</h1>
 
 <p align="center">
-  <strong>Run AI on your Mac. Faster than anything else.</strong>
+  <strong>The fastest way to run AI models on Apple Silicon.</strong>
 </p>
 
 <p align="center">
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  Run local AI models on your Mac — no cloud, no API costs. Works with Cursor, Claude Code, and any OpenAI-compatible app.
+  Rapid-MLX is a local LLM inference engine for Macs. It speaks the OpenAI Chat / Responses / Embeddings APIs, so anything that talks to ChatGPT — Cursor, Claude Code, Aider, Codex CLI, LangChain, PydanticAI, your own scripts — just works against <code>http://localhost:8000</code>. No cloud, no API key, no per-token cost.
 </p>
 
 <p align="center">
@@ -31,21 +31,25 @@
 <p align="center">
   <img src="https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/docs/assets/demo.gif" alt="Rapid-MLX demo — install, serve Gemma 4, chat, tool calling" width="700">
   <br>
-  <em>pip install → serve Gemma 4 26B → chat + tool calling → works with PydanticAI, LangChain, Aider, and more.</em>
+  <em>pip install → serve Gemma 4 → chat + tool calling → works with PydanticAI, LangChain, Aider, and more.</em>
 </p>
+
+---
+
+## What runs on your Mac
 
 | | Your Mac | Model | Speed (tok/s) | What works |
 |:---|:---:|:---:|:---:|:---:|
 | **16 GB** MacBook Air | Qwen3.5-4B | 147 tok/s | Chat, coding, tools |
 | **24 GB** MacBook Pro | Qwen3.5-9B | 101 tok/s | Great all-rounder |
-| **32+ GB** Mac Mini / Studio | 🆕 Gemma 4 12B | 64 tok/s | Vision-capable + tools |
+| **32+ GB** Mac Mini / Studio | Gemma 4 12B | 64 tok/s | Vision + tools |
 | **32+ GB** Mac Mini / Studio | GPT-OSS 20B | 119 tok/s | Harmony-native, 100% tools |
 | **32+ GB** Mac Mini / Studio | Qwen3.6-35B-A3B | 93 tok/s | 256 MoE experts, 262K context |
 | **48+ GB** Mac Mini / Studio | Qwen3.5-35B-A3B 8bit | 80 tok/s | Best balance of smart + fast |
 | **96+ GB** Mac Studio / Pro | Qwen3.5-122B | 57 tok/s¹ | Frontier-level intelligence |
-| **128+ GB** Mac Studio Ultra | DeepSeek V4 Flash 158B-A13B | 31-56 tok/s¹ | Day-0 frontier MoE, 1M context |
+| **128+ GB** Mac Studio Ultra | DeepSeek V4 Flash 158B-A13B | 31–56 tok/s¹ | Day-0 frontier MoE, 1M context |
 
-<sub>Single-user end-to-end throughput (B=1: one request at a time, 256 max output tokens, `output_tokens / wall-clock` incl. first-token latency), median of 3 rounds. `chat_template_kwargs.enable_thinking=False` passed where the engine honours it. Tested on M3 Ultra 256 GB / rapid-mlx v0.6.83 (fused top-p sampler). ¹ carried over from 2026-04 bench — disk-constrained on this refresh.</sub>
+<sub>Single-user end-to-end throughput (B=1: one request at a time, 256 max output tokens, `output_tokens / wall-clock` incl. first-token latency), median of 3 rounds. `chat_template_kwargs.enable_thinking=False` passed where the engine honours it. Tested on M3 Ultra 256 GB / rapid-mlx v0.6.83 (fused top-p sampler). ¹ carried over from 2026-04 bench — disk-constrained on this refresh. The full sizing table with HuggingFace links is in [Choose Your Model](#choose-your-model).</sub>
 
 <details>
 <summary><b>New to local AI? Quick glossary</b></summary>
@@ -54,8 +58,8 @@
 - **4bit / 8bit** — compression levels for models. 4bit uses less memory (recommended); 8bit is higher quality.
 - **TTFT** (Time To First Token) — how long before the AI starts responding.
 - **Tool calling** — the AI can call functions in your code. Used by Cursor, Claude Code, and coding assistants.
-- **OpenAI API compatible** — Rapid-MLX speaks the same language as ChatGPT's API, so any app that works with ChatGPT can work with Rapid-MLX by just changing the server address.
-- **Ollama / llama.cpp** — other popular tools for running local AI. The only **apples-to-apples** row in our table is GPT-OSS 20B (identical weights both sides) — Rapid-MLX runs it **2.3x faster than Ollama** under B=4 concurrent load. On the **Qwen3 closest-tag** rows (Qwen3.5/3.6 DeltaNet isn't on llama.cpp yet, so we compare against `qwen3:Nb`) Rapid-MLX leads 1.7–2.4x. The **Gemma 4 row** is tied at parity with Ollama's Gemma 3 (different architectures, 1.0x). Against `mlx-lm serve` (same MLX weights) Rapid-MLX is **1.2–1.5x faster**. Full caveats in [Benchmarks](#benchmarks).
+- **OpenAI-compatible** — Rapid-MLX speaks the same HTTP API as ChatGPT, so any app that works with ChatGPT can work with Rapid-MLX by pointing at `http://localhost:8000/v1`.
+- **Ollama / llama.cpp** — other popular local-AI runtimes. The only **apples-to-apples** row in our benchmark is GPT-OSS 20B (identical weights both sides) — Rapid-MLX runs it **2.3× faster than Ollama** under B=4 concurrent load. On the **Qwen3 closest-tag** rows (Qwen3.5/3.6 DeltaNet isn't on llama.cpp yet) Rapid-MLX leads 1.7–2.4×. The **Gemma 4** row ties Ollama's Gemma 3 (different architectures, 1.0×). Against `mlx-lm serve` (same MLX weights) Rapid-MLX is **1.2–1.5× faster**. Full caveats in [Benchmarks](#benchmarks).
 
 </details>
 
@@ -63,12 +67,12 @@
 
 ## Quick Start
 
-**Step 1 — Install** (pick one):
+**1. Install** (pick one):
 
 ```bash
 # uv (recommended — one command, isolated env, auto-manages Python)
 uv tool install rapid-mlx@latest
-# Don't have uv yet? Install it first: curl -LsSf https://astral.sh/uv/install.sh | sh
+# Don't have uv yet? curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Or one-liner with auto-setup (installs Python if needed)
 curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
@@ -84,15 +88,44 @@ pip install rapid-mlx
 
 Upgrade later: `uv tool upgrade rapid-mlx` / `brew upgrade rapid-mlx` / `pip install -U rapid-mlx`.
 
-> **Vision/multimodal models** (Gemma 4, Qwen-VL, etc.) need extras: `pip install 'rapid-mlx[vision]'`. Text-only install is ~460 MB; vision adds ~322 MB. See [Optional Extras](#optional-extras) for the full list.
+**2. Chat with a model right now:**
 
-> **Audio (TTS / STT)** — `pip install 'rapid-mlx[audio]'` unlocks `kokoro`, `chatterbox`, `vibevoice`, `whisper`, `parakeet`, and friends behind OpenAI's `/v1/audio/speech` and `/v1/audio/transcriptions`. See [Supported audio models](#supported-audio-models).
+```bash
+rapid-mlx chat
+```
 
-> **"No matching distribution" error?** Your Python is too old. Run `python3 --version` — if it says 3.9, install a newer Python: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`
+Defaults to `qwen3.5-4b-4bit`. First run downloads the model (~2.5 GB) — you'll see a progress bar. Drops you into a REPL when it's ready. Type `/help` for slash commands, `/exit` to quit. Pass `--think` to surface chain-of-thought, `--no-think` to skip it for faster replies.
 
-> **`Refusing to load formula ... from untrusted tap`?** Homebrew 4.x requires third-party taps to be explicitly trusted before install. The `brew trust raullenchai/rapid-mlx` line above is what marks the tap as trusted — without it, even after `brew tap`, the install is refused. Trust is per-machine and persists across upgrades.
+**3. Or serve it for use from other apps:**
 
-> **`Tapping homebrew/core` / `Operation not permitted` during `brew install`?** Brew 5.x's install sandbox can't auto-tap `homebrew/core` mid-install. Pre-tap it once, then retry:
+```bash
+rapid-mlx serve qwen3.5-4b-4bit
+```
+
+Starts an OpenAI-compatible HTTP server. Wait for `Ready: http://localhost:8000/v1`, then point Cursor, Claude Code, Aider, LangChain, the OpenAI SDK — anything — at `http://localhost:8000/v1`.
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"default","messages":[{"role":"user","content":"Say hello"}]}'
+```
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+print(client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Say hello"}],
+).choices[0].message.content)
+```
+
+> **Vision/multimodal models** (Gemma 4, Qwen-VL) need extras: `pip install 'rapid-mlx[vision]'`. Text-only install is ~460 MB; vision adds ~322 MB. See [Optional Extras](#optional-extras).
+
+> **"No matching distribution" from pip?** Your Python is too old. Run `python3 --version` — if it says 3.9, run `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`.
+
+> **`Refusing to load formula ... from untrusted tap`?** Homebrew 4.x requires third-party taps to be explicitly trusted before install. Run `brew trust raullenchai/rapid-mlx` (per-machine, persists across upgrades) then retry `brew install rapid-mlx`.
+
+> **`brew install` stalls on `Tapping homebrew/core`?** Brew 5.x's install sandbox can't auto-tap `homebrew/core` mid-install. Pre-tap it once, then retry:
 > ```bash
 > brew tap homebrew/core --force   # ~1.3 GB, one-time
 > brew tap raullenchai/rapid-mlx
@@ -100,224 +133,109 @@ Upgrade later: `uv tool upgrade rapid-mlx` / `brew upgrade rapid-mlx` / `pip ins
 > brew install rapid-mlx
 > ```
 
-**Step 2 — Talk to a model right now** (one command, no second terminal):
-```bash
-rapid-mlx chat
-```
-Defaults to `qwen3.5-4b-4bit`. First run downloads the model (~2.5 GB) — you'll see a progress bar. Drops you into a REPL when it's ready. Type `/help` for slash commands, `/exit` to quit. Pass `--think` to surface chain-of-thought.
-
-**Step 2b — Or serve a model for use from other apps:**
-```bash
-rapid-mlx serve qwen3.5-4b-4bit
-```
-Same model, same download — but this starts an OpenAI-compatible HTTP server instead of a REPL. Wait for `Ready: http://localhost:8000/v1`.
-
-> Want vision? `pip install 'rapid-mlx[vision]'` then `rapid-mlx serve gemma-4-26b-4bit` (~14 GB).
-
-**Step 3 — Hit the API** (from a second terminal tab):
-```bash
-curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"default","messages":[{"role":"user","content":"Say hello"}]}'
-```
-
-That's it — you now have an OpenAI-compatible AI server on `localhost:8000`. Point any app at `http://localhost:8000/v1` and it just works.
-
-**Step 4 — Share it publicly** (optional — get a `https://` URL anyone can hit):
-```bash
-rapid-mlx share qwen3.6-27b-8bit
-```
-This spawns the same local serve and tunnels it through `rapidserver.quicksilverpro.io` over a WebSocket. Your terminal prints a public OpenAI-compatible endpoint plus a bearer key — point any chat UI or OpenAI SDK at it. Bearer auth, a locked-down CORS allowlist, and a default 120 RPM rate-limit are wired on the spawned child; closing the terminal tears the tunnel down.
-
-The default chat surface is our hosted Big-AGI fork (tool calling, personas, voice — no signup); any OpenAI-compatible client also works, e.g. `OPENAI_API_BASE_URL=<share-url>/v1 OPENAI_API_KEY=<bearer> open-webui serve`.
-
-> Pick a 27B-class model or larger for a usable share experience — 4B is fine for local dev but too small for live chat (`rapid-mlx models` lists all aliases).
-
-> **Want a Claude Code-like TUI?** Rapid-MLX is the *backend* — pair it with an open-source agent CLI like [OpenCode](https://github.com/sst/opencode) or [codex](https://github.com/openai/codex) for the full slash-commands / tool-use / multi-turn experience. Run `rapid-mlx agents opencode --setup` (or `codex --setup`) to wire it up automatically.
-
-> **Tip:** Run `rapid-mlx models` to see all available model aliases. For a smaller/faster model, try `rapid-mlx serve qwen3.5-9b-4bit` (~5 GB).
-
-<details>
-<summary>More install options</summary>
-
-**From source** (for development):
-```bash
-git clone https://github.com/raullenchai/Rapid-MLX.git
-cd Rapid-MLX && pip install -e .
-```
-
-**Vision models** (adds mlx-vlm + opencv + torch, ~322 MB extra):
-```bash
-pip install 'rapid-mlx[vision]'
-```
-
-**Audio** (TTS/STT via mlx-audio):
-```bash
-pip install 'rapid-mlx[audio]'
-```
-</details>
-
-> **Not into the terminal?** [**Rapid-MLX Desktop**](https://rapidmlx.com) is a Mac app that bundles the same `rapid-mlx` engine inside a one-click GUI — drag to Applications, pick a model, chat. No Python, no `pip`, no `brew`. The CLI here is still the source of truth for serving and scripting; the desktop app is the friendlier on-ramp.
-
-**Try it with Python** (make sure the server is running, then `pip install openai`):
-
-```python
-from openai import OpenAI
-client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")  # any value works, no real key needed
-
-response = client.chat.completions.create(
-    model="default",
-    messages=[{"role": "user", "content": "Say hello"}],
-)
-print(response.choices[0].message.content)
-```
+> **Not into the terminal?** [**Rapid-MLX Desktop**](https://rapidmlx.com) bundles the same engine inside a one-click Mac app — drag to Applications, pick a model, chat. The CLI here is still the source of truth for serving and scripting; the desktop app is the friendlier on-ramp.
 
 ---
 
-## Works With
+## Why Rapid-MLX
 
-### Agent Harnesses (MHI-tested)
+If you're comparing against Ollama, LM Studio, `mlx-lm serve`, or `llama.cpp`:
+
+- **Fastest on Apple Silicon, measured.** Under concurrent load (B=4), Rapid-MLX is **2.3× faster than Ollama** on the apples-to-apples GPT-OSS 20B row (identical weights both sides), leads by **1.7–2.4×** across the Qwen3.5 / Qwen3.6 closest-tag Ollama rows, and runs **1.2–1.5× faster than `mlx-lm serve`** on shared MLX weights. Full table in [Benchmarks](#benchmarks).
+- **Drop-in OpenAI / Anthropic API.** Same `/v1/chat/completions` and `/v1/responses` as OpenAI, plus `/v1/messages` for the Anthropic SDK and Claude Code. No client-side adapter required.
+- **Tool calling that actually works under 4-bit quantization.** 17 parser formats with automatic recovery — when a quantized model emits a malformed tool call as text, Rapid-MLX detects it and rebuilds the structured `tool_calls` object instead of failing silently. Verified end-to-end against Cursor, Codex CLI, Claude Code, Aider, LangChain, PydanticAI, smolagents.
+- **Prompt cache, even on hybrid RNN models, sharable across tenants.** Standard transformers get radix-tree prefix cache — N clients hitting the same 2k-token system prompt converge on the same trie node (O(prefix_len) lookup vs. O(log N + LCP_scan) on hash caches). Hybrid models (Qwen3.5 DeltaNet) get RNN state snapshots restored in ~0.1 ms instead of re-running hundreds of tokens through the recurrent layers. 2–5× faster TTFT on every architecture, always on.
+- **Long-prompt prefill acceleration.** PFlash scores 32K+ prompts and only prefills the sink + recent tail + query-relevant middle — **3.87–8.5× faster cold-start TTFT** with full needle-in-a-haystack recall. Default-on for verified aliases; `--pflash always` forces it for any model.
+- **TurboQuant K8V4 KV codec, default-on for verified MoE.** 9 Qwen3.5/3.6 hero aliases ship with K8V4 (K 8-bit + V 4-bit after Walsh-Hadamard + Lloyd-Max) turned on — codec compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. Set `--kv-cache-turboquant none` to force off.
+- **Day-0 frontier models.** DeepSeek V4 Flash 158B-A13B, Qwen3.6 with 262K context, DiffusionGemma 26B (non-autoregressive), Gemma 4 vision — all behind the same Chat Completions API.
+
+---
+
+## Use Cases
+
+The same `rapid-mlx` binary covers four very different workflows. Pick the one closest to what you want to do:
+
+### 1. Chat in the terminal
+
+```bash
+rapid-mlx chat qwen3.5-9b-4bit
+```
+
+A streaming REPL with slash commands (`/help`, `/system`, `/save`, `/clear`). No second process needed. Use `--think` / `--no-think` to control chain-of-thought. Aliased as `rapid-mlx run` for Ollama muscle memory.
+
+### 2. OpenAI-compatible server for your apps
+
+```bash
+rapid-mlx serve qwen3.5-9b-4bit
+```
+
+Point Cursor, Continue.dev, Open WebUI, LibreChat, the OpenAI Python SDK, LangChain, PydanticAI, smolagents at `http://localhost:8000/v1`. Tool calling, streaming, reasoning separation, structured JSON output, and embeddings are all on the standard endpoints. See [Connect Your Client](#connect-your-client) for one-shot configs.
+
+### 3. Agent backends: Codex CLI, Claude Code, Aider, OpenCode
+
+Rapid-MLX is the *backend* — pair it with an open-source agent CLI for the full Claude Code-like experience.
+
+```bash
+rapid-mlx serve qwen3.6-27b-8bit          # or any tool-capable alias
+rapid-mlx agents codex --setup            # writes ~/.codex/config.toml
+codex                                      # now talks to your local model
+```
+
+- **Codex CLI** (OpenAI's official Rust agent, 0.136.0+) hits `/v1/responses`. Verified end-to-end on Qwen3.5-9B / Qwen3.6-27B for chat, file read/write, shell, multi-step, and source analysis. Release gate G7b probes the codex-shape SSE on every tag. ([guide](docs/guides/codex-cli.md))
+- **Claude Code** hits `/v1/messages` (Anthropic SDK). `ANTHROPIC_BASE_URL=http://localhost:8000 claude`.
+- **Aider / OpenCode / OpenClaude / Goose / Hermes / Claw Code** — `rapid-mlx agents <name> --setup` writes the right config file.
+
+### 4. Benchmark your hardware and contribute to the community
+
+```bash
+rapid-mlx bench qwen3.5-9b-4bit --submit
+```
+
+Runs the standardized B=1 community benchmark (greedy, 128 + 512 token buckets, 5 rounds each), shows you the JSON payload, asks for consent, and opens the PR via `gh` if you have it (or prints a compare-page URL if you don't). Submitted rows land in [community-benchmarks/submissions/](community-benchmarks/submissions/) and show up on [rapidmlx.com](https://rapidmlx.com) once merged. Your bench helps everyone else pick the right model for their Mac.
+
+### Bonus: share a public URL
+
+```bash
+rapid-mlx share qwen3.6-27b-8bit
+```
+
+Tunnels your local server through `rapidserver.quicksilverpro.io` over a WebSocket. Prints a public OpenAI-compatible endpoint plus a bearer key — point any chat UI or OpenAI SDK at it. Bearer auth, CORS allowlist, and a 120 RPM rate-limit are wired automatically; closing the terminal tears the tunnel down. The default chat surface is our hosted Big-AGI fork (tool calling, personas, voice — no signup); any OpenAI-compatible client also works. Pick a 27B-class model or larger for a usable share experience.
+
+---
+
+## Connect Your Client
+
+### Tested integrations
+
+**Agent harnesses** (auto-setup with `rapid-mlx agents <name> --setup`):
 
 | Harness | Type | Notes |
 |---------|------|-------|
+| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim, verified end-to-end against codex 0.136.0 ([guide](docs/guides/codex-cli.md)) |
+| [Claude Code](https://www.anthropic.com/claude-code) | Agent | Anthropic SDK via `/v1/messages` — `ANTHROPIC_BASE_URL=http://localhost:8000 claude` |
+| [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
+| [OpenCode](https://github.com/sst/opencode) | TUI Agent | Claude Code-like terminal UX, OpenAI-compat provider |
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Agent | 62 tools, multi-turn ([test](tests/integrations/test_hermes.py)) |
+| [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
+| [OpenClaude](https://github.com/Gitlawb/openclaude) | Agent | Anthropic SDK, `CLAUDE_CODE_USE_OPENAI=1` ([test](tests/integrations/test_anthropic_sdk.py)) |
+| [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
 | [PydanticAI](https://ai.pydantic.dev) | Framework | Typed agents, structured output ([test](tests/integrations/test_pydantic_ai_full.py)) |
 | [LangChain](https://langchain.com) | Framework | `ChatOpenAI`, tools, streaming ([test](tests/integrations/test_langchain.py)) |
 | [smolagents](https://github.com/huggingface/smolagents) | Framework | CodeAgent + ToolCallingAgent ([test](tests/integrations/test_smolagents_full.py)) |
-| [OpenClaude](https://github.com/Gitlawb/openclaude) (Anthropic SDK) | Agent | `CLAUDE_CODE_USE_OPENAI=1` ([test](tests/integrations/test_anthropic_sdk.py)) |
-| [Aider](https://aider.chat) | Agent | CLI edit-and-commit, architect mode ([test](tests/integrations/test_aider.sh)) |
-| [Goose](https://github.com/block/goose) | Agent | Ollama provider via `OLLAMA_HOST` |
-| [OpenCode](https://github.com/sst/opencode) | TUI Agent | Claude Code-like terminal UX, OpenAI-compat provider |
-| [Codex CLI](https://github.com/openai/codex) | Agent | OpenAI's official Rust agent — `/v1/responses` shim, verified end-to-end against codex 0.136.0 on Qwen3.5-9B / Qwen3.6-27B (chat + file read/write + shell + multi-step + source analysis); release gauntlet G7b probes the codex-shape SSE on every tag ([guide](docs/guides/codex-cli.md), [release gate](docs/development/releasing.md)) |
-| [Claude Code](https://www.anthropic.com/claude-code) | Agent | Anthropic SDK via `/v1/messages` — `ANTHROPIC_BASE_URL=http://localhost:8000` |
-| [Claw Code](https://github.com/ultraworkers/claw-code) | Agent | OpenAI & Anthropic endpoints |
 
-### UI / IDE Clients
+**UI / IDE clients:**
 
 | Client | Status | Setup |
 |--------|--------|-------|
-| [Cursor](https://cursor.com) | Compatible | `rapid-mlx launch cursor` ([see below](#one-shot-bootstrap-rapid-mlx-launch)) |
-| [Claude Code](https://claude.ai/code) | Tested | `rapid-mlx launch claude-code` |
-| [Cline](https://github.com/cline/cline) (VS Code) | Compatible | `rapid-mlx launch cline` |
-| [Continue.dev](https://continue.dev) | Compatible | `rapid-mlx launch continue-dev` |
+| [Cursor](https://cursor.com) | Compatible | Settings → OpenAI Base URL |
+| [Continue.dev](https://continue.dev) | Compatible | VS Code / JetBrains extension |
 | [LibreChat](https://librechat.ai) | Tested | Docker ([test](tests/integrations/test_librechat_docker.py)) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | Tested | Docker ([test](tests/integrations/test_openwebui.py)) |
 | Any OpenAI-compatible app | Compatible | Point at `http://localhost:8000/v1` |
 
-### One-shot bootstrap: `rapid-mlx launch`
+### Quick setup snippets
 
-The fastest way to wire an IDE client to your local rapid-mlx server is the
-`launch` subcommand — one verb, no copy-pasting base URLs into nested
-settings panels:
-
-```bash
-pip install rapid-mlx
-
-# Which clients are installed on this Mac?
-rapid-mlx launch list
-
-# Patch Cline (VS Code) to route at the local server and start serve
-# in the background.
-rapid-mlx launch cline --model qwen3.5-4b-4bit --start-server
-
-# Or wire every detected client at once.
-rapid-mlx launch --all --model qwen3.5-9b-4bit --start-server
-```
-
-What it does, per client:
-
-| Client | Config patched | Keys set |
-|--------|----------------|----------|
-| **cline** | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | `apiProvider`, `openAiBaseUrl`, `openAiApiKey`, `openAiModelId` |
-| **claude-code** | `~/.config/claude/settings.json` | `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_API_KEY`, `env.ANTHROPIC_MODEL` |
-| **continue-dev** | `~/.continue/config.json` | Appends/updates a `rapid-mlx` entry under `models[]` |
-| **cursor** | `~/Library/Application Support/Cursor/User/settings.json` | `cursor.aiprovider.openai.{baseUrl,apiKey,model}` |
-
-Every patch:
-
-- Backs up the existing config to `<path>.bak.<timestamp>` (printed to
-  stderr) so you can recover from a bad patch with `mv <bak> <path>`.
-- Atomically replaces the file (write-temp + rename) so a Ctrl-C never
-  leaves a half-written JSON file on disk.
-- Preserves every other key in the existing config — `customInstructions`,
-  MCP servers, theme settings, etc.
-
-Useful flags:
-
-- `--dry-run` — print what would change without touching disk.
-- `--server-url <url>` — point clients somewhere other than
-  `http://127.0.0.1:8000` (e.g. a `rapid-mlx share` URL).
-- `--start-server` — also fire `rapid-mlx serve <model> --port <port>`
-  detached; PID written to `~/.rapid-mlx/launch.pid`.
-- `--port <int>` — port for `--start-server` (default 8000).
-
-
-### Claude Code
-
-**Claude Code** (Anthropic's web-based code editor) works with Rapid-MLX via the Anthropic Messages API endpoint (`/v1/messages`).
-
-**Terminal 1 — Start the Rapid-MLX server:**
-```bash
-rapid-mlx serve qwen3.5-9b-4bit
-```
-Wait for: `Ready: http://localhost:8000/v1`
-
-**Terminal 2 — Launch Claude Code pointing to your local server:**
-```bash
-export ANTHROPIC_BASE_URL="http://localhost:8000"
-export ANTHROPIC_API_KEY="not-needed"
-claude --model claude-opus-4-5
-```
-
-The server accepts any `claude-*` or `gpt-*` model name in requests and routes them to the loaded engine (configured on the server). The response always reflects the actual loaded model, not the client-requested name. This means:
-- Claude Code can use `--model claude-opus-4-5` or any other alias
-- The server runs whatever model you specified with `rapid-mlx serve <model>`
-- Tool calling and streaming work out of the box with Qwen3.5 / Qwen3.6 models
-
-**Tip:** For the best Claude Code experience on a 24 GB MacBook Pro, use `qwen3.5-9b-4bit` — it's smart enough for coding tasks while staying responsive.
-
-### Model-Harness Index (MHI)
-
-MHI measures how well a model works with a specific agent harness. It combines three dimensions:
-
-| Dimension | Weight | What it measures | Source |
-|---|---|---|---|
-| **Tool Calling** | 50% | Can the model+harness execute function calls correctly? | `rapid-mlx agents --test` |
-| **HumanEval** | 30% | Can the model generate correct code? | [HumanEval](https://github.com/openai/human-eval) (10 tasks) |
-| **MMLU** | 20% | Does the harness degrade base knowledge? | [tinyMMLU](https://huggingface.co/datasets/tinyBenchmarks/tinyMMLU) (10 tasks) |
-
-**MHI = 0.50 × ToolCalling + 0.30 × HumanEval + 0.20 × MMLU** (scale 0-100)
-
-| Model | Best MHI | Best Harness | Tool Calling |
-|---|---|---|---|
-| **Qwopus 27B** | **92** | All (Hermes, PydanticAI, LangChain, smolagents) | 100% |
-| **Qwen3.5 27B** | **82** | Hermes / PydanticAI / LangChain | 100% |
-| **Llama 3.3 70B** | **83** | smolagents (text-based) | 100% |
-| **Nemotron Nano 30B** | **59** | PydanticAI / LangChain | 91-93% |
-| **Gemma 4 26B** | **62** | Hermes / smolagents | 100% |
-
-<details>
-<summary>Full MHI table (25 model-harness combinations) + methodology</summary>
-
-**MHI = 0.50 × ToolCalling + 0.30 × HumanEval + 0.20 × MMLU** (scale 0-100)
-
-Run `rapid-mlx agents` to see all supported agents and `python3 scripts/mhi_eval.py` to compute MHI on your own setup.
-
-| Model + Harness | Tool Calling | HumanEval | MMLU | **MHI** |
-|---|---|---|---|---|
-| **Qwopus 27B** + Hermes | 100% | 80% | 90% | **92** |
-| **Qwopus 27B** + PydanticAI | 100% | 80% | 90% | **92** |
-| **Qwen3.5 27B** + Hermes | 100% | 40% | 100% | **82** |
-| **Llama 3.3 70B** + smolagents | 100% | 50% | 90% | **83** |
-| **DeepSeek-R1 32B** + smolagents | 100% | 30% | 100% | **79** |
-| **Gemma 4 26B** + Hermes | 100% | 0% | 60% | **62** |
-| **Nemotron Nano 30B** + PydanticAI | 93% | 0% | 60% | **59** |
-
-</details>
-
-**Quick setup for popular apps:**
-
-**Cursor:** Settings → Models → Add Model:
+**Cursor** — Settings → Models → Add Model:
 ```
 OpenAI API Base:  http://localhost:8000/v1
 API Key:          not-needed
@@ -325,26 +243,28 @@ Model name:       default          (or qwen3.5-9b-4bit — either works)
 ```
 Cursor's agent/composer mode uses tool calls automatically — Rapid-MLX handles them natively with Qwen3.5 models, no extra flags needed.
 
-**Claw Code:**
+**Codex CLI** — `rapid-mlx agents codex --setup` writes `~/.codex/config.toml` for you. Or by hand:
+```toml
+model = "default"
+model_provider = "rapid-mlx"
+
+[model_providers.rapid-mlx]
+name = "Rapid-MLX (local)"
+base_url = "http://localhost:8000/v1"
+# If rapid-mlx was started with --api-key, add env_key = "RAPID_MLX_API_KEY"
+# and `export RAPID_MLX_API_KEY=...`. Don't use api_key = "..." — Codex
+# CLI's --strict-config rejects inline literals.
+```
+Then `codex` (or `codex exec '<query>'`) routes through `/v1/responses`. See the [Codex CLI guide](docs/guides/codex-cli.md).
+
+**Claude Code:**
 ```bash
-export OPENAI_BASE_URL=http://localhost:8000/v1
-export OPENAI_API_KEY=not-needed
-claw --model "openai/default" prompt "summarize this repo"
+ANTHROPIC_BASE_URL=http://localhost:8000 ANTHROPIC_API_KEY=not-needed claude
 ```
 
-**OpenClaude:**
+**Aider:**
 ```bash
-CLAUDE_CODE_USE_OPENAI=1 OPENAI_BASE_URL=http://localhost:8000/v1 \
-OPENAI_API_KEY=not-needed OPENAI_MODEL=default openclaude -p "hello"
-```
-
-**Hermes Agent** (`~/.hermes/config.yaml`):
-```yaml
-model:
-  provider: "custom"
-  default: "default"
-  base_url: "http://localhost:8000/v1"
-  context_length: 32768
+aider --openai-api-base http://localhost:8000/v1 --openai-api-key not-needed
 ```
 
 **Goose:**
@@ -353,13 +273,8 @@ GOOSE_PROVIDER=ollama OLLAMA_HOST=http://localhost:8000 \
 GOOSE_MODEL=default goose run --text "hello"
 ```
 
-**Claude Code:**
-```bash
-OPENAI_BASE_URL=http://localhost:8000/v1 claude
-```
-
 <details>
-<summary><strong>More client setup instructions</strong></summary>
+<summary><strong>More client setup snippets (Continue.dev, OpenCode, LibreChat, Open WebUI, Hermes, PydanticAI, smolagents, Anthropic SDK)</strong></summary>
 
 **Continue.dev** (`~/.continue/config.yaml`):
 ```yaml
@@ -369,36 +284,6 @@ models:
     model: default
     apiBase: http://localhost:8000/v1
     apiKey: not-needed
-```
-
-**Aider:**
-```bash
-aider --openai-api-base http://localhost:8000/v1 --openai-api-key not-needed
-```
-
-**Swival** (`~/.swival/config.toml`):
-```toml
-[profiles.rapidmlx]
-provider = "generic"
-base_url = "http://127.0.0.1:8000"
-model = "default"
-```
-
-Run with:
-```bash
-swival --profile rapidmlx "summarize this repo"
-```
-
-**Open WebUI** (Docker one-liner):
-```bash
-docker run -d -p 3000:8080 \
-  --add-host=host.docker.internal:host-gateway \
-  -e ENABLE_OLLAMA_API=False \
-  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
-  -e OPENAI_API_KEY=not-needed \
-  -v open-webui:/app/backend/data \
-  --name open-webui \
-  ghcr.io/open-webui/open-webui:main
 ```
 
 **OpenCode** (`opencode.json` in your project root):
@@ -419,20 +304,52 @@ docker run -d -p 3000:8080 \
 }
 ```
 
-**Codex CLI** (`~/.codex/config.toml` — or run `rapid-mlx agents codex --setup` to write this for you):
-```toml
-model = "default"
-model_provider = "rapid-mlx"
-
-[model_providers.rapid-mlx]
-name = "Rapid-MLX (local)"
-base_url = "http://localhost:8000/v1"
-# If rapid-mlx was started with --api-key, add env_key = "RAPID_MLX_API_KEY"
-# and `export RAPID_MLX_API_KEY=...`. Don't use api_key = "..." — Codex
-# CLI's --strict-config rejects inline literals.
+**Open WebUI** (Docker one-liner):
+```bash
+docker run -d -p 3000:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  -e ENABLE_OLLAMA_API=False \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
+  -e OPENAI_API_KEY=not-needed \
+  -v open-webui:/app/backend/data \
+  --name open-webui \
+  ghcr.io/open-webui/open-webui:main
 ```
 
-Then `codex` (or `codex exec '<query>'`) talks to the local model via `/v1/responses`. See the [Codex CLI guide](docs/guides/codex-cli.md) for the full setup.
+**LibreChat** (`librechat.yaml`, under `endpoints.custom`):
+```yaml
+- name: "Rapid-MLX"
+  apiKey: "rapid-mlx"
+  baseURL: "http://localhost:8000/v1/"
+  models:
+    default: ["default"]
+    fetch: true
+  titleConvo: true
+  titleModel: "current_model"
+  modelDisplayLabel: "Rapid-MLX"
+```
+
+**Hermes Agent** (`~/.hermes/config.yaml`):
+```yaml
+model:
+  provider: "custom"
+  default: "default"
+  base_url: "http://localhost:8000/v1"
+  context_length: 32768
+```
+
+**OpenClaude:**
+```bash
+CLAUDE_CODE_USE_OPENAI=1 OPENAI_BASE_URL=http://localhost:8000/v1 \
+OPENAI_API_KEY=not-needed OPENAI_MODEL=default openclaude -p "hello"
+```
+
+**Claw Code:**
+```bash
+export OPENAI_BASE_URL=http://localhost:8000/v1
+export OPENAI_API_KEY=not-needed
+claw --model "openai/default" prompt "summarize this repo"
+```
 
 **PydanticAI** (`pip install pydantic-ai`):
 ```python
@@ -447,8 +364,7 @@ model = OpenAIChatModel(
         api_key="not-needed",
     ),
 )
-agent = Agent(model)
-print(agent.run_sync("What is 2+2?").output)
+print(Agent(model).run_sync("What is 2+2?").output)
 ```
 
 **smolagents** (`pip install smolagents`):
@@ -460,21 +376,7 @@ model = OpenAIServerModel(
     api_base="http://localhost:8000/v1",
     api_key="not-needed",
 )
-agent = CodeAgent(tools=[], model=model)
-agent.run("What is 5 multiplied by 7?")
-```
-
-**LibreChat** (`librechat.yaml`, under `endpoints.custom`):
-```yaml
-- name: "Rapid-MLX"
-  apiKey: "rapid-mlx"
-  baseURL: "http://localhost:8000/v1/"
-  models:
-    default: ["default"]
-    fetch: true
-  titleConvo: true
-  titleModel: "current_model"
-  modelDisplayLabel: "Rapid-MLX"
+CodeAgent(tools=[], model=model).run("What is 5 multiplied by 7?")
 ```
 
 **Anthropic SDK** (`pip install anthropic`):
@@ -492,6 +394,51 @@ print(message.content[0].text)
 
 </details>
 
+### Model-Harness Index (MHI)
+
+MHI measures how well a model works with a specific agent harness. It combines three dimensions:
+
+| Dimension | Weight | What it measures | Source |
+|---|---|---|---|
+| **Tool Calling** | 50% | Can the model+harness execute function calls correctly? | `rapid-mlx agents --test` |
+| **HumanEval** | 30% | Can the model generate correct code? | [HumanEval](https://github.com/openai/human-eval) (10 tasks) |
+| **MMLU** | 20% | Does the harness degrade base knowledge? | [tinyMMLU](https://huggingface.co/datasets/tinyBenchmarks/tinyMMLU) (10 tasks) |
+
+**MHI = 0.50 × ToolCalling + 0.30 × HumanEval + 0.20 × MMLU** (scale 0-100)
+
+| Model | Best MHI | Best Harness | Tool Calling |
+|---|---|---|---|
+| **Qwopus 27B** | **92** | Hermes / PydanticAI / LangChain / smolagents | 100% |
+| **Qwen3.5 27B** | **82** | Hermes / PydanticAI / LangChain | 100% |
+| **Llama 3.3 70B** | **83** | smolagents (text-based) | 100% |
+| **Nemotron Nano 30B** | **59** | PydanticAI / LangChain | 91–93% |
+| **Gemma 4 26B** | **62** | Hermes / smolagents | 100% |
+
+Run `rapid-mlx agents` to list supported agents and `python3 scripts/mhi_eval.py` to compute MHI on your own setup.
+
+---
+
+## Command Reference
+
+| Command | What it does |
+|---|---|
+| `rapid-mlx chat [model]` | Interactive chat REPL (alias: `rapid-mlx run`) |
+| `rapid-mlx serve <model>` | Start an OpenAI-compatible HTTP server |
+| `rapid-mlx share <model>` | Same as `serve`, but tunneled to a public URL |
+| `rapid-mlx agents [name]` | List agent integrations; `--setup` / `--test` per integration |
+| `rapid-mlx bench <model>` | Throughput benchmark; `--submit` runs the standardized B=1 community bench and opens a PR |
+| `rapid-mlx models` | List all aliases (`--cached` shows only locally-downloaded ones; `ls` is a top-level alias) |
+| `rapid-mlx pull <model>` | Download a model to the HF cache without starting a server |
+| `rapid-mlx rm <model>` | Remove a cached model |
+| `rapid-mlx ps` | List running `rapid-mlx` servers |
+| `rapid-mlx info <model>` | Show the per-model profile (parsers, hybrid / MoE flags, DFlash eligibility) |
+| `rapid-mlx doctor` | Self-diagnostic — Metal, imports, CLI, inference pipeline |
+| `rapid-mlx upgrade` | Detect install method (brew / pip / install.sh) and upgrade |
+| `rapid-mlx telemetry <status\|enable\|disable\|preview\|reset>` | Manage anonymous usage telemetry (off by default; see [Telemetry](#telemetry)) |
+| `rapid-mlx version` | Print the installed version |
+
+Every subcommand supports `--help`. Tab completion is wired automatically via `argcomplete` — see [shell completion](#shell-completion) if it doesn't fire.
+
 ---
 
 ## Choose Your Model
@@ -500,31 +447,31 @@ print(message.content[0].text)
 
 The model has to fit in your Mac's RAM. If your Mac slows down or Activity Monitor shows red memory pressure, pick a smaller model from the table below.
 
-> **Browse the full catalog** at [**models.rapidmlx.com**](https://models.rapidmlx.com/) — 80+ MLX-quantised models on a free R2 mirror with resumable downloads, no HuggingFace rate limits. `rapid-mlx pull <alias>` fetches from there automatically.
-
 | Your Mac | Best Model | RAM Used | Speed (B=1) | Quality |
 |----------|-----------|---------|-------|---------|
 | **16 GB** MacBook Air/Pro | [Qwen3.5-4B 4bit](https://huggingface.co/mlx-community/Qwen3.5-4B-MLX-4bit) | 2.4 GB | 147 tok/s | Good for chat and simple tasks |
 | **24 GB** MacBook Pro | [Qwen3.5-9B 4bit](https://huggingface.co/mlx-community/Qwen3.5-9B-4bit) | 5.1 GB | 101 tok/s | Great all-rounder |
 | **32 GB** Mac Mini / Studio | [Qwen3.5-27B 4bit](https://huggingface.co/mlx-community/Qwen3.5-27B-4bit) | 15.3 GB | 37 tok/s | Solid coding model |
-| **32 GB** Mac Mini / Studio | 🆕 [Gemma 4 12B 4bit](https://huggingface.co/mlx-community/gemma-4-12B-it-4bit) | 7 GB | 64 tok/s | Vision-capable + tool calling |
+| **32 GB** Mac Mini / Studio | [Gemma 4 12B 4bit](https://huggingface.co/mlx-community/gemma-4-12B-it-4bit) | 7 GB | 64 tok/s | Vision-capable + tool calling |
 | **32 GB** Mac Mini / Studio | [GPT-OSS 20B MXFP4](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8) | 11 GB | 119 tok/s | Harmony-native, 100% tools |
 | **32 GB** Mac Mini / Studio | [Qwen3.6-35B-A3B 4bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit) | 20 GB | 93 tok/s | 256 MoE experts, 262K context |
 | **36 GB** MacBook Pro M3/M4 Pro | [Qwen3.5-27B 4bit](https://huggingface.co/mlx-community/Qwen3.5-27B-4bit) | 15.3 GB | 37 tok/s | Same as 32 GB — extra headroom for long contexts |
 | **48 GB** Mac Mini / Studio | [Qwen3.5-35B-A3B 8bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-8bit) | 37 GB | 80 tok/s | **Sweet spot** — smart + fast |
 | **64 GB** Mac Mini / Studio | [Qwen3.5-35B-A3B 8bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-8bit) | 37 GB | 80 tok/s | Same model, more room for KV cache |
 | **96 GB** Mac Studio / Pro | [Qwen3.5-122B mxfp4](https://huggingface.co/nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx) | 65 GB | 57 tok/s¹ | Best model, fits comfortably |
-| **128 GB** Mac Studio / Pro | 🆕 [DeepSeek V4 Flash 2-bit DQ](https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ) | 91 GB | 56 tok/s¹ | 158B-A13B frontier MoE, day-0 (chat only) |
+| **128 GB** Mac Studio / Pro | [DeepSeek V4 Flash 2-bit DQ](https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ) | 91 GB | 56 tok/s¹ | 158B-A13B frontier MoE, day-0 (chat only) |
 | **192 GB** Mac Studio / Pro | [Qwen3.5-122B 8bit](https://huggingface.co/mlx-community/Qwen3.5-122B-A10B-8bit) | 130 GB | 44 tok/s¹ | Maximum quality |
-| **256 GB** Mac Studio Ultra | 🆕 [DeepSeek V4 Flash 8-bit](https://huggingface.co/mlx-community/DeepSeek-V4-Flash-8bit) | 136 GB | 31 tok/s¹ | 158B-A13B frontier MoE, 1M context (chat only) |
+| **256 GB** Mac Studio Ultra | [DeepSeek V4 Flash 8-bit](https://huggingface.co/mlx-community/DeepSeek-V4-Flash-8bit) | 136 GB | 31 tok/s¹ | 158B-A13B frontier MoE, 1M context (chat only) |
 
-<sub>Speed = single-user end-to-end throughput (B=1: one request, 256 max output tokens, output_tokens / wall-clock including first-token latency), median of 3 rounds. rapid-mlx v0.6.83 (fused top-p sampler) on M3 Ultra 256 GB, 2026-06-09. ¹ Carried over from prior bench (disk-constrained on this refresh).</sub>
+<sub>Speed = single-user end-to-end throughput (B=1: one request, 256 max output tokens, `output_tokens / wall-clock` including first-token latency), median of 3 rounds. rapid-mlx v0.6.83 (fused top-p sampler) on M3 Ultra 256 GB, 2026-06-09. ¹ Carried over from prior bench (disk-constrained on this refresh).</sub>
 
-> **4bit vs 8bit:** 4bit models are compressed to use less memory (recommended for most users). 8bit models are higher quality but need more RAM. "mxfp4" is a high-quality 4bit format.
+> **Not getting the speed in the table?** Most likely the model is reasoning before answering — add `--no-think` to skip chain-of-thought. See [Troubleshooting](#troubleshooting).
 
-### Naming convention
+> **4bit vs 8bit:** 4bit models are compressed to use less memory (recommended for most users). 8bit models are higher quality but need more RAM. "mxfp4" is a high-quality 4-bit format.
 
-Every alias follows the same template so you can read off the model family, parameter count, training technique, and quantization at a glance:
+### Alias naming convention
+
+Every alias follows the same template:
 
 `<family>-<version>-<params>-<modality?>-<technique?>-<quant>`
 
@@ -532,14 +479,14 @@ Every alias follows the same template so you can read off the model family, para
 |---|---|---|
 | **family** | Model family | `gemma`, `qwen`, `llama`, `mistral`, `deepseek`, `phi` |
 | **version** | Major version | `-4`, `3.5`, `3.6`, `-r1`, `-v4-flash` |
-| **params** | Parameter count (MoE includes the active count) | `12b`, `27b`, `35b-a3b` (35B total / 3B active) |
+| **params** | Parameter count (MoE includes active count) | `12b`, `27b`, `35b-a3b` (35B total / 3B active) |
 | **modality** *(optional)* | Non-text variants | `-vl` (vision), `-coder` (code) |
 | **technique** *(optional)* | Training-time modifier | `-qat` (Quantization-Aware Training), `-distill`, `-thinking` |
-| **quant** *(mandatory)* | Quantization tier (see below) | `-4bit`, `-8bit`, `-mxfp4`, `-qat-8bit`, … |
+| **quant** *(mandatory)* | Quantization tier | `-4bit`, `-8bit`, `-mxfp4`, `-qat-8bit`, … |
 
-The **quantization suffix is mandatory on every alias** — `qwen3.5-4b-4bit` not `qwen3.5-4b`, `gemma-4-12b-qat-8bit` not `gemma-4-12b-qat`. This mirrors LM Studio's `…-MLX-4bit` / `…-MLX-8bit` HuggingFace convention so you never have to guess the bit width.
+The **quantization suffix is mandatory on every alias** — `qwen3.5-4b-4bit` not `qwen3.5-4b`. This mirrors LM Studio's `…-MLX-4bit` HuggingFace convention so you never guess the bit width. `-qat` is a *technique* suffix, not a quant — it stacks before the quant (so a QAT-trained Gemma 4 12B in 4-bit is `gemma-4-12b-qat-4bit`).
 
-| Suffix | Meaning |
+| Quant suffix | Meaning |
 |---|---|
 | `-4bit` | Standard MLX 4-bit (most common) |
 | `-8bit` | Standard MLX 8-bit (higher quality, ~2× RAM) |
@@ -550,93 +497,35 @@ The **quantization suffix is mandatory on every alias** — `qwen3.5-4b-4bit` no
 | `-ud` | Unsloth Dynamic (mixed-precision per-layer) |
 | `-unpacked` | Original FP16 / BF16 weights, no quantization |
 
-`-qat` is a *technique* suffix, not a quant — it stacks before the quant. So a QAT-trained Gemma 4 12B in 4-bit is `gemma-4-12b-qat-4bit`, and the 8-bit variant is `gemma-4-12b-qat-8bit`.
-
-Decoded examples:
-
-- `gemma-4-12b-qat-4bit` = Gemma 4 · 12B params · QAT-trained · 4-bit quant
-- `qwen3.5-35b-8bit` = Qwen 3.5 · 35B params (3B active MoE) · 8-bit quant
-- `gpt-oss-20b-mxfp4-q8` = GPT-OSS · 20B params · MXFP4 weights + Q8 head
-- `bonsai-1.7b-unpacked` = Bonsai · 1.7B params · no quantization
-
 ### Full model lineup
 
-103 explicit aliases across 15 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and per-alias capabilities.
+**128+ explicit aliases across 30+ families** ship today (`rapid-mlx models`), including audio (13 TTS + 13 STT) and embedding aliases. `rapid-mlx info <alias>` shows the per-alias profile — parser, hybrid / MoE flags, K8V4 eligibility, DFlash / MTP eligibility.
 
 <details>
-<summary><strong>Show all 103 aliases by family</strong></summary>
+<summary><strong>Text families at a glance</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
-| **Qwen3.5** | `qwen3.5-4b-4bit`, `-4b-8bit`, `-9b-4bit`, `-9b-8bit`, `-27b-4bit`, `-27b-8bit`, `-35b-4bit`, `-35b-8bit`, `-122b-mxfp4`, `-122b-8bit` | DeltaNet hybrid |
-| **Qwen3.6** | `qwen3.6-27b-4bit`, `-27b-8bit`, `-27b-ud`, `-35b-4bit`, `-35b-6bit`, `-35b-8bit`, `-35b-dwq`, `-35b-ud` | 262K ctx, 256 MoE experts |
-| **Qwen3** | `qwen3-0.6b-4bit`, `-0.6b-8bit`, `-4b-8bit`, `-8b-4bit`, `-8b-8bit`, `qwen3-coder-4bit`, `qwen3-coder-30b-4bit`, `qwen3-vl-4b-4bit`, `-8b-4bit`, `-30b-4bit` | Coding + vision |
-| **Qwen2.5** | `qwen2.5-14b-4bit` | Legacy 14B base for back-compat agents |
+| **Qwen3.5** | `qwen3.5-4b-4bit`, `-4b-8bit`, `-9b-4bit`, `-9b-8bit`, `-9b-6bit`, `-27b-4bit`, `-27b-6bit`, `-27b-8bit`, `-35b-4bit`, `-35b-6bit`, `-35b-8bit`, `-122b-mxfp4`, `-122b-8bit` | DeltaNet hybrid; **27b-8bit DFlash-eligible**; K8V4-verified: `-9b-4bit`, `-9b-8bit`, `-27b-4bit`, `-27b-8bit`, `-35b-6bit` |
+| **Qwen3.6** | `qwen3.6-27b-4bit`, `-27b-8bit`, `-27b-ud`, `-35b-4bit`, `-35b-6bit`, `-35b-8bit`, `-35b-dwq`, `-35b-ud` | 262K ctx, 256 MoE experts; **27b-8bit DFlash-eligible**; K8V4-verified: `-35b-4bit`, `-35b-6bit`, `-35b-8bit`, `-35b-dwq` |
+| **Qwen3** | `qwen3-0.6b-8bit`, `-4b-8bit`, `-8b-8bit`, `qwen3-coder-4bit`, `qwen3-coder-30b-4bit`, `qwen3-vl-4b-4bit`, `-8b-4bit`, `-30b-4bit` | Coding + vision |
 | **Qwopus** | `qwopus-9b-4bit`, `qwopus-27b-4bit`, `qwopus-27b-8bit` | 92 MHI on tool calling |
-| **DeepSeek** | `deepseek-r1-8b-4bit`, `-32b-4bit`, `deepseek-v4-flash-2bit`, `-4bit`, `-8bit`, `deepseek-coder-v2-lite-16b-4bit` | R1 reasoning + V4 Flash 158B-A13B day-0 + Coder V2 Lite |
-| **Gemma** | `gemma-4-e2b-4bit`, `-e4b-4bit`, `gemma-4-12b-4bit`, `-12b-8bit`, `-12b-qat-4bit`, `-12b-qat-8bit`, `-26b-4bit`, `-26b-qat-4bit`, `-31b-4bit`, `-31b-8bit`, `-31b-qat-4bit`, `-31b-qat-8bit`, `gemma3-1b-4bit`, `-1b-qat-4bit`, `-4b-qat-4bit`, `-12b-4bit`, `-27b-4bit`, `-27b-qat-4bit` | Vision-capable; QAT variants; Gemma 4 e-series mobile sizes |
+| **DeepSeek** | `deepseek-r1-8b-4bit`, `-32b-4bit`, `deepseek-coder-v2-lite-16b-4bit`, `deepseek-v4-flash-2bit`, `-4bit`, `-8bit` | R1 reasoning + V4 Flash 158B-A13B day-0 |
+| **Gemma** | `gemma-3n-e4b-4bit`, `gemma-4-12b-4bit`, `-12b-8bit`, `-12b-qat-4bit`, `-12b-qat-8bit`, `-26b-4bit`, `-26b-qat-4bit`, `-31b-4bit`, `-31b-8bit`, `-31b-qat-4bit`, `-31b-qat-8bit`, `gemma3-1b-4bit`, `-12b-4bit`, `-27b-4bit` | Vision-capable; QAT variants |
 | **Llama / Hermes** | `llama3-1b-4bit`, `-3b-4bit`, `llama-3.1-8b-4bit`, `-8b-8bit`, `hermes3-8b-4bit`, `hermes4-70b-4bit` | |
 | **GLM** | `glm4.5-air-4bit`, `glm4.7-9b-4bit` | |
 | **GPT-OSS** | `gpt-oss-20b-mxfp4-q8` | Harmony native |
-| **MiniMax** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4` | |
+| **MiniMax / Kimi** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4`, `kimi-48b-4bit`, `kimi-k2.5-3bit` | |
 | **Mistral / Devstral** | `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit` | |
-| **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit`, `vibethinker-1.5b-4bit`, `vibethinker-3b-8bit` | Weibo VibeThinker 1.5B / 3B reasoning (MIT) |
-| 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
-| 🆕 **UI-TARS** | `ui-tars-1.5-7b-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-dpo-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-sft-4bit`, `-8bit`, `ui-tars-72b-dpo-4bit` | ByteDance GUI agent (Qwen2-VL); Computer-Use actions parsed as OpenAI `tool_calls` + Anthropic `tool_use` (`name="computer"`) |
+| **Phi / Granite / Nemotron / Bonsai / SmolLM** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit` | |
+| **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
+| **Tmax / VibeThinker / Nanbeige / Holo3.1 / Bonsai / SmolLM / EmbeddingGemma / UI** | `tmax-9b-4bit`, `tmax-27b-4bit`, `vibethinker-*`, `nanbeige4.1-*`, `holo3.1-a3b-*`, `ui-*`, `embeddinggemma-*` | Community aliases (MLX-first-mover, agentic, GUI, embeddings) |
 
-`rapid-mlx info <alias>` shows per-alias capabilities (parser, hybrid / MoE flags, TurboQuant K8V4 eligibility).
+TurboQuant **K8V4 KV codec is default-on** for 9 verified Qwen3.5/3.6 MoE aliases (see [Features](#features)); DFlash and MTP speculative drafters are opt-in per alias (`rapid-mlx info <alias>` shows what's eligible).
 
 </details>
 
-### Supported audio models
-
-Audio support landed in **0.8.13** behind the `[audio]` extra. **26 aliases** ship today (13 TTS + 13 STT), all served through the same OpenAI-compatible endpoints — `POST /v1/audio/speech` for synthesis and `POST /v1/audio/transcriptions` for recognition. Engines load **lazily** on the first `/v1/audio/*` request, so booting a TTS/STT alias is as fast as booting a text model — no boot-time weight download.
-
-```bash
-pip install 'rapid-mlx[audio]==0.8.13'
-```
-
-| Mode | Alias | HuggingFace repo | Notes |
-|---|---|---|---|
-| **TTS** | `kokoro` (default) | `mlx-community/Kokoro-82M-bf16` | 12 voices (`af_heart`, `af_bella`, …) |
-| **TTS** | `kokoro-4bit` | Kokoro-82M 4-bit | Same voices, lower RAM |
-| **TTS** | `chatterbox` | `mlx-community/chatterbox-turbo-fp16` | Conversational, low-latency |
-| **TTS** | `vibevoice` | `mlx-community/VibeVoice-Realtime-0.5B-4bit` | 25 voices across en/de/fr/jp/kr/pt/sp/it/pl/nl/in/cn |
-| **TTS** | `voxcpm` | `mlx-community/VoxCPM1.5` | High-quality multilingual |
-| **TTS** | `dia` | `mlx-community/Dia-1.6B-4bit` | Expressive dialogue model |
-| **STT** | `whisper` / `whisper-1` | `mlx-community/whisper-large-v3-mlx` | OpenAI-spec aliases (drop-in for `whisper-1`) |
-| **STT** | `whisper-tiny`, `whisper-base`, `whisper-small`, `whisper-medium` | Whisper size variants | Pick by Mac RAM |
-| **STT** | `whisper-large-v3-turbo` | Whisper turbo | Faster decode, near-large quality |
-| **STT** | `parakeet` / `parakeet-v3` | `mlx-community/parakeet-tdt-0.6b-v2` / v3 | NVIDIA TDT, English-only, very fast |
-
-Run `rapid-mlx models --audio` for the full 26-alias list.
-
-**Try TTS** — synth a clip with Kokoro:
-
-```bash
-pip install 'rapid-mlx[audio]'
-rapid-mlx serve kokoro --port 8000
-
-# OpenAI-compatible TTS
-curl -X POST http://127.0.0.1:8000/v1/audio/speech \
-  -H "Content-Type: application/json" \
-  -d '{"model":"kokoro","input":"Hello world","voice":"af_heart","response_format":"mp3"}' \
-  --output out.mp3
-```
-
-**Try STT** — transcribe a clip with Whisper:
-
-```bash
-rapid-mlx serve whisper --port 8001
-curl -X POST http://127.0.0.1:8001/v1/audio/transcriptions \
-  -F "file=@speech.wav" -F "model=whisper-1"
-```
-
-Both endpoints match the OpenAI shape, so the official `openai` Python / JS SDKs work unchanged (`base_url="http://localhost:8000/v1"`).
-
-### Copy-paste commands
-
-Pick the one that matches your Mac. Run `rapid-mlx models` to see all available aliases.
+### Copy-paste serve commands
 
 ```bash
 # 16 GB — lightweight, fast
@@ -644,9 +533,6 @@ rapid-mlx serve qwen3.5-4b-4bit --port 8000
 
 # 24 GB — best small model
 rapid-mlx serve qwen3.5-9b-4bit --port 8000
-
-# 32 GB — solid coding model
-rapid-mlx serve qwen3.5-27b-4bit --port 8000
 
 # 32 GB — Gemma 4 12B (vision-capable, 64 tok/s)
 rapid-mlx serve gemma-4-12b-4bit --port 8000
@@ -658,56 +544,35 @@ rapid-mlx serve gpt-oss-20b-mxfp4-q8 --port 8000
 rapid-mlx serve qwen3.6-35b-4bit --port 8000
 
 # 48+ GB — sweet spot (Qwen3.5-35B-A3B 8bit, 80 tok/s)
-rapid-mlx serve qwen3.5-35b-8bit --prefill-step-size 8192 --port 8000  # faster first response
+rapid-mlx serve qwen3.5-35b-8bit --prefill-step-size 8192 --port 8000
 
 # 96+ GB — frontier (Qwen3.5-122B mxfp4)
 rapid-mlx serve qwen3.5-122b-mxfp4 --prefill-step-size 8192 --port 8000
 
-# Coding agent — fast MoE, great for Claude Code / Cursor
-rapid-mlx serve qwen3-coder-4bit --prefill-step-size 8192 --port 8000  # MoE = only uses part of the model, so it's fast
+# Coding agent — fast MoE
+rapid-mlx serve qwen3-coder-4bit --prefill-step-size 8192 --port 8000
 
-# Vision — image understanding (see note below)
+# Vision — image understanding (needs [vision] extras)
 rapid-mlx serve qwen3-vl-4b-4bit --mllm --port 8000
 
-# 🆕 Text-diffusion — DiffusionGemma 26B-A4B (block denoising, not autoregressive)
-rapid-mlx serve diffusion-gemma-26b-4bit --port 8000  # needs [vision] extras for mlx-vlm 0.6.3+
-```
-
-> **Vision deps:** Install into the same environment where rapid-mlx lives:
-> - `install.sh` users: `~/.rapid-mlx/bin/pip install 'rapid-mlx[vision]'`
-> - `pip` users: `pip install 'rapid-mlx[vision]'` (in the same venv)
-> - `brew` users: `$(brew --prefix)/opt/rapid-mlx/libexec/bin/pip install 'rapid-mlx[vision]'`
-
-### 🆕 Text-Diffusion (DiffusionGemma 26B-A4B)
-
-DiffusionGemma is a **non-autoregressive** language model — instead of emitting one token at a time, it denoises whole blocks of tokens in parallel via a diffusion process. Rapid-MLX wraps it behind the standard OpenAI Chat Completions API, so any client (chat UIs, agent harnesses, your own scripts) talks to it the same way it talks to Qwen / Gemma / GPT-OSS.
-
-```bash
-pip install 'rapid-mlx[vision]'       # mlx-vlm 0.6.3+ provides the diffusion runtime
+# Text-diffusion — DiffusionGemma 26B-A4B (block denoising, needs [vision] for mlx-vlm 0.6.3+)
 rapid-mlx serve diffusion-gemma-26b-4bit --port 8000
 ```
 
-**B=1 single-user benchmark** (M3 Ultra 256 GB, mlx-community/diffusiongemma-26B-A4B-it-4bit, median of 3 runs + 1 warmup):
-
-| `max_tokens` | TTFT | E2E | Aggregate tok/s |
-|---:|---:|---:|---:|
-| 64 | 1.47s | 1.47s | 43 |
-| 256 | 6.00s | 6.00s | 43 |
-| 1024 | 5.71s | 19.58s | 37 |
-
-> Diffusion models emit tokens in **whole denoising blocks**, so the conventional `decode_tok/s = tokens / (e2e − ttft)` metric isn't meaningful here (ttft ≈ e2e for short outputs). The table reports **aggregate** throughput — `tokens / total_wall_time` — i.e. how many tokens actually land in the chat window per second. Throughput climbs with output length because the per-step denoising cost amortizes across more emitted tokens.
-
-Reproduce the table: `python3.12 scripts/bench_diffusion_gemma.py --port 8000`.
+> **Vision deps:** Install into the same environment where rapid-mlx lives:
+> - `pip` users: `pip install 'rapid-mlx[vision]'` (in the same venv)
+> - `install.sh` users: `~/.rapid-mlx/bin/pip install 'rapid-mlx[vision]'`
+> - `brew` users: `$(brew --prefix)/opt/rapid-mlx/libexec/bin/pip install 'rapid-mlx[vision]'`
 
 <details>
-<summary><strong>Parser auto-detection & manual overrides</strong></summary>
+<summary><strong>Parser auto-detection &amp; manual overrides</strong></summary>
 
 Parsers are **auto-detected from the model name** — you don't need to specify `--tool-call-parser` or `--reasoning-parser` for supported families. Explicit flags always override auto-detection.
 
-| Model Family | Auto-detected `--tool-call-parser` | Auto-detected `--reasoning-parser` | Notes |
+| Model Family | `--tool-call-parser` | `--reasoning-parser` | Notes |
 |-------------|---------------------|---------------------|-------|
 | Qwen3.5 (all sizes) | `hermes` | `qwen3` | **Recommended** — 100% tool calling |
-| 🆕 Qwen3.6 | `qwen3_coder_xml` | `qwen3` | XML tool format, 262K context |
+| Qwen3.6 | `qwen3_coder_xml` | `qwen3` | XML tool format, 262K context |
 | Qwen3-Coder-Next | `hermes` | *(none)* | Fast coding, non-thinking mode |
 | DeepSeek R1-0528 / V3.1 | `deepseek_v31` | `deepseek_r1` | Dedicated V3.1 parser |
 | DeepSeek R1 (older) | `deepseek` | `deepseek_r1` | With reasoning |
@@ -725,6 +590,30 @@ All 17 parsers include automatic recovery — if a quantized model outputs broke
 
 </details>
 
+<details>
+<summary><strong>Text-Diffusion (DiffusionGemma 26B-A4B)</strong></summary>
+
+DiffusionGemma is a **non-autoregressive** language model — instead of emitting one token at a time, it denoises whole blocks of tokens in parallel via a diffusion process. Rapid-MLX wraps it behind the standard OpenAI Chat Completions API.
+
+```bash
+pip install 'rapid-mlx[vision]'       # mlx-vlm 0.6.3+ provides the diffusion runtime
+rapid-mlx serve diffusion-gemma-26b-4bit --port 8000
+```
+
+**B=1 single-user benchmark** (M3 Ultra 256 GB, mlx-community/diffusiongemma-26B-A4B-it-4bit, median of 3 runs + 1 warmup):
+
+| `max_tokens` | TTFT | E2E | Aggregate tok/s |
+|---:|---:|---:|---:|
+| 64 | 1.47s | 1.47s | 43 |
+| 256 | 6.00s | 6.00s | 43 |
+| 1024 | 5.71s | 19.58s | 37 |
+
+Diffusion models emit tokens in **whole denoising blocks**, so the conventional `decode_tok/s = tokens / (e2e − ttft)` metric isn't meaningful here (ttft ≈ e2e for short outputs). The table reports **aggregate** throughput — `tokens / total_wall_time` — i.e. how many tokens actually land in the chat window per second. Throughput climbs with output length because the per-step denoising cost amortizes across more emitted tokens.
+
+Reproduce: `python3.12 scripts/bench_diffusion_gemma.py --port 8000`.
+
+</details>
+
 ---
 
 ## Benchmarks
@@ -735,7 +624,7 @@ Tested on **Mac Studio M3 Ultra (256 GB)**, 2026-06-06. Workload is **B=4 sustai
 
 Versions: rapid-mlx **v0.6.80**, mlx-lm **0.31.3**, Ollama **0.24.0** (latest stable).
 
-Aggregate throughput = sum of output tokens across all four streams ÷ wall-clock seconds — the metric that matters for a server fronting multiple users or a TUI firing parallel sub-agents. Per-user decode is roughly aggregate ÷ 4 on a true batching engine; on Ollama 0.24 (no in-flight batching) the four streams effectively serialize, so the per-stream decode-only rate (`output_tokens / (e2e − ttft)`, recorded as `median_per_stream_tps` in the raw JSON) sits at or slightly above the aggregate. That is expected and not a metric mismatch — decode-only excludes prefill while aggregate spans the entire wall-clock window. The Ollama daemon also caches the previously loaded model in memory across rows; `OllamaEngine.stop()` only unloads the row's own tag, so cross-row Metal residency effects are possible — `ollama ps` between rows shows what's actually resident.
+Aggregate throughput = sum of output tokens across all four streams ÷ wall-clock seconds — the metric that matters for a server fronting multiple users or a TUI firing parallel sub-agents. Per-user decode is roughly aggregate ÷ 4 on a true batching engine; on Ollama 0.24 (no in-flight batching) the four streams effectively serialize.
 
 | Model (rapid-mlx alias) | rapid-mlx (B=4) | mlx-lm serve | Ollama tag (closest) | Ollama (B=4) | vs mlx-lm | vs Ollama |
 |---|---:|---:|---|---:|:-:|:-:|
@@ -751,10 +640,6 @@ Aggregate throughput = sum of output tokens across all four streams ÷ wall-cloc
 
 <sub>¹ Ollama Qwen3 base, not Qwen3.5 — DeltaNet hybrid arch isn't on llama.cpp yet. ² Closest dense Qwen3; Unsloth Qwen3.6-27B GGUF fails to load on Ollama 0.24. ³ mlx-lm 0.31.3 has no Gemma 4 loader (it lives in mlx-vlm). ⁴ Gemma 4 not yet on llama.cpp — Gemma 3 is the closest. ⁵ Closest MoE A3B available; Qwen3.5/3.6-35B-A3B don't have a llama.cpp build yet.</sub>
 
-> **Different Mac?** Numbers above are one M3 Ultra. See community-submitted runs across M1/M2/M3/M4 Apple Silicon at [**rapidmlx.com/performance**](https://rapidmlx.com/performance/) — sortable by chip × model × version. Submit your own with `rapid-mlx bench <alias> --submit`.
-
-*Full benchmark data with all models, TTFT tables, DeltaNet snapshots, and engine comparison below.*
-
 Reproduce the throughput table:
 
 ```bash
@@ -763,14 +648,14 @@ python3.12 scripts/bench_readme_refresh.py \
   --engines rapid-mlx,mlx-lm,ollama
 ```
 
-Raw JSON per round + per-stream tok/s land in `reports/benchmarks/readme-refresh/`.
+Raw JSON per round + per-stream tok/s land in `reports/benchmarks/readme-refresh/`. **Want to add your hardware?** Run `rapid-mlx bench <alias> --submit` — it opens a PR for you and your numbers show up on [rapidmlx.com](https://rapidmlx.com).
 
 <details>
 <summary><strong>TTFT — Prompt Cache Advantage</strong></summary>
 
 Prompt cache keeps multi-turn conversations fast. For standard transformers, KV cache trimming gives sub-100ms TTFT. For hybrid RNN models (Qwen3.5 DeltaNet), we use state snapshots — the first technique to bring prompt cache to non-trimmable architectures on MLX.
 
-<sub>Numbers below were last verified 2026-04 — the prefix-cache code path has not changed since. The 2026-06 throughput refresh focused on decode tok/s under concurrent load; a TTFT refresh is tracked separately.</sub>
+<sub>Numbers below were last verified 2026-04 — the prefix-cache code path has not changed since.</sub>
 
 **Pure KV cache (transformers):**
 
@@ -806,7 +691,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 </details>
 
 <details>
-<summary><strong>Capability Comparison</strong></summary>
+<summary><strong>Capability comparison vs other Apple-Silicon runtimes</strong></summary>
 
 | Feature | Rapid-MLX | oMLX | Ollama | llama.cpp | mlx-lm serve |
 |---------|-----------|------|--------|-----------|-------------|
@@ -825,17 +710,20 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 </details>
 
 <details>
-<summary><strong>Optimization Techniques Per Model</strong></summary>
+<summary><strong>Optimization techniques per model</strong></summary>
 
 | Technique | What it does | Models |
 |-----------|-------------|--------|
-| **KV prompt cache** | Trim KV cache to common prefix, skip re-prefill | All transformer models |
-| **DeltaNet state snapshots** | Deep-copy RNN state at prefix boundary, restore in ~0.1ms | Qwen3.5 (4B, 9B, 27B, 35B, 122B), Qwen3-Coder-Next |
+| **Radix prefix cache** | O(prefix_len) trie lookup + copy-on-write nodes for multi-tenant shared system prompts | All transformer models (default `--prefix-cache-index radix`) |
+| **DeltaNet state snapshots** | Deep-copy RNN state at prefix boundary, restore in ~0.1 ms | Qwen3.5 (4B, 9B, 27B, 35B, 122B), Qwen3-Coder-Next |
 | **Hybrid cache sync** | Keep trimmable KV + non-trimmable RNN layers in sync | Qwen3.5 (Gated DeltaNet + attention) |
+| **PFlash sparse prefill** | Score long prompt, prefill only sink + tail + relevant middle | Default-on for verified aliases; `--pflash always` |
 | **Tool logits bias** | Jump-forward decoding — bias logits toward structured tokens | All models with `--enable-tool-logits-bias` |
 | **Auto tool recovery** | Detect broken text-format tool calls, convert to structured | All 17 parser formats (incl. Gemma 4) |
-| **TurboQuant K8V4 codec** | Rotate + Lloyd-Max compress K (8-bit) + V (4-bit) cache — codec compresses KV to ~1/2.4 (~58% savings); lossless across the default-on alias matrix (mxfp4 excluded). Radix prefix cache is independent and saves additional bytes proportional to inter-request prefix overlap — the two are orthogonal and do not multiply. | All models with `--kv-cache-turboquant`; default-on for 9 verified Qwen3.5/3.6 aliases |
+| **TurboQuant K8V4 codec** | K 8-bit + V 4-bit after Walsh-Hadamard + Lloyd-Max (~1/2.4 compression, lossless across verified matrix) | Default-on for 9 verified Qwen3.5/3.6 aliases; `--kv-cache-turboquant k8v4\|v4\|none` |
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
+| **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--enable-dflash` |
+| **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--enable-mtp` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
 | **Cloud routing** | Offload high-token requests to cloud LLM when local is slow | All models with `--cloud-model` |
@@ -857,7 +745,7 @@ Tool calling (30 scenarios), coding (HumanEval+), reasoning (MATH-500), general 
 
 <sub>Decode = single-user end-to-end throughput refreshed 2026-06-06 against rapid-mlx v0.6.80. ¹ Carried over from the 2026-04 bench (not re-measured this round).</sub>
 
-Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool calling, coding, reasoning, general) across every alias and emits a fresh `evals/SCORECARD.md`. The `Decode` column above is the throughput rapid-mlx achieves on each row — see the [Benchmarks](#benchmarks) section for the cross-engine throughput reproduction command.
+Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool calling, coding, reasoning, general) across every alias and emits a fresh `evals/SCORECARD.md`.
 
 </details>
 
@@ -865,47 +753,56 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 
 ## Features
 
-### Tool Calling
+| Feature | What it does |
+|---|---|
+| **Tool calling** | OpenAI-compatible, 17 parser formats, automatic recovery when quantized models break (4-bit Qwen, Gemma, Llama, etc.). |
+| **Reasoning separation** | Models with chain-of-thought (Qwen3, DeepSeek-R1, MiniMax, GPT-OSS) emit reasoning in a separate `reasoning_content` field, cleanly streamed alongside `content`. Casual chat + tool-call requests auto-disable thinking for lower TTFT (0.8.x+). |
+| **Radix prefix cache** | Multi-tenant shared system prompts converge on the same radix node — O(prefix_len) lookup vs. O(log N + LCP_scan) on hash-keyed caches. Default index is `radix`; `--prefix-cache-index hash` for regressions. Always on; disable with `--disable-prefix-cache`. |
+| **RNN prompt cache** | For hybrid models (Qwen3.5 DeltaNet), RNN state snapshots restore non-trimmable layers in ~0.1 ms instead of re-running the recurrent stack. 2–5× faster TTFT vs. mlx-lm on the DeltaNet aliases. |
+| **PFlash prefill acceleration** | Sparse prefill on 32K+ prompts (attention sink + recent tail + query-relevant middle) — **3.87–8.5× TTFT on cold long prompts** with full needle-in-a-haystack recall. Default-on for verified aliases; `--pflash always` forces it. |
+| **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
+| **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
+| **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
+| **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
-Full OpenAI-compatible tool calling with 17 parser formats and **automatic recovery when quantized models break**. Models at 4-bit degrade after multiple tool rounds — Rapid-MLX auto-detects broken output and converts it back to structured `tool_calls`.
-
-### Reasoning Separation
-
-Models with chain-of-thought (Qwen3, DeepSeek-R1) output reasoning in a separate `reasoning_content` field — cleanly separated from `content` in streaming mode. Works with Qwen3, DeepSeek-R1, MiniMax, and GPT-OSS reasoning formats.
-
-### Prompt Cache
-
-Persistent cache across requests — only new tokens are prefilled on each turn. For standard transformers, KV cache trimming. For hybrid models (Qwen3.5 DeltaNet), RNN state snapshots restore non-trimmable layers from memory instead of re-computing. 2-5x faster TTFT on all architectures. Always on, no flags needed.
-
-### Smart Cloud Routing
-
-Large-context requests auto-route to a cloud LLM (GPT-5, Claude, etc.) when local prefill would be slow. Routing based on new tokens after cache hit. `--cloud-model openai/gpt-5 --cloud-threshold 20000`
-
-### Multimodal
-
-Vision, audio (STT/TTS), video understanding, and text embeddings — all through the same OpenAI-compatible API. Audio (new in 0.8.13) ships 26 aliases — 13 TTS (Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia) and 13 STT (Whisper, Parakeet) — served via `POST /v1/audio/speech` and `POST /v1/audio/transcriptions`. See [Supported audio models](#supported-audio-models).
-
-### PFlash Prefill Acceleration
-
-Long prompts are slow to *start* — the first token waits on the whole context to prefill, and on Apple Silicon that prefill is the bottleneck. PFlash scores a long prompt and prefills only the tokens that matter (the attention sink, the recent tail, and the query-relevant middle), cutting **cold-start TTFT by 3.87–8.5×** on 32K+ prompts with full needle-in-a-haystack recall. Pure-Python, no extra dependencies, and **on by default** for verified models.
-
-```bash
-rapid-mlx serve qwen3.5-9b-4bit          # PFlash auto-on for verified aliases
-rapid-mlx serve <model> --pflash always  # force it on for any model
-```
-
-PFlash speeds up the prompt going *in*. The 0.9 line ships a fused single-kernel sampler (faster than mlx-vlm's, identical sampling math), logprobs API, structured JSON output (`response_format`), continuous batching, the TurboQuant K8V4 KV codec (default-on for 9 verified Qwen3.5/3.6 aliases), and [3300+ tests](tests/).
-
-> *DFlash (block-diffusion speculative drafter) remains in the tree as experimental, flag-gated code (`pip install 'rapid-mlx[dflash]'`, `--enable-dflash`). The drafter's accept rate is workload-sensitive and is being re-validated; not included in the 0.9 release-claim set.*
-
----
+**K8V4 default-on aliases** (9 as of 0.9.9): `qwen3.5-9b-4bit`, `qwen3.5-9b-8bit`, `qwen3.5-27b-4bit`, `qwen3.5-27b-8bit`, `qwen3.5-35b-6bit`, `qwen3.6-35b-4bit`, `qwen3.6-35b-6bit`, `qwen3.6-35b-8bit`, `qwen3.6-35b-dwq`. Radix prefix cache is independent and saves additional bytes proportional to inter-request prefix overlap — the two are orthogonal.
 
 <details>
-<summary><strong>Server Flags Reference</strong></summary>
+<summary><strong>Speculative decoding — DFlash, MTP, SuffixDecoding</strong></summary>
+
+Three drafters ship in-tree. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
+
+**DFlash** — block-diffusion drafter (via mlx-vlm), single-user path. Opt in with `--enable-dflash`; requires `pip install 'rapid-mlx[dflash]'`.
+
+| Alias | Drafter | Avg speedup | Min / Max |
+|---|---|---|---|
+| `qwen3.6-27b-8bit` | `z-lab/Qwen3.6-27B-DFlash` | **1.49×** | 1.06× / 2.07× |
+| `qwen3.5-27b-8bit` | `z-lab/Qwen3.5-27B-DFlash` | **1.31×** | 0.59× / 2.15× |
+
+```bash
+pip install 'rapid-mlx[dflash]'
+rapid-mlx info qwen3.5-27b-8bit       # check per-gate eligibility
+rapid-mlx serve qwen3.5-27b-8bit --enable-dflash
+```
+
+Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without `--enable-dflash` for those.
+
+**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--enable-mtp` on MTP-trained checkpoints. Auto-tune of `--mtp-num-draft-tokens` per workload is roadmapped for the 0.9.1x line.
+
+**SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
+
+Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
+
+</details>
+
+<details>
+<summary><strong>Server flags reference</strong></summary>
 
 > You don't need any flags to get started — the defaults work for most setups. These are for advanced tuning.
 
-### Core
+**Core**
 
 | Flag | Description | Default |
 |------|-------------|---------|
@@ -914,35 +811,38 @@ PFlash speeds up the prompt going *in*. The 0.9 line ships a fused single-kernel
 | `--port` | Port to bind to | `8000` |
 | `--max-tokens` | Default max tokens for generation | `32768` |
 
-### Tool Calling & Reasoning
+**Tool calling & reasoning**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--tool-call-parser` | Parser: `hermes`, `minimax`, `qwen`, `llama`, `deepseek`, etc. | *(auto-detected)* |
 | `--reasoning-parser` | Parser: `qwen3`, `deepseek_r1`, `minimax`, `gpt_oss`, `harmony`, `glm4`, `gemma4` | *(auto-detected)* |
+| `--no-thinking` / `--no-think` | Disable reasoning even if auto-detected; faster, no `<think>` traces | off |
 | `--enable-tool-logits-bias` | Jump-forward decoding for faster tool calls | off |
 
-### Performance
+**Performance**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--prefill-step-size` | Tokens per prefill chunk | `2048` |
-| `--kv-cache-turboquant` | TurboQuant KV-cache codec (`k8v4` = K8 + V4, ~1/2.4 codec compression; `v4` = V-only legacy; `none` = off). Default-on for 9 verified Qwen3.5/3.6 aliases; workload-dependent in absolute bytes. | auto (on for verified aliases) |
+| `--kv-cache-turboquant` | TurboQuant KV-cache codec (`k8v4` = K 8-bit + V 4-bit, ~1/2.4 compression; `v4` = legacy V-only; `none` = off). Default-on for 9 verified Qwen3.5/3.6 aliases. | auto (`k8v4` on verified aliases, else off) |
 | `--kv-cache-quantization` | Quantize prefix cache entries for memory savings | off |
 | `--enable-prefix-cache` / `--disable-prefix-cache` | Cache common prefixes across requests | on |
-| `--enable-dflash` | DFlash speculative decoding (experimental, single-user, opt-in; install with `pip install 'rapid-mlx[dflash]'`) | off |
+| `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
+| `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
+| `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` / `qwen3.6-27b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
 
-### Cloud Routing
+**Cloud routing**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--cloud-model` | litellm model string (e.g. `openai/gpt-5`) | *(disabled)* |
 | `--cloud-threshold` | New token threshold to trigger cloud routing | `20000` |
 
-### Security & Other
+**Security & other**
 
 | Flag | Description | Default |
 |------|-------------|---------|
@@ -950,27 +850,10 @@ PFlash speeds up the prompt going *in*. The 0.9 line ships a fused single-kernel
 | `--rate-limit` | Requests per minute per client | *(unlimited)* |
 | `--timeout` | Request timeout in seconds | `1800` |
 | `--mllm` / `--no-mllm` | Force / disable multimodal (vision) mode | auto-detect |
-| `--force-openai-harmony-streaming` | Force the openai-harmony streaming router on (escape hatch — debug-only, raises on non-harmony tokenizers) | auto-detect |
+| `--force-openai-harmony-streaming` | Force the openai-harmony streaming router on (debug-only) | auto-detect |
 | `--no-openai-harmony-streaming` | Disable the openai-harmony streaming router; fall back to the legacy state machine | auto-detect |
 | `--mcp-config` | MCP configuration file for tool integration | *(none)* |
-| `--embedding-model` | Pre-load embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | *(none)* |
-
-</details>
-
-<details>
-<summary><strong>Common Issues</strong></summary>
-
-**"parameters not found in model" warnings at startup** — Normal for VLMs. Vision weights are auto-skipped.
-
-**Out of memory / very slow (<5 tok/s)** — Model too big. Check [What fits my Mac?](#what-fits-my-mac) Try a smaller quantization (4bit) or smaller model.
-
-**Empty responses** — Remove `--reasoning-parser` for non-thinking models.
-
-**Tool calls as plain text** — Set the correct `--tool-call-parser` for your model. Even without it, Rapid-MLX auto-recovers most cases.
-
-**Other issues?** Run `rapid-mlx doctor` for self-diagnostics.
-
-**Slow first response** — Two different causes: (1) Qwen3.5 models reason before answering — add `--no-thinking` to skip reasoning for faster responses, or (2) cold start on long prompts — add `--prefill-step-size 8192` to speed up processing. Subsequent turns hit prompt cache and are 10-30x faster.
+| `--embedding-model` | Pre-load embedding model at startup | *(none)* |
 
 </details>
 
@@ -982,52 +865,62 @@ The base `pip install rapid-mlx` is ~460 MB and covers all text-only models. Vis
 
 | Extra | Install | Adds | What it unlocks |
 |---|---|---|---|
-| `vision` | `pip install 'rapid-mlx[vision]'` | ~322 MB | Gemma 4, Qwen-VL, video understanding (mlx-vlm + opencv + torch) |
-| `audio` | `pip install 'rapid-mlx[audio]'` | ~600 MB | TTS (Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia) + STT (Whisper, Parakeet) via `/v1/audio/speech` & `/v1/audio/transcriptions` (mlx-audio + miniaudio + soundfile + sounddevice + numba) |
+| `vision` | `pip install 'rapid-mlx[vision]'` | ~322 MB | Gemma 4, Qwen-VL, DiffusionGemma, video understanding (mlx-vlm + opencv + torch) |
+| `audio` | `pip install 'rapid-mlx[audio]'` | ~600 MB | 26 TTS/STT aliases (Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia, Whisper, Parakeet) via `/v1/audio/speech` and `/v1/audio/transcriptions`; bundles Silero VAD for silence pre-trim (guards Whisper against silence hallucination) |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | ~50 MB | `/v1/embeddings` endpoint (mlx-embeddings) |
 | `chat` | `pip install 'rapid-mlx[chat]'` | ~150 MB | Built-in Gradio chat UI |
 | `guided` | `pip install 'rapid-mlx[guided]'` | ~80 MB | Schema-constrained JSON generation (outlines) |
+| `dflash` | `pip install 'rapid-mlx[dflash]'` | ~50 MB | DFlash speculative decoding runtime (text-only, no torch) |
 | `all` | `pip install 'rapid-mlx[all]'` | ~1.1 GB | Vision + audio + chat + embeddings |
 
-If you installed via Homebrew and want vision/audio support, use `pip install 'rapid-mlx[vision]'` (or `[audio]`) inside your own Python 3.10+ venv — that gives you the full feature set without rebuilding the brew formula.
+If you installed via Homebrew, install extras into the brew-managed Python so the `rapid-mlx` binary picks them up:
+
+```bash
+$(brew --prefix)/opt/rapid-mlx/libexec/bin/pip install 'rapid-mlx[vision]'   # or [audio], [embeddings], ...
+```
+
+(A separate venv-local `pip install 'rapid-mlx[vision]'` also works, but only affects the `rapid-mlx` inside that venv — the brew-installed binary keeps its own libexec Python.)
 
 ---
 
 ## Troubleshooting
 
-Run the built-in environment-health probe (works from `pip install`, no dev tools needed, no model load, ≤5 s):
+Run the built-in self-diagnostic (works from `pip install`, no dev tools needed):
 
 ```bash
 rapid-mlx doctor
 ```
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                  🩺 Rapid-MLX Doctor                    │
-└─────────────────────────────────────────────────────────┘
-
-◆ System
-  ✓ Apple Silicon (Apple M3 Pro, 36 GB)
-  ✓ macOS 14.3 (Darwin 23.3.0)
-  ✓ Free disk: 162 GB
-◆ Python
-  ✓ Python 3.12.13
-◆ Required Packages
-  ✓ mlx 0.29.x
-  ✓ mlx-lm 0.31.x
-  ✓ transformers 5.x
-  ✓ fastapi 0.x
-  ✓ uvicorn 0.x
-  ✓ rapid-mlx 0.7.22
-◆ HuggingFace Cache / Network / Shell Integration / Optional Tools
-  ...
-────────────────────────────────────────
-Summary: 18 ok, 4 warnings, 0 issues
+Rapid-MLX Doctor
+============================================================
+  [metal] OK        # Apple Silicon Metal GPU available
+  [imports] OK      # Core modules import cleanly
+  [cli] OK          # CLI commands respond
+  [model_load] OK   # Inference pipeline works
+Result: PASS
 ```
 
-Use `rapid-mlx doctor --verbose` to see the underlying probe detail (exact path, version, response code) for each check.
+**Common gotchas:**
 
-Want to validate model inference instead? That lives at `rapid-mlx bench <model> --tier {smoke,check,full,benchmark}` — doctor is purely env-health now.
+- **Getting much lower tok/s than the speed table?** Most often the model is reasoning before answering. Qwen3.5 and Qwen3.6 default to thinking-on, which doubles the work. Add `--no-think` to `chat` or `serve` to skip chain-of-thought. (This is the cause of the most common bug report — see [issue #567](https://github.com/raullenchai/Rapid-MLX/issues/567).)
+- **Out of memory or very slow (<5 tok/s).** Model too big for your RAM. Check [What fits my Mac?](#what-fits-my-mac) and pick a smaller quant (4-bit) or smaller model.
+- **Empty responses.** Remove `--reasoning-parser` for non-thinking models.
+- **Tool calls coming through as plain text.** Set the right `--tool-call-parser` for your model, or rely on auto-detection. Even without it, Rapid-MLX auto-recovers most cases.
+- **Slow first response.** Two causes: (1) Qwen3.5/3.6 think before answering — add `--no-think`; (2) cold prefill on long prompts — add `--prefill-step-size 8192`. Subsequent turns hit prompt cache and are 10–30× faster.
+- **"parameters not found in model" warnings at startup.** Normal for VLMs — vision weights are auto-skipped.
+
+### Shell completion
+
+Tab completion works automatically when installed via Homebrew. For pip / install.sh, activate it once:
+
+```bash
+# zsh / bash
+eval "$(register-python-argcomplete rapid-mlx)"
+
+# Or system-wide:
+activate-global-python-argcomplete
+```
 
 ---
 
@@ -1047,7 +940,7 @@ Rapid-MLX **can** send anonymous usage data to help us prioritise the right mode
 
 - Prompts, completions, tool-call arguments, file contents, or any user-generated text
 - Local file paths, working directory, or model paths beyond their HF repo ID
-- IPs or hostnames (Phase 2 will route through a Cloudflare Worker that strips IPs before forwarding to the aggregator; Phase 1 ships no transport at all)
+- IPs or hostnames (Phase 2 routes through a Cloudflare Worker that strips IPs before forwarding; Phase 1 ships no transport at all)
 - API keys, environment variable values, auth headers
 - Stack trace messages or argument values
 
@@ -1070,17 +963,11 @@ RAPID_MLX_TELEMETRY=0 rapid-mlx serve qwen3.5-9b-4bit
 rapid-mlx --no-telemetry serve qwen3.5-9b-4bit
 ```
 
-There is intentionally **no env-var equivalent for force-on** — opting in must be an explicit one-time `rapid-mlx telemetry enable`. CI agents will never silently contribute.
-
-### Where the code lives
-
-Everything is in [`vllm_mlx/telemetry/`](vllm_mlx/telemetry/) — read it. Phase 1 (this release) ships the consent mechanism and CLI surface; **no network code is in the codebase yet**. Phase 2 will add the transport behind the same opt-in gate; the schema is documented in [`vllm_mlx/telemetry/schema.py`](vllm_mlx/telemetry/schema.py). Tracking issue: [#236](https://github.com/raullenchai/Rapid-MLX/issues/236).
+There is intentionally **no env-var equivalent for force-on** — opting in must be an explicit one-time `rapid-mlx telemetry enable`. CI agents will never silently contribute. Code lives in [`vllm_mlx/telemetry/`](vllm_mlx/telemetry/); tracking issue [#236](https://github.com/raullenchai/Rapid-MLX/issues/236).
 
 ---
 
 ## Development
-
-### Quick start
 
 ```bash
 git clone https://github.com/raullenchai/Rapid-MLX.git
@@ -1088,11 +975,7 @@ cd Rapid-MLX
 pip install -e ".[dev]"
 ```
 
-### Testing
-
-Two layers: **user-facing doctor** (ships with pip) and **dev test suite** (source checkout only).
-
-#### Dev test commands
+**Test commands:**
 
 | Command | What | Time | Needs server? |
 |---------|------|------|---------------|
@@ -1101,30 +984,21 @@ Two layers: **user-facing doctor** (ships with pip) and **dev test suite** (sour
 | `make smoke` | lint + unit | ~1 min | No |
 | `make stress` | 8-scenario stress test | ~5 min | Yes |
 | `make soak` | 10-min agent soak test | 10 min | Yes |
+| `make check` | 1-model regression harness (auto starts server) | ~10 min | auto |
+| `make full` | 3 models + 12 agent profiles | ~1 hr | auto |
 
 For stress/soak, start a server first:
+
 ```bash
-rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit --enable-auto-tool-choice --tool-call-parser hermes
+rapid-mlx serve qwen3.5-4b-4bit
 # In another terminal:
 make stress
 ```
 
-Or use the script directly for more options:
-```bash
-python scripts/dev_test.py smoke              # lint + unit
-python scripts/dev_test.py stress --port 8000 # custom port
-python scripts/dev_test.py full               # everything
-```
+Or use the script directly for more options: `python scripts/dev_test.py {smoke,stress,full}`.
 
-#### Regression harness (multi-model)
-
-```bash
-make check              # 1 model (~10 min, auto starts server)
-make full               # 3 models + 12 agent profiles (~1 hr)
-make benchmark          # all local models (overnight)
-```
-
-### Architecture
+<details>
+<summary><strong>Architecture overview</strong></summary>
 
 ```
 vllm_mlx/
@@ -1136,6 +1010,7 @@ vllm_mlx/
   routes/
     chat.py              # /v1/chat/completions
     completions.py       # /v1/completions
+    responses.py         # /v1/responses (Codex CLI)
     anthropic.py         # /v1/messages (Anthropic API)
     health.py, models.py, embeddings.py, audio.py, mcp_routes.py
   engine/                # BatchedEngine (continuous batching)
@@ -1144,16 +1019,13 @@ vllm_mlx/
   speculative/           # DFlash, SuffixDecoding, MTP drafters
   agents/                # 12 agent profiles (YAML)
   runtime/               # Model registry, cache persistence
-  doctor/                # Environment-health probe (rapid-mlx doctor)
-  bench/                 # Model-validation tier runner (rapid-mlx bench --tier ...)
+  doctor/                # User self-diagnostic
 scripts/                 # Dev-only (NOT shipped with pip)
-  dev_test.py            # Unified test entry point
-  stress_test.py         # 8-scenario stress test
-  agent_soak_test.py     # 10-min agent soak test
-  mhi_eval.py            # Compute MHI scores against a running server
 tests/                   # pytest unit tests (3300+)
 harness/                 # Regression baselines + thresholds
 ```
+
+</details>
 
 ---
 
@@ -1161,11 +1033,13 @@ harness/                 # Regression baselines + thresholds
 
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
-| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3-2× decode (workload-dependent) | Experimental (`--enable-dflash`, `[dflash]` extra; re-validation in 0.9.x) |
-| [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1-1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
-| MTP — Multi-Token Prediction head | 1.4-1.7× decode | Experimental (requires MTP-trained checkpoint) |
-| [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3-6.5× decode | Not started |
-| [ReDrafter](https://arxiv.org/abs/2403.09919) — Apple's RNN draft head | 1.4-1.5× decode | Not started |
+| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--enable-dflash`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
+| [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
+| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |
+| [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |
+| [ReDrafter](https://arxiv.org/abs/2403.09919) — Apple's RNN draft head | 1.4–1.5× decode | Not started |
+
+See [ROADMAP.md](ROADMAP.md) for the full backlog.
 
 ---
 


### PR DESCRIPTION
## Summary

A top-to-bottom rewrite of `README.md`, polished for 0.9.9. The structure matches what a first-time visitor needs in 60 seconds; every fact is verified against `pyproject.toml`, `vllm_mlx/cli.py`, and `vllm_mlx/aliases.json` at HEAD (0.9.9).

Main changes (5 groups):

- **New "Why Rapid-MLX" + "Use Cases" sections.** The previous README jumped from install into "Works With" then models without ever telling the reader why to pick Rapid-MLX over Ollama / LM Studio / mlx-lm-serve, or what the 4 core workflows are. Now: concrete differentiators — 2.3x vs Ollama on the apples-to-apples GPT-OSS 20B row (identical weights both sides), radix prefix cache + RNN state snapshots for hybrid models, PFlash sparse prefill for long prompts, TurboQuant K8V4 default-on for 9 verified MoE aliases, drop-in OpenAI + Anthropic APIs, day-0 frontier models — then 4 clean use-case sections (chat REPL, OpenAI server, agent backends, community-bench).
- **Codex CLI promoted to a first-class use case.** Shipped in 0.7.12 (`/v1/responses` via #588, three silent-fail bugs fixed in #597); previously buried in the harness table. Now called out with the `rapid-mlx agents codex --setup` one-liner and a link to `docs/guides/codex-cli.md`.
- **New "Command Reference" table.** Single compact table with every `rapid-mlx <cmd>` and a one-line purpose, replacing the wall of nested code blocks. Adds `pull`, `rm`, `ps`, `info`, `upgrade`, `telemetry`, `share`, `chat/run` aliases that were undocumented or scattered.
- **0.8/0.9 delta sweep.** TurboQuant K8V4 KV codec default-on for 9 verified Qwen3.5/3.6 hero MoE aliases; radix-tree prefix cache index (R15-P1 task #303) as the default lookup; PFlash sparse prefill default-on for verified aliases (3.87-8.5x TTFT on 32K+ prompts); MTP head speculative decode opt-in via `--enable-mtp` with per-workload auto-tune roadmapped for the 0.9.1x line; Silero VAD bundled with `[audio]` for silence pre-trim; 128+ aliases across 30+ families (Tmax, Holo3.1, VibeThinker, Nanbeige, UI, EmbeddingGemma additions since 0.7). `--host` default corrected to `127.0.0.1` (loopback-only).
- **Troubleshooting leads with the #1 confused-user report (#567).** A user benchmarked Qwen3.5-9B-4bit on M4 Pro 24 GB, got 44 tok/s instead of the table's 101, and filed a documentation issue. Root cause: thinking-on default doubles the work. The new Troubleshooting section leads with this gotcha and surfaces `--no-think` prominently in Quick Start, the sizing table caption, the flags reference, and Troubleshooting itself.

Also: consolidated the prior split between "Works With" tables and scattered client-config snippets into one "Connect Your Client" section (most-used 4 configs in the open; the long tail of 8 collapsed behind a `<details>`). Server flags moved into a `<details>` with cleaner grouping.

## Test plan

Pre-merge verification (done during authoring): every anchor link (`#what-fits-my-mac`, `#choose-your-model`, `#benchmarks`, `#troubleshooting`, `#optional-extras`) resolves; every `rapid-mlx <cmd>` and flag shown is present in `vllm_mlx/cli.py`; every model alias mentioned is in `vllm_mlx/aliases.json` (spot-checked, including the 9 K8V4-verified aliases and the `qwen3.5-35b-6bit` reference codex flagged); every test-link in the integrations table points at a real file under `tests/integrations/`; `docs/guides/codex-cli.md` and `docs/development/releasing.md` both exist; the render preview on GitHub reads end-to-end as a first-time visitor. No code paths touched — this is docs-only, so no runtime regression risk. Codex review addressed: server-flags row for `--kv-cache-turboquant` now matches the K8V4-default-on claim, and the Ollama-vs-Rapid-MLX ratio is stated as the exact apples-to-apples 2.3x rather than a range that overshot the GPT-OSS row.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>