### PR TITLE
perf(deps): bump openai-harmony 0.0.6 → 0.0.8 + mlx-embeddings 0.0.5 → 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.14"
+version = "0.7.15"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -73,7 +73,7 @@ dependencies = [
     # #468 #480). Same library vLLM and SGLang delegate to for gpt-oss
     # tool calling. Soft-imported at runtime; the legacy custom state
     # machine remains the fallback if the dep is unavailable.
-    "openai-harmony>=0.0.6",
+    "openai-harmony>=0.0.8",
 ]
 
 [project.optional-dependencies]
@@ -99,7 +99,7 @@ dflash = [
 ]
 # Embedding endpoint
 embeddings = [
-    "mlx-embeddings>=0.0.5",
+    "mlx-embeddings>=0.1.0",
 ]
 # Gradio chat UI
 chat = [
@@ -120,7 +120,7 @@ all = [
     "gradio>=4.0.0",
     "pytz>=2024.1",
     # embeddings
-    "mlx-embeddings>=0.0.5",
+    "mlx-embeddings>=0.1.0",
     # dflash (text-only path covered by mlx-vlm above; listed for clarity)
 ]
 dev = [


### PR DESCRIPTION
## Summary

Two minor dependency bumps shipped together. Both libraries kept their public API stable — no code changes required in `vllm_mlx/`.

- `openai-harmony>=0.0.6` → `>=0.0.8`
- `mlx-embeddings>=0.0.5` → `>=0.1.0`
- Version bump: `0.7.14` → `0.7.15`

## Upstream changes

### openai-harmony 0.0.6 → 0.0.8

This is effectively a **packaging-only bump**. The git diff `v0.0.6...v0.0.8` in the upstream repo (openai/harmony) is a single commit that touches only `Cargo.toml` / `Cargo.lock` (version string `0.0.6` → `0.0.8`). The 0.0.7 number was skipped on PyPI (likely a release-script retry — both 0.0.6 and 0.0.8 wheels were uploaded 4 minutes apart on 2025-11-05).

The substantive parser fixes that landed around this release window were already in **v0.0.6**, which we already met:

- `d59b0ad` StreamableParser: use replacement character for invalid UTF-8 sequences (#83)
- `6e02144` fix: handle malformed messages missing `<|message|>` token (#82)
- `e0ce87d` add missing `.with_recipient('assistant')` in tool-message demo code (#63)

So this bump only ensures users get the latest packaged wheel; functional behavior of `StreamableParser` / `Role` / `HarmonyEncodingName` is unchanged.

### mlx-embeddings 0.0.5 → 0.1.0

A real minor jump with quality fixes, new model support, and dependency cleanup. PRs merged between v0.0.5 and v0.1.0:

- **#43 `fix(gemma3)`**: Fix embedding quality for bidirectional models. Cosine similarity vs SentenceTransformers reference jumped from 0.73–0.90 to 1.0000 (FP32) / 0.9999 (BF16). Root cause was a missing additive attention-mask conversion (`(1 - mask) * -1e9`) and wrong pooling order before normalization.
- **#45 `fix(siglip)`**: Fix MHA cross-attention in SiglipMultiheadAttentionPoolingHead — was doing self-attention instead of cross-attention on the probe. Output shape now correctly `(batch, 1, hidden)`.
- **#42 Transformers 5.0 compatibility**: Use `processor.__call__` instead of `batch_encode_plus` (removed in transformers 5.0). We already require `transformers>=5.0`, so this was strictly necessary for the embeddings extra.
- **#40 Make `mlx_vlm` optional**: We get `mlx_vlm` separately via `[vision]` extras anyway, so this is a no-op for us.
- **#47 q_mode quantization** (mlx-lm parity).
- **New models**: ColIdefics3 + LoRA adapters (#30), qwen3-vl (#52), Llama Bidirectional embeddings (#53), Llama Nemotron VL multimodal embeddings (#54).
- **Version housekeeping**: #44 bumped to 0.0.6, #55 + #56 bumped to 0.1.0.

## API compatibility check

Grepped `vllm_mlx/` for call sites and verified against the v0.1.0 / v0.0.8 source:

| Call site | API used | Status |
|---|---|---|
| `vllm_mlx/embedding.py:36` | `from mlx_embeddings import load` | `load(path_or_hf_repo, ...)` signature unchanged across 0.0.5 → 0.1.0 |
| `vllm_mlx/embedding.py:79` | `output.text_embeds` | Output schema unchanged |
| `vllm_mlx/output_router_harmony.py:214` | `from openai_harmony import Role, StreamableParser` | Public symbols stable |
| `vllm_mlx/output_router_harmony.py:484` | `from openai_harmony import HarmonyEncodingName, load_harmony_encoding` | Public symbols stable |

**No code modifications required.**

## Test results

### Targeted (harmony + embeddings)

```
tests/test_embeddings.py                         9 passed
tests/test_embeddings_timeout_admission.py      32 passed
tests/test_finalize_harmony_raw_text.py         24 passed
tests/test_harmony_parsers.py                   97 passed
tests/test_output_router.py                     53 passed
tests/parsers/regressions/test_issue_513_*       27 passed
tests/parsers/regressions/test_issue_455_*        3 passed, 3 xfailed
tests/parsers/regressions/test_issue_468_*        2 xfailed
tests/parsers/regressions/test_issue_444_*       24 passed
                                                ─────────────
                                                269 passed, 5 xfailed
```

All clean.

### Full unit suite (excluding live-server e2e + optional 3rd-party SDK tests)

```
5146 passed, 12 skipped, 17 deselected, 7 xfailed, 16 failed
```

All 16 failures are **pre-existing on `main`** — verified by stashing the bump and re-running the same set. They split as:

- `test_event_loop.py` (2) — aiohttp client_exceptions
- `test_platform.py` (4) — `ModuleNotFoundError: torch` in the text-only venv
- `test_sampler_fast_path.py` (2) — `GenerationBatch` import + tiny top-p shape
- `test_sampling_params_passthrough.py` (2) — `make_logits_processors` lost `presence_penalty` (mlx-lm issue #355)
- `test_model_registry.py` (6) — test-ordering flakes (pass in isolation on both base + this branch)
- `test_community_bench.py::test_validate_rejects_bad_datetime_format` (1, deselected) — confirmed pre-existing on `main` directly

None of these touch `openai_harmony` or `mlx_embeddings` code paths.

## Test plan

- [x] Targeted harmony + embeddings tests pass (269/269 + 5 xfailed)
- [x] Full unit suite shows no new failures vs `main` (5146 passing, 16 pre-existing failures verified)
- [x] `pip show openai-harmony mlx-embeddings` reports 0.0.8 / 0.1.0
- [x] No code-level API changes required (grep'd all call sites)
- [x] `pr_validate` gauntlet — codex_review clean; stress_e2e_bench full 3-model matrix passes (360s server-boot timeout from PR #606 unblocked the 45-80GB models); 8/9 agent integrations pass — the 1 failure is anthropic_sdk × Qwen3.6 thinking-mode behavior (pre-existing on main, unrelated to dep bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
