### PR TITLE
perf(deps): bump mlx-lm 0.31.0 → 0.31.3 — pulls in batch-cache fixes, flags decode-throughput regression on hybrid+MoE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.15"
+version = "0.7.16"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     # Core — these are all you need for `rapid-mlx serve <text-model>`
     "mlx>=0.29.0",
-    "mlx-lm>=0.31.0",  # 0.31+ required for ArraysCache native batching (hybrid models)
+    "mlx-lm>=0.31.3",  # 0.31.3: BatchKVCache/BatchRotatingKVCache extend() dim fix (PR #1141, #1169, #1177) + thread-local generation stream (PR #1090). 0.31.2 brought non-trimmable prefix cache (hybrid models) + batch generator refactor + presence/frequency penalties. 0.31.0 yanked upstream ("Batched KV cache cross contamination").
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",


### PR DESCRIPTION
## Summary

Bumps the `mlx-lm` floor from `>=0.31.0` to `>=0.31.3` to pick up the upstream batch-KV-cache correctness fixes and the thread-local generation stream. Also bumps `rapid-mlx` 0.7.15 → 0.7.16 (CI version-check).

## What 0.31.1 → 0.31.3 brings

From the [official mlx-lm release notes](https://github.com/ml-explore/mlx-lm/releases):

**0.31.2 highlights:**
- **Caching system prompt and user messages for non-trimmable caches** — the key feature for our hybrid models (Qwen3.5/3.6 DeltaNet + Mamba2 path); their RNN-state caches are non-trimmable, and our prefix cache currently only works on regular transformer paths.
- **Batch generator refactoring** — upstream rewrote the batch generator (PR #1072).
- **Presence and frequency penalties** — native upstream support (PR #971).

**0.31.3 highlights (bugfixes):**
- **Fix batch dimension mismatch in `BatchKVCache` and `BatchRotatingKVCache` extend()** (PRs #1141, #1169, #1177) — direct batch-path correctness fix.
- **Thread local generation stream** (PR #1090) — accompanies MLX 0.31.2.
- Various tool-parser fixes (Gemma 4, MiniMax M2, Mistral, Qwen3 coder), Apertus `tie_word_embeddings`, dwq safetensors check, TokenizerWrapper `NoneType` think-tokens, Gemma 4 KV-shared layer projection cleanup.

**Why bump even though 0.31.0 satisfies the floor:** upstream **yanked 0.31.0** with reason \"Batched KV cache cross contamination\". Anyone installing fresh today already gets 0.31.3 via pip's yanked-version skip, but the floor pin was misleading and the comment was stale.

## Benchmark data — pre vs post (M3 Ultra, B=1, greedy, 5 rounds + 1 warmup)

Standardized B=1 community-bench (`run_standardized_bench` from `vllm_mlx/community_bench/runner.py`). Median across 5 measured rounds. tg = decode tok/s, pp = prefill tok/s. Buckets are llama-bench-style: short (prompt=512, max=128), long (prompt=2048, max=512).

| Alias                  | mlx-lm  | tg128  | tg512  | pp128  | pp2048 | ttft_s ms | ttft_l ms | peak MB |
| ---------------------- | ------- | ------ | ------ | ------ | ------ | --------- | --------- | ------- |
| qwen3.5-9b-4bit        | 0.31.0  | 113.35 | 112.83 | 1082.1 | 1137.1 | 494.4     | 1892.6    | 6427    |
| qwen3.5-9b-4bit        | 0.31.3  | 110.43 | 109.85 | 1072.5 | 1124.7 | 498.8     | 1913.5    | 6453    |
| **Δ**                  |         | **−2.58%** | **−2.64%** | −0.89% | −1.09% | +0.89% | +1.10% | +0.4% |
| qwen3.5-35b-8bit (A3B MoE hybrid) | 0.31.0 r1 | 85.43 | 83.95 | 1752.5 | 2130.1 | 305.3 | 1010.3 | 36940 |
| qwen3.5-35b-8bit       | 0.31.3 r1 | 79.94 | 77.45 | 1715.1 | 2106.0 | 311.9 | 1021.9 | 36972 |
| qwen3.5-35b-8bit       | 0.31.0 r2 | 84.58 | 83.30 | 1742.4 | 2122.8 | —     | —      | —     |
| qwen3.5-35b-8bit       | 0.31.3 r2 | 79.29 | 77.43 | 1711.5 | 2105.4 | —     | —      | —     |
| **Δ (r1)**             |         | **−6.43%** | **−7.75%** | −2.14% | −1.13% | +2.16% | +1.15% | +0.1% |
| **Δ (r2)**             |         | **−6.25%** | **−7.05%** | −1.77% | −0.82% | —      | —      | —     |
| qwen3.6-27b-8bit       | 0.31.0  | 20.05  | 19.77  | 288.5  | 314.6  | 1854.3    | 6840.4    | 34998   |
| qwen3.6-27b-8bit       | 0.31.3  | 19.73  | 19.57  | 286.8  | 313.9  | 1865.1    | 6855.7    | 35069   |
| **Δ**                  |         | **−1.55%** | **−0.99%** | −0.58% | −0.22% | +0.58% | +0.22% | +0.2% |

Skipped `qwen3.5-27b-8bit` (the 4th alias in the original test plan) because the weights were not in the local HF cache and disk was tight (~106 GB free; model is ~30 GB). The three above already span small-dense-hybrid, MoE-hybrid, and large-dense-hybrid — enough to characterize the delta.

Raw JSON saved to `/tmp/perf-mlx-lm-0.31.3-bench/{pre,post}-*.json` on the bench host. Bench driver script at `/tmp/perf-mlx-lm-0.31.3-bench/run_bench.py` (calls `run_standardized_bench` directly, skips the `--submit` PR-open flow).

## Regression flagged

**`qwen3.5-35b-8bit` (A3B MoE hybrid) loses 6-7% on decode throughput** going from 0.31.0 to 0.31.3. This exceeds the project's −5% \"flag loudly\" threshold. Both bench runs (r1 and r2) reproduce the delta within 1% of each other, so this is not measurement noise. Smaller decode regressions (1-3%) on the other two aliases tested.

Possible causes (not investigated in this PR):
- The 0.31.2 batch generator refactor (PR #1072) changed per-step bookkeeping.
- The non-trimmable prefix cache plumbing added overhead on the RNN-state path even when the cache is empty (bench runs with `enable_prefix_cache=False`, so this would be pure overhead).
- Thread-local generation stream (PR #1090) — extra `mx.new_thread_local_stream` lookup per step.

**Decision for the maintainer:** the correctness fixes from 0.31.3 (BatchKVCache cross-contamination, thread-local streams that our engine already depends on per `tests/test_mllm_batch_generator.py:112` and `tests/test_dflash_integration.py:794`) are arguably worth shipping even with the decode hit. But if the perf regression on the largest MoE alias is unacceptable, we should either:
1. Stay on `>=0.31.1` (first non-yanked patch) and skip 0.31.2's prefix-cache feature, OR
2. File an upstream issue + investigation before merging.

## Files changed

`pyproject.toml`:
- `mlx-lm>=0.31.0` → `mlx-lm>=0.31.3`
- Comment updated to reference the actual 0.31.2/0.31.3 changes and the 0.31.0 yank.
- `version = \"0.7.15\"` → `version = \"0.7.16\"` (CI version-check).

No test files needed updates — searched for hardcoded `mlx-lm==0.31.0` and `mlx_lm.__version__` pins, none found. The `\"mlx\": \"0.31.2\"` strings in `tests/test_community_bench.py` are test-fixture data, not version assertions.

## Test plan

- [x] `.venv/bin/pytest -q --ignore=tests/integrations --deselect tests/test_event_loop.py` — 5172 passed, 19 skipped, 19 deselected, 7 xfailed in 75s. Both deselected/skipped areas are unrelated to mlx-lm (anthropic SDK not installed, event-loop test needs a live server on :8000).
- [x] `ruff check vllm_mlx` — All checks passed.
- [x] Manual bench run on 3 hybrid aliases (table above). Pre/post comparisons reproducible across 2 runs for the regressed alias.
- [x] `mlx-lm==0.31.3` installs cleanly from PyPI with the rest of the lock (no transitive conflict).
- [ ] `pr_validate` adversarial review (maintainer gate).
- [ ] Maintainer decision on the −6-7% decode regression on `qwen3.5-35b-8bit` — accept the correctness/feature trade, or stay on 0.31.1?

🤖 Generated with [Claude Code](https://claude.com/claude-code)