### PR TITLE
chore(pr_validate): add diffusion-gemma family to golden_models matrix

### DIFF
--- a/scripts/pr_validate/golden_models.yaml
+++ b/scripts/pr_validate/golden_models.yaml
@@ -118,6 +118,38 @@ families:
         ram_gb_required: 18
         quality_tier: smoke
 
+  - family: diffusion-gemma
+    candidates:
+      # Added 2026-06-16 (v0.7.15) to close the DiffusionEngine coverage
+      # gap. ``modality: text-diffusion`` aliases route via
+      # ``vllm_mlx/runtime/diffusion_lane.py::DiffusionEngine`` →
+      # ``mlx_vlm.generate.diffusion.stream_diffusion_generate`` —
+      # completely independent from BatchedEngine (the AR LLM path the
+      # other families cover). Without an entry here, any PR that
+      # silently breaks ``server.load_model``'s modality dispatch or
+      # any DiffusionEngine internals would slip through pr_validate.
+      # Live v0.7.15 e2e (subagent ``a89586066e0144bf2``): 154 s
+      # download+boot+request, coherent ``"Hello there!"`` response in
+      # 4 tokens, server log clean, mmap released on shutdown.
+      #
+      # Quant choice (deviates from the project's 8-bit-only policy
+      # documented above): we use 4-bit here because the test purpose
+      # is ENGINE-PATH coverage, NOT model correctness — DiffusionGemma
+      # is a Gemma-4 derivative and inherits the instruction-following
+      # weaknesses that got Gemma 4 excluded above. Neither quant would
+      # cleanly pass the full agent battery; the 8-bit would just cost
+      # ~14 GB more disk and ~30-60 s more boot for the same engine-
+      # wiring signal. Tagged ``smoke`` so the multi-tool pydantic_ai
+      # test (which the model class can't pass regardless of quant) is
+      # suppressed; anthropic_sdk + langchain still run as smoke
+      # coverage of the gemma4 tool-call parser × DiffusionEngine seam.
+      #
+      # RAM: ~14 GB 4-bit weights + ~3 GB denoising canvas (256-token
+      # canvas × per-step activation) + MLX runtime overhead → 20 GB.
+      - id: mlx-community/diffusiongemma-26B-A4B-it-4bit
+        ram_gb_required: 20
+        quality_tier: smoke
+
   - family: harmony
     candidates:
       # Added 2026-05-21 to close the router-allowlist coverage gap surfaced
@@ -216,6 +248,13 @@ overrides:
   # convention above).
   "mlx-community/gpt-oss-20b-MXFP4-Q8":
     args: ["--enable-auto-tool-choice", "--tool-call-parser", "harmony"]
+  # DiffusionGemma uses the gemma4 tool-call wire format (alias profile
+  # in ``vllm_mlx/aliases.json`` declares ``tool_call_parser: gemma4``;
+  # auto-detect picks it through the alias). Explicit override mirrors
+  # the qwen / harmony convention above for grep-traceability at the
+  # validation surface.
+  "mlx-community/diffusiongemma-26B-A4B-it-4bit":
+    args: ["--enable-auto-tool-choice", "--tool-call-parser", "gemma4"]
 
 # Agent integrations — each is a tests/integrations/ test_X.py script
 # we exec against the live server. The matrix is models × agents.


### PR DESCRIPTION
## Summary

- Adds **diffusion-gemma** family to `scripts/pr_validate/golden_models.yaml`, closing the **DiffusionEngine** coverage gap. Until now, zero entries in the matrix exercised `vllm_mlx/runtime/diffusion_lane.py` — every other model in the registry uses `BatchedEngine` (the AR LLM lane).
- Candidate: `mlx-community/diffusiongemma-26B-A4B-it-4bit` (`ram_gb_required: 20`, `quality_tier: smoke`).
- Adds the explicit `--tool-call-parser gemma4` override mirroring the qwen / harmony convention for grep-traceability at the validation surface.

## Why now

v0.7.15 ships with the `diffusion-gemma-26b-*` aliases routed via `modality: text-diffusion` → `DiffusionEngine` → `mlx_vlm.generate.diffusion.stream_diffusion_generate`. A live e2e on this version confirmed:

- Server boots cleanly with `--model diffusion-gemma-26b-4bit`
- `/v1/chat/completions` returns a coherent response (`"Hello there!"`, completion_tokens=4)
- 154 s wall-clock cold-cache (download + load + first request)
- mmap released on PID kill

Without an entry in the pr_validate matrix, any PR that broke `server.load_model`'s modality dispatch or any DiffusionEngine internal would silently slip through — exactly the class of bug we got burned on in the v0.7.11/v0.7.15 SOP recovery.

## Quant-choice deviation (4-bit, not 8-bit)

The file's policy header notes that correctness candidates should use 8-bit so model noise doesn't masquerade as rapid-mlx regressions. This entry deviates:

| Aspect | Why 4-bit is correct here |
| --- | --- |
| **Test purpose** | Engine-wiring coverage, NOT model correctness. We're verifying DiffusionEngine boots / dispatches / streams — not that the model picks tools well. |
| **Model class** | DiffusionGemma inherits Gemma-4 instruction-following weaknesses. Gemma 4 is explicitly excluded from this matrix for that reason; neither quant of DiffusionGemma would cleanly pass the full agent battery. |
| **Cost** | 8-bit would cost ~14 GB more disk and ~30-60 s more boot per CI run for an identical engine-wiring signal. |

`quality_tier: smoke` suppresses the multi-tool `pydantic_ai` test that the model class can't pass regardless of quant. `anthropic_sdk` and `langchain` still run as smoke coverage of the **gemma4 parser × DiffusionEngine seam** — a wire combo no other matrix entry exercises.

## Test plan

This PR is a CI-matrix-only edit (yaml + overrides table); no runtime code touched.

- [x] Live e2e against v0.7.15 confirms the candidate model boots, accepts `/v1/chat/completions`, and returns a coherent response in 154 s wall-clock (cold cache). Details in the "Why now" section.
- [x] yaml structure validated by pr_validate's `fetch` + `codex_review` steps on this PR (codex r1 found no blocking issues, file parses).
- [x] No runtime / dependency / lockfile changes — `lint` / `targeted_tests` / `full_unit` all unaffected (`stress_e2e_bench` is the only step that consumes this yaml, and it gates on blast=high — this PR is blast=medium and intentionally does not invoke it; the new family will be exercised end-to-end on the next blast=high PR that lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)