### PR TITLE
fix(tests): make tool_call_e2e skip predicate auth-aware

### DIFF
--- a/tests/test_tool_call_e2e.py
+++ b/tests/test_tool_call_e2e.py
@@ -246,12 +246,30 @@ MAX_ROUNDS = 8
 
 
 def _server_available() -> bool:
-    """Check if vllm-mlx server is running."""
+    """Check if a vllm-mlx server on :8000 is reachable AND unauthenticated.
+
+    The tests POST to ``/v1/chat/completions`` without any Authorization
+    header. A server with an API key configured will respond 401 there,
+    but its ``/health`` endpoint stays 200 (intentionally — health probes
+    must not require auth). Probing ``/health`` alone therefore reports
+    "available" against an auth-protected server, the tests then run,
+    each request bounces off auth, ``run_agent_loop`` returns
+    ``content=None``, and every test fails with ``AssertionError:
+    Expected text response``.
+
+    We additionally probe ``/v1/models`` — the surface the tests
+    actually use — and require it to answer 200 unauthenticated. Any
+    non-200 (401, 503, connection error) is treated as "no usable
+    server" and the suite skips cleanly.
+    """
     if not _HTTPX:
         return False
     try:
-        r = httpx.get("http://localhost:8000/health", timeout=2.0)
-        return r.status_code == 200
+        h = httpx.get("http://localhost:8000/health", timeout=2.0)
+        if h.status_code != 200:
+            return False
+        m = httpx.get("http://localhost:8000/v1/models", timeout=2.0)
+        return m.status_code == 200
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary

`tests/test_tool_call_e2e.py::_server_available()` only probed `/health` to decide whether to skip the suite. `/health` intentionally stays 200 even when the server is started with `--api-key …` (health probes must not require auth). On any dev box running `rapid-mlx serve --api-key …` on the default port 8000, this caused:

1. `_server_available()` returns `True`
2. Tests run for real
3. Every POST to `/v1/chat/completions` bounces off auth (401)
4. `run_agent_loop` returns `content=None`
5. All 5 `TestToolCallE2E` tests fail with `AssertionError: Expected text response` in <0.1 s

These five red rows were also silently in the `full_unit` step of `scripts/pr_validate` on at least **PR #606** and **PR #607** — pre-existing failures that had nothing to do with the diff under review and almost slipped past as "known-flake" noise.

## Fix

Also probe `/v1/models` (the surface the tests actually use) and require 200 unauthenticated. Any non-200 (401 from auth, 503, connection error) is treated as "no usable server" and the suite skips cleanly. Behaviour against a no-auth dev server is unchanged.

## Test plan

- [x] Local: `pytest tests/test_tool_call_e2e.py -v` → 6 skipped in 0.07s (against an auth-protected server on :8000)
- [x] Manually verified the skip reason surfaces: `vllm-mlx server not running on localhost:8000` (existing message — accurate for the user-facing intent)
- [x] No behavioural change vs. main when no server is running (both code paths return False on connection error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)