### PR TITLE
fix(rate-limit): bound cleanup cost + protect active entries (#195)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -844,7 +844,7 @@ class TestRateLimiterHTTPResponse:
         for i in range(60):
             assert f"stale_{i}" not in limiter._requests
 
-    def test_rate_limiter_cleanup_amortized_constant_time(self):
+    def test_rate_limiter_cleanup_amortized_constant_time(self, monkeypatch):
         """Cleanup cost is amortized — not run on every request when dict is large.
 
         Regression for issue #195: previously every request walked the full
@@ -852,10 +852,19 @@ class TestRateLimiterHTTPResponse:
         quadratic worst-case work over a burst of requests. The fix throttles
         the sweep to at most once per window, so back-to-back requests after
         a sweep must not retrigger it.
+
+        The monotonic clock is patched so this is independent of wall time
+        and won't flake on slow/suspended CI workers.
         """
         import time
 
+        from vllm_mlx.middleware import auth as auth_mod
         from vllm_mlx.server import RateLimiter
+
+        # Hold the monotonic clock steady so the throttle window cannot
+        # silently elapse mid-test.
+        fake_mono = [1000.0]
+        monkeypatch.setattr(auth_mod.time, "monotonic", lambda: fake_mono[0])
 
         limiter = RateLimiter(requests_per_minute=1000, enabled=True)
 
@@ -867,21 +876,28 @@ class TestRateLimiterHTTPResponse:
                 limiter._requests[key] = [recent]
                 limiter._last_seen[key] = recent
 
-        # First call triggers a sweep and stamps _last_cleanup.
+        # First call triggers a sweep and stamps _last_cleanup_mono.
         limiter.is_allowed("client_0")
-        first_cleanup = limiter._last_cleanup
+        first_cleanup = limiter._last_cleanup_mono
         assert first_cleanup > 0, "first call should have run cleanup"
 
-        # The very next call (sub-second later) must NOT retrigger cleanup.
+        # The very next call (no monotonic-clock advance) must NOT retrigger.
         limiter.is_allowed("client_1")
-        assert limiter._last_cleanup == first_cleanup, (
+        assert limiter._last_cleanup_mono == first_cleanup, (
             "cleanup ran twice within the same window — amortization broken"
         )
 
-        # Hammer the limiter many times; cleanup must remain pinned.
+        # Hammer the limiter many times; cleanup must remain pinned even if
+        # the clock crawls forward slightly (still inside the 60s throttle).
+        fake_mono[0] += 10.0  # < window_size
         for i in range(50):
             limiter.is_allowed(f"client_{i % 200}")
-        assert limiter._last_cleanup == first_cleanup
+        assert limiter._last_cleanup_mono == first_cleanup
+
+        # Advance past the throttle window — now a sweep is allowed again.
+        fake_mono[0] += limiter.window_size + 1.0
+        limiter.is_allowed("client_2")
+        assert limiter._last_cleanup_mono > first_cleanup
 
     def test_rate_limiter_cleanup_does_not_evict_current_client(self):
         """The client whose request triggers the sweep is never evicted.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -899,6 +899,39 @@ class TestRateLimiterHTTPResponse:
         limiter.is_allowed("client_2")
         assert limiter._last_cleanup_mono > first_cleanup
 
+    def test_rate_limiter_first_cleanup_never_throttled(self, monkeypatch):
+        """The very first eligible sweep must run regardless of monotonic-clock value.
+
+        Regression for codex round-2 NIT on PR #610: a freshly-booted system
+        can have ``time.monotonic()`` smaller than ``window_size``, so a
+        zero-initialized throttle would incorrectly suppress the first sweep.
+        Initializing to ``-inf`` guarantees the first sweep always runs.
+        """
+        import time
+
+        from vllm_mlx.middleware import auth as auth_mod
+        from vllm_mlx.server import RateLimiter
+
+        # Pin monotonic clock to a small value (simulates fresh boot).
+        monkeypatch.setattr(auth_mod.time, "monotonic", lambda: 1.0)
+
+        limiter = RateLimiter(requests_per_minute=10, enabled=True)
+
+        # Seed >100 stale entries.
+        old = time.time() - 120.0
+        with limiter._lock:
+            for i in range(101):
+                key = f"stale_{i}"
+                limiter._requests[key] = [old]
+                limiter._last_seen[key] = old
+
+        assert len(limiter._requests) == 101
+        # First call must actually sweep, not be silently throttled.
+        limiter.is_allowed("fresh_client")
+        assert len(limiter._requests) < 101, (
+            "first sweep was throttled despite monotonic() < window_size"
+        )
+
     def test_rate_limiter_cleanup_does_not_evict_current_client(self):
         """The client whose request triggers the sweep is never evicted.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -800,6 +800,117 @@ class TestRateLimiterHTTPResponse:
         # new_client should still be present
         assert "new_client" in limiter._requests
 
+    def test_rate_limiter_cleanup_preserves_active_entries(self):
+        """Cleanup never deletes a client whose timestamps are still inside the window.
+
+        Regression for issue #195: the stale-entry sweep used to walk every
+        entry on every request once the dict held >100 clients and could
+        clobber the entry of the very client whose request triggered it.
+        """
+        import time
+
+        from vllm_mlx.server import RateLimiter
+
+        limiter = RateLimiter(requests_per_minute=10, enabled=True)
+
+        now = time.time()
+        recent = now - 5.0  # well inside the 60s window
+        with limiter._lock:
+            # 50 active clients (recent), 60 stale clients (expired).
+            for i in range(50):
+                key = f"active_{i}"
+                limiter._requests[key] = [recent]
+                limiter._last_seen[key] = recent
+            old = now - 120.0
+            for i in range(60):
+                key = f"stale_{i}"
+                limiter._requests[key] = [old]
+                limiter._last_seen[key] = old
+
+        # 110 entries total — over the 100 threshold, so a sweep will run.
+        assert len(limiter._requests) == 110
+
+        # Drive an active client. The sweep MUST keep its entry and all other
+        # active entries.
+        allowed, _ = limiter.is_allowed("active_0")
+        assert allowed is True
+
+        for i in range(50):
+            assert f"active_{i}" in limiter._requests, (
+                f"active client active_{i} was incorrectly reaped"
+            )
+
+        # Stale entries should be gone.
+        for i in range(60):
+            assert f"stale_{i}" not in limiter._requests
+
+    def test_rate_limiter_cleanup_amortized_constant_time(self):
+        """Cleanup cost is amortized — not run on every request when dict is large.
+
+        Regression for issue #195: previously every request walked the full
+        dict (and the per-entry timestamp list) once size > 100, giving
+        quadratic worst-case work over a burst of requests. The fix throttles
+        the sweep to at most once per window, so back-to-back requests after
+        a sweep must not retrigger it.
+        """
+        import time
+
+        from vllm_mlx.server import RateLimiter
+
+        limiter = RateLimiter(requests_per_minute=1000, enabled=True)
+
+        now = time.time()
+        recent = now - 5.0
+        with limiter._lock:
+            for i in range(200):
+                key = f"client_{i}"
+                limiter._requests[key] = [recent]
+                limiter._last_seen[key] = recent
+
+        # First call triggers a sweep and stamps _last_cleanup.
+        limiter.is_allowed("client_0")
+        first_cleanup = limiter._last_cleanup
+        assert first_cleanup > 0, "first call should have run cleanup"
+
+        # The very next call (sub-second later) must NOT retrigger cleanup.
+        limiter.is_allowed("client_1")
+        assert limiter._last_cleanup == first_cleanup, (
+            "cleanup ran twice within the same window — amortization broken"
+        )
+
+        # Hammer the limiter many times; cleanup must remain pinned.
+        for i in range(50):
+            limiter.is_allowed(f"client_{i % 200}")
+        assert limiter._last_cleanup == first_cleanup
+
+    def test_rate_limiter_cleanup_does_not_evict_current_client(self):
+        """The client whose request triggers the sweep is never evicted.
+
+        Even if its only recorded timestamp would qualify it as stale, the
+        sweep must not remove its bucket out from under it, because the
+        caller is about to read/write that bucket immediately afterwards.
+        """
+        import time
+
+        from vllm_mlx.server import RateLimiter
+
+        limiter = RateLimiter(requests_per_minute=10, enabled=True)
+
+        now = time.time()
+        old = now - 120.0  # outside the 60s window
+        with limiter._lock:
+            for i in range(101):
+                key = f"client_{i}"
+                limiter._requests[key] = [old]
+                limiter._last_seen[key] = old
+
+        # Drive the same key whose recorded data looks stale. It must end
+        # up tracked with the new timestamp, not silently dropped.
+        allowed, _ = limiter.is_allowed("client_0")
+        assert allowed is True
+        assert "client_0" in limiter._requests
+        assert len(limiter._requests["client_0"]) == 1
+
 
 # =============================================================================
 # Integration Tests (require running server)

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -56,25 +56,29 @@ class RateLimiter:
         # so the sweep avoids the per-entry ``max(v)`` scan that drove the
         # quadratic worst case.
         self._last_seen: dict[str, float] = {}
-        self._last_cleanup: float = 0.0
+        # Throttle is keyed off ``time.monotonic()`` so a backwards NTP step
+        # cannot suppress sweeps far longer than ``window_size``. Wall time
+        # is still used for the request-window math (timestamps must round-
+        # trip with retry-after semantics).
+        self._last_cleanup_mono: float = 0.0
         self._lock = threading.Lock()
 
-    def _maybe_cleanup(
-        self, current_time: float, window_start: float, client_id: str
-    ) -> None:
+    def _maybe_cleanup(self, window_start: float, client_id: str) -> None:
         """Sweep stale entries. Must be called with ``self._lock`` held.
 
-        Throttled to at most once per ``window_size`` seconds and skipped
-        entirely when the dict is small. The current ``client_id`` is never
-        evicted — removing it here would either be a wasted op (the caller
-        is about to re-create it) or race-prone in the rare case the sweep
-        encountered a brand-new defaultdict-inserted empty list for it.
+        Throttled to at most once per ``window_size`` seconds (measured on
+        the monotonic clock so NTP/wall-clock adjustments cannot starve it)
+        and skipped entirely when the dict is small. The current ``client_id``
+        is never evicted — removing it here would either be a wasted op (the
+        caller is about to re-create it) or race-prone in the rare case the
+        sweep encountered a brand-new defaultdict-inserted empty list for it.
         """
         if len(self._requests) <= self._CLEANUP_DICT_THRESHOLD:
             return
-        if current_time - self._last_cleanup < self.window_size:
+        now_mono = time.monotonic()
+        if now_mono - self._last_cleanup_mono < self.window_size:
             return
-        self._last_cleanup = current_time
+        self._last_cleanup_mono = now_mono
 
         # Snapshot keys to avoid mutating during iteration.
         for k in list(self._requests.keys()):
@@ -95,13 +99,11 @@ class RateLimiter:
         window_start = current_time - self.window_size
 
         with self._lock:
-            self._maybe_cleanup(current_time, window_start, client_id)
+            self._maybe_cleanup(window_start, client_id)
 
             # Filter the current client's window. Strict ``>`` matches the
             # original semantics (timestamps exactly at window_start are out).
-            timestamps = [
-                t for t in self._requests[client_id] if t > window_start
-            ]
+            timestamps = [t for t in self._requests[client_id] if t > window_start]
             self._requests[client_id] = timestamps
 
             if len(timestamps) >= self.requests_per_minute:
@@ -135,7 +137,7 @@ def configure_rate_limiter(
         rate_limiter.enabled = enabled
         rate_limiter._requests.clear()
         rate_limiter._last_seen.clear()
-        rate_limiter._last_cleanup = 0.0
+        rate_limiter._last_cleanup_mono = 0.0
     return rate_limiter
 
 

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -59,8 +59,11 @@ class RateLimiter:
         # Throttle is keyed off ``time.monotonic()`` so a backwards NTP step
         # cannot suppress sweeps far longer than ``window_size``. Wall time
         # is still used for the request-window math (timestamps must round-
-        # trip with retry-after semantics).
-        self._last_cleanup_mono: float = 0.0
+        # trip with retry-after semantics). Initialized to ``-inf`` so the
+        # first eligible request always sweeps, even on a freshly booted
+        # system where ``time.monotonic()`` may itself be smaller than
+        # ``window_size``.
+        self._last_cleanup_mono: float = float("-inf")
         self._lock = threading.Lock()
 
     def _maybe_cleanup(self, window_start: float, client_id: str) -> None:
@@ -137,7 +140,7 @@ def configure_rate_limiter(
         rate_limiter.enabled = enabled
         rate_limiter._requests.clear()
         rate_limiter._last_seen.clear()
-        rate_limiter._last_cleanup_mono = 0.0
+        rate_limiter._last_cleanup_mono = float("-inf")
     return rate_limiter
 
 

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -25,14 +25,66 @@ _RATE_LIMIT_HMAC_KEY = secrets.token_bytes(32)
 
 
 class RateLimiter:
-    """Simple in-memory rate limiter using sliding window."""
+    """Simple in-memory rate limiter using sliding window.
+
+    Stale-entry cleanup is amortized O(1) per request:
+
+    * A separate ``_last_seen`` map records each client's most recent timestamp
+      so the sweep is O(N) over the dict (no per-entry ``max(v)`` scan, which
+      previously made the worst case quadratic when the dict held >100 active
+      clients — each request walked every entry, each entry scanned its
+      window-length timestamp list).
+    * The sweep runs at most once per ``window_size`` interval rather than on
+      every request, so a busy server with >100 active clients no longer pays
+      O(N) per request just to walk the dict.
+    * The current client's entry is always preserved during the sweep — only
+      entries whose newest timestamp is strictly older than ``window_start``
+      are deleted, so a client that made any request inside the window cannot
+      have its counter wiped out by an unrelated concurrent client.
+    """
+
+    # Soft cap that gates cleanup. Kept at 100 to preserve historical behavior
+    # (and the existing regression test in test_server.py).
+    _CLEANUP_DICT_THRESHOLD = 100
 
     def __init__(self, requests_per_minute: int = 60, enabled: bool = False):
         self.requests_per_minute = requests_per_minute
         self.enabled = enabled
         self.window_size = 60.0
         self._requests: dict[str, list[float]] = defaultdict(list)
+        # ``_last_seen[k]`` mirrors ``max(_requests[k])`` for every tracked k,
+        # so the sweep avoids the per-entry ``max(v)`` scan that drove the
+        # quadratic worst case.
+        self._last_seen: dict[str, float] = {}
+        self._last_cleanup: float = 0.0
         self._lock = threading.Lock()
+
+    def _maybe_cleanup(
+        self, current_time: float, window_start: float, client_id: str
+    ) -> None:
+        """Sweep stale entries. Must be called with ``self._lock`` held.
+
+        Throttled to at most once per ``window_size`` seconds and skipped
+        entirely when the dict is small. The current ``client_id`` is never
+        evicted — removing it here would either be a wasted op (the caller
+        is about to re-create it) or race-prone in the rare case the sweep
+        encountered a brand-new defaultdict-inserted empty list for it.
+        """
+        if len(self._requests) <= self._CLEANUP_DICT_THRESHOLD:
+            return
+        if current_time - self._last_cleanup < self.window_size:
+            return
+        self._last_cleanup = current_time
+
+        # Snapshot keys to avoid mutating during iteration.
+        for k in list(self._requests.keys()):
+            if k == client_id:
+                # Never reap the entry that's about to be touched.
+                continue
+            last = self._last_seen.get(k)
+            if last is None or last <= window_start:
+                self._requests.pop(k, None)
+                self._last_seen.pop(k, None)
 
     def is_allowed(self, client_id: str) -> tuple[bool, int]:
         """Check if request is allowed. Returns (is_allowed, retry_after_seconds)."""
@@ -43,25 +95,28 @@ class RateLimiter:
         window_start = current_time - self.window_size
 
         with self._lock:
-            if len(self._requests) > 100:
-                stale = [
-                    k
-                    for k, v in self._requests.items()
-                    if not v or max(v) <= window_start
-                ]
-                for k in stale:
-                    del self._requests[k]
+            self._maybe_cleanup(current_time, window_start, client_id)
 
-            self._requests[client_id] = [
+            # Filter the current client's window. Strict ``>`` matches the
+            # original semantics (timestamps exactly at window_start are out).
+            timestamps = [
                 t for t in self._requests[client_id] if t > window_start
             ]
+            self._requests[client_id] = timestamps
 
-            if len(self._requests[client_id]) >= self.requests_per_minute:
-                oldest = min(self._requests[client_id])
+            if len(timestamps) >= self.requests_per_minute:
+                # ``min`` matches the original semantics; timestamps are
+                # append-ordered so this is also the head.
+                oldest = min(timestamps)
                 retry_after = int(oldest + self.window_size - current_time) + 1
+                # Track the rejected request's time so an entry that's still
+                # actively probing the limit isn't considered stale on the
+                # next sweep.
+                self._last_seen[client_id] = current_time
                 return False, max(1, retry_after)
 
-            self._requests[client_id].append(current_time)
+            timestamps.append(current_time)
+            self._last_seen[client_id] = current_time
             return True, 0
 
 
@@ -79,6 +134,8 @@ def configure_rate_limiter(
         rate_limiter.requests_per_minute = requests_per_minute
         rate_limiter.enabled = enabled
         rate_limiter._requests.clear()
+        rate_limiter._last_seen.clear()
+        rate_limiter._last_cleanup = 0.0
     return rate_limiter
 
 


### PR DESCRIPTION
## Summary

Fixes #195. The `RateLimiter` stale-entry sweep in `vllm_mlx/middleware/auth.py` had two issues:

1. **Quadratic worst case** — once the dict held >100 entries, every request walked all N keys and called `max(v)` over each key's window-length timestamp list (O(N*W) per request, O(N^2*W) over a burst).
2. **Could clobber active entries** — the sweep ran on the full dict including the current request's bucket; a freshly-inserted defaultdict empty list for the in-flight client could be deleted before the caller wrote to it.

## Fix

- New `_last_seen: dict[str, float]` map mirrors each client's newest timestamp so the sweep is O(N), no per-entry `max(v)` scan.
- Sweep is throttled to at most once per `window_size` (60s) — amortized O(1) per request.
- Sweep explicitly skips the `client_id` of the in-flight request.

Same 60s sliding window, same 100-key cleanup threshold, same retry-after semantics.

## Why this approach over alternatives

- Considered switching to a `deque` per client for O(1) head pop. Doesn't address the dict-walk cost (the actual quadratic source) and is a bigger refactor — punted to keep the fix narrow per repo conventions.
- Considered a background sweeper thread. Adds a thread for a class that's already in-process and lock-protected — overkill for the bounded data size; the on-request throttled sweep is simpler.
- Considered widening the cleanup threshold to e.g. 1000. Doesn't help an attacker who creates >>1000 keys, and would mask the quadratic behavior rather than fix it.

## Risk assessment

- **Memory**: one extra `dict[str, float]` mirroring `_requests` keys. ~24B/key extra. Negligible.
- **Latency on hot path**: removes work (no more per-entry `max(v)` scan, no more sweep on every request once dict is large). The lock-held path is now strictly faster in the worst case. The non-pathological case (small dict) is unchanged — cleanup is a single `len()` check that returns early.
- The rate-limit dict is only populated when `--rate-limit` is enabled; default deployments are unaffected.

## Test plan

- [x] `pytest tests/test_server.py -k RateLimiter` — 10 passed (7 existing + 3 new)
- [x] `pytest tests/test_config_and_middleware.py tests/test_anthropic_route_auth.py tests/test_responses_route.py` — 72 passed (no auth/rate-limit regressions)
- [x] `ruff check vllm_mlx/middleware/auth.py tests/test_server.py` — clean
- [x] New regression `test_rate_limiter_cleanup_preserves_active_entries` — 50 active clients all survive a sweep triggered by their own request
- [x] New regression `test_rate_limiter_cleanup_amortized_constant_time` — back-to-back requests after a sweep do NOT retrigger it
- [x] New regression `test_rate_limiter_cleanup_does_not_evict_current_client` — even when the in-flight client's only timestamp is stale, its bucket survives the sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)