### PR TITLE
fix(scheduler+build): #611 ignore_eos reuse key + #230 sidecar .pyc seal

### DIFF
--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -173,6 +173,36 @@ rm -rf \
     "$STAGE/python/share/man"
 find "$STAGE" -type d -name __pycache__ -prune -exec rm -rf {} +
 
+# Pre-compile every .py in the bundled stdlib + site-packages BEFORE
+# we codesign. Otherwise CPython's import machinery writes .pyc files
+# into __pycache__/ at runtime on first use, those additions are
+# unsealed (codesign --verify --deep reports "a sealed resource is
+# missing or invalid"), and any `spctl --assess` after first launch
+# rejects the bundle:
+#
+#   * Migration Assistant copy to a new Mac → first launch fails
+#     "App is damaged, move to Trash".
+#   * macOS major upgrade re-evaluates Gatekeeper → same.
+#   * User moves /Applications/Rapid-MLX Desktop.app and back → same.
+#
+# rapid-desktop issue #230 — confirmed in v0.6.14 with 1008 stray
+# .pyc files post-launch. Notarisation is unaffected (the ticket lives
+# in xattr metadata, not the sealed resource directory), only the
+# spctl-assess re-check path.
+#
+# SOURCE_DATE_EPOCH freezes the .pyc magic-number timestamp so builds
+# stay byte-reproducible — without it every CI re-run produces a
+# different bundle and the upstream `MACHO_BASELINE_COUNT` drift
+# heuristic becomes meaningless. Falls back to 0 when the build runs
+# outside a git checkout (smoke test fixtures).
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "$REPO_ROOT" log -1 --format=%ct HEAD 2>/dev/null || echo 0)}"
+export SOURCE_DATE_EPOCH
+echo "==> pre-compiling .pyc cache (SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH)"
+"$STAGE/python/bin/python3.12" -m compileall -q -f -j 0 \
+    "$STAGE/python/lib/python3.12" \
+    "$STAGE/site-packages" \
+    || { echo "ERR: compileall failed; bundle would seal-break on first launch" >&2; exit 1; }
+
 # ----- step 4: shim entrypoint -----------------------------------------
 
 cp "${REPO_ROOT}/scripts/sidecar-shim.sh" "$STAGE/bin/rapid-mlx"

--- a/scripts/sidecar-shim.sh
+++ b/scripts/sidecar-shim.sh
@@ -42,6 +42,15 @@ ROOT="$(cd "$BIN_DIR/.." && pwd)"
 export PYTHONHOME="$ROOT/python"
 export PYTHONPATH="$ROOT/site-packages"
 export PYTHONNOUSERSITE=1
+# Belt-and-braces on top of build-sidecar.sh's pre-compile pass:
+# refuse to write any new .pyc at runtime even if a downstream import
+# path slips through that the pre-compile didn't cover. Without this,
+# ANY post-build .pyc write would break codesign's seal and any
+# subsequent `spctl --assess` (Migration Assistant copy, macOS major
+# upgrade re-evaluation, fresh quarantine after move/rename) would
+# reject the bundle as "a sealed resource is missing or invalid".
+# rapid-desktop #230.
+export PYTHONDONTWRITEBYTECODE=1
 unset PYTHONSTARTUP
 
 exec "$ROOT/python/bin/python3.12" -s -m vllm_mlx.cli "$@"

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -280,6 +280,85 @@ def test_scheduler_honours_ignore_eos() -> None:
     assert immutable_model == frozenset({1, 2, 3})  # unchanged
 
 
+def test_scheduler_batch_generator_reuse_key_includes_ignore_eos() -> None:
+    """Issue #611 — the third half of the #567 fix: the scheduler's
+    BatchGenerator reuse key must differ when ``ignore_eos`` differs.
+
+    Before the fix, ``_ensure_batch_generator`` keyed reuse on the
+    sampler tuple (temperature, top_p, min_p, top_k) only, so two
+    requests with identical samplers but different ``ignore_eos`` would
+    silently share the same generator. The first request's stop-token
+    set (empty if ignore_eos=True, model-EOS if False) leaked to the
+    second — a benchmark probe with ``ignore_eos=True`` followed by a
+    normal chat call would run to ``max_tokens`` instead of stopping at
+    EOS.
+
+    Drive the production method directly with a minimal stub scheduler.
+    Asserting against a recomputed copy of the tuple would let a future
+    refactor silently drop ``ignore_eos`` from the production tuple if
+    the same refactor updated the test in lockstep; calling the real
+    method makes that escape impossible.
+    """
+    from vllm_mlx.request import SamplingParams
+    from vllm_mlx.scheduler import Scheduler
+
+    sentinel = object()
+    create_calls = []
+    close_calls = []
+
+    class StubScheduler:
+        batch_generator = None
+        running = False
+        memory_aware_cache = None
+        prefix_cache = None
+        _current_sampler_params = None
+
+        def _close_batch_generator(self) -> None:
+            close_calls.append(self.batch_generator)
+            self.batch_generator = None
+
+        def _create_batch_generator(self, sp):
+            create_calls.append(sp)
+            return sentinel
+
+    stub = StubScheduler()
+
+    base_kwargs = dict(
+        max_tokens=512,
+        temperature=0.0,
+        top_p=1.0,
+        min_p=0.0,
+        top_k=-1,
+    )
+    p_strip_eos = SamplingParams(**base_kwargs, ignore_eos=True)
+    p_default = SamplingParams(**base_kwargs, ignore_eos=False)
+
+    Scheduler._ensure_batch_generator(stub, p_strip_eos)
+    assert len(create_calls) == 1, "first request should build a generator"
+    assert stub.batch_generator is sentinel
+
+    closes_after_first = len(close_calls)
+    Scheduler._ensure_batch_generator(stub, p_default)
+    assert len(create_calls) == 2, (
+        "second request with different ignore_eos must rebuild the "
+        "generator — the empty stop-token set from the ignore_eos=True "
+        "request would otherwise leak to this normal request (#611)."
+    )
+    assert len(close_calls) > closes_after_first, (
+        "the previous generator must be torn down before the rebuild "
+        "so its resources aren't leaked."
+    )
+
+    # And the inverse — second identical call MUST reuse (sanity that
+    # we didn't accidentally invalidate reuse for the happy path).
+    Scheduler._ensure_batch_generator(stub, p_default)
+    assert len(create_calls) == 2, (
+        "two consecutive requests with the same sampler tuple AND same "
+        "ignore_eos must share a single BatchGenerator (no regression "
+        "on the reuse fast path)."
+    )
+
+
 def test_standardized_config_dict_matches_schema_consts() -> None:
     """The hardcoded constants in ``config`` must equal the schema's
     ``const`` values — schema validation depends on this."""

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -299,6 +299,12 @@ def test_scheduler_batch_generator_reuse_key_includes_ignore_eos() -> None:
     the same refactor updated the test in lockstep; calling the real
     method makes that escape impossible.
     """
+    # vllm_mlx.scheduler imports mlx unconditionally at module top, so
+    # this test only runs where Apple Silicon mlx is installed; on Linux
+    # CI it skips. pr_validate (PR #612 round 1) classified it as a
+    # regression for failing on Linux with ModuleNotFoundError — the
+    # skip restores the correct "no mlx → no opinion" semantics.
+    pytest.importorskip("mlx")
     from vllm_mlx.request import SamplingParams
     from vllm_mlx.scheduler import Scheduler
 
@@ -333,12 +339,12 @@ def test_scheduler_batch_generator_reuse_key_includes_ignore_eos() -> None:
     p_strip_eos = SamplingParams(**base_kwargs, ignore_eos=True)
     p_default = SamplingParams(**base_kwargs, ignore_eos=False)
 
-    Scheduler._ensure_batch_generator(stub, p_strip_eos)
+    assert Scheduler._ensure_batch_generator(stub, p_strip_eos) is True
     assert len(create_calls) == 1, "first request should build a generator"
     assert stub.batch_generator is sentinel
 
     closes_after_first = len(close_calls)
-    Scheduler._ensure_batch_generator(stub, p_default)
+    assert Scheduler._ensure_batch_generator(stub, p_default) is True
     assert len(create_calls) == 2, (
         "second request with different ignore_eos must rebuild the "
         "generator — the empty stop-token set from the ignore_eos=True "
@@ -351,11 +357,36 @@ def test_scheduler_batch_generator_reuse_key_includes_ignore_eos() -> None:
 
     # And the inverse — second identical call MUST reuse (sanity that
     # we didn't accidentally invalidate reuse for the happy path).
-    Scheduler._ensure_batch_generator(stub, p_default)
+    assert Scheduler._ensure_batch_generator(stub, p_default) is True
     assert len(create_calls) == 2, (
         "two consecutive requests with the same sampler tuple AND same "
         "ignore_eos must share a single BatchGenerator (no regression "
         "on the reuse fast path)."
+    )
+
+    # Codex r1 P2 (PR #612): with the running batch holding an
+    # ignore_eos=False generator, a new ignore_eos=True request MUST be
+    # refused so the caller (_schedule_waiting) requeues it. Without
+    # this guard, the previous fix only closed the idle-reuse leak — a
+    # request that overlapped a running batch would still inherit the
+    # stale stop_tokens.
+    stub.running = {"req-active": object()}  # non-empty truthy
+    creates_before_overlap = len(create_calls)
+    closes_before_overlap = len(close_calls)
+    refused = Scheduler._ensure_batch_generator(stub, p_strip_eos)
+    assert refused is False, (
+        "request with different ignore_eos must be REFUSED while a "
+        "previous batch is still running — otherwise it inherits the "
+        "wrong stop_tokens (codex P2 on PR #612)."
+    )
+    assert len(create_calls) == creates_before_overlap, (
+        "refused request must not have created a new BatchGenerator."
+    )
+    assert len(close_calls) == closes_before_overlap, (
+        "refused request must not have closed the running BatchGenerator."
+    )
+    assert stub.batch_generator is sentinel, (
+        "the live generator must remain intact for the running batch."
     )
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2483,8 +2483,20 @@ class Scheduler:
                 logger.debug(f"Error closing BatchGenerator: {e}")
             self.batch_generator = None
 
-    def _ensure_batch_generator(self, sampling_params: SamplingParams) -> None:
-        """Ensure BatchGenerator exists with compatible settings."""
+    def _ensure_batch_generator(self, sampling_params: SamplingParams) -> bool:
+        """Ensure BatchGenerator exists with compatible settings.
+
+        Returns:
+            ``True`` if a compatible generator is ready for the caller
+            to insert this request into. ``False`` if the caller MUST
+            requeue the request — the current generator's
+            ``stop_tokens`` / sampler differ from what this request
+            requires, and there are active requests still draining, so
+            admitting now would silently bind this request to the wrong
+            stop-token set. The contract is a hard refusal, not advisory;
+            ``_schedule_waiting`` requeues on ``False`` to preserve
+            ignore_eos semantics across overlapping batches.
+        """
         # `_assemble_stop_tokens` returns the empty set when
         # ``ignore_eos=True`` and the model's stop-token set otherwise.
         # The choice is captured inside the BatchGenerator at construction
@@ -2510,13 +2522,22 @@ class Scheduler:
             self.batch_generator is None
             or self._current_sampler_params != sampler_params
         ):
-            # If we have an existing generator with requests, we need to drain it first
+            # If we have an existing generator with requests, the new
+            # request's stop_tokens / sampler are incompatible with the
+            # live generator. Refuse admission — the caller (
+            # ``_schedule_waiting``) requeues and retries on the next
+            # step, after the running batch has had a chance to drain.
+            # Previously we returned without recreating but left the
+            # stale generator in place; ``_schedule_waiting`` would then
+            # insert the new request into it, silently inheriting the
+            # wrong ignore_eos behavior (codex P2 on PR #612).
             if self.batch_generator is not None and self.running:
                 logger.warning(
                     "Sampling parameters changed with active requests. "
-                    "New requests will use new parameters after current batch completes."
+                    "Requeuing request — admission deferred until current "
+                    "batch drains so stop_tokens / sampler remain consistent."
                 )
-                return
+                return False
 
             # Keep prefix cache across BatchGenerator recreations.
             # KV cache entries depend only on the input tokens, not on
@@ -2540,6 +2561,8 @@ class Scheduler:
             self._close_batch_generator()
             self.batch_generator = self._create_batch_generator(sampling_params)
             self._current_sampler_params = sampler_params
+
+        return True
 
     def _validate_cache(self, cache: Any) -> bool:
         """
@@ -2974,8 +2997,15 @@ class Scheduler:
         while self.waiting and len(self.running) < self.config.max_num_seqs:
             request = self.waiting.popleft()
 
-            # Ensure we have a batch generator
-            self._ensure_batch_generator(request.sampling_params)
+            # Ensure we have a batch generator. The False return means
+            # the live generator has incompatible stop_tokens / sampler
+            # for this request and is still draining — we must NOT admit
+            # into the stale generator (Rapid-MLX #611 / codex P2 on
+            # PR #612). Requeue and break so the next ``step`` retries
+            # once the running batch completes.
+            if not self._ensure_batch_generator(request.sampling_params):
+                self.waiting.appendleft(request)
+                break
 
             if self.batch_generator is None:
                 # Put back and try again later

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2485,11 +2485,24 @@ class Scheduler:
 
     def _ensure_batch_generator(self, sampling_params: SamplingParams) -> None:
         """Ensure BatchGenerator exists with compatible settings."""
+        # `_assemble_stop_tokens` returns the empty set when
+        # ``ignore_eos=True`` and the model's stop-token set otherwise.
+        # The choice is captured inside the BatchGenerator at construction
+        # time, so two requests with identical sampler tuples but
+        # different ``ignore_eos`` MUST NOT share a generator — else a
+        # benchmark probe with ``ignore_eos=True`` will silently strip
+        # EOS stops from the next chat call (or vice versa). Folding the
+        # flag into the reuse key is the smallest fix; the alternative
+        # would be to re-stamp ``stop_tokens`` on the live generator,
+        # which we deliberately avoid because the BatchGenerator's
+        # mlx-lm internals are not designed for in-place mutation.
+        # Surfaced by Rapid-MLX issue #611.
         sampler_params = (
             sampling_params.temperature,
             sampling_params.top_p,
             sampling_params.min_p,
             sampling_params.top_k,
+            bool(sampling_params.ignore_eos),
         )
 
         # Create new generator if needed or if sampling params changed


### PR DESCRIPTION
## Summary

Two independent bugs fixed together because they were both found during the same fresh production audit on rapid-desktop v0.6.14, and bundling avoids two version bumps in the same week.

### #611 — `Scheduler._ensure_batch_generator` reuse key drops `ignore_eos`

`_current_sampler_params` keyed BatchGenerator reuse on the 4-tuple `(temperature, top_p, min_p, top_k)` only. `ignore_eos` is folded into the generator's `stop_tokens` set at construction time (`set()` when `ignore_eos=True`, model EOS otherwise) but was NOT part of the reuse decision. Two requests with identical samplers but different `ignore_eos` silently shared the same generator, so the first request's stop-token policy leaked to the second:

- benchmark probe (`ignore_eos=True`) → chat call → chat runs to `max_tokens` instead of stopping at EOS.
- chat call → benchmark probe → benchmark hits EOS early instead of running its full `max_tokens`.

**Fix**: fold `bool(sampling_params.ignore_eos)` into the reuse tuple. New test `test_scheduler_batch_generator_reuse_key_includes_ignore_eos` drives the production method directly with a stub Scheduler.

**Codex r1 P2 follow-up**: when the live generator is still running with mismatched params, `_ensure_batch_generator` previously logged and returned silently, but `_schedule_waiting` then admitted the new request into the stale generator anyway — so the leak persisted for overlapping batches. The method now returns `bool`; the False path tells `_schedule_waiting` to requeue until the running batch drains. Test extended to drive the running-batch refusal path.

Filed by codex review of rapid-desktop PR [#228](https://github.com/machinefi/rapid-desktop/pull/228). Closes [#611](https://github.com/raullenchai/Rapid-MLX/issues/611).

### #230 — sidecar's runtime `.pyc` writes break codesign seal

Confirmed in the v0.6.14 rapid-desktop bundle: `codesign --verify --deep` reports **1008 "file added" entries**, all under `Contents/Resources/rapid-mlx/python/lib/python3.12/.../__pycache__/*.pyc` — CPython's lazy bytecode-cache writes from the bundled sidecar on first import. `build-sidecar.sh` previously stripped `__pycache__` before sign time (intentional, for build reproducibility) but never re-populated it.

| Scenario | Result before fix |
| --- | --- |
| Fresh DMG download → first launch | ✅ Pass (bundle is pristine) |
| Day-to-day use on the install machine | ✅ Works — macOS doesn't re-check spctl once an app is admitted |
| Migration Assistant copy to a new Mac | ❌ "App is damaged, move to Trash" |
| macOS major upgrade re-evaluates Gatekeeper | ❌ Same |
| `mv /Applications/…app ~/Desktop` and back | ❌ Same |
| Auto-update path (`Installer.swift`) | ✅ Unaffected — bypasses Gatekeeper |

**Fix**:
- `build-sidecar.sh` runs `python -m compileall -q -f -j 0` on the bundled stdlib + site-packages AFTER the `__pycache__` strip, BEFORE the codesign sweep — so the .pyc files are part of the seal. `SOURCE_DATE_EPOCH` is pinned to the latest commit time so .pyc bytes are reproducible.
- `sidecar-shim.sh` sets `PYTHONDONTWRITEBYTECODE=1` as a belt-and-braces guard: any future import path the pre-compile didn't cover (downstream extension, a stdlib module we forgot to enumerate) still cannot dirty the seal.

Filed during v0.6.14 cliclick walkthru round B (2026-06-16). Closes [machinefi/rapid-desktop#230](https://github.com/machinefi/rapid-desktop/issues/230) once a rapid-desktop release bumps the submodule to a tag containing this commit.

## Test plan

- [x] `pytest tests/test_community_bench.py -k "ignore_eos or batch_generator_reuse" -v` — both tests PASS locally on M3 Ultra (mlx-backed)
- [x] New test guarded with `pytest.importorskip("mlx")` so it skips (not regresses) on Linux CI runners that lack mlx
- [x] CI green (pr_validate scorecard + sidecar build + CI matrix)

Release / submodule bump / desktop re-release are handled in separate PRs once this lands (per Release SOP — one concern per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)