### PR TITLE
feat(aliases): add Kimi-K2.6 and Qwen3-8B-4bit short-name aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.18"
+version = "0.7.19"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -186,6 +186,14 @@
     "is_moe": false,
     "supports_spec_decode": true
   },
+  "qwen3-8b-4bit": {
+    "hf_path": "mlx-community/Qwen3-8B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
   "llama-3.1-8b-8bit": {
     "hf_path": "mlx-community/Meta-Llama-3.1-8B-Instruct-8bit",
     "tool_call_parser": "llama",
@@ -617,6 +625,13 @@
   },
   "kimi-k2.5-3bit": {
     "hf_path": "mlx-community/Kimi-K2.5-3bit",
+    "tool_call_parser": "kimi",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": true
+  },
+  "kimi-k2.6-dq3-q8": {
+    "hf_path": "mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8",
     "tool_call_parser": "kimi",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,


### PR DESCRIPTION
## Summary

Tier 3 mlx-community alias additions filling concrete gaps in our existing coverage.

- **`kimi-k2.6-dq3-q8`** -> `mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8`
  Newest Kimi K2 snapshot. We currently ship K2 (`kimi-48b-4bit`) and K2.5 (`kimi-k2.5-3bit`); no shortcut for K2.6 today. **~57K monthly downloads, 8 likes on HF.** Parser wiring follows `kimi-k2.5-3bit` exactly (Kimi tool parser + qwen3 reasoning parser — same Qwen3-style chat template with `<think>` injection).

- **`qwen3-8b-4bit`** -> `mlx-community/Qwen3-8B-4bit`
  Missing 4-bit quant of Qwen3-8B. We currently only expose the 8-bit variant (`qwen3-8b-8bit`), so users wanting a smaller memory footprint have no short alias. **~19K monthly downloads, 10 likes on HF.** Wiring mirrors `qwen3-8b-8bit` exactly.

Both HF paths verified live (HTTP 200 against `huggingface.co/api/models/...`). The `Kimi-K2.6-mlx-DQ3_K_M-q8` upload uses the unusual `DQ3_K_M-q8` hybrid quant suffix — that is the actual repo id (not a typo), confirmed via the HF API head request.

Version bump: 0.7.16 -> 0.7.19 (claimed slot per sibling Tier 1/Tier 2 PR coordination).

## Test plan

- [x] `python3.12 -m pytest tests/test_aliases* -x` — 785 passed (parametrized contract tests automatically cover both new aliases: org/repo shape, registered tool/reasoning parsers, hybrid/spec-decode consistency, key allowlist).
- [x] `python3.12 -c "import json; json.load(open('vllm_mlx/aliases.json'))"` parses cleanly; both new keys present with expected wiring.
- [x] Verified parser/flag wiring matches sibling aliases in each family (`kimi-k2.5-3bit` for Kimi; `qwen3-8b-8bit` for Qwen3) — no novel field combinations introduced.

Generated with Claude Code.