### PR TITLE
feat(aliases): expose 4 popular Tier 1 mlx-community models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.16"
+version = "0.7.17"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -614,6 +614,13 @@ _CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
     "gemma3-1b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma3-12b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma3-27b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    # Gemma 3 QAT variants — same sampling as the PTQ siblings above. QAT
+    # changes weight distribution (training with simulated quantization),
+    # not the decoding distribution, so Google's chat sampling guidance
+    # applies unchanged. (Matches the Gemma 4 QAT block below.)
+    "gemma3-1b-qat-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma3-4b-qat-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma3-27b-qat-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     # Gemma 4 — official Google sampling guidance hasn't been
     # published yet at the time of writing; we extrapolate from the
     # Gemma 3 family card. Revisit when an official Gemma 4 doc lands.

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -420,6 +420,26 @@
       "top_k": 64
     }
   },
+  "gemma3-4b-qat-4bit": {
+    "hf_path": "mlx-community/gemma-3-4b-it-qat-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "qwen2.5-14b-4bit": {
+    "hf_path": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
   "phi-4-14b-4bit": {
     "hf_path": "mlx-community/phi-4-4bit",
     "tool_call_parser": "hermes",
@@ -678,8 +698,32 @@
       "top_k": 64
     }
   },
+  "gemma3-1b-qat-4bit": {
+    "hf_path": "mlx-community/gemma-3-1b-it-qat-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
   "gemma3-27b-4bit": {
     "hf_path": "mlx-community/gemma-3-27b-it-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma3-27b-qat-4bit": {
+    "hf_path": "mlx-community/gemma-3-27b-it-qat-4bit",
     "tool_call_parser": "hermes",
     "reasoning_parser": null,
     "is_hybrid": false,


### PR DESCRIPTION
## Summary

Adds short-name aliases for four high-traffic mlx-community models so users no longer need to type the full HF path:

- `qwen2.5-14b-4bit` -> `mlx-community/Qwen2.5-14B-Instruct-4bit`
- `gemma3-4b-qat-4bit` -> `mlx-community/gemma-3-4b-it-qat-4bit`
- `gemma3-27b-qat-4bit` -> `mlx-community/gemma-3-27b-it-qat-4bit`
- `gemma3-1b-qat-4bit` -> `mlx-community/gemma-3-1b-it-qat-4bit`

Naming follows the existing `gemma3-*` convention already used in `aliases.json` (e.g. `gemma3-12b-4bit`). The `-qat-` infix disambiguates the new QAT entries from the existing non-QAT short names (`gemma3-1b-4bit`, `gemma3-27b-4bit`). For Qwen2.5 there were no prior 2.5-family aliases, so `qwen2.5-14b-4bit` follows the same `<family>-<size>-<bits>` pattern as the Qwen3/Qwen3.5 entries.

### Parser wiring

- **Qwen2.5-Instruct**: `hermes` tool parser, no reasoning parser (Qwen2.5 is non-thinking; reasoning arrived in Qwen3).
- **Gemma 3 QAT**: same wiring as the existing non-QAT `gemma3-*` entries — `hermes` tool parser, no reasoning parser, `supports_spec_decode: true`, Gemma chat sampling defaults. QAT changes weight distribution, not the decoding distribution, mirroring how the `gemma-4-*-qat-*` block in the file already handles this.

### Popularity rationale (HF API, captured at triage)

| Model | Downloads/month | Likes |
|---|---|---|
| `Qwen2.5-14B-Instruct-4bit` | ~82K | 11 |
| `gemma-3-4b-it-qat-4bit` | ~74K | 9 |
| `gemma-3-27b-it-qat-4bit` | ~31K | 23 |
| `gemma-3-1b-it-qat-4bit` | ~30K | 5 |

The 4B QAT fills a gap in our existing Gemma 3 coverage (we shipped 1b/12b/27b); the 27B QAT is meaningfully higher quality than the plain-4bit variant at the same size.

### Other

- Version bumped 0.7.16 -> 0.7.17 (aliases.json edits trip the version-bump CI gate).
- The 3 new gemma3-QAT aliases are pinned in `_CURATED_RECOMMENDED_SAMPLING` so the contract test catches any future bulk-edit drift; the rationale comment mirrors the existing Gemma 4 QAT block right below it.

## Test plan

- [x] `python3.12 -m pytest tests/test_aliases_contract.py tests/test_alias_recommended_sampling.py tests/test_model_aliases.py tests/test_model_registry.py` — 849 passed. The parametrised `_alias_ids()` sweep auto-covers the 4 new entries (hf_path shape, tool/reasoning parser registered, hybrid-vs-spec-decode consistency, suffix tier enum, only-known-keys, POPULAR_ALIASES cross-ref).
- [x] `python3.12 -m pytest tests/test_model_auto_config.py tests/test_model_profiles_ssot.py tests/test_cli_models.py tests/test_api_models.py` — 190 passed; new entries don't perturb auto-config / SSOT.
- [x] `python3.12 -c "import json; json.load(open('vllm_mlx/aliases.json'))"` — JSON parses cleanly, total alias count goes 75 -> 79.