### PR TITLE
feat(aliases): expose gemma-4 e2b and e4b mlx variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.17"
+version = "0.7.18"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -624,6 +624,11 @@ _CURATED_RECOMMENDED_SAMPLING: dict[str, dict[str, float]] = {
     # Gemma 4 — official Google sampling guidance hasn't been
     # published yet at the time of writing; we extrapolate from the
     # Gemma 3 family card. Revisit when an official Gemma 4 doc lands.
+    # Gemma 4 "effective" variants (e2b/e4b) share the same chat-tuned
+    # training recipe as their full-size siblings, so the same sampling
+    # guidance applies.
+    "gemma-4-e2b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
+    "gemma-4-e4b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-12b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-12b-8bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},
     "gemma-4-26b-4bit": {"temperature": 1.0, "top_p": 0.95, "top_k": 64.0},

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -270,6 +270,32 @@
       "code_edit": 0.584
     }
   },
+  "gemma-4-e2b-4bit": {
+    "hf_path": "mlx-community/gemma-4-e2b-it-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
+  "gemma-4-e4b-4bit": {
+    "hf_path": "mlx-community/gemma-4-e4b-it-4bit",
+    "tool_call_parser": "gemma4",
+    "reasoning_parser": "gemma4",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64
+    }
+  },
   "gemma-4-12b-4bit": {
     "hf_path": "mlx-community/gemma-4-12B-it-4bit",
     "tool_call_parser": "gemma4",


### PR DESCRIPTION
## Summary

Tier 2 mlx-community aliases for the gemma-4 "effective" checkpoints — the smaller-than-12B chat-tuned variants that fill a real size gap in the gemma-4 family. Today rapid-mlx ships gemma-4-12b / 26b / 31b (+ QAT variants) but has no short-name route to anything smaller, which forces users onto the gemma-3 family or full HF paths.

- \`gemma-4-e2b-4bit\` -> \`mlx-community/gemma-4-e2b-it-4bit\` (~46K downloads/month, 18 likes; effective 2B inference)
- \`gemma-4-e4b-4bit\` -> \`mlx-community/gemma-4-e4b-it-4bit\` (~29K downloads/month, 28 likes; effective 4B inference)

Sampling guidance reuses the Gemma 4 chat card values (\`temperature=1.0, top_p=0.95, top_k=64\`), wired through \`_CURATED_RECOMMENDED_SAMPLING\` with a note that the "effective" variants share the chat-tuned training recipe of their full-size siblings.

Version bump: **0.7.16 -> 0.7.18** (Tier 1 sibling PR is parked on 0.7.17). If Tier 1 lands after this PR, I'll rebase and bump accordingly.

## Test plan

- [x] \`python3.12 -m pytest tests/test_aliases_contract.py -x\` — 785 tests pass; parametrised tests (\`test_alias_hf_path_is_org_slash_repo\`, \`test_alias_tool_parser_is_registered\`, \`test_alias_only_uses_known_keys\`, etc.) pick up the 2 new aliases automatically, and the new curated entries hold the \`_CURATED_RECOMMENDED_SAMPLING\` pin.
- [x] \`python3.12 -m pytest tests/test_cli_argcomplete.py -x\` — 16 tests pass; tab-completer continues to match the \`gemma-4-*\` prefix correctly.
- [x] Manual reachability: both HF paths return HTTP 200 (\`mlx-community/gemma-4-e2b-it-4bit\` and \`mlx-community/gemma-4-e4b-it-4bit\`).
- [x] \`python -c 'import json; json.load(open("vllm_mlx/aliases.json"))'\` — JSON parses cleanly as 77-alias dict including the 2 new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)