### PR TITLE
chore: bump version to 0.7.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.17"
+version = "0.7.18"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cuts v0.7.18 — bundles three merged-since-0.7.15 PRs into a single release tag (auto-release.yml fires off `chore: bump version to X.Y.Z` subject; intermediate bumps in #564 + #614 silently advanced pyproject without tagging).

### Included since v0.7.15

- **#564** — `chore(aliases): drop gemma-3n-e4b-4bit (over-aligned, refuses real-world queries)`
- **#612** — `fix(scheduler+build): #611 ignore_eos reuse key + #230 sidecar .pyc seal` — closes Rapid-MLX [#611](https://github.com/raullenchai/Rapid-MLX/issues/611) and rapid-desktop [#230](https://github.com/machinefi/rapid-desktop/issues/230)
- **#614** — `feat(aliases): expose 4 popular Tier 1 mlx-community models`

### Release SOP gates (pre-flight)

- [x] **G1** `make release-smoke` — clean-venv install + import of `vllm_mlx`, `.scheduler`, `.server`, `.cli`, `.benchmark` → PASS
- [x] **G2** Codex review × 2 rounds — r1 + r2 on PR #612 (r1 found one P2 → fixed → r2 clean)
- [x] **G3** `python3.12 scripts/audit_cli_config_fidelity.py` → `CLI ↔ Config fidelity: OK` (exit 0)
- [x] **G4** `make smoke` — lint + audit + 1933 unit tests → 3/3 PASS (85.7s)
- [x] **G5** `python3.12 scripts/dev_test.py stress --port 8765` against live qwen3.5-4b-4bit → 8/8 PASS (37.5s)
- [x] **G6** Repro of the #611 fix path on live server: ignore_eos=true probe followed by normal chat — chat finished with `finish_reason: stop` and content `"ok"` (without the fix it would have inherited empty `stop_tokens` and run to `max_tokens`)
- [ ] G7 SDK integrations — skipped (no parser / API surface touched since 0.7.15)
- [ ] G8 micro-bench of changed code path — skipped (#611 fix is scheduler bookkeeping, not on the per-token hot path; #230 fix is build-only; #564/#614 are aliases.json)
- [x] **G9** 10 sequential `/v1/completions` requests on live qwen3.5-4b-4bit: mean 136.5 tok/s, median 137.4, one 110 outlier — within Qwen3.5-4B baseline ±20%
- [ ] G10 cross-chip-family gate — NOT TRIGGERED (no mlx / mlx-lm / mlx-vlm / mlx-metal pin bumps since 0.7.15; current floors mlx≥0.29.0, mlx-lm≥0.31.0, mlx-vlm≥0.6.3 unchanged)
- [ ] G11 auto-routing escape-hatch gate — NOT TRIGGERED (no new `is_*_model()` helpers / auto-detection added)

## Test plan

- [x] All applicable SOP gates green pre-flight (above)
- [x] CI green (lint, type-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, sidecar build, validate)
- [x] Pre-existing #564 + #614 already merged and shipped on main; this PR is the version-bump trailer

After merge: auto-release.yml tags `v0.7.18` and publish.yml fans out to PyPI + Homebrew. Then rapid-desktop submodule bumps to this tag for the v0.7.0 launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)