### PR TITLE
refactor(bench+doctor): lift model-validation checks from doctor/checks/ to bench/tiers/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.20"
+version = "0.7.21"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -1551,9 +1551,9 @@ LOAD_MODEL_ENTRYPOINT_EXEMPTIONS: frozenset[str] = frozenset(
         # Doctor harness — runs internal probes, not user-facing
         # request serving. The doctor checks own routing via the
         # serve command they spawn.
-        "doctor/checks/perf.py",
-        "doctor/checks/api.py",
-        "doctor/checks/benchmark.py",
+        "bench/tiers/perf.py",
+        "bench/tiers/api.py",
+        "bench/tiers/benchmark.py",
         "doctor/checks/load.py",
         "doctor/server.py",
         # Eval harness — bench / scoring tool, not a serving entrypoint.

--- a/vllm_mlx/bench/__init__.py
+++ b/vllm_mlx/bench/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-validation benchmarks.
+
+This package owns the model-side checks (smoke/speed/harness/stress/agents)
+that used to live under ``vllm_mlx.doctor.checks``.  ``doctor`` is now
+strictly environment-health; anything that boots a server or measures a
+model belongs here.
+"""

--- a/vllm_mlx/bench/tiers/__init__.py
+++ b/vllm_mlx/bench/tiers/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark tiers — one module per validation category.
+
+Each module exposes ``check_*`` / ``benchmark_*`` functions consumed by
+``vllm_mlx.doctor.cli`` (today) and ``vllm_mlx.bench.cli`` (later PR).
+"""
+
+from . import agent, api, benchmark, perf, smoke, stress
+
+__all__ = ["agent", "api", "benchmark", "perf", "smoke", "stress"]

--- a/vllm_mlx/bench/tiers/agent.py
+++ b/vllm_mlx/bench/tiers/agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import time
 
-from ..runner import CheckResult, Status
+from ...doctor.runner import CheckResult, Status
 
 
 def check_agent_profile(
@@ -22,7 +22,7 @@ def check_agent_profile(
     """
     t0 = time.perf_counter()
     try:
-        # Three dots: vllm_mlx/doctor/checks/ → vllm_mlx/agents/
+        # Three dots: vllm_mlx/bench/tiers/ → vllm_mlx/agents/
         from ...agents import get_profile
         from ...agents.testing import AgentTestRunner, TestStatus
     except ImportError as e:

--- a/vllm_mlx/bench/tiers/api.py
+++ b/vllm_mlx/bench/tiers/api.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 
 import time
 
-from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+from ...doctor.runner import (
+    REPO_ROOT,
+    CheckResult,
+    Status,
+    python_executable,
+    run_subprocess,
+)
 
 
 def check_smoke_matrix(port: int) -> CheckResult:

--- a/vllm_mlx/bench/tiers/benchmark.py
+++ b/vllm_mlx/bench/tiers/benchmark.py
@@ -7,7 +7,13 @@ import json
 import os
 import time
 
-from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+from ...doctor.runner import (
+    REPO_ROOT,
+    CheckResult,
+    Status,
+    python_executable,
+    run_subprocess,
+)
 
 
 def benchmark_one_cell(

--- a/vllm_mlx/bench/tiers/perf.py
+++ b/vllm_mlx/bench/tiers/perf.py
@@ -7,7 +7,13 @@ import json
 import os
 import time
 
-from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+from ...doctor.runner import (
+    REPO_ROOT,
+    CheckResult,
+    Status,
+    python_executable,
+    run_subprocess,
+)
 
 
 def check_autoresearch(port: int, runs: int = 1) -> CheckResult:

--- a/vllm_mlx/bench/tiers/smoke.py
+++ b/vllm_mlx/bench/tiers/smoke.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+from ...doctor.runner import (
+    REPO_ROOT,
+    CheckResult,
+    Status,
+    python_executable,
+    run_subprocess,
+)
 
 
 def check_pytest_unit() -> CheckResult:

--- a/vllm_mlx/bench/tiers/stress.py
+++ b/vllm_mlx/bench/tiers/stress.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 import re
 import time
 
-from ..runner import REPO_ROOT, CheckResult, Status, python_executable, run_subprocess
+from ...doctor.runner import (
+    REPO_ROOT,
+    CheckResult,
+    Status,
+    python_executable,
+    run_subprocess,
+)
 
 
 def check_stress(port: int) -> CheckResult:

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -130,7 +130,7 @@ def run_smoke_tier():
 
 def run_check_tier(model: str, update_baselines: bool = False):
     """Boot a server with ``model`` and run API + perf + agent checks."""
-    from .checks import smoke
+    from ..bench.tiers import smoke
 
     print(f"Rapid-MLX Doctor — check tier (model={model})")
     print("=" * 60)
@@ -158,7 +158,7 @@ def run_check_tier(model: str, update_baselines: bool = False):
 
 def run_full_tier(models: list[str], update_baselines: bool = False):
     """Loop check-tier work across multiple models + run all agent profiles."""
-    from .checks import smoke
+    from ..bench.tiers import smoke
 
     print(f"Rapid-MLX Doctor — full tier (models={', '.join(models)})")
     print("=" * 60)
@@ -249,7 +249,7 @@ def _run_per_model_block(
     See the constant's docstring for why a single generous value beats
     every per-model / per-tier heuristic we tried.
     """
-    from .checks import agent, api, perf, stress
+    from ..bench.tiers import agent, api, perf, stress
     from .server import ServerStartFailed, serve
 
     if boot_timeout_s is None:
@@ -330,7 +330,7 @@ def run_benchmark_tier(models: list[str] | None = None):
     'latest.md' alias.  Designed to be runnable overnight — no agent
     profile sweep, no baseline diff, just numbers for the table.
     """
-    from .checks import benchmark, smoke
+    from ..bench.tiers import benchmark, smoke
     from .discovery import discover_local_models, load_aliases
     from .scorecard import render_scorecard, write_scorecard
     from .server import ServerStartFailed, serve


### PR DESCRIPTION
## Summary

**PR 1 of 4** — re-architecting `doctor` (env-health) vs `bench` (model-validation); **zero behavior change in this PR.** This PR is the prep step that lifts the benchmark-flavored modules out of `doctor/checks/` so a later PR can slim down `doctor` and another can wire `bench --tier smoke|speed|harness`.

## File moves

| From | To |
|---|---|
| `vllm_mlx/doctor/checks/smoke.py` | `vllm_mlx/bench/tiers/smoke.py` |
| `vllm_mlx/doctor/checks/perf.py` | `vllm_mlx/bench/tiers/perf.py` |
| `vllm_mlx/doctor/checks/benchmark.py` | `vllm_mlx/bench/tiers/benchmark.py` |
| `vllm_mlx/doctor/checks/stress.py` | `vllm_mlx/bench/tiers/stress.py` |
| `vllm_mlx/doctor/checks/agent.py` | `vllm_mlx/bench/tiers/agent.py` |
| `vllm_mlx/doctor/checks/api.py` | `vllm_mlx/bench/tiers/api.py` |

`user.py` stays in `doctor/checks/` — it is the only true env-health probe.

## Option chosen: A (direct import update)

`vllm_mlx/doctor/cli.py` import paths now point at the new package (`from ..bench.tiers import smoke, perf, benchmark, stress, agent, api`). No re-export shim files were left behind in `doctor/checks/`. Cleaner diff for PR #4; no import cycles found.

Inside the moved modules, `from ..runner import ...` was rewritten to `from ...doctor.runner import ...` because the relative path now traverses `vllm_mlx/bench/tiers/` → `vllm_mlx/doctor/`. `REPO_ROOT` (used by `perf`, `benchmark`, `stress`, `api`, `smoke`) is an absolute path resolved from `pyproject.toml`, so script references in `scripts/` and `tests/` continue to work unchanged.

## Side-fix included

`tests/test_no_mllm_flag.py` has a `LOAD_MODEL_ENTRYPOINT_EXEMPTIONS` set keyed by relative path. The three entries that point at moved files (`perf.py`, `api.py`, `benchmark.py`) were updated to `bench/tiers/…`. The pre-existing `doctor/checks/load.py` entry (file does not exist; harmless no-op) was left untouched — out of scope.

## Version bump

`0.7.20` → `0.7.21` (version-check guard requirement).

## Test plan

- [x] `python3.12 -m pytest tests/ -q --ignore=tests/integrations --ignore=tests/test_event_loop.py` — 5273 passed / 18 skipped / 7 xfailed
- [x] `tests/test_event_loop.py` failure is pre-existing on `main` (requires a live server at `127.0.0.1:8000`); not caused by this PR
- [x] `python3.12 -c "import vllm_mlx.doctor.cli; import vllm_mlx.bench.tiers"` — clean
- [x] `python3.12 -m vllm_mlx.cli doctor` — smoke tier still runs (PASS)
- [x] `rapid-mlx doctor benchmark --help` — surface unchanged
- [x] No import cycles introduced
- [x] Version bumped 0.7.20 → 0.7.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)