### PR TITLE
feat(community-bench): schema v2 with tier-tagged smoke/harness results

### DIFF
--- a/community-benchmarks/schema.json
+++ b/community-benchmarks/schema.json
@@ -18,8 +18,8 @@
   "properties": {
     "schema_version": {
       "type": "integer",
-      "const": 1,
-      "description": "Bump when the schema changes incompatibly. Aggregator skips rows it doesn't understand."
+      "enum": [1, 2],
+      "description": "Bump when the schema changes incompatibly. Aggregator skips rows it doesn't understand. v1 = speed buckets only. v2 = optional tier-tagged smoke + harness results alongside speed (when ``tier == 'smoke'|'harness'|'all'``); a v2 submission with no new fields is the SAME wire shape as v1 minus the version integer."
     },
     "submission_id": {
       "type": "string",
@@ -185,8 +185,92 @@
       "type": ["integer", "null"],
       "minimum": 0,
       "description": "Max of `mx.metal.get_active_memory()` observed across all measured rounds, in MiB. null if unavailable."
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["speed", "smoke", "harness", "all"],
+      "description": "v2 only. Which bench tier produced this submission. ``speed`` (default if absent) = the historical short+long buckets — wire-shape identical to v1. ``smoke`` = single-prompt boot probe; populates ``smoke_result``. ``harness`` = adversarial CLI-harness gauntlet; populates ``harness_result``. ``all`` = all three. The aggregator decides which views to render off the tier tag; missing tier on a v2 payload is treated as ``speed`` for backwards compatibility with v1 submitters who just bumped the version integer."
+    },
+    "smoke_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["boot_time_ms", "first_prompt_ok", "first_token_latency_ms", "response_excerpt"],
+      "properties": {
+        "boot_time_ms": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Wall-clock from `rapid-mlx serve` start to the moment the model accepts requests."
+        },
+        "first_prompt_ok": {
+          "type": "boolean",
+          "description": "True iff the first single-prompt smoke probe returned a non-empty response without error."
+        },
+        "first_token_latency_ms": {
+          "type": "number",
+          "minimum": 0,
+          "description": "TTFT for the smoke probe in milliseconds. Distinct from the speed-bucket TTFT (which is a per-round median over 5 measured rounds against a synthetic 512/2048-token prompt)."
+        },
+        "response_excerpt": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "First ≤200 chars of the smoke response. Truncated for privacy/size; the aggregator displays it verbatim for sanity review."
+        }
+      },
+      "description": "v2 only. Boot + first-prompt smoke probe result. Required iff ``tier`` is ``smoke`` or ``all``; absent for tier=speed and tier=harness."
+    },
+    "harness_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["codex", "opencode", "hermes", "aider", "langchain"],
+      "properties": {
+        "codex":     {"$ref": "#/$defs/harnessAdapterResult"},
+        "opencode":  {"$ref": "#/$defs/harnessAdapterResult"},
+        "hermes":    {"$ref": "#/$defs/harnessAdapterResult"},
+        "aider":     {"$ref": "#/$defs/harnessAdapterResult"},
+        "langchain": {"$ref": "#/$defs/harnessAdapterResult"}
+      },
+      "description": "v2 only. Per-adapter results from the agent-harness gauntlet. Required iff ``tier`` is ``harness`` or ``all``; absent for tier=speed and tier=smoke. Each entry carries a pass/fail flag, the round-trip duration, and a short error excerpt on failure (null on pass)."
     }
   },
+  "allOf": [
+    {
+      "comment": "v2 conditional: when tier requires smoke_result/harness_result, enforce presence. v1 submissions skip these branches entirely (the if-clause requires schema_version==2 AND the relevant tier value).",
+      "if": {
+        "properties": {
+          "schema_version": {"const": 2},
+          "tier": {"enum": ["smoke", "all"]}
+        },
+        "required": ["schema_version", "tier"]
+      },
+      "then": {"required": ["smoke_result"]}
+    },
+    {
+      "if": {
+        "properties": {
+          "schema_version": {"const": 2},
+          "tier": {"enum": ["harness", "all"]}
+        },
+        "required": ["schema_version", "tier"]
+      },
+      "then": {"required": ["harness_result"]}
+    },
+    {
+      "comment": "v1 has none of the v2 fields. Reject v1 payloads that try to smuggle in tier/smoke_result/harness_result so the wire shape stays unambiguous.",
+      "if": {
+        "properties": {"schema_version": {"const": 1}},
+        "required": ["schema_version"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {"required": ["tier"]},
+            {"required": ["smoke_result"]},
+            {"required": ["harness_result"]}
+          ]
+        }
+      }
+    }
+  ],
   "$defs": {
     "bucketResult": {
       "type": "object",
@@ -228,6 +312,27 @@
         "min": {"type": "number", "minimum": 0},
         "max": {"type": "number", "minimum": 0},
         "stddev": {"type": "number", "minimum": 0}
+      }
+    },
+    "harnessAdapterResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "duration_s", "error_excerpt"],
+      "properties": {
+        "passed": {
+          "type": "boolean",
+          "description": "True iff the adapter completed the harness scenario end-to-end without raising."
+        },
+        "duration_s": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Wall-clock duration of the adapter run in seconds. Recorded even on failure so reviewers can spot adapters that hang vs adapters that fail fast."
+        },
+        "error_excerpt": {
+          "type": ["string", "null"],
+          "maxLength": 200,
+          "description": "First ≤200 chars of the adapter's error output. ``null`` on success; non-null short string on failure. Kept tight so a stack-trace-spammy adapter doesn't bloat the submission file."
+        }
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.21"
+version = "0.7.22"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_payload_builder_v2_full.py
+++ b/tests/test_payload_builder_v2_full.py
@@ -32,8 +32,7 @@ def _stub_inputs():
     hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
     sw = Software(macos="26.5.1", rapid_mlx="0.7.6", mlx="0.31.2", python="3.12.13")
     rounds = [
-        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
-        for _ in range(5)
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0) for _ in range(5)
     ]
     bench = BenchResult(
         short=BucketResult(rounds_raw=rounds),
@@ -52,11 +51,15 @@ _SMOKE = {
     "response_excerpt": "The capital of France is Paris.",
 }
 _HARNESS = {
-    "codex":     {"passed": True,  "duration_s": 11.4, "error_excerpt": None},
-    "opencode":  {"passed": True,  "duration_s":  9.8, "error_excerpt": None},
-    "hermes":    {"passed": False, "duration_s":  3.1, "error_excerpt": "tool_call schema mismatch"},
-    "aider":     {"passed": True,  "duration_s": 14.2, "error_excerpt": None},
-    "langchain": {"passed": True,  "duration_s": 18.5, "error_excerpt": None},
+    "codex": {"passed": True, "duration_s": 11.4, "error_excerpt": None},
+    "opencode": {"passed": True, "duration_s": 9.8, "error_excerpt": None},
+    "hermes": {
+        "passed": False,
+        "duration_s": 3.1,
+        "error_excerpt": "tool_call schema mismatch",
+    },
+    "aider": {"passed": True, "duration_s": 14.2, "error_excerpt": None},
+    "langchain": {"passed": True, "duration_s": 18.5, "error_excerpt": None},
 }
 
 

--- a/tests/test_payload_builder_v2_full.py
+++ b/tests/test_payload_builder_v2_full.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``build_submission_payload(tier='all', smoke_result=..., harness_result=...)``
+populates all three sections AND the result validates against the
+schema.
+
+This is the future-state path that PR #4 (or wherever
+``bench --tier all --submit`` gets wired in) will call. We test the
+builder here so that downstream wiring only needs to verify that it
+*calls* the builder correctly — the payload shape is locked in.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+
+
+def _stub_inputs():
+    from vllm_mlx.community_bench.hardware import Hardware, Software
+    from vllm_mlx.community_bench.runner import (
+        BenchResult,
+        BucketResult,
+        RoundResult,
+    )
+
+    hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
+    sw = Software(macos="26.5.1", rapid_mlx="0.7.6", mlx="0.31.2", python="3.12.13")
+    rounds = [
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
+        for _ in range(5)
+    ]
+    bench = BenchResult(
+        short=BucketResult(rounds_raw=rounds),
+        long=BucketResult(rounds_raw=rounds),
+        peak_ram_mb=8192,
+        prompt_hash="deadbeefcafebabe",
+        sampling="greedy",
+    )
+    return hw, sw, bench
+
+
+_SMOKE = {
+    "boot_time_ms": 1234.5,
+    "first_prompt_ok": True,
+    "first_token_latency_ms": 87.0,
+    "response_excerpt": "The capital of France is Paris.",
+}
+_HARNESS = {
+    "codex":     {"passed": True,  "duration_s": 11.4, "error_excerpt": None},
+    "opencode":  {"passed": True,  "duration_s":  9.8, "error_excerpt": None},
+    "hermes":    {"passed": False, "duration_s":  3.1, "error_excerpt": "tool_call schema mismatch"},
+    "aider":     {"passed": True,  "duration_s": 14.2, "error_excerpt": None},
+    "langchain": {"passed": True,  "duration_s": 18.5, "error_excerpt": None},
+}
+
+
+def _build_full() -> dict:
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    hw, sw, bench = _stub_inputs()
+    return build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes="full-tier smoke",
+        now=datetime(2026, 6, 15, 10, 30, 0, tzinfo=timezone.utc),
+        tier="all",
+        smoke_result=_SMOKE,
+        harness_result=_HARNESS,
+    )
+
+
+def test_full_payload_has_all_three_sections() -> None:
+    payload = _build_full()
+    assert payload["schema_version"] == 2
+    assert payload["tier"] == "all"
+    assert payload["smoke_result"] == _SMOKE
+    assert payload["harness_result"] == _HARNESS
+    # The speed buckets MUST still be present alongside the new
+    # sections — tier='all' is additive, not "this is a non-speed run".
+    assert "buckets" in payload
+    assert {"short", "long"} <= payload["buckets"].keys()
+
+
+def test_full_payload_validates_against_schema() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=_build_full(), schema=schema)
+
+
+def test_tier_smoke_alone_validates() -> None:
+    """``tier='smoke'`` populates only smoke_result; harness_result is
+    omitted entirely. Must validate."""
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    hw, sw, bench = _stub_inputs()
+    payload = build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes=None,
+        now=datetime(2026, 6, 15, tzinfo=timezone.utc),
+        tier="smoke",
+        smoke_result=_SMOKE,
+    )
+    assert payload["tier"] == "smoke"
+    assert payload["smoke_result"] == _SMOKE
+    assert "harness_result" not in payload
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_tier_harness_alone_validates() -> None:
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    hw, sw, bench = _stub_inputs()
+    payload = build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes=None,
+        now=datetime(2026, 6, 15, tzinfo=timezone.utc),
+        tier="harness",
+        harness_result=_HARNESS,
+    )
+    assert payload["tier"] == "harness"
+    assert payload["harness_result"] == _HARNESS
+    assert "smoke_result" not in payload
+    jsonschema.validate(instance=payload, schema=schema)

--- a/tests/test_payload_builder_v2_kwargs.py
+++ b/tests/test_payload_builder_v2_kwargs.py
@@ -46,8 +46,7 @@ def _stub_inputs():
     hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
     sw = Software(macos="26.5.1", rapid_mlx="0.7.6", mlx="0.31.2", python="3.12.13")
     rounds = [
-        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
-        for _ in range(5)
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0) for _ in range(5)
     ]
     bench = BenchResult(
         short=BucketResult(rounds_raw=rounds),

--- a/tests/test_payload_builder_v2_kwargs.py
+++ b/tests/test_payload_builder_v2_kwargs.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``build_submission_payload`` v2 kwarg contract.
+
+The existing ``--submit`` flow calls ``build_submission_payload``
+without the new v2 kwargs. After bumping ``SCHEMA_VERSION`` to 2 and
+adding the kwargs, that flow MUST keep producing the same wire shape
+it always did — modulo the version integer itself.
+
+This pins three properties:
+
+1. Default-kwargs ``build_submission_payload`` produces a payload
+   identical to a v1 payload except for ``schema_version`` (now 2).
+2. ``tier="speed"`` produces a payload with ``"tier": "speed"`` added
+   and nothing else changed.
+3. The payload still validates against the v2 schema.
+
+If any of these break, a contributor who upgrades their CLI but
+doesn't change their workflow has their submissions silently rejected
+or — worse — silently mislabelled.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+
+
+def _stub_inputs():
+    """Recreate the synthetic Hardware/Software/BenchResult bundle that
+    the existing ``tests/test_community_bench.py`` uses for payload tests.
+    Keeping the inputs in lockstep here avoids cross-test imports.
+    """
+    from vllm_mlx.community_bench.hardware import Hardware, Software
+    from vllm_mlx.community_bench.runner import (
+        BenchResult,
+        BucketResult,
+        RoundResult,
+    )
+
+    hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
+    sw = Software(macos="26.5.1", rapid_mlx="0.7.6", mlx="0.31.2", python="3.12.13")
+    rounds = [
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
+        for _ in range(5)
+    ]
+    bench = BenchResult(
+        short=BucketResult(rounds_raw=rounds),
+        long=BucketResult(rounds_raw=rounds),
+        peak_ram_mb=8192,
+        prompt_hash="deadbeefcafebabe",
+        sampling="greedy",
+    )
+    return hw, sw, bench
+
+
+def _build(tier=None, smoke_result=None, harness_result=None) -> dict:
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    hw, sw, bench = _stub_inputs()
+    return build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes="unit test",
+        now=datetime(2026, 6, 15, 10, 30, 0, tzinfo=timezone.utc),
+        tier=tier,
+        smoke_result=smoke_result,
+        harness_result=harness_result,
+    )
+
+
+def test_default_kwargs_emit_no_v2_only_fields() -> None:
+    """No tier kwarg ⇒ no tier / smoke_result / harness_result in the
+    wire shape. This is what makes a default-flow v2 submission a
+    drop-in superset of v1.
+    """
+    payload = _build()
+    assert "tier" not in payload
+    assert "smoke_result" not in payload
+    assert "harness_result" not in payload
+
+
+def test_default_kwargs_match_v1_modulo_version() -> None:
+    """The byte-level snapshot: pop the version integer and the payload
+    is identical to what the same call produced under v1 (which we
+    reconstruct here by mutating the version to 1).
+    """
+    payload = _build()
+    assert payload["schema_version"] == 2
+    # ``submission_id`` is uuid4-derived so it's not byte-stable across
+    # runs; everything else IS deterministic given the frozen ``now``,
+    # the hardcoded sampling, and the synthetic bench result.
+    payload.pop("submission_id")
+    payload["schema_version"] = 1  # the only legitimate v1↔v2 delta
+    expected = {
+        "schema_version": 1,
+        "submitted_at": "2026-06-15T10:30:00+00:00",
+        "hardware": {
+            "chip": "Apple M4 Pro",
+            "ram_gb": 24,
+            "cpu_cores": 12,
+            "gpu_cores": 20,
+        },
+        "software": {
+            "macos": "26.5.1",
+            "rapid_mlx": "0.7.6",
+            "mlx": "0.31.2",
+            "python": "3.12.13",
+        },
+        "model": {
+            "alias": "qwen3.5-9b-4bit",
+            "hf_path": "mlx-community/Qwen3.5-9B-4bit",
+        },
+        # config / buckets are tested for shape by
+        # ``test_build_payload_matches_schema`` in the existing suite;
+        # here we only need the v1-equivalence delta, not the full
+        # nested literal.
+        "config": payload["config"],
+        "buckets": payload["buckets"],
+        "notes": "unit test",
+        "peak_ram_mb": 8192,
+    }
+    assert payload == expected
+
+
+def test_tier_speed_emits_only_tier_field() -> None:
+    """Explicit ``tier="speed"`` adds nothing other than the tier
+    string itself. This is the path PR #2 will route the existing
+    ``--submit`` flow through.
+    """
+    payload = _build(tier="speed")
+    assert payload["tier"] == "speed"
+    assert "smoke_result" not in payload
+    assert "harness_result" not in payload
+
+
+def test_tier_speed_payload_validates_against_v2_schema() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=_build(tier="speed"), schema=schema)
+
+
+def test_default_kwargs_payload_validates_against_v2_schema() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=_build(), schema=schema)
+
+
+def test_invalid_tier_value_raises() -> None:
+    """Builder validates tier values at the boundary — the schema check
+    in CI would also catch this, but failing in-process gives the
+    future CLI dispatcher a clean ``ValueError`` to report.
+    """
+    with pytest.raises(ValueError, match="tier must be one of"):
+        _build(tier="totally-made-up")
+
+
+def test_tier_smoke_without_smoke_result_raises() -> None:
+    """Boundary check: ``tier='smoke'`` without the matching result
+    block is a misuse, not an empty bucket."""
+    with pytest.raises(ValueError, match="smoke_result"):
+        _build(tier="smoke")
+
+
+def test_tier_harness_without_harness_result_raises() -> None:
+    with pytest.raises(ValueError, match="harness_result"):
+        _build(tier="harness")
+
+
+def test_smoke_result_without_smoke_tier_raises() -> None:
+    """The inverse: passing data with no matching tier is a mislabel."""
+    smoke = {
+        "boot_time_ms": 100.0,
+        "first_prompt_ok": True,
+        "first_token_latency_ms": 10.0,
+        "response_excerpt": "ok",
+    }
+    with pytest.raises(ValueError, match="smoke_result was provided"):
+        _build(tier="speed", smoke_result=smoke)
+
+
+def test_harness_result_without_harness_tier_raises() -> None:
+    harness = {
+        adapter: {"passed": True, "duration_s": 1.0, "error_excerpt": None}
+        for adapter in ("codex", "opencode", "hermes", "aider", "langchain")
+    }
+    with pytest.raises(ValueError, match="harness_result was provided"):
+        _build(tier="speed", harness_result=harness)

--- a/tests/test_schema_v2_accepts_minimal_v2.py
+++ b/tests/test_schema_v2_accepts_minimal_v2.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Schema v2 minimal-shape acceptance: a payload that only bumps
+``schema_version`` to 2 (and otherwise carries the exact v1 fields)
+must validate.
+
+This is the contract the aggregator banks on: an aggregator that
+understands v2 can treat a minimal v2 row identically to a v1 row,
+because the only difference on the wire is the integer in the version
+slot. Without this guarantee, contributors who upgrade their CLI but
+don't run the new ``--tier`` flag would suddenly be unable to submit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+SUBMISSIONS_DIR = REPO_ROOT / "community-benchmarks" / "submissions"
+
+
+def _first_v1_payload() -> dict:
+    """Read any existing v1 submission as a realistic starting point.
+
+    Building one by hand from scratch would force us to track every
+    ``const`` / ``required`` field the schema enforces — and the schema
+    is the contract under test. Reusing a real v1 payload keeps the
+    test honest: anything beyond the version bump is unchanged.
+    """
+    files = sorted(SUBMISSIONS_DIR.glob("*.json"))
+    if not files:
+        pytest.skip("no existing v1 submissions to base the test on")
+    return json.loads(files[0].read_text())
+
+
+def test_v2_minimal_payload_validates() -> None:
+    """A v2 payload with no new fields populated is just a v1 payload
+    with ``schema_version: 2``. It MUST validate.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _first_v1_payload()
+    payload["schema_version"] = 2
+    # No tier / smoke_result / harness_result — this is the "minimal v2"
+    # case the aggregator must treat identically to v1.
+
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_v2_payload_with_tier_speed_validates() -> None:
+    """Explicit ``tier: 'speed'`` is the legacy bench tier label and
+    must NOT require smoke_result/harness_result. This is the path the
+    existing ``--submit`` flow will take once PR #2 routes
+    ``--tier speed --submit`` through ``build_submission_payload``.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _first_v1_payload()
+    payload["schema_version"] = 2
+    payload["tier"] = "speed"
+
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_v2_payload_with_full_tier_all_validates() -> None:
+    """``tier: 'all'`` + populated smoke + harness is the full v2 row."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _first_v1_payload()
+    payload["schema_version"] = 2
+    payload["tier"] = "all"
+    payload["smoke_result"] = {
+        "boot_time_ms": 1234.0,
+        "first_prompt_ok": True,
+        "first_token_latency_ms": 87.5,
+        "response_excerpt": "Hello! I'd be happy to help.",
+    }
+    payload["harness_result"] = {
+        adapter: {"passed": True, "duration_s": 12.3, "error_excerpt": None}
+        for adapter in ("codex", "opencode", "hermes", "aider", "langchain")
+    }
+
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_v1_payload_with_v2_field_is_rejected() -> None:
+    """A v1 payload carrying a v2-only field is ambiguous (aggregator
+    would have to guess which tier produced it). The ``allOf`` block in
+    the schema enforces this rejection so the wire shape per version
+    stays unambiguous.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _first_v1_payload()
+    # schema_version stays 1 — but we sneak in a v2-only field.
+    payload["tier"] = "speed"
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)

--- a/tests/test_schema_v2_accepts_v1.py
+++ b/tests/test_schema_v2_accepts_v1.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Schema v2 backwards-compatibility: every existing v1 submission file
+on disk must continue to validate against the v2 schema.
+
+Schema evolution from v1 → v2 is *additive only* — three optional
+top-level fields (``tier``, ``smoke_result``, ``harness_result``) plus a
+widened ``schema_version`` enum (``[1, 2]``). The historical v1
+submissions in ``community-benchmarks/submissions/`` are the regression
+corpus. If any of them ever stop validating, the evolution stopped
+being additive and the schema change is wrong.
+
+We re-validate by importing ``jsonschema`` directly rather than
+shelling out to ``scripts/validate.py`` because we only want the
+*schema* gate exercised here — the alias / sanity / dedup gates are
+covered by the existing ``test_community_bench.py`` corpus tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+SUBMISSIONS_DIR = REPO_ROOT / "community-benchmarks" / "submissions"
+
+
+def _existing_submissions() -> list[Path]:
+    """Every JSON file in ``community-benchmarks/submissions/``.
+
+    Empty list short-circuits the parametrize loop — pytest will skip
+    the test rather than report zero collected, so the harness still
+    reports a clean run on a fresh checkout that hasn't accumulated
+    submissions yet.
+    """
+    if not SUBMISSIONS_DIR.exists():
+        return []
+    return sorted(SUBMISSIONS_DIR.glob("*.json"))
+
+
+@pytest.mark.parametrize(
+    "submission_path",
+    _existing_submissions(),
+    ids=lambda p: p.name,
+)
+def test_existing_v1_submission_validates_against_v2_schema(
+    submission_path: Path,
+) -> None:
+    """Each v1 file in the corpus must validate against the v2 schema.
+
+    The schema's ``schema_version`` enum was widened from ``const: 1``
+    to ``enum: [1, 2]``; existing files keep ``schema_version: 1`` and
+    none of the new ``tier`` / ``smoke_result`` / ``harness_result``
+    fields. The top-level ``allOf`` includes a guard that REJECTS v1
+    payloads carrying any v2-only field, so a v1 file that accidentally
+    started using the new fields would fail loudly. Neither of those
+    fixture files does — this test is the regression for that.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    payload = json.loads(submission_path.read_text())
+    # Sanity: each corpus file we're guarding really IS a v1 payload.
+    # If this ever flips to 2, the test below is no longer testing
+    # backwards compatibility — it's just self-checking v2.
+    assert payload["schema_version"] == 1, (
+        f"{submission_path.name} is not a v1 submission anymore; "
+        f"move it out of the v1 regression set."
+    )
+    # Will raise jsonschema.ValidationError if the schema rejects it.
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_corpus_is_nonempty() -> None:
+    """Belt-and-braces: if the v1 corpus is empty, the parametrize
+    loop above silently does nothing. Fail explicitly so a future
+    accidental ``rm`` of the submissions dir doesn't hide a schema
+    regression behind a green CI.
+    """
+    files = _existing_submissions()
+    assert len(files) >= 2, (
+        f"Expected at least the two seed v1 submissions in "
+        f"{SUBMISSIONS_DIR}; found {len(files)}. The v1 regression "
+        f"corpus must stay populated."
+    )

--- a/tests/test_schema_v2_rejects_partial_harness.py
+++ b/tests/test_schema_v2_rejects_partial_harness.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Schema v2 tier ↔ result invariants: when ``tier`` declares a bucket,
+the matching result block MUST be present.
+
+Two invariants enforced by the top-level ``allOf`` in
+``community-benchmarks/schema.json``:
+
+1. ``tier in ("smoke", "all")``    → ``smoke_result`` required.
+2. ``tier in ("harness", "all")`` → ``harness_result`` required.
+
+Without these checks, an aggregator can't tell whether a missing block
+means "this tier didn't run" or "the tier ran but the data was lost".
+Both interpretations corrupt the dashboard.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+SUBMISSIONS_DIR = REPO_ROOT / "community-benchmarks" / "submissions"
+
+
+def _v2_base_payload() -> dict:
+    """Realistic v2-shaped starting payload: a real v1 row with the
+    version bumped. Tests below populate the tier/result fields."""
+    files = sorted(SUBMISSIONS_DIR.glob("*.json"))
+    if not files:
+        pytest.skip("no existing v1 submissions to base the test on")
+    payload = json.loads(files[0].read_text())
+    payload["schema_version"] = 2
+    return payload
+
+
+_VALID_SMOKE = {
+    "boot_time_ms": 1234.0,
+    "first_prompt_ok": True,
+    "first_token_latency_ms": 87.5,
+    "response_excerpt": "Hello!",
+}
+_VALID_HARNESS = {
+    adapter: {"passed": True, "duration_s": 12.3, "error_excerpt": None}
+    for adapter in ("codex", "opencode", "hermes", "aider", "langchain")
+}
+
+
+def test_tier_harness_without_harness_result_rejected() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "harness"
+    # No harness_result populated — must fail.
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=payload, schema=schema)
+    # Make sure the error fingerprint identifies the missing field —
+    # otherwise a schema bug could trip "rejected" via the wrong path
+    # (e.g. ``tier`` value rejected) and the test would pass for the
+    # wrong reason.
+    assert "harness_result" in str(excinfo.value)
+
+
+def test_tier_smoke_without_smoke_result_rejected() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "smoke"
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=payload, schema=schema)
+    assert "smoke_result" in str(excinfo.value)
+
+
+def test_tier_all_without_either_result_rejected() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "all"
+    # Neither smoke_result nor harness_result. Must fail on the FIRST
+    # missing field that jsonschema reports — both invariants apply.
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_tier_all_with_only_smoke_rejected() -> None:
+    """``tier=all`` requires BOTH blocks; only one is still partial."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "all"
+    payload["smoke_result"] = _VALID_SMOKE
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=payload, schema=schema)
+    assert "harness_result" in str(excinfo.value)
+
+
+def test_harness_result_missing_adapter_rejected() -> None:
+    """Every one of the five adapter slots is required when
+    ``harness_result`` is populated. Omitting one would let a
+    contributor publish a partial gauntlet result.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "harness"
+    partial = dict(_VALID_HARNESS)
+    del partial["langchain"]
+    payload["harness_result"] = partial
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=payload, schema=schema)
+    assert "langchain" in str(excinfo.value)
+
+
+def test_harness_result_extra_adapter_rejected() -> None:
+    """``additionalProperties: false`` on ``harness_result`` rejects
+    unknown adapter slots — otherwise a contributor could ship an
+    ad-hoc adapter the dashboard would silently ignore.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "harness"
+    extra = dict(_VALID_HARNESS)
+    extra["my-cool-adapter"] = {
+        "passed": True,
+        "duration_s": 1.0,
+        "error_excerpt": None,
+    }
+    payload["harness_result"] = extra
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_smoke_result_excerpt_oversize_rejected() -> None:
+    """``response_excerpt`` is capped at 200 chars to keep submissions
+    compact. A 1000-char paste from a chatty model would otherwise leak
+    arbitrary content into the corpus.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    payload = _v2_base_payload()
+    payload["tier"] = "smoke"
+    payload["smoke_result"] = dict(_VALID_SMOKE, response_excerpt="x" * 201)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)

--- a/vllm_mlx/community_bench/__init__.py
+++ b/vllm_mlx/community_bench/__init__.py
@@ -17,10 +17,20 @@ Each layer can be unit-tested independently; nothing imports model
 weights or MLX state until ``runner`` runs.
 """
 
-SCHEMA_VERSION: int = 1
+SCHEMA_VERSION: int = 2
 """Bump in lockstep with ``community-benchmarks/schema.json``'s
-``schema_version`` const. Submissions carry this so the aggregator can
-ignore rows from a schema it doesn't understand instead of failing."""
+``schema_version`` enum. Submissions carry this so the aggregator can
+ignore rows from a schema it doesn't understand instead of failing.
+
+v1 → v2 (additive only): three optional top-level fields — ``tier``,
+``smoke_result``, ``harness_result``. A v2 submission with only
+``schema_version`` bumped and none of the new fields populated is the
+SAME wire shape as v1 minus the version integer, so the aggregator can
+treat it interchangeably. The new fields kick in when the CLI is run
+with ``bench --tier {smoke,harness,all} --submit`` — the dispatch for
+``--tier all --submit`` itself is wired in a follow-up PR; this module
+just exposes the kwargs so the payload builder can carry the data when
+the CLI calls it."""
 
 # Synthetic prompt seed. Locked per schema_version so the prompt_hash
 # field in submissions stays bit-stable across all submitters — that's

--- a/vllm_mlx/community_bench/submission.py
+++ b/vllm_mlx/community_bench/submission.py
@@ -116,17 +116,11 @@ def build_submission_payload(
     # future CLI code that wires this up — schema errors surface as
     # opaque jsonschema messages with full property paths.
     if tier is not None and tier not in ("speed", "smoke", "harness", "all"):
-        raise ValueError(
-            f"tier must be one of speed/smoke/harness/all, got {tier!r}"
-        )
+        raise ValueError(f"tier must be one of speed/smoke/harness/all, got {tier!r}")
     if tier in ("smoke", "all") and smoke_result is None:
-        raise ValueError(
-            f"tier={tier!r} requires smoke_result to be populated"
-        )
+        raise ValueError(f"tier={tier!r} requires smoke_result to be populated")
     if tier in ("harness", "all") and harness_result is None:
-        raise ValueError(
-            f"tier={tier!r} requires harness_result to be populated"
-        )
+        raise ValueError(f"tier={tier!r} requires harness_result to be populated")
     # Inverse: passing a result without the matching tier would land an
     # ambiguous payload in the corpus (aggregator doesn't know which
     # tier produced it). Cheaper to reject here than to debug a

--- a/vllm_mlx/community_bench/submission.py
+++ b/vllm_mlx/community_bench/submission.py
@@ -68,6 +68,10 @@ def build_submission_payload(
     bench: BenchResult,
     notes: str | None,
     now: datetime | None = None,
+    *,
+    tier: str | None = None,
+    smoke_result: dict | None = None,
+    harness_result: dict | None = None,
 ) -> dict:
     """Build the full JSON payload for one submission.
 
@@ -78,12 +82,65 @@ def build_submission_payload(
     The returned dict's key order matches the schema's ``required`` list
     so that ``json.dumps(indent=2)`` produces a stable, readable layout
     when shown to the user for consent.
+
+    Schema v2 optional kwargs:
+
+    - ``tier`` — which bench tier produced this submission
+      (``"speed"`` | ``"smoke"`` | ``"harness"`` | ``"all"``). If
+      ``None``, the field is omitted entirely so the aggregator treats
+      the row as v1-equivalent. This keeps the byte-for-byte equivalence
+      with v1 that the existing ``--submit`` flow relies on, modulo the
+      version integer itself.
+    - ``smoke_result`` — required iff ``tier in ("smoke", "all")``. The
+      schema enforces the same invariant via a top-level ``allOf``
+      conditional, and we ALSO ``ValueError`` here so a misuse from a
+      future caller surfaces immediately rather than as a schema
+      validation failure two layers up.
+    - ``harness_result`` — required iff ``tier in ("harness", "all")``.
+      Same coupling as ``smoke_result``.
+
+    The ``schema_version`` field on the wire is always
+    ``SCHEMA_VERSION`` (currently 2). v2 with no new fields is a
+    superset of v1 — the aggregator can ignore the bump and treat the
+    row as a speed-only submission, which is the design contract.
     """
     submitted_at = (now or datetime.now(timezone.utc)).isoformat(timespec="seconds")
     # The schema expects ``date-time`` format; the ``+00:00`` suffix is
     # the canonical ISO 8601 UTC form (NOT bare 'Z', NOT naive). Strip
     # any sub-second precision so two clean submissions a moment apart
     # don't look like noise.
+
+    # Validate the tier ↔ result coupling at the boundary. The schema's
+    # ``allOf`` block enforces the same thing in CI, but failing here
+    # with a clear Python-side error message is friendlier for the
+    # future CLI code that wires this up — schema errors surface as
+    # opaque jsonschema messages with full property paths.
+    if tier is not None and tier not in ("speed", "smoke", "harness", "all"):
+        raise ValueError(
+            f"tier must be one of speed/smoke/harness/all, got {tier!r}"
+        )
+    if tier in ("smoke", "all") and smoke_result is None:
+        raise ValueError(
+            f"tier={tier!r} requires smoke_result to be populated"
+        )
+    if tier in ("harness", "all") and harness_result is None:
+        raise ValueError(
+            f"tier={tier!r} requires harness_result to be populated"
+        )
+    # Inverse: passing a result without the matching tier would land an
+    # ambiguous payload in the corpus (aggregator doesn't know which
+    # tier produced it). Cheaper to reject here than to debug a
+    # mis-labelled row in the dashboard later.
+    if smoke_result is not None and tier not in ("smoke", "all"):
+        raise ValueError(
+            f"smoke_result was provided but tier={tier!r} does not include "
+            f"the smoke bucket (must be 'smoke' or 'all')"
+        )
+    if harness_result is not None and tier not in ("harness", "all"):
+        raise ValueError(
+            f"harness_result was provided but tier={tier!r} does not "
+            f"include the harness bucket (must be 'harness' or 'all')"
+        )
 
     payload: dict = {
         "schema_version": SCHEMA_VERSION,
@@ -102,6 +159,16 @@ def build_submission_payload(
         payload["notes"] = notes
     if bench.peak_ram_mb is not None:
         payload["peak_ram_mb"] = bench.peak_ram_mb
+    # v2 optional fields — only emit when populated so the wire shape
+    # for a default (tier=None) v2 submission is byte-equivalent to a
+    # v1 submission modulo the version integer. The snapshot test for
+    # this lives in tests/test_payload_builder_v2_kwargs.py.
+    if tier is not None:
+        payload["tier"] = tier
+    if smoke_result is not None:
+        payload["smoke_result"] = smoke_result
+    if harness_result is not None:
+        payload["harness_result"] = harness_result
     return payload
 
 


### PR DESCRIPTION
## Summary

PR **3 of 4** in the bench-tier series (PR 1 = #618). Widens the
`community-benchmarks` submission schema from v1 → v2 so a future
`bench --tier all --submit` flow can attach a smoke-probe result AND
the agent-harness gauntlet result alongside the existing speed
buckets in a single PR submission. The CLI dispatch for the new
`--tier` flag is **out of scope** here — that's PR 2 / a follow-up.
This PR only ships the schema, the payload-builder kwargs, and the
validator coverage.

## Schema diff (additive only)

```diff
- "schema_version": { "type": "integer", "const": 1, ... }
+ "schema_version": { "type": "integer", "enum": [1, 2], ... }

+ "tier":           { "enum": ["speed", "smoke", "harness", "all"] }     # optional, v2 only
+ "smoke_result":   { boot_time_ms, first_prompt_ok, first_token_latency_ms, response_excerpt }
+ "harness_result": { codex, opencode, hermes, aider, langchain }        # each: passed/duration_s/error_excerpt

+ "allOf": [
+   { if: { schema_version==2, tier in [smoke,all]    } then: required smoke_result   },
+   { if: { schema_version==2, tier in [harness,all]  } then: required harness_result },
+   { if: { schema_version==1 } then: NOT (tier|smoke_result|harness_result) }
+ ]
```

`additionalProperties: false` is preserved at every level. The
runtime `SCHEMA_VERSION` constant bumps to 2 in lockstep.

`build_submission_payload` grows three optional keyword-only kwargs
(`tier`, `smoke_result`, `harness_result`). Default-kwargs calls
produce a payload byte-identical to v1 modulo the version integer —
locked in by `test_default_kwargs_match_v1_modulo_version`.

## Compatibility

All existing v1 submissions in `community-benchmarks/submissions/`
re-validate clean against the v2 schema. The GHA validator already
re-runs the full corpus whenever schema/validator/aliases change, so
schema-evolution regressions surface on the next PR. The v2 conditional
`allOf` block explicitly rejects v1 payloads carrying any v2-only
field, so the wire shape per version stays unambiguous.

## Design tradeoff

Picked JSON Schema `allOf` + `if`/`then` conditionals for the tier ↔
result invariant instead of carrying the rule only in the validator
script. Pros: the schema is the single source of truth for the wire
shape; any consumer (the aggregator, the website, a downstream
analytics job) gets the contract for free. Con: `if`/`then` is
draft-2019-09+, which we're already using (`draft/2020-12`), so no
compatibility hit. Also added in-process `ValueError` guards in
`build_submission_payload` for the same invariants — schema errors
surface as opaque jsonschema messages with full property paths;
in-process raises give the future CLI dispatcher a clean, narrow
error to surface.

## Test plan

- [x] `tests/test_schema_v2_accepts_v1.py` — every existing v1
      submission in the corpus still validates against the v2 schema
      (parametrized over `community-benchmarks/submissions/*.json`)
- [x] `tests/test_schema_v2_accepts_minimal_v2.py` — a v2 payload
      with only the version bumped (no `tier` / `smoke_result` /
      `harness_result`) validates; explicit `tier: "speed"` validates
      with no result blocks; a v1 payload that smuggles in a v2-only
      field is rejected
- [x] `tests/test_schema_v2_rejects_partial_harness.py` —
      tier=harness without `harness_result`, tier=smoke without
      `smoke_result`, tier=all with neither, tier=all with only smoke,
      `harness_result` missing one adapter, `harness_result` with an
      extra adapter, and oversize `response_excerpt` are all rejected
      with the matching field name in the error
- [x] `tests/test_payload_builder_v2_kwargs.py` —
      `build_submission_payload()` default kwargs emit no v2-only
      fields, the produced payload byte-matches the v1 snapshot
      modulo `schema_version`, both default and `tier="speed"`
      payloads validate against the v2 schema, and invalid
      tier/result combinations raise `ValueError` at the boundary
- [x] `tests/test_payload_builder_v2_full.py` —
      `build_submission_payload(tier="all", smoke_result=..., harness_result=...)`
      populates all three sections AND validates; tier="smoke"-alone
      and tier="harness"-alone paths also validate
- [x] `python community-benchmarks/scripts/validate.py` — full
      submissions corpus re-validates clean against the v2 schema
- [x] `python3.12 -c "from vllm_mlx.community_bench.runner import SCHEMA_VERSION; assert SCHEMA_VERSION == 2"`
- [x] Full unit suite (5301 passed, 18 skipped, 16 deselected, 7
      xfailed; only failure is the unrelated `test_event_loop_responsiveness`
      flake that needs a running server on localhost:8000)

Builds on #618 (PR 1 of 4). Out of scope: wiring
`--tier all --submit` into the CLI dispatch (PR 2 / follow-up) and
any changes under `bench/tiers/` or `vllm_mlx/doctor/`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>