### PR TITLE
feat(bench): unify --tier and --submit (PR #5 of 4+1 series)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Claude Code harness artifacts (worktrees, scheduled-task locks,
+# session metadata). These leak into ``git status`` on every dogfood
+# run of ``rapid-mlx bench --submit``, which refuses to open a PR
+# from a dirty tree — keeping them ignored is the only reliable way
+# to land community-bench submissions from a Claude Code session.
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.24"
+version = "0.7.25"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_bench_tier_all.py
+++ b/tests/test_bench_tier_all.py
@@ -21,7 +21,14 @@ from vllm_mlx.bench.tier_runner import TierResult, run_tier
 
 @contextlib.contextmanager
 def _fake_serve(model, port=None, **kwargs):
-    yield {"base_url": f"http://127.0.0.1:{port}/v1", "port": port}
+    yield {
+        "base_url": f"http://127.0.0.1:{port}/v1",
+        "port": port,
+        # boot_time_ms threads through to ``_run_smoke`` for the
+        # schema-v2 ``smoke_result.boot_time_ms`` field; pinned for
+        # reproducible test output.
+        "boot_time_ms": 1234.5,
+    }
 
 
 @pytest.fixture
@@ -36,7 +43,7 @@ def patch_serve_only():
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
     ):
         yield
 
@@ -45,7 +52,7 @@ def test_all_runs_smoke_speed_harness_in_order(patch_serve_only, capsys):
     """Happy path: all 3 tiers run in smoke → speed → harness order."""
     call_order: list[str] = []
 
-    def _smoke_stub(model, base_url):
+    def _smoke_stub(model, base_url, boot_time_ms=None):
         call_order.append("smoke")
         return TierResult(name="smoke", passed=True, duration_s=0.5, detail="PASS")
 
@@ -81,7 +88,7 @@ def test_all_aborts_after_smoke_failure(patch_serve_only, capsys):
     """If smoke fails, --tier all must NOT run speed or harness."""
     call_order: list[str] = []
 
-    def _smoke_fail(model, base_url):
+    def _smoke_fail(model, base_url, boot_time_ms=None):
         call_order.append("smoke")
         return TierResult(
             name="smoke",
@@ -126,7 +133,7 @@ def test_all_continues_past_speed_failure(patch_serve_only, capsys):
     """Speed failure does NOT abort the sweep — harness still runs."""
     call_order: list[str] = []
 
-    def _smoke_stub(model, base_url):
+    def _smoke_stub(model, base_url, boot_time_ms=None):
         call_order.append("smoke")
         return TierResult(name="smoke", passed=True, duration_s=0.5)
 
@@ -159,7 +166,11 @@ def test_all_boots_server_exactly_once(capsys):
     @contextlib.contextmanager
     def _counting_serve(model, port=None, **kwargs):
         boot_count["n"] += 1
-        yield {"base_url": f"http://127.0.0.1:{port}/v1", "port": port}
+        yield {
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "port": port,
+            "boot_time_ms": 1234.5,
+        }
 
     def _free_port(lo, hi):
         return 8500
@@ -167,7 +178,7 @@ def test_all_boots_server_exactly_once(capsys):
     def _stub(model, port, **kwargs):
         return TierResult(name="x", passed=True, duration_s=0.1)
 
-    def _smoke_stub(model, base_url):
+    def _smoke_stub(model, base_url, boot_time_ms=None):
         return TierResult(name="smoke", passed=True, duration_s=0.1)
 
     def _speed_stub(model, base_url, sampled=False):
@@ -181,7 +192,7 @@ def test_all_boots_server_exactly_once(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _counting_serve),
+        patch("vllm_mlx.bench._server.serve", _counting_serve),
         patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub),
         patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub),
         patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub),
@@ -200,9 +211,13 @@ def test_all_with_base_url_skips_server_boot(capsys):
     @contextlib.contextmanager
     def _counting_serve(model, port=None, **kwargs):
         boot_count["n"] += 1
-        yield {"base_url": f"http://127.0.0.1:{port}/v1", "port": port}
+        yield {
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "port": port,
+            "boot_time_ms": 1234.5,
+        }
 
-    def _smoke_stub(model, base_url):
+    def _smoke_stub(model, base_url, boot_time_ms=None):
         return TierResult(name="smoke", passed=True, duration_s=0.1)
 
     def _speed_stub(model, base_url, sampled=False):
@@ -225,7 +240,7 @@ def test_all_with_base_url_skips_server_boot(capsys):
         return _FakeResp()
 
     with (
-        patch("vllm_mlx.doctor.server.serve", _counting_serve),
+        patch("vllm_mlx.bench._server.serve", _counting_serve),
         patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub),
         patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub),
         patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub),

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -21,7 +21,14 @@ from vllm_mlx.bench.tier_runner import HARNESS_PROFILES, run_tier
 
 @contextlib.contextmanager
 def _fake_serve(model, port=None, **kwargs):
-    yield {"base_url": f"http://127.0.0.1:{port}/v1", "port": port}
+    yield {
+        "base_url": f"http://127.0.0.1:{port}/v1",
+        "port": port,
+        # Schema-v2 ``smoke_result.boot_time_ms`` source — pinned so
+        # tier=harness tests that incidentally hit the smoke probe
+        # (e.g. tier=all) still see deterministic output.
+        "boot_time_ms": 1234.5,
+    }
 
 
 def _make_fake_report(*, passed=10, failed=0, errored=0, skipped=2, results=None):
@@ -63,7 +70,7 @@ def patch_harness_environment():
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_fake_runner_init),
     ):
@@ -125,7 +132,7 @@ def test_harness_single_failure_marks_tier_failed(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
     ):
@@ -171,7 +178,7 @@ def test_harness_crash_in_runner_does_not_abort_sweep(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
     ):
@@ -208,7 +215,7 @@ def test_harness_missing_profile_marks_as_failure(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
     ):

--- a/tests/test_bench_tier_smoke.py
+++ b/tests/test_bench_tier_smoke.py
@@ -76,8 +76,15 @@ class _FakeClient:
 
 @contextlib.contextmanager
 def _fake_serve(model, port=None, **kwargs):
-    """Drop-in for vllm_mlx.doctor.server.serve — no subprocess."""
-    yield {"base_url": f"http://127.0.0.1:{port}/v1", "port": port}
+    """Drop-in for vllm_mlx.bench._server.serve — no subprocess."""
+    yield {
+        "base_url": f"http://127.0.0.1:{port}/v1",
+        "port": port,
+        # boot_time_ms threads through to ``_run_smoke`` for the
+        # schema-v2 ``smoke_result.boot_time_ms`` field; pinned for
+        # reproducible test output.
+        "boot_time_ms": 1234.5,
+    }
 
 
 @pytest.fixture
@@ -104,7 +111,7 @@ def patch_smoke_environment():
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("httpx.Client", _client_factory),
     ):
         yield
@@ -142,7 +149,7 @@ def test_smoke_fail_when_no_four_in_response(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("httpx.Client", _client_factory),
     ):
         rc = run_tier(model="qwen3.5-4b-4bit", tier="smoke")
@@ -263,7 +270,7 @@ def test_smoke_skips_role_only_chunk_for_ttft(capsys):
             "vllm_mlx.bench.tier_runner._find_free_port_in_range",
             side_effect=_free_port,
         ),
-        patch("vllm_mlx.doctor.server.serve", _fake_serve),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("httpx.Client", _client_factory),
     ):
         rc = run_tier(model="qwen3.5-4b-4bit", tier="smoke")

--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -1,0 +1,562 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx bench <model> --tier <T> --submit`` — PR #5 unification.
+
+PR #2 landed ``--tier`` and PR #3 landed schema v2 with optional
+``smoke_result`` / ``harness_result`` sub-objects, but the CLI kept
+the two flags mutually-exclusive (a stub exit-2 guard with a comment
+literally saying "PR #3 will unify them"). PR #5 removes the guard
+and wires the combo end-to-end.
+
+These tests pin the wiring contract:
+
+- ``run_tier(..., return_results=True)`` returns
+  ``(int, {smoke_result, harness_result})`` carrying the schema-v2
+  sub-objects (with ``None`` for tiers that didn't run).
+- ``run_tier`` without ``return_results=True`` keeps its legacy
+  ``int`` return type — no caller-visible drift for code that just
+  wants the exit code.
+- ``build_submission_payload(tier=..., smoke_result=...,
+  harness_result=...)`` accepts the dicts the dispatcher emits and
+  produces a payload that validates against ``schema.json`` for every
+  tier value (smoke / harness / all). Speed/buckets are always
+  present because the schema requires them.
+- The previously-mutual-exclusive guard is gone: ``bench --tier all
+  --submit`` parses cleanly and dispatches into the new combo flow.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx.bench.tier_runner import TierResult, run_tier
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "community-benchmarks" / "schema.json"
+
+
+# --------------------------------------------------------------------- #
+# Stub inputs                                                            #
+# --------------------------------------------------------------------- #
+
+
+def _stub_bench_inputs():
+    """Build the hardware / software / BenchResult triple that
+    ``build_submission_payload`` consumes. Mirrors the fixtures in
+    ``tests/test_payload_builder_v2_full.py`` so behavior is
+    cross-consistent across the schema-v2 test suite.
+    """
+    from vllm_mlx.community_bench.hardware import Hardware, Software
+    from vllm_mlx.community_bench.runner import (
+        BenchResult,
+        BucketResult,
+        RoundResult,
+    )
+
+    hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
+    sw = Software(macos="26.5.1", rapid_mlx="0.7.25", mlx="0.31.2", python="3.12.13")
+    rounds = [
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
+        for _ in range(5)
+    ]
+    bench = BenchResult(
+        short=BucketResult(rounds_raw=rounds),
+        long=BucketResult(rounds_raw=rounds),
+        peak_ram_mb=8192,
+        prompt_hash="deadbeefcafebabe",
+        sampling="greedy",
+    )
+    return hw, sw, bench
+
+
+_SMOKE_PAYLOAD = {
+    "boot_time_ms": 1234.5,
+    "first_prompt_ok": True,
+    "first_token_latency_ms": 87.0,
+    "response_excerpt": "2+2 equals 4.",
+}
+
+_HARNESS_PAYLOAD = {
+    "codex": {"passed": True, "duration_s": 11.4, "error_excerpt": None},
+    "opencode": {"passed": True, "duration_s": 9.8, "error_excerpt": None},
+    "hermes": {"passed": True, "duration_s": 7.1, "error_excerpt": None},
+    "aider": {"passed": True, "duration_s": 14.2, "error_excerpt": None},
+    "langchain": {"passed": True, "duration_s": 18.5, "error_excerpt": None},
+}
+
+
+# --------------------------------------------------------------------- #
+# Server-boot context manager stub                                       #
+# --------------------------------------------------------------------- #
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _fake_serve(model, port=None, **kwargs):
+    yield {
+        "base_url": f"http://127.0.0.1:{port}/v1",
+        "port": port,
+        "boot_time_ms": 1234.5,
+    }
+
+
+def _patch_serve_boot():
+    """Bundle the server-boot + free-port patches for tier_runner tests."""
+
+    def _free_port(lo, hi):
+        return 8500
+
+    return [
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
+    ]
+
+
+# --------------------------------------------------------------------- #
+# run_tier: structured return contract                                   #
+# --------------------------------------------------------------------- #
+
+
+def test_run_tier_returns_payload_when_requested():
+    """``return_results=True`` flips the return type to (int, dict).
+
+    The dict carries the schema-v2-shaped ``smoke_result`` and
+    ``harness_result`` for tiers that ran (or ``None`` otherwise),
+    so the ``--submit`` wiring can feed it straight to
+    ``build_submission_payload`` without re-running tier work.
+    """
+
+    def _smoke_stub(model, base_url, boot_time_ms=None):
+        return TierResult(
+            name="smoke",
+            passed=True,
+            duration_s=0.5,
+            detail="PASS",
+            payload=dict(_SMOKE_PAYLOAD),
+        )
+
+    def _harness_stub(model, base_url):
+        return TierResult(
+            name="harness",
+            passed=True,
+            duration_s=30.0,
+            detail="5/5 pass",
+            payload=dict(_HARNESS_PAYLOAD),
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_serve_boot():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
+        )
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub)
+        )
+
+        result = run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="all",
+            return_results=True,
+            skip_speed=True,
+        )
+
+    assert isinstance(result, tuple), (
+        "return_results=True must change the return type to a tuple"
+    )
+    rc, payload = result
+    assert rc == 0, f"happy path should exit 0; got {rc}"
+    assert payload["smoke_result"] == _SMOKE_PAYLOAD
+    assert payload["harness_result"] == _HARNESS_PAYLOAD
+
+
+def test_run_tier_default_signature_unchanged():
+    """Without ``return_results=True``, ``run_tier`` still returns ``int``.
+
+    Locks the back-compat contract: PR #2's callers (e.g. release_check_m3.sh
+    G7b) MUST not see a behavior change just because the kwarg exists.
+    """
+
+    def _smoke_stub(model, base_url, boot_time_ms=None):
+        return TierResult(name="smoke", passed=True, duration_s=0.1)
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_serve_boot():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
+        )
+
+        result = run_tier(model="qwen3.5-4b-4bit", tier="smoke")
+
+    assert isinstance(result, int), (
+        "default ``run_tier`` MUST return int, not tuple — back-compat"
+    )
+    assert result == 0
+
+
+def test_run_tier_returns_payload_with_none_for_missing_tiers():
+    """When a tier didn't run, its slot in the payload dict is ``None``.
+
+    For ``tier='smoke'`` the dispatcher only runs smoke, so
+    ``harness_result`` MUST be ``None`` in the returned dict — the
+    caller can pattern-match on that rather than checking key presence.
+    """
+
+    def _smoke_stub(model, base_url, boot_time_ms=None):
+        return TierResult(
+            name="smoke",
+            passed=True,
+            duration_s=0.5,
+            payload=dict(_SMOKE_PAYLOAD),
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_serve_boot():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
+        )
+
+        rc, payload = run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="smoke",
+            return_results=True,
+        )
+
+    assert rc == 0
+    assert payload["smoke_result"] == _SMOKE_PAYLOAD
+    assert payload["harness_result"] is None, (
+        "harness didn't run for tier=smoke; harness_result MUST be None"
+    )
+
+
+def test_run_tier_skip_speed_avoids_lightweight_probe():
+    """``skip_speed=True`` on tier='all' MUST NOT invoke ``_run_speed``.
+
+    The --submit combo path uses ``run_standardized_bench`` directly
+    for the speed bucket because the locked B=1 numbers are what
+    community-benchmarks compares against. Running the lightweight
+    HTTP probe alongside it would waste cycles AND produce non-
+    comparable numbers next to the submitted ones (confusing).
+    """
+    calls: list[str] = []
+
+    def _smoke_stub(model, base_url, boot_time_ms=None):
+        calls.append("smoke")
+        return TierResult(
+            name="smoke",
+            passed=True,
+            duration_s=0.1,
+            payload=dict(_SMOKE_PAYLOAD),
+        )
+
+    def _speed_stub(model, base_url, sampled=False):
+        calls.append("speed")
+        return TierResult(name="speed", passed=True, duration_s=0.1)
+
+    def _harness_stub(model, base_url):
+        calls.append("harness")
+        return TierResult(
+            name="harness",
+            passed=True,
+            duration_s=0.1,
+            payload=dict(_HARNESS_PAYLOAD),
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_serve_boot():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
+        )
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub)
+        )
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub)
+        )
+
+        run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="all",
+            return_results=True,
+            skip_speed=True,
+        )
+
+    assert "speed" not in calls, (
+        f"skip_speed=True must skip the lightweight speed probe; calls={calls}"
+    )
+    assert calls == ["smoke", "harness"], (
+        f"--tier all skip_speed must run smoke → harness; got {calls}"
+    )
+
+
+def test_run_tier_skip_speed_ignored_for_non_all_tier():
+    """``skip_speed`` is a tier=='all'-only knob.
+
+    For tier='speed' alone, skip_speed makes no sense — the user
+    asked for ``--tier speed``, the dispatcher honours it. Adding
+    skip_speed=True to a tier='speed' call MUST still run the speed
+    probe (otherwise we'd silently no-op).
+    """
+    calls: list[str] = []
+
+    def _speed_stub(model, base_url, sampled=False):
+        calls.append("speed")
+        return TierResult(name="speed", passed=True, duration_s=0.1)
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_serve_boot():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub)
+        )
+
+        run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="speed",
+            return_results=True,
+            skip_speed=True,
+        )
+
+    assert calls == ["speed"], (
+        f"skip_speed must be tier='all' only; got calls={calls}"
+    )
+
+
+# --------------------------------------------------------------------- #
+# Payload shape: tier='all' --submit                                     #
+# --------------------------------------------------------------------- #
+
+
+def test_tier_all_submit_payload_shape():
+    """``tier='all'`` + smoke/harness inputs build a v2-valid payload.
+
+    Locked invariants:
+
+    - ``schema_version == 2``
+    - ``tier == 'all'``
+    - ``smoke_result``, ``harness_result``, AND ``buckets`` all present
+      (the schema requires ``buckets`` unconditionally — the speed
+      bucket of a tier=all submission still comes from
+      ``run_standardized_bench``).
+    - Payload validates against ``community-benchmarks/schema.json``.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    hw, sw, bench = _stub_bench_inputs()
+    payload = build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes="PR5 tier=all combo",
+        now=datetime(2026, 6, 17, 10, 30, 0, tzinfo=timezone.utc),
+        tier="all",
+        smoke_result=_SMOKE_PAYLOAD,
+        harness_result=_HARNESS_PAYLOAD,
+    )
+
+    assert payload["schema_version"] == 2
+    assert payload["tier"] == "all"
+    assert payload["smoke_result"] == _SMOKE_PAYLOAD
+    assert payload["harness_result"] == _HARNESS_PAYLOAD
+    # The schema requires ``buckets`` for every submission (including
+    # tier=smoke / harness / all). The speed numbers carry through
+    # from the BenchResult we ran in --submit's phase 2.
+    assert "buckets" in payload
+    assert {"short", "long"} <= payload["buckets"].keys()
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_tier_smoke_submit_populates_smoke_result_only():
+    """``tier='smoke'`` + smoke_result yields a v2-valid payload with
+    NO harness_result.
+
+    The schema's ``allOf`` block requires ``smoke_result`` for
+    ``tier='smoke'`` AND forbids passing ``harness_result`` when the
+    tier doesn't include the harness bucket. The builder enforces
+    that coupling locally so callers get a clean Python-side error
+    rather than a downstream schema-validation failure two layers up.
+
+    Note: the schema also requires the top-level ``buckets`` field
+    on every submission (PR #3's design: speed numbers always
+    accompany a community-bench row). So a tier=smoke submission
+    DOES still carry the standardized-bench buckets — the smoke
+    result is additive, not replacement. The "no buckets" reading
+    of the spec would contradict the locked schema.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    hw, sw, bench = _stub_bench_inputs()
+    payload = build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes=None,
+        now=datetime(2026, 6, 17, tzinfo=timezone.utc),
+        tier="smoke",
+        smoke_result=_SMOKE_PAYLOAD,
+    )
+
+    assert payload["tier"] == "smoke"
+    assert payload["smoke_result"] == _SMOKE_PAYLOAD
+    assert "harness_result" not in payload, (
+        "tier=smoke MUST NOT emit harness_result (schema forbids it)"
+    )
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_tier_harness_submit_populates_harness_result_only():
+    """``tier='harness'`` + harness_result yields a v2-valid payload with
+    NO smoke_result.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    from vllm_mlx.community_bench.submission import build_submission_payload
+
+    hw, sw, bench = _stub_bench_inputs()
+    payload = build_submission_payload(
+        hardware=hw,
+        software=sw,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        bench=bench,
+        notes=None,
+        now=datetime(2026, 6, 17, tzinfo=timezone.utc),
+        tier="harness",
+        harness_result=_HARNESS_PAYLOAD,
+    )
+
+    assert payload["tier"] == "harness"
+    assert payload["harness_result"] == _HARNESS_PAYLOAD
+    assert "smoke_result" not in payload
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+# --------------------------------------------------------------------- #
+# CLI surface: mutual-exclusive guard removed                            #
+# --------------------------------------------------------------------- #
+
+
+def test_mutual_exclusive_guard_removed():
+    """``bench --tier all --submit`` MUST NOT hard-fail at parse time.
+
+    PR #2 left an exit-2 guard in ``bench_command`` with a comment
+    saying "PR #3 will unify them". PR #5 removes it. The guarantee
+    we're locking is that the dispatcher routes both flags into the
+    combined flow without the old error message ever printing.
+
+    We exercise this via ``main()`` (the real entry point) with a
+    stub ``bench_command`` so the parser path is unmodified — that's
+    the only way to catch a regression where someone re-introduces
+    the guard inside an argparse hook.
+    """
+    import sys as _sys
+
+    from vllm_mlx import cli as _cli
+
+    captured = {}
+
+    def _fake_bench_command(args):
+        captured["called"] = True
+        captured["tier"] = getattr(args, "tier", None)
+        captured["submit"] = getattr(args, "submit", False)
+
+    old_bench = _cli.bench_command
+    old_argv = _sys.argv
+    _cli.bench_command = _fake_bench_command
+    _sys.argv = [
+        "rapid-mlx",
+        "bench",
+        "qwen3.5-9b-4bit",
+        "--tier",
+        "all",
+        "--submit",
+        "--notes",
+        "x",
+    ]
+    try:
+        # main() may sys.exit; capture it.
+        try:
+            _cli.main()
+        except SystemExit as e:
+            assert e.code in (None, 0), (
+                f"main() exited with non-success code {e.code} — "
+                "the mutual-exclusive guard appears to still be in place"
+            )
+    finally:
+        _cli.bench_command = old_bench
+        _sys.argv = old_argv
+
+    assert captured.get("called") is True, (
+        "main() must dispatch to bench_command when --tier and --submit "
+        "are both set (guard removal regression)"
+    )
+    assert captured["tier"] == "all"
+    assert captured["submit"] is True
+
+
+def test_tier_submit_routes_through_unified_flow(monkeypatch):
+    """``bench_command`` MUST route --tier+--submit to ``_run_tier_submit_flow``.
+
+    We monkeypatch the combined flow to capture the call, then build a
+    minimal Namespace and invoke ``bench_command`` directly. Proves
+    the bench dispatcher takes the new combo branch BEFORE either the
+    bare ``_run_submit_flow`` or bare ``run_tier`` branches — order
+    matters because both single-flag paths would otherwise grab
+    half the work each and leave the user with a half-built payload.
+    """
+    import argparse
+    import importlib
+
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    captured = {}
+
+    def _fake_combo(args):
+        captured["called"] = True
+        captured["tier"] = args.tier
+        captured["submit"] = args.submit
+        return 0
+
+    monkeypatch.setattr(cli, "_run_tier_submit_flow", _fake_combo)
+
+    args = argparse.Namespace(
+        model="qwen3.5-9b-4bit",
+        tier="all",
+        submit=True,
+        base_url=None,
+        sampled=False,
+        force_disk_check=False,
+        notes=None,
+        repo_root=None,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.bench_command(args)
+    assert excinfo.value.code == 0
+    assert captured.get("called") is True, (
+        "bench_command MUST route --tier+--submit to the combined flow"
+    )
+    assert captured["tier"] == "all"
+    assert captured["submit"] is True

--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -501,6 +501,109 @@ def test_mutual_exclusive_guard_removed():
     assert captured["submit"] is True
 
 
+def test_tier_submit_refuses_base_url(capsys):
+    """``--base-url`` MUST be rejected for the --submit combo.
+
+    Regression coverage for codex PR #623 BLOCKING-1: when the user
+    attaches to a pre-existing server we never measured boot, AND the
+    in-process standardized bench would run against a separately-
+    loaded engine — so the submitted payload would mislabel both
+    smoke and speed numbers. The right call is to fail fast with a
+    clear error pointing them at the supported workflow (drop
+    --base-url and let --submit boot the server itself).
+    """
+    import argparse
+
+    from vllm_mlx.cli import _run_tier_submit_flow
+
+    args = argparse.Namespace(
+        model="qwen3.5-9b-4bit",
+        tier="all",
+        submit=True,
+        base_url="http://127.0.0.1:8000",
+        sampled=False,
+        force_disk_check=False,
+        notes=None,
+        repo_root=None,
+    )
+
+    rc = _run_tier_submit_flow(args)
+    assert rc == 2, "--base-url with --submit MUST exit 2 (setup error)"
+
+    captured = capsys.readouterr()
+    assert "--base-url is incompatible with --submit" in captured.err, (
+        "error message must explain WHY --base-url is incompatible "
+        "with --submit (boot_time_ms + standardized bench correctness)"
+    )
+
+
+def test_smoke_payload_is_none_when_boot_time_unknown(capsys):
+    """``_run_smoke`` with ``boot_time_ms=None`` MUST set payload=None.
+
+    Regression coverage for codex PR #623 BLOCKING-1's defensive
+    second layer: even if a future caller bypasses the
+    ``--base-url`` + ``--submit`` guard in cli.py, ``_run_smoke``
+    itself refuses to invent a ``0.0`` boot-time placeholder. The
+    schema's ``boot_time_ms: number, minimum: 0`` would happily
+    accept ``0.0`` but the aggregator can't distinguish that from
+    "machine boots this model in zero ms" — so the producer fails
+    closed and lets the caller decide what to do with the missing
+    metric.
+    """
+    from vllm_mlx.bench.tier_runner import _run_smoke
+
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "test-model"}]}
+
+    class _FakeStreamResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            return iter(
+                [
+                    'data: {"choices":[{"delta":{"content":"4"}}]}',
+                    "data: [DONE]",
+                ]
+            )
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url):
+            return _FakeResp()
+
+        def stream(self, method, url, json=None):
+            return _FakeStreamResp()
+
+    with patch("httpx.Client", lambda *a, **k: _FakeClient()):
+        r = _run_smoke(
+            model="qwen3.5-4b-4bit",
+            base_url="http://127.0.0.1:8500/v1",
+            boot_time_ms=None,
+        )
+
+    assert r.passed is True, "smoke should still PASS — '4' is in the response"
+    assert r.payload is None, (
+        "boot_time_ms=None MUST yield payload=None (defensive coverage of "
+        "PR #623 BLOCKING-1; never invent a 0.0 boot-time)"
+    )
+
+
 def test_tier_submit_routes_through_unified_flow(monkeypatch):
     """``bench_command`` MUST route --tier+--submit to ``_run_tier_submit_flow``.
 

--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -60,8 +60,7 @@ def _stub_bench_inputs():
     hw = Hardware(chip="Apple M4 Pro", ram_gb=24, cpu_cores=12, gpu_cores=20)
     sw = Software(macos="26.5.1", rapid_mlx="0.7.25", mlx="0.31.2", python="3.12.13")
     rounds = [
-        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0)
-        for _ in range(5)
+        RoundResult(decode_tps=42.0, prefill_tps=500.0, ttft_ms=120.0) for _ in range(5)
     ]
     bench = BenchResult(
         short=BucketResult(rounds_raw=rounds),
@@ -156,9 +155,7 @@ def test_run_tier_returns_payload_when_requested():
     with contextlib.ExitStack() as stack:
         for p in _patch_serve_boot():
             stack.enter_context(p)
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
-        )
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub))
         stack.enter_context(
             patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub)
         )
@@ -192,9 +189,7 @@ def test_run_tier_default_signature_unchanged():
     with contextlib.ExitStack() as stack:
         for p in _patch_serve_boot():
             stack.enter_context(p)
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
-        )
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub))
 
         result = run_tier(model="qwen3.5-4b-4bit", tier="smoke")
 
@@ -223,9 +218,7 @@ def test_run_tier_returns_payload_with_none_for_missing_tiers():
     with contextlib.ExitStack() as stack:
         for p in _patch_serve_boot():
             stack.enter_context(p)
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
-        )
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub))
 
         rc, payload = run_tier(
             model="qwen3.5-4b-4bit",
@@ -276,12 +269,8 @@ def test_run_tier_skip_speed_avoids_lightweight_probe():
     with contextlib.ExitStack() as stack:
         for p in _patch_serve_boot():
             stack.enter_context(p)
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub)
-        )
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub)
-        )
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_smoke", _smoke_stub))
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub))
         stack.enter_context(
             patch("vllm_mlx.bench.tier_runner._run_harness", _harness_stub)
         )
@@ -318,9 +307,7 @@ def test_run_tier_skip_speed_ignored_for_non_all_tier():
     with contextlib.ExitStack() as stack:
         for p in _patch_serve_boot():
             stack.enter_context(p)
-        stack.enter_context(
-            patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub)
-        )
+        stack.enter_context(patch("vllm_mlx.bench.tier_runner._run_speed", _speed_stub))
 
         run_tier(
             model="qwen3.5-4b-4bit",
@@ -329,9 +316,7 @@ def test_run_tier_skip_speed_ignored_for_non_all_tier():
             skip_speed=True,
         )
 
-    assert calls == ["speed"], (
-        f"skip_speed must be tier='all' only; got calls={calls}"
-    )
+    assert calls == ["speed"], f"skip_speed must be tier='all' only; got calls={calls}"
 
 
 # --------------------------------------------------------------------- #

--- a/tests/test_submit_gitignore.py
+++ b/tests/test_submit_gitignore.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``.gitignore`` MUST list ``.claude/`` so ``--submit`` works from a
+Claude-Code worktree.
+
+PR #5's dogfood pass kept getting blocked at the ``_git_is_clean``
+gate inside ``submit_interactive`` because every Claude Code session
+drops ``.claude/scheduled_tasks.lock`` and ``.claude/worktrees/*`` as
+untracked files. ``--submit`` refuses (correctly) to open a PR from a
+dirty tree — but those files are NEVER part of the actual diff the
+contributor cares about, so the right fix is to ignore them at the
+repo level.
+
+This test locks the contract: if a maintainer ever removes the
+``.claude/`` entry, the test fails and explains why putting it back
+matters for the community-submit UX.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_gitignore_lists_claude_directory():
+    """``.gitignore`` must contain a top-level ``.claude/`` rule.
+
+    We check for the literal pattern (not a fancy regex over
+    ``git check-ignore``) because the failure mode we care about is
+    *someone deleted the line*, not "git's ignore semantics changed".
+    """
+    gitignore = REPO_ROOT / ".gitignore"
+    assert gitignore.exists(), ".gitignore must exist at repo root"
+    contents = gitignore.read_text()
+
+    # Accept any of: bare ``.claude/``, line-ending variant, or a
+    # qualified rule like ``/.claude/``. We don't accept commented-out
+    # forms (``# .claude/``) — that's the regression we're guarding.
+    accepted = (".claude/", "/.claude/")
+    matched = any(
+        line.strip() in accepted
+        for line in contents.splitlines()
+        if not line.strip().startswith("#")
+    )
+    assert matched, (
+        ".gitignore must list `.claude/` so `rapid-mlx bench --submit` "
+        "can open a PR from a Claude Code worktree (PR #5 wired this "
+        "after the dogfood run got blocked by `.claude/scheduled_tasks.lock` "
+        "and `.claude/worktrees/*` showing up in `git status`)."
+    )

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subprocess lifecycle helper for ``rapid-mlx serve`` during bench tier runs.
+
+Previously lived at ``vllm_mlx/doctor/server.py``; PR #622 slimmed the
+doctor module to pure env-health and deleted the file, but
+``vllm_mlx/bench/tier_runner.py`` still imported it — so every actual
+``rapid-mlx bench --tier ...`` invocation (which is exactly the path
+that took over the model-validation work) crashed with
+``ModuleNotFoundError: No module named 'vllm_mlx.doctor.server'``.
+
+PR #5 (the --tier/--submit unification) moves the helper to the bench
+package, which is the only consumer left in-tree. The implementation
+is unchanged byte-for-byte from the original except:
+
+- yields ``boot_time_ms`` in the info dict so the tier-smoke probe can
+  populate ``smoke_result.boot_time_ms`` for the community-bench
+  schema (PR #3 added that field; PR #5 wires the producer).
+- ``REPO_ROOT`` / ``python_executable`` are imported from the same
+  ``vllm_mlx.doctor.runner`` module that PR #622 kept around — no new
+  duplication; if doctor.runner ever moves, both this module and the
+  rest of the bench/ stack track it from one place.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from ..doctor.runner import REPO_ROOT, python_executable
+
+
+class ServerStartFailed(RuntimeError):  # noqa: N818 — domain-specific error name
+    """Server did not become healthy within the timeout."""
+
+
+def find_free_port() -> int:
+    """Pick a free TCP port on localhost.
+
+    OS-assigned ephemeral; tiny TOCTOU race between close and reuse
+    that doesn't matter for a single-host harness.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def serve(
+    model: str,
+    port: int | None = None,
+    log_path: Path | None = None,
+    extra_args: list[str] | None = None,
+    boot_timeout_s: int = 180,
+    model_path: str | Path | None = None,
+):
+    """Boot ``rapid-mlx serve <model>`` and yield the live base URL.
+
+    Yields a dict with:
+
+    - ``base_url`` — ``http://127.0.0.1:<port>/v1``
+    - ``health_url`` — ``http://127.0.0.1:<port>/health``
+    - ``port`` — the resolved port (matches the caller's request when set)
+    - ``boot_time_ms`` — wall-clock from process spawn to the first 200
+      from ``/health``. Populated for the community-bench smoke probe
+      (schema v2 ``smoke_result.boot_time_ms``).
+
+    On exit, SIGTERM the whole process group; escalate to SIGKILL after
+    10s. ``log_path`` if provided receives the server's combined
+    stdout/stderr.
+    """
+    if port is None:
+        port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    health_url = f"{base_url}/health"
+    v1_url = f"{base_url}/v1"
+
+    serve_target = str(model_path) if model_path else model
+    cmd = [
+        python_executable(),
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        serve_target,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    log_fh = open(log_path, "w") if log_path else subprocess.DEVNULL
+    t_spawn = time.perf_counter()
+    proc = subprocess.Popen(  # noqa: S603 — args constructed by us
+        cmd,
+        cwd=REPO_ROOT,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+        # New process group so we can signal the whole tree on teardown
+        # (uvicorn + worker children). POSIX-only; we don't run on win.
+        preexec_fn=os.setsid if sys.platform != "win32" else None,
+    )
+
+    try:
+        _wait_for_health(health_url, proc, boot_timeout_s)
+        boot_time_ms = (time.perf_counter() - t_spawn) * 1000.0
+        yield {
+            "base_url": v1_url,
+            "health_url": health_url,
+            "port": port,
+            "boot_time_ms": boot_time_ms,
+        }
+    finally:
+        _terminate(proc)
+        if log_fh is not subprocess.DEVNULL:
+            log_fh.close()
+
+
+def _wait_for_health(health_url: str, proc: subprocess.Popen, timeout_s: int) -> None:
+    """Poll /health until 200 or timeout. Abort early if the process dies."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise ServerStartFailed(
+                f"server exited with code {proc.returncode} before becoming healthy"
+            )
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+            time.sleep(0.5)
+    raise ServerStartFailed(
+        f"server did not respond at {health_url} within {timeout_s}s"
+    )
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Best-effort clean teardown of a server process group."""
+    if proc.poll() is not None:
+        return
+    try:
+        if sys.platform != "win32":
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            if sys.platform != "win32":
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+            proc.wait(timeout=5)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            pass
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+__all__ = ["serve", "find_free_port", "ServerStartFailed"]

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -139,9 +139,16 @@ def serve(
 
 
 def _wait_for_health(health_url: str, proc: subprocess.Popen, timeout_s: int) -> None:
-    """Poll /health until 200 or timeout. Abort early if the process dies."""
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
+    """Poll /health until 200 or timeout. Abort early if the process dies.
+
+    Uses ``time.monotonic()`` for the deadline so a system clock
+    adjustment mid-boot (NTP step, manual ``date`` change) can't
+    shorten or extend the health wait incorrectly (Codex PR #623
+    review NIT-2). ``time.time()`` would happily measure negative
+    elapsed time if the clock stepped backwards.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
         if proc.poll() is not None:
             raise ServerStartFailed(
                 f"server exited with code {proc.returncode} before becoming healthy"

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -97,18 +97,31 @@ def serve(
     if extra_args:
         cmd.extend(extra_args)
 
+    # Open the log file BEFORE the try/finally so the Popen call has
+    # an fd to point ``stdout=`` at — but guard with a narrow
+    # try/except so an exception INSIDE ``Popen`` (path error, OS
+    # resource exhaustion, etc.) doesn't leak the file handle.
+    # The outer try/finally below then owns the fh for the rest of
+    # the lifetime; this guard only covers the spawn window where
+    # the outer try hasn't started yet. (Codex PR #623 BLOCKING-2.)
     log_fh = open(log_path, "w") if log_path else subprocess.DEVNULL
-    t_spawn = time.perf_counter()
-    proc = subprocess.Popen(  # noqa: S603 — args constructed by us
-        cmd,
-        cwd=REPO_ROOT,
-        stdout=log_fh,
-        stderr=subprocess.STDOUT,
-        env=os.environ.copy(),
-        # New process group so we can signal the whole tree on teardown
-        # (uvicorn + worker children). POSIX-only; we don't run on win.
-        preexec_fn=os.setsid if sys.platform != "win32" else None,
-    )
+    try:
+        t_spawn = time.perf_counter()
+        proc = subprocess.Popen(  # noqa: S603 — args constructed by us
+            cmd,
+            cwd=REPO_ROOT,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            env=os.environ.copy(),
+            # New process group so we can signal the whole tree on
+            # teardown (uvicorn + worker children). POSIX-only; we
+            # don't run on win.
+            preexec_fn=os.setsid if sys.platform != "win32" else None,
+        )
+    except BaseException:
+        if log_fh is not subprocess.DEVNULL:
+            log_fh.close()
+        raise
 
     try:
         _wait_for_health(health_url, proc, boot_timeout_s)

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -245,15 +245,19 @@ def _run_smoke(
             passed=False,
             duration_s=elapsed,
             detail=f"FAIL: {type(exc).__name__}: {exc}",
-            # Schema-shaped failure payload — the submit path can still
-            # build a valid v2 row when the smoke probe fails, so the
-            # community-bench corpus has visibility into "model booted
-            # but couldn't answer 2+2". Emitted ONLY when we actually
-            # measured the boot ourselves; when ``boot_time_ms`` is
-            # ``None`` (--base-url attach path) we set ``payload=None``
-            # instead of inventing a ``0.0`` placeholder that the
-            # corpus can't tell apart from "machine boots in zero ms"
-            # (Codex PR #623 BLOCKING-1).
+            # Schema-shaped failure payload — diagnostic only under
+            # current policy. ``_run_tier_submit_flow`` aborts BEFORE
+            # consuming this payload when smoke fails (no point
+            # benching a model that can't say "4"), so the populated
+            # failure payload here is for the human-readable tier
+            # output and for any future caller that chooses to
+            # surface a failure-row to the corpus. Emitted ONLY when
+            # we actually measured the boot ourselves; when
+            # ``boot_time_ms`` is ``None`` (--base-url attach path)
+            # we set ``payload=None`` instead of inventing a ``0.0``
+            # placeholder that the corpus can't tell apart from
+            # "machine boots in zero ms" (Codex PR #623 BLOCKING-1,
+            # review-round-2 NIT-3 clarified the policy).
             payload=(
                 {
                     "boot_time_ms": float(boot_time_ms),

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -176,11 +176,15 @@ def _run_smoke(
 
     ``boot_time_ms`` is threaded through from ``_serve_or_attach`` so
     the schema v2 ``smoke_result.boot_time_ms`` field carries the real
-    spawn-to-healthy wall-clock; ``None`` when the user attached via
-    ``--base-url`` (we never measured the boot they paid for) — the
-    payload reports ``0.0`` in that case to satisfy the schema's
-    ``minimum: 0`` constraint while still being unambiguously "we
-    don't know" (a real boot takes seconds).
+    spawn-to-healthy wall-clock. When ``None`` (the user attached via
+    ``--base-url``, we never measured the boot they paid for) the
+    returned ``TierResult.payload`` is itself ``None`` — fails closed
+    rather than invent a ``0.0`` placeholder that the corpus can't
+    tell apart from "machine boots this model in zero ms" (Codex
+    PR #623 BLOCKING-1). The CLI's ``_run_tier_submit_flow`` refuses
+    ``--base-url`` for ``--submit`` so this null-payload case can
+    only surface via the non-submit ``--tier smoke --base-url``
+    path where the payload is never consumed.
     """
     import httpx
 
@@ -244,15 +248,22 @@ def _run_smoke(
             # Schema-shaped failure payload — the submit path can still
             # build a valid v2 row when the smoke probe fails, so the
             # community-bench corpus has visibility into "model booted
-            # but couldn't answer 2+2".
-            payload={
-                "boot_time_ms": float(boot_time_ms)
+            # but couldn't answer 2+2". Emitted ONLY when we actually
+            # measured the boot ourselves; when ``boot_time_ms`` is
+            # ``None`` (--base-url attach path) we set ``payload=None``
+            # instead of inventing a ``0.0`` placeholder that the
+            # corpus can't tell apart from "machine boots in zero ms"
+            # (Codex PR #623 BLOCKING-1).
+            payload=(
+                {
+                    "boot_time_ms": float(boot_time_ms),
+                    "first_prompt_ok": False,
+                    "first_token_latency_ms": 0.0,
+                    "response_excerpt": (f"[error] {type(exc).__name__}: {exc}"[:200]),
+                }
                 if boot_time_ms is not None
-                else 0.0,
-                "first_prompt_ok": False,
-                "first_token_latency_ms": 0.0,
-                "response_excerpt": f"[error] {type(exc).__name__}: {exc}"[:200],
-            },
+                else None
+            ),
         )
 
     elapsed = time.perf_counter() - t0
@@ -272,13 +283,21 @@ def _run_smoke(
         # 200 chars (schema maxLength); the truncation happens here so
         # the displayed-vs-submitted bytes match exactly. TTFT defaults
         # to 0.0 when the stream emitted no content delta (first_prompt
-        # was not ok in that case).
-        payload={
-            "boot_time_ms": float(boot_time_ms) if boot_time_ms is not None else 0.0,
-            "first_prompt_ok": ok,
-            "first_token_latency_ms": float(ttft_ms) if ttft_ms is not None else 0.0,
-            "response_excerpt": response_text[:200],
-        },
+        # was not ok in that case). When ``boot_time_ms`` is ``None``
+        # (--base-url attach path) we OMIT the payload entirely — see
+        # the matching comment in the failure branch for the rationale.
+        payload=(
+            {
+                "boot_time_ms": float(boot_time_ms),
+                "first_prompt_ok": ok,
+                "first_token_latency_ms": (
+                    float(ttft_ms) if ttft_ms is not None else 0.0
+                ),
+                "response_excerpt": response_text[:200],
+            }
+            if boot_time_ms is not None
+            else None
+        ),
     )
 
 

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -246,7 +246,9 @@ def _run_smoke(
             # community-bench corpus has visibility into "model booted
             # but couldn't answer 2+2".
             payload={
-                "boot_time_ms": float(boot_time_ms) if boot_time_ms is not None else 0.0,
+                "boot_time_ms": float(boot_time_ms)
+                if boot_time_ms is not None
+                else 0.0,
                 "first_prompt_ok": False,
                 "first_token_latency_ms": 0.0,
                 "response_excerpt": f"[error] {type(exc).__name__}: {exc}"[:200],
@@ -624,9 +626,7 @@ def run_tier(
                 if tier == "all" and not r.passed:
                     print()
                     print("  Aborting --tier all: smoke failed.")
-                    return _finalize_with_results(
-                        results, overall_t0, return_results
-                    )
+                    return _finalize_with_results(results, overall_t0, return_results)
 
             # PR #5: --submit code path sets skip_speed=True for tier='all'
             # because it runs the locked B=1 standardized bench against the

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -49,12 +49,35 @@ TIER_PORT_MAX = 8599
 
 @dataclass
 class TierResult:
-    """One tier's outcome. Aggregated by ``--tier all``."""
+    """One tier's outcome. Aggregated by ``--tier all``.
+
+    ``payload`` is the schema-v2-shaped sub-object the
+    community-bench submission would attach for this tier:
+
+    - smoke → matches the schema's ``smoke_result`` object
+      (boot_time_ms / first_prompt_ok / first_token_latency_ms /
+      response_excerpt).
+    - harness → matches the schema's ``harness_result`` object (the
+      per-adapter mapping with passed/duration_s/error_excerpt).
+    - speed → ``None`` here; the schema-shaped speed buckets come
+      from ``run_standardized_bench`` (PR #5's --submit path), not
+      from this HTTP-driven dispatcher. The lightweight
+      tier-speed probe is intentionally NOT submitted to
+      community-benchmarks because its numbers aren't comparable to
+      the locked B=1 protocol.
+
+    Populated unconditionally so ``--tier ... --submit`` can read the
+    same dict that the non-submit human-readable path already prints,
+    with no extra round-trip. Default ``None`` preserves the legacy
+    callsite signature for any caller that doesn't care about the
+    submission payload.
+    """
 
     name: str  # "smoke" | "speed" | "harness"
     passed: bool
     duration_s: float
     detail: str = ""
+    payload: dict | None = None
 
 
 def _find_free_port_in_range(lo: int, hi: int) -> int:
@@ -133,7 +156,11 @@ def _normalize_openai_base(base_url: str | None, port: int) -> str:
 # --------------------------------------------------------------------- #
 
 
-def _run_smoke(model: str, base_url: str) -> TierResult:
+def _run_smoke(
+    model: str,
+    base_url: str,
+    boot_time_ms: float | None = None,
+) -> TierResult:
     """Boot probe: send one prompt, assert response contains "4".
 
     The prompt is "Hello, what is 2+2?" — small models reliably answer
@@ -146,6 +173,14 @@ def _run_smoke(model: str, base_url: str) -> TierResult:
     the port to each tier, which meant ``--base-url`` against a non-localhost
     host (or a https scheme) was silently ignored (codex review #621
     BLOCKING).
+
+    ``boot_time_ms`` is threaded through from ``_serve_or_attach`` so
+    the schema v2 ``smoke_result.boot_time_ms`` field carries the real
+    spawn-to-healthy wall-clock; ``None`` when the user attached via
+    ``--base-url`` (we never measured the boot they paid for) — the
+    payload reports ``0.0`` in that case to satisfy the schema's
+    ``minimum: 0`` constraint while still being unambiguously "we
+    don't know" (a real boot takes seconds).
     """
     import httpx
 
@@ -206,6 +241,16 @@ def _run_smoke(model: str, base_url: str) -> TierResult:
             passed=False,
             duration_s=elapsed,
             detail=f"FAIL: {type(exc).__name__}: {exc}",
+            # Schema-shaped failure payload — the submit path can still
+            # build a valid v2 row when the smoke probe fails, so the
+            # community-bench corpus has visibility into "model booted
+            # but couldn't answer 2+2".
+            payload={
+                "boot_time_ms": float(boot_time_ms) if boot_time_ms is not None else 0.0,
+                "first_prompt_ok": False,
+                "first_token_latency_ms": 0.0,
+                "response_excerpt": f"[error] {type(exc).__name__}: {exc}"[:200],
+            },
         )
 
     elapsed = time.perf_counter() - t0
@@ -216,7 +261,23 @@ def _run_smoke(model: str, base_url: str) -> TierResult:
         f"{'PASS' if ok else 'FAIL'} model={model} ttft={ttft_display}ms "
         f"response={response_text[:60]!r}"
     )
-    return TierResult(name="smoke", passed=ok, duration_s=elapsed, detail=detail)
+    return TierResult(
+        name="smoke",
+        passed=ok,
+        duration_s=elapsed,
+        detail=detail,
+        # Schema-v2 ``smoke_result``. ``response_excerpt`` is capped at
+        # 200 chars (schema maxLength); the truncation happens here so
+        # the displayed-vs-submitted bytes match exactly. TTFT defaults
+        # to 0.0 when the stream emitted no content delta (first_prompt
+        # was not ok in that case).
+        payload={
+            "boot_time_ms": float(boot_time_ms) if boot_time_ms is not None else 0.0,
+            "first_prompt_ok": ok,
+            "first_token_latency_ms": float(ttft_ms) if ttft_ms is not None else 0.0,
+            "response_excerpt": response_text[:200],
+        },
+    )
 
 
 def _run_speed(model: str, base_url: str, sampled: bool = False) -> TierResult:
@@ -384,6 +445,23 @@ def _run_harness(model: str, base_url: str) -> TierResult:
     elapsed = time.perf_counter() - t0
     all_passed = all(ok for _, ok, _, _ in per_harness)
 
+    # Schema-v2 ``harness_result`` shape: one entry per HARNESS_PROFILES
+    # adapter with {passed, duration_s, error_excerpt}. On pass,
+    # error_excerpt is ``null`` (schema enforces ``["string", "null"]``);
+    # on fail, the first 200 chars of the existing detail line — same
+    # truncation cap as schema. The dict is keyed by adapter name; the
+    # schema's ``additionalProperties: false`` plus ``required`` of all
+    # 5 keys means this stays in lock-step with HARNESS_PROFILES (a
+    # mismatch is a schema-validation failure at submission time).
+    payload = {
+        name: {
+            "passed": ok,
+            "duration_s": float(dur),
+            "error_excerpt": None if ok else (detail or "")[:200],
+        }
+        for name, ok, dur, detail in per_harness
+    }
+
     # Render a human-readable summary line per harness.
     lines = [f"harness sweep model={model}"]
     for name, ok, dur, detail in per_harness:
@@ -394,6 +472,7 @@ def _run_harness(model: str, base_url: str) -> TierResult:
         passed=all_passed,
         duration_s=elapsed,
         detail="\n".join(lines),
+        payload=payload,
     )
 
 
@@ -407,11 +486,15 @@ def _serve_or_attach(
     base_url: str | None,
     boot_timeout_s: int = 600,
 ):
-    """Yield ``(port, owns_server)``.
+    """Yield ``(port, owns_server, boot_time_ms)``.
 
     If ``base_url`` is set, attach to that server — caller is responsible
-    for its lifecycle. Otherwise boot one on a port in
-    ``[TIER_PORT_MIN, TIER_PORT_MAX]`` and clean it up on exit.
+    for its lifecycle and ``boot_time_ms`` is ``None`` (the user
+    already paid the boot cost, we didn't measure it). Otherwise boot
+    one on a port in ``[TIER_PORT_MIN, TIER_PORT_MAX]`` and clean it
+    up on exit; ``boot_time_ms`` is the wall-clock from spawn to first
+    healthy /health response, which feeds the schema v2
+    ``smoke_result.boot_time_ms`` field.
     """
     import contextlib
 
@@ -439,19 +522,24 @@ def _serve_or_attach(
                     "Start `rapid-mlx serve <model>` on that port first, "
                     "or drop --base-url to let bench --tier boot its own."
                 )
-            yield port, False
+            yield port, False, None
             return
 
-        # Boot our own. Reuse the doctor's server helper since it's
-        # already battle-tested (proc-group teardown, /health polling).
+        # Boot our own. Helper lives in the bench/ package now (PR #5
+        # — PR #622 deleted the original ``doctor/server.py`` without
+        # repointing this import, breaking every tier invocation; the
+        # bench/ package is the only consumer left so we relocated it
+        # alongside the dispatcher). Battle-tested code path: proc-group
+        # teardown + /health polling, plus a boot_time_ms readout we
+        # need for ``smoke_result.boot_time_ms`` in the v2 schema.
         port = _find_free_port_in_range(TIER_PORT_MIN, TIER_PORT_MAX)
-        from ..doctor.server import serve
+        from ._server import serve
 
         # log_path=None → DEVNULL; the user-facing tier output is the
         # interesting signal. For debugging, the user can re-run with
         # `rapid-mlx serve <model> --port <port>` themselves.
         with serve(model=model, port=port, boot_timeout_s=boot_timeout_s) as info:
-            yield info["port"], True
+            yield info["port"], True, info.get("boot_time_ms")
 
     return _ctx()
 
@@ -467,13 +555,35 @@ def run_tier(
     base_url: str | None = None,
     sampled: bool = False,
     boot_timeout_s: int = 600,
-) -> int:
+    return_results: bool = False,
+    skip_speed: bool = False,
+):
     """Dispatch to the requested tier. Returns process exit code.
 
     ``tier`` is one of: ``"smoke"``, ``"speed"``, ``"harness"``, ``"all"``.
     Server is booted ONCE (or attached via ``base_url``) and torn down
     on exit. For ``"all"``, smoke runs first and aborts the sequence
     on failure — there's no point benching a model that can't say "4".
+
+    Two PR #5 additions (default-off for back-compat):
+
+    - ``return_results=True`` flips the return type to
+      ``tuple[int, dict]`` where the dict carries schema-v2-shaped
+      ``smoke_result`` / ``harness_result`` sub-objects (None when the
+      corresponding tier didn't run, e.g. ``tier=speed``). The
+      ``--tier ... --submit`` wiring needs this so it can feed
+      ``build_submission_payload`` without re-running the tier work.
+    - ``skip_speed=True`` is honored only when ``tier == "all"`` and
+      tells the dispatcher to skip the lightweight HTTP-based speed
+      probe. The caller (``--tier all --submit``) is going to run the
+      locked B=1 ``run_standardized_bench`` against the same model
+      separately — running the lightweight probe too would just
+      double-cost the bench (and produce numbers that aren't comparable
+      to the submitted ones, which is misleading).
+
+    Without either kwarg, the signature and return type are byte-for-
+    byte identical to the PR #2 surface — existing callers continue to
+    receive ``int``.
     """
     if tier not in ("smoke", "speed", "harness", "all"):
         print(
@@ -481,6 +591,8 @@ def run_tier(
             "smoke / speed / harness / all",
             file=sys.stderr,
         )
+        if return_results:
+            return 2, {"smoke_result": None, "harness_result": None}
         return 2
 
     print(f"Rapid-MLX bench — tier={tier} model={model}")
@@ -490,7 +602,11 @@ def run_tier(
     results: list[TierResult] = []
 
     try:
-        with _serve_or_attach(model, base_url, boot_timeout_s) as (port, owns):
+        with _serve_or_attach(model, base_url, boot_timeout_s) as (
+            port,
+            owns,
+            boot_time_ms,
+        ):
             # Build the fully-qualified base URL ONCE. Each tier gets
             # the same string, so --base-url's scheme + host are honored
             # end-to-end (codex review #621 BLOCKING).
@@ -502,15 +618,23 @@ def run_tier(
             print()
 
             if tier in ("smoke", "all"):
-                r = _run_smoke(model, openai_base)
+                r = _run_smoke(model, openai_base, boot_time_ms=boot_time_ms)
                 _print_tier_result(r)
                 results.append(r)
                 if tier == "all" and not r.passed:
                     print()
                     print("  Aborting --tier all: smoke failed.")
-                    return _finalize(results, overall_t0)
+                    return _finalize_with_results(
+                        results, overall_t0, return_results
+                    )
 
-            if tier in ("speed", "all"):
+            # PR #5: --submit code path sets skip_speed=True for tier='all'
+            # because it runs the locked B=1 standardized bench against the
+            # same model right after. The lightweight tier-speed probe is
+            # explicitly NOT comparable to the standardized numbers, so
+            # running both would just waste cycles AND mislead anyone
+            # eyeballing the two outputs.
+            if tier in ("speed", "all") and not (tier == "all" and skip_speed):
                 r = _run_speed(model, openai_base, sampled=sampled)
                 _print_tier_result(r)
                 results.append(r)
@@ -521,9 +645,52 @@ def run_tier(
                 results.append(r)
     except Exception as exc:  # noqa: BLE001 — surface as exit code, not traceback
         print(f"\n  Error during tier run: {type(exc).__name__}: {exc}")
+        if return_results:
+            return 1, _collect_payload(results)
         return 1
 
-    return _finalize(results, overall_t0)
+    return _finalize_with_results(results, overall_t0, return_results)
+
+
+def _collect_payload(results: list[TierResult]) -> dict:
+    """Pull the schema-v2 sub-objects out of the per-tier results.
+
+    Always returns the same shape so the caller can pattern-match
+    without ``in`` checks:
+
+    - ``smoke_result``: the smoke TierResult's payload, or ``None`` if
+      smoke didn't run.
+    - ``harness_result``: same for harness.
+
+    Speed is intentionally absent — the speed bucket of a v2
+    submission comes from ``run_standardized_bench``, not from the
+    tier dispatcher's lightweight HTTP probe (whose numbers aren't
+    comparable to the locked B=1 protocol).
+    """
+    out: dict = {"smoke_result": None, "harness_result": None}
+    for r in results:
+        if r.name == "smoke":
+            out["smoke_result"] = r.payload
+        elif r.name == "harness":
+            out["harness_result"] = r.payload
+    return out
+
+
+def _finalize_with_results(
+    results: list[TierResult],
+    t0: float,
+    return_results: bool,
+):
+    """Print summary, then return either ``int`` or ``(int, dict)``.
+
+    Kept as a separate helper so every early-exit branch in
+    ``run_tier`` shapes its return value consistently — the int-vs-
+    tuple decision lives in exactly one place.
+    """
+    rc = _finalize(results, t0)
+    if return_results:
+        return rc, _collect_payload(results)
+    return rc
 
 
 def _print_tier_result(r: TierResult) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1145,6 +1145,38 @@ def _run_tier_submit_flow(args) -> int:
     tier = args.tier
     assert tier in ("smoke", "speed", "harness", "all"), tier
 
+    # Reject --base-url for the --submit combo (Codex PR #623
+    # BLOCKING-1). The community-bench corpus aggregates by
+    # (chip, model, version) — every submission MUST reflect the
+    # contributor's actual hardware booting their actual model. Two
+    # gaps if we allowed --base-url:
+    #
+    # 1. ``smoke_result.boot_time_ms`` is meaningless when the
+    #    server was already up (we didn't measure the user's boot);
+    #    the producer would have to invent a ``0.0`` placeholder
+    #    that downstream consumers can't distinguish from "machine
+    #    boots the model in zero ms" — a misleading row in the DB.
+    # 2. Phase 2 runs ``run_standardized_bench`` IN PROCESS against
+    #    a freshly-loaded engine, so the buckets numbers would NOT
+    #    match the server the user pointed at. We'd publish a
+    #    payload labelling itself as the user's setup while the
+    #    speed numbers came from a separate engine init.
+    #
+    # The narrow --tier (no --submit) --base-url path is still
+    # supported — that's the gauntlet/release_check use case where
+    # we WANT to validate against an already-running server.
+    if getattr(args, "base_url", None):
+        print(
+            "  Error: --base-url is incompatible with --submit. "
+            "Community-bench submissions must reflect a fresh boot of "
+            "your model on your hardware — smoke_result.boot_time_ms "
+            "and the standardized B=1 buckets are both measured "
+            "in-process. Drop --base-url and let bench --tier "
+            "--submit boot the server itself.",
+            file=sys.stderr,
+        )
+        return 2
+
     # tier='speed' --submit is the historical --submit path with a
     # new ``tier='speed'`` tag on the payload. No phase 1 needed.
     if tier == "speed":

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1143,7 +1143,20 @@ def _run_tier_submit_flow(args) -> int:
     adapter failure flags.
     """
     tier = args.tier
-    assert tier in ("smoke", "speed", "harness", "all"), tier
+    # Validate the tier even though argparse's ``choices=`` should
+    # have rejected anything else — a programmatic Namespace (e.g.
+    # someone constructing args directly) could bypass argparse, and
+    # the previous ``assert`` would be stripped under ``python -O``
+    # (Codex PR #623 review NIT-1). Explicit guard returns 2 with a
+    # readable error rather than blowing up later inside the submit
+    # flow with a less targeted traceback.
+    if tier not in ("smoke", "speed", "harness", "all"):
+        print(
+            f"  Error: unknown tier {tier!r}; expected one of "
+            "smoke / speed / harness / all",
+            file=sys.stderr,
+        )
+        return 2
 
     # Reject --base-url for the --submit combo (Codex PR #623
     # BLOCKING-1). The community-bench corpus aggregates by

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1113,7 +1113,120 @@ def serve_command(args):
     )
 
 
-def _run_submit_flow(args) -> int:
+def _run_tier_submit_flow(args) -> int:
+    """``rapid-mlx bench <model> --tier <T> --submit`` — PR #5 unification.
+
+    Three-phase pipeline:
+
+    1. Run the requested tier's smoke / harness work through the
+       existing HTTP-server-backed dispatcher (``run_tier`` with
+       ``return_results=True``). For ``tier='all'`` we pass
+       ``skip_speed=True`` because phase 2 will produce the comparable
+       speed numbers directly from the engine; running the lightweight
+       HTTP-speed probe too would just double-cost the bench AND
+       produce a second set of non-comparable numbers next to it.
+       For ``tier='speed'`` phase 1 is a no-op — straight to phase 2.
+    2. Run the locked B=1 ``run_standardized_bench`` against the same
+       model so the schema-required ``buckets`` field carries the
+       comparable numbers the community-benchmarks corpus expects.
+       This phase IS what plain ``--submit`` (no ``--tier``) has
+       always done; the tier kwargs just decorate the payload.
+    3. Build the schema-v2 payload and run the standard interactive
+       submit flow (consent → write → commit → push → gh pr create).
+
+    Tier-failure handling: if phase 1's smoke probe FAILS, abort
+    before phase 2 — there's no point benching a model that can't
+    answer "what is 2+2?". A phase 1 harness failure does NOT abort:
+    submitting a failure row IS the point of the harness tier (the
+    aggregator wants visibility into "this combo doesn't pass the
+    gauntlet"), so we proceed and let the payload carry the per-
+    adapter failure flags.
+    """
+    tier = args.tier
+    assert tier in ("smoke", "speed", "harness", "all"), tier
+
+    # tier='speed' --submit is the historical --submit path with a
+    # new ``tier='speed'`` tag on the payload. No phase 1 needed.
+    if tier == "speed":
+        return _run_submit_flow(args, tier="speed")
+
+    # Phase 1: run the tier dispatcher to capture smoke/harness data.
+    # Speed bucket is intentionally skipped (see docstring); ``run_tier``
+    # only honours ``skip_speed`` when tier=='all'.
+    from .bench.tier_runner import run_tier
+
+    rc, tier_results = run_tier(
+        model=args.model,
+        tier=tier,
+        base_url=getattr(args, "base_url", None),
+        sampled=getattr(args, "sampled", False),
+        return_results=True,
+        skip_speed=True,
+    )
+    smoke_result = tier_results.get("smoke_result")
+    harness_result = tier_results.get("harness_result")
+
+    # Abort gating. The smoke probe is a hard prerequisite for ANY
+    # submission: if the model can't say "4" the speed numbers we'd
+    # collect in phase 2 would be misleading at best and a fork-and-
+    # burn of the user's compute at worst. Harness failures are
+    # surfaced THROUGH the payload (the schema's per-adapter
+    # ``passed: false`` carries the signal); we DON'T abort there.
+    if tier in ("smoke", "all") and smoke_result is not None:
+        if not smoke_result.get("first_prompt_ok", False):
+            print(
+                "\n  Submission aborted: smoke probe failed. The model "
+                "couldn't answer the boot prompt cleanly — submitting "
+                "speed/harness numbers from this run would be "
+                "misleading. Re-check the model + environment with "
+                "`rapid-mlx bench <model> --tier smoke` first.",
+                file=sys.stderr,
+            )
+            return 1
+
+    if tier == "smoke" and smoke_result is None:
+        # Phase 1 errored before producing smoke_result (e.g. server
+        # boot failure). The exit code from ``run_tier`` is already
+        # the right thing to return — don't try to phase 2 without
+        # the required smoke_result data.
+        print(
+            "\n  Submission aborted: smoke phase did not produce a "
+            "result (server boot likely failed). Nothing was sent.",
+            file=sys.stderr,
+        )
+        return rc or 1
+    if tier == "harness" and harness_result is None:
+        print(
+            "\n  Submission aborted: harness phase did not produce a "
+            "result. Nothing was sent.",
+            file=sys.stderr,
+        )
+        return rc or 1
+    if tier == "all" and (smoke_result is None or harness_result is None):
+        print(
+            "\n  Submission aborted: --tier all did not produce both "
+            "smoke and harness results. Nothing was sent.",
+            file=sys.stderr,
+        )
+        return rc or 1
+
+    # Phase 2 + 3 reuse the existing standardized + submit path; the
+    # tier kwargs decorate the payload built inside ``_run_submit_flow``.
+    return _run_submit_flow(
+        args,
+        tier=tier,
+        smoke_result=smoke_result,
+        harness_result=harness_result,
+    )
+
+
+def _run_submit_flow(
+    args,
+    *,
+    tier: str | None = None,
+    smoke_result: dict | None = None,
+    harness_result: dict | None = None,
+) -> int:
     """Execute the standardized B=1 community-bench + PR-open flow.
 
     Routed-to from ``bench_command`` whenever ``--submit`` is set.
@@ -1121,6 +1234,19 @@ def _run_submit_flow(args) -> int:
     completely untouched — the standardized path imports its own
     deps lazily so that users who never touch ``--submit`` don't pay
     the import cost of the community_bench module.
+
+    PR #5 added the schema-v2 tier-tagging kwargs:
+
+    - ``tier`` — string copied verbatim into the ``tier`` field of the
+      payload (``"speed"`` | ``"smoke"`` | ``"harness"`` | ``"all"``).
+      ``None`` (the default, used by ``--submit`` without ``--tier``)
+      omits the field, preserving byte-for-byte equivalence with the
+      v1 ``--submit`` payload shape.
+    - ``smoke_result`` / ``harness_result`` — schema-v2 sub-objects
+      from the tier dispatcher. The builder enforces the
+      tier↔result coupling so passing the wrong combo here ``ValueError``s
+      at the payload-build line rather than landing a half-shaped row
+      in the submissions corpus.
     """
     import asyncio
     from pathlib import Path
@@ -1360,6 +1486,15 @@ def _run_submit_flow(args) -> int:
                     hf_path=hf_path,
                     bench=bench,
                     notes=notes,
+                    # v2 tier-tagging: pass through only when the caller
+                    # supplied them. The builder validates the tier ↔
+                    # smoke_result/harness_result coupling — passing
+                    # ``smoke_result`` for ``tier=speed`` would
+                    # ``ValueError`` here rather than land a half-shaped
+                    # row in the corpus.
+                    tier=tier,
+                    smoke_result=smoke_result,
+                    harness_result=harness_result,
                 )
                 rc = submit_interactive(payload, repo_root)
                 if rc != 0:
@@ -1389,18 +1524,17 @@ def bench_command(args):
     _mlx_compat.install()
 
     # --tier routes through the user-facing tier dispatcher (PR #2 of
-    # the bench-consolidation series). Mutually-exclusive with --submit
-    # for now; PR #3 will unify them. Keep this branch ABOVE --submit
-    # so a future maintainer can't accidentally let --submit win when
-    # both flags are set (we'd rather hard-fail and tell the user).
+    # the bench-consolidation series). PR #5 unified --tier with
+    # --submit: when both flags are set the dispatcher runs the
+    # requested smoke/harness work for the schema-v2 sub-objects and
+    # ALSO runs the locked B=1 ``run_standardized_bench`` so the
+    # required ``buckets`` field carries comparable numbers (the
+    # lightweight tier-speed probe is NEVER submitted — its results
+    # aren't apples-to-apples with the community DB).
+    if getattr(args, "tier", None) and getattr(args, "submit", False):
+        sys.exit(_run_tier_submit_flow(args))
+
     if getattr(args, "tier", None):
-        if getattr(args, "submit", False):
-            print(
-                "  Error: --tier and --submit are mutually-exclusive. "
-                "Run --tier to validate, then --submit to upload.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
         from .bench.tier_runner import run_tier
 
         sys.exit(


### PR DESCRIPTION
## Why

PR #2 (#621) shipped `rapid-mlx bench --tier` and PR #3 (#620) shipped the schema-v2 with optional `smoke_result` / `harness_result` sub-objects, but the CLI kept the two flags mutually-exclusive. The comment at `vllm_mlx/cli.py:1391-1395` literally says *"PR #3 will unify them"* — but PR #3 only landed the schema. This PR closes the gap.

## Surface changes

- `rapid-mlx bench <model> --tier all --submit` works end-to-end. The combo routes through a new `_run_tier_submit_flow` that:
  1. Runs the requested smoke/harness work via the HTTP-server-backed tier dispatcher (with `skip_speed=True` because phase 2 produces the comparable numbers).
  2. Runs the locked B=1 `run_standardized_bench` for the schema-required `buckets` field.
  3. Opens the submission PR carrying the v2 `tier` / `smoke_result` / `harness_result` decorations.
- **The lightweight tier-speed probe is NEVER submitted.** Its numbers aren't comparable to the locked B=1 protocol; running both would waste cycles AND mislead anyone diffing the two. `run_tier` gained a `skip_speed=True` kwarg (tier='all'-only) for this.
- Plain `--submit` (no `--tier`) is byte-identical to before, modulo the v2 `schema_version` integer that PR #3 already bumped.
- Smoke probe **failure** aborts before phase 2 (no point benching a model that can't answer "what is 2+2?"). Harness **failure** does NOT abort — the per-adapter `passed: false` IS the signal the corpus wants.

## Wiring

- `run_tier(..., return_results=True)` flips the return type to `tuple[int, dict]` carrying schema-v2-shaped sub-objects (with `None` for tiers that didn't run). Default remains `int` so PR #2 callers (release_check_m3.sh G7b) are unaffected.
- `TierResult` grew an optional `payload` field; `_run_smoke` and `_run_harness` populate it inline so the same dict the human-readable path prints is what `--submit` reads — no extra round-trip.
- `build_submission_payload` already accepted the v2 kwargs (PR #3); this PR just feeds them.

## Collateral fix

PR #622 deleted `vllm_mlx/doctor/server.py` but left `tier_runner.py` importing it, so every real `--tier` invocation crashed with `ModuleNotFoundError`. Existing tier tests masked the bug because they monkeypatched the import path. This PR:

- Relocates `serve` to `vllm_mlx/bench/_server.py` — the bench package is the only consumer left.
- Threads `boot_time_ms` through the context manager so `smoke_result.boot_time_ms` carries the real spawn-to-healthy wall-clock (schema v2 required).

## `.gitignore`

Added `.claude/` at the top of `.gitignore`. Every Claude Code session leaves `.claude/scheduled_tasks.lock` and `.claude/worktrees/*` as untracked files, and `--submit` (correctly) refuses to open a PR from a dirty tree. Without this, dogfooding the new combo flow from a Claude Code worktree is structurally blocked — which is exactly what triggered this PR's dogfood run to fail.

## Version

0.7.24 → 0.7.25.

## Test plan

- [x] `tests/test_bench_tier_submit_combo.py` (10 new tests):
  - `return_results=True` returns `(int, dict)` with schema-v2 sub-objects.
  - Default `run_tier` signature unchanged — still returns `int`.
  - Missing tiers map to `None` in the returned payload dict.
  - `skip_speed=True` avoids the lightweight HTTP probe for `tier='all'`.
  - `skip_speed=True` is ignored for `tier='speed'` (no silent no-op).
  - `tier='all' --submit` payload validates against `schema.json`.
  - `tier='smoke'` populates `smoke_result` only (no `harness_result`).
  - `tier='harness'` populates `harness_result` only (no `smoke_result`).
  - The mutual-exclusive guard is gone — `bench --tier all --submit` parses cleanly.
  - `bench_command` routes the combo into `_run_tier_submit_flow` (not the bare paths).
- [x] `tests/test_submit_gitignore.py` (1 new test) — `.claude/` listed in `.gitignore`.
- [x] Existing 21 tier tests pass after rebasing onto the new patch target (`vllm_mlx.bench._server.serve`) and smoke-stub signature with `boot_time_ms`. (They were silently broken on `main` since #622.)
- [x] Full unit suite: 5341 passed, 18 skipped (one pre-existing integration-test failure deselected — `tests/test_event_loop.py` requires a real server on `127.0.0.1:8000`).
- [x] `python -m vllm_mlx.cli bench --help` shows both `--tier` and `--submit` cleanly.
- [x] `bench --tier all --submit` no longer hits the exit-2 guard (locked by `test_mutual_exclusive_guard_removed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)