### PR TITLE
chore(aliases): add qwen3-0.6b-4bit for desktop first-paint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.24"
+version = "0.7.25"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -162,6 +162,14 @@
     "is_hybrid": false,
     "supports_spec_decode": true
   },
+  "qwen3-0.6b-4bit": {
+    "hf_path": "mlx-community/Qwen3-0.6B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true
+  },
   "qwen3-0.6b-8bit": {
     "hf_path": "mlx-community/Qwen3-0.6B-8bit",
     "tool_call_parser": "hermes",


### PR DESCRIPTION
## Summary

Adds `qwen3-0.6b-4bit` -> `mlx-community/Qwen3-0.6B-4bit` to `vllm_mlx/aliases.json` so that **rapid-desktop v0.7.1** can bundle a ~320MB instant-on model in its DMG. This unblocks the first-paint UX fix where v0.7.0 currently forces a 7+GB HuggingFace download on first launch and stalls on `cas-bridge.xethub.hf.co` / `huggingface_hub` 10s read-timeouts.

Profile is symmetric to the existing `qwen3-0.6b-8bit` entry:

```json
"qwen3-0.6b-4bit": {
  "hf_path": "mlx-community/Qwen3-0.6B-4bit",
  "tool_call_parser": "hermes",
  "reasoning_parser": "qwen3",
  "is_hybrid": false,
  "is_moe": false,
  "supports_spec_decode": true
}
```

## Why the 4-bit and not the 8-bit?

The desktop bundle target is the on-disk footprint of the safetensors shard. 4-bit weighs ~320MB single-file, 8-bit ~600MB. Sniff-test (qwen3-0.6b-4bit vs gemma-3-270m-it-4bit on 9 creative/arithmetic/code prompts) won 7/9 for Qwen3, including all arithmetic and code prompts where the gemma 270M variant loops or breaks. Qwen3 family lineage also gives chat-template / tool-call shape continuity with every RAMBucketedDefault upgrade target.

## Naming

`qwen3-0.6b-4bit` complies with the canonical `<family>-<size>-<quant>` convention. No bare aliases.

## Verification

```bash
python3.12 -c "from vllm_mlx.model_aliases import resolve_profile; print(resolve_profile('qwen3-0.6b-4bit'))"
# AliasProfile(hf_path='mlx-community/Qwen3-0.6B-4bit', tool_call_parser='hermes', reasoning_parser='qwen3', is_hybrid=False, is_moe=False, supports_spec_decode=True, ...)

python3.12 -m pytest tests/test_model_profiles_ssot.py tests/test_aliases_contract.py -x -q
# 897 passed
```

## Test plan

- [x] AliasProfile resolves
- [x] SSOT + alias-contract tests pass (897/897)
- [x] pyproject.toml version bumped 0.7.24 -> 0.7.25 (required by version-bump-check workflow when aliases.json changes)