### PR TITLE
fix(sidecar): disable hf_xet by default to unblock model downloads

### DIFF
--- a/scripts/sidecar-shim.sh
+++ b/scripts/sidecar-shim.sh
@@ -51,6 +51,20 @@ export PYTHONNOUSERSITE=1
 # reject the bundle as "a sealed resource is missing or invalid".
 # rapid-desktop #230.
 export PYTHONDONTWRITEBYTECODE=1
+
+# HuggingFace download path. hf_xet 1.5.1 (the chunked-download client
+# huggingface_hub 1.19 selects by default) stalls at ~6 MB transferred
+# and emits no error, leaving model downloads frozen at "0 of N files"
+# on residential macOS networks. Diagnosed 2026-06-16 against a v0.7.0
+# install: raw curl through cas-bridge.xethub.hf.co / us.aws.cdn.hf.co
+# pulls 200 MB at a steady 2.3 MB/s; the Python client on the same
+# socket hangs zero-progress for >5 min. Disabling Xet routes the
+# downloader back onto plain HTTPS range-GETs against the same CDN,
+# which works. HF_HUB_DOWNLOAD_TIMEOUT=300 is cheap insurance on the
+# slower link. Both honor ${VAR:-default} so power-users can override.
+export HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
+export HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-300}"
+
 unset PYTHONSTARTUP
 
 exec "$ROOT/python/bin/python3.12" -s -m vllm_mlx.cli "$@"


### PR DESCRIPTION
## Summary

Disable `hf_xet` by default in `scripts/sidecar-shim.sh` to fix the "0 of N files" first-launch download stall.

## Root cause

Diagnosed 2026-06-16 from a v0.7.0 install (rapid-desktop) where every >5 GB model hung at zero progress on first launch:

| Test | Result |
|---|---|
| DNS / TLS to `huggingface.co`, `cas-bridge.xethub.hf.co`, `us.aws.cdn.hf.co` | all OK, <150 ms TLS |
| `curl --range 0-209715200` through `cas-bridge` (200 MB sustained) | **2.29 MB/s, steady, no stall** |
| `huggingface_hub.snapshot_download` defaults (hf_xet enabled) | **stalled at ~6 MB / 0 B over 60 s / killed after 5 min, no error** |
| Same client with `HF_HUB_DISABLE_XET=1` | **steady ~2.5 MB/s past 120 MB** |

The Xet bridge CDNs and HF backbone are healthy. The `hf_xet` 1.5.1 chunked-download client is what hangs. Plain HTTPS range-GETs against the identical CDN work fine.

## Fix

Two env exports in the sidecar shim:

```sh
export HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
export HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-300}"
```

- `${VAR:-default}` form preserves operator override (`HF_HUB_DISABLE_XET=0` re-enables Xet for environments where it works).
- Timeout bump is cheap insurance for slow residential links Xet historically masked behind chunked retries.

## Test plan

- [x] `sh -n scripts/sidecar-shim.sh` — syntax OK
- [x] Diff is 14 lines, single file, no behavior change beyond the two new env exports

## Post-merge verification (not a pre-merge gate)

After this PR lands → next rapid-mlx version cut → rapid-desktop submodule bump → new DMG built: a fresh-install model download must reach ≥10 MB transferred within 30 s (vs the current 6 MB hang). To re-verify, first run `launchctl unsetenv HF_HUB_DISABLE_XET` to clear any prior user-level workaround so the test exercises only the shim-injected default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)