### PR TITLE
chore: bump version to 0.7.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.25"
+version = "0.7.26"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bump pyproject 0.7.25 → 0.7.26 so `auto-release.yml` tags `v0.7.26` and `publish.yml` fans out to PyPI + Homebrew.
- 0.7.25's feature work (PRs #618/#620/#621/#622/#623/#624) is already on main but never shipped because none of those subjects matched the bump regex.

## What ships in 0.7.26
- `bench --tier {smoke,speed,harness,all}` (#621)
- `bench --tier ... --submit` unified flow (#623)
- `doctor` slimmed to pure env-health (#622)
- community-benchmarks schema v2 (#620)
- `qwen3-0.6b-4bit` alias (#624)

## Test plan
N/A — this is a pure version bump (1-line diff in `pyproject.toml`). Behavior is verified post-merge by watching `auto-release.yml` → `publish.yml` → PyPI + Homebrew tap.