### PR TITLE
fix(release): accept squash-merge suffix in bump subject regex

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,11 +30,11 @@ jobs:
           SUBJECT=$(git log -1 --pretty=%s)
           echo "subject: $SUBJECT"
 
-          # Strict format: ``chore: bump version to X.Y.Z``.
-          # We don't try to be clever — version bumps are intentional
-          # and the dev should match this exact form.
-          if echo "$SUBJECT" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+$'; then
-            VERSION=$(echo "$SUBJECT" | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+          # Strict format: ``chore: bump version to X.Y.Z``, optionally
+          # followed by GitHub's squash-merge suffix `` (#N)``. v0.7.26
+          # slipped because the strict ``$`` anchor rejected the suffix.
+          if echo "$SUBJECT" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
+            VERSION=$(echo "$SUBJECT" | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Detected version bump → v$VERSION"


### PR DESCRIPTION
## Summary
- `auto-release.yml` regex required `chore: bump version to X.Y.Z` to be the **entire** commit subject, but GitHub's squash-merge auto-appends ` (#N)`. v0.7.26 (PR #628) silently fell through to "Not a version bump — skipping", so the tag + GitHub release had to be cut by hand.
- Same gate snagged historic v0.7.20 (#617) — the author field on that release is `raullenchai`, not `github-actions`.

## Fix
- Allow an optional ` (#N)` tail in the regex.
- Adjust the sed extractor to strip whatever follows the version.

## Verification
- The new regex still rejects malformed subjects (e.g. `chore: bump version to 1.2`, `feat: bump version to 1.2.3`, `chore: bump version to 1.2.3 extra`).
- It now accepts both `chore: bump version to 0.7.26` and `chore: bump version to 0.7.26 (#628)`.

## Test plan
N/A — workflow fix; verified by inspection. Will take effect on the next bump PR.