### PR TITLE
fix(bench): smoke probe handles reasoning models + stdin/stderr hygiene

### DIFF
--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -604,6 +604,93 @@ def test_smoke_payload_is_none_when_boot_time_unknown(capsys):
     )
 
 
+def test_smoke_passes_when_only_reasoning_content_streams():
+    """``_run_smoke`` MUST recognize ``delta.reasoning_content``.
+
+    Reasoning-parser models (qwen3, gemma4, deepseek_r1) emit their
+    ``<think>...</think>`` block as ``delta.reasoning_content`` instead
+    of ``delta.content`` — at small max_tokens budgets they can finish
+    the reasoning block while still inside it, never producing a
+    content delta at all. Pre-fix behavior on v0.7.26 was: smoke
+    FAIL on every reasoning-parser model with empty response, because
+    the probe only inspected ``delta.content``. qwen3-0.6b-4bit and
+    qwen3-8b-4bit both surfaced this during release dogfood.
+
+    This test pins the new behavior: smoke PASSES when the answer ("4")
+    appears in ``reasoning_content``, the payload's ``response_excerpt``
+    is the reasoning text tagged with ``[reasoning]``, and TTFT is
+    measured from the first reasoning chunk.
+    """
+    from vllm_mlx.bench.tier_runner import _run_smoke
+
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "qwen3-0.6b-4bit"}]}
+
+    class _FakeStreamResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            # Pure reasoning stream, no content deltas at all — what
+            # qwen3-0.6b-4bit actually emits for "what is 2+2" at
+            # max_tokens=64. We split the answer "4" across two chunks
+            # so the test also catches accidental "first chunk only"
+            # regressions.
+            return iter(
+                [
+                    'data: {"choices":[{"delta":{"reasoning_content":"Let me think. "}}]}',
+                    'data: {"choices":[{"delta":{"reasoning_content":"2+2 = 4."}}]}',
+                    "data: [DONE]",
+                ]
+            )
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url):
+            return _FakeResp()
+
+        def stream(self, method, url, json=None):
+            return _FakeStreamResp()
+
+    with patch("httpx.Client", lambda *a, **k: _FakeClient()):
+        r = _run_smoke(
+            model="qwen3-0.6b-4bit",
+            base_url="http://127.0.0.1:8500/v1",
+            boot_time_ms=2500.0,
+        )
+
+    assert r.passed is True, (
+        "smoke MUST pass when '4' is in reasoning_content — reasoning-parser "
+        "models legitimately answer inside <think>...</think>"
+    )
+    assert r.payload is not None
+    assert r.payload["first_prompt_ok"] is True
+    assert r.payload["first_token_latency_ms"] > 0, (
+        "TTFT must be measured from the first reasoning chunk, not 0.0"
+    )
+    assert "[reasoning]" in r.payload["response_excerpt"], (
+        "When only reasoning content streamed, response_excerpt MUST be "
+        "tagged so the corpus / log reader knows it came from "
+        "delta.reasoning_content, not delta.content"
+    )
+    assert "4" in r.payload["response_excerpt"]
+
+
 def test_tier_submit_routes_through_unified_flow(monkeypatch):
     """``bench_command`` MUST route --tier+--submit to ``_run_tier_submit_flow``.
 

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -29,12 +29,15 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 from ..doctor.runner import REPO_ROOT, python_executable
+
+_BOOT_LOG_TAIL_LINES = 30
 
 
 class ServerStartFailed(RuntimeError):  # noqa: N818 — domain-specific error name
@@ -104,12 +107,28 @@ def serve(
     # The outer try/finally below then owns the fh for the rest of
     # the lifetime; this guard only covers the spawn window where
     # the outer try hasn't started yet. (Codex PR #623 BLOCKING-2.)
-    log_fh = open(log_path, "w") if log_path else subprocess.DEVNULL
+    #
+    # If the caller didn't provide a log_path, route output to a temp
+    # file anyway so that on a boot crash we can replay the tail in
+    # the ``ServerStartFailed`` exception. Older code piped both
+    # streams to DEVNULL, which left users staring at
+    # ``server exited with code 3`` with nothing to act on (the
+    # gemma-4 / gemma3-multimodal aliases hit this — the real error
+    # was ``mlx-vlm not installed`` but bench surfaced nothing).
+    tmp_log: Path | None = None
+    if log_path is not None:
+        log_fh = open(log_path, "w")
+    else:
+        tmp_log = Path(
+            tempfile.mkstemp(prefix=f"rapid-mlx-bench-{port}-", suffix=".log")[1]
+        )
+        log_fh = open(tmp_log, "w")
     try:
         t_spawn = time.perf_counter()
         proc = subprocess.Popen(  # noqa: S603 — args constructed by us
             cmd,
             cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             env=os.environ.copy(),
@@ -119,12 +138,22 @@ def serve(
             preexec_fn=os.setsid if sys.platform != "win32" else None,
         )
     except BaseException:
-        if log_fh is not subprocess.DEVNULL:
-            log_fh.close()
+        log_fh.close()
+        if tmp_log is not None:
+            tmp_log.unlink(missing_ok=True)
         raise
 
     try:
-        _wait_for_health(health_url, proc, boot_timeout_s)
+        try:
+            _wait_for_health(health_url, proc, boot_timeout_s)
+        except ServerStartFailed as exc:
+            log_fh.flush()
+            tail = _read_log_tail(log_path or tmp_log, _BOOT_LOG_TAIL_LINES)
+            if tail:
+                raise ServerStartFailed(
+                    f"{exc}\n--- server log tail ---\n{tail}"
+                ) from exc
+            raise
         boot_time_ms = (time.perf_counter() - t_spawn) * 1000.0
         yield {
             "base_url": v1_url,
@@ -134,8 +163,21 @@ def serve(
         }
     finally:
         _terminate(proc)
-        if log_fh is not subprocess.DEVNULL:
-            log_fh.close()
+        log_fh.close()
+        if tmp_log is not None:
+            tmp_log.unlink(missing_ok=True)
+
+
+def _read_log_tail(log_path: Path | None, max_lines: int) -> str:
+    """Return the last ``max_lines`` lines of ``log_path``, best-effort."""
+    if log_path is None:
+        return ""
+    try:
+        with open(log_path, errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return ""
+    return "".join(lines[-max_lines:]).strip()
 
 
 def _wait_for_health(health_url: str, proc: subprocess.Popen, timeout_s: int) -> None:

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -204,14 +204,25 @@ def _run_smoke(
             # that would otherwise understate TTFT (codex review #621 NIT).
             ttft_ms: float | None = None
             content_parts: list[str] = []
+            reasoning_parts: list[str] = []
             req_start = time.perf_counter()
+            # max_tokens=256 (was 64): qwen3 / gemma4 / deepseek_r1 reasoning
+            # parsers route the first chunk of tokens into ``<think>...</think>``
+            # and emit them as ``delta.reasoning_content`` rather than
+            # ``delta.content``. A 64-token budget could be entirely consumed
+            # by the reasoning prefix on very small models (qwen3-0.6b-4bit
+            # hit this — smoke failed with response='' even on a healthy
+            # boot). 256 gives reasoning models room to finish thinking and
+            # produce the actual answer without making the probe slow on
+            # non-reasoning models (they stop at ~5-10 content tokens via
+            # finish_reason=stop).
             with client.stream(
                 "POST",
                 f"{base_url}/chat/completions",
                 json={
                     "model": model_id,
                     "messages": [{"role": "user", "content": "Hello, what is 2+2?"}],
-                    "max_tokens": 64,
+                    "max_tokens": 256,
                     "stream": True,
                     "temperature": 0,
                 },
@@ -229,15 +240,21 @@ def _run_smoke(
                         chunk = _json.loads(payload)
                     except ValueError:
                         continue
-                    delta = (
-                        chunk.get("choices", [{}])[0]
-                        .get("delta", {})
-                        .get("content", "")
-                    )
-                    if delta:
+                    delta_obj = chunk.get("choices", [{}])[0].get("delta", {})
+                    content_delta = delta_obj.get("content") or ""
+                    # Reasoning-parser models (qwen3, gemma4, deepseek_r1)
+                    # stream ``<think>...</think>`` into reasoning_content
+                    # instead of content. We track both so the smoke probe
+                    # passes for reasoning models AND measures TTFT from
+                    # whichever stream fires first.
+                    reasoning_delta = delta_obj.get("reasoning_content") or ""
+                    if content_delta or reasoning_delta:
                         if ttft_ms is None:
                             ttft_ms = (time.perf_counter() - req_start) * 1000
-                        content_parts.append(delta)
+                        if content_delta:
+                            content_parts.append(content_delta)
+                        if reasoning_delta:
+                            reasoning_parts.append(reasoning_delta)
     except Exception as exc:  # noqa: BLE001 — smoke must never crash
         elapsed = time.perf_counter() - t0
         return TierResult(
@@ -272,11 +289,23 @@ def _run_smoke(
 
     elapsed = time.perf_counter() - t0
     response_text = "".join(content_parts)
-    ok = "4" in response_text
+    reasoning_text = "".join(reasoning_parts)
+    # Pass if either stream produced "4" — reasoning models may answer
+    # entirely inside ``<think>`` for short prompts, and that's still a
+    # healthy boot.
+    ok = "4" in response_text or "4" in reasoning_text
+    # If only reasoning content streamed (no content delta at all), use
+    # it as the displayed excerpt so the user can see what the model
+    # actually said. Prefix with ``[reasoning]`` so the source is
+    # obvious in the corpus / logs.
+    if not response_text and reasoning_text:
+        display_text = f"[reasoning] {reasoning_text}"
+    else:
+        display_text = response_text
     ttft_display = f"{ttft_ms:.0f}" if ttft_ms is not None else "?"
     detail = (
         f"{'PASS' if ok else 'FAIL'} model={model} ttft={ttft_display}ms "
-        f"response={response_text[:60]!r}"
+        f"response={display_text[:60]!r}"
     )
     return TierResult(
         name="smoke",
@@ -297,7 +326,7 @@ def _run_smoke(
                 "first_token_latency_ms": (
                     float(ttft_ms) if ttft_ms is not None else 0.0
                 ),
-                "response_excerpt": response_text[:200],
+                "response_excerpt": display_text[:200],
             }
             if boot_time_ms is not None
             else None


### PR DESCRIPTION
## Summary
Three bench-infra bugs surfaced during the v0.7.26 release dogfood. All in `vllm_mlx/bench/` and all bite the unified `--tier ... --submit` path.

## Bugs

### 1. Reasoning-parser smoke false-negatives (Bug 4)
Models with `reasoning_parser` (qwen3, gemma4, deepseek_r1) stream `<think>...</think>` as `delta.reasoning_content`, not `delta.content`. `_run_smoke` only inspected `delta.content` → `response=''` → FAIL on a healthy boot. Cost qwen3-0.6b-4bit and qwen3-8b-4bit during dogfood.

**Fix:** read both deltas, pass when `"4"` appears in either, bump `max_tokens` from 64 → 256 so reasoning models have room to finish thinking AND answer. `response_excerpt` is tagged `[reasoning] ...` when only reasoning streamed.

### 2. `--submit` consent eaten by spawned child (Bug 1)
`_server.serve` didn't pass `stdin=subprocess.DEVNULL` to `Popen`. Under `echo y | rapid-mlx bench --submit`, the child read the `y\n` during boot; `_ask_consent` then saw EOF and cancelled. Cost gemma3-1b-qat-4bit a real submission.

**Fix:** pin child stdin to DEVNULL.

### 3. `ServerStartFailed` gave nothing to act on (Bug 2)
When `log_path=None`, stdout went to DEVNULL and stderr was merged in. Boot crash → `server exited with code 3` with zero context. Masked the real `ImportError: 'mlx-vlm' dependency missing` for all four gemma-vision aliases.

**Fix:** always route to a temp log (cleaned up at teardown); on `_wait_for_health` failure, include last 30 lines of the log in the exception.

## Test plan
- New unit test `test_smoke_passes_when_only_reasoning_content_streams` covers (1)
- (2) and (3) are subprocess-level — verified by re-running the dogfood sweep after merge

Found-by: v0.7.26 release dogfood (see `/tmp/release_val_v0.7.26/results.md`).