### PR TITLE
fix(agents): hint at profile.install_cmd when harness deps missing

### DIFF
--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -1152,12 +1152,35 @@ class AgentTestRunner:
 
             # If module failed to execute, report it as an error
             if exec_error is not None:
+                # ImportError / ModuleNotFoundError nearly always means
+                # the harness deps weren't installed in the rapid-mlx
+                # venv. The profile's ``install_cmd`` is exactly that
+                # hint; surface it in the message so users have a
+                # one-line copy-paste fix instead of "Module execution
+                # failed: No module named 'langchain_core'" with no
+                # path forward (v0.7.26 dogfood found this on every
+                # langchain harness run).
+                hint = ""
+                if isinstance(exec_error, (ImportError, ModuleNotFoundError)):
+                    try:
+                        testing = self.profile.get_testing_for_version(
+                            self.agent_version
+                        )
+                        if testing and testing.install_cmd:
+                            hint = (
+                                f" [hint: harness deps missing — run "
+                                f"`{testing.install_cmd}` in the rapid-mlx venv]"
+                            )
+                    except (AttributeError, KeyError):
+                        # Profile shape changed under us — fall back to
+                        # the bare error rather than crash the harness.
+                        pass
                 return [
                     TestResult(
                         f"specific:{test_module_name}",
                         TestStatus.ERROR,
                         duration_ms=(time.time() - t0) * 1000,
-                        message=f"Module execution failed: {exec_error!s:.120}",
+                        message=f"Module execution failed: {exec_error!s:.120}{hint}",
                         category="specific",
                     )
                 ]


### PR DESCRIPTION
## Summary
v0.7.26 dogfood ran the langchain harness on every alias and got `Module execution failed: No module named 'langchain_core'` each time. The rapid-mlx uv-tool venv doesn't ship langchain-openai — the profile's `install_cmd: pip install langchain-openai` is documentation, not an executed step. Users had nothing to act on.

This change surfaces the documented install command in the error message when the exec_error is an `ImportError`/`ModuleNotFoundError`. One-line copy-paste fix instead of needing to dig into the profile YAML.

Before:
```
Module execution failed: No module named 'langchain_core'
```

After:
```
Module execution failed: No module named 'langchain_core' [hint: harness deps missing — run `pip install langchain-openai` in the rapid-mlx venv]
```

## Test plan
Re-running the langchain harness during the v0.7.26 dogfood post-merge verification will confirm the new message shape.

Found-by: v0.7.26 release dogfood.