### PR TITLE
fix(gemma4): autodetect bare-fp layers in checkpoint to dodge altup quant bug

### DIFF
--- a/tests/test_gemma4_altup_autodetect.py
+++ b/tests/test_gemma4_altup_autodetect.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the gemma-4 altup-projection autodetect fix.
+
+v0.7.26 release dogfood found that ``rapid-mlx serve gemma-4-e2b-4bit``
+crashed at first decode step with::
+
+    ValueError: [quantized_matmul] The weight matrix should be uint32
+    but received bfloat16
+
+Root cause: ``mlx-community/gemma-4-e2b-it-4bit`` (and ``-e4b-``) ship
+with the ``per_layer_model_projection`` Linear stored as bare
+bfloat16 on disk — mlx-community's QAT pipeline intentionally keeps a
+handful of "altup" projection layers in full precision. Our prior
+loader applied ``nn.quantize(model, ...)`` blanket, converted that
+Linear to QuantizedLinear, then loaded the bf16 weight into it. At
+inference time ``mx.quantized_matmul`` raised on the dtype mismatch
+and the server emitted 0 tokens.
+
+The fix is in ``load_gemma4_text``: before ``nn.quantize`` runs, scan
+sanitized weights, mark any path whose ``.weight`` is bf16/fp16/fp32
+with NO ``.scales`` companion (= "kept fp16 on purpose"), and skip
+quantization on those paths.
+
+These tests pin the two pure-logic pieces of that fix
+(``_bare_fp_weight_paths`` and ``_path_matches_any_suffix``) so a
+future refactor can't silently re-introduce the regression. The
+end-to-end serve verification is covered by re-running the dogfood
+on ``gemma-4-e2b-4bit`` post-merge.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from vllm_mlx.models.gemma4_text import (
+    _bare_fp_weight_paths,
+    _path_matches_any_suffix,
+)
+
+
+def _fp_tensor(dtype=mx.bfloat16):
+    return mx.zeros((2, 2), dtype=dtype)
+
+
+def _q_tensor_uint32():
+    return mx.zeros((2, 2), dtype=mx.uint32)
+
+
+# ---------------------------------------------------------------------- #
+# _bare_fp_weight_paths                                                  #
+# ---------------------------------------------------------------------- #
+
+
+def test_bare_fp_weight_paths_finds_altup_projection():
+    """The exact mlx-community/gemma-4-e2b layout: per_layer_model_projection
+    has a bare bfloat16 ``.weight`` and no ``.scales`` / ``.biases``.
+    """
+    sanitized = {
+        # Properly quantized layer (uint32 weight + scales + biases)
+        "language_model.model.layers.0.self_attn.q_proj.weight": _q_tensor_uint32(),
+        "language_model.model.layers.0.self_attn.q_proj.scales": _fp_tensor(),
+        "language_model.model.layers.0.self_attn.q_proj.biases": _fp_tensor(),
+        # The "altup" projection that mlx-community kept as bf16
+        "language_model.model.per_layer_model_projection.weight": _fp_tensor(),
+    }
+    skip = _bare_fp_weight_paths(sanitized)
+    assert "language_model.model.per_layer_model_projection" in skip
+    assert "language_model.model.layers.0.self_attn.q_proj" not in skip
+
+
+def test_bare_fp_weight_paths_empty_when_all_quantized():
+    """Variant where every Linear was quantized (gemma-4-12b/26b/31b).
+
+    The 12b/26b/31b checkpoints don't even have ``per_layer_model_projection``,
+    but the broader invariant is: when every weight has a uint32 ``.weight``
+    + ``.scales``, the skip-set is empty and ``nn.quantize`` behaves exactly
+    like it did before the fix. This is the regression-proof for larger
+    variants.
+    """
+    sanitized = {
+        "language_model.model.layers.0.self_attn.q_proj.weight": _q_tensor_uint32(),
+        "language_model.model.layers.0.self_attn.q_proj.scales": _fp_tensor(),
+        "language_model.model.layers.0.self_attn.q_proj.biases": _fp_tensor(),
+        "language_model.model.layers.0.mlp.gate_proj.weight": _q_tensor_uint32(),
+        "language_model.model.layers.0.mlp.gate_proj.scales": _fp_tensor(),
+        "language_model.model.layers.0.mlp.gate_proj.biases": _fp_tensor(),
+    }
+    skip = _bare_fp_weight_paths(sanitized)
+    assert skip == set(), (
+        f"Expected empty skip-set when every weight is uint32 + scales — "
+        f"got {skip}. Regression: this would over-skip quantization on "
+        f"checkpoints where every layer was properly quantized."
+    )
+
+
+def test_bare_fp_weight_paths_treats_fp16_and_fp32_the_same():
+    """Different storage dtypes for un-quantized layers all skip the same way."""
+    sanitized = {
+        "model.norm.weight": _fp_tensor(mx.float16),
+        "model.embed_tokens.weight": _fp_tensor(mx.float32),
+        "model.per_layer_model_projection.weight": _fp_tensor(mx.bfloat16),
+    }
+    skip = _bare_fp_weight_paths(sanitized)
+    assert skip == {
+        "model.norm",
+        "model.embed_tokens",
+        "model.per_layer_model_projection",
+    }
+
+
+def test_bare_fp_weight_paths_ignores_non_weight_tails():
+    """Keys without a ``.weight`` suffix don't pollute the skip-set.
+
+    Some modules ship ``.bias``, ``.running_mean``, etc. without ``.weight``
+    — we only care about Linear-like layers whose quantization status is
+    determined by the ``.weight``+``.scales`` shape.
+    """
+    sanitized = {
+        "model.layer_norm.bias": _fp_tensor(),
+        "model.attention.attn_mask": _fp_tensor(),
+    }
+    assert _bare_fp_weight_paths(sanitized) == set()
+
+
+# ---------------------------------------------------------------------- #
+# _path_matches_any_suffix                                               #
+# ---------------------------------------------------------------------- #
+
+
+def test_path_matches_when_full_suffix_aligns():
+    """nn.quantize visits with ``language_model.model.X``; sanitized keys
+    use the same prefix, so direct equality wins.
+    """
+    suffixes = {"language_model.model.per_layer_model_projection"}
+    assert _path_matches_any_suffix(
+        "language_model.model.per_layer_model_projection",
+        suffixes,
+    )
+
+
+def test_path_does_not_match_sibling_module():
+    """Don't over-match: per-layer ``self_attn.k_proj`` must not collide
+    with ``per_layer_model_projection`` just because both end in
+    ``_projection``-ish tokens.
+    """
+    suffixes = {"language_model.model.per_layer_model_projection"}
+    assert not _path_matches_any_suffix(
+        "language_model.model.layers.0.self_attn.k_proj",
+        suffixes,
+    )
+
+
+def test_path_does_not_match_different_layer_index():
+    """layers.0.q_proj and layers.5.q_proj are different modules even
+    though both end in ``q_proj`` — the predicate must distinguish."""
+    suffixes = {"language_model.model.layers.0.self_attn.q_proj"}
+    assert not _path_matches_any_suffix(
+        "language_model.model.layers.5.self_attn.q_proj",
+        suffixes,
+    )
+
+
+def test_path_matches_empty_suffixes_is_false():
+    """Fast-path: an empty skip-set should always return False, so
+    variants with no bare-fp layers (e.g. all of 12b/26b/31b) pay
+    zero per-module cost in the predicate."""
+    assert not _path_matches_any_suffix("anything.anywhere", set())

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -27,6 +27,81 @@ import mlx.nn as nn
 logger = logging.getLogger(__name__)
 
 
+_FP_DTYPES_NOT_QUANTIZED = (
+    mx.bfloat16,
+    mx.float16,
+    mx.float32,
+)
+
+
+def _bare_fp_weight_paths(sanitized: dict) -> set[str]:
+    """Return paths whose ``.weight`` is stored as bare fp (no scales/biases).
+
+    These are layers the checkpoint deliberately left unquantized (e.g.
+    the ``per_layer_model_projection`` "altup" projection on gemma-4-e2b/
+    e4b). The blanket ``nn.quantize`` path would otherwise convert them
+    to QuantizedLinear and then ``mx.quantized_matmul`` would raise at
+    inference time on the bf16 weight that disk supplied.
+
+    We return the bare-path (no ``.weight`` suffix) so it can be matched
+    against ``nn.quantize``'s dotted module paths via suffix-equality.
+    """
+    weight_paths = {k[: -len(".weight")] for k in sanitized if k.endswith(".weight")}
+    skip: set[str] = set()
+    for base in weight_paths:
+        wkey = f"{base}.weight"
+        scales = f"{base}.scales"
+        biases = f"{base}.biases"
+        w = sanitized.get(wkey)
+        if w is None:
+            continue
+        # A truly quantized weight will have dtype uint32 AND a matching
+        # ``.scales`` companion. A bare fp16/bf16 ``.weight`` with no
+        # scales companion means "checkpoint kept this layer in full
+        # precision on purpose".
+        if w.dtype in _FP_DTYPES_NOT_QUANTIZED and (
+            scales not in sanitized and biases not in sanitized
+        ):
+            skip.add(base)
+    return skip
+
+
+def _path_matches_any_suffix(path: str, suffixes: set[str]) -> bool:
+    """Is ``path`` a suffix-match for any of ``suffixes``?
+
+    ``nn.quantize`` visits each ``to_quantized``-able module with a
+    dotted path relative to the root (e.g.
+    ``language_model.model.per_layer_model_projection``). The
+    sanitized-weights keys come from disk and may carry slightly
+    different prefixes (``model.``, ``language_model.model.``)
+    depending on which wrapper layer they live under. So we match
+    by suffix on the bare module path (everything before ``.weight``)
+    rather than equality.
+    """
+    if not suffixes:
+        return False
+    for suffix in suffixes:
+        # Direct suffix match handles "language_model.model.X" vs
+        # nn.quantize path "language_model.model.X" naturally; the
+        # second form ("model.X") falls out because Python's str.endswith
+        # also accepts the bare tail.
+        if path == suffix or path.endswith("." + suffix.split(".")[-1]):
+            # Verify the FULL final segment matches (don't let
+            # "self_attn.k_proj" suffix-match against
+            # "self_attn.k_proj_extra" — both end with "k_proj" but
+            # the latter isn't the same module).
+            if path.split(".")[-1] == suffix.split(".")[-1]:
+                # Match more of the path to avoid colliding with sibling
+                # modules in different layers. Compare the last N tokens
+                # of each.
+                p_tokens = path.split(".")
+                s_tokens = suffix.split(".")
+                n = min(len(p_tokens), len(s_tokens))
+                if p_tokens[-n:] == s_tokens[-n:]:
+                    return True
+    return False
+
+
 def is_gemma4_model(model_path: str | Path) -> bool:
     """Check if the model at the given path is a Gemma 4 model.
 
@@ -173,6 +248,42 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     # Wrap for mlx-lm compatibility
     model = Gemma4TextWrapper(language_model)
 
+    # Load weights once up front (mmap-backed, cheap) — we'll feed these
+    # back into ``model.load_weights`` after quantization. Sanitize per
+    # shard so peak memory stays proportional to the text-only model,
+    # not the full multimodal checkpoint (#123).
+    weight_files = sorted(
+        f for f in p.glob("*.safetensors") if not f.name.startswith("._")
+    )
+    if not weight_files:
+        raise FileNotFoundError(f"No .safetensors files in {p}")
+    sanitized = {}
+    for wf in weight_files:
+        shard = mx.load(str(wf))
+        sanitized.update(model.sanitize(shard))
+        del shard
+
+    # Identify layers the checkpoint stored as bare fp16/bf16 instead of
+    # quantized (uint32 ``.weight`` + ``.scales`` + ``.biases``).
+    # mlx-community's QAT pipeline intentionally leaves a few layers in
+    # full precision — on the gemma-4-e2b/e4b "altup" variants this
+    # includes ``per_layer_model_projection``. Our prior code applied
+    # ``nn.quantize`` blanket, converted that Linear to QuantizedLinear,
+    # then loaded a bare bfloat16 ``.weight`` into it. At inference time
+    # ``mx.quantized_matmul`` raised:
+    #
+    #   ValueError: [quantized_matmul] The weight matrix should be
+    #   uint32 but received bfloat16
+    #
+    # …and the server emitted 0 tokens with finish_reason=length. Self-
+    # tuning the predicate from disk dtype keeps the post-quantize model
+    # bit-exactly consistent with what mlx-community shipped: layers
+    # they quantized stay quantized, layers they left fp16 stay fp16.
+    # On variants where every ``.weight`` IS quantized (12b/26b/31b
+    # don't even have per_layer_model_projection), this set is empty
+    # and behavior is identical to the previous code.
+    skip_quant_paths = _bare_fp_weight_paths(sanitized)
+
     # Apply quantization config if present (converts Linear → QuantizedLinear)
     quant_config = config.get("quantization", config.get("quantization_config"))
     if quant_config:
@@ -190,6 +301,14 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
                     if kk in ("bits", "group_size", "mode")
                 }
 
+        if skip_quant_paths:
+            logger.info(
+                "[gemma4] %d layer(s) kept as fp16 per checkpoint "
+                "(e.g. %s) — won't be quantized",
+                len(skip_quant_paths),
+                next(iter(skip_quant_paths)),
+            )
+
         if overrides:
             logger.info(
                 "[gemma4] Mixed quantization: %d-bit default, %d overrides (8-bit MLP)",
@@ -199,6 +318,8 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
 
             def _class_predicate(path, module):
                 if not hasattr(module, "to_quantized"):
+                    return False
+                if _path_matches_any_suffix(path, skip_quant_paths):
                     return False
                 # Check per-layer overrides
                 # Override keys use "language_model.model.layers..." but nn.quantize
@@ -217,23 +338,21 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
                 default_bits,
                 default_gs,
             )
-            nn.quantize(model, bits=default_bits, group_size=default_gs)
 
-    # Load weights — sanitize per shard to keep peak memory proportional
-    # to the text-model size, not the full multimodal checkpoint.  On
-    # Gemma 4 the multimodal shards can be >2× the language-model
-    # weight, so loading everything then sanitizing would transiently
-    # allocate the entire checkpoint and OOM smaller Macs.  Fixes #123.
-    weight_files = sorted(
-        f for f in p.glob("*.safetensors") if not f.name.startswith("._")
-    )
-    if not weight_files:
-        raise FileNotFoundError(f"No .safetensors files in {p}")
-    sanitized = {}
-    for wf in weight_files:
-        shard = mx.load(str(wf))
-        sanitized.update(model.sanitize(shard))
-        del shard
+            def _class_predicate(path, module):
+                if not hasattr(module, "to_quantized"):
+                    return False
+                if _path_matches_any_suffix(path, skip_quant_paths):
+                    return False
+                return True
+
+            nn.quantize(
+                model,
+                class_predicate=_class_predicate,
+                group_size=default_gs,
+                bits=default_bits,
+            )
+
     model.load_weights(list(sanitized.items()), strict=False)
 
     # Verify weights loaded


### PR DESCRIPTION
## Summary
v0.7.26 release dogfood caught both `gemma-4-e2b-4bit` and `gemma-4-e4b-4bit` returning **0 tokens with `finish_reason=length`** — server crashed at first decode step with:

```
ValueError: [quantized_matmul] The weight matrix should be uint32 but received bfloat16
```

raised by `mlx_vlm/models/gemma4/language.py:441 project_per_layer_inputs` on every prefill.

## Root cause
`mlx-community/gemma-4-e2b-it-4bit` (and `-e4b-`) ship `per_layer_model_projection.weight` as **bare bfloat16** on disk — no `.scales` / `.biases`. mlx-community's QAT pipeline intentionally keeps this "altup" projection in full precision (the e2b/e4b "edge" architecture needs its full dynamic range; 12b/26b/31b don't even have the layer).

Our prior `load_gemma4_text` applied `nn.quantize(model, ...)` blanket → converted the Linear to `QuantizedLinear` → loaded the bf16 weight into the quantized container. At inference time `mx.quantized_matmul` raised on the dtype mismatch.

## Fix
**Self-tune the quantization predicate from disk weights.** Load + sanitize weights BEFORE `nn.quantize`. New helper `_bare_fp_weight_paths` scans the sanitized dict; any path whose `.weight` is bf16/fp16/fp32 with no `.scales` companion = checkpoint kept it fp on purpose → predicate skips quantization for that path → it stays a plain `Linear` and accepts the bf16 weight cleanly.

## Regression analysis
The skip-set is empty for any checkpoint where every `.weight` is properly quantized (uint32 + matching scales + biases), so `nn.quantize` runs identically to before:

| Variant | Skip-set | Impact |
|---|---|---|
| gemma-4-e2b/e4b-4bit | `{per_layer_model_projection}` | **fixed** (was unusable) |
| gemma-4-12b-4bit | ∅ — layer not present per index probe | identical to before |
| gemma-4-31b-4bit | ∅ — layer not present per index probe | identical to before |
| gemma-4-26b-4bit | ∅ (gated repo; sibling pattern) | identical to before |
| gemma3-*, gemma2-*, gemma-* | n/a — different loader | unaffected |
| any model with all-uint32 weights | ∅ | bit-exact |

8 new unit tests in `tests/test_gemma4_altup_autodetect.py` pin both directions (altup detected on e2b shape; empty skip-set for all-quantized shape; no sibling-module collisions in suffix match).

## End-to-end verification

```
$ rapid-mlx bench gemma-4-e2b-4bit --tier smoke
PASS model=...gemma-4-e2b-it-4bit ttft=136ms response='2 + 2 equals 4.'

$ rapid-mlx bench gemma-4-e4b-4bit --tier smoke
PASS model=...gemma-4-e4b-it-4bit ttft=281ms response='2 + 2 equals 4.'
```

Both produced 0 tokens on v0.7.26 main.

## Follow-up
Worth filing an upstream issue at `ml-explore/mlx-vlm` for the `project_per_layer_inputs` quantization handling — this fix only sidesteps it from our loader.