### PR TITLE
fix(pr_validate): pin codex to openai provider + opt-in post-merge audit

### DIFF
--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -386,6 +386,19 @@ class CodexReviewStep(Step):
                         # README + step description promise gpt-5.5.
                         "--model",
                         CODEX_MODEL,
+                        # Force the OpenAI cloud provider for the review
+                        # call. The user's config.toml may set
+                        # ``model_provider = "rapid-mlx"`` for normal
+                        # codex use (so codex routes to local server),
+                        # but pr_validate wants the gpt-5.5 cloud model
+                        # talking through OpenAI, not the local mlx
+                        # server. Without this override, codex tries to
+                        # refresh /models against the rapid-mlx server
+                        # and exits 1 because rapid-mlx's OpenAI-shaped
+                        # ``{"data": [...]}`` response lacks the
+                        # ``models`` field codex 0.136+ expects.
+                        "-c",
+                        'model_provider="openai"',
                         # Skip the "is this a git repo?" check — we
                         # deliberately run codex outside the repo (in
                         # an empty tempdir, see ``cwd=`` below).

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -106,8 +106,7 @@ class FetchStep(Step):
         # an abandoned branch isn't a workflow we want to enable.
         state = meta.get("state", "")
         merged_audit_ok = (
-            state == "MERGED"
-            and os.environ.get("PR_VALIDATE_ALLOW_MERGED") == "1"
+            state == "MERGED" and os.environ.get("PR_VALIDATE_ALLOW_MERGED") == "1"
         )
         if state != "OPEN" and not merged_audit_ok:
             return StepResult(

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -98,8 +98,18 @@ class FetchStep(Step):
         # Refuse closed/merged PRs as a default — the user can still
         # run validation on them by editing this gate, but the common
         # case of "is this merge-safe" wants an OPEN PR.
+        # PR_VALIDATE_ALLOW_MERGED=1 opens a narrow escape hatch for
+        # post-merge audit (confirm a recently-landed PR has no
+        # regressions, replay scorecard for changelog inclusion, etc.).
+        # CLOSED-without-merge stays refused: a contributor who closed
+        # the PR explicitly walked away — replaying validation against
+        # an abandoned branch isn't a workflow we want to enable.
         state = meta.get("state", "")
-        if state != "OPEN" and os.environ.get("PR_VALIDATE_ALLOW_MERGED") != "1":
+        merged_audit_ok = (
+            state == "MERGED"
+            and os.environ.get("PR_VALIDATE_ALLOW_MERGED") == "1"
+        )
+        if state != "OPEN" and not merged_audit_ok:
             return StepResult(
                 name=self.name,
                 status="fail",

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -15,6 +15,7 @@ random foreign code.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import shutil
 import subprocess
@@ -98,7 +99,7 @@ class FetchStep(Step):
         # run validation on them by editing this gate, but the common
         # case of "is this merge-safe" wants an OPEN PR.
         state = meta.get("state", "")
-        if state != "OPEN":
+        if state != "OPEN" and os.environ.get("PR_VALIDATE_ALLOW_MERGED") != "1":
             return StepResult(
                 name=self.name,
                 status="fail",


### PR DESCRIPTION
## Why

Two small fixes surfaced while running pr_validate on PR #641 earlier today.

### 1. \`codex_review.py\` — pin \`model_provider=\"openai\"\`

codex CLI 0.136+ refreshes \`/v1/models\` against the configured \`model_provider\`'s \`base_url\` before each \`codex exec\` and exits 1 when the response lacks a top-level \`models\` field.

When a contributor has set \`model_provider = \"rapid-mlx\"\` in \`~/.codex/config.toml\` for normal local-LLM use, codex hits rapid-mlx's server, gets OpenAI-shaped \`{\"data\": [...]}\` back (rapid-mlx correctly implements the OpenAI spec), and dies. The pr_validate adversarial-review step then silently degraded to skip with no review ever happening.

Pass \`-c model_provider=\"openai\"\` on the \`codex exec\` invocation so gpt-5.5 review always routes through OpenAI cloud regardless of the user's local provider config. This is what the existing inline comment on the \`--model CODEX_MODEL\` line already implied (README + step description promise gpt-5.5 = the cloud route).

### 2. \`fetch.py\` — opt-in \`PR_VALIDATE_ALLOW_MERGED=1\` escape hatch

The existing default refuses MERGED/CLOSED PRs because \"is this merge-safe?\" wants an OPEN PR. The fetch step's own comment already notes *\"the user can still run validation on them by editing this gate\"* — this just exposes the same affordance as an env var so the user doesn't have to edit code to do a post-merge audit (which is a real workflow: confirming a recently-landed PR has no regressions, replaying the scorecard for changelog inclusion, etc.).

Default behavior unchanged.

## Blast radius

\`scripts/pr_validate/steps/\` only — no runtime code, no tests touched. +15 / -1 LOC across 2 files.

## Test plan

- [x] Codex review step exercised against PR #641 earlier today with the override — completed and surfaced no blocking issues (vs. previously bailing out on the /models mismatch)
- [x] Post-merge audit on PR #641 ran end-to-end after \`PR_VALIDATE_ALLOW_MERGED=1\` was set (\`fetch\` PASSed instead of failing the \"PR is MERGED, not OPEN\" gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)