### PR TITLE
fix(tests): filter v1-only submissions in v2-accepts-v1 regression set

### DIFF
--- a/tests/test_schema_v2_accepts_v1.py
+++ b/tests/test_schema_v2_accepts_v1.py
@@ -28,16 +28,32 @@ SUBMISSIONS_DIR = REPO_ROOT / "community-benchmarks" / "submissions"
 
 
 def _existing_submissions() -> list[Path]:
-    """Every JSON file in ``community-benchmarks/submissions/``.
+    """Every v1 JSON file in ``community-benchmarks/submissions/``.
+
+    Filter to ``schema_version == 1`` so this regression set keeps
+    its meaning (does v2 schema still accept v1 wire shape?) as v2
+    submissions accumulate in the same directory. Without the filter,
+    a real v2 submission with ``tier``/``smoke_result``/``harness_result``
+    is parametrized into a test that asserts ``schema_version == 1`` and
+    fails with a misleading "not a v1 submission anymore" message —
+    the file was always v2.
 
     Empty list short-circuits the parametrize loop — pytest will skip
     the test rather than report zero collected, so the harness still
     reports a clean run on a fresh checkout that hasn't accumulated
-    submissions yet.
+    v1 submissions yet.
     """
     if not SUBMISSIONS_DIR.exists():
         return []
-    return sorted(SUBMISSIONS_DIR.glob("*.json"))
+    out: list[Path] = []
+    for p in sorted(SUBMISSIONS_DIR.glob("*.json")):
+        try:
+            payload = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if payload.get("schema_version") == 1:
+            out.append(p)
+    return out
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

\`tests/test_schema_v2_accepts_v1.py\` started failing on \`main\` immediately after the 8 community-bench submissions (#627, #630, #633–#637, #640) landed today.

The test's \`_existing_submissions()\` parametrize source globbed **every** \`.json\` in \`community-benchmarks/submissions/\` on the assumption that the corpus stays v1 forever. After today's merges, the loop fed the new v2 files into a test that asserts \`schema_version == 1\` — and they failed with the misleading message:

\`\`\`
X is not a v1 submission anymore; move it out of the v1 regression set
\`\`\`

…but those files were *born* v2 (came from the \`bench --tier all --submit\` flow). They were never v1.

## Fix

Filter \`_existing_submissions()\` to \`schema_version == 1\` so the regression set keeps its original meaning ("does the v2 schema still accept v1 wire shape?") regardless of how many v2 entries pile up next to it. v1 corpus stays at the two 2026-06-15 seed files and the \`test_corpus_is_nonempty\` belt-and-braces guard still trips if those ever disappear.

## Blast radius

Tests only. +19 / -3 LOC in one file.

## Test plan

- [x] \`pytest tests/test_schema_v2_accepts_v1.py -v\` → 3 passed (2 v1 parametrize cases + corpus_is_nonempty), 0 failed
- [x] Verified the 8 new v2 submissions are now filtered out of the loop (they were the 8 failures pre-fix)
- [x] Verified the 2 seed v1 submissions still match the filter (regression coverage preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)