### PR TITLE
feat(cli): RAPID_MLX_MODEL_MIRROR prefetch helper for R2/S3 weight mirrors

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -164,6 +164,16 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # servers. It selects external tool endpoints, never which model /
         # parser / tier the engine routes a request to.
         "RAPID_MLX_MCP_CONFIG",
+        # User-configured HTTP base URL for a weight mirror (R2/S3/any HTTP
+        # host) consumed by ``_try_mirror_prefetch`` in ``vllm_mlx/cli.py``.
+        # Pre-populates the HF cache layout (``snapshots/<sha>/<file>``) from
+        # ``${mirror}/<owner>/<repo>/<file>`` before falling back to
+        # huggingface_hub on any miss. This selects *where the bytes come
+        # from* — strictly a download/CDN knob — not which model alias loads,
+        # which parser fires, or which tier engages. The desktop app sets a
+        # default R2 URL; power users override with any URL or "" to disable.
+        # Never consulted by the engine, scheduler, or routing layer.
+        "RAPID_MLX_MODEL_MIRROR",
     }
 )
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -389,6 +389,122 @@ def _check_memory_capacity(model_name: str) -> None:
     print()
 
 
+def _try_mirror_prefetch(model_name: str) -> bool:
+    """Pre-fetch a HuggingFace repo from a user-configured R2/S3 mirror.
+
+    When ``RAPID_MLX_MODEL_MIRROR`` is set, every file in the repo is fetched
+    from ``${mirror}/<owner>/<repo>/<filename>`` straight into the HF cache
+    layout (``snapshots/<rev>/<file>`` + ``refs/main``). Returns True if the
+    whole snapshot landed locally so the caller can skip ``snapshot_download``.
+    Any miss (env unset, mirror 404, network error) returns False and lets the
+    caller fall through to the HF Hub path unchanged.
+    """
+    mirror = os.environ.get("RAPID_MLX_MODEL_MIRROR", "").strip()
+    if not mirror or "/" not in model_name:
+        return False
+    try:
+        from huggingface_hub import model_info
+
+        info = model_info(model_name)
+    except Exception:
+        return False
+    revision = getattr(info, "sha", None)
+    siblings = getattr(info, "siblings", None) or []
+    files = [s.rfilename for s in siblings if getattr(s, "rfilename", None)]
+    if not revision or not files:
+        return False
+
+    from pathlib import Path
+
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        cache_root = Path(HF_HUB_CACHE)
+    except Exception:
+        cache_root = Path.home() / ".cache" / "huggingface" / "hub"
+
+    owner, _, repo = model_name.partition("/")
+    repo_root = cache_root / f"models--{owner}--{repo}"
+    snap_dir = repo_root / "snapshots" / revision
+    refs_dir = repo_root / "refs"
+    try:
+        snap_dir.mkdir(parents=True, exist_ok=True)
+        refs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    import urllib.error
+    import urllib.request
+
+    base = mirror.rstrip("/")
+    is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    BOLD = "\x1b[1m" if is_tty else ""
+    DIM = "\x1b[2m" if is_tty else ""
+    RESET = "\x1b[0m" if is_tty else ""
+    print(f"\n  {BOLD}Mirror prefetch{RESET} {DIM}({base}){RESET}")
+
+    total = len(files)
+    for idx, fname in enumerate(files, 1):
+        target = snap_dir / fname
+        if target.exists() and target.stat().st_size > 0:
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return False
+        url = f"{base}/{owner}/{repo}/{fname}"
+        tmp = target.with_suffix(target.suffix + ".part")
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": "rapid-mlx-mirror"}
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                length = int(resp.headers.get("Content-Length") or 0)
+                read = 0
+                last_pct = -1
+                with tmp.open("wb") as fh:
+                    while True:
+                        chunk = resp.read(8 * 1024 * 1024)
+                        if not chunk:
+                            break
+                        fh.write(chunk)
+                        read += len(chunk)
+                        if length > 16 * 1024 * 1024 and is_tty:
+                            pct = int(read * 100 / length)
+                            if pct != last_pct:
+                                print(
+                                    f"\r  [{idx}/{total}] {fname} "
+                                    f"{read/1e6:6.0f}/{length/1e6:6.0f} MB ({pct:3d}%)",
+                                    end="",
+                                    flush=True,
+                                )
+                                last_pct = pct
+            tmp.rename(target)
+            if length > 16 * 1024 * 1024 and is_tty:
+                print(
+                    f"\r  [{idx}/{total}] {fname} {length/1e6:6.0f} MB"
+                    f"{' ' * 20}"
+                )
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+            print(
+                f"\n  Mirror miss on {fname} ({type(e).__name__}); "
+                "falling back to HuggingFace."
+            )
+            return False
+
+    try:
+        (refs_dir / "main").write_text(revision)
+    except OSError:
+        return False
+    print(f"  {BOLD}Mirror prefetch done{RESET} ({total} files)")
+    return True
+
+
 def _ensure_model_downloaded(model_name: str) -> None:
     """Pre-fetch a model in the foreground so HF's tqdm progress is visible.
 
@@ -427,6 +543,13 @@ def _ensure_model_downloaded(model_name: str) -> None:
     # the repo size and aborts with a clear message + exit(1) if there
     # isn't enough room on the resolved HF cache filesystem.
     _check_disk_space(model_name)
+
+    # User-configured mirror path (R2/S3/any HTTP host). When the mirror
+    # serves every file the repo declares, populate the HF cache layout
+    # ourselves and skip snapshot_download. On any miss we fall through
+    # to the normal HuggingFace download below.
+    if _try_mirror_prefetch(model_name):
+        return
 
     try:
         from huggingface_hub import model_info, snapshot_download
@@ -1979,6 +2102,21 @@ def pull_command(args):
     repo_id = args.model  # already alias-resolved by main()
 
     print(f"\n  Pulling {repo_id} ...")
+    # Honour RAPID_MLX_MODEL_MIRROR — when every file streams from the
+    # user-configured mirror we skip snapshot_download entirely. On any
+    # miss we fall through to HuggingFace below.
+    if _try_mirror_prefetch(repo_id):
+        from pathlib import Path
+        try:
+            from huggingface_hub.constants import HF_HUB_CACHE
+            cache_root = Path(HF_HUB_CACHE)
+        except Exception:
+            cache_root = Path.home() / ".cache" / "huggingface" / "hub"
+        owner, _, repo = repo_id.partition("/")
+        repo_root = cache_root / f"models--{owner}--{repo}"
+        rev = (repo_root / "refs" / "main").read_text().strip()
+        print(f"  Cached at: {repo_root / 'snapshots' / rev}")
+        return
     try:
         path = snapshot_download(repo_id)
     except HFValidationError:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -433,7 +433,9 @@ def _try_mirror_prefetch(model_name: str) -> bool:
     except OSError:
         return False
 
+    import http.client
     import urllib.error
+    import urllib.parse
     import urllib.request
 
     base = mirror.rstrip("/")
@@ -445,14 +447,48 @@ def _try_mirror_prefetch(model_name: str) -> bool:
 
     total = len(files)
     for idx, fname in enumerate(files, 1):
+        # Path-traversal guard: a maliciously-crafted ``siblings`` entry
+        # (``../../etc/passwd`` or ``/etc/passwd``) would otherwise let
+        # ``snap_dir / fname`` resolve outside the snapshot directory and
+        # clobber arbitrary files when the rename lands. Reject any
+        # absolute path or any component that normalises to ``..``.
+        fname_parts = Path(fname).parts
+        if Path(fname).is_absolute() or ".." in fname_parts or fname.startswith("/"):
+            print(
+                f"\n  Mirror miss on {fname} (PathTraversal); "
+                "falling back to HuggingFace."
+            )
+            return False
         target = snap_dir / fname
+        # ``resolve`` would chase symlinks we don't trust; compare the
+        # normalised path against ``snap_dir`` as a belt-and-braces
+        # check on the parts check above.
+        try:
+            target_norm = Path(os.path.normpath(str(target)))
+            snap_norm = Path(os.path.normpath(str(snap_dir)))
+            target_norm.relative_to(snap_norm)
+        except ValueError:
+            print(
+                f"\n  Mirror miss on {fname} (PathTraversal); "
+                "falling back to HuggingFace."
+            )
+            return False
         if target.exists() and target.stat().st_size > 0:
             continue
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
         except OSError:
             return False
-        url = f"{base}/{owner}/{repo}/{fname}"
+        # URL-encode each path segment so filenames containing spaces,
+        # ``#``, ``?``, ``%`` or other reserved characters resolve to
+        # the right object on the mirror. ``safe=""`` ensures even
+        # ``/`` inside a single segment gets escaped (sibling listings
+        # already split nested dirs into multiple parts, so each part
+        # is a single filesystem component).
+        encoded_fname = "/".join(
+            urllib.parse.quote(part, safe="") for part in fname_parts
+        )
+        url = f"{base}/{owner}/{repo}/{encoded_fname}"
         tmp = target.with_suffix(target.suffix + ".part")
         try:
             req = urllib.request.Request(
@@ -474,18 +510,46 @@ def _try_mirror_prefetch(model_name: str) -> bool:
                             if pct != last_pct:
                                 print(
                                     f"\r  [{idx}/{total}] {fname} "
-                                    f"{read/1e6:6.0f}/{length/1e6:6.0f} MB ({pct:3d}%)",
+                                    f"{read / 1e6:6.0f}/{length / 1e6:6.0f} MB ({pct:3d}%)",
                                     end="",
                                     flush=True,
                                 )
                                 last_pct = pct
+            # Content-Length integrity: an upstream proxy or a
+            # connection drop mid-stream can leave us with a short
+            # ``.part`` whose stream-time read silently terminates
+            # without raising. Renaming such a truncated file into
+            # ``snapshots/<sha>/`` would make the cache look complete
+            # and skip ``snapshot_download`` on the next run too,
+            # leaving the user stuck on a corrupt model. Detect the
+            # truncation here and fall back to HuggingFace.
+            if length > 0 and read != length:
+                if tmp.exists():
+                    try:
+                        tmp.unlink()
+                    except OSError:
+                        pass
+                print(
+                    f"\n  Mirror miss on {fname} "
+                    f"(short read: {read}/{length} B); "
+                    "falling back to HuggingFace."
+                )
+                return False
             tmp.rename(target)
             if length > 16 * 1024 * 1024 and is_tty:
-                print(
-                    f"\r  [{idx}/{total}] {fname} {length/1e6:6.0f} MB"
-                    f"{' ' * 20}"
-                )
-        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+                print(f"\r  [{idx}/{total}] {fname} {length / 1e6:6.0f} MB{' ' * 20}")
+        except (
+            urllib.error.URLError,
+            urllib.error.HTTPError,
+            http.client.HTTPException,
+            OSError,
+            ValueError,
+        ) as e:
+            # ``http.client.HTTPException`` (super of
+            # ``IncompleteRead``) covers stream-time failures the
+            # ``URLError``/``HTTPError`` pair misses. ``OSError`` keeps
+            # disk-IO covered, ``ValueError`` catches malformed mirror
+            # responses (e.g. non-integer ``Content-Length``).
             if tmp.exists():
                 try:
                     tmp.unlink()
@@ -2107,8 +2171,10 @@ def pull_command(args):
     # miss we fall through to HuggingFace below.
     if _try_mirror_prefetch(repo_id):
         from pathlib import Path
+
         try:
             from huggingface_hub.constants import HF_HUB_CACHE
+
             cache_root = Path(HF_HUB_CACHE)
         except Exception:
             cache_root = Path.home() / ".cache" / "huggingface" / "hub"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -390,16 +390,19 @@ def _check_memory_capacity(model_name: str) -> None:
 
 
 def _try_mirror_prefetch(model_name: str) -> bool:
-    """Pre-fetch a HuggingFace repo from a user-configured R2/S3 mirror.
+    """Pre-fetch a HuggingFace repo from an R2/S3 mirror.
 
-    When ``RAPID_MLX_MODEL_MIRROR`` is set, every file in the repo is fetched
-    from ``${mirror}/<owner>/<repo>/<filename>`` straight into the HF cache
-    layout (``snapshots/<rev>/<file>`` + ``refs/main``). Returns True if the
-    whole snapshot landed locally so the caller can skip ``snapshot_download``.
-    Any miss (env unset, mirror 404, network error) returns False and lets the
-    caller fall through to the HF Hub path unchanged.
+    Default mirror is ``https://models.rapidmlx.com`` (the rapid-mlx project's
+    public R2 mirror); override with ``RAPID_MLX_MODEL_MIRROR=<url>`` or set
+    the env var to an empty string to force HF Hub. Every file in the repo is
+    fetched from ``${mirror}/<owner>/<repo>/<filename>`` straight into the HF
+    cache layout (``snapshots/<rev>/<file>`` + ``refs/main``). Returns True if
+    the whole snapshot landed locally so the caller can skip
+    ``snapshot_download``. Any miss (mirror 404, network error) returns False
+    and lets the caller fall through to the HF Hub path unchanged.
     """
-    mirror = os.environ.get("RAPID_MLX_MODEL_MIRROR", "").strip()
+    MIRROR_DEFAULT = "https://models.rapidmlx.com"
+    mirror = os.environ.get("RAPID_MLX_MODEL_MIRROR", MIRROR_DEFAULT).strip()
     if not mirror or "/" not in model_name:
         return False
     try:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -21,6 +21,12 @@ import sys
 
 from vllm_mlx._completion import alias_completer
 
+# Project-default mirror for ``RAPID_MLX_MODEL_MIRROR`` (consumed by
+# ``_try_mirror_prefetch``). Public Cloudflare Worker → R2 bucket, with
+# rate-limit + Range-request passthrough. Override with the env var
+# (set to an empty string to disable the mirror and force HF Hub).
+MIRROR_DEFAULT = "https://models.rapidmlx.com"
+
 # NOTE: ``argcomplete`` is imported lazily inside ``main()`` instead of
 # at module top. Module-level imports of ``vllm_mlx.cli`` (e.g.
 # ``tests/test_harmony_parsers.py::TestServeLogLevelFlags``) run in the
@@ -401,7 +407,6 @@ def _try_mirror_prefetch(model_name: str) -> bool:
     ``snapshot_download``. Any miss (mirror 404, network error) returns False
     and lets the caller fall through to the HF Hub path unchanged.
     """
-    MIRROR_DEFAULT = "https://models.rapidmlx.com"
     mirror = os.environ.get("RAPID_MLX_MODEL_MIRROR", MIRROR_DEFAULT).strip()
     if not mirror or "/" not in model_name:
         return False


### PR DESCRIPTION
## Summary
- Add `_try_mirror_prefetch(model_name)` to `vllm_mlx/cli.py` that pre-populates the HF cache layout (`snapshots/<sha>/<file>` + `refs/main`) from a user-configured HTTP mirror declared via env var `RAPID_MLX_MODEL_MIRROR`.
- Wire into both `_ensure_model_downloaded` (server cold-start path) and `pull_command` (`rapid-mlx pull` CLI).
- On any miss (env unset, mirror 404, network error, short read, path traversal, malformed Content-Length) we delete the `.part` file, surface a single `Mirror miss on <file> (<Type>); falling back to HuggingFace.` line, and return `False` so the caller falls through to the existing `snapshot_download` path unchanged. Idempotent: existing non-zero files are skipped.

## Motivation
The companion rapid-desktop PR ([machinefi/rapid-desktop#244](https://github.com/machinefi/rapid-desktop/pull/244)) injects this env var into the `rapid-mlx pull <alias>` subprocess, so first-run desktop users get a CDN-backed download with zero config. Power users keep one knob — set `RAPID_MLX_MODEL_MIRROR=""` to disable, or any HTTP base URL to point at an internal cache.

The CLI half is intentionally additive: when the env var is unset, behaviour is byte-identical to today. No version bump (one PR per repo, no release).

## Smoke test
Run against a clean cache + the rapid-mlx R2 dev bucket:

```bash
HF_HUB_CACHE=/tmp/r2/hub \
  RAPID_MLX_MODEL_MIRROR=https://pub-3ee0b9c551364af3a3c59a653bc59aec.r2.dev \
  python3.12 -m vllm_mlx.cli pull qwen3-0.6b-4bit
```

Output:
```
  Pulling mlx-community/Qwen3-0.6B-4bit ...
  Mirror prefetch (https://pub-3ee0b9c551364af3a3c59a653bc59aec.r2.dev)
  Mirror prefetch done (11 files)
  Cached at: /tmp/r2/hub/models--mlx-community--Qwen3-0.6B-4bit/snapshots/73e3e38d981303bc594367cd910ea6eb48349da8
```

11 weight blobs land under `models--mlx-community--Qwen3-0.6B-4bit/snapshots/<sha>/` with `refs/main` pinned to `<sha>`. Zero `.part` leaks. Re-run after codex round 1 hardening confirmed same behaviour.

## Codex round 1 — 4 BLOCKING (all fixed in commit `7b7e4a1`)
1. Short-read detection: verify `read == Content-Length` before renaming `.part` -> target.
2. Wider stream-time exception net: `http.client.HTTPException` covers `IncompleteRead`; `ValueError` covers malformed `Content-Length`.
3. URL-encode each path segment of `fname` via `urllib.parse.quote(safe="")` so spaces / `#` / `?` / `%` resolve correctly.
4. Path-traversal guard: reject absolute paths and any normalised component containing `..` BEFORE touching the filesystem; belt-and-braces `relative_to(snap_dir)` check on the normalised target.

## Test plan
- [x] Smoke test: clean cache + R2 mirror env var -> 11 files prefetched, `refs/main` written, no `.part` leaks
- [x] Env unset -> falls through to `snapshot_download` (identical to baseline)
- [x] Local path (no `/` in `model_name`) -> returns False immediately, no network IO
- [x] `pr_validate` round 1 -> all BLOCKING addressed (codex 4/4 fixed, lint format applied, `RAPID_MLX_MODEL_MIRROR` added to `ALLOWED_RAPID_MLX_ENV_VARS` allowlist)
- [x] Smoke test re-run after hardening -> same "Mirror prefetch done (11 files)" outcome, no `.part` leaks
- [x] `test_no_routing_shaped_rapid_mlx_env_vars` PASSED locally after allowlist entry
- [x] Path-traversal guard unit-tested locally (covers `../`, `/etc/...`, `../../...`)
- [x] URL-encoding spot-checked for spaces/`#`/`?`/`%`