### PR TITLE
fix(cli): wire R2 mirror prefetch into serve_command (#651)

### DIFF
--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -2413,3 +2413,44 @@ def test_cached_hf_blob_symlink_skips_rehash(
     assert hf_mock.call_count == 0
     # File still resolves correctly.
     assert link.read_bytes() == payload
+
+
+# ---------------------------------------------------------------------------
+# Wiring assertions: serve must NOT bypass the mirror
+# ---------------------------------------------------------------------------
+
+
+def _function_loads_global(func, name: str) -> bool:
+    """Return True iff ``func``'s bytecode loads the named global.
+
+    Bytecode-level check survives a refactor that would delete the
+    actual call but leave a stale string-search match in a comment.
+    Mirrors the helper in ``test_memory_capacity_check.py``.
+    """
+    import dis
+
+    return any(
+        ins.opname in ("LOAD_GLOBAL", "LOAD_NAME", "LOAD_DEREF") and ins.argval == name
+        for ins in dis.get_instructions(func)
+    )
+
+
+def test_serve_command_calls_ensure_model_downloaded():
+    """``rapid-mlx serve <alias>`` on a cold cache must route through the
+    R2 mirror — not fall into ``mlx_lm.load`` → ``snapshot_download``
+    directly. Issue #651: Desktop saw HF tqdm ``Fetching 9 files: 0%``
+    streaming the 6.7 GB shard at ~5 MB/s while the mirror would have
+    delivered it at ~50 MB/s.
+
+    The cheapest defense is ``_ensure_model_downloaded(args.model)``
+    early in serve_command — it's a no-op on local paths / fully-cached
+    repos, and tries the mirror before HF on cold pulls. A future
+    refactor that drops this call would re-introduce #651, so this is
+    a bytecode-level wiring assertion.
+    """
+    from vllm_mlx import cli
+
+    assert _function_loads_global(cli.serve_command, "_ensure_model_downloaded"), (
+        "serve_command must call _ensure_model_downloaded so cold-cache "
+        "serves go through the R2 mirror (issue #651)"
+    )

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -2420,19 +2420,55 @@ def test_cached_hf_blob_symlink_skips_rehash(
 # ---------------------------------------------------------------------------
 
 
-def _function_loads_global(func, name: str) -> bool:
-    """Return True iff ``func``'s bytecode loads the named global.
+def _function_calls_global(func, name: str) -> bool:
+    """Return True iff ``func``'s bytecode contains a LOAD_GLOBAL/NAME/DEREF
+    of ``name`` followed by a CALL op within the same function body.
 
-    Bytecode-level check survives a refactor that would delete the
-    actual call but leave a stale string-search match in a comment.
-    Mirrors the helper in ``test_memory_capacity_check.py``.
+    Stricter than a bare ``LOAD_GLOBAL`` check — a future refactor that
+    merely references ``name`` (e.g. ``f = _ensure_model_downloaded``
+    without ever calling it) would still satisfy LOAD_GLOBAL but
+    silently re-introduce #651. The CALL-follows requirement closes
+    that gap.
+
+    Codex round-1 BLOCKING #1 to PR #654.
     """
     import dis
 
-    return any(
-        ins.opname in ("LOAD_GLOBAL", "LOAD_NAME", "LOAD_DEREF") and ins.argval == name
-        for ins in dis.get_instructions(func)
-    )
+    insts = list(dis.get_instructions(func))
+    for idx, ins in enumerate(insts):
+        if (
+            ins.opname in ("LOAD_GLOBAL", "LOAD_NAME", "LOAD_DEREF")
+            and ins.argval == name
+        ):
+            # Walk forward looking for a CALL. Any number of LOAD_FAST /
+            # LOAD_ATTR / LOAD_CONST / PUSH_NULL ops can stack arguments
+            # between the load and the call; anything else (STORE_*, a
+            # second LOAD_GLOBAL of an unrelated name, RETURN_*, etc.)
+            # means the loaded reference was used for something other
+            # than calling it — keep scanning for another LOAD of the
+            # same name.
+            allowed_between = {
+                "LOAD_FAST",
+                "LOAD_ATTR",
+                "LOAD_CONST",
+                "LOAD_DEREF",
+                "PUSH_NULL",
+                "COPY",
+                "SWAP",
+                "PRECALL",
+                "KW_NAMES",
+                "LOAD_METHOD",
+                "CACHE",
+            }
+            for follow in insts[idx + 1 : idx + 12]:
+                if follow.opname in ("CALL", "CALL_FUNCTION", "CALL_METHOD"):
+                    return True
+                if follow.opname in allowed_between:
+                    continue
+                # Hit a non-argument-stacking op — this LOAD was not
+                # immediately followed by a CALL.
+                break
+    return False
 
 
 def test_serve_command_calls_ensure_model_downloaded():
@@ -2446,11 +2482,13 @@ def test_serve_command_calls_ensure_model_downloaded():
     early in serve_command — it's a no-op on local paths / fully-cached
     repos, and tries the mirror before HF on cold pulls. A future
     refactor that drops this call would re-introduce #651, so this is
-    a bytecode-level wiring assertion.
+    a bytecode-level wiring assertion that requires both the LOAD and
+    a CALL following it.
     """
     from vllm_mlx import cli
 
-    assert _function_loads_global(cli.serve_command, "_ensure_model_downloaded"), (
-        "serve_command must call _ensure_model_downloaded so cold-cache "
-        "serves go through the R2 mirror (issue #651)"
+    assert _function_calls_global(cli.serve_command, "_ensure_model_downloaded"), (
+        "serve_command must CALL _ensure_model_downloaded (not just "
+        "reference it) so cold-cache serves go through the R2 mirror "
+        "(issue #651). Codex round-1 BLOCKING #1 to PR #654."
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -535,6 +535,14 @@ def serve_command(args):
     if prompt_upgrade_if_available():
         sys.exit(0)
 
+    # Pre-fetch the model via the R2 mirror (with HF fallback) BEFORE the
+    # heavy server boot. Without this, ``serve`` falls into
+    # ``mlx_lm.load`` → ``huggingface_hub.snapshot_download`` directly and
+    # skips the mirror entirely (#651). ``_ensure_model_downloaded`` is a
+    # no-op on local paths and on fully-cached repos, so this is free on
+    # the warm path.
+    _ensure_model_downloaded(args.model)
+
     # Import unified server
     from . import server
     from .middleware.auth import configure_rate_limiter


### PR DESCRIPTION
## Summary

Wires the R2 mirror prefetch into `serve_command` (#651) and confirms that resumable downloads (#653) are already shipped by #650.

## #651 — `serve` bypassed the mirror

`rapid-mlx serve <alias>` on a cold cache was going straight into `load_model` → `mlx_lm.load` → `huggingface_hub.snapshot_download`, **bypassing the R2 mirror that `pull_command` and `chat_command` already use** (#647, #650). Desktop users hit `Fetching 9 files: 0%` (HF tqdm at ~5 MB/s) instead of the ~50 MB/s end-to-end the mirror delivers on the same machine.

Fix: one-line addition in `serve_command` — reuse `_ensure_model_downloaded(args.model)` right after the version-check, mirroring what `chat_command` already does. It:

- no-ops on local paths
- no-ops on fully-cached repos (cheap `is_repo_cached` probe)
- routes through `_try_mirror_prefetch` on cold pulls (R2 → HF fallback per file)
- falls back to plain `snapshot_download` if the mirror is disabled (`RAPID_MLX_MODEL_MIRROR=""`) or any file misses both R2 and HF

No new abstractions, no changes to `load_model`, no new deps.

## #653 — already done by #650

`_try_mirror_prefetch` now delegates to `vllm_mlx/_mirror.py::download_with_mirror_fallback`, which already implements HTTP Range resume (lines 258-490 on main):

- Sends `Range: bytes=<offset>-` when a non-empty `.part` exists (line 327)
- Accepts both 206 (resume) and 200 (server-forced restart) responses (line 336)
- **Full** Content-Range tuple validation including total-size check (lines 355-371) — catches proxy bugs that #653 didn't anticipate
- Per-byte streaming sha256 verification (stronger than the ETag check #653 proposed — survives mirror object rewrites)
- Lands rename-on-completion so partial files never poison `snapshots/<rev>/`

The `.part`/`.lock` files even moved to a dedicated sidecar (`<repo_root>/.rapid-mlx-mirror/`) to prevent any collision with legitimate HF cache files.

So #653 is closeable as fixed-in-#650.

## Wiring assertion (codex r1 BLOCKING addressed)

Initial test used a bare `LOAD_GLOBAL` check, which would still pass if a future refactor referenced `_ensure_model_downloaded` without calling it. Tightened to require both the LOAD and a CALL within ~12 bytecode ops, with a negative control proving ref-only patterns are rejected.

## Test plan

- [x] New test `test_serve_command_calls_ensure_model_downloaded` passes (tightened to require CALL after LOAD)
- [x] Negative control verified: function that references-but-doesn't-call returns False
- [x] Full `tests/test_mirror_pull.py` suite passes (48/48 → 48/48 after retest)
- [x] `full_unit` pr_validate stage passes (5422 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new third-party dependencies
- [x] No changes to `load_model` / `server.py`
- [x] Local path / fully-cached short-circuit preserved (handled by `_ensure_model_downloaded` itself)
- [x] `RAPID_MLX_MODEL_MIRROR=""` opt-out still works (handled by `_try_mirror_prefetch`)
- [x] CI green
- [x] Bytecode-level wiring assertion catches accidental future regression

Closes #651
Closes #653