### PR TITLE
docs(install): two-step brew tap+install for Homebrew 4.x untrusted-tap policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 ```bash
 # Homebrew (recommended — just works, no Python version issues)
 brew tap raullenchai/rapid-mlx
+brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 
 # pip (requires Python 3.10+ — macOS ships 3.9, so install Python first if needed)
@@ -79,12 +80,13 @@ curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 
 > **"No matching distribution" error?** Your Python is too old. Run `python3 --version` — if it says 3.9, install a newer Python: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`
 
-> **`Refusing to load formula ... from untrusted tap`?** Homebrew 4.x defaults to refusing direct one-shot installs from third-party taps. Run `brew tap raullenchai/rapid-mlx` first (the two-step block above), then `brew install rapid-mlx`. One-time per machine.
+> **`Refusing to load formula ... from untrusted tap`?** Homebrew 4.x requires third-party taps to be explicitly trusted before install. The `brew trust raullenchai/rapid-mlx` line above is what marks the tap as trusted — without it, even after `brew tap`, the install is refused. Trust is per-machine and persists across upgrades.
 
 > **`Tapping homebrew/core` / `Operation not permitted` during `brew install`?** Brew 5.x's install sandbox can't auto-tap `homebrew/core` mid-install. Pre-tap it once, then retry:
 > ```bash
 > brew tap homebrew/core --force   # ~1.3 GB, one-time
 > brew tap raullenchai/rapid-mlx
+> brew trust raullenchai/rapid-mlx
 > brew install rapid-mlx
 > ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@
 
 ```bash
 # Homebrew (recommended — just works, no Python version issues)
-brew install raullenchai/rapid-mlx/rapid-mlx
+brew tap raullenchai/rapid-mlx
+brew install rapid-mlx
 
 # pip (requires Python 3.10+ — macOS ships 3.9, so install Python first if needed)
 pip install rapid-mlx
@@ -78,10 +79,13 @@ curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 
 > **"No matching distribution" error?** Your Python is too old. Run `python3 --version` — if it says 3.9, install a newer Python: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`
 
+> **`Refusing to load formula ... from untrusted tap`?** Homebrew 4.x defaults to refusing direct one-shot installs from third-party taps. Run `brew tap raullenchai/rapid-mlx` first (the two-step block above), then `brew install rapid-mlx`. One-time per machine.
+
 > **`Tapping homebrew/core` / `Operation not permitted` during `brew install`?** Brew 5.x's install sandbox can't auto-tap `homebrew/core` mid-install. Pre-tap it once, then retry:
 > ```bash
 > brew tap homebrew/core --force   # ~1.3 GB, one-time
-> brew install raullenchai/rapid-mlx/rapid-mlx
+> brew tap raullenchai/rapid-mlx
+> brew install rapid-mlx
 > ```
 
 **Step 2 — Talk to a model right now** (one command, no second terminal):

--- a/README.md
+++ b/README.md
@@ -61,20 +61,23 @@
 **Step 1 — Install** (pick one):
 
 ```bash
-# Homebrew (recommended — just works, no Python version issues)
+# uv (recommended — one command, isolated env, auto-manages Python)
+uv tool install rapid-mlx@latest
+# Don't have uv yet? Install it first: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Or one-liner with auto-setup (installs Python if needed)
+curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+
+# Homebrew (Mac-native — needs tap + trust before install on Homebrew 4.x)
 brew tap raullenchai/rapid-mlx
 brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 
 # pip (requires Python 3.10+ — macOS ships 3.9, so install Python first if needed)
 pip install rapid-mlx
-
-# uv (isolated tool env — to refresh later: `uv tool upgrade rapid-mlx`)
-uv tool install rapid-mlx@latest
-
-# Or one-liner with auto-setup (installs Python if needed)
-curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
 ```
+
+Upgrade later: `uv tool upgrade rapid-mlx` / `brew upgrade rapid-mlx` / `pip install -U rapid-mlx`.
 
 > **Vision/multimodal models** (Gemma 4, Qwen-VL, etc.) need extras: `pip install 'rapid-mlx[vision]'`. Text-only install is ~460 MB; vision adds ~322 MB. See [Optional Extras](#optional-extras) for the full list.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,27 @@
 - macOS on Apple Silicon (M1/M2/M3/M4)
 - Python 3.10+
 
-## Install with Homebrew (recommended)
+## Install with uv (recommended)
+
+```bash
+uv tool install rapid-mlx@latest
+```
+
+One command, isolated tool venv, no Python-version juggling — uv finds (or
+installs) the right Python automatically. Upgrade later with
+`uv tool upgrade rapid-mlx`. If you don't have uv yet, install it first:
+`curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+## One-liner install script
+
+```bash
+curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+```
+
+Auto-installs Python if needed, then `pipx install rapid-mlx`. Good fallback
+if you don't want to install `uv` first.
+
+## Install with Homebrew
 
 ```bash
 brew tap raullenchai/rapid-mlx
@@ -27,12 +47,6 @@ pip install rapid-mlx
 
 If `python3 --version` reports 3.9 (macOS default), install a newer Python
 first: `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`.
-
-### One-liner with auto-setup
-
-```bash
-curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
-```
 
 ### From source (for development)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,8 +8,14 @@
 ## Install with Homebrew (recommended)
 
 ```bash
-brew install raullenchai/rapid-mlx/rapid-mlx
+brew tap raullenchai/rapid-mlx
+brew install rapid-mlx
 ```
+
+The `brew tap` step is required: Homebrew 4.x refuses one-shot installs from
+third-party taps (`Refusing to load formula ... from untrusted tap`). The tap
+only needs to be added once per machine; `brew upgrade rapid-mlx` after that
+works directly.
 
 ## Install with pip
 
@@ -84,6 +90,12 @@ Use a smaller quantized model:
 rapid-mlx serve qwen3.5-4b-4bit
 ```
 
+### `Refusing to load formula ... from untrusted tap`
+
+Homebrew 4.x refuses one-shot installs from third-party taps. Use the
+two-step install at the top of this page (`brew tap raullenchai/rapid-mlx`
+then `brew install rapid-mlx`). Only needs to be done once per machine.
+
 ### `brew install` fails with `Operation not permitted`
 
 Brew 5.x's install sandbox sometimes can't auto-tap `homebrew/core` mid-install.
@@ -91,5 +103,6 @@ Pre-tap it once, then retry:
 
 ```bash
 brew tap homebrew/core --force   # ~1.3 GB, one-time
-brew install raullenchai/rapid-mlx/rapid-mlx
+brew tap raullenchai/rapid-mlx
+brew install rapid-mlx
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,13 +9,15 @@
 
 ```bash
 brew tap raullenchai/rapid-mlx
+brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 ```
 
-The `brew tap` step is required: Homebrew 4.x refuses one-shot installs from
-third-party taps (`Refusing to load formula ... from untrusted tap`). The tap
-only needs to be added once per machine; `brew upgrade rapid-mlx` after that
-works directly.
+All three steps are required. Homebrew 4.x refuses one-shot installs from
+third-party taps with `Refusing to load formula ... from untrusted tap` —
+the `brew trust` line is what marks the tap as trusted. Tap + trust are
+both per-machine and persist across upgrades; `brew upgrade rapid-mlx`
+after the first install works directly.
 
 ## Install with pip
 
@@ -92,9 +94,10 @@ rapid-mlx serve qwen3.5-4b-4bit
 
 ### `Refusing to load formula ... from untrusted tap`
 
-Homebrew 4.x refuses one-shot installs from third-party taps. Use the
-two-step install at the top of this page (`brew tap raullenchai/rapid-mlx`
-then `brew install rapid-mlx`). Only needs to be done once per machine.
+Homebrew 4.x refuses installs from third-party taps until you mark them
+trusted. Run the three-step install at the top of this page (tap, trust,
+install). The `brew trust` line is the one that flips the refusal off.
+Only needs to be done once per machine.
 
 ### `brew install` fails with `Operation not permitted`
 
@@ -104,5 +107,6 @@ Pre-tap it once, then retry:
 ```bash
 brew tap homebrew/core --force   # ~1.3 GB, one-time
 brew tap raullenchai/rapid-mlx
+brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 ```


### PR DESCRIPTION
## Summary

Homebrew 4.x's default policy refuses one-shot installs from third-party taps:

\`\`\`
Error: Refusing to load formula raullenchai/rapid-mlx/rapid-mlx from untrusted tap raullenchai/rapid-mlx.
\`\`\`

User hit this on a v0.7.27 fresh install. The fix is the standard \`brew tap <user>/<repo>\` first, then \`brew install <formula>\` — one-time per machine, after which \`brew upgrade rapid-mlx\` works directly.

## Changes

- \`README.md\` Quick Start: show two-step install + add a new troubleshooting tip for the \`untrusted tap\` error
- \`docs/getting-started/installation.md\`: same two-step pattern, plus a dedicated troubleshooting subsection
- \`docs/getting-started/installation.md\` existing \`Operation not permitted\` recipe: switch to two-step form so the recovery command itself isn't broken by the same policy

## Test plan

- [x] \`brew tap raullenchai/rapid-mlx\` then \`brew install rapid-mlx\` works on a fresh machine (the user just confirmed this is the fix)
- [x] No code changes — pure docs
- [x] Existing one-liner install script (\`install.sh\`) is unaffected — only the manual \`brew install\` path
- [x] No new dependencies