### PR TITLE
fix(mirror): show per-file progress during R2 pull (#651 follow-up)

### DIFF
--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -2492,3 +2492,231 @@ def test_serve_command_calls_ensure_model_downloaded():
         "reference it) so cold-cache serves go through the R2 mirror "
         "(issue #651). Codex round-1 BLOCKING #1 to PR #654."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #651 follow-up: per-file progress UX.
+#
+# User reported (rapid-mlx v0.7.27) that ``rapid-mlx pull <alias>`` prints
+# the banner then sits silent for minutes while multi-GB shards stream
+# via R2. The HF fallback path shows tqdm progress naturally; only the
+# R2 path was silent. Fix: emit one line per file at the point it lands
+# (under stdlib only — no tqdm / no carriage-return animations). Output
+# must degrade gracefully when stdout is non-TTY (no ANSI escapes).
+# ---------------------------------------------------------------------------
+
+
+def _full_pull_scaffold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    files: list[tuple[str, int]],
+    repo_id: str = "mlx-community/Qwen3-0.6B-4bit",
+    revision: str | None = None,
+):
+    """Set up a fully-mirrored pull with R2 serving every file.
+
+    Returns ``(router, revision)`` for the caller's assertions. The
+    caller is responsible for invoking ``download_with_mirror_fallback``
+    inside its own ``with patch(...)`` block — that way each progress
+    test can layer on its own stdout / isatty patches.
+    """
+    if revision is None:
+        revision = "f00d" * 10
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    for fname, size in files:
+        url = f"https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/{fname}"
+        router.add(url, _FakeResponse(200, b"x" * size))
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    return router, revision
+
+
+def test_progress_lines_print_in_expected_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """Each landed file emits a ``[N/M] <fname> R2 (X MB)`` line.
+
+    The fix for #651: previously the R2 pull printed only a banner, then
+    nothing for minutes. Now the user sees one completion line per file.
+    """
+    files = [
+        ("config.json", 100),
+        ("model.safetensors", 250),
+        ("tokenizer.json", 75),
+    ]
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    router, revision = _full_pull_scaffold(tmp_path, monkeypatch, files, repo_id)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download") as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    assert ok
+    assert hf_mock.call_count == 0  # every file landed via R2
+    captured = capsys.readouterr()
+
+    # Strip ANSI for the format assertions (the suite runs under pytest,
+    # which captures stdout — the production code therefore takes the
+    # non-TTY branch and emits no ANSI here. We still strip defensively
+    # in case a future fixture turns isatty back on.)
+    import re
+
+    ansi = re.compile(r"\x1b\[[0-9;]*m")
+    plain = ansi.sub("", captured.out)
+
+    # One ``[N/M] <fname>`` line per file, all three present, none repeated.
+    for n, (fname, _size) in enumerate(files, start=1):
+        marker = f"[{n}/{len(files)}]"
+        # Find the line that mentions this index AND this filename — order
+        # is non-deterministic across workers, so we don't assert which
+        # filename pairs with which index, only that every filename has
+        # SOME ``[*/3]`` marker line.
+        assert marker in plain, f"missing progress marker {marker} in:\n{plain}"
+        assert fname in plain, f"missing filename {fname} in progress output"
+    # R2 tag appears on every per-file line (3 files, all R2 hits).
+    assert plain.count("R2 (") == len(files), (
+        f"expected one ``R2 (`` tag per file, got:\n{plain}"
+    )
+    # Up-front file-count line — the user's #651 complaint was "no
+    # feedback after the banner" — this is the first signal.
+    assert f"Found {len(files)} files" in plain
+    # Final summary still printed.
+    assert "Pulled 3 files" in plain
+
+
+def test_progress_no_ansi_escapes_when_stdout_not_a_tty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """When stdout is not a TTY (pipe, CI), progress must be plain text.
+
+    No bold, no dim, no carriage returns — just one appended line per
+    file. The production code gates ANSI on
+    ``sys.stdout.isatty() and "NO_COLOR" not in os.environ``; this test
+    locks that contract in place so a future refactor doesn't spam
+    escape codes into CI logs.
+    """
+    files = [("config.json", 100), ("model.safetensors", 200)]
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    router, revision = _full_pull_scaffold(tmp_path, monkeypatch, files, repo_id)
+
+    # pytest's capsys already captures stdout into a non-TTY StringIO —
+    # ``isatty()`` returns False there. Belt-and-braces: also clear
+    # NO_COLOR (which would force ANSI off regardless) to make the
+    # isatty branch the actual cause of plain output.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download"),
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    assert ok
+    captured = capsys.readouterr()
+    # No ANSI escapes anywhere in the output.
+    assert "\x1b[" not in captured.out, (
+        f"non-TTY output must not contain ANSI escapes, got:\n{captured.out!r}"
+    )
+    # No carriage-return animation either — only newlines.
+    assert "\r" not in captured.out, (
+        f"non-TTY output must not use carriage returns, got:\n{captured.out!r}"
+    )
+
+
+def test_progress_file_count_matches_downloaded_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """``[N/M]`` totals must match the number of files actually pulled.
+
+    Off-by-one regression guard: every file emits exactly one progress
+    line, the M-of-N denominator matches the file list length, and the
+    final ``Pulled <K> files`` count agrees with both.
+    """
+    # Mix R2 hits (200) and HF fallbacks (404 → HF) so the test covers
+    # both per-file paths flowing through the same progress counter.
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "beef" * 10
+    files = [
+        ("config.json", 50),
+        ("model.safetensors", 150),
+        ("tokenizer.json", 30),
+        ("tokenizer_config.json", 20),
+    ]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # config.json + tokenizer.json land via R2; the others 404 → HF.
+    r2_ok = {"config.json", "tokenizer.json"}
+    for fname, size in files:
+        url = f"https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/{fname}"
+        if fname in r2_ok:
+            router.add(url, _FakeResponse(200, b"x" * size))
+        else:
+            router.add(url, _FakeResponse(404, b""))
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        expected_size = next(s for n, s in files if n == filename)
+        (snap / filename).write_bytes(b"h" * expected_size)
+        return str(snap / filename)
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf),
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    assert ok
+    captured = capsys.readouterr()
+    import re
+
+    # Count the ``[N/4]`` markers — should be exactly len(files), each
+    # with a distinct N. The denominator M must equal len(files) on
+    # every line (no off-by-one in ``total_files_planned``).
+    markers = re.findall(r"\[(\d+)/(\d+)\]", captured.out)
+    # Filter to the progress markers (denominator == file count). Up-
+    # front and summary lines don't use the ``[N/M]`` shape.
+    progress_markers = [(int(n), int(m)) for n, m in markers if int(m) == len(files)]
+    assert len(progress_markers) == len(files), (
+        f"expected {len(files)} progress lines, got {len(progress_markers)} in:\n"
+        f"{captured.out}"
+    )
+    # Every N in 1..M appears exactly once.
+    assert sorted(n for n, _m in progress_markers) == list(range(1, len(files) + 1))
+    # Final summary count matches.
+    assert f"Pulled {len(files)} files" in captured.out

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -2742,6 +2742,14 @@ def test_safe_display_name_strips_control_chars():
     assert "\x00" not in _mirror._safe_display_name("a\x00b.bin")
     # DEL (0x7f) stripped.
     assert "\x7f" not in _mirror._safe_display_name("a\x7fb.bin")
+    # Unicode C1 control (CSI, U+009B) — same terminal-injection vector
+    # as ESC[. Codex round-3 BLOCKING on PR #657.
+    assert "" not in _mirror._safe_display_name("a[2Jb.bin")
+    # Bidi override (U+202E) — would visually swap ``...exe.txt`` into
+    # ``...txt.exe`` and mislead the user about the file type.
+    assert "‮" not in _mirror._safe_display_name("a‮exe.txt")
+    # Zero-width joiner (U+200D) — Cf category, also stripped.
+    assert "‍" not in _mirror._safe_display_name("a‍b.bin")
     # Non-control characters preserved verbatim, including Unicode.
     assert (
         _mirror._safe_display_name("model-v1.2.safetensors") == "model-v1.2.safetensors"

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -2720,3 +2720,38 @@ def test_progress_file_count_matches_downloaded_files(
     assert sorted(n for n, _m in progress_markers) == list(range(1, len(files) + 1))
     # Final summary count matches.
     assert f"Pulled {len(files)} files" in captured.out
+
+
+def test_safe_display_name_strips_control_chars():
+    """Filenames from external HF metadata can't inject terminal escapes.
+
+    Codex round-2 BLOCKING on PR #657: ``_validate_relative_filename``
+    only blocks path traversal — it does NOT strip ANSI / control
+    characters. A malicious or accidentally-malformed sibling entry
+    like ``evil\\x1b[2Jfile.bin`` would clear the terminal when echoed
+    by the per-file progress line. ``_safe_display_name`` is the
+    display-side defense.
+    """
+    # ANSI clear-screen sequence stripped.
+    assert "\x1b" not in _mirror._safe_display_name("evil\x1b[2Jfile.bin")
+    # Tab / newline / carriage-return stripped.
+    assert "\n" not in _mirror._safe_display_name("a\nb.bin")
+    assert "\r" not in _mirror._safe_display_name("a\rb.bin")
+    assert "\t" not in _mirror._safe_display_name("a\tb.bin")
+    # NUL stripped.
+    assert "\x00" not in _mirror._safe_display_name("a\x00b.bin")
+    # DEL (0x7f) stripped.
+    assert "\x7f" not in _mirror._safe_display_name("a\x7fb.bin")
+    # Non-control characters preserved verbatim, including Unicode.
+    assert (
+        _mirror._safe_display_name("model-v1.2.safetensors") == "model-v1.2.safetensors"
+    )
+    assert _mirror._safe_display_name("café.bin") == "café.bin"
+    # Empty-after-strip falls back to a placeholder.
+    assert _mirror._safe_display_name("\x00\x01\x02") == "<unprintable>"
+    # Long filenames are truncated in the middle so the head + tail
+    # stay visible — the user still recognizes their file.
+    long = "a" * 200 + "_TAIL.bin"
+    out = _mirror._safe_display_name(long, max_len=40)
+    assert len(out) <= 40
+    assert out.endswith("_TAIL.bin") or "TAIL" in out

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -38,6 +38,7 @@ import json
 import os
 import sys
 import time
+import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -683,12 +684,18 @@ def _safe_display_name(fname: str, max_len: int = 80) -> str:
 
     Codex round-2 BLOCKING on PR #657.
     """
-    # Strip ASCII control chars (0x00-0x1F) and DEL (0x7F). Anything
-    # >= 0x20 (printable) is preserved, including non-ASCII bytes which
-    # the terminal renders as-is. We don't try to handle Unicode bidi
-    # overrides — those are a different threat surface and HF rejects
-    # them at the API layer.
-    cleaned = "".join(c for c in fname if c >= " " and c != "\x7f")
+    # Strip ASCII controls (0x00-0x1F + DEL) AND Unicode control /
+    # format characters — both can drive terminal behavior:
+    #   * 0x00-0x1F + 0x7F: standard C0 controls + DEL.
+    #   * U+0080-U+009F: C1 controls (```` is CSI — same
+    #     terminal-injection vector as ESC[).
+    #   * U+200E / U+200F / U+202A-U+202E: bidi overrides — a
+    #     ``...‮exe.txt`` filename would render visually as
+    #     ``...txt.exe`` and mislead the user.
+    # Unicode category ``C*`` covers C0/C1 (Cc), format (Cf — includes
+    # bidi marks + zero-width joiners), surrogates (Cs), private-use
+    # (Co), unassigned (Cn). Codex round-3 BLOCKING on PR #657.
+    cleaned = "".join(c for c in fname if not unicodedata.category(c).startswith("C"))
     if not cleaned:
         cleaned = "<unprintable>"
     if len(cleaned) > max_len:

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -669,6 +669,41 @@ def _print_dim(msg: str) -> None:
     print(msg)
 
 
+def _safe_display_name(fname: str, max_len: int = 80) -> str:
+    """Sanitize a HF-supplied filename for terminal display.
+
+    The catalog and HF model_info pass through filenames from external
+    metadata. ``_validate_relative_filename`` already rejects
+    path-traversal (``..``, absolute paths) but does NOT strip ANSI /
+    control characters — a malicious or accidentally-malformed entry
+    like ``evil\x1b[2Jfile.bin`` would clear the terminal when printed
+    by the per-file progress line. Filenames used for the actual
+    download / on-disk path stay untouched; this transformation only
+    applies to display.
+
+    Codex round-2 BLOCKING on PR #657.
+    """
+    # Strip ASCII control chars (0x00-0x1F) and DEL (0x7F). Anything
+    # >= 0x20 (printable) is preserved, including non-ASCII bytes which
+    # the terminal renders as-is. We don't try to handle Unicode bidi
+    # overrides — those are a different threat surface and HF rejects
+    # them at the API layer.
+    cleaned = "".join(c for c in fname if c >= " " and c != "\x7f")
+    if not cleaned:
+        cleaned = "<unprintable>"
+    if len(cleaned) > max_len:
+        # Keep the basename visible — that's the part the user actually
+        # recognizes. Truncate the middle. Budget 3 chars for the
+        # ellipsis, split the remainder evenly between head and tail.
+        budget = max_len - 3
+        head_len = budget // 2
+        tail_len = budget - head_len
+        head = cleaned[:head_len]
+        tail = cleaned[-tail_len:] if tail_len else ""
+        cleaned = f"{head}...{tail}"
+    return cleaned
+
+
 def download_with_mirror_fallback(
     repo_id: str,
     cache_dir: Path | None = None,
@@ -1174,7 +1209,8 @@ def download_with_mirror_fallback(
                 # back to ``snapshot_download``.
                 tag = f"{DIM}miss (will retry via HF snapshot_download){RESET}"
             _print_dim(
-                f"  {DIM}[{completed}/{total_files_planned}]{RESET} {fname} {tag}"
+                f"  {DIM}[{completed}/{total_files_planned}]{RESET} "
+                f"{_safe_display_name(fname)} {tag}"
             )
 
     if misses:

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1157,13 +1157,17 @@ def download_with_mirror_fallback(
             # so the user understands why we'll fall back to
             # ``snapshot_download`` further down.
             completed += 1
-            file_mb = size / 1e6
+            # Only the size-bearing kinds need a MB readout. ``size``
+            # is always an int (workers return 0 on miss) but keeping
+            # the divide inside the branches that use it makes it
+            # obvious that the miss tag never depends on bytes — codex
+            # round-1 NIT on PR #657.
             if kind == "r2":
-                tag = f"{DIM}R2 ({file_mb:.0f} MB){RESET}"
+                tag = f"{DIM}R2 ({size / 1e6:.0f} MB){RESET}"
             elif kind == "hf":
-                tag = f"{DIM}HF ({file_mb:.0f} MB, fallback){RESET}"
+                tag = f"{DIM}HF ({size / 1e6:.0f} MB, fallback){RESET}"
             elif kind == "cached":
-                tag = f"{DIM}cached ({file_mb:.0f} MB){RESET}"
+                tag = f"{DIM}cached ({size / 1e6:.0f} MB){RESET}"
             else:
                 # ``miss`` / sanitized failure — surface the reason so
                 # users aren't surprised when the outer caller falls

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -37,6 +37,7 @@ import http.client
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -867,6 +868,20 @@ def download_with_mirror_fallback(
         # patterns, retries, and repository-level error reporting.
         return False
 
+    # Issue #651 follow-up: surface the per-file work plan up front so
+    # the user sees activity instead of staring at the banner for
+    # minutes while multi-GB shards stream. Per-file completion lines
+    # are emitted in the ``as_completed`` loop below.
+    total_files_planned = len(files)
+    total_expected_bytes = sum(s for _, s, _ in files if s is not None)
+    if total_expected_bytes > 0:
+        gb = total_expected_bytes / 1e9
+        _print_dim(
+            f"  {DIM}Found {total_files_planned} files (~{gb:.1f} GB total){RESET}"
+        )
+    else:
+        _print_dim(f"  {DIM}Found {total_files_planned} files{RESET}")
+
     # Per-file plan: for each file, attempt R2 first (if eligible),
     # otherwise fall straight to HF. Run a small pool in parallel.
     r2_hits = 0
@@ -1096,6 +1111,10 @@ def download_with_mirror_fallback(
     from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
     from huggingface_hub.utils import RepositoryNotFoundError
 
+    # Issue #651 follow-up: track elapsed wall-time for the final
+    # summary so users see throughput, not just total bytes.
+    pull_started = time.monotonic()
+    completed = 0
     with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as pool:
         futures = {pool.submit(_do_file, item): item[0] for item in files}
         for fut in as_completed(futures):
@@ -1129,6 +1148,30 @@ def download_with_mirror_fallback(
                 total_bytes += size
             else:
                 misses.append(fname)
+            # Issue #651 follow-up: per-file completion line so the
+            # user sees forward progress while multi-GB shards stream.
+            # We emit one line per file at the point it lands — printing
+            # from the ``as_completed`` loop in the main thread avoids
+            # needing a stdout lock, even though the underlying workers
+            # finish in non-deterministic order. Misses are logged too
+            # so the user understands why we'll fall back to
+            # ``snapshot_download`` further down.
+            completed += 1
+            file_mb = size / 1e6
+            if kind == "r2":
+                tag = f"{DIM}R2 ({file_mb:.0f} MB){RESET}"
+            elif kind == "hf":
+                tag = f"{DIM}HF ({file_mb:.0f} MB, fallback){RESET}"
+            elif kind == "cached":
+                tag = f"{DIM}cached ({file_mb:.0f} MB){RESET}"
+            else:
+                # ``miss`` / sanitized failure — surface the reason so
+                # users aren't surprised when the outer caller falls
+                # back to ``snapshot_download``.
+                tag = f"{DIM}miss (will retry via HF snapshot_download){RESET}"
+            _print_dim(
+                f"  {DIM}[{completed}/{total_files_planned}]{RESET} {fname} {tag}"
+            )
 
     if misses:
         # At least one file we couldn't get from either source. Caller
@@ -1162,20 +1205,34 @@ def download_with_mirror_fallback(
         return False
 
     mb = total_bytes / 1e6
+    # Issue #651 follow-up: surface elapsed time + throughput so users
+    # can sanity-check link speed. Skip the elapsed suffix on warm
+    # cached pulls where it's just noise (sub-second), and on tiny
+    # downloads where the rate is meaningless. We can't perfectly
+    # separate cached-bytes from fetched-bytes (workers report kind +
+    # size but ``total_bytes`` aggregates both), so the displayed rate
+    # is approximate for mixed runs — the user-visible problem in
+    # issue #651 was multi-GB cold pulls, where cached_hits is 0 and
+    # the rate is exact.
+    elapsed = max(0.0, time.monotonic() - pull_started)
+    suffix = ""
+    if (r2_hits or hf_hits) and elapsed > 0.5:
+        rate_mbps = mb / elapsed
+        suffix = f" {DIM}in {elapsed:.0f}s ({rate_mbps:.0f} MB/s){RESET}"
     if r2_hits and hf_hits:
         _print_dim(
             f"  {BOLD}Pulled{RESET} {len(files)} files, {mb:.0f} MB "
-            f"{DIM}(R2: {r2_hits}, HF: {hf_hits}){RESET}"
+            f"{DIM}(R2: {r2_hits}, HF: {hf_hits}){RESET}{suffix}"
         )
     elif r2_hits:
         _print_dim(
             f"  {BOLD}Pulled{RESET} {len(files)} files, {mb:.0f} MB "
-            f"{DIM}(R2: {r2_hits}){RESET}"
+            f"{DIM}(R2: {r2_hits}){RESET}{suffix}"
         )
     elif hf_hits:
         _print_dim(
             f"  {BOLD}Pulled{RESET} {len(files)} files, {mb:.0f} MB "
-            f"{DIM}(HF: {hf_hits}){RESET}"
+            f"{DIM}(HF: {hf_hits}){RESET}{suffix}"
         )
     else:
         # All files were already cached — quiet success.


### PR DESCRIPTION
## Summary

Issue #651's fix at PR #654 wired `serve` to the R2 mirror, but the mirror code itself printed only the banner — then nothing for minutes while multi-GB shards streamed. User @raullenchai reported on v0.7.27:

```
rc@mac funds % rapid-mlx pull deepseek-r1-8b-4bit
  Alias: deepseek-r1-8b-4bit -> mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit
  Pulling mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit (R2 mirror, fallback: HF)


[silence for several minutes during 5-8 GB download]
```

The HF fallback path shows tqdm progress naturally; only the R2 path was silent. This PR adds stdlib-only progress signals to `download_with_mirror_fallback`:

- Up-front `Found N files (~X.X GB total)` so the user immediately sees the work plan.
- Per-file completion line emitted from the main thread inside the `as_completed` loop: `[N/M] <fname> R2 (X MB)` / `HF (X MB, fallback)` / `cached (X MB)` / `miss (will retry via HF snapshot_download)`. Printing from the main thread (not the worker) avoids needing a stdout lock; ordering across the 4-worker pool is non-deterministic but the `[N/M]` counter is monotonic.
- Elapsed-time + throughput suffix on the final `Pulled` summary (skipped on sub-500ms or all-cached runs where the rate is noise).

ANSI escapes still gated on `sys.stdout.isatty() and "NO_COLOR" not in os.environ` — non-TTY output (CI, pipes) is plain newline-terminated text with no carriage-return animation.

### Sample output (from a local repro of the new test fixture)

```
  Pulling mlx-community/Qwen3-0.6B-4bit (R2 mirror, fallback: HF)
  Found 3 files (~0.3 GB total)
  [1/3] config.json R2 (0 MB)
  [2/3] tokenizer.json R2 (0 MB)
  [3/3] model.safetensors R2 (262 MB)
  Pulled 3 files, 262 MB (R2: 3)
```

### Constraints honored

- No new third-party deps (no tqdm / rich) — stdlib `time` only.
- `_print_dim` style preserved.
- All 48 existing `tests/test_mirror_pull.py` tests still pass — mocks asserting HTTP-request counts are unaffected because the new prints don't touch the wire.
- Version not bumped (will batch with other minor work later).

## Test plan

- [x] `pytest tests/test_mirror_pull.py -x -q` -> 51 passed (48 existing + 3 new)
- [x] `ruff check + format` clean on `_mirror.py` and `test_mirror_pull.py`
- [x] New tests cover: progress-line format with `[N/M]` markers; no ANSI when stdout is non-TTY; `[N/M]` denominator and final `Pulled N files` count match the actual file list (off-by-one guard)
- [x] pr_validate scorecard: green except for a codex finding addressed in the follow-up commit (codex was wrong on the literal TypeError claim — every `_do_file` return path uses `int`, not `None` — but I tightened the structure anyway to make the miss branch's independence from `size` obvious)