### PR TITLE
fix(harness): SKIP-not-FAIL when agent refuses init on small context (#655)

### DIFF
--- a/tests/test_agent_query_context_skip.py
+++ b/tests/test_agent_query_context_skip.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the soft-skip behavior when a harness refuses init on context window.
+
+Regression coverage for issue #655: the v0.7.27 release SOP's M3 gauntlet
+G7b aborted because Hermes Agent refuses to initialize on Qwen3.5-9B-4bit
+(advertised context window 32K, Hermes minimum 64K). The subprocess
+exited 0 and wrote the refusal to stdout, so before this fix:
+
+  - ``_agent_query`` returned ``(output, None)``
+  - ``_test_e2e_file_read`` saw "no expected substring" and reported FAIL
+  - The harness sweep ended 27p 7f 0e 0s and ``set -e`` aborted the gauntlet
+
+After the fix, ``_agent_query`` detects the refusal pattern and propagates
+a ``SKIP:``-prefixed err sentinel; the three ``_test_e2e_*`` callers
+honor that prefix and report SKIP instead of FAIL. The harness sweep
+stays honest (0 FAIL, N SKIP) and the gauntlet continues to the
+remaining gates.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vllm_mlx.agents.testing import (
+    TestStatus,
+    _agent_query,
+    _err_to_status,
+    _test_e2e_chat,
+    _test_e2e_file_read,
+    _test_e2e_terminal,
+)
+
+
+def _stub_completed_proc(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Build a stand-in for the subprocess.run() result."""
+
+    class _Stub:
+        def __init__(self):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
+
+    return _Stub()
+
+
+# --------------------------------------------------------------------------- #
+# _err_to_status: the three-bucket mapping                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_err_to_status_not_found_is_skip():
+    assert _err_to_status("Binary not found: hermes") is TestStatus.SKIP
+
+
+def test_err_to_status_skip_prefix_is_skip():
+    assert _err_to_status("SKIP: agent refused init — context window") is TestStatus.SKIP
+
+
+def test_err_to_status_timeout_is_error():
+    assert _err_to_status("TIMEOUT") is TestStatus.ERROR
+
+
+def test_err_to_status_arbitrary_is_error():
+    assert _err_to_status("Agent error: server issue") is TestStatus.ERROR
+
+
+# --------------------------------------------------------------------------- #
+# _agent_query: the detection happens once at the subprocess boundary         #
+# --------------------------------------------------------------------------- #
+
+
+HERMES_REFUSAL_STDOUT = (
+    "Failed to initialize agent: Model mlx-community/Qwen3.5-9B-4bit has a "
+    "context window of 32,768 tokens, which is below the minimum 64,000 "
+    "required by Hermes Agent.\n"
+)
+
+
+def test_agent_query_detects_context_refusal_as_skip():
+    """The Hermes-style "context window below minimum" refusal → SKIP err."""
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT),
+        ),
+    ):
+        out, err = _agent_query("hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10)
+    assert out is None, "On refusal, output must be suppressed so downstream tests route via err"
+    assert err is not None
+    assert err.startswith("SKIP:"), (
+        f"Refusal must be propagated with a SKIP: prefix so _test_e2e_* "
+        f"recognize it; got err={err!r}"
+    )
+
+
+def test_agent_query_passes_through_normal_output():
+    """A clean subprocess success returns ``(output, None)`` as before."""
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/codex"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout="The answer is 4.\n"),
+        ),
+    ):
+        out, err = _agent_query("codex", "codex -q '{query}'", "what is 2+2?", timeout=10)
+    assert err is None
+    assert out is not None and "4" in out
+
+
+def test_agent_query_does_not_match_unrelated_failures():
+    """\"Failed to initialize agent\" alone (no \"context window\") is NOT a SKIP.
+
+    Other init failures (missing API key, bad config, etc) should remain
+    ERROR — auto-skipping would mask real harness regressions.
+    """
+    bad_init_no_context = (
+        "Failed to initialize agent: missing OPENAI_API_KEY environment variable\n"
+    )
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=bad_init_no_context),
+        ),
+    ):
+        out, err = _agent_query("hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10)
+    # Output passes through (not None); downstream tests then route via
+    # "no expected substring" → FAIL, which is the correct signal for a
+    # genuine harness misconfiguration.
+    assert err is None
+    assert out is not None and "OPENAI_API_KEY" in out
+
+
+# --------------------------------------------------------------------------- #
+# Each of the three _test_e2e_* functions must route SKIP-prefixed err → SKIP #
+# --------------------------------------------------------------------------- #
+
+
+def test_e2e_chat_routes_skip_prefix_to_skip_status():
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT),
+        ),
+    ):
+        result = _test_e2e_chat("hermes", "hermes chat -q '{query}' -Q", timeout=10)
+    assert result.status is TestStatus.SKIP, (
+        f"e2e_chat must SKIP on Hermes context-window refusal (#655), not FAIL/ERROR. "
+        f"Got status={result.status}, message={result.message!r}"
+    )
+
+
+def test_e2e_file_read_routes_skip_prefix_to_skip_status():
+    """Direct regression for the gauntlet line in #655."""
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT),
+        ),
+    ):
+        result = _test_e2e_file_read(
+            "hermes", "hermes chat -q '{query}' -Q", timeout=10
+        )
+    assert result.status is TestStatus.SKIP
+    assert "context window" in (result.message or "").lower() or "context window" in (
+        result.message or ""
+    )
+
+
+def test_e2e_terminal_routes_skip_prefix_to_skip_status():
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT),
+        ),
+    ):
+        result = _test_e2e_terminal(
+            "hermes", "hermes chat -q '{query}' -Q", timeout=10, agent_name="hermes"
+        )
+    assert result.status is TestStatus.SKIP
+
+
+def test_e2e_tests_still_error_on_genuine_failure():
+    """A real subprocess crash must still be ERROR, not SKIP — guards against
+    over-broad SKIP routing masking regressions."""
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            side_effect=TimeoutError("simulated timeout"),
+        ),
+    ):
+        result = _test_e2e_file_read(
+            "hermes", "hermes chat -q '{query}' -Q", timeout=1
+        )
+    # TimeoutError raised inside _agent_query → caught by the bare ``except
+    # Exception`` and turned into err=str(exc); the resulting err is NOT
+    # "not found" and does NOT start with "SKIP:", so the test routes to
+    # ERROR — which is the correct signal for a genuine subprocess failure.
+    assert result.status is TestStatus.ERROR, (
+        f"A genuine subprocess failure must remain ERROR (not SKIP). "
+        f"Got {result.status}, message={result.message!r}"
+    )

--- a/tests/test_agent_query_context_skip.py
+++ b/tests/test_agent_query_context_skip.py
@@ -53,7 +53,9 @@ def test_err_to_status_not_found_is_skip():
 
 
 def test_err_to_status_skip_prefix_is_skip():
-    assert _err_to_status("SKIP: agent refused init — context window") is TestStatus.SKIP
+    assert (
+        _err_to_status("SKIP: agent refused init — context window") is TestStatus.SKIP
+    )
 
 
 def test_err_to_status_timeout_is_error():
@@ -85,12 +87,27 @@ def test_agent_query_detects_context_refusal_as_skip():
             return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT),
         ),
     ):
-        out, err = _agent_query("hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10)
-    assert out is None, "On refusal, output must be suppressed so downstream tests route via err"
+        out, err = _agent_query(
+            "hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10
+        )
+    assert out is None, (
+        "On refusal, output must be suppressed so downstream tests route via err"
+    )
     assert err is not None
     assert err.startswith("SKIP:"), (
         f"Refusal must be propagated with a SKIP: prefix so _test_e2e_* "
         f"recognize it; got err={err!r}"
+    )
+    # The actionable bits — model name and the actual vs required token
+    # counts — must survive into the SKIP message (codex NIT #659).
+    # Without them, the user has to dig in the server log to learn what
+    # the harness wanted vs what the model offered.
+    assert "Qwen3.5-9B-4bit" in err, (
+        f"SKIP message must carry the model name; got err={err!r}"
+    )
+    assert "32,768" in err and "64,000" in err, (
+        f"SKIP message must carry the advertised vs minimum context values; "
+        f"got err={err!r}"
     )
 
 
@@ -103,7 +120,9 @@ def test_agent_query_passes_through_normal_output():
             return_value=_stub_completed_proc(stdout="The answer is 4.\n"),
         ),
     ):
-        out, err = _agent_query("codex", "codex -q '{query}'", "what is 2+2?", timeout=10)
+        out, err = _agent_query(
+            "codex", "codex -q '{query}'", "what is 2+2?", timeout=10
+        )
     assert err is None
     assert out is not None and "4" in out
 
@@ -124,7 +143,9 @@ def test_agent_query_does_not_match_unrelated_failures():
             return_value=_stub_completed_proc(stdout=bad_init_no_context),
         ),
     ):
-        out, err = _agent_query("hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10)
+        out, err = _agent_query(
+            "hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10
+        )
     # Output passes through (not None); downstream tests then route via
     # "no expected substring" → FAIL, which is the correct signal for a
     # genuine harness misconfiguration.
@@ -194,9 +215,7 @@ def test_e2e_tests_still_error_on_genuine_failure():
             side_effect=TimeoutError("simulated timeout"),
         ),
     ):
-        result = _test_e2e_file_read(
-            "hermes", "hermes chat -q '{query}' -Q", timeout=1
-        )
+        result = _test_e2e_file_read("hermes", "hermes chat -q '{query}' -Q", timeout=1)
     # TimeoutError raised inside _agent_query → caught by the bare ``except
     # Exception`` and turned into err=str(exc); the resulting err is NOT
     # "not found" and does NOT start with "SKIP:", so the test routes to

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -740,11 +740,50 @@ def _agent_query(
         output = proc.stdout + proc.stderr
         if "error" in output.lower() and "HTTP 4" in output:
             return None, "Agent error: server issue"
+        # Harness self-refuses to initialize when the served model's
+        # advertised context window is below what the harness's tool-rich
+        # system prompt requires (issue #655 — Hermes hard-requires 64K;
+        # qwen3.5-4b/9b-4bit advertise 32K, so init always fails on those).
+        # The subprocess exits 0 and writes the refusal to stdout, so
+        # without this check downstream tests see "no expected substring"
+        # and report FAIL — which is dishonest, it's a harness-config
+        # mismatch, not a rapid-mlx regression. Propagate as SKIP via the
+        # ``SKIP:``-prefixed err sentinel that each ``_test_e2e_*`` already
+        # honors.
+        if (
+            "Failed to initialize agent" in output
+            and "context window" in output
+        ):
+            return None, (
+                "SKIP: agent refused init — served model's context window "
+                "is below the harness minimum (see output for details)"
+            )
         return output, None
     except subprocess.TimeoutExpired:
         return None, "TIMEOUT"
     except Exception as e:
         return None, str(e)
+
+
+def _err_to_status(err: str | None) -> TestStatus:
+    """Map an ``_agent_query`` err string to the right TestStatus.
+
+    Three buckets, in priority order:
+
+    - ``"not found"`` → SKIP. Harness binary isn't installed; we can't
+      run the e2e gate and shouldn't pretend to.
+    - ``"SKIP:"`` prefix → SKIP. ``_agent_query`` propagates this for
+      harness-side init refusals where rapid-mlx has nothing to fix —
+      currently the Hermes-on-32K-context case (#655).
+    - anything else → ERROR. Subprocess crashed / timed out / etc.
+    """
+    if not err:
+        return TestStatus.PASS  # caller shouldn't pass empty err but stay safe
+    if "not found" in err:
+        return TestStatus.SKIP
+    if err.startswith("SKIP:"):
+        return TestStatus.SKIP
+    return TestStatus.ERROR
 
 
 def _test_e2e_chat(binary: str, query_cmd: str, timeout: int) -> TestResult:
@@ -754,7 +793,7 @@ def _test_e2e_chat(binary: str, query_cmd: str, timeout: int) -> TestResult:
         binary, query_cmd, "What is 2+2? Reply with just the number.", timeout
     )
     if err:
-        status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
+        status = _err_to_status(err)
         return TestResult(
             "e2e_chat",
             status,
@@ -785,7 +824,7 @@ def _test_e2e_file_read(binary: str, query_cmd: str, timeout: int) -> TestResult
         binary, query_cmd, "Read the first line of pyproject.toml", timeout
     )
     if err:
-        status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
+        status = _err_to_status(err)
         return TestResult(
             "e2e_file_read",
             status,
@@ -819,7 +858,7 @@ def _test_e2e_terminal(
         binary, query_cmd, f"Run 'echo {marker}' and show me the output", timeout
     )
     if err:
-        status = TestStatus.SKIP if "not found" in (err or "") else TestStatus.ERROR
+        status = _err_to_status(err)
         return TestResult(
             "e2e_terminal",
             status,

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -750,13 +750,26 @@ def _agent_query(
         # mismatch, not a rapid-mlx regression. Propagate as SKIP via the
         # ``SKIP:``-prefixed err sentinel that each ``_test_e2e_*`` already
         # honors.
-        if (
-            "Failed to initialize agent" in output
-            and "context window" in output
-        ):
+        if "Failed to initialize agent" in output and "context window" in output:
+            # Extract the first matching line from the subprocess output so
+            # the resulting TestResult.message carries the actual model
+            # name + advertised vs minimum token counts (codex NIT #659).
+            # Without this, the user sees a generic "below the harness
+            # minimum" and has to dig in the server log to learn which
+            # model and what numbers — the very signal that makes this
+            # actionable.
+            refusal_line = next(
+                (
+                    line.strip()
+                    for line in output.splitlines()
+                    if "Failed to initialize agent" in line
+                ),
+                "",
+            )
+            detail = f": {refusal_line[:200]}" if refusal_line else ""
             return None, (
-                "SKIP: agent refused init — served model's context window "
-                "is below the harness minimum (see output for details)"
+                f"SKIP: agent refused init — served model's context window "
+                f"is below the harness minimum{detail}"
             )
         return output, None
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary

- The v0.7.27 release SOP's M3 gauntlet (G7b Part A, `bench --tier harness`) aborted because Hermes Agent hard-requires ≥64K context and `Qwen3.5-{4B,9B}-4bit` advertise 32K. `hermes chat -q ...` exits 0 and writes `Failed to initialize agent: ... context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent.` to stdout. Downstream `_test_e2e_*` saw "no expected substring" → FAIL → `set -e` killed the gauntlet. The model is too small for this specific harness; there's no rapid-mlx regression to investigate, so reporting FAIL is dishonest.
- Detect at the `_agent_query` boundary (one site; all three e2e tests inherit). Conservative pattern: ONLY `"Failed to initialize agent"` AND `"context window"` together → propagate as `SKIP:`-prefixed err. Other init failures (missing API key, bad config) stay ERROR so real harness regressions aren't masked.
- Factor the err → status three-way (`"not found"` → SKIP, `SKIP:` prefix → SKIP, else ERROR) into `_err_to_status` so the three callsites stay in lockstep.

## Test plan

- [x] `tests/test_agent_query_context_skip.py` — 11 new assertions:
  - `_err_to_status` bucket mapping (not-found / SKIP: / arbitrary / TIMEOUT)
  - `_agent_query` detects Hermes refusal → SKIP-prefixed err
  - `_agent_query` does NOT misroute other init failures (missing API key stays passthrough → ERROR)
  - Each `_test_e2e_{chat,file_read,terminal}` routes SKIP-prefix → `TestStatus.SKIP`
  - Genuine TimeoutError still routes to `TestStatus.ERROR`
- [x] Existing `test_agent_test_runner_refresh_config.py`, `test_bench_tier_harness.py`, `test_hermes_harness_contract.py` all still PASS
- [x] Broader sweep `tests/ -k "agent or hermes or harness or testing" --ignore=tests/integrations` → 106 passed
- [x] `ruff check` clean

## Related

- Closes #655
- v0.7.27 release SOP (the run that surfaced this); R2 mirror prefetch (#651) and PFlash (#287) are unaffected — the gauntlet line that failed is purely harness ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)