### PR TITLE
fix(tests): guard integration-script top-level exit() so pytest can collect

### DIFF
--- a/tests/integrations/test_anthropic_sdk.py
+++ b/tests/integrations/test_anthropic_sdk.py
@@ -33,126 +33,129 @@ def _first_text(response) -> str:
     raise AssertionError(f"No text block in response.content: {response.content}")
 
 
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# Reasoning models burn dozens-to-hundreds of tokens inside the
-# ``thinking`` block before emitting any visible text — give them
-# enough headroom on small models (qwen3-0.6b) to finish thinking +
-# answer. Per-test caps are unchanged in spirit (small enough that a
-# loop is still bounded); they're just lifted off the old 50-token
-# floor that pre-dated thinking-block emission in v0.6.56.
-_MAX_TOKENS_SHORT = 256
-_MAX_TOKENS_LONG = 384
+    # Reasoning models burn dozens-to-hundreds of tokens inside the
+    # ``thinking`` block before emitting any visible text — give them
+    # enough headroom on small models (qwen3-0.6b) to finish thinking +
+    # answer. Per-test caps are unchanged in spirit (small enough that a
+    # loop is still bounded); they're just lifted off the old 50-token
+    # floor that pre-dated thinking-block emission in v0.6.56.
+    _MAX_TOKENS_SHORT = 256
+    _MAX_TOKENS_LONG = 384
 
-# === 1. Plain message ===
-print("=== Test 1: Plain message ===")
-try:
-    r = client.messages.create(
-        model=MODEL_ID,
-        max_tokens=_MAX_TOKENS_SHORT,
-        messages=[
-            {"role": "user", "content": "What is 2+2? Reply with just the number."}
-        ],
-    )
-    text = _first_text(r)
-    assert "4" in text, text
-    print(f"PASS: {text[:80]}")
-    results["1_plain"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_plain"] = f"FAIL: {str(e)[:120]}"
+    # === 1. Plain message ===
+    print("=== Test 1: Plain message ===")
+    try:
+        r = client.messages.create(
+            model=MODEL_ID,
+            max_tokens=_MAX_TOKENS_SHORT,
+            messages=[
+                {"role": "user", "content": "What is 2+2? Reply with just the number."}
+            ],
+        )
+        text = _first_text(r)
+        assert "4" in text, text
+        print(f"PASS: {text[:80]}")
+        results["1_plain"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_plain"] = f"FAIL: {str(e)[:120]}"
 
-# === 2. System prompt ===
-print("\n=== Test 2: System prompt ===")
-try:
-    r = client.messages.create(
-        model=MODEL_ID,
-        max_tokens=_MAX_TOKENS_SHORT,
-        system="You are a calculator. Output only the integer result.",
-        messages=[{"role": "user", "content": "9 * 8"}],
-    )
-    text = _first_text(r)
-    assert "72" in text, text
-    print(f"PASS: {text[:80]}")
-    results["2_system"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_system"] = f"FAIL: {str(e)[:120]}"
+    # === 2. System prompt ===
+    print("\n=== Test 2: System prompt ===")
+    try:
+        r = client.messages.create(
+            model=MODEL_ID,
+            max_tokens=_MAX_TOKENS_SHORT,
+            system="You are a calculator. Output only the integer result.",
+            messages=[{"role": "user", "content": "9 * 8"}],
+        )
+        text = _first_text(r)
+        assert "72" in text, text
+        print(f"PASS: {text[:80]}")
+        results["2_system"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_system"] = f"FAIL: {str(e)[:120]}"
 
-# === 3. Multi-turn conversation ===
-print("\n=== Test 3: Multi-turn ===")
-try:
-    msgs = [
-        {"role": "user", "content": "My favorite color is blue. Remember this."},
-        {"role": "assistant", "content": "Got it, your favorite color is blue."},
-        {"role": "user", "content": "What is my favorite color?"},
-    ]
-    r = client.messages.create(
-        model=MODEL_ID, max_tokens=_MAX_TOKENS_LONG, messages=msgs
-    )
-    text = _first_text(r)
-    assert "blue" in text.lower(), text
-    print(f"PASS: {text[:80]}")
-    results["3_multi_turn"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["3_multi_turn"] = f"FAIL: {str(e)[:120]}"
+    # === 3. Multi-turn conversation ===
+    print("\n=== Test 3: Multi-turn ===")
+    try:
+        msgs = [
+            {"role": "user", "content": "My favorite color is blue. Remember this."},
+            {"role": "assistant", "content": "Got it, your favorite color is blue."},
+            {"role": "user", "content": "What is my favorite color?"},
+        ]
+        r = client.messages.create(
+            model=MODEL_ID, max_tokens=_MAX_TOKENS_LONG, messages=msgs
+        )
+        text = _first_text(r)
+        assert "blue" in text.lower(), text
+        print(f"PASS: {text[:80]}")
+        results["3_multi_turn"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["3_multi_turn"] = f"FAIL: {str(e)[:120]}"
 
-# === 4. Streaming ===
-print("\n=== Test 4: Streaming ===")
-try:
-    chunks = []
-    with client.messages.stream(
-        model=MODEL_ID,
-        max_tokens=_MAX_TOKENS_LONG,
-        messages=[{"role": "user", "content": "Count from 1 to 5, comma-separated."}],
-    ) as stream:
-        for text in stream.text_stream:
-            chunks.append(text)
-    full = "".join(chunks)
-    assert "1" in full and "5" in full, full
-    print(f"PASS: {len(chunks)} chunks, content={full[:80]}")
-    results["4_stream"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["4_stream"] = f"FAIL: {str(e)[:120]}"
+    # === 4. Streaming ===
+    print("\n=== Test 4: Streaming ===")
+    try:
+        chunks = []
+        with client.messages.stream(
+            model=MODEL_ID,
+            max_tokens=_MAX_TOKENS_LONG,
+            messages=[
+                {"role": "user", "content": "Count from 1 to 5, comma-separated."}
+            ],
+        ) as stream:
+            for text in stream.text_stream:
+                chunks.append(text)
+        full = "".join(chunks)
+        assert "1" in full and "5" in full, full
+        print(f"PASS: {len(chunks)} chunks, content={full[:80]}")
+        results["4_stream"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["4_stream"] = f"FAIL: {str(e)[:120]}"
 
-# === 5. Tool use ===
-print("\n=== Test 5: Tool use ===")
-try:
-    r = client.messages.create(
-        model=MODEL_ID,
-        max_tokens=200,
-        tools=[
-            {
-                "name": "get_weather",
-                "description": "Get the weather for a city.",
-                "input_schema": {
-                    "type": "object",
-                    "properties": {"city": {"type": "string"}},
-                    "required": ["city"],
-                },
-            }
-        ],
-        messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
-    )
-    # Find tool_use blocks
-    tool_uses = [b for b in r.content if b.type == "tool_use"]
-    assert len(tool_uses) > 0, f"No tool_use in {r.content}"
-    tu = tool_uses[0]
-    assert tu.name == "get_weather", tu.name
-    assert "city" in tu.input, tu.input
-    assert "tokyo" in tu.input["city"].lower(), tu.input
-    print(f"PASS: tool={tu.name}, input={tu.input}")
-    results["5_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["5_tool"] = f"FAIL: {str(e)[:120]}"
+    # === 5. Tool use ===
+    print("\n=== Test 5: Tool use ===")
+    try:
+        r = client.messages.create(
+            model=MODEL_ID,
+            max_tokens=200,
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ],
+            messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+        )
+        # Find tool_use blocks
+        tool_uses = [b for b in r.content if b.type == "tool_use"]
+        assert len(tool_uses) > 0, f"No tool_use in {r.content}"
+        tu = tool_uses[0]
+        assert tu.name == "get_weather", tu.name
+        assert "city" in tu.input, tu.input
+        assert "tokyo" in tu.input["city"].lower(), tu.input
+        print(f"PASS: tool={tu.name}, input={tu.input}")
+        results["5_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["5_tool"] = f"FAIL: {str(e)[:120]}"
 
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-print(f"Anthropic SDK: {passed}/{len(results)} passed")
-for k, v in results.items():
-    print(f"  {k}: {v[:120]}")
-exit(0 if passed == len(results) else 1)
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    print(f"Anthropic SDK: {passed}/{len(results)} passed")
+    for k, v in results.items():
+        print(f"  {k}: {v[:120]}")
+    exit(0 if passed == len(results) else 1)

--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -21,130 +21,137 @@ llm = ChatOpenAI(
     temperature=0.0,
 )
 
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# === 1. Plain invoke ===
-print("=== Test 1: Plain invoke ===")
-try:
-    r = llm.invoke(
-        [HumanMessage(content="Reply with just '4' (the digit). What is 2+2?")]
-    )
-    assert "4" in r.content, r.content
-    print(f"PASS: {r.content[:80]}")
-    results["1_plain"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_plain"] = f"FAIL: {str(e)[:120]}"
+    # === 1. Plain invoke ===
+    print("=== Test 1: Plain invoke ===")
+    try:
+        r = llm.invoke(
+            [HumanMessage(content="Reply with just '4' (the digit). What is 2+2?")]
+        )
+        assert "4" in r.content, r.content
+        print(f"PASS: {r.content[:80]}")
+        results["1_plain"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_plain"] = f"FAIL: {str(e)[:120]}"
 
-# === 2. System + User multi-message ===
-print("\n=== Test 2: System + User ===")
-try:
-    r = llm.invoke(
-        [
-            SystemMessage(
-                content="You are a calculator. Output ONLY the integer result, nothing else."
-            ),
-            HumanMessage(content="7 * 8"),
-        ]
-    )
-    assert "56" in r.content, r.content
-    print(f"PASS: {r.content[:80]}")
-    results["2_system"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_system"] = f"FAIL: {str(e)[:120]}"
+    # === 2. System + User multi-message ===
+    print("\n=== Test 2: System + User ===")
+    try:
+        r = llm.invoke(
+            [
+                SystemMessage(
+                    content="You are a calculator. Output ONLY the integer result, nothing else."
+                ),
+                HumanMessage(content="7 * 8"),
+            ]
+        )
+        assert "56" in r.content, r.content
+        print(f"PASS: {r.content[:80]}")
+        results["2_system"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_system"] = f"FAIL: {str(e)[:120]}"
 
-# === 3. Streaming ===
-print("\n=== Test 3: Streaming ===")
-try:
-    chunks = []
-    for chunk in llm.stream([HumanMessage(content="Count 1 to 5, comma-separated.")]):
-        chunks.append(chunk.content)
-    full = "".join(chunks)
-    assert "1" in full and "5" in full, full
-    assert len(chunks) > 1, f"Expected multiple chunks, got {len(chunks)}"
-    print(f"PASS: {len(chunks)} chunks, content={full[:80]}")
-    results["3_stream"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["3_stream"] = f"FAIL: {str(e)[:120]}"
+    # === 3. Streaming ===
+    print("\n=== Test 3: Streaming ===")
+    try:
+        chunks = []
+        for chunk in llm.stream(
+            [HumanMessage(content="Count 1 to 5, comma-separated.")]
+        ):
+            chunks.append(chunk.content)
+        full = "".join(chunks)
+        assert "1" in full and "5" in full, full
+        assert len(chunks) > 1, f"Expected multiple chunks, got {len(chunks)}"
+        print(f"PASS: {len(chunks)} chunks, content={full[:80]}")
+        results["3_stream"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["3_stream"] = f"FAIL: {str(e)[:120]}"
 
-# === 4. Tool calling (single tool) ===
-print("\n=== Test 4: Single tool call ===")
-try:
+    # === 4. Tool calling (single tool) ===
+    print("\n=== Test 4: Single tool call ===")
+    try:
 
-    @tool
-    def get_weather(city: str) -> str:
-        """Get weather for a city."""
-        return f"sunny, 22C in {city}"
+        @tool
+        def get_weather(city: str) -> str:
+            """Get weather for a city."""
+            return f"sunny, 22C in {city}"
 
-    llm_with_tools = llm.bind_tools([get_weather])
-    r = llm_with_tools.invoke([HumanMessage(content="What's the weather in Paris?")])
-    tool_calls = r.tool_calls if hasattr(r, "tool_calls") else []
-    assert len(tool_calls) > 0, f"No tool calls. content={r.content[:200]}"
-    tc = tool_calls[0]
-    assert tc["name"] == "get_weather", tc
-    assert "city" in tc["args"], tc
-    assert "paris" in tc["args"]["city"].lower(), tc
-    print(f"PASS: tool={tc['name']}, args={tc['args']}")
-    results["4_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["4_tool"] = f"FAIL: {str(e)[:120]}"
+        llm_with_tools = llm.bind_tools([get_weather])
+        r = llm_with_tools.invoke(
+            [HumanMessage(content="What's the weather in Paris?")]
+        )
+        tool_calls = r.tool_calls if hasattr(r, "tool_calls") else []
+        assert len(tool_calls) > 0, f"No tool calls. content={r.content[:200]}"
+        tc = tool_calls[0]
+        assert tc["name"] == "get_weather", tc
+        assert "city" in tc["args"], tc
+        assert "paris" in tc["args"]["city"].lower(), tc
+        print(f"PASS: tool={tc['name']}, args={tc['args']}")
+        results["4_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["4_tool"] = f"FAIL: {str(e)[:120]}"
 
-# === 5. Multi-tool (model picks one) ===
-print("\n=== Test 5: Multi-tool selection ===")
-try:
+    # === 5. Multi-tool (model picks one) ===
+    print("\n=== Test 5: Multi-tool selection ===")
+    try:
 
-    @tool
-    def add(a: int, b: int) -> int:
-        """Add two numbers."""
-        return a + b
+        @tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
 
-    @tool
-    def multiply(a: int, b: int) -> int:
-        """Multiply two numbers."""
-        return a * b
+        @tool
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
 
-    llm_multi = llm.bind_tools([add, multiply])
-    r = llm_multi.invoke(
-        [HumanMessage(content="What is 6 multiplied by 7? Use a tool.")]
-    )
-    tool_calls = r.tool_calls if hasattr(r, "tool_calls") else []
-    assert len(tool_calls) > 0, f"No tool calls. content={r.content[:200]}"
-    tc = tool_calls[0]
-    assert tc["name"] == "multiply", f"Expected multiply, got {tc['name']}"
-    assert tc["args"].get("a") in (6, 7), tc
-    assert tc["args"].get("b") in (6, 7), tc
-    print(f"PASS: tool={tc['name']}, args={tc['args']}")
-    results["5_multi_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["5_multi_tool"] = f"FAIL: {str(e)[:120]}"
+        llm_multi = llm.bind_tools([add, multiply])
+        r = llm_multi.invoke(
+            [HumanMessage(content="What is 6 multiplied by 7? Use a tool.")]
+        )
+        tool_calls = r.tool_calls if hasattr(r, "tool_calls") else []
+        assert len(tool_calls) > 0, f"No tool calls. content={r.content[:200]}"
+        tc = tool_calls[0]
+        assert tc["name"] == "multiply", f"Expected multiply, got {tc['name']}"
+        assert tc["args"].get("a") in (6, 7), tc
+        assert tc["args"].get("b") in (6, 7), tc
+        print(f"PASS: tool={tc['name']}, args={tc['args']}")
+        results["5_multi_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["5_multi_tool"] = f"FAIL: {str(e)[:120]}"
 
-# === 6. Structured output ===
-print("\n=== Test 6: Structured output (with_structured_output) ===")
-try:
+    # === 6. Structured output ===
+    print("\n=== Test 6: Structured output (with_structured_output) ===")
+    try:
 
-    class Person(BaseModel):
-        name: str = Field(description="The person's name")
-        age: int = Field(description="The person's age in years")
+        class Person(BaseModel):
+            name: str = Field(description="The person's name")
+            age: int = Field(description="The person's age in years")
 
-    structured_llm = llm.with_structured_output(Person)
-    r = structured_llm.invoke([HumanMessage(content="Extract: 'Bob is 42 years old'")])
-    assert isinstance(r, Person), type(r)
-    assert r.name.lower() == "bob", r.name
-    assert r.age == 42, r.age
-    print(f"PASS: {r}")
-    results["6_structured"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["6_structured"] = f"FAIL: {str(e)[:120]}"
+        structured_llm = llm.with_structured_output(Person)
+        r = structured_llm.invoke(
+            [HumanMessage(content="Extract: 'Bob is 42 years old'")]
+        )
+        assert isinstance(r, Person), type(r)
+        assert r.name.lower() == "bob", r.name
+        assert r.age == 42, r.age
+        print(f"PASS: {r}")
+        results["6_structured"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["6_structured"] = f"FAIL: {str(e)[:120]}"
 
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-print(f"LangChain: {passed}/{len(results)} passed")
-for k, v in results.items():
-    print(f"  {k}: {v[:120]}")
-exit(0 if passed == len(results) else 1)
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    print(f"LangChain: {passed}/{len(results)} passed")
+    for k, v in results.items():
+        print(f"  {k}: {v[:120]}")
+    exit(0 if passed == len(results) else 1)

--- a/tests/integrations/test_librechat_docker.py
+++ b/tests/integrations/test_librechat_docker.py
@@ -20,98 +20,101 @@ EMAIL = f"test-{uuid.uuid4().hex[:8]}@test.local"
 PASSWORD = "TestPassword123!"
 NAME = "Test User"
 
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# === 1. Register ===
-print("=== Test 1: Register user ===")
-try:
-    r = requests.post(
-        f"{LC}/api/auth/register",
-        json={
-            "name": NAME,
-            "username": EMAIL.split("@")[0],
-            "email": EMAIL,
-            "password": PASSWORD,
-            "confirm_password": PASSWORD,
-        },
-        timeout=15,
-    )
-    assert r.status_code in (200, 201), (
-        f"register failed: {r.status_code} {r.text[:200]}"
-    )
-    print(f"PASS: status={r.status_code}")
-    results["1_register"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_register"] = f"FAIL: {str(e)[:150]}"
+    # === 1. Register ===
+    print("=== Test 1: Register user ===")
+    try:
+        r = requests.post(
+            f"{LC}/api/auth/register",
+            json={
+                "name": NAME,
+                "username": EMAIL.split("@")[0],
+                "email": EMAIL,
+                "password": PASSWORD,
+                "confirm_password": PASSWORD,
+            },
+            timeout=15,
+        )
+        assert r.status_code in (200, 201), (
+            f"register failed: {r.status_code} {r.text[:200]}"
+        )
+        print(f"PASS: status={r.status_code}")
+        results["1_register"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_register"] = f"FAIL: {str(e)[:150]}"
 
-# === 2. Login ===
-print("\n=== Test 2: Login ===")
-session = requests.Session()
-token = None
-try:
-    r = session.post(
-        f"{LC}/api/auth/login",
-        json={"email": EMAIL, "password": PASSWORD},
-        timeout=15,
-    )
-    assert r.status_code == 200, f"login failed: {r.status_code} {r.text[:200]}"
-    data = r.json()
-    token = data.get("token") or (data.get("user") or {}).get("token")
-    assert token, f"no token in response: {data}"
-    print(f"PASS: got token len={len(token)}")
-    results["2_login"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_login"] = f"FAIL: {str(e)[:150]}"
+    # === 2. Login ===
+    print("\n=== Test 2: Login ===")
+    session = requests.Session()
+    token = None
+    try:
+        r = session.post(
+            f"{LC}/api/auth/login",
+            json={"email": EMAIL, "password": PASSWORD},
+            timeout=15,
+        )
+        assert r.status_code == 200, f"login failed: {r.status_code} {r.text[:200]}"
+        data = r.json()
+        token = data.get("token") or (data.get("user") or {}).get("token")
+        assert token, f"no token in response: {data}"
+        print(f"PASS: got token len={len(token)}")
+        results["2_login"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_login"] = f"FAIL: {str(e)[:150]}"
 
-if not token:
-    print("\nCannot continue without token")
-    print(f"results={results}")
-    exit(1)
+    if not token:
+        print("\nCannot continue without token")
+        print(f"results={results}")
+        exit(1)
 
-headers = {"Authorization": f"Bearer {token}"}
+    headers = {"Authorization": f"Bearer {token}"}
 
-# === 3. List endpoints — Rapid-MLX must be present ===
-print("\n=== Test 3: GET /api/endpoints ===")
-try:
-    r = session.get(f"{LC}/api/endpoints", headers=headers, timeout=10)
-    assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
-    eps = r.json()
-    print(f"  raw keys: {list(eps.keys())}")
-    custom = eps.get("custom") or {}
-    print(
-        f"  custom subkeys: {list(custom.keys()) if isinstance(custom, dict) else custom}"
-    )
-    assert "Rapid-MLX" in str(eps), f"Rapid-MLX not in endpoints: {eps}"
-    print("PASS: Rapid-MLX endpoint is registered")
-    results["3_endpoints"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["3_endpoints"] = f"FAIL: {str(e)[:150]}"
+    # === 3. List endpoints — Rapid-MLX must be present ===
+    print("\n=== Test 3: GET /api/endpoints ===")
+    try:
+        r = session.get(f"{LC}/api/endpoints", headers=headers, timeout=10)
+        assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
+        eps = r.json()
+        print(f"  raw keys: {list(eps.keys())}")
+        custom = eps.get("custom") or {}
+        print(
+            f"  custom subkeys: {list(custom.keys()) if isinstance(custom, dict) else custom}"
+        )
+        assert "Rapid-MLX" in str(eps), f"Rapid-MLX not in endpoints: {eps}"
+        print("PASS: Rapid-MLX endpoint is registered")
+        results["3_endpoints"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["3_endpoints"] = f"FAIL: {str(e)[:150]}"
 
-# === 4. List models for the Rapid-MLX endpoint (this proves fetch:true worked) ===
-print("\n=== Test 4: GET /api/models ===")
-try:
-    r = session.get(f"{LC}/api/models", headers=headers, timeout=15)
-    assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
-    models = r.json()
-    print(f"  models keys: {list(models.keys())[:20]}")
-    rapid_models = models.get("Rapid-MLX") or models.get("custom", {}).get("Rapid-MLX")
-    assert rapid_models, f"No Rapid-MLX models in {models}"
-    assert any("gemma" in m.lower() for m in rapid_models), (
-        f"gemma not in {rapid_models}"
-    )
-    print(f"PASS: {len(rapid_models)} model(s) fetched: {rapid_models}")
-    results["4_models"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["4_models"] = f"FAIL: {str(e)[:200]}"
+    # === 4. List models for the Rapid-MLX endpoint (this proves fetch:true worked) ===
+    print("\n=== Test 4: GET /api/models ===")
+    try:
+        r = session.get(f"{LC}/api/models", headers=headers, timeout=15)
+        assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
+        models = r.json()
+        print(f"  models keys: {list(models.keys())[:20]}")
+        rapid_models = models.get("Rapid-MLX") or models.get("custom", {}).get(
+            "Rapid-MLX"
+        )
+        assert rapid_models, f"No Rapid-MLX models in {models}"
+        assert any("gemma" in m.lower() for m in rapid_models), (
+            f"gemma not in {rapid_models}"
+        )
+        print(f"PASS: {len(rapid_models)} model(s) fetched: {rapid_models}")
+        results["4_models"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["4_models"] = f"FAIL: {str(e)[:200]}"
 
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-print(f"LibreChat E2E: {passed}/{len(results)} passed")
-for k, v in results.items():
-    print(f"  {k}: {v[:200]}")
-exit(0 if passed == len(results) else 1)
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    print(f"LibreChat E2E: {passed}/{len(results)} passed")
+    for k, v in results.items():
+        print(f"  {k}: {v[:200]}")
+    exit(0 if passed == len(results) else 1)

--- a/tests/integrations/test_openwebui.py
+++ b/tests/integrations/test_openwebui.py
@@ -16,137 +16,140 @@ OW = "http://localhost:3000"
 EMAIL = f"test-{uuid.uuid4().hex[:8]}@test.local"
 PASSWORD = "TestPassword123!"
 NAME = "Test User"
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# === 1. Register ===
-print("=== Test 1: Register ===")
-try:
-    r = requests.post(
-        f"{OW}/api/v1/auths/signup",
-        json={
-            "name": NAME,
-            "email": EMAIL,
-            "password": PASSWORD,
-        },
-        timeout=15,
-    )
-    assert r.status_code in (200, 201), f"{r.status_code} {r.text[:200]}"
-    data = r.json()
-    token = data.get("token")
-    assert token, f"no token: {data}"
-    print("PASS: registered + got token")
-    results["1_register"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_register"] = f"FAIL: {str(e)[:150]}"
-    token = None
+    # === 1. Register ===
+    print("=== Test 1: Register ===")
+    try:
+        r = requests.post(
+            f"{OW}/api/v1/auths/signup",
+            json={
+                "name": NAME,
+                "email": EMAIL,
+                "password": PASSWORD,
+            },
+            timeout=15,
+        )
+        assert r.status_code in (200, 201), f"{r.status_code} {r.text[:200]}"
+        data = r.json()
+        token = data.get("token")
+        assert token, f"no token: {data}"
+        print("PASS: registered + got token")
+        results["1_register"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_register"] = f"FAIL: {str(e)[:150]}"
+        token = None
 
-if not token:
-    print("Cannot continue without token")
+    if not token:
+        print("Cannot continue without token")
+        for k, v in results.items():
+            print(f"  {k}: {v}")
+        exit(1)
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # === 2. List models ===
+    print("\n=== Test 2: List models ===")
+    try:
+        r = requests.get(f"{OW}/api/models", headers=headers, timeout=15)
+        assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
+        models = r.json()
+        model_list = models.get("data", models) if isinstance(models, dict) else models
+        model_ids = (
+            [m.get("id", m.get("name", "?")) for m in model_list]
+            if isinstance(model_list, list)
+            else []
+        )
+        assert len(model_ids) > 0, f"empty model list: {models}"
+        print(f"PASS: {len(model_ids)} model(s): {model_ids[:3]}")
+        results["2_models"] = "PASS"
+        target_model = model_ids[0]
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_models"] = f"FAIL: {str(e)[:150]}"
+        target_model = None
+
+    # === 3. Chat completion via OpenAI proxy ===
+    print("\n=== Test 3: Chat via OpenAI proxy ===")
+    if target_model:
+        try:
+            r = requests.post(
+                f"{OW}/api/chat/completions",
+                headers={**headers, "Content-Type": "application/json"},
+                json={
+                    "model": target_model,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "What is 5+3? Reply with just the number.",
+                        }
+                    ],
+                    "max_tokens": 50,
+                    "stream": False,
+                },
+                timeout=120,
+            )
+            assert r.status_code == 200, f"{r.status_code} {r.text[:300]}"
+            data = r.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "8" in content, content
+            print(f"PASS: {content[:80]}")
+            results["3_chat"] = "PASS"
+        except Exception as e:
+            print(f"FAIL: {e}")
+            results["3_chat"] = f"FAIL: {str(e)[:150]}"
+    else:
+        results["3_chat"] = "SKIP: no model"
+
+    # === 4. Streaming chat ===
+    print("\n=== Test 4: Streaming chat ===")
+    if target_model:
+        try:
+            r = requests.post(
+                f"{OW}/api/chat/completions",
+                headers={**headers, "Content-Type": "application/json"},
+                json={
+                    "model": target_model,
+                    "messages": [
+                        {"role": "user", "content": "Say 'hello' in one word."}
+                    ],
+                    "max_tokens": 20,
+                    "stream": True,
+                },
+                stream=True,
+                timeout=60,
+            )
+            assert r.status_code == 200, f"{r.status_code}"
+            chunks = 0
+            content = ""
+            for line in r.iter_lines():
+                if not line:
+                    continue
+                line = line.decode()
+                if not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                obj = json.loads(payload)
+                delta = obj.get("choices", [{}])[0].get("delta", {}).get("content", "")
+                content += delta
+                chunks += 1
+            assert chunks > 0, "no chunks"
+            print(f"PASS: {chunks} chunks, content={content[:50]}")
+            results["4_stream"] = "PASS"
+        except Exception as e:
+            print(f"FAIL: {e}")
+            results["4_stream"] = f"FAIL: {str(e)[:150]}"
+    else:
+        results["4_stream"] = "SKIP: no model"
+
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    print(f"Open WebUI: {passed}/{len(results)} passed")
     for k, v in results.items():
         print(f"  {k}: {v}")
-    exit(1)
-
-headers = {"Authorization": f"Bearer {token}"}
-
-# === 2. List models ===
-print("\n=== Test 2: List models ===")
-try:
-    r = requests.get(f"{OW}/api/models", headers=headers, timeout=15)
-    assert r.status_code == 200, f"{r.status_code} {r.text[:200]}"
-    models = r.json()
-    model_list = models.get("data", models) if isinstance(models, dict) else models
-    model_ids = (
-        [m.get("id", m.get("name", "?")) for m in model_list]
-        if isinstance(model_list, list)
-        else []
-    )
-    assert len(model_ids) > 0, f"empty model list: {models}"
-    print(f"PASS: {len(model_ids)} model(s): {model_ids[:3]}")
-    results["2_models"] = "PASS"
-    target_model = model_ids[0]
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_models"] = f"FAIL: {str(e)[:150]}"
-    target_model = None
-
-# === 3. Chat completion via OpenAI proxy ===
-print("\n=== Test 3: Chat via OpenAI proxy ===")
-if target_model:
-    try:
-        r = requests.post(
-            f"{OW}/api/chat/completions",
-            headers={**headers, "Content-Type": "application/json"},
-            json={
-                "model": target_model,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": "What is 5+3? Reply with just the number.",
-                    }
-                ],
-                "max_tokens": 50,
-                "stream": False,
-            },
-            timeout=120,
-        )
-        assert r.status_code == 200, f"{r.status_code} {r.text[:300]}"
-        data = r.json()
-        content = data["choices"][0]["message"]["content"]
-        assert "8" in content, content
-        print(f"PASS: {content[:80]}")
-        results["3_chat"] = "PASS"
-    except Exception as e:
-        print(f"FAIL: {e}")
-        results["3_chat"] = f"FAIL: {str(e)[:150]}"
-else:
-    results["3_chat"] = "SKIP: no model"
-
-# === 4. Streaming chat ===
-print("\n=== Test 4: Streaming chat ===")
-if target_model:
-    try:
-        r = requests.post(
-            f"{OW}/api/chat/completions",
-            headers={**headers, "Content-Type": "application/json"},
-            json={
-                "model": target_model,
-                "messages": [{"role": "user", "content": "Say 'hello' in one word."}],
-                "max_tokens": 20,
-                "stream": True,
-            },
-            stream=True,
-            timeout=60,
-        )
-        assert r.status_code == 200, f"{r.status_code}"
-        chunks = 0
-        content = ""
-        for line in r.iter_lines():
-            if not line:
-                continue
-            line = line.decode()
-            if not line.startswith("data: "):
-                continue
-            payload = line[6:]
-            if payload == "[DONE]":
-                break
-            obj = json.loads(payload)
-            delta = obj.get("choices", [{}])[0].get("delta", {}).get("content", "")
-            content += delta
-            chunks += 1
-        assert chunks > 0, "no chunks"
-        print(f"PASS: {chunks} chunks, content={content[:50]}")
-        results["4_stream"] = "PASS"
-    except Exception as e:
-        print(f"FAIL: {e}")
-        results["4_stream"] = f"FAIL: {str(e)[:150]}"
-else:
-    results["4_stream"] = "SKIP: no model"
-
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-print(f"Open WebUI: {passed}/{len(results)} passed")
-for k, v in results.items():
-    print(f"  {k}: {v}")
-exit(0 if passed == len(results) else 1)
+    exit(0 if passed == len(results) else 1)

--- a/tests/integrations/test_pydantic_ai_full.py
+++ b/tests/integrations/test_pydantic_ai_full.py
@@ -23,133 +23,134 @@ model = OpenAIChatModel(
     ),
 )
 
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# === 1. Plain completion ===
-print("=== Test 1: Plain completion ===")
-try:
-    agent = Agent(model)
-    r = agent.run_sync("What is 2+2? Reply with just the number.")
-    assert "4" in r.output, r.output
-    print(f"PASS: {r.output[:80]}")
-    results["1_plain"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_plain"] = f"FAIL: {e}"
-
-# === 2. Streaming ===
-print("\n=== Test 2: Streaming ===")
-try:
-
-    async def stream_test():
+    # === 1. Plain completion ===
+    print("=== Test 1: Plain completion ===")
+    try:
         agent = Agent(model)
-        chunks = []
-        async with agent.run_stream(
-            "Count from 1 to 5, separated by commas."
-        ) as result:
-            async for delta in result.stream_text(delta=True):
-                chunks.append(delta)
-        return "".join(chunks)
+        r = agent.run_sync("What is 2+2? Reply with just the number.")
+        assert "4" in r.output, r.output
+        print(f"PASS: {r.output[:80]}")
+        results["1_plain"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_plain"] = f"FAIL: {e}"
 
-    out = asyncio.run(stream_test())
-    assert len(out) > 5, f"Too short: {out}"
-    assert any(d in out for d in ["1", "2", "3"]), out
-    print(f"PASS: chunks={len(out)} chars, output={out[:80]}")
-    results["2_stream"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_stream"] = f"FAIL: {e}"
+    # === 2. Streaming ===
+    print("\n=== Test 2: Streaming ===")
+    try:
 
-# === 3. Structured output (BaseModel) ===
-print("\n=== Test 3: Structured output ===")
-try:
+        async def stream_test():
+            agent = Agent(model)
+            chunks = []
+            async with agent.run_stream(
+                "Count from 1 to 5, separated by commas."
+            ) as result:
+                async for delta in result.stream_text(delta=True):
+                    chunks.append(delta)
+            return "".join(chunks)
 
-    class Person(BaseModel):
-        name: str
-        age: int
+        out = asyncio.run(stream_test())
+        assert len(out) > 5, f"Too short: {out}"
+        assert any(d in out for d in ["1", "2", "3"]), out
+        print(f"PASS: chunks={len(out)} chars, output={out[:80]}")
+        results["2_stream"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_stream"] = f"FAIL: {e}"
 
-    agent = Agent(model, output_type=Person)
-    r = agent.run_sync("Extract: 'Alice is 30 years old'")
-    assert isinstance(r.output, Person), type(r.output)
-    assert r.output.name.lower() == "alice", r.output.name
-    assert r.output.age == 30, r.output.age
-    print(f"PASS: {r.output}")
-    results["3_structured"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["3_structured"] = f"FAIL: {e}"
+    # === 3. Structured output (BaseModel) ===
+    print("\n=== Test 3: Structured output ===")
+    try:
 
-# === 4. Tool calling (single) ===
-print("\n=== Test 4: Single tool call ===")
-try:
-    agent = Agent(model)
+        class Person(BaseModel):
+            name: str
+            age: int
 
-    @agent.tool_plain
-    def get_weather(city: str) -> str:
-        """Get the weather for a city."""
-        return f"sunny, 22C in {city}"
+        agent = Agent(model, output_type=Person)
+        r = agent.run_sync("Extract: 'Alice is 30 years old'")
+        assert isinstance(r.output, Person), type(r.output)
+        assert r.output.name.lower() == "alice", r.output.name
+        assert r.output.age == 30, r.output.age
+        print(f"PASS: {r.output}")
+        results["3_structured"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["3_structured"] = f"FAIL: {e}"
 
-    r = agent.run_sync("What's the weather in Paris?")
-    assert "Paris" in r.output or "22" in r.output, r.output
-    called = any("get_weather" in str(m) for m in r.all_messages())
-    assert called, "tool not called"
-    print(f"PASS: {r.output[:80]}")
-    results["4_tool_single"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["4_tool_single"] = f"FAIL: {e}"
+    # === 4. Tool calling (single) ===
+    print("\n=== Test 4: Single tool call ===")
+    try:
+        agent = Agent(model)
 
-# === 5. Multi-turn conversation ===
-print("\n=== Test 5: Multi-turn ===")
-try:
-    # PydanticAI defaults max_tokens to ~1024; on verbose 4B-class models the
-    # second turn can spill past that. Raise the cap so the SDK contract test
-    # checks rapid-mlx behaviour, not PydanticAI's default ceiling.
-    agent = Agent(model, model_settings={"max_tokens": 2048})
-    r1 = agent.run_sync("My name is Bob. Remember this.")
-    r2 = agent.run_sync("What is my name?", message_history=r1.all_messages())
-    assert "bob" in r2.output.lower(), r2.output
-    print(f"PASS: turn2 = {r2.output[:80]}")
-    results["5_multi_turn"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["5_multi_turn"] = f"FAIL: {e}"
+        @agent.tool_plain
+        def get_weather(city: str) -> str:
+            """Get the weather for a city."""
+            return f"sunny, 22C in {city}"
 
-# === 6. Multiple tools, sequential ===
-print("\n=== Test 6: Multiple tools ===")
-try:
-    # Sequential tool calls accumulate output across two tool-call round trips;
-    # PydanticAI's default max_tokens ceiling kicks in before the final answer
-    # on small models. Same fix as test 5.
-    agent = Agent(model, model_settings={"max_tokens": 2048})
+        r = agent.run_sync("What's the weather in Paris?")
+        assert "Paris" in r.output or "22" in r.output, r.output
+        called = any("get_weather" in str(m) for m in r.all_messages())
+        assert called, "tool not called"
+        print(f"PASS: {r.output[:80]}")
+        results["4_tool_single"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["4_tool_single"] = f"FAIL: {e}"
 
-    @agent.tool_plain
-    def add(a: int, b: int) -> int:
-        """Add two numbers."""
-        return a + b
+    # === 5. Multi-turn conversation ===
+    print("\n=== Test 5: Multi-turn ===")
+    try:
+        # PydanticAI defaults max_tokens to ~1024; on verbose 4B-class models the
+        # second turn can spill past that. Raise the cap so the SDK contract test
+        # checks rapid-mlx behaviour, not PydanticAI's default ceiling.
+        agent = Agent(model, model_settings={"max_tokens": 2048})
+        r1 = agent.run_sync("My name is Bob. Remember this.")
+        r2 = agent.run_sync("What is my name?", message_history=r1.all_messages())
+        assert "bob" in r2.output.lower(), r2.output
+        print(f"PASS: turn2 = {r2.output[:80]}")
+        results["5_multi_turn"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["5_multi_turn"] = f"FAIL: {e}"
 
-    @agent.tool_plain
-    def multiply(a: int, b: int) -> int:
-        """Multiply two numbers."""
-        return a * b
+    # === 6. Multiple tools, sequential ===
+    print("\n=== Test 6: Multiple tools ===")
+    try:
+        # Sequential tool calls accumulate output across two tool-call round trips;
+        # PydanticAI's default max_tokens ceiling kicks in before the final answer
+        # on small models. Same fix as test 5.
+        agent = Agent(model, model_settings={"max_tokens": 2048})
 
-    r = agent.run_sync("Compute (3+4)*5 using the tools. Show the result.")
-    assert "35" in r.output, r.output
-    called_tools = [str(m) for m in r.all_messages()]
-    add_called = any("add" in t for t in called_tools)
-    mul_called = any("multiply" in t for t in called_tools)
-    assert add_called and mul_called, f"add={add_called} mul={mul_called}"
-    print(f"PASS: {r.output[:80]}")
-    results["6_multi_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["6_multi_tool"] = f"FAIL: {e}"
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
 
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-total = len(results)
-print(f"PydanticAI: {passed}/{total} passed")
-for k, v in results.items():
-    print(f"  {k}: {v[:120]}")
-exit(0 if passed == total else 1)
+        @agent.tool_plain
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        r = agent.run_sync("Compute (3+4)*5 using the tools. Show the result.")
+        assert "35" in r.output, r.output
+        called_tools = [str(m) for m in r.all_messages()]
+        add_called = any("add" in t for t in called_tools)
+        mul_called = any("multiply" in t for t in called_tools)
+        assert add_called and mul_called, f"add={add_called} mul={mul_called}"
+        print(f"PASS: {r.output[:80]}")
+        results["6_multi_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["6_multi_tool"] = f"FAIL: {e}"
+
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    total = len(results)
+    print(f"PydanticAI: {passed}/{total} passed")
+    for k, v in results.items():
+        print(f"  {k}: {v[:120]}")
+    exit(0 if passed == total else 1)

--- a/tests/integrations/test_smolagents_full.py
+++ b/tests/integrations/test_smolagents_full.py
@@ -17,101 +17,102 @@ model = OpenAIServerModel(
     api_key="not-needed",
 )
 
-results = {}
+if __name__ == "__main__":
+    results = {}
 
-# === 1. CodeAgent simple ===
-print("=== Test 1: CodeAgent arithmetic ===")
-try:
-    agent = CodeAgent(tools=[], model=model, max_steps=3)
-    out = agent.run("Compute 12 * 8 and return the integer.")
-    assert "96" in str(out), out
-    print(f"PASS: {str(out)[:80]}")
-    results["1_code_simple"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["1_code_simple"] = f"FAIL: {str(e)[:120]}"
+    # === 1. CodeAgent simple ===
+    print("=== Test 1: CodeAgent arithmetic ===")
+    try:
+        agent = CodeAgent(tools=[], model=model, max_steps=3)
+        out = agent.run("Compute 12 * 8 and return the integer.")
+        assert "96" in str(out), out
+        print(f"PASS: {str(out)[:80]}")
+        results["1_code_simple"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["1_code_simple"] = f"FAIL: {str(e)[:120]}"
 
-# === 2. CodeAgent with tool ===
-print("\n=== Test 2: CodeAgent + custom tool ===")
-try:
+    # === 2. CodeAgent with tool ===
+    print("\n=== Test 2: CodeAgent + custom tool ===")
+    try:
 
-    @tool
-    def get_temp(city: str) -> str:
-        """Returns the current temperature for a city.
+        @tool
+        def get_temp(city: str) -> str:
+            """Returns the current temperature for a city.
 
-        Args:
-            city: Name of the city.
-        """
-        return f"The temperature in {city} is 18 degrees Celsius."
+            Args:
+                city: Name of the city.
+            """
+            return f"The temperature in {city} is 18 degrees Celsius."
 
-    agent = CodeAgent(tools=[get_temp], model=model, max_steps=4)
-    out = agent.run("What is the temperature in Tokyo?")
-    assert "18" in str(out) or "Tokyo" in str(out), out
-    print(f"PASS: {str(out)[:80]}")
-    results["2_code_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["2_code_tool"] = f"FAIL: {str(e)[:120]}"
+        agent = CodeAgent(tools=[get_temp], model=model, max_steps=4)
+        out = agent.run("What is the temperature in Tokyo?")
+        assert "18" in str(out) or "Tokyo" in str(out), out
+        print(f"PASS: {str(out)[:80]}")
+        results["2_code_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["2_code_tool"] = f"FAIL: {str(e)[:120]}"
 
-# === 3. ToolCallingAgent (uses tool_calls API instead of code) ===
-print("\n=== Test 3: ToolCallingAgent + tool ===")
-try:
+    # === 3. ToolCallingAgent (uses tool_calls API instead of code) ===
+    print("\n=== Test 3: ToolCallingAgent + tool ===")
+    try:
 
-    @tool
-    def add_nums(a: int, b: int) -> int:
-        """Add two integers.
+        @tool
+        def add_nums(a: int, b: int) -> int:
+            """Add two integers.
 
-        Args:
-            a: first number
-            b: second number
-        """
-        return a + b
+            Args:
+                a: first number
+                b: second number
+            """
+            return a + b
 
-    agent = ToolCallingAgent(tools=[add_nums], model=model, max_steps=4)
-    out = agent.run("What is 17 + 25? Use the add_nums tool.")
-    assert "42" in str(out), out
-    print(f"PASS: {str(out)[:80]}")
-    results["3_tool_calling_agent"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["3_tool_calling_agent"] = f"FAIL: {str(e)[:120]}"
+        agent = ToolCallingAgent(tools=[add_nums], model=model, max_steps=4)
+        out = agent.run("What is 17 + 25? Use the add_nums tool.")
+        assert "42" in str(out), out
+        print(f"PASS: {str(out)[:80]}")
+        results["3_tool_calling_agent"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["3_tool_calling_agent"] = f"FAIL: {str(e)[:120]}"
 
-# === 4. Multi-tool ToolCallingAgent ===
-print("\n=== Test 4: ToolCallingAgent + multiple tools ===")
-try:
+    # === 4. Multi-tool ToolCallingAgent ===
+    print("\n=== Test 4: ToolCallingAgent + multiple tools ===")
+    try:
 
-    @tool
-    def square(n: int) -> int:
-        """Square a number.
+        @tool
+        def square(n: int) -> int:
+            """Square a number.
 
-        Args:
-            n: number
-        """
-        return n * n
+            Args:
+                n: number
+            """
+            return n * n
 
-    @tool
-    def double(n: int) -> int:
-        """Double a number.
+        @tool
+        def double(n: int) -> int:
+            """Double a number.
 
-        Args:
-            n: number
-        """
-        return n * 2
+            Args:
+                n: number
+            """
+            return n * 2
 
-    agent = ToolCallingAgent(tools=[square, double], model=model, max_steps=6)
-    out = agent.run("What is the square of 6, then doubled? Use the tools.")
-    # 6^2 = 36, doubled = 72
-    assert "72" in str(out), f"Expected 72, got: {out}"
-    print(f"PASS: {str(out)[:80]}")
-    results["4_multi_tool"] = "PASS"
-except Exception as e:
-    print(f"FAIL: {e}")
-    results["4_multi_tool"] = f"FAIL: {str(e)[:120]}"
+        agent = ToolCallingAgent(tools=[square, double], model=model, max_steps=6)
+        out = agent.run("What is the square of 6, then doubled? Use the tools.")
+        # 6^2 = 36, doubled = 72
+        assert "72" in str(out), f"Expected 72, got: {out}"
+        print(f"PASS: {str(out)[:80]}")
+        results["4_multi_tool"] = "PASS"
+    except Exception as e:
+        print(f"FAIL: {e}")
+        results["4_multi_tool"] = f"FAIL: {str(e)[:120]}"
 
-# === Summary ===
-print("\n" + "=" * 50)
-passed = sum(1 for v in results.values() if v == "PASS")
-print(f"smolagents: {passed}/{len(results)} passed")
-for k, v in results.items():
-    print(f"  {k}: {v[:120]}")
-exit(0 if passed == len(results) else 1)
+    # === Summary ===
+    print("\n" + "=" * 50)
+    passed = sum(1 for v in results.values() if v == "PASS")
+    print(f"smolagents: {passed}/{len(results)} passed")
+    for k, v in results.items():
+        print(f"  {k}: {v[:120]}")
+    exit(0 if passed == len(results) else 1)


### PR DESCRIPTION
## Summary

- Files in `tests/integrations/` are manual integration scripts (not pytest modules). They run imperative test blocks at module top-level and end with `exit(0 if passed == len(results) else 1)`.
- When pytest tries to collect anything under `tests/` (e.g. `pytest tests/ -k "agent or hermes or harness or testing"`), it imports those modules, the `exit(...)` fires with `results == {}`, and pytest reports `SystemExit: 1` -> `INTERNALERROR`. Nothing collects.
- Wrap the driver block (from `results = {}` through the final `exit(...)`) in `if __name__ == "__main__":` so the modules import cleanly under pytest while still running normally via `python <file>`.

Touched: `test_anthropic_sdk.py`, `test_langchain.py`, `test_librechat_docker.py`, `test_openwebui.py`, `test_pydantic_ai_full.py`, `test_smolagents_full.py`.

## Test plan

- [x] `python tests/integrations/test_anthropic_sdk.py` (no server) -> exits 1, runs all 5 test blocks. Direct invocation still works.
- [x] `python tests/integrations/test_langchain.py` (no server) -> exits 1, runs all 6 test blocks.
- [x] `pytest tests/integrations/ --collect-only -q` -> 20 tests collected, no INTERNALERROR.
- [x] `pytest tests/ -k "agent or hermes or harness or testing" --collect-only -q` -> 126/5642 tests collected cleanly (was previously broken by `SystemExit` during collection).
- [x] `ruff format` + `ruff check` pass on all touched files.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>