### PR TITLE
fix(mirror): write R2 LFS downloads to blobs/<sha> + symlink (#652)

### DIFF
--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import urllib.error
 from pathlib import Path
 from typing import Any
@@ -2413,6 +2414,171 @@ def test_cached_hf_blob_symlink_skips_rehash(
     assert hf_mock.call_count == 0
     # File still resolves correctly.
     assert link.read_bytes() == payload
+
+
+# ---------------------------------------------------------------------------
+# Issue #652 — after a sha-verified R2 download of an LFS file, the
+# bytes must land at ``blobs/<sha>`` and the snapshot path must be a
+# RELATIVE symlink to that blob. Matches HF's own cache layout, so the
+# blob-name shortcut at the warm-cache check fires uniformly for both
+# R2-sourced and HF-sourced cache state — avoiding multi-GB rehashes
+# on every warm pull.
+# ---------------------------------------------------------------------------
+
+
+def test_r2_lfs_download_writes_blob_and_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import hashlib
+
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "a1b2" * 10
+    payload = b"W" * 1024
+    sha = hashlib.sha256(payload).hexdigest()
+    files = [("model.safetensors", 1024, sha)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/model.safetensors",
+        _FakeResponse(200, payload),
+    )
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download") as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    assert ok
+    assert hf_mock.call_count == 0
+
+    repo_root = tmp_path / "models--mlx-community--Qwen3-0.6B-4bit"
+    blob = repo_root / "blobs" / sha
+    snap_file = repo_root / "snapshots" / revision / "model.safetensors"
+
+    # The verified bytes live at ``blobs/<sha>`` as a regular file.
+    assert blob.is_file()
+    assert not blob.is_symlink()
+    assert blob.read_bytes() == payload
+
+    # The snapshot path is a symlink (NOT a regular file) pointing at
+    # the blob via a RELATIVE path. Matching HF's own layout exactly
+    # is what makes the warm-pull blob-name shortcut fire — an
+    # absolute symlink would also work for ``resolve().name`` but
+    # diverges from HF's layout, so codify "relative" here.
+    assert snap_file.is_symlink()
+    link_target = os.readlink(snap_file)
+    assert not os.path.isabs(link_target), (
+        f"snapshot symlink must be relative, got {link_target!r}"
+    )
+    # Resolves to the blob.
+    assert snap_file.resolve() == blob.resolve()
+    # And reading through the symlink still yields the payload.
+    assert snap_file.read_bytes() == payload
+
+
+def test_warm_r2_pull_uses_blob_name_shortcut(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Second pull of the same model must NOT rehash the LFS blob.
+
+    Issue #652 root cause: the old code wrote R2 bytes as a regular
+    file at ``snapshots/<sha>/<file>``, so the cached-check site
+    couldn't take its ``symlink.name == expected_sha256`` shortcut on
+    the second pull — every warm pull rehashed multi-GB shards. With
+    the blob+symlink layout, the shortcut fires and the second pull
+    is rehash-free.
+    """
+    import hashlib
+
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "b2c3" * 10
+    payload = b"S" * 4096
+    sha = hashlib.sha256(payload).hexdigest()
+    files = [("model.safetensors", 4096, sha)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/model.safetensors",
+        _FakeResponse(200, payload),
+    )
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+
+    # First (cold) pull — populates blobs/<sha> and the snapshot
+    # symlink via the R2 path.
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download") as hf_mock,
+    ):
+        assert _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+        assert hf_mock.call_count == 0
+
+    repo_root = tmp_path / "models--mlx-community--Qwen3-0.6B-4bit"
+    snap_file = repo_root / "snapshots" / revision / "model.safetensors"
+    assert snap_file.is_symlink()  # cold pull installed the layout.
+
+    # Second (warm) pull — instrument ``hashlib.sha256`` so any new
+    # hasher creation during the second pull is detected. The blob-
+    # name shortcut at the cached-check site must skip the rehash
+    # entirely. A second router with NO file URL registered ensures
+    # an accidental refetch would AssertionError too.
+    warm_router = _UrlRouter()
+    warm_router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+
+    import hashlib as _hashlib_mod
+
+    real_sha256 = _hashlib_mod.sha256
+    hasher_calls: list[None] = []
+
+    def _spy_sha256(*args, **kwargs):
+        hasher_calls.append(None)
+        return real_sha256(*args, **kwargs)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=warm_router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download") as hf_mock_warm,
+        patch.object(_hashlib_mod, "sha256", side_effect=_spy_sha256),
+    ):
+        assert _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+        assert hf_mock_warm.call_count == 0
+
+    # No file URL probed on the warm pull (only the catalog).
+    file_reqs = [r for r in warm_router.requests if "model.safetensors" in r["url"]]
+    assert file_reqs == [], f"warm pull refetched LFS file: {file_reqs}"
+    # And — the load-bearing assertion — no sha256 hasher was created
+    # during the warm pull. The blob-name shortcut fired.
+    assert hasher_calls == [], (
+        f"warm pull rehashed the LFS blob ({len(hasher_calls)} hashers)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -250,6 +250,7 @@ def _download_one_from_r2(
     expected_sha256: str | None = None,
     sidecar_dir: Path,
     sidecar_key: str,
+    repo_root: Path | None = None,
 ) -> tuple[bool, str]:
     """Download a single file from R2 into ``target``.
 
@@ -274,6 +275,14 @@ def _download_one_from_r2(
     text assets), there is no LFS sha and the integrity check falls
     back to size-only — the realistic threat surface for tiny config
     files is much smaller.
+
+    Issue #652: when ``expected_sha256`` is provided and ``repo_root``
+    is set, the verified bytes land at ``repo_root/blobs/<sha>`` and
+    ``target`` becomes a relative symlink to that blob — matching HF's
+    own cache layout, so subsequent warm pulls hit the blob-name
+    shortcut at the cached-check site (skipping a multi-GB rehash).
+    Non-LFS files (no ``expected_sha256``) stay as regular files at
+    ``target`` for parity with HF's own layout for tiny configs.
     """
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -291,7 +300,12 @@ def _download_one_from_r2(
     lock_fh = _acquire_part_lock(lock_path)
     try:
         return _do_r2_download(
-            url, target, tmp, expected_size, expected_sha256=expected_sha256
+            url,
+            target,
+            tmp,
+            expected_size,
+            expected_sha256=expected_sha256,
+            repo_root=repo_root,
         )
     finally:
         _release_part_lock(lock_fh, lock_path)
@@ -304,6 +318,7 @@ def _do_r2_download(
     expected_size: int | None,
     *,
     expected_sha256: str | None = None,
+    repo_root: Path | None = None,
 ) -> tuple[bool, str]:
     """Inner R2 download body — runs with the per-file lock held.
 
@@ -478,12 +493,118 @@ def _do_r2_download(
         _safe_unlink(tmp)
         return False, f"final-size-mismatch:{final_size}!={expected_size}"
 
+    # Issue #652: for LFS files (``expected_sha256`` known) land the
+    # verified bytes at ``repo_root/blobs/<sha>`` and symlink the
+    # snapshot path at it — matches HF's own layout exactly so the
+    # blob-name shortcut at the warm-cache check fires uniformly for
+    # both R2-sourced and HF-sourced cache state. Non-LFS files
+    # (config.json, tokenizer.json, etc.) stay as regular files at
+    # ``target``; HF does the same for those.
+    if expected_sha256 is not None and repo_root is not None:
+        ok, reason = _install_lfs_blob_and_symlink(
+            tmp, target, repo_root, expected_sha256
+        )
+        if not ok:
+            _safe_unlink(tmp)
+            return False, reason
+        return True, ""
+
     try:
         tmp.rename(target)
     except OSError as e:
         _safe_unlink(tmp)
         return False, f"rename:{type(e).__name__}"
     return True, ""
+
+
+def _install_lfs_blob_and_symlink(
+    tmp: Path,
+    target: Path,
+    repo_root: Path,
+    expected_sha256: str,
+) -> tuple[bool, str]:
+    """Land verified LFS bytes at ``blobs/<sha>`` and symlink ``target``.
+
+    Issue #652. After R2 has produced sha-verified bytes in ``tmp``,
+    we want the resulting cache state to match HF's own layout:
+
+    * The bytes live at ``repo_root/blobs/<expected_sha256>``.
+    * ``target`` (the snapshot path) is a relative symlink at
+      ``../../blobs/<expected_sha256>`` so a warm pull's blob-name
+      shortcut (``resolved.name == expected_sha256``) fires and we
+      skip rehashing multi-GB shards.
+
+    Atomic + concurrency-safe:
+
+    * Hold an ``fcntl.flock`` on the blob path while we materialize it,
+      so two parallel pulls of the same file don't race on the rename.
+    * Write to a ``<sha>.tmp`` sibling under ``blobs/`` then ``rename``
+      onto the final blob — a kill mid-rename cannot leave a half-
+      written blob with the canonical name (rename is atomic on
+      POSIX).
+    * If another process already materialized ``blobs/<sha>`` before
+      we acquired the lock, just symlink to it and drop our ``tmp``
+      (size+sha are already validated upstream, so any existing blob
+      with that name has the same content).
+    """
+    blobs_dir = repo_root / "blobs"
+    blob_path = blobs_dir / expected_sha256
+    try:
+        blobs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return False, f"blob-mkdir:{type(e).__name__}"
+
+    # Per-blob lock keeps two concurrent pulls of the same LFS file
+    # from racing on the blob write. We reuse ``_acquire_part_lock``'s
+    # flock-on-lockfile pattern; the lockfile lives next to the blob.
+    blob_lock = blobs_dir / f"{expected_sha256}.lock"
+    lock_fh = _acquire_part_lock(blob_lock)
+    try:
+        # Race: another process (or another worker in this process)
+        # may have already materialized the blob between our pre-lock
+        # check and now. If it's there with content, drop our tmp and
+        # just symlink. sha+size were validated by the caller, so any
+        # blob already at the canonical name has identical bytes.
+        if blob_path.exists() and not blob_path.is_symlink():
+            _safe_unlink(tmp)
+        else:
+            # Atomic install: write to a ``.tmp`` sibling first so a
+            # kill mid-rename can't leave a partial file at the
+            # canonical blob name. ``Path.rename`` is atomic on POSIX
+            # when source and destination share a filesystem (they
+            # do — both under ``blobs/``).
+            blob_tmp = blobs_dir / f"{expected_sha256}.tmp"
+            _safe_unlink(blob_tmp)
+            try:
+                tmp.rename(blob_tmp)
+            except OSError as e:
+                return False, f"blob-stage:{type(e).__name__}"
+            try:
+                blob_tmp.rename(blob_path)
+            except OSError as e:
+                _safe_unlink(blob_tmp)
+                return False, f"blob-rename:{type(e).__name__}"
+
+        # Install the snapshot symlink. HF uses a relative symlink
+        # (``../../blobs/<sha>``) so the cache is portable across
+        # parent-directory moves; match that exactly. ``target`` may
+        # already exist (stale file / broken symlink from a prior
+        # interrupted run) — clear it before symlinking.
+        _safe_unlink(target)
+        # Snapshot files live at ``snapshots/<rev>/<fname>``; blobs at
+        # ``blobs/<sha>``. The relative path from the snapshot file's
+        # parent (``snapshots/<rev>/``) to the blob is therefore
+        # ``../../blobs/<sha>``. Computing it explicitly via
+        # ``os.path.relpath`` keeps the symlink correct even if a
+        # future change reshapes the layout.
+        rel = os.path.relpath(blob_path, start=target.parent)
+        try:
+            target.symlink_to(rel)
+        except OSError as e:
+            return False, f"symlink:{type(e).__name__}"
+        return True, ""
+    finally:
+        _release_part_lock(lock_fh, blob_lock)
 
 
 def _parse_content_range(
@@ -1111,6 +1232,7 @@ def download_with_mirror_fallback(
                 expected_sha256=expected_sha256,
                 sidecar_dir=sidecar_dir,
                 sidecar_key=_sidecar_key_for(fname),
+                repo_root=repo_root,
             )
             if ok:
                 try:


### PR DESCRIPTION
Closes #652.

After a sha-verified R2 LFS download, atomically install the verified bytes at `repo_root/blobs/<expected_sha256>` and make `snapshots/<rev>/<file>` a relative symlink (`../../blobs/<sha>`). Matches HF's own cache layout exactly, so the existing blob-name shortcut at the warm-cache check (`symlink.resolve().name == expected_sha256`) fires uniformly for both R2-sourced and HF-sourced state.

**Why:** PR #650 round-15 review surfaced this as the highest-impact deferred perf finding. With the old layout (regular file at `snapshots/<sha>/<file>`), every warm `rapid-mlx pull` of an R2-sourced model rehashed every multi-GB shard; with HF's blob+symlink layout the shortcut skips the rehash. Non-LFS files (config.json, tokenizer.json) stay as regular files at the snapshot path — HF does the same.

**Safety:**
- Per-blob `fcntl.flock` serializes the materialization so two concurrent pulls of the same LFS file don't race.
- Atomic install via `<sha>.tmp` -> `<sha>` rename so a SIGKILL mid-install can't leave a partial file at the canonical blob name.
- Post-lock existence check handles the parallel-pull race: if the blob already exists, drop our `.tmp` and just symlink.
- Existing symlink-escape guards already accept symlinks pointing under `repo_root/blobs/` exclusively — our new symlink lands inside that subtree.

## Test plan

- [x] `test_r2_lfs_download_writes_blob_and_symlink` — asserts `blobs/<sha>` is a regular file, snapshot path is a RELATIVE symlink resolving to the blob, payload roundtrips through the symlink.
- [x] `test_warm_r2_pull_uses_blob_name_shortcut` — instruments `hashlib.sha256` across a warm pull and asserts NO hasher is created (blob-name shortcut fired). Also asserts the warm pull makes no file request and no HF fallback.
- [x] `.venv/bin/python -m pytest tests/test_mirror_pull.py -x -q` passes (54 tests).
- [x] `ruff format` + `ruff check` clean on changed files.

Skipped: the `test_mirror_pull.py:2299/2377` tightness nits called out in the issue — the new `test_r2_lfs_download_writes_blob_and_symlink` and `test_warm_r2_pull_uses_blob_name_shortcut` already make the load-bearing layout + shortcut assertions directly, so tightening adjacent indirect assertions in older tests is not additive coverage.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>