### PR TITLE
fix(harness): whitespace-resilient hermes context-window detection (#659 round-1 verify-pass)

### DIFF
--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -110,7 +110,16 @@ def hermes_query(query, timeout_sec=120):
         # needs. Surfacing this as FAIL is dishonest — it isn't a
         # rapid-mlx regression, it's the served model being too small
         # for this specific harness setup. Caller should SKIP.
-        if "Failed to initialize agent" in output and "context window" in output:
+        #
+        # IMPORTANT: collapse whitespace before the substring check.
+        # The hermes binary hard-wraps stderr at ~100 cols, so the
+        # literal ``"context window"`` substring would miss when
+        # wrapping splits the phrase as ``"context\nwindow"`` (#659
+        # round-1 verify-pass uncovered this).
+        import re as _re
+
+        collapsed = _re.sub(r"\s+", " ", output)
+        if "Failed to initialize agent" in collapsed and "context window" in collapsed:
             return None, (
                 "SKIP: Hermes requires larger context than served model "
                 "provides (Hermes init refused)"

--- a/tests/test_agent_query_context_skip.py
+++ b/tests/test_agent_query_context_skip.py
@@ -77,6 +77,18 @@ HERMES_REFUSAL_STDOUT = (
     "required by Hermes Agent.\n"
 )
 
+# Exactly the bytes the real hermes binary prints — it hard-wraps at
+# ~100 cols so the phrase "context window" ends up split as
+# "context\nwindow". A literal substring check misses this case, which
+# is what slipped through #659 round-1 and re-broke the gauntlet. Keep
+# this fixture verbatim so any future regression of the detection
+# layer's whitespace tolerance trips the test, not the user.
+HERMES_REFUSAL_STDOUT_WRAPPED = (
+    "Failed to initialize agent: Model mlx-community/Qwen3.5-9B-4bit has a context\n"
+    "window of 32,768 tokens, which is below the minimum 64,000 required by Hermes\n"
+    "Agent.  Choose a model with at least 64K context.\n"
+)
+
 
 def test_agent_query_detects_context_refusal_as_skip():
     """The Hermes-style "context window below minimum" refusal → SKIP err."""
@@ -109,6 +121,36 @@ def test_agent_query_detects_context_refusal_as_skip():
         f"SKIP message must carry the advertised vs minimum context values; "
         f"got err={err!r}"
     )
+
+
+def test_agent_query_detects_context_refusal_when_phrase_is_line_wrapped():
+    """Direct regression for the #659 round-1 verify-pass finding.
+
+    The real hermes binary hard-wraps stderr at ~100 cols, so the
+    phrase "context window" arrives split as "context\\nwindow". The
+    initial #659 fix used a literal ``"context window" in output``
+    substring check that missed this — gauntlet hermes line was still
+    ``27p 7f 0e 0s`` after the merge. Detection must collapse
+    whitespace first so the wrapped form is recognized.
+    """
+    with (
+        patch("vllm_mlx.agents.testing.shutil.which", return_value="/fake/hermes"),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=_stub_completed_proc(stdout=HERMES_REFUSAL_STDOUT_WRAPPED),
+        ),
+    ):
+        out, err = _agent_query(
+            "hermes", "hermes chat -q '{query}' -Q", "hi", timeout=10
+        )
+    assert out is None
+    assert err is not None and err.startswith("SKIP:"), (
+        f"Wrapped-phrase refusal must STILL be detected; got err={err!r}"
+    )
+    # And the model name + numbers still survive into the message after
+    # whitespace normalization.
+    assert "Qwen3.5-9B-4bit" in err, f"model name lost; err={err!r}"
+    assert "32,768" in err and "64,000" in err, f"context numbers lost; err={err!r}"
 
 
 def test_agent_query_passes_through_normal_output():

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -750,23 +751,30 @@ def _agent_query(
         # mismatch, not a rapid-mlx regression. Propagate as SKIP via the
         # ``SKIP:``-prefixed err sentinel that each ``_test_e2e_*`` already
         # honors.
-        if "Failed to initialize agent" in output and "context window" in output:
-            # Extract the first matching line from the subprocess output so
+        #
+        # IMPORTANT: collapse whitespace first. The hermes binary hard-
+        # wraps stderr at ~100 cols, so a literal ``"context window"``
+        # substring check misses when wrapping splits the phrase as
+        # ``"context\nwindow"`` — which is exactly what tripped the
+        # initial #655 fix in production (#659 round-1 verify-pass).
+        collapsed = re.sub(r"\s+", " ", output).strip()
+        if "Failed to initialize agent" in collapsed and "context window" in collapsed:
+            # Extract the actual refusal sentence (everything from
+            # "Failed to initialize agent" through the next period) so
             # the resulting TestResult.message carries the actual model
             # name + advertised vs minimum token counts (codex NIT #659).
             # Without this, the user sees a generic "below the harness
             # minimum" and has to dig in the server log to learn which
             # model and what numbers — the very signal that makes this
             # actionable.
-            refusal_line = next(
-                (
-                    line.strip()
-                    for line in output.splitlines()
-                    if "Failed to initialize agent" in line
-                ),
-                "",
-            )
-            detail = f": {refusal_line[:200]}" if refusal_line else ""
+            # Non-greedy through to a period FOLLOWED BY whitespace or
+            # end-of-string. The plain ``[^.]*\.`` form stops at the
+            # first period — which on a model name like "Qwen3.5" is
+            # mid-sentence, truncating the model identifier and the
+            # advertised/minimum numbers.
+            m = re.search(r"Failed to initialize agent.*?\.(?=\s|$)", collapsed)
+            refusal_line = (m.group(0) if m else "")[:200]
+            detail = f": {refusal_line}" if refusal_line else ""
             return None, (
                 f"SKIP: agent refused init — served model's context window "
                 f"is below the harness minimum{detail}"


### PR DESCRIPTION
## Summary

- PR #659 added soft-skip routing in `_agent_query` but used a literal `"context window" in output` substring check.
- M3 gauntlet verify run on Qwen3.5-9B-4bit (cached, no download) showed hermes line STILL `27p 7f 0e 0s` after the #659 merge — identical to the pre-fix shape. Root cause: the real hermes binary hard-wraps stderr at ~100 cols, so the actual output contains `"context\nwindow"`, the literal substring missed, `err` stayed `None`, and the per-test "no expected substring" assertion surfaced the init message as FAIL.
- Fix: collapse whitespace before the substring check (and before the model-name extraction). Same one-line bug at `tests/integrations/test_hermes.py::hermes_query:113` — fixed in this PR too. Regex extraction tightened with a `\s+` lookahead so the model name (`Qwen3.5-9B-4bit`) and numbers (`32,768` / `64,000`) survive even when the version-string period is mid-sentence.

## Test plan

- [x] New regression test `test_agent_query_detects_context_refusal_when_phrase_is_line_wrapped` pins the **exact bytes** the real hermes binary emits, including the ~100-col mid-phrase wrap. Future regression of whitespace tolerance trips the test, not the user.
- [x] Existing `test_agent_query_detects_context_refusal_as_skip` still passes (non-wrapped fixture).
- [x] Existing tests for passthrough, unrelated init failures, all three `_test_e2e_*`, and TimeoutError → ERROR control all still pass.
- [x] `ruff check` + `ruff format --check` clean.

## Followup plan (after merge)

Re-run M3 gauntlet G7b on Qwen3.5-9B-4bit. Win condition: hermes line shows e2e_* tests as SKIP (not FAIL), the `f` count drops, sweep does NOT abort with `set -e`.

## Related

- #655 (original issue)
- #659 (round-1 fix that had the literal-substring bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)