### PR TITLE
chore: bump version to 0.7.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.27"
+version = "0.7.28"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release v0.7.28. After merge, auto-release.yml tags `v0.7.28` and publish.yml ships to PyPI + Homebrew.

## Changelog (since v0.7.27)

- **pull UX** — per-file progress lines during R2 mirror downloads. Pull no longer goes silent for minutes on multi-shard models. (#657, follow-up to #651)
- **pull perf** — R2 LFS downloads land in `blobs/<sha>` + relative symlink, matching HF cache layout. Warm re-pulls of the same model are instant instead of re-hashing every shard. (#652 / #661)
- **gauntlet ergonomics** — `bench --tier harness` now SKIPs (not FAILs) when an agent harness refuses init because the served model's context window is below the harness minimum (Hermes hard-requires ≥64K; Qwen3.5-{4B,9B}-4bit advertise 32K). Closes #655 via #659 + #662 — #659 round-1 missed line-wrapped output; #662 collapses whitespace before the detection. The M3 gauntlet now completes cleanly on small-context models instead of `set -e`-aborting at G7b.
- **test ergonomics** — `tests/integrations/*.py` no longer `SystemExit` on pytest collection (they used a bare top-level `exit(...)` for direct-invocation mode). Pytest sweeps including `tests/integrations/` no longer INTERNALERROR. (#660)

## Test plan

- [x] `pyproject.toml` version bump only (1 line). No code changes.
- [x] `cli_description_quality` PR body has rationale.
- [x] All four feature PRs above were independently pr_validate MERGE-SAFE and codex-clean.
- [x] M3 gauntlet G7b verification run in flight against `9e6d06e` (#662 merge SHA) on Qwen3.5-9B-4bit — see follow-up comment with results before merge.

## Release SOP plan (after merge)

1. Auto-release.yml fires on the squash-merged commit subject `chore: bump version to 0.7.28 (#NNN)` → tags `v0.7.28` → creates GitHub release.
2. Publish.yml fires on release:published → publishes to PyPI + bumps Homebrew formula.
3. Verify: `uv tool install rapid-mlx@0.7.28` clean-room install, then `rapid-mlx version` should report `0.7.28`.
4. Verify: `brew tap raullenchai/rapid-mlx && brew trust raullenchai/rapid-mlx && brew install rapid-mlx` reports `0.7.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)