### PR TITLE
fix(scheduler): allow concurrent batching with different temperatures

### DIFF
--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -390,6 +390,162 @@ def test_scheduler_batch_generator_reuse_key_includes_ignore_eos() -> None:
     )
 
 
+def test_scheduler_batch_generator_reuses_across_different_sampler_params() -> None:
+    """PR #665 perf fix — requests with different sampler params
+    (temperature, top_p, min_p, top_k) but identical stop config MUST
+    share the same BatchGenerator.
+
+    Before the fix, the reuse key included the full sampler tuple
+    (temperature, top_p, min_p, top_k, ignore_eos), so two concurrent
+    requests with different temperatures forced serial processing. A
+    33K-token agentic request (default temp) blocked a 352-token
+    concurrent request (different temp) for 115 seconds in production.
+
+    Per-request samplers are passed to ``batch_gen.insert(samplers=[...])``
+    directly, so the only generator-level invariant is stop config —
+    sampler params don't need to match for reuse.
+    """
+    pytest.importorskip("mlx")
+    from vllm_mlx.request import SamplingParams
+    from vllm_mlx.scheduler import Scheduler
+
+    sentinel = object()
+    create_calls = []
+
+    class StubScheduler:
+        batch_generator = None
+        running = False
+        memory_aware_cache = None
+        prefix_cache = None
+        _current_sampler_params = None
+
+        def _close_batch_generator(self) -> None:
+            self.batch_generator = None
+
+        def _create_batch_generator(self, sp):
+            create_calls.append(sp)
+            return sentinel
+
+    stub = StubScheduler()
+
+    # Same stop config (defaults: empty stop_token_ids, ignore_eos=False);
+    # different sampler params across every axis the old key checked.
+    p_low = SamplingParams(
+        max_tokens=512, temperature=0.0, top_p=1.0, min_p=0.0, top_k=-1
+    )
+    p_high = SamplingParams(
+        max_tokens=512, temperature=0.8, top_p=0.95, min_p=0.05, top_k=50
+    )
+
+    assert Scheduler._ensure_batch_generator(stub, p_low) is True
+    assert len(create_calls) == 1, "first request should build a generator"
+
+    assert Scheduler._ensure_batch_generator(stub, p_high) is True
+    assert len(create_calls) == 1, (
+        "two requests with different sampler params but identical stop "
+        "config MUST reuse the BatchGenerator (PR #665). Before the fix, "
+        "sampler params were in the reuse key, forcing serialization of "
+        "concurrent requests with different temperatures (115s production "
+        "stall reported by Claude Code agentic workloads)."
+    )
+
+    # Also verify reuse holds when an overlap would otherwise refuse:
+    # the previous-running guard kicks in on key MISMATCH, not on reuse.
+    stub.running = {"req-active": object()}
+    assert Scheduler._ensure_batch_generator(stub, p_high) is True
+    assert len(create_calls) == 1, (
+        "reuse on a running batch must still succeed when stop config "
+        "matches — sampler-only differences never trigger the requeue."
+    )
+
+
+def test_scheduler_batch_generator_reuse_key_includes_stop_token_ids() -> None:
+    """PR #665 correctness fix — requests with different
+    ``stop_token_ids`` must NOT share a BatchGenerator.
+
+    Before the fix, the reuse key was (temperature, top_p, min_p, top_k,
+    ignore_eos), excluding caller-supplied ``stop_token_ids``. Two
+    requests with the same sampler params but different stop sequences
+    would silently share a generator built around the first request's
+    stop set — the second request's stop tokens were ignored.
+
+    The new key folds ``frozenset(stop_token_ids)`` in, so a mismatch
+    triggers a rebuild (or, with an active batch, a requeue).
+    """
+    pytest.importorskip("mlx")
+    from vllm_mlx.request import SamplingParams
+    from vllm_mlx.scheduler import Scheduler
+
+    sentinel = object()
+    create_calls = []
+    close_calls = []
+
+    class StubScheduler:
+        batch_generator = None
+        running = False
+        memory_aware_cache = None
+        prefix_cache = None
+        _current_sampler_params = None
+
+        def _close_batch_generator(self) -> None:
+            close_calls.append(self.batch_generator)
+            self.batch_generator = None
+
+        def _create_batch_generator(self, sp):
+            create_calls.append(sp)
+            return sentinel
+
+    stub = StubScheduler()
+
+    base = dict(max_tokens=512, temperature=0.0, top_p=1.0, min_p=0.0, top_k=-1)
+    p_stop_a = SamplingParams(**base, stop_token_ids=[42])
+    p_stop_b = SamplingParams(**base, stop_token_ids=[99])
+
+    assert Scheduler._ensure_batch_generator(stub, p_stop_a) is True
+    assert len(create_calls) == 1
+
+    closes_before = len(close_calls)
+    assert Scheduler._ensure_batch_generator(stub, p_stop_b) is True
+    assert len(create_calls) == 2, (
+        "different stop_token_ids MUST rebuild the BatchGenerator — "
+        "before PR #665 the second request would silently inherit the "
+        "first request's stop set (correctness bug)."
+    )
+    assert len(close_calls) > closes_before, (
+        "the old generator must be torn down before the rebuild."
+    )
+
+    # Order-independence: the key is a frozenset, so list order of
+    # stop_token_ids must not affect reuse. [1, 2] and [2, 1] are the
+    # same stop set semantically — they must share a generator.
+    p_stop_ab = SamplingParams(**base, stop_token_ids=[1, 2])
+    p_stop_ba = SamplingParams(**base, stop_token_ids=[2, 1])
+
+    assert Scheduler._ensure_batch_generator(stub, p_stop_ab) is True
+    creates_before = len(create_calls)
+    assert Scheduler._ensure_batch_generator(stub, p_stop_ba) is True
+    assert len(create_calls) == creates_before, (
+        "stop_token_ids list order MUST NOT affect reuse — frozenset "
+        "in the key normalizes ordering."
+    )
+
+    # Overlap with running batch + different stop_token_ids → refuse
+    # (mirrors the ignore_eos requeue path; protects the same invariant).
+    stub.running = {"req-active": object()}
+    creates_pre_overlap = len(create_calls)
+    closes_pre_overlap = len(close_calls)
+    refused = Scheduler._ensure_batch_generator(
+        stub, SamplingParams(**base, stop_token_ids=[7])
+    )
+    assert refused is False, (
+        "request with mismatching stop_token_ids MUST be refused while a "
+        "previous batch is still running — otherwise it would inherit "
+        "the active batch's stop set."
+    )
+    assert len(create_calls) == creates_pre_overlap
+    assert len(close_calls) == closes_pre_overlap
+
+
 def test_standardized_config_dict_matches_schema_consts() -> None:
     """The hardcoded constants in ``config`` must equal the schema's
     ``const`` values — schema validation depends on this."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4256,7 +4256,9 @@ Examples:
         type=int,
         default=0,
         help="Max prefill tokens per scheduler step (0=disabled). "
-        "Prevents starvation of active requests during long prefills.",
+        "Breaks large prompts into chunks to prevent concurrent requests from starving. "
+        "Recommended for Claude Code and agentic workloads with large tool schemas: "
+        "--chunked-prefill-tokens 2048",
     )
     # MTP (Multi-Token Prediction)
     serve_parser.add_argument(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2527,36 +2527,37 @@ class Scheduler:
             self.batch_generator = None
 
     def _ensure_batch_generator(self, sampling_params: SamplingParams) -> bool:
-        """Ensure BatchGenerator exists with compatible settings.
+        """Ensure BatchGenerator exists with compatible stop token configuration.
 
         Returns:
             ``True`` if a compatible generator is ready for the caller
             to insert this request into. ``False`` if the caller MUST
-            requeue the request — the current generator's
-            ``stop_tokens`` / sampler differ from what this request
-            requires, and there are active requests still draining, so
-            admitting now would silently bind this request to the wrong
-            stop-token set. The contract is a hard refusal, not advisory;
-            ``_schedule_waiting`` requeues on ``False`` to preserve
-            ignore_eos semantics across overlapping batches.
+            requeue the request — the current generator's stop_tokens
+            differ from what this request requires, and there are active
+            requests still draining, so admitting now would silently bind
+            this request to the wrong stop-token set. The contract is a hard
+            refusal, not advisory; ``_schedule_waiting`` requeues on ``False``
+            to preserve stop_token and ignore_eos semantics across overlapping
+            batches. Per-request samplers (temperature, top_p, etc.) do NOT
+            trigger a new generator — they are passed directly to insert().
         """
-        # `_assemble_stop_tokens` returns the empty set when
-        # ``ignore_eos=True`` and the model's stop-token set otherwise.
-        # The choice is captured inside the BatchGenerator at construction
-        # time, so two requests with identical sampler tuples but
-        # different ``ignore_eos`` MUST NOT share a generator — else a
-        # benchmark probe with ``ignore_eos=True`` will silently strip
-        # EOS stops from the next chat call (or vice versa). Folding the
-        # flag into the reuse key is the smallest fix; the alternative
-        # would be to re-stamp ``stop_tokens`` on the live generator,
-        # which we deliberately avoid because the BatchGenerator's
-        # mlx-lm internals are not designed for in-place mutation.
-        # Surfaced by Rapid-MLX issue #611.
+        # Per-request samplers (temperature, top_p, min_p, top_k) are passed
+        # directly to batch_gen.insert(..., samplers=[request_sampler]), so
+        # they do NOT need to match the global BatchGenerator sampler. The
+        # only generator-level invariant is stop_tokens, which is computed at
+        # init time via _assemble_stop_tokens(sampling_params, model_stop_tokens).
+        #
+        # Two requests must share the same BatchGenerator iff they produce the
+        # same final stop_tokens set. Since model_stop_tokens is invariant
+        # (fixed per model/server run), the key is:
+        # (frozenset(request.stop_token_ids), request.ignore_eos).
+        #
+        # Requests with different temperatures but same stop config can now
+        # batch together, fixing issue where Claude Code's big agentic request
+        # (33K tokens, default temp) blocked smaller concurrent requests with
+        # different temps for 115 seconds (Rapid-MLX #611 follow-up).
         sampler_params = (
-            sampling_params.temperature,
-            sampling_params.top_p,
-            sampling_params.min_p,
-            sampling_params.top_k,
+            frozenset(sampling_params.stop_token_ids or ()),
             bool(sampling_params.ignore_eos),
         )
 
@@ -2576,9 +2577,9 @@ class Scheduler:
             # wrong ignore_eos behavior (codex P2 on PR #612).
             if self.batch_generator is not None and self.running:
                 logger.warning(
-                    "Sampling parameters changed with active requests. "
+                    "Stop token configuration changed with active requests. "
                     "Requeuing request — admission deferred until current "
-                    "batch drains so stop_tokens / sampler remain consistent."
+                    "batch drains so stop_tokens remain consistent."
                 )
                 return False
 


### PR DESCRIPTION
## Problem

Claude Code sends large agentic prompts (~33K tokens with full tool schemas) that trigger slow prefill phases. When concurrent requests arrive with different sampling parameters (e.g., different temperature), they serialize unnecessarily because the scheduler's  key includes temperature/top_p/min_p/top_k.

This forces the second request to wait 115+ seconds even though:
1. Per-request samplers are already passed to 
2. Temperature/top_p don't need to match globally

Additionally, the key excluded `stop_token_ids`, creating a silent correctness bug where requests with different stop sequences could share a BatchGenerator.

## Solution

### 1. Fix sampler params key (scheduler.py:2543-2562)

Replace `(temperature, top_p, min_p, top_k, ignore_eos)` with `(frozenset(stop_token_ids), ignore_eos)`:
- Only generator-level invariants: stop tokens are set at BatchGenerator init and can't be changed
- Per-request samplers are passed directly to insert() and override the global sampler
- Frozenset ensures correctness: requests with different stop sequences get different keys

### 2. Improve chunked-prefill discoverability (cli.py:4258-4261)

Update `--chunked-prefill-tokens` help text to call out Claude Code and agentic workloads as the intended use case, with recommended starting value of 2048.

## Testing

Verified:
- Two streaming requests with different temperatures batch together (`running=2` in scheduler logs)
- Requests with different stop sequences do not inherit each other's stops
- Help text mentions Claude Code and agentic workloads  
- Second-turn cache hits work and TTFT drops dramatically

Closes #611