### PR TITLE
fix(prefix-cache): async + deadline-aware shutdown flush, prevents orphaned .new/ on SIGTERM

### DIFF
--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -93,9 +93,10 @@ class TestStepThread:
 
         captured = {}
 
-        def fake_save(cache_dir):
+        def fake_save(cache_dir, should_abort=None):
             captured["thread"] = threading.current_thread().name
             captured["cache_dir"] = cache_dir
+            captured["should_abort"] = should_abort
             return True
 
         engine_core.scheduler.save_cache_to_disk.side_effect = fake_save

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -174,6 +174,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # default R2 URL; power users override with any URL or "" to disable.
         # Never consulted by the engine, scheduler, or routing layer.
         "RAPID_MLX_MODEL_MIRROR",
+        # SIGTERM-grace budget (seconds, float) for the lifespan prefix-cache
+        # flush in ``vllm_mlx/runtime/cache.py``. Defaults to 3.5s so a
+        # multi-GB save commits its partial snapshot before downstream
+        # supervisors (rapid-desktop's 5s grace, systemd / Docker / launchd
+        # equivalents) escalate to SIGKILL and orphan ``<cache_dir>.new/``.
+        # Pure deadline knob — never selects model, parser, or tier.
+        "RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET",
     }
 )
 

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1621,22 +1621,44 @@ def test_adapt_should_abort_handles_keyword_only_and_args_kwargs():
     assert adapted(1.5) is False
     assert captured == [1.5]
 
-    # **kwargs: must receive predicted_sec.
+    # **kwargs only: must be called BY KEYWORD as predicted_sec=...
+    # (codex PR #667 round 4 BLOCKING-1: round 3 classified **kwargs
+    # as positional-capable and raised TypeError on call). The
+    # predicate sees the value via ``kw["predicted_sec"]``.
     captured = []
 
-    def pred(**kw):
+    def kw_only_pred(**kw):
         captured.append(kw.get("predicted_sec", "no-arg"))
         return False
 
-    # The adapter passes positionally, so **kwargs alone doesn't get
-    # the value as a kwarg — but the function still gets CALLED with
-    # the right shape (no TypeError). That's the contract being
-    # pinned: no exception raised.
-    adapted = _adapt_should_abort(
-        lambda *a, **kw: captured.append(("args", a)) or False
-    )
+    adapted = _adapt_should_abort(kw_only_pred)
     assert adapted(2.5) is False
-    assert captured == [("args", (2.5,))]
+    assert captured == [2.5], (
+        f"**kwargs predicate must receive predicted_sec by keyword, got {captured}"
+    )
+
+    # Keyword-only ``predicted_sec=...`` — same routing as **kwargs.
+    captured = []
+
+    def kw_only_named(*, predicted_sec=0.0):
+        captured.append(predicted_sec)
+        return False
+
+    adapted = _adapt_should_abort(kw_only_named)
+    assert adapted(3.5) is False
+    assert captured == [3.5]
+
+    # ``*args, **kwargs`` — positional path wins (it accepts positional
+    # via the ``*args`` part).
+    captured = []
+
+    def star_args(*a, **kw):
+        captured.append(("args", a, "kw", kw))
+        return False
+
+    adapted = _adapt_should_abort(star_args)
+    assert adapted(2.5) is False
+    assert captured == [("args", (2.5,), "kw", {})]
 
 
 def test_save_prefix_cache_to_disk_zero_budget_disables_deadline(tmp_path, monkeypatch):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1468,18 +1468,31 @@ def test_save_prefix_cache_to_disk_fallback_for_legacy_engine_signature(monkeypa
     )
 
 
-def test_save_prefix_cache_to_disk_other_typeerror_surfaces(monkeypatch):
-    """The fallback above is gated on the TypeError message mentioning
-    ``should_abort``. Other TypeErrors (e.g. a buggy engine passing
-    wrong positional types) should propagate up so they're visible in
-    logs/CI, not silently swallowed via the legacy retry path.
+def test_save_prefix_cache_to_disk_no_retry_on_internal_typeerror(monkeypatch):
+    """Codex PR #667 round 2 BLOCKING-2 regression.
+
+    The round-1 fallback caught any ``TypeError`` whose message
+    mentioned ``should_abort`` and retried via the legacy signature —
+    a compatible engine raising that error AFTER partial side effects
+    (write to disk, metric increment) would be invoked TWICE, doubling
+    the side effects.
+
+    Round-2 detection is signature-based (``inspect.signature``) up
+    front, so an internal TypeError raised by the engine method body
+    propagates without retry. We assert exactly one call.
     """
     from vllm_mlx import config as _config_mod
     from vllm_mlx.runtime import cache as _cache_mod
 
+    calls = {"n": 0}
+
     class _BuggyEngine:
+        # Signature DOES accept should_abort — so detection passes,
+        # call proceeds, error raised internally must NOT trigger a
+        # legacy-signature retry.
         def save_cache_to_disk(self, cache_dir, should_abort=None):
-            raise TypeError("some unrelated type error in inner save")
+            calls["n"] += 1
+            raise TypeError("internal failure mentioning should_abort somewhere")
 
     class _FakeCfg:
         engine = _BuggyEngine()
@@ -1489,41 +1502,29 @@ def test_save_prefix_cache_to_disk_other_typeerror_surfaces(monkeypatch):
     monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
     monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
 
-    # The runtime wrapper's try/except swallows ``Exception`` for
-    # ``Failed to save cache to disk`` logging — assert via no-raise
-    # behavior + log capture would be flakier than just asserting the
-    # fallback wasn't taken. Use an attribute counter for that.
-    calls = {"n": 0}
-    orig = _BuggyEngine.save_cache_to_disk
-
-    def counting(self, cache_dir, should_abort=None):
-        calls["n"] += 1
-        return orig(self, cache_dir, should_abort=should_abort)
-
-    monkeypatch.setattr(_BuggyEngine, "save_cache_to_disk", counting)
-
     _cache_mod.save_prefix_cache_to_disk(budget_sec=1.0)
     assert calls["n"] == 1, (
-        "fallback must NOT retry on a TypeError that's not about the "
-        f"should_abort kwarg, got {calls['n']} calls"
+        f"engine method must be invoked exactly once even on internal "
+        f"TypeError — round-1 fallback double-called via legacy path, "
+        f"got {calls['n']} calls"
     )
 
 
 def test_save_to_disk_skips_entry_when_predicted_write_exceeds_budget(tmp_path):
-    """Codex PR #667 round 1 BLOCKING-2 — at the ``save_to_disk`` layer.
+    """Codex PR #667 round 1 BLOCKING-2 + round 2 BLOCKING-1.
 
     The per-entry loop must consult the predicate WITH a
     ``predicted_sec`` estimate so a large entry that would straddle
     the deadline never starts its (uninterruptible) ``save_prompt_cache``
-    write. Without this, the failure mode the deadline gate exists to
-    prevent — SIGKILL-during-entry-write → orphaned ``cache_dir.new/``
-    — survives the fix.
+    write. Round 2 refines: entry 0 always passes ``predicted_sec=0``
+    (no observed sample → don't lock ourselves out before saving
+    anything; the round 1 50 MB/s bootstrap floor over-predicted a
+    typical 300 MB entry at 6 s and tripped the budget immediately).
+    Entry 1+ then carries a non-zero forward-looking estimate built
+    from observed bytes/sec.
     """
     cache_dir = tmp_path / "snap"
     cache = fresh_cache()
-    # Three entries; predicate fires only when predicted_sec > 0 so
-    # the loop's forward-looking check is what trips it (not the
-    # at-now check).
     cache.store(list(range(11)), make_kvcache(num_tokens=11))
     cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
     cache.store(list(range(50, 61)), make_kvcache(num_tokens=11, fill=3.0))
@@ -1532,19 +1533,62 @@ def test_save_to_disk_skips_entry_when_predicted_write_exceeds_budget(tmp_path):
 
     def predicate(predicted_sec=0.0):
         seen_predicted.append(predicted_sec)
-        # Trip whenever the caller passes a non-zero estimate — proves
-        # the per-entry loop is feeding the estimator forward.
+        # Trip on the first NON-zero call — entry 0 passes 0
+        # (bootstrap), entry 1+ passes the observed-throughput
+        # estimate. The transition from 0 → >0 is what proves the
+        # forward-looking machinery is in place.
         return predicted_sec > 0
 
-    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is False
-    assert seen_predicted, (
-        "the per-entry loop must call should_abort(predicted_sec=...) "
-        "at least once — codex PR #667 BLOCKING-2: without the "
-        "predicted_sec arg the loop can straddle the deadline"
+    # Entry 0 saves (predicted=0 → predicate False), entry 1 trips
+    # (predicted>0 → predicate True), commit. saved=1 → returns True.
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+    assert len(seen_predicted) >= 2, (
+        f"loop should call predicate for entry 0 AND entry 1, got {seen_predicted}"
     )
-    assert seen_predicted[0] > 0, (
-        f"first call should pass a non-zero predicted_sec (bootstrap "
-        f"estimate from the floor throughput), got {seen_predicted[0]}"
+    assert seen_predicted[0] == 0.0, (
+        f"entry 0 should receive predicted_sec=0 (no observed sample "
+        f"yet — round 2 BLOCKING-1 fix), got {seen_predicted[0]}"
+    )
+    assert seen_predicted[1] > 0, (
+        f"entry 1 should receive predicted_sec>0 from observed "
+        f"throughput — proves the loop is updating its rate estimate "
+        f"between entries, got {seen_predicted[1]}"
+    )
+    # Entry 0 was committed via atomic rename.
+    assert not (tmp_path / "snap.new").exists()
+    assert (cache_dir / "index.json").exists()
+    index = json.loads((cache_dir / "index.json").read_text())
+    assert index["num_entries"] == 1
+
+
+def test_save_to_disk_entry_zero_attempts_when_no_observed_throughput(tmp_path):
+    """Codex PR #667 round 2 BLOCKING-1 regression, pinned at the layer
+    where the bug lived.
+
+    Direct proof that the round-1 bootstrap floor regression is gone:
+    with a generous 60 s budget and a predicate that fires ONLY when
+    the predicate receives a non-zero ``predicted_sec``, the previous
+    code (50 MB/s bootstrap) would have predicted entry 0 at a few
+    hundred ms (well within budget) and saved it anyway — so a
+    targeted test catches the FAILURE mode (saves nothing because
+    bootstrap over-predicts) only by pinning the "predicted_sec is 0
+    for entry 0" invariant directly.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+
+    seen_predicted = []
+
+    def predicate(predicted_sec=0.0):
+        seen_predicted.append(predicted_sec)
+        return False  # never trip — we just want to record the calls
+
+    cache.save_to_disk(str(cache_dir), should_abort=predicate)
+    assert seen_predicted == [0.0], (
+        f"entry 0 must be called with predicted_sec=0 — the round-1 "
+        f"50 MB/s bootstrap floor over-predicted typical entries and "
+        f"tripped budget before any save. Got {seen_predicted}"
     )
 
 

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1510,86 +1510,133 @@ def test_save_prefix_cache_to_disk_no_retry_on_internal_typeerror(monkeypatch):
     )
 
 
-def test_save_to_disk_skips_entry_when_predicted_write_exceeds_budget(tmp_path):
-    """Codex PR #667 round 1 BLOCKING-2 + round 2 BLOCKING-1.
+def test_save_to_disk_predicts_entry_zero_from_bootstrap_floor(tmp_path):
+    """Codex PR #667 round 3 BLOCKING-1.
 
-    The per-entry loop must consult the predicate WITH a
-    ``predicted_sec`` estimate so a large entry that would straddle
-    the deadline never starts its (uninterruptible) ``save_prompt_cache``
-    write. Round 2 refines: entry 0 always passes ``predicted_sec=0``
-    (no observed sample → don't lock ourselves out before saving
-    anything; the round 1 50 MB/s bootstrap floor over-predicted a
-    typical 300 MB entry at 6 s and tripped the budget immediately).
-    Entry 1+ then carries a non-zero forward-looking estimate built
-    from observed bytes/sec.
+    Entry 0 must receive a non-zero forward-looking ``predicted_sec``
+    derived from the 150 MB/s bootstrap floor — round 2 passed 0 here
+    and let a catastrophically large first entry straddle the SIGTERM
+    grace deadline, leaving ``cache_dir.new/`` orphaned. The estimate
+    scales with ``entry.memory_bytes`` so a too-large entry-0 trips
+    BEFORE its (uninterruptible) ``save_prompt_cache`` call starts.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+
+    seen_predicted = []
+
+    def predicate(predicted_sec=0.0):
+        seen_predicted.append(predicted_sec)
+        return False  # never trip — just record what the loop sends
+
+    cache.save_to_disk(str(cache_dir), should_abort=predicate)
+    assert len(seen_predicted) == 1
+    assert seen_predicted[0] > 0, (
+        f"entry 0 must receive a non-zero predicted_sec (bootstrap "
+        f"150 MB/s × entry size) — round 2 used 0 here and let huge "
+        f"entries straddle the deadline (codex round 3 BLOCKING-1). "
+        f"Got {seen_predicted[0]}"
+    )
+
+
+def test_save_to_disk_skips_entry_zero_when_predicted_exceeds_budget(tmp_path):
+    """Forward-looking check now fires on entry 0 — proves a
+    catastrophically large first entry can't straddle the deadline.
+
+    Predicate trips on any non-trivial ``predicted_sec``. Result:
+    ``saved == 0`` because even entry 0 is gated, and ``save_to_disk``
+    returns False with the staging dir cleaned up (not committed
+    empty, not left as an orphan).
     """
     cache_dir = tmp_path / "snap"
     cache = fresh_cache()
     cache.store(list(range(11)), make_kvcache(num_tokens=11))
     cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
-    cache.store(list(range(50, 61)), make_kvcache(num_tokens=11, fill=3.0))
 
     seen_predicted = []
 
     def predicate(predicted_sec=0.0):
         seen_predicted.append(predicted_sec)
-        # Trip on the first NON-zero call — entry 0 passes 0
-        # (bootstrap), entry 1+ passes the observed-throughput
-        # estimate. The transition from 0 → >0 is what proves the
-        # forward-looking machinery is in place.
-        return predicted_sec > 0
+        return predicted_sec > 0  # trip on any forward-looking estimate
 
-    # Entry 0 saves (predicted=0 → predicate False), entry 1 trips
-    # (predicted>0 → predicate True), commit. saved=1 → returns True.
-    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
-    assert len(seen_predicted) >= 2, (
-        f"loop should call predicate for entry 0 AND entry 1, got {seen_predicted}"
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is False
+    assert len(seen_predicted) == 1, (
+        f"loop should abort on first predicate trip (entry 0), got "
+        f"{len(seen_predicted)} calls"
     )
-    assert seen_predicted[0] == 0.0, (
-        f"entry 0 should receive predicted_sec=0 (no observed sample "
-        f"yet — round 2 BLOCKING-1 fix), got {seen_predicted[0]}"
-    )
-    assert seen_predicted[1] > 0, (
-        f"entry 1 should receive predicted_sec>0 from observed "
-        f"throughput — proves the loop is updating its rate estimate "
-        f"between entries, got {seen_predicted[1]}"
-    )
-    # Entry 0 was committed via atomic rename.
+    assert not (tmp_path / "snap").exists()
     assert not (tmp_path / "snap.new").exists()
-    assert (cache_dir / "index.json").exists()
-    index = json.loads((cache_dir / "index.json").read_text())
-    assert index["num_entries"] == 1
 
 
-def test_save_to_disk_entry_zero_attempts_when_no_observed_throughput(tmp_path):
-    """Codex PR #667 round 2 BLOCKING-1 regression, pinned at the layer
-    where the bug lived.
+def test_save_to_disk_accepts_zero_arg_predicate_back_compat(tmp_path):
+    """Codex PR #667 round 3 BLOCKING-2 regression.
 
-    Direct proof that the round-1 bootstrap floor regression is gone:
-    with a generous 60 s budget and a predicate that fires ONLY when
-    the predicate receives a non-zero ``predicted_sec``, the previous
-    code (50 MB/s bootstrap) would have predicted entry 0 at a few
-    hundred ms (well within budget) and saved it anyway — so a
-    targeted test catches the FAILURE mode (saves nothing because
-    bootstrap over-predicts) only by pinning the "predicted_sec is 0
-    for entry 0" invariant directly.
+    Round-1 docstrings described ``should_abort`` as a zero-arg
+    callable. Round-2 changed the loop to ``should_abort(predicted_sec)``
+    but external callers / older fixtures may still pass a zero-arg
+    predicate. The auto-adapter in ``_adapt_should_abort`` must handle
+    both shapes without raising ``TypeError``.
     """
     cache_dir = tmp_path / "snap"
     cache = fresh_cache()
     cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
 
-    seen_predicted = []
+    calls = {"n": 0}
 
-    def predicate(predicted_sec=0.0):
-        seen_predicted.append(predicted_sec)
-        return False  # never trip — we just want to record the calls
+    # Deliberately ZERO-ARG predicate — the round-1 documented shape.
+    def predicate():
+        calls["n"] += 1
+        return calls["n"] > 1  # save entry 0, abort entry 1
 
-    cache.save_to_disk(str(cache_dir), should_abort=predicate)
-    assert seen_predicted == [0.0], (
-        f"entry 0 must be called with predicted_sec=0 — the round-1 "
-        f"50 MB/s bootstrap floor over-predicted typical entries and "
-        f"tripped budget before any save. Got {seen_predicted}"
+    # Must not raise. Must save entry 0 and commit via rename.
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+    assert calls["n"] >= 2
+    assert not (tmp_path / "snap.new").exists()
+    index = json.loads((cache_dir / "index.json").read_text())
+    assert index["num_entries"] == 1
+
+
+def test_adapt_should_abort_handles_keyword_only_and_args_kwargs():
+    """``_adapt_should_abort`` must classify a few non-obvious callable
+    shapes correctly. Regressions here would silently call the wrong
+    shape and either raise TypeError mid-save or drop the
+    ``predicted_sec`` arg (re-introducing the round-1 BLOCKING-2 bug).
+    """
+    from vllm_mlx.memory_cache import _adapt_should_abort
+
+    # None passes through.
+    assert _adapt_should_abort(None) is None
+
+    # Zero-arg: must be called with no args.
+    captured = []
+    adapted = _adapt_should_abort(lambda: captured.append("z") or True)
+    assert adapted(0.5) is True
+    assert captured == ["z"]
+
+    # One-arg positional: must receive predicted_sec.
+    captured = []
+    adapted = _adapt_should_abort(lambda p: captured.append(p) or False)
+    assert adapted(1.5) is False
+    assert captured == [1.5]
+
+    # **kwargs: must receive predicted_sec.
+    captured = []
+
+    def pred(**kw):
+        captured.append(kw.get("predicted_sec", "no-arg"))
+        return False
+
+    # The adapter passes positionally, so **kwargs alone doesn't get
+    # the value as a kwarg — but the function still gets CALLED with
+    # the right shape (no TypeError). That's the contract being
+    # pinned: no exception raised.
+    adapted = _adapt_should_abort(
+        lambda *a, **kw: captured.append(("args", a)) or False
     )
+    assert adapted(2.5) is False
+    assert captured == [("args", (2.5,))]
 
 
 def test_save_prefix_cache_to_disk_zero_budget_disables_deadline(tmp_path, monkeypatch):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1151,3 +1151,213 @@ def test_save_aborts_on_post_filter_dir_loss(tmp_path, monkeypatch):
     )
     # No half-baked cache_dir should have been created
     assert not (cache_dir / "index.json").exists()
+
+
+# --------------------------------------------------------------------------
+# Shutdown-deadline ("should_abort") partial-commit path
+# --------------------------------------------------------------------------
+#
+# Rapid-desktop only gives the rapid-mlx sidecar ~5s between SIGTERM and
+# SIGKILL. The previous synchronous flush would write entries linearly,
+# get SIGKILLed mid-write, and leave ``<cache_dir>.new/`` orphaned on
+# disk — no cache survives to the next launch. The fix lets the lifespan
+# pass a ``should_abort`` predicate down to the per-entry loop; when it
+# trips the loop stops and STILL commits the entries that did finish via
+# the atomic directory-rename swap.
+
+
+def test_save_to_disk_partial_commit_on_abort(tmp_path):
+    """should_abort fires after one entry — staging dir must still be
+    committed via atomic rename and the surviving entry must be
+    loadable on the next session.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    # Three entries; the predicate will fire after the first finishes.
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
+    cache.store(list(range(50, 61)), make_kvcache(num_tokens=11, fill=3.0))
+
+    calls = {"n": 0}
+
+    def predicate():
+        # Fire from the second invocation onward so entry 0 lands but
+        # entries 1 and 2 are skipped.
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+
+    # Critical invariant: the staging dir is gone — committed via rename.
+    assert not (tmp_path / "snap.new").exists(), (
+        "should_abort path must still run the atomic-rename swap so the "
+        "staging dir is never left orphaned — that's the whole point of "
+        "the fix vs. the pre-existing SIGKILL behavior"
+    )
+    # And the committed dir holds the surviving entry plus a consistent index.
+    assert (cache_dir / "index.json").exists()
+    index = json.loads((cache_dir / "index.json").read_text())
+    assert index["num_entries"] == 1
+    assert len(index["entries"]) == 1
+    assert (cache_dir / "entry_0.safetensors").exists()
+    assert (cache_dir / "entry_0_tokens.bin").exists()
+
+    # Re-loading must succeed and surface exactly the entry that survived.
+    cache2 = fresh_cache()
+    loaded = cache2.load_from_disk(str(cache_dir))
+    assert loaded == 1
+    entry = next(iter(cache2._entries.values()))
+    assert entry.tokens == tuple(range(11))
+
+
+def test_save_to_disk_aborts_before_first_entry_returns_false(tmp_path):
+    """If the deadline already passed before the first write, ``should_abort``
+    fires immediately, ``saved == 0``, and the staging dir is cleaned up
+    rather than committed empty. Matches the existing "no entries saved
+    successfully, aborting" branch.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=lambda: True) is False
+    assert not cache_dir.exists()
+    assert not (tmp_path / "snap.new").exists()
+
+
+def test_save_to_disk_predicate_none_preserves_full_flush(tmp_path):
+    """Passing ``should_abort=None`` must be equivalent to the legacy call
+    shape — all entries get written, no early break. Protects the offline
+    ``rapid-mlx`` CLI path and the existing tests from regressing.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=None) is True
+    index = json.loads((cache_dir / "index.json").read_text())
+    assert index["num_entries"] == 2
+    assert (cache_dir / "entry_0.safetensors").exists()
+    assert (cache_dir / "entry_1.safetensors").exists()
+
+
+def test_save_prefix_cache_to_disk_runs_off_event_loop(tmp_path, monkeypatch):
+    """Regression for the lifespan shutdown bug: ``save_prefix_cache_to_disk``
+    must be wrapped in ``asyncio.to_thread`` so the asyncio loop stays
+    responsive while the multi-GB flush streams to disk.
+
+    Shape: pretend the engine takes 1 second to flush. Drive a tiny
+    coroutine that fires the save AND, on the same loop, polls a
+    monotonic counter every 50ms. Assert the counter advances multiple
+    times concurrently with the save — i.e. the loop wasn't blocked.
+    """
+    import asyncio
+    import time as _time
+
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    class _SlowEngine:
+        def save_cache_to_disk(self, cache_dir, should_abort=None):
+            # Block for ~600ms on the worker thread — caller is supposed
+            # to wrap us in asyncio.to_thread so the loop keeps spinning.
+            _time.sleep(0.6)
+            return True
+
+    class _FakeCfg:
+        engine = _SlowEngine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    async def _drive():
+        ticks: list[float] = []
+        t0 = _time.monotonic()
+
+        async def _ticker():
+            while _time.monotonic() - t0 < 0.6:
+                ticks.append(_time.monotonic() - t0)
+                await asyncio.sleep(0.05)
+
+        # Mimic the lifespan shutdown call shape exactly.
+        await asyncio.gather(
+            asyncio.to_thread(_cache_mod.save_prefix_cache_to_disk),
+            _ticker(),
+        )
+        return ticks
+
+    ticks = asyncio.run(_drive())
+    # If the save was running on the loop thread, the ticker wouldn't
+    # have produced more than a single tick before the save returned;
+    # with asyncio.to_thread the ticker advances every ~50ms.
+    assert len(ticks) >= 5, (
+        f"event loop was blocked during cache flush — only saw {len(ticks)} "
+        f"ticks in 600ms (expected ≥5). Did the lifespan shutdown lose its "
+        f"asyncio.to_thread wrap?"
+    )
+
+
+def test_save_prefix_cache_to_disk_respects_budget(tmp_path, monkeypatch):
+    """``save_prefix_cache_to_disk`` must build a deadline predicate from
+    the budget arg and forward it as ``should_abort`` to the engine. With
+    a 0.1s budget and a save that takes ≥0.2s to even get its first
+    callback, the predicate is True on first call.
+    """
+    import time as _time
+
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    captured = {"pred": None}
+
+    class _Engine:
+        def save_cache_to_disk(self, cache_dir, should_abort=None):
+            captured["pred"] = should_abort
+            # Sleep past the deadline so the predicate is guaranteed True.
+            _time.sleep(0.25)
+            return False
+
+    class _FakeCfg:
+        engine = _Engine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=0.1)
+    pred = captured["pred"]
+    assert pred is not None, (
+        "save_prefix_cache_to_disk must pass a should_abort predicate"
+    )
+    assert pred() is True, "deadline-backed predicate should be tripped after sleep"
+
+
+def test_save_prefix_cache_to_disk_zero_budget_disables_deadline(tmp_path, monkeypatch):
+    """A budget of 0 (or negative) means "full flush, no deadline" — the
+    engine should receive ``should_abort=None`` so the offline CLI path
+    is unaffected.
+    """
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    captured = {"pred": "unset"}
+
+    class _Engine:
+        def save_cache_to_disk(self, cache_dir, should_abort=None):
+            captured["pred"] = should_abort
+            return True
+
+    class _FakeCfg:
+        engine = _Engine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=0.0)
+    assert captured["pred"] is None

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1180,9 +1180,13 @@ def test_save_to_disk_partial_commit_on_abort(tmp_path):
 
     calls = {"n": 0}
 
-    def predicate():
+    def predicate(predicted_sec=0.0):
         # Fire from the second invocation onward so entry 0 lands but
-        # entries 1 and 2 are skipped.
+        # entries 1 and 2 are skipped. Accepts ``predicted_sec`` to
+        # match the forward-looking predicate contract added in PR
+        # #667 round 2 — production callers pass an estimated per-
+        # entry write duration; this test ignores it and gates on
+        # call count for deterministic single-vs-multi-entry behavior.
         calls["n"] += 1
         return calls["n"] > 1
 
@@ -1220,7 +1224,13 @@ def test_save_to_disk_aborts_before_first_entry_returns_false(tmp_path):
     cache = fresh_cache()
     cache.store(list(range(11)), make_kvcache(num_tokens=11))
 
-    assert cache.save_to_disk(str(cache_dir), should_abort=lambda: True) is False
+    assert (
+        cache.save_to_disk(
+            str(cache_dir),
+            should_abort=lambda predicted_sec=0.0: True,
+        )
+        is False
+    )
     assert not cache_dir.exists()
     assert not (tmp_path / "snap.new").exists()
 
@@ -1242,26 +1252,35 @@ def test_save_to_disk_predicate_none_preserves_full_flush(tmp_path):
     assert (cache_dir / "entry_1.safetensors").exists()
 
 
-def test_save_prefix_cache_to_disk_runs_off_event_loop(tmp_path, monkeypatch):
-    """Regression for the lifespan shutdown bug: ``save_prefix_cache_to_disk``
-    must be wrapped in ``asyncio.to_thread`` so the asyncio loop stays
-    responsive while the multi-GB flush streams to disk.
+def test_shutdown_save_prefix_cache_runs_off_event_loop(tmp_path, monkeypatch):
+    """Regression for the lifespan shutdown bug, pinned at the production
+    callsite.
 
-    Shape: pretend the engine takes 1 second to flush. Drive a tiny
-    coroutine that fires the save AND, on the same loop, polls a
-    monotonic counter every 50ms. Assert the counter advances multiple
-    times concurrently with the save — i.e. the loop wasn't blocked.
+    Drives ``server._shutdown_save_prefix_cache`` directly — NOT a
+    test-local ``asyncio.to_thread`` wrapper around the save function.
+    Codex flagged PR #667 round 1 because the prior shape wrapped
+    ``to_thread`` test-side, so a regression that dropped the wrapper
+    from the lifespan helper would still pass. This version exercises
+    the helper that's literally what ``lifespan`` awaits — if anyone
+    replaces the ``await asyncio.to_thread(...)`` line in
+    ``_shutdown_save_prefix_cache`` with a direct call, the slow fake
+    engine below blocks the loop and the ticker count drops to 1.
+
+    Shape: pretend the engine takes ~600ms to flush. Drive the helper
+    AND a 50ms ticker concurrently. Assert the ticker advances
+    multiple times — i.e. the loop wasn't blocked.
     """
     import asyncio
     import time as _time
 
     from vllm_mlx import config as _config_mod
+    from vllm_mlx import server as _server_mod
     from vllm_mlx.runtime import cache as _cache_mod
 
     class _SlowEngine:
         def save_cache_to_disk(self, cache_dir, should_abort=None):
-            # Block for ~600ms on the worker thread — caller is supposed
-            # to wrap us in asyncio.to_thread so the loop keeps spinning.
+            # Block for ~600ms on the worker thread — production wrap
+            # is asyncio.to_thread so the loop stays responsive.
             _time.sleep(0.6)
             return True
 
@@ -1272,6 +1291,11 @@ def test_save_prefix_cache_to_disk_runs_off_event_loop(tmp_path, monkeypatch):
 
     monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
     monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+    # ``_shutdown_save_prefix_cache`` checks ``_engine is not None``
+    # AND ``hasattr(_engine, "save_cache_to_disk")`` before delegating
+    # to the runtime save. Substitute a stub that satisfies both so
+    # the helper actually runs.
+    monkeypatch.setattr(_server_mod, "_engine", _SlowEngine())
 
     async def _drive():
         ticks: list[float] = []
@@ -1282,22 +1306,36 @@ def test_save_prefix_cache_to_disk_runs_off_event_loop(tmp_path, monkeypatch):
                 ticks.append(_time.monotonic() - t0)
                 await asyncio.sleep(0.05)
 
-        # Mimic the lifespan shutdown call shape exactly.
+        # Drive the production lifespan helper as-is. Don't wrap it
+        # in asyncio.to_thread out here — that would re-introduce the
+        # original bug the test exists to catch.
         await asyncio.gather(
-            asyncio.to_thread(_cache_mod.save_prefix_cache_to_disk),
+            _server_mod._shutdown_save_prefix_cache(),
             _ticker(),
         )
         return ticks
 
     ticks = asyncio.run(_drive())
-    # If the save was running on the loop thread, the ticker wouldn't
-    # have produced more than a single tick before the save returned;
-    # with asyncio.to_thread the ticker advances every ~50ms.
     assert len(ticks) >= 5, (
         f"event loop was blocked during cache flush — only saw {len(ticks)} "
-        f"ticks in 600ms (expected ≥5). Did the lifespan shutdown lose its "
-        f"asyncio.to_thread wrap?"
+        f"ticks in 600ms (expected ≥5). Did _shutdown_save_prefix_cache "
+        f"lose its asyncio.to_thread wrap?"
     )
+
+
+def test_shutdown_save_prefix_cache_no_op_when_engine_missing(monkeypatch):
+    """Companion guard: when ``server._engine`` is None (no model loaded
+    yet at shutdown, or already torn down), the helper returns silently
+    instead of blowing up with AttributeError. This is the production
+    failure mode for ``rapid-mlx serve --help`` lifecycle interruption
+    where shutdown lands before startup finished.
+    """
+    import asyncio
+
+    from vllm_mlx import server as _server_mod
+
+    monkeypatch.setattr(_server_mod, "_engine", None)
+    asyncio.run(_server_mod._shutdown_save_prefix_cache())  # must not raise
 
 
 def test_save_prefix_cache_to_disk_respects_budget(tmp_path, monkeypatch):
@@ -1334,6 +1372,180 @@ def test_save_prefix_cache_to_disk_respects_budget(tmp_path, monkeypatch):
         "save_prefix_cache_to_disk must pass a should_abort predicate"
     )
     assert pred() is True, "deadline-backed predicate should be tripped after sleep"
+
+
+def test_save_prefix_cache_to_disk_predicate_is_forward_looking(tmp_path, monkeypatch):
+    """Codex PR #667 round 1 BLOCKING-2 regression.
+
+    The predicate must accept a ``predicted_sec`` argument and return
+    True when starting that operation would push past the budget — not
+    just when wall-clock has already crossed the deadline. Without
+    this shape, a single 300 MB ``save_prompt_cache`` call lasting 2 s
+    can straddle a 3.5 s budget and get SIGKILL'd mid-write, leaving
+    ``cache_dir.new/`` orphaned. We exercise the contract directly so
+    a regression that drops the kwarg fails locally instead of
+    presenting as "rare orphan dir on shutdown" in production.
+    """
+    import time as _time
+
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    captured = {"pred": None}
+
+    class _Engine:
+        def save_cache_to_disk(self, cache_dir, should_abort=None):
+            captured["pred"] = should_abort
+            return False
+
+    class _FakeCfg:
+        engine = _Engine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    # 2 s budget — comfortably under the headroom-padded deadline (so
+    # the at-deadline check is False) but a 5 s predicted operation
+    # blows past it.
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=2.0)
+    pred = captured["pred"]
+    assert pred is not None
+    assert pred(predicted_sec=0.0) is False, (
+        "predicate fires too eagerly — a 2s budget shouldn't trip at t=0 "
+        "with no predicted duration"
+    )
+    assert pred(predicted_sec=5.0) is True, (
+        "predicate must look forward: starting a 5s op under a 2s budget "
+        "should abort BEFORE the op begins, not let it straddle the deadline"
+    )
+    # Sanity: the no-arg call shape (legacy `should_abort()`) also still
+    # works thanks to the default arg, but should NOT trip at t=0.
+    # This keeps tests / callers that don't yet pass predicted_sec
+    # compatible during the transition.
+    _ = pred()
+    # Wait past the deadline (minus headroom) — at-now check should now trip.
+    _time.sleep(2.0)
+    assert pred() is True, "at-now check should trip after wall-clock past deadline"
+
+
+def test_save_prefix_cache_to_disk_fallback_for_legacy_engine_signature(monkeypatch):
+    """Codex PR #667 round 1 BLOCKING-1 regression.
+
+    External / third-party engine implementations may still expose the
+    legacy one-argument ``save_cache_to_disk(cache_dir)`` signature.
+    The runtime helper unconditionally passes ``should_abort=`` which
+    would raise ``TypeError`` against those engines, losing the entire
+    save. The fallback retries the call with the legacy positional
+    shape — losing deadline awareness, but preserving the save.
+    """
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    calls = []
+
+    class _LegacyEngine:
+        # Note: no ``should_abort`` kwarg — emulates a pre-#667 plugin.
+        def save_cache_to_disk(self, cache_dir):
+            calls.append(cache_dir)
+            return True
+
+    class _FakeCfg:
+        engine = _LegacyEngine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    # Must not raise. Must reach the engine. Must not crash the
+    # lifespan shutdown.
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=1.0)
+    assert len(calls) == 1, (
+        "legacy engine should be invoked once after the deadline-aware "
+        "call's TypeError is caught + fallback retried"
+    )
+
+
+def test_save_prefix_cache_to_disk_other_typeerror_surfaces(monkeypatch):
+    """The fallback above is gated on the TypeError message mentioning
+    ``should_abort``. Other TypeErrors (e.g. a buggy engine passing
+    wrong positional types) should propagate up so they're visible in
+    logs/CI, not silently swallowed via the legacy retry path.
+    """
+    from vllm_mlx import config as _config_mod
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    class _BuggyEngine:
+        def save_cache_to_disk(self, cache_dir, should_abort=None):
+            raise TypeError("some unrelated type error in inner save")
+
+    class _FakeCfg:
+        engine = _BuggyEngine()
+        model_path = "fake/model"
+        model_name = None
+
+    monkeypatch.setattr(_cache_mod, "get_config", lambda: _FakeCfg())
+    monkeypatch.setattr(_config_mod, "get_config", lambda: _FakeCfg())
+
+    # The runtime wrapper's try/except swallows ``Exception`` for
+    # ``Failed to save cache to disk`` logging — assert via no-raise
+    # behavior + log capture would be flakier than just asserting the
+    # fallback wasn't taken. Use an attribute counter for that.
+    calls = {"n": 0}
+    orig = _BuggyEngine.save_cache_to_disk
+
+    def counting(self, cache_dir, should_abort=None):
+        calls["n"] += 1
+        return orig(self, cache_dir, should_abort=should_abort)
+
+    monkeypatch.setattr(_BuggyEngine, "save_cache_to_disk", counting)
+
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=1.0)
+    assert calls["n"] == 1, (
+        "fallback must NOT retry on a TypeError that's not about the "
+        f"should_abort kwarg, got {calls['n']} calls"
+    )
+
+
+def test_save_to_disk_skips_entry_when_predicted_write_exceeds_budget(tmp_path):
+    """Codex PR #667 round 1 BLOCKING-2 — at the ``save_to_disk`` layer.
+
+    The per-entry loop must consult the predicate WITH a
+    ``predicted_sec`` estimate so a large entry that would straddle
+    the deadline never starts its (uninterruptible) ``save_prompt_cache``
+    write. Without this, the failure mode the deadline gate exists to
+    prevent — SIGKILL-during-entry-write → orphaned ``cache_dir.new/``
+    — survives the fix.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    # Three entries; predicate fires only when predicted_sec > 0 so
+    # the loop's forward-looking check is what trips it (not the
+    # at-now check).
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+    cache.store(list(range(20, 31)), make_kvcache(num_tokens=11, fill=2.0))
+    cache.store(list(range(50, 61)), make_kvcache(num_tokens=11, fill=3.0))
+
+    seen_predicted = []
+
+    def predicate(predicted_sec=0.0):
+        seen_predicted.append(predicted_sec)
+        # Trip whenever the caller passes a non-zero estimate — proves
+        # the per-entry loop is feeding the estimator forward.
+        return predicted_sec > 0
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is False
+    assert seen_predicted, (
+        "the per-entry loop must call should_abort(predicted_sec=...) "
+        "at least once — codex PR #667 BLOCKING-2: without the "
+        "predicted_sec arg the loop can straddle the deadline"
+    )
+    assert seen_predicted[0] > 0, (
+        f"first call should pass a non-zero predicted_sec (bootstrap "
+        f"estimate from the floor throughput), got {seen_predicted[0]}"
+    )
 
 
 def test_save_prefix_cache_to_disk_zero_budget_disables_deadline(tmp_path, monkeypatch):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1778,10 +1778,15 @@ class BatchedEngine(BaseEngine):
             return result
         return False
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
-        """Save prefix cache to disk for persistence across restarts."""
+    def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:
+        """Save prefix cache to disk for persistence across restarts.
+
+        ``should_abort`` is forwarded to the underlying engine so the
+        lifespan SIGTERM-grace deadline can short-circuit a multi-GB
+        flush; see ``EngineCore.save_cache_to_disk`` for details.
+        """
         if self._engine:
-            return self._engine.save_cache_to_disk(cache_dir)
+            return self._engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
         return False
 
     def load_cache_from_disk(self, cache_dir: str) -> int:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -993,15 +993,23 @@ class EngineCore:
         """Get prefix cache statistics."""
         return self.scheduler.get_cache_stats()
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
+    def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:
         """Save prefix cache to disk.
 
         Routed through the mlx-step worker thread because the KV-cache
         arrays are tagged with that thread's generation_stream; trying to
         materialize them from the asyncio loop thread raises
         "There is no Stream(gpu, N) in current thread."
+
+        ``should_abort`` is a zero-arg callable evaluated between entries
+        inside ``MemoryAwarePrefixCache.save_to_disk``. The lifespan
+        shutdown plumbs a deadline-backed predicate through so a
+        multi-GB flush can commit early instead of being SIGKILLed
+        mid-write and leaving ``cache_dir.new/`` orphaned.
         """
-        return self._run_on_step_thread(self.scheduler.save_cache_to_disk, cache_dir)
+        return self._run_on_step_thread(
+            self.scheduler.save_cache_to_disk, cache_dir, should_abort=should_abort
+        )
 
     def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk.
@@ -1153,9 +1161,9 @@ class AsyncEngineCore:
         """Get prefix cache statistics."""
         return self.engine.get_cache_stats()
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
+    def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:
         """Save prefix cache to disk."""
-        return self.engine.save_cache_to_disk(cache_dir)
+        return self.engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
 
     def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk."""

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1001,11 +1001,16 @@ class EngineCore:
         materialize them from the asyncio loop thread raises
         "There is no Stream(gpu, N) in current thread."
 
-        ``should_abort`` is a zero-arg callable evaluated between entries
-        inside ``MemoryAwarePrefixCache.save_to_disk``. The lifespan
-        shutdown plumbs a deadline-backed predicate through so a
-        multi-GB flush can commit early instead of being SIGKILLed
-        mid-write and leaving ``cache_dir.new/`` orphaned.
+        ``should_abort`` is a ``Callable[[float], bool]`` evaluated
+        between entries inside ``MemoryAwarePrefixCache.save_to_disk``.
+        The ``float`` arg is the predicted write duration of the NEXT
+        entry — the predicate answers "would starting that write push
+        us past the deadline?" so a single uninterruptible
+        ``save_prompt_cache`` call can't straddle the deadline and
+        still get SIGKILLed mid-write (the round-1 at-now check could).
+        Zero-arg predicates are accepted for backwards compatibility
+        via auto-detection; the deadline-backed predicate the lifespan
+        plumbs through is one-arg.
         """
         return self._run_on_step_thread(
             self.scheduler.save_cache_to_disk, cache_dir, should_abort=should_abort

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -45,6 +45,50 @@ _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 _MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
 
 
+def _adapt_should_abort(predicate):
+    """Adapt a ``should_abort`` predicate to the one-arg contract.
+
+    The forward-looking shape ``Callable[[float], bool]`` is the new
+    contract, but external callers / older fixtures may pass a
+    zero-arg ``Callable[[], bool]`` from the round-1 docstring.
+    Inspect the signature once and return a normalized
+    ``Callable[[float], bool]`` that calls the inner predicate
+    correctly. ``None`` passes through unchanged.
+
+    Codex PR #667 round 3 BLOCKING-2: round-2 unconditionally called
+    ``should_abort(predicted_sec)`` which raises ``TypeError`` against
+    zero-arg predicates documented in the previous contract.
+    """
+    if predicate is None:
+        return None
+
+    import inspect
+
+    try:
+        sig = inspect.signature(predicate)
+    except (TypeError, ValueError):
+        # Builtin / C-extension / partial — assume one-arg shape
+        # (it's the contract going forward); a runtime TypeError on
+        # invocation is no worse than what callers got before.
+        return lambda predicted_sec: predicate(predicted_sec)
+
+    # Does the predicate accept ANY positional / keyword arg?
+    accepts_arg = any(
+        p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.VAR_KEYWORD,
+        )
+        for p in sig.parameters.values()
+    )
+    if accepts_arg:
+        return lambda predicted_sec: predicate(predicted_sec)
+    return lambda predicted_sec: predicate()
+
+
 def _safetensors_is_complete(path: str) -> bool:
     """Validate a safetensors file is at least as long as its header claims.
 
@@ -1172,19 +1216,35 @@ class MemoryAwarePrefixCache:
         Args:
             cache_dir: Final committed directory path (``.new`` / ``.old``
                 staging dirs are siblings).
-            should_abort: Optional zero-arg callable that returns True when
-                the caller wants the save loop to stop early — used by the
-                lifespan shutdown to enforce a SIGTERM-grace deadline so a
-                multi-GB save doesn't get SIGKILLed mid-flight and leave
-                ``cache_dir.new/`` orphaned (rapid-desktop only gives the
-                sidecar ~5s before SIGKILL). When the callable trips, the
-                loop stops, the entries that did finish are verified, and
-                the staging dir is committed via the same atomic rename as
-                a normal save — so a partial result is preferable to the
-                previous behavior (truncated mid-entry → orphaned ``.new``
-                → lost cache on next launch). A None value preserves the
-                pre-existing "save everything, no deadline" behavior used
-                by tests and the offline ``rapid-mlx`` CLI.
+            should_abort: Optional ``Callable[[float], bool]`` that returns
+                True when the caller wants the save loop to stop early. The
+                ``float`` arg is ``predicted_sec`` — the per-entry loop's
+                estimate of how long the NEXT entry's write will take, so
+                the predicate can answer "would starting that operation
+                push us past the deadline?" rather than only firing AFTER
+                wall-clock has already crossed it (codex PR #667 round 1
+                BLOCKING-2 — a single uninterruptible 300 MB
+                ``save_prompt_cache`` call can straddle the deadline and
+                still get SIGKILL'd mid-write if the check is at-now only).
+
+                Used by the lifespan shutdown to enforce a SIGTERM-grace
+                deadline so a multi-GB save doesn't get SIGKILLed mid-
+                flight and leave ``cache_dir.new/`` orphaned (rapid-
+                desktop only gives the sidecar ~5s before SIGKILL). When
+                the callable trips, the loop stops, the entries that did
+                finish are verified, and the staging dir is committed via
+                the same atomic rename as a normal save — so a partial
+                result is preferable to the previous behavior (truncated
+                mid-entry → orphaned ``.new`` → lost cache on next
+                launch).
+
+                Backwards-compatible: a zero-arg ``Callable[[], bool]``
+                (the round-1 documented shape) is auto-adapted via
+                ``_adapt_should_abort`` so external callers / older
+                fixtures don't break — see codex round 3 BLOCKING-2.
+                A ``None`` value preserves the pre-existing "save
+                everything, no deadline" behavior used by tests and the
+                offline ``rapid-mlx`` CLI.
 
         Returns True if at least one entry was committed to disk.
         """
@@ -1244,28 +1304,37 @@ class MemoryAwarePrefixCache:
         # deadline and get SIGKILL'd mid-write (leaves ``cache_dir.new/``
         # orphaned; this is the bug the deadline gate exists to prevent).
         #
-        # Entry 0 gets ``predicted_sec=0`` — no observed sample yet,
-        # and a conservative bootstrap floor (the round-1 50 MB/s try)
-        # over-predicted a typical 300 MB entry at 6 s, tripping the
-        # default 3.5 s budget BEFORE saving anything and preserving
-        # zero cache. Strictly worse than letting entry 0 attempt and
-        # letting the next-launch orphan-cleanup recover if it
-        # overshoots (codex PR #667 round 2 BLOCKING-1). Entry 1+
-        # then has real measured throughput to predict from.
+        # Bootstrap floor for entry 0 (no observed sample yet) is
+        # 150 MB/s — calibrated so:
+        #   - typical Gemma 4 26B entry (~250 MB) predicts ~1.7 s,
+        #     comfortably fitting the 3.1 s safe budget (3.5 s budget −
+        #     0.4 s commit headroom);
+        #   - genuinely oversized entry (~600 MB+) predicts >4 s and
+        #     correctly trips before write starts — would straddle
+        #     deadline either way.
+        # Round 1 used 50 MB/s and over-predicted typical entries
+        # (codex round 2 BLOCKING-1). Round 2 used 0 and let huge
+        # entries straddle the deadline (codex round 3 BLOCKING-1).
+        # 150 MB/s is the goldilocks middle ground: 3× round 1, gives
+        # real-world observed throughput (~875 MB/s during the
+        # original incident) ~6× safety margin while still catching
+        # genuinely-too-large entries.
+        _BOOTSTRAP_BYTES_PER_SEC = 150 * _BYTES_PER_MB
+        # Support BOTH zero-arg and one-arg ``should_abort`` predicates
+        # at the per-entry layer. The new contract is
+        # ``Callable[[float], bool]`` (forward-looking) but external
+        # callers may still pass a zero-arg shape from the round 1
+        # docstring contract — auto-detect and adapt instead of
+        # raising TypeError. Codex PR #667 round 3 BLOCKING-2.
+        check_abort = _adapt_should_abort(should_abort)
         total_bytes_written = 0
         total_write_seconds = 0.0
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
             if total_write_seconds > 0:
                 observed_bps = total_bytes_written / total_write_seconds
-                predicted_sec = entry.memory_bytes / observed_bps
             else:
-                # Bootstrap: no observed sample yet → let entry 0 try.
-                # The at-now component of the predicate (wall-clock vs
-                # safe_deadline) still applies, so a late-arriving
-                # SIGTERM that already exhausted the budget before
-                # entry 0 even started will still abort.
-                observed_bps = 0.0
-                predicted_sec = 0.0
+                observed_bps = _BOOTSTRAP_BYTES_PER_SEC
+            predicted_sec = entry.memory_bytes / observed_bps
             # Deadline-aware early exit: the lifespan handler installs a
             # ``should_abort`` predicate driven by the SIGTERM-grace budget.
             # Once it trips we stop persisting NEW entries but still run
@@ -1274,22 +1343,16 @@ class MemoryAwarePrefixCache:
             # rather than left in ``cache_dir.new/``. ``saved >= 1`` is
             # the gate that controls whether the rename happens —
             # nothing else changes from the full-flush path.
-            if should_abort is not None and should_abort(predicted_sec):
+            if check_abort is not None and check_abort(predicted_sec):
                 aborted_early = True
-                if observed_bps > 0:
-                    detail = (
-                        f"(predicted {predicted_sec * 1000:.0f}ms write at "
-                        f"{observed_bps / _BYTES_PER_MB:.0f}MB/s)"
-                    )
-                else:
-                    # Entry 0: no observed throughput; the at-now check
-                    # is what tripped, not a forward-looking estimate.
-                    detail = "(wall-clock already past shutdown deadline)"
+                bps_label = "observed" if total_write_seconds > 0 else "bootstrap floor"
                 logger.warning(
                     f"[cache_persist] shutdown budget would not fit "
-                    f"entry {i}/{total_entries} {detail} — "
-                    f"committing {saved} entries that finished before "
-                    f"deadline"
+                    f"entry {i}/{total_entries} "
+                    f"(predicted {predicted_sec * 1000:.0f}ms write at "
+                    f"{observed_bps / _BYTES_PER_MB:.0f}MB/s "
+                    f"[{bps_label}]) — committing {saved} entries that "
+                    f"finished before deadline"
                 )
                 break
             entry_path, tokens_path = _entry_paths(i)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1237,7 +1237,34 @@ class MemoryAwarePrefixCache:
         saved = 0
         aborted_early = False
         total_entries = len(self._entries)
+        # Track observed disk throughput so we can predict whether the
+        # NEXT entry's write will fit within the shutdown budget. The
+        # predicate fires forward-looking — if we don't predict, a
+        # single in-flight ``save_prompt_cache`` call can run past the
+        # deadline and get SIGKILL'd mid-write (leaves ``cache_dir.new/``
+        # orphaned; this is the bug the deadline gate exists to prevent).
+        #
+        # Floor of 50 MB/s reflects the worst sustained NVMe rate we've
+        # observed on Apple Silicon under thermal pressure / disk-cache
+        # full. Real M-series SSDs do 500-1000 MB/s peak, but we'd
+        # rather skip a borderline entry than orphan a staging dir.
+        _FLOOR_BYTES_PER_SEC = 50 * _BYTES_PER_MB
+        total_bytes_written = 0
+        total_write_seconds = 0.0
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
+            # Predict this entry's write duration. Use observed
+            # bytes/sec from completed entries once we have any sample;
+            # bootstrap on the conservative floor for entry 0. Scaling
+            # by ``entry.memory_bytes`` (not the EMA-of-seconds the
+            # prior round used) means very different entry sizes get
+            # individually-correct predictions instead of averaging
+            # toward a single point estimate.
+            observed_bps = (
+                total_bytes_written / total_write_seconds
+                if total_write_seconds > 0
+                else _FLOOR_BYTES_PER_SEC
+            )
+            predicted_sec = entry.memory_bytes / observed_bps
             # Deadline-aware early exit: the lifespan handler installs a
             # ``should_abort`` predicate driven by the SIGTERM-grace budget.
             # Once it trips we stop persisting NEW entries but still run
@@ -1246,15 +1273,19 @@ class MemoryAwarePrefixCache:
             # rather than left in ``cache_dir.new/``. ``saved >= 1`` is
             # the gate that controls whether the rename happens —
             # nothing else changes from the full-flush path.
-            if should_abort is not None and should_abort():
+            if should_abort is not None and should_abort(predicted_sec):
                 aborted_early = True
                 logger.warning(
-                    f"[cache_persist] shutdown budget exhausted at entry "
-                    f"{i}/{total_entries} — committing {saved} entries "
-                    f"that finished before deadline"
+                    f"[cache_persist] shutdown budget would not fit "
+                    f"entry {i}/{total_entries} "
+                    f"(predicted {predicted_sec * 1000:.0f}ms write at "
+                    f"{observed_bps / _BYTES_PER_MB:.0f}MB/s) — "
+                    f"committing {saved} entries that finished before "
+                    f"deadline"
                 )
                 break
             entry_path, tokens_path = _entry_paths(i)
+            entry_t0 = _time.monotonic()
             try:
                 # Dequantize QuantizedKVCache layers before saving.
                 # save_prompt_cache requires .state and .meta_state which
@@ -1298,6 +1329,14 @@ class MemoryAwarePrefixCache:
                     }
                 )
                 saved += 1
+                # Feed the throughput estimator. We measure including
+                # both the safetensors write and the tokens sidecar so
+                # the next entry's prediction reflects the full per-
+                # entry cost, not just the KV blob.
+                elapsed = _time.monotonic() - entry_t0
+                if elapsed > 0:
+                    total_bytes_written += entry.memory_bytes
+                    total_write_seconds += elapsed
                 logger.info(
                     f"[cache_persist] saved entry {i}: "
                     f"{len(tokens_key)} tokens, "

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1145,7 +1145,11 @@ class MemoryAwarePrefixCache:
     # Disk persistence — survives server restarts
     # -----------------------------------------------------------------
 
-    def save_to_disk(self, cache_dir: str) -> bool:
+    def save_to_disk(
+        self,
+        cache_dir: str,
+        should_abort=None,
+    ) -> bool:
         """Save all cache entries to disk using mlx_lm's safetensors format.
 
         The snapshot is committed via a directory-rename to make it
@@ -1165,7 +1169,24 @@ class MemoryAwarePrefixCache:
               entry_1_tokens.bin
               ...
 
-        Returns True if at least one entry was saved.
+        Args:
+            cache_dir: Final committed directory path (``.new`` / ``.old``
+                staging dirs are siblings).
+            should_abort: Optional zero-arg callable that returns True when
+                the caller wants the save loop to stop early — used by the
+                lifespan shutdown to enforce a SIGTERM-grace deadline so a
+                multi-GB save doesn't get SIGKILLed mid-flight and leave
+                ``cache_dir.new/`` orphaned (rapid-desktop only gives the
+                sidecar ~5s before SIGKILL). When the callable trips, the
+                loop stops, the entries that did finish are verified, and
+                the staging dir is committed via the same atomic rename as
+                a normal save — so a partial result is preferable to the
+                previous behavior (truncated mid-entry → orphaned ``.new``
+                → lost cache on next launch). A None value preserves the
+                pre-existing "save everything, no deadline" behavior used
+                by tests and the offline ``rapid-mlx`` CLI.
+
+        Returns True if at least one entry was committed to disk.
         """
         import shutil
         import time as _time
@@ -1214,7 +1235,25 @@ class MemoryAwarePrefixCache:
         }
 
         saved = 0
+        aborted_early = False
+        total_entries = len(self._entries)
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
+            # Deadline-aware early exit: the lifespan handler installs a
+            # ``should_abort`` predicate driven by the SIGTERM-grace budget.
+            # Once it trips we stop persisting NEW entries but still run
+            # the verify + index + atomic-rename steps below so the
+            # partial snapshot we already have on disk gets COMMITTED
+            # rather than left in ``cache_dir.new/``. ``saved >= 1`` is
+            # the gate that controls whether the rename happens —
+            # nothing else changes from the full-flush path.
+            if should_abort is not None and should_abort():
+                aborted_early = True
+                logger.warning(
+                    f"[cache_persist] shutdown budget exhausted at entry "
+                    f"{i}/{total_entries} — committing {saved} entries "
+                    f"that finished before deadline"
+                )
+                break
             entry_path, tokens_path = _entry_paths(i)
             try:
                 # Dequantize QuantizedKVCache layers before saving.
@@ -1300,7 +1339,13 @@ class MemoryAwarePrefixCache:
                 f"persisting {len(verified)} that survived"
             )
             index["entries"] = verified
-            index["num_entries"] = len(verified)
+        # Always pin num_entries to the actually-verified count. The initial
+        # value was ``total_entries`` (set before the save loop) which is
+        # wrong both when we aborted early AND when some entry files
+        # vanished mid-save — index.json must agree with the entry list it
+        # ships alongside, or load_from_disk's ``num_entries`` read drifts
+        # from reality and downstream callers report a phantom count.
+        index["num_entries"] = len(index["entries"])
 
         # Defensively recreate new_dir before the index.json write — the
         # filter above proves at least one entry's files exist, so the
@@ -1354,10 +1399,11 @@ class MemoryAwarePrefixCache:
             shutil.rmtree(old_dir, ignore_errors=True)
 
         dt = _time.monotonic() - t0
+        tail = " (partial — shutdown deadline hit)" if aborted_early else ""
         logger.info(
-            f"[cache_persist] SAVED {saved}/{len(self._entries)} entries "
+            f"[cache_persist] SAVED {saved}/{total_entries} entries "
             f"to {cache_dir} in {dt:.1f}s "
-            f"({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
+            f"({self._current_memory / _BYTES_PER_MB:.0f}MB total){tail}"
         )
         return saved > 0
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -67,25 +67,44 @@ def _adapt_should_abort(predicate):
     try:
         sig = inspect.signature(predicate)
     except (TypeError, ValueError):
-        # Builtin / C-extension / partial — assume one-arg shape
-        # (it's the contract going forward); a runtime TypeError on
-        # invocation is no worse than what callers got before.
+        # Builtin / C-extension / partial — assume positional one-arg
+        # shape (it's the contract going forward); a runtime TypeError
+        # on invocation is no worse than what callers got before.
         return lambda predicted_sec: predicate(predicted_sec)
 
-    # Does the predicate accept ANY positional / keyword arg?
-    accepts_arg = any(
-        p.kind
-        in (
+    # Classify the predicate's calling convention. Codex PR #667 round
+    # 4 BLOCKING-1: a naive "accepts ANY arg" check sent keyword-only
+    # and ``**kwargs``-only callables down the positional path, which
+    # raises ``TypeError`` on the very first call — defeating the
+    # whole point of the adapter. We have to distinguish the call
+    # shape, not just "accepts something".
+    accepts_positional = False
+    accepts_keyword_only_predicted_sec = False
+    has_var_kwargs = False
+    for p in sig.parameters.values():
+        if p.kind in (
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.KEYWORD_ONLY,
-            inspect.Parameter.VAR_KEYWORD,
-        )
-        for p in sig.parameters.values()
-    )
-    if accepts_arg:
+        ):
+            accepts_positional = True
+        elif p.kind == inspect.Parameter.KEYWORD_ONLY:
+            if p.name == "predicted_sec":
+                accepts_keyword_only_predicted_sec = True
+        elif p.kind == inspect.Parameter.VAR_KEYWORD:
+            has_var_kwargs = True
+
+    if accepts_positional:
+        # ``def pred(p)`` / ``def pred(p, **kw)`` / ``def pred(*args)``
+        # — positional is the natural shape.
         return lambda predicted_sec: predicate(predicted_sec)
+    if accepts_keyword_only_predicted_sec or has_var_kwargs:
+        # ``def pred(*, predicted_sec=0.0)`` — must use the keyword.
+        # ``def pred(**kw)`` — keyword is the only shape it accepts;
+        # the predicate may or may not look for ``predicted_sec`` in
+        # ``kw``, but passing it by name is the contract.
+        return lambda predicted_sec: predicate(predicted_sec=predicted_sec)
+    # Zero parameters → call with no args (round-1 documented shape).
     return lambda predicted_sec: predicate()
 
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1244,27 +1244,28 @@ class MemoryAwarePrefixCache:
         # deadline and get SIGKILL'd mid-write (leaves ``cache_dir.new/``
         # orphaned; this is the bug the deadline gate exists to prevent).
         #
-        # Floor of 50 MB/s reflects the worst sustained NVMe rate we've
-        # observed on Apple Silicon under thermal pressure / disk-cache
-        # full. Real M-series SSDs do 500-1000 MB/s peak, but we'd
-        # rather skip a borderline entry than orphan a staging dir.
-        _FLOOR_BYTES_PER_SEC = 50 * _BYTES_PER_MB
+        # Entry 0 gets ``predicted_sec=0`` — no observed sample yet,
+        # and a conservative bootstrap floor (the round-1 50 MB/s try)
+        # over-predicted a typical 300 MB entry at 6 s, tripping the
+        # default 3.5 s budget BEFORE saving anything and preserving
+        # zero cache. Strictly worse than letting entry 0 attempt and
+        # letting the next-launch orphan-cleanup recover if it
+        # overshoots (codex PR #667 round 2 BLOCKING-1). Entry 1+
+        # then has real measured throughput to predict from.
         total_bytes_written = 0
         total_write_seconds = 0.0
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
-            # Predict this entry's write duration. Use observed
-            # bytes/sec from completed entries once we have any sample;
-            # bootstrap on the conservative floor for entry 0. Scaling
-            # by ``entry.memory_bytes`` (not the EMA-of-seconds the
-            # prior round used) means very different entry sizes get
-            # individually-correct predictions instead of averaging
-            # toward a single point estimate.
-            observed_bps = (
-                total_bytes_written / total_write_seconds
-                if total_write_seconds > 0
-                else _FLOOR_BYTES_PER_SEC
-            )
-            predicted_sec = entry.memory_bytes / observed_bps
+            if total_write_seconds > 0:
+                observed_bps = total_bytes_written / total_write_seconds
+                predicted_sec = entry.memory_bytes / observed_bps
+            else:
+                # Bootstrap: no observed sample yet → let entry 0 try.
+                # The at-now component of the predicate (wall-clock vs
+                # safe_deadline) still applies, so a late-arriving
+                # SIGTERM that already exhausted the budget before
+                # entry 0 even started will still abort.
+                observed_bps = 0.0
+                predicted_sec = 0.0
             # Deadline-aware early exit: the lifespan handler installs a
             # ``should_abort`` predicate driven by the SIGTERM-grace budget.
             # Once it trips we stop persisting NEW entries but still run
@@ -1275,11 +1276,18 @@ class MemoryAwarePrefixCache:
             # nothing else changes from the full-flush path.
             if should_abort is not None and should_abort(predicted_sec):
                 aborted_early = True
+                if observed_bps > 0:
+                    detail = (
+                        f"(predicted {predicted_sec * 1000:.0f}ms write at "
+                        f"{observed_bps / _BYTES_PER_MB:.0f}MB/s)"
+                    )
+                else:
+                    # Entry 0: no observed throughput; the at-now check
+                    # is what tripped, not a forward-looking estimate.
+                    detail = "(wall-clock already past shutdown deadline)"
                 logger.warning(
                     f"[cache_persist] shutdown budget would not fit "
-                    f"entry {i}/{total_entries} "
-                    f"(predicted {predicted_sec * 1000:.0f}ms write at "
-                    f"{observed_bps / _BYTES_PER_MB:.0f}MB/s) — "
+                    f"entry {i}/{total_entries} {detail} — "
                     f"committing {saved} entries that finished before "
                     f"deadline"
                 )

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -6,10 +6,39 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import time
 
 from ..config import get_config
 
 logger = logging.getLogger(__name__)
+
+# SIGTERM-grace budget for the shutdown flush. Downstream supervisors
+# (rapid-desktop / launchd / systemd / Docker) typically send SIGTERM
+# then SIGKILL ~5-10s later if the process hasn't exited. The previous
+# synchronous flush could run for tens of seconds on multi-GB caches
+# and was consistently truncated mid-write, leaving ``<cache_dir>.new/``
+# orphaned and losing the KV-cache hit on the next launch. The default
+# of 3.5s is the largest value that still leaves enough room under a
+# 5s SIGTERM grace for ``engine.stop()`` + telemetry session_end +
+# uvicorn's own teardown to finish before SIGKILL. Override with the
+# ``RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET`` env var (seconds, float;
+# ``0`` disables the deadline and restores the old "flush everything"
+# behavior — useful for offline CLI saves where no signal is coming).
+_DEFAULT_SHUTDOWN_BUDGET_SEC = 3.5
+
+
+def _shutdown_budget_sec() -> float:
+    raw = os.environ.get("RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET")
+    if raw is None:
+        return _DEFAULT_SHUTDOWN_BUDGET_SEC
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            f"[lifespan] invalid RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET={raw!r}, "
+            f"falling back to default {_DEFAULT_SHUTDOWN_BUDGET_SEC}s"
+        )
+        return _DEFAULT_SHUTDOWN_BUDGET_SEC
 
 
 def load_prefix_cache_from_disk() -> None:
@@ -29,15 +58,38 @@ def load_prefix_cache_from_disk() -> None:
         logger.warning(f"[lifespan] Failed to load cache from disk: {e}", exc_info=True)
 
 
-def save_prefix_cache_to_disk() -> None:
-    """Save prefix cache to disk during shutdown."""
+def save_prefix_cache_to_disk(budget_sec: float | None = None) -> None:
+    """Save prefix cache to disk during shutdown.
+
+    Runs against a wall-clock budget (default
+    :data:`_DEFAULT_SHUTDOWN_BUDGET_SEC`, overridable via the
+    ``RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET`` env var). When the
+    deadline is reached the per-entry loop inside
+    ``MemoryAwarePrefixCache.save_to_disk`` stops and the partial
+    snapshot is committed via the same atomic rename as a full flush —
+    so we never leave the staging ``<cache_dir>.new/`` directory orphaned
+    when SIGKILL eventually lands. A budget of ``0`` (or a negative
+    value) disables the deadline entirely.
+    """
     cfg = get_config()
     if cfg.engine is None:
         return
+    if budget_sec is None:
+        budget_sec = _shutdown_budget_sec()
+    deadline = time.monotonic() + budget_sec if budget_sec > 0 else None
+    should_abort = (
+        (lambda dl=deadline: time.monotonic() >= dl) if deadline is not None else None
+    )
     try:
         d = get_cache_dir()
-        logger.info(f"[lifespan] Saving prefix cache to {d}")
-        saved = cfg.engine.save_cache_to_disk(d)
+        if deadline is not None:
+            logger.info(
+                f"[lifespan] Saving prefix cache to {d} "
+                f"(shutdown budget {budget_sec:.1f}s)"
+            )
+        else:
+            logger.info(f"[lifespan] Saving prefix cache to {d} (no shutdown budget)")
+        saved = cfg.engine.save_cache_to_disk(d, should_abort=should_abort)
         if saved:
             logger.info(f"[lifespan] Saved prefix cache to {d}")
         else:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -139,24 +139,41 @@ def _call_save_cache_to_disk(engine, cache_dir: str, should_abort):
     or third-party engine implementations may still expose the legacy
     one-argument signature. Without the fallback the kwarg would raise
     ``TypeError`` and the entire save would be lost — strictly worse
-    than no-deadline persistence. So we try the deadline-aware path
-    first and fall back to the legacy signature if the kwarg isn't
-    accepted.
+    than no-deadline persistence.
+
+    Detection is signature-based (``inspect.signature``) rather than
+    catch-and-retry-on-TypeError: codex PR #667 round 2 flagged that a
+    compatible engine raising ``TypeError`` mid-execution with the
+    ``should_abort`` substring would cause an unintended SECOND call
+    via the legacy path, doubling any side effects (writes / index
+    increments / metric counters). Inspecting the signature up front
+    has zero chance of misclassifying an internal exception as a
+    signature mismatch.
     """
+    import inspect
+
     try:
+        sig = inspect.signature(engine.save_cache_to_disk)
+    except (TypeError, ValueError):
+        # Builtin / C-extension methods may not expose a Python
+        # signature. Conservatively call the deadline-aware path —
+        # the engine almost certainly accepts the kwarg if it's been
+        # updated. We don't fall back here because a fallback retry
+        # is exactly the double-call hazard codex flagged.
         return engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
-    except TypeError as e:
-        # Only fall back when the rejection is specifically about the
-        # new kwarg. Any other TypeError (e.g. wrong path type) should
-        # surface to the caller unchanged.
-        if "should_abort" not in str(e):
-            raise
-        logger.warning(
-            "[lifespan] engine.save_cache_to_disk does not accept "
-            "should_abort kwarg — falling back to legacy signature "
-            "(no deadline awareness for this engine)"
-        )
-        return engine.save_cache_to_disk(cache_dir)
+
+    accepts_should_abort = "should_abort" in sig.parameters or any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+    if accepts_should_abort:
+        return engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
+
+    logger.warning(
+        "[lifespan] engine.save_cache_to_disk does not accept "
+        "should_abort kwarg — calling legacy signature "
+        "(no deadline awareness for this engine)"
+    )
+    return engine.save_cache_to_disk(cache_dir)
 
 
 def get_cache_dir() -> str:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -26,6 +26,16 @@ logger = logging.getLogger(__name__)
 # behavior — useful for offline CLI saves where no signal is coming).
 _DEFAULT_SHUTDOWN_BUDGET_SEC = 3.5
 
+# Headroom reserved after the per-entry loop exits for the atomic
+# rename + ``index.json`` write + stale ``.old`` cleanup. Without it a
+# perfectly-budgeted save could finish a write at T = deadline and then
+# get SIGKILL'd during the commit — leaving ``cache_dir.new/`` orphaned
+# anyway (the exact failure mode this whole gate exists to prevent).
+# 400 ms is comfortably above the observed commit cost across all
+# entry-count fixtures + leaves ~600 ms of slack under a 5 s SIGTERM
+# grace for ``engine.stop()`` and uvicorn teardown.
+_COMMIT_HEADROOM_SEC = 0.4
+
 
 def _shutdown_budget_sec() -> float:
     raw = os.environ.get("RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET")
@@ -76,26 +86,77 @@ def save_prefix_cache_to_disk(budget_sec: float | None = None) -> None:
         return
     if budget_sec is None:
         budget_sec = _shutdown_budget_sec()
-    deadline = time.monotonic() + budget_sec if budget_sec > 0 else None
-    should_abort = (
-        (lambda dl=deadline: time.monotonic() >= dl) if deadline is not None else None
-    )
+    should_abort = _make_should_abort(budget_sec) if budget_sec > 0 else None
     try:
         d = get_cache_dir()
-        if deadline is not None:
+        if should_abort is not None:
             logger.info(
                 f"[lifespan] Saving prefix cache to {d} "
-                f"(shutdown budget {budget_sec:.1f}s)"
+                f"(shutdown budget {budget_sec:.1f}s, "
+                f"commit headroom {_COMMIT_HEADROOM_SEC:.1f}s)"
             )
         else:
             logger.info(f"[lifespan] Saving prefix cache to {d} (no shutdown budget)")
-        saved = cfg.engine.save_cache_to_disk(d, should_abort=should_abort)
+        saved = _call_save_cache_to_disk(cfg.engine, d, should_abort)
         if saved:
             logger.info(f"[lifespan] Saved prefix cache to {d}")
         else:
             logger.info("[lifespan] No cache to save")
     except Exception as e:
         logger.warning(f"[lifespan] Failed to save cache to disk: {e}", exc_info=True)
+
+
+def _make_should_abort(budget_sec: float):
+    """Build a forward-looking deadline predicate.
+
+    Returns a callable ``predicate(predicted_sec=0.0)`` that returns
+    ``True`` when starting an operation of ``predicted_sec`` duration
+    would push wall-clock past ``deadline - _COMMIT_HEADROOM_SEC``.
+
+    The forward-looking shape is what codex flagged on PR #667 round 1:
+    the previous predicate ``time.monotonic() >= deadline`` only fired
+    BEFORE an entry's write started, so a single ``save_prompt_cache``
+    call running past the budget would still get SIGKILL'd mid-write
+    and leave ``cache_dir.new/`` orphaned — the exact failure this PR
+    claims to fix. Callers (currently ``MemoryAwarePrefixCache.save_to
+    _disk``) pass an estimated duration for the NEXT operation and the
+    predicate decides whether to start it or commit-what-we-have.
+    """
+    deadline = time.monotonic() + budget_sec
+    safe_deadline = deadline - _COMMIT_HEADROOM_SEC
+
+    def predicate(predicted_sec: float = 0.0) -> bool:
+        return time.monotonic() + predicted_sec >= safe_deadline
+
+    return predicate
+
+
+def _call_save_cache_to_disk(engine, cache_dir: str, should_abort):
+    """Invoke ``engine.save_cache_to_disk`` with backwards-compat fallback.
+
+    Internal engines (``BatchedEngine``, ``EngineCore``, ``Scheduler``)
+    all accept the ``should_abort`` kwarg as of this PR, but external
+    or third-party engine implementations may still expose the legacy
+    one-argument signature. Without the fallback the kwarg would raise
+    ``TypeError`` and the entire save would be lost — strictly worse
+    than no-deadline persistence. So we try the deadline-aware path
+    first and fall back to the legacy signature if the kwarg isn't
+    accepted.
+    """
+    try:
+        return engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
+    except TypeError as e:
+        # Only fall back when the rejection is specifically about the
+        # new kwarg. Any other TypeError (e.g. wrong path type) should
+        # surface to the caller unchanged.
+        if "should_abort" not in str(e):
+            raise
+        logger.warning(
+            "[lifespan] engine.save_cache_to_disk does not accept "
+            "should_abort kwarg — falling back to legacy signature "
+            "(no deadline awareness for this engine)"
+        )
+        return engine.save_cache_to_disk(cache_dir)
 
 
 def get_cache_dir() -> str:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4060,10 +4060,13 @@ class Scheduler:
     def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:
         """Save prefix cache to disk for persistence across restarts.
 
-        ``should_abort`` is an optional zero-arg callable that signals
-        the lifespan SIGTERM-grace deadline to the per-entry loop inside
-        ``MemoryAwarePrefixCache.save_to_disk``. See that method's
-        docstring for the partial-commit guarantee.
+        ``should_abort`` is an optional ``Callable[[float], bool]``
+        (the ``float`` is the next entry's predicted write duration)
+        that signals the lifespan SIGTERM-grace deadline to the per-
+        entry loop inside ``MemoryAwarePrefixCache.save_to_disk``.
+        Zero-arg callables are accepted via auto-detection for
+        backwards compatibility. See that method's docstring for the
+        partial-commit guarantee.
         """
         if self.memory_aware_cache is not None:
             return self.memory_aware_cache.save_to_disk(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4057,10 +4057,18 @@ class Scheduler:
     # Cache persistence
     # -----------------------------------------------------------------
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
-        """Save prefix cache to disk for persistence across restarts."""
+    def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:
+        """Save prefix cache to disk for persistence across restarts.
+
+        ``should_abort`` is an optional zero-arg callable that signals
+        the lifespan SIGTERM-grace deadline to the per-entry loop inside
+        ``MemoryAwarePrefixCache.save_to_disk``. See that method's
+        docstring for the partial-commit guarantee.
+        """
         if self.memory_aware_cache is not None:
-            return self.memory_aware_cache.save_to_disk(cache_dir)
+            return self.memory_aware_cache.save_to_disk(
+                cache_dir, should_abort=should_abort
+            )
         logger.info("[cache_persist] no memory-aware cache to save")
         return False
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -242,6 +242,31 @@ from .runtime.cache import (
 )
 
 
+async def _shutdown_save_prefix_cache() -> None:
+    """Lifespan shutdown step: persist prefix cache off the event loop.
+
+    The synchronous ``_save_prefix_cache_to_disk`` call streams 200-300
+    MB per entry through ``save_prompt_cache`` under the GIL. Calling
+    it on the asyncio loop thread (which is what the lifespan handler
+    runs on) starves any other coroutine waiting on the same loop for
+    tens of seconds — ``/healthz`` polls from supervisors that still
+    consider us "stopping" hang, graceful-shutdown HTTP responses
+    never flush, etc.
+
+    Extracted from inline-in-lifespan so tests can pin the
+    ``asyncio.to_thread`` wrapper at its production callsite. Codex
+    flagged PR #667 round 1 because the previous test wrapped
+    ``to_thread`` itself — a regression that dropped the wrapper from
+    the lifespan would not have been caught. The test now drives THIS
+    function and watches whether the loop stays responsive during the
+    save; if anyone in the future replaces the ``await asyncio.to_thread
+    (...)`` line below with a direct call, the regression fires.
+    """
+    if _engine is None or not hasattr(_engine, "save_cache_to_disk"):
+        return
+    await asyncio.to_thread(_save_prefix_cache_to_disk)
+
+
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
     global _engine, _mcp_manager
@@ -364,17 +389,12 @@ async def lifespan(app: FastAPI):
 
     # Shutdown: Save cache to disk BEFORE stopping engine.
     #
-    # Run on a worker thread so the asyncio loop stays responsive while
-    # the multi-GB save streams to disk — uvicorn's lifespan task is the
-    # only thing waiting on us, but anything else attached to the loop
-    # (graceful-shutdown HTTP responses, /healthz polls from supervisors
-    # that still consider us "stopping") gets to make progress instead
-    # of being starved for tens of seconds. The save itself respects a
-    # wall-clock SIGTERM-grace budget (see runtime/cache.py) and commits
-    # whatever finished via the atomic rename even if the deadline trips
-    # — so a downstream SIGKILL never leaves ``<cache_dir>.new/`` orphaned.
-    if _engine is not None and hasattr(_engine, "save_cache_to_disk"):
-        await asyncio.to_thread(_save_prefix_cache_to_disk)
+    # Delegates to ``_shutdown_save_prefix_cache`` which wraps the
+    # synchronous save in ``asyncio.to_thread`` — see that function's
+    # docstring for the rationale. Extracted so the regression test
+    # pins the wrapper at the production callsite rather than wrapping
+    # ``to_thread`` test-side (codex PR #667 round 1 BLOCKING-3).
+    await _shutdown_save_prefix_cache()
 
     # Shutdown: Close MCP connections and stop engine
     if _mcp_manager is not None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -38,6 +38,7 @@ The server provides:
 """
 
 import argparse
+import asyncio
 import gc
 import logging
 import os
@@ -361,9 +362,19 @@ async def lifespan(app: FastAPI):
     # Shutdown: stop accepting "ready" before tearing things down.
     get_config().ready = False
 
-    # Shutdown: Save cache to disk BEFORE stopping engine
+    # Shutdown: Save cache to disk BEFORE stopping engine.
+    #
+    # Run on a worker thread so the asyncio loop stays responsive while
+    # the multi-GB save streams to disk — uvicorn's lifespan task is the
+    # only thing waiting on us, but anything else attached to the loop
+    # (graceful-shutdown HTTP responses, /healthz polls from supervisors
+    # that still consider us "stopping") gets to make progress instead
+    # of being starved for tens of seconds. The save itself respects a
+    # wall-clock SIGTERM-grace budget (see runtime/cache.py) and commits
+    # whatever finished via the atomic rename even if the deadline trips
+    # — so a downstream SIGKILL never leaves ``<cache_dir>.new/`` orphaned.
     if _engine is not None and hasattr(_engine, "save_cache_to_disk"):
-        _save_prefix_cache_to_disk()
+        await asyncio.to_thread(_save_prefix_cache_to_disk)
 
     # Shutdown: Close MCP connections and stop engine
     if _mcp_manager is not None:


### PR DESCRIPTION
## User-visible bug

> prefix-cache persist truncated on SIGTERM, leaves `<cache_dir>.new/` directory orphaned

When uvicorn delivers SIGTERM to `rapid-mlx serve` (rapid-desktop quit, launchd Stop, systemd graceful-stop, Docker stop, ...), the FastAPI lifespan shutdown hook runs `save_prefix_cache_to_disk()` **synchronously** on the asyncio loop thread. The save itself is a per-entry loop that calls `mlx_lm.models.cache.save_prompt_cache` on each KV cache entry — for production models like Gemma 4 26B that's 200-300 MB per safetensors file, all in linear wall-clock order, all under the GIL.

Live evidence from rapid-desktop quit at 18:30 on `mlx-community/gemma-4-26b-a4b-it-4bit` (PID 57809):

```
INFO:rapid_mlx.runtime.cache:[lifespan] Saving prefix cache to .../gemma-4-26b-a4b-it-4bit--e527bf6c
INFO:rapid_mlx.memory_cache:[cache_persist] saved entry 0: 1263 tokens, 224.7MB KV, ...
INFO:rapid_mlx.memory_cache:[cache_persist] saved entry 1: 1292 tokens, 225.2MB KV, ...
...
INFO:rapid_mlx.memory_cache:[cache_persist] saved entry 18: 2941 tokens, 257.4MB KV, ...
[SIGKILL ~5s in]
```

~4.4 GB written, only 18 of N entries finished. The atomic `<cache_dir>.new/ → <cache_dir>` rename never ran, so the staging dir was wedged in `.new/` until manual cleanup AND the next launch lost the KV-cache hit entirely.

Rapid-desktop PR #255 ships a 5s → 30s SIGTERM-grace mitigation but the proper fix lives here — with the budget gate below, even a 5s grace produces a clean committed snapshot.

## Design (one paragraph + trade-offs)

Two changes that work together:

1. **`asyncio.to_thread` in the lifespan shutdown** so the asyncio loop stays responsive (`/healthz`, graceful-shutdown responses, anything else attached to the loop gets to make progress instead of being starved for tens of seconds).

2. **A `should_abort` predicate plumbed from `runtime/cache.py` → `BatchedEngine` → `EngineCore` → `Scheduler` → `MemoryAwarePrefixCache.save_to_disk`**. The per-entry loop checks it after every entry; when the SIGTERM-grace deadline trips (default **3.5s**, env-overridable via `RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET`), the loop stops AND the partial snapshot is still committed via the same atomic directory rename. So a downstream SIGKILL after 5s leaves `<cache_dir>/index.json` + N entries on disk, never an orphan `.new/`.

**Trade-off considered.** The user's prompt offered three approaches:

- *Periodic background persist during steady-state.* The most user-visible win because shutdown becomes a no-op and the cache survives even a kill -9. But it's a much larger surface area (dirty-set tracking, evict-then-delete-on-disk sync, sibling-process coordination, retry on transient I/O), and entries are large enough that batched writes would have to compete with live decode for disk bandwidth. Out of scope for a focused bug fix; left as follow-up.
- *Async lifespan flush via `asyncio.to_thread` alone.* Necessary but not sufficient — uvicorn still waits on the lifespan to return, and `to_thread` only moves the wait off the loop, not the deadline. We adopt this AS PART of the fix to keep the loop responsive, but pair it with...
- *Interruptible flush via signal handler / deadline.* Picked. Smallest diff, preserves on-disk format, preserves the existing partial-recovery and atomic-rename invariants the load path already encodes, and is what actually solves the orphaned-`.new/` symptom.

## What changed

| File | What |
| --- | --- |
| `vllm_mlx/memory_cache.py` | `save_to_disk(cache_dir, should_abort=None)` — per-entry abort check + always-correct `num_entries` in index.json. |
| `vllm_mlx/scheduler.py` | `save_cache_to_disk` forwards `should_abort`. |
| `vllm_mlx/engine_core.py` | `EngineCore.save_cache_to_disk` + `AsyncEngineCore.save_cache_to_disk` forward `should_abort`. |
| `vllm_mlx/engine/batched.py` | `BatchedEngine.save_cache_to_disk` forwards `should_abort`. |
| `vllm_mlx/runtime/cache.py` | `save_prefix_cache_to_disk(budget_sec=None)` builds the deadline predicate; default 3.5s, `RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET` env override, `0` disables for offline CLI saves. |
| `vllm_mlx/server.py` | Lifespan shutdown now `await asyncio.to_thread(_save_prefix_cache_to_disk)`. |

`should_abort=None` everywhere is the legacy "no deadline, flush everything" path used by the existing tests and the offline `rapid-mlx` CLI — no behavior change there.

## Tests (regression coverage in `tests/test_prefix_cache_persistence.py`)

- `test_save_to_disk_partial_commit_on_abort` — predicate fires after entry 0 of 3; asserts the staging dir was renamed away (no orphan `.new/`), `index.json` exists with `num_entries=1`, and the surviving entry round-trips through `load_from_disk`.
- `test_save_to_disk_aborts_before_first_entry_returns_false` — predicate fires immediately; asserts `False` return, no committed dir, no orphan `.new/` (matches the existing "no entries saved successfully" branch).
- `test_save_to_disk_predicate_none_preserves_full_flush` — guards the offline-CLI path against behavior drift.
- `test_save_prefix_cache_to_disk_runs_off_event_loop` — drives the lifespan-shape call shape with a slow fake engine + concurrent 50ms ticker; asserts the ticker advances ≥5 times during a 600ms save (which it can't do if the save still blocks the loop).
- `test_save_prefix_cache_to_disk_respects_budget` — passes `budget_sec=0.1`, sleeps past it inside the fake engine, asserts the captured predicate evaluates True.
- `test_save_prefix_cache_to_disk_zero_budget_disables_deadline` — guards the offline-CLI "no deadline" path.

Also updated `tests/test_engine_step_thread.py::test_save_cache_to_disk_routes_to_worker` for the new kwarg, and allowlisted `RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET` in `tests/test_no_out_of_band_routing.py::ALLOWED_RAPID_MLX_ENV_VARS` (with the standard non-routing comment block — it's a pure deadline knob, never selects model / parser / tier).

## Verification

- `python3.12 -m pytest tests/ -q --ignore=tests/integrations` — **5602 passed**, 18 skipped, 16 deselected, 7 xfailed, **0 new failures**. The 2 pre-existing `test_event_loop.py` failures are connection errors on `127.0.0.1:8000` (need a live server, unrelated).
- `python3.12 -m ruff check + format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)