### PR TITLE
fix(tests): test_langchain harness path — module-level results dict

### DIFF
--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -1,6 +1,7 @@
 """Thorough LangChain test suite against local rapid-mlx server."""
 
 import os
+import sys
 
 import httpx as _httpx
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -21,9 +22,19 @@ llm = ChatOpenAI(
     temperature=0.0,
 )
 
-if __name__ == "__main__":
-    results = {}
+# ``results`` is read by the ``rapid-mlx bench --tier harness`` path
+# (``vllm_mlx/agents/testing.py::_run_specific_tests`` does
+# ``getattr(mod, "results", {})`` after ``spec.loader.exec_module``).
+# It MUST be defined at module level so the harness can pick it up — PR
+# #660 originally moved it inside ``if __name__ == "__main__":`` to keep
+# ``pytest`` collection from triggering ``exit()``, which left the harness
+# load path with an empty mapping and the gate reporting "No test results
+# found (missing 'results' dict or all tests skipped)".
+results: dict[str, str] = {}
 
+
+def _run_tests() -> None:
+    """Run the live test battery; populates the module-level ``results``."""
     # === 1. Plain invoke ===
     print("=== Test 1: Plain invoke ===")
     try:
@@ -154,4 +165,18 @@ if __name__ == "__main__":
     print(f"LangChain: {passed}/{len(results)} passed")
     for k, v in results.items():
         print(f"  {k}: {v[:120]}")
-    exit(0 if passed == len(results) else 1)
+
+
+# Run the battery in two cases:
+#   1. Direct invocation: ``python tests/integrations/test_langchain.py``
+#   2. Harness load: ``rapid-mlx bench --tier harness`` calls
+#      ``importlib.util.spec_from_file_location`` then ``exec_module``.
+# Skip under pytest collection so ``pytest tests/integrations/...`` sweeps
+# can import the module without triggering live API calls — restores the
+# PR #660 fix without re-introducing the empty-results harness bug.
+_UNDER_PYTEST = "_pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
+if not _UNDER_PYTEST:
+    _run_tests()
+    if __name__ == "__main__":
+        _passed = sum(1 for v in results.values() if v == "PASS")
+        exit(0 if _passed == len(results) else 1)


### PR DESCRIPTION
## Why

The v0.7.29 release-check-m3 gauntlet (G7b harness sweep) failed on langchain with:

```
specific:test_langchain.py: No test results found (missing 'results' dict or all tests skipped)
```

The other 4 first-class harnesses (codex / opencode / hermes / aider) passed. Hermes works because it has \`results = {}\` at module level; langchain does not (post-PR #660).

## Root cause

PR #660 (\`f63d5fa\`) wrapped the entire driver block (including \`results = {}\`) in \`if __name__ == "__main__":\` to stop pytest collection from triggering the trailing \`exit(0|1)\` as an INTERNALERROR. That fix worked for pytest but silently broke the \`rapid-mlx bench --tier harness\` path:

- Harness loads via \`importlib.util.spec_from_file_location\` → \`exec_module\` (\`vllm_mlx/agents/testing.py:1214-1230\`).
- That sets \`__name__\` to the spec name (\`specific_test_test_langchain.py\`), not \`"__main__"\`.
- The guarded driver block never runs, \`results\` is never bound at module level.
- The harness then sees \`getattr(mod, "results", {})\` return empty and reports the error above.

The bug was latent in the v0.7.28 wheel — anyone running \`rapid-mlx bench --tier harness\` against a 0.7.28 install hit the same failure on the langchain row.

## Fix

Keep PR #660's pytest-collection goal but also let the harness path populate \`results\`:

- Move \`results: dict[str, str] = {}\` back to module level.
- Wrap the test body in \`_run_tests()\`.
- Run \`_run_tests()\` when NOT under pytest (\`_pytest in sys.modules\` or \`PYTEST_CURRENT_TEST\` env var set). Direct invocation AND harness \`exec_module\` both go through this path; pytest collection skips it.
- \`exit(0|1)\` stays inside \`if __name__ == "__main__":\` (harness patches \`sys.exit\` to no-op anyway).

The bundled copy \`vllm_mlx/_integration_tests/test_langchain.py\` is a symlink to the source file — one edit updates both wheel and dev paths.

## Verification

Done locally with the dev server up at \`http://127.0.0.1:8000/v1\`:

| Path | Behavior |
|---|---|
| \`importlib.util.spec_from_file_location\` + \`exec_module\` (harness sim) | populates \`results\` with 6 entries |
| \`pytest tests/integrations/test_langchain.py --collect-only\` | 0 tests collected, 0 errors, no API calls |
| \`python tests/integrations/test_langchain.py\` | runs + \`exit(0\|1)\` |

The other modules with the same \`__main__\` guard (anthropic_sdk, pydantic_ai_full, librechat_docker, openwebui, smolagents_full) are exercised today only through G7 / direct invocation where \`__name__\` IS \`"__main__"\`, so they don't hit this bug. Narrow fix to unblock the v0.7.29 release; a follow-up can apply the same pattern if any of them gets wired into \`specific_tests\` later.

## Release-gating

Required for v0.7.29 to ship cleanly through the M3 release-check gauntlet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)