### PR TITLE
chore(curation): drop 3 kimi aliases (kimi-48b-4bit, kimi-k2.5-3bit, kimi-k2.6-dq3-q8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Decoded examples:
 | **Llama / Hermes** | `llama3-1b-4bit`, `-3b-4bit`, `llama-3.1-8b-8bit`, `hermes3-8b-4bit`, `hermes4-70b-4bit` | |
 | **GLM** | `glm4.5-air-4bit`, `glm4.7-9b-4bit` | |
 | **GPT-OSS** | `gpt-oss-20b-mxfp4-q8` | Harmony native |
-| **MiniMax / Kimi** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4`, `kimi-48b-4bit`, `kimi-k2.5-3bit` | |
+| **MiniMax** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4` | |
 | **Mistral / Devstral** | `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit` | |
 | **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit` | |
 | 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.29"
+version = "0.7.30"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/rename_map.json
+++ b/scripts/rename_map.json
@@ -31,8 +31,6 @@
   "granite4-tiny": "granite4-tiny-4bit",
   "hermes3-8b": "hermes3-8b-4bit",
   "hermes4-70b": "hermes4-70b-4bit",
-  "kimi-48b": "kimi-48b-4bit",
-  "kimi-k2.5": "kimi-k2.5-3bit",
   "llama-3.1-8b-8bit": "llama-3.1-8b-8bit",
   "llama3-1b": "llama3-1b-4bit",
   "llama3-3b": "llama3-3b-4bit",

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -508,13 +508,13 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
 
 def test_audit_batch_reasoning_parser_wirings() -> None:
     """Pin the Model Onboarding SOP audit fixes for reasoning_parser
-    on nemotron / kimi-k2.5-3bit / hermes4 aliases. Each was previously
+    on nemotron / hermes4 aliases. Each was previously
     ``null`` despite the model emitting ``<think>``/``</think>``
     blocks — without the parser, those blocks leak into
     ``message.content``.
 
     Parser choice rationale:
-    - nemotron-30b-4bit/nano + kimi-k2.5-3bit use a Qwen3-style template that
+    - nemotron-30b-4bit/nano use a Qwen3-style template that
       INJECTS ``<think>`` into the prompt (gated by ``enable_thinking``
       / ``thinking`` flag). ``qwen3`` parser's ``finalize_streaming``
       correction handles the "no </think> ever appeared → emit as
@@ -526,7 +526,6 @@ def test_audit_batch_reasoning_parser_wirings() -> None:
     profiles = list_profiles()
     expected = {
         "nemotron-30b-4bit": "qwen3",
-        "kimi-k2.5-3bit": "qwen3",
         "hermes4-70b-4bit": "glm4",
     }
     for alias, parser in expected.items():
@@ -650,12 +649,6 @@ def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:
     ), (
         "gpt-oss-20b-mxfp4-q8 must not regress to the 404 path; current canonical "
         "upload is mlx-community/gpt-oss-20b-MXFP4-Q8."
-    )
-    # kimi-48b-4bit previously pointed at mlx-community/Kimi-K2-Instruct-Q4_0-MLX
-    # (404). The replacement Kimi-K2-Instruct-4bit is large
-    # (~540 GB) but is the actual mlx-community Kimi K2 Instruct release.
-    assert "Q4_0" not in profiles["kimi-48b-4bit"].hf_path, (
-        "kimi-48b-4bit must not regress to the Q4_0 path which 404s."
     )
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -642,27 +642,6 @@
     "is_hybrid": true,
     "supports_spec_decode": false
   },
-  "kimi-48b-4bit": {
-    "hf_path": "mlx-community/Kimi-K2-Instruct-4bit",
-    "tool_call_parser": "kimi",
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "supports_spec_decode": true
-  },
-  "kimi-k2.5-3bit": {
-    "hf_path": "mlx-community/Kimi-K2.5-3bit",
-    "tool_call_parser": "kimi",
-    "reasoning_parser": "qwen3",
-    "is_hybrid": false,
-    "supports_spec_decode": true
-  },
-  "kimi-k2.6-dq3-q8": {
-    "hf_path": "mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8",
-    "tool_call_parser": "kimi",
-    "reasoning_parser": "qwen3",
-    "is_hybrid": false,
-    "supports_spec_decode": true
-  },
   "ministral-3b-4bit": {
     "hf_path": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
     "tool_call_parser": "hermes",


### PR DESCRIPTION
## Summary

User decision after the 2026-06-18 overnight R2 mirror campaign: all three kimi entries are too large to mirror on the rapid-mlx catalog.

| alias | HF actual | audit said | gap |
|---|---|---|---|
| `kimi-k2.5-3bit` | 418 GB | 1.1 GB | 380x |
| `kimi-48b-4bit` | 538 GB | 24 GB | 22x |
| `kimi-k2.6-dq3-q8` | 438 GB | 438 GB | (user-excluded from the start) |

Combined ~1.4 TB would dominate the R2 bucket, and with no downstream demand signal we're un-curating rather than mirroring.

## Changes

- `vllm_mlx/aliases.json`: 3 entries removed (84 → 81).
- `tests/test_aliases_contract.py`:
  - `kimi-k2.5-3bit` removed from the reasoning-parser audit fixture.
  - `kimi-48b-4bit` Q4_0-regression-guard assertion removed.
  - Still 908/908 green locally.
- `README.md`: drop kimi family names from the curated-aliases feature table (now "MiniMax" instead of "MiniMax / Kimi").
- `scripts/rename_map.json`: drop "kimi-48b" + "kimi-k2.5" legacy short-name mappings.

## NOT changed (deliberately)

- `vllm_mlx/parsers/kimi.py` + the kimi tool-call parser code stays. Un-curating an alias != removing parser support; users can still:
  ```
  rapid-mlx serve mlx-community/Kimi-K2-Instruct-4bit --tool-call-parser kimi
  ```
  against the raw HF path. The README parser-table row + `docs/guides/tool-calling.md` example are intentionally retained.
- `harness/scorecard/latest.md`: regenerated by the benchmark harness; refreshes on next run.

## Follow-up

A separate PR on `rapidmlx.com/models-worker` removes the matching entries from `manifest.json` so https://models.rapidmlx.com/ drops the three "not_mirrored" tiles.

## Test plan

- [x] `pytest tests/test_aliases_contract.py` 908/908 green
- [x] grep for residual kimi alias refs: only the parser-docs example remains (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)