### PR TITLE
fix(sidecar): bundle mlx-vlm --no-deps + Pillow so gemma-4 loaders import

### DIFF
--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -46,11 +46,20 @@ PBS_VERSION="${PBS_VERSION:-3.12.13}"
 # How many Mach-Os we expect to sign. A drift here means a new wheel
 # added a .so OR a dependency moved a binary, both of which need
 # re-baselining. Re-locked on the first authoritative CI run on
-# GitHub-hosted macos-15 (run 27472544784). The original Phase 2 spike
-# value of 77 was measured on a developer M3 Ultra and included
-# build-time artifacts that the strip step removes on a fresh runner
-# — 51 is the canonical "what actually ships" number.
-MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-51}"
+# GitHub-hosted macos-15 (run 27472544784) at 51 (the canonical "what
+# actually ships" number — the original Phase 2 spike value of 77
+# included build-time artifacts the strip step removes on a fresh
+# runner). Re-locked again at 77 on 2026-06-18 (run 27767093261) after
+# bundling Pillow alongside mlx-vlm in step 2.5: Pillow ships 8
+# `.cpython-312-darwin.so` modules (_avif, _imaging{,cms,ft,math,morph,tk},
+# _webp) + 18 `.dylibs/` vendored libraries (libavif, libbrotli{common,dec},
+# libfreetype, libharfbuzz, libjpeg, liblcms2, liblzma, libopenjp2,
+# libpng16, libsharpyuv, libtiff, libwebp{,demux,mux}, libXau, libxcb,
+# libz). All 26 new Mach-Os are standard well-formed Pillow-wheel
+# binaries (same mechanism as mlx_metal / numpy / safetensors etc.
+# already vendor) and codesign cleanly with the existing identity loop
+# at the end of this script — no signing-safety spike re-run needed.
+MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-77}"
 # Allow modest drift without blocking — wheel updates sometimes shift
 # 1-2 .so files. Bigger drift means a new dependency, needs review.
 # Widened from 3 → 5 since we're now at a smaller baseline and the

--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -154,6 +154,40 @@ python3.12 -m pip install \
     --upgrade \
     "$REPO_ROOT"
 
+# ----- step 2.5: bundle mlx-vlm --no-deps + Pillow ---------------------
+#
+# Even though we skip the [vision] extras to stay under rapid-desktop's
+# 500 MB CI gate, the gemma-4 family (12 aliases on the curated catalog —
+# gemma-4-12b-4bit, -12b-qat-4bit/8bit, -26b-4bit, -26b-qat-4bit,
+# -31b-{4,8}bit, -31b-qat-{4,8}bit, and friends) NEEDS the
+# ``mlx_vlm.models.gemma4_unified`` architecture classes to load, even
+# in text-only mode. v0.7.7 shipped without this and every gemma-4
+# server start crashed with::
+#
+#     ImportError: Gemma 4 models require the optional
+#         `mlx-vlm` dependency for the model architecture classes.
+#
+# ``--no-deps`` keeps the mlx-vlm install at ~9 MB (just the Python
+# classes) instead of pulling torch + cv2 + torchvision (~322 MB
+# cascade) the way ``[vision]`` extras would. mlx-vlm's __init__.py
+# eagerly chains ``from .convert import convert`` → ``.utils`` → ``PIL``,
+# so ``import mlx_vlm`` fails without Pillow even on the text-only path.
+# All other eager deps (transformers, requests, huggingface_hub,
+# safetensors, numpy, mlx) are already bundled by rapid-mlx's own
+# install above, so Pillow is the only additional dep we need.
+# We pin to the same ``>=0.6.3`` floor pyproject.toml's [vision] extras
+# pin so the bundled mlx-vlm tracks the DiffusionGemma + gemma4_unified
+# architecture support the loader needs.
+echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader path)"
+python3.12 -m pip install \
+    --target "$STAGE/site-packages" \
+    --no-warn-script-location \
+    --no-compile \
+    --no-deps \
+    --upgrade \
+    'mlx-vlm>=0.6.3' \
+    'Pillow>=10.0'
+
 # ----- step 3: strip dev / unused artifacts ----------------------------
 
 echo "==> stripping dev artifacts"


### PR DESCRIPTION
## Summary

- v0.7.7 Desktop DMG shipped without `mlx_vlm` in the bundled sidecar's `site-packages/`; every `gemma-4-*` alias (12 entries on the curated catalog) crashed at load with `ImportError: Gemma 4 models require the optional 'mlx-vlm' dependency for the model architecture classes` from `vllm_mlx/models/gemma4_text.py:236`.
- Root cause: `scripts/build-sidecar.sh` pip-installs `$REPO_ROOT` without `[vision]` extras (extras would pull torch + torchvision + cv2 ≈ 322 MB, blowing rapid-desktop's 500 MB CI gate) — but the gemma-4 loader needs `mlx_vlm.models.gemma4.{config,language}` even for text-only inference because the architecture classes only live inside mlx-vlm's tree.
- Fix: new step 2.5 installs `mlx-vlm>=0.6.3` with `--no-deps` plus `Pillow>=10.0` (Pillow is the only eager-import dep not already covered — mlx-vlm's `__init__` chains `.convert` → `.utils` → `PIL`). All other eager deps (transformers, requests, huggingface_hub, safetensors, numpy, mlx) are already bundled by rapid-mlx's own install.
- Companion commit: `MACHO_BASELINE_COUNT` bumped 51 → 77 (Pillow vendors 8 `.so` modules + 18 `.dylibs/` libs; comment block records the rationale for the next Pillow churn).

## Size impact (clean local build, `BUNDLE_MODEL=0`)

| | Raw bundle | Tarball (.tar.gz) |
|---|---|---|
| v0.7.7 baseline | 384 MB | 143 MB |
| v0.7.8 (this PR) | **420 MB** | **134 MB** |
| Delta | +36 MB (mlx_vlm 9 + Pillow 13 + dist-info) | -9 MB |
| CI gate | 500 MB (80 MB headroom) | DMG delta gate 50 MB |

Tarball is smaller despite the raw delta because Pillow ships dylibs (.dylib / .so) that gzip well, plus upstream wheel-size churn.

## Verification (local + bundled-server E2E)

```bash
BUNDLE_MODEL=0 bash scripts/build-sidecar.sh
cd build/sidecar-stage/rapid-mlx
PYTHONPATH=$PWD/site-packages ./python/bin/python3.12 -c '
  import mlx_vlm; print(mlx_vlm.__version__);
  from mlx_vlm.models import gemma4_unified;
  from vllm_mlx.models.gemma4_text import load_gemma4_text
'
# → mlx_vlm 0.6.3 / gemma4_unified loaded / load_gemma4_text importable
```

Also booted the bundled sidecar end-to-end on two real checkpoints (see follow-up comment for full logs):

- `gemma-4-e2b-4bit`: 35 layers loaded, chat 200 OK, **80.9 / 94.7 tok/s**
- `gemma-4-12b-4bit`: 48 layers loaded, chat 200 OK, **52.9 tok/s** (`content: "HELLO"` / `content: "2 + 2 = 4"`)
- `OutputRouter Gemma 4 format detected: channel=100/101, tool=48/49` — gemma4 reasoning + tool parser engaged

Both checkpoints fall back to `vllm_mlx/models/gemma4_text.py`'s text-only path because mlx-vlm 0.6.3's gemma4_unified class doesn't match these specific checkpoint layouts — but that's a **post-import** failure inside model instantiation. v0.7.7 died at `import mlx_vlm` itself with `ModuleNotFoundError`, so it never even reached the fallback.

## Test plan

- [x] Local clean rebuild (`rm -rf build/sidecar-stage && BUNDLE_MODEL=0 bash scripts/build-sidecar.sh`) succeeds including the `MACHO_BASELINE_COUNT=77` assertion
- [x] `import mlx_vlm` succeeds via the bundled Python with `bin/rapid-mlx`'s `PYTHONPATH`
- [x] `from mlx_vlm.models import gemma4_unified` succeeds (this is the symbol the loader imports)
- [x] `from vllm_mlx.models.gemma4_text import load_gemma4_text` succeeds
- [x] Raw bundle 420 MB < 500 MB CI gate
- [x] Tarball 134 MB < 143 MB v0.7.7 baseline (DMG delta gate well under 50 MB)
- [x] `rapid-mlx serve gemma-4-e2b-4bit` + `rapid-mlx serve gemma-4-12b-4bit` both boot + serve chat 200 OK against the bundled sidecar (E2E proof in PR comment)
- [x] CI: `Build sidecar (arm64)` green on the second push (baseline-bump commit `7221d36`)

## Follow-up

`rapid-desktop` v0.7.8 will submodule-bump to the tag carrying this fix and re-cut the DMG. End-to-end gemma-4 launch from the actual DMG (not just the staging tree) belongs in that PR, not here.