### PR TITLE
fix(chat): symmetric tool_choice enforcement across parser paths (#571)

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -1112,3 +1112,100 @@ def test_synthesize_forced_tool_call_helper_shape():
     # not parse or re-serialise, matching the model-emitted shape.
     tc2 = _synthesize_forced_tool_call("calc", arguments='{"expr":"1+1"}')
     assert tc2.function.arguments == '{"expr":"1+1"}'
+
+
+def test_named_function_outside_tools_returns_422(monkeypatch):
+    """Codex R1 BLOCKING (#675): the named-function synthesis branch
+    must never fabricate a call to a tool the client did not submit.
+
+    The early prompt-level validation (~chat.py:488) already 400s when
+    ``tool_choice`` names a function absent from ``request.tools``, but
+    that gate sits hundreds of lines upstream from the post-parse
+    synthesis branch — a future refactor could shift or bypass it, at
+    which point the synthesis path would mint a call to
+    ``ghost_function`` and ship a 200 with a fabricated tool_call to a
+    tool the client never defined.
+
+    This test exercises the defense-in-depth at the synthesis branch
+    DIRECTLY by monkeypatching ``_parse_tool_calls_with_parser`` (which
+    runs between the early gate and the synthesis branch, with the
+    ``request`` object in scope) to clear ``request.tools`` and rewrite
+    ``request.tool_choice`` to a ghost target — simulating a future
+    bypass of the early 400 gate. The synthesis branch must then refuse
+    rather than fabricating, surfacing as 422.
+    """
+    from vllm_mlx.routes import chat as chat_module
+
+    synth_calls: list[str] = []
+    real_synth = chat_module._synthesize_forced_tool_call
+
+    def _spy(name, arguments="{}"):
+        synth_calls.append(name)
+        return real_synth(name, arguments)
+
+    monkeypatch.setattr(chat_module, "_synthesize_forced_tool_call", _spy)
+
+    # Simulate the BLOCKING scenario: by the time the synthesis branch
+    # runs, ``request.tools`` no longer contains ``_target``. We
+    # achieve this by hooking ``_parse_tool_calls_with_parser`` — it
+    # runs after the early gate and has the ``request`` in scope, so
+    # we can mutate ``request.tools`` and ``request.tool_choice`` to
+    # the post-bypass state. Returns ``("", None)`` to match the empty
+    # parser-output path that triggers synthesis.
+    real_parse = chat_module._parse_tool_calls_with_parser
+
+    def _bypass_then_parse(text, request, structured_tool_calls=None):
+        # Rewrite ``tool_choice`` to a ghost target while leaving
+        # ``request.tools`` intact (it still contains ``real_function``)
+        # so the synthesis branch's outer guard (line ~1212:
+        # ``request.tool_choice is not None and request.tools``) lets
+        # us in — and the new ``_target_is_submitted`` check must then
+        # fail closed (422), not synthesise.
+        request.tool_choice = {
+            "type": "function",
+            "function": {"name": "ghost_function"},
+        }
+        return real_parse(text, request, structured_tool_calls=structured_tool_calls)
+
+    monkeypatch.setattr(
+        chat_module, "_parse_tool_calls_with_parser", _bypass_then_parse
+    )
+
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do it"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "real_function",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            # Early-gate-friendly: real_function IS in tools so the
+            # upstream 400 doesn't fire; the parser hook then rewrites
+            # state to the BLOCKING scenario.
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "real_function"},
+            },
+            "max_tokens": 32,
+        },
+    )
+    # Defense-in-depth must produce 422 — NEVER 200 with a fabricated
+    # call to ``ghost_function``.
+    assert resp.status_code == 422, resp.text
+    assert "ghost_function" in resp.text
+    # The critical assertion: the synthesis helper must NEVER be
+    # invoked with the ghost name. Without the BLOCKING fix, this
+    # would record ``["ghost_function"]`` and the response would be a
+    # 200 with a fabricated call.
+    assert "ghost_function" not in synth_calls, (
+        f"BLOCKING REGRESSION: _synthesize_forced_tool_call was called "
+        f"with ghost target; calls={synth_calls!r}"
+    )

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -932,3 +932,183 @@ def test_tool_call_name_returns_none_when_no_name_anywhere():
     """
     assert _tool_call_name({}) is None
     assert _tool_call_name(object()) is None
+
+
+# ======================================================================
+# Issue #571 — parser-path symmetry for forced ``tool_choice``
+#
+# Pre-#571: text-parser engines (hermes / qwen3_coder / minimax / glm47)
+# 422'd on ``tool_choice="required"`` and on the named-function form
+# whenever the model produced text the parser didn't recognise.
+# Channel-routed engines (harmony / gemma4) succeeded on identical
+# requests because the ``OutputRouter`` lifts structured tool_calls out
+# of a dedicated channel. The asymmetry broke clients (Cline, Codex,
+# OpenAI SDKs) that hard-code a forced ``tool_choice``: same wire
+# format, parser-dependent outcome.
+#
+# Fix: synthesise a tool_call server-side when the target tool is
+# unambiguous — named-function names it, or ``"required"`` paired with
+# a single tool entry resolves it. ``"required"`` with multiple tools
+# is genuinely ambiguous and still 422s with the pre-#571 message.
+# ======================================================================
+
+
+def test_required_with_single_tool_synthesizes_when_parser_empty():
+    """#571: ``tool_choice="required"`` with EXACTLY ONE tool and a
+    parser that returned no tool_calls must synthesise a call to that
+    sole tool. Without this, hermes-class engines 422 on the same
+    request that harmony returns 200 for, breaking OpenAI's
+    parser-agnostic ``tool_choice`` contract.
+    """
+    engine = _RecordingEngine()  # parser path returns empty
+    client = _make_client(engine)
+    single_tool = [_TOOLS_FIXTURE[0]]  # just get_weather
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hi."}],
+            "tools": single_tool,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    tcs = body["choices"][0]["message"].get("tool_calls") or []
+    assert len(tcs) == 1, f"expected 1 synthesized tool_call, got {len(tcs)}"
+    assert tcs[0]["function"]["name"] == "get_weather"
+    # Arguments default to ``"{}"`` — the contract guarantee is "a
+    # tool_call is present", not "the arguments are correct".
+    assert tcs[0]["function"]["arguments"] == "{}"
+
+
+def test_required_with_multiple_tools_still_422_when_parser_empty():
+    """#571: ``tool_choice="required"`` with MULTIPLE tools and an
+    empty parser output is genuinely ambiguous — the route can't pick
+    a winner, so the pre-#571 422 still fires. Pins the boundary so
+    future refactors don't silently default to ``tools[0]``.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hi."}],
+            "tools": _TOOLS_FIXTURE,  # two tools
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "required" in resp.text.lower()
+
+
+def test_named_function_synthesizes_when_parser_empty():
+    """#571: ``tool_choice={"type":"function","function":{"name":X}}``
+    with an empty parser output must synthesise a call to X. The
+    target tool is named in the request — there's no ambiguity. This
+    is the precise case from issue #571's repro
+    (``tool_choice={type:function,function:{name:web_search}}`` →
+    422 on hermes, 200 on harmony).
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hi."}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_time"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    tcs = body["choices"][0]["message"].get("tool_calls") or []
+    assert len(tcs) == 1
+    assert tcs[0]["function"]["name"] == "get_time"
+    assert tcs[0]["function"]["arguments"] == "{}"
+
+
+def test_named_function_wrong_call_still_422_after_571():
+    """#571 regression: synthesis fires ONLY when the parser returned
+    NOTHING. When the model actively defied the choice and called a
+    different tool, the route must still 422 — silently dropping the
+    model's real output and substituting our synthesised stub would
+    be a worse client experience than the explicit failure.
+    """
+    # Engine returns get_time even though tool_choice pins get_weather.
+    engine = _ToolCallingEngine(fn_name="get_time", arguments='{"city":"Tokyo"}')
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Pick a function"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "get_time" in resp.text
+
+
+def test_harmony_path_unchanged_by_571(monkeypatch):
+    """#571 regression: the harmony / channel-routed path already
+    succeeded by emitting structured tool_calls — synthesis must NOT
+    fire there (it would double the response). Verified by feeding
+    the route an engine that surfaces ``GenerationOutput.tool_calls``
+    directly (the harmony surface) and asserting the result carries
+    exactly one call with the engine's name + arguments, not the
+    synthesised ``"{}"`` stub.
+    """
+    # ``_ToolCallingEngine`` already surfaces structured tool_calls
+    # via ``GenerationOutput.tool_calls`` — the same passthrough
+    # ``HarmonyStreamingRouter`` uses (#515).
+    engine = _ToolCallingEngine(fn_name="get_weather", arguments='{"city":"Tokyo"}')
+    # No text parser configured — exact harmony shape on the route's
+    # perspective: structured surface, parser path bypassed.
+    client = _make_client(engine, tool_call_parser=None)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    tcs = body["choices"][0]["message"].get("tool_calls") or []
+    assert len(tcs) == 1
+    # Engine-emitted, NOT synthesised — args must carry the engine's
+    # payload, not the ``"{}"`` stub.
+    assert tcs[0]["function"]["name"] == "get_weather"
+    assert tcs[0]["function"]["arguments"] == '{"city":"Tokyo"}'
+
+
+def test_synthesize_forced_tool_call_helper_shape():
+    """Pin the synthesised wire shape: id prefix, type=function,
+    function.name = target, function.arguments = string (JSON-encoded).
+    Stops future refactors from accidentally emitting ``arguments`` as
+    a dict (the OpenAI ToolCall spec uses a JSON string).
+    """
+    from vllm_mlx.routes.chat import _synthesize_forced_tool_call
+
+    tc = _synthesize_forced_tool_call("get_weather")
+    assert tc.id.startswith("call_")
+    assert tc.type == "function"
+    assert tc.function.name == "get_weather"
+    assert isinstance(tc.function.arguments, str)
+    assert tc.function.arguments == "{}"
+
+    # Custom arguments are passed through verbatim — the helper does
+    # not parse or re-serialise, matching the model-emitted shape.
+    tc2 = _synthesize_forced_tool_call("calc", arguments='{"expr":"1+1"}')
+    assert tc2.function.arguments == '{"expr":"1+1"}'

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1250,6 +1250,22 @@ async def _create_chat_completion_impl(
             if _target:
                 _names = [_tool_call_name(tc) for tc in tool_calls or []]
                 _mismatched = [n for n in _names if n != _target]
+                # Codex R1 BLOCKING (#675): defense-in-depth — never
+                # synthesise a call to a function the client did not
+                # submit. The early prompt-level validation (~line 488)
+                # already 400s when ``_target`` is absent from
+                # ``request.tools``, but a future refactor could shift
+                # or bypass that gate, and the synthesis branch must
+                # not trust ``_target`` blindly. Gate on the submitted
+                # tool-name set; on miss, raise 422 rather than
+                # fabricating a call to a tool the client never
+                # defined.
+                _submitted_tool_names = {
+                    t.function.get("name")
+                    for t in (request.tools or [])
+                    if t.type == "function"
+                }
+                _target_is_submitted = _target in _submitted_tool_names
                 # #571: when the parser returned NOTHING (``_names`` is
                 # empty), the request still has a deterministic target
                 # — the named-function form names it. Synthesise rather
@@ -1260,7 +1276,7 @@ async def _create_chat_completion_impl(
                 # surface as 422 — synthesising over a real wrong call
                 # would silently drop the model's output and is a worse
                 # client experience than the explicit failure.
-                if not _names:
+                if not _names and _target_is_submitted:
                     logger.warning(
                         "tool_choice pinned function %r on a parser-only path "
                         "produced no tool_calls; synthesising a call with "
@@ -1269,6 +1285,21 @@ async def _create_chat_completion_impl(
                         _target,
                     )
                     tool_calls = [_synthesize_forced_tool_call(_target)]
+                elif not _names and not _target_is_submitted:
+                    # Codex R1 BLOCKING (#675): named tool_choice points
+                    # at a function that is not in ``request.tools`` —
+                    # we must not fabricate a call to it. The early 400
+                    # gate normally catches this; reaching here implies
+                    # the gate was bypassed (e.g. cloud-fallback rewrite
+                    # or future refactor). Refuse rather than synthesise.
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"tool_choice pinned function {_target!r} but it is "
+                            "not present in the request's 'tools' array; refusing "
+                            "to synthesise a call to an undefined tool."
+                        ),
+                    )
                 elif _mismatched:
                     raise HTTPException(
                         status_code=422,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -120,6 +120,43 @@ def _tool_call_name(tc) -> str | None:
     return getattr(tc, "name", None)
 
 
+def _synthesize_forced_tool_call(name: str, arguments: str = "{}"):
+    """Build a single ``ToolCall`` for a forced ``tool_choice`` whose
+    text parser surfaced no calls (#571).
+
+    Text-parser paths (hermes / qwen3_coder / minimax / glm47 / …) only
+    surface a tool_call when the model emits the parser's wire markers.
+    Channel-routed paths (harmony / gemma4) bypass the text parser
+    entirely — the ``OutputRouter`` extracts structured tool_calls
+    directly. The two surfaces therefore diverge on the same request:
+    a forced ``tool_choice`` succeeds on harmony because the model
+    produced the structured channel, but 422s on hermes when the model
+    produced text that the parser failed to recognise.
+
+    The OpenAI ``tool_choice`` contract is parser-agnostic: when the
+    client forces a tool call, the response MUST carry one. To restore
+    symmetry we synthesise a tool_call server-side when the target tool
+    is unambiguous (named-function, or ``"required"`` with a single
+    tool). Arguments default to ``"{}"`` because we have no signal
+    about what the model intended to pass; downstream
+    ``_validate_tool_call_params`` logs a warning when required
+    parameters are missing, mirroring the diagnostic surface clients
+    already see for model-generated calls with bad arguments. The
+    contract guarantee is "a tool_call is present", not "the arguments
+    are correct".
+    """
+    # Lazy import — ToolCall / FunctionCall live alongside the request
+    # model in ``api.models``. The lazy form keeps the synthesis path
+    # scoped to forced-choice requests; the common case pays nothing.
+    from ..api.models import FunctionCall, ToolCall
+
+    return ToolCall(
+        id=f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=FunctionCall(name=name, arguments=arguments),
+    )
+
+
 def _engine_supports_channel_routed_tool_calls(engine) -> bool:
     """Probe whether the engine's tokenizer yields a channel-routed
     streaming path that can emit structured tool calls without a text
@@ -1143,28 +1180,60 @@ async def _create_chat_completion_impl(
     if tool_calls and len(tool_calls) > 1 and request.parallel_tool_calls is False:
         tool_calls = tool_calls[:1]
 
-    # ``tool_choice="required"`` post-parse enforcement (#468). The system
-    # suffix injected above (``_TOOL_USE_REQUIRED_SUFFIX``) makes the model
-    # overwhelmingly likely to comply, but local inference has no
-    # decoder-level guarantee. When the parser comes back empty we 422
-    # rather than ship a contract-violating response (OpenAI spec: a
-    # tool_call is GUARANTEED present in the response when ``required``
-    # is set). For the named-function form we also verify the right tool
-    # fired. Streaming path is best-effort prompt-injection only; once
-    # SSE chunks are out we can't 422 mid-flight.
+    # ``tool_choice="required"`` post-parse enforcement (#468 / #571).
+    # The system suffix injected above (``_TOOL_USE_REQUIRED_SUFFIX``)
+    # makes the model overwhelmingly likely to comply, but local
+    # inference has no decoder-level guarantee.
+    #
+    # Channel-routed engines (harmony / gemma4) bypass the text parser
+    # entirely: the ``OutputRouter`` lifts structured tool_calls out of
+    # a dedicated channel, so a forced ``tool_choice`` is satisfied
+    # whenever the model fires the tool — the parser path is irrelevant.
+    #
+    # Text-parser engines (hermes / qwen3_coder / minimax / glm47 / …)
+    # only surface a tool_call when the model emits the parser's wire
+    # markers. The same model behaviour that produces a structured call
+    # on harmony can produce text that the hermes regex fails to
+    # recognise — and pre-#571 the 422 here fired for hermes while
+    # harmony returned 200, breaking parser-agnostic contracts.
+    #
+    # The OpenAI ``tool_choice`` contract is parser-agnostic: when the
+    # client forces a tool call, the response MUST carry one. To
+    # restore symmetry we synthesise a tool_call server-side when the
+    # target tool is unambiguous — named-function form (the name is
+    # the choice), or ``"required"`` with a single tool entry (the
+    # name is unique). When ``"required"`` is paired with multiple
+    # tools and the parser returned nothing, we genuinely cannot pick
+    # — fall back to 422 with a message that points to the
+    # ``{type:"function",function:{name:X}}`` form as the escape
+    # hatch, matching pre-#571 wording for that diagnostic.
+    # Streaming path is best-effort prompt-injection only; once SSE
+    # chunks are out we can't 422 mid-flight.
     if request.tool_choice is not None and request.tools:
         if request.tool_choice == "required" and not tool_calls:
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    'tool_choice="required" but the model returned a text response '
-                    "with no tool_calls. Local inference has no decoder-level "
-                    "constraint; the system-prompt enforcement was insufficient "
-                    "for this prompt. Retry with a more concrete user message or "
-                    'use tool_choice={"type":"function","function":{"name":...}} '
-                    "to pin a specific tool."
-                ),
-            )
+            if len(request.tools) == 1:
+                _solo_name = request.tools[0].function.get("name")
+                if _solo_name:
+                    logger.warning(
+                        "tool_choice='required' on a parser-only path produced "
+                        "no tool_calls; synthesising a call to the sole "
+                        "available tool %r with empty arguments to honor the "
+                        "OpenAI tool_call-guaranteed contract (#571).",
+                        _solo_name,
+                    )
+                    tool_calls = [_synthesize_forced_tool_call(_solo_name)]
+            if not tool_calls:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        'tool_choice="required" but the model returned a text response '
+                        "with no tool_calls. Local inference has no decoder-level "
+                        "constraint; the system-prompt enforcement was insufficient "
+                        "for this prompt. Retry with a more concrete user message or "
+                        'use tool_choice={"type":"function","function":{"name":...}} '
+                        "to pin a specific tool."
+                    ),
+                )
         if (
             isinstance(request.tool_choice, dict)
             and request.tool_choice.get("type") == "function"
@@ -1181,12 +1250,31 @@ async def _create_chat_completion_impl(
             if _target:
                 _names = [_tool_call_name(tc) for tc in tool_calls or []]
                 _mismatched = [n for n in _names if n != _target]
-                if not _names or _mismatched:
+                # #571: when the parser returned NOTHING (``_names`` is
+                # empty), the request still has a deterministic target
+                # — the named-function form names it. Synthesise rather
+                # than 422 so hermes matches harmony on the same input.
+                # A non-empty-but-wrong list (the model called a
+                # different tool) is a different failure mode: the
+                # model actively defied the choice, which we still
+                # surface as 422 — synthesising over a real wrong call
+                # would silently drop the model's output and is a worse
+                # client experience than the explicit failure.
+                if not _names:
+                    logger.warning(
+                        "tool_choice pinned function %r on a parser-only path "
+                        "produced no tool_calls; synthesising a call with "
+                        "empty arguments to honor the OpenAI tool_call-"
+                        "guaranteed contract (#571).",
+                        _target,
+                    )
+                    tool_calls = [_synthesize_forced_tool_call(_target)]
+                elif _mismatched:
                     raise HTTPException(
                         status_code=422,
                         detail=(
                             f"tool_choice pinned function {_target!r} but the model "
-                            f"emitted calls to {_mismatched or 'no tool'}. Local "
+                            f"emitted calls to {_mismatched}. Local "
                             "inference cannot decoder-enforce a specific function; "
                             "retry with a more direct user message."
                         ),


### PR DESCRIPTION
## Summary

Closes #571. ``tool_choice="required"`` and the named-function form
now succeed across all parser paths — hermes / qwen3_coder /
minimax / glm47 now behave the same as harmony / gemma4 on
identical forced-choice requests, restoring OpenAI's
parser-agnostic ``tool_choice`` contract.

## Root cause

Channel-routed engines (harmony / gemma4) lift structured
tool_calls out of a dedicated ``OutputRouter`` channel — the text
parser is bypassed. Text-parser engines (hermes / qwen3_coder / …)
only surface a tool_call when the model emits the parser's wire
markers. When the model produced text the parser didn't recognise,
the post-parse enforcement gate added in #468 (``chat.py:1156``)
fired 422 — but only on the parser path. Same wire request, same
``tools``, same ``tool_choice``: 200 on harmony, 422 on hermes.

Cline / Codex / OpenAI SDKs that hard-code ``tool_choice="required"``
or ``{"type":"function","function":{"name":X}}`` saw silent
parser-dependent breakage with no schema-level signal.

## Fix

Synthesise a ``ToolCall`` server-side when a forced ``tool_choice``
produces no tool_calls AND the target tool is unambiguous:

* named-function (``{"type":"function","function":{"name":X}}``) —
  the name is the choice; synth ``{name: X, arguments: "{}"}``;
* ``"required"`` paired with exactly one tool — the name is unique;
  synth that tool with empty arguments.

``"required"`` paired with multiple tools is genuinely ambiguous
(no safe default) and continues to 422 with the pre-fix message
pointing to the named-function form as the escape hatch.

A model that actively defied a named choice (parser surfaced a
DIFFERENT tool) still 422s — silently dropping the model's real
output for a synthesised stub is a worse client experience than
the explicit failure.

Arguments default to ``"{}"`` because we have no signal about what
the model intended. ``_validate_tool_call_params`` logs a warning
when required parameters are missing, matching the diagnostic
surface clients already see for model-generated calls with bad
args. The contract guarantee is "a tool_call is present", not
"the arguments are correct".

## Files touched

- ``vllm_mlx/routes/chat.py`` — new ``_synthesize_forced_tool_call``
  helper; post-parse gate at line ~1146 now synthesises before
  raising 422 when the target is unambiguous.
- ``tests/test_chat_route_tool_choice_enforcement.py`` — six new
  tests covering the symmetric behaviour and the boundary that
  preserves the 422 path.

## Test plan

- [x] ``test_required_with_single_tool_synthesizes_when_parser_empty``
- [x] ``test_required_with_multiple_tools_still_422_when_parser_empty``
- [x] ``test_named_function_synthesizes_when_parser_empty``
- [x] ``test_named_function_wrong_call_still_422_after_571``
- [x] ``test_harmony_path_unchanged_by_571``
- [x] ``test_synthesize_forced_tool_call_helper_shape``
- [x] All 31 existing ``test_chat_route_tool_choice_enforcement``
      tests still pass (no regression on the #468 / #518 gates).
- [x] Adjacent suites green:
      ``test_chat_route_tool_tag_leak.py``, ``test_tool_calling.py``,
      ``test_tool_call_e2e.py``, ``test_batched_engine_tool_call_normalization.py``,
      ``test_parallel_tool_calls.py``, ``test_tool_call_streaming_parity.py``,
      ``test_streaming_tool_filter.py``. (The single
      ``test_multi_step_tool_chain`` failure pre-dates this branch —
      reproduces on ``main`` with the changes stashed.)
- [x] ``ruff check`` + ``ruff format`` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)