### PR TITLE
fix: rescue silent-drop on unterminated reasoning (#569)

### DIFF
--- a/tests/test_chat_logprobs_channel_routing.py
+++ b/tests/test_chat_logprobs_channel_routing.py
@@ -146,8 +146,27 @@ def test_logprobs_path_without_channel_falls_back_unchanged():
     assert msg.get("reasoning_content") in (None, "")
 
 
-def test_logprobs_path_reasoning_only_keeps_content_empty():
-    """Analysis-only stream (no final channel) must NOT leak into content."""
+def test_logprobs_path_reasoning_only_surfaces_via_rescue():
+    """Analysis-only stream (no final channel) on the logprobs path.
+
+    Issue #569 updated the contract for this scenario: a reasoning-only
+    turn was previously emitted with ``content=null``, which agentic
+    OpenAI clients (Cline / Cursor / Codex CLI) reading only the
+    ``content`` field would see as an empty assistant message. The
+    route-layer ``_rescue_silent_drop_from_reasoning`` now surfaces
+    the reasoning trace as ``content`` while keeping
+    ``reasoning_content`` populated — duplication between the two
+    fields is the lesser evil vs. a silently empty response.
+
+    What this test STILL pins (the #442 contract): reasoning channel
+    text does not appear in content via the BLEED path (parser leaking
+    analysis content because the channel split failed). The text we
+    see in ``content`` here is the EXPLICIT rescue, not a regex leak —
+    the engine-level test ``test_truncated_analysis_drops_content_
+    and_recovers_reasoning`` in ``tests/test_engine_router_non_stream``
+    still asserts the engine returns ``content == ""`` on the same
+    input shape.
+    """
     chunks = [
         ("reasoning", "thinking only, no final."),
     ]
@@ -167,7 +186,11 @@ def test_logprobs_path_reasoning_only_keeps_content_empty():
     assert resp.status_code == 200, resp.text
     body = resp.json()
     msg = body["choices"][0]["message"]
-    assert not msg.get("content"), (
-        f"content must be empty when stream is reasoning-only; got {msg['content']!r}"
+    # #569: rescue fires — content carries the reasoning trace so the
+    # assistant turn isn't silently empty for OpenAI-compat clients.
+    assert msg.get("content") == "thinking only, no final.", (
+        f"#569: content must surface reasoning when otherwise empty; "
+        f"got {msg.get('content')!r}"
     )
+    # reasoning_content stays populated unchanged.
     assert msg.get("reasoning_content") == "thinking only, no final."

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -125,6 +125,44 @@ def test_rescue_noop_when_reasoning_empty_string():
     assert rescued is None
 
 
+def test_rescue_noop_when_reasoning_is_whitespace_only():
+    """Codex round-1 NIT on #676: whitespace-only ``reasoning_text``
+    (``"   \\n\\t  "``) must NOT pass the rescue predicate.
+    Pre-fix the helper only checked truthiness, so a non-empty
+    whitespace string was promoted to ``content`` and clients saw a
+    technically-non-null but semantically-empty assistant turn.
+    Post-fix the predicate uses ``.strip()`` so semantically-empty
+    whitespace is treated identically to ``None`` / ``""`` — no
+    rescue, no fabrication; the existing empty-response path fires.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="   \n\t  ",
+        tool_calls=None,
+    )
+    assert rescued is None, (
+        f"whitespace-only reasoning must not promote to content; got {rescued!r}"
+    )
+
+
+def test_rescue_preserves_leading_trailing_whitespace_in_rescued_content():
+    """The whitespace-only gate must use ``.strip()`` on the
+    predicate only — the assigned content stays untouched so a
+    legitimately-padded thought trace (``"  Thought.  "``) keeps its
+    original framing. The predicate sees non-empty content via
+    ``.strip()``; the returned value is the raw original.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="  Real thought.  ",
+        tool_calls=None,
+    )
+    assert rescued == "  Real thought.  ", (
+        "predicate must use strip() but the returned value must be "
+        f"the original (un-stripped) reasoning text; got {rescued!r}"
+    )
+
+
 def test_rescue_noop_when_tool_calls_empty_list():
     """``tool_calls`` is sometimes an empty list rather than
     ``None`` (parser returned no matches). Treat it as falsy — the
@@ -551,3 +589,150 @@ def test_streaming_rescue_noop_when_content_was_streamed():
         )
     finally:
         reset_config()
+
+
+# ── response_format gate: codex round-1 BLOCKING on #676 ─────────────
+
+
+class _ReasoningOnlyChatEngine:
+    """Non-streaming engine that returns ONLY reasoning text.
+
+    Reproduces the gemma-4 stuck-thought non-streaming shape: the
+    token-level router populated ``reasoning_text`` but emitted no
+    final/content channel and no tool call. The chat route's normal
+    ``content`` extraction yields empty/None; the rescue would
+    normally surface the reasoning trace as ``content`` — but a
+    structured-output (``response_format`` = ``json_object`` /
+    ``json_schema``) request MUST keep the rescue suppressed because
+    reasoning prose is almost never valid JSON and would break the
+    OpenAI-compat structured-output contract.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, reasoning_text: str):
+        self._reasoning_text = reasoning_text
+        self.chat_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text="",
+            new_text="",
+            prompt_tokens=4,
+            completion_tokens=8,
+            finished=True,
+            finish_reason="stop",
+            channel="reasoning",
+            reasoning_text=self._reasoning_text,
+        )
+
+
+def _run_chat_route_with_response_format(response_format: dict) -> dict:
+    """Helper: drive the chat route via TestClient with a
+    reasoning-only engine and the given ``response_format``. Returns
+    the parsed JSON response body so the test can assert on
+    ``content`` / ``reasoning_content``.
+    """
+    import json as _json
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    cfg.engine = _ReasoningOnlyChatEngine(
+        reasoning_text="Need to think about the JSON shape the user wants",
+    )
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": False,
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "give me JSON"}],
+                "response_format": response_format,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        return _json.loads(resp.text)
+    finally:
+        reset_config()
+
+
+def test_rescue_skipped_when_response_format_is_json_object():
+    """Codex round-1 BLOCKING on #676: when a client requests
+    ``response_format={"type": "json_object"}``, the route MUST NOT
+    rescue reasoning text into ``content``. Reasoning prose is
+    almost never valid JSON, so surfacing it would break the
+    OpenAI-compat structured-output contract (clients expect either
+    validated JSON or the existing empty/error path so they can
+    retry, not surprise prose).
+
+    Post-fix invariant: ``content`` is ``None`` (or empty), the
+    reasoning trace stays in ``reasoning_content`` so it isn't
+    lost, and the structured-output client sees the unchanged
+    empty path.
+    """
+    body = _run_chat_route_with_response_format({"type": "json_object"})
+
+    choice = body["choices"][0]
+    msg = choice["message"]
+    # The rescue must NOT fire — content stays None / absent.
+    assert not msg.get("content"), (
+        "#676 BLOCKING: rescue must be suppressed for "
+        f"response_format=json_object; got content={msg.get('content')!r}"
+    )
+    # Reasoning is still surfaced via reasoning_content so the
+    # trace isn't lost — operator can still debug, client gets the
+    # existing structured-output empty/error path.
+    assert "think" in (msg.get("reasoning_content") or "").lower()
+
+
+def test_rescue_skipped_when_response_format_is_json_schema():
+    """Same #676 BLOCKING contract for ``json_schema``: structured
+    output requests MUST NOT have reasoning prose surfaced as
+    ``content``. Validated JSON or the existing empty/error path —
+    never surprise prose that the client will then fail to parse
+    against the requested schema.
+    """
+    body = _run_chat_route_with_response_format(
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+            },
+        }
+    )
+
+    choice = body["choices"][0]
+    msg = choice["message"]
+    assert not msg.get("content"), (
+        "#676 BLOCKING: rescue must be suppressed for "
+        f"response_format=json_schema; got content={msg.get('content')!r}"
+    )
+    assert "think" in (msg.get("reasoning_content") or "").lower()

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -145,6 +145,33 @@ def test_rescue_noop_when_reasoning_is_whitespace_only():
     )
 
 
+def test_rescue_noop_when_final_content_is_whitespace_only():
+    """Codex round-3 NIT on #676: whitespace-only ``final_content``
+    (``"   \\n"``) is semantically empty to OpenAI-compat clients —
+    the assistant turn shows as blank even though the field is a
+    non-empty string. Pre-fix the helper's early-exit predicate was
+    a plain truthiness check (``if final_content: return …``), so a
+    whitespace-only string blocked the rescue and the client saw an
+    empty assistant turn despite the engine having produced a
+    legitimate reasoning trace.
+
+    Post-fix the predicate strips before returning: whitespace-only
+    ``final_content`` is treated identically to ``None`` / ``""``,
+    so the rescue FIRES and the reasoning trace surfaces as content.
+    Pins the contract: any ``final_content`` that ``.strip()``s to
+    empty must NOT block the rescue when reasoning is present.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content="   \n",
+        reasoning_text="Real reasoning trace that should be rescued",
+        tool_calls=None,
+    )
+    assert rescued == "Real reasoning trace that should be rescued", (
+        "whitespace-only final_content must be treated as semantically "
+        f"absent so rescue can fire; got {rescued!r}"
+    )
+
+
 def test_rescue_preserves_leading_trailing_whitespace_in_rescued_content():
     """The whitespace-only gate must use ``.strip()`` on the
     predicate only — the assigned content stays untouched so a
@@ -586,6 +613,77 @@ def test_streaming_rescue_noop_when_content_was_streamed():
         assert streamed_content == "Hello world.", (
             f"happy path content stream must equal engine output; "
             f"got {streamed_content!r}"
+        )
+    finally:
+        reset_config()
+
+
+def test_streaming_rescue_noop_when_reasoning_is_whitespace_only():
+    """Codex round-3 BLOCKING on #676: the streaming rescue used to
+    promote ``processor.accumulated_reasoning`` directly into
+    ``delta.content`` on the terminal chunk, bypassing the helper's
+    whitespace guard. A reasoning-only stream of ``"   \\n"`` would
+    then emit a semantically empty ``delta.content`` while the
+    non-streaming path correctly suppressed it via the helper.
+
+    Post-fix the streaming rescue routes through
+    ``_rescue_silent_drop_from_reasoning`` so both paths share the
+    same predicate (whitespace + content + tool-call absence). A
+    whitespace-only reasoning stream therefore yields NO
+    ``delta.content`` on any chunk — same shape the non-streaming
+    counterpart pins at the unit level. Mirrors
+    ``test_rescue_noop_when_reasoning_is_whitespace_only`` for the
+    SSE surface so the streaming/non-streaming parity is locked in.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    # Reasoning deltas that concatenate to whitespace-only — the
+    # exact stuck-thought edge case where the helper's guard must
+    # suppress the streaming rescue identically to non-streaming.
+    cfg.engine = _ReasoningOnlyStreamEngine(
+        reasoning_deltas=["   ", "\n", "\t  "],
+    )
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        events = _parse_sse(resp.text)
+        assert events, "expected at least one SSE chunk"
+
+        # No SSE chunk may carry semantically-non-empty content.
+        # Pre-fix the terminal chunk would carry ``"   \n\t  "`` as
+        # ``delta.content``; post-fix the helper's whitespace
+        # predicate fires and no content is emitted at all.
+        streamed_content = ""
+        for ev in events:
+            for choice in ev.get("choices", []):
+                delta = choice.get("delta") or {}
+                if delta.get("content"):
+                    streamed_content += delta["content"]
+        assert not streamed_content.strip(), (
+            "#676 round-3 BLOCKING (streaming): whitespace-only "
+            "accumulated reasoning must NOT promote to delta.content "
+            f"on any SSE chunk; got streamed_content={streamed_content!r}"
         )
     finally:
         reset_config()

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -670,20 +670,27 @@ def test_streaming_rescue_noop_when_reasoning_is_whitespace_only():
         events = _parse_sse(resp.text)
         assert events, "expected at least one SSE chunk"
 
-        # No SSE chunk may carry semantically-non-empty content.
-        # Pre-fix the terminal chunk would carry ``"   \n\t  "`` as
-        # ``delta.content``; post-fix the helper's whitespace
-        # predicate fires and no content is emitted at all.
-        streamed_content = ""
-        for ev in events:
-            for choice in ev.get("choices", []):
-                delta = choice.get("delta") or {}
-                if delta.get("content"):
-                    streamed_content += delta["content"]
-        assert not streamed_content.strip(), (
-            "#676 round-3 BLOCKING (streaming): whitespace-only "
+        # Codex round-4 BLOCKING on #676: collect EVERY ``delta.content``
+        # value without stripping, so an incorrectly-emitted
+        # whitespace-only payload (``"   \n\t  "``) is caught instead
+        # of being silently coerced to empty by ``.strip()``. Pre-fix
+        # this assertion was ``not streamed_content.strip()``, which
+        # would still pass under the exact regression we're guarding
+        # against — a self-defeating test. The new shape lists every
+        # raw ``delta.content`` value emitted on any chunk and asserts
+        # the list is empty; any emission at all (whitespace, empty
+        # string, real text) is a regression.
+        content_values = [
+            (choice.get("delta") or {}).get("content")
+            for ev in events
+            for choice in ev.get("choices", [])
+            if "content" in (choice.get("delta") or {})
+        ]
+        assert content_values == [], (
+            "#676 round-4 BLOCKING (streaming): whitespace-only "
             "accumulated reasoning must NOT promote to delta.content "
-            f"on any SSE chunk; got streamed_content={streamed_content!r}"
+            "on any SSE chunk; expected zero content emissions but "
+            f"got {content_values!r}"
         )
     finally:
         reset_config()

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #569.
+
+gemma-4-26b-4bit multi-turn tool calls silently drop content + tool_calls
+when reasoning doesn't terminate. The model gets stuck inside
+``<|channel>thought\n…`` and runs out of its token budget before
+emitting any ``<|tool_call>`` or ``<|channel>content`` marker. The
+engine's token-level ``OutputRouter`` correctly routes every token to
+``reasoning``, but the route then emits an OpenAI-compat message with
+``content=null`` and ``tool_calls=null`` while ``reasoning_content``
+carries the entire stuck thought. Agentic clients (Cline, Cursor,
+Codex CLI) read ``content`` and ``tool_calls`` only, see an empty
+message, and either retry into the same trap or stall.
+
+The fix: ``_rescue_silent_drop_from_reasoning`` runs at the route
+layer AFTER tool-call parsing and AFTER the reasoning/content split.
+When ``final_content`` is empty/None AND no ``tool_calls`` fired AND
+``reasoning_text`` is non-empty, surface ``reasoning_text`` as
+``content``. ``reasoning_content`` stays populated unchanged
+(duplication between fields is the lesser evil vs. silent drop).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+from vllm_mlx.service.helpers import (
+    _finalize_content_and_reasoning,
+    _rescue_silent_drop_from_reasoning,
+)
+
+# ── Unit tests for the rescue helper ─────────────────────────────────
+
+
+def test_rescue_fires_when_content_none_no_tools_with_reasoning():
+    """Exact #569 production failure: ``final_content`` empty/None,
+    ``tool_calls`` empty/None, ``reasoning_text`` non-empty. The
+    rescue surfaces reasoning as content so the assistant message is
+    non-empty for OpenAI-compat clients.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="The user wants weather for SF. I should call get_weather",
+        tool_calls=None,
+    )
+    assert rescued == ("The user wants weather for SF. I should call get_weather"), (
+        "rescue must surface reasoning trace when content+tool_calls are both empty"
+    )
+
+
+def test_rescue_fires_when_content_empty_string():
+    """Empty-string ``final_content`` (downstream sanitization
+    collapsed everything to empty) is treated the same as ``None`` —
+    the user-visible field is silently empty either way.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content="",
+        reasoning_text="Some reasoning trace",
+        tool_calls=None,
+    )
+    assert rescued == "Some reasoning trace"
+
+
+def test_rescue_noop_when_content_present():
+    """Happy path: ``final_content`` is non-empty. Rescue must NOT
+    overwrite the model's actual answer with the reasoning trace.
+    This is the regression guard against the rescue firing on the
+    properly-terminated gemma-4 multi-turn flow (the success case the
+    bug report says must NOT regress).
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content="The answer is 42.",
+        reasoning_text="I thought about it carefully...",
+        tool_calls=None,
+    )
+    assert rescued == "The answer is 42.", (
+        "rescue must not clobber legitimate content with reasoning"
+    )
+
+
+def test_rescue_noop_when_tool_calls_fired():
+    """When the model emitted a tool call, ``content`` is
+    legitimately ``None`` per the OpenAI spec (the tool call IS the
+    response). Rescue must NOT fire — surfacing the pre-call
+    reasoning as content would confuse the OpenAI client into
+    interpreting it as a text reply alongside the tool call.
+    """
+    fake_tool_calls = [{"id": "call_x", "type": "function"}]
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="I'll call get_weather for SF",
+        tool_calls=fake_tool_calls,
+    )
+    assert rescued is None, (
+        "tool-call turns must keep content=None; rescue must not fire"
+    )
+
+
+def test_rescue_noop_when_reasoning_also_empty():
+    """If the model truly produced nothing (no content, no
+    reasoning, no tool call), there's nothing to rescue with.
+    ``None`` propagates — we do NOT fabricate content. The upstream
+    bug (model silent) is the operator's problem to debug, but the
+    rescue layer doesn't make it worse.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=None,
+        tool_calls=None,
+    )
+    assert rescued is None
+
+
+def test_rescue_noop_when_reasoning_empty_string():
+    """Empty-string ``reasoning_text`` (the engine populated the
+    field but the value is empty) is treated the same as ``None``:
+    no rescue, no fabrication.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="",
+        tool_calls=None,
+    )
+    assert rescued is None
+
+
+def test_rescue_noop_when_tool_calls_empty_list():
+    """``tool_calls`` is sometimes an empty list rather than
+    ``None`` (parser returned no matches). Treat it as falsy — the
+    rescue fires when content is empty AND there are no actual
+    calls, regardless of whether the field is ``None`` or ``[]``.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="Some thought",
+        tool_calls=[],
+    )
+    assert rescued == "Some thought"
+
+
+# ── Integration: parser-level repro of the truncated thought ─────────
+
+
+def test_gemma4_parser_returns_no_reasoning_on_unterminated_thought():
+    """Pins the upstream surface: the Gemma 4 reasoning parser's
+    ``extract_reasoning`` returns ``(None, raw_text_with_marker)``
+    when the thought channel never closed. This is what feeds the
+    silent-drop path — the parser bails, the route then drops content.
+
+    The parser behavior itself is correct (it can't infer where a
+    missing close marker SHOULD have been); the route-layer rescue
+    is what protects clients from the consequence. This test pins
+    the parser's behavior so future parser changes don't silently
+    bypass the rescue's reason for existing.
+    """
+    p = Gemma4ReasoningParser()
+    truncated = (
+        "<|channel>thought\nLet me think. The user asked about weather. "
+        "I should call get_weather with city=SF. But first let me check"
+    )
+    reasoning, content = p.extract_reasoning(truncated)
+    assert reasoning is None, (
+        "parser must not pretend it extracted reasoning from an "
+        f"unterminated thought; got {reasoning!r}"
+    )
+    # Content is the raw text (markers preserved). The route's
+    # ``clean_output_text`` + ``strip_thinking_tags`` will collapse
+    # this; the rescue handles the resulting empty content.
+    assert content is not None and "Let me think" in content
+
+
+# ── Integration: full _finalize + rescue chain on engine-routed input ──
+
+
+def test_finalize_plus_rescue_recovers_stuck_gemma4_thought():
+    """End-to-end stitching of the helpers chain that the chat route
+    executes. Simulates the engine path for gemma-4-26b-4bit stuck
+    mid-thought: the token-level ``OutputRouter`` populated
+    ``engine_reasoning_text`` (token-routed reasoning trace) and
+    cleared ``cleaned_text``. ``_finalize_content_and_reasoning``
+    short-circuits on the non-empty ``engine_reasoning_text`` and
+    returns ``("", reasoning)``. ``_rescue_silent_drop_from_reasoning``
+    then surfaces the reasoning as content.
+    """
+    engine_reasoning = (
+        "Need to figure out what weather tool wants. The city is SF. "
+        "Let me think about format"
+    )
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text="<|channel>thought\n" + engine_reasoning,
+        cleaned_text="",
+        tool_calls=[],
+        reasoning_parser=Gemma4ReasoningParser(),
+        engine_reasoning_text=engine_reasoning,
+    )
+    # First leg: engine-routed reasoning wins, cleaned_text stays empty.
+    assert cleaned_text == ""
+    assert reasoning_text == engine_reasoning
+
+    # Simulate the route's final_content compute path: empty
+    # cleaned_text -> final_content stays None (mirror chat.py:1252-1257).
+    final_content = None
+    if cleaned_text:  # pragma: no cover — path not taken in this scenario
+        final_content = cleaned_text
+
+    # Apply the rescue.
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content, reasoning_text, tool_calls=None
+    )
+    assert rescued == engine_reasoning, (
+        "end-to-end rescue must surface the engine-routed reasoning trace "
+        "as content when the model got stuck mid-thought"
+    )
+
+
+def test_finalize_plus_rescue_preserves_happy_path():
+    """Happy path: model emits properly-terminated thought + content.
+    Engine routes both → ``cleaned_text`` carries the final answer,
+    ``reasoning_text`` carries the thought trace. The rescue must
+    NOT fire — the user's content is the model's actual answer, not
+    its thought trace. Pins the no-regress contract from issue #569.
+    """
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text="<|channel>thought\nLet me think.<channel|>"
+        "<|channel>content\nThe answer is 42.<channel|>",
+        cleaned_text="The answer is 42.",
+        tool_calls=[],
+        reasoning_parser=Gemma4ReasoningParser(),
+        engine_reasoning_text="Let me think.",
+    )
+    assert cleaned_text == "The answer is 42."
+    assert reasoning_text == "Let me think."
+
+    rescued = _rescue_silent_drop_from_reasoning(
+        cleaned_text, reasoning_text, tool_calls=None
+    )
+    assert rescued == "The answer is 42.", (
+        "happy-path content must NOT be overwritten by the reasoning trace"
+    )
+
+
+def test_finalize_plus_rescue_preserves_tool_call_path():
+    """Tool-call path: model emits reasoning then a tool call. The
+    OpenAI spec says ``content`` is ``None`` for tool-call turns
+    (the tool call IS the response). Rescue must NOT fire — surfacing
+    the pre-call reasoning as content would make the client see both
+    a text reply AND a tool call, which violates the contract.
+    """
+    fake_tool_calls = [
+        {
+            "id": "call_x",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+        }
+    ]
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text="<|channel>thought\nNeed weather.<channel|>"
+        '<|tool_call>call:get_weather{city:<|"|>SF<|"|>}<tool_call|>',
+        cleaned_text="",  # tool parser stripped to empty
+        tool_calls=fake_tool_calls,
+        reasoning_parser=Gemma4ReasoningParser(),
+        engine_reasoning_text="Need weather.",
+    )
+    assert reasoning_text == "Need weather."
+
+    rescued = _rescue_silent_drop_from_reasoning(
+        None, reasoning_text, tool_calls=fake_tool_calls
+    )
+    assert rescued is None, "tool-call turns must keep content=None"
+
+
+# ── Integration: ChatCompletion response assembly ────────────────────
+
+
+@pytest.fixture
+def fake_chat_finalize():
+    """Wraps the chat route's final assembly so the test exercises
+    the exact sequence the production handler runs. Returns
+    ``(final_content, reasoning_content)`` — the two fields that
+    matter for the silent-drop regression.
+    """
+
+    def _finalize(
+        *,
+        cleaned_text: str,
+        reasoning_text: str | None,
+        tool_calls: list | None,
+    ):
+        from vllm_mlx.api.utils import (
+            clean_output_text,
+            sanitize_output,
+            strip_thinking_tags,
+        )
+
+        final_content = None
+        if cleaned_text:
+            final_content = strip_thinking_tags(clean_output_text(cleaned_text))
+            final_content = sanitize_output(final_content)
+
+        final_content = _rescue_silent_drop_from_reasoning(
+            final_content, reasoning_text, tool_calls
+        )
+        return final_content, reasoning_text
+
+    return _finalize
+
+
+def test_assistant_message_non_empty_when_only_reasoning_fired(fake_chat_finalize):
+    """Pins the issue #569 contract at the assembly layer: when the
+    model produced only a reasoning trace, the AssistantMessage MUST
+    have ``content`` populated (so Cline/Cursor/Codex CLI don't see
+    an empty turn). ``reasoning_content`` stays populated unchanged.
+    """
+    content, reasoning = fake_chat_finalize(
+        cleaned_text="",
+        reasoning_text="The user wants weather. I should call get_weather",
+        tool_calls=None,
+    )
+    assert content is not None and content != "", (
+        "issue #569: assistant turn must not be silently empty"
+    )
+    assert "weather" in content
+    assert reasoning == "The user wants weather. I should call get_weather"
+
+
+def test_assistant_message_truly_empty_when_nothing_fired(fake_chat_finalize):
+    """Defensive: when the model produced NOTHING at all (no content,
+    no reasoning, no tool call), the rescue does NOT fabricate
+    content. ``content`` stays ``None`` so the route emits the
+    OpenAI-spec empty-message shape. The upstream "model produced
+    nothing" bug is a separate concern; rescue doesn't paper over it.
+    """
+    content, reasoning = fake_chat_finalize(
+        cleaned_text="",
+        reasoning_text=None,
+        tool_calls=None,
+    )
+    assert content is None
+    assert reasoning is None
+
+
+# ── Streaming surface: SSE terminal-chunk rescue ─────────────────────
+
+
+class _ReasoningOnlyStreamEngine:
+    """Streaming engine that yields ONLY reasoning-channel chunks.
+
+    Reproduces the gemma-4 stuck-thought streaming shape: per-token
+    output emits on the reasoning channel, the stream ends without
+    ever transitioning to a content channel or tool call. The
+    streaming chat route's terminal chunk should rescue the
+    accumulated reasoning trace into ``delta.content`` so OpenAI-compat
+    clients reading only the content stream see something.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, reasoning_deltas: list[str]):
+        self._deltas = reasoning_deltas
+        self.stream_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        accumulated_reasoning = ""
+        for i, delta in enumerate(self._deltas):
+            accumulated_reasoning += delta
+            is_last = i == len(self._deltas) - 1
+            yield GenerationOutput(
+                text="",
+                new_text=delta,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                channel="reasoning",
+                reasoning_text=accumulated_reasoning,
+            )
+
+
+def _parse_sse(text: str) -> list[dict]:
+    """Extract JSON payloads from an SSE response body."""
+    import json
+
+    events = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def test_streaming_rescue_surfaces_reasoning_as_terminal_content():
+    """SSE streaming surface: when the model emits only reasoning
+    deltas during the loop AND no tool call fires, the terminal
+    chunk's ``delta.content`` MUST carry the accumulated reasoning
+    trace. The per-delta ``reasoning_content`` chunks already went
+    out during the loop; this extra ``content`` in the terminal
+    chunk is the no-silent-drop guarantee for OpenAI-compat agentic
+    clients (Cline, Cursor, Codex CLI) reading the content stream
+    only.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    cfg.engine = _ReasoningOnlyStreamEngine(
+        reasoning_deltas=[
+            "Need to think about ",
+            "the weather query. ",
+            "I should call get_weather but first",
+        ]
+    )
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None  # engine reasoning_text is authoritative
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "weather?"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        events = _parse_sse(resp.text)
+        assert events, "expected at least the terminal SSE chunk"
+
+        terminal_events = [
+            e
+            for e in events
+            if any(ch.get("finish_reason") is not None for ch in e.get("choices", []))
+        ]
+        assert terminal_events, "expected an SSE chunk with finish_reason set"
+        terminal = terminal_events[-1]
+        delta = terminal["choices"][0].get("delta", {})
+
+        # #569: terminal chunk surfaces accumulated reasoning as content
+        # so the content stream is non-empty for clients that ignore
+        # reasoning_content.
+        terminal_content = delta.get("content")
+        assert terminal_content, (
+            f"#569 streaming: terminal chunk MUST carry rescued content; "
+            f"got {terminal_content!r}"
+        )
+        # The rescued content is the accumulated reasoning trace.
+        assert "weather query" in terminal_content
+    finally:
+        reset_config()
+
+
+def test_streaming_rescue_noop_when_content_was_streamed():
+    """Streaming happy path: when content was emitted during the
+    loop, the rescue MUST NOT fire and duplicate the accumulated
+    text into the terminal chunk on TOP of what the normal terminal
+    delta carries (which can legitimately be the last content delta,
+    merged in by the postprocessor when ``output.finished=True``).
+
+    The post-fix invariant we pin: the union of content deltas across
+    all SSE chunks equals the original streamed text — no duplication
+    of the WHOLE accumulated content via rescue.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.routes.chat import router as chat_router
+
+    class _NormalEngine:
+        preserve_native_tool_format = False
+        is_mllm = False
+        supports_guided_generation = False
+        tokenizer = None
+
+        def build_prompt(self, messages, tools=None, enable_thinking=None):
+            return "PROMPT"
+
+        async def stream_chat(self, messages, **kwargs):
+            for i, txt in enumerate(["Hello ", "world."]):
+                is_last = i == 1
+                yield GenerationOutput(
+                    text=txt,
+                    new_text=txt,
+                    prompt_tokens=4,
+                    completion_tokens=i + 1,
+                    finished=is_last,
+                    finish_reason="stop" if is_last else None,
+                    channel=None,
+                )
+
+    cfg = reset_config()
+    cfg.engine = _NormalEngine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        events = _parse_sse(resp.text)
+
+        # Concatenate every content delta across the whole stream.
+        # The streamed content should equal the original engine
+        # output exactly — no rescue duplication, no missing bytes.
+        streamed_content = ""
+        for ev in events:
+            for choice in ev.get("choices", []):
+                delta = choice.get("delta") or {}
+                if delta.get("content"):
+                    streamed_content += delta["content"]
+        assert streamed_content == "Hello world.", (
+            f"happy path content stream must equal engine output; "
+            f"got {streamed_content!r}"
+        )
+    finally:
+        reset_config()

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -736,3 +736,144 @@ def test_rescue_skipped_when_response_format_is_json_schema():
         f"response_format=json_schema; got content={msg.get('content')!r}"
     )
     assert "think" in (msg.get("reasoning_content") or "").lower()
+
+
+# ── streaming response_format gate: codex round-2 BLOCKING on #676 ──
+
+
+def _run_streaming_chat_route_with_response_format(response_format: dict) -> list[dict]:
+    """Helper: drive the streaming chat route via TestClient with a
+    reasoning-only streaming engine and the given ``response_format``.
+    Returns the parsed list of SSE event dicts so tests can assert
+    that the terminal chunk does NOT carry rescued ``delta.content``
+    (because structured output was requested).
+
+    Mirrors ``_run_chat_route_with_response_format`` but drives
+    ``stream=True`` — pins the streaming counterpart of the same
+    contract. Factored so the ``json_object`` and ``json_schema``
+    cases share the entire harness; only the request body differs.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    cfg.engine = _ReasoningOnlyStreamEngine(
+        reasoning_deltas=[
+            "Need to think about ",
+            "the JSON shape ",
+            "the user wants",
+        ]
+    )
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "give me JSON"}],
+                "response_format": response_format,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        return _parse_sse(resp.text)
+    finally:
+        reset_config()
+
+
+def test_streaming_rescue_skipped_when_response_format_is_json_object():
+    """Codex round-2 BLOCKING on #676: the SSE/streaming rescue path
+    must apply the same ``response_format`` gate as the non-streaming
+    path. Pre-fix, ``stream=true`` requests with
+    ``response_format={"type": "json_object"}`` would still get the
+    reasoning trace surfaced in ``delta.content`` on the terminal
+    chunk, breaking the OpenAI-compat structured-output contract for
+    streaming clients exactly as the non-streaming path used to
+    before round 1.
+
+    Post-fix invariant: NO SSE chunk carries reasoning prose in
+    ``delta.content``. Per-delta ``delta.reasoning_content`` chunks
+    still go out during the loop (debuggability), and the terminal
+    chunk's ``delta.content`` is empty / absent so structured-output
+    clients see the existing empty path and can retry — never
+    surprise prose.
+    """
+    events = _run_streaming_chat_route_with_response_format({"type": "json_object"})
+    assert events, "expected at least one SSE chunk"
+
+    # Aggregate every delta.content across the whole stream — none of
+    # them should carry the reasoning trace. Per-delta reasoning
+    # chunks SHOULD still flow on the reasoning_content channel so
+    # operators can debug.
+    streamed_content = ""
+    streamed_reasoning = ""
+    for ev in events:
+        for choice in ev.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                streamed_content += delta["content"]
+            if delta.get("reasoning_content"):
+                streamed_reasoning += delta["reasoning_content"]
+
+    assert not streamed_content, (
+        "#676 BLOCKING (streaming): no SSE chunk may surface reasoning "
+        "as delta.content when response_format=json_object; "
+        f"got streamed_content={streamed_content!r}"
+    )
+    # Reasoning trace must still be preserved on the reasoning channel.
+    assert "json shape" in streamed_reasoning.lower(), (
+        "reasoning_content must still flow during the loop for "
+        f"debuggability; got reasoning={streamed_reasoning!r}"
+    )
+
+
+def test_streaming_rescue_skipped_when_response_format_is_json_schema():
+    """Same #676 BLOCKING contract for ``json_schema`` on the
+    streaming path: structured output requests MUST NOT have
+    reasoning prose surfaced as ``delta.content`` on the terminal
+    chunk. Validated JSON or the existing empty path — never
+    surprise prose the client will fail to parse against the
+    requested schema.
+    """
+    events = _run_streaming_chat_route_with_response_format(
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+            },
+        }
+    )
+    assert events, "expected at least one SSE chunk"
+
+    streamed_content = ""
+    streamed_reasoning = ""
+    for ev in events:
+        for choice in ev.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                streamed_content += delta["content"]
+            if delta.get("reasoning_content"):
+                streamed_reasoning += delta["reasoning_content"]
+
+    assert not streamed_content, (
+        "#676 BLOCKING (streaming): no SSE chunk may surface reasoning "
+        "as delta.content when response_format=json_schema; "
+        f"got streamed_content={streamed_content!r}"
+    )
+    assert "json shape" in streamed_reasoning.lower()

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -39,6 +39,7 @@ from ..service.helpers import (
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
     _release_admission_unless_committed,
+    _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_temperature,
@@ -287,6 +288,17 @@ async def create_anthropic_message(
             # consider "sanitized" client-facing content. Pre-existing gap
             # flagged by codex during the #413 review.
             final_content = sanitize_output(final_content)
+
+        # Issue #569: never silently drop. Mirror the OpenAI route's
+        # rescue so the Anthropic surface gets the same protection
+        # against silently-empty assistant turns when the model gets
+        # stuck inside reasoning (gemma-4-26b-4bit multi-turn failure
+        # mode). The Anthropic adapter downstream renders the
+        # rescued ``content`` into a TextBlock; without this it would
+        # emit a completely empty ``content=[]`` Messages response.
+        final_content = _rescue_silent_drop_from_reasoning(
+            final_content, reasoning_text, tool_calls
+        )
 
         finish_reason = "tool_calls" if tool_calls else output.finish_reason
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -55,6 +55,7 @@ from ..service.helpers import (
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
     _release_admission_unless_committed,
+    _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -1256,6 +1257,18 @@ async def _create_chat_completion_impl(
         if response_format and final_content:
             final_content = extract_json_from_response(final_content)
 
+    # Issue #569: never silently drop. If the assistant turn would
+    # otherwise have ``content=null`` AND ``tool_calls=null`` but the
+    # engine surfaced ``reasoning_text`` (gemma-4-26b-4bit multi-turn
+    # where the model got stuck inside ``<|channel>thought\n…`` and
+    # ran out of tokens before emitting a closer / final / tool call),
+    # surface the reasoning trace as ``content`` so OpenAI-compat
+    # agentic clients reading only ``content``/``tool_calls`` don't
+    # see an empty message.
+    final_content = _rescue_silent_drop_from_reasoning(
+        final_content, reasoning_text, tool_calls
+    )
+
     # Build logprobs for response if requested
     choice_logprobs = None
     if want_logprobs and token_logprobs_list:
@@ -1530,6 +1543,38 @@ async def stream_chat_completion(
             # plain-text streams (deltas already drained content during
             # the loop), so this typically just adds the held suffix.
             terminal_content = (finish_event.content or "") + finalize_content
+
+            # Issue #569 streaming rescue: if NOTHING was streamed as
+            # ``content`` across the whole turn AND no ``tool_calls``
+            # fired AND the model produced reasoning, surface the
+            # accumulated reasoning trace as ``content`` in the
+            # terminal chunk. Mirrors the non-streaming rescue in
+            # ``_rescue_silent_drop_from_reasoning`` so streaming
+            # clients (Cline, Cursor, Codex CLI) reading the
+            # assembled ``content`` stream don't end the turn on an
+            # empty buffer when gemma-4 (etc.) got stuck inside
+            # ``<|channel>thought\n…`` and never emitted any closer
+            # / final / tool call. Per-delta ``reasoning_content``
+            # chunks have already been sent during the loop; this
+            # adds a NEW ``content`` chunk at the end (duplication of
+            # the same text across the two channels is the lesser
+            # evil vs. a silently empty content stream).
+            already_streamed_content = bool(processor.accumulated_text)
+            has_any_tool_calls = bool(fallback_tool_calls) or (
+                finish_event.finish_reason == "tool_calls"
+            )
+            if (
+                not already_streamed_content
+                and not terminal_content
+                and not has_any_tool_calls
+                and processor.accumulated_reasoning
+            ):
+                terminal_content = processor.accumulated_reasoning
+                logger.info(
+                    "[SSE-RESCUE-#569] terminal chunk content empty + no tool "
+                    "calls; surfacing %d-char reasoning trace as content",
+                    len(terminal_content),
+                )
             final_chunk = ChatCompletionChunk(
                 id=response_id,
                 created=_sse_created,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1588,6 +1588,22 @@ async def stream_chat_completion(
             # explicitly suppressing exactly that. Structured-output
             # clients expect validated JSON or the existing empty
             # path so they can retry — never surprise prose.
+            #
+            # Codex round-3 BLOCKING on #676: route the streaming
+            # rescue through ``_rescue_silent_drop_from_reasoning``
+            # instead of promoting ``processor.accumulated_reasoning``
+            # directly. The previous direct-promotion branch bypassed
+            # the helper's whitespace guard, so a reasoning-only
+            # stream of ``"   \n"`` would emit a semantically empty
+            # ``delta.content`` while non-streaming correctly
+            # suppressed it. Funneling both paths through the same
+            # helper means the predicate (whitespace + content
+            # presence + tool-call absence) is defined ONCE and the
+            # two paths cannot drift. The structured-output gate
+            # stays here at the call site (parallel to non-streaming
+            # at chat.py:~1285), because it depends on per-request
+            # ``response_format`` which the rescue helper has no
+            # access to.
             already_streamed_content = bool(processor.accumulated_text)
             has_any_tool_calls = bool(fallback_tool_calls) or (
                 finish_event.finish_reason == "tool_calls"
@@ -1597,17 +1613,38 @@ async def stream_chat_completion(
             )
             if (
                 not already_streamed_content
-                and not terminal_content
                 and not has_any_tool_calls
-                and processor.accumulated_reasoning
                 and not structured_output_requested
             ):
-                terminal_content = processor.accumulated_reasoning
-                logger.info(
-                    "[SSE-RESCUE-#569] terminal chunk content empty + no tool "
-                    "calls; surfacing %d-char reasoning trace as content",
-                    len(terminal_content),
+                # Pass ``terminal_content or None`` so the helper
+                # sees the same "empty vs whitespace vs real"
+                # distinction the non-streaming path does. Pass
+                # ``None`` for ``tool_calls`` because we've already
+                # checked ``has_any_tool_calls`` above — the helper's
+                # tool-call branch would never fire here regardless,
+                # but keeping the call symmetric with non-streaming
+                # is the point.
+                rescued_content = _rescue_silent_drop_from_reasoning(
+                    terminal_content or None,
+                    processor.accumulated_reasoning,
+                    None,
                 )
+                # The helper returns the rescued reasoning ONLY when
+                # all four predicates pass (empty/whitespace content,
+                # no tool calls, non-empty/non-whitespace reasoning).
+                # Otherwise it returns the original input — for our
+                # pass it returns ``terminal_content or None``. We
+                # only want to overwrite when the helper actually
+                # promoted reasoning to content, i.e. the returned
+                # value differs from what we passed in.
+                if rescued_content and rescued_content != (terminal_content or None):
+                    terminal_content = rescued_content
+                    logger.info(
+                        "[SSE-RESCUE-#569] terminal chunk content empty + no "
+                        "tool calls; surfacing %d-char reasoning trace as "
+                        "content",
+                        len(terminal_content),
+                    )
             final_chunk = ChatCompletionChunk(
                 id=response_id,
                 created=_sse_created,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1265,9 +1265,24 @@ async def _create_chat_completion_impl(
     # surface the reasoning trace as ``content`` so OpenAI-compat
     # agentic clients reading only ``content``/``tool_calls`` don't
     # see an empty message.
-    final_content = _rescue_silent_drop_from_reasoning(
-        final_content, reasoning_text, tool_calls
-    )
+    #
+    # Codex round-1 BLOCKING on #676: skip the rescue when the client
+    # requested structured output (``response_format`` =
+    # ``json_object`` / ``json_schema``). Reasoning prose is almost
+    # never valid JSON, so surfacing it as ``content`` would break
+    # the OpenAI-compat structured-output contract and feed the
+    # client garbage prose instead of validated JSON. The existing
+    # empty/error path lets a structured-output client retry rather
+    # than be surprise-fed unstructured text. Agentic (no
+    # ``response_format``) clients still get the rescue.
+    rf_type = getattr(response_format, "type", None)
+    if isinstance(response_format, dict):
+        rf_type = response_format.get("type")
+    structured_output_requested = rf_type in ("json_object", "json_schema")
+    if not structured_output_requested:
+        final_content = _rescue_silent_drop_from_reasoning(
+            final_content, reasoning_text, tool_calls
+        )
 
     # Build logprobs for response if requested
     choice_logprobs = None

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -52,6 +52,7 @@ from ..service.helpers import (
     _extract_streaming_token_logprobs,
     _finalize_content_and_reasoning,
     _inject_json_instruction,
+    _is_structured_output_requested,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
     _release_admission_unless_committed,
@@ -1275,11 +1276,13 @@ async def _create_chat_completion_impl(
     # empty/error path lets a structured-output client retry rather
     # than be surprise-fed unstructured text. Agentic (no
     # ``response_format``) clients still get the rescue.
-    rf_type = getattr(response_format, "type", None)
-    if isinstance(response_format, dict):
-        rf_type = response_format.get("type")
-    structured_output_requested = rf_type in ("json_object", "json_schema")
-    if not structured_output_requested:
+    #
+    # Codex round-2 BLOCKING on #676: the predicate is now factored
+    # into ``_is_structured_output_requested`` so the streaming
+    # rescue path (chat.py:~1580) can call the SAME predicate. Round
+    # 1 inlined the check here only; codex round 2 caught the
+    # streaming path drifting because it had no gate at all.
+    if not _is_structured_output_requested(response_format):
         final_content = _rescue_silent_drop_from_reasoning(
             final_content, reasoning_text, tool_calls
         )
@@ -1574,15 +1577,30 @@ async def stream_chat_completion(
             # adds a NEW ``content`` chunk at the end (duplication of
             # the same text across the two channels is the lesser
             # evil vs. a silently empty content stream).
+            #
+            # Codex round-2 BLOCKING on #676: gate on the SAME
+            # ``_is_structured_output_requested`` predicate as the
+            # non-streaming path (chat.py:~1283). Without this, a
+            # ``stream=true`` request with
+            # ``response_format={"type": "json_object"|"json_schema"}``
+            # would still receive reasoning prose in
+            # ``delta.content`` despite the non-streaming path
+            # explicitly suppressing exactly that. Structured-output
+            # clients expect validated JSON or the existing empty
+            # path so they can retry — never surprise prose.
             already_streamed_content = bool(processor.accumulated_text)
             has_any_tool_calls = bool(fallback_tool_calls) or (
                 finish_event.finish_reason == "tool_calls"
+            )
+            structured_output_requested = _is_structured_output_requested(
+                request.response_format
             )
             if (
                 not already_streamed_content
                 and not terminal_content
                 and not has_any_tool_calls
                 and processor.accumulated_reasoning
+                and not structured_output_requested
             ):
                 terminal_content = processor.accumulated_reasoning
                 logger.info(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -316,9 +316,15 @@ def _rescue_silent_drop_from_reasoning(
     * Tool-call path: ``tool_calls`` non-empty → the spec already
       requires ``content`` to be ``None`` (the tool call IS the
       response); rescue does NOT fire.
-    * Truly empty: ``reasoning_text`` empty too → nothing to rescue
-      with; ``None`` propagates. The model genuinely produced
-      nothing; we don't fabricate content.
+    * Truly empty: ``reasoning_text`` empty OR whitespace-only →
+      nothing semantically rescue-worthy; ``None`` propagates. The
+      whitespace-only check (codex round-1 NIT on #676) closes a
+      gap where ``"   \n"`` would surface as non-empty ``content``
+      while still being semantically empty to clients. The
+      ORIGINAL ``reasoning_text`` is returned untouched (no
+      ``.strip()`` on the assignment) so callers that DO want the
+      whitespace preserved still see it as-is — the strip is on
+      the predicate only.
 
     The rescue lives at the route layer (not the engine) because the
     engine's ``_route_tokens_for_channels`` has a tested contract
@@ -334,7 +340,7 @@ def _rescue_silent_drop_from_reasoning(
         return final_content
     if tool_calls:
         return final_content
-    if not reasoning_text:
+    if not reasoning_text or not reasoning_text.strip():
         return final_content
     return reasoning_text
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -281,6 +281,64 @@ def _finalize_content_and_reasoning(
     return cleaned_text, reasoning_text
 
 
+def _rescue_silent_drop_from_reasoning(
+    final_content: str | None,
+    reasoning_text: str | None,
+    tool_calls: list | None,
+) -> str | None:
+    """Issue #569: never silently drop an assistant turn.
+
+    The route layer's normal ``content`` extraction can legitimately
+    produce an empty ``final_content`` when the model emits ONLY
+    reasoning tokens and never closes the reasoning channel into a
+    ``content``/``final`` channel or a tool call. The exact production
+    failure mode: ``gemma-4-26b-4bit`` multi-turn tool flows where the
+    model gets stuck inside ``<|channel>thought\\n...`` and runs out of
+    its token budget before emitting any ``<|tool_call>`` or
+    ``<|channel>content`` marker. The engine's token-level
+    ``OutputRouter`` correctly routes every token to ``reasoning`` —
+    but the route then emits an OpenAI-compat message with
+    ``content=null`` and ``tool_calls=null`` while
+    ``reasoning_content`` carries the entire stuck thought. Agentic
+    clients (Cline, Cursor, Codex CLI) read ``content`` and
+    ``tool_calls`` only, see an empty message, and either retry into
+    the same trap or stall.
+
+    Rescue rule: when ``final_content`` is empty/None AND no
+    ``tool_calls`` fired AND ``reasoning_text`` is non-empty, surface
+    ``reasoning_text`` as ``content``. ``reasoning_content`` stays
+    populated unchanged — duplication between the two fields is the
+    lesser evil vs. a silently empty response.
+
+    Cases that fall through unchanged:
+
+    * Happy path: ``final_content`` is non-empty → return as-is.
+    * Tool-call path: ``tool_calls`` non-empty → the spec already
+      requires ``content`` to be ``None`` (the tool call IS the
+      response); rescue does NOT fire.
+    * Truly empty: ``reasoning_text`` empty too → nothing to rescue
+      with; ``None`` propagates. The model genuinely produced
+      nothing; we don't fabricate content.
+
+    The rescue lives at the route layer (not the engine) because the
+    engine's ``_route_tokens_for_channels`` has a tested contract
+    (issue #442's harmony fix pins ``content == ""`` when only the
+    analysis channel fires) — flipping that at the engine level
+    would re-leak analysis text into ``content`` for the original
+    #442 case. The rescue runs AFTER tool-call parsing and AFTER the
+    reasoning/content split, as a final route-level safety net so
+    silent drops never escape to clients regardless of which model
+    family produced them.
+    """
+    if final_content:
+        return final_content
+    if tool_calls:
+        return final_content
+    if not reasoning_text:
+        return final_content
+    return reasoning_text
+
+
 def _parser_accepts_enable_thinking(reasoning_parser) -> bool:
     """Return True iff ``reasoning_parser.extract_reasoning`` declares
     an ``enable_thinking`` parameter (or ``**kwargs`` catch-all).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -345,6 +345,35 @@ def _rescue_silent_drop_from_reasoning(
     return reasoning_text
 
 
+def _is_structured_output_requested(response_format) -> bool:
+    """Codex round-2 BLOCKING on #676: shared predicate for "client
+    asked for structured output" — used by BOTH the non-streaming
+    and streaming silent-drop rescue gates in
+    ``vllm_mlx/routes/chat.py`` to decide whether to suppress the
+    reasoning→content rescue.
+
+    Returns ``True`` iff ``response_format.type`` is ``json_object``
+    or ``json_schema`` — the two OpenAI-compat shapes where surfacing
+    reasoning prose as ``content`` would feed the client unstructured
+    text instead of validated JSON (or the existing empty/error path
+    they can retry on). ``text`` (the default) and ``None`` return
+    ``False`` so agentic clients still get the rescue.
+
+    Accepts either a Pydantic ``ResponseFormat`` object (real route
+    use) or a raw ``dict`` (tests / inbound JSON). Round 1 inlined
+    this same check at the non-streaming call site only; round 2
+    pulled it into a helper after codex caught the streaming path
+    drifting — one definition, two call sites, no chance for the
+    two predicates to disagree again.
+    """
+    if response_format is None:
+        return False
+    rf_type = getattr(response_format, "type", None)
+    if isinstance(response_format, dict):
+        rf_type = response_format.get("type")
+    return rf_type in ("json_object", "json_schema")
+
+
 def _parser_accepts_enable_thinking(reasoning_parser) -> bool:
     """Return True iff ``reasoning_parser.extract_reasoning`` declares
     an ``enable_thinking`` parameter (or ``**kwargs`` catch-all).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -312,7 +312,15 @@ def _rescue_silent_drop_from_reasoning(
 
     Cases that fall through unchanged:
 
-    * Happy path: ``final_content`` is non-empty → return as-is.
+    * Happy path: ``final_content`` is non-empty AND has at least one
+      non-whitespace char → return as-is. Whitespace-only
+      ``final_content`` (``"   \n"``) is treated as semantically
+      absent for rescue purposes (codex round-3 NIT on #676): an
+      OpenAI-compat client still sees an empty assistant turn, so
+      the rescue must be allowed to fire when reasoning is present.
+      The strip is on the predicate only — the original
+      ``final_content`` propagates back on the happy path so callers
+      that DO want the whitespace preserved still see it as-is.
     * Tool-call path: ``tool_calls`` non-empty → the spec already
       requires ``content`` to be ``None`` (the tool call IS the
       response); rescue does NOT fire.
@@ -335,8 +343,19 @@ def _rescue_silent_drop_from_reasoning(
     reasoning/content split, as a final route-level safety net so
     silent drops never escape to clients regardless of which model
     family produced them.
+
+    Codex round-3 BLOCKING on #676: this helper is now the SINGLE
+    predicate for both the non-streaming AND streaming rescue paths
+    (chat.py:~1285 and chat.py:~1605). The streaming path used to
+    promote ``processor.accumulated_reasoning`` directly into
+    ``delta.content`` without the whitespace guard, so a
+    reasoning-only stream of ``"   \n"`` would emit a semantically
+    empty ``delta.content`` while non-streaming correctly suppressed
+    it. Routing both call sites through this helper closes that
+    asymmetry — the predicate cannot drift between the two paths
+    because there's only one of it.
     """
-    if final_content:
+    if final_content and final_content.strip():
         return final_content
     if tool_calls:
         return final_content


### PR DESCRIPTION
Closes #569.

## Summary

- Adds a route-layer rescue (`_rescue_silent_drop_from_reasoning`) so a model getting stuck inside `<|channel>thought\n…` never produces a silently-empty `content=null, tool_calls=null` OpenAI-compat message.
- Wired into `/v1/chat/completions` (non-streaming + streaming terminal chunk) and `/v1/messages` so both surfaces give the same no-silent-drop guarantee.

## Root cause

`gemma-4-26b-4bit` multi-turn tool flows: the model enters `<|channel>thought\n…` and runs out of its token budget before emitting `<|tool_call>` or `<|channel>content`. The engine's token-level `OutputRouter` correctly routes every token to reasoning, so `_route_tokens_for_channels` returns `(reasoning="…", content="")` — that's the desired pinned behavior from issue #442 (don't leak analysis text into content via parser bleed). The route then runs `_finalize_content_and_reasoning`, which short-circuits on the non-empty `engine_reasoning_text` and returns `(cleaned_text="", reasoning_text=…)`. The route's `final_content = strip_thinking_tags(clean_output_text(""))` collapses to `None`, and the `AssistantMessage` ships with `content=null` while `reasoning_content` carries the whole stuck thought. Agentic OpenAI clients (Cline, Cursor, Codex CLI) read `content` and `tool_calls` only — they see an empty message and stall.

## Fix

`_rescue_silent_drop_from_reasoning` runs at the route layer AFTER tool-call parsing and AFTER the reasoning/content split. When `final_content` is empty/None AND no `tool_calls` fired AND `reasoning_text` is non-empty, it surfaces `reasoning_text` as `content`. `reasoning_content` stays populated unchanged — duplication between the two fields is the lesser evil vs. a silently empty response.

The rescue lives at the route layer (not the engine) so it does NOT regress issue #442 (`_route_tokens_for_channels` still returns `content == ""` when only the analysis channel fires — pinned by `test_truncated_analysis_drops_content_and_recovers_reasoning`). The non-streaming + Anthropic paths use the helper directly; the streaming SSE path applies the same logic to the terminal chunk via `processor.accumulated_text`/`accumulated_reasoning`.

Round-1 codex review on this PR added two refinements:
- `response_format` gate: structured-output requests (`json_object` / `json_schema`) skip the rescue so reasoning prose can't break the OpenAI-compat JSON contract — clients see the existing empty/error path and can retry.
- Whitespace-only `reasoning_text` (`"   \n"`) is treated as semantically empty; the predicate uses `.strip()` so the helper does not surface a non-null but vacuous `content`. The original (un-stripped) text is still returned for legitimate padded thoughts.

## Files touched

- `vllm_mlx/service/helpers.py` — adds `_rescue_silent_drop_from_reasoning`; predicate now strips whitespace.
- `vllm_mlx/routes/chat.py` — calls the rescue after `final_content` is computed, gates on `response_format` for structured output, and applies the same logic to the streaming terminal chunk.
- `vllm_mlx/routes/anthropic.py` — calls the rescue so `/v1/messages` doesn't diverge.
- `tests/test_silent_drop_rescue_569.py` — new (now 19 tests including the round-1 regression guards).
- `tests/test_chat_logprobs_channel_routing.py` — updates `test_logprobs_path_reasoning_only_keeps_content_empty` (renamed `…_surfaces_via_rescue`) to reflect the new route-layer contract while explicitly noting the engine-level #442 invariant is unchanged.

## Test plan

- [x] `pytest tests/test_silent_drop_rescue_569.py tests/test_chat_logprobs_channel_routing.py` — 22 tests, all pass (includes the 4 round-1 regression guards: whitespace-only predicate, whitespace preservation, `response_format=json_object`, `response_format=json_schema`).
- [x] Full test suite excluding integrations/event-loop (which need a live :8000 server): 5631 passed, 19 skipped, 7 xfailed.
- [x] `ruff check` + `ruff format` clean on every touched file.
- [x] Pinned existing engine #442 contract is unchanged: `tests/test_engine_router_non_stream.py::test_truncated_analysis_drops_content_and_recovers_reasoning` still asserts `content == ""` at the engine layer.
- [x] Pinned the happy-path no-regress contract: `test_rescue_noop_when_content_present` + `test_finalize_plus_rescue_preserves_happy_path` + `test_streaming_rescue_noop_when_content_was_streamed`.
- [x] Pinned the tool-call no-regress contract: `test_rescue_noop_when_tool_calls_fired` + `test_finalize_plus_rescue_preserves_tool_call_path`.
- [x] Pinned the structured-output no-regress contract (codex round-1 BLOCKING): `test_rescue_skipped_when_response_format_is_json_object` + `test_rescue_skipped_when_response_format_is_json_schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)