### PR TITLE
docs(readme): lead with PFlash/DFlash speed story + fix stale nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,10 +510,10 @@ Decoded examples:
 
 ### Full model lineup
 
-72 explicit aliases across 13 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
+81 explicit aliases across 13 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
 
 <details>
-<summary><strong>Show all 72 aliases by family</strong></summary>
+<summary><strong>Show all 81 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
@@ -787,6 +787,17 @@ Large-context requests auto-route to a cloud LLM (GPT-5, Claude, etc.) when loca
 
 Vision, audio (STT/TTS), video understanding, and text embeddings — all through the same OpenAI-compatible API.
 
+### PFlash Prefill Acceleration
+
+Long prompts are slow to *start* — the first token waits on the whole context to prefill, and on Apple Silicon that prefill is the bottleneck. PFlash scores a long prompt and prefills only the tokens that matter (the attention sink, the recent tail, and the query-relevant middle), cutting **cold-start TTFT by 3.87–8.5×** on 32K+ prompts with full needle-in-a-haystack recall. Pure-Python, no extra dependencies, and **on by default** for verified models.
+
+```bash
+rapid-mlx serve qwen3.5-9b-4bit          # PFlash auto-on for verified aliases
+rapid-mlx serve <model> --pflash always  # force it on for any model
+```
+
+PFlash speeds up the prompt going *in*; **DFlash** speeds up the tokens coming *out*.
+
 ### DFlash Speculative Decoding (single-user)
 
 z-lab's block-diffusion drafter (via mlx-vlm) accelerates single-stream generation on validated Qwen3.5/3.6 27B aliases. Opt in with `--enable-dflash`:
@@ -802,11 +813,11 @@ rapid-mlx info qwen3.5-27b-8bit       # check per-gate eligibility
 rapid-mlx serve qwen3.5-27b-8bit --enable-dflash
 ```
 
-**Workload sensitivity**: speedup varies by entropy. Coding / math / summarization typically see **1.5-2.7×**; high-entropy creative writing and long-form chat can dip to **0.6-0.9×** because the drafter's training distribution diverges from open-ended generation. This is a known pattern in spec-decode literature ([arXiv 2604.14682](https://arxiv.org/abs/2604.14682), [AdaEDL](https://arxiv.org/abs/2410.18351)) — not a bug. Other Qwen3.5/3.6 sizes (35B-A3B MoE, 122B-A10B MoE) were benched and rejected because their average speedup was below the gate.
+**Best on coding, math, and summarization** (typically **1.5–2.7×**); open-ended creative writing can dip below 1×, so DFlash is gated to the aliases where it reliably wins.
 
 **v1 limitations**: DFlash mode runs a dedicated single-user server (mlx-vlm doesn't expose a batched DFlash kernel yet). Tool calling, MCP, and embeddings aren't available in DFlash mode — restart without `--enable-dflash` for those.
 
-Also: logprobs API, structured JSON output (`response_format`), continuous batching, KV cache quantization (`--kv-cache-quantization`), and [3300+ tests](tests/).
+Also: a fused single-kernel sampler (faster than mlx-vlm's, identical sampling math), logprobs API, structured JSON output (`response_format`), continuous batching, KV cache quantization (`--kv-cache-quantization`), and [3300+ tests](tests/).
 
 ---
 

--- a/vllm_mlx/gradio_app.py
+++ b/vllm_mlx/gradio_app.py
@@ -7,7 +7,7 @@ and supports text, images, and video files.
 
 Usage:
     # First start the server with a multimodal model:
-    rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+    rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     # Then run this app:
     rapid-mlx-chat
@@ -275,7 +275,7 @@ Examples:
     rapid-mlx-chat --share
 
 Note: Make sure the rapid-mlx server is running with a multimodal model:
-    rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+    rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
         """,
     )
     parser.add_argument(

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1599,8 +1599,6 @@ class MLXMultimodalLM:
                 logger.warning(f"Cache fetch failed: {e}")
 
         # Generate - use KV cache if available from previous identical request
-        start_time = time.time()
-
         # Create or reuse prompt cache for prefix caching speedup
         prompt_cache = None
         skip_prompt_processing = False

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -426,7 +426,6 @@ async def _create_chat_completion_impl(
         total_chars += len(content)
         if m.role == "user":
             last_user_preview = content[:300]
-    has_tools = bool(request.tools)
     n_tools = len(request.tools) if request.tools else 0
     logger.info(
         f"[REQUEST] POST /v1/chat/completions stream={request.stream} "


### PR DESCRIPTION
Makes the README's speed story attract developers (new acceleration tech → faster) instead of reading like a research dump, and fixes a few small nits. Scoped, no behavior changes.

## README — focused on the speed hooks
- **New: PFlash Prefill Acceleration section.** PFlash was completely undocumented despite being on-by-default for verified models. Added a tight, dev-facing blurb: **3.87–8.5× cold-start TTFT** on 32K+ prompts with full needle-in-a-haystack recall, pure-Python, zero deps. Framed as the inbound half of the **PFlash (in) / DFlash (out)** pair so the two "Flash" techniques read as a matched speed story.
- **Trimmed the DFlash section.** Cut the "workload sensitivity" paragraph from a spec-decode-literature review (arXiv citations, rejected MoE sizes) down to one developer-relevant sentence. Kept the table, the command, and the v1 limitations devs actually need.
- **Surfaced the fused sampler.** "faster than mlx-vlm's, identical sampling math" — was buried in benchmark footnotes only.

## Nits
- **Stale alias count:** \`72\` → \`81\` in two spots (matches \`vllm_mlx/aliases.json\`, 81 keys).
- **Broken command in \`rapid-mlx-chat --help\`:** \`gradio_app.py\` docstring + argparse epilog told users to run \`rapid-mlx --model ...\`, but the current CLI has no \`--model\` flag (\`serve\` takes a positional model). Fixed to \`rapid-mlx serve <model> --port 8000\`.
- **Dead locals removed:** \`chat.py\` \`has_tools\` and \`mllm.py\` \`start_time\` (assigned, never read; confirmed via pyflakes).

All three touched Python files compile; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)