### PR TITLE
chore: bump version to 0.7.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.30"
+version = "0.7.31"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Bump pyproject.toml 0.7.30 → 0.7.31 to trigger the auto-release pipeline.

## What ships in v0.7.31

10 PRs landed since v0.7.29:

| PR | Summary |
|---|---|
| #671 | drop 3 kimi aliases (kimi-48b-4bit, kimi-k2.5-3bit, kimi-k2.6-dq3-q8) — combined ~1.4 TB, no demand signal |
| #665 | scheduler: allow concurrent batching with different temperatures (#665) |
| #674 | feat(cache): stub HTTP API for KV cache export/import (#476) — 501 stubs + path sandbox + atomic writes |
| #610 | rate-limit: bound cleanup cost + protect active entries (#195) |
| #550 | cheetah glyph in serve/chat/share startup banners |
| #675 | chat: symmetric tool_choice enforcement across parser paths (#571) |
| #676 | rescue silent-drop on unterminated reasoning (#569) — gemma-4 streaming + non-streaming silent-drop fix |
| #678 | docs(readme): lead with PFlash/DFlash speed story |
| #677 | `_mirror`: reject silent 200+empty-body R2 responses as miss (not "R2 (0 MB)") |
| #679 | remove dead code — pipeline/, bench/tiers/, scratch artefacts (~1.5k LOC + 256 KB) |

## Why skip 0.7.30?

v0.7.30 was claimed by #671's `pyproject.toml` bump but auto-release never fired — that PR's squash subject was `chore(curation): drop 3 kimi aliases ...` instead of the `chore: bump version to X.Y.Z` subject the workflow parses. Cleanest path is to skip 0.7.30 entirely so users go 0.7.29 → 0.7.31 without a stranded version number.

## Pre-release gauntlet

- ✅ **G1 release-smoke**: clean-room install + import every release surface
- ✅ **G5–G9 release-check-m3** on `qwen3.5-9b-4bit`:
  - Round 1 hit a `streaming_basic` flake on opencode harness ("No content/reasoning chunks") — reproduced 0/10 in solo isolation hammering the exact same payload, confirmed transient
  - Round 2 ALL PASS: codex 18.1s 12p, opencode 5.5s 10p, hermes 29.2s 22p, aider 0.4s 2p, langchain 9.2s 15p
  - G9 latency: mean 97.2 tok/s, spread 2.1 across 10 runs (first-run cold cache excluded)
  - G8 parser microbench: all 4 parsers (hermes, minimax, glm47, harmony) under threshold

## Test plan

- [x] G1 release-smoke PASS
- [x] G5-G9 release-check-m3 PASS (round 2, after confirmed flake)
- [x] No new model downloads; testing on cached models only

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>