### PR TITLE
fix(lint): drop unused 'time' import in mllm.py

### DIFF
--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1559,8 +1559,6 @@ class MLXMultimodalLM:
 
         # Prefix caching with vision embedding support
         # Following LMCache approach: cache vision embeddings to skip encoder on hit
-        import time
-
         from mlx_vlm.models import cache as vlm_cache
 
         # use_cache was already popped near the top of chat() — don't re-pop


### PR DESCRIPTION
## Summary

CI started failing on main with `F401 'time' imported but unused` at `vllm_mlx/models/mllm.py:1562` immediately after the v0.7.31 release merge (#680). The dead import has been there since #20 (PR introducing MLLM continuous batching) — it never had any consumer; `grep -n 'time\.'` over the whole file returns zero matches.

## Why pr_validate didn't catch this

`pr_validate` lints **only changed files** so the bump PR (#680, 1 line in `pyproject.toml`) passed lint. The full-tree `ruff check vllm_mlx/ tests/` in `.github/workflows/ci.yml` lints **everything** and surfaced the pre-existing dead import.

## Fix

One-line delete of `import time` at line 1562. No behaviour change.

## Test plan

- [x] `ruff check vllm_mlx/ tests/` → clean
- [x] `pytest tests/ -q --no-header --ignore=tests/integrations --ignore=tests/test_event_loop.py` → no regressions

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>