### PR TITLE
feat(anthropic): native structured output via output_config.format=json_schema (upstream #42396)

### DIFF
--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``output_config`` on the Anthropic /v1/messages surface.
+
+Backport of upstream vLLM PR #42396 (v0.22.0). Covers:
+
+- Pydantic model parsing for ``output_config.format = json_schema``
+  (including alias handling for the ``schema`` field).
+- Adapter translation Anthropic ``output_config`` → OpenAI
+  ``response_format``, including the unsupported-type / missing-schema
+  validation paths surfaced as ``AnthropicOutputConfigError``.
+- Route-level HTTP 400 propagation of those validation errors.
+- ``output_config.effort`` is accepted but does NOT mutate the
+  forwarded ``chat_kwargs`` — it belongs to a separate concurrent
+  backport (Pick 1).
+- Backward compatibility: requests with no ``output_config`` behave
+  identically to the pre-backport surface.
+
+The route-level tests reuse the lightweight-engine fixture pattern from
+``test_anthropic_route_auth.py`` so they avoid importing the MLX-backed
+engine, which keeps CI hermetic.
+"""
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from vllm_mlx.api.anthropic_adapter import (
+    AnthropicOutputConfigError,
+    _convert_output_config,
+    anthropic_to_openai,
+)
+from vllm_mlx.api.anthropic_models import (
+    AnthropicMessage,
+    AnthropicOutputConfig,
+    AnthropicOutputFormat,
+    AnthropicRequest,
+)
+from vllm_mlx.api.models import ResponseFormat
+
+# =============================================================================
+# Pydantic model parsing
+# =============================================================================
+
+
+class TestAnthropicOutputFormatModel:
+    """Parse the Anthropic ``output_config.format`` shape."""
+
+    def test_minimal_json_schema(self):
+        fmt = AnthropicOutputFormat(
+            type="json_schema",
+            schema={"type": "object", "properties": {"x": {"type": "string"}}},
+        )
+        assert fmt.type == "json_schema"
+        assert fmt.schema_ == {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+        }
+        # name/description/strict are optional
+        assert fmt.name is None
+        assert fmt.description is None
+        assert fmt.strict is None
+
+    def test_full_json_schema_with_optional_fields(self):
+        fmt = AnthropicOutputFormat(
+            type="json_schema",
+            schema={"type": "object"},
+            name="person",
+            description="A person record",
+            strict=True,
+        )
+        assert fmt.name == "person"
+        assert fmt.description == "A person record"
+        assert fmt.strict is True
+
+    def test_schema_alias_round_trips_via_model_dump(self):
+        """``schema_`` ↔ ``schema`` alias must survive a dump/load cycle."""
+        fmt = AnthropicOutputFormat(type="json_schema", schema={"type": "object"})
+        # by_alias=True so external serialization uses the wire name.
+        dumped = fmt.model_dump(by_alias=True)
+        assert "schema" in dumped
+        assert "schema_" not in dumped
+        re_parsed = AnthropicOutputFormat(**dumped)
+        assert re_parsed.schema_ == {"type": "object"}
+
+    def test_missing_type_raises(self):
+        with pytest.raises(ValidationError):
+            AnthropicOutputFormat(schema={"type": "object"})
+
+
+class TestAnthropicOutputConfigModel:
+    """Parse the Anthropic ``output_config`` wrapper."""
+
+    def test_empty_config_allowed(self):
+        cfg = AnthropicOutputConfig()
+        assert cfg.format is None
+        assert cfg.effort is None
+
+    def test_with_format(self):
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(type="json_schema", schema={})
+        )
+        assert cfg.format is not None
+        assert cfg.format.type == "json_schema"
+
+    def test_effort_field_is_accepted_but_separate(self):
+        """``effort`` is part of Pick 1 (concurrent reasoning-effort PR).
+
+        We accept it on the Pydantic model today so the two PRs don't
+        race on the same shape during merge, but this PR must NOT act
+        on the value. The adapter-level test below asserts the value
+        doesn't leak into the OpenAI request.
+        """
+        cfg = AnthropicOutputConfig(effort="high")
+        assert cfg.effort == "high"
+
+
+# =============================================================================
+# Adapter translation
+# =============================================================================
+
+
+def _req(**kwargs) -> AnthropicRequest:
+    defaults = {
+        "model": "default",
+        "messages": [AnthropicMessage(role="user", content="hi")],
+        "max_tokens": 32,
+    }
+    defaults.update(kwargs)
+    return AnthropicRequest(**defaults)
+
+
+class TestConvertOutputConfigUnit:
+    """Direct unit tests for ``_convert_output_config``."""
+
+    def test_none_passthrough(self):
+        assert _convert_output_config(None) is None
+
+    def test_format_none_passthrough(self):
+        assert _convert_output_config(AnthropicOutputConfig(format=None)) is None
+
+    def test_json_schema_translates(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(
+                type="json_schema",
+                schema=schema,
+                name="person",
+                description="A person",
+                strict=True,
+            )
+        )
+        rf = _convert_output_config(cfg)
+        assert isinstance(rf, ResponseFormat)
+        assert rf.type == "json_schema"
+        assert rf.json_schema is not None
+        assert rf.json_schema.name == "person"
+        assert rf.json_schema.description == "A person"
+        assert rf.json_schema.schema_ == schema
+        assert rf.json_schema.strict is True
+
+    def test_json_schema_name_defaults_to_response(self):
+        rf = _convert_output_config(
+            AnthropicOutputConfig(
+                format=AnthropicOutputFormat(type="json_schema", schema={})
+            )
+        )
+        assert rf is not None
+        assert rf.json_schema.name == "response"
+
+    def test_json_schema_strict_defaults_to_false(self):
+        rf = _convert_output_config(
+            AnthropicOutputConfig(
+                format=AnthropicOutputFormat(type="json_schema", schema={})
+            )
+        )
+        assert rf is not None
+        assert rf.json_schema.strict is False
+
+    def test_unsupported_type_raises(self):
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(type="regex", schema={})
+        )
+        with pytest.raises(AnthropicOutputConfigError) as exc:
+            _convert_output_config(cfg)
+        # The error must call out the surface and the rejected type so
+        # operators reading server logs can map a 400 to the offending
+        # request field without grepping internals.
+        msg = str(exc.value)
+        assert "json_schema" in msg
+        assert "/v1/messages" in msg
+        assert "'regex'" in msg
+
+    def test_missing_schema_raises(self):
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(type="json_schema")  # schema absent
+        )
+        with pytest.raises(AnthropicOutputConfigError) as exc:
+            _convert_output_config(cfg)
+        assert "schema" in str(exc.value)
+
+    def test_non_dict_schema_raises(self):
+        """If callers bypass the Pydantic model (e.g. by constructing the
+        adapter input directly), a non-dict schema must still be
+        rejected by the adapter rather than crashing downstream.
+        """
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(type="json_schema", schema={})
+        )
+        # bypass model coercion by mutating the field post-construction
+        cfg.format.schema_ = "not a dict"  # type: ignore[assignment]
+        with pytest.raises(AnthropicOutputConfigError):
+            _convert_output_config(cfg)
+
+
+class TestAnthropicToOpenaiOutputConfig:
+    """End-to-end adapter translation including ``output_config``."""
+
+    def test_no_output_config_leaves_response_format_none(self):
+        """Backward compat: pre-existing requests must not gain a
+        ``response_format`` field after the backport.
+        """
+        result = anthropic_to_openai(_req())
+        assert result.response_format is None
+
+    def test_output_config_json_schema_propagates(self):
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(
+                type="json_schema",
+                schema={"type": "object", "properties": {"a": {"type": "integer"}}},
+                name="thing",
+            )
+        )
+        result = anthropic_to_openai(_req(output_config=cfg))
+        assert result.response_format is not None
+        assert result.response_format.type == "json_schema"
+        assert result.response_format.json_schema.name == "thing"
+
+    def test_effort_field_does_not_alter_openai_request(self):
+        """``effort`` is part of Pick 1 — this PR must accept the field
+        on the wire but not mutate any OpenAI-side parameter.
+
+        We diff the model dump of a request with effort vs. without to
+        guarantee no sneaky side effects. The adapter copies sampling
+        params straight through (temperature/top_p/top_k/max_tokens),
+        so equivalence of the OpenAI request is the right invariant.
+        """
+        baseline = anthropic_to_openai(_req())
+        with_effort = anthropic_to_openai(
+            _req(output_config=AnthropicOutputConfig(effort="high"))
+        )
+        assert baseline.model_dump() == with_effort.model_dump()
+
+    def test_unsupported_format_raises(self):
+        cfg = AnthropicOutputConfig(
+            format=AnthropicOutputFormat(type="regex", schema={})
+        )
+        with pytest.raises(AnthropicOutputConfigError):
+            anthropic_to_openai(_req(output_config=cfg))
+
+    def test_missing_schema_raises(self):
+        cfg = AnthropicOutputConfig(format=AnthropicOutputFormat(type="json_schema"))
+        with pytest.raises(AnthropicOutputConfigError):
+            anthropic_to_openai(_req(output_config=cfg))
+
+
+# =============================================================================
+# Route-level: HTTP 400 surface
+# =============================================================================
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def encode(self, text: str) -> list[int]:  # pragma: no cover - simple stub
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+
+
+class _RecordingEngine:
+    """Captures every ``chat`` call so tests can assert what was forwarded.
+
+    This is the "recording engine that captures ``chat_kwargs``" pattern
+    called for by the task spec, so we can pin that ``output_config.effort``
+    really doesn't leak into the engine's sampling kwargs.
+    """
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.calls: list[SimpleNamespace] = []
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        return _GenerationOutput(
+            text='{"name": "alice"}',
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason="stop",
+        )
+
+
+def _install_lightweight_engine_modules(monkeypatch):
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.anthropic",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "anthropic"),
+)
+_MISSING = object()
+
+
+@pytest.fixture
+def anthropic_client(monkeypatch):
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.routes.anthropic import router
+
+    cfg = reset_config()
+    # Keep auth out of the way for these tests — output_config validation
+    # runs after auth and we want the 400 / 200 surface clean.
+    cfg.api_key = None
+    cfg.engine = _RecordingEngine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    app.include_router(router)
+    yield SimpleNamespace(client=TestClient(app), engine=cfg.engine)
+
+    reset_config()
+    rate_limiter.enabled = False
+    rate_limiter._requests.clear()
+
+    for name, previous in previous_modules.items():
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (module_name, attr), previous in previous_attrs.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if previous is _MISSING:
+            if hasattr(module, attr):
+                delattr(module, attr)
+        else:
+            setattr(module, attr, previous)
+
+
+def _payload(**extra) -> dict:
+    body = {
+        "model": "test-model",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "give me a name"}],
+    }
+    body.update(extra)
+    return body
+
+
+class TestRouteOutputConfigSurface:
+    """HTTP-level coverage for the 400 / 200 paths."""
+
+    def test_round_trip_json_schema_returns_200(self, anthropic_client):
+        resp = anthropic_client.client.post(
+            "/v1/messages",
+            json=_payload(
+                output_config={
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"name": {"type": "string"}},
+                            "required": ["name"],
+                        },
+                        "name": "person",
+                    }
+                }
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # The recording engine returns ``'{"name": "alice"}'`` as the
+        # text — the Anthropic adapter wraps it in a text content block.
+        # Parse it as JSON and verify the schema's ``name`` key.
+        text_blocks = [b for b in body["content"] if b["type"] == "text"]
+        assert text_blocks, "expected at least one text block in response"
+        parsed = json.loads(text_blocks[0]["text"])
+        assert isinstance(parsed, dict)
+        assert "name" in parsed
+
+    def test_unknown_format_type_returns_400(self, anthropic_client):
+        resp = anthropic_client.client.post(
+            "/v1/messages",
+            json=_payload(output_config={"format": {"type": "regex", "schema": {}}}),
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "json_schema" in detail
+        assert "/v1/messages" in detail
+        # The engine must NOT have been invoked for a 400.
+        assert anthropic_client.engine.calls == []
+
+    def test_missing_schema_returns_400(self, anthropic_client):
+        resp = anthropic_client.client.post(
+            "/v1/messages",
+            json=_payload(output_config={"format": {"type": "json_schema"}}),
+        )
+        assert resp.status_code == 400
+        assert "schema" in resp.json()["detail"]
+        assert anthropic_client.engine.calls == []
+
+    def test_invalid_schema_type_returns_400(self, anthropic_client):
+        """A non-object ``schema`` must be rejected as 400 — the route
+        wraps Pydantic ``ValidationError`` from manual request construction
+        so clients see a clean 400 instead of a 500.
+        """
+        resp = anthropic_client.client.post(
+            "/v1/messages",
+            json=_payload(
+                output_config={
+                    "format": {"type": "json_schema", "schema": "not a dict"}
+                }
+            ),
+        )
+        assert resp.status_code == 400, resp.text
+        assert anthropic_client.engine.calls == []
+
+    def test_no_output_config_is_backward_compatible(self, anthropic_client):
+        """Requests with no ``output_config`` must behave identically to
+        the pre-backport surface — engine called once, no ``response_format``
+        passed through, 200 OK.
+        """
+        resp = anthropic_client.client.post("/v1/messages", json=_payload())
+        assert resp.status_code == 200, resp.text
+        assert len(anthropic_client.engine.calls) == 1
+
+    def test_effort_field_accepted_but_does_not_alter_chat_kwargs(
+        self, anthropic_client
+    ):
+        """``output_config.effort`` is Pick 1 territory — accepting the
+        field is required for forward-compat with Anthropic SDKs, but
+        this PR must NOT alter what the engine receives.
+
+        We pin via the recording engine: send two identical requests,
+        one with ``effort: high``, one without, and assert the captured
+        ``chat_kwargs`` are equal.
+        """
+        # baseline — no output_config at all
+        baseline_resp = anthropic_client.client.post("/v1/messages", json=_payload())
+        assert baseline_resp.status_code == 200
+
+        # with effort field (no format) — must accept and ignore
+        effort_resp = anthropic_client.client.post(
+            "/v1/messages",
+            json=_payload(output_config={"effort": "high"}),
+        )
+        assert effort_resp.status_code == 200
+
+        assert len(anthropic_client.engine.calls) == 2
+        baseline_kwargs = anthropic_client.engine.calls[0].kwargs
+        effort_kwargs = anthropic_client.engine.calls[1].kwargs
+        assert baseline_kwargs == effort_kwargs, (
+            "output_config.effort leaked into engine chat kwargs — "
+            "this field belongs to Pick 1 (concurrent PR)."
+        )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -14,6 +14,7 @@ import uuid
 
 from .anthropic_models import (
     AnthropicMessage,
+    AnthropicOutputConfig,
     AnthropicRequest,
     AnthropicResponse,
     AnthropicResponseContentBlock,
@@ -24,8 +25,22 @@ from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     Message,
+    ResponseFormat,
+    ResponseFormatJsonSchema,
     ToolDefinition,
 )
+
+
+class AnthropicOutputConfigError(ValueError):
+    """Raised when ``output_config`` on a /v1/messages request is malformed.
+
+    Adapter-layer error type — the route layer (``routes/anthropic.py``)
+    converts this into ``HTTPException(400)``. Kept distinct from a plain
+    ``ValueError`` so the route can match on type without sniffing the
+    message string, and to make grep-for-callers trivial. Codex review
+    flagged the message string as the validation surface; subclassing
+    here gives both ergonomic typing AND a stable string identity.
+    """
 
 
 def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
@@ -82,6 +97,13 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     if request.tool_choice:
         tool_choice = _convert_tool_choice(request.tool_choice)
 
+    # Translate ``output_config.format = json_schema`` (Anthropic shape,
+    # upstream vLLM PR #42396) into the OpenAI ``response_format`` shape
+    # the chat-completions guided-decode pipeline already understands.
+    # Adapter-layer validation: invalid shapes raise
+    # ``AnthropicOutputConfigError``; the route converts that to HTTP 400.
+    response_format = _convert_output_config(request.output_config)
+
     return ChatCompletionRequest(
         model=request.model,
         messages=messages,
@@ -98,6 +120,7 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
         stop=request.stop_sequences,
         tools=tools,
         tool_choice=tool_choice,
+        response_format=response_format,
     )
 
 
@@ -344,6 +367,68 @@ def _convert_tool_choice(tool_choice: dict) -> str | dict | None:
         return "none"
 
     return "auto"
+
+
+def _convert_output_config(
+    output_config: AnthropicOutputConfig | None,
+) -> ResponseFormat | None:
+    """Translate Anthropic ``output_config`` → OpenAI ``response_format``.
+
+    Backport of upstream vLLM PR #42396. Only ``format.type == "json_schema"``
+    is supported on this surface today; downstream of this call the existing
+    chat-completions guided-decode pipeline (``api/guided.py`` + outlines)
+    runs unchanged.
+
+    ``output_config.effort`` is intentionally NOT translated here — see the
+    docstring on ``AnthropicOutputConfig``. The field is accepted by the
+    Pydantic model but Pick 1 (a concurrent PR) owns wiring it through.
+
+    Raises:
+        AnthropicOutputConfigError: when ``format.type`` is not
+            ``"json_schema"`` or when the ``schema`` field is missing /
+            not a JSON object. The route layer converts this to HTTP 400.
+    """
+    if output_config is None or output_config.format is None:
+        return None
+
+    fmt = output_config.format
+    fmt_type = fmt.type
+    if fmt_type != "json_schema":
+        # Mirror the message style of routes/chat.py's 400 responses so
+        # error strings on the two surfaces look like siblings.
+        raise AnthropicOutputConfigError(
+            f"output_config.format.type={fmt_type!r} is not supported on "
+            "/v1/messages; only 'json_schema' is accepted. See upstream "
+            "vLLM PR #42396 for the backport contract."
+        )
+
+    schema = fmt.schema_
+    if schema is None:
+        raise AnthropicOutputConfigError(
+            "output_config.format.schema is required when "
+            "output_config.format.type == 'json_schema' on /v1/messages."
+        )
+    if not isinstance(schema, dict):
+        # Pydantic would have already coerced strings/lists away here for
+        # the dict-typed field, but guard explicitly so the message stays
+        # informative if a future schema type widens.
+        raise AnthropicOutputConfigError(
+            "output_config.format.schema must be a JSON object "
+            f"(got {type(schema).__name__})."
+        )
+
+    # ResponseFormatJsonSchema requires ``name`` — default to "response"
+    # to match the existing OpenAI surface's behavior when the field is
+    # absent (see api/tool_calling.build_json_system_prompt fallback).
+    return ResponseFormat(
+        type="json_schema",
+        json_schema=ResponseFormatJsonSchema(
+            name=fmt.name or "response",
+            description=fmt.description,
+            schema=schema,
+            strict=fmt.strict if fmt.strict is not None else False,
+        ),
+    )
 
 
 def _convert_stop_reason(openai_reason: str | None) -> str:

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -50,6 +50,61 @@ class AnthropicToolDef(BaseModel):
     input_schema: dict | None = None
 
 
+class AnthropicOutputFormat(BaseModel):
+    """Output format spec inside ``output_config``.
+
+    Upstream vLLM PR #42396 (shipped v0.22.0) added native structured
+    output to the Anthropic Messages surface via
+    ``output_config.format = json_schema``. This mirrors the OpenAI
+    ``response_format.json_schema`` shape so the existing guided-decode
+    pipeline (see ``api/guided.py`` + outlines) can drive constrained
+    JSON output on ``/v1/messages`` clients (e.g. Claude SDKs) without
+    a separate code path.
+
+    ``type`` is the only Pydantic-required field. Today only
+    ``"json_schema"`` is accepted; any other value is rejected with
+    HTTP 400 inside ``anthropic_to_openai`` (with a clear error message
+    pointing at this surface), and the adapter additionally enforces
+    that ``schema`` is a dict for ``type == "json_schema"``.
+    """
+
+    type: str  # only "json_schema" is supported on this surface today
+    # JSON Schema dict. Required when ``type == "json_schema"``; the
+    # adapter rejects requests where it is missing or not an object
+    # (400). Declared as Optional/dict here so the Pydantic parse
+    # surfaces validation in the adapter's domain-specific error
+    # message rather than as a generic "field required" 422.
+    schema_: dict | None = Field(default=None, alias="schema")
+    name: str | None = None
+    description: str | None = None
+    strict: bool | None = None
+
+    class Config:
+        populate_by_name = True
+
+
+class AnthropicOutputConfig(BaseModel):
+    """Output-side configuration for an Anthropic Messages request.
+
+    Backport of upstream vLLM PR #42396 (v0.22.0). Mirrors the Anthropic
+    SDK's ``output_config`` shape so SDKs can request structured output
+    via ``output_config.format = json_schema`` without falling back to
+    tool-call-emulated structured output.
+
+    ``effort`` is accepted but intentionally NOT acted on here — it is
+    part of a separate concurrent backport (Pick 1, reasoning-effort).
+    Declaring the field today prevents the two PRs from racing on the
+    same model shape during merge; the Pick 1 PR wires the value into
+    the sampling cascade. Until then, any value the client supplies
+    (low / medium / high / xhigh / max) is silently ignored.
+    """
+
+    format: AnthropicOutputFormat | None = None
+    # Accepted-but-ignored: see class docstring. Pick 1 (separate PR)
+    # will wire this into the sampling cascade.
+    effort: str | None = None
+
+
 class AnthropicRequest(BaseModel):
     """Request for Anthropic Messages API."""
 
@@ -65,6 +120,11 @@ class AnthropicRequest(BaseModel):
     tool_choice: dict | None = None
     metadata: dict | None = None
     top_k: int | None = None
+    # Upstream vLLM PR #42396 (v0.22.0) — native structured output on
+    # /v1/messages via ``output_config.format = json_schema``. Optional;
+    # absence preserves the pre-existing free-form text path so existing
+    # SDK callers see no behavior change.
+    output_config: AnthropicOutputConfig | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -9,8 +9,13 @@ from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
+from pydantic import ValidationError
 
-from ..api.anthropic_adapter import anthropic_to_openai, openai_to_anthropic
+from ..api.anthropic_adapter import (
+    AnthropicOutputConfigError,
+    anthropic_to_openai,
+    openai_to_anthropic,
+)
 from ..api.anthropic_models import AnthropicRequest
 from ..api.models import (
     AssistantMessage,
@@ -115,7 +120,15 @@ async def create_anthropic_message(
     through the existing engine, and converts the response back.
     """
     body = await request.json()
-    anthropic_request = AnthropicRequest(**body)
+    # ``AnthropicRequest`` is constructed manually (not as a FastAPI body
+    # parameter), so Pydantic ``ValidationError`` would otherwise surface
+    # as a generic 500. Catch it explicitly to give clients a 400 with
+    # the actual validation detail — matches the ergonomics of the
+    # ``output_config`` 400 path below (PR #42396 backport).
+    try:
+        anthropic_request = AnthropicRequest(**body)
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     if not (anthropic_request.model or "").startswith(("claude-", "gpt-")):
         _validate_model_name(anthropic_request.model)
@@ -161,8 +174,14 @@ async def create_anthropic_message(
                 cfg_for_log.model_name,
             )
 
-        # Convert Anthropic request -> OpenAI request
-        openai_request = anthropic_to_openai(anthropic_request)
+        # Convert Anthropic request -> OpenAI request. The adapter raises
+        # ``AnthropicOutputConfigError`` (a ``ValueError`` subclass) on
+        # malformed ``output_config`` payloads — backport of upstream vLLM
+        # PR #42396; map directly to HTTP 400 with the adapter's message.
+        try:
+            openai_request = anthropic_to_openai(anthropic_request)
+        except AnthropicOutputConfigError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
         if anthropic_request.stream:
             _admission_committed = True


### PR DESCRIPTION
## Summary

Backport of upstream [vllm-project/vllm PR #42396](https://github.com/vllm-project/vllm/pull/42396) (shipped vLLM v0.22.0). Adds native JSON-Schema-constrained output to the Anthropic ``/v1/messages`` surface.

The Anthropic SDK exposes structured output through ``output_config.format = json_schema``. We translate that shape into the OpenAI ``response_format`` shape the existing chat-completions guided-decode pipeline (``api/guided.py`` + outlines) already drives. No new generation path; just a new wire surface.

### What changes

- ``AnthropicOutputFormat`` + ``AnthropicOutputConfig`` Pydantic models on ``api/anthropic_models.py``.
- ``_convert_output_config`` in ``api/anthropic_adapter.py`` translates ``output_config.format = json_schema`` → ``response_format`` and raises ``AnthropicOutputConfigError`` (ValueError subclass) on unsupported types, missing schemas, or non-dict schemas.
- ``routes/anthropic.py`` converts ``AnthropicOutputConfigError`` → HTTP 400. It also now wraps manual ``AnthropicRequest`` construction so Pydantic ``ValidationError`` surfaces as 400 rather than 500 (incidental fix surfaced by the new validation path).

### Coexistence with Pick 1 (concurrent reasoning-effort PR)

Anthropic also recently added an ``effort`` field under ``output_config``. That field belongs to a separate concurrent backport (Pick 1). To prevent a merge race on the same Pydantic shape, this PR declares ``effort: str | None = None`` on ``AnthropicOutputConfig`` and intentionally does NOT act on it. Pick 1 wires the value into the sampling cascade. A test pins this contract: setting ``effort`` produces byte-identical ``chat_kwargs`` to a request without it.

### Backward compatibility (this is on PyPI)

``output_config`` is optional. Pre-backport callers see no behavior change — verified by ``test_no_output_config_is_backward_compatible``. The new field defaults to ``None`` everywhere.

### Spec / shape

```
output_config: {
  format: {
    type: \"json_schema\",
    schema: { ... JSON Schema ... },
    name?: str,
    description?: str,
    strict?: bool
  } | null,
  effort?: str   # accepted-but-ignored (Pick 1)
} | null
```

Validation:
- ``format.type`` other than ``\"json_schema\"`` → 400
- ``format.schema`` missing → 400
- ``format.schema`` non-dict → 400

## Test plan

- [x] Pydantic parsing including ``schema`` ↔ ``schema_`` alias round-trip
- [x] Adapter unit tests: each validation path raises ``AnthropicOutputConfigError`` with operator-friendly message
- [x] Adapter unit test: ``effort`` does NOT alter the produced OpenAI request (model_dump diff)
- [x] Route 200: valid ``json_schema`` request round-trips through ``/v1/messages``
- [x] Route 400: unknown format type, missing schema, non-dict schema
- [x] Recording-engine test: ``effort`` field does NOT mutate forwarded ``chat_kwargs``
- [x] Backward-compat: requests with no ``output_config`` produce identical engine call to pre-backport
- [x] All 163 existing anthropic-related tests still pass
- [x] ``ruff check`` + ``ruff format --check`` clean

## Upstream reference

- Upstream PR: https://github.com/vllm-project/vllm/pull/42396
- Shipped in: vLLM v0.22.0