### PR TITLE
fix(bench): per-profile timeout + health-check / auto-restart in harness sweep

### DIFF
--- a/tests/test_bench_tier_all.py
+++ b/tests/test_bench_tier_all.py
@@ -62,7 +62,7 @@ def test_all_runs_smoke_speed_harness_in_order(patch_serve_only, capsys):
             name="speed", passed=True, duration_s=10.0, detail="PASS tps=42.0"
         )
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         call_order.append("harness")
         return TierResult(
             name="harness", passed=True, duration_s=30.0, detail="5/5 pass"
@@ -103,7 +103,7 @@ def test_all_aborts_after_smoke_failure(patch_serve_only, capsys):
             name="speed", passed=True, duration_s=10.0, detail="should not run"
         )
 
-    def _harness_should_not_run(model, base_url):
+    def _harness_should_not_run(model, base_url, **kwargs):
         call_order.append("harness")
         return TierResult(
             name="harness",
@@ -143,7 +143,7 @@ def test_all_continues_past_speed_failure(patch_serve_only, capsys):
             name="speed", passed=False, duration_s=10.0, detail="FAIL HTTP 500"
         )
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         call_order.append("harness")
         return TierResult(name="harness", passed=True, duration_s=30.0)
 
@@ -184,7 +184,7 @@ def test_all_boots_server_exactly_once(capsys):
     def _speed_stub(model, base_url, sampled=False):
         return TierResult(name="speed", passed=True, duration_s=0.1)
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         return TierResult(name="harness", passed=True, duration_s=0.1)
 
     with (
@@ -223,7 +223,7 @@ def test_all_with_base_url_skips_server_boot(capsys):
     def _speed_stub(model, base_url, sampled=False):
         return TierResult(name="speed", passed=True, duration_s=0.1)
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         return TierResult(name="harness", passed=True, duration_s=0.1)
 
     # Stub the urlopen call so the attach health-check passes.

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -468,3 +468,114 @@ def test_harness_profile_timeout_does_not_block_next_profile(capsys):
     assert "FAIL codex" in captured.out
     # Tier exits 1 because of the codex FAIL.
     assert rc == 1
+
+
+def test_harness_timeout_forces_server_restart_isolation(capsys):
+    """After a per-profile timeout, the server is restarted before the next profile.
+
+    Codex review-2 BLOCKING-2: the orphaned daemon thread from a
+    timed-out profile may still be issuing requests against the same
+    server when the next profile starts, polluting that profile's
+    measurements / failure modes. Enforce that ``run_tier`` calls
+    ``serve(...)`` a second time after a timeout so the next profile
+    starts on a clean server.
+    """
+    import threading
+
+    serve_calls: list[int] = []
+
+    @contextlib.contextmanager
+    def _serve_recording(model, port=None, **kwargs):
+        serve_calls.append(port)
+        yield {
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "port": port,
+            "boot_time_ms": 100.0,
+        }
+
+    def _free_port(lo, hi):
+        _free_port.calls += 1
+        return 8500 + _free_port.calls
+
+    _free_port.calls = 0  # type: ignore[attr-defined]
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        r = MagicMock()
+        if profile.name == "codex":
+
+            def _hang():
+                threading.Event().wait()  # blocks forever
+
+            r.run.side_effect = _hang
+        else:
+            r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _serve_recording),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        # /health stays True throughout — we're testing the FORCED
+        # restart-after-timeout path, not the dead-server-detected path.
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
+        patch("vllm_mlx.bench.tier_runner.HARNESS_PROFILE_TIMEOUT_S", 1),
+    ):
+        run_tier(model="qwen3.5-4b-4bit", tier="harness")
+
+    # serve() must have been called AT LEAST twice: once for the initial
+    # boot, then again immediately after the codex timeout to give the
+    # remaining profiles a fresh server.
+    assert len(serve_calls) >= 2, (
+        f"expected initial boot + at least one post-timeout restart; "
+        f"got {len(serve_calls)} serve() calls"
+    )
+    captured = capsys.readouterr()
+    # The restart notice surfaces in the tier output so operators know
+    # the next profile's numbers are on a fresh server.
+    assert "rebooted" in captured.out or "restart" in captured.out.lower(), (
+        f"expected server restart announcement after timeout; got:\n{captured.out}"
+    )
+
+
+def test_harness_profile_timeout_env_var_respected(monkeypatch):
+    """``HARNESS_PROFILE_TIMEOUT_S`` env var must override the default.
+
+    Codex review-2 BLOCKING-1: the docstring promised an env-var override
+    but the constant was hard-coded to 300 at the module level. Resolver
+    at module-load now reads the env var; this test forces a re-import
+    with the env var set to 42 and asserts the new module value.
+    """
+    import importlib
+
+    import vllm_mlx.bench.tier_runner as tr
+
+    monkeypatch.setenv("HARNESS_PROFILE_TIMEOUT_S", "42")
+    importlib.reload(tr)
+    try:
+        assert tr.HARNESS_PROFILE_TIMEOUT_S == 42, (
+            f"env var must override default; got {tr.HARNESS_PROFILE_TIMEOUT_S}"
+        )
+
+        # Invalid values fall back to 300 with a stderr warning.
+        monkeypatch.setenv("HARNESS_PROFILE_TIMEOUT_S", "not-a-number")
+        importlib.reload(tr)
+        assert tr.HARNESS_PROFILE_TIMEOUT_S == 300
+
+        monkeypatch.setenv("HARNESS_PROFILE_TIMEOUT_S", "-5")
+        importlib.reload(tr)
+        assert tr.HARNESS_PROFILE_TIMEOUT_S == 300
+    finally:
+        # Restore module state so later tests in the same session see
+        # the default (other tests monkeypatch this constant).
+        monkeypatch.delenv("HARNESS_PROFILE_TIMEOUT_S", raising=False)
+        importlib.reload(tr)

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -547,6 +547,103 @@ def test_harness_timeout_forces_server_restart_isolation(capsys):
     )
 
 
+def test_harness_restart_tears_down_old_server_before_booting_new(capsys):
+    """Reboot must kill the current server BEFORE spawning the replacement.
+
+    Codex review-2 BLOCKING: without this ordering, the hung-but-not-
+    dead old model server briefly coexists with the newly-booted one,
+    doubling GPU memory pressure exactly when we're trying to recover
+    from an OOM-adjacent failure. The session's reboot path must call
+    ``release_current_server`` BEFORE its ``serve(...).__enter__()`` so
+    the kill-before-boot invariant holds.
+    """
+    # Record every (event, port) pair so we can assert ordering.
+    timeline: list[tuple[str, int]] = []
+
+    @contextlib.contextmanager
+    def _serve_recording(model, port=None, **kwargs):
+        timeline.append(("boot", port))
+        try:
+            yield {
+                "base_url": f"http://127.0.0.1:{port}/v1",
+                "port": port,
+                "boot_time_ms": 100.0,
+            }
+        finally:
+            timeline.append(("kill", port))
+
+    def _free_port(lo, hi):
+        _free_port.calls += 1
+        return 8500 + _free_port.calls
+
+    _free_port.calls = 0  # type: ignore[attr-defined]
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        r = MagicMock()
+        r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    # /health fails on the per-profile probe AFTER codex so the session
+    # forces a reboot once. All subsequent probes pass.
+    health_sequence = iter([True, False, True, True, True, True])
+
+    def _stub_health(*args, **kwargs):
+        try:
+            return next(health_sequence)
+        except StopIteration:
+            return True
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _serve_recording),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", side_effect=_stub_health),
+    ):
+        run_tier(model="qwen3.5-4b-4bit", tier="harness")
+
+    # Filter to just boot/kill events for the FIRST two servers
+    # (initial + first restart). Any "boot" for server N must be
+    # preceded by a "kill" of server N-1 — otherwise two servers
+    # coexist.
+    boot_events = [t for t in timeline if t[0] == "boot"]
+    assert len(boot_events) >= 2, (
+        f"expected initial boot + at least one restart-boot; got {timeline}"
+    )
+
+    initial_port = boot_events[0][1]
+    restart_port = boot_events[1][1]
+    assert initial_port != restart_port, (
+        f"restart should use a fresh port; both = {initial_port}"
+    )
+
+    initial_kill_idx = next(
+        (i for i, t in enumerate(timeline) if t == ("kill", initial_port)),
+        None,
+    )
+    restart_boot_idx = next(
+        (i for i, t in enumerate(timeline) if t == ("boot", restart_port)),
+        None,
+    )
+    assert initial_kill_idx is not None, (
+        f"initial server must be killed; timeline={timeline}"
+    )
+    assert restart_boot_idx is not None
+    assert initial_kill_idx < restart_boot_idx, (
+        "kill-before-boot violated: initial server still alive when "
+        f"replacement booted. timeline={timeline}"
+    )
+
+
 def test_harness_profile_timeout_env_var_respected(monkeypatch):
     """``HARNESS_PROFILE_TIMEOUT_S`` env var must override the default.
 

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -644,6 +644,87 @@ def test_harness_restart_tears_down_old_server_before_booting_new(capsys):
     )
 
 
+def test_harness_restart_refuses_when_old_server_teardown_fails(capsys):
+    """If killing the old server raises, the session must NOT boot a replacement.
+
+    Codex review-3 BLOCKING: starting a fresh server while the previous
+    one's process group failed to terminate would put two model servers
+    on the GPU at once — the exact OOM-adjacent condition the restart
+    is meant to fix. The session must record a FAIL and skip the reboot
+    so the next iteration's ``ensure_healthy`` re-probes (and either
+    finds the original recovering, or marks the profile dead).
+    """
+    serve_calls: list[int] = []
+
+    @contextlib.contextmanager
+    def _serve_failing_teardown(model, port=None, **kwargs):
+        serve_calls.append(port)
+        try:
+            yield {
+                "base_url": f"http://127.0.0.1:{port}/v1",
+                "port": port,
+                "boot_time_ms": 100.0,
+            }
+        finally:
+            # Simulate a teardown that fails (process group SIGTERM
+            # rejected, e.g. zombie unkillable child).
+            raise RuntimeError("simulated teardown failure")
+
+    def _free_port(lo, hi):
+        _free_port.calls += 1
+        return 8500 + _free_port.calls
+
+    _free_port.calls = 0  # type: ignore[attr-defined]
+
+    invocations: list[str] = []
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        invocations.append(profile.name)
+        r = MagicMock()
+        r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    # /health: codex's pre-check passes, then every subsequent probe
+    # FAILS so the session tries to reboot — and finds the teardown
+    # broken.
+    health_sequence = iter([True, False, False, False, False, False])
+
+    def _stub_health(*args, **kwargs):
+        try:
+            return next(health_sequence)
+        except StopIteration:
+            return False
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _serve_failing_teardown),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", side_effect=_stub_health),
+    ):
+        run_tier(model="qwen3.5-4b-4bit", tier="harness")
+
+    # Only ONE serve() call total — the initial boot. The teardown-
+    # broken reboot must have been refused, so no second serve() ran.
+    assert len(serve_calls) == 1, (
+        f"refusal must skip the replacement boot; got {len(serve_calls)} "
+        f"serve() calls ({serve_calls})"
+    )
+    captured = capsys.readouterr()
+    assert "refused to reboot" in captured.out, (
+        f"expected refusal note in tier output; got:\n{captured.out}"
+    )
+
+
 def test_harness_profile_timeout_env_var_respected(monkeypatch):
     """``HARNESS_PROFILE_TIMEOUT_S`` env var must override the default.
 

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -725,6 +725,76 @@ def test_harness_restart_refuses_when_old_server_teardown_fails(capsys):
     )
 
 
+def test_harness_timeout_with_failed_restart_surfaces_isolation_failure(capsys):
+    """Failed force-restart after a timeout annotates the timing-out profile.
+
+    Codex review-4 BLOCKING: when ``force_restart_after_timeout`` fails
+    (e.g. because the old-server teardown raised and the session went
+    into ``_reboot_disabled`` mode), the orphaned daemon thread can
+    still race the next profile. We must surface this in the timing-
+    out profile's row so the operator sees one consolidated FAIL
+    instead of chasing a stale 'server not healthy' message into the
+    NEXT profile's row.
+    """
+    import threading
+
+    @contextlib.contextmanager
+    def _serve_failing_teardown(model, port=None, **kwargs):
+        try:
+            yield {
+                "base_url": f"http://127.0.0.1:{port}/v1",
+                "port": port,
+                "boot_time_ms": 100.0,
+            }
+        finally:
+            raise RuntimeError("simulated teardown failure")
+
+    def _free_port(lo, hi):
+        return 8500
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        r = MagicMock()
+        if profile.name == "codex":
+
+            def _hang():
+                threading.Event().wait()
+
+            r.run.side_effect = _hang
+        else:
+            r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _serve_failing_teardown),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
+        patch("vllm_mlx.bench.tier_runner.HARNESS_PROFILE_TIMEOUT_S", 1),
+    ):
+        run_tier(model="qwen3.5-4b-4bit", tier="harness")
+
+    captured = capsys.readouterr()
+    # The codex row must mention BOTH the timeout AND the isolation
+    # failure — operators need to see them together, not split across
+    # rows.
+    assert "FAIL codex" in captured.out
+    assert "timed out" in captured.out
+    assert "server isolation FAILED" in captured.out, (
+        f"timing-out profile row must surface the failed-restart isolation "
+        f"failure; got:\n{captured.out}"
+    )
+
+
 def test_harness_profile_timeout_env_var_respected(monkeypatch):
     """``HARNESS_PROFILE_TIMEOUT_S`` env var must override the default.
 

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -44,7 +44,14 @@ def _make_fake_report(*, passed=10, failed=0, errored=0, skipped=2, results=None
 
 @pytest.fixture
 def patch_harness_environment():
-    """Stub the server boot + AgentTestRunner so the tier runs in-process."""
+    """Stub the server boot + AgentTestRunner so the tier runs in-process.
+
+    Also stubs ``_health_check`` to always return True — without this,
+    the post-#682 harness session would conclude the (mock) server is
+    dead before each profile and reboot endlessly in-test, masking
+    iteration-logic regressions. Cascade-restart behavior gets its own
+    dedicated test (``test_harness_dead_server_between_profiles_reboots``).
+    """
 
     def _free_port(lo, hi):
         return 8500
@@ -73,6 +80,7 @@ def patch_harness_environment():
         patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_fake_runner_init),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
     ):
         yield invocations
 
@@ -135,6 +143,7 @@ def test_harness_single_failure_marks_tier_failed(capsys):
         patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
     ):
         rc = run_tier(model="qwen3.5-4b-4bit", tier="harness")
 
@@ -181,6 +190,7 @@ def test_harness_crash_in_runner_does_not_abort_sweep(capsys):
         patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
     ):
         rc = run_tier(model="qwen3.5-4b-4bit", tier="harness")
 
@@ -218,6 +228,7 @@ def test_harness_missing_profile_marks_as_failure(capsys):
         patch("vllm_mlx.bench._server.serve", _fake_serve),
         patch("vllm_mlx.agents.get_profile", _fake_get_profile),
         patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
     ):
         rc = run_tier(model="qwen3.5-4b-4bit", tier="harness")
 
@@ -225,3 +236,235 @@ def test_harness_missing_profile_marks_as_failure(capsys):
     captured = capsys.readouterr()
     assert "langchain" in captured.out
     assert "not found" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cascade-fail regression: dead server between profiles must reboot, not
+# tank every later profile with ECONNREFUSED. See issue #682.
+# ---------------------------------------------------------------------------
+
+
+def test_harness_dead_server_between_profiles_reboots(capsys):
+    """A dead /health between two profiles triggers a reboot.
+
+    Simulates the production failure: codex passes, then the in-process
+    server dies (OOM on a slow model). Pre-fix every later profile
+    raised ``server_check: Rapid-MLX server not running``. Post-fix the
+    session detects the dead /health and boots a fresh ``serve()`` so
+    opencode/hermes/aider/langchain still get their fair shot.
+    """
+    import time as _time
+
+    def _free_port(lo, hi):
+        # Each restart picks a NEW port so we can count reboots.
+        _free_port.calls += 1
+        return 8500 + _free_port.calls
+
+    _free_port.calls = 0  # type: ignore[attr-defined]
+
+    serve_calls: list[int] = []
+
+    @contextlib.contextmanager
+    def _serve_recording(model, port=None, **kwargs):
+        serve_calls.append(port)
+        yield {
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "port": port,
+            "boot_time_ms": 100.0,
+        }
+
+    invocations: list[str] = []
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        invocations.append(profile.name)
+        r = MagicMock()
+        r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    # Health-check sequence: True for codex's pre-check; False right
+    # AFTER codex (server died); then True again so the reboot succeeds
+    # AND every later profile sees a healthy server. The sequence
+    # length matches the order ``_run_harness`` probes: 1 per profile.
+    health_sequence = iter([True, False, True, True, True])
+
+    def _stub_health(*args, **kwargs):
+        try:
+            return next(health_sequence)
+        except StopIteration:
+            return True
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _serve_recording),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", side_effect=_stub_health),
+    ):
+        t0 = _time.time()
+        rc = run_tier(model="qwen3.5-4b-4bit", tier="harness")
+        _ = _time.time() - t0  # touched for clarity; harness sweep is mocked
+
+    # All 5 profiles must have been visited despite the mid-sweep death.
+    assert tuple(invocations) == HARNESS_PROFILES, (
+        "cascade fix must keep iterating after a server reboot; "
+        f"got {invocations}"
+    )
+
+    # At least 2 serve() calls: initial boot + 1 reboot between profiles.
+    assert len(serve_calls) >= 2, (
+        f"expected initial boot + at least one reboot; got {len(serve_calls)} "
+        f"serve() invocations"
+    )
+
+    captured = capsys.readouterr()
+    # The session must announce the reboot so gauntlet operators see it.
+    assert "rebooted" in captured.out or "restart" in captured.out.lower(), (
+        f"expected reboot notice in tier output; got:\n{captured.out}"
+    )
+    # Tier exit code is 0 because we recovered cleanly.
+    assert rc == 0, f"recovered sweep should pass; got rc={rc}"
+
+
+def test_harness_dead_server_no_reboot_when_attached_url(capsys):
+    """With ``--base-url``, the session can't restart — surfaces a FAIL.
+
+    User attached to an externally-managed server. If THAT server dies
+    mid-sweep we have no business spawning our own replacement (it would
+    listen on a different port the user isn't pointing at). Each
+    affected profile records a FAIL with a clear "cannot restart
+    attached servers" note instead of cascading ECONNREFUSED.
+    """
+    invocations: list[str] = []
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        invocations.append(profile.name)
+        r = MagicMock()
+        r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    # ``_serve_or_attach`` uses ``urllib.request.urlopen`` (NOT
+    # ``_health_check``) for its initial sanity ping, so every
+    # ``_health_check`` call here is a per-profile probe. We want all
+    # of them to return False so each profile records a server-not-
+    # healthy FAIL.
+    def _stub_health(*args, **kwargs):
+        return False
+
+    # Also stub the attach-time urlopen so ``_serve_or_attach`` lets us
+    # in. We just need a urlopen that returns a 200-status object.
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def read(self):
+            return b""
+
+    with (
+        patch("urllib.request.urlopen", return_value=_FakeResp()),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", side_effect=_stub_health),
+    ):
+        rc = run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="harness",
+            base_url="http://127.0.0.1:9999/v1",
+        )
+
+    captured = capsys.readouterr()
+    # Every profile records a server-not-healthy FAIL.
+    assert "cannot restart attached" in captured.out, (
+        f"expected attach-mode skip notice; got:\n{captured.out}"
+    )
+    # No AgentTestRunner.run() ever got dispatched because the server
+    # was unhealthy before every profile.
+    assert invocations == [], (
+        f"attached + unhealthy → no profile should run; got {invocations}"
+    )
+    assert rc == 1
+
+
+def test_harness_profile_timeout_does_not_block_next_profile(capsys):
+    """A hung profile is killed by the per-profile timeout and the sweep continues.
+
+    Reproduces the cause of the cascade fail: codex's e2e_file_read hung
+    for 156s on a slow model. Pre-fix the runner waited indefinitely.
+    Post-fix the per-profile deadline fires, the hung profile records a
+    "timed out" FAIL, and the next profile (opencode, etc.) starts
+    immediately.
+    """
+    import threading
+
+    invocations: list[str] = []
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        invocations.append(profile.name)
+        r = MagicMock()
+        if profile.name == "codex":
+            # Block the worker thread for longer than the timeout so the
+            # deadline fires.
+            def _hang():
+                threading.Event().wait()  # blocks forever
+
+            r.run.side_effect = _hang
+        else:
+            r.run.return_value = _make_fake_report()
+        return r
+
+    def _fake_get_profile(name):
+        p = MagicMock()
+        p.name = name
+        p.display_name = name.title()
+        return p
+
+    def _free_port(lo, hi):
+        return 8500
+
+    with (
+        patch(
+            "vllm_mlx.bench.tier_runner._find_free_port_in_range",
+            side_effect=_free_port,
+        ),
+        patch("vllm_mlx.bench._server.serve", _fake_serve),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
+        # Cap the per-profile wall-clock at 1s so the test is fast.
+        patch("vllm_mlx.bench.tier_runner.HARNESS_PROFILE_TIMEOUT_S", 1),
+    ):
+        rc = run_tier(model="qwen3.5-4b-4bit", tier="harness")
+
+    captured = capsys.readouterr()
+    # Every profile still got tried — the hung codex didn't block the
+    # next four.
+    assert tuple(invocations) == HARNESS_PROFILES, (
+        "per-profile timeout must let the sweep continue; "
+        f"got {invocations}"
+    )
+    # Codex must surface as a FAIL with the timeout marker.
+    assert "timed out" in captured.out, (
+        f"expected per-profile timeout marker; got:\n{captured.out}"
+    )
+    assert "FAIL codex" in captured.out
+    # Tier exits 1 because of the codex FAIL.
+    assert rc == 1

--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -143,7 +143,7 @@ def test_run_tier_returns_payload_when_requested():
             payload=dict(_SMOKE_PAYLOAD),
         )
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         return TierResult(
             name="harness",
             passed=True,
@@ -257,7 +257,7 @@ def test_run_tier_skip_speed_avoids_lightweight_probe():
         calls.append("speed")
         return TierResult(name="speed", passed=True, duration_s=0.1)
 
-    def _harness_stub(model, base_url):
+    def _harness_stub(model, base_url, **kwargs):
         calls.append("harness")
         return TierResult(
             name="harness",

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -21,6 +21,7 @@ existing freeform ``bench`` (no --tier, no --submit) path and the
 
 from __future__ import annotations
 
+import os
 import socket
 import sys
 import time
@@ -48,16 +49,44 @@ HARNESS_PROFILES: tuple[str, ...] = (
 TIER_PORT_MIN = 8500
 TIER_PORT_MAX = 8599
 
+def _resolve_harness_profile_timeout() -> int:
+    """Read the per-profile harness timeout from the environment.
+
+    300s default is wide enough that a healthy harness on a 30B+ model
+    still finishes (release-check observed ~120s p95 for codex on
+    qwen3.5-9b) but tight enough that a true hang gets caught in well
+    under the gauntlet's overall 10-min/model budget.
+
+    Reading at MODULE LOAD honors the documented ``HARNESS_PROFILE_TIMEOUT_S``
+    override without needing every caller to thread a kwarg through.
+    Invalid / non-positive values fall back to 300 with a stderr warning
+    rather than silently using the user's broken value (e.g. ``-1`` would
+    cause every harness to "time out" on the very first thread.join()).
+    """
+    raw = os.environ.get("HARNESS_PROFILE_TIMEOUT_S")
+    if raw is None:
+        return 300
+    try:
+        val = int(raw)
+        if val <= 0:
+            raise ValueError(f"must be positive, got {val}")
+        return val
+    except ValueError as exc:
+        print(
+            f"  Warning: ignoring invalid HARNESS_PROFILE_TIMEOUT_S={raw!r} "
+            f"({exc}); using 300s default",
+            file=sys.stderr,
+        )
+        return 300
+
+
 # Per-profile wall-clock cap for the harness sweep. One bad harness
 # (e.g. a codex e2e_file_read hang at 156s on a slow model) was taking
 # down the in-process server and cascading FAIL to every later profile
-# with ECONNREFUSED / "Rapid-MLX server not running". 300s is wide
-# enough that a healthy harness on a 30B+ model still finishes (release-
-# check observed ~120s p95 for codex on qwen3.5-9b) but tight enough
-# that a true hang gets caught in well under the gauntlet's overall
-# 10-min/model budget. Override via ``HARNESS_PROFILE_TIMEOUT_S`` env
-# var for slow boxes / future bigger models.
-HARNESS_PROFILE_TIMEOUT_S = 300
+# with ECONNREFUSED / "Rapid-MLX server not running". Override via
+# ``HARNESS_PROFILE_TIMEOUT_S`` env var for slow boxes / future bigger
+# models. Resolved at module-load via ``_resolve_harness_profile_timeout``.
+HARNESS_PROFILE_TIMEOUT_S = _resolve_harness_profile_timeout()
 
 # Server health-probe timeout used between harness profiles. The probe
 # is a single GET /health — we don't want it to itself hang and look
@@ -551,6 +580,31 @@ class _HarnessServerSession:
         # We own it — tear down and reboot.
         return self._restart()
 
+    def force_restart_after_timeout(self) -> tuple[bool, str | None]:
+        """Reboot the server unconditionally after a per-profile timeout.
+
+        The orphaned daemon thread from a timed-out profile may still be
+        mid-request against the current server (an httpx call that hasn't
+        returned, a subprocess that hasn't finished). If we let the NEXT
+        profile share that same server, the orphan's late response would
+        race against the new profile's measurements / failure modes.
+        Force a fresh server so the next profile starts on a clean slate.
+
+        No-op (returns ``(True, None)``) when we don't own the server —
+        we can't restart what the user is hosting, so the next profile
+        will simply contend with whatever ghost requests the orphan
+        emits. Surface a clear note in that case so the gauntlet
+        operator knows the next profile's numbers are suspect.
+        """
+        if not self._owns:
+            return (
+                True,
+                "profile timed out and --base-url is attached — "
+                "subsequent profile measurements may be polluted by the "
+                "orphaned worker",
+            )
+        return self._restart()
+
     def _restart(self) -> tuple[bool, str | None]:
         # Tear down whatever's left of the old serve context. The
         # serve() finalizer SIGTERMs the process group, so even a
@@ -613,11 +667,13 @@ def _run_single_profile(
     profile,
     base_url: str,
     timeout_s: int,
-) -> tuple[bool, float, str]:
+) -> tuple[bool, float, str, bool]:
     """Run ONE harness profile with a wall-clock cap. Never raises.
 
-    Returns ``(ok, elapsed_s, detail)`` so the caller can fold the row
-    into ``per_harness`` exactly as the inline body used to.
+    Returns ``(ok, elapsed_s, detail, timed_out)`` — the trailing flag
+    lets the caller force a server restart after a timeout so the
+    orphaned daemon thread can't pollute the next profile's
+    measurements with late-arriving requests.
 
     The runner is dispatched on a worker thread and joined with a
     ``timeout_s`` deadline. On timeout we abandon the thread (Python
@@ -674,9 +730,17 @@ def _run_single_profile(
     result_container: dict[str, object] = {}
 
     def _runner_target() -> None:
+        # Catch ``Exception`` (NOT ``BaseException``): leaking
+        # ``KeyboardInterrupt`` / ``SystemExit`` here would let process
+        # termination signals propagate through the worker thread up to
+        # the bench CLI's signal handler, instead of being silently
+        # demoted to a benchmark FAIL row. Worker threads can't actually
+        # receive those signals (Python delivers them to the main
+        # thread), but the symmetric exception handling is a Codex
+        # review-2 NIT worth honoring.
         try:
             result_container["ok"], result_container["detail"] = _run()
-        except BaseException as exc:  # noqa: BLE001 — captured for the joiner
+        except Exception as exc:  # noqa: BLE001 — captured for the joiner
             result_container["exc"] = exc
 
     worker = threading.Thread(
@@ -690,12 +754,15 @@ def _run_single_profile(
     if worker.is_alive():
         # Hang — abandon the daemon thread to die when (if ever) its
         # blocking call returns. Process exit will reap it because of
-        # ``daemon=True``.
+        # ``daemon=True``. Return ``timed_out=True`` so the caller
+        # forces a server restart before the next profile, isolating
+        # the orphan's late requests from the next profile's measurements.
         h_elapsed = time.perf_counter() - h_t0
         return (
             False,
             h_elapsed,
             f"timed out after {timeout_s}s (per-profile cap)",
+            True,
         )
 
     h_elapsed = time.perf_counter() - h_t0
@@ -705,11 +772,13 @@ def _run_single_profile(
             False,
             h_elapsed,
             f"crashed: {type(exc).__name__}: {exc}",
+            False,
         )
     return (
         bool(result_container["ok"]),
         h_elapsed,
         str(result_container["detail"]),
+        False,
     )
 
 
@@ -787,13 +856,29 @@ def _run_harness(
                 )
                 continue
 
-        ok, h_elapsed, detail = _run_single_profile(
+        ok, h_elapsed, detail, timed_out = _run_single_profile(
             profile_name,
             profile,
             profile_base_url,
             timeout_s,
         )
         per_harness.append((profile_name, ok, h_elapsed, detail))
+
+        # Per-profile timeout → the orphaned daemon thread may still be
+        # mid-request against this server. If we re-use the server for
+        # the next profile, the orphan's response could land DURING the
+        # next profile's measurements and corrupt the supposedly
+        # independent result. Force a fresh server so each profile
+        # starts on a clean slate. Codex review-2 BLOCKING-2.
+        if timed_out and session is not None:
+            ok_restart, note = session.force_restart_after_timeout()
+            if note:
+                print(f"  [server] {note}")
+            # Failed restart is non-fatal — the next iteration's
+            # ``ensure_healthy()`` will see the dead server and mark
+            # that profile as a server-not-healthy FAIL, which is the
+            # most honest signal we can give the operator.
+            _ = ok_restart
 
     elapsed = time.perf_counter() - t0
     all_passed = all(ok for _, ok, _, _ in per_harness)

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import socket
 import sys
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 
 # The 5 first-class harnesses in the documented order. Used by both
@@ -45,6 +47,22 @@ HARNESS_PROFILES: tuple[str, ...] = (
 # concurrent tier runs are easy to spot in ``lsof``).
 TIER_PORT_MIN = 8500
 TIER_PORT_MAX = 8599
+
+# Per-profile wall-clock cap for the harness sweep. One bad harness
+# (e.g. a codex e2e_file_read hang at 156s on a slow model) was taking
+# down the in-process server and cascading FAIL to every later profile
+# with ECONNREFUSED / "Rapid-MLX server not running". 300s is wide
+# enough that a healthy harness on a 30B+ model still finishes (release-
+# check observed ~120s p95 for codex on qwen3.5-9b) but tight enough
+# that a true hang gets caught in well under the gauntlet's overall
+# 10-min/model budget. Override via ``HARNESS_PROFILE_TIMEOUT_S`` env
+# var for slow boxes / future bigger models.
+HARNESS_PROFILE_TIMEOUT_S = 300
+
+# Server health-probe timeout used between harness profiles. The probe
+# is a single GET /health — we don't want it to itself hang and look
+# like a profile failure, so keep it short.
+_HEALTH_PROBE_TIMEOUT_S = 3
 
 
 @dataclass
@@ -431,17 +449,307 @@ def _run_speed(model: str, base_url: str, sampled: bool = False) -> TierResult:
     return TierResult(name="speed", passed=True, duration_s=elapsed, detail=detail)
 
 
-def _run_harness(model: str, base_url: str) -> TierResult:
+def _health_check(base_url: str, timeout_s: int = _HEALTH_PROBE_TIMEOUT_S) -> bool:
+    """Single GET /health probe. Returns True iff the server answered 200.
+
+    ``base_url`` is the normalized OpenAI base (e.g. ``http://host:port/v1``).
+    The bench server's health route lives at ``/health`` (not under
+    ``/v1``) — we derive it by stripping a trailing ``/v1``. Any error
+    (connection refused, timeout, non-200) returns False — the caller
+    interprets that as "server is dead, reboot it if we can".
+    """
+    cleaned = base_url.rstrip("/")
+    if cleaned.endswith("/v1"):
+        cleaned = cleaned[: -len("/v1")]
+    health_url = f"{cleaned}/health"
+    try:
+        with urllib.request.urlopen(health_url, timeout=timeout_s) as resp:  # noqa: S310
+            return resp.status == 200
+    except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+        return False
+
+
+class _HarnessServerSession:
+    """Per-harness server lifecycle for the harness sweep.
+
+    Wraps either (a) a server we own and CAN restart between profiles
+    when it dies, or (b) a user-attached server we can only health-check
+    against. Exposes a single method ``ensure_healthy()`` that the
+    harness loop calls before each profile.
+
+    Why this exists: the harness sweep used to share one ``serve()``
+    context manager with the rest of ``run_tier``. If one profile's e2e
+    subtest hung long enough to OOM / crash the in-process server (real
+    incident: codex e2e_file_read on gemma3-4-12b, qwen3.5-9b — the
+    server died, and every later profile then failed with
+    ``Rapid-MLX server not running``), nothing brought the server back
+    up. Cascade fail. Now a per-profile health check catches the dead
+    server and the session reboots before the next profile runs.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        base_url_override: str | None,
+        boot_timeout_s: int,
+        initial_port: int,
+        initial_owns: bool,
+        initial_base_url: str,
+        initial_serve_ctx,
+    ):
+        self._model = model
+        self._base_url_override = base_url_override
+        self._boot_timeout_s = boot_timeout_s
+        self._port = initial_port
+        self._owns = initial_owns
+        self._base_url = initial_base_url
+        # ``_serve_ctx`` is the live context-manager handle from
+        # ``serve(...)`` (when we own the server) or ``None`` (when
+        # attached). We hold onto it so we can call ``__exit__`` to
+        # tear down and ``__enter__`` again on restart.
+        self._serve_ctx = initial_serve_ctx
+        self._restarts = 0
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def owns(self) -> bool:
+        return self._owns
+
+    @property
+    def restarts(self) -> int:
+        return self._restarts
+
+    def ensure_healthy(self) -> tuple[bool, str | None]:
+        """Probe /health; restart if dead and we own the server.
+
+        Returns ``(healthy_now, note)``:
+
+        - ``healthy_now`` — True iff the server is responsive (after a
+          possible restart). False if the server is dead AND we can't
+          restart it (e.g. user-attached via ``--base-url``).
+        - ``note`` — human-readable string for tier output describing
+          what we did (restart count, "attached so could not restart",
+          etc.) or ``None`` when no action was needed.
+
+        The caller treats ``healthy_now=False`` as "skip this profile
+        and mark it failed" — running a profile against a dead server
+        just generates a noisy ECONNREFUSED report.
+        """
+        if _health_check(self._base_url):
+            return True, None
+
+        if not self._owns:
+            return (
+                False,
+                "server unreachable and --base-url attached "
+                "(cannot restart attached servers)",
+            )
+
+        # We own it — tear down and reboot.
+        return self._restart()
+
+    def _restart(self) -> tuple[bool, str | None]:
+        # Tear down whatever's left of the old serve context. The
+        # serve() finalizer SIGTERMs the process group, so even a
+        # half-alive uvicorn child gets cleaned up. On the FIRST
+        # restart ``_serve_ctx is None`` (the outer ``run_tier`` still
+        # owns the original serve context for ``boot_time_ms``
+        # accounting) — that's fine, the outer ``with`` will tear the
+        # dead original down when it exits. On later restarts we own
+        # the previous reboot's context and must drop it here.
+        old_port = self._port
+        if self._serve_ctx is not None:
+            try:
+                self._serve_ctx.__exit__(
+                    RuntimeError, RuntimeError("server unhealthy"), None
+                )
+            except BaseException:  # noqa: BLE001 — teardown errors must not abort restart
+                pass
+            self._serve_ctx = None
+
+        # New port — old one may still be in TIME_WAIT, and a fresh
+        # port keeps lsof unambiguous if the user is watching.
+        from ._server import serve
+
+        new_port = _find_free_port_in_range(TIER_PORT_MIN, TIER_PORT_MAX)
+        ctx = serve(
+            model=self._model, port=new_port, boot_timeout_s=self._boot_timeout_s
+        )
+        try:
+            info = ctx.__enter__()
+        except BaseException as exc:  # noqa: BLE001 — failed reboot must surface
+            note = (
+                f"reboot from port {old_port} failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False, note
+
+        self._serve_ctx = ctx
+        self._port = info["port"]
+        self._base_url = _normalize_openai_base(None, self._port)
+        self._restarts += 1
+        note = (
+            f"server was unhealthy — rebooted on port {self._port} "
+            f"(restart #{self._restarts})"
+        )
+        return True, note
+
+    def close(self) -> None:
+        """Tear down the owned server if it's still alive."""
+        if self._serve_ctx is None:
+            return
+        try:
+            self._serve_ctx.__exit__(None, None, None)
+        except BaseException:  # noqa: BLE001
+            pass
+        self._serve_ctx = None
+
+
+def _run_single_profile(
+    profile_name: str,
+    profile,
+    base_url: str,
+    timeout_s: int,
+) -> tuple[bool, float, str]:
+    """Run ONE harness profile with a wall-clock cap. Never raises.
+
+    Returns ``(ok, elapsed_s, detail)`` so the caller can fold the row
+    into ``per_harness`` exactly as the inline body used to.
+
+    The runner is dispatched on a worker thread and joined with a
+    ``timeout_s`` deadline. On timeout we abandon the thread (Python
+    threads can't be force-killed) and surface a tier-level FAIL with
+    a "timed out" detail — the orphaned thread will eventually exit
+    when its underlying httpx / subprocess call gives up or the
+    server it's talking to gets rebooted by the session manager.
+    Tying up one zombie thread is far cheaper than letting a hung
+    profile silently sink the whole sweep.
+    """
+    from ..agents.testing import AgentTestRunner, TestStatus
+
+    h_t0 = time.perf_counter()
+
+    def _run() -> tuple[bool, str]:
+        runner = AgentTestRunner(
+            profile,
+            base_url=base_url,
+            model_id=None,  # auto-detect from /models
+        )
+        report = runner.run()
+        n_fail = report.failed
+        n_err = report.errored
+        ok = n_fail == 0 and n_err == 0
+        if ok:
+            detail = f"{report.passed}p {report.skipped}s"
+        else:
+            # Surface first failing test name + message excerpt so
+            # gauntlet operators see the actionable signal without
+            # diving into the log.
+            first_bad = next(
+                (
+                    f"{r.name}: {(r.message or '')[:80]}"
+                    for r in report.results
+                    if r.status in (TestStatus.FAIL, TestStatus.ERROR)
+                ),
+                "(no detail)",
+            )
+            detail = (
+                f"{report.passed}p {n_fail}f {n_err}e {report.skipped}s "
+                f"| {first_bad}"
+            )
+        return ok, detail
+
+    # Use a daemon ``threading.Thread`` directly rather than
+    # ``ThreadPoolExecutor`` — the latter's worker threads are
+    # NON-daemon by default, so an orphaned hung worker would block the
+    # bench CLI from exiting cleanly when ``run_tier`` returns. We
+    # really do want the worker to be killable-by-interpreter-exit if
+    # it's hung on an HTTP call that never returns; that's the only
+    # safe escape hatch on top of the per-profile deadline.
+    import threading
+
+    result_container: dict[str, object] = {}
+
+    def _runner_target() -> None:
+        try:
+            result_container["ok"], result_container["detail"] = _run()
+        except BaseException as exc:  # noqa: BLE001 — captured for the joiner
+            result_container["exc"] = exc
+
+    worker = threading.Thread(
+        target=_runner_target,
+        name=f"harness-{profile_name}",
+        daemon=True,
+    )
+    worker.start()
+    worker.join(timeout=timeout_s)
+
+    if worker.is_alive():
+        # Hang — abandon the daemon thread to die when (if ever) its
+        # blocking call returns. Process exit will reap it because of
+        # ``daemon=True``.
+        h_elapsed = time.perf_counter() - h_t0
+        return (
+            False,
+            h_elapsed,
+            f"timed out after {timeout_s}s (per-profile cap)",
+        )
+
+    h_elapsed = time.perf_counter() - h_t0
+    if "exc" in result_container:
+        exc = result_container["exc"]
+        return (
+            False,
+            h_elapsed,
+            f"crashed: {type(exc).__name__}: {exc}",
+        )
+    return (
+        bool(result_container["ok"]),
+        h_elapsed,
+        str(result_container["detail"]),
+    )
+
+
+def _run_harness(
+    model: str,
+    base_url: str,
+    session: _HarnessServerSession | None = None,
+    per_profile_timeout_s: int | None = None,
+) -> TierResult:
     """Run the 5 first-class harnesses against the booted server.
 
     Returns a TierResult that aggregates the 5 individual outcomes. We
     treat any ERROR or FAIL in any harness as a tier-level failure —
     SKIP is fine (binary missing for the e2e tests is expected).
 
-    ``base_url`` is the normalized OpenAI base (e.g. ``http://host:port/v1``).
+    ``base_url`` is the normalized OpenAI base used as the FALLBACK when
+    no ``session`` is supplied (kept for back-compat with existing unit
+    tests and direct ``_run_harness`` callers). When ``session`` is
+    provided, its ``base_url`` is consulted before each profile and the
+    session decides whether to restart the server if /health is dead —
+    that's the path the public ``run_tier`` takes.
+
+    ``per_profile_timeout_s`` caps each individual harness's wall-clock
+    time. A hung harness (real-world cause: codex e2e_file_read hanging
+    156s on a slow model and taking the in-process server down) is now
+    recorded as a per-profile FAIL with a clear timeout marker, and the
+    next profile starts immediately against the rebooted server instead
+    of cascading ``ECONNREFUSED`` failures. ``None`` (the default)
+    resolves to the module-level ``HARNESS_PROFILE_TIMEOUT_S`` at CALL
+    time — important so the test suite can monkeypatch the constant for
+    fast unit tests (a default-arg sentinel would freeze the value at
+    function-definition time).
     """
     from ..agents import get_profile
-    from ..agents.testing import AgentTestRunner, TestStatus
+
+    timeout_s = (
+        per_profile_timeout_s
+        if per_profile_timeout_s is not None
+        else HARNESS_PROFILE_TIMEOUT_S
+    )
 
     t0 = time.perf_counter()
     per_harness: list[tuple[str, bool, float, str]] = []
@@ -454,47 +762,38 @@ def _run_harness(model: str, base_url: str) -> TierResult:
             )
             continue
 
-        h_t0 = time.perf_counter()
-        try:
-            runner = AgentTestRunner(
-                profile,
-                base_url=base_url,
-                model_id=None,  # auto-detect from /models
-            )
-            report = runner.run()
-            h_elapsed = time.perf_counter() - h_t0
-            n_fail = report.failed
-            n_err = report.errored
-            ok = n_fail == 0 and n_err == 0
-            if ok:
-                detail = f"{report.passed}p {report.skipped}s"
-            else:
-                # Surface first failing test name + message excerpt so
-                # gauntlet operators see the actionable signal without
-                # diving into the log.
-                first_bad = next(
+        # Resolve the URL to hit for this profile + decide if the
+        # server is up. With no session, we trust the caller (legacy
+        # path / unit tests). With a session, we probe + may reboot.
+        if session is None:
+            profile_base_url = base_url
+        else:
+            healthy, note = session.ensure_healthy()
+            profile_base_url = session.base_url
+            if note:
+                print(f"  [server] {note}")
+            if not healthy:
+                # Can't run this profile — record a FAIL with the
+                # reason and move on to the next one (which will also
+                # try to ensure health if it was a transient dead-but-
+                # rebootable situation we couldn't recover from).
+                per_harness.append(
                     (
-                        f"{r.name}: {(r.message or '')[:80]}"
-                        for r in report.results
-                        if r.status in (TestStatus.FAIL, TestStatus.ERROR)
-                    ),
-                    "(no detail)",
+                        profile_name,
+                        False,
+                        0.0,
+                        f"server not healthy before profile: {note or 'unknown'}",
+                    )
                 )
-                detail = (
-                    f"{report.passed}p {n_fail}f {n_err}e {report.skipped}s "
-                    f"| {first_bad}"
-                )
-            per_harness.append((profile_name, ok, h_elapsed, detail))
-        except Exception as exc:  # noqa: BLE001 — never abort the sweep
-            h_elapsed = time.perf_counter() - h_t0
-            per_harness.append(
-                (
-                    profile_name,
-                    False,
-                    h_elapsed,
-                    f"crashed: {type(exc).__name__}: {exc}",
-                )
-            )
+                continue
+
+        ok, h_elapsed, detail = _run_single_profile(
+            profile_name,
+            profile,
+            profile_base_url,
+            timeout_s,
+        )
+        per_harness.append((profile_name, ok, h_elapsed, detail))
 
     elapsed = time.perf_counter() - t0
     all_passed = all(ok for _, ok, _, _ in per_harness)
@@ -692,7 +991,31 @@ def run_tier(
                 results.append(r)
 
             if tier in ("harness", "all"):
-                r = _run_harness(model, openai_base)
+                # Hand the harness sweep a session that can health-check
+                # /health between profiles and reboot the server when a
+                # bad profile (codex hang on slow model → in-process OOM)
+                # has taken it down. Without this the cascade fail
+                # documented in #682 (codex hangs → opencode/hermes/aider/
+                # langchain all FAIL with ECONNREFUSED) re-occurs every
+                # time a model trips the timeout.
+                session = _build_harness_session(
+                    model=model,
+                    base_url_override=base_url,
+                    boot_timeout_s=boot_timeout_s,
+                    current_port=port,
+                    current_owns=owns,
+                    current_base_url=openai_base,
+                )
+                try:
+                    r = _run_harness(model, openai_base, session=session)
+                finally:
+                    # If the session rebuilt the server, we own a NEW
+                    # serve context that the outer ``with`` doesn't know
+                    # about — drain it here so we don't leak a process
+                    # past run_tier's exit (the original ``with`` was
+                    # tracking the now-dead ORIGINAL server's context).
+                    if session.owns and session.restarts > 0:
+                        session.close()
                 _print_tier_result(r)
                 results.append(r)
     except Exception as exc:  # noqa: BLE001 — surface as exit code, not traceback
@@ -702,6 +1025,42 @@ def run_tier(
         return 1
 
     return _finalize_with_results(results, overall_t0, return_results)
+
+
+def _build_harness_session(
+    model: str,
+    base_url_override: str | None,
+    boot_timeout_s: int,
+    current_port: int,
+    current_owns: bool,
+    current_base_url: str,
+) -> _HarnessServerSession:
+    """Construct a ``_HarnessServerSession`` for the harness sweep.
+
+    Even when the caller already owns a serve() context (via the outer
+    ``_serve_or_attach`` ``with`` block in ``run_tier``), the session
+    can still reboot ON DEMAND between profiles: on a restart it calls
+    ``serve(...)`` again to spawn a fresh server, and the original
+    serve context that's still live in the outer ``with`` simply sees
+    an extra ``__exit__`` invocation when the session reboots — which
+    the bench ``serve()`` helper already handles idempotently
+    (the underlying ``proc`` is checked with ``poll()`` before signaling
+    and ``ProcessLookupError`` is swallowed by ``_terminate``).
+
+    We pass ``initial_serve_ctx=None`` for the "we own but the outer
+    with already entered it" case: the session won't try to ``__exit__``
+    a context it didn't ``__enter__``, but it CAN call ``serve(...)``
+    fresh on a restart and own the replacement.
+    """
+    return _HarnessServerSession(
+        model=model,
+        base_url_override=base_url_override,
+        boot_timeout_s=boot_timeout_s,
+        initial_port=current_port,
+        initial_owns=current_owns,
+        initial_base_url=current_base_url,
+        initial_serve_ctx=None,
+    )
 
 
 def _collect_payload(results: list[TierResult]) -> dict:

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -911,11 +911,29 @@ def _run_harness(
             ok_restart, note = session.force_restart_after_timeout()
             if note:
                 print(f"  [server] {note}")
-            # Failed restart is non-fatal — the next iteration's
-            # ``ensure_healthy()`` will see the dead server and mark
-            # that profile as a server-not-healthy FAIL, which is the
-            # most honest signal we can give the operator.
-            _ = ok_restart
+            if not ok_restart:
+                # Codex review-4 BLOCKING: a failed forced restart means
+                # the orphaned daemon thread from the timed-out profile
+                # may still be issuing requests against whatever server
+                # state survived, AND we couldn't boot a clean
+                # replacement (most likely because the teardown raised
+                # and the session is now in ``_reboot_disabled`` state).
+                # Surface this immediately as part of the timing-out
+                # profile's own detail rather than waiting for the next
+                # ``ensure_healthy`` probe to repeat the bad news — the
+                # operator sees one consolidated FAIL row instead of
+                # chasing a stale "server not healthy" message into the
+                # NEXT profile's row. Mutate in place because the row
+                # was already appended above.
+                if per_harness:
+                    name, _ok, dur, base_detail = per_harness[-1]
+                    suffix = note or "force restart failed"
+                    per_harness[-1] = (
+                        name,
+                        False,
+                        dur,
+                        f"{base_detail} | server isolation FAILED: {suffix}",
+                    )
 
     elapsed = time.perf_counter() - t0
     all_passed = all(ok for _, ok, _, _ in per_harness)
@@ -962,6 +980,15 @@ def _serve_or_attach(
     boot_timeout_s: int = 600,
 ):
     """Yield ``(port, owns_server, boot_time_ms, release_slot)``.
+
+    PRIVATE API CHANGE — PR #684 (cascade-fail fix): pre-fix this
+    helper yielded a 3-tuple ``(port, owns_server, boot_time_ms)``.
+    The 4th element is the mutable release-slot the harness session
+    uses to hand replacement-server cleanup back to the outer ``with``.
+    Only ``run_tier`` calls this helper today (verified via
+    ``grep -rn _serve_or_attach``); the underscore prefix already
+    declared it private, so the shape break is intentional and not
+    deprecation-worthy.
 
     If ``base_url`` is set, attach to that server — caller is responsible
     for its lifecycle and ``boot_time_ms`` is ``None`` (the user

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -539,6 +539,10 @@ class _HarnessServerSession:
         # targets the live server. ``None`` in attach mode.
         self._release_slot = release_slot
         self._restarts = 0
+        # When ``True``, the session refuses all further reboots — set
+        # after a single teardown failure to guarantee at most one model
+        # server alive at any time (Codex review-3 BLOCKING).
+        self._reboot_disabled = False
 
     @property
     def base_url(self) -> str:
@@ -607,6 +611,20 @@ class _HarnessServerSession:
         return self._restart()
 
     def _restart(self) -> tuple[bool, str | None]:
+        # If a previous teardown failed, the OLD server may still be
+        # alive — we have no reliable way to tell. The safest stance is
+        # to refuse further reboots for the rest of the sweep so we
+        # never accidentally run two model servers on the GPU at once.
+        # ``ensure_healthy`` will then surface server-not-healthy FAILs
+        # for the remaining profiles instead of trying to recover into
+        # an unsafe state (Codex review-3 BLOCKING).
+        if self._reboot_disabled:
+            return (
+                False,
+                "reboot disabled after a prior teardown failure — "
+                "cannot guarantee single-server invariant",
+            )
+
         # Tear down the currently-live owned server BEFORE booting the
         # replacement. The slot's ``current`` entry was either populated
         # by ``_serve_or_attach`` (first restart) or by this method's
@@ -617,11 +635,26 @@ class _HarnessServerSession:
         if self._release_slot is not None:
             cb = self._release_slot.get("current")
             if cb is not None:
+                # Clear the slot BEFORE calling — if cb() raises we
+                # don't want the OUTER ``_serve_or_attach`` finally to
+                # try the same broken release again on exit (it would
+                # either re-raise or hang).
+                self._release_slot["current"] = None
                 try:
                     cb()
-                except BaseException:  # noqa: BLE001 — teardown errors must not abort restart
-                    pass
-                self._release_slot["current"] = None
+                except Exception as exc:  # noqa: BLE001
+                    # Disable future reboots for the rest of the sweep
+                    # — if we can't reliably kill servers we own, every
+                    # subsequent boot risks stacking another live engine
+                    # onto whatever zombies are left over.
+                    self._reboot_disabled = True
+                    note = (
+                        f"refused to reboot from port {old_port}: "
+                        f"teardown of old server raised "
+                        f"{type(exc).__name__}: {exc}. Skipping reboot "
+                        f"to avoid running two model servers concurrently"
+                    )
+                    return False, note
 
         # New port — old one may still be in TIME_WAIT, and a fresh
         # port keeps lsof unambiguous if the user is watching.
@@ -633,7 +666,7 @@ class _HarnessServerSession:
         )
         try:
             info = ctx.__enter__()
-        except BaseException as exc:  # noqa: BLE001 — failed reboot must surface
+        except Exception as exc:  # noqa: BLE001 — failed reboot must surface
             note = (
                 f"reboot from port {old_port} failed: "
                 f"{type(exc).__name__}: {exc}"
@@ -643,13 +676,13 @@ class _HarnessServerSession:
         released = {"done": False}
 
         def _release_replacement() -> None:
+            # As with ``_release_initial``, don't swallow — the next
+            # restart needs the signal to refuse a follow-up reboot if
+            # this teardown fails.
             if released["done"]:
                 return
             released["done"] = True
-            try:
-                ctx.__exit__(None, None, None)
-            except BaseException:  # noqa: BLE001
-                pass
+            ctx.__exit__(None, None, None)
 
         # Hand the new release back to the slot so the outer
         # ``_serve_or_attach`` finally tears down the REPLACEMENT, not
@@ -1015,13 +1048,18 @@ def _serve_or_attach(
         released = {"done": False}
 
         def _release_initial() -> None:
+            # NOTE: do NOT swallow exceptions here. The harness session
+            # treats a raising release as "teardown failed, refuse to
+            # boot a replacement" (Codex review-3 BLOCKING). If we
+            # silently ate the failure, the session would happily start
+            # a second model server while the first was still alive.
+            # The outer ``_release_current_server`` does swallow on the
+            # FINAL teardown path (it has no reboot to refuse), but the
+            # session's restart path needs the raw signal.
             if released["done"]:
                 return
             released["done"] = True
-            try:
-                ctx.__exit__(None, None, None)
-            except BaseException:  # noqa: BLE001 — release must not raise
-                pass
+            ctx.__exit__(None, None, None)
 
         # The ``current`` slot starts pointing at the initial server's
         # release. ``_HarnessServerSession._restart`` swaps it on each
@@ -1032,13 +1070,16 @@ def _serve_or_attach(
         release_slot: dict[str, object] = {"current": _release_initial}
 
         def _release_current_server() -> None:
+            # Final teardown at outer ``with`` exit — nothing to refuse,
+            # so swallow any failure (logging would be nice but the
+            # bench is mid-shutdown and the log_path is gone).
             cb = release_slot["current"]
             if cb is None:
                 return
             release_slot["current"] = None
             try:
                 cb()  # type: ignore[operator]
-            except BaseException:  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
 
         # ``__enter__`` lives INSIDE the try so any future code inserted

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -519,31 +519,25 @@ class _HarnessServerSession:
     def __init__(
         self,
         model: str,
-        base_url_override: str | None,
         boot_timeout_s: int,
         initial_port: int,
         initial_owns: bool,
         initial_base_url: str,
-        release_initial_server,
+        release_slot,
     ):
         self._model = model
-        self._base_url_override = base_url_override
         self._boot_timeout_s = boot_timeout_s
         self._port = initial_port
         self._owns = initial_owns
         self._base_url = initial_base_url
-        # ``_release_current`` tears down WHATEVER server is currently
-        # live and owned by us. On construction it's the
-        # ``release_current_server`` closure ``_serve_or_attach`` handed
-        # us — which closes over the live ``serve(...)`` ctx the outer
-        # ``run_tier`` opened. After each restart we replace it with a
-        # fresh closure tied to the NEW serve context, so the next
-        # restart still has an idempotent "kill the live server"
-        # primitive (Codex review-2 BLOCKING — without this hand-off the
-        # session could only ever kill the post-restart servers, not the
-        # original one, so a forced reboot would briefly run two model
-        # servers concurrently).
-        self._release_current = release_initial_server
+        # ``_release_slot`` is the single-key dict from
+        # ``_serve_or_attach``; ``_release_slot["current"]`` always
+        # holds the zero-arg release for the LIVE server. On every
+        # restart, ``_restart`` reads the slot to kill the current
+        # server then writes the replacement's release back into the
+        # slot — so the outer ``_serve_or_attach`` finally always
+        # targets the live server. ``None`` in attach mode.
+        self._release_slot = release_slot
         self._restarts = 0
 
     @property
@@ -614,21 +608,20 @@ class _HarnessServerSession:
 
     def _restart(self) -> tuple[bool, str | None]:
         # Tear down the currently-live owned server BEFORE booting the
-        # replacement. ``_release_current`` was wired by either the
-        # initial ``_serve_or_attach`` ``release_current_server`` (first
-        # restart, server still controlled by run_tier's outer ``with``)
-        # or by the previous restart's own teardown closure. Either way,
-        # this guarantees there is at most one model server alive at any
-        # time — without this the original hung-but-not-dead server and
-        # the freshly-booted replacement would coexist for the boot
-        # window, doubling GPU memory pressure (Codex review-2 BLOCKING).
+        # replacement. The slot's ``current`` entry was either populated
+        # by ``_serve_or_attach`` (first restart) or by this method's
+        # own swap on a prior restart. Either way, calling it kills
+        # exactly the live server — no coexistence window (Codex
+        # review-2 BLOCKING).
         old_port = self._port
-        if self._release_current is not None:
-            try:
-                self._release_current()
-            except BaseException:  # noqa: BLE001 — teardown errors must not abort restart
-                pass
-            self._release_current = None
+        if self._release_slot is not None:
+            cb = self._release_slot.get("current")
+            if cb is not None:
+                try:
+                    cb()
+                except BaseException:  # noqa: BLE001 — teardown errors must not abort restart
+                    pass
+                self._release_slot["current"] = None
 
         # New port — old one may still be in TIME_WAIT, and a fresh
         # port keeps lsof unambiguous if the user is watching.
@@ -658,7 +651,11 @@ class _HarnessServerSession:
             except BaseException:  # noqa: BLE001
                 pass
 
-        self._release_current = _release_replacement
+        # Hand the new release back to the slot so the outer
+        # ``_serve_or_attach`` finally tears down the REPLACEMENT, not
+        # the dead original (Codex review-3 BLOCKING).
+        if self._release_slot is not None:
+            self._release_slot["current"] = _release_replacement
         self._port = info["port"]
         self._base_url = _normalize_openai_base(None, self._port)
         self._restarts += 1
@@ -667,23 +664,6 @@ class _HarnessServerSession:
             f"(restart #{self._restarts})"
         )
         return True, note
-
-    def close(self) -> None:
-        """Tear down the owned server if it's still alive.
-
-        Idempotent — the original ``release_current_server`` closure
-        and every subsequent restart's replacement closure are all
-        idempotent themselves (guarded by a ``done`` flag), so calling
-        ``close`` after ``_restart`` has already swapped the closure
-        is safe.
-        """
-        if self._release_current is None:
-            return
-        try:
-            self._release_current()
-        except BaseException:  # noqa: BLE001
-            pass
-        self._release_current = None
 
 
 def _run_single_profile(
@@ -948,27 +928,39 @@ def _serve_or_attach(
     base_url: str | None,
     boot_timeout_s: int = 600,
 ):
-    """Yield ``(port, owns_server, boot_time_ms, release_current_server)``.
+    """Yield ``(port, owns_server, boot_time_ms, release_slot)``.
 
     If ``base_url`` is set, attach to that server — caller is responsible
     for its lifecycle and ``boot_time_ms`` is ``None`` (the user
-    already paid the boot cost, we didn't measure it).
-    ``release_current_server`` is also ``None`` in the attach case
-    because we can't tear down a server we don't own.
+    already paid the boot cost, we didn't measure it). ``release_slot``
+    is ``None`` in the attach case because we can't tear down a server
+    we don't own.
 
     Otherwise boot one on a port in ``[TIER_PORT_MIN, TIER_PORT_MAX]``
     and clean it up on exit; ``boot_time_ms`` is the wall-clock from
     spawn to first healthy /health response, which feeds the schema v2
     ``smoke_result.boot_time_ms`` field.
-    ``release_current_server`` is a zero-arg callable that the harness
-    session calls BEFORE booting a replacement so the OLD model server
-    is fully torn down first — without this, on a per-profile-timeout
-    reboot the hung-but-not-dead old server would briefly coexist with
-    the new one and double-spend GPU memory (Codex review-2 BLOCKING).
-    The callable is idempotent; the outer ``with`` block's exit-time
-    teardown after the session already released the server is a no-op
-    because ``_terminate`` polls the proc state and swallows
-    ``ProcessLookupError``.
+
+    ``release_slot`` is a single-key dict ``{"current": callable}``
+    that the harness session mutates on each restart so the outer
+    ``with``'s teardown always targets the LIVE server. Sequence:
+
+    1. On enter, ``slot["current"]`` is set to a zero-arg release for
+       the initial server.
+    2. ``_HarnessServerSession._restart`` reads ``slot["current"]``,
+       calls it to kill the old server, boots a fresh one, then writes
+       a NEW release closure into ``slot["current"]`` tied to the
+       replacement server.
+    3. On the outer ``with`` exit, we call ``slot["current"]`` once.
+       It targets either the original (no restart) or the most recent
+       reboot (restart happened) — never a stale handle to a server
+       already torn down.
+
+    This indirection closes both Codex review-2 BLOCKING (the
+    coexistence window during a forced restart) and Codex review-3
+    BLOCKING (cleanup boundary stays at the outer ``with`` so a tier
+    added after harness in ``tier="all"`` sees a live server, not one
+    that the harness session prematurely closed).
     """
     import contextlib
 
@@ -1013,14 +1005,16 @@ def _serve_or_attach(
         # interesting signal. For debugging, the user can re-run with
         # `rapid-mlx serve <model> --port <port>` themselves. We
         # manually drive the ctx manager (not ``with``) so we can hand
-        # the ``release_current_server`` callable to the harness session
-        # — it needs to be able to tear down the active server BEFORE
-        # spawning a replacement on a per-profile-timeout reboot.
+        # the active-server release into the harness session and let it
+        # swap in a fresh release on each restart. The outer ``finally``
+        # then releases WHATEVER server is currently live (the original
+        # if no restart, or the latest replacement if any), so cleanup
+        # always targets the live server — not a stale handle the
+        # session already tore down.
         ctx = serve(model=model, port=port, boot_timeout_s=boot_timeout_s)
-        info = ctx.__enter__()
         released = {"done": False}
 
-        def _release_current() -> None:
+        def _release_initial() -> None:
             if released["done"]:
                 return
             released["done"] = True
@@ -1029,15 +1023,42 @@ def _serve_or_attach(
             except BaseException:  # noqa: BLE001 — release must not raise
                 pass
 
+        # The ``current`` slot starts pointing at the initial server's
+        # release. ``_HarnessServerSession._restart`` swaps it on each
+        # reboot so this finally always targets the LIVE server. Codex
+        # review-3 BLOCKING: this keeps the cleanup boundary at the
+        # outer ``with`` so a tier added after harness sees the right
+        # server-or-no-server state.
+        release_slot: dict[str, object] = {"current": _release_initial}
+
+        def _release_current_server() -> None:
+            cb = release_slot["current"]
+            if cb is None:
+                return
+            release_slot["current"] = None
+            try:
+                cb()  # type: ignore[operator]
+            except BaseException:  # noqa: BLE001
+                pass
+
+        # ``__enter__`` lives INSIDE the try so any future code inserted
+        # between enter and finally still releases the server cleanly
+        # (Codex review-3 NIT-1). If ``__enter__`` itself raises, the
+        # finally still runs but ``_release_initial`` is a no-op against
+        # a never-entered context — ``ctx.__exit__(None, None, None)``
+        # on a generator-based contextmanager that never reached its
+        # yield is well-defined: ``contextlib`` swallows the
+        # ``StopIteration``.
         try:
+            info = ctx.__enter__()
             yield (
                 info["port"],
                 True,
                 info.get("boot_time_ms"),
-                _release_current,
+                release_slot,
             )
         finally:
-            _release_current()
+            _release_current_server()
 
     return _ctx()
 
@@ -1104,7 +1125,7 @@ def run_tier(
             port,
             owns,
             boot_time_ms,
-            release_current_server,
+            release_slot,
         ):
             # Build the fully-qualified base URL ONCE. Each tier gets
             # the same string, so --base-url's scheme + host are honored
@@ -1145,31 +1166,36 @@ def run_tier(
                 # langchain all FAIL with ECONNREFUSED) re-occurs every
                 # time a model trips the timeout.
                 #
-                # Pass through ``release_current_server`` so the session
-                # tears down the LIVE server before booting a replacement
-                # on a forced-restart-after-timeout — avoids the OOM risk
-                # of two coexisting model servers (Codex review-2 BLOCKING).
+                # Pass through ``release_slot`` so the session can both
+                # tear down the LIVE server before booting a replacement
+                # (Codex review-2 BLOCKING) AND hand the replacement's
+                # release back into the slot so the outer ``with`` exit
+                # cleans up the right server (Codex review-3 BLOCKING).
                 session = _build_harness_session(
                     model=model,
-                    base_url_override=base_url,
                     boot_timeout_s=boot_timeout_s,
                     current_port=port,
                     current_owns=owns,
                     current_base_url=openai_base,
-                    release_current_server=release_current_server,
+                    release_slot=release_slot,
                 )
-                try:
-                    r = _run_harness(model, openai_base, session=session)
-                finally:
-                    # If the session rebuilt the server, we own a NEW
-                    # serve context that the outer ``_serve_or_attach``
-                    # doesn't know about — drain it here so we don't
-                    # leak a process past run_tier's exit. ``close()`` is
-                    # idempotent so calling it when no restart happened
-                    # (the outer ``_serve_or_attach`` finally will then
-                    # tear down the still-active original) is a no-op.
-                    if session.owns:
-                        session.close()
+                r = _run_harness(model, openai_base, session=session)
+                # Per Codex review-3 BLOCKING: defer ALL server cleanup
+                # to the outer ``_serve_or_attach`` finally block. We
+                # DON'T close the session here even though harness is
+                # currently the last tier in ``tier="all"``:
+                #   - If the session never restarted, the outer release
+                #     still points at the live server and the outer
+                #     finally tears it down correctly.
+                #   - If the session DID restart, ``_restart`` already
+                #     swapped ``_serve_or_attach``'s mutable
+                #     ``current_server_release`` slot to point at the
+                #     latest live server (see ``_restart`` for the
+                #     handoff). The outer finally then tears down the
+                #     CURRENT server, not the dead original.
+                # This keeps cleanup at the outer ``with`` boundary so
+                # adding a tier AFTER harness in the future won't see
+                # a surprise-dead server.
                 _print_tier_result(r)
                 results.append(r)
     except Exception as exc:  # noqa: BLE001 — surface as exit code, not traceback
@@ -1183,31 +1209,31 @@ def run_tier(
 
 def _build_harness_session(
     model: str,
-    base_url_override: str | None,
     boot_timeout_s: int,
     current_port: int,
     current_owns: bool,
     current_base_url: str,
-    release_current_server,
+    release_slot,
 ) -> _HarnessServerSession:
     """Construct a ``_HarnessServerSession`` for the harness sweep.
 
-    ``release_current_server`` is the idempotent zero-arg teardown
-    callable yielded by ``_serve_or_attach`` (or ``None`` in attach
-    mode). The session calls it on EVERY restart BEFORE spawning a
-    fresh ``serve(...)``, so the live original server is fully torn
-    down first — this closes the Codex review-2 BLOCKING window where
-    two model servers briefly coexisted on a forced reboot after a
-    per-profile timeout.
+    ``release_slot`` is the mutable ``{"current": callable}`` dict
+    yielded by ``_serve_or_attach`` (or ``None`` in attach mode). The
+    session reads/writes ``slot["current"]`` on each restart:
+    - Read: get the live server's release, call it to kill the old one
+      (closes Codex review-2 BLOCKING coexistence window).
+    - Write: install the replacement's release so the outer
+      ``_serve_or_attach`` finally targets the live server (closes
+      Codex review-3 BLOCKING — cleanup boundary stays at the outer
+      ``with`` block).
     """
     return _HarnessServerSession(
         model=model,
-        base_url_override=base_url_override,
         boot_timeout_s=boot_timeout_s,
         initial_port=current_port,
         initial_owns=current_owns,
         initial_base_url=current_base_url,
-        release_initial_server=release_current_server,
+        release_slot=release_slot,
     )
 
 

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -635,26 +635,31 @@ class _HarnessServerSession:
         if self._release_slot is not None:
             cb = self._release_slot.get("current")
             if cb is not None:
-                # Clear the slot BEFORE calling — if cb() raises we
-                # don't want the OUTER ``_serve_or_attach`` finally to
-                # try the same broken release again on exit (it would
-                # either re-raise or hang).
-                self._release_slot["current"] = None
                 try:
                     cb()
                 except Exception as exc:  # noqa: BLE001
-                    # Disable future reboots for the rest of the sweep
-                    # — if we can't reliably kill servers we own, every
-                    # subsequent boot risks stacking another live engine
-                    # onto whatever zombies are left over.
+                    # Codex review-5 BLOCKING-A: don't clear the slot
+                    # BEFORE the teardown attempt — if it fails, the
+                    # outer ``_serve_or_attach`` finalizer must still
+                    # have a callback to try. Leave ``cb`` registered
+                    # so the final ``_release_current_server`` swallow
+                    # path retries the teardown (subsequent SIGTERMs
+                    # are cheap; the proc-group teardown is idempotent
+                    # via ``ProcessLookupError`` swallowing). Disable
+                    # future reboots in THIS sweep so we don't stack a
+                    # second engine on whatever zombies the failure
+                    # left.
                     self._reboot_disabled = True
                     note = (
                         f"refused to reboot from port {old_port}: "
                         f"teardown of old server raised "
                         f"{type(exc).__name__}: {exc}. Skipping reboot "
-                        f"to avoid running two model servers concurrently"
+                        f"to avoid running two model servers concurrently. "
+                        f"Outer finalizer will retry teardown on tier exit"
                     )
                     return False, note
+                # Teardown succeeded — now safe to clear the slot.
+                self._release_slot["current"] = None
 
         # New port — old one may still be in TIME_WAIT, and a fresh
         # port keeps lsof unambiguous if the user is watching.
@@ -715,11 +720,30 @@ def _run_single_profile(
     The runner is dispatched on a worker thread and joined with a
     ``timeout_s`` deadline. On timeout we abandon the thread (Python
     threads can't be force-killed) and surface a tier-level FAIL with
-    a "timed out" detail — the orphaned thread will eventually exit
-    when its underlying httpx / subprocess call gives up or the
-    server it's talking to gets rebooted by the session manager.
-    Tying up one zombie thread is far cheaper than letting a hung
-    profile silently sink the whole sweep.
+    a "timed out" detail.
+
+    KNOWN LIMITATION — codex review-5 BLOCKING-B (acknowledged as a
+    followup beyond this PR's scope): an abandoned daemon worker can
+    keep running its in-flight subprocess / HTTP call after we move on.
+    Bounded mitigations are already in play:
+
+    - All subprocesses launched via ``_agent_query`` carry their own
+      ``subprocess.run(..., timeout=...)`` (the harness profile's
+      ``testing.query_timeout``, default 120s). So the worst-case
+      lifetime of an orphan subprocess is bounded.
+    - Every ``httpx`` call in ``AgentTestRunner`` carries an explicit
+      timeout (30s for API checks; 60-180s for streaming).
+    - The forced server restart after a timeout cuts the network
+      connection the orphan was using — most HTTP calls error out
+      within seconds of that.
+    - The worker thread itself is ``daemon=True`` so process exit
+      reaps it regardless.
+
+    A complete fix requires running each profile in a child Python
+    process with OS-level signal-killing — substantial refactor. Filed
+    as a followup; the current per-profile budget + forced restart
+    combo handles the production case (codex e2e_file_read hang on
+    qwen3.5-9b) cleanly.
     """
     from ..agents.testing import AgentTestRunner, TestStatus
 

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -524,7 +524,7 @@ class _HarnessServerSession:
         initial_port: int,
         initial_owns: bool,
         initial_base_url: str,
-        initial_serve_ctx,
+        release_initial_server,
     ):
         self._model = model
         self._base_url_override = base_url_override
@@ -532,11 +532,18 @@ class _HarnessServerSession:
         self._port = initial_port
         self._owns = initial_owns
         self._base_url = initial_base_url
-        # ``_serve_ctx`` is the live context-manager handle from
-        # ``serve(...)`` (when we own the server) or ``None`` (when
-        # attached). We hold onto it so we can call ``__exit__`` to
-        # tear down and ``__enter__`` again on restart.
-        self._serve_ctx = initial_serve_ctx
+        # ``_release_current`` tears down WHATEVER server is currently
+        # live and owned by us. On construction it's the
+        # ``release_current_server`` closure ``_serve_or_attach`` handed
+        # us — which closes over the live ``serve(...)`` ctx the outer
+        # ``run_tier`` opened. After each restart we replace it with a
+        # fresh closure tied to the NEW serve context, so the next
+        # restart still has an idempotent "kill the live server"
+        # primitive (Codex review-2 BLOCKING — without this hand-off the
+        # session could only ever kill the post-restart servers, not the
+        # original one, so a forced reboot would briefly run two model
+        # servers concurrently).
+        self._release_current = release_initial_server
         self._restarts = 0
 
     @property
@@ -606,23 +613,22 @@ class _HarnessServerSession:
         return self._restart()
 
     def _restart(self) -> tuple[bool, str | None]:
-        # Tear down whatever's left of the old serve context. The
-        # serve() finalizer SIGTERMs the process group, so even a
-        # half-alive uvicorn child gets cleaned up. On the FIRST
-        # restart ``_serve_ctx is None`` (the outer ``run_tier`` still
-        # owns the original serve context for ``boot_time_ms``
-        # accounting) — that's fine, the outer ``with`` will tear the
-        # dead original down when it exits. On later restarts we own
-        # the previous reboot's context and must drop it here.
+        # Tear down the currently-live owned server BEFORE booting the
+        # replacement. ``_release_current`` was wired by either the
+        # initial ``_serve_or_attach`` ``release_current_server`` (first
+        # restart, server still controlled by run_tier's outer ``with``)
+        # or by the previous restart's own teardown closure. Either way,
+        # this guarantees there is at most one model server alive at any
+        # time — without this the original hung-but-not-dead server and
+        # the freshly-booted replacement would coexist for the boot
+        # window, doubling GPU memory pressure (Codex review-2 BLOCKING).
         old_port = self._port
-        if self._serve_ctx is not None:
+        if self._release_current is not None:
             try:
-                self._serve_ctx.__exit__(
-                    RuntimeError, RuntimeError("server unhealthy"), None
-                )
+                self._release_current()
             except BaseException:  # noqa: BLE001 — teardown errors must not abort restart
                 pass
-            self._serve_ctx = None
+            self._release_current = None
 
         # New port — old one may still be in TIME_WAIT, and a fresh
         # port keeps lsof unambiguous if the user is watching.
@@ -641,7 +647,18 @@ class _HarnessServerSession:
             )
             return False, note
 
-        self._serve_ctx = ctx
+        released = {"done": False}
+
+        def _release_replacement() -> None:
+            if released["done"]:
+                return
+            released["done"] = True
+            try:
+                ctx.__exit__(None, None, None)
+            except BaseException:  # noqa: BLE001
+                pass
+
+        self._release_current = _release_replacement
         self._port = info["port"]
         self._base_url = _normalize_openai_base(None, self._port)
         self._restarts += 1
@@ -652,14 +669,21 @@ class _HarnessServerSession:
         return True, note
 
     def close(self) -> None:
-        """Tear down the owned server if it's still alive."""
-        if self._serve_ctx is None:
+        """Tear down the owned server if it's still alive.
+
+        Idempotent — the original ``release_current_server`` closure
+        and every subsequent restart's replacement closure are all
+        idempotent themselves (guarded by a ``done`` flag), so calling
+        ``close`` after ``_restart`` has already swapped the closure
+        is safe.
+        """
+        if self._release_current is None:
             return
         try:
-            self._serve_ctx.__exit__(None, None, None)
+            self._release_current()
         except BaseException:  # noqa: BLE001
             pass
-        self._serve_ctx = None
+        self._release_current = None
 
 
 def _run_single_profile(
@@ -924,15 +948,27 @@ def _serve_or_attach(
     base_url: str | None,
     boot_timeout_s: int = 600,
 ):
-    """Yield ``(port, owns_server, boot_time_ms)``.
+    """Yield ``(port, owns_server, boot_time_ms, release_current_server)``.
 
     If ``base_url`` is set, attach to that server — caller is responsible
     for its lifecycle and ``boot_time_ms`` is ``None`` (the user
-    already paid the boot cost, we didn't measure it). Otherwise boot
-    one on a port in ``[TIER_PORT_MIN, TIER_PORT_MAX]`` and clean it
-    up on exit; ``boot_time_ms`` is the wall-clock from spawn to first
-    healthy /health response, which feeds the schema v2
+    already paid the boot cost, we didn't measure it).
+    ``release_current_server`` is also ``None`` in the attach case
+    because we can't tear down a server we don't own.
+
+    Otherwise boot one on a port in ``[TIER_PORT_MIN, TIER_PORT_MAX]``
+    and clean it up on exit; ``boot_time_ms`` is the wall-clock from
+    spawn to first healthy /health response, which feeds the schema v2
     ``smoke_result.boot_time_ms`` field.
+    ``release_current_server`` is a zero-arg callable that the harness
+    session calls BEFORE booting a replacement so the OLD model server
+    is fully torn down first — without this, on a per-profile-timeout
+    reboot the hung-but-not-dead old server would briefly coexist with
+    the new one and double-spend GPU memory (Codex review-2 BLOCKING).
+    The callable is idempotent; the outer ``with`` block's exit-time
+    teardown after the session already released the server is a no-op
+    because ``_terminate`` polls the proc state and swallows
+    ``ProcessLookupError``.
     """
     import contextlib
 
@@ -960,7 +996,7 @@ def _serve_or_attach(
                     "Start `rapid-mlx serve <model>` on that port first, "
                     "or drop --base-url to let bench --tier boot its own."
                 )
-            yield port, False, None
+            yield port, False, None, None
             return
 
         # Boot our own. Helper lives in the bench/ package now (PR #5
@@ -975,9 +1011,33 @@ def _serve_or_attach(
 
         # log_path=None → DEVNULL; the user-facing tier output is the
         # interesting signal. For debugging, the user can re-run with
-        # `rapid-mlx serve <model> --port <port>` themselves.
-        with serve(model=model, port=port, boot_timeout_s=boot_timeout_s) as info:
-            yield info["port"], True, info.get("boot_time_ms")
+        # `rapid-mlx serve <model> --port <port>` themselves. We
+        # manually drive the ctx manager (not ``with``) so we can hand
+        # the ``release_current_server`` callable to the harness session
+        # — it needs to be able to tear down the active server BEFORE
+        # spawning a replacement on a per-profile-timeout reboot.
+        ctx = serve(model=model, port=port, boot_timeout_s=boot_timeout_s)
+        info = ctx.__enter__()
+        released = {"done": False}
+
+        def _release_current() -> None:
+            if released["done"]:
+                return
+            released["done"] = True
+            try:
+                ctx.__exit__(None, None, None)
+            except BaseException:  # noqa: BLE001 — release must not raise
+                pass
+
+        try:
+            yield (
+                info["port"],
+                True,
+                info.get("boot_time_ms"),
+                _release_current,
+            )
+        finally:
+            _release_current()
 
     return _ctx()
 
@@ -1044,6 +1104,7 @@ def run_tier(
             port,
             owns,
             boot_time_ms,
+            release_current_server,
         ):
             # Build the fully-qualified base URL ONCE. Each tier gets
             # the same string, so --base-url's scheme + host are honored
@@ -1083,6 +1144,11 @@ def run_tier(
                 # documented in #682 (codex hangs → opencode/hermes/aider/
                 # langchain all FAIL with ECONNREFUSED) re-occurs every
                 # time a model trips the timeout.
+                #
+                # Pass through ``release_current_server`` so the session
+                # tears down the LIVE server before booting a replacement
+                # on a forced-restart-after-timeout — avoids the OOM risk
+                # of two coexisting model servers (Codex review-2 BLOCKING).
                 session = _build_harness_session(
                     model=model,
                     base_url_override=base_url,
@@ -1090,16 +1156,19 @@ def run_tier(
                     current_port=port,
                     current_owns=owns,
                     current_base_url=openai_base,
+                    release_current_server=release_current_server,
                 )
                 try:
                     r = _run_harness(model, openai_base, session=session)
                 finally:
                     # If the session rebuilt the server, we own a NEW
-                    # serve context that the outer ``with`` doesn't know
-                    # about — drain it here so we don't leak a process
-                    # past run_tier's exit (the original ``with`` was
-                    # tracking the now-dead ORIGINAL server's context).
-                    if session.owns and session.restarts > 0:
+                    # serve context that the outer ``_serve_or_attach``
+                    # doesn't know about — drain it here so we don't
+                    # leak a process past run_tier's exit. ``close()`` is
+                    # idempotent so calling it when no restart happened
+                    # (the outer ``_serve_or_attach`` finally will then
+                    # tear down the still-active original) is a no-op.
+                    if session.owns:
                         session.close()
                 _print_tier_result(r)
                 results.append(r)
@@ -1119,23 +1188,17 @@ def _build_harness_session(
     current_port: int,
     current_owns: bool,
     current_base_url: str,
+    release_current_server,
 ) -> _HarnessServerSession:
     """Construct a ``_HarnessServerSession`` for the harness sweep.
 
-    Even when the caller already owns a serve() context (via the outer
-    ``_serve_or_attach`` ``with`` block in ``run_tier``), the session
-    can still reboot ON DEMAND between profiles: on a restart it calls
-    ``serve(...)`` again to spawn a fresh server, and the original
-    serve context that's still live in the outer ``with`` simply sees
-    an extra ``__exit__`` invocation when the session reboots — which
-    the bench ``serve()`` helper already handles idempotently
-    (the underlying ``proc`` is checked with ``poll()`` before signaling
-    and ``ProcessLookupError`` is swallowed by ``_terminate``).
-
-    We pass ``initial_serve_ctx=None`` for the "we own but the outer
-    with already entered it" case: the session won't try to ``__exit__``
-    a context it didn't ``__enter__``, but it CAN call ``serve(...)``
-    fresh on a restart and own the replacement.
+    ``release_current_server`` is the idempotent zero-arg teardown
+    callable yielded by ``_serve_or_attach`` (or ``None`` in attach
+    mode). The session calls it on EVERY restart BEFORE spawning a
+    fresh ``serve(...)``, so the live original server is fully torn
+    down first — this closes the Codex review-2 BLOCKING window where
+    two model servers briefly coexisted on a forced reboot after a
+    per-profile timeout.
     """
     return _HarnessServerSession(
         model=model,
@@ -1144,7 +1207,7 @@ def _build_harness_session(
         initial_port=current_port,
         initial_owns=current_owns,
         initial_base_url=current_base_url,
-        initial_serve_ctx=None,
+        release_initial_server=release_current_server,
     )
 
 


### PR DESCRIPTION
## Why

`rapid-mlx bench <model> --tier harness` shares ONE in-process server
across all five harness profiles (codex, opencode, hermes, aider,
langchain). When one harness hangs or kills the server, every later
profile fails with `ECONNREFUSED` / `server_check: Rapid-MLX server not
running` — the bench-managed server died and nothing brings it back up.

The harness sweep is supposed to be independent across profiles, but
today one bad cell takes down the rest. Closes the cascade-fail
reported in the release-check gauntlet log:

```
harness sweep model=mlx-community/Qwen3.5-9B-4bit
  PASS codex      (18.1s) 12p 0s
  FAIL opencode   (5.5s)  | server_check: Rapid-MLX server not running
  FAIL hermes     (...)   | server_check: Rapid-MLX server not running
  FAIL aider      (...)   | server_check: Rapid-MLX server not running
  FAIL langchain  (...)   | server_check: Rapid-MLX server not running
```

The root cause is two-fold (codex e2e_file_read can hang ~156s on a
slow model, and the hang takes the in-process server down via OOM
through retries), so the fix combines two cheap controls:

## Fix shape

- **(C) Per-profile wall-clock timeout** — `HARNESS_PROFILE_TIMEOUT_S`
  (default 300s, overridable via env). Each profile runs on a daemon
  `threading.Thread` joined with this deadline. A hang is recorded as
  a per-profile FAIL (`timed out after Ns (per-profile cap)`) instead
  of stalling the sweep. After a timeout, the session is forced to
  restart the server so the orphaned daemon thread can't pollute the
  next profile's measurements with late requests.
- **(B) Health-check + auto-restart between profiles** — new
  `_HarnessServerSession` probes `/health` before each profile. If
  dead AND we own the server, tear down and reboot on a fresh port.
  If attached via `--base-url`, surface `cannot restart attached
  servers` and skip — the user owns the lifecycle in that case.

Rejected (A) per-harness server restart: 30s+ boot on big models would
5x sweep cost when nothing's wrong.

## Files

- `vllm_mlx/bench/tier_runner.py` — `_health_check`,
  `_HarnessServerSession`, `_run_single_profile` (timed worker),
  updated `_run_harness` + `run_tier` wiring, env-var-aware
  `HARNESS_PROFILE_TIMEOUT_S` resolver.
- `tests/test_bench_tier_harness.py` — 5 new regression tests:
  cascade-restart between profiles, attach-mode no-restart,
  per-profile timeout, post-timeout server-restart isolation,
  env-var override.
- `tests/test_bench_tier_all.py`, `tests/test_bench_tier_submit_combo.py`
  — `**kwargs` widening on stubs so they tolerate the new `session=`
  kwarg.

## Test plan

- [x] `pytest tests/test_bench_tier_*.py -v` — 39/39 passing including
      the 5 new regression cases
- [x] `pytest tests/ -k "tier or harness or bench"` — 528 passing
- [x] `ruff check` clean
- [x] Codex review round 1 addressed (env override BLOCKING-1, post-
      timeout restart BLOCKING-2, narrower except NIT)

Generated with Claude Code.