### PR TITLE
docs(codex-profile): add gemma-4-12b thought-loop known-issue note

### DIFF
--- a/vllm_mlx/agents/profiles/codex.yaml
+++ b/vllm_mlx/agents/profiles/codex.yaml
@@ -69,3 +69,4 @@ known_issues:
   - "`previous_response_id` is not implemented (openai/codex#3841) and the rapid-mlx shim is stateless — Codex re-sends the full conversation in `input[]` each turn, which is what makes the local backend work."
   - "Codex hardcodes `stream: true`; rapid-mlx's /v1/responses emits the 7 SSE events Codex parses (response.created, response.output_text.delta, response.function_call_arguments.delta, response.completed, etc.)."
   - "Codex's `reasoning.effort` field is accepted but not yet mapped to enable_thinking — set thinking via `rapid-mlx serve --enable-thinking` instead."
+  - "gemma-4-12b-it (any quant) hangs Codex ~60% of trials on tool-use prompts due to a model-side `thought\\n…` degenerate loop — model bug filed at huggingface.co/google/gemma-4-12B-it/discussions/41 (downstream tracking issue #686 closed). Use qwen3.5/3.6 models for Codex CLI agent workflows."


### PR DESCRIPTION
## Summary

One-line addition to \`vllm_mlx/agents/profiles/codex.yaml\` \`known_issues\` documenting the gemma-4-12b thought-loop hang surfaced in issue #686 and filed upstream at the model repo (https://huggingface.co/google/gemma-4-12B-it/discussions/41). The closed issue's comment promised this profile note — landing it for real.

## Test plan

- [x] No code change; docs-only addition to a YAML profile
- [x] Issue #686 closed with a pointer to this note + the upstream HF discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)