### PR TITLE
fix(responses): wrap ResponsesRequest construction → 400 on bad input

### DIFF
--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -354,6 +354,42 @@ class TestStatelessGate:
         assert engine.calls == []
 
 
+class TestResponsesPydanticValidation:
+    """Codex bundled-review finding on the v0.7.32 bundle: #685 added a
+    strict ``reasoning_max_tokens`` ``model_validator(mode="before")``
+    that raises ``ValidationError`` on bad input (``0``, ``true``,
+    ``"100"``). Since ``create_response()`` constructs
+    ``ResponsesRequest(**body)`` manually outside of FastAPI's body
+    binding, an uncaught ``ValidationError`` would surface as 500. The
+    route wraps construction in try/except and re-raises as 400 —
+    matches the same pattern in ``routes/anthropic.py``.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [0, -1, True, False, "100"],
+        ids=["zero", "negative", "bool-true", "bool-false", "string"],
+    )
+    def test_invalid_reasoning_max_tokens_returns_400(
+        self, responses_client, bad_value
+    ):
+        client = responses_client.client
+        engine = responses_client.engine
+
+        response = client.post(
+            "/v1/responses",
+            json=_payload(reasoning_max_tokens=bad_value),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert response.status_code == 400, (
+            f"reasoning_max_tokens={bad_value!r} must surface as 400, "
+            f"got {response.status_code}: {response.text}"
+        )
+        assert "reasoning_max_tokens" in response.text
+        assert engine.calls == []
+
+
 # ---------------------------------------------------------------------------
 # Codex-style multi-item input replay
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -22,6 +22,7 @@ from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
+from pydantic import ValidationError
 
 from ..api.models import (
     AssistantMessage,
@@ -107,7 +108,19 @@ async def create_response(request: Request):
     path is the hot path.
     """
     body = await request.json()
-    responses_request = ResponsesRequest(**body)
+    # ``ResponsesRequest`` is constructed manually (not as a FastAPI body
+    # parameter), so Pydantic ``ValidationError`` would otherwise surface
+    # as a generic 500. Catch it explicitly to give clients a 400 with
+    # the actual validation detail — matches the same pattern in
+    # ``routes/anthropic.py``. Codex bundled-review finding on the
+    # v0.7.32 release bundle: #685's strict ``reasoning_max_tokens``
+    # ``model_validator(mode="before")`` now raises on bad input
+    # (``0``, ``true``, ``"100"``), and without this catch a malformed
+    # client request would 500 here instead of 400.
+    try:
+        responses_request = ResponsesRequest(**body)
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     # Statelessness gate — see module docstring. Codex CLI does not set
     # this field; clients that DO use it would get silent prompt loss


### PR DESCRIPTION
## Summary

Codex **bundled-review finding** on the v0.7.32 release bundle (7 PRs since v0.7.31): #685 added a strict `model_validator(mode="before")` on `ResponsesRequest.reasoning_max_tokens` that raises `ValueError` for `0`, negatives, bools, and string-int values. `create_response()` in `routes/responses.py` constructs `ResponsesRequest(**body)` manually outside FastAPI body binding, so an uncaught Pydantic `ValidationError` would surface as a generic **500** — turning bad client input into a server error instead of an actionable 400.

#683's Anthropic route already wraps construction in try/except + 400. This PR matches that pattern in the Responses route so all three API surfaces (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) behave consistently.

## Why this wasn't caught by #685's own codex pass

Single-PR codex reviews see only the PR's diff. The Responses route's `ResponsesRequest(**body)` construction line wasn't in #685's diff (it was pre-existing) — the validator was new but the unhandled construction site was old. The interaction only surfaces when you review the bundle.

## Test plan

- [x] 5 parametrized regression tests in `TestResponsesPydanticValidation` covering `0`, `-1`, `True`, `False`, `"100"` — all return 400 with `reasoning_max_tokens` in the detail
- [x] Sibling `test_previous_response_id_returns_400` continues to pass — confirms the existing `HTTPException(400)` path isn't broken
- [x] Pattern mirrors `routes/anthropic.py:128-131` (`try: ... except ValidationError as e: raise HTTPException(400, str(e))`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)