### PR TITLE
style(bench/tier_runner+tests): ruff format collapse string concatenations

### DIFF
--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -315,8 +315,7 @@ def test_harness_dead_server_between_profiles_reboots(capsys):
 
     # All 5 profiles must have been visited despite the mid-sweep death.
     assert tuple(invocations) == HARNESS_PROFILES, (
-        "cascade fix must keep iterating after a server reboot; "
-        f"got {invocations}"
+        f"cascade fix must keep iterating after a server reboot; got {invocations}"
     )
 
     # At least 2 serve() calls: initial boot + 1 reboot between profiles.
@@ -458,8 +457,7 @@ def test_harness_profile_timeout_does_not_block_next_profile(capsys):
     # Every profile still got tried — the hung codex didn't block the
     # next four.
     assert tuple(invocations) == HARNESS_PROFILES, (
-        "per-profile timeout must let the sweep continue; "
-        f"got {invocations}"
+        f"per-profile timeout must let the sweep continue; got {invocations}"
     )
     # Codex must surface as a FAIL with the timeout marker.
     assert "timed out" in captured.out, (

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -49,6 +49,7 @@ HARNESS_PROFILES: tuple[str, ...] = (
 TIER_PORT_MIN = 8500
 TIER_PORT_MAX = 8599
 
+
 def _resolve_harness_profile_timeout() -> int:
     """Read the per-profile harness timeout from the environment.
 
@@ -672,10 +673,7 @@ class _HarnessServerSession:
         try:
             info = ctx.__enter__()
         except Exception as exc:  # noqa: BLE001 — failed reboot must surface
-            note = (
-                f"reboot from port {old_port} failed: "
-                f"{type(exc).__name__}: {exc}"
-            )
+            note = f"reboot from port {old_port} failed: {type(exc).__name__}: {exc}"
             return False, note
 
         released = {"done": False}
@@ -774,8 +772,7 @@ def _run_single_profile(
                 "(no detail)",
             )
             detail = (
-                f"{report.passed}p {n_fail}f {n_err}e {report.skipped}s "
-                f"| {first_bad}"
+                f"{report.passed}p {n_fail}f {n_err}e {report.skipped}s | {first_bad}"
             )
         return ok, detail
 


### PR DESCRIPTION
## Summary

Lint failing on main since #684 merged. Newer ruff format on CI's Python 3.13 runner collapses three short \`(str + f-str)\` concats into single f-strings inside assertion messages and a note builder. pr_validate's Python 3.12 ruff didn't flag them.

Also adds the missing blank line between \`TIER_PORT_MAX\` and \`_resolve_harness_profile_timeout()\` (E302).

Pure whitespace / syntax-shape change — no behavior delta.

## Test plan

- [x] \`python3.12 -m ruff format --check vllm_mlx/ tests/\` clean post-fix
- [x] Targeted run on the affected tests: \`pytest tests/test_bench_tier_harness.py -q\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)