### PR TITLE
chore: bump version to 0.7.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.31"
+version = "0.7.32"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cut v0.7.32 release. **9 PRs since v0.7.31** plus the 2 post-bundle catches:

### Features
- **#683** `feat(anthropic)`: native structured output via `output_config.format=json_schema` (upstream vLLM #42396 backport)
- **#685** `feat(api)`: per-request `reasoning_max_tokens` cap + Anthropic `output_config.effort` (upstream #20859/#42396/#43402 backport) — 3 API surfaces, 60+ unit tests, 14 codex rounds

### Fixes
- **#682** `fix(_mirror)`: aggregate `[bytes] D/T` heartbeat — fixes rapid-desktop v0.7.10 "stuck at 83%" UX bug (per-pull tracker, R2-failure rollback, display clamp, resume-prefix credit)
- **#684** `fix(bench)`: per-profile timeout + health-check / auto-restart in harness sweep (codex CLI hangs no longer cascade)
- **#687** `fix(api/utils)`: suppress gemma-4 `<|tool_call>...<tool_call|>` wire markers in streaming output (issue #686 secondary finding)
- **#681** `fix(lint)`: drop unused `time` import in mllm.py
- **#690** `fix(responses)`: wrap `ResponsesRequest(**body)` → 400 on bad input (caught by bundled codex review — #685's strict validator silently turned 400 → 500 on the Responses route)
- **#691** `style(bench)`: ruff format collapse (Python 3.13 ruff regression from #684)

### Docs
- **#688** `docs(codex-profile)`: gemma-4-12b thought-loop known-issue note (linked to upstream HF discussion at google/gemma-4-12B-it#41 and downstream issue #686)

## Pre-release gauntlet (this branch)

- [x] **G1 release-smoke** (clean-room venv install + import all release surfaces) — PASS
- [x] **G5-G9 M3-local gauntlet** (release-check-m3) — ALL gates green
  - harness sweep: 5/5 (codex / opencode / hermes / aider / langchain) — PASS
  - G6 `parallel_tool_calls=false` cap — PASS
  - G8 parser microbench (hermes/minimax/glm47/harmony) — under threshold
  - G9 10-sequential latency: **mean 98.1 tok/s, spread 1.8** (qwen3.5-9b-4bit)
- [x] **Bundled codex review (2 rounds)** — 1 real finding (→ #690), 1 false positive (verified by 5770 passing on Linux 3.10/3.11/3.12 + Apple Silicon)
- [x] **Main CI**: lint + type-check + test-matrix + test-apple-silicon all green post-#691

## Notes

- Strict subject regex match: `chore: bump version to 0.7.32` — squash with clean subject (no `(#N)` suffix) to trigger `auto-release.yml`.
- Closes our v0.7.32 release sequence — `publish.yml` then fans out to PyPI + Homebrew tap dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)