### PR TITLE
feat(release): G12 random-coverage gate — sample N small models × M harnesses × K rounds

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -347,6 +347,50 @@ echo "  G8 — parser microbench (extract_tool_calls × 10000)"
 line
 "$PY" scripts/microbench_parsers.py
 
+#-------------------- G12 random-coverage -------------------------
+# Randomized sweep across small/medium aliases × harnesses × rounds.
+# Catches model-specific regressions that the fixed gauntlet (one
+# model — qwen3.5-9b-4bit) by construction cannot see. PR #687
+# (gemma-4 ``<|tool_call>`` wire-marker leak) is exactly the kind of
+# bug this gate would have caught at release time instead of after.
+#
+# Seed: today's UTC date YYYYMMDD → reproducible per release day.
+# Cleanup: each sampled model's HF cache is removed after testing so
+# successive release cuts don't fill the disk.
+#
+# Set RAPID_MLX_SKIP_G12=1 to skip this gate (e.g. when iterating on
+# the bump PR itself without re-running the full sweep). The CI-side
+# preflight ALSO runs G1+G10+G11, so a single local skip-of-G12 still
+# leaves multiple gates covering the bump-PR diff.
+if [ "${RAPID_MLX_SKIP_G12:-0}" = "1" ]; then
+  line
+  echo "  G12 — random-coverage [SKIPPED via RAPID_MLX_SKIP_G12=1]"
+  line
+else
+  line
+  echo "  G12 — random-coverage (sampled models × harnesses × rounds)"
+  line
+  # Free the gauntlet's main server so G12 owns the port + GPU.
+  # ``cleanup`` is the trap-installed teardown defined at the top of
+  # this script — calling it manually here releases the PID file too.
+  cleanup
+  sleep 2
+  # Wait for the port to actually free (cleanup sends TERM; the server
+  # then runs PR #667's deadline-aware prefix-cache flush on shutdown).
+  for _ in $(seq 1 10); do
+    if ! lsof -i ":$PORT" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  "$PY" scripts/release_check_m3_random.py \
+    --port "$PORT" \
+    --models "${G12_MODELS:-2}" \
+    --harnesses "${G12_HARNESSES:-2}" \
+    --rounds "${G12_ROUNDS:-3}" \
+    --report /tmp/release-check-m3-random.log
+fi
+
 #-------------------- Done ----------------------------------------
 line
 echo "  release-check-m3: ALL gates green for $MODEL"

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -144,8 +144,24 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
 
 
 def _free_disk_gb(path: Path) -> float:
-    """Free space in GB on the filesystem holding ``path``."""
-    usage = shutil.disk_usage(path)
+    """Free space in GB on the filesystem holding ``path``.
+
+    Walks up to the nearest existing ancestor when ``path`` itself
+    doesn't exist yet — the cache root may be on a custom mount whose
+    leaf hasn't been created until the first model is downloaded.
+    ``shutil.disk_usage`` errors on missing paths, which would block
+    G12 from starting on a brand-new ``HF_HUB_CACHE=/data/hf-cache``
+    rig where ``/data/`` exists but the leaf doesn't.
+    """
+    p = path
+    while not p.exists():
+        parent = p.parent
+        if parent == p:
+            # Walked all the way to the root and still nothing exists.
+            # Let shutil.disk_usage raise — something is very wrong.
+            break
+        p = parent
+    usage = shutil.disk_usage(p)
     return usage.free / (1024**3)
 
 
@@ -384,12 +400,18 @@ def main() -> int:
         )
         return 2
 
-    free_gb = _free_disk_gb(Path.home() / ".cache")
+    # Check free space on the disk that ACTUALLY holds the HF cache —
+    # an install with ``HF_HUB_CACHE=/data/hf-cache`` may have plenty of
+    # space on ``/data`` while ``~/.cache`` is tight (or vice-versa).
+    # Codex round-2 PR #693 caught this — ``~/.cache`` is wrong for any
+    # non-default HF install.
+    cache_root = _hf_cache_root()
+    free_gb = _free_disk_gb(cache_root)
     if free_gb < MIN_FREE_DISK_GB:
         print(
-            f"  Error: only {free_gb:.1f} GB free on the HF cache disk; "
-            f"refusing to start (need {MIN_FREE_DISK_GB} GB). Clear caches "
-            f"and retry.",
+            f"  Error: only {free_gb:.1f} GB free on the HF cache disk "
+            f"({cache_root}); refusing to start (need {MIN_FREE_DISK_GB} GB). "
+            f"Clear caches and retry.",
             file=sys.stderr,
         )
         return 2

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -87,6 +87,21 @@ SERVE_READY_TIMEOUT_S = 600  # 10 minutes
 ROUND_TIMEOUT_S = 360
 
 
+# Match a parameter-count token bounded by name separators (``-``,
+# ``_``, ``.``, start, or end) followed by ``b``/``B`` and another
+# separator/end. Rejects the quantization suffix ``-4bit`` (the ``b``
+# is followed by ``it``) and the version-number-only names like
+# ``glm4.5-air`` (no ``b`` after the digits at all). Parsing the
+# parameter count from the **hf_path's repo segment** is more reliable
+# than from the alias slug — repo names by upstream convention spell
+# the size as ``\d+(\.\d+)?B`` (Qwen3.5-9B, Llama-3.2-1B, gemma-4-12B)
+# whereas alias slugs sometimes encode model version instead of size.
+# Fail-closed: if no size token is found, the alias is skipped rather
+# than guessed at — guessing landed us with ``glm4.5-air-4bit`` parsing
+# as a 4 B model and slipping past the disk-budget filter.
+_SIZE_TOKEN_RE = re.compile(r"(?:^|[-_.])(\d+(?:\.\d+)?)[bB](?=[-_.]|$)")
+
+
 def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
     """Return ``[(alias_name, hf_repo_path), ...]`` after applying the
     eligibility filter documented in the module docstring.
@@ -108,16 +123,20 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
             # Known-bad: model-side ``thought\n…`` loop on agent prompts.
             # See issue #686 + HF discussion google/gemma-4-12B-it#41.
             continue
-        match = re.search(r"(\d+(?:\.\d+)?)b", name.lower())
-        if not match:
-            continue
-        size_b = float(match.group(1))
-        if not (4.0 <= size_b <= 12.0):
-            continue
         # Use .get() — a future schema change that omits ``hf_path``
         # should silently skip the entry, not crash the gauntlet.
         hf_path = entry.get("hf_path") if isinstance(entry, dict) else None
         if not hf_path:
+            continue
+        repo_name = hf_path.split("/")[-1]
+        match = _SIZE_TOKEN_RE.search(repo_name)
+        if not match:
+            # Fail closed: cannot parse a real parameter count from the
+            # repo name — skip rather than guess and risk admitting an
+            # oversized model into the sweep.
+            continue
+        size_b = float(match.group(1))
+        if not (4.0 <= size_b <= 12.0):
             continue
         out.append((size_b, name, hf_path))
     out.sort()
@@ -130,23 +149,59 @@ def _free_disk_gb(path: Path) -> float:
     return usage.free / (1024**3)
 
 
+def _hf_cache_root() -> Path:
+    """Resolve the HuggingFace Hub cache root, mirroring
+    ``huggingface_hub.constants.HF_HUB_CACHE`` lookup order:
+
+      1. ``HF_HUB_CACHE`` (modern)
+      2. ``HUGGINGFACE_HUB_CACHE`` (legacy)
+      3. ``$HF_HOME/hub`` (when HF_HOME is set)
+      4. ``~/.cache/huggingface/hub`` (default)
+
+    Hard-coding ``~/.cache/huggingface/hub`` meant installs that point
+    HF elsewhere (CI runners, multi-disk dev rigs) would download into
+    one place and have G12 try to clean another, ballooning disk usage
+    across release cycles. The cleanup must target the actual snapshot
+    tree this run's download landed in.
+    """
+    for env in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
+        v = os.environ.get(env)
+        if v:
+            return Path(v).expanduser()
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home).expanduser() / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
 def _hf_cache_dir(hf_repo_path: str) -> Path:
     """Path of the HuggingFace cache entry for ``hf_repo_path``."""
-    return (
-        Path.home()
-        / ".cache"
-        / "huggingface"
-        / "hub"
-        / f"models--{hf_repo_path.replace('/', '--')}"
-    )
+    return _hf_cache_root() / f"models--{hf_repo_path.replace('/', '--')}"
 
 
-def _wait_for_server(port: int, deadline_s: float, log_path: Path) -> bool:
-    """Poll ``/v1/models`` until the server responds 200 or the
-    deadline expires. Returns True on success, False on timeout."""
+def _wait_for_server(
+    proc: subprocess.Popen, port: int, deadline_s: float, log_path: Path
+) -> bool:
+    """Poll ``/v1/models`` until the server responds 200, the child
+    exits, or the deadline expires. Returns True on success, False
+    otherwise.
+
+    Watching ``proc.poll()`` matters: if ``rapid-mlx serve`` aborts at
+    import time (missing alias, port collision raced past the
+    pre-flight, mlx-lm import error on a clean venv), there is no port
+    that will ever come up. Without this check we'd burn the full 600 s
+    deadline polling a dead child.
+    """
     url = f"http://127.0.0.1:{port}/v1/models"
     start = time.monotonic()
     while time.monotonic() - start < deadline_s:
+        rc = proc.poll()
+        if rc is not None:
+            print(
+                f"  serve process exited early (rc={rc}) before reaching ready state",
+                file=sys.stderr,
+            )
+            break
         try:
             with urllib.request.urlopen(url, timeout=3) as resp:
                 if resp.status == 200:
@@ -294,6 +349,32 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    # ===== Argument bounds =====
+    # ``random.sample(population, k)`` raises ``ValueError`` for k > len.
+    # We want an actionable release-gate error instead of a Python
+    # traceback when someone passes ``G12_HARNESSES=6`` or
+    # ``G12_MODELS=0`` from the shell wrapper.
+    if args.models < 1:
+        print(
+            f"  Error: --models must be ≥1 (got {args.models}).",
+            file=sys.stderr,
+        )
+        return 2
+    if not (1 <= args.harnesses <= len(HARNESS_PROFILES)):
+        print(
+            f"  Error: --harnesses must be 1..{len(HARNESS_PROFILES)} "
+            f"(got {args.harnesses}); the registry has "
+            f"{len(HARNESS_PROFILES)} harness profile(s).",
+            file=sys.stderr,
+        )
+        return 2
+    if args.rounds < 1:
+        print(
+            f"  Error: --rounds must be ≥1 (got {args.rounds}).",
+            file=sys.stderr,
+        )
+        return 2
+
     # ===== Pre-flight =====
     if not _port_free(args.port):
         print(
@@ -376,7 +457,7 @@ def main() -> int:
                 cwd=REPO_ROOT,
             )
         try:
-            if not _wait_for_server(args.port, SERVE_READY_TIMEOUT_S, log_path):
+            if not _wait_for_server(proc, args.port, SERVE_READY_TIMEOUT_S, log_path):
                 msg = f"{alias}: server did not respond within {SERVE_READY_TIMEOUT_S}s"
                 print(f"  FAIL  {msg}", file=sys.stderr)
                 with report_path.open("a") as fh:

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""G12 release-gauntlet random-coverage gate.
+
+The fixed gauntlet only exercises ``qwen3.5-9b-4bit`` — every release
+ships without ever booting the other ~28 registered small/medium
+aliases. PR #687 (gemma-4 ``<|tool_call>`` wire-marker leak) is a
+class of bug that only surfaces when you actually run the model.
+
+This script bolts a randomized sweep onto the existing gauntlet:
+
+    for each of N seeded-random models (from the eligible alias set):
+        boot rapid-mlx serve <model> --port $PORT --no-thinking
+        for each of M seeded-random harnesses (from the 5 first-class):
+            for r in 1..K rounds:
+                run `bench --tier harness` with the env-filter scoped
+                to just that one harness, against the booted server
+        stop the server (clean shutdown, wait for port to free)
+        rm -rf ~/.cache/huggingface/hub/models--<repo> so the disk
+        doesn't balloon across release cycles
+
+Defaults: N=2, M=2, K=3 → 12 sweeps × ~30s avg ≈ 6-12 min wall-clock
+(plus model download + boot time, which dominates for cold caches).
+
+The seed is today's UTC date (``YYYYMMDD``) — same calendar day cuts
+of the release reproduce the same model × harness picks, so a failure
+is repro-able by another contributor running the script on the same
+day with the same alias inventory.
+
+Failure handling: any harness round that fails surfaces a non-zero
+exit code. The shell gauntlet ``set -e``'s out on the first bad gate.
+
+Disk safety: the script REFUSES to start if free space < 30 GB
+(typical 4-bit small models are 2-6 GB on disk; the largest 12B 4-bit
+land at ~7 GB; a worst-case 2-model sweep with no cleanup would
+allocate ~14 GB, but cleanup runs after each model so peak working set
+is one model at a time + 5 GB headroom).
+
+Eligibility filter (sample pool):
+  * 4 ≤ size_B ≤ 12  (smaller models can't actually solve harness tasks
+                       → false-fail spam; larger models bust the disk
+                       budget on M3 16/32 GB systems)
+  * 4-bit quant only  (8-bit is 2x download cost for the same coverage)
+  * no kimi-*         (deliberately heavy class, explicit user exclude)
+  * no -vl- variants  (vision; harness tasks are text-only)
+  * no gemma-4-*      (known model-side hang on tool-use prompts; see
+                       issue #686 + huggingface/google/gemma-4-12B-it
+                       discussion #41 — would burn 156s+ per round on
+                       a known-bad model and add zero signal)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Mirror of ``vllm_mlx.bench.tier_runner.HARNESS_PROFILES`` — hardcoded
+# here so this script doesn't need to import the package (which would
+# pull mlx_lm at module-load and fail in a clean-venv sanity run).
+HARNESS_PROFILES = ("codex", "opencode", "hermes", "aider", "langchain")
+
+# Disk safety floor — refuse to start if the cache disk has less than
+# this. Sized for one 12B-4bit model + 5 GB headroom.
+MIN_FREE_DISK_GB = 30
+
+# Per-server-boot deadline. First-time downloads can be slow; this is
+# tight enough to flag a hung boot but loose enough to tolerate a slow
+# HF connection on a 7-GB shard.
+SERVE_READY_TIMEOUT_S = 600  # 10 minutes
+
+# Per-harness-round timeout. The harness runner's own per-profile cap
+# is 300s (HARNESS_PROFILE_TIMEOUT_S); we add headroom for the
+# bench-CLI startup cost.
+ROUND_TIMEOUT_S = 360
+
+
+def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
+    """Return ``[(alias_name, hf_repo_path), ...]`` after applying the
+    eligibility filter documented in the module docstring.
+
+    Sorted by size then name so the seeded random.sample is stable
+    across machines that read the same aliases.json — list order
+    matters for ``random.sample`` reproducibility.
+    """
+    data = json.loads(aliases_path.read_text())
+    out: list[tuple[float, str, str]] = []
+    for name, entry in data.items():
+        if not name.endswith("-4bit"):
+            continue
+        if "kimi" in name.lower():
+            continue
+        if "-vl-" in name.lower():
+            continue
+        if name.lower().startswith("gemma-4-"):
+            # Known-bad: model-side ``thought\n…`` loop on agent prompts.
+            # See issue #686 + HF discussion google/gemma-4-12B-it#41.
+            continue
+        match = re.search(r"(\d+(?:\.\d+)?)b", name.lower())
+        if not match:
+            continue
+        size_b = float(match.group(1))
+        if not (4.0 <= size_b <= 12.0):
+            continue
+        # Use .get() — a future schema change that omits ``hf_path``
+        # should silently skip the entry, not crash the gauntlet.
+        hf_path = entry.get("hf_path") if isinstance(entry, dict) else None
+        if not hf_path:
+            continue
+        out.append((size_b, name, hf_path))
+    out.sort()
+    return [(name, hf) for _, name, hf in out]
+
+
+def _free_disk_gb(path: Path) -> float:
+    """Free space in GB on the filesystem holding ``path``."""
+    usage = shutil.disk_usage(path)
+    return usage.free / (1024**3)
+
+
+def _hf_cache_dir(hf_repo_path: str) -> Path:
+    """Path of the HuggingFace cache entry for ``hf_repo_path``."""
+    return (
+        Path.home()
+        / ".cache"
+        / "huggingface"
+        / "hub"
+        / f"models--{hf_repo_path.replace('/', '--')}"
+    )
+
+
+def _wait_for_server(port: int, deadline_s: float, log_path: Path) -> bool:
+    """Poll ``/v1/models`` until the server responds 200 or the
+    deadline expires. Returns True on success, False on timeout."""
+    url = f"http://127.0.0.1:{port}/v1/models"
+    start = time.monotonic()
+    while time.monotonic() - start < deadline_s:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+            pass
+        time.sleep(2)
+    # Dump the last 30 lines of the server log so the operator sees
+    # why we gave up — same shape the shell gauntlet uses.
+    if log_path.exists():
+        print("  server log (last 30 lines):", file=sys.stderr)
+        for line in log_path.read_text(errors="replace").splitlines()[-30:]:
+            print(f"    {line}", file=sys.stderr)
+    return False
+
+
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex(("127.0.0.1", port)) != 0
+
+
+def _stop_server(proc: subprocess.Popen, port: int, deadline_s: float = 30) -> None:
+    """Gracefully terminate the server and wait for the port to free.
+
+    The server's SIGTERM handler flushes the prefix cache (post-PR #667
+    deadline-aware shutdown), so we give it real time to land.
+    """
+    if proc.poll() is None:
+        proc.terminate()
+    try:
+        proc.wait(timeout=deadline_s)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+    # Belt-and-braces — confirm the port released before we move on.
+    start = time.monotonic()
+    while time.monotonic() - start < 5 and not _port_free(port):
+        time.sleep(0.5)
+
+
+def _run_harness_round(
+    *,
+    alias: str,
+    harness: str,
+    base_url: str,
+    log_path: Path,
+) -> tuple[bool, float, str]:
+    """Run one ``bench --tier harness`` invocation scoped to one
+    harness. Returns ``(ok, wall_clock_s, error_excerpt)``."""
+    env = {**os.environ, "RAPID_MLX_HARNESS_PROFILES_FILTER": harness}
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "bench",
+        alias,
+        "--tier",
+        "harness",
+        "--base-url",
+        base_url,
+    ]
+    t0 = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd,
+            env=env,
+            timeout=ROUND_TIMEOUT_S,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        dur = time.monotonic() - t0
+        return False, dur, f"round timed out after {ROUND_TIMEOUT_S}s"
+    dur = time.monotonic() - t0
+    # Append the subprocess output to our log so a failure has
+    # a debuggable trail. ``"a"`` mode is single-write-atomic enough for
+    # our single-threaded sweep loop.
+    with log_path.open("a") as fh:
+        fh.write(
+            f"\n=== {alias}/{harness} (exit={result.returncode}, {dur:.1f}s) ===\n"
+        )
+        fh.write(result.stdout or "")
+        if result.stderr:
+            fh.write("\n--- stderr ---\n")
+            fh.write(result.stderr)
+    if result.returncode != 0:
+        # Pull the FAIL line from the bench output as the excerpt.
+        excerpt = ""
+        for line in (result.stdout or "").splitlines():
+            if "FAIL" in line:
+                excerpt = line.strip()[:200]
+                break
+        if not excerpt:
+            excerpt = f"exit {result.returncode}; see {log_path}"
+        return False, dur, excerpt
+    return True, dur, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seed",
+        default=time.strftime("%Y%m%d", time.gmtime()),
+        help="Deterministic seed (default: today's UTC date YYYYMMDD).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to boot rapid-mlx serve on (default: 8000).",
+    )
+    parser.add_argument(
+        "--models",
+        type=int,
+        default=2,
+        help="Number of models to sample (default: 2).",
+    )
+    parser.add_argument(
+        "--harnesses",
+        type=int,
+        default=2,
+        help="Number of harnesses to sample per model (default: 2).",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=3,
+        help="Rounds per (model × harness) pair (default: 3).",
+    )
+    parser.add_argument(
+        "--report",
+        default="/tmp/release-check-m3-random.log",
+        help="Path to write the human-readable summary report to.",
+    )
+    parser.add_argument(
+        "--aliases-json",
+        default=str(REPO_ROOT / "vllm_mlx" / "aliases.json"),
+        help="Path to aliases.json (default: in-tree copy).",
+    )
+    parser.add_argument(
+        "--keep-cache",
+        action="store_true",
+        help="Skip the per-model HF cache cleanup (debug aid).",
+    )
+    args = parser.parse_args()
+
+    # ===== Pre-flight =====
+    if not _port_free(args.port):
+        print(
+            f"  Error: port {args.port} already in use — kill the existing "
+            f"server before running G12.",
+            file=sys.stderr,
+        )
+        return 2
+
+    free_gb = _free_disk_gb(Path.home() / ".cache")
+    if free_gb < MIN_FREE_DISK_GB:
+        print(
+            f"  Error: only {free_gb:.1f} GB free on the HF cache disk; "
+            f"refusing to start (need {MIN_FREE_DISK_GB} GB). Clear caches "
+            f"and retry.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # ===== Sample =====
+    eligible = _eligible_aliases(Path(args.aliases_json))
+    if len(eligible) < args.models:
+        print(
+            f"  Error: only {len(eligible)} eligible aliases; need {args.models}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    rng = random.Random(args.seed)
+    sampled_models = rng.sample(eligible, args.models)
+    # Independent seed stream per model so the harness pick for model A
+    # doesn't shift when we change ``--models``.
+    sampled = []
+    for alias, hf_path in sampled_models:
+        per_model_rng = random.Random(f"{args.seed}::{alias}")
+        hs = per_model_rng.sample(list(HARNESS_PROFILES), args.harnesses)
+        sampled.append((alias, hf_path, hs))
+
+    print("=" * 60)
+    print("  G12 — random-coverage release gate")
+    print(f"  seed:     {args.seed}")
+    print(f"  models:   {args.models} (of {len(eligible)} eligible)")
+    print(f"  harnesses:{args.harnesses} (of {len(HARNESS_PROFILES)})")
+    print(f"  rounds:   {args.rounds}")
+    print(f"  report:   {args.report}")
+    print(f"  free GB:  {free_gb:.1f}")
+    print("=" * 60)
+    print("  Sampled matrix:")
+    for alias, _, hs in sampled:
+        print(f"    {alias:<28} × harnesses={hs}")
+    print("=" * 60)
+
+    # Reset the report log.
+    report_path = Path(args.report)
+    report_path.write_text(
+        f"G12 random-coverage report (seed={args.seed})\n" + "=" * 60 + "\n"
+    )
+
+    # ===== Sweep =====
+    failures: list[str] = []
+    for alias, hf_path, harnesses in sampled:
+        print()
+        print(f"  >> Booting {alias} on port {args.port}…")
+        log_path = Path(f"/tmp/release-check-m3-random-{alias}.log")
+        log_path.write_text("")
+        with log_path.open("w") as logfh:
+            proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "vllm_mlx.cli",
+                    "serve",
+                    alias,
+                    "--port",
+                    str(args.port),
+                    "--no-thinking",
+                ],
+                stdout=logfh,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            )
+        try:
+            if not _wait_for_server(args.port, SERVE_READY_TIMEOUT_S, log_path):
+                msg = f"{alias}: server did not respond within {SERVE_READY_TIMEOUT_S}s"
+                print(f"  FAIL  {msg}", file=sys.stderr)
+                with report_path.open("a") as fh:
+                    fh.write(f"FAIL  {msg}\n")
+                failures.append(msg)
+                continue
+            print(f"     server up ({alias}); harnesses={harnesses}")
+            base_url = f"http://127.0.0.1:{args.port}"
+            for harness in harnesses:
+                for r in range(1, args.rounds + 1):
+                    ok, dur, excerpt = _run_harness_round(
+                        alias=alias,
+                        harness=harness,
+                        base_url=base_url,
+                        log_path=log_path,
+                    )
+                    marker = "PASS" if ok else "FAIL"
+                    line = (
+                        f"     {marker} {alias}/{harness} "
+                        f"round {r}/{args.rounds} ({dur:.1f}s)"
+                    )
+                    if excerpt:
+                        line += f"  — {excerpt}"
+                    print(line)
+                    with report_path.open("a") as fh:
+                        fh.write(line + "\n")
+                    if not ok:
+                        failures.append(f"{alias}/{harness} round {r}: {excerpt}")
+        finally:
+            print(f"  << Stopping {alias}…")
+            _stop_server(proc, args.port)
+            if not args.keep_cache:
+                cache_dir = _hf_cache_dir(hf_path)
+                if cache_dir.exists():
+                    print(f"     rm -rf {cache_dir}")
+                    shutil.rmtree(cache_dir, ignore_errors=True)
+
+    # ===== Verdict =====
+    print()
+    print("=" * 60)
+    if failures:
+        print(f"  G12: {len(failures)} failure(s)")
+        for f in failures:
+            print(f"    - {f}")
+        print(f"  Full log: {args.report}")
+        print("=" * 60)
+        return 1
+    print("  G12: ALL rounds passed")
+    print(f"  Full log: {args.report}")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -825,3 +825,102 @@ def test_harness_profile_timeout_env_var_respected(monkeypatch):
         # the default (other tests monkeypatch this constant).
         monkeypatch.delenv("HARNESS_PROFILE_TIMEOUT_S", raising=False)
         importlib.reload(tr)
+
+
+# ---------------------------------------------------------------------------
+# RAPID_MLX_HARNESS_PROFILES_FILTER — env-var subset filter used by G12.
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessProfilesFilter:
+    """G12 (random-coverage) sets ``RAPID_MLX_HARNESS_PROFILES_FILTER``
+    to scope a ``--tier harness`` sweep to a randomly-picked subset of
+    the 5 first-class harnesses. The filter must:
+      * accept a single profile (``"codex"``)
+      * accept comma-separated multi (``"codex,aider"``)
+      * tolerate whitespace + trailing commas
+      * warn-and-drop unknown profile names
+      * warn-and-disable (return None) on empty / all-unknown
+      * return None when the env var is unset (default behavior)
+    """
+
+    @staticmethod
+    def _reload():
+        import importlib
+
+        import vllm_mlx.bench.tier_runner as tr
+
+        importlib.reload(tr)
+        return tr
+
+    def test_no_env_var_returns_none(self, monkeypatch):
+        monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER is None
+        finally:
+            tr = self._reload()  # restore for siblings
+
+    def test_single_profile_filter(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", "codex")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER == ("codex",)
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()
+
+    def test_comma_separated_filter(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", "codex,aider,langchain")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER == ("codex", "aider", "langchain")
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()
+
+    def test_whitespace_and_trailing_commas_tolerated(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", " codex , aider , ")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER == ("codex", "aider")
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()
+
+    def test_unknown_profile_warned_and_dropped(self, monkeypatch, capsys):
+        # Mix of valid + invalid; valid ones survive.
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", "codex,bogus,aider")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER == ("codex", "aider")
+            captured = capsys.readouterr()
+            assert "bogus" in captured.err
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()
+
+    def test_all_unknown_disables_filter(self, monkeypatch, capsys):
+        # All-unknown: warn and disable filter rather than silently
+        # sweeping zero profiles (which would look like a successful
+        # but coverage-empty run).
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", "bogus,nope")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER is None
+            captured = capsys.readouterr()
+            assert "matched zero" in captured.err
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()
+
+    def test_empty_string_disables_filter(self, monkeypatch, capsys):
+        monkeypatch.setenv("RAPID_MLX_HARNESS_PROFILES_FILTER", "   ")
+        tr = self._reload()
+        try:
+            assert tr.HARNESS_PROFILES_FILTER is None
+            captured = capsys.readouterr()
+            assert "empty/whitespace" in captured.err
+        finally:
+            monkeypatch.delenv("RAPID_MLX_HARNESS_PROFILES_FILTER", raising=False)
+            self._reload()

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -188,6 +188,16 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # bearer-token holder could write arbitrary files. Pure filesystem
         # sandbox knob; never consulted by the engine or scheduler.
         "RAPID_MLX_CACHE_EXPORT_DIR",
+        # G12 release-gauntlet random-coverage gate
+        # (``scripts/release_check_m3_random.py``) sets this to a single
+        # harness name (or comma-separated subset) when running a scoped
+        # sweep against a booted server. ``tier_runner._resolve_harness_
+        # profiles_filter`` consumes it to whittle the harness loop down
+        # to just the picked names. Test/CI knob — never consulted by the
+        # engine, scheduler, or any routing layer. ``vllm_mlx.cli``
+        # refuses ``--submit`` while it's set so a scoped sweep can't
+        # silently produce a schema-incomplete community-bench payload.
+        "RAPID_MLX_HARNESS_PROFILES_FILTER",
     }
 )
 

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for scripts/release_check_m3_random.py — G12 release-gauntlet
+random-coverage gate. The orchestrator script lives outside the
+``vllm_mlx`` package so we import it via importlib."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "release_check_m3_random.py"
+)
+
+
+@pytest.fixture(scope="module")
+def g12():
+    """Load the orchestrator script as a module so its helpers can be
+    unit-tested without spawning subprocesses."""
+    spec = importlib.util.spec_from_file_location("g12", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_aliases() -> dict[str, dict]:
+    """A shrunken aliases.json fixture covering every eligibility
+    branch (size in/out of band, vision marker, kimi marker, gemma-4
+    marker, 8bit vs 4bit, missing hf_path)."""
+    return {
+        # In-band (4-12 B, 4-bit, no special excludes)
+        "qwen3.5-9b-4bit": {"hf_path": "mlx-community/Qwen3.5-9B-4bit"},
+        "qwen3-8b-4bit": {"hf_path": "mlx-community/Qwen3-8B-4bit"},
+        "glm4.5-air-4bit": {"hf_path": "mlx-community/GLM-4.5-Air-4bit"},
+        "hermes3-8b-4bit": {"hf_path": "mlx-community/Hermes-3-Llama-3.1-8B-4bit"},
+        # Out-of-band: too small (< 4 B) — harnesses would false-fail.
+        "qwen3-0.6b-4bit": {"hf_path": "mlx-community/Qwen3-0.6B-4bit"},
+        "llama3-1b-4bit": {"hf_path": "mlx-community/Llama-3.2-1B-Instruct-4bit"},
+        "smollm3-3b-4bit": {"hf_path": "mlx-community/SmolLM3-3B-4bit"},
+        # Out-of-band: too large (> 12 B).
+        "qwen3.5-27b-4bit": {"hf_path": "mlx-community/Qwen3.5-27B-4bit"},
+        # Excluded: vision variant.
+        "qwen3-vl-8b-4bit": {"hf_path": "mlx-community/Qwen3-VL-8B-Instruct-4bit"},
+        # Excluded: kimi family (heavy + user-flagged).
+        "kimi-k2-9b-4bit": {"hf_path": "fake/Kimi-K2-9B-4bit"},
+        # Excluded: gemma-4 family (issue #686 thought-loop hang).
+        "gemma-4-12b-4bit": {"hf_path": "mlx-community/gemma-4-12B-it-4bit"},
+        "gemma-4-e4b-4bit": {"hf_path": "mlx-community/gemma-4-e4b-it-4bit"},
+        # Excluded: 8-bit quant (we sample 4-bit only).
+        "qwen3.5-9b-8bit": {"hf_path": "mlx-community/Qwen3.5-9B-8bit"},
+        # Skipped silently: missing hf_path field.
+        "broken-9b-4bit": {"tool_call_parser": "hermes"},
+    }
+
+
+def test_eligible_aliases_filters_correctly(g12, tmp_path):
+    """The 4 in-band entries survive; everything else is filtered."""
+    p = tmp_path / "aliases.json"
+    p.write_text(json.dumps(_fake_aliases()))
+    eligible = g12._eligible_aliases(p)
+    names = {name for name, _ in eligible}
+    assert names == {
+        "qwen3.5-9b-4bit",
+        "qwen3-8b-4bit",
+        "glm4.5-air-4bit",
+        "hermes3-8b-4bit",
+    }
+
+
+def test_eligible_aliases_sorted_for_reproducible_sampling(g12, tmp_path):
+    """``random.sample`` is order-sensitive — eligibility must return
+    in deterministic order so the same seed picks the same models
+    across machines / future aliases.json additions to unrelated
+    entries.
+
+    The function sorts by ``(size_B, name)``. We verify determinism by
+    invoking twice and checking order also doesn't depend on dict
+    insertion order in the source JSON.
+    """
+    p = tmp_path / "aliases.json"
+    aliases = _fake_aliases()
+    p.write_text(json.dumps(aliases))
+    eligible_a = g12._eligible_aliases(p)
+    eligible_b = g12._eligible_aliases(p)
+    assert eligible_a == eligible_b
+    # Write the same aliases in REVERSED insertion order — sort must
+    # produce the same output regardless of dict-iteration order.
+    p_reversed = tmp_path / "aliases_reversed.json"
+    p_reversed.write_text(json.dumps(dict(reversed(list(aliases.items())))))
+    eligible_c = g12._eligible_aliases(p_reversed)
+    assert eligible_a == eligible_c, (
+        "eligibility must be order-stable across source-file dict orderings"
+    )
+
+
+def test_real_aliases_json_yields_nonzero_pool(g12):
+    """Sanity check against the in-tree aliases.json: at least 5
+    eligible models must exist or the gauntlet has nothing to sample.
+    If this trips after a future aliases prune, raise the floor or
+    adjust the filter to admit a wider band."""
+    real = Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
+    eligible = g12._eligible_aliases(real)
+    assert len(eligible) >= 5, (
+        f"need ≥5 sample-eligible aliases for meaningful G12 random "
+        f"coverage; only {len(eligible)} pass the filter — "
+        f"check the size band / new exclude rules in "
+        f"release_check_m3_random.py"
+    )
+
+
+def test_hf_cache_dir_shape(g12):
+    """Cleanup path must match HuggingFace's actual snapshot layout
+    (``models--<owner>--<repo>``) so the rm -rf at end-of-model
+    actually deletes the right tree, not a sibling."""
+    p = g12._hf_cache_dir("mlx-community/Qwen3.5-9B-4bit")
+    assert p.name == "models--mlx-community--Qwen3.5-9B-4bit"
+    assert p.parent.name == "hub"
+    assert p.parent.parent.name == "huggingface"

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -171,6 +171,21 @@ def test_hf_cache_dir_shape(g12, monkeypatch):
     assert p.parent.parent.name == "huggingface"
 
 
+def test_free_disk_gb_walks_to_existing_ancestor(g12, tmp_path):
+    """``_free_disk_gb`` must tolerate a non-existent leaf — the cache
+    root may be on a custom mount whose ``models--owner--repo`` leaf
+    hasn't been created until the first download. Without the ancestor
+    walk, ``shutil.disk_usage`` raises ``FileNotFoundError`` on a
+    brand-new ``HF_HUB_CACHE=/data/hf-cache`` rig where ``/data/``
+    exists but ``hf-cache`` doesn't. Codex round-2 PR #693 review.
+    """
+    missing_leaf = tmp_path / "nonexistent" / "deeper" / "still-missing"
+    assert not missing_leaf.exists()
+    # Should return a real positive number, not raise.
+    free_gb = g12._free_disk_gb(missing_leaf)
+    assert free_gb > 0
+
+
 def test_hf_cache_root_honors_env_vars(g12, tmp_path, monkeypatch):
     """``_hf_cache_root`` must respect ``HF_HUB_CACHE``,
     ``HUGGINGFACE_HUB_CACHE`` and ``HF_HOME`` in the same precedence

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -30,13 +30,19 @@ def g12():
 def _fake_aliases() -> dict[str, dict]:
     """A shrunken aliases.json fixture covering every eligibility
     branch (size in/out of band, vision marker, kimi marker, gemma-4
-    marker, 8bit vs 4bit, missing hf_path)."""
+    marker, 8bit vs 4bit, missing hf_path, fail-closed name-without-
+    size token)."""
     return {
         # In-band (4-12 B, 4-bit, no special excludes)
         "qwen3.5-9b-4bit": {"hf_path": "mlx-community/Qwen3.5-9B-4bit"},
         "qwen3-8b-4bit": {"hf_path": "mlx-community/Qwen3-8B-4bit"},
-        "glm4.5-air-4bit": {"hf_path": "mlx-community/GLM-4.5-Air-4bit"},
         "hermes3-8b-4bit": {"hf_path": "mlx-community/Hermes-3-Llama-3.1-8B-4bit"},
+        # Fail-closed: the repo name carries no parameter-count token
+        # (``Air`` is a variant name, ``4.5`` is the version). The old
+        # parser regex extracted ``4`` from ``-4bit`` and admitted this
+        # entry as a 4 B model — codex PR #693 review caught it. The
+        # post-fix parser refuses to guess and skips the entry.
+        "glm4.5-air-4bit": {"hf_path": "mlx-community/GLM-4.5-Air-4bit"},
         # Out-of-band: too small (< 4 B) — harnesses would false-fail.
         "qwen3-0.6b-4bit": {"hf_path": "mlx-community/Qwen3-0.6B-4bit"},
         "llama3-1b-4bit": {"hf_path": "mlx-community/Llama-3.2-1B-Instruct-4bit"},
@@ -58,7 +64,13 @@ def _fake_aliases() -> dict[str, dict]:
 
 
 def test_eligible_aliases_filters_correctly(g12, tmp_path):
-    """The 4 in-band entries survive; everything else is filtered."""
+    """The 3 in-band entries survive; everything else is filtered.
+
+    Note ``glm4.5-air-4bit`` is **expected** to be excluded — its repo
+    name (``GLM-4.5-Air-4bit``) carries no parameter-count token, so
+    the post-codex-#693 parser fails closed rather than mis-attributing
+    a 4 B size from the ``-4bit`` quantization suffix.
+    """
     p = tmp_path / "aliases.json"
     p.write_text(json.dumps(_fake_aliases()))
     eligible = g12._eligible_aliases(p)
@@ -66,9 +78,40 @@ def test_eligible_aliases_filters_correctly(g12, tmp_path):
     assert names == {
         "qwen3.5-9b-4bit",
         "qwen3-8b-4bit",
-        "glm4.5-air-4bit",
         "hermes3-8b-4bit",
     }
+
+
+def test_eligible_aliases_does_not_parse_quant_suffix_as_size(g12, tmp_path):
+    """Regression: the size parser MUST NOT match ``-4bit`` / ``-8bit``
+    as a fake 4 B / 8 B model size.
+
+    Round-1 codex review of PR #693 caught this — the original regex
+    ``(\\d+(?:\\.\\d+)?)b`` greedily matched the ``4b`` inside ``4bit``,
+    so any 4-bit alias without a real size token in its repo name
+    (e.g. ``GLM-4.5-Air-4bit``) slipped past the 4-12 B disk filter as
+    a phantom 4 B model. The post-fix parser requires the ``b`` token
+    to be bounded by name separators so the quant suffix can't match.
+    """
+    aliases = {
+        # Repo name has NO parameter-count token. Must fail closed.
+        "phantom-air-4bit": {"hf_path": "fake/Phantom-Air-4bit"},
+        # Same idea, 8-bit suffix.
+        "phantom-air-8bit": {"hf_path": "fake/Phantom-Air-8bit"},
+        # Real size token IS present — must survive (control case).
+        "good-9b-4bit": {"hf_path": "fake/Good-9B-4bit"},
+    }
+    p = tmp_path / "aliases.json"
+    p.write_text(json.dumps(aliases))
+    eligible = dict(g12._eligible_aliases(p))
+    assert "phantom-air-4bit" not in eligible, (
+        "size parser must not extract 4 from -4bit quant suffix"
+    )
+    assert "phantom-air-8bit" not in eligible, (
+        "the 8-bit alias is filtered by quant-only rule anyway, but its "
+        "repo name also has no real size token — both filters apply"
+    )
+    assert eligible.get("good-9b-4bit") == "fake/Good-9B-4bit"
 
 
 def test_eligible_aliases_sorted_for_reproducible_sampling(g12, tmp_path):
@@ -112,11 +155,50 @@ def test_real_aliases_json_yields_nonzero_pool(g12):
     )
 
 
-def test_hf_cache_dir_shape(g12):
+def test_hf_cache_dir_shape(g12, monkeypatch):
     """Cleanup path must match HuggingFace's actual snapshot layout
     (``models--<owner>--<repo>``) so the rm -rf at end-of-model
-    actually deletes the right tree, not a sibling."""
+    actually deletes the right tree, not a sibling.
+
+    Pin the env to the default branch — other tests in the module may
+    leave ``HF_HOME`` / ``HF_HUB_CACHE`` set in this process.
+    """
+    for env in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"):
+        monkeypatch.delenv(env, raising=False)
     p = g12._hf_cache_dir("mlx-community/Qwen3.5-9B-4bit")
     assert p.name == "models--mlx-community--Qwen3.5-9B-4bit"
     assert p.parent.name == "hub"
     assert p.parent.parent.name == "huggingface"
+
+
+def test_hf_cache_root_honors_env_vars(g12, tmp_path, monkeypatch):
+    """``_hf_cache_root`` must respect ``HF_HUB_CACHE``,
+    ``HUGGINGFACE_HUB_CACHE`` and ``HF_HOME`` in the same precedence
+    order as ``huggingface_hub.constants.HF_HUB_CACHE`` — otherwise
+    G12 downloads into one place and tries to ``rm -rf`` another,
+    leaving the actual snapshots on disk to balloon across releases.
+    Codex round-1 review of PR #693 caught this.
+    """
+    for env in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"):
+        monkeypatch.delenv(env, raising=False)
+
+    # Modern override
+    target = tmp_path / "modern"
+    monkeypatch.setenv("HF_HUB_CACHE", str(target))
+    assert g12._hf_cache_root() == target
+    monkeypatch.delenv("HF_HUB_CACHE")
+
+    # Legacy override
+    target = tmp_path / "legacy"
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(target))
+    assert g12._hf_cache_root() == target
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE")
+
+    # HF_HOME — cache root is ``$HF_HOME/hub``
+    target = tmp_path / "home"
+    monkeypatch.setenv("HF_HOME", str(target))
+    assert g12._hf_cache_root() == target / "hub"
+    monkeypatch.delenv("HF_HOME")
+
+    # Default
+    assert g12._hf_cache_root() == Path.home() / ".cache" / "huggingface" / "hub"

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -81,6 +81,55 @@ def _resolve_harness_profile_timeout() -> int:
         return 300
 
 
+def _resolve_harness_profiles_filter() -> tuple[str, ...] | None:
+    """Read an optional ``RAPID_MLX_HARNESS_PROFILES_FILTER`` env var.
+
+    Comma-separated list of profile names to scope the harness sweep to
+    (e.g. ``"codex,aider"`` runs only those two and skips
+    opencode/hermes/langchain). Used by ``scripts/release_check_m3_random.py``
+    (G12) to randomly subset the sweep per (model × harness) pick
+    without ballooning gauntlet wall-clock.
+
+    Returns ``None`` (no filter) when the env var is absent. When set:
+    * Unknown profile names → stderr warning + dropped from the run.
+    * All names unknown → stderr warning + None (no filter — abort the
+      filter rather than silently sweep nothing).
+    * Empty value or whitespace-only → stderr warning + None.
+
+    Reading at MODULE LOAD mirrors the timeout env above so callers
+    don't have to thread a kwarg through ``--tier harness``.
+    """
+    raw = os.environ.get("RAPID_MLX_HARNESS_PROFILES_FILTER")
+    if raw is None:
+        return None
+    requested = tuple(name.strip() for name in raw.split(",") if name.strip())
+    if not requested:
+        print(
+            "  Warning: RAPID_MLX_HARNESS_PROFILES_FILTER is empty/whitespace; "
+            "ignoring filter and running all profiles.",
+            file=sys.stderr,
+        )
+        return None
+    known = set(HARNESS_PROFILES)
+    valid = tuple(name for name in requested if name in known)
+    invalid = tuple(name for name in requested if name not in known)
+    if invalid:
+        print(
+            f"  Warning: RAPID_MLX_HARNESS_PROFILES_FILTER includes "
+            f"unknown profile(s) {invalid!r}; valid profiles are "
+            f"{HARNESS_PROFILES}.",
+            file=sys.stderr,
+        )
+    if not valid:
+        print(
+            "  Warning: RAPID_MLX_HARNESS_PROFILES_FILTER matched zero "
+            "valid profiles; ignoring filter and running all profiles.",
+            file=sys.stderr,
+        )
+        return None
+    return valid
+
+
 # Per-profile wall-clock cap for the harness sweep. One bad harness
 # (e.g. a codex e2e_file_read hang at 156s on a slow model) was taking
 # down the in-process server and cascading FAIL to every later profile
@@ -88,6 +137,12 @@ def _resolve_harness_profile_timeout() -> int:
 # ``HARNESS_PROFILE_TIMEOUT_S`` env var for slow boxes / future bigger
 # models. Resolved at module-load via ``_resolve_harness_profile_timeout``.
 HARNESS_PROFILE_TIMEOUT_S = _resolve_harness_profile_timeout()
+
+# Optional comma-separated subset of ``HARNESS_PROFILES`` to scope a
+# sweep to. None = no filter (sweep all 5). Resolved at module-load via
+# ``_resolve_harness_profiles_filter``. See that helper for env-var
+# semantics and edge-case handling.
+HARNESS_PROFILES_FILTER: tuple[str, ...] | None = _resolve_harness_profiles_filter()
 
 # Server health-probe timeout used between harness profiles. The probe
 # is a single GET /health — we don't want it to itself hang and look
@@ -881,7 +936,13 @@ def _run_harness(
     t0 = time.perf_counter()
     per_harness: list[tuple[str, bool, float, str]] = []
 
-    for profile_name in HARNESS_PROFILES:
+    # Optional subset filter — see ``_resolve_harness_profiles_filter``
+    # for env-var semantics. Iterating over the filtered list (not
+    # HARNESS_PROFILES) preserves the documented order while skipping
+    # profiles not in the active sweep. G12 (random-coverage) uses this
+    # to scope to e.g. 2 of the 5 harnesses per (model × round) pick.
+    profiles_to_run = HARNESS_PROFILES_FILTER or HARNESS_PROFILES
+    for profile_name in profiles_to_run:
         profile = get_profile(profile_name)
         if profile is None:
             per_harness.append(
@@ -967,6 +1028,14 @@ def _run_harness(
     # schema's ``additionalProperties: false`` plus ``required`` of all
     # 5 keys means this stays in lock-step with HARNESS_PROFILES (a
     # mismatch is a schema-validation failure at submission time).
+    #
+    # When ``HARNESS_PROFILES_FILTER`` is active, ``per_harness`` only
+    # contains entries for the filtered profiles — the resulting payload
+    # is NOT submission-safe (missing keys). The submit flow rejects
+    # ``--base-url`` (the only path that combines tier + submit) AND the
+    # filter env is only set by G12, which never passes ``--submit``.
+    # Adding a hard refusal in ``_run_tier_submit_flow`` would be belt-
+    # and-braces — see release_check_m3_random.py for the only caller.
     payload = {
         name: {
             "passed": ok,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1358,6 +1358,25 @@ def _run_tier_submit_flow(args) -> int:
     # The narrow --tier (no --submit) --base-url path is still
     # supported — that's the gauntlet/release_check use case where
     # we WANT to validate against an already-running server.
+    # Belt-and-braces: an active ``RAPID_MLX_HARNESS_PROFILES_FILTER``
+    # produces a partial harness payload (only the filtered keys), which
+    # would fail the schema-v2 ``required`` set at submission time
+    # downstream. The G12 gauntlet path only sets this env when calling
+    # ``--tier harness --base-url`` (no --submit) — but a future caller
+    # combining ``--submit`` with the filter would silently break here.
+    # Refuse loudly instead.
+    if os.environ.get("RAPID_MLX_HARNESS_PROFILES_FILTER"):
+        print(
+            "  Error: --submit is incompatible with "
+            "RAPID_MLX_HARNESS_PROFILES_FILTER. The filter scopes the "
+            "sweep to a subset of harnesses, producing a payload that "
+            "would fail the community-bench schema's required-keys check "
+            "(all 5 harnesses must be present). Unset the env var or "
+            "drop --submit.",
+            file=sys.stderr,
+        )
+        return 2
+
     if getattr(args, "base_url", None):
         print(
             "  Error: --base-url is incompatible with --submit. "


### PR DESCRIPTION
## Summary

Adds **G12** — a randomized release-gauntlet gate that boots N small models from the eligible alias pool and runs M harnesses × K rounds against each. Default is 2 × 2 × 3 = 12 sweeps, blocking release on any failure.

**Motivation:** Issue #686 (gemma-4 `<|tool_call>` wire-marker leak) was a model-specific class of regression that only surfaced when the model was actually booted under a real harness. The existing fixed gauntlet only exercises `qwen3.5-9b-4bit` — every release ships without ever booting the other ~28 registered small/medium aliases. This gate closes that blind spot without ballooning gauntlet wall-clock or disk.

## Design

- **Eligibility filter** (sample pool — see `scripts/release_check_m3_random.py` docstring):
  - 4 ≤ size_B ≤ 12 (smaller can't solve harness tasks → false-fail; larger busts M3 disk budget)
  - 4-bit quants only (8-bit doubles download cost for the same coverage signal)
  - excludes kimi-* (heavy, explicit user exclude)
  - excludes -vl- (vision; harness tasks are text-only)
  - excludes gemma-4-* (known model-side hang on tool-use prompts, see #686 + HF discussion)
- **Seed = today's UTC `YYYYMMDD`** so same-day reproductions land on the same model × harness picks.
- **Disk safety:** refuses to start if free disk < 30 GB; `rm -rf` the HF snapshot for each model after its rounds finish so peak working set is one model at a time.
- **Server lifecycle:** boot → wait for `/v1/models` (600 s, proc-aware so dead children fail fast) → run rounds (360 s each) → SIGTERM → wait for port release.
- **Cache resolution:** `_hf_cache_root()` mirrors `huggingface_hub` lookup order (`HF_HUB_CACHE` → `HUGGINGFACE_HUB_CACHE` → `$HF_HOME/hub` → default) so cleanup targets the actual snapshot tree even on non-default HF installs.

## Implementation

| File | Change |
|---|---|
| `vllm_mlx/bench/tier_runner.py` | New `_resolve_harness_profiles_filter()` reads `RAPID_MLX_HARNESS_PROFILES_FILTER`; tolerates whitespace, unknown names, empty string. Filter wired into harness loop. |
| `vllm_mlx/cli.py` | Belt-and-braces guard: `--submit` + filter env raises at parse time. A scoped sweep produces a payload missing required harness keys, which the community-bench schema would reject downstream — surfacing the error at the CLI is cheaper than failing at upload. |
| `scripts/release_check_m3_random.py` | **New** orchestrator: eligibility, seeding, boot, sweep, stop, cleanup. Round-1 codex fixes: separator-bounded size parser (fail-closed), env-aware HF cache root, args bounds validation, proc-aware server wait. |
| `scripts/release_check_m3.sh` | New G12 section after the fixed gauntlet. Supports `RAPID_MLX_SKIP_G12=1` for emergency releases plus `G12_MODELS` / `G12_HARNESSES` / `G12_ROUNDS` for tuning. |
| `tests/test_no_out_of_band_routing.py` | Allowlist `RAPID_MLX_HARNESS_PROFILES_FILTER` as a test/CI knob (never consulted by engine/scheduler/routing). |

## Test plan

- [x] `tests/test_release_check_random.py` (6 tests): eligibility filter, quant-suffix regression, reproducible-order sort, real `aliases.json` has ≥5 eligible models, HF cache dir shape, env-var resolution precedence
- [x] `tests/test_bench_tier_harness.py` +7 tests: `HARNESS_PROFILES_FILTER` env parsing (single, comma-sep, whitespace, unknown, all-unknown, empty)
- [x] `tests/test_no_out_of_band_routing.py`: env-var allowlist gate passes
- [x] Manual: `RAPID_MLX_HARNESS_PROFILES_FILTER=codex python3.12 -m vllm_mlx.cli bench qwen3.5-9b-4bit --tier harness --submit` rejects with the expected error message
- [x] Real `aliases.json` yields 9 eligible models under the new parser (≥5 floor)

## Notes

- Gate runs **after** the fixed gauntlet so a single-model regression in the canonical alias still fails fast at G1–G9.
- Default sweep size (12 runs) chosen to add ~10–20 min wall-clock — the bottleneck is model download for cold caches, not the harness rounds themselves.
- End-to-end validation against a real model boot is part of the **next** release cut (the gate is built to provide it) — it's not a pre-merge check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)