### PR TITLE
fix(pr_validate): per-candidate stress_timeout_s override

### DIFF
--- a/scripts/pr_validate/golden_models.yaml
+++ b/scripts/pr_validate/golden_models.yaml
@@ -149,6 +149,7 @@ families:
       - id: mlx-community/diffusiongemma-26B-A4B-it-4bit
         ram_gb_required: 20
         quality_tier: smoke
+        stress_timeout_s: 1800  # text-diffusion: ~2x autoregressive per-token wall-clock
 
   - family: harmony
     candidates:

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -65,6 +65,13 @@ SERVER_REQUEST_TIMEOUT_S = 180
 # the prefix cache to disk — for large models this can run past the old
 # 10s budget. 30s covers a 35B model's cache flush comfortably.
 PORT_FREE_TIMEOUT_S = 30
+# Default wall-clock budget for ``scripts/stress_test.py``. Sized for
+# autoregressive models on the 27-35B golden registry; intentionally
+# tight to surface regressions. Text-diffusion candidates override this
+# via ``stress_timeout_s`` in golden_models.yaml — see ``ModelChoice``
+# and issue #664. Do NOT bump this default to accommodate diffusion;
+# that would weaken regression detection on autoregressive models.
+DEFAULT_STRESS_TIMEOUT_S = 900
 RAM_HEADROOM_GB = 8.0  # leave this much free for the OS + model load spike
 
 
@@ -75,6 +82,14 @@ class ModelChoice:
     ram_gb_required: float
     quality_tier: str
     extra_args: list[str]
+    # Per-candidate override for the ``scripts/stress_test.py`` wall-clock
+    # budget. Default ``None`` falls back to ``DEFAULT_STRESS_TIMEOUT_S``
+    # (900s / 15min) which is sized for autoregressive models. Text-
+    # diffusion models (e.g. DiffusionGemma) iteratively denoise all
+    # positions in parallel per step, so per-token wall-clock is materially
+    # higher and the long-generation sub-test can blow the 15-min budget.
+    # See issue #664.
+    stress_timeout_s: int | None = None
 
 
 class StressE2EBenchStep(Step):
@@ -230,6 +245,8 @@ def _select_models(registry: dict[str, Any], usable_gb: float) -> list[ModelChoi
     for family in registry.get("families", []):
         for cand in family["candidates"]:
             if cand["ram_gb_required"] <= usable_gb:
+                raw_timeout = cand.get("stress_timeout_s")
+                stress_timeout_s = int(raw_timeout) if raw_timeout is not None else None
                 out.append(
                     ModelChoice(
                         family=family["family"],
@@ -239,6 +256,7 @@ def _select_models(registry: dict[str, Any], usable_gb: float) -> list[ModelChoi
                         extra_args=list(
                             (overrides.get(cand["id"], {}) or {}).get("args", [])
                         ),
+                        stress_timeout_s=stress_timeout_s,
                     )
                 )
                 break  # stop at first fit per family
@@ -450,6 +468,16 @@ def _force_kill_port(port: int) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _effective_stress_timeout(choice: ModelChoice) -> int:
+    """Resolve the wall-clock budget for ``scripts/stress_test.py`` for
+    ``choice``. Returns the per-candidate ``stress_timeout_s`` override
+    when set in golden_models.yaml, else ``DEFAULT_STRESS_TIMEOUT_S``.
+
+    Extracted so the resolution is unit-testable without mocking
+    ``subprocess.run`` (see issue #664)."""
+    return choice.stress_timeout_s or DEFAULT_STRESS_TIMEOUT_S
+
+
 def _run_stress(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
     log = ctx.artifact_path(f"stress-{_safe_name(choice.model_id)}.log")
     proc = subprocess.run(  # noqa: S603
@@ -457,7 +485,7 @@ def _run_stress(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
         capture_output=True,
         text=True,
         cwd=str(ctx.repo_root),
-        timeout=900,
+        timeout=_effective_stress_timeout(choice),
     )
     log.write_text((proc.stdout or "") + (proc.stderr or ""))
     summary = _grep_last(proc.stdout, "passed")

--- a/tests/test_pr_validate_stress_timeout.py
+++ b/tests/test_pr_validate_stress_timeout.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the per-candidate ``stress_timeout_s`` override on the
+``stress_e2e_bench`` pr_validate step.
+
+Issue #664: the previous hardcoded ``timeout=900`` (15 min) for
+``scripts/stress_test.py`` was sized for autoregressive models. Text-
+diffusion models (e.g. ``mlx-community/diffusiongemma-26B-A4B-it-4bit``)
+denoise all positions in parallel per step, so per-token wall-clock is
+materially higher and the long-generation sub-test can blow the 15-min
+budget. The fix adds an optional ``stress_timeout_s`` field on
+``ModelChoice`` (loaded from ``golden_models.yaml``) that overrides the
+default. This test locks in:
+
+* ``_effective_stress_timeout`` returns the override when set.
+* ``_effective_stress_timeout`` falls back to 900 when unset.
+* ``_run_stress`` propagates that value to ``subprocess.run``'s
+  ``timeout=`` kwarg (the actual regression site).
+* The diffusiongemma entry in ``golden_models.yaml`` ships with
+  ``stress_timeout_s: 1800`` (config-drift gate).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.pr_validate.steps import stress_e2e_bench
+from scripts.pr_validate.steps.stress_e2e_bench import (
+    DEFAULT_STRESS_TIMEOUT_S,
+    ModelChoice,
+    _effective_stress_timeout,
+    _run_stress,
+)
+
+
+def _make_choice(stress_timeout_s: int | None = None) -> ModelChoice:
+    return ModelChoice(
+        family="diffusion-gemma",
+        model_id="mlx-community/diffusiongemma-26B-A4B-it-4bit",
+        ram_gb_required=20.0,
+        quality_tier="smoke",
+        extra_args=[],
+        stress_timeout_s=stress_timeout_s,
+    )
+
+
+def test_effective_timeout_uses_override_when_set() -> None:
+    """A candidate carrying ``stress_timeout_s`` (e.g. the diffusion
+    family) gets its override, not the autoregressive default."""
+    choice = _make_choice(stress_timeout_s=1800)
+    assert _effective_stress_timeout(choice) == 1800
+
+
+def test_effective_timeout_falls_back_to_default_when_unset() -> None:
+    """Autoregressive candidates leave ``stress_timeout_s`` at ``None``
+    and must keep the tight 900s default — bumping the default would
+    weaken regression detection (see issue #664)."""
+    choice = _make_choice(stress_timeout_s=None)
+    assert _effective_stress_timeout(choice) == 900
+    assert _effective_stress_timeout(choice) == DEFAULT_STRESS_TIMEOUT_S
+
+
+def test_run_stress_passes_override_to_subprocess(tmp_path: Path) -> None:
+    """The regression site: ``_run_stress`` must forward the resolved
+    timeout to ``subprocess.run``. Mock subprocess and capture the
+    kwargs."""
+    choice = _make_choice(stress_timeout_s=1800)
+    ctx = SimpleNamespace(
+        artifact_path=lambda name: tmp_path / name,
+        repo_root=tmp_path,
+    )
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="3 passed", stderr="")
+
+    with patch.object(stress_e2e_bench.subprocess, "run", side_effect=fake_run):
+        result = _run_stress(ctx, choice)
+
+    assert captured["timeout"] == 1800
+    assert result["status"] == "pass"
+
+
+def test_run_stress_falls_back_to_default_when_unset(tmp_path: Path) -> None:
+    """Symmetric: unset ``stress_timeout_s`` → ``subprocess.run`` sees
+    900, not None / 0 / a different default."""
+    choice = _make_choice(stress_timeout_s=None)
+    ctx = SimpleNamespace(
+        artifact_path=lambda name: tmp_path / name,
+        repo_root=tmp_path,
+    )
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="3 passed", stderr="")
+
+    with patch.object(stress_e2e_bench.subprocess, "run", side_effect=fake_run):
+        _run_stress(ctx, choice)
+
+    assert captured["timeout"] == 900
+
+
+def test_golden_models_yaml_diffusiongemma_has_override() -> None:
+    """Config-drift gate: the diffusiongemma candidate in
+    ``golden_models.yaml`` MUST carry ``stress_timeout_s: 1800``. If
+    someone reverts the YAML without reverting the dataclass plumbing,
+    this test catches it before the next high-blast PR hangs for 15 min."""
+    import yaml
+
+    registry_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "pr_validate"
+        / "golden_models.yaml"
+    )
+    registry = yaml.safe_load(registry_path.read_text())
+
+    diffusion_candidate = None
+    for family in registry.get("families", []):
+        if family.get("family") == "diffusion-gemma":
+            for cand in family.get("candidates", []):
+                if cand.get("id") == "mlx-community/diffusiongemma-26B-A4B-it-4bit":
+                    diffusion_candidate = cand
+                    break
+            break
+
+    assert diffusion_candidate is not None, (
+        "diffusion-gemma family / candidate missing from golden_models.yaml"
+    )
+    assert diffusion_candidate.get("stress_timeout_s") == 1800, (
+        "diffusiongemma stress_timeout_s must be 1800s (text-diffusion "
+        "denoise per step is ~2x autoregressive per-token wall-clock — "
+        "see issue #664)"
+    )
+
+
+def test_select_models_picks_up_stress_timeout_from_yaml(tmp_path: Path) -> None:
+    """The loader (``_select_models``) must thread ``stress_timeout_s``
+    from the YAML dict into the ``ModelChoice``. Otherwise the YAML
+    change above is silently dropped at the data boundary."""
+    registry = {
+        "families": [
+            {
+                "family": "diffusion-gemma",
+                "candidates": [
+                    {
+                        "id": "mlx-community/diffusiongemma-26B-A4B-it-4bit",
+                        "ram_gb_required": 20,
+                        "quality_tier": "smoke",
+                        "stress_timeout_s": 1800,
+                    }
+                ],
+            },
+            {
+                "family": "ar-model",
+                "candidates": [
+                    {
+                        "id": "fake/ar-model",
+                        "ram_gb_required": 10,
+                        "quality_tier": "golden",
+                        # no stress_timeout_s → must stay None and fall
+                        # through to 900s at the timeout site.
+                    }
+                ],
+            },
+        ],
+        "overrides": {},
+    }
+    choices = stress_e2e_bench._select_models(registry, usable_gb=100.0)
+    by_family = {c.family: c for c in choices}
+
+    assert by_family["diffusion-gemma"].stress_timeout_s == 1800
+    assert by_family["ar-model"].stress_timeout_s is None
+    assert _effective_stress_timeout(by_family["ar-model"]) == 900


### PR DESCRIPTION
## Summary

Closes #664.

The hardcoded `timeout=900` (15 min) in `scripts/pr_validate/steps/stress_e2e_bench.py::_run_stress` was sized for autoregressive models. Text-diffusion candidates (`mlx-community/diffusiongemma-26B-A4B-it-4bit`) denoise all positions in parallel per step, so per-token wall-clock is materially higher and the "Long generation — 1024 token output" stress sub-test alone can blow the 15-min budget for this model class. Surfaced as a `TimeoutExpired` on the v0.7.28 release scorecard once DiffusionEngine coverage was added to the matrix.

## Fix (issue #664, option A — per-candidate override)

- New optional `stress_timeout_s` field on each candidate in `scripts/pr_validate/golden_models.yaml`.
- New `DEFAULT_STRESS_TIMEOUT_S = 900` module constant (the previously hardcoded value). **Intentionally not bumped** — keeping the default tight preserves regression detection on autoregressive models, which the issue calls out as deliberate.
- `ModelChoice` gains `stress_timeout_s: int | None = None`.
- `_select_models` threads `stress_timeout_s` from the YAML dict into the `ModelChoice`.
- New `_effective_stress_timeout(choice)` helper resolves `choice.stress_timeout_s or DEFAULT_STRESS_TIMEOUT_S`; it is the single source consumed at the `subprocess.run(..., timeout=...)` site. Extracted so the resolution is unit-testable without mocking `subprocess.run` end-to-end.
- `golden_models.yaml`: only the diffusiongemma candidate gets `stress_timeout_s: 1800` with an inline comment `# text-diffusion: ~2x autoregressive per-token wall-clock`. No other YAML entries are touched.

## Tests

New `tests/test_pr_validate_stress_timeout.py` (6 cases):

- `_effective_stress_timeout` returns the override when set.
- `_effective_stress_timeout` falls back to 900 when unset.
- `_run_stress` forwards the resolved timeout to `subprocess.run` (the regression site), in both override and default branches — `subprocess.run` is patched and the `timeout=` kwarg captured.
- `_select_models` reads `stress_timeout_s` from the YAML dict for the diffusion family, leaves it `None` for AR candidates, and the AR candidate still resolves to 900s at the timeout site.
- Config-drift gate: `golden_models.yaml`'s diffusiongemma entry must carry `stress_timeout_s == 1800` so a partial revert can't silently re-introduce the 15-min cliff.

## Test plan

- [x] `python3.12 -m ruff format scripts/pr_validate/steps/stress_e2e_bench.py tests/test_pr_validate_stress_timeout.py` — clean
- [x] `python3.12 -m ruff check scripts/pr_validate/steps/stress_e2e_bench.py tests/test_pr_validate_stress_timeout.py` — All checks passed
- [x] `python3.12 -m pytest tests/test_pr_validate*.py -x -q` — 189 passed
_Note: end-to-end validation against a real diffusiongemma boot is what the override is built to provide — it surfaces on the next high-blast-radius PR or release cut. Not a pre-merge check._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
