### PR TITLE
fix(mirror): guarantee _PROGRESS.flush() via try/finally around pool

### DIFF
--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3559,3 +3559,91 @@ def test_safe_display_name_strips_control_chars():
     out = _mirror._safe_display_name(long, max_len=40)
     assert len(out) <= 40
     assert out.endswith("_TAIL.bin") or "TAIL" in out
+
+
+def test_progress_tracker_flush_runs_even_when_worker_raises_unwhitelisted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression for issue #689 (PR #682 follow-up).
+
+    The per-pull ``_ProgressTracker.flush()`` call lived AFTER the
+    ``with ThreadPoolExecutor(...)`` block but OUTSIDE any try/finally.
+    If a worker raised a non-whitelisted exception (e.g. ``TypeError``
+    from a programmer error or future refactor — only ``OSError`` /
+    ``TimeoutError`` / ``URLError`` / ``HTTPError`` / HF error shapes
+    are converted to a silent miss), the exception propagated past
+    ``pool.__exit__`` and ``flush()`` never ran. Result: the desktop
+    progress bar plateaus short of 100% before the failure banner.
+
+    The fix wraps the pool block in ``try: ... finally: flush()`` so
+    the final heartbeat always lands. This test pins that:
+
+    * Monkeypatch ``_download_one_from_r2`` to raise ``TypeError``,
+      which propagates out of the per-file worker (``_do_file``).
+    * Spy on ``_ProgressTracker.flush`` to count invocations.
+    * Assert the exception still propagates (the fix must NOT swallow
+      it — programmer errors should still surface a real stack trace).
+    * Assert ``flush()`` ran exactly once despite the failure path.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "dead" * 10
+    files = [
+        ("config.json", 100),
+        ("model.safetensors", 600),
+    ]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+
+    # Spy on flush() at the class level so we catch the call regardless
+    # of which per-pull instance ran. The original is restored by
+    # monkeypatch teardown.
+    flush_calls: list[int] = []
+    real_flush = _mirror._ProgressTracker.flush
+
+    def _spy_flush(self):
+        flush_calls.append(1)
+        return real_flush(self)
+
+    monkeypatch.setattr(_mirror._ProgressTracker, "flush", _spy_flush)
+
+    # Make the per-file R2 worker raise a non-whitelisted exception.
+    # ``_do_file`` calls ``_download_one_from_r2`` on the R2 path and
+    # does NOT catch ``TypeError``, so it propagates out of the worker;
+    # ``fut.result()`` in the dispatcher loop re-raises it, the
+    # whitelisted ``except`` clause doesn't match, and the exception
+    # leaves the ``with`` block. Without the fix, the post-with
+    # ``progress_tracker.flush()`` is skipped.
+    def _boom(*_args, **_kwargs):
+        raise TypeError("simulated programmer error in R2 worker")
+
+    monkeypatch.setattr(_mirror, "_download_one_from_r2", _boom)
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download"),
+        pytest.raises(TypeError, match="simulated programmer error"),
+    ):
+        _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    # The exception must propagate AND flush() must still have fired.
+    # Exactly one call: one ``_ProgressTracker`` instance per pull, one
+    # ``finally`` clause, one flush. More than one would suggest a
+    # double-flush regression (e.g. someone added an inner flush inside
+    # the ``with`` body without removing the outer one).
+    assert flush_calls == [1], (
+        f"expected exactly one _ProgressTracker.flush() call after the "
+        f"unwhitelisted worker exception, got {len(flush_calls)}. "
+        f"The post-with flush is gated by a try/finally so the desktop "
+        f"progress bar lands at 100% even on the failure path."
+    )

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1464,92 +1464,102 @@ def download_with_mirror_fallback(
     # summary so users see throughput, not just total bytes.
     pull_started = time.monotonic()
     completed = 0
-    with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as pool:
-        futures = {pool.submit(_do_file, item): item[0] for item in files}
-        for fut in as_completed(futures):
-            fname = futures[fut]
-            # Codex round-3 NIT #1: narrow the worker exception net.
-            # Only convert expected network / filesystem / HF errors into
-            # a silent "miss". Programmer errors (TypeError, etc.) and
-            # HF validation errors propagate so misuse surfaces a real
-            # stack trace instead of disappearing into the fallback.
-            try:
-                _, kind, size = fut.result()
-            except (
-                OSError,
-                TimeoutError,
-                urllib.error.URLError,
-                urllib.error.HTTPError,
-                EntryNotFoundError,
-                RepositoryNotFoundError,
-                HfHubHTTPError,
-            ):
-                kind, size = "miss", 0
-            if kind == "r2":
-                r2_hits += 1
-                total_bytes += size
-            elif kind == "hf":
-                hf_hits += 1
-                total_bytes += size
-                # HF fallback's tqdm doesn't feed into the R2 chunk loop,
-                # so the aggregate tracker would miss these bytes
-                # entirely. Bump it at completion so the heartbeat
-                # reflects HF-fallback files too (size known once
-                # ``hf_hub_download`` returned). Codex R4 defensive
-                # guard: skip the credit when stat() returned 0 (rare —
-                # broken symlink / disappearing snapshot path), since
-                # ``add(0)`` is a no-op anyway. Belt-and-braces against
-                # future refactors that might surface a non-int ``size``.
-                if isinstance(size, int) and size > 0:
-                    progress_tracker.add(size)
-            elif kind == "cached":
-                # Already present — count as r2/hf-neutral but include
-                # bytes so the summary reflects the full snapshot size.
-                total_bytes += size
-                # Cached files never enter the chunk loop — credit them
-                # to the tracker on the dispatcher thread so the
-                # heartbeat doesn't undercount a warm pull. Same defensive
-                # guard as the HF arm above (codex R4 on PR #682).
-                if isinstance(size, int) and size > 0:
-                    progress_tracker.add(size)
-            else:
-                misses.append(fname)
-            # Issue #651 follow-up: per-file completion line so the
-            # user sees forward progress while multi-GB shards stream.
-            # We emit one line per file at the point it lands — printing
-            # from the ``as_completed`` loop in the main thread avoids
-            # needing a stdout lock, even though the underlying workers
-            # finish in non-deterministic order. Misses are logged too
-            # so the user understands why we'll fall back to
-            # ``snapshot_download`` further down.
-            completed += 1
-            # Only the size-bearing kinds need a MB readout. ``size``
-            # is always an int (workers return 0 on miss) but keeping
-            # the divide inside the branches that use it makes it
-            # obvious that the miss tag never depends on bytes — codex
-            # round-1 NIT on PR #657.
-            if kind == "r2":
-                tag = f"{DIM}R2 ({size / 1e6:.0f} MB){RESET}"
-            elif kind == "hf":
-                tag = f"{DIM}HF ({size / 1e6:.0f} MB, fallback){RESET}"
-            elif kind == "cached":
-                tag = f"{DIM}cached ({size / 1e6:.0f} MB){RESET}"
-            else:
-                # ``miss`` / sanitized failure — surface the reason so
-                # users aren't surprised when the outer caller falls
-                # back to ``snapshot_download``.
-                tag = f"{DIM}miss (will retry via HF snapshot_download){RESET}"
-            _print_dim(
-                f"  {DIM}[{completed}/{total_files_planned}]{RESET} "
-                f"{_safe_display_name(fname)} {tag}"
-            )
-
-    # Final heartbeat: a sub-500 ms tail of bytes can finish between the
-    # last throttle window and the loop exit. Emit one unconditional
-    # ``[bytes] D/T`` so the desktop's progress bar lands at 100% before
-    # the next phase banner ("Verifying snapshot…", "Warming up…")
-    # appears.
-    progress_tracker.flush()
+    # Issue #689: wrap the pool block in try/finally so the final
+    # ``progress_tracker.flush()`` always fires — even when a worker
+    # raises a non-whitelisted exception (e.g. ``TypeError`` from a
+    # future refactor) and the exception propagates past
+    # ``pool.__exit__``. Without this guard the desktop progress bar
+    # plateaus short of 100% before the failure banner. The exception
+    # still propagates; we just guarantee the heartbeat lands first.
+    try:
+        with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as pool:
+            futures = {pool.submit(_do_file, item): item[0] for item in files}
+            for fut in as_completed(futures):
+                fname = futures[fut]
+                # Codex round-3 NIT #1: narrow the worker exception net.
+                # Only convert expected network / filesystem / HF errors into
+                # a silent "miss". Programmer errors (TypeError, etc.) and
+                # HF validation errors propagate so misuse surfaces a real
+                # stack trace instead of disappearing into the fallback.
+                try:
+                    _, kind, size = fut.result()
+                except (
+                    OSError,
+                    TimeoutError,
+                    urllib.error.URLError,
+                    urllib.error.HTTPError,
+                    EntryNotFoundError,
+                    RepositoryNotFoundError,
+                    HfHubHTTPError,
+                ):
+                    kind, size = "miss", 0
+                if kind == "r2":
+                    r2_hits += 1
+                    total_bytes += size
+                elif kind == "hf":
+                    hf_hits += 1
+                    total_bytes += size
+                    # HF fallback's tqdm doesn't feed into the R2 chunk loop,
+                    # so the aggregate tracker would miss these bytes
+                    # entirely. Bump it at completion so the heartbeat
+                    # reflects HF-fallback files too (size known once
+                    # ``hf_hub_download`` returned). Codex R4 defensive
+                    # guard: skip the credit when stat() returned 0 (rare —
+                    # broken symlink / disappearing snapshot path), since
+                    # ``add(0)`` is a no-op anyway. Belt-and-braces against
+                    # future refactors that might surface a non-int ``size``.
+                    if isinstance(size, int) and size > 0:
+                        progress_tracker.add(size)
+                elif kind == "cached":
+                    # Already present — count as r2/hf-neutral but include
+                    # bytes so the summary reflects the full snapshot size.
+                    total_bytes += size
+                    # Cached files never enter the chunk loop — credit them
+                    # to the tracker on the dispatcher thread so the
+                    # heartbeat doesn't undercount a warm pull. Same defensive
+                    # guard as the HF arm above (codex R4 on PR #682).
+                    if isinstance(size, int) and size > 0:
+                        progress_tracker.add(size)
+                else:
+                    misses.append(fname)
+                # Issue #651 follow-up: per-file completion line so the
+                # user sees forward progress while multi-GB shards stream.
+                # We emit one line per file at the point it lands — printing
+                # from the ``as_completed`` loop in the main thread avoids
+                # needing a stdout lock, even though the underlying workers
+                # finish in non-deterministic order. Misses are logged too
+                # so the user understands why we'll fall back to
+                # ``snapshot_download`` further down.
+                completed += 1
+                # Only the size-bearing kinds need a MB readout. ``size``
+                # is always an int (workers return 0 on miss) but keeping
+                # the divide inside the branches that use it makes it
+                # obvious that the miss tag never depends on bytes — codex
+                # round-1 NIT on PR #657.
+                if kind == "r2":
+                    tag = f"{DIM}R2 ({size / 1e6:.0f} MB){RESET}"
+                elif kind == "hf":
+                    tag = f"{DIM}HF ({size / 1e6:.0f} MB, fallback){RESET}"
+                elif kind == "cached":
+                    tag = f"{DIM}cached ({size / 1e6:.0f} MB){RESET}"
+                else:
+                    # ``miss`` / sanitized failure — surface the reason so
+                    # users aren't surprised when the outer caller falls
+                    # back to ``snapshot_download``.
+                    tag = f"{DIM}miss (will retry via HF snapshot_download){RESET}"
+                _print_dim(
+                    f"  {DIM}[{completed}/{total_files_planned}]{RESET} "
+                    f"{_safe_display_name(fname)} {tag}"
+                )
+    finally:
+        # Final heartbeat: a sub-500 ms tail of bytes can finish between the
+        # last throttle window and the loop exit. Emit one unconditional
+        # ``[bytes] D/T`` so the desktop's progress bar lands at 100% before
+        # the next phase banner ("Verifying snapshot…", "Warming up…")
+        # appears. The ``finally`` clause (issue #689) ensures this also
+        # runs on the exception path so the bar doesn't plateau short of
+        # 100% before the failure banner.
+        progress_tracker.flush()
 
     if misses:
         # At least one file we couldn't get from either source. Caller


### PR DESCRIPTION
## What broke

`vllm_mlx/_mirror.py`'s per-pull `_ProgressTracker.flush()` call (added by #682) lived AFTER the `with ThreadPoolExecutor(...)` block in `download_with_mirror_fallback`, but OUTSIDE any try/finally.

The dispatcher loop's `except` only catches a whitelist of expected error shapes:

```python
except (
    OSError,
    TimeoutError,
    urllib.error.URLError,
    urllib.error.HTTPError,
    EntryNotFoundError,
    RepositoryNotFoundError,
    HfHubHTTPError,
):
    kind, size = "miss", 0
```

A non-whitelisted exception (e.g. `TypeError` from a programmer error or future refactor) propagates past `pool.__exit__` and the post-with `flush()` never runs. Result: the desktop progress bar plateaus short of 100% before the failure banner. Minor UX regression — not a correctness bug. NIT severity.

## Fix

Wrap the pool block in `try: ... finally: progress_tracker.flush()` so the final `[bytes] D/T` heartbeat always lands, even on the unwhitelisted-error path. The exception still propagates unchanged; we only guarantee one extra heartbeat ahead of the stack trace.

## Test

`test_progress_tracker_flush_runs_even_when_worker_raises_unwhitelisted` in `tests/test_mirror_pull.py`:

1. Monkeypatches `_download_one_from_r2` to raise `TypeError` from a per-file worker.
2. Spies on `_ProgressTracker.flush` at the class level to count invocations.
3. Asserts the exception still propagates via `pytest.raises(TypeError)` (the fix must not swallow it — programmer errors should still surface a real stack trace).
4. Asserts `flush()` ran exactly once despite the failure path.

Verified the test fails on `main` (records 0 flush calls) and passes with the fix (records 1).

## Scope

Touches only `vllm_mlx/_mirror.py` and `tests/test_mirror_pull.py`. No version bump (internal-only change; `_mirror.py` is not in the watched paths).

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)