### PR TITLE
fix(server): skip port preflight in --listen-fd mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.33"
+version = "0.7.34"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -384,9 +384,7 @@ def test_serve_command_skips_port_preflight_when_listen_fd_set(
         blocker.listen(1)
         blocked_port = blocker.getsockname()[1]
 
-        ns = _minimal_serve_ns(
-            listen_fd=11, host="127.0.0.1", port=blocked_port
-        )
+        ns = _minimal_serve_ns(listen_fd=11, host="127.0.0.1", port=blocked_port)
         # If the preflight runs, this raises SystemExit(1) before reaching
         # the uvicorn.run stub. The test passes only when the preflight
         # is correctly skipped in the listen-fd branch.

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -358,6 +358,47 @@ def test_serve_command_dispatches_uvicorn_with_host_port_when_listen_fd_unset(
     assert cfg.bind_listen_fd is None
 
 
+def test_serve_command_skips_port_preflight_when_listen_fd_set(
+    stub_heavy_serve_deps,
+):
+    """When ``--listen-fd N`` is set, ``serve_command`` MUST skip the
+    ``host``/``port`` bind preflight. The supervisor has already bound
+    the socket; running our own bind check against the same address
+    always collides and would refuse to start.
+
+    Regression: PR #696 introduced ``--listen-fd`` but the preflight at
+    the top of ``serve_command`` kept running unconditionally, so any
+    real socket-activation launcher hit "Port N is already in use" and
+    ``sys.exit(1)`` before ever reaching ``uvicorn.run``.
+    """
+    import socket
+
+    captured = _capture_uvicorn_run(stub_heavy_serve_deps)
+
+    # Pre-bind the default serve port so the preflight WOULD fail if it
+    # ran. Using SO_REUSEADDR matches the production preflight's own
+    # socket setup — the preflight only fails when something is actively
+    # listening, not when the port is in TIME_WAIT.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        blocked_port = blocker.getsockname()[1]
+
+        ns = _minimal_serve_ns(
+            listen_fd=11, host="127.0.0.1", port=blocked_port
+        )
+        # If the preflight runs, this raises SystemExit(1) before reaching
+        # the uvicorn.run stub. The test passes only when the preflight
+        # is correctly skipped in the listen-fd branch.
+        cli.serve_command(ns)
+
+    assert captured.get("fd") == 11, (
+        f"expected uvicorn.run(fd=11, ...), got {captured!r}"
+    )
+    assert "host" not in captured
+    assert "port" not in captured
+
+
 def test_serve_command_resets_stale_bind_fields_between_invocations(
     stub_heavy_serve_deps,
 ):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1192,19 +1192,24 @@ def serve_command(args):
     # previous rapid-mlx process exited), even though uvicorn would happily
     # bind it. Caused spurious "port in use" errors for back-to-back server
     # starts in the validation pipeline.
-    import socket
+    #
+    # Skip in --listen-fd mode: the supervisor has already bound the socket
+    # and handed us the fd. There is no host/port for us to check, and any
+    # bind we attempt here would race or collide with the inherited socket.
+    if getattr(args, "listen_fd", None) is None:
+        import socket
 
-    _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    try:
-        _sock.bind((args.host, args.port))
-        _sock.close()
-    except OSError:
-        print(f"\n  Error: Port {args.port} is already in use.")
-        print(
-            f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
-        )
-        sys.exit(1)
+        _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            _sock.bind((args.host, args.port))
+            _sock.close()
+        except OSError:
+            print(f"\n  Error: Port {args.port} is already in use.")
+            print(
+                f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
+            )
+            sys.exit(1)
 
     # Check disk space before downloading model
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1199,17 +1199,21 @@ def serve_command(args):
     if getattr(args, "listen_fd", None) is None:
         import socket
 
-        _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            _sock.bind((args.host, args.port))
-            _sock.close()
-        except OSError:
-            print(f"\n  Error: Port {args.port} is already in use.")
-            print(
-                f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
-            )
-            sys.exit(1)
+        # ``with`` here guarantees the preflight socket is closed on every
+        # exit path — including OSError during ``bind``. The previous form
+        # called ``_sock.close()`` only on the success branch, which leaked
+        # the fd whenever the bind raised (e.g. when running under a test
+        # harness that catches ``SystemExit``).
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
+            _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                _sock.bind((args.host, args.port))
+            except OSError:
+                print(f"\n  Error: Port {args.port} is already in use.")
+                print(
+                    f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
+                )
+                sys.exit(1)
 
     # Check disk space before downloading model
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))


### PR DESCRIPTION
## Summary

- **Regression from PR #696.** When `rapid-mlx serve --listen-fd <N>` was added for socket activation, the host/port bind preflight at the top of `serve_command` kept running unconditionally. The supervisor has already bound the listening socket on `args.host:args.port`, so the preflight ALWAYS collides — every real socket-activation launch hit `Port N is already in use` and `sys.exit(1)` before reaching `uvicorn.run`.
- **Fix:** guard the preflight on `args.listen_fd is None`. In the fd branch there is no host/port for us to check; any bind we attempt races or collides with the inherited socket.
- **Test:** added `test_serve_command_skips_port_preflight_when_listen_fd_set` — pre-binds a real listener, then drives `serve_command(...)` with `--listen-fd N`, asserts the dispatch reaches the `uvicorn.run` stub. Without the fix this raises `SystemExit(1)` and the test fails.

## Why the existing tests missed it

The behavioral tests in `tests/test_serve_listen_fd.py` only used the argparse-default port (8000) in a clean env. The preflight bound it cleanly, didn't error, didn't print — the collision case was never exercised. The new test pre-binds a real OS-assigned port so the preflight WOULD fail if it ran.

## How it was caught

Tier 3 regression validation: drove `rapid-mlx serve --listen-fd 3` via a launcher script that does the supervisor's pre-bind. The server died at the preflight on the first attempt; with the fix it boots cleanly and serves correctly through auth + 5-concurrent stress.

## Test plan

- [x] `pytest tests/test_serve_listen_fd.py` — 20/20 pass (new test included)
- [x] Live socket-activation launch: launcher pre-binds, `rapid-mlx serve --listen-fd 3` boots, banner prints `Uvicorn running on socket ('127.0.0.1', 8000)`
- [x] Anonymous request → 401 (bind→auth ordering held)
- [x] 5 concurrent authed completions → 5×200
- [x] Post-stress anon → still 401
- [x] Version bumped 0.7.33 → 0.7.34 (this PR makes a previously-broken user-facing flag actually work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)