### PR TITLE
fix(diffusion): close stream_diffusion_generate on every exit path (#698)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.34"
+version = "0.7.35"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -3106,3 +3106,173 @@ class TestChannelHeaderStrip:
             f"channel header not stripped on trailing-finish path: {combined!r}"
         )
         assert "Yes." in combined
+
+
+class TestGeneratorClosedOnEveryExit:
+    """Issue #698 regression: ``_run_generator`` MUST call
+    ``gen.close()`` on every exit path. Python's ``for`` statement
+    does NOT close a generator on early ``break`` or ``return`` — it
+    leaves the generator's frame (and all mlx-vlm tensors rooted to
+    it) waiting for cyclic GC. One ``max_tokens=1024`` request was
+    enough to keep ~10-15 GB of MLX denoising state rooted across
+    the persistent worker thread, sending subsequent short requests
+    into swap-thrash and 100× latency cliffs.
+
+    The fix wraps the for-loop in ``try/finally`` with an explicit
+    ``gen.close()``. These tests pin all three exit paths:
+
+      * ``finish_reason`` triggers the in-loop ``return``
+      * ``cancel_event`` triggers the in-loop ``break``
+      * generator exhausts naturally (no finish_reason) → falls
+        through to the trailing-finish-chunk path
+
+    All three MUST call ``close()`` exactly once.
+    """
+
+    def _drive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        yields: list[FakeGenerationResult],
+        *,
+        cancel_before_run: bool = False,
+        cancel_at_yield: int | None = None,
+    ) -> dict[str, Any]:
+        """Boot the engine, drive ``_run_generator`` against tracking
+        yields, return the close-count state dict.
+
+        ``__next__`` must live on the class (not the instance) — the
+        for-loop iterator protocol uses CPython type-slot lookup, so
+        an instance attribute named ``__next__`` is silently ignored.
+        We thread ``cancel_event`` + ``cancel_at_yield`` into the
+        TrackingGen class itself so the cancel-arm fires from the
+        class-level method.
+        """
+        import queue as _queue
+        import threading as _threading
+
+        _install_mlx_vlm_mock(monkeypatch, stream_yields=yields)
+        diffusion_mod = sys.modules["mlx_vlm.generate.diffusion"]
+        state: dict[str, Any] = {"close_calls": 0, "yielded": 0}
+        cancel_event = _threading.Event()
+        if cancel_before_run:
+            cancel_event.set()
+
+        class _TrackingGen:
+            """Class-defined ``__iter__``/``__next__``/``close`` so the
+            iterator protocol picks them up via type slots."""
+
+            def __init__(self, items: list[FakeGenerationResult]) -> None:
+                self._items = iter(items)
+
+            def __iter__(self) -> _TrackingGen:
+                return self
+
+            def __next__(self) -> FakeGenerationResult:
+                item = next(self._items)
+                state["yielded"] += 1
+                # Flip the cancel event AFTER counting this yield —
+                # _run_generator's per-iteration cancel check fires
+                # at the TOP of the next iteration, so the break
+                # exits before consuming any further yields.
+                if (
+                    cancel_at_yield is not None
+                    and state["yielded"] >= cancel_at_yield
+                ):
+                    cancel_event.set()
+                return item
+
+            def close(self) -> None:
+                state["close_calls"] += 1
+
+        def _factory(*_a: Any, **_k: Any) -> _TrackingGen:
+            return _TrackingGen(list(yields))
+
+        diffusion_mod.stream_diffusion_generate = _factory  # type: ignore[attr-defined]
+
+        from vllm_mlx.runtime.diffusion_lane import (
+            DiffusionEngine,
+            DiffusionGenerationConfig,
+        )
+
+        engine = DiffusionEngine(model_name="x/y")
+        engine._load_blocking()
+
+        thread_q: _queue.Queue[Any] = _queue.Queue()
+        engine._run_generator(
+            "prompt",
+            16,
+            DiffusionGenerationConfig(),
+            thread_q,
+            cancel_event,
+        )
+        return state
+
+    def test_close_called_on_finish_reason_return(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit via in-loop ``return`` when ``finish_reason`` is set."""
+        yields = [
+            FakeGenerationResult(text="hello", diffusion_block_complete=True),
+            FakeGenerationResult(text=" world", finish_reason="stop"),
+        ]
+        state = self._drive(monkeypatch, yields)
+        assert state["close_calls"] == 1, (
+            f"generator close() called {state['close_calls']}× on finish_reason "
+            f"path; expected exactly 1"
+        )
+
+    def test_close_called_when_generator_exhausts_naturally(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit via the for-loop's natural end (no finish_reason in
+        any chunk → falls through to the trailing-finish-chunk path
+        AFTER the try/finally."""
+        yields = [
+            FakeGenerationResult(text="alpha", diffusion_block_complete=True),
+            FakeGenerationResult(text="beta", diffusion_block_complete=True),
+        ]
+        state = self._drive(monkeypatch, yields)
+        assert state["close_calls"] == 1, (
+            f"generator close() called {state['close_calls']}× on natural "
+            f"exhaustion; expected exactly 1"
+        )
+
+    def test_close_called_on_cancel_break(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit via in-loop ``break`` when ``cancel_event`` flips mid-stream."""
+        yields = [
+            FakeGenerationResult(text="a", diffusion_block_complete=True),
+            FakeGenerationResult(text="b", diffusion_block_complete=True),
+            FakeGenerationResult(text="c", diffusion_block_complete=True),
+            FakeGenerationResult(text="d", finish_reason="stop"),
+        ]
+        state = self._drive(monkeypatch, yields, cancel_at_yield=2)
+        assert state["close_calls"] == 1, (
+            f"generator close() called {state['close_calls']}× on cancel "
+            f"break path; expected exactly 1"
+        )
+        # And the cancel must have actually short-circuited — we did
+        # not consume all 4 yields.
+        assert state["yielded"] < len(yields), (
+            f"cancel did not stop consumption: yielded={state['yielded']} "
+            f"of {len(yields)} (regression: cancel arm broken)"
+        )
+
+    def test_close_not_called_when_pre_cancel_short_circuits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the top-of-function cancel-check fires, the generator
+        is NEVER created, so there is nothing to close. The fix must
+        not introduce a phantom ``close()`` on a generator that
+        wasn't allocated."""
+        yields = [FakeGenerationResult(text="x", finish_reason="stop")]
+        state = self._drive(monkeypatch, yields, cancel_before_run=True)
+        assert state["close_calls"] == 0, (
+            f"generator close() called {state['close_calls']}× even though "
+            f"pre-cancel should skip generator allocation entirely"
+        )
+        assert state["yielded"] == 0, (
+            "generator yielded items despite pre-cancel — _run_generator "
+            "did NOT short-circuit before stream_diffusion_generate"
+        )

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -3174,10 +3174,7 @@ class TestGeneratorClosedOnEveryExit:
                 # _run_generator's per-iteration cancel check fires
                 # at the TOP of the next iteration, so the break
                 # exits before consuming any further yields.
-                if (
-                    cancel_at_yield is not None
-                    and state["yielded"] >= cancel_at_yield
-                ):
+                if cancel_at_yield is not None and state["yielded"] >= cancel_at_yield:
                     cancel_event.set()
                 return item
 

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -1390,7 +1390,26 @@ class DiffusionEngine(BaseEngine):
         if cancel_event.is_set():
             return
 
-        for result in stream_diffusion_generate(
+        # Hoist the generator out of the for-loop so we can close() it
+        # on every exit path. issue #698: when the loop exits early via
+        # ``break`` (cancel) or ``return`` (finish_reason), Python's
+        # for-statement does NOT call ``gen.close()`` — it relies on
+        # cyclic GC to eventually reclaim the generator's frame. That
+        # frame holds mlx-vlm's denoising state (noise schedule
+        # buffers, intermediate logits/embeddings, KV cache) sized
+        # proportional to ``max_tokens``. One ``max_tokens=1024``
+        # request leaves ~10-15 GB of MLX tensors rooted to the
+        # un-GC'd frame; the persistent worker thread then accumulates
+        # subsequent requests' allocations on top, sending RSS into
+        # swap and latency from ~4 s to 560 s by req ~27 in the Tier 4
+        # soak.
+        #
+        # Wrapping the for-loop in try/finally with an explicit
+        # ``gen.close()`` raises ``GeneratorExit`` into the mlx-vlm
+        # frame, which unwinds its locals immediately — MLX tensors
+        # are refcounted, so they free as soon as the frame's last
+        # reference goes away. No global GC pause needed.
+        gen = stream_diffusion_generate(
             self._model,
             self._processor,
             tokenizer,
@@ -1398,66 +1417,74 @@ class DiffusionEngine(BaseEngine):
             None,  # pixel_values — text-only path
             None,  # attention_mask — auto from input_ids
             **kwargs,
-        ):
-            # Cancellation point — stream_chat sets this on an early
-            # stop-sequence match or on disconnect so the worker
-            # doesn't keep burning GPU up to ``max_tokens`` after the
-            # caller has stopped consuming output. codex round 3 [P2]:
-            # without this, a stop in the first block left the worker
-            # generating hundreds of tokens before it could pick up
-            # the next queued request.
-            if cancel_event.is_set():
-                break
-            if getattr(result, "is_draft", False):
-                # Mid-canvas denoising preview; ignore for SSE.
-                continue
+        )
+        try:
+            for result in gen:
+                # Cancellation point — stream_chat sets this on an early
+                # stop-sequence match or on disconnect so the worker
+                # doesn't keep burning GPU up to ``max_tokens`` after the
+                # caller has stopped consuming output. codex round 3 [P2]:
+                # without this, a stop in the first block left the worker
+                # generating hundreds of tokens before it could pick up
+                # the next queued request.
+                if cancel_event.is_set():
+                    break
+                if getattr(result, "is_draft", False):
+                    # Mid-canvas denoising preview; ignore for SSE.
+                    continue
 
-            if getattr(result, "prompt_tokens", 0):
-                last_prompt_tokens = result.prompt_tokens
-            if getattr(result, "generation_tokens", 0):
-                last_completion_tokens = result.generation_tokens
-            # codex pr_validate r5 NIT: ``... or last_token`` silently
-            # swallows token id 0 (Gemma's <pad>, plus countless other
-            # tokenizers' sentinel tokens) — keep the previous token id
-            # only when the result truly omits the field.
-            _tok = getattr(result, "token", None)
-            if _tok is not None:
-                last_token = int(_tok)
+                if getattr(result, "prompt_tokens", 0):
+                    last_prompt_tokens = result.prompt_tokens
+                if getattr(result, "generation_tokens", 0):
+                    last_completion_tokens = result.generation_tokens
+                # codex pr_validate r5 NIT: ``... or last_token`` silently
+                # swallows token id 0 (Gemma's <pad>, plus countless other
+                # tokenizers' sentinel tokens) — keep the previous token id
+                # only when the result truly omits the field.
+                _tok = getattr(result, "token", None)
+                if _tok is not None:
+                    last_token = int(_tok)
 
-            text_piece = result.text or ""
-            if text_piece:
-                block_parts.append(text_piece)
+                text_piece = result.text or ""
+                if text_piece:
+                    block_parts.append(text_piece)
 
-            block_complete = bool(getattr(result, "diffusion_block_complete", False))
-            finish_reason = getattr(result, "finish_reason", None)
+                block_complete = bool(
+                    getattr(result, "diffusion_block_complete", False)
+                )
+                finish_reason = getattr(result, "finish_reason", None)
 
-            if block_complete or finish_reason:
-                joined = "".join(block_parts)
-                block_parts.clear()
-                if not first_block_emitted and joined:
-                    # Strip a leaked Gemma diffusion channel header.
-                    # No-op for plain content; saves the chat client
-                    # from seeing ``thought\n`` as the model's first
-                    # words on prompts that triggered the thought
-                    # channel.
-                    joined = _strip_leading_channel_header(joined)
-                if joined or finish_reason:
-                    if joined:
-                        first_block_emitted = True
-                    out_q.put(
-                        GenerationOutput(
-                            text="",
-                            new_text=joined,
-                            tokens=[last_token],
-                            prompt_tokens=last_prompt_tokens,
-                            completion_tokens=last_completion_tokens,
-                            finish_reason=(finish_reason if finish_reason else None),
-                            finished=bool(finish_reason),
-                            channel="content",
+                if block_complete or finish_reason:
+                    joined = "".join(block_parts)
+                    block_parts.clear()
+                    if not first_block_emitted and joined:
+                        # Strip a leaked Gemma diffusion channel header.
+                        # No-op for plain content; saves the chat client
+                        # from seeing ``thought\n`` as the model's first
+                        # words on prompts that triggered the thought
+                        # channel.
+                        joined = _strip_leading_channel_header(joined)
+                    if joined or finish_reason:
+                        if joined:
+                            first_block_emitted = True
+                        out_q.put(
+                            GenerationOutput(
+                                text="",
+                                new_text=joined,
+                                tokens=[last_token],
+                                prompt_tokens=last_prompt_tokens,
+                                completion_tokens=last_completion_tokens,
+                                finish_reason=(
+                                    finish_reason if finish_reason else None
+                                ),
+                                finished=bool(finish_reason),
+                                channel="content",
+                            )
                         )
-                    )
-                if finish_reason:
-                    return
+                    if finish_reason:
+                        return
+        finally:
+            gen.close()
 
         # Generator exited without an explicit finish_reason — treat
         # as a hard stop. We ALWAYS emit a finish chunk here even when


### PR DESCRIPTION
## Summary

Closes #698 — DiffusionEngine memory leak + latency cliff after a single long request.

- **Root cause:** `_run_generator` inlined `stream_diffusion_generate` directly in `for result in stream_diffusion_generate(...)`. Python's `for`-statement does NOT call `gen.close()` on early `break` (cancel) or `return` (finish_reason) — it relies on cyclic GC to eventually reclaim the generator's frame. That frame holds mlx-vlm's denoising state (noise schedule buffers, intermediate logits, KV cache) sized proportional to `max_tokens`. One `max_tokens=1024` request leaves ~10-15 GB of MLX tensors rooted to the un-GC'd frame; the persistent worker thread then accumulates subsequent requests' allocations on top, sending RSS into swap (16.5 → 31 GB) and latency from ~4 s to 560 s by req ~27.
- **Fix:** hoist the generator out of the for-loop, wrap in `try/finally` with explicit `gen.close()`. Closing raises `GeneratorExit` into the mlx-vlm frame, which unwinds its locals immediately — MLX tensors are refcounted, so they free as soon as the frame's last reference goes away. No global GC pause needed; no behavioral change to the cancel-arm, the finish_reason-return, or the trailing-finish-chunk emit.

## How it was caught

Tier 4 of post-merge regression sweep: 30-min soak driver, 8 prompts × `max_tokens=256`, every 10th request at `max_tokens=1024`. Issue #698 has the full timeline.

```
[   5s] req   1 mt= 256 ttft= 5.19s e2e=  5.19s tok=256 rss=16539.5MB
[  76s] req  19 mt= 256 ttft= 6.09s e2e=  6.09s tok=256 rss=16556.4MB
[ 106s] req  20 mt=1024 ttft= 8.56s e2e= 30.31s tok=821 rss=16597.3MB  ← long
[ 119s] req  21 mt= 256 ttft=12.91s e2e= 12.91s tok=256 rss=16637.5MB  ← already leaking
[ 228s] req  24 mt= 256 ttft=46.77s e2e= 46.77s tok=158 rss=18304.1MB
[ 964s] req  27 mt= 256 ttft=560.01s e2e=560.01s tok=256 rss=30991.8MB
```

## Test plan

- [x] 4 new regression tests pin every exit path:
  - `test_close_called_on_finish_reason_return` — in-loop `return` → 1× close
  - `test_close_called_when_generator_exhausts_naturally` — trailing-finish path → 1× close
  - `test_close_called_on_cancel_break` — in-loop `break` → 1× close
  - `test_close_not_called_when_pre_cancel_short_circuits` — generator never allocated → 0× close
- [x] Full diffusion-engine suite: 80/80 pass
- [x] Version bumped 0.7.34 → 0.7.35 (user-facing reliability fix)

## Risks

- AR lane (BatchedEngine) unaffected — uses mlx-lm's AR generator on a different code path; no consumption of `stream_diffusion_generate`.
- Vision/hybrid lanes unaffected — only DiffusionEngine consumes this generator.
- `gen.close()` on an already-exhausted generator is a no-op (Python's documented behavior) — natural exhaustion path stays safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)