### PR TITLE
fix(routes/anthropic): suppress duplicate thinking block on non-thinking models (#702)

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -682,3 +682,20 @@ class TestOpenaiToAnthropic:
         result = openai_to_anthropic(resp, "default")  # kwarg omitted
         assert any(b.type == "thinking" for b in result.content)
         assert any(b.type == "text" for b in result.content)
+
+    def test_whitespace_only_reasoning_omits_thinking_block(self):
+        """Codex r1 NIT on #702: whitespace-only ``reasoning_content``
+        (``"   \\n"``) must NOT open a leading ``thinking`` block
+        — Claude Code would render it as a blank thought. Mirrors the
+        ``_rescue_silent_drop_from_reasoning`` whitespace guard so the
+        two paths agree on what "semantically empty reasoning" means.
+        """
+        resp = self._make_response(
+            content="real answer",
+            reasoning_content="   \n  \t  ",
+        )
+        result = openai_to_anthropic(resp, "default", reasoning_enabled=True)
+        assert all(b.type != "thinking" for b in result.content)
+        text_blocks = [b for b in result.content if b.type == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "real answer"

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -604,3 +604,81 @@ class TestOpenaiToAnthropic:
         resp = self._make_response(content="hi", reasoning_content=None)
         result = openai_to_anthropic(resp, "default")
         assert all(b.type != "thinking" for b in result.content)
+
+    def test_reasoning_disabled_omits_thinking_block(self):
+        """Issue #702: when the served alias has ``reasoning_parser:
+        null`` in ``aliases.json``, the route passes
+        ``reasoning_enabled=False`` to the adapter. The adapter must
+        suppress the ``thinking`` block regardless of what
+        ``reasoning_content`` carries — Anthropic's public API never
+        emits one for non-extended-thinking models, so emitting it
+        would break client capability detection.
+        """
+        resp = self._make_response(
+            content="hello world",
+            reasoning_content="this trace must not leak",
+        )
+        result = openai_to_anthropic(resp, "default", reasoning_enabled=False)
+        # No thinking block at all.
+        assert all(b.type != "thinking" for b in result.content)
+        # Text block survives.
+        text_blocks = [b for b in result.content if b.type == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "hello world"
+
+    def test_reasoning_equals_content_suppresses_thinking_block(self):
+        """Issue #702: ``_rescue_silent_drop_from_reasoning`` (#569)
+        deliberately promotes a stuck reasoning trace into ``content``
+        so the OpenAI-side message isn't silently empty. The Anthropic
+        adapter has no other way to know
+        ``reasoning_content == content`` is a rescue artifact, so it
+        would dutifully emit BOTH blocks carrying the same string.
+        Claude Code / claude-cli / langchain-anthropic then render the
+        same paragraph twice. Suppress the ``thinking`` block in that
+        case and surface only ``text``.
+        """
+        duplicated = "I think this is the answer."
+        resp = self._make_response(
+            content=duplicated,
+            reasoning_content=duplicated,
+        )
+        # ``reasoning_enabled=True`` matches a thinking-capable alias —
+        # the dedup guard must fire even on those, because the rescue
+        # path runs for thinking-capable aliases too.
+        result = openai_to_anthropic(resp, "default", reasoning_enabled=True)
+        assert all(b.type != "thinking" for b in result.content)
+        text_blocks = [b for b in result.content if b.type == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == duplicated
+
+    def test_reasoning_enabled_distinct_reasoning_still_emits_thinking(self):
+        """Regression guard for #702: a genuinely thinking-capable
+        alias that produced a real thought trace (distinct from the
+        answer) must still get its ``thinking`` block.
+        """
+        resp = self._make_response(
+            content="Final answer.",
+            reasoning_content="Let me think.",
+        )
+        result = openai_to_anthropic(resp, "default", reasoning_enabled=True)
+        assert len(result.content) == 2
+        assert result.content[0].type == "thinking"
+        assert result.content[0].thinking == "Let me think."
+        assert result.content[1].type == "text"
+        assert result.content[1].text == "Final answer."
+
+    def test_reasoning_enabled_default_preserves_legacy_behavior(self):
+        """``reasoning_enabled`` defaults to True so external callers
+        that don't pass the kwarg (older tests, third-party imports)
+        keep their existing pre-#702 behavior. Only the explicit
+        equality dedup gate fires.
+        """
+        # Distinct reasoning + content → thinking block still appears
+        # without passing the kwarg.
+        resp = self._make_response(
+            content="Final answer.",
+            reasoning_content="Let me think.",
+        )
+        result = openai_to_anthropic(resp, "default")  # kwarg omitted
+        assert any(b.type == "thinking" for b in result.content)
+        assert any(b.type == "text" for b in result.content)

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -447,3 +447,295 @@ def test_stream_route_bypasses_implicit_parser_for_non_thinking_alias():
     )
 
     reset_config()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Codex r3 MAJOR (probe 5): wire-format byte-level pinning.
+#
+# The five tests above parse SSE payloads into Python objects via
+# ``_parse_sse_events`` and then check semantic invariants. That misses
+# wire-format regressions Anthropic SDKs are sensitive to:
+#   * spurious ``content_block_start`` for ``type="thinking"`` even when
+#     no thinking delta follows (clients enter "extended thinking" UI);
+#   * empty ``text_delta`` events (``"delta":{"text":""}``) — Anthropic's
+#     reference client treats these as noise and some downstream tools
+#     interrupt rendering;
+#   * missing or duplicated ``content_block_stop`` for the demoted text
+#     block.
+#
+# The tests below pin the raw event prefix bytes and assert exact
+# framing so future regressions on the streaming gate (or on
+# ``_emit_content_pieces``) surface immediately.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _split_raw_sse(body: str) -> list[str]:
+    """Return raw ``event: ... \ndata: ...`` blocks (no trailing \n\n)."""
+    return [chunk for chunk in body.split("\n\n") if chunk.strip()]
+
+
+def test_stream_route_wire_format_no_thinking_start_byte_level():
+    """No ``event: content_block_start`` byte sequence whose data
+    payload contains ``"type": "thinking"`` may appear in the raw
+    bytes. Stronger than the parsed-object check: a regression that
+    emits a malformed JSON payload (e.g. wrong field order or extra
+    keys) would still trip this assertion because we grep the data
+    line directly.
+    """
+    engine = _StreamingEngineEmittingReasoningChannel()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+
+    # Every event block carrying ``content_block_start`` must NOT
+    # contain ``"thinking"`` ANYWHERE in its data line.
+    for raw in _split_raw_sse(body):
+        if "content_block_start" not in raw:
+            continue
+        data_line = next(
+            (line for line in raw.splitlines() if line.startswith("data: ")),
+            "",
+        )
+        assert '"type":"thinking"' not in data_line.replace(" ", ""), (
+            f"non-thinking alias leaked a thinking content_block_start "
+            f"into raw SSE: {raw!r}"
+        )
+
+
+def test_stream_route_wire_format_no_empty_text_delta():
+    """No ``text_delta`` event in the raw stream may carry an empty
+    string. Codex r3 MAJOR (probe 1) — strip-whitespace guards must
+    prevent the streaming surface from opening an empty content
+    block or emitting an empty delta to the client.
+    """
+    engine = _StreamingEngineEmittingReasoningChannel()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+
+    for raw in _split_raw_sse(body):
+        if "content_block_delta" not in raw:
+            continue
+        data_line = next(
+            (line for line in raw.splitlines() if line.startswith("data: ")),
+            "",
+        )
+        if "text_delta" not in data_line:
+            continue
+        payload = json.loads(data_line.removeprefix("data: "))
+        delta_text = payload.get("delta", {}).get("text", None)
+        assert delta_text != "", f"empty text_delta leaked into SSE stream: raw={raw!r}"
+
+
+def test_stream_route_wire_format_event_prefix_and_terminator():
+    """Each non-empty event chunk must follow the ``event: <name>\n``
+    ``data: <json>\n\n`` shape exactly. Anthropic SDKs parse on this
+    framing; a missing ``\n\n`` terminator or extra whitespace would
+    silently break clients.
+    """
+    engine = _StreamingEngineEmittingReasoningChannel()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+
+    # The body must end with a terminator. Trailing-newline tolerance
+    # mirrors what Anthropic's reference SSE parser expects.
+    assert body.endswith("\n\n"), (
+        f"SSE body missing trailing terminator: tail={body[-20:]!r}"
+    )
+
+    for raw in _split_raw_sse(body):
+        lines = raw.splitlines()
+        # Each event block we emit has 2 lines: ``event: ...`` and
+        # ``data: ...``. (No comments / multi-line data.)
+        assert len(lines) == 2, (
+            f"unexpected SSE chunk shape (expected 2 lines): {lines!r}"
+        )
+        assert lines[0].startswith("event: "), (
+            f"first SSE line must start with 'event: ': {lines[0]!r}"
+        )
+        assert lines[1].startswith("data: "), (
+            f"second SSE line must start with 'data: ': {lines[1]!r}"
+        )
+        # data must be JSON-parseable
+        json.loads(lines[1].removeprefix("data: "))
+
+
+def test_stream_route_wire_format_exactly_one_text_block_for_demoted_stream():
+    """When the engine emits two reasoning deltas on a non-thinking
+    alias the gate demotes them to text. The raw stream must contain
+    exactly ONE ``content_block_start`` ``type="text"`` (consecutive
+    same-type pieces merge in ``_emit_content_pieces``) and exactly
+    ONE matching ``content_block_stop``. Catches regressions that
+    would emit ``start/stop/start/stop`` instead.
+    """
+    engine = _StreamingEngineEmittingReasoningChannel()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+
+    text_starts = 0
+    text_stops = 0
+    open_text_index: int | None = None
+    for raw in _split_raw_sse(body):
+        data_line = next(
+            (line for line in raw.splitlines() if line.startswith("data: ")),
+            "",
+        )
+        if not data_line:
+            continue
+        payload = json.loads(data_line.removeprefix("data: "))
+        if payload.get("type") == "content_block_start":
+            block_type = payload.get("content_block", {}).get("type")
+            if block_type == "text":
+                text_starts += 1
+                open_text_index = payload.get("index")
+        elif payload.get("type") == "content_block_stop":
+            # Match against the most-recently-opened text block.
+            if open_text_index is not None and payload.get("index") == open_text_index:
+                text_stops += 1
+                open_text_index = None
+
+    assert text_starts == 1, (
+        f"expected exactly 1 text content_block_start (merged); "
+        f"got {text_starts} in body={body!r}"
+    )
+    assert text_stops == 1, (
+        f"expected exactly 1 matching content_block_stop; "
+        f"got {text_stops} in body={body!r}"
+    )
+
+
+def test_stream_route_drops_whitespace_only_reasoning_delta():
+    """Codex r3 MAJOR (probe 1): a channel="reasoning" delta carrying
+    pure whitespace must NOT open a thinking content_block_start, nor
+    emit an empty/whitespace thinking_delta. Mirrors the non-stream
+    ``openai_to_anthropic`` predicate (``reasoning_text.strip() != ""``).
+    """
+
+    class _ReasoningChannelWhitespaceOnly:
+        preserve_native_tool_format = False
+        is_mllm = False
+        supports_guided_generation = False
+        tokenizer = None
+
+        def __init__(self):
+            self.stream_calls: list[dict[str, Any]] = []
+
+        def build_prompt(self, messages, tools=None, enable_thinking=None):
+            return "PROMPT"
+
+        async def stream_chat(self, messages, **kwargs):
+            self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+            # Whitespace-only reasoning — must be filtered.
+            yield GenerationOutput(
+                text="   \n",
+                new_text="   \n",
+                tokens=[1],
+                prompt_tokens=4,
+                completion_tokens=1,
+                finished=False,
+                finish_reason=None,
+                channel="reasoning",
+            )
+            yield GenerationOutput(
+                text="   \nanswer",
+                new_text="answer",
+                tokens=[1, 2],
+                prompt_tokens=4,
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+                channel="content",
+            )
+
+    # Switch to a thinking-capable alias so the gate is the no-op
+    # branch — we want to confirm the WHITESPACE-DROP guard fires
+    # even when the alias IS reasoning-capable.
+    cfg = reset_config()
+    engine = _ReasoningChannelWhitespaceOnly()
+    cfg.engine = engine
+    cfg.model_name = "thinking-model"
+    cfg.model_registry = None
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = "hermes"
+    cfg.tool_parser = None
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "thinking-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    thinking_starts = [
+        e
+        for e in events
+        if e.get("type") == "content_block_start"
+        and e.get("content_block", {}).get("type") == "thinking"
+    ]
+    assert thinking_starts == [], (
+        f"whitespace-only reasoning leaked a thinking content block; "
+        f"got starts={thinking_starts!r}"
+    )
+    # The content delta still surfaces.
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    assembled = "".join(text_deltas)
+    assert assembled == "answer", (
+        f"expected 'answer' to surface; got {assembled!r} from {text_deltas!r}"
+    )
+
+    reset_config()

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -859,3 +859,104 @@ def test_stream_route_preserves_intra_thinking_whitespace():
     assert text_text == "ANSWER", f"answer text missing or wrong: got {text_text!r}"
 
     reset_config()
+
+
+class _StreamingNonThinkingChannelHelloSpace:
+    """Engine that streams ``("reasoning", "hello") -> ("reasoning", " ")
+    -> ("content", "world")`` to exercise the codex r5 MAJOR fix.
+
+    On a non-thinking alias the gate demotes the first delta to a text
+    block. The second (whitespace-only) reasoning delta MUST also
+    demote to text so the open text block continues to receive
+    ``"hello "`` rather than truncating to ``"hello"``. The third
+    (content) delta then appends ``"world"`` to the same block.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.stream_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        yield GenerationOutput(
+            text="hello",
+            new_text="hello",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="hello ",
+            new_text=" ",
+            tokens=[1, 2],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="hello world",
+            new_text="world",
+            tokens=[1, 2, 3],
+            prompt_tokens=4,
+            completion_tokens=3,
+            finished=True,
+            finish_reason="stop",
+            channel="content",
+        )
+
+
+def test_stream_route_demoted_text_keeps_intra_block_whitespace():
+    """Codex r5 MAJOR: on a non-thinking alias, a whitespace-only
+    reasoning delta that arrives AFTER a non-empty reasoning delta
+    must demote into the open text block (giving ``"hello world"``),
+    not be dropped (which would give ``"helloworld"``).
+    """
+    engine = _StreamingNonThinkingChannelHelloSpace()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+
+    # No thinking block should be opened.
+    thinking_starts = [
+        e
+        for e in events
+        if e.get("type") == "content_block_start"
+        and e.get("content_block", {}).get("type") == "thinking"
+    ]
+    assert thinking_starts == [], (
+        f"non-thinking alias opened a thinking block: {thinking_starts!r}"
+    )
+
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    assembled = "".join(text_deltas)
+    assert assembled == "hello world", (
+        f"expected 'hello world' (whitespace preserved into open text "
+        f"block); got {assembled!r} from {text_deltas!r}"
+    )

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -189,8 +189,7 @@ def test_non_stream_route_suppresses_thinking_for_non_thinking_alias():
     body = resp.json()
     block_types = [b["type"] for b in body["content"]]
     assert "thinking" not in block_types, (
-        "non-thinking alias must NOT emit a thinking block; "
-        f"got blocks={block_types!r}"
+        f"non-thinking alias must NOT emit a thinking block; got blocks={block_types!r}"
     )
     # Text block survives so the assistant turn isn't silently empty.
     text_blocks = [b for b in body["content"] if b["type"] == "text"]

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -576,19 +576,19 @@ def test_stream_route_wire_format_event_prefix_and_terminator():
 
     for raw in _split_raw_sse(body):
         lines = raw.splitlines()
-        # Each event block we emit has 2 lines: ``event: ...`` and
-        # ``data: ...``. (No comments / multi-line data.)
-        assert len(lines) == 2, (
-            f"unexpected SSE chunk shape (expected 2 lines): {lines!r}"
-        )
+        # Required framing (codex r4 NIT — relaxed from "exactly 2
+        # lines" to avoid over-pinning today's emitters): each chunk
+        # MUST start with an ``event:`` line and MUST contain a JSON-
+        # parseable ``data:`` line. Comments (``:`` lines) and
+        # multi-line ``data:`` framing remain valid SSE shapes that a
+        # future legitimate change might introduce.
+        assert lines, f"empty SSE chunk: {raw!r}"
         assert lines[0].startswith("event: "), (
             f"first SSE line must start with 'event: ': {lines[0]!r}"
         )
-        assert lines[1].startswith("data: "), (
-            f"second SSE line must start with 'data: ': {lines[1]!r}"
-        )
-        # data must be JSON-parseable
-        json.loads(lines[1].removeprefix("data: "))
+        data_line = next((line for line in lines if line.startswith("data: ")), None)
+        assert data_line is not None, f"SSE chunk missing 'data:' line: {lines!r}"
+        json.loads(data_line.removeprefix("data: "))
 
 
 def test_stream_route_wire_format_exactly_one_text_block_for_demoted_stream():
@@ -737,5 +737,125 @@ def test_stream_route_drops_whitespace_only_reasoning_delta():
     assert assembled == "answer", (
         f"expected 'answer' to surface; got {assembled!r} from {text_deltas!r}"
     )
+
+    reset_config()
+
+
+class _StreamingEngineInterleavedThinking:
+    """Engine that streams `<think>first\n\nsecond</think>` to exercise
+    the codex r4 MAJOR fix: intra-thinking whitespace separators must
+    survive the gate so the rendered thinking block is `first\n\nsecond`
+    (a paragraph break) and not `firstsecond` (visually concatenated).
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.stream_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        # Emit content in three reasoning-channel deltas: "first",
+        # whitespace separator, "second", then a content delta.
+        yield GenerationOutput(
+            text="first",
+            new_text="first",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="first\n\n",
+            new_text="\n\n",
+            tokens=[1, 2],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="first\n\nsecond",
+            new_text="second",
+            tokens=[1, 2, 3],
+            prompt_tokens=4,
+            completion_tokens=3,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="first\n\nsecondANSWER",
+            new_text="ANSWER",
+            tokens=[1, 2, 3, 4],
+            prompt_tokens=4,
+            completion_tokens=4,
+            finished=True,
+            finish_reason="stop",
+            channel="content",
+        )
+
+
+def test_stream_route_preserves_intra_thinking_whitespace():
+    """Codex r4 MAJOR: whitespace between two non-empty thinking
+    chunks must NOT be dropped by the gate — it is an intra-thinking
+    paragraph separator the model emitted on purpose. The fix made
+    ``_gate_thinking_pieces`` state-aware (current_block_type) so a
+    whitespace piece is dropped only when it would OPEN a blank
+    thinking block.
+    """
+    cfg = reset_config()
+    engine = _StreamingEngineInterleavedThinking()
+    cfg.engine = engine
+    cfg.model_name = "thinking-model"
+    cfg.model_registry = None
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = "hermes"
+    cfg.tool_parser = None
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "thinking-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+
+    # Assemble the full thinking content from thinking_delta events.
+    thinking_text = "".join(
+        e["delta"]["thinking"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "thinking_delta"
+    )
+    assert thinking_text == "first\n\nsecond", (
+        "intra-thinking whitespace separator was dropped — "
+        f"got {thinking_text!r}, expected 'first\\n\\nsecond'"
+    )
+    # And the answer still surfaces in a text block.
+    text_text = "".join(
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    )
+    assert text_text == "ANSWER", f"answer text missing or wrong: got {text_text!r}"
 
     reset_config()

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -309,3 +309,142 @@ def test_stream_route_demotes_reasoning_channel_for_non_thinking_alias():
     assert text_starts, (
         f"expected at least one text content_block_start; got events={events!r}"
     )
+
+
+class _StreamingEngineNoChannelTags:
+    """Engine that streams plain text deltas with NO ``channel`` tag.
+
+    This exercises the codex r2 BLOCKING path: a non-thinking alias is
+    served beside a thinking GLOBAL parser (Qwen3 / hermes), so
+    ``cfg.reasoning_parser_name`` is set. Without the parser-bypass
+    fix, implicit-mode parsers would classify each delta as
+    ``reasoning`` until ``finalize_streaming`` emits a correction at
+    end-of-stream. The gate would demote per-delta pieces to text but
+    the finalize emission goes through a separate code path
+    (``content_block_start type='text'``) — same bytes would then
+    appear twice in the stream.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.stream_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        # Plain text answer, no channel tag, no <think> markers — a
+        # non-thinking alias's normal output.
+        yield GenerationOutput(
+            text="hello ",
+            new_text="hello ",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            channel=None,
+        )
+        yield GenerationOutput(
+            text="hello world",
+            new_text="world",
+            tokens=[1, 2],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+def test_stream_route_bypasses_implicit_parser_for_non_thinking_alias():
+    """Codex r2 BLOCKING on #702: when the alias is non-thinking but
+    ``cfg.reasoning_parser_name`` is set (thinking global default), the
+    streaming path must bypass the reasoning parser entirely so an
+    implicit-mode parser's ``finalize_streaming`` correction can't
+    re-emit the demoted reasoning bytes as a second text block —
+    visible duplication. The route must instead stream each delta
+    through ``think_router`` (no <think> tags → all text), single
+    block, no finalize re-emission.
+    """
+    engine = _StreamingEngineNoChannelTags()
+    # Override the single-model fallback to "thinking global default".
+    # The route must STILL gate because the per-request alias
+    # (model_name="non-thinking-alias") is non-thinking via the
+    # registry.
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "thinking-default"
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.tool_parser = None
+
+    registry = ModelRegistry()
+    registry.add(
+        ModelEntry(
+            engine=engine,
+            model_name="thinking-default",
+            model_path="thinking-default",
+            reasoning_parser="qwen3",
+        ),
+        is_default=True,
+    )
+    registry.add(
+        ModelEntry(
+            engine=engine,
+            model_name="non-thinking-alias",
+            model_path="non-thinking-alias",
+            reasoning_parser=None,
+        ),
+    )
+    cfg.model_registry = registry
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "non-thinking-alias",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    events = _parse_sse_events(resp.text)
+    # No thinking block opens.
+    starts = [e for e in events if e.get("type") == "content_block_start"]
+    for start in starts:
+        block = start.get("content_block", {})
+        assert block.get("type") != "thinking", (
+            "non-thinking alias must NOT open a thinking content block "
+            f"in the SSE stream; got {start!r}"
+        )
+    # And the model bytes appear EXACTLY ONCE in the stream — not
+    # duplicated by finalize_streaming. Collect all text_delta payloads
+    # and confirm the concatenation equals what the engine emitted.
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    assembled = "".join(text_deltas)
+    # The engine emitted ``"hello "`` + ``"world"`` (two new_text
+    # chunks). After the gate, each chunk emerges as one text_delta;
+    # finalize_streaming MUST NOT re-emit the same bytes a second time
+    # (the codex r2 BLOCKING regression shape).
+    assert assembled == "hello world", (
+        f"expected exactly 'hello world' (one copy); got {assembled!r} "
+        f"from text_deltas={text_deltas!r}"
+    )
+
+    reset_config()

--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Route-level regression for the /v1/messages thinking-block gate (#702).
+
+Adapter-level coverage lives in ``tests/test_anthropic_adapter.py``; this
+file walks the full FastAPI route through ``TestClient`` to lock in the
+predicate that codex r1 BLOCKING called out — the route must consult
+the per-request alias's reasoning capability via
+``_resolve_reasoning_enabled``, not the process-global
+``cfg.reasoning_parser`` singleton.
+
+Two surfaces:
+
+* Non-streaming: ``cfg.reasoning_parser = None`` (alias has
+  ``reasoning_parser: null``). Engine returns ``reasoning_text`` anyway
+  — the rescue duplication shape from #569 — and the route must surface
+  only a ``text`` content block, never ``thinking``.
+* Streaming: same alias config, engine emits a delta tagged with
+  ``channel="reasoning"``. The route must demote it to ``text_delta``
+  in the SSE stream so clients never see ``content_block_start`` for a
+  ``thinking`` block.
+"""
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.anthropic import router as anthropic_router
+from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+from vllm_mlx.service.helpers import _resolve_reasoning_enabled
+
+
+class _NonStreamingEngineEmittingReasoning:
+    """Engine whose non-stream output carries ``reasoning_text``.
+
+    Mimics the post-#569 rescue shape: ``content`` and
+    ``reasoning_text`` agree on the same string because the OpenAI-side
+    response builder copied reasoning into content to avoid a silently
+    empty assistant turn. On the Anthropic surface this used to leak
+    BOTH a ``thinking`` block AND a ``text`` block carrying the same
+    string — F-010.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, content: str, reasoning: str):
+        self._content = content
+        self._reasoning = reasoning
+        self.chat_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text=self._content,
+            raw_text=self._content,
+            reasoning_text=self._reasoning,
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+class _StreamingEngineEmittingReasoningChannel:
+    """Engine whose stream tags a delta with ``channel="reasoning"``.
+
+    Models routed through the engine ``OutputRouter`` (gemma4 / harmony
+    family) surface tokens with explicit channel tags. The Anthropic
+    streaming route used to open a ``thinking`` content block on
+    ``channel="reasoning"`` unconditionally, even for aliases that
+    declared ``reasoning_parser: null`` in ``aliases.json``. Issue #702
+    moved the gate to ``_resolve_reasoning_enabled`` so the same alias
+    config now demotes those deltas to ``text``.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self):
+        self.stream_calls: list[dict[str, Any]] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        # Reasoning-channel delta — would normally open a ``thinking``
+        # block. With the gate, it must demote to text.
+        yield GenerationOutput(
+            text="hello ",
+            new_text="hello ",
+            tokens=[1],
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            channel="reasoning",
+        )
+        yield GenerationOutput(
+            text="hello world",
+            new_text="world",
+            tokens=[1, 2],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            channel="content",
+        )
+
+
+def _make_client(engine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    # Non-thinking alias — the predicate ``_resolve_reasoning_enabled``
+    # falls back to ``cfg.reasoning_parser is not None`` in single-model
+    # mode, so ``None`` means "alias is not reasoning-capable" and the
+    # ``thinking`` block must be suppressed on both surfaces.
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.tool_parser = None
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    reset_config()
+
+
+def _parse_sse_events(body: str) -> list[dict]:
+    events = []
+    for raw_event in body.split("\n\n"):
+        data_line = next(
+            (line for line in raw_event.splitlines() if line.startswith("data: ")),
+            None,
+        )
+        if not data_line:
+            continue
+        payload = data_line.removeprefix("data: ")
+        if payload == "[DONE]":
+            continue
+        events.append(json.loads(payload))
+    return events
+
+
+def test_non_stream_route_suppresses_thinking_for_non_thinking_alias():
+    """Issue #702: when the served alias has ``reasoning_parser: null``
+    (single-model mode → ``cfg.reasoning_parser is None``), the route
+    must NOT emit a ``thinking`` block even if the engine surfaced
+    ``reasoning_text``. The exact F-010 shape: ``content`` and
+    ``reasoning_text`` carry the same string because the rescue (#569)
+    copied reasoning into content.
+    """
+    duplicated = "I think this is the answer."
+    engine = _NonStreamingEngineEmittingReasoning(
+        content=duplicated,
+        reasoning=duplicated,
+    )
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "say something"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    block_types = [b["type"] for b in body["content"]]
+    assert "thinking" not in block_types, (
+        "non-thinking alias must NOT emit a thinking block; "
+        f"got blocks={block_types!r}"
+    )
+    # Text block survives so the assistant turn isn't silently empty.
+    text_blocks = [b for b in body["content"] if b["type"] == "text"]
+    assert len(text_blocks) == 1
+    assert text_blocks[0]["text"] == duplicated
+
+
+def test_resolve_reasoning_enabled_uses_registry_entry_not_global():
+    """Codex r1 BLOCKING on #702: in multi-model mode the predicate
+    must consult the per-request registry entry, not the process-global
+    ``cfg.reasoning_parser`` singleton. Otherwise a non-thinking alias
+    served alongside a thinking default would still emit a duplicate
+    ``thinking`` block because the global parser is set.
+    """
+    cfg = reset_config()
+    # Global says "reasoning parser is set" (matches the default model).
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = "hermes"
+    # Registry overrides for two aliases:
+    #   - thinking-alias has reasoning_parser="hermes"
+    #   - non-thinking-alias has reasoning_parser=None
+    registry = ModelRegistry()
+    registry.add(
+        ModelEntry(
+            engine=object(),
+            model_name="thinking-alias",
+            model_path="thinking-alias",
+            reasoning_parser="hermes",
+        ),
+        is_default=True,
+    )
+    registry.add(
+        ModelEntry(
+            engine=object(),
+            model_name="non-thinking-alias",
+            model_path="non-thinking-alias",
+            reasoning_parser=None,
+        ),
+    )
+    cfg.model_registry = registry
+
+    assert _resolve_reasoning_enabled("thinking-alias") is True
+    assert _resolve_reasoning_enabled("non-thinking-alias") is False
+    # Unknown alias falls back to registry's default entry — the
+    # thinking-alias, so reasoning_enabled stays True. This matches
+    # how ``get_entry`` and ``get_engine`` already behave for unknown
+    # names in the registry.
+    assert _resolve_reasoning_enabled("does-not-exist") is True
+
+    reset_config()
+
+
+def test_resolve_reasoning_enabled_falls_back_to_global_without_registry():
+    """Single-model mode (``cfg.model_registry`` is None) keeps the
+    legacy semantics: the gate uses the global
+    ``cfg.reasoning_parser`` / ``cfg.reasoning_parser_name`` pair
+    because there's no per-alias metadata to consult. Both are
+    populated together by ``server.load_model`` so checking either is
+    equivalent; the helper accepts both so unit-test fixtures that
+    only set the name keep working.
+    """
+    cfg = reset_config()
+    cfg.model_registry = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    assert _resolve_reasoning_enabled("any-name") is False
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = "hermes"
+    assert _resolve_reasoning_enabled("any-name") is True
+    # Either field alone is enough — exercises the OR branch the
+    # helper uses for test-fixture compatibility.
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = "hermes"
+    assert _resolve_reasoning_enabled("any-name") is True
+    cfg.reasoning_parser = object()
+    cfg.reasoning_parser_name = None
+    assert _resolve_reasoning_enabled("any-name") is True
+    reset_config()
+
+
+def test_stream_route_demotes_reasoning_channel_for_non_thinking_alias():
+    """Issue #702 streaming variant: engine emits a delta tagged
+    ``channel="reasoning"`` (e.g. tokenizer carries
+    ``<|channel>thought`` but the alias opted out of the reasoning
+    parser). Route must demote to ``text_delta`` so clients never see
+    a ``content_block_start`` for ``type="thinking"``.
+    """
+    engine = _StreamingEngineEmittingReasoningChannel()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    events = _parse_sse_events(resp.text)
+    # No content_block_start should announce a thinking block.
+    starts = [e for e in events if e.get("type") == "content_block_start"]
+    for start in starts:
+        block = start.get("content_block", {})
+        assert block.get("type") != "thinking", (
+            "non-thinking alias must NOT open a thinking content block "
+            f"in the SSE stream; got {start!r}"
+        )
+    # Conversely, the model's bytes still surface — at least one text
+    # block must appear so the assistant turn isn't silently empty.
+    text_starts = [
+        e for e in starts if e.get("content_block", {}).get("type") == "text"
+    ]
+    assert text_starts, (
+        f"expected at least one text content_block_start; got events={events!r}"
+    )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -209,14 +209,20 @@ def openai_to_anthropic(
         # Both cases collapse to "emit text only" under the same
         # predicate: the reasoning channel must be enabled AND the
         # reasoning bytes must differ from the content bytes (and be
-        # non-empty). When the predicate fails we still surface the
-        # answer as ``text`` — silent drop is the worse failure mode
-        # (#569).
+        # non-empty AND non-whitespace). When the predicate fails we
+        # still surface the answer as ``text`` — silent drop is the
+        # worse failure mode (#569). The whitespace-only guard mirrors
+        # ``_rescue_silent_drop_from_reasoning`` which treats
+        # ``"   \n"`` as semantically empty — without this gate the
+        # adapter would emit a leading ``thinking`` block of pure
+        # whitespace that Claude Code surfaces as a blank thought.
+        # Codex r1 NIT on PR #705.
         reasoning_text = choice.message.reasoning_content
         text = choice.message.content
         emit_thinking = (
             reasoning_enabled
             and bool(reasoning_text)
+            and reasoning_text.strip() != ""
             and reasoning_text != text
         )
         # Add thinking block FIRST so it appears before the answer text,

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -161,6 +161,8 @@ def _resolve_reasoning_max_tokens(request: AnthropicRequest) -> int | None:
 def openai_to_anthropic(
     response: ChatCompletionResponse,
     model: str,
+    *,
+    reasoning_enabled: bool = True,
 ) -> AnthropicResponse:
     """
     Convert an OpenAI Chat Completions response to Anthropic Messages API format.
@@ -168,6 +170,14 @@ def openai_to_anthropic(
     Args:
         response: OpenAI ChatCompletionResponse
         model: Model name for the response
+        reasoning_enabled: Whether the served alias is configured with a
+            ``reasoning_parser`` (i.e. structurally capable of producing
+            reasoning text). When False, the ``thinking`` block is never
+            emitted regardless of what ``reasoning_content`` carries —
+            matches Anthropic's public API where non-extended-thinking
+            models never emit a ``thinking`` block. Defaults to True so
+            external callers that don't pass the flag keep their existing
+            behavior (pre-issue #702).
 
     Returns:
         Anthropic Messages API response
@@ -176,24 +186,57 @@ def openai_to_anthropic(
     choice = response.choices[0] if response.choices else None
 
     if choice:
+        # Issue #702: emit a ``thinking`` block iff the alias is
+        # reasoning-capable AND the reasoning text is genuinely distinct
+        # from the answer text.
+        #
+        # Without this gate, two failure modes leak into Anthropic clients:
+        #   (1) An alias with ``reasoning_parser: null`` whose OpenAI-side
+        #       response happens to carry ``reasoning_content`` would
+        #       still get a ``thinking`` block. Anthropic's public API
+        #       never emits one for non-extended-thinking models, so any
+        #       client branching on ``content[0].type == "thinking"``
+        #       mis-detects capability.
+        #   (2) The ``_rescue_silent_drop_from_reasoning`` helper (#569)
+        #       deliberately promotes a stuck reasoning trace into
+        #       ``content`` so the OpenAI-side message isn't silently
+        #       empty. The adapter has no other way to know
+        #       ``reasoning_content == content`` is a rescue artifact, so
+        #       it would dutifully emit BOTH blocks carrying the same
+        #       string — Claude Code / claude-cli / langchain-anthropic
+        #       render the same paragraph twice.
+        #
+        # Both cases collapse to "emit text only" under the same
+        # predicate: the reasoning channel must be enabled AND the
+        # reasoning bytes must differ from the content bytes (and be
+        # non-empty). When the predicate fails we still surface the
+        # answer as ``text`` — silent drop is the worse failure mode
+        # (#569).
+        reasoning_text = choice.message.reasoning_content
+        text = choice.message.content
+        emit_thinking = (
+            reasoning_enabled
+            and bool(reasoning_text)
+            and reasoning_text != text
+        )
         # Add thinking block FIRST so it appears before the answer text,
         # matching Anthropic's extended-thinking SDK convention. Without
         # this block ``<think>...</think>`` reasoning would silently
         # disappear from the non-streaming response — issue #413.
-        if choice.message.reasoning_content:
+        if emit_thinking:
             content.append(
                 AnthropicResponseContentBlock(
                     type="thinking",
-                    thinking=choice.message.reasoning_content,
+                    thinking=reasoning_text,
                 )
             )
 
         # Add text content
-        if choice.message.content:
+        if text:
             content.append(
                 AnthropicResponseContentBlock(
                     type="text",
-                    text=choice.message.content,
+                    text=text,
                 )
             )
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -557,43 +557,91 @@ async def _stream_anthropic_messages(
 
     def _gate_thinking_pieces(
         pieces: list[tuple[str, str]],
+        current_block_type: str | None,
     ) -> list[tuple[str, str]]:
-        """Suppress ``thinking`` pieces when the alias is non-thinking.
+        """Apply the #702 capability gate + non-stream parity filter.
 
-        Returns a new list where every ``("thinking", text)`` piece is
-        rewritten to ``("text", text)`` when ``_reasoning_enabled`` is
-        False. The rewrite preserves order so the SSE block stream
-        still matches what the model actually emitted; downstream
-        ``_emit_content_pieces`` merges consecutive same-type pieces
-        into a single content block.
+        Two concerns, in one pass:
 
-        Additionally drops whitespace-only ``thinking`` pieces regardless
-        of ``_reasoning_enabled`` so the streaming surface matches the
-        non-stream ``openai_to_anthropic`` predicate at
-        ``anthropic_adapter.py`` (``reasoning_text.strip() != ""``).
-        Anthropic's public API does not emit empty content blocks; the
-        per-site guards above filter common cases (cap-split kept-bytes
-        + reasoning_parser-emitted whitespace deltas) but ``think_router``
-        can still emerge with a ``("thinking", "   ")`` piece when a
-        ``<think>...</think>`` literal contains only whitespace. Codex
-        r3 MAJOR (probe 1).
+        1. **Non-thinking alias demotion.** When ``_reasoning_enabled``
+           is False (per-request alias has ``reasoning_parser: null``
+           in ``aliases.json``), every ``("thinking", text)`` piece is
+           rewritten to ``("text", text)``. The rewrite preserves order
+           so downstream ``_emit_content_pieces`` still merges
+           consecutive same-type pieces into a single content block.
+
+        2. **No-empty-block parity with non-stream.** The non-stream
+           ``openai_to_anthropic`` predicate skips a thinking block when
+           ``reasoning_text.strip() == ""``. Mirror that on the
+           streaming surface so a model that emits ``<think> </think>``
+           or a whitespace-only reasoning channel delta does NOT open a
+           thinking ``content_block_start`` + whitespace
+           ``thinking_delta`` that Claude Code surfaces as a blank
+           thought bubble.
+
+        The whitespace guard is **state-aware**: a whitespace-only
+        thinking piece is only dropped when it would OPEN a blank
+        thinking block — i.e. no thinking block is currently open in
+        the SSE stream (``current_block_type != "thinking"``) AND no
+        later piece in this batch carries non-whitespace thinking
+        content that would mark the leading whitespace as an
+        intra-thinking separator. This preserves the
+        ``"first" + "\n\n" + "second"`` shape that the model uses to
+        break thinking into paragraphs without leaking the
+        ``"   " -> open empty block`` shape (codex r3 MAJOR probe 1,
+        refined per codex r4 MAJOR).
+
+        ``current_block_type`` is the block type currently OPEN at the
+        downstream emitter (None / "text" / "thinking") — when it's
+        "thinking" we ALWAYS keep whitespace because it's an intra-block
+        continuation, never a block opener.
         """
-        if _reasoning_enabled:
-            return [
-                piece
-                for piece in pieces
-                if not (piece[0] == "thinking" and not piece[1].strip())
-            ]
+        # First, walk pieces and compute whether each whitespace-only
+        # thinking piece sits at a "block-opening" position. The piece
+        # opens a block iff no thinking block is currently open at the
+        # emitter AND no earlier piece in this batch already emitted
+        # non-whitespace thinking content.
+        thinking_block_open = current_block_type == "thinking"
         out: list[tuple[str, str]] = []
         for block_type, text in pieces:
             if block_type == "thinking":
-                # Demote to text; if the demoted text is also pure
-                # whitespace we still drop it (no value emitting an
-                # empty text_delta to the client).
-                if text.strip():
+                if not text.strip():
+                    # Whitespace-only thinking piece.
+                    if not thinking_block_open:
+                        # Would open a blank thinking block — drop it.
+                        # On the non-thinking branch we also drop it
+                        # because demoting to ("text", "   ") would
+                        # likewise open a blank text block.
+                        continue
+                    # An intra-thinking separator. Keep it on the
+                    # reasoning-enabled path; demote on the non-thinking
+                    # path (it stays inside an already-open text block
+                    # on that branch because demoted "thinking" became
+                    # "text" earlier in this same pass).
+                    if _reasoning_enabled:
+                        out.append(("thinking", text))
+                    else:
+                        out.append(("text", text))
+                    continue
+                # Non-whitespace thinking content. On the reasoning-
+                # enabled branch keep as thinking; on the non-thinking
+                # branch demote to text.
+                if _reasoning_enabled:
+                    out.append(("thinking", text))
+                else:
                     out.append(("text", text))
+                # A non-empty thinking piece opens a thinking block on
+                # the reasoning-enabled path; track so subsequent
+                # whitespace pieces in this batch are kept as
+                # intra-block continuations.
+                thinking_block_open = _reasoning_enabled
             else:
                 out.append((block_type, text))
+                # A non-thinking piece closes any open thinking block
+                # (the emitter will emit a content_block_stop on the
+                # type switch).
+                if block_type != "thinking":
+                    thinking_block_open = False
         return out
 
     # Emit message_start
@@ -794,18 +842,18 @@ async def _stream_anthropic_messages(
                         # eventually sees a final answer instead of an
                         # endless thinking_delta stream.
                         kept, overflow = _account_for_reasoning(reasoning)
-                        # Codex r3 MAJOR (probe 1): mirror the non-stream
-                        # whitespace guard at
-                        # ``anthropic_adapter.openai_to_anthropic`` — never
-                        # open a ``thinking`` block for purely whitespace
-                        # reasoning (Anthropic spec: don't emit empty
-                        # content blocks). Without this guard a
-                        # channel="reasoning" delta carrying just
-                        # ``"   \n"`` would open a thinking
-                        # ``content_block_start`` + whitespace
-                        # ``thinking_delta`` that Claude Code surfaces as
-                        # a blank thought bubble.
-                        if kept and kept.strip():
+                        if kept:
+                            # Don't filter whitespace here — a
+                            # whitespace-only chunk may be an
+                            # intra-thinking separator (e.g. "\n\n"
+                            # between two thinking paragraphs). The
+                            # state-aware ``_gate_thinking_pieces``
+                            # below preserves separators when a thinking
+                            # block is already open and only drops a
+                            # piece that would otherwise OPEN a blank
+                            # thinking block. Mirrors the non-stream
+                            # predicate's whole-text ``.strip()`` check
+                            # (codex r3 probe 1, refined per r4 MAJOR).
                             pieces_routed.append(("thinking", kept))
                         if overflow:
                             filtered = tool_filter.process(overflow)
@@ -844,7 +892,7 @@ async def _stream_anthropic_messages(
                     # ``thinking`` block on a non-extended-thinking
                     # alias.
                     events, current_block_type, block_index = _emit_content_pieces(
-                        _gate_thinking_pieces(pieces_routed),
+                        _gate_thinking_pieces(pieces_routed, current_block_type),
                         current_block_type,
                         block_index,
                     )
@@ -907,16 +955,12 @@ async def _stream_anthropic_messages(
                     reasoning = strip_special_tokens(delta_msg.reasoning)
                     if reasoning:
                         kept, overflow = _account_for_reasoning(reasoning)
-                        # Codex r3 MAJOR (probe 1): same whitespace
-                        # guard as the channel-routed branch above and
-                        # the non-stream ``openai_to_anthropic``
-                        # predicate. Reasoning parsers can emit a
-                        # delta whose ``.reasoning`` is whitespace
-                        # only (e.g. qwen3 splitting on a newline
-                        # boundary); opening a thinking block here
-                        # would surface a blank thought bubble in
-                        # Claude Code.
-                        if kept and kept.strip():
+                        if kept:
+                            # See site A's note: intra-thinking
+                            # whitespace separators must reach
+                            # ``_gate_thinking_pieces`` so it can
+                            # preserve them when a thinking block is
+                            # already open (codex r4 MAJOR).
                             pieces.append(("thinking", kept))
                         if overflow:
                             # Codex round-7 BLOCKING #1: emitting
@@ -1003,7 +1047,7 @@ async def _stream_anthropic_messages(
                             pieces.append(("text", filtered))
                 if pieces:
                     events, current_block_type, block_index = _emit_content_pieces(
-                        _gate_thinking_pieces(pieces),
+                        _gate_thinking_pieces(pieces, current_block_type),
                         current_block_type,
                         block_index,
                     )
@@ -1023,7 +1067,7 @@ async def _stream_anthropic_messages(
                     continue
                 pieces = think_router.process(filtered)
                 events, current_block_type, block_index = _emit_content_pieces(
-                    _gate_thinking_pieces(pieces),
+                    _gate_thinking_pieces(pieces, current_block_type),
                     current_block_type,
                     block_index,
                 )
@@ -1041,7 +1085,7 @@ async def _stream_anthropic_messages(
         else:
             pieces_flush = think_router.process(remaining)
         events, current_block_type, block_index = _emit_content_pieces(
-            _gate_thinking_pieces(pieces_flush),
+            _gate_thinking_pieces(pieces_flush, current_block_type),
             current_block_type,
             block_index,
         )
@@ -1052,7 +1096,7 @@ async def _stream_anthropic_messages(
         flush_pieces = think_router.flush()
         if flush_pieces:
             events, current_block_type, block_index = _emit_content_pieces(
-                _gate_thinking_pieces(flush_pieces),
+                _gate_thinking_pieces(flush_pieces, current_block_type),
                 current_block_type,
                 block_index,
             )

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -515,18 +515,38 @@ async def _stream_anthropic_messages(
     # ``thinking`` content block — Anthropic's public API doesn't
     # emit one for non-extended-thinking models, so any client that
     # branches on ``content_block.type == "thinking"`` would
-    # mis-detect capability. Resolved through
-    # ``_resolve_reasoning_enabled`` so it consults the per-request
-    # registry entry first (multi-model mode) instead of the
-    # process-global ``cfg.reasoning_parser_name`` (codex r1 BLOCKING
-    # on PR #705). Applied via ``_gate_thinking_pieces`` below to
-    # every place this function constructs ``("thinking", ...)``
-    # pieces: channel-routed (engine OutputRouter), reasoning-parser
-    # delta split, and the raw ``<think>`` think_router heuristic.
-    # When the gate fires the reasoning bytes are demoted to a
-    # ``text`` piece so the assistant turn still surfaces the model's
-    # output (silent drop is the worse failure mode, #569).
-    _reasoning_enabled = _resolve_reasoning_enabled(anthropic_request.model)
+    # mis-detect capability. Applied via ``_gate_thinking_pieces``
+    # below to every place this function constructs
+    # ``("thinking", ...)`` pieces: channel-routed (engine
+    # OutputRouter), reasoning-parser delta split, and the raw
+    # ``<think>`` think_router heuristic. When the gate fires the
+    # reasoning bytes are demoted to a ``text`` piece so the
+    # assistant turn still surfaces the model's output (silent drop
+    # is the worse failure mode, #569).
+    #
+    # Resolution: consult the per-request registry entry first
+    # (multi-model mode), fall back to the global parser pair in
+    # single-model mode (codex r1 BLOCKING on PR #705). Inlined here
+    # so the predicate consumes the SAME ``cfg`` object the rest of
+    # this function already reads — sharing avoids a second
+    # ``get_config()`` call that test fixtures patching
+    # ``anthropic_route.get_config`` would miss.
+    _reasoning_enabled = False
+    if cfg.model_registry:
+        try:
+            _entry = cfg.model_registry.get_entry(anthropic_request.model)
+        except KeyError:
+            _entry = None
+        if _entry is not None:
+            _reasoning_enabled = bool(getattr(_entry, "reasoning_parser", None))
+        else:
+            _reasoning_enabled = cfg.reasoning_parser is not None or bool(
+                cfg.reasoning_parser_name
+            )
+    else:
+        _reasoning_enabled = cfg.reasoning_parser is not None or bool(
+            cfg.reasoning_parser_name
+        )
 
     def _gate_thinking_pieces(
         pieces: list[tuple[str, str]],
@@ -618,6 +638,21 @@ async def _stream_anthropic_messages(
     # up the work, and `_should_start_in_thinking` already returns False
     # for enable_thinking=False, so the answer streams as text.
     if chat_kwargs.get("enable_thinking") is False:
+        reasoning_parser = None
+    # Issue #702 codex r2 BLOCKING: when the per-request alias is NOT
+    # reasoning-capable, also bypass the parser entirely. Implicit-mode
+    # parsers (Qwen3 / hermes) classify ordinary chunks as reasoning
+    # until ``finalize_streaming`` emits a correction at end-of-stream
+    # — and the finalize correction is emitted as plain ``text``
+    # without going through ``_gate_thinking_pieces``. If we only
+    # gated the per-delta pieces, a non-thinking alias served beside a
+    # thinking global would stream the demoted reasoning bytes as
+    # text AND then the finalize correction would emit the SAME bytes
+    # again — visible duplication. Dropping the parser here puts the
+    # stream on the ``think_router`` path which only opens thinking
+    # blocks on literal ``<think>`` tags in the raw stream (and is
+    # itself gated by ``_gate_thinking_pieces`` below).
+    if not _reasoning_enabled:
         reasoning_parser = None
     if reasoning_parser:
         reasoning_parser.reset_state()

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -531,6 +531,13 @@ async def _stream_anthropic_messages(
     # this function already reads — sharing avoids a second
     # ``get_config()`` call that test fixtures patching
     # ``anthropic_route.get_config`` would miss.
+    #
+    # Capability is captured ONCE at request entry and frozen in the
+    # ``_gate_thinking_pieces`` closure for the entire SSE response.
+    # A hot-reload that mutates ``cfg.model_registry`` mid-stream
+    # MUST NOT change the gating behavior partway through one
+    # response — clients expect a single coherent SSE contract per
+    # request (codex r3 NIT probe 4).
     _reasoning_enabled = False
     if cfg.model_registry:
         try:
@@ -558,16 +565,36 @@ async def _stream_anthropic_messages(
         False. The rewrite preserves order so the SSE block stream
         still matches what the model actually emitted; downstream
         ``_emit_content_pieces`` merges consecutive same-type pieces
-        into a single content block. No-op (return input unchanged)
-        when the alias IS reasoning-capable, so this is a zero-cost
-        wrapper on the happy path.
+        into a single content block.
+
+        Additionally drops whitespace-only ``thinking`` pieces regardless
+        of ``_reasoning_enabled`` so the streaming surface matches the
+        non-stream ``openai_to_anthropic`` predicate at
+        ``anthropic_adapter.py`` (``reasoning_text.strip() != ""``).
+        Anthropic's public API does not emit empty content blocks; the
+        per-site guards above filter common cases (cap-split kept-bytes
+        + reasoning_parser-emitted whitespace deltas) but ``think_router``
+        can still emerge with a ``("thinking", "   ")`` piece when a
+        ``<think>...</think>`` literal contains only whitespace. Codex
+        r3 MAJOR (probe 1).
         """
         if _reasoning_enabled:
-            return pieces
-        return [
-            ("text", text) if block_type == "thinking" else (block_type, text)
-            for block_type, text in pieces
-        ]
+            return [
+                piece
+                for piece in pieces
+                if not (piece[0] == "thinking" and not piece[1].strip())
+            ]
+        out: list[tuple[str, str]] = []
+        for block_type, text in pieces:
+            if block_type == "thinking":
+                # Demote to text; if the demoted text is also pure
+                # whitespace we still drop it (no value emitting an
+                # empty text_delta to the client).
+                if text.strip():
+                    out.append(("text", text))
+            else:
+                out.append((block_type, text))
+        return out
 
     # Emit message_start
     message_start = {
@@ -767,7 +794,18 @@ async def _stream_anthropic_messages(
                         # eventually sees a final answer instead of an
                         # endless thinking_delta stream.
                         kept, overflow = _account_for_reasoning(reasoning)
-                        if kept:
+                        # Codex r3 MAJOR (probe 1): mirror the non-stream
+                        # whitespace guard at
+                        # ``anthropic_adapter.openai_to_anthropic`` — never
+                        # open a ``thinking`` block for purely whitespace
+                        # reasoning (Anthropic spec: don't emit empty
+                        # content blocks). Without this guard a
+                        # channel="reasoning" delta carrying just
+                        # ``"   \n"`` would open a thinking
+                        # ``content_block_start`` + whitespace
+                        # ``thinking_delta`` that Claude Code surfaces as
+                        # a blank thought bubble.
+                        if kept and kept.strip():
                             pieces_routed.append(("thinking", kept))
                         if overflow:
                             filtered = tool_filter.process(overflow)
@@ -869,7 +907,16 @@ async def _stream_anthropic_messages(
                     reasoning = strip_special_tokens(delta_msg.reasoning)
                     if reasoning:
                         kept, overflow = _account_for_reasoning(reasoning)
-                        if kept:
+                        # Codex r3 MAJOR (probe 1): same whitespace
+                        # guard as the channel-routed branch above and
+                        # the non-stream ``openai_to_anthropic``
+                        # predicate. Reasoning parsers can emit a
+                        # delta whose ``.reasoning`` is whitespace
+                        # only (e.g. qwen3 splitting on a newline
+                        # boundary); opening a thinking block here
+                        # would surface a blank thought bubble in
+                        # Claude Code.
+                        if kept and kept.strip():
                             pieces.append(("thinking", kept))
                         if overflow:
                             # Codex round-7 BLOCKING #1: emitting

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -596,52 +596,60 @@ async def _stream_anthropic_messages(
         "thinking" we ALWAYS keep whitespace because it's an intra-block
         continuation, never a block opener.
         """
-        # First, walk pieces and compute whether each whitespace-only
-        # thinking piece sits at a "block-opening" position. The piece
-        # opens a block iff no thinking block is currently open at the
-        # emitter AND no earlier piece in this batch already emitted
-        # non-whitespace thinking content.
-        thinking_block_open = current_block_type == "thinking"
+        # Track the EFFECTIVE open block type — i.e. what the
+        # downstream emitter currently has open after the gate's
+        # rewrites, NOT the raw piece type the model emitted. This
+        # lets the non-thinking branch route a whitespace-only
+        # ``("thinking", " ")`` piece into an already-open TEXT block
+        # (demoted to ("text", " ")) instead of dropping it. Codex r5
+        # MAJOR.
+        #
+        # ``effective`` is one of None / "text" / "thinking" and
+        # reflects what ``_emit_content_pieces`` will have open after
+        # consuming the pieces ``out`` so far.
+        effective: str | None = current_block_type
         out: list[tuple[str, str]] = []
         for block_type, text in pieces:
             if block_type == "thinking":
                 if not text.strip():
-                    # Whitespace-only thinking piece.
-                    if not thinking_block_open:
-                        # Would open a blank thinking block — drop it.
-                        # On the non-thinking branch we also drop it
-                        # because demoting to ("text", "   ") would
-                        # likewise open a blank text block.
-                        continue
-                    # An intra-thinking separator. Keep it on the
-                    # reasoning-enabled path; demote on the non-thinking
-                    # path (it stays inside an already-open text block
-                    # on that branch because demoted "thinking" became
-                    # "text" earlier in this same pass).
-                    if _reasoning_enabled:
+                    # Whitespace-only thinking piece. Decide whether to
+                    # drop, keep as thinking, or demote to text based
+                    # on which (if any) block is currently open.
+                    if effective == "thinking":
+                        # Intra-thinking separator — keep as-is on the
+                        # reasoning-enabled path. (The non-thinking
+                        # branch can't see ``effective == "thinking"``
+                        # because demotion below sets ``effective`` to
+                        # "text" rather than "thinking".)
                         out.append(("thinking", text))
-                    else:
+                    elif effective == "text" and not _reasoning_enabled:
+                        # Non-thinking branch with an open text block:
+                        # demote the whitespace so it lands inside the
+                        # current text block (codex r5 MAJOR — without
+                        # this, ``("thinking", "hello") + ("thinking",
+                        # " ")`` would stream as ``"hello"`` instead of
+                        # ``"hello "``).
                         out.append(("text", text))
+                    else:
+                        # No relevant open block — dropping it avoids
+                        # opening a blank thinking OR blank text block.
+                        # The non-stream predicate (.strip()) does the
+                        # same.
+                        continue
                     continue
-                # Non-whitespace thinking content. On the reasoning-
-                # enabled branch keep as thinking; on the non-thinking
-                # branch demote to text.
+                # Non-whitespace thinking content. Reasoning-enabled
+                # keeps as thinking; non-thinking demotes to text.
                 if _reasoning_enabled:
                     out.append(("thinking", text))
+                    effective = "thinking"
                 else:
                     out.append(("text", text))
-                # A non-empty thinking piece opens a thinking block on
-                # the reasoning-enabled path; track so subsequent
-                # whitespace pieces in this batch are kept as
-                # intra-block continuations.
-                thinking_block_open = _reasoning_enabled
+                    effective = "text"
             else:
                 out.append((block_type, text))
-                # A non-thinking piece closes any open thinking block
-                # (the emitter will emit a content_block_stop on the
-                # type switch).
-                if block_type != "thinking":
-                    thinking_block_open = False
+                # ``block_type`` is already not "thinking" in this
+                # branch — track the effective open block as that type.
+                effective = block_type
         return out
 
     # Emit message_start

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -342,8 +342,20 @@ async def create_anthropic_message(
             usage=_build_usage(output, reasoning_text),
         )
 
+        # Issue #702: signal the alias's reasoning capability to the
+        # adapter so it can suppress the ``thinking`` content block when
+        # the served alias has ``reasoning_parser: null`` in
+        # ``aliases.json``. Without this gate, an OpenAI-side response
+        # that happens to carry ``reasoning_content`` (or the
+        # ``_rescue_silent_drop_from_reasoning`` duplication into
+        # ``content`` above) would emit a ``thinking`` block on a model
+        # that Anthropic's public API would never produce one for,
+        # breaking client capability detection and rendering the same
+        # paragraph twice.
         anthropic_response = openai_to_anthropic(
-            openai_response, cfg.model_name or anthropic_request.model
+            openai_response,
+            cfg.model_name or anthropic_request.model,
+            reasoning_enabled=cfg.reasoning_parser is not None,
         )
         return Response(
             content=anthropic_response.model_dump_json(exclude_none=True),

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -47,6 +47,7 @@ from ..service.helpers import (
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
+    _resolve_reasoning_enabled,
     _resolve_temperature,
     _resolve_top_p,
     _validate_model_name,
@@ -352,10 +353,17 @@ async def create_anthropic_message(
         # that Anthropic's public API would never produce one for,
         # breaking client capability detection and rendering the same
         # paragraph twice.
+        #
+        # Resolve via ``_resolve_reasoning_enabled`` so the predicate
+        # consults the per-request registry entry first (multi-model
+        # mode) and only falls back to the global ``cfg.reasoning_parser``
+        # singleton. Codex r1 BLOCKING on PR #705 — global-only lookup
+        # would let the duplicate leak when a non-thinking alias is
+        # served alongside a thinking default.
         anthropic_response = openai_to_anthropic(
             openai_response,
             cfg.model_name or anthropic_request.model,
-            reasoning_enabled=cfg.reasoning_parser is not None,
+            reasoning_enabled=_resolve_reasoning_enabled(anthropic_request.model),
         )
         return Response(
             content=anthropic_response.model_dump_json(exclude_none=True),
@@ -500,6 +508,46 @@ async def _stream_anthropic_messages(
     resolved_thinking = _resolve_enable_thinking(openai_request)
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
+
+    # Issue #702: per-request alias-level reasoning capability gate.
+    # When the served alias declares ``reasoning_parser: null`` in
+    # ``aliases.json``, the streaming path must NEVER open a
+    # ``thinking`` content block — Anthropic's public API doesn't
+    # emit one for non-extended-thinking models, so any client that
+    # branches on ``content_block.type == "thinking"`` would
+    # mis-detect capability. Resolved through
+    # ``_resolve_reasoning_enabled`` so it consults the per-request
+    # registry entry first (multi-model mode) instead of the
+    # process-global ``cfg.reasoning_parser_name`` (codex r1 BLOCKING
+    # on PR #705). Applied via ``_gate_thinking_pieces`` below to
+    # every place this function constructs ``("thinking", ...)``
+    # pieces: channel-routed (engine OutputRouter), reasoning-parser
+    # delta split, and the raw ``<think>`` think_router heuristic.
+    # When the gate fires the reasoning bytes are demoted to a
+    # ``text`` piece so the assistant turn still surfaces the model's
+    # output (silent drop is the worse failure mode, #569).
+    _reasoning_enabled = _resolve_reasoning_enabled(anthropic_request.model)
+
+    def _gate_thinking_pieces(
+        pieces: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
+        """Suppress ``thinking`` pieces when the alias is non-thinking.
+
+        Returns a new list where every ``("thinking", text)`` piece is
+        rewritten to ``("text", text)`` when ``_reasoning_enabled`` is
+        False. The rewrite preserves order so the SSE block stream
+        still matches what the model actually emitted; downstream
+        ``_emit_content_pieces`` merges consecutive same-type pieces
+        into a single content block. No-op (return input unchanged)
+        when the alias IS reasoning-capable, so this is a zero-cost
+        wrapper on the happy path.
+        """
+        if _reasoning_enabled:
+            return pieces
+        return [
+            ("text", text) if block_type == "thinking" else (block_type, text)
+            for block_type, text in pieces
+        ]
 
     # Emit message_start
     message_start = {
@@ -710,8 +758,22 @@ async def _stream_anthropic_messages(
                         delta_text[:64],
                     )
                 if pieces_routed:
+                    # Issue #702: gate thinking-piece emission on the
+                    # alias's reasoning capability. ``OutputRouter`` is
+                    # purely token-based and would surface reasoning
+                    # for ANY alias whose tokenizer carries
+                    # ``<|channel>thought`` / harmony analysis tokens
+                    # — including aliases that declared
+                    # ``reasoning_parser: null`` (capability opt-out
+                    # for a tokenizer that nominally supports
+                    # channels). Demote to text so the model output
+                    # still surfaces and clients don't see a
+                    # ``thinking`` block on a non-extended-thinking
+                    # alias.
                     events, current_block_type, block_index = _emit_content_pieces(
-                        pieces_routed, current_block_type, block_index
+                        _gate_thinking_pieces(pieces_routed),
+                        current_block_type,
+                        block_index,
                     )
                     for event in events:
                         yield event
@@ -859,7 +921,9 @@ async def _stream_anthropic_messages(
                             pieces.append(("text", filtered))
                 if pieces:
                     events, current_block_type, block_index = _emit_content_pieces(
-                        pieces, current_block_type, block_index
+                        _gate_thinking_pieces(pieces),
+                        current_block_type,
+                        block_index,
                     )
                     for event in events:
                         yield event
@@ -877,7 +941,9 @@ async def _stream_anthropic_messages(
                     continue
                 pieces = think_router.process(filtered)
                 events, current_block_type, block_index = _emit_content_pieces(
-                    pieces, current_block_type, block_index
+                    _gate_thinking_pieces(pieces),
+                    current_block_type,
+                    block_index,
                 )
                 for event in events:
                     yield event
@@ -893,7 +959,9 @@ async def _stream_anthropic_messages(
         else:
             pieces_flush = think_router.process(remaining)
         events, current_block_type, block_index = _emit_content_pieces(
-            pieces_flush, current_block_type, block_index
+            _gate_thinking_pieces(pieces_flush),
+            current_block_type,
+            block_index,
         )
         for event in events:
             yield event
@@ -902,7 +970,9 @@ async def _stream_anthropic_messages(
         flush_pieces = think_router.flush()
         if flush_pieces:
             events, current_block_type, block_index = _emit_content_pieces(
-                flush_pieces, current_block_type, block_index
+                _gate_thinking_pieces(flush_pieces),
+                current_block_type,
+                block_index,
             )
             for event in events:
                 yield event

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -933,6 +933,37 @@ def get_engine(model_name: str | None = None) -> BaseEngine:
     return cfg.engine
 
 
+def _resolve_reasoning_enabled(model_name: str | None) -> bool:
+    """Return whether the selected alias is reasoning-capable.
+
+    Issue #702: the Anthropic-compat route gates the ``thinking``
+    content block on this predicate so that a non-thinking alias (i.e.
+    one whose ``aliases.json`` entry declares ``reasoning_parser:
+    null``) never emits one regardless of what the OpenAI-side
+    response carries.
+
+    In multi-model mode (``cfg.model_registry`` set) the served alias
+    can be a per-request choice rather than the process-wide default,
+    so consult the registry entry first. Fall back to the global
+    ``cfg.reasoning_parser`` / ``cfg.reasoning_parser_name`` pair
+    (single-model mode) when registry lookup fails — both fields are
+    populated together by ``server.load_model`` so either being set
+    means "this serve has a reasoning parser configured". Accept
+    either to keep test fixtures that only set
+    ``cfg.reasoning_parser_name`` working unchanged. Codex r1
+    BLOCKING on PR #705.
+    """
+    cfg = get_config()
+    if cfg.model_registry:
+        try:
+            entry = cfg.model_registry.get_entry(model_name)
+        except KeyError:
+            entry = None
+        if entry is not None:
+            return bool(getattr(entry, "reasoning_parser", None))
+    return cfg.reasoning_parser is not None or bool(cfg.reasoning_parser_name)
+
+
 def _validate_model_name(request_model: str) -> None:
     """Validate that the request model name matches a served model."""
     if request_model is None:


### PR DESCRIPTION
## Summary

- `POST /v1/messages` on a non-thinking-capable alias was emitting BOTH a `thinking` block AND a `text` block carrying the same string, breaking Claude-Code / claude-cli / langchain-anthropic clients that surface them separately.
- Adapter now gates the `thinking` block on `reasoning_enabled and reasoning_content and reasoning_content != content` (plus a whitespace-only guard).
- Route passes `_resolve_reasoning_enabled(request.model)` — consults the per-request `ModelRegistry` entry first (multi-model mode), falls back to global `cfg.reasoning_parser` / `cfg.reasoning_parser_name`.
- Streaming `/v1/messages` gated identically via `_gate_thinking_pieces`; reasoning_parser instantiation bypassed for non-thinking aliases so `finalize_streaming` can't re-emit demoted reasoning bytes as a second text block.

## Root cause

Two compounding bugs in `vllm_mlx/api/anthropic_adapter.py::openai_to_anthropic`:

1. The adapter unconditionally emitted a `thinking` block whenever `message.reasoning_content` was truthy, regardless of whether the served alias declared `reasoning_parser: null` in `aliases.json`. Anthropic's public API never emits one for non-extended-thinking models.
2. `_rescue_silent_drop_from_reasoning` (#569) deliberately promotes a stuck reasoning trace into `content` so the assistant turn isn't silently empty. For OpenAI clients harmless; for Anthropic clients the adapter had no way to know `reasoning_content == content` is a rescue artifact and emitted both blocks.

## Reproduce (pre-fix)

```python
from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
from vllm_mlx.api.models import (
    AssistantMessage, ChatCompletionChoice, ChatCompletionResponse, Usage,
)
dup = "I think this is the answer."
msg = AssistantMessage(content=dup, reasoning_content=dup)
choice = ChatCompletionChoice(message=msg, finish_reason="stop")
resp = ChatCompletionResponse(model="gemma-4-12b-4bit", choices=[choice],
                              usage=Usage(prompt_tokens=10, completion_tokens=8, total_tokens=18))
print([(b.type, getattr(b, b.type, None)) for b in openai_to_anthropic(resp, "gemma-4-12b-4bit").content])
# Before: [('thinking', 'I think this is the answer.'), ('text', 'I think this is the answer.')]
# After:  [('text', 'I think this is the answer.')]
```

## API compat

- New `reasoning_enabled: bool = True` kwarg on `openai_to_anthropic`. Default-True keeps every external caller (server.py, third-party imports) on their pre-#702 behavior — only the equality dedup gate is unconditional.

## Codex r1 + r2 BLOCKING/NIT resolved

- **r1 BLOCKING #1** (global parser singleton) → `_resolve_reasoning_enabled(model_name)` helper consults per-request `ModelRegistry` entry first.
- **r1 BLOCKING #2** (streaming path ungated) → `_gate_thinking_pieces` closure demotes every `("thinking", text)` piece to `("text", text)` for non-thinking aliases, applied at every `_emit_content_pieces` call site.
- **r1 NIT #1** (whitespace-only reasoning) → predicate strengthened to `reasoning.strip() != ""`.
- **r1 NIT #2** (route-level coverage) → new `tests/test_anthropic_route_thinking_gate.py` walks the full FastAPI route via `TestClient`.
- **r2 BLOCKING #1** (implicit-mode `finalize_streaming` re-emission) → bypass parser construction entirely when `_reasoning_enabled` is False so the stream falls through to `think_router` (which only opens thinking on literal `<think>` tags).

## Tests added

- `tests/test_anthropic_adapter.py`: 5 new (4 from r1 + 1 whitespace).
- `tests/test_anthropic_route_thinking_gate.py`: 5 new (non-stream route, channel-routed stream, implicit-parser bypass, registry-vs-global predicate, single-model fallback predicate).

## Test plan

- [x] `python3.12 -m pytest tests/test_anthropic_adapter.py tests/test_anthropic_route_thinking_gate.py -x -q` → 63 passed
- [x] `python3.12 -m pytest tests/ -k anthropic --ignore=tests/integrations -q` → 191 passed
- [x] `python3.12 -m pytest tests/ -q --ignore=tests/integrations` (excl. unrelated batched-perf timing flake) → 5840 passed, 18 skipped, 7 xfailed
- [x] `make lint` (ruff check + ruff format --check) → all green

Closes #702.