### PR TITLE
fix(serve): cap request body + reject oversize prompts (F-007 DoS, #463)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.35"
+version = "0.7.36"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -308,9 +308,7 @@ def test_enforce_for_messages_template_error_raises_400():
         def build_prompt(self, messages, tools=None):  # noqa: ARG002
             # Mirrors the error shape Jinja raises when a chat template
             # references an undefined variable like ``user``.
-            raise ValueError(
-                "TemplateError: 'user' is undefined in chat template"
-            )
+            raise ValueError("TemplateError: 'user' is undefined in chat template")
 
     with pytest.raises(HTTPException) as excinfo:
         enforce_context_length_for_messages(
@@ -366,9 +364,7 @@ def test_enforce_for_messages_non_template_exception_silent_fallthrough():
         is_mllm = False
 
         def build_prompt(self, messages, tools=None):  # noqa: ARG002
-            raise AttributeError(
-                "'BatchedEngine' object has no attribute '_model'"
-            )
+            raise AttributeError("'BatchedEngine' object has no attribute '_model'")
 
     # No exception — fall through silently. Caller (route) goes on to
     # invoke engine.chat() where the real loaded-state check fires.

--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -283,6 +283,126 @@ def test_enforce_tolerates_none_max_tokens():
     enforce_context_length(eng, prompt_tokens=2048, max_tokens=None)  # equal → ok
 
 
+# ─── enforce_context_length_for_messages: build_prompt failure paths ─
+
+
+def test_enforce_for_messages_template_error_raises_400():
+    """Codex r3 F7: when ``build_prompt`` raises a chat-template /
+    malformed-tools-schema error, the helper must surface it as a
+    clean HTTP 400 instead of silently dropping the preflight token
+    gate (which previously let the request fall through to the engine
+    which then re-rendered the same template and re-emitted the same
+    400 from a deeper layer).
+
+    Fail-fast saves a wasted engine.chat() round trip and pins the
+    error shape so the structured-envelope handler can attach the
+    OpenAI-style ``invalid_request_error`` envelope.
+    """
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length_for_messages
+
+    class _TemplateErrorEngine:
+        is_mllm = False
+
+        def build_prompt(self, messages, tools=None):  # noqa: ARG002
+            # Mirrors the error shape Jinja raises when a chat template
+            # references an undefined variable like ``user``.
+            raise ValueError(
+                "TemplateError: 'user' is undefined in chat template"
+            )
+
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length_for_messages(
+            _TemplateErrorEngine(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    exc = excinfo.value
+    assert exc.status_code == 400
+    assert "Chat template error" in str(exc.detail)
+
+
+def test_enforce_for_messages_template_error_lowercase_match():
+    """Some Jinja errors come through as plain ``ValueError`` whose
+    class name doesn't carry ``TemplateError`` but whose message does
+    (e.g. ``"Unknown template tag"``). The sniff must catch the
+    lowercase ``template`` substring too, matching the route-level
+    handler at ``routes/chat.py``.
+    """
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length_for_messages
+
+    class _LowercaseTemplateEngine:
+        is_mllm = False
+
+        def build_prompt(self, messages, tools=None):  # noqa: ARG002
+            raise RuntimeError("Unknown template tag at line 42")
+
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length_for_messages(
+            _LowercaseTemplateEngine(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert excinfo.value.status_code == 400
+
+
+def test_enforce_for_messages_non_template_exception_silent_fallthrough():
+    """Other ``build_prompt`` failure modes (engine half-loaded,
+    tokenizer crash, transient state) keep the original silent-
+    fallthrough behavior so the downstream scheduler / engine.chat()
+    path still has a chance to run. The body-size middleware remains
+    the last DoS line.
+
+    Without this distinction a TOCTOU between the engine warm-up and
+    a chat request would 500 every preflight when the previous
+    behavior would 200 once the engine completed loading.
+    """
+    from vllm_mlx.service.helpers import enforce_context_length_for_messages
+
+    class _GenericFailureEngine:
+        is_mllm = False
+
+        def build_prompt(self, messages, tools=None):  # noqa: ARG002
+            raise AttributeError(
+                "'BatchedEngine' object has no attribute '_model'"
+            )
+
+    # No exception — fall through silently. Caller (route) goes on to
+    # invoke engine.chat() where the real loaded-state check fires.
+    enforce_context_length_for_messages(
+        _GenericFailureEngine(),
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+
+def test_enforce_for_messages_http_exception_passes_through():
+    """If ``build_prompt`` itself raises an ``HTTPException`` (e.g. the
+    engine surfaces a structured 503 because the model isn't loaded),
+    the helper must NOT shadow it with a 400 sniff — the engine's
+    deliberate HTTP status must win.
+    """
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length_for_messages
+
+    class _HttpEngine:
+        is_mllm = False
+
+        def build_prompt(self, messages, tools=None):  # noqa: ARG002
+            raise HTTPException(status_code=503, detail="model not loaded")
+
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length_for_messages(
+            _HttpEngine(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert excinfo.value.status_code == 503
+
+
 # ─── End-to-end shape: structured handler passes envelope through ───
 
 

--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the prompt-token context-length pre-check.
+
+Even within the wire-level body cap (``middleware/body_size.py``),
+a 8 MiB ASCII payload can hold ~2M tokens — well past every model
+context window. ``service/helpers.py::enforce_context_length`` must
+reject those prompts with HTTP 400 / ``context_length_exceeded``
+BEFORE the scheduler starts prefill, so a client that fits inside
+the byte cap but exceeds the context window still gets a clean
+structured error instead of a wasted ~60 s prefill (F-007 /
+rapid-desktop#273).
+
+These tests exercise the helper directly with fake engines so they
+run on any machine without model load — the integration with the
+chat route is covered by ``test_chat_route_*`` smoke runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Helpers under test depend on the engine contract (``_model.args.*``,
+# ``tokenizer.encode``) — both surfaces exist regardless of mlx-lm
+# availability, so this file runs everywhere. The chat route import
+# itself transitively pulls in mlx, so we don't import it here.
+
+
+class _StubArgs:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _StubModel:
+    def __init__(self, args=None, config=None):
+        if args is not None:
+            self.args = args
+        if config is not None:
+            self.config = config
+
+
+class _StubTokenizer:
+    """Minimal tokenizer surface: ``encode``, ``model_max_length``,
+    ``bos_token``. Token count is intentionally deterministic
+    (1 token per 4 characters) so the test can hit specific
+    boundaries without depending on a real BPE."""
+
+    def __init__(self, model_max_length=None, bos_token=None, chars_per_token=4):
+        if model_max_length is not None:
+            self.model_max_length = model_max_length
+        self.bos_token = bos_token
+        self._cpt = chars_per_token
+
+    def encode(self, text, add_special_tokens=True):  # noqa: ARG002
+        return [0] * max(1, len(text) // self._cpt)
+
+
+class _StubEngine:
+    """Stand-in for ``BatchedEngine`` for the unit tests below. Only
+    surfaces the attributes the helpers read — keeps the test fast
+    and free of mlx-lm. The real engine wiring is exercised by the
+    audio/chat integration tests."""
+
+    is_mllm = False
+
+    def __init__(self, model=None, tokenizer=None):
+        self._model = model
+        self._tokenizer = tokenizer
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+
+# ─── get_model_max_context ─────────────────────────────────────────
+
+
+def test_max_context_from_args_top_level():
+    """Plain text LLMs (Llama, Mistral, Qwen3 dense) expose
+    ``max_position_embeddings`` directly on ``model.args``."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(max_position_embeddings=32768)))
+    assert get_model_max_context(eng) == 32768
+
+
+def test_max_context_from_nested_text_config():
+    """Multimodal models (Qwen3.5, Gemma 4 VLM) nest the text-config
+    under ``model.args.text_config.max_position_embeddings``. The
+    helper must walk one level deeper."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    text_cfg = _StubArgs(max_position_embeddings=262144)
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(text_config=text_cfg)))
+    assert get_model_max_context(eng) == 262144
+
+
+def test_max_context_from_model_config_attribute():
+    """Some HF-style models expose ``model.config.max_position_embeddings``
+    instead of ``model.args``. Resolution must fall through to it
+    when ``args`` is absent or unhelpful."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    cfg = _StubArgs(max_position_embeddings=8192)
+    eng = _StubEngine(model=_StubModel(config=cfg))
+    assert get_model_max_context(eng) == 8192
+
+
+def test_max_context_from_tokenizer_when_model_silent():
+    """Engines whose loader doesn't propagate the config still
+    surface a useful cap via ``tokenizer.model_max_length``."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    tok = _StubTokenizer(model_max_length=4096)
+    eng = _StubEngine(tokenizer=tok)
+    assert get_model_max_context(eng) == 4096
+
+
+def test_max_context_ignores_hf_sentinel_value():
+    """HuggingFace tokenizers report ``model_max_length=1e30`` when
+    no cap is known. We must NOT treat that as a real cap (it'd
+    leave the gate effectively disabled). Helper falls through to
+    the fallback in that case."""
+    from vllm_mlx.service.helpers import (
+        _FALLBACK_MAX_CONTEXT_TOKENS,
+        get_model_max_context,
+    )
+
+    tok = _StubTokenizer(model_max_length=int(1e30))
+    eng = _StubEngine(tokenizer=tok)
+    assert get_model_max_context(eng) == _FALLBACK_MAX_CONTEXT_TOKENS
+
+
+def test_max_context_falls_back_when_no_metadata():
+    """Engine with no model and no tokenizer surfaces the fallback
+    constant. The fallback is intentionally enormous so legitimate
+    requests pass while DoS-shape prompts (≈ millions of tokens)
+    still trip."""
+    from vllm_mlx.service.helpers import (
+        _FALLBACK_MAX_CONTEXT_TOKENS,
+        get_model_max_context,
+    )
+
+    eng = _StubEngine()
+    assert get_model_max_context(eng) == _FALLBACK_MAX_CONTEXT_TOKENS
+
+
+# ─── count_prompt_tokens ───────────────────────────────────────────
+
+
+def test_count_prompt_tokens_uses_tokenizer_encode():
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine(tokenizer=_StubTokenizer(chars_per_token=4))
+    assert count_prompt_tokens(eng, "x" * 400) == 100
+
+
+def test_count_prompt_tokens_returns_zero_on_no_tokenizer():
+    """No tokenizer → return 0 so the caller treats the check as a
+    metadata edge case rather than a 500."""
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine()
+    assert count_prompt_tokens(eng, "hello") == 0
+
+
+def test_count_prompt_tokens_handles_encode_exception():
+    """If the tokenizer raises (model isn't fully loaded yet, edge
+    case), we still want 0 — not a 500. The downstream engine call
+    will produce a clean error."""
+
+    class _Broken:
+        bos_token = None
+
+        def encode(self, text, add_special_tokens=True):  # noqa: ARG002
+            raise RuntimeError("tokenizer not ready")
+
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine(tokenizer=_Broken())
+    assert count_prompt_tokens(eng, "hi") == 0
+
+
+# ─── enforce_context_length ────────────────────────────────────────
+
+
+def test_enforce_under_cap_is_silent():
+    """Prompts inside the window pass through with no exception."""
+    from vllm_mlx.service.helpers import enforce_context_length
+
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(max_position_embeddings=2048)))
+    enforce_context_length(eng, prompt_tokens=512, max_tokens=512)  # 1024 ≤ 2048
+
+
+def test_enforce_over_cap_raises_400_context_length_exceeded():
+    """A prompt past the cap raises HTTP 400 with the OpenAI-style
+    ``context_length_exceeded`` envelope. This is the load-bearing
+    test — without this we go right back to the F-007 silent hang."""
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length
+
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(max_position_embeddings=2048)))
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length(eng, prompt_tokens=3000, max_tokens=0)
+
+    exc = excinfo.value
+    assert exc.status_code == 400
+    assert isinstance(exc.detail, dict)
+    err = exc.detail["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "context_length_exceeded"
+    assert err["param"] == "messages"
+    # The message must mention both the cap and the requested length
+    # so the user can shrink the prompt without guessing.
+    assert "2048" in err["message"]
+    assert "3000" in err["message"]
+
+
+def test_enforce_includes_max_tokens_in_budget():
+    """Prompt fits alone but ``prompt + max_tokens`` exceeds the cap.
+    OpenAI's own ``context_length_exceeded`` fires in this case so we
+    mirror it — rejecting now avoids a mid-generation truncation."""
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length
+
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(max_position_embeddings=4096)))
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length(eng, prompt_tokens=3500, max_tokens=1000)
+
+    err = excinfo.value.detail["error"]
+    assert err["code"] == "context_length_exceeded"
+    # Requested = 3500 + 1000 = 4500
+    assert "4500" in err["message"]
+
+
+def test_enforce_tolerates_none_max_tokens():
+    """``max_tokens`` is optional in the request; the helper must
+    accept ``None`` and only validate the prompt half."""
+    from vllm_mlx.service.helpers import enforce_context_length
+
+    eng = _StubEngine(model=_StubModel(args=_StubArgs(max_position_embeddings=2048)))
+    enforce_context_length(eng, prompt_tokens=2048, max_tokens=None)  # equal → ok
+
+
+# ─── End-to-end shape: structured handler passes envelope through ───
+
+
+def test_structured_detail_passes_through_global_handler():
+    """The global HTTP exception handler in ``vllm_mlx/server.py``
+    must recognise ``HTTPException(detail={"error": {...}})`` and
+    emit the structured envelope unchanged, so SDKs that introspect
+    ``error.code`` see ``context_length_exceeded`` rather than a
+    stringified Python dict.
+
+    This guards against a refactor of the handler that re-wraps the
+    detail and silently strips ``code`` / ``param`` from
+    structured-detail callers."""
+    pytest.importorskip("mlx_lm")  # global handler module pulls in mlx
+
+    from fastapi import FastAPI, HTTPException
+
+    app = FastAPI()
+
+    @app.post("/v1/test")
+    async def _handler():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": "boom",
+                    "type": "invalid_request_error",
+                    "code": "context_length_exceeded",
+                    "param": "messages",
+                }
+            },
+        )
+
+    # Re-register the global handler from vllm_mlx.server on our tiny app
+    # so we exercise the actual production handler, not FastAPI's default.
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from vllm_mlx.server import _http_exception_handler
+
+    app.add_exception_handler(StarletteHTTPException, _http_exception_handler)
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    resp = client.post("/v1/test")
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "context_length_exceeded"
+    assert body["error"]["param"] == "messages"
+    assert body["error"]["message"] == "boom"

--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -164,6 +164,45 @@ def test_count_prompt_tokens_returns_zero_on_no_tokenizer():
     assert count_prompt_tokens(eng, "hello") == 0
 
 
+def test_count_prompt_tokens_handles_list_of_ints():
+    """codex round-2 BLOCKING #3: token-id list prompts must be
+    counted directly via ``len()``, not run through
+    ``tokenizer.encode`` (which would 0-out the count and bypass the
+    DoS gate)."""
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    # No tokenizer needed — the helper short-circuits on list shape.
+    eng = _StubEngine()
+    assert count_prompt_tokens(eng, [1, 2, 3, 4, 5]) == 5
+
+
+def test_count_prompt_tokens_handles_list_of_token_id_lists():
+    """Multi-prompt batched-token form (``list[list[int]]``) — the
+    helper returns the worst-case (longest) so the DoS gate fires on
+    the worst entry, not silently bypasses."""
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine()
+    assert count_prompt_tokens(eng, [[1, 2], [1, 2, 3, 4]]) == 4
+
+
+def test_count_prompt_tokens_returns_zero_on_empty_list():
+    """Empty token-id list — no DoS risk, no count."""
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine()
+    assert count_prompt_tokens(eng, []) == 0
+
+
+def test_count_prompt_tokens_returns_zero_on_unknown_shape():
+    """Non-str / non-list — caller should be using a different code
+    path. Return 0 so the cap defers to engine-side validation."""
+    from vllm_mlx.service.helpers import count_prompt_tokens
+
+    eng = _StubEngine(tokenizer=_StubTokenizer())
+    assert count_prompt_tokens(eng, 42) == 0
+
+
 def test_count_prompt_tokens_handles_encode_exception():
     """If the tokenizer raises (model isn't fully loaded yet, edge
     case), we still want 0 — not a 500. The downstream engine call

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -158,6 +158,12 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # bearer key in argv (visible to ``ps`` for any local user).
         # Pure auth-config knob; routing decisions never read it.
         "RAPID_MLX_API_KEY",
+        # Server-side: fallback for ``--max-request-bytes`` (DoS defense,
+        # rapid-desktop#273 / #463). Enforces the ASGI-layer body cap in
+        # ``vllm_mlx/middleware/body_size.py``. Pure wire-level size gate
+        # — never selects a model, parser, or routing tier; it only
+        # decides whether a request body is admitted at all.
+        "RAPID_MLX_MAX_REQUEST_BYTES",
         # Path to the MCP server config file (formerly VLLM_MLX_MCP_CONFIG).
         # Plumbs ``--mcp-config`` from the CLI to the FastAPI lifespan and is
         # consumed only by ``vllm_mlx/mcp/config.py`` to discover MCP tool

--- a/tests/test_request_body_size_limit.py
+++ b/tests/test_request_body_size_limit.py
@@ -448,6 +448,59 @@ def test_get_request_is_not_capped():
     assert resp.status_code == 200
 
 
+def test_oversized_body_returns_413_before_auth_check():
+    """Codex r3 F3: pin the deliberate ordering choice — the body-size
+    cap runs at the ASGI layer (``add_middleware`` is the outermost
+    Starlette middleware stack), while bearer-token auth is a FastAPI
+    ``Depends(verify_api_key)`` at the route level. So an oversized
+    unauthenticated POST is rejected with 413, NOT 401 — denying
+    unauthenticated clients the cap-probing reconnaissance channel.
+
+    This is the deliberate design (reject DoS payloads cheapest, before
+    any per-request work including auth). The test exists to make the
+    ordering load-bearing — anyone moving the body cap *behind* the
+    auth dependency will fail it and have to think about it.
+    """
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import install_request_body_limit_middleware
+
+    get_config().max_request_bytes = 1024  # 1 KiB cap
+
+    app = FastAPI()
+
+    auth_calls = {"n": 0}
+
+    async def _fake_auth():
+        # Simulates a bearer check that would 401 if reached. The
+        # 413 must trip before we ever land here.
+        auth_calls["n"] += 1
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=401, detail="Missing bearer")
+
+    from fastapi import Depends
+
+    @app.post("/v1/chat/completions", dependencies=[Depends(_fake_auth)])
+    async def _gated(payload: dict):  # noqa: ARG001
+        return {"ok": True}
+
+    install_request_body_limit_middleware(app)
+    client = TestClient(app)
+
+    oversized = {"messages": [{"role": "user", "content": "x" * 4096}]}
+    resp = client.post(
+        "/v1/chat/completions",
+        json=oversized,
+        # No Authorization header — auth would normally 401.
+    )
+    assert resp.status_code == 413, (
+        f"expected 413 (body cap before auth), got {resp.status_code}"
+    )
+    assert auth_calls["n"] == 0, (
+        "auth dependency ran before the body cap — ordering regressed"
+    )
+
+
 def test_cli_flag_overrides_config_default():
     """The ``--max-request-bytes`` flag is wired through
     ``vllm_mlx.server._max_request_bytes`` and ``_sync_config`` into

--- a/tests/test_request_body_size_limit.py
+++ b/tests/test_request_body_size_limit.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the global request-body size cap.
+
+Defends against the F-007 DoS pattern (rapid-desktop#273 / #463):
+a 10–100 MB JSON body silently ran ~60–90 s of useless prefill on a
+27B alias before the client gave up. The cap MUST reject oversized
+bodies at the ASGI layer with HTTP 413 *before* FastAPI JSON parsing
+runs.
+
+The audio variant has its own multipart-aware cap with a higher
+budget — these tests assert the JSON-route cap leaves that path alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Same skip rationale as test_audio_upload_size_limit.py — the audio
+# import is light (no model load) but the middleware module itself
+# pulls in ``vllm_mlx.config`` which transitively imports mlx-lm.
+pytest.importorskip(
+    "mlx.core",
+    reason="middleware imports transitively pull in mlx; "
+    "runs on Apple Silicon / dev, not minimal Linux CI runners",
+)
+pytest.importorskip(
+    "mlx_lm",
+    reason="middleware imports transitively pull in mlx_lm; "
+    "runs on Apple Silicon / dev, not minimal Linux CI runners",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config():
+    """Each test starts from a clean ServerConfig singleton so the
+    8 MiB default isn't carried over from a previous test that
+    monkey-patched ``max_request_bytes``."""
+    from vllm_mlx.config.server_config import get_config, reset_config
+
+    reset_config()
+    yield
+    # Restore default for the next module.
+    get_config().max_request_bytes = 8 * 1024 * 1024
+
+
+def _build_app() -> FastAPI:
+    """A minimal FastAPI app wired exactly like ``vllm_mlx.server`` —
+    the request-body middleware plus a tiny POST handler under one of
+    the guarded path prefixes. Keeps the body-size guard the only
+    moving piece under test."""
+    from vllm_mlx.middleware.body_size import install_request_body_limit_middleware
+
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _echo(payload: dict):
+        return {"received_bytes": len(json.dumps(payload).encode("utf-8"))}
+
+    @app.post("/v1/embeddings")
+    async def _emb(payload: dict):  # noqa: ARG001
+        return {"ok": True}
+
+    @app.post("/healthz")  # outside the guarded prefix
+    async def _health(payload: dict):  # noqa: ARG001
+        return {"ok": True}
+
+    install_request_body_limit_middleware(app)
+    return app
+
+
+def test_honest_content_length_over_cap_returns_413():
+    """A request advertising Content-Length > cap must be rejected
+    with HTTP 413 in microseconds. No JSON parsing, no Pydantic
+    construction.
+
+    This is the F-007 happy-path: a malicious client advertises a
+    huge body and the server bounces it immediately. The legacy
+    behavior (60-90 s prefill) only happens once the body is read,
+    so the proof-by-receive-tracer in
+    ``test_body_never_reaches_handler_on_413`` below covers the
+    "did we actually read the bytes" property.
+    """
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 1024  # 1 KiB cap
+
+    app = _build_app()
+    client = TestClient(app)
+
+    # 4 KiB body well over the 1 KiB cap.
+    big_payload = {"data": "x" * 4096}
+    resp = client.post("/v1/chat/completions", json=big_payload)
+
+    assert resp.status_code == 413, resp.text
+    body = resp.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "request_too_large"
+    assert "1024" in body["error"]["message"]
+
+
+def test_body_just_under_cap_passes_through():
+    """Positive control: a body under the cap must reach the handler
+    and return its normal response. Catches regressions where the
+    middleware is overly aggressive (e.g. off-by-one on the boundary,
+    or rejection of every POST regardless of size)."""
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 16 * 1024  # 16 KiB cap
+
+    app = _build_app()
+    client = TestClient(app)
+
+    small_payload = {"messages": [{"role": "user", "content": "hi"}]}
+    resp = client.post("/v1/chat/completions", json=small_payload)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["received_bytes"] > 0
+
+
+def test_disabled_when_cap_is_zero():
+    """``--max-request-bytes 0`` (the documented escape hatch)
+    must disable the cap entirely. Operators with their own DoS
+    controls upstream rely on this."""
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 0
+
+    app = _build_app()
+    client = TestClient(app)
+
+    # 256 KiB payload — small enough that the test stays fast, but
+    # well above any reasonable accidental default we might land on.
+    big_payload = {"data": "y" * (256 * 1024)}
+    resp = client.post("/v1/chat/completions", json=big_payload)
+    assert resp.status_code == 200, resp.text
+
+
+def test_unguarded_path_is_not_capped():
+    """The cap only applies to ``/v1/*`` / ``/internal/*`` /
+    ``/anthropic/*`` paths. Probes like ``/healthz``, ``/metrics``,
+    or anything else outside those prefixes must pass through even
+    if their body would exceed the cap. Without this scoping, a
+    health-check tool that POSTs JSON would 413 spuriously."""
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 512  # tiny cap
+
+    app = _build_app()
+    client = TestClient(app)
+
+    big_payload = {"data": "z" * 4096}
+    resp = client.post("/healthz", json=big_payload)
+    assert resp.status_code == 200, resp.text
+
+
+def test_audio_path_is_excluded_from_generic_cap():
+    """The audio transcription endpoint has its own multipart-aware
+    25 MB cap (see ``routes/audio.py``). The generic JSON cap MUST
+    NOT short-circuit it — a legitimate 5 MB voice upload should
+    flow through to the audio middleware, not get bounced by the
+    8 MiB JSON cap at a wire-level honest-Content-Length check.
+
+    We assert by ensuring our generic middleware does NOT respond
+    to ``/v1/audio/transcriptions`` even when the body advertises
+    a length that would otherwise exceed our cap."""
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 1024
+
+    app = _build_app()
+
+    # Add the route AFTER the middleware so the middleware definitely
+    # sees the path; assert the request reaches the handler instead
+    # of being 413'd at our layer.
+    @app.post("/v1/audio/transcriptions")
+    async def _aud(payload: dict):  # noqa: ARG001
+        return {"ok": True}
+
+    client = TestClient(app)
+    big_payload = {"data": "a" * 4096}
+    resp = client.post("/v1/audio/transcriptions", json=big_payload)
+    # Reached the handler — our cap did NOT apply.
+    assert resp.status_code == 200, resp.text
+
+
+def test_body_never_reaches_handler_on_413():
+    """The load-bearing assertion: when the cap fires on an honest
+    Content-Length, NO ``http.request`` message is ever drained
+    from the ``receive`` channel. This is the empirical proof that
+    we don't repeat the F-007 pattern where the body is read +
+    JSON-parsed + tokenized before we bounce.
+
+    A receive-tracer counts how often the inner ASGI app sees a
+    body message. If the middleware does its job, that count is 0.
+    """
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().max_request_bytes = 1024
+
+    receive_calls = []
+
+    async def _inner_app(scope, receive, send):
+        # If the middleware does its job, this never runs.
+        while True:
+            msg = await receive()
+            receive_calls.append(msg.get("type"))
+            if not msg.get("more_body"):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RequestBodyLimitMiddleware(_inner_app)
+
+    body = b"X" * 16384  # 16 KiB, far over the 1 KiB cap
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode("ascii")),
+        ],
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 413, sent
+    # The inner app was never reached — no body parsing happened.
+    assert receive_calls == [], (
+        f"middleware let body parsing begin (receive saw {receive_calls}) — "
+        "guard regressed to a handler-level check"
+    )
+
+
+def test_chunked_streaming_body_aborts_mid_stream():
+    """The chunked / no-Content-Length / lying-Content-Length attack
+    path. The client omits Content-Length and streams chunks past
+    the cap. The middleware MUST stop calling ``receive`` once the
+    running total exceeds the cap and emit a 413.
+
+    Without this guard, a Transfer-Encoding: chunked client could
+    stream gigabytes before any byte-count gate fired."""
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().max_request_bytes = 1024  # 1 KiB cap
+
+    async def _draining_inner(scope, receive, send):
+        while True:
+            msg = await receive()
+            if msg.get("type") == "http.disconnect":
+                return
+            if not msg.get("more_body"):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RequestBodyLimitMiddleware(_draining_inner)
+
+    total_chunks = 16
+    chunk_size = 256
+    received_count = {"n": 0}
+
+    async def receive():
+        i = received_count["n"]
+        received_count["n"] += 1
+        if i >= total_chunks:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        more = i < total_chunks - 1
+        return {"type": "http.request", "body": b"X" * chunk_size, "more_body": more}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    # No Content-Length — chunked transfer encoding scope.
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/json"),
+            (b"transfer-encoding", b"chunked"),
+        ],
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 413, sent
+
+    # The cap is 1024 B at 256 B/chunk → trip on chunk 5 (1280 > 1024).
+    # We must NOT have drained all 16 chunks.
+    assert received_count["n"] < total_chunks, (
+        f"middleware read {received_count['n']}/{total_chunks} chunks — "
+        "streaming abort regressed"
+    )
+    assert received_count["n"] <= 6, (
+        f"middleware over-read: {received_count['n']} chunks of "
+        f"{chunk_size} B vs limit 1024"
+    )
+
+
+def test_get_request_is_not_capped():
+    """The middleware skips GET (and other body-less methods) entirely
+    so it adds no latency to ``/v1/models``, ``/v1/health/...``,
+    etc. A spuriously large GET shouldn't be possible in HTTP/1.1
+    anyway, but we still want zero per-request overhead on read
+    paths."""
+    from vllm_mlx.config.server_config import get_config
+
+    get_config().max_request_bytes = 1  # absurdly tiny — every body would fail
+
+    app = _build_app()
+
+    @app.get("/v1/models")
+    async def _list():
+        return {"data": []}
+
+    client = TestClient(app)
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200
+
+
+def test_cli_flag_overrides_config_default():
+    """The ``--max-request-bytes`` flag is wired through
+    ``vllm_mlx.server._max_request_bytes`` and ``_sync_config`` into
+    ``ServerConfig.max_request_bytes``. We don't exercise the full
+    CLI here (too heavy — needs model load) but we do assert the
+    wiring: writing the module global and calling ``_sync_config``
+    propagates the value to the config singleton the middleware
+    reads."""
+    import vllm_mlx.server as server_mod
+    from vllm_mlx.config.server_config import get_config
+
+    original = server_mod._max_request_bytes
+    try:
+        server_mod._max_request_bytes = 12345
+        server_mod._sync_config()
+        assert get_config().max_request_bytes == 12345
+    finally:
+        server_mod._max_request_bytes = original
+        server_mod._sync_config()

--- a/tests/test_request_body_size_limit.py
+++ b/tests/test_request_body_size_limit.py
@@ -20,19 +20,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# Same skip rationale as test_audio_upload_size_limit.py — the audio
-# import is light (no model load) but the middleware module itself
-# pulls in ``vllm_mlx.config`` which transitively imports mlx-lm.
-pytest.importorskip(
-    "mlx.core",
-    reason="middleware imports transitively pull in mlx; "
-    "runs on Apple Silicon / dev, not minimal Linux CI runners",
-)
-pytest.importorskip(
-    "mlx_lm",
-    reason="middleware imports transitively pull in mlx_lm; "
-    "runs on Apple Silicon / dev, not minimal Linux CI runners",
-)
+# NIT from codex round 1: ``RequestBodyLimitMiddleware`` is pure ASGI
+# logic with no mlx-lm import path — ``vllm_mlx.middleware.body_size``
+# only pulls in ``vllm_mlx.config.server_config`` (a dataclass) and
+# stdlib. Empirically verified: the module loads under an import hook
+# that blocks ``mlx*``. So we no longer ``importorskip("mlx.core")``
+# here — the security gate gets exercised on every runner, including
+# the minimal Linux pr-validate CI matrix.
 
 
 @pytest.fixture(autouse=True)
@@ -340,6 +334,83 @@ def test_chunked_streaming_body_aborts_mid_stream():
     assert received_count["n"] <= 6, (
         f"middleware over-read: {received_count['n']} chunks of "
         f"{chunk_size} B vs limit 1024"
+    )
+
+
+def test_no_double_response_when_handler_already_sent_headers():
+    """Codex round-1 BLOCKING #2 regression: if a downstream handler
+    has already emitted ``http.response.start`` BEFORE the cap trips
+    (e.g. a streaming handler that reads body lazily after first
+    flushing 200 OK headers), the middleware must NOT inject a 413
+    on top of the in-flight response — that would corrupt the wire.
+
+    Test design: build an inner app that emits ``http.response.start``
+    BEFORE reading the body, then reads chunks. The cap trips inside
+    the read loop; the middleware catches ``_BodyTooLargeError`` and must
+    silently let the response complete (logged warning, no double 413).
+    """
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().max_request_bytes = 1024
+
+    async def _start_then_read_inner(scope, receive, send):
+        # Emit response start BEFORE reading body — this is the
+        # codex-flagged window where a 413 from the middleware would
+        # collide with an in-flight 200.
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        # Now read body — middleware will raise _BodyTooLargeError here.
+        while True:
+            msg = await receive()
+            if not msg.get("more_body"):
+                break
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RequestBodyLimitMiddleware(_start_then_read_inner)
+
+    body = b"X" * 4096
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/json"),
+            (b"transfer-encoding", b"chunked"),
+        ],
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    # Exactly one http.response.start frame on the wire — no 413
+    # injected after the 200 went out. This is the load-bearing
+    # assertion that the codex BLOCKING was about.
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert len(starts) == 1, sent
+    assert starts[0]["status"] == 200, (
+        "middleware injected a 413 on top of an in-flight 200 — "
+        "double-response regression"
     )
 
 

--- a/tests/test_request_body_size_limit.py
+++ b/tests/test_request_body_size_limit.py
@@ -405,12 +405,25 @@ def test_no_double_response_when_handler_already_sent_headers():
 
     # Exactly one http.response.start frame on the wire — no 413
     # injected after the 200 went out. This is the load-bearing
-    # assertion that the codex BLOCKING was about.
+    # assertion that the codex round-1 BLOCKING #2 was about.
     starts = [m for m in sent if m["type"] == "http.response.start"]
     assert len(starts) == 1, sent
     assert starts[0]["status"] == 200, (
         "middleware injected a 413 on top of an in-flight 200 — "
         "double-response regression"
+    )
+    # codex round-2 BLOCKING #2: the test must also assert the
+    # response stream was properly terminated. Without the close-frame
+    # logic added in round 2, the middleware would silently return
+    # leaving the client hanging on a Content-Length / chunked
+    # trailer that never arrived.
+    terminal_bodies = [
+        m
+        for m in sent
+        if m["type"] == "http.response.body" and not m.get("more_body", False)
+    ]
+    assert len(terminal_bodies) == 1, (
+        f"response stream not terminated after cap trip — got {sent}"
     )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -882,6 +882,14 @@ def serve_command(args):
             try:
                 server._max_request_bytes = max(0, int(_env))
             except ValueError:
+                # Explicit reset (codex round-2 NIT): without this,
+                # an in-process callsite that mutated ``_max_request_bytes``
+                # before serve_command runs would silently leak a stale
+                # value past a malformed env var, which is the worst
+                # possible failure shape — bigger cap than the operator
+                # intended. Fall back to the documented 8 MiB default
+                # explicitly.
+                server._max_request_bytes = 8 * 1024 * 1024
                 logger.warning(
                     "%s=%r is not an integer; falling back to the 8 MiB default",
                     _env_name,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -866,6 +866,27 @@ def serve_command(args):
     # backwards-compat with existing scripts.
     server._api_key = args.api_key or os.environ.get("RAPID_MLX_API_KEY")
     server._default_timeout = args.timeout
+
+    # Per-request body-size cap. Resolution order:
+    #   1. ``--max-request-bytes`` (explicit CLI flag, including 0 to disable)
+    #   2. ``RAPID_MLX_MAX_REQUEST_BYTES`` env var
+    #   3. ``ServerConfig`` dataclass default (8 MiB)
+    # See vllm_mlx/middleware/body_size.py for the DoS rationale.
+    _max_body_arg = getattr(args, "max_request_bytes", None)
+    if _max_body_arg is not None:
+        server._max_request_bytes = max(0, int(_max_body_arg))
+    else:
+        _env_name = "RAPID_MLX_MAX_REQUEST_BYTES"
+        _env = os.environ.get(_env_name, "").strip()
+        if _env:
+            try:
+                server._max_request_bytes = max(0, int(_env))
+            except ValueError:
+                logger.warning(
+                    "%s=%r is not an integer; falling back to the 8 MiB default",
+                    _env_name,
+                    _env,
+                )
     # Configure CORS
     cors_origins = args.cors_origins if args.cors_origins else ["*"]
     server.configure_cors(cors_origins)
@@ -4521,6 +4542,22 @@ Examples:
         type=int,
         default=0,
         help="Rate limit requests per minute per client (0 = disabled)",
+    )
+    # Hard cap on per-request body size — DoS defense.
+    # See ``vllm_mlx/middleware/body_size.py`` for the rationale (pre-fix:
+    # a 10 MB body silently ran a ~60 s full prefill on a 27B alias before
+    # the client timed out; rapid-desktop#273 + #463). Default 8 MiB fits
+    # a 128k-token prompt with tool schemas; 0 disables the cap.
+    serve_parser.add_argument(
+        "--max-request-bytes",
+        type=int,
+        default=None,
+        help=(
+            "Maximum HTTP request body size in bytes (default: 8 MiB = "
+            "8388608). Requests over this cap are rejected with HTTP 413 "
+            "before JSON parsing or tokenization runs. 0 disables the cap. "
+            "Falls back to the RAPID_MLX_MAX_REQUEST_BYTES env var if unset."
+        ),
     )
     serve_parser.add_argument(
         "--timeout",

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -101,6 +101,21 @@ class ServerConfig:
     # --- Auth ---
     api_key: str | None = None
 
+    # --- Request-body size cap (DoS defense, #463 / rapid-desktop#273) ---
+    # Hard cap on the wire-level request body size (bytes). Enforced at
+    # the ASGI layer by ``RequestBodyLimitMiddleware`` BEFORE FastAPI
+    # JSON parsing or tokenization runs, so an attacker who sends a
+    # multi-MB body (10 MB → ~60 s hang, 100 MB → ~90 s hang were
+    # observed pre-fix on a 27B alias) is bounced with 413 in
+    # microseconds instead of starving a worker through full prefill.
+    #
+    # Default 8 MiB comfortably fits a 128k-token Qwen prompt
+    # (≈ 500 KB JSON) plus tool schemas and a small inline image_url,
+    # while still rejecting the 10–100 MB DoS payloads documented in
+    # rapid-desktop#273. Overridable via ``--max-request-bytes`` or
+    # ``RAPID_MLX_MAX_REQUEST_BYTES``; ``0`` disables the cap.
+    max_request_bytes: int = 8 * 1024 * 1024
+
     # --- Cloud routing ---
     cloud_router: Any = None
 

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -69,6 +69,7 @@ class _BodyTooLargeError(Exception):
         super().__init__(f"streamed {streamed_bytes} bytes over body cap")
         self.streamed_bytes = streamed_bytes
 
+
 # Path prefixes the cap applies to. We deliberately scope to ``/v1/``
 # (and ``/internal/`` for parity) so internal probes like
 # ``/docs``/``/openapi.json``/``/metrics`` are never gated — those
@@ -166,7 +167,20 @@ class RequestBodyLimitMiddleware:
         # its own response between the trip and our wrapper noticing,
         # leading to a 413 colliding with an in-flight 200/499.
         total = {"bytes": 0}
+        # Two-stage state machine: track whether ``http.response.start``
+        # is on the wire (downstream began responding) and whether a
+        # terminal ``http.response.body`` with ``more_body=False`` has
+        # been flushed (response fully complete). Both are needed to
+        # decide what to do when ``_BodyTooLargeError`` propagates out
+        # of the downstream app:
+        #   * neither set  → emit a fresh 413, normal path
+        #   * start only   → response is incomplete; emit a terminal
+        #                    empty body frame so the client doesn't
+        #                    hang waiting for more bytes (codex round-2
+        #                    BLOCKING #1)
+        #   * both set     → response already complete; nothing to do
         downstream_started_response = {"value": False}
+        downstream_completed_response = {"value": False}
 
         async def bounded_receive():
             msg = await receive()
@@ -178,32 +192,57 @@ class RequestBodyLimitMiddleware:
             return msg
 
         async def guarded_send(msg):
-            # Track whether the downstream app has begun writing its own
-            # response. If the cap trips AFTER the start frame is on the
-            # wire we cannot safely emit a 413 (would corrupt the stream)
-            # — log and let the response complete naturally. This window
-            # is tiny in practice: a chat handler reads the body BEFORE
-            # emitting a response start, so trip→raise happens long
-            # before any send.
-            if msg.get("type") == "http.response.start":
+            # Track the lifecycle of the downstream's own response so
+            # the boundary catch below can decide between "emit 413",
+            # "close the stream", or "do nothing" without guessing.
+            mtype = msg.get("type")
+            if mtype == "http.response.start":
                 downstream_started_response["value"] = True
+            elif mtype == "http.response.body" and not msg.get("more_body", False):
+                downstream_completed_response["value"] = True
             await send(msg)
 
         try:
             await self.app(scope, bounded_receive, guarded_send)
         except _BodyTooLargeError as exc:
+            if downstream_completed_response["value"]:
+                # Response is fully on the wire — somehow the cap tripped
+                # AFTER the final body frame. Nothing to do; the
+                # exception is just bubbling out of a tail coroutine.
+                logger.debug(
+                    "body cap tripped after downstream completed response "
+                    "(streamed=%d, limit=%d)",
+                    exc.streamed_bytes,
+                    limit,
+                )
+                return
             if downstream_started_response["value"]:
-                # Cannot inject a 413 mid-stream without writing
-                # ill-formed HTTP — the response frame has already been
-                # flushed. Log and let the connection close. In practice
-                # this is unreachable: handlers consume the full body
-                # before emitting any response.
+                # Headers flushed but no terminal body frame. We cannot
+                # change the status code, but we MUST close the body
+                # stream so the client doesn't hang on Content-Length /
+                # chunked-trailer expectations. Emit an empty terminal
+                # frame and log a warning. (codex round-2 BLOCKING #1)
                 logger.warning(
                     "request body cap (%d) tripped after downstream "
-                    "began writing response; %d bytes streamed",
+                    "began writing response; %d bytes streamed — "
+                    "closing response body stream",
                     limit,
                     exc.streamed_bytes,
                 )
+                try:
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"",
+                            "more_body": False,
+                        }
+                    )
+                except Exception:
+                    # Connection may already be torn down — best-effort.
+                    logger.debug(
+                        "terminal body frame send failed after cap trip",
+                        exc_info=True,
+                    )
                 return
             await _send_413(
                 send,

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -55,6 +55,20 @@ logger = logging.getLogger(__name__)
 # skip the receive-wrapper overhead for them.
 _GUARDED_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
+
+class _BodyTooLargeError(Exception):
+    """Sentinel raised from ``bounded_receive`` when the running tally
+    exceeds the cap. Caught at the middleware boundary so we emit
+    exactly one 413 from outside the downstream app — this prevents
+    the codex round-1 BLOCKING #2 fragile-double-response shape, where
+    ``http.disconnect`` from receive lets the downstream app emit a
+    "client closed" response AND we then emit a 413 on top.
+    """
+
+    def __init__(self, streamed_bytes: int) -> None:
+        super().__init__(f"streamed {streamed_bytes} bytes over body cap")
+        self.streamed_bytes = streamed_bytes
+
 # Path prefixes the cap applies to. We deliberately scope to ``/v1/``
 # (and ``/internal/`` for parity) so internal probes like
 # ``/docs``/``/openapi.json``/``/metrics`` are never gated — those
@@ -140,68 +154,63 @@ class RequestBodyLimitMiddleware:
         # the cap. We do NOT trust the Content-Length even when it's
         # under the cap — a lying client could advertise 1 KB and then
         # stream 100 MB, so the tally guards both.
-        tripped = {"value": False}
+        #
+        # Design (codex round-1 BLOCKING #2): raise ``_BodyTooLargeError``
+        # from ``bounded_receive`` the moment the tally trips. This
+        # propagates through Starlette's request-handling — JSON parser,
+        # multipart parser, body-reading coroutines all surface the
+        # exception cleanly — and we catch it at the boundary below
+        # to emit exactly ONE 413 from outside the downstream app.
+        # The previous "synthetic http.disconnect + guarded_send 413"
+        # shape was fragile because a downstream handler could emit
+        # its own response between the trip and our wrapper noticing,
+        # leading to a 413 colliding with an in-flight 200/499.
         total = {"bytes": 0}
+        downstream_started_response = {"value": False}
 
         async def bounded_receive():
-            if tripped["value"]:
-                # Signal disconnect so Starlette's JSON parser exits
-                # cleanly. This is the same shape AudioBodyLimitMiddleware
-                # uses — confirmed empirically that fastapi's
-                # ``Request.json()`` raises ``ClientDisconnect`` when
-                # receive yields disconnect, which the wrap-send below
-                # turns into our documented 413.
-                return {"type": "http.disconnect"}
             msg = await receive()
             if msg.get("type") == "http.request":
                 body_len = len(msg.get("body", b"") or b"")
                 total["bytes"] += body_len
                 if total["bytes"] > limit:
-                    tripped["value"] = True
-                    return {"type": "http.disconnect"}
+                    raise _BodyTooLargeError(total["bytes"])
             return msg
 
-        sent_413 = {"value": False}
-
         async def guarded_send(msg):
-            if tripped["value"] and not sent_413["value"]:
-                sent_413["value"] = True
-                await _send_413(
-                    send,
-                    advertised=None,
-                    limit=limit,
-                    streaming=True,
-                    streamed=total["bytes"],
-                )
-                return
-            if sent_413["value"]:
-                # Downstream tried to send after we already wrote 413;
-                # drop the message to avoid double-write.
-                return
+            # Track whether the downstream app has begun writing its own
+            # response. If the cap trips AFTER the start frame is on the
+            # wire we cannot safely emit a 413 (would corrupt the stream)
+            # — log and let the response complete naturally. This window
+            # is tiny in practice: a chat handler reads the body BEFORE
+            # emitting a response start, so trip→raise happens long
+            # before any send.
+            if msg.get("type") == "http.response.start":
+                downstream_started_response["value"] = True
             await send(msg)
 
         try:
             await self.app(scope, bounded_receive, guarded_send)
-        except Exception:
-            # If we tripped the cap, the downstream app raised because
-            # of the synthetic disconnect we injected — translate that
-            # into the documented 413. Anything else is a real error;
-            # surface it normally.
-            if not tripped["value"]:
-                raise
-
-        # Fallback 413 emission: catches the silent-drop-on-disconnect
-        # path where Starlette returns without sending a response at
-        # all after seeing our disconnect, and the swallowed-exception
-        # path above.
-        if tripped["value"] and not sent_413["value"]:
-            sent_413["value"] = True
+        except _BodyTooLargeError as exc:
+            if downstream_started_response["value"]:
+                # Cannot inject a 413 mid-stream without writing
+                # ill-formed HTTP — the response frame has already been
+                # flushed. Log and let the connection close. In practice
+                # this is unreachable: handlers consume the full body
+                # before emitting any response.
+                logger.warning(
+                    "request body cap (%d) tripped after downstream "
+                    "began writing response; %d bytes streamed",
+                    limit,
+                    exc.streamed_bytes,
+                )
+                return
             await _send_413(
                 send,
                 advertised=None,
                 limit=limit,
                 streaming=True,
-                streamed=total["bytes"],
+                streamed=exc.streamed_bytes,
             )
 
 

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generic request-body size cap for all POST/PUT/PATCH routes.
+
+Why this lives at the ASGI layer (not a FastAPI ``Depends`` or
+``Request.body()`` check inside each handler):
+
+* FastAPI dependency-injection runs AFTER Starlette has already invoked
+  ``json.loads`` on the request body to populate the route's Pydantic
+  model. By the time a ``Depends`` callable fires, the entire payload
+  has been read off ``receive`` and JSON-decoded — a 100 MB body of
+  random bytes has already cost a worker ~1 s of pure JSON parsing and
+  is sitting in RAM (plus a second copy as the Pydantic model). The
+  symptom F-007 documented (rapid-desktop#273): 10 MB body → ~60 s
+  full-prefill hang, 100 MB → ~90 s. Both bodies were ASCII so JSON
+  parsing succeeded; the worker then ran prefill against a multi-million-
+  token prompt and the client gave up before the response started.
+
+* Running the cap as ASGI middleware lets us reject in two ways:
+
+    1. **Honest ``Content-Length`` fast path** — advertised length over
+       cap → 413 with zero ``receive`` calls. Cheapest possible bounce.
+
+    2. **Streaming slow path** — wrap ``receive`` so it tallies streamed
+       body bytes. When the running total exceeds the cap we inject a
+       synthetic ``http.disconnect`` (Starlette's JSON parser honors it,
+       stops reading, raises) and the wrapper emits the 413 from the
+       outside. This covers ``Transfer-Encoding: chunked`` and any
+       client that omits or understates ``Content-Length``.
+
+Mirrors :class:`vllm_mlx.routes.audio.AudioBodyLimitMiddleware` but
+applies to a different scope — see ``_GUARDED_METHODS`` /
+``_path_is_guarded``: every POST/PUT/PATCH/DELETE to ``/v1/...``
+(chat, completions, embeddings, models, audio, anthropic, mcp, …).
+
+The cap is read from ``ServerConfig.max_request_bytes`` at request
+time, so ``rapid-mlx serve --max-request-bytes N`` (or the env var)
+takes effect without restart in tests that mutate the config.
+A value of ``0`` disables the cap entirely (escape hatch for
+operators whose internal deployments have other DoS controls).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+from typing import Any
+
+from ..config.server_config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+# Methods that can carry a body large enough to be a DoS surface.
+# GET/HEAD/OPTIONS/TRACE have no meaningful body in our routes, so we
+# skip the receive-wrapper overhead for them.
+_GUARDED_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Path prefixes the cap applies to. We deliberately scope to ``/v1/``
+# (and ``/internal/`` for parity) so internal probes like
+# ``/docs``/``/openapi.json``/``/metrics`` are never gated — those
+# endpoints have no body and the middleware would just add overhead.
+_GUARDED_PREFIXES = ("/v1/", "/internal/", "/anthropic/")
+
+# Paths owned by a more specific middleware that applies its own,
+# domain-appropriate cap. We skip them here so the generic 8 MiB JSON
+# cap doesn't trample a 25 MB Whisper upload that the audio middleware
+# already validates. See ``vllm_mlx/routes/audio.py``.
+_EXCLUDED_PATHS = frozenset({"/v1/audio/transcriptions"})
+
+
+def _path_is_guarded(path: str | None) -> bool:
+    if not path:
+        return False
+    if path in _EXCLUDED_PATHS:
+        return False
+    return any(path.startswith(prefix) for prefix in _GUARDED_PREFIXES)
+
+
+def _resolve_limit() -> int:
+    """Look up the current cap from the live ServerConfig singleton.
+
+    Resolving per-request (not at middleware init) lets tests mutate
+    ``ServerConfig.max_request_bytes`` between cases without rebuilding
+    the FastAPI app. The cost is one attribute access on a dataclass,
+    negligible against the per-request socket round-trip.
+    """
+    try:
+        cap = int(get_config().max_request_bytes)
+    except Exception:
+        # Defensive fallback: if the config singleton is in some
+        # half-initialised state during shutdown, fall back to the
+        # dataclass default rather than crashing the request. 0 here
+        # would mean "unlimited" — silently disabling the gate is a
+        # worse outcome than a sane default.
+        cap = 8 * 1024 * 1024
+    return max(0, cap)
+
+
+class RequestBodyLimitMiddleware:
+    """ASGI middleware enforcing :attr:`ServerConfig.max_request_bytes`."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            return await self.app(scope, receive, send)
+        if scope.get("method") not in _GUARDED_METHODS:
+            return await self.app(scope, receive, send)
+        if not _path_is_guarded(scope.get("path")):
+            return await self.app(scope, receive, send)
+
+        limit = _resolve_limit()
+        if limit == 0:
+            # Cap explicitly disabled by operator. Skip the wrapper to
+            # avoid per-message overhead.
+            return await self.app(scope, receive, send)
+
+        # Fast path: honest Content-Length.
+        advertised: int | None = None
+        for raw_name, raw_value in scope.get("headers", ()):
+            if raw_name.lower() == b"content-length":
+                try:
+                    advertised = int(raw_value.decode("latin-1"))
+                except (UnicodeDecodeError, ValueError):
+                    advertised = None
+                break
+
+        if advertised is not None and advertised > limit:
+            await _send_413(
+                send,
+                advertised=advertised,
+                limit=limit,
+                streaming=False,
+            )
+            return
+
+        # Slow path: chunked / no-Content-Length / lying Content-Length.
+        # Wrap receive so we abort the moment the running total exceeds
+        # the cap. We do NOT trust the Content-Length even when it's
+        # under the cap — a lying client could advertise 1 KB and then
+        # stream 100 MB, so the tally guards both.
+        tripped = {"value": False}
+        total = {"bytes": 0}
+
+        async def bounded_receive():
+            if tripped["value"]:
+                # Signal disconnect so Starlette's JSON parser exits
+                # cleanly. This is the same shape AudioBodyLimitMiddleware
+                # uses — confirmed empirically that fastapi's
+                # ``Request.json()`` raises ``ClientDisconnect`` when
+                # receive yields disconnect, which the wrap-send below
+                # turns into our documented 413.
+                return {"type": "http.disconnect"}
+            msg = await receive()
+            if msg.get("type") == "http.request":
+                body_len = len(msg.get("body", b"") or b"")
+                total["bytes"] += body_len
+                if total["bytes"] > limit:
+                    tripped["value"] = True
+                    return {"type": "http.disconnect"}
+            return msg
+
+        sent_413 = {"value": False}
+
+        async def guarded_send(msg):
+            if tripped["value"] and not sent_413["value"]:
+                sent_413["value"] = True
+                await _send_413(
+                    send,
+                    advertised=None,
+                    limit=limit,
+                    streaming=True,
+                    streamed=total["bytes"],
+                )
+                return
+            if sent_413["value"]:
+                # Downstream tried to send after we already wrote 413;
+                # drop the message to avoid double-write.
+                return
+            await send(msg)
+
+        try:
+            await self.app(scope, bounded_receive, guarded_send)
+        except Exception:
+            # If we tripped the cap, the downstream app raised because
+            # of the synthetic disconnect we injected — translate that
+            # into the documented 413. Anything else is a real error;
+            # surface it normally.
+            if not tripped["value"]:
+                raise
+
+        # Fallback 413 emission: catches the silent-drop-on-disconnect
+        # path where Starlette returns without sending a response at
+        # all after seeing our disconnect, and the swallowed-exception
+        # path above.
+        if tripped["value"] and not sent_413["value"]:
+            sent_413["value"] = True
+            await _send_413(
+                send,
+                advertised=None,
+                limit=limit,
+                streaming=True,
+                streamed=total["bytes"],
+            )
+
+
+def _format_message(
+    *,
+    advertised: int | None,
+    limit: int,
+    streaming: bool,
+    streamed: int | None = None,
+) -> str:
+    if streaming:
+        return (
+            f"Request body too large: streamed {streamed or 0} bytes "
+            f"exceeded the {limit}-byte server cap "
+            "(set via --max-request-bytes / RAPID_MLX_MAX_REQUEST_BYTES)"
+        )
+    return (
+        f"Request body too large: Content-Length {advertised} bytes "
+        f"exceeds the {limit}-byte server cap "
+        "(set via --max-request-bytes / RAPID_MLX_MAX_REQUEST_BYTES)"
+    )
+
+
+async def _send_413(
+    send,
+    *,
+    advertised: int | None,
+    limit: int,
+    streaming: bool,
+    streamed: int | None = None,
+) -> None:
+    """Emit an OpenAI-shaped 413 JSON response from inside ASGI middleware.
+
+    We hand-roll the response (rather than raise ``HTTPException``)
+    because the FastAPI exception machinery needs the request body to
+    be drained — exactly what we're trying to avoid. The envelope
+    matches the OpenAI error shape used by the rest of the codebase
+    (see ``vllm_mlx/server.py::_http_exception_handler``):
+
+      {"error": {"message": ..., "type": "invalid_request_error",
+                 "code": "request_too_large", "param": null}}
+    """
+    message = _format_message(
+        advertised=advertised,
+        limit=limit,
+        streaming=streaming,
+        streamed=streamed,
+    )
+    body = _json.dumps(
+        {
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "code": "request_too_large",
+                "param": None,
+            }
+        }
+    ).encode("utf-8")
+    try:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+    except Exception:
+        # Best-effort: if the connection is already torn down, log and
+        # move on. Re-raising here would mask the real cap-trip cause
+        # in the request log.
+        logger.debug("body-size 413 send failed (client already disconnected)")
+
+
+def install_request_body_limit_middleware(app: Any) -> None:
+    """Attach :class:`RequestBodyLimitMiddleware` to ``app``.
+
+    Centralised for the same reason the audio variant has its own
+    install helper — keeps the wiring discoverable from this module
+    rather than buried in app-construction code, and gives tests a
+    single hook to call when standing up a minimal app fixture."""
+    app.add_middleware(RequestBodyLimitMiddleware)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -52,6 +52,7 @@ from ..service.helpers import (
     _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
+    enforce_context_length_for_messages,
     get_engine,
 )
 
@@ -182,6 +183,30 @@ async def create_anthropic_message(
             openai_request = anthropic_to_openai(anthropic_request)
         except AnthropicOutputConfigError as e:
             raise HTTPException(status_code=400, detail=str(e))
+
+        # Context-length pre-check — same DoS gate the chat/completions/
+        # responses routes enforce. Render the prompt through the engine's
+        # chat template, count tokens, raise 400 ``context_length_exceeded``
+        # if over the model cap. Runs BEFORE the stream/non-stream branch
+        # so streaming clients can't bypass the gate by setting
+        # ``stream: true``. See service/helpers.py for rationale.
+        try:
+            _ctx_messages, _, _ = extract_multimodal_content(
+                openai_request.messages,
+                preserve_native_format=engine.preserve_native_tool_format,
+            )
+        except Exception:
+            _ctx_messages = None
+        if _ctx_messages is not None:
+            enforce_context_length_for_messages(
+                engine,
+                _ctx_messages,
+                tools=openai_request.tools,
+                max_tokens=_resolve_max_tokens(
+                    openai_request.max_tokens,
+                    _resolve_enable_thinking(openai_request),
+                ),
+            )
 
         if anthropic_request.stream:
             _admission_committed = True

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -67,8 +67,7 @@ from ..service.helpers import (
     _validate_tool_call_params,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
-    count_prompt_tokens,
-    enforce_context_length,
+    enforce_context_length_for_messages,
     get_engine,
     get_usage,
 )
@@ -740,35 +739,16 @@ async def _create_chat_completion_impl(
         chat_kwargs["enable_thinking"] = resolved_thinking
 
     # Context-length pre-check (DoS defense + UX, rapid-desktop#273 / #463).
-    #
-    # Even within the wire-level body cap from ``middleware/body_size.py``,
-    # a 8 MiB ASCII body can hold ~2M tokens — well past every model
-    # context window. Counting prompt tokens here lets us return
-    # ``context_length_exceeded`` (400) BEFORE the scheduler starts
-    # prefill, instead of running prefill to its useless conclusion
-    # (the symptom F-007 documented: 60–90 s of wasted compute, worker
-    # starved, client times out).
-    #
-    # Scoped to non-MLLM engines for the same reason cloud routing is:
-    # ``build_prompt`` rejects MLLM, image tokens have a separate
-    # accounting path, and a vision request's "prompt size" isn't
-    # purely a text-token count. MLLM context limits are tracked
-    # separately by the scheduler.
-    if not engine.is_mllm:
-        try:
-            _ctx_prompt = engine.build_prompt(messages, tools=request.tools)
-        except HTTPException:
-            raise
-        except Exception:  # pragma: no cover - template errors handled downstream
-            _ctx_prompt = None
-        if _ctx_prompt is not None:
-            _prompt_tokens = count_prompt_tokens(engine, _ctx_prompt)
-            if _prompt_tokens > 0:
-                enforce_context_length(
-                    engine,
-                    _prompt_tokens,
-                    max_tokens=chat_kwargs.get("max_tokens"),
-                )
+    # See ``service/helpers.py::enforce_context_length_for_messages`` for
+    # the rationale (8 MiB body still holds ~2M tokens → context window
+    # blown → ~60–90 s of wasted prefill before client gives up). Same
+    # gate runs in routes/completions, routes/anthropic, routes/responses.
+    enforce_context_length_for_messages(
+        engine,
+        messages,
+        tools=request.tools,
+        max_tokens=chat_kwargs.get("max_tokens"),
+    )
 
     # Cloud routing: offload large-context requests to cloud LLM.
     #

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -67,6 +67,8 @@ from ..service.helpers import (
     _validate_tool_call_params,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
+    count_prompt_tokens,
+    enforce_context_length,
     get_engine,
     get_usage,
 )
@@ -736,6 +738,37 @@ async def _create_chat_completion_impl(
 
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
+
+    # Context-length pre-check (DoS defense + UX, rapid-desktop#273 / #463).
+    #
+    # Even within the wire-level body cap from ``middleware/body_size.py``,
+    # a 8 MiB ASCII body can hold ~2M tokens — well past every model
+    # context window. Counting prompt tokens here lets us return
+    # ``context_length_exceeded`` (400) BEFORE the scheduler starts
+    # prefill, instead of running prefill to its useless conclusion
+    # (the symptom F-007 documented: 60–90 s of wasted compute, worker
+    # starved, client times out).
+    #
+    # Scoped to non-MLLM engines for the same reason cloud routing is:
+    # ``build_prompt`` rejects MLLM, image tokens have a separate
+    # accounting path, and a vision request's "prompt size" isn't
+    # purely a text-token count. MLLM context limits are tracked
+    # separately by the scheduler.
+    if not engine.is_mllm:
+        try:
+            _ctx_prompt = engine.build_prompt(messages, tools=request.tools)
+        except HTTPException:
+            raise
+        except Exception:  # pragma: no cover - template errors handled downstream
+            _ctx_prompt = None
+        if _ctx_prompt is not None:
+            _prompt_tokens = count_prompt_tokens(engine, _ctx_prompt)
+            if _prompt_tokens > 0:
+                enforce_context_length(
+                    engine,
+                    _prompt_tokens,
+                    max_tokens=chat_kwargs.get("max_tokens"),
+                )
 
     # Cloud routing: offload large-context requests to cloud LLM.
     #

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -87,9 +87,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         # ``service/helpers.py::enforce_context_length_for_prompt``.
         _resolved_max = _resolve_max_tokens(request.max_tokens)
         for _p in prompts:
-            enforce_context_length_for_prompt(
-                engine, _p, max_tokens=_resolved_max
-            )
+            enforce_context_length_for_prompt(engine, _p, max_tokens=_resolved_max)
 
         if request.stream:
             _admission_committed = True

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -30,6 +30,7 @@ from ..service.helpers import (
     _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
+    enforce_context_length_for_prompt,
     get_engine,
     get_usage,
 )
@@ -78,6 +79,17 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             f"max_tokens={request.max_tokens} temp={request.temperature} "
             f"prompt_chars={prompt_len} prompt_preview={prompt_preview!r}"
         )
+
+        # Context-length pre-check — same DoS gate the chat/anthropic/
+        # responses routes enforce. Raw-prompt API skips chat templating
+        # but the prompt-token budget still applies. Iterate the list
+        # form because each entry hits prefill independently. See
+        # ``service/helpers.py::enforce_context_length_for_prompt``.
+        _resolved_max = _resolve_max_tokens(request.max_tokens)
+        for _p in prompts:
+            enforce_context_length_for_prompt(
+                engine, _p, max_tokens=_resolved_max
+            )
 
         if request.stream:
             _admission_committed = True

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -60,6 +60,7 @@ from ..service.helpers import (
     _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
+    enforce_context_length_for_messages,
     get_engine,
 )
 
@@ -164,6 +165,27 @@ async def create_response(request: Request):
             )
 
         openai_request = responses_to_openai(responses_request)
+
+        # Context-length pre-check — same DoS gate the chat/completions/
+        # anthropic routes enforce. Runs BEFORE the stream branch so
+        # streaming clients can't bypass by setting ``stream: true``.
+        try:
+            _ctx_messages, _, _ = extract_multimodal_content(
+                openai_request.messages,
+                preserve_native_format=engine.preserve_native_tool_format,
+            )
+        except Exception:
+            _ctx_messages = None
+        if _ctx_messages is not None:
+            enforce_context_length_for_messages(
+                engine,
+                _ctx_messages,
+                tools=openai_request.tools,
+                max_tokens=_resolve_max_tokens(
+                    openai_request.max_tokens,
+                    _resolve_enable_thinking(openai_request),
+                ),
+            )
 
         if responses_request.stream:
             _admission_committed = True

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -207,6 +207,13 @@ _embedding_model_locked: str | None = None  # Set when --embedding-model is used
 _api_key: str | None = None
 _auth_warning_logged: bool = False
 
+# Per-request body size cap (DoS defense). 0 disables. Resolved from
+# CLI ``--max-request-bytes`` / ``RAPID_MLX_MAX_REQUEST_BYTES`` and
+# pushed into ``ServerConfig.max_request_bytes`` via ``_sync_config``;
+# the ASGI middleware (``middleware/body_size.py``) reads it per
+# request, so a test fixture mutating the config takes effect immediately.
+_max_request_bytes: int = 8 * 1024 * 1024
+
 # Reasoning parser (for models like Qwen3, DeepSeek-R1, MiniMax)
 _reasoning_parser = None  # ReasoningParser instance when enabled
 _reasoning_parser_name: str | None = None  # Parser name (e.g., "minimax")
@@ -444,6 +451,19 @@ from .routes.audio import install_audio_body_limit_middleware  # noqa: E402
 
 install_audio_body_limit_middleware(app)
 
+# SECURITY: blanket request-body size cap across all /v1/* routes.
+# Defends against the DoS pattern documented in rapid-desktop#273 / #463
+# where a 10–100 MB JSON body silently runs full prefill (~60–90 s on a
+# 27B alias) before the client times out. See middleware/body_size.py
+# for the design rationale, the path-scoping (skips
+# ``/v1/audio/transcriptions`` so the multipart-aware 25 MB cap upstream
+# is not trampled by the generic 8 MiB JSON cap), and the limit lookup
+# (ServerConfig.max_request_bytes, overridable via --max-request-bytes /
+# RAPID_MLX_MAX_REQUEST_BYTES).
+from .middleware.body_size import install_request_body_limit_middleware  # noqa: E402
+
+install_request_body_limit_middleware(app)
+
 # CORS configuration — configurable via --cors-origins CLI flag
 
 
@@ -496,6 +516,21 @@ async def _http_exception_handler(
         409: "conflict_error",
         429: "rate_limit_error",
     }
+
+    # Structured-detail escape hatch: route handlers may raise
+    # ``HTTPException(detail={"error": {...}})`` to emit a custom
+    # OpenAI-shaped envelope (e.g. ``code: "context_length_exceeded"``
+    # for the token-budget gate). When the detail already carries the
+    # full ``{"error": {...}}`` shape, pass it through unchanged so the
+    # ``code`` / ``param`` fields land in the response. Bare-string
+    # detail keeps the legacy wrapping below.
+    detail = exc.detail
+    if isinstance(detail, dict) and isinstance(detail.get("error"), dict):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=detail,
+            headers=getattr(exc, "headers", None),
+        )
 
     return JSONResponse(
         status_code=exc.status_code,
@@ -915,6 +950,7 @@ def _sync_config() -> None:
     cfg.embedding_engine = _embedding_engine
     cfg.embedding_model_locked = _embedding_model_locked
     cfg.api_key = _api_key
+    cfg.max_request_bytes = _max_request_bytes
     cfg.cloud_router = _cloud_router
     cfg.gc_control = _gc_control
     cfg.no_thinking = _no_thinking

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1424,3 +1424,158 @@ async def _wait_with_disconnect(
             disconnect_task.cancel()
         if not task.done():
             task.cancel()
+
+
+# ─── Context-length pre-check (DoS defense, rapid-desktop#273 / #463) ──
+#
+# A 8 MiB body of plain ASCII is still ~2M tokens — well past any model's
+# context window. The body-size middleware ``vllm_mlx/middleware/body_size.py``
+# stops the worst of the DoS, but a request that fits inside the byte
+# cap can still drag a small-context model into pointless prefill.
+#
+# These helpers surface the model's max context length and raise a
+# structured OpenAI ``context_length_exceeded`` error when a prompt is
+# too long, so the rejection lands BEFORE the engine starts prefill.
+
+# Sentinel-large fallback used when the model exposes no useful context
+# field. We do NOT silently bypass the gate (returning ``None`` would
+# accept any prompt); instead we use a value so large that legitimate
+# requests pass while the DoS pattern (≈ millions of tokens in one body)
+# still trips. Sized for 8 MiB body cap × ~3.5 chars/token worst-case.
+_FALLBACK_MAX_CONTEXT_TOKENS = 4_194_304
+
+
+def get_model_max_context(engine) -> int:
+    """Return the model's max prompt-token context window for ``engine``.
+
+    Resolution order (first hit wins):
+      1. ``engine._model.args.max_position_embeddings`` — mlx-lm dense
+         LLMs and most MLX models expose the HF config there.
+      2. ``engine._model.args.text_config.max_position_embeddings`` —
+         multimodal Qwen3.5 / Gemma 4 nest the text-config inside.
+      3. ``engine._model.config.max_position_embeddings`` — older
+         attribute style.
+      4. ``engine.tokenizer.model_max_length`` if not the HuggingFace
+         "VERY_LARGE_INTEGER" sentinel (``1e30``). Some tokenizers
+         report a useful cap here even when the model object doesn't.
+      5. ``_FALLBACK_MAX_CONTEXT_TOKENS`` — see module-level comment.
+
+    The function is intentionally permissive about missing fields: we'd
+    rather pass through a request the model can handle than refuse a
+    legitimate one on metadata absence. The byte cap stays as the
+    last-resort DoS gate even if every probe falls through.
+    """
+
+    def _maybe_int(value) -> int | None:
+        try:
+            ivalue = int(value)
+        except (TypeError, ValueError):
+            return None
+        if ivalue <= 0:
+            return None
+        return ivalue
+
+    model = getattr(engine, "_model", None) or getattr(engine, "model", None)
+
+    if model is not None:
+        args = getattr(model, "args", None)
+        if args is not None:
+            direct = _maybe_int(getattr(args, "max_position_embeddings", None))
+            if direct is not None:
+                return direct
+            text_cfg = getattr(args, "text_config", None)
+            if text_cfg is not None:
+                nested = _maybe_int(
+                    getattr(text_cfg, "max_position_embeddings", None)
+                )
+                if nested is not None:
+                    return nested
+        config = getattr(model, "config", None)
+        if config is not None:
+            cfg_direct = _maybe_int(getattr(config, "max_position_embeddings", None))
+            if cfg_direct is not None:
+                return cfg_direct
+            text_cfg = getattr(config, "text_config", None)
+            if text_cfg is not None:
+                nested = _maybe_int(
+                    getattr(text_cfg, "max_position_embeddings", None)
+                )
+                if nested is not None:
+                    return nested
+
+    tokenizer = getattr(engine, "tokenizer", None) or getattr(engine, "_tokenizer", None)
+    if tokenizer is not None:
+        tok_max = getattr(tokenizer, "model_max_length", None)
+        if tok_max is not None:
+            # HuggingFace tokenizers report 1e30 ("no cap known") which
+            # is useless as a guard. Treat anything above 10M as the
+            # sentinel since no real model has that context yet.
+            if isinstance(tok_max, int | float) and 0 < tok_max < 10_000_000:
+                return int(tok_max)
+
+    return _FALLBACK_MAX_CONTEXT_TOKENS
+
+
+def count_prompt_tokens(engine, prompt: str) -> int:
+    """Return the integer prompt-token count under ``engine``'s tokenizer.
+
+    Mirrors the BOS-handling that ``BatchedEngine.estimate_new_tokens``
+    does — adds special tokens only when the prompt doesn't already
+    start with the model's BOS. Returns 0 on tokenizer failure so the
+    caller falls through to engine-side validation rather than 500-ing
+    on a metadata edge case.
+    """
+    tokenizer = getattr(engine, "tokenizer", None) or getattr(engine, "_tokenizer", None)
+    if tokenizer is None:
+        return 0
+    try:
+        bos = getattr(tokenizer, "bos_token", None)
+        add_special_tokens = bos is None or not prompt.startswith(bos)
+        token_ids = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
+        return len(token_ids)
+    except Exception:
+        logger.debug("count_prompt_tokens: tokenizer.encode failed", exc_info=True)
+        return 0
+
+
+def enforce_context_length(
+    engine,
+    prompt_tokens: int,
+    *,
+    max_tokens: int | None = None,
+) -> None:
+    """Raise HTTP 400 ``context_length_exceeded`` if ``prompt_tokens`` is
+    over the model's max context window.
+
+    The check also includes ``max_tokens`` (the requested completion
+    budget) so a borderline prompt that would force the decoder past
+    the cap is rejected up-front rather than mid-generation. OpenAI's
+    own error is shaped the same way — ``context_length_exceeded``
+    fires when ``prompt + completion > model max``.
+    """
+    max_context = get_model_max_context(engine)
+    completion = int(max_tokens) if max_tokens else 0
+    requested_total = int(prompt_tokens) + max(0, completion)
+    if requested_total <= max_context:
+        return
+
+    # Format the message in the OpenAI shape so SDKs can branch on the
+    # ``code`` field. The exception handler in ``vllm_mlx/server.py``
+    # wraps the ``detail`` payload back into the OpenAI envelope.
+    detail = (
+        f"This model's maximum context length is {max_context} tokens. "
+        f"However, you requested {requested_total} tokens "
+        f"({int(prompt_tokens)} prompt + {max(0, completion)} completion). "
+        "Please reduce the length of the messages or completion."
+    )
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": detail,
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded",
+                "param": "messages",
+            }
+        },
+    )

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1485,9 +1485,7 @@ def get_model_max_context(engine) -> int:
                 return direct
             text_cfg = getattr(args, "text_config", None)
             if text_cfg is not None:
-                nested = _maybe_int(
-                    getattr(text_cfg, "max_position_embeddings", None)
-                )
+                nested = _maybe_int(getattr(text_cfg, "max_position_embeddings", None))
                 if nested is not None:
                     return nested
         config = getattr(model, "config", None)
@@ -1497,13 +1495,13 @@ def get_model_max_context(engine) -> int:
                 return cfg_direct
             text_cfg = getattr(config, "text_config", None)
             if text_cfg is not None:
-                nested = _maybe_int(
-                    getattr(text_cfg, "max_position_embeddings", None)
-                )
+                nested = _maybe_int(getattr(text_cfg, "max_position_embeddings", None))
                 if nested is not None:
                     return nested
 
-    tokenizer = getattr(engine, "tokenizer", None) or getattr(engine, "_tokenizer", None)
+    tokenizer = getattr(engine, "tokenizer", None) or getattr(
+        engine, "_tokenizer", None
+    )
     if tokenizer is not None:
         tok_max = getattr(tokenizer, "model_max_length", None)
         if tok_max is not None:
@@ -1525,7 +1523,9 @@ def count_prompt_tokens(engine, prompt: str) -> int:
     caller falls through to engine-side validation rather than 500-ing
     on a metadata edge case.
     """
-    tokenizer = getattr(engine, "tokenizer", None) or getattr(engine, "_tokenizer", None)
+    tokenizer = getattr(engine, "tokenizer", None) or getattr(
+        engine, "_tokenizer", None
+    )
     if tokenizer is None:
         return 0
     try:
@@ -1579,3 +1579,72 @@ def enforce_context_length(
             }
         },
     )
+
+
+def enforce_context_length_for_messages(
+    engine,
+    messages: list,
+    *,
+    tools: list | None = None,
+    max_tokens: int | None = None,
+) -> None:
+    """Run the context-length gate for a chat-style request.
+
+    Renders the prompt through the engine's chat template (same path
+    used by ``BatchedEngine.build_prompt``), counts the tokens, then
+    delegates to :func:`enforce_context_length`. Wraps the template /
+    tokenization step in a permissive try-except so a metadata edge
+    case (e.g. unloaded engine on a route stub) doesn't 500 — the
+    downstream scheduler still has its own validation.
+
+    Scoped to text-only engines: MLLM models accept image / video /
+    audio inputs whose token cost is computed by the multimodal
+    processor and tracked separately by ``MLLMScheduler``. The
+    body-size middleware still bounds the wire-level payload for
+    those routes.
+
+    Used by chat, anthropic, and responses routes so the same DoS gate
+    applies regardless of which compatibility surface the client uses.
+    """
+    if getattr(engine, "is_mllm", False):
+        return
+    build_prompt = getattr(engine, "build_prompt", None)
+    if build_prompt is None:
+        return
+    try:
+        prompt = build_prompt(messages, tools=tools)
+    except HTTPException:
+        raise
+    except Exception:
+        # Chat-template errors surface as 400 downstream where the
+        # route handler can render a user-facing message — re-raising
+        # here would swallow that context.
+        return
+    if not prompt:
+        return
+    prompt_tokens = count_prompt_tokens(engine, prompt)
+    if prompt_tokens <= 0:
+        return
+    enforce_context_length(engine, prompt_tokens, max_tokens=max_tokens)
+
+
+def enforce_context_length_for_prompt(
+    engine,
+    prompt: str,
+    *,
+    max_tokens: int | None = None,
+) -> None:
+    """Run the context-length gate for a raw-prompt completion request.
+
+    Same shape as :func:`enforce_context_length_for_messages` but for
+    routes that already hold a raw text prompt (``/v1/completions``).
+    No chat template applied — the client provided the string verbatim.
+    """
+    if getattr(engine, "is_mllm", False):
+        return
+    if not prompt:
+        return
+    prompt_tokens = count_prompt_tokens(engine, prompt)
+    if prompt_tokens <= 0:
+        return
+    enforce_context_length(engine, prompt_tokens, max_tokens=max_tokens)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1514,15 +1514,49 @@ def get_model_max_context(engine) -> int:
     return _FALLBACK_MAX_CONTEXT_TOKENS
 
 
-def count_prompt_tokens(engine, prompt: str) -> int:
+def count_prompt_tokens(engine, prompt) -> int:
     """Return the integer prompt-token count under ``engine``'s tokenizer.
 
-    Mirrors the BOS-handling that ``BatchedEngine.estimate_new_tokens``
-    does — adds special tokens only when the prompt doesn't already
-    start with the model's BOS. Returns 0 on tokenizer failure so the
-    caller falls through to engine-side validation rather than 500-ing
-    on a metadata edge case.
+    Accepts both string prompts (chat-template output, raw completions)
+    and pre-tokenised forms (list[int] / list[list[int]]). The
+    completions API contract today is ``str | list[str]`` (token-id
+    prompts would be an OpenAI feature flag), but the helper is the
+    one DoS-gate boundary and codex round-2 BLOCKING #3 flagged that a
+    list arriving there should not silently bypass the cap. So we
+    handle both shapes explicitly: token-id lists skip tokenization
+    entirely and use ``len()``; strings flow through ``tokenizer.encode``
+    with BOS-aware ``add_special_tokens`` handling that mirrors
+    ``BatchedEngine.estimate_new_tokens``.
+
+    Returns 0 on tokenizer failure / unknown shape so the caller
+    falls through to engine-side validation rather than 500-ing on a
+    metadata edge case. The wire-level body cap stays as the last
+    line of DoS defense.
     """
+    # Pre-tokenised forms — pure-arithmetic answer, no tokenizer needed.
+    if isinstance(prompt, list):
+        if not prompt:
+            return 0
+        first = prompt[0]
+        if isinstance(first, int):
+            # list[int] — a single tokenised prompt.
+            return len(prompt)
+        if isinstance(first, list):
+            # list[list[int]] — multi-prompt batch; conservatively
+            # return the longest so the cap fires on the worst entry.
+            try:
+                return max((len(p) for p in prompt if isinstance(p, list)), default=0)
+            except TypeError:
+                return 0
+        # Fall through for list[str] — caller should have unpacked it,
+        # but defensively handle the single-string case.
+        if isinstance(first, str) and len(prompt) == 1:
+            prompt = first
+        else:
+            return 0
+    if not isinstance(prompt, str):
+        return 0
+
     tokenizer = getattr(engine, "tokenizer", None) or getattr(
         engine, "_tokenizer", None
     )
@@ -1630,7 +1664,7 @@ def enforce_context_length_for_messages(
 
 def enforce_context_length_for_prompt(
     engine,
-    prompt: str,
+    prompt,
     *,
     max_tokens: int | None = None,
 ) -> None:
@@ -1638,7 +1672,10 @@ def enforce_context_length_for_prompt(
 
     Same shape as :func:`enforce_context_length_for_messages` but for
     routes that already hold a raw text prompt (``/v1/completions``).
-    No chat template applied — the client provided the string verbatim.
+    No chat template applied — the client provided the string (or
+    list-of-ints token sequence) verbatim. ``count_prompt_tokens``
+    handles both shapes; see its docstring for the codex round-2
+    BLOCKING #3 rationale on non-string prompts.
     """
     if getattr(engine, "is_mllm", False):
         return

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1649,10 +1649,26 @@ def enforce_context_length_for_messages(
         prompt = build_prompt(messages, tools=tools)
     except HTTPException:
         raise
-    except Exception:
-        # Chat-template errors surface as 400 downstream where the
-        # route handler can render a user-facing message — re-raising
-        # here would swallow that context.
+    except Exception as exc:
+        # Chat-template / malformed-tools-schema failures are user-
+        # facing config errors. Fail fast with a clean 400 here so the
+        # route doesn't waste cycles re-rendering the same template
+        # downstream just to surface the same diagnosis (codex r3 F7).
+        # Other exception shapes (tokenizer 500s, engine half-loaded
+        # races) keep their original silent-fallthrough so the
+        # scheduler's own validation has a chance to run — the
+        # body-size middleware is still the last DoS line.
+        err_msg = str(exc)
+        err_type = type(exc).__name__
+        if (
+            "TemplateError" in err_type
+            or "template" in err_msg.lower()
+            or ("user" in err_msg.lower() and "found" in err_msg.lower())
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat template error: {err_msg}",
+            )
         return
     if not prompt:
         return


### PR DESCRIPTION
## Summary

Closes the F-007 DoS surface (rapid-desktop#273 / #463): a 10–100 MB JSON body silently runs ~60–90 s of full prefill on a 27B alias before the client times out. A malicious client can starve workers cheaply, no auth needed.

Two complementary gates, both rejecting **before** any compute cost is incurred:

1. **ASGI request-body cap** (`vllm_mlx/middleware/body_size.py`) — default 8 MiB, configurable via `--max-request-bytes` / `RAPID_MLX_MAX_REQUEST_BYTES`; `0` disables. Honest `Content-Length` fast path (zero `receive` calls), wrapped-`receive` slow path for chunked / lying-`Content-Length`. OpenAI-shaped 413 with `code=request_too_large`. Scoped to `/v1/*` / `/internal/*` / `/anthropic/*`, excludes `/v1/audio/transcriptions` so the existing multipart-aware 25 MB Whisper cap upstream isn't trampled.

2. **Per-request context-length pre-check** (`service/helpers.py`) — even within the byte cap, 8 MiB of ASCII is ~2M tokens. `enforce_context_length` walks `model.args.max_position_embeddings` (also the nested `text_config` form used by VLMs), `model.config.*`, and `tokenizer.model_max_length` (ignoring HF's 1e30 sentinel). Rejects with `code=context_length_exceeded` (400) — matches OpenAI's own error shape. Falls through to a permissive 4M-token cap on metadata-poor engines.

Also extends `vllm_mlx/server.py::_http_exception_handler` to pass through `HTTPException(detail={"error": {...}})` envelopes unchanged so structured `code` / `param` fields survive in the response.

## Why this default

**8 MiB**: comfortably fits a 128k-token Qwen prompt (~500 KB JSON) plus tool schemas and a small inline `image_url`, while still rejecting the 10–100 MB DoS payloads documented in the linked issues. Lower would cut into legitimate large-context users; higher would let the DoS pattern slip through with a few extra seconds of latency.

## Test plan

23 new tests, all green locally:

- [x] `tests/test_request_body_size_limit.py` (9) — honest `Content-Length` over cap → 413, chunked-streaming abort mid-body, **body-never-reaches-handler tracer** (proves no `receive` is drained on rejection), audio-path exclusion, unguarded path passthrough, cap=0 disables, CLI ↔ config wiring.
- [x] `tests/test_context_length_exceeded.py` (14) — `max_position_embeddings` resolution paths (top-level, nested `text_config`, `model.config`, tokenizer fallback, HF sentinel ignored), `enforce` raises 400 with structured envelope, `max_tokens` included in budget, structured detail passes through global handler.
- [x] `make smoke` (lint + audit + 5693 unit tests) green.

## Tracking

- rapid-desktop#273 (F-007 evidence with curl repros)
- #463 (consolidated body-size + error-envelope tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)