### PR TITLE
feat(aliases): add VibeThinker-1.5B + 3B aliases (closes #670)

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Decoded examples:
 81 explicit aliases across 13 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
 
 <details>
-<summary><strong>Show all 81 aliases by family</strong></summary>
+<summary><strong>Show all 82 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
@@ -528,7 +528,7 @@ Decoded examples:
 | **GPT-OSS** | `gpt-oss-20b-mxfp4-q8` | Harmony native |
 | **MiniMax** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4` | |
 | **Mistral / Devstral** | `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit` | |
-| **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit` | |
+| **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit`, `vibethinker-3b-8bit` | Weibo VibeThinker 3B reasoning (MIT) |
 | 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
 
 ✨ = DFlash speculative decoding supported (opt in with `--enable-dflash`). `rapid-mlx info <alias>` shows per-alias capabilities.

--- a/README.md
+++ b/README.md
@@ -510,10 +510,10 @@ Decoded examples:
 
 ### Full model lineup
 
-81 explicit aliases across 13 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
+83 explicit aliases across 13 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
 
 <details>
-<summary><strong>Show all 82 aliases by family</strong></summary>
+<summary><strong>Show all 83 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
@@ -528,7 +528,7 @@ Decoded examples:
 | **GPT-OSS** | `gpt-oss-20b-mxfp4-q8` | Harmony native |
 | **MiniMax** | `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4` | |
 | **Mistral / Devstral** | `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit` | |
-| **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit`, `vibethinker-3b-8bit` | Weibo VibeThinker 3B reasoning (MIT) |
+| **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit`, `vibethinker-1.5b-4bit`, `vibethinker-3b-8bit` | Weibo VibeThinker 1.5B / 3B reasoning (MIT) |
 | 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
 
 ✨ = DFlash speculative decoding supported (opt in with `--enable-dflash`). `rapid-mlx info <alias>` shows per-alias capabilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.37"
+version = "0.7.38"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -602,24 +602,30 @@ def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
         )
 
 
-def test_vibethinker_family_wires_deepseek_r1_reasoning_parser() -> None:
-    """VibeThinker-3B (Weibo AI, base = Qwen2.5-Coder-3B) is a reasoning
-    model whose chat template does NOT inject ``<think>`` — the model
-    emits ``<think>...</think>`` blocks autonomously on every response.
-    Without ``reasoning_parser`` set, those blocks leak into
-    ``choices[0].message.content`` as plain text and break clients that
-    expect ``reasoning_content`` to carry the chain-of-thought.
+@pytest.mark.parametrize(
+    "alias",
+    ["vibethinker-1.5b-4bit", "vibethinker-3b-8bit"],
+)
+def test_vibethinker_family_wires_deepseek_r1_reasoning_parser(alias: str) -> None:
+    """VibeThinker (Weibo AI; 1.5B base = Qwen2.5-Math-1.5B, 3B base =
+    Qwen2.5-Coder-3B) is a reasoning family whose chat template does
+    NOT inject ``<think>`` — the model emits ``<think>...</think>``
+    blocks autonomously on every response. Without ``reasoning_parser``
+    set, those blocks leak into ``choices[0].message.content`` as plain
+    text and break clients that expect ``reasoning_content`` to carry
+    the chain-of-thought.
 
-    Pin the wiring so a future PR can't silently revert it to ``null``.
-    Also pins ``tool_call_parser=None`` — the model card explicitly
-    states tool calling is unsupported even though the inherited Qwen2
-    vocab carries ``<tool_call>`` tokens (community reports confirm the
-    model reasons about the template instead of emitting tool calls).
-    Verified format source:
+    Pin the wiring so a future PR can't silently revert it to ``null``
+    for either size. Also pins ``tool_call_parser=None`` — the model
+    card explicitly states tool calling is unsupported even though the
+    inherited Qwen2 vocab carries ``<tool_call>`` tokens (community
+    reports confirm the model reasons about the template instead of
+    emitting tool calls).
+    Verified format sources:
     https://huggingface.co/mlx-community/VibeThinker-3B-8bit
+    https://huggingface.co/mlx-community/VibeThinker-1.5B-mlx-4bit
     """
     profiles = list_profiles()
-    alias = "vibethinker-3b-8bit"
     assert alias in profiles, f"{alias} missing from aliases.json"
     assert profiles[alias].reasoning_parser == "deepseek_r1", (
         f"{alias}: reasoning_parser must be 'deepseek_r1' (VibeThinker emits "

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -602,6 +602,48 @@ def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
         )
 
 
+def test_vibethinker_family_wires_deepseek_r1_reasoning_parser() -> None:
+    """VibeThinker-3B (Weibo AI, base = Qwen2.5-Coder-3B) is a reasoning
+    model whose chat template does NOT inject ``<think>`` — the model
+    emits ``<think>...</think>`` blocks autonomously on every response.
+    Without ``reasoning_parser`` set, those blocks leak into
+    ``choices[0].message.content`` as plain text and break clients that
+    expect ``reasoning_content`` to carry the chain-of-thought.
+
+    Pin the wiring so a future PR can't silently revert it to ``null``.
+    Also pins ``tool_call_parser=None`` — the model card explicitly
+    states tool calling is unsupported even though the inherited Qwen2
+    vocab carries ``<tool_call>`` tokens (community reports confirm the
+    model reasons about the template instead of emitting tool calls).
+    Verified format source:
+    https://huggingface.co/mlx-community/VibeThinker-3B-8bit
+    """
+    profiles = list_profiles()
+    alias = "vibethinker-3b-8bit"
+    assert alias in profiles, f"{alias} missing from aliases.json"
+    assert profiles[alias].reasoning_parser == "deepseek_r1", (
+        f"{alias}: reasoning_parser must be 'deepseek_r1' (VibeThinker emits "
+        f"`<think>` blocks autonomously). Got {profiles[alias].reasoning_parser!r}."
+    )
+    assert profiles[alias].tool_call_parser is None, (
+        f"{alias}: tool_call_parser must be None — VibeThinker is not "
+        f"trained for tool calling per the upstream model card. "
+        f"Got {profiles[alias].tool_call_parser!r}."
+    )
+    # Reasoning-model sampling guidance: temperature=1.0, top_p=0.95
+    # (paper-recommended; greedy temperature=0 produces garbage on
+    # reasoning models that depend on diverse beam exploration).
+    sampling = dict(profiles[alias].recommended_sampling or ())
+    assert sampling.get("temperature") == 1.0, (
+        f"{alias}: recommended_sampling.temperature must be 1.0 per the "
+        f"VibeThinker paper. Got {sampling.get('temperature')!r}."
+    )
+    assert sampling.get("top_p") == 0.95, (
+        f"{alias}: recommended_sampling.top_p must be 0.95 per the "
+        f"VibeThinker paper. Got {sampling.get('top_p')!r}."
+    )
+
+
 def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:
     """Pin replacement paths for aliases that previously pointed at HF
     repos that no longer exist (or never existed).

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -159,6 +159,29 @@ class TestDetectModelConfig:
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is True
 
+    # VibeThinker (Weibo AI reasoning derivative, base = Qwen2.5-Coder-3B).
+    # Verify both the alias path (vibethinker-3b-8bit → JSON profile) and
+    # the bare-HF-path regex fallback (WeiboAI/VibeThinker-3B, served by
+    # full repo id without an alias) wire ``deepseek_r1`` reasoning parser
+    # so ``<think>...</think>`` blocks land in ``reasoning_content`` not
+    # ``content``. ``tool_call_parser`` stays None — model card explicitly
+    # disowns tool calling.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "vibethinker-3b-8bit",
+            "mlx-community/VibeThinker-3B-8bit",
+            "WeiboAI/VibeThinker-3B",
+        ],
+    )
+    def test_vibethinker(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.reasoning_parser == "deepseek_r1"
+        assert cfg.tool_call_parser is None
+        assert cfg.is_hybrid is False
+        assert cfg.supports_spec_decode is True
+
     @pytest.mark.parametrize(
         "model_path",
         [

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -159,16 +159,20 @@ class TestDetectModelConfig:
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is True
 
-    # VibeThinker (Weibo AI reasoning derivative, base = Qwen2.5-Coder-3B).
-    # Verify both the alias path (vibethinker-3b-8bit → JSON profile) and
-    # the bare-HF-path regex fallback (WeiboAI/VibeThinker-3B, served by
-    # full repo id without an alias) wire ``deepseek_r1`` reasoning parser
-    # so ``<think>...</think>`` blocks land in ``reasoning_content`` not
+    # VibeThinker (Weibo AI reasoning family; 1.5B base = Qwen2.5-Math-1.5B,
+    # 3B base = Qwen2.5-Coder-3B). Verify both the alias paths
+    # (vibethinker-{1.5b-4bit,3b-8bit} → JSON profile) and the bare-HF-path
+    # regex fallback (WeiboAI/VibeThinker-{1.5B,3B}, served by full repo id
+    # without an alias) wire ``deepseek_r1`` reasoning parser so
+    # ``<think>...</think>`` blocks land in ``reasoning_content`` not
     # ``content``. ``tool_call_parser`` stays None — model card explicitly
     # disowns tool calling.
     @pytest.mark.parametrize(
         "model_path",
         [
+            "vibethinker-1.5b-4bit",
+            "mlx-community/VibeThinker-1.5B-mlx-4bit",
+            "WeiboAI/VibeThinker-1.5B",
             "vibethinker-3b-8bit",
             "mlx-community/VibeThinker-3B-8bit",
             "WeiboAI/VibeThinker-3B",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -856,6 +856,18 @@
     "supports_spec_decode": true,
     "suffix_decoding_tier": "unknown"
   },
+  "vibethinker-1.5b-4bit": {
+    "hf_path": "mlx-community/VibeThinker-1.5B-mlx-4bit",
+    "tool_call_parser": null,
+    "reasoning_parser": "deepseek_r1",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95
+    }
+  },
   "vibethinker-3b-8bit": {
     "hf_path": "mlx-community/VibeThinker-3B-8bit",
     "tool_call_parser": null,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -856,6 +856,18 @@
     "supports_spec_decode": true,
     "suffix_decoding_tier": "unknown"
   },
+  "vibethinker-3b-8bit": {
+    "hf_path": "mlx-community/VibeThinker-3B-8bit",
+    "tool_call_parser": null,
+    "reasoning_parser": "deepseek_r1",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": true,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95
+    }
+  },
   "diffusion-gemma-26b-4bit": {
     "hf_path": "mlx-community/diffusiongemma-26B-A4B-it-4bit",
     "modality": "text-diffusion",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -134,6 +134,24 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             supports_spec_decode=False,
         ),
     ),
+    # VibeThinker (Weibo AI reasoning derivative, base = Qwen2.5-Coder-3B).
+    # Pure-attention Qwen2 architecture; chat template does NOT inject
+    # ``<think>`` — the model emits ``<think>...</think>`` autonomously on
+    # every response. ``deepseek_r1`` parser handles that "model decides"
+    # contract (same as DeepSeek-R1 distill on Qwen base). Model card
+    # explicitly states tool calling is unsupported even though the
+    # inherited Qwen2 vocab carries ``<tool_call>`` tokens, so leave
+    # ``tool_call_parser=None``. Placed before the generic ``qwen`` regex
+    # would have been (there is none today) — this pattern is the only
+    # signal for full-HF-path serves of ``WeiboAI/VibeThinker-3B`` or
+    # ``mlx-community/VibeThinker-3B-*`` that miss the alias lookup.
+    (
+        re.compile(r"vibethinker", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser=None,
+            reasoning_parser="deepseek_r1",
+        ),
+    ),
     # Qwen3-Coder-Next / Qwen3-Next — hybrid linear attention, BEFORE
     # the generic Qwen3-Coder regex (which would otherwise win and tag
     # this as pure-attention by mistake).


### PR DESCRIPTION
## Summary

Adds end-to-end support for [VibeThinker-3B](https://huggingface.co/WeiboAI/VibeThinker-3B) AND [VibeThinker-1.5B](https://huggingface.co/WeiboAI/VibeThinker-1.5B) (Weibo AI, MIT-licensed; 3B base = Qwen2.5-Coder-3B, 1.5B base = Qwen2.5-Math-1.5B). Closes #670.

- New alias `vibethinker-3b-8bit` → `mlx-community/VibeThinker-3B-8bit` (~3.1 GB on disk, runs on every Mac).
- New alias `vibethinker-1.5b-4bit` → `mlx-community/VibeThinker-1.5B-mlx-4bit` (885 MB, the only quant available on mlx-community for the 1.5B).
- `reasoning_parser=deepseek_r1` on both. The chat template does NOT inject `<think>`; the model emits `<think>...</think>` autonomously on every response (same contract as the existing DeepSeek-V4-Flash / DeepSeek-R1 distill family).
- `tool_call_parser=null` on both. The model card explicitly disowns tool calling even though the inherited Qwen2 vocab carries `<tool_call>` tokens (community reports confirm the model reasons about the template instead of emitting tool calls).
- `recommended_sampling={temperature: 1.0, top_p: 0.95}` per the paper — greedy `temperature=0` produces garbage on reasoning models.
- Architecturally `Qwen2ForCausalLM` / `model_type=qwen2`; mlx-lm 0.31 supports it natively, no new model code needed.

## Files changed

- `vllm_mlx/aliases.json` — two new profile entries
- `vllm_mlx/model_auto_config.py` — `vibethinker` regex so bare-HF-path serves (`WeiboAI/VibeThinker-{1.5B,3B}`, `mlx-community/VibeThinker-{1.5B,3B}-*`) still wire the right parsers when the alias lookup is bypassed
- `tests/test_aliases_contract.py` — parametrized pin of reasoning_parser, tool_call_parser, and the curated sampling values for both sizes so a bulk edit can't silently regress them
- `tests/test_model_auto_config.py` — regex-fallback coverage across six shape variants (alias name, mlx-community path, upstream WeiboAI path; for both 1.5B and 3B)
- `README.md` — list in the "Other" family row; bump alias count 81 → 83
- `pyproject.toml` — 0.7.37 → 0.7.38 to satisfy the `version-check.yml` guard triggered by aliases.json + model_auto_config.py changes (per `docs/development/releasing.md` §"Adding a new model")

## Caveats (worth documenting per maintainer comment on #670)

1. **Tool calling: officially unsupported.** Vocab carries `<tool_call>` / `</tool_call>` tokens (inherited from Qwen2.5) but the model was not trained on tool-calling data. Profile pins `tool_call_parser=null` accordingly.
2. **Benchmark claims (AIME 94.3, LiveCodeBench v6 80.2) have not been independently reproduced.** The PR does not headline these numbers anywhere — neutral "1.5B / 3B reasoning model from Weibo AI" framing only.
3. **`use_sliding_window=false`** on the upstream config, so the 32K sliding-window concern in the issue thread does not apply at inference time.

## Local smoke test (M3 Ultra, before pushing — 3B)

- Boot: `rapid-mlx serve vibethinker-3b-8bit --port 8003` — clean startup, engine resolved the alias profile correctly: `tool_call_parser=None, reasoning_parser=deepseek_r1, is_hybrid=False, supports_spec_decode=True`.
- Non-stream chat completion ("What is 17 × 23? Show brief reasoning.", temperature=1.0, top_p=0.95, max_tokens=512):
  - `reasoning_content` length: 1187 chars (carries the full `<think>` body)
  - `content` length: 140 chars; `<think>` / `</think>` tags **not** leaked
  - `usage.completion_tokens_details.reasoning_tokens=240` correctly tracked
  - Math correct: 391
  - `finish_reason=length` (hit the 512 cap mid-CoT)
- Streaming SSE: 80 tokens in 1.76s (~45 tok/s), TTFT ~128 ms, ends with `data: [DONE]`. Every chunk delta carried `reasoning_content` (the model was still inside `<think>` for that short prompt).
- Weights deleted after the smoke test per the standing "download one, test one, delete one" policy.

## Test plan

- [x] Full unit suite (5860 tests, +18 vs main from new parametrize cases) — passes, no regressions
- [x] Alias-related files specifically (1011 tests across `test_aliases_contract`, `test_model_auto_config`, `test_model_aliases`, `test_alias_recommended_sampling`, `test_model_registry`) — all green
- [x] Local serve + non-stream + stream chat completion verified, reasoning routing confirmed (3B; 1.5B uses identical wiring)
- [x] Weights cleaned up after test
- [x] Maintainer M3 release-check-m3 gauntlet (1.5B uses the same wiring as 3B; no new code paths to gauntlet)

Ping @raullenchai for review.
