### PR TITLE
chore: bump version to 0.7.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.36"
+version = "0.7.37"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## What's new in v0.7.37

Round 1 + 2 of the v0.7.13 stress sweep on rapid-desktop surfaced 4 server-side findings; all four landed with codex-converge gating before this bump.

### Fixes
- **#703** `fix(parser/llama)`: accept bare JSON and `<|python_tag|>` tool calls (F-008) — closes the `llama-3.1-8b-4bit` "every reply is a raw web_search JSON" UX. Streaming + non-streaming surfaces, plus `tool_choice="required"` symmetry. 49 new regression tests. **8 codex rounds** to converge (caught 1B+3M / 1B+1M / 1M / 1M / 1M×3 sites before clean).
- **#705** `fix(routes/anthropic)`: suppress duplicate `thinking` block on non-thinking models (F-010). Adapter gate + implicit-parser bypass + streaming wire-byte pinning. 10 new tests. **6 codex rounds** to converge (caught streaming whitespace-strip-too-aggressive, hello-world breakage).
- **#706** `fix(serve)`: cap request body + reject oversize prompts (F-007 DoS, #463) — closes the 10–100 MB body hang documented in rapid-desktop#273. `--max-request-bytes 8388608` default + `RAPID_MLX_MAX_REQUEST_BYTES` env; per-request token-budget pre-check across `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/messages`. 28+ new tests. **4 codex rounds** to converge.

### Features
- **#704** `feat(routes)`: Prometheus `/metrics` endpoint (closes #701). 14 metrics mapped to existing `engine.get_stats()` / `scheduler.get_stats()` / prefix-cache stats — zero new instrumentation. Sticky-counter accumulator for cache `_total` monotonicity across cache-clear. Handwritten emitter (no `prometheus_client` runtime dep). **3 codex rounds** to converge.

### SOP change
This is the first release shipped under the new "codex review until convergence" SOP (no fixed round cap). Replaces the prior "max 2 rounds" cap that let real bugs ship in v0.7.14 (rapid-desktop). Across these 4 PRs the new SOP caught **6 BLOCKING / 9 MAJOR** that 2-round rounds would have shipped.