### PR TITLE
fix(mllm): bump prefill_step_size to 8192 + surface per-batch-cap as HTTP 400 (#682)

### DIFF
--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VLM chat-route image handling — regression for issue #682.
+
+Pins two contracts at the ``/v1/chat/completions`` route layer:
+
+1. **Image content is forwarded to the MLLM engine.** A multipart user
+   message with ``{"type": "image_url", ...}`` parts must reach
+   ``engine.chat`` / ``engine.stream_chat`` so the engine can extract
+   the image bytes itself (chat.py:577-598 builds raw ``messages``
+   without flattening multimodal content for the MLLM branch).
+
+2. **Engine-side prompt-cap errors surface as HTTP 400.** A 1920×1080
+   screenshot decoded by Qwen3-VL produces ~2200+ vision tokens — past
+   the default ``prefill_step_size=2048`` cap that
+   ``mllm_batch_generator._process_prompts`` enforces. Pre-fix the
+   scheduler swallowed the ValueError as ``finish_reason="length"`` +
+   empty content; the route returned HTTP 200 + empty assistant
+   message; Desktop rendered the misleading "Reached max_tokens
+   before any output" error (``ChatViewModel.swift:491``).
+
+Post-fix:
+- ``mllm_scheduler._step_no_queue`` classifies "exceeds the per-batch
+  cap" as a client error → ``RequestOutput.error`` is set.
+- ``stream_outputs`` raises ``ValueError`` instead of yielding the
+  fake-success output.
+- ``routes/chat.py`` maps the marker substring to HTTP 400 so the
+  client sees an actionable message instead of a generic 500.
+
+Both tests use a stub MLLM engine; no real model is loaded, so they
+run in unit-test CI without an Apple Silicon GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+
+
+class _StubMLLMEngine:
+    """Mock MLLM engine. Records the messages it received and either
+    returns a canned ``GenerationOutput`` or raises a ValueError that
+    mimics the engine-layer error path.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = True
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, *, raise_msg: str | None = None):
+        self._raise_msg = raise_msg
+        self.chat_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, *, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        if self._raise_msg is not None:
+            raise ValueError(self._raise_msg)
+        return GenerationOutput(
+            text="A blue background.",
+            new_text="A blue background.",
+            prompt_tokens=2300,
+            completion_tokens=4,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        if self._raise_msg is not None:
+            raise ValueError(self._raise_msg)
+        text = "A blue background."
+        yield GenerationOutput(
+            text=text,
+            new_text=text,
+            prompt_tokens=2300,
+            completion_tokens=4,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+def _make_client(engine: _StubMLLMEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "qwen3-vl-8b-4bit"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = None
+    cfg.reasoning_parser_name = None
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+_IMAGE_DATA_URL = (
+    # 1×1 transparent PNG — the route doesn't decode the bytes, the
+    # stub engine doesn't either; this just exercises the message-shape
+    # plumbing through the route → engine boundary.
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII="
+)
+
+
+def _multipart_user_message(text: str) -> dict:
+    """OpenAI-style multipart user message: one text + one image_url part."""
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URL}},
+        ],
+    }
+
+
+def test_chat_route_forwards_image_url_content_to_mllm_engine():
+    """Multimodal user content reaches the MLLM engine intact.
+
+    The chat route's MLLM branch (chat.py:577-598) must NOT flatten
+    image_url parts out of ``messages`` before calling ``engine.chat``
+    — the engine extracts images itself via
+    ``extract_multimodal_content`` inside ``stream_chat`` /
+    ``chat``. A refactor that ran ``extract_multimodal_content``
+    twice (once at the route, once in the engine) would corrupt the
+    chat template — Qwen3-VL's Jinja template expects content-list
+    parts with ``{"type":"image"}`` to emit ``<|vision_start|>…<|vision_end|>``
+    tokens, but the route handler would have already stripped them.
+
+    Pin: the engine received a message whose ``content`` is a LIST
+    (not a flat string), with at least one ``type=image_url`` part.
+    """
+    engine = _StubMLLMEngine()
+    client = _make_client(engine)
+
+    payload = {
+        "model": "qwen3-vl-8b-4bit",
+        "messages": [_multipart_user_message("What is this?")],
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "stream": False,
+    }
+
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    # Engine got called exactly once on the non-streaming path.
+    assert len(engine.chat_calls) == 1
+    fwd_msgs = engine.chat_calls[0]["messages"]
+    assert len(fwd_msgs) == 1
+
+    # The route normalises pydantic Message → dict via model_dump, so
+    # the content is a list of dicts (not Pydantic ContentPart models).
+    msg = fwd_msgs[0]
+    assert isinstance(msg, dict)
+    assert msg["role"] == "user"
+    assert isinstance(msg["content"], list), (
+        f"MLLM branch must forward list content, got {type(msg['content']).__name__}"
+    )
+
+    parts = msg["content"]
+    types = [p.get("type") for p in parts if isinstance(p, dict)]
+    assert "text" in types, f"text part missing: {types}"
+    assert "image_url" in types, (
+        f"image_url part dropped by route before reaching engine: {types}"
+    )
+
+    # Image URL payload survives end-to-end.
+    image_part = next(p for p in parts if p.get("type") == "image_url")
+    assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_chat_route_maps_per_batch_cap_error_to_http_400():
+    """Engine raises "exceeds the per-batch cap" → route returns 400.
+
+    Pre-fix this surfaced as HTTP 200 + empty assistant message +
+    ``finish_reason=length`` (#682). Desktop's ChatViewModel rendered
+    the misleading "Reached max_tokens before any output" error
+    because finish_reason==length with zero tokens.
+
+    Post-fix: the chat route recognises the per-batch-cap marker and
+    converts to HTTP 400 with the actionable engine message
+    ("downscale the image / raise --prefill-step-size").
+    """
+    engine = _StubMLLMEngine(
+        raise_msg=(
+            "Total prompt tokens (2292) exceeds the per-batch cap "
+            "(2048 for 1 request(s)). For image inputs, downscale the "
+            "image; for text inputs, shorten the prompt or restart "
+            "the server with --prefill-step-size set higher."
+        )
+    )
+    client = _make_client(engine)
+
+    payload = {
+        "model": "qwen3-vl-8b-4bit",
+        "messages": [_multipart_user_message("这是谁")],
+        "max_tokens": 64,
+        "temperature": 0.0,
+        "stream": False,
+    }
+
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 400, (
+        f"per-batch cap error must surface as 400, got "
+        f"{resp.status_code}: {resp.text[:400]}"
+    )
+
+    body = resp.json()
+    detail = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "exceeds the per-batch cap" in detail, (
+        f"detail must carry the actionable engine message; got {detail!r}"
+    )
+    assert "downscale the image" in detail
+    assert "--prefill-step-size" in detail
+
+
+def test_chat_route_maps_image_fetch_error_to_http_400_still_works():
+    """The earlier #457 fix path must not regress alongside #682.
+
+    Both ``Failed to process image`` and ``exceeds the per-batch cap``
+    are now routed through the same client-error branch; this guards
+    against a future refactor accidentally narrowing the mapping back
+    to one of them.
+    """
+    engine = _StubMLLMEngine(
+        raise_msg="Failed to process image: 404 Client Error",
+    )
+    client = _make_client(engine)
+
+    payload = {
+        "model": "qwen3-vl-8b-4bit",
+        "messages": [_multipart_user_message("describe")],
+        "max_tokens": 32,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 400
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -555,12 +555,8 @@ def test_resolve_mllm_prefill_step_size_bumps_text_default_to_mllm_default():
     from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
     from vllm_mlx.scheduler import SchedulerConfig
 
-    text_default = SchedulerConfig.__dataclass_fields__[
-        "prefill_step_size"
-    ].default
-    mllm_default = MLLMSchedulerConfig.__dataclass_fields__[
-        "prefill_step_size"
-    ].default
+    text_default = SchedulerConfig.__dataclass_fields__["prefill_step_size"].default
+    mllm_default = MLLMSchedulerConfig.__dataclass_fields__["prefill_step_size"].default
 
     # The MLLM default must exceed the text default — otherwise the
     # bump is a no-op — and must cover a typical 1920×1080 screenshot.

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -10,6 +10,7 @@ pass it through — including when it's ``None``.
 """
 
 import mlx.core as mx
+import pytest
 
 from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
 
@@ -441,3 +442,255 @@ def test_step_heterogeneous_then_homogeneous_populates_shared(monkeypatch):
     assert gen._shared_batch_sampler[0] == (0.5, 0.85)
     # 3 total: 2 from the het batch + 1 fresh for the new homogeneous key.
     assert len(make_sampler_calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# Per-batch cap regression — issue #682
+# ---------------------------------------------------------------------------
+#
+# A high-resolution image (e.g. a 1920×1080 desktop screenshot) decodes to
+# ~2200 vision tokens with Qwen3-VL's preprocessor. The original
+# ``MLLMSchedulerConfig.prefill_step_size=1024`` default + the
+# ``BatchedEngine._start_mllm`` fallback of 2048 (from SchedulerConfig)
+# were both too low for typical VLM workloads. With ``prefill_step_size=
+# 2048`` a single-request 2292-token batch failed the cap and the
+# MLLMScheduler swallowed the ValueError as a soft truncation — the
+# route returned 200 OK with empty content + finish_reason=length and
+# Desktop rendered the misleading "Reached max_tokens before any output"
+# error.
+#
+# The fix bumps the MLLM-side prefill_step_size to 8192 in two places:
+#   - ``MLLMSchedulerConfig.prefill_step_size`` default (for direct
+#     scheduler construction, e.g. programmatic use).
+#   - ``BatchedEngine._start_mllm`` reads the SchedulerConfig value and
+#     applies ``_resolve_mllm_prefill_step_size`` (a bump-policy, NOT a
+#     floor) so a server started with the text-LLM default
+#     (--prefill-step-size 2048) gets the VLM-tuned 8192. Explicit
+#     operator-set values are honored as-is — including smaller ones
+#     for memory-constrained deployments (codex r2 MAJOR contract).
+#
+# The cap arithmetic itself is unchanged — it still bounds aggregate
+# merge-time memory; the bump-policy only raises the per-request budget
+# for image-heavy prompts on the default code path.
+
+
+def _make_cap_request(uid: int, token_count: int) -> MLLMBatchRequest:
+    """Build a request whose ``input_ids.size`` is ``token_count``."""
+    return MLLMBatchRequest(
+        uid=uid,
+        request_id=f"r{uid}",
+        prompt="x",
+        max_tokens=8,
+        input_ids=mx.zeros((token_count,), dtype=mx.int32),
+    )
+
+
+def _gen_with_prefill_cap(prefill_step_size: int) -> MLLMBatchGenerator:
+    """Generator with a tunable cap, no real model/processor needed.
+
+    ``_process_prompts`` only reads ``self.prefill_step_size`` /
+    ``self._stats`` / ``self.vision_cache`` before raising the cap error,
+    so a bare construction is enough to exercise the check.
+    """
+    gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    gen.prefill_step_size = prefill_step_size
+    gen.vision_cache = None
+    gen.model = object()
+    gen.language_model = object()
+    gen.processor = object()
+    gen.mm_processor = None
+
+    class _Stats:
+        prompt_tokens = 0
+        prompt_time = 0.0
+        num_images_processed = 0
+        vision_encoding_time = 0.0
+
+    gen._stats = _Stats()
+    return gen
+
+
+def test_mllm_scheduler_config_default_prefill_step_size_covers_screenshot():
+    """``MLLMSchedulerConfig.prefill_step_size`` default must cover a
+    typical 1920×1080 screenshot's vision-token count.
+
+    Pre-fix the default was 1024 — even an 800×600 image would have
+    failed the cap on a direct ``MLLMSchedulerConfig()`` construction.
+    Post-fix the default is 8192, comfortably above the ~2200-token
+    Qwen3-VL output for 1920×1080.
+    """
+    from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+
+    cfg = MLLMSchedulerConfig()
+    # 1920×1080 Qwen3-VL: ~2200 vision tokens + chat-template + text.
+    # Default must be high enough that a single such request never
+    # trips the cap on its own size (#682).
+    assert cfg.prefill_step_size >= 8192, (
+        f"MLLMSchedulerConfig.prefill_step_size default ({cfg.prefill_step_size}) "
+        f"must be at least 8192 to cover 1920×1080 screenshots without "
+        f"tripping the per-batch cap (#682)."
+    )
+
+
+def test_resolve_mllm_prefill_step_size_bumps_text_default_to_mllm_default():
+    """Pin the MLLM ``prefill_step_size`` bump-policy (#682).
+
+    The CLI ships ``--prefill-step-size 2048`` (text-LLM tuned). Without
+    the bump, every Desktop sidecar serving a VLM would inherit 2048
+    and trip the per-batch cap on a 1920×1080 screenshot.
+
+    Codex r2 MAJOR: an earlier draft used ``max(value, 8192)`` which
+    silently overrode memory-constrained operators who explicitly set
+    a smaller value. The fix bumps only when the value matches the
+    SchedulerConfig dataclass default — any explicit value is honored.
+
+    Codex r3 NIT: the bump-policy is extracted as
+    ``_resolve_mllm_prefill_step_size`` so this test exercises the
+    production helper directly (not a copied mirror expression) and
+    is robust to refactors of ``_start_mllm``.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.engine.batched import _resolve_mllm_prefill_step_size
+    from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    text_default = SchedulerConfig.__dataclass_fields__[
+        "prefill_step_size"
+    ].default
+    mllm_default = MLLMSchedulerConfig.__dataclass_fields__[
+        "prefill_step_size"
+    ].default
+
+    # The MLLM default must exceed the text default — otherwise the
+    # bump is a no-op — and must cover a typical 1920×1080 screenshot.
+    assert mllm_default > text_default, (
+        f"MLLM default ({mllm_default}) must exceed text default "
+        f"({text_default}); otherwise the #682 bump is inert."
+    )
+    assert mllm_default >= 8192, (
+        f"MLLM default ({mllm_default}) must cover 1920×1080 Qwen3-VL "
+        f"(~2200 tokens) with headroom for multi-image messages (#682)."
+    )
+
+    def _resolved(user_value):
+        return _resolve_mllm_prefill_step_size(
+            user_value,
+            text_default=text_default,
+            mllm_default=mllm_default,
+        )
+
+    # Default → bumped (the Desktop sidecar case).
+    assert _resolved(text_default) == mllm_default, (
+        f"text-LLM default ({text_default}) must bump to MLLM default "
+        f"({mllm_default}) — this is the #682 fix for Desktop sidecars."
+    )
+
+    # Explicit smaller value → honored. This is the codex r2 MAJOR
+    # contract: the engine must NOT silently override a user's
+    # explicit smaller choice.
+    for explicit_smaller in [256, 512, 1024, 1500]:
+        assert _resolved(explicit_smaller) == explicit_smaller, (
+            f"explicit prefill_step_size={explicit_smaller} must be "
+            f"honored as-is (codex r2 MAJOR); got {_resolved(explicit_smaller)}"
+        )
+
+    # Explicit larger value → honored (high-end deployment).
+    for explicit_larger in [4096, 8192, 16384, 65536]:
+        assert _resolved(explicit_larger) == explicit_larger, (
+            f"explicit prefill_step_size={explicit_larger} must be "
+            f"honored as-is; got {_resolved(explicit_larger)}"
+        )
+
+    # ``None`` covers BOTH the "no scheduler_config" path AND the
+    # "config object without the attribute" path — the latter via
+    # ``getattr(cfg, "prefill_step_size", None)`` in ``_start_mllm``
+    # returning ``None`` when the attribute is missing (codex r3 NIT).
+    assert _resolved(None) == mllm_default, (
+        "missing attribute / no scheduler_config must default to MLLM-tuned"
+    )
+
+    # And the getattr path: an object that genuinely lacks the attribute
+    # also resolves to the MLLM default. Pins the "config attribute
+    # absent" contract that codex r3 NIT called out as untested.
+    cfg_without_attr = SimpleNamespace()  # no prefill_step_size attribute
+    resolved_missing = _resolve_mllm_prefill_step_size(
+        getattr(cfg_without_attr, "prefill_step_size", None),
+        text_default=text_default,
+        mllm_default=mllm_default,
+    )
+    assert resolved_missing == mllm_default
+
+    # Explicit value EXACTLY equal to text_default is treated as
+    # "took the default" — documented trade-off, #682 outweighs the
+    # rare operator who explicitly wants 2048 on VLM. Pinned here so
+    # a future refactor that flips the equality direction is caught.
+    assert _resolved(text_default) == mllm_default
+
+
+def test_per_batch_cap_fires_on_oversized_batch_with_actionable_message(
+    monkeypatch,
+):
+    """The cap is still a real guard — it MUST fire when prompts truly
+    exceed the budget, with an actionable error message.
+
+    Codex r1 BLOCKING: an earlier draft made the cap tautological by
+    deriving ``per_request_cap`` from the batch's own max. That removed
+    the memory guard entirely. This test pins the cap as a real check
+    and pins the error message wording so the MLLMScheduler client-error
+    classifier and the routes/chat.py 400-mapping continue to match.
+    """
+    # Tiny cap to force the check to fire with a small request size.
+    gen = _gen_with_prefill_cap(prefill_step_size=100)
+    monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
+
+    # 500-token request, cap = 100 × 1 = 100 ⇒ 500 > 100 ⇒ raises.
+    request = _make_cap_request(uid=0, token_count=500)
+
+    with pytest.raises(ValueError) as excinfo:
+        MLLMBatchGenerator._process_prompts(gen, [request])
+
+    msg = str(excinfo.value)
+    # Must keep this exact substring — MLLMScheduler's client-error
+    # classifier matches on it (#682). If the phrase drifts the
+    # soft-truncation regression comes back.
+    assert "exceeds the per-batch cap" in msg, (
+        f"cap error must keep the marker substring; got: {msg}"
+    )
+    # Actionable levers — must call out image-downscale for VLM users.
+    assert "downscale the image" in msg, (
+        f"cap error must suggest image downscale; got: {msg}"
+    )
+    assert "--prefill-step-size" in msg, (
+        f"cap error must mention --prefill-step-size for the text path; got: {msg}"
+    )
+
+
+def test_per_batch_cap_does_not_fail_at_default_on_typical_screenshot(
+    monkeypatch,
+):
+    """End-to-end pin: with the production MLLM default
+    ``prefill_step_size=8192``, a single 2292-token request (Qwen3-VL
+    on a 1920×1080 screenshot) must NOT trip the cap.
+
+    Pre-fix with default 2048 this raised ValueError("exceeds the
+    per-batch cap") which the scheduler swallowed as
+    ``finish_reason="length"`` + empty content (#682).
+    """
+    gen = _gen_with_prefill_cap(prefill_step_size=8192)
+    monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
+
+    # 2292 tokens — typical Qwen3-VL token count for a 1920×1080 image.
+    request = _make_cap_request(uid=0, token_count=2292)
+
+    # The function will still raise SOMETHING downstream (we handed it
+    # bare ``object()`` for model / language_model so the real prefill
+    # path can't run), but it must NOT be the per-batch-cap error.
+    with pytest.raises(Exception) as excinfo:  # noqa: BLE001 — see below
+        MLLMBatchGenerator._process_prompts(gen, [request])
+
+    err_msg = str(excinfo.value)
+    assert "exceeds the per-batch cap" not in err_msg, (
+        f"with the production MLLM default (8192), a 2292-token "
+        f"single-request batch must pass the cap; got: {err_msg}"
+    )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -109,6 +109,51 @@ def _channel_name(channel: Channel) -> str:
     return _CHANNEL_TO_STRING[channel]
 
 
+def _resolve_mllm_prefill_step_size(
+    user_value: int | None,
+    *,
+    text_default: int,
+    mllm_default: int,
+) -> int:
+    """Apply the MLLM ``prefill_step_size`` bump-policy (#682).
+
+    A 1920×1080 screenshot decoded by Qwen3-VL produces ~2200 vision
+    tokens — past the 2048 text-LLM default that ``SchedulerConfig``
+    ships with. The per-batch cap in
+    ``mllm_batch_generator._process_prompts`` would otherwise fire
+    silently and surface as ``finish_reason="length"`` + empty content
+    (#682).
+
+    Policy:
+    - ``None`` or value equal to ``text_default`` → ``mllm_default``
+      (the Desktop-sidecar happy path).
+    - Any other value → honored as-is (memory-constrained operators
+      and high-end deployments keep their explicit choice; codex r2
+      MAJOR contract).
+
+    Trade-off: a user who explicitly picks exactly ``text_default``
+    on a VLM is treated as "took the default" and gets bumped. Closing
+    #682 outweighs the rare operator who deliberately wants the text
+    default on VLM. Operators who want the smaller value can pick any
+    nearby number (e.g. 2049) and it's honored.
+
+    Args:
+        user_value: ``getattr(scheduler_config, "prefill_step_size", None)``
+            — ``None`` covers both "no scheduler_config" and "config
+            object without the attribute".
+        text_default: ``SchedulerConfig.prefill_step_size``'s
+            dataclass default (the CLI default).
+        mllm_default: ``MLLMSchedulerConfig.prefill_step_size``'s
+            dataclass default (the MLLM-tuned value).
+
+    Returns:
+        The resolved ``prefill_step_size`` for the MLLM scheduler.
+    """
+    if user_value is None or user_value == text_default:
+        return mllm_default
+    return user_value
+
+
 def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
     """Pick a Metal free-cache size that scales with the device's working set.
 
@@ -511,6 +556,15 @@ class BatchedEngine(BaseEngine):
         from ..engine_core import _init_mlx_step_thread
         from ..mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
         from ..models.mllm import MLXMultimodalLM
+        from ..scheduler import SchedulerConfig
+
+        # MLLM-tuned default for ``prefill_step_size``. Vision tokens balloon
+        # the prompt size on VLMs (~2200 tokens for a 1920×1080 Qwen3-VL
+        # screenshot), so we override only when the user left the text-LLM
+        # default (2048) — see the bump-policy comment below for the rationale.
+        _MLLM_DEFAULT_PREFILL_STEP_SIZE = MLLMSchedulerConfig.__dataclass_fields__[
+            "prefill_step_size"
+        ].default
 
         # Load the MLLM model on a dedicated worker thread (#170 / #174 fix
         # extended to MLLM). mlx-lm 0.31.3+ tags every mx.array with the
@@ -574,7 +628,17 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 32
         )
-        prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", 2048)
+        # ``prefill_step_size`` for MLLM is the per-request budget that
+        # caps total prompt tokens (vision + text). See
+        # ``_resolve_mllm_prefill_step_size`` for the bump-policy
+        # rationale (#682).
+        prefill_step_size = _resolve_mllm_prefill_step_size(
+            getattr(self._scheduler_config, "prefill_step_size", None),
+            text_default=SchedulerConfig.__dataclass_fields__[
+                "prefill_step_size"
+            ].default,
+            mllm_default=_MLLM_DEFAULT_PREFILL_STEP_SIZE,
+        )
         # Carry the user-configured admission cap across to the MLLM
         # scheduler. Without this, a server started with
         # ``SchedulerConfig(max_concurrent_requests=N)`` would always

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -685,13 +685,29 @@ class MLLMBatchGenerator:
 
         # Guard against excessive memory usage during cache merge.
         # Each token in the batch requires KV entries across all layers.
+        #
+        # The error string MUST keep the ``exceeds the per-batch cap``
+        # phrase — ``MLLMScheduler._step_no_queue`` matches on it to
+        # classify the error as client-actionable (#682) and ``routes/
+        # chat.py`` maps it to HTTP 400 with the actionable message.
+        # If the phrase ever drifts, the soft-truncation regression
+        # comes back: the route would return HTTP 200 with empty
+        # content + ``finish_reason="length"`` and the Desktop client
+        # would render "Reached max_tokens before any output".
+        #
+        # The message also calls out image-downscale as a lever
+        # explicitly, because vision tokens dominate the prompt budget
+        # on a typical screenshot and "shorten the prompt" is not a
+        # useful instruction when the prompt is mostly image patches.
         max_batch_tokens = self.prefill_step_size * len(requests)
         if total_prompt_tokens > max_batch_tokens:
             raise ValueError(
                 f"Total prompt tokens ({total_prompt_tokens}) exceeds the "
                 f"per-batch cap ({max_batch_tokens} = prefill_step_size "
                 f"{self.prefill_step_size} × {len(requests)} request(s)). "
-                f"Raise the cap with --prefill-step-size, or shorten the prompt."
+                f"For image inputs, downscale the image; for text inputs, "
+                f"shorten the prompt or restart the server with "
+                f"--prefill-step-size set higher."
             )
 
         # Run vision encoding for each request with its own KVCache.

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -62,8 +62,15 @@ class MLLMSchedulerConfig:
     prefill_batch_size: int = 16
     # Completion batch size
     completion_batch_size: int = 16
-    # Prefill step size for chunked prefill
-    prefill_step_size: int = 1024
+    # Prefill step size — per-request prompt-token budget. Vision tokens
+    # balloon the prompt size on VLMs (a 1920×1080 screenshot alone is
+    # ~2200 tokens on Qwen3-VL), so the MLLM-side default is 8192 to
+    # cover typical desktop screenshots and small multi-image messages
+    # out-of-the-box. ``BatchedEngine._start_mllm`` applies a bump-policy
+    # (see ``_resolve_mllm_prefill_step_size``) so a SchedulerConfig
+    # carrying the text-LLM default (2048) gets bumped to 8192, while
+    # any explicit operator-set value is honored as-is (#682, codex r2).
+    prefill_step_size: int = 8192
     # Enable vision embedding cache
     enable_vision_cache: bool = True
     # Maximum cache entries
@@ -714,22 +721,30 @@ class MLLMScheduler:
                     if uids_to_remove:
                         self.batch_generator.remove(uids_to_remove)
 
-                # Differentiate CLIENT errors (image/video fetch failures)
-                # from SERVER errors (oversized prompt, runtime crash).
+                # Differentiate CLIENT errors (image/video fetch failures,
+                # oversized prompt) from SERVER errors (runtime crash).
                 # Client errors get a non-None ``error`` field so
                 # ``stream_outputs`` can raise — letting the route layer
                 # convert to HTTP 400 instead of the previous silent
                 # 200+empty-content+finish_reason=length pattern that
                 # caused #457 (Anthropic SDK clients + curl saw a 200 OK
-                # with no signal that the image fetch had failed).
+                # with no signal that the image fetch had failed) and
+                # #682 (Desktop users sending 1920×1080 screenshots to a
+                # VLM saw an empty assistant message + "Reached max_tokens
+                # before any output" rendered by the client).
                 #
-                # Non-client errors keep the legacy
-                # finish_reason="length"+empty-text behavior to avoid
-                # breaking callers that handle oversized-prompt as a soft
-                # truncation rather than a hard failure.
+                # The "per-batch cap" string is the marker raised by
+                # ``mllm_batch_generator._process_prompts`` when prompt
+                # tokens (vision + text) exceed the configured cap. For
+                # VLM the typical trigger is a high-resolution image; the
+                # error message already tells the user to downscale or
+                # raise --prefill-step-size, so surfacing the message
+                # is strictly more informative than the legacy soft
+                # truncation.
                 is_client_error = (
                     "Failed to process image" in err_msg
                     or "Failed to process video" in err_msg
+                    or "exceeds the per-batch cap" in err_msg
                 )
                 # Create error outputs (queue delivery deferred to caller).
                 for request_id in error_ids:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -275,9 +275,16 @@ async def create_anthropic_message(
                     status_code=400, detail=f"Chat template error: {err_msg}"
                 )
             # Multimodal fetch failures → 400 (parity with chat route, #457).
+            # Per-batch-cap errors from the MLLM engine also surface as
+            # client-actionable → 400 (parity with chat route, #682). The
+            # MLLM scheduler classifier in ``mllm_scheduler._step_no_queue``
+            # treats both as client errors; this route must map both to 400
+            # or Anthropic-style clients get a 500 for what is really an
+            # oversized-image / oversized-prompt user error.
             if (
                 "Failed to process image" in err_msg
                 or "Failed to process video" in err_msg
+                or "exceeds the per-batch cap" in err_msg
             ):
                 raise HTTPException(status_code=400, detail=err_msg)
             raise

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1156,7 +1156,20 @@ async def _create_chat_completion_impl(
         # "Failed to process image|video" prefix. Convert to 400 so VLM
         # clients get a clear error instead of a 200 with empty completion
         # (#457).
-        if "Failed to process image" in err_msg or "Failed to process video" in err_msg:
+        #
+        # The "exceeds the per-batch cap" marker comes from
+        # ``mllm_batch_generator._process_prompts`` when vision + text
+        # tokens exceed the configured cap. The MLLM scheduler now flags
+        # this as a client-actionable error (#682); without the explicit
+        # 400 mapping the engine would still return ``HTTPException``-less
+        # 500. Surface as 400 so Desktop / curl clients see the actionable
+        # message ("downscale image / raise --prefill-step-size") instead
+        # of a generic server error.
+        if (
+            "Failed to process image" in err_msg
+            or "Failed to process video" in err_msg
+            or "exceeds the per-batch cap" in err_msg
+        ):
             raise HTTPException(status_code=400, detail=err_msg)
         raise
     finally:

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -262,7 +262,17 @@ async def _non_stream(
             raise HTTPException(
                 status_code=400, detail=f"Chat template error: {err_msg}"
             )
-        if "Failed to process image" in err_msg or "Failed to process video" in err_msg:
+        # Multimodal fetch failures + MLLM per-batch-cap errors → 400
+        # (parity with chat route, #457 / #682). The MLLM scheduler
+        # classifier already treats both as client-actionable; this route
+        # must map both to 400 or the /v1/responses surface returns a 500
+        # for what is really an oversized-image / oversized-prompt user
+        # error.
+        if (
+            "Failed to process image" in err_msg
+            or "Failed to process video" in err_msg
+            or "exceeds the per-batch cap" in err_msg
+        ):
             raise HTTPException(status_code=400, detail=err_msg)
         raise
 


### PR DESCRIPTION
Closes #682

## Why

Rapid-MLX Desktop v0.7.15 user reports ``VLM 有问题``: sending a screenshot (1920×1080+) plus a text prompt to ``/v1/chat/completions`` with ``qwen3-vl-8b-4bit`` returns HTTP 200 with empty ``content``, ``finish_reason="length"``, ``usage.completion_tokens=0``. Desktop renders the misleading "Reached max_tokens before any output" error (``ChatViewModel.swift:491``).

Reproduced locally on ``qwen3-vl-4b-4bit`` (smaller sibling):
- 320×240 ✓ works
- 640×480 to 1280×720 ✓ works
- 1920×1080 and up ✗ empty content + ``finish_reason=length``

Sidecar logs revealed: ``mllm_batch_generator._process_prompts`` raised ``ValueError("Total prompt tokens (2292) exceeds the per-batch cap (2048 = prefill_step_size 2048 × 1 request(s))")``. ``MLLMScheduler._step_no_queue`` swallowed it as a soft truncation, producing fake-success ``RequestOutput`` with empty text + ``finish_reason="length"``.

**Root cause**: a 1920×1080 image decodes to ~2200 vision tokens on Qwen3-VL, past the 2048 ``prefill_step_size`` default that ``SchedulerConfig`` ships with — because that default was tuned for text-only LLMs. The MLLM path needs a higher default, AND the cap-exceeded error needs to surface as a client-actionable 400 rather than be swallowed as a fake-success.

## The fix

Five coordinated changes:

1. **``mllm_scheduler``** classifies ``"exceeds the per-batch cap"`` as a client-actionable error so ``stream_outputs`` raises ``ValueError`` instead of yielding the empty fake-success output (same shape as the existing #457 image-fetch error classification).
2. **``routes/chat.py`` + ``routes/anthropic.py`` + ``routes/responses.py``** map the marker substring to HTTP 400 with the actionable engine message (parity with the existing #457 image-fetch mapping). Per-batch-cap errors raised by ``engine.chat`` on any of the three OpenAI-compat surfaces now produce a 400 with a clear message instead of a 500.
3. **``mllm_batch_generator``** error message now calls out image-downscale as the actionable lever for VLM users, because "shorten the prompt" was misleading when vision tokens dominate the prompt budget.
4. **``BatchedEngine._start_mllm``** bumps ``SchedulerConfig.prefill_step_size`` to 8192 when the value matches the text-LLM default (2048), via the new ``_resolve_mllm_prefill_step_size`` helper. Explicit operator-set values — including smaller ones for memory-constrained deployments — are honored as-is (codex r2 contract).
5. **``MLLMSchedulerConfig.prefill_step_size``** default bumped from 1024 → 8192 to keep direct-construction users on a sane MLLM default.

## End-to-end verification

Tested on ``qwen3-vl-4b-4bit`` against a running sidecar:

- 1920×1080 image + Chinese prompt ``"这是谁"``: HTTP 200, ``finish_reason=stop``, 34 Chinese tokens.
- 1920×1200: ``finish_reason=stop``, 50 Chinese tokens.
- 4096×4096 (16395 vision tokens, past the 8192 default): HTTP 400 with the actionable engine message.
- Streaming surface still emits the message via the existing ``_disconnect_guard`` SSE error chunk (same pattern as #457).

## Tests

- ``tests/test_chat_route_vlm_image.py`` (new): three route-level contracts using ``FastAPI TestClient`` + stub MLLM engine — image_url survives route→engine boundary, per-batch-cap → HTTP 400, image-fetch → HTTP 400 (regression for #457).
- ``tests/test_mllm_batch_generator.py``: five unit tests pinning the cap arithmetic, error-message wording, ``MLLMSchedulerConfig`` default, and the bump-policy at every truth-table boundary (None, missing-attribute, text-default → bumped, explicit smaller, explicit larger).

All 1202 affected tests pass; ``ruff`` clean.

## Codex review: 5 rounds to convergence

- **r1 BLOCKING**: an early draft of the cap formula was tautological (made the guard unreachable). Reverted; took a different approach via the ``prefill_step_size`` bump.
- **r2 MAJOR**: ``max(value, 8192)`` floor silently overrode explicit smaller operator values. Replaced with bump-policy: only bump when value matches text default.
- **r3 MAJOR**: ``anthropic.py`` + ``responses.py`` needed parity 400 mapping. Plus NITs on comment typo + stale "floor" wording. All addressed.
- **r4 MAJOR**: streaming surfaces still return HTTP 200 (the ``StreamingResponse`` opens before ``engine.stream_chat`` runs). Scoped out — same behavior as the existing #457 streaming path; the SSE error chunk already carries the actionable message; eager pre-validation is a separate scoped change.
- **r5**: 0 BLOCKING / 0 MAJOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)