### PR TITLE
fix(reasoning): VibeThinker integration follow-up (Case-4 rescue + codex r1/r2/r4 P2 SSE-boundary)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.39"
+version = "0.7.40"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -661,42 +661,80 @@ def test_vibethinker_family_wires_deepseek_r1_reasoning_parser(alias: str) -> No
     )
 
 
-@pytest.mark.parametrize(
-    "alias",
-    [
-        "qwen3-4b-thinking-2507-4bit",
-        "qwen3-4b-instruct-2507-4bit",
-        "qwen3-vl-2b-4bit",
-    ],
-)
-def test_qwen3_small_models_batch_wires_qwen3_parsers(alias: str) -> None:
-    """The Qwen3 ≤5B additions (Thinking-2507, Instruct-2507, VL-2B)
-    must all carry the Qwen3 family parser pair (``hermes`` for tool
-    calls + ``qwen3`` for reasoning).
+def test_qwen3_4b_thinking_2507_wires_qwen3_reasoning_parser() -> None:
+    """The Qwen3-4B-Thinking-2507 variant emits ``<think>...</think>``
+    blocks autonomously on every response; it MUST carry the
+    ``qwen3`` reasoning parser so the trace lands in
+    ``reasoning_content`` instead of leaking into ``content``.
 
-    The ``qwen3`` reasoning parser is the right pick even for the
-    non-thinking ``Instruct`` variant — the parser stays inert on
-    output that contains no ``<think>...</think>`` blocks and never
-    swallows content; pinning it keeps the wiring uniform across the
-    whole Qwen3 family and matches existing entries like
-    ``qwen3-4b-8bit`` / ``qwen3-vl-4b-4bit``.
-
-    Pinning here so a future PR can't silently revert the Thinking-2507
-    entry to ``reasoning_parser=null`` (which would leak ``<think>``
-    blocks into ``content``) or downgrade the Instruct-2507 entry away
-    from the family default (which would create a parser-mismatch hop
-    for clients that round-robin across Qwen3 sizes).
+    Pinned separately from the non-thinking siblings (Instruct-2507
+    + VL-2B) because the non-thinking variants must NOT carry the
+    parser — see the docstring on
+    ``test_qwen3_small_non_thinking_variants_have_no_reasoning_parser``
+    for the fuzz-evidence rationale (PR #715 bundle).
     """
     profiles = list_profiles()
+    alias = "qwen3-4b-thinking-2507-4bit"
     assert alias in profiles, f"{alias} missing from aliases.json"
     assert profiles[alias].tool_call_parser == "hermes", (
         f"{alias}: tool_call_parser must be 'hermes' (Qwen3 family default). "
         f"Got {profiles[alias].tool_call_parser!r}."
     )
     assert profiles[alias].reasoning_parser == "qwen3", (
-        f"{alias}: reasoning_parser must be 'qwen3' — the parser is inert "
-        f"on outputs without `<think>` blocks, so it's safe for both the "
-        f"Thinking and Instruct variants. Got {profiles[alias].reasoning_parser!r}."
+        f"{alias}: reasoning_parser must be 'qwen3' — the Thinking-2507 "
+        f"variant emits `<think>` blocks autonomously. "
+        f"Got {profiles[alias].reasoning_parser!r}."
+    )
+    assert profiles[alias].is_hybrid is False, (
+        f"{alias}: Qwen3-4B is pure-attention, not hybrid."
+    )
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "qwen3-4b-instruct-2507-4bit",
+        "qwen3-vl-2b-4bit",
+    ],
+)
+def test_qwen3_small_non_thinking_variants_have_no_reasoning_parser(
+    alias: str,
+) -> None:
+    """The Qwen3-4B-Instruct-2507 and Qwen3-VL-2B-Instruct aliases are
+    NON-thinking variants — their model cards explicitly state no
+    ``<think>`` emission and the 2026-06-18 fuzz battery against PR
+    #714 confirmed the symptom: with ``reasoning_parser=qwen3`` wired
+    AND the client passing ``enable_thinking=True`` (or the parser's
+    Case-4 fallback firing on a no-tag output) the entire response
+    is duplicated into BOTH ``content`` AND ``reasoning_content``,
+    leaving a confusing assistant turn for the caller.
+
+    The qwen3 parser's Case-4 "no tags AND enable_thinking=True →
+    everything is reasoning" path is the load-bearing addition for
+    #575 — it's correct for actual thinking models but a footgun for
+    non-thinking variants that never produce ``<think>`` regardless
+    of the kwarg. Setting ``reasoning_parser=null`` short-circuits
+    the whole reasoning path so output flows directly to ``content``
+    as the non-thinking variants intend.
+
+    Pinning here so a future PR can't silently re-wire the qwen3
+    parser on the strength of "but the family default is qwen3" — the
+    Thinking-2507 sibling keeps the family parser (see
+    ``test_qwen3_4b_thinking_2507_wires_qwen3_reasoning_parser``).
+    """
+    profiles = list_profiles()
+    assert alias in profiles, f"{alias} missing from aliases.json"
+    assert profiles[alias].tool_call_parser == "hermes", (
+        f"{alias}: tool_call_parser stays 'hermes' (the model can emit "
+        f"hermes-style tool calls via the Qwen3 vocab; only the reasoning "
+        f"parser is being cleared). Got {profiles[alias].tool_call_parser!r}."
+    )
+    assert profiles[alias].reasoning_parser is None, (
+        f"{alias}: reasoning_parser must be None — this is a NON-thinking "
+        f"Qwen3 variant and the qwen3 parser's Case-4 fallback duplicates "
+        f"the whole output into both content + reasoning_content when the "
+        f"client passes enable_thinking=True. See PR #715 bundle (fuzz "
+        f"finding A). Got {profiles[alias].reasoning_parser!r}."
     )
     assert profiles[alias].is_hybrid is False, (
         f"{alias}: Qwen3 (2B / 4B / VL) is pure-attention, not hybrid. "
@@ -824,6 +862,84 @@ def test_gemma_3n_multimodal_aliases_share_family_sampling() -> None:
         assert sampling.get("top_k") == 64, (
             f"{alias}: top_k must be 64. Got {sampling.get('top_k')!r}."
         )
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "phi-3.5-mini-4bit",
+        "gemma-3n-e2b-4bit",
+        "gemma-3n-e4b-4bit",
+    ],
+)
+def test_no_tool_call_support_aliases_have_null_tool_call_parser(
+    alias: str,
+) -> None:
+    """Models whose chat templates can't emit hermes-style tool grammar
+    must carry ``tool_call_parser=null`` so the route doesn't
+    advertise tools the model can't fulfil.
+
+    The 2026-06-18 fuzz battery against PR #714 sent tool-call prompts
+    to each ≤5B alias and recorded whether the model emitted a parseable
+    ``<tool_call>...</tool_call>`` envelope:
+
+    * ``phi-3.5-mini-4bit`` (Microsoft Phi-3.5) — chat template only
+      defines ``<|user|>`` / ``<|assistant|>`` / ``<|end|>``; no
+      ``<tool_call>`` special tokens. Tool-call attempts get ignored.
+    * ``gemma-3n-e2b-4bit`` / ``gemma-3n-e4b-4bit`` (Google Gemma 3n
+      multimodal) — chat template injects no tool-call markers; model
+      replies with plain prose when asked to use a tool.
+
+    With ``tool_call_parser=hermes`` (the prior wiring carried over
+    from the family-default seed) the route still SCANS for hermes
+    markup and returns ``tool_calls=[]`` + raw text in ``content`` —
+    not a crash, but it advertises ``tools`` capability in the
+    OpenAI surface that the model can't honour, which clients
+    consuming the ``/v1/models`` capability discovery treat as a
+    bug. Setting ``tool_call_parser=null`` is the honest signal.
+
+    ``phi-4-mini-reasoning-4bit`` is deliberately NOT in this list —
+    Phi-4-mini-reasoning CAN emit tool calls (the parser works), it
+    just spends most of its 256-token default budget on thinking
+    first. Users bump ``max_tokens=1024+`` for tool use; the alias
+    config stays at ``tool_call_parser=hermes``.
+
+    Pinned here so a future PR can't silently re-wire ``hermes``
+    on the strength of "but the family default is hermes" — the
+    family default is correct for the chat-format families that
+    ship tool tokens, and wrong for these three that don't.
+    """
+    profiles = list_profiles()
+    assert alias in profiles, f"{alias} missing from aliases.json"
+    assert profiles[alias].tool_call_parser is None, (
+        f"{alias}: tool_call_parser must be None — the model's chat "
+        f"template can't emit hermes-style tool grammar (PR #715 fuzz "
+        f"finding D). Got {profiles[alias].tool_call_parser!r}."
+    )
+
+
+def test_phi_4_mini_reasoning_keeps_hermes_tool_call_parser() -> None:
+    """Counter-pin to ``test_no_tool_call_support_aliases_have_null_tool_call_parser``:
+    ``phi-4-mini-reasoning-4bit`` MUST stay at ``tool_call_parser=hermes``.
+
+    The Phi-4-mini-reasoning variant CAN emit tool calls (the hermes
+    parser successfully extracts them when the model gets enough
+    decode budget) — it just spends most of its 256-token default
+    budget on its autonomous ``<think>...</think>`` block before
+    producing the tool call. Users need ``max_tokens=1024+`` for
+    reliable tool use; the parser wiring itself is correct.
+
+    Pinned separately so a "let's clean up tool_call_parser on
+    phi family" sweep can't silently flip this entry to ``null``
+    on the strength of pattern-matching to phi-3.5.
+    """
+    profile = list_profiles()["phi-4-mini-reasoning-4bit"]
+    assert profile.tool_call_parser == "hermes", (
+        f"phi-4-mini-reasoning-4bit: tool_call_parser must stay 'hermes' — "
+        f"the model CAN tool-call (parser works), it just needs more "
+        f"max_tokens for the thinking block. See PR #715 bundle. "
+        f"Got {profile.tool_call_parser!r}."
+    )
 
 
 def test_aliases_with_known_broken_hf_paths_stay_fixed() -> None:

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -616,11 +616,17 @@ def test_vibethinker_family_wires_deepseek_r1_reasoning_parser(alias: str) -> No
     the chain-of-thought.
 
     Pin the wiring so a future PR can't silently revert it to ``null``
-    for either size. Also pins ``tool_call_parser=None`` — the model
-    card explicitly states tool calling is unsupported even though the
-    inherited Qwen2 vocab carries ``<tool_call>`` tokens (community
-    reports confirm the model reasons about the template instead of
-    emitting tool calls).
+    for either size. Also pins ``tool_call_parser="hermes"`` — the
+    inherited Qwen2 vocab carries ``<tool_call>`` / ``</tool_call>``
+    tokens and the 2026-06-17 VibeThinker-3B-8bit live test confirmed
+    the model emits BOTH ``<tool_call>{"name": ...}</tool_call>`` and
+    bare ``<function=name>...</function>`` wire shapes for tool calls.
+    With ``tool_call_parser=null`` the OutputRouter's token-level
+    fallback caught the ``<tool_call>`` shape "by accident" but the
+    bare ``<function>`` shape leaked into ``content`` as raw text.
+    Hermes parser handles both shapes natively (see
+    ``HermesToolParser.TOOL_CALL_PATTERN`` and
+    ``BARE_FUNCTION_PATTERN``).
     Verified format sources:
     https://huggingface.co/mlx-community/VibeThinker-3B-8bit
     https://huggingface.co/mlx-community/VibeThinker-1.5B-mlx-4bit
@@ -631,9 +637,12 @@ def test_vibethinker_family_wires_deepseek_r1_reasoning_parser(alias: str) -> No
         f"{alias}: reasoning_parser must be 'deepseek_r1' (VibeThinker emits "
         f"`<think>` blocks autonomously). Got {profiles[alias].reasoning_parser!r}."
     )
-    assert profiles[alias].tool_call_parser is None, (
-        f"{alias}: tool_call_parser must be None — VibeThinker is not "
-        f"trained for tool calling per the upstream model card. "
+    assert profiles[alias].tool_call_parser == "hermes", (
+        f"{alias}: tool_call_parser must be 'hermes' — VibeThinker is "
+        f"Qwen2-derived and emits both <tool_call>{{...}}</tool_call> and "
+        f"bare <function=name>...</function> shapes. The 2026-06-17 live "
+        f"test confirmed the bare-function shape leaks into content "
+        f"without the hermes parser. "
         f"Got {profiles[alias].tool_call_parser!r}."
     )
     # Reasoning-model sampling guidance: temperature=1.0, top_p=0.95

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -633,9 +633,11 @@ def test_vibethinker_family_wires_deepseek_r1_reasoning_parser(alias: str) -> No
     """
     profiles = list_profiles()
     assert alias in profiles, f"{alias} missing from aliases.json"
-    assert profiles[alias].reasoning_parser == "deepseek_r1", (
-        f"{alias}: reasoning_parser must be 'deepseek_r1' (VibeThinker emits "
-        f"`<think>` blocks autonomously). Got {profiles[alias].reasoning_parser!r}."
+    assert profiles[alias].reasoning_parser == "vibethinker", (
+        f"{alias}: reasoning_parser must be 'vibethinker' — a DeepSeek-R1 "
+        f"variant with NO_TAG_CONTENT_THRESHOLD=1024 (vs base 64) to handle "
+        f"the documented preamble-before-`<think>` shape (codex r2 P2). "
+        f"Got {profiles[alias].reasoning_parser!r}."
     )
     assert profiles[alias].tool_call_parser == "hermes", (
         f"{alias}: tool_call_parser must be 'hermes' — VibeThinker is "

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -28,6 +28,7 @@ the retry branch.
 
 from __future__ import annotations
 
+from vllm_mlx.reasoning.deepseek_r1_parser import DeepSeekR1ReasoningParser
 from vllm_mlx.reasoning.harmony_parser import HarmonyReasoningParser
 from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
 from vllm_mlx.service.helpers import _finalize_content_and_reasoning
@@ -497,3 +498,176 @@ def test_575_r2_qwen3_case4_still_clears_when_thinking_on():
     )
     assert reasoning == _QWEN3_TRUNCATED_THOUGHT.strip()
     assert not cleaned
+
+
+# ---------------------------------------------------------------------------
+# 2026-06-17 VibeThinker live-test regression: truncated ``<think>`` opener
+# without ``</think>`` (``finish_reason=length`` mid-thought) used to leak
+# the byte-identical reasoning trace into BOTH ``content`` AND
+# ``reasoning_content``. The helper now clears ``cleaned_text`` when the
+# parser returns ``(reasoning, None)`` AND ``cleaned_text`` opens with an
+# unclosed ``<think>``. See ``first_parse_was_truncated_think`` in
+# ``vllm_mlx/service/helpers.py``.
+# ---------------------------------------------------------------------------
+
+_VIBETHINKER_TRUNCATED_THINK = (
+    "<think>\nStep 1: Let's analyze the problem.\n"
+    "Step 2: Apply the formula.\n"
+    "Step 3: We need to compute 7 * 12 = 84.\n"
+    "Step 4: Then we add 5 to get 89.\n"
+    "Step 5: Let me double-check by another method"
+    # NO ``</think>`` — finish_reason=length truncated mid-thought.
+)
+
+
+def test_vibethinker_truncated_think_no_duplicate_content_reasoning():
+    """2026-06-17 VibeThinker live-test repro: ``<think>...`` truncated
+    with no ``</think>`` used to surface the whole trace identically in
+    BOTH ``content`` and ``reasoning_content`` (live-test math row:
+    content_len == reasoning_len == 5449, byte-identical). The fix
+    clears ``cleaned_text`` when the parser returns ``(reasoning,
+    None)`` AND ``cleaned_text`` opens with an unclosed ``<think>``.
+
+    This test would FAIL on main because the leak plug in
+    ``_finalize_content_and_reasoning`` only fires on Case-4 (no tag at
+    all) — Case-3 (unclosed ``<think>`` opener) falls through and the
+    raw text echoes into both fields.
+    """
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_VIBETHINKER_TRUNCATED_THINK,
+        cleaned_text=_VIBETHINKER_TRUNCATED_THINK,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        # No ``enable_thinking`` signal from the caller — the literal
+        # ``<think>`` token in the output is the model's own evidence
+        # of thinking, so the fix must NOT be gated on this flag.
+        enable_thinking=None,
+    )
+    # Reasoning trace recovered
+    assert reasoning is not None
+    assert "Step 3" in reasoning
+    # Content explicitly blanked — must NOT duplicate the reasoning
+    # trace (the live-test bug signature).
+    assert not cleaned, (
+        f"truncated <think> trace leaked into content: {cleaned!r}"
+    )
+    # Defensive: the trace must not appear in content.
+    assert "Step 1" not in (cleaned or "")
+
+
+def test_vibethinker_truncated_think_with_thinking_enabled_explicit():
+    """Same as the test above but with the caller passing
+    ``enable_thinking=True``. The plug must also fire on this path
+    (was already implicitly covered by the Case-4 ``enable_thinking=True``
+    branch, but Case-3 is gated independently — pin both paths)."""
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=_VIBETHINKER_TRUNCATED_THINK,
+        cleaned_text=_VIBETHINKER_TRUNCATED_THINK,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=True,
+    )
+    assert reasoning is not None
+    assert "Step 3" in reasoning
+    assert not cleaned
+
+
+def test_normal_closed_think_block_still_splits_correctly():
+    """Counter-test: a normal ``<think>...</think>answer`` shape with
+    BOTH tags present must still split into reasoning + content. The
+    new leak-plug gate requires ``</think>`` to be ABSENT, so this
+    well-formed case must be unaffected."""
+    raw = "<think>step by step reasoning</think>The answer is 42."
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+    )
+    assert reasoning == "step by step reasoning"
+    assert cleaned == "The answer is 42."
+
+
+def test_vibethinker_truncated_think_engine_routed_no_duplicate():
+    """2026-06-17 VibeThinker live-test repro — engine-routed path.
+
+    When ``engine_reasoning_text`` is non-empty the helper short-
+    circuits to ``_apply_reasoning_cap`` BEFORE the reasoning-parser
+    branch runs. In that path the leak-plug below the parser never
+    fires, so a truncated ``<think>`` opener in ``cleaned_text``
+    leaks straight into the client's ``content`` field (live-test
+    math row: content_starts_with='<think>We need to find...').
+
+    The fix blanks ``cleaned_text`` in the engine-routed branch too
+    when ``cleaned_text`` opens with an unclosed ``<think>``,
+    mirroring the post-parser plug.
+    """
+    raw = "<think>Let me work through this step by step. 7 * 12 ="
+    engine_reasoning = "Let me work through this step by step. 7 * 12 ="
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        # Any parser will do — the engine-reasoning short-circuit
+        # bypasses the parser entirely.
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+    )
+    # Reasoning comes from the engine (router-routed).
+    assert reasoning == engine_reasoning
+    # Content explicitly blanked — must NOT duplicate the trace
+    # (the live-test bug signature).
+    assert not cleaned, (
+        f"truncated <think> trace leaked into engine-routed content: {cleaned!r}"
+    )
+
+
+def test_engine_routed_closed_think_block_passes_through():
+    """Counter-test for the engine-routed branch: a normal closed
+    ``<think>...</think>answer`` shape in ``cleaned_text`` MUST be
+    preserved. The new gate requires the opening tag at lstrip-start
+    AND no closing tag, so a well-formed block is unaffected."""
+    raw = "<think>reasoning</think>The answer is 42."
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="reasoning",
+        enable_thinking=None,
+    )
+    assert reasoning == "reasoning"
+    # cleaned_text passed through intact — both ``<think>`` and
+    # ``</think>`` are present, the gate is OFF.
+    assert cleaned == raw
+
+
+def test_truncated_think_with_pre_think_content_is_conservatively_preserved():
+    """Defensive corner: if the model emits some content BEFORE
+    ``<think>`` and is then truncated, the leading-position check
+    (``text_to_parse.lstrip().startswith("<think>")``) protects that
+    pre-think content from being silently dropped — instead it falls
+    through to the default behaviour. The point is to avoid the leak
+    plug overshooting on cases the live test didn't cover."""
+    raw = "Here is some content\n<think>truncated thought"
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+    )
+    # Parser extracts the post-``<think>`` portion as reasoning.
+    assert reasoning == "truncated thought"
+    # Cleaned_text is NOT blanked — leading text is preserved (even if
+    # the ``<think>`` tag itself is also present; downstream sanitisers
+    # handle that). This is conservative; an aggressive variant might
+    # try to extract "Here is some content" but the live test repro
+    # doesn't require it.
+    assert cleaned == raw

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -647,13 +647,48 @@ def test_engine_routed_closed_think_block_passes_through():
     assert cleaned == raw
 
 
-def test_truncated_think_with_pre_think_content_is_conservatively_preserved():
-    """Defensive corner: if the model emits some content BEFORE
-    ``<think>`` and is then truncated, the leading-position check
-    (``text_to_parse.lstrip().startswith("<think>")``) protects that
-    pre-think content from being silently dropped — instead it falls
-    through to the default behaviour. The point is to avoid the leak
-    plug overshooting on cases the live test didn't cover."""
+def test_engine_routed_truncated_think_preserves_preamble():
+    """Same as the engine-routed test above, but with a chatty
+    preamble before the unclosed ``<think>``. ``partition`` preserves
+    the preamble as content while dropping the leaked trace."""
+    raw = (
+        "Okay, let me think about this carefully and step by step.\n\n"
+        "<think>I should compute 7 * 12 = 84, then add 5..."
+    )
+    engine_reasoning = "I should compute 7 * 12 = 84, then add 5..."
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+    )
+    assert reasoning == engine_reasoning
+    # Preamble preserved, leaked thought dropped.
+    assert cleaned == "Okay, let me think about this carefully and step by step."
+    assert "compute 7 * 12" not in cleaned
+    assert "<think>" not in cleaned
+
+
+def test_truncated_think_with_pre_think_content_preserves_preamble():
+    """Codex r1 P2 follow-up: when the model emits a preamble BEFORE
+    ``<think>`` and is then truncated, the trim must preserve the
+    preamble as content while dropping the unclosed thought trace.
+
+    The original VibeThinker bug report explicitly calls out this
+    shape (the merge_intervals streaming case — model emits a chatty
+    multi-sentence intro before its ``<think>`` opener). The first
+    iteration of this fix used a conservative
+    ``lstrip().startswith("<think>")`` gate that LEAKED the trace
+    into content for this case; codex r1 flagged it.
+
+    The fix uses ``partition("<think>")[0]`` so:
+      * Start-aligned (math row): preamble == "" → cleaned == ""
+      * Preamble shape (merge_intervals): preamble preserved →
+        content stays semantically meaningful while the leaked thought
+        is dropped.
+    """
     raw = "Here is some content\n<think>truncated thought"
     cleaned, reasoning = _finalize_content_and_reasoning(
         raw_text=raw,
@@ -665,9 +700,11 @@ def test_truncated_think_with_pre_think_content_is_conservatively_preserved():
     )
     # Parser extracts the post-``<think>`` portion as reasoning.
     assert reasoning == "truncated thought"
-    # Cleaned_text is NOT blanked — leading text is preserved (even if
-    # the ``<think>`` tag itself is also present; downstream sanitisers
-    # handle that). This is conservative; an aggressive variant might
-    # try to extract "Here is some content" but the live test repro
-    # doesn't require it.
-    assert cleaned == raw
+    # The preamble is preserved; the unclosed ``<think>`` opener and
+    # the leaked trace are dropped. (Trailing whitespace before
+    # ``<think>`` is also stripped by ``.rstrip()`` for clean
+    # downstream rendering.)
+    assert cleaned == "Here is some content"
+    # Defensive: the raw thought must NOT survive in content.
+    assert "truncated thought" not in cleaned
+    assert "<think>" not in cleaned

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -549,9 +549,7 @@ def test_vibethinker_truncated_think_no_duplicate_content_reasoning():
     assert "Step 3" in reasoning
     # Content explicitly blanked — must NOT duplicate the reasoning
     # trace (the live-test bug signature).
-    assert not cleaned, (
-        f"truncated <think> trace leaked into content: {cleaned!r}"
-    )
+    assert not cleaned, f"truncated <think> trace leaked into content: {cleaned!r}"
     # Defensive: the trace must not appear in content.
     assert "Step 1" not in (cleaned or "")
 
@@ -769,3 +767,82 @@ def test_engine_routed_truncated_think_with_cap_does_not_leak_overflow():
     assert len(reasoning) == 40
     assert cleaned == ""
     assert "thinking out loud" not in (cleaned or "")
+
+
+# ---------------------------------------------------------------------------
+# Bug B (PR #715 fuzz bundle): the truncated-``<think>`` leak plug must
+# fire for ALL reasoning parsers whose ``extract_reasoning`` returns
+# ``(reasoning, None)`` on unclosed-``<think>`` input — including the
+# Qwen3 parser used by ``qwen3-4b-thinking-2507-4bit``. The plug lives in
+# the shared ``_finalize_content_and_reasoning`` helper so coverage
+# should be parser-agnostic; pinning here so a parser-specific override
+# can't silently regress.
+# ---------------------------------------------------------------------------
+
+
+def test_qwen3_truncated_think_no_duplicate_content_reasoning():
+    """Same bug shape as the VibeThinker repro above, but via the
+    ``Qwen3ReasoningParser`` (the parser wired for
+    ``qwen3-4b-thinking-2507-4bit`` and the rest of the Qwen3
+    thinking family). The fuzz battery confirmed
+    ``finish_reason=length`` mid-``<think>`` on Qwen3-4B-Thinking-2507
+    produced byte-identical content + reasoning_content before the
+    leak plug landed.
+
+    Since the plug fires on the parser's ``(reasoning, None)`` return
+    shape rather than the parser class, this test would FAIL if a
+    future PR routed Qwen3 truncated-think through a different
+    branch that bypasses the plug.
+    """
+    raw = _VIBETHINKER_TRUNCATED_THINK
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+    )
+    assert reasoning is not None
+    assert "Step 3" in reasoning
+    assert not cleaned, (
+        f"qwen3 truncated <think> trace leaked into content: {cleaned!r}"
+    )
+
+
+def test_qwen3_truncated_think_with_enable_thinking_true():
+    """Qwen3 + ``enable_thinking=True`` — the explicit-thinking signal
+    must NOT cause the plug to mis-fire and also must NOT double-clear
+    cleaned_text in a way that breaks the existing #575 Case-4 path."""
+    raw = _VIBETHINKER_TRUNCATED_THINK
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=True,
+    )
+    assert reasoning is not None
+    assert "Step 3" in reasoning
+    assert not cleaned
+
+
+def test_qwen3_engine_routed_truncated_think_no_duplicate():
+    """Engine-routed path with Qwen3 parser wired (the typical
+    Qwen3-4B-Thinking-2507 production shape: OutputRouter handles the
+    ``<think>`` token boundary, then helper finalizes)."""
+    raw = "<think>Let me solve this. 7 * 12 = 84, then I need to..."
+    engine_reasoning = "Let me solve this. 7 * 12 = 84, then I need to..."
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+    )
+    assert reasoning == engine_reasoning
+    assert not cleaned, (
+        f"qwen3 engine-routed truncated <think> trace leaked: {cleaned!r}"
+    )

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -708,3 +708,64 @@ def test_truncated_think_with_pre_think_content_preserves_preamble():
     # Defensive: the raw thought must NOT survive in content.
     assert "truncated thought" not in cleaned
     assert "<think>" not in cleaned
+
+
+# Codex r3 P2 — reasoning cap must not re-leak truncated thought.
+
+
+def test_truncated_think_with_reasoning_cap_does_not_leak_overflow():
+    """Codex r3 P2: ``_apply_reasoning_cap`` prepends over-cap reasoning
+    into ``cleaned_text`` so the wire ordering matches the model's
+    emission. That's correct for closed ``<think>...</think>answer``
+    splits but WRONG for truncated thoughts — the overflow IS the
+    leaked thought trace.
+
+    The fix routes the truncated-``<think>`` paths through
+    ``_truncate_reasoning_only`` which caps reasoning but does NOT
+    rewrite ``cleaned_text``. Without this, a client setting
+    ``reasoning_max_tokens=100`` against a 4000-char truncated
+    thought would still see ~3600 chars of reasoning prose in
+    ``content``.
+
+    Both branches (engine-routed and parser-routed) of
+    ``_finalize_content_and_reasoning`` must use the
+    reasoning-only cap when the plug fires.
+    """
+    # Long enough that the cap (default chars≈max_tokens*4) bites.
+    long_thought = "<think>" + ("step by step reasoning " * 100)
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=long_thought,
+        cleaned_text=long_thought,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+        reasoning_max_tokens=10,  # 40 chars
+    )
+    # Reasoning capped at 40 chars.
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    # The overflow MUST NOT be written into cleaned_text — the
+    # client setting a small cap explicitly asked for thought
+    # truncation, not for the overflow to surface as content.
+    assert cleaned == ""
+    assert "step by step reasoning" not in (cleaned or "")
+
+
+def test_engine_routed_truncated_think_with_cap_does_not_leak_overflow():
+    """Same as above but for the engine-routed short-circuit branch."""
+    raw = "<think>" + ("the model is thinking out loud " * 100)
+    engine_reasoning = "the model is thinking out loud " * 100
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+        reasoning_max_tokens=10,  # 40 chars
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    assert cleaned == ""
+    assert "thinking out loud" not in (cleaned or "")

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -16,10 +16,14 @@ class TestDetectModelConfig:
     """Test detect_model_config with various model paths."""
 
     # Qwen family (non-Coder) — covers the original Qwen3 line, the
-    # Qwen3.5 family, Qwen3-4B-Thinking/Instruct-2507 small variants,
-    # and Qwen3-VL-2B (the 2025/2026 VL slot below the existing 4B
-    # entry). The ``qwen3`` regex resolves all of these to the same
-    # ``hermes`` + ``qwen3`` parser pair.
+    # Qwen3.5 family, and the Qwen3-4B-Thinking-2507 small variant.
+    # The ``qwen3`` regex resolves all of these to the same ``hermes``
+    # + ``qwen3`` parser pair.
+    #
+    # Qwen3-4B-Instruct-2507 and Qwen3-VL-2B-Instruct deliberately NOT
+    # listed here — they are NON-thinking variants and have their own
+    # auto-config regex (above the generic ``qwen3``) that clears the
+    # reasoning parser. See ``test_qwen3_non_thinking_variants`` below.
     @pytest.mark.parametrize(
         "model_path",
         [
@@ -27,10 +31,7 @@ class TestDetectModelConfig:
             "mlx-community/Qwen3-0.6B-MLX-4bit",
             "/Users/someone/.lmstudio/models/mlx-community/Qwen3.5-122B-A10B-8bit",
             "mlx-community/Qwen3-4B-Thinking-2507-4bit",
-            "mlx-community/Qwen3-4B-Instruct-2507-4bit",
             "Qwen/Qwen3-4B-Thinking-2507",
-            "mlx-community/Qwen3-VL-2B-Instruct-4bit",
-            "Qwen/Qwen3-VL-2B-Instruct",
         ],
     )
     def test_qwen_family(self, model_path):
@@ -38,6 +39,34 @@ class TestDetectModelConfig:
         assert config is not None
         assert config.tool_call_parser == "hermes"
         assert config.reasoning_parser == "qwen3"
+
+    # Qwen3 non-thinking variants — Instruct-2507 and VL-2B. These do
+    # NOT emit ``<think>...</think>`` autonomously; wiring the qwen3
+    # reasoning parser duplicates the response into BOTH content and
+    # reasoning_content when the client passes ``enable_thinking=True``
+    # (PR #715 bundle, fuzz finding A). The dedicated regex MUST win
+    # over the generic ``qwen3`` regex.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+            "Qwen/Qwen3-4B-Instruct-2507",
+            "mlx-community/Qwen3-VL-2B-Instruct-4bit",
+            "Qwen/Qwen3-VL-2B-Instruct",
+        ],
+    )
+    def test_qwen3_non_thinking_variants(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == "hermes", (
+            f"{model_path}: tool_call_parser stays 'hermes'. "
+            f"Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.reasoning_parser is None, (
+            f"{model_path}: reasoning_parser must be None — non-thinking "
+            f"Qwen3 variant. Did the specific regex get demoted below the "
+            f"generic 'qwen3' regex? Got {cfg.reasoning_parser!r}."
+        )
 
     # GLM family
     @pytest.mark.parametrize(
@@ -291,17 +320,11 @@ class TestDetectModelConfig:
         assert config.tool_call_parser == "kimi"
         assert config.reasoning_parser is None
 
-    # Gemma — covers Gemma 3 family AND Gemma 3n on-device multimodal
-    # (the ``gemma`` regex catches both; gemma-3n config.json reports
-    # model_type=gemma3n but the family default at the alias layer is
-    # the same hermes/no-reasoning wiring).
+    # Gemma 3 (non-3n) — text-only family; carries hermes tool format.
     @pytest.mark.parametrize(
         "model_path",
         [
             "mlx-community/gemma-3-12b-it-4bit",
-            "mlx-community/gemma-3n-E2B-it-4bit",
-            "lmstudio-community/gemma-3n-E4B-it-MLX-4bit",
-            "google/gemma-3n-E2B-it",
         ],
     )
     def test_gemma(self, model_path):
@@ -310,15 +333,38 @@ class TestDetectModelConfig:
         assert config.tool_call_parser == "hermes"
         assert config.reasoning_parser is None
 
-    # Phi (non-reasoning) — covers Phi-4-mini-instruct and Phi-3.5-mini
-    # which share the same ``phi[-_]?[34]`` regex → hermes / no-reasoning
-    # default.
+    # Gemma 3n — on-device multimodal (text+image+audio). Chat
+    # template defines no tool-call special tokens; pin
+    # ``tool_call_parser=None`` so HF-path serves don't advertise tool
+    # capability the model can't honour (PR #715 bundle, fuzz
+    # finding D).
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/gemma-3n-E2B-it-4bit",
+            "lmstudio-community/gemma-3n-E4B-it-MLX-4bit",
+            "google/gemma-3n-E2B-it",
+        ],
+    )
+    def test_gemma_3n_no_tool_calls(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser is None, (
+            f"{model_path}: tool_call_parser must be None — Gemma 3n chat "
+            f"template carries no tool-call tokens (PR #715 fuzz finding "
+            f"D). Did the gemma-3n regex get demoted below the generic "
+            f"'gemma' regex? Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.reasoning_parser is None
+
+    # Phi-4-mini-instruct (non-reasoning) — the only remaining Phi
+    # family member with hermes tool calls. Phi-3.5-mini moved to
+    # ``test_phi_3_5_no_tool_calls`` (no tool support) and
+    # Phi-4-mini-reasoning has its own test below (deepseek_r1 parser).
     @pytest.mark.parametrize(
         "model_path",
         [
             "mlx-community/Phi-4-mini-instruct-4bit",
-            "microsoft/Phi-3.5-mini-instruct",
-            "mlx-community/Phi-3.5-mini-instruct-4bit",
         ],
     )
     def test_phi(self, model_path):
@@ -326,6 +372,28 @@ class TestDetectModelConfig:
         assert config is not None
         assert config.tool_call_parser == "hermes"
         assert config.reasoning_parser is None
+
+    # Phi-3.5-mini — chat template defines no ``<tool_call>`` special
+    # token; the model ignores tool prompts (PR #715 bundle, fuzz
+    # finding D). Pin ``tool_call_parser=None``. The dedicated regex
+    # MUST win over the generic ``phi[-_]?[34]`` regex.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "microsoft/Phi-3.5-mini-instruct",
+            "mlx-community/Phi-3.5-mini-instruct-4bit",
+        ],
+    )
+    def test_phi_3_5_no_tool_calls(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser is None, (
+            f"{model_path}: tool_call_parser must be None — Phi-3.5-mini "
+            f"chat template carries no tool tokens (PR #715 fuzz finding "
+            f"D). Did the phi-3.5 regex get demoted below the generic "
+            f"'phi' regex? Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.reasoning_parser is None
 
     # Phi-4-mini-reasoning — Microsoft's math-tuned reasoning variant.
     # Smoke-verified to emit autonomous ``<think>...</think>`` blocks

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -176,8 +176,12 @@ class TestDetectModelConfig:
     # regex fallback (WeiboAI/VibeThinker-{1.5B,3B}, served by full repo id
     # without an alias) wire ``deepseek_r1`` reasoning parser so
     # ``<think>...</think>`` blocks land in ``reasoning_content`` not
-    # ``content``. ``tool_call_parser`` stays None — model card explicitly
-    # disowns tool calling.
+    # ``content``. ``tool_call_parser`` is ``hermes`` after the
+    # 2026-06-17 live test confirmed the model emits both
+    # ``<tool_call>{...}</tool_call>`` and bare
+    # ``<function=name>...</function>`` shapes — see
+    # ``test_aliases_contract.test_vibethinker_family_wires_deepseek_r1_reasoning_parser``
+    # for the full rationale.
     @pytest.mark.parametrize(
         "model_path",
         [
@@ -193,7 +197,7 @@ class TestDetectModelConfig:
         cfg = detect_model_config(model_path)
         assert cfg is not None
         assert cfg.reasoning_parser == "deepseek_r1"
-        assert cfg.tool_call_parser is None
+        assert cfg.tool_call_parser == "hermes"
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is True
 

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -196,7 +196,9 @@ class TestDetectModelConfig:
     def test_vibethinker(self, model_path):
         cfg = detect_model_config(model_path)
         assert cfg is not None
-        assert cfg.reasoning_parser == "deepseek_r1"
+        # ``vibethinker`` parser — DeepSeek-R1 variant with a larger
+        # no-tag threshold for preamble-before-``<think>`` (codex r2 P2).
+        assert cfg.reasoning_parser == "vibethinker"
         assert cfg.tool_call_parser == "hermes"
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is True

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -933,8 +933,11 @@ class TestDeepSeekNoTagThreshold:
         """Long output without any tags should become content after threshold."""
         parser.reset_state()
 
-        # Generate text longer than 64 chars without any think tags
-        text = "This is a regular response without any thinking tags. " * 3
+        # Generate text longer than NO_TAG_CONTENT_THRESHOLD (1024 chars,
+        # bumped from 64 in 2026-06-17 VibeThinker fix) without any
+        # think tags.
+        text = "This is a regular response without any thinking tags. " * 25
+        assert len(text) > parser.NO_TAG_CONTENT_THRESHOLD
         accumulated = ""
         content_parts = []
         reasoning_parts = []
@@ -1013,7 +1016,8 @@ class TestDeepSeekNoTagThreshold:
         """finalize_streaming should not correct long no-tag output (already content)."""
         parser.reset_state()
 
-        text = "A" * 100  # Over threshold
+        # Over threshold (bumped from 64 → 1024, 2026-06-17 VibeThinker fix).
+        text = "A" * (parser.NO_TAG_CONTENT_THRESHOLD + 50)
         accumulated = ""
 
         for char in text:

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -933,10 +933,9 @@ class TestDeepSeekNoTagThreshold:
         """Long output without any tags should become content after threshold."""
         parser.reset_state()
 
-        # Generate text longer than NO_TAG_CONTENT_THRESHOLD (1024 chars,
-        # bumped from 64 in 2026-06-17 VibeThinker fix) without any
-        # think tags.
-        text = "This is a regular response without any thinking tags. " * 25
+        # Generate text longer than NO_TAG_CONTENT_THRESHOLD (64 chars
+        # on the base ``deepseek_r1`` parser) without any think tags.
+        text = "This is a regular response without any thinking tags. " * 3
         assert len(text) > parser.NO_TAG_CONTENT_THRESHOLD
         accumulated = ""
         content_parts = []
@@ -1016,7 +1015,6 @@ class TestDeepSeekNoTagThreshold:
         """finalize_streaming should not correct long no-tag output (already content)."""
         parser.reset_state()
 
-        # Over threshold (bumped from 64 → 1024, 2026-06-17 VibeThinker fix).
         text = "A" * (parser.NO_TAG_CONTENT_THRESHOLD + 50)
         accumulated = ""
 

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -566,6 +566,27 @@ class TestThinkParserSSEBoundary:
         )
         assert content == "done"
 
+    def test_split_opener_completes_with_partial_end_tag_no_leak(self):
+        """Codex r4 P2 follow-up: when the same chunk that completes a
+        split opener ALSO ends with a partial ``</think>``, the recovery
+        branch must withhold the partial-end-tag suffix from the emit
+        so the next chunk can complete the close. Otherwise the literal
+        ``</thi`` bytes leak into ``reasoning_content`` and the client
+        sees stray closing-tag bytes (live-fuzz repro shape:
+        ``['<thi', 'nk>OK</thi', 'nk>ans']``)."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<thi", "nk>OK</thi", "nk>ans"],
+        )
+        assert reasoning == "OK", (
+            f"split opener + split closer in same completing delta must "
+            f"not leak partial-end-tag bytes — got reasoning={reasoning!r}"
+        )
+        assert content == "ans", (
+            f"content after split closer must be clean — got content={content!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # GptOssReasoningParser

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -307,7 +307,11 @@ class TestDeepSeekR1:
         assert self.parser.end_token == "</think>"
 
     def test_no_tag_threshold_constant(self):
-        assert self.parser.NO_TAG_CONTENT_THRESHOLD == 64
+        # Bumped from 64 → 1024 chars (2026-06-17 VibeThinker live test)
+        # to give Qwen2-derived reasoning models room to emit a chatty
+        # preamble before the ``<think>`` opener. See class docstring
+        # in ``DeepSeekR1ReasoningParser`` for rationale.
+        assert self.parser.NO_TAG_CONTENT_THRESHOLD == 1024
 
     def test_no_start_only_end(self):
         """DeepSeek-R1 handles implicit start tag."""
@@ -331,7 +335,10 @@ class TestDeepSeekR1:
     def test_streaming_no_tag_past_threshold(self):
         """After threshold chars without tags, treat as content."""
         self.parser.reset_state()
-        long_text = "x" * 100
+        # Use a length well past the new 1024-char threshold so the
+        # streaming branch routes to ``content`` regardless of future
+        # threshold tweaks.
+        long_text = "x" * 2000
         result = self.parser.extract_reasoning_streaming("", long_text, long_text)
         assert result.content == long_text
 
@@ -354,7 +361,9 @@ class TestDeepSeekR1:
         """Long output without tags: no correction (already handled by threshold)."""
         self.parser.reset_state()
         self.parser._saw_any_tag = False
-        result = self.parser.finalize_streaming("x" * 100)
+        # Past the 1024-char threshold ⇒ already routed to ``content``
+        # mid-stream, so ``finalize_streaming`` has nothing to correct.
+        result = self.parser.finalize_streaming("x" * 2000)
         assert result is None
 
     def test_finalize_with_tags_no_correction(self):

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -546,6 +546,26 @@ class TestThinkParserSSEBoundary:
         assert reasoning == "x > 5 and y < 10"
         assert content == "done"
 
+    def test_split_opener_completed_with_reasoning_no_duplication(self):
+        """Codex r2 P2 follow-up: when the start tag straddles SSE
+        chunks AND the completing chunk also carries reasoning bytes
+        (``['<thi', 'nk>Okay', ' more']``), the held suffix from the
+        prior ``<thi`` delta must be cleared after consumption. A
+        leftover held value caused the next ``start_in_prev`` delta to
+        compute ``already_emitted_after_opener`` as if the held bytes
+        were un-emitted reasoning, re-emitting the just-sent text and
+        duplicating streamed reasoning."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<thi", "nk>Okay", " more", "</think>", "done"],
+        )
+        assert reasoning == "Okay more", (
+            f"split opener + reasoning in same delta must not duplicate "
+            f"reasoning on subsequent deltas — got reasoning={reasoning!r}"
+        )
+        assert content == "done"
+
 
 # ---------------------------------------------------------------------------
 # GptOssReasoningParser

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -375,6 +375,143 @@ class TestDeepSeekR1:
         assert result is None
 
 
+class TestThinkParserSSEBoundary:
+    """SSE-boundary withhold for split ``<think>`` / ``</think>`` tags
+    (PR #715 bundle, fuzz finding C).
+
+    The 2026-06-18 fuzz battery against PR #714 hit
+    ``phi-4-mini-reasoning-4bit`` with streaming requests and observed
+    ``content=">\\n", reasoning="<thinkOkay..."`` — the parser was
+    splitting the literal ``<think>`` open tag across SSE chunk
+    boundaries and falling through ``_handle_explicit_think``'s
+    "treat as content" fallback for the trailing tag bytes.
+
+    Tested via the ``DeepSeekR1ReasoningParser`` concrete class (the
+    base parser is abstract); ``Qwen3ReasoningParser`` inherits the
+    same streaming machinery and gets coverage via the
+    inheritance-sensitive ``test_qwen3_sse_boundary_inherited``
+    test below.
+    """
+
+    @staticmethod
+    def _run_stream(parser, chunks):
+        """Replay ``chunks`` through the parser's streaming interface
+        exactly the way ``stream_chat_completion`` does and return
+        ``(joined_reasoning, joined_content)``."""
+        parser.reset_state()
+        prev = ""
+        reasoning = ""
+        content = ""
+        for ch in chunks:
+            cur = prev + ch
+            msg = parser.extract_reasoning_streaming(prev, cur, ch)
+            if msg:
+                if msg.reasoning:
+                    reasoning += msg.reasoning
+                if msg.content:
+                    content += msg.content
+            prev = cur
+        return reasoning, content
+
+    def test_start_tag_straddles_sse_boundary(self):
+        """``<think>`` split as ``<thi`` / ``nk>`` MUST produce clean
+        reasoning + clean content — no literal tag bytes in either
+        channel. This is the exact phi-4-mini-reasoning fuzz repro."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<thi", "nk>", "Okay, ", "thinking.", "</think>", "Hello!"],
+        )
+        assert "<thi" not in reasoning, (
+            f"partial start tag leaked into reasoning: {reasoning!r}"
+        )
+        assert "<thi" not in content, (
+            f"partial start tag leaked into content: {content!r}"
+        )
+        assert reasoning == "Okay, thinking."
+        assert content == "Hello!"
+
+    def test_start_tag_split_one_char_at_a_time(self):
+        """Worst-case: every character is its own SSE chunk. The parser
+        must still reconstruct ``<think>`` from 7 one-char deltas
+        without leaking any of the partial bytes."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            list("<think>") + ["Okay"] + ["</think>"] + ["Hi"],
+        )
+        assert reasoning == "Okay"
+        assert content == "Hi"
+
+    def test_end_tag_straddles_sse_boundary(self):
+        """``</think>`` split as ``</thi`` / ``nk>`` MUST not leak the
+        literal closing tag bytes into either channel."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<think>", "thinking", "</thi", "nk>", "answer"],
+        )
+        assert "</thi" not in reasoning, (
+            f"partial end tag leaked into reasoning: {reasoning!r}"
+        )
+        assert "</thi" not in content
+        assert reasoning == "thinking"
+        assert content == "answer"
+
+    def test_false_prefix_lt_recovered(self):
+        """A lone ``<`` that turns out to NOT be a tag must be flushed
+        into the stream on the next delta (not silently dropped).
+
+        Regression for the held-buffer flush: an aggressive withhold
+        without recovery would swallow user-visible characters."""
+        parser = DeepSeekR1ReasoningParser()
+        # Use the streaming interface directly so we don't hit the
+        # NO_TAG_CONTENT_THRESHOLD path in the subclass.
+        reasoning, _ = self._run_stream(parser, ["<", "angle bracket"])
+        assert reasoning == "<angle bracket", (
+            f"held '<' was dropped instead of flushed: {reasoning!r}"
+        )
+
+    def test_qwen3_sse_boundary_inherited(self):
+        """Qwen3 parser inherits the streaming machinery and must get
+        the same SSE-boundary safety as deepseek_r1."""
+        from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
+
+        parser = Qwen3ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<thi", "nk>", "Okay", "</think>", "Hello!"],
+        )
+        assert "<thi" not in reasoning
+        assert "<thi" not in content
+        assert reasoning == "Okay"
+        assert content == "Hello!"
+
+    def test_classic_in_delta_tag_unaffected(self):
+        """Regression: when the entire ``<think>...</think>`` arrives
+        in normal chunks (no straddle), behaviour must be unchanged."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<think>", "reasoning here", "</think>", "the answer"],
+        )
+        assert reasoning == "reasoning here"
+        assert content == "the answer"
+
+    def test_no_tags_at_all_streams_normally(self):
+        """Regression: no-tag streams must still reach the Case-3
+        fallback (reasoning) without being held indefinitely."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["plain ", "answer"],
+        )
+        # Case 3 routes no-tag to reasoning; finalize_streaming corrects
+        # it. We only check the streamed bytes here are intact.
+        assert reasoning == "plain answer"
+        assert content == ""
+
+
 # ---------------------------------------------------------------------------
 # GptOssReasoningParser
 # ---------------------------------------------------------------------------

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -511,6 +511,41 @@ class TestThinkParserSSEBoundary:
         assert reasoning == "plain answer"
         assert content == ""
 
+    def test_false_partial_tag_inside_think_block_flushed(self):
+        """Codex r1 P2 follow-up: when a ``<`` appears mid-reasoning
+        and the next delta resolves it to non-tag content, the held
+        ``<`` must be flushed back into reasoning. Without the
+        recovery the byte was silently dropped — reasoning text
+        ``2 < 5`` would render as ``2  5`` (the comparison operator
+        eaten by the partial-tag withhold).
+
+        This case fires inside an OPEN ``<think>`` block
+        (``start_in_prev`` True), distinct from the Case-3 fallback
+        path the prior tests cover. Codex flagged the asymmetry
+        before merge."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<think>2 ", "<", " 5</think>", "ans"],
+        )
+        assert reasoning == "2 < 5", (
+            f"false partial tag inside <think> block must flush — got "
+            f"reasoning={reasoning!r}"
+        )
+        assert content == "ans"
+
+    def test_in_think_block_with_lt_and_gt_chars(self):
+        """Counter-test: reasoning that includes both ``<`` and ``>``
+        characters mid-text (common in math / code) must not be
+        garbled by the partial-tag withhold."""
+        parser = DeepSeekR1ReasoningParser()
+        reasoning, content = self._run_stream(
+            parser,
+            ["<think>x > 5 and y < 10", "</think>", "done"],
+        )
+        assert reasoning == "x > 5 and y < 10"
+        assert content == "done"
+
 
 # ---------------------------------------------------------------------------
 # GptOssReasoningParser

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -307,11 +307,12 @@ class TestDeepSeekR1:
         assert self.parser.end_token == "</think>"
 
     def test_no_tag_threshold_constant(self):
-        # Bumped from 64 → 1024 chars (2026-06-17 VibeThinker live test)
-        # to give Qwen2-derived reasoning models room to emit a chatty
-        # preamble before the ``<think>`` opener. See class docstring
-        # in ``DeepSeekR1ReasoningParser`` for rationale.
-        assert self.parser.NO_TAG_CONTENT_THRESHOLD == 1024
+        # Codex r2 P2 — kept at 64 on the base ``deepseek_r1`` parser
+        # so distilled-on-Qwen aliases that open with ``<think>``
+        # immediately don't pay the wider-buffer cost. The Qwen2-derived
+        # VibeThinker family that needs a 1024-char window lives in
+        # ``VibeThinkerReasoningParser`` (registered as ``vibethinker``).
+        assert self.parser.NO_TAG_CONTENT_THRESHOLD == 64
 
     def test_no_start_only_end(self):
         """DeepSeek-R1 handles implicit start tag."""
@@ -335,10 +336,7 @@ class TestDeepSeekR1:
     def test_streaming_no_tag_past_threshold(self):
         """After threshold chars without tags, treat as content."""
         self.parser.reset_state()
-        # Use a length well past the new 1024-char threshold so the
-        # streaming branch routes to ``content`` regardless of future
-        # threshold tweaks.
-        long_text = "x" * 2000
+        long_text = "x" * 100
         result = self.parser.extract_reasoning_streaming("", long_text, long_text)
         assert result.content == long_text
 
@@ -361,9 +359,7 @@ class TestDeepSeekR1:
         """Long output without tags: no correction (already handled by threshold)."""
         self.parser.reset_state()
         self.parser._saw_any_tag = False
-        # Past the 1024-char threshold ⇒ already routed to ``content``
-        # mid-stream, so ``finalize_streaming`` has nothing to correct.
-        result = self.parser.finalize_streaming("x" * 2000)
+        result = self.parser.finalize_streaming("x" * 100)
         assert result is None
 
     def test_finalize_with_tags_no_correction(self):

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -1150,6 +1150,5 @@ def test_streaming_rescue_still_fires_for_gemma4_stuck_thought_shape():
         raw_text=trace,
     )
     assert rescued == trace, (
-        "gemma-4 #569 failure mode must still rescue — got "
-        f"rescued={rescued!r}"
+        f"gemma-4 #569 failure mode must still rescue — got rescued={rescued!r}"
     )

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -1152,3 +1152,79 @@ def test_streaming_rescue_still_fires_for_gemma4_stuck_thought_shape():
     assert rescued == trace, (
         f"gemma-4 #569 failure mode must still rescue — got rescued={rescued!r}"
     )
+
+
+# Bug C / Bug 3 cross-cut: PR #715 bundle live-test repro for
+# ``reasoning_is_case4``.
+
+
+def test_rescue_skipped_when_reasoning_is_case4_and_length():
+    """PR #715 bundle, fuzz finding C / VibeThinker live-test repro:
+    when the parser's Case-4 fallback fired (no tags in raw_text,
+    ``enable_thinking=True``, parser routed the whole output to
+    reasoning, helper blanked cleaned_text=""), the rescue MUST NOT
+    surface that reasoning as content.
+
+    Without this gate, the route mistakes the post-Case-4 empty
+    content for a #569 silent drop and feeds the client byte-
+    identical content + reasoning_content (live-test repro: model
+    answered "What is 2+2?" with plain prose, no ``<think>`` token
+    emitted at all, raw_text did NOT start with ``<think>`` — so the
+    original narrow opener gate missed it).
+    """
+    trace = (
+        'First, the user asked "What is 2+2?" This seems like a '
+        "simple arithmetic question. Let me think..."
+    )
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=trace,
+        tool_calls=None,
+        finish_reason="length",
+        # No ``<think>`` literal — model emitted plain prose. Without
+        # the case4 gate the rescue would surface the trace.
+        raw_text=trace,
+        reasoning_is_case4=True,
+    )
+    assert rescued is None, (
+        f"Case-4 length-truncated reasoning must NOT be surfaced as "
+        f"content — got rescued={rescued!r}"
+    )
+
+
+def test_rescue_fires_when_case4_but_finish_is_stop():
+    """Counter-test: the Case-4 gate is specifically for the
+    ``length`` x case4 INTERSECTION. A model that voluntarily ended
+    after emitting only reasoning (no ``<think>`` token, finish=stop)
+    is a genuine silent drop — rescue still fires.
+
+    Uncommon but real (a chatty model that "talks itself out" of the
+    final answer). The same shape #569 was originally written for
+    on gemma-4."""
+    trace = "thought trace that ended cleanly without a final answer"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=trace,
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text=trace,
+        reasoning_is_case4=True,
+    )
+    assert rescued == trace
+
+
+def test_rescue_fires_when_length_but_not_case4():
+    """Counter-test: ``finish_reason="length"`` without the Case-4
+    signal AND without the ``<think>`` opener still rescues — the
+    original #569 gemma-4 stuck-thought failure shape. The case4
+    gate is additive, not replacing, the narrow opener gate."""
+    trace = "gemma-4 analysis channel content"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=trace,
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=trace,
+        reasoning_is_case4=False,
+    )
+    assert rescued == trace

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -1098,3 +1098,58 @@ def test_rescue_skipped_when_closed_think_block_truncated_after():
     # </think> is in raw_text, so the gate does NOT fire → rescue runs
     # normally and surfaces the reasoning.
     assert rescued == "complete thought"
+
+
+# Codex r3 P1 — streaming rescue must skip truncated `<think>`.
+
+
+def test_streaming_rescue_gate_skips_synthetic_truncated_think():
+    """Codex r3 P1: when streaming, the parser consumes ``<think>``
+    as a state transition so ``accumulated_reasoning`` doesn't carry
+    the literal opener. The route synthesises a ``raw_text`` of
+    ``"<think>" + accumulated_reasoning`` when the parser's
+    ``_saw_any_tag`` flag indicates an unclosed opener was seen, then
+    feeds that to the rescue. The rescue's existing
+    ``finish=length + raw_text.lstrip().startswith("<think>") +
+    "</think>" not in raw_text`` gate then suppresses the rescue
+    uniformly with the non-streaming path.
+
+    Pin the gate semantics: synthetic ``"<think>" + trace`` with
+    ``finish="length"`` MUST suppress the rescue.
+    """
+    trace = "the model is in the middle of thinking..."
+    synthetic_raw = "<think>" + trace
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=trace,
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=synthetic_raw,
+    )
+    assert rescued is None, (
+        "streaming truncated-<think> path must suppress rescue — got "
+        f"rescued={rescued!r}"
+    )
+
+
+def test_streaming_rescue_still_fires_for_gemma4_stuck_thought_shape():
+    """Counter-test: gemma-4 stuck-thought streaming shape — the
+    original #569 failure — has no ``<think>`` opener in the
+    accumulated reasoning. The route DOES NOT synthesise a
+    ``<think>`` prefix for it (``_saw_any_tag`` is False on a
+    non-``<think>`` parser like gemma4), so the rescue's gate stays
+    OFF and the rescue still fires. Pin that path against drift."""
+    trace = "the model is stuck inside the analysis channel"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text=trace,
+        tool_calls=None,
+        finish_reason="length",
+        # No ``<think>`` prefix — the route did not synthesise one
+        # because ``_saw_any_tag`` was False on the (non-think) parser.
+        raw_text=trace,
+    )
+    assert rescued == trace, (
+        "gemma-4 #569 failure mode must still rescue — got "
+        f"rescued={rescued!r}"
+    )

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -982,3 +982,119 @@ def test_streaming_rescue_skipped_when_response_format_is_json_schema():
         f"got streamed_content={streamed_content!r}"
     )
     assert "json shape" in streamed_reasoning.lower()
+
+
+# ── 2026-06-17 VibeThinker truncated-``<think>`` rescue gate ──────────
+
+
+def test_rescue_skipped_when_truncated_think_with_finish_length():
+    """2026-06-17 VibeThinker live-test repro: when ``finish_reason="length"``
+    AND ``raw_text`` opens with an unclosed ``<think>``, the rescue must
+    NOT fire. The reasoning trace is an in-progress thought, not a
+    final answer — surfacing it as ``content`` would feed clients the
+    SAME bytes as ``reasoning_content`` and break the "content is the
+    final answer" contract.
+
+    Live-test signature: content_len == reasoning_len (modulo the
+    ``<think>`` opener), byte-identical. After fix: content stays
+    ``None`` so clients can detect "model ran out of budget" via
+    ``finish_reason="length"``.
+    """
+    raw = "<think>The user wants me to compute 17 * 23. Step 1: 17 * 20 = 340"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="The user wants me to compute 17 * 23. Step 1: 17 * 20 = 340",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        "rescue must NOT fire on truncated-<think> + finish_reason=length; "
+        f"got rescued={rescued!r}"
+    )
+
+
+def test_rescue_skipped_when_truncated_think_with_leading_whitespace():
+    """The leading-position check uses ``lstrip().startswith`` so the
+    gate still fires when ``raw_text`` opens with whitespace before
+    ``<think>`` (the chat-template may emit a leading newline)."""
+    raw = "\n  <think>thinking truncated"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="thinking truncated",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    assert rescued is None
+
+
+def test_rescue_still_fires_on_length_when_raw_text_lacks_open_think():
+    """Counter-test for the new gate: a ``finish_reason="length"``
+    response WITHOUT an unclosed ``<think>`` opener (e.g. gemma-4
+    stuck inside ``<|channel>thought\\n…`` — the original #569
+    failure mode) must STILL rescue. The new gate only blocks the
+    rescue when the model's raw text explicitly carries an unclosed
+    ``<think>`` opener."""
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="reasoning that got truncated",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text="reasoning that got truncated",  # no <think> opener
+    )
+    assert rescued == "reasoning that got truncated", (
+        "rescue MUST fire for #569 gemma-4 failure mode even when "
+        "finish_reason=length, when raw_text does not start with <think>"
+    )
+
+
+def test_rescue_still_fires_on_truncated_think_when_finish_is_stop():
+    """Counter-test: ``raw_text`` opens with unclosed ``<think>`` but
+    ``finish_reason`` is ``stop`` (model voluntarily ended without
+    producing a final answer). The new gate is specifically the
+    ``length`` x truncated-think INTERSECTION — other shapes still
+    rescue. This protects models that emit only a thought block then
+    stop (uncommon but possible)."""
+    raw = "<think>just a thought"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="just a thought",
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text=raw,
+    )
+    assert rescued == "just a thought"
+
+
+def test_rescue_still_fires_on_truncated_think_when_finish_unknown():
+    """Counter-test: when ``finish_reason`` is ``None`` (legacy caller
+    that doesn't thread the kwarg), the gate is conservative and
+    rescue still fires. The kwarg defaults to ``None`` for back-
+    compat with existing callers."""
+    raw = "<think>just a thought"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="just a thought",
+        tool_calls=None,
+    )
+    assert rescued == "just a thought"
+
+
+def test_rescue_skipped_when_closed_think_block_truncated_after():
+    """Edge case: ``raw_text`` contains a CLOSED ``<think>...</think>``
+    block plus partial answer truncated at length. The gate uses
+    ``"</think>" not in raw_text`` so the closed block bypasses the
+    rescue-skip and the rescue fires normally (the rescue's normal
+    predicates still gate it appropriately)."""
+    raw = "<think>complete thought</think>The ans"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="complete thought",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    # </think> is in raw_text, so the gate does NOT fire → rescue runs
+    # normally and surfaces the reasoning.
+    assert rescued == "complete thought"

--- a/tests/test_streaming_newlines.py
+++ b/tests/test_streaming_newlines.py
@@ -191,14 +191,7 @@ class TestDeepSeekNoTagComparison:
         """DeepSeek-R1 correctly switches to content after threshold."""
         parser.reset_state()
 
-        # Generate text longer than NO_TAG_CONTENT_THRESHOLD (1024 chars)
-        # to exercise the mid-stream flip from reasoning → content. The
-        # threshold was bumped from 64 → 1024 to accommodate VibeThinker
-        # preambles before ``<think>`` (2026-06-17 live test).
-        text = (
-            "This is a regular response without any thinking tags. It should be content. "
-            * 20
-        )
+        text = "This is a regular response without any thinking tags. It should be content. "
         assert len(text) > parser.NO_TAG_CONTENT_THRESHOLD, (
             "test fixture must exceed threshold to exercise the flip"
         )
@@ -217,33 +210,43 @@ class TestDeepSeekNoTagComparison:
                     reasoning_parts.append(result.reasoning)
 
         full_content = "".join(content_parts)
-        # Once past the threshold (now 1024), DeepSeek-R1 starts treating
-        # no-tag deltas as content.
+        # Once past the threshold, DeepSeek-R1 starts treating no-tag
+        # deltas as content.
         assert len(full_content) > 0, "DeepSeek should have content for no-tag output"
 
-    def test_vibethinker_preamble_before_think_routes_reasoning_correctly(
-        self, parser
-    ):
+    def test_vibethinker_preamble_before_think_routes_reasoning_correctly(self):
         """VibeThinker live-test regression (2026-06-17): the model emits a
         chatty multi-sentence preamble (~13 tokens, ~80 chars) BEFORE its
-        ``<think>`` opener. With the old 64-char threshold, streaming
+        ``<think>`` opener. With the base 64-char threshold, streaming
         flipped routing to ``content`` mid-preamble; by the time the
-        literal ``<think>`` arrived, the whole reasoning trace leaked into
-        ``content`` deltas. The 1024-char threshold gives the preamble
-        room to land inside the reasoning buffer; once ``<think>``
-        arrives, the standard ``_handle_explicit_think`` path routes
-        subsequent tokens to reasoning, and the final answer after
-        ``</think>`` lands in ``content``.
+        literal ``<think>`` arrived, the whole reasoning trace leaked
+        into ``content`` deltas.
+
+        The fix is the ``vibethinker`` parser — a ``DeepSeekR1ReasoningParser``
+        subclass with a 1024-char threshold (codex r2 P2 scoped narrowly
+        to the VibeThinker family). The base ``deepseek_r1`` parser keeps
+        its 64-char threshold to avoid widening the reasoning-buffer
+        window globally for distilled-on-Qwen aliases that open with
+        ``<think>`` immediately.
+
+        This test pins the new ``vibethinker`` parser end-to-end through
+        the parser registry so a future refactor that loses the
+        registration trips here.
         """
-        parser.reset_state()
+        vibethinker_parser = get_parser("vibethinker")()
+        vibethinker_parser.reset_state()
+        assert vibethinker_parser.NO_TAG_CONTENT_THRESHOLD == 1024, (
+            "vibethinker parser must register the larger 1024-char threshold"
+        )
 
         # 80-char preamble (~13 tokens), then ``<think>...</think>``,
         # then the final answer. Mirrors the failing merge_intervals
         # case from the live test.
         preamble = "Okay, let me think about this carefully and work through it step by step.\n\n"
-        assert 64 < len(preamble) < parser.NO_TAG_CONTENT_THRESHOLD, (
-            "preamble must straddle the OLD 64-char threshold (fail-on-main "
-            "guarantee) and stay under the NEW threshold."
+        assert 64 < len(preamble) < vibethinker_parser.NO_TAG_CONTENT_THRESHOLD, (
+            "preamble must straddle the base 64-char threshold (fail-on-base "
+            "guarantee) and stay under the vibethinker subclass's 1024-char "
+            "threshold."
         )
         reasoning_body = "<think>\nStep 1: scan the intervals. Step 2: merge overlaps.\n</think>"
         answer = "def merge_intervals(intervals):\n    return sorted(intervals)"
@@ -256,7 +259,9 @@ class TestDeepSeekNoTagComparison:
         for char in full_text:
             prev = accumulated
             accumulated += char
-            result = parser.extract_reasoning_streaming(prev, accumulated, char)
+            result = vibethinker_parser.extract_reasoning_streaming(
+                prev, accumulated, char
+            )
             if result is None:
                 continue
             if result.content:

--- a/tests/test_streaming_newlines.py
+++ b/tests/test_streaming_newlines.py
@@ -191,7 +191,17 @@ class TestDeepSeekNoTagComparison:
         """DeepSeek-R1 correctly switches to content after threshold."""
         parser.reset_state()
 
-        text = "This is a regular response without any thinking tags. It should be content."
+        # Generate text longer than NO_TAG_CONTENT_THRESHOLD (1024 chars)
+        # to exercise the mid-stream flip from reasoning → content. The
+        # threshold was bumped from 64 → 1024 to accommodate VibeThinker
+        # preambles before ``<think>`` (2026-06-17 live test).
+        text = (
+            "This is a regular response without any thinking tags. It should be content. "
+            * 20
+        )
+        assert len(text) > parser.NO_TAG_CONTENT_THRESHOLD, (
+            "test fixture must exceed threshold to exercise the flip"
+        )
         accumulated = ""
         content_parts = []
         reasoning_parts = []
@@ -207,6 +217,68 @@ class TestDeepSeekNoTagComparison:
                     reasoning_parts.append(result.reasoning)
 
         full_content = "".join(content_parts)
-        # DeepSeek-R1 has NO_TAG_CONTENT_THRESHOLD = 64, so after 64 chars
-        # it starts treating as content
+        # Once past the threshold (now 1024), DeepSeek-R1 starts treating
+        # no-tag deltas as content.
         assert len(full_content) > 0, "DeepSeek should have content for no-tag output"
+
+    def test_vibethinker_preamble_before_think_routes_reasoning_correctly(
+        self, parser
+    ):
+        """VibeThinker live-test regression (2026-06-17): the model emits a
+        chatty multi-sentence preamble (~13 tokens, ~80 chars) BEFORE its
+        ``<think>`` opener. With the old 64-char threshold, streaming
+        flipped routing to ``content`` mid-preamble; by the time the
+        literal ``<think>`` arrived, the whole reasoning trace leaked into
+        ``content`` deltas. The 1024-char threshold gives the preamble
+        room to land inside the reasoning buffer; once ``<think>``
+        arrives, the standard ``_handle_explicit_think`` path routes
+        subsequent tokens to reasoning, and the final answer after
+        ``</think>`` lands in ``content``.
+        """
+        parser.reset_state()
+
+        # 80-char preamble (~13 tokens), then ``<think>...</think>``,
+        # then the final answer. Mirrors the failing merge_intervals
+        # case from the live test.
+        preamble = "Okay, let me think about this carefully and work through it step by step.\n\n"
+        assert 64 < len(preamble) < parser.NO_TAG_CONTENT_THRESHOLD, (
+            "preamble must straddle the OLD 64-char threshold (fail-on-main "
+            "guarantee) and stay under the NEW threshold."
+        )
+        reasoning_body = "<think>\nStep 1: scan the intervals. Step 2: merge overlaps.\n</think>"
+        answer = "def merge_intervals(intervals):\n    return sorted(intervals)"
+
+        full_text = preamble + reasoning_body + answer
+        accumulated = ""
+        content_parts = []
+        reasoning_parts = []
+
+        for char in full_text:
+            prev = accumulated
+            accumulated += char
+            result = parser.extract_reasoning_streaming(prev, accumulated, char)
+            if result is None:
+                continue
+            if result.content:
+                content_parts.append(result.content)
+            if result.reasoning:
+                reasoning_parts.append(result.reasoning)
+
+        joined_reasoning = "".join(reasoning_parts)
+        joined_content = "".join(content_parts)
+
+        # The final answer (post-``</think>``) MUST land in content.
+        assert "merge_intervals" in joined_content, (
+            f"final answer leaked out of content. content={joined_content!r}"
+        )
+        # The reasoning trace from inside ``<think>...</think>`` MUST
+        # land in reasoning_content (this is the live-test bug
+        # signature: previously the trace leaked into content after the
+        # 64-char flip).
+        assert "scan the intervals" in joined_reasoning, (
+            f"reasoning trace lost. reasoning={joined_reasoning!r}"
+        )
+        # And the final answer must NOT appear in reasoning_content.
+        assert "merge_intervals" not in joined_reasoning, (
+            "final answer leaked into reasoning_content"
+        )

--- a/tests/test_streaming_newlines.py
+++ b/tests/test_streaming_newlines.py
@@ -248,7 +248,9 @@ class TestDeepSeekNoTagComparison:
             "guarantee) and stay under the vibethinker subclass's 1024-char "
             "threshold."
         )
-        reasoning_body = "<think>\nStep 1: scan the intervals. Step 2: merge overlaps.\n</think>"
+        reasoning_body = (
+            "<think>\nStep 1: scan the intervals. Step 2: merge overlaps.\n</think>"
+        )
         answer = "def merge_intervals(intervals):\n    return sorted(intervals)"
 
         full_text = preamble + reasoning_body + answer

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -891,7 +891,7 @@
   "qwen3-4b-instruct-2507-4bit": {
     "hf_path": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": "qwen3",
+    "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true
@@ -926,7 +926,7 @@
   },
   "phi-3.5-mini-4bit": {
     "hf_path": "mlx-community/Phi-3.5-mini-instruct-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
@@ -935,14 +935,14 @@
   "qwen3-vl-2b-4bit": {
     "hf_path": "mlx-community/Qwen3-VL-2B-Instruct-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": "qwen3",
+    "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true
   },
   "gemma-3n-e2b-4bit": {
     "hf_path": "mlx-community/gemma-3n-E2B-it-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
@@ -955,7 +955,7 @@
   },
   "gemma-3n-e4b-4bit": {
     "hf_path": "lmstudio-community/gemma-3n-E4B-it-MLX-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -859,7 +859,7 @@
   "vibethinker-1.5b-4bit": {
     "hf_path": "mlx-community/VibeThinker-1.5B-mlx-4bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "vibethinker",
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true,
@@ -871,7 +871,7 @@
   "vibethinker-3b-8bit": {
     "hf_path": "mlx-community/VibeThinker-3B-8bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "vibethinker",
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -858,7 +858,7 @@
   },
   "vibethinker-1.5b-4bit": {
     "hf_path": "mlx-community/VibeThinker-1.5B-mlx-4bit",
-    "tool_call_parser": null,
+    "tool_call_parser": "hermes",
     "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "is_moe": false,
@@ -870,7 +870,7 @@
   },
   "vibethinker-3b-8bit": {
     "hf_path": "mlx-community/VibeThinker-3B-8bit",
-    "tool_call_parser": null,
+    "tool_call_parser": "hermes",
     "reasoning_parser": "deepseek_r1",
     "is_hybrid": false,
     "is_moe": false,

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -207,6 +207,28 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
         ),
     ),
+    # Qwen3 non-thinking variants — these explicitly DO NOT emit
+    # ``<think>...</think>`` and the qwen3 reasoning parser's Case-4
+    # fallback ("no tags + ``enable_thinking=True`` → all output is
+    # reasoning", #575) duplicates the entire response into BOTH
+    # ``content`` and ``reasoning_content`` when the client passes
+    # ``enable_thinking=True``. The 2026-06-18 fuzz battery against PR
+    # #714 caught this on the Qwen3-VL-2B-Instruct and
+    # Qwen3-4B-Instruct-2507 4-bit MLX repacks.
+    #
+    # MUST come BEFORE the generic ``qwen3`` regex below. The Thinking
+    # sibling (Qwen3-4B-Thinking-2507) takes the family default since
+    # ``thinking`` won't match either of these.
+    (
+        re.compile(
+            r"qwen3[-_]?(?:vl[-_]?2b|4b[-_]?instruct)",
+            re.IGNORECASE,
+        ),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser=None,
+        ),
+    ),
     # Qwen3 (pure attention, the original Qwen3 line)
     (
         re.compile(r"qwen3", re.IGNORECASE),
@@ -271,6 +293,20 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         ModelConfig(
             tool_call_parser="gemma4",
             reasoning_parser="gemma4",
+        ),
+    ),
+    # Gemma 3n — on-device multimodal (text+image+audio). The chat
+    # template does NOT define tool-call special tokens, and the 2026-
+    # 06-18 fuzz battery against PR #714 confirmed the model ignores
+    # tool prompts entirely (returns prose, not a parseable envelope).
+    # ``tool_call_parser=hermes`` advertised tool capability the model
+    # cannot honour. Match BEFORE the generic ``gemma`` regex so the
+    # 3n variants resolve to ``tool_call_parser=None``.
+    (
+        re.compile(r"gemma[-_]?3n", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser=None,
+            reasoning_parser=None,
         ),
     ),
     # Gemma 2/3 (hermes format)
@@ -339,6 +375,21 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         ModelConfig(
             tool_call_parser="hermes",
             reasoning_parser="deepseek_r1",
+        ),
+    ),
+    # Phi-3.5-mini — the chat template only defines ``<|user|>`` /
+    # ``<|assistant|>`` / ``<|end|>`` (no ``<tool_call>`` special token);
+    # the 2026-06-18 fuzz battery against PR #714 confirmed the model
+    # ignores tool prompts. Pin ``tool_call_parser=None`` BEFORE the
+    # generic ``phi`` regex so the bare-HF-path serves don't advertise
+    # tool capability the model cannot honour. The Phi-4 family (which
+    # CAN tool-call) and Phi-4-mini-reasoning (handled above) are
+    # unaffected.
+    (
+        re.compile(r"phi[-_]?3\.?5", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser=None,
+            reasoning_parser=None,
         ),
     ),
     # Phi

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -138,17 +138,26 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # Pure-attention Qwen2 architecture; chat template does NOT inject
     # ``<think>`` — the model emits ``<think>...</think>`` autonomously on
     # every response. ``deepseek_r1`` parser handles that "model decides"
-    # contract (same as DeepSeek-R1 distill on Qwen base). Model card
-    # explicitly states tool calling is unsupported even though the
-    # inherited Qwen2 vocab carries ``<tool_call>`` tokens, so leave
-    # ``tool_call_parser=None``. Placed before the generic ``qwen`` regex
-    # would have been (there is none today) — this pattern is the only
-    # signal for full-HF-path serves of ``WeiboAI/VibeThinker-3B`` or
+    # contract (same as DeepSeek-R1 distill on Qwen base).
+    #
+    # 2026-06-17 VibeThinker live test (PR for #708 follow-up): although
+    # the upstream model card disowns tool calling, the inherited Qwen2
+    # vocab carries the ``<tool_call>`` / ``</tool_call>`` and
+    # ``<function=...>`` tokens AND the live test confirmed the 3B-8bit
+    # weights emit BOTH shapes when prompted with tools (Test 4 of the
+    # live-test report). Wire ``hermes`` parser so the bare
+    # ``<function=name>...</function>`` shape (which the OutputRouter
+    # token-fallback misses) lands in ``tool_calls`` instead of leaking
+    # as raw text into ``content``.
+    #
+    # Placed before the generic ``qwen`` regex would have been (there is
+    # none today) — this pattern is the only signal for full-HF-path
+    # serves of ``WeiboAI/VibeThinker-3B`` or
     # ``mlx-community/VibeThinker-3B-*`` that miss the alias lookup.
     (
         re.compile(r"vibethinker", re.IGNORECASE),
         ModelConfig(
-            tool_call_parser=None,
+            tool_call_parser="hermes",
             reasoning_parser="deepseek_r1",
         ),
     ),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -158,7 +158,12 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         re.compile(r"vibethinker", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="hermes",
-            reasoning_parser="deepseek_r1",
+            # ``vibethinker`` parser — DeepSeek-R1 variant with a 1024-char
+            # no-tag threshold for the preamble-before-``<think>`` shape
+            # (codex r2 P2 — keeps the base ``deepseek_r1`` threshold at 64
+            # for distilled-on-Qwen aliases that DO open with ``<think>``
+            # immediately).
+            reasoning_parser="vibethinker",
         ),
     ),
     # Qwen3-Coder-Next / Qwen3-Next — hybrid linear attention, BEFORE

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -75,7 +75,10 @@ def list_parsers() -> list[str]:
 
 def _register_builtin_parsers():
     """Register built-in parsers."""
-    from .deepseek_r1_parser import DeepSeekR1ReasoningParser
+    from .deepseek_r1_parser import (
+        DeepSeekR1ReasoningParser,
+        VibeThinkerReasoningParser,
+    )
     from .gemma4_parser import Gemma4ReasoningParser
     from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
@@ -86,6 +89,11 @@ def _register_builtin_parsers():
     register_parser("gemma4", Gemma4ReasoningParser)
     register_parser("qwen3", Qwen3ReasoningParser)
     register_parser("deepseek_r1", DeepSeekR1ReasoningParser)
+    # ``vibethinker`` — DeepSeek-R1 variant with a 1024-char no-tag
+    # threshold (vs. 64) to accommodate VibeThinker's preamble-before-
+    # ``<think>`` shape. See ``VibeThinkerReasoningParser`` docstring
+    # for the 2026-06-17 live-test rationale (codex r2 P2).
+    register_parser("vibethinker", VibeThinkerReasoningParser)
     register_parser("glm4", Glm4ReasoningParser)
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -81,25 +81,18 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
 
     # Character threshold for no-tag content detection.
     # If no think tags are seen after this many characters, treat output as
-    # content rather than reasoning. DeepSeek-R1 always emits ``<think>`` as
-    # the first generated token, so the original 64-char window (~15-20
-    # tokens) was generous for that model — but the 2026-06-17 VibeThinker
-    # live test surfaced a Qwen2-derived reasoning model that emits a
-    # chatty preamble ("Okay, let me think about this carefully...") for
-    # 13+ tokens BEFORE its ``<think>`` opener. The 64-char threshold
-    # flipped streaming routing to ``content`` mid-preamble; by the time
-    # the literal ``<think>`` arrived, the reasoning trace was already
-    # leaking into ``content`` deltas.
+    # content rather than reasoning. Real reasoning models emit <think> within
+    # the first few tokens; 64 chars (~15-20 tokens) is a safe threshold for
+    # DeepSeek-R1, which always opens with the ``<think>`` token.
     #
-    # Bumping to 1024 chars (~250-300 tokens) gives the model room to
-    # produce a multi-sentence preamble before ``<think>`` while still
-    # protecting against unbounded buffering of genuinely no-think
-    # responses — ``finalize_streaming`` below issues the
-    # reasoning → content correction at end-of-stream for short no-tag
-    # outputs that stay under the threshold for the entire response.
-    # Defined as a class attribute so subclasses or per-alias adapters
-    # can override without forking the base implementation.
-    NO_TAG_CONTENT_THRESHOLD = 1024
+    # Subclasses can override this when their model emits a preamble before
+    # the ``<think>`` opener — see ``VibeThinkerReasoningParser`` for the
+    # Qwen2-derived VibeThinker family (2026-06-17 live test) which needs a
+    # larger window. Codex r2 P2: keeping the base threshold at 64 avoids
+    # globally widening the reasoning-buffer window for all DeepSeek-R1-family
+    # callers (the parent class is still wired to ``deepseek-r1`` and several
+    # distilled-on-Qwen aliases that DO open with ``<think>`` immediately).
+    NO_TAG_CONTENT_THRESHOLD = 64
 
     def extract_reasoning_streaming(
         self,
@@ -180,3 +173,35 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
             # yield a chunk that moves reasoning → content.
             return DeltaMessage(content=accumulated_text)
         return None
+
+
+class VibeThinkerReasoningParser(DeepSeekR1ReasoningParser):
+    """DeepSeek-R1 variant for the VibeThinker (Weibo AI) family.
+
+    VibeThinker is Qwen2-derived (1.5B base = Qwen2.5-Math-1.5B, 3B base
+    = Qwen2.5-Coder-3B) and emits a chatty multi-sentence preamble BEFORE
+    its ``<think>`` opener — observed in the 2026-06-17 live test:
+
+        "Okay, let me think about this carefully and step by step.\n\n"
+        "<think>Step 1: scan the intervals..."
+
+    The 80-char preamble (~13 tokens) blows past the parent class's
+    64-char ``NO_TAG_CONTENT_THRESHOLD``, so streaming routing flipped
+    from reasoning → content mid-preamble; by the time the literal
+    ``<think>`` arrived, the reasoning trace was already leaking into
+    ``content`` deltas (live-test merge_intervals row).
+
+    A 1024-char (~250-300 token) window gives the model room to produce
+    a multi-sentence preamble before ``<think>`` while ``finalize_streaming``
+    still issues the reasoning → content correction for genuinely no-tag
+    short responses that stay under the new threshold for the entire
+    stream.
+
+    Scoped narrowly to the VibeThinker family (codex r2 P2): widening the
+    parent class's threshold globally would push every DeepSeek-R1-family
+    no-tag answer under 1024 chars into the reasoning channel and delay
+    visible ``content`` until completion. This subclass localises the
+    larger window to the only model that actually needs it.
+    """
+
+    NO_TAG_CONTENT_THRESHOLD = 1024

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -81,9 +81,25 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
 
     # Character threshold for no-tag content detection.
     # If no think tags are seen after this many characters, treat output as
-    # content rather than reasoning. Real reasoning models emit <think> within
-    # the first few tokens; 64 chars (~15-20 tokens) is a safe threshold.
-    NO_TAG_CONTENT_THRESHOLD = 64
+    # content rather than reasoning. DeepSeek-R1 always emits ``<think>`` as
+    # the first generated token, so the original 64-char window (~15-20
+    # tokens) was generous for that model — but the 2026-06-17 VibeThinker
+    # live test surfaced a Qwen2-derived reasoning model that emits a
+    # chatty preamble ("Okay, let me think about this carefully...") for
+    # 13+ tokens BEFORE its ``<think>`` opener. The 64-char threshold
+    # flipped streaming routing to ``content`` mid-preamble; by the time
+    # the literal ``<think>`` arrived, the reasoning trace was already
+    # leaking into ``content`` deltas.
+    #
+    # Bumping to 1024 chars (~250-300 tokens) gives the model room to
+    # produce a multi-sentence preamble before ``<think>`` while still
+    # protecting against unbounded buffering of genuinely no-think
+    # responses — ``finalize_streaming`` below issues the
+    # reasoning → content correction at end-of-stream for short no-tag
+    # outputs that stay under the threshold for the entire response.
+    # Defined as a class attribute so subclasses or per-alias adapters
+    # can override without forking the base implementation.
+    NO_TAG_CONTENT_THRESHOLD = 1024
 
     def extract_reasoning_streaming(
         self,

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -385,7 +385,6 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # the just-emitted reasoning bytes as "still un-emitted" and
         # re-emit them, duplicating the streamed reasoning (codex
         # caught this with the ``['<thi', 'nk>Okay', ' more']`` repro).
-        self._held_tag_suffix_len = 0
         start_idx_cur = current_text.find(self.start_token)
         prev_len = len(current_text) - len(delta_text)
         # Bytes of delta_text BEFORE the start_token's last char —
@@ -403,10 +402,31 @@ class BaseThinkingReasoningParser(ReasoningParser):
             if end_idx >= 0:
                 content_part = reasoning_part[end_idx + len(self.end_token) :]
                 reasoning_part = reasoning_part[:end_idx]
+                self._held_tag_suffix_len = 0
                 return DeltaMessage(
                     reasoning=reasoning_part or None,
                     content=content_part or None,
                 )
+        # Codex r4 P2 follow-up: when the same chunk that completes a
+        # split opener ALSO ends with a partial ``</think>`` (e.g.
+        # chunks ``"<thi"``, ``"nk>OK</thi"``, ``"nk>ans"``), we must
+        # withhold the trailing partial-end-tag bytes so they don't
+        # leak literally into ``reasoning_content``. Reuse the same
+        # ``_held_partial_tag_len`` machinery as the Case-3 / start_in_prev
+        # branches so the next delta's ``start_in_prev`` path can
+        # complete the close cleanly.
+        held = self._held_partial_tag_len(current_text)
+        self._held_tag_suffix_len = held
+        if held > 0 and reasoning_part:
+            # Strip the trailing partial-tag bytes from this emit.
+            # The withhold is measured on ``current_text``; convert to
+            # a slice on ``reasoning_part`` (which is the suffix of
+            # delta_text after the opener overlap).
+            safe_end_in_current = len(current_text) - held
+            # Position in current_text where reasoning_part starts:
+            reasoning_start_in_current = prev_len + tag_overlap
+            keep = max(0, safe_end_in_current - reasoning_start_in_current)
+            reasoning_part = reasoning_part[:keep]
         return DeltaMessage(reasoning=reasoning_part or None)
 
     def _handle_implicit_think(

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -264,49 +264,84 @@ class BaseThinkingReasoningParser(ReasoningParser):
         start_in_delta = self.start_token in delta_text
 
         if start_in_prev:
-            # We're after the start token
-            if end_in_delta:
-                # Transition: end token in this delta
-                idx = delta_text.find(self.end_token)
-                reasoning_part = delta_text[:idx]
-                content_part = delta_text[idx + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning_part if reasoning_part else None,
-                    content=content_part if content_part else None,
-                )
-            elif end_in_prev:
-                # Already past reasoning phase - pure content
+            # We're after the start token. Use emit-by-position
+            # bookkeeping uniformly so held partial-tag bytes from
+            # previous deltas (PR #715 bundle, fuzz finding C — codex
+            # r1 P2 follow-up) are correctly flushed whether the end
+            # tag arrives in this delta, straddles it, or is still
+            # pending.
+            #
+            # ``emitted_so_far`` is the position in ``current_text``
+            # up through which we've already emitted reasoning bytes
+            # on prior deltas. We compute it from the position right
+            # after the start tag (so the ``<think>`` opener bytes
+            # are never counted) PLUS however many bytes after the
+            # opener were already emitted on prior deltas (i.e.
+            # previous_text minus the held-suffix region). When the
+            # opener completed on the previous delta, previous_text
+            # ends exactly at or before the end of ``<think>`` and the
+            # ``max()`` keeps emitted_so_far at the post-opener start.
+            start_idx_cur = current_text.find(self.start_token)
+            after_start_in_current = start_idx_cur + len(self.start_token)
+            prev_held = self._held_tag_suffix_len
+            already_emitted_after_opener = max(
+                0, len(previous_text) - prev_held - after_start_in_current
+            )
+            emitted_so_far = after_start_in_current + already_emitted_after_opener
+            if end_in_prev:
+                # Already past reasoning phase - pure content. No
+                # held bookkeeping (we're outside the reasoning
+                # region); just emit the delta.
+                self._held_tag_suffix_len = 0
                 return DeltaMessage(content=delta_text)
-            else:
-                # SSE-boundary end-tag recovery (PR #715 bundle, fuzz
-                # finding C): when ``end_token`` straddles previous_text
-                # + delta_text (e.g. delta=``nk>`` after prev ending
-                # with ``</thi``), ``end_in_delta`` is False even though
-                # the close tag is now complete in ``current_text``.
-                # Detect via the indexes and split delta_text on the
-                # tag boundary — otherwise the trailing ``nk>`` would
-                # leak into ``reasoning_content``.
-                end_idx_cur = current_text.find(self.end_token)
+            # End tag may be in current_text (delta or straddle) or
+            # still pending.
+            end_idx_cur = current_text.find(self.end_token)
+            if end_idx_cur >= 0:
+                # End tag is complete in current_text. Emit all
+                # un-emitted reasoning bytes up to the end tag, then
+                # any post-tag bytes as content.
+                self._held_tag_suffix_len = 0
+                # Reasoning portion: everything from emitted_so_far up
+                # to the start of the end tag, but clipped so we don't
+                # re-emit prefix bytes that were part of the
+                # ``<think>`` opener (when start_in_prev is True the
+                # opener has already been consumed; if held bytes
+                # were ALSO consumed as part of the now-complete end
+                # tag, those bytes must be excluded from reasoning).
+                reasoning_part = current_text[emitted_so_far:end_idx_cur]
+                content_part = current_text[end_idx_cur + len(self.end_token) :]
+                # ``content_part`` includes everything after the end
+                # tag in current_text — but only the portion in
+                # ``delta_text`` is new. Anything from ``previous_text``
+                # past the end tag was already emitted on a prior
+                # delta. Slice to keep only the new content bytes.
                 prev_len = len(current_text) - len(delta_text)
-                if end_idx_cur >= 0 and end_idx_cur < prev_len:
-                    # Close tag straddles boundary. Pre-tag bytes of
-                    # delta_text belong to the in-progress tag (already
-                    # tail-end of ``</think>``); drop them. Post-tag
-                    # bytes are content.
-                    after_tag_in_current = end_idx_cur + len(self.end_token)
-                    post_tag_offset = max(0, after_tag_in_current - prev_len)
-                    content_part = delta_text[post_tag_offset:]
-                    return DeltaMessage(content=content_part or None)
-                # Still in reasoning phase — but withhold any trailing
-                # bytes that could be a partial end-tag (the next
-                # delta may complete it).
-                held = self._held_partial_tag_len(current_text)
-                if held > 0:
-                    safe = delta_text[: max(0, len(delta_text) - held)]
-                    if not safe:
-                        return None
-                    return DeltaMessage(reasoning=safe)
-                return DeltaMessage(reasoning=delta_text)
+                content_start_in_current = end_idx_cur + len(self.end_token)
+                if content_start_in_current < prev_len:
+                    content_part = content_part[prev_len - content_start_in_current :]
+                # ``reasoning_part`` may be empty if the held bytes
+                # turned out to be the start of the end tag (e.g. we
+                # held ``</thi`` and now see ``nk>``); in that case
+                # ``emitted_so_far`` already passes ``end_idx_cur``
+                # and reasoning_part is empty — OK.
+                if end_idx_cur < emitted_so_far:
+                    reasoning_part = ""
+                return DeltaMessage(
+                    reasoning=reasoning_part or None,
+                    content=content_part or None,
+                )
+            # End tag not yet in current_text. Withhold any trailing
+            # partial-tag suffix so the next delta can complete it.
+            held = self._held_partial_tag_len(current_text)
+            safe_end = len(current_text) - held
+            self._held_tag_suffix_len = held
+            if safe_end <= emitted_so_far:
+                return None
+            emit = current_text[emitted_so_far:safe_end]
+            if not emit:
+                return None
+            return DeltaMessage(reasoning=emit)
 
         elif start_in_delta:
             # Start token is in this delta

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -44,11 +44,18 @@ class BaseThinkingReasoningParser(ReasoningParser):
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
         self._saw_any_tag = False
+        # SSE-boundary withhold (PR #715 bundle, fuzz finding C): the
+        # number of trailing bytes of ``previous_text`` that we held back
+        # on the prior delta because they looked like a partial tag
+        # prefix. Used to flush them on the next delta when the prefix
+        # turned out NOT to be a tag.
+        self._held_tag_suffix_len = 0
 
     def reset_state(self):
         """Reset state for a new streaming request."""
         super().reset_state()
         self._saw_any_tag = False
+        self._held_tag_suffix_len = 0
 
     def extract_reasoning(
         self,
@@ -165,7 +172,12 @@ class BaseThinkingReasoningParser(ReasoningParser):
         if start_in_current:
             self._saw_any_tag = True
             return self._handle_explicit_think(
-                previous_text, delta_text, start_in_prev, end_in_prev, end_in_delta
+                previous_text,
+                current_text,
+                delta_text,
+                start_in_prev,
+                end_in_prev,
+                end_in_delta,
             )
 
         # Case 2: No <think> but </think> found - implicit reasoning mode
@@ -181,11 +193,68 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # We choose to treat as reasoning IF we haven't seen </think> yet,
         # because if think was in prompt, we want to capture the reasoning.
         # This will be corrected once </think> is seen.
-        return DeltaMessage(reasoning=delta_text)
+        #
+        # SSE-boundary withhold (PR #715 bundle, fuzz finding C): when the
+        # model emits the literal ``<think>`` open tag autonomously (phi-4-
+        # mini-reasoning / nanbeige4.1 family), the tag can be split across
+        # SSE chunk boundaries (e.g. delta=``<thi`` then ``nk>``). Without
+        # the withhold, the partial ``<thi`` would land in
+        # ``reasoning_content`` and the trailing ``nk>`` would fall through
+        # the next-tick ``_handle_explicit_think`` fallback into
+        # ``content``, leaving the client with a visibly mangled response
+        # (live-fuzz repro: ``content=">\n", reasoning="<thinkOkay..."``).
+        #
+        # Strategy: ``self._held_tag_suffix_len`` records how many trailing
+        # bytes of ``previous_text`` we withheld on the prior delta. The
+        # bytes already emitted from ``current_text`` are everything
+        # except the last ``self._held_tag_suffix_len`` bytes of
+        # ``previous_text``. On this delta, we compute the new partial-tag
+        # suffix in ``current_text`` and emit the difference (i.e. the
+        # bytes that have moved out of the partial-tag region).
+        prev_held = self._held_tag_suffix_len
+        held = self._held_partial_tag_len(current_text)
+        # Position in current_text up to which we've already emitted.
+        emitted_so_far = len(previous_text) - prev_held
+        # Position in current_text up to which we can safely emit now.
+        safe_end = len(current_text) - held
+        self._held_tag_suffix_len = held
+        if safe_end <= emitted_so_far:
+            # Nothing new safe to emit yet — the whole delta (and possibly
+            # some of previous_text's held bytes) is still in the partial-
+            # tag region. Wait for the next delta.
+            return None
+        emit = current_text[emitted_so_far:safe_end]
+        if not emit:
+            return None
+        return DeltaMessage(reasoning=emit)
+
+    def _held_partial_tag_len(self, current_text: str) -> int:
+        """Length of the suffix of ``current_text`` that could be a strict
+        prefix of ``start_token`` or ``end_token``.
+
+        Used by the Case-3 SSE-boundary withhold (see
+        ``extract_reasoning_streaming``). Returns the LONGEST matching
+        prefix length so a ``<thin`` suffix holds back all 4 chars (the
+        next delta might be ``k>`` completing ``<think>``).
+
+        Excludes the full-match case — if ``current_text`` already ends
+        with the complete ``start_token`` / ``end_token`` we don't need
+        to withhold, the regular Case-1 / Case-2 branches will pick it
+        up on the next pass.
+        """
+        for tag in (self.start_token, self.end_token):
+            # Search from longest possible prefix down to 1 char so the
+            # LONGEST partial-tag suffix wins.
+            max_len = min(len(tag) - 1, len(current_text))
+            for n in range(max_len, 0, -1):
+                if current_text.endswith(tag[:n]):
+                    return n
+        return 0
 
     def _handle_explicit_think(
         self,
         previous_text: str,
+        current_text: str,
         delta_text: str,
         start_in_prev: bool,
         end_in_prev: bool,
@@ -209,7 +278,34 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 # Already past reasoning phase - pure content
                 return DeltaMessage(content=delta_text)
             else:
-                # Still in reasoning phase
+                # SSE-boundary end-tag recovery (PR #715 bundle, fuzz
+                # finding C): when ``end_token`` straddles previous_text
+                # + delta_text (e.g. delta=``nk>`` after prev ending
+                # with ``</thi``), ``end_in_delta`` is False even though
+                # the close tag is now complete in ``current_text``.
+                # Detect via the indexes and split delta_text on the
+                # tag boundary — otherwise the trailing ``nk>`` would
+                # leak into ``reasoning_content``.
+                end_idx_cur = current_text.find(self.end_token)
+                prev_len = len(current_text) - len(delta_text)
+                if end_idx_cur >= 0 and end_idx_cur < prev_len:
+                    # Close tag straddles boundary. Pre-tag bytes of
+                    # delta_text belong to the in-progress tag (already
+                    # tail-end of ``</think>``); drop them. Post-tag
+                    # bytes are content.
+                    after_tag_in_current = end_idx_cur + len(self.end_token)
+                    post_tag_offset = max(0, after_tag_in_current - prev_len)
+                    content_part = delta_text[post_tag_offset:]
+                    return DeltaMessage(content=content_part or None)
+                # Still in reasoning phase — but withhold any trailing
+                # bytes that could be a partial end-tag (the next
+                # delta may complete it).
+                held = self._held_partial_tag_len(current_text)
+                if held > 0:
+                    safe = delta_text[: max(0, len(delta_text) - held)]
+                    if not safe:
+                        return None
+                    return DeltaMessage(reasoning=safe)
                 return DeltaMessage(reasoning=delta_text)
 
         elif start_in_delta:
@@ -232,8 +328,40 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     reasoning=reasoning_part if reasoning_part else None
                 )
 
-        # Fallback - treat as content
-        return DeltaMessage(content=delta_text)
+        # SSE-boundary recovery (PR #715 bundle, fuzz finding C): the
+        # start_token straddles ``previous_text`` and ``delta_text`` —
+        # ``start_in_current=True`` but neither ``start_in_prev`` nor
+        # ``start_in_delta`` is True. The Case-3 withhold in
+        # ``extract_reasoning_streaming`` already held the matching
+        # suffix of the previous delta, so we ONLY need to emit the
+        # portion of ``delta_text`` that lands AFTER the now-complete
+        # start_token. Pre-withhold (without this branch) the trailing
+        # bytes of the tag (e.g. ``nk>``) would fall through to the
+        # old ``return DeltaMessage(content=delta_text)`` fallback and
+        # leak literally into ``content`` — the original live-fuzz
+        # bug shape on phi-4-mini-reasoning / nanbeige4.1.
+        start_idx_cur = current_text.find(self.start_token)
+        prev_len = len(current_text) - len(delta_text)
+        # Bytes of delta_text BEFORE the start_token's last char —
+        # these are the tail of an in-progress tag whose head sits in
+        # previous_text. They're tag bytes, not user-visible text;
+        # drop them.
+        after_start_in_current = start_idx_cur + len(self.start_token)
+        # Number of delta_text chars that fall before the end of the
+        # start tag (these are tag chars, drop them).
+        tag_overlap = max(0, after_start_in_current - prev_len)
+        reasoning_part = delta_text[tag_overlap:] if delta_text else ""
+        if end_in_delta:
+            # End tag also lands in this delta — split.
+            end_idx = reasoning_part.find(self.end_token)
+            if end_idx >= 0:
+                content_part = reasoning_part[end_idx + len(self.end_token) :]
+                reasoning_part = reasoning_part[:end_idx]
+                return DeltaMessage(
+                    reasoning=reasoning_part or None,
+                    content=content_part or None,
+                )
+        return DeltaMessage(reasoning=reasoning_part or None)
 
     def _handle_implicit_think(
         self,

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -375,6 +375,17 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # old ``return DeltaMessage(content=delta_text)`` fallback and
         # leak literally into ``content`` — the original live-fuzz
         # bug shape on phi-4-mini-reasoning / nanbeige4.1.
+        #
+        # Codex r2 P2 follow-up: clear ``_held_tag_suffix_len`` after
+        # consuming the straddle. The held bytes were part of the
+        # start tag (not pending reasoning) and on the NEXT delta the
+        # ``start_in_prev`` branch's emit-by-position bookkeeping uses
+        # the held value to compute ``already_emitted_after_opener``.
+        # Leaving it non-zero would cause the bookkeeping to treat
+        # the just-emitted reasoning bytes as "still un-emitted" and
+        # re-emit them, duplicating the streamed reasoning (codex
+        # caught this with the ``['<thi', 'nk>Okay', ' more']`` repro).
+        self._held_tag_suffix_len = 0
         start_idx_cur = current_text.find(self.start_token)
         prev_len = len(current_text) - len(delta_text)
         # Bytes of delta_text BEFORE the start_token's last char —

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -312,6 +312,7 @@ async def create_anthropic_message(
         # uses (chat.py). Skipping this is what #413 fixed — the Anthropic surface
         # used to silently drop ``<think>...</think>`` content on the non-streaming
         # path while OpenAI preserved it as ``reasoning_content``.
+        cleaned_text_before_helper = cleaned_text
         cleaned_text, reasoning_text = _finalize_content_and_reasoning(
             raw_text=output.raw_text or output.text,
             cleaned_text=cleaned_text,
@@ -355,12 +356,24 @@ async def create_anthropic_message(
         # rescued ``content`` into a TextBlock; without this it would
         # emit a completely empty ``content=[]`` Messages response.
         finish_reason = "tool_calls" if tool_calls else output.finish_reason
+        # PR #715 bundle, fuzz finding C: detect helper Case-4 blank
+        # (parser routed whole no-tag output to reasoning, helper
+        # cleared cleaned_text=""). See chat.py route for the full
+        # rationale.
+        reasoning_is_case4 = bool(
+            cleaned_text_before_helper
+            and not cleaned_text
+            and reasoning_text
+            and cfg.reasoning_parser is not None
+            and not (getattr(output, "reasoning_text", "") or "")
+        )
         final_content = _rescue_silent_drop_from_reasoning(
             final_content,
             reasoning_text,
             tool_calls,
             finish_reason=finish_reason,
             raw_text=output.raw_text or output.text,
+            reasoning_is_case4=reasoning_is_case4,
         )
 
         openai_response = ChatCompletionResponse(

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -354,11 +354,14 @@ async def create_anthropic_message(
         # mode). The Anthropic adapter downstream renders the
         # rescued ``content`` into a TextBlock; without this it would
         # emit a completely empty ``content=[]`` Messages response.
-        final_content = _rescue_silent_drop_from_reasoning(
-            final_content, reasoning_text, tool_calls
-        )
-
         finish_reason = "tool_calls" if tool_calls else output.finish_reason
+        final_content = _rescue_silent_drop_from_reasoning(
+            final_content,
+            reasoning_text,
+            tool_calls,
+            finish_reason=finish_reason,
+            raw_text=output.raw_text or output.text,
+        )
 
         openai_response = ChatCompletionResponse(
             model=cfg.model_name or openai_request.model,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1431,7 +1431,11 @@ async def _create_chat_completion_impl(
     # streaming path drifting because it had no gate at all.
     if not _is_structured_output_requested(response_format):
         final_content = _rescue_silent_drop_from_reasoning(
-            final_content, reasoning_text, tool_calls
+            final_content,
+            reasoning_text,
+            tool_calls,
+            finish_reason=finish_reason,
+            raw_text=output.raw_text or output.text,
         )
 
     # Build logprobs for response if requested
@@ -1774,6 +1778,19 @@ async def stream_chat_completion(
                 # tool-call branch would never fire here regardless,
                 # but keeping the call symmetric with non-streaming
                 # is the point.
+                # Streaming: deliberately do NOT pass the truncated-
+                # ``<think>`` gate (``finish_reason`` / ``raw_text``)
+                # here. Streaming routes ``<think>`` directly to the
+                # reasoning channel so ``accumulated_reasoning`` never
+                # carries the literal ``<think>`` opener — the gate
+                # would never fire usefully. Streaming clients rely
+                # on per-delta channel signalling and the
+                # ``finish_reason="length"`` chunk to detect
+                # truncation, so the silent-drop rescue stays opt-in
+                # via the existing predicates. (Non-streaming sees
+                # the literal ``<think>`` in ``output.raw_text`` and
+                # gates on that — see chat.py:~1420 for the symmetric
+                # gated call site.)
                 rescued_content = _rescue_silent_drop_from_reasoning(
                     terminal_content or None,
                     processor.accumulated_reasoning,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1347,6 +1347,7 @@ async def _create_chat_completion_impl(
     # The tool_calls vs no-tool_calls split is encapsulated in
     # _finalize_content_and_reasoning so the regression test suite can exercise
     # the same orchestration without re-implementing it.
+    cleaned_text_before_helper = cleaned_text
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
         raw_text=output.raw_text or output.text,
         cleaned_text=cleaned_text,
@@ -1430,12 +1431,31 @@ async def _create_chat_completion_impl(
     # 1 inlined the check here only; codex round 2 caught the
     # streaming path drifting because it had no gate at all.
     if not _is_structured_output_requested(response_format):
+        # PR #715 bundle, fuzz finding C / live-test repro: when the
+        # parser's Case-4 fallback blanked ``cleaned_text`` (no tags +
+        # ``enable_thinking=True`` → route the whole output to
+        # reasoning, #575), the rescue must NOT then surface that
+        # reasoning back as ``content`` — that would duplicate the
+        # trace byte-identically into both fields. The helper signals
+        # Case-4 by returning an empty ``cleaned_text`` when the
+        # pre-helper text was non-empty AND a reasoning_parser was
+        # wired AND the engine wasn't already routing (engine path
+        # has its own plug). Detect by comparing the pre- and post-
+        # helper ``cleaned_text``.
+        reasoning_is_case4 = bool(
+            cleaned_text_before_helper
+            and not cleaned_text
+            and reasoning_text
+            and cfg.reasoning_parser is not None
+            and not (getattr(output, "reasoning_text", "") or "")
+        )
         final_content = _rescue_silent_drop_from_reasoning(
             final_content,
             reasoning_text,
             tool_calls,
             finish_reason=finish_reason,
             raw_text=output.raw_text or output.text,
+            reasoning_is_case4=reasoning_is_case4,
         )
 
     # Build logprobs for response if requested
@@ -1807,12 +1827,29 @@ async def stream_chat_completion(
                     if saw_open_no_close
                     else processor.accumulated_reasoning or ""
                 )
+                # PR #715 bundle, fuzz finding C: streaming Case-4
+                # mirror of the non-streaming detection. When the
+                # parser never saw a ``<think>``/``</think>`` token
+                # (``_saw_any_tag`` False) BUT routed everything into
+                # reasoning (accumulated_text empty, accumulated_reasoning
+                # non-empty) AND a parser is wired, the streamer's
+                # Case-3 fallback ("no tags seen yet → reasoning") IS
+                # firing — analogous to the non-streaming Case-4
+                # blanking. Suppress the rescue on length-truncated
+                # streams in that state too.
+                reasoning_is_case4_stream = bool(
+                    rp
+                    and not getattr(rp, "_saw_any_tag", False)
+                    and processor.accumulated_reasoning
+                    and not processor.accumulated_text
+                )
                 rescued_content = _rescue_silent_drop_from_reasoning(
                     terminal_content or None,
                     processor.accumulated_reasoning,
                     None,
                     finish_reason=finish_event.finish_reason,
                     raw_text=synthetic_raw,
+                    reasoning_is_case4=reasoning_is_case4_stream,
                 )
                 # The helper returns the rescued reasoning ONLY when
                 # all four predicates pass (empty/whitespace content,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1778,23 +1778,42 @@ async def stream_chat_completion(
                 # tool-call branch would never fire here regardless,
                 # but keeping the call symmetric with non-streaming
                 # is the point.
-                # Streaming: deliberately do NOT pass the truncated-
-                # ``<think>`` gate (``finish_reason`` / ``raw_text``)
-                # here. Streaming routes ``<think>`` directly to the
-                # reasoning channel so ``accumulated_reasoning`` never
-                # carries the literal ``<think>`` opener — the gate
-                # would never fire usefully. Streaming clients rely
-                # on per-delta channel signalling and the
-                # ``finish_reason="length"`` chunk to detect
-                # truncation, so the silent-drop rescue stays opt-in
-                # via the existing predicates. (Non-streaming sees
-                # the literal ``<think>`` in ``output.raw_text`` and
-                # gates on that — see chat.py:~1420 for the symmetric
-                # gated call site.)
+                # Codex r3 P1: streaming rescue must skip the
+                # truncated-``<think>`` case. The streaming reasoning
+                # parser consumes the literal ``<think>`` token as a
+                # state transition, so ``accumulated_reasoning`` never
+                # carries it — but the parser's ``_saw_any_tag`` flag
+                # records that a ``<think>``/``</think>`` boundary was
+                # crossed. When the model truncated mid-thought
+                # (``finish_reason="length"`` AND the parser saw the
+                # opener AND never saw the closer), the reasoning
+                # trace is NOT the final answer and promoting it to
+                # ``content`` re-introduces the leak the non-streaming
+                # gate now suppresses. Synthesise a ``raw_text`` with
+                # an unclosed ``<think>`` opener so the rescue's
+                # existing finish=length-with-unclosed-think gate
+                # fires uniformly across both paths.
+                rp = processor.reasoning_parser
+                saw_open_no_close = bool(
+                    rp
+                    and getattr(rp, "_saw_any_tag", False)
+                    and "</think>"
+                    not in (
+                        processor.accumulated_reasoning
+                        + processor.accumulated_text
+                    )
+                )
+                synthetic_raw = (
+                    "<think>" + processor.accumulated_reasoning
+                    if saw_open_no_close
+                    else processor.accumulated_reasoning or ""
+                )
                 rescued_content = _rescue_silent_drop_from_reasoning(
                     terminal_content or None,
                     processor.accumulated_reasoning,
                     None,
+                    finish_reason=finish_event.finish_reason,
+                    raw_text=synthetic_raw,
                 )
                 # The helper returns the rescued reasoning ONLY when
                 # all four predicates pass (empty/whitespace content,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1799,8 +1799,7 @@ async def stream_chat_completion(
                     and getattr(rp, "_saw_any_tag", False)
                     and "</think>"
                     not in (
-                        processor.accumulated_reasoning
-                        + processor.accumulated_text
+                        processor.accumulated_reasoning + processor.accumulated_text
                     )
                 )
                 synthetic_raw = (

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -469,6 +469,8 @@ def _rescue_silent_drop_from_reasoning(
     tool_calls: list | None,
     finish_reason: str | None = None,
     raw_text: str | None = None,
+    *,
+    reasoning_is_case4: bool = False,
 ) -> str | None:
     """Issue #569: never silently drop an assistant turn.
 
@@ -562,12 +564,28 @@ def _rescue_silent_drop_from_reasoning(
     # (e.g. a non-thinking model truncated mid-answer where reasoning
     # was empty but content was building) still get rescued — the
     # opener check is the discriminator.
+    #
+    # Also gate on the helper-Case-4 signal (``reasoning_is_case4``)
+    # passed from the route — covers the PR #715-bundle live-test
+    # repro where VibeThinker is asked a no-tool no-think prompt:
+    # the chat template doesn't pre-inject ``<think>``, the model
+    # answers in plain prose (no ``<think>`` token emitted), but the
+    # route still defaults ``enable_thinking=True`` for the family.
+    # The parser's Case-4 fallback routes the WHOLE output to
+    # reasoning AND the helper blanks ``cleaned_text=""``. The
+    # ``raw_text`` opener check then misses (raw_text doesn't start
+    # with ``<think>``), and the rescue without the Case-4 signal
+    # mistakes the no-content state for a #569 silent drop and
+    # surfaces the reasoning as content — duplicating the trace
+    # byte-identically. The Case-4 signal stops that.
     if (
         finish_reason == "length"
         and raw_text
         and raw_text.lstrip().startswith("<think>")
         and "</think>" not in raw_text
     ):
+        return final_content
+    if finish_reason == "length" and reasoning_is_case4:
         return final_content
     return reasoning_text
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -205,8 +205,23 @@ def _finalize_content_and_reasoning(
         # intro BEFORE ``<think>``, then truncates mid-thought) —
         # ``partition`` handles both the start-aligned (math row) and
         # preamble (live-test merge_intervals streaming) cases.
-        if cleaned_text and "<think>" in cleaned_text and "</think>" not in cleaned_text:
+        truncated_think = (
+            cleaned_text
+            and "<think>" in cleaned_text
+            and "</think>" not in cleaned_text
+        )
+        if truncated_think:
             cleaned_text = cleaned_text.partition("<think>")[0].rstrip()
+            # Codex r3 P2: ``_apply_reasoning_cap`` prepends the
+            # over-cap reasoning suffix back into ``cleaned_text`` so
+            # the wire ordering matches the model's emission order —
+            # but for a truncated thought the overflow IS the leaked
+            # thought, which is exactly what we just trimmed. Use the
+            # reasoning-only cap so cleaned_text stays blanked / preamble-
+            # only and the overflow does NOT re-leak into ``content``.
+            return cleaned_text, _truncate_reasoning_only(
+                engine_reasoning_text, reasoning_max_tokens
+            )
         return _apply_reasoning_cap(
             cleaned_text, engine_reasoning_text, reasoning_max_tokens
         )
@@ -361,8 +376,44 @@ def _finalize_content_and_reasoning(
         # for the merge_intervals streaming row it preserves the
         # ~80-char chatty intro the model emitted before ``<think>``.
         if first_parse_was_truncated_think:
-            cleaned_text = cleaned_text.partition("<think>")[0].rstrip()
+            cleaned_text = (cleaned_text or "").partition("<think>")[0].rstrip()
+            # Codex r3 P2: bypass the cleaned_text overflow prepend
+            # path of ``_apply_reasoning_cap`` for truncated thoughts
+            # — see the engine-routed branch above for the rationale.
+            return cleaned_text, _truncate_reasoning_only(
+                reasoning_text, reasoning_max_tokens
+            )
     return _apply_reasoning_cap(cleaned_text, reasoning_text, reasoning_max_tokens)
+
+
+def _truncate_reasoning_only(
+    reasoning_text: str | None,
+    reasoning_max_tokens: int | None,
+) -> str | None:
+    """Cap ``reasoning_text`` to the per-request budget WITHOUT
+    rerouting the overflow into ``content``.
+
+    Used by the truncated-``<think>`` plug paths
+    (``first_parse_was_truncated_think`` and the engine-routed
+    branch) where the reasoning trace is an in-progress thought,
+    not the final answer. ``_apply_reasoning_cap``'s default
+    behaviour of prepending overflow into ``cleaned_text`` would
+    re-introduce exactly the leak the plug is trying to prevent —
+    codex r3 P2.
+
+    Uses the same chars-÷4 heuristic as ``_apply_reasoning_cap``
+    so the OpenAI usage block stays consistent across both paths.
+    """
+    if (
+        reasoning_max_tokens is None
+        or not reasoning_text
+        or not isinstance(reasoning_text, str)
+    ):
+        return reasoning_text
+    max_chars = reasoning_max_tokens * 4
+    if len(reasoning_text) <= max_chars:
+        return reasoning_text
+    return reasoning_text[:max_chars]
 
 
 def _apply_reasoning_cap(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -196,18 +196,17 @@ def _finalize_content_and_reasoning(
         #
         # ``strip_thinking_tags`` (the downstream sanitiser) only
         # matches **closed** ``<think>…</think>`` blocks, so the
-        # unclosed opener falls through. Detect the pattern here and
-        # blank ``cleaned_text`` — symmetric with the
-        # ``first_parse_was_truncated_think`` plug below for the no-
-        # engine-routing path. The literal ``<think>`` token in the
-        # cleaned text is the model's own evidence that thinking was
-        # active for this turn, so the leak plug runs unconditionally.
-        if (
-            cleaned_text
-            and cleaned_text.lstrip().startswith("<think>")
-            and "</think>" not in cleaned_text
-        ):
-            cleaned_text = ""
+        # unclosed opener falls through. Trim everything from the
+        # ``<think>`` opener onward — preserves any pre-think preamble
+        # ("Okay, let me think...\n<think>...") as legitimate
+        # ``content`` while dropping the leaked thought trace.
+        # Codex r1 P2: the previous ``startswith`` check missed the
+        # documented VibeThinker preamble shape (model emits a chatty
+        # intro BEFORE ``<think>``, then truncates mid-thought) —
+        # ``partition`` handles both the start-aligned (math row) and
+        # preamble (live-test merge_intervals streaming) cases.
+        if cleaned_text and "<think>" in cleaned_text and "</think>" not in cleaned_text:
+            cleaned_text = cleaned_text.partition("<think>")[0].rstrip()
         return _apply_reasoning_cap(
             cleaned_text, engine_reasoning_text, reasoning_max_tokens
         )
@@ -271,7 +270,7 @@ def _finalize_content_and_reasoning(
         # reasoning_len == 5449, byte-identical).
         #
         # Signal: parser returned reasoning-only AND ``text_to_parse``
-        # *starts with* an unclosed ``<think>`` opener (so the parser's
+        # contains an unclosed ``<think>`` opener (so the parser's
         # ``(reasoning, None)`` was Case-3, not Case-4, not the
         # harmony-style ``(None, None)`` rescued by the retry above).
         # Unlike the #575 plug, this branch is NOT gated on
@@ -279,22 +278,22 @@ def _finalize_content_and_reasoning(
         # output is the model's own evidence that thinking was active
         # for this turn, irrespective of what the caller passed.
         #
-        # The leading-position check (``lstrip().startswith``) is the
-        # conservatism knob: a truncated ``<think>`` mid-text could
-        # also produce ``(reasoning, None)`` from the parser, but in
-        # that case the text BEFORE ``<think>`` was legitimate content
-        # that the client should still see. Restricting the clear to
-        # the "everything is thinking" shape protects that hypothetical
-        # case from being silently dropped. The live-test repro
-        # (VibeThinker math row, content_len == reasoning_len == 5449)
-        # always opens with ``<think>`` so the leading check still
-        # catches it.
+        # Codex r1 P2: the previous ``lstrip().startswith("<think>")``
+        # gate missed the documented VibeThinker preamble shape (the
+        # model emits a chatty intro BEFORE ``<think>``, then truncates
+        # mid-thought). The fix below uses ``partition("<think>")[0]``
+        # so a preamble like ``"Okay, let me think...\n<think>..."``
+        # has the preamble preserved as ``content`` while the unclosed
+        # thought trace is dropped (the trace is already carried in
+        # ``reasoning_text``). Catches BOTH the live-test math row
+        # (``<think>`` at lstrip-start) and the merge_intervals
+        # streaming row (preamble before ``<think>``).
         first_parse_was_truncated_think = (
             new_reasoning is not None
             and new_cleaned is None
             and bool(text_to_parse)
+            and "<think>" in text_to_parse
             and "</think>" not in text_to_parse
-            and text_to_parse.lstrip().startswith("<think>")
         )
         # Harmony retry: the engine's ``clean_output_text`` strips
         # ``<|channel|>analysis<|message|>…`` markers before the route
@@ -354,8 +353,15 @@ def _finalize_content_and_reasoning(
         # signal independent of ``enable_thinking`` — see the
         # ``first_parse_was_truncated_think`` definition for the
         # full rationale and the live-test repro.
+        #
+        # ``partition`` keeps any pre-think preamble (legitimate
+        # content) and drops the unclosed thought trace (already
+        # carried in ``reasoning_text``). For the live-test math
+        # row the preamble is empty so this collapses to ``""``;
+        # for the merge_intervals streaming row it preserves the
+        # ~80-char chatty intro the model emitted before ``<think>``.
         if first_parse_was_truncated_think:
-            cleaned_text = ""
+            cleaned_text = cleaned_text.partition("<think>")[0].rstrip()
     return _apply_reasoning_cap(cleaned_text, reasoning_text, reasoning_max_tokens)
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -181,6 +181,33 @@ def _finalize_content_and_reasoning(
     # the parser. (No reasoning_parser is still a short-circuit
     # below.) Issue #442.
     if engine_reasoning_text:
+        # 2026-06-17 VibeThinker live test: when the engine routes via
+        # ``OutputRouter`` (Qwen ``<think>`` token IDs) and the response
+        # is truncated mid-thought (``finish_reason=length``), the
+        # router emits ``reasoning_text`` (the post-``<think>`` trace)
+        # but ``cleaned_text`` — passed through from
+        # ``clean_output_text`` which preserves ``<think>`` blocks for
+        # the parser stack — still carries the full raw text including
+        # the unclosed ``<think>`` opener and the trace. The result is
+        # ``content`` and ``reasoning_content`` carrying the same
+        # bytes (the live-test math row showed content_len=4974,
+        # reasoning_content_len=4967, identical except for the
+        # ``<think>`` opener).
+        #
+        # ``strip_thinking_tags`` (the downstream sanitiser) only
+        # matches **closed** ``<think>…</think>`` blocks, so the
+        # unclosed opener falls through. Detect the pattern here and
+        # blank ``cleaned_text`` — symmetric with the
+        # ``first_parse_was_truncated_think`` plug below for the no-
+        # engine-routing path. The literal ``<think>`` token in the
+        # cleaned text is the model's own evidence that thinking was
+        # active for this turn, so the leak plug runs unconditionally.
+        if (
+            cleaned_text
+            and cleaned_text.lstrip().startswith("<think>")
+            and "</think>" not in cleaned_text
+        ):
+            cleaned_text = ""
         return _apply_reasoning_cap(
             cleaned_text, engine_reasoning_text, reasoning_max_tokens
         )
@@ -227,6 +254,47 @@ def _finalize_content_and_reasoning(
             and bool(text_to_parse)
             and "<think>" not in text_to_parse
             and "</think>" not in text_to_parse
+        )
+        # 2026-06-17 VibeThinker live test: Case-3 (truncated
+        # ``<think>`` with no ``</think>``) leaks identically to Case-4
+        # but the #575 plug above doesn't catch it because ``<think>``
+        # IS in ``text_to_parse``. Parser returned ``(reasoning, None)``
+        # — i.e. the reasoning parser found a ``<think>`` opener and
+        # routed everything after it into reasoning — but the original
+        # ``cleaned_text`` still carries the full raw text including
+        # ``<think>…<the trace>``. ``strip_thinking_tags`` (the
+        # downstream sanitiser) only matches CLOSED ``<think>…</think>``
+        # blocks, so a truncated ``finish_reason=length`` response
+        # with an unclosed ``<think>`` opener falls straight through
+        # and the client sees identical bytes in ``content`` and
+        # ``reasoning_content`` (live-test math row: content_len ==
+        # reasoning_len == 5449, byte-identical).
+        #
+        # Signal: parser returned reasoning-only AND ``text_to_parse``
+        # *starts with* an unclosed ``<think>`` opener (so the parser's
+        # ``(reasoning, None)`` was Case-3, not Case-4, not the
+        # harmony-style ``(None, None)`` rescued by the retry above).
+        # Unlike the #575 plug, this branch is NOT gated on
+        # ``enable_thinking`` — the literal ``<think>`` token in the
+        # output is the model's own evidence that thinking was active
+        # for this turn, irrespective of what the caller passed.
+        #
+        # The leading-position check (``lstrip().startswith``) is the
+        # conservatism knob: a truncated ``<think>`` mid-text could
+        # also produce ``(reasoning, None)`` from the parser, but in
+        # that case the text BEFORE ``<think>`` was legitimate content
+        # that the client should still see. Restricting the clear to
+        # the "everything is thinking" shape protects that hypothetical
+        # case from being silently dropped. The live-test repro
+        # (VibeThinker math row, content_len == reasoning_len == 5449)
+        # always opens with ``<think>`` so the leading check still
+        # catches it.
+        first_parse_was_truncated_think = (
+            new_reasoning is not None
+            and new_cleaned is None
+            and bool(text_to_parse)
+            and "</think>" not in text_to_parse
+            and text_to_parse.lstrip().startswith("<think>")
         )
         # Harmony retry: the engine's ``clean_output_text`` strips
         # ``<|channel|>analysis<|message|>…`` markers before the route
@@ -280,6 +348,13 @@ def _finalize_content_and_reasoning(
         # that case is the legitimate final-channel answer that
         # MUST survive (codex R2 BLOCKING).
         if enable_thinking is True and first_parse_was_case4:
+            cleaned_text = ""
+        # Truncated-``<think>`` plug (2026-06-17). Mirrors the #575
+        # Case-4 plug above but fires on the explicit-start-no-end
+        # signal independent of ``enable_thinking`` — see the
+        # ``first_parse_was_truncated_think`` definition for the
+        # full rationale and the live-test repro.
+        if first_parse_was_truncated_think:
             cleaned_text = ""
     return _apply_reasoning_cap(cleaned_text, reasoning_text, reasoning_max_tokens)
 
@@ -335,6 +410,8 @@ def _rescue_silent_drop_from_reasoning(
     final_content: str | None,
     reasoning_text: str | None,
     tool_calls: list | None,
+    finish_reason: str | None = None,
+    raw_text: str | None = None,
 ) -> str | None:
     """Issue #569: never silently drop an assistant turn.
 
@@ -410,6 +487,30 @@ def _rescue_silent_drop_from_reasoning(
     if tool_calls:
         return final_content
     if not reasoning_text or not reasoning_text.strip():
+        return final_content
+    # 2026-06-17 VibeThinker live test: when the model was truncated
+    # mid-thought (``finish_reason="length"``) with an unclosed
+    # ``<think>`` opener in ``raw_text``, the reasoning trace is NOT
+    # the final answer — it's an interrupted chain of thought. Surfacing
+    # it as ``content`` per the #569 rescue would feed the client the
+    # SAME bytes as ``reasoning_content`` and break the "content is the
+    # final answer" contract. Skip the rescue and let the client see
+    # ``content=null`` so they can detect "model ran out of budget
+    # before producing an answer" via the ``finish_reason="length"``
+    # signal — symmetric with how OpenAI's o1 / o3 behave on truncated
+    # reasoning.
+    #
+    # Gate on BOTH ``finish_reason="length"`` AND raw_text opening with
+    # an unclosed ``<think>``. Other ``finish_reason="length"`` cases
+    # (e.g. a non-thinking model truncated mid-answer where reasoning
+    # was empty but content was building) still get rescued — the
+    # opener check is the discriminator.
+    if (
+        finish_reason == "length"
+        and raw_text
+        and raw_text.lstrip().startswith("<think>")
+        and "</think>" not in raw_text
+    ):
         return final_content
     return reasoning_text
 


### PR DESCRIPTION
## Summary

Follow-up to PR #715 (merged at 6f12b31) bundling 4 additional bug fixes surfaced AFTER merge:

1. **Case-4 rescue gate** (`7f30fb4`) — live-smoke critical. Without this, VibeThinker asked "What is 2+2?" with `max_tokens=32` produced byte-identical `content` and `reasoning_content` (length 119 each). Root cause: parser Case-4 fallback fires when `enable_thinking=True` and no `<think>` tag is emitted, helper blanks `cleaned_text=\"\"`, then `_rescue_silent_drop_from_reasoning` (#569) surfaces reasoning as content, leaving both populated. The narrow `raw_text.lstrip().startswith(\"<think>\")` gate from the merged PR misses VibeThinker because it emits plain prose, not a literal `<think>` token. Adds `reasoning_is_case4` keyword-only param to the rescue helper plumbed through `routes/chat.py` and `routes/anthropic.py`; gates rescue on `(finish_reason == \"length\" and reasoning_is_case4)`.

2. **codex r1 P2** (`741851e`) — false partial-tag bytes inside an open `<think>` block (e.g. chunks `[\"<think>2 \", \"<\", \" 5</think>\", \"ans\"]`) were dropped instead of flushed. The `start_in_prev` branch had its own ad-hoc withhold logic that didn't thread `_held_tag_suffix_len`. Fixed by uniform emit-by-position bookkeeping across Case-3 and `start_in_prev`.

3. **codex r2 P2** (`d9ce51f`) — split-opener completing chunk (e.g. `[\"<thi\", \"nk>Okay\", \" more\"]`) duplicated reasoning to `\"OkayOkay more\"` because the held suffix from `<thi` wasn't cleared after the SSE-boundary recovery branch consumed it. Fixed by resetting `_held_tag_suffix_len = 0` in the recovery branch.

4. **codex r4 P2** (`e3e1122`) — when the same chunk that completes a split opener ALSO ends with a partial `</think>` (e.g. `[\"<thi\", \"nk>OK</thi\", \"nk>ans\"]`), the recovery branch emitted `\"OK</thi\"` as reasoning because it only checked for a complete end tag in the delta, never applying the partial-tag withhold. Subsequent chunks then treated the close as consumed, leaking literal `</thi` bytes into `reasoning_content`. Fixed by applying `_held_partial_tag_len` withhold to `reasoning_part` post-end-check.

## Tests added

- `tests/test_silent_drop_rescue_569.py` — 3 Case-4 tests (skip when length+case4, fire when case4+stop, fire when length+not-case4).
- `tests/test_reasoning_parsers.py::TestThinkParserSSEBoundary` — 4 new SSE-boundary tests on top of the 7 merged in PR #715:
  - `test_false_partial_tag_inside_think_block_flushed` (codex r1 P2)
  - `test_in_think_block_with_lt_and_gt_chars`
  - `test_split_opener_completed_with_reasoning_no_duplication` (codex r2 P2)
  - `test_split_opener_completes_with_partial_end_tag_no_leak` (codex r4 P2)

## Verification

- All 11 SSE-boundary tests pass (`tests/test_reasoning_parsers.py::TestThinkParserSSEBoundary`).
- All 159 reasoning parser tests pass.
- Full unit suite green (6146 passed, excluding integration tests that need a running server).
- Codex round 5 returned clean: \"The change correctly withholds partial closing tags when a split opener completes in the same chunk, and the added regression test covers the targeted scenario. I did not find any newly introduced blocking issues in the diff.\"

## Live smoke (pre-PR #715 merge, confirming Case-4 fix)

- VibeThinker-3B-8bit: `\"What is 2+2?\"` with `max_tokens=32` — pre-fix: `content_len == reasoning_len == 119`. Post-Case-4-gate: content empty (reasoning trace stays in `reasoning_content` only, no duplication).
- qwen3-4b-instruct-2507-4bit: regression-free under the new auto-config (no reasoning_parser).

## Test plan

- [ ] CI green on `fix/vibethinker-followup-codex-rounds`
- [ ] pr_validate clean (will run after PR opens)
- [ ] Manual smoke on `vibethinker-3b-8bit` to reconfirm Case-4 gate

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>