### PR TITLE
fix(api): always emit message.content per OpenAI spec (F-040)

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -742,3 +742,84 @@ class TestModelSerialization:
         )
         data = schema.model_dump(by_alias=True)
         assert "schema" in data
+
+    # F-040 regression: ``content`` MUST always be present on the wire,
+    # even when the route serializes the response with ``exclude_none=True``
+    # and the underlying value is ``None`` (e.g. reasoning consumed the
+    # whole budget and we truncated mid-``<think>``). Standard OpenAI
+    # clients read ``resp["choices"][0]["message"]["content"]`` and crash
+    # with ``KeyError: 'content'`` if the field is missing.
+    def test_assistant_message_content_always_present_in_json(self):
+        """``content`` is REQUIRED in OpenAI's chat.completion schema (string|null)."""
+        msg = AssistantMessage(
+            content=None,
+            reasoning_content="I was thinking but ran out of budget mid-thought.",
+        )
+        data = json.loads(msg.model_dump_json(exclude_none=True))
+        assert "content" in data, (
+            "F-040: 'content' must always appear on the wire (OpenAI spec); "
+            "any standard SDK client crashes with KeyError otherwise."
+        )
+        assert data["content"] is None
+        # reasoning alias still surfaces for backward-compat
+        assert data["reasoning"] == data["reasoning_content"]
+
+    def test_assistant_message_content_present_via_model_dump(self):
+        """Direct ``model_dump(exclude_none=True)`` also surfaces ``content``."""
+        msg = AssistantMessage(content=None, reasoning_content="…")
+        data = msg.model_dump(exclude_none=True)
+        assert "content" in data
+        assert data["content"] is None
+
+    def test_chat_completion_response_content_always_present(self):
+        """Parent ``ChatCompletionResponse.model_dump_json(exclude_none=True)``
+        must preserve ``message.content`` (the actual production path in
+        ``routes/chat.py`` non-streaming responses)."""
+        resp = ChatCompletionResponse(
+            model="reasoning-model",
+            choices=[
+                ChatCompletionChoice(
+                    message=AssistantMessage(
+                        content=None,
+                        reasoning_content="Truncated mid-think.",
+                    ),
+                    finish_reason="length",
+                )
+            ],
+        )
+        payload = json.loads(resp.model_dump_json(exclude_none=True))
+        message = payload["choices"][0]["message"]
+        assert "content" in message
+        assert message["content"] is None
+        # Make sure we did not regress the role / reasoning shape.
+        assert message["role"] == "assistant"
+        assert message["reasoning_content"] == "Truncated mid-think."
+
+    def test_chunk_delta_terminal_with_reasoning_has_content_null(self):
+        """F-040 (streaming): the terminal chunk delta for a reasoning-only
+        finish must expose ``content: null`` so clients reading
+        ``chunk.choices[0].delta.content`` on the last chunk do not crash.
+        """
+        delta = ChatCompletionChunkDelta(
+            reasoning_content="…", content=None
+        )
+        data = json.loads(delta.model_dump_json(exclude_none=True))
+        assert "content" in data
+        assert data["content"] is None
+
+    def test_chunk_delta_pure_content_stays_lean(self):
+        """Per-token content-only deltas keep their minimal shape — we do
+        NOT inject ``reasoning_content: null`` or other noise on every
+        chunk (per-token streaming budget must stay tight)."""
+        delta = ChatCompletionChunkDelta(content="Hello")
+        data = json.loads(delta.model_dump_json(exclude_none=True))
+        assert data == {"content": "Hello"}
+
+    def test_chunk_delta_empty_stays_empty(self):
+        """A truly empty terminal delta (e.g. guided-decoding finish chunk)
+        still serializes to ``{}`` — we do not pollute pure
+        finish-marker chunks with a spurious ``content: null``.
+        """
+        delta = ChatCompletionChunkDelta()
+        data = json.loads(delta.model_dump_json(exclude_none=True))
+        assert data == {}

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -800,9 +800,7 @@ class TestModelSerialization:
         finish must expose ``content: null`` so clients reading
         ``chunk.choices[0].delta.content`` on the last chunk do not crash.
         """
-        delta = ChatCompletionChunkDelta(
-            reasoning_content="…", content=None
-        )
+        delta = ChatCompletionChunkDelta(reasoning_content="…", content=None)
         data = json.loads(delta.model_dump_json(exclude_none=True))
         assert "content" in data
         assert data["content"] is None

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -670,27 +670,37 @@ def test_streaming_rescue_noop_when_reasoning_is_whitespace_only():
         events = _parse_sse(resp.text)
         assert events, "expected at least one SSE chunk"
 
-        # Codex round-4 BLOCKING on #676: collect EVERY ``delta.content``
-        # value without stripping, so an incorrectly-emitted
-        # whitespace-only payload (``"   \n\t  "``) is caught instead
-        # of being silently coerced to empty by ``.strip()``. Pre-fix
-        # this assertion was ``not streamed_content.strip()``, which
-        # would still pass under the exact regression we're guarding
-        # against — a self-defeating test. The new shape lists every
-        # raw ``delta.content`` value emitted on any chunk and asserts
-        # the list is empty; any emission at all (whitespace, empty
-        # string, real text) is a regression.
+        # Codex round-4 BLOCKING on #676: collect EVERY non-null
+        # ``delta.content`` value without stripping, so an
+        # incorrectly-emitted whitespace-only payload (``"   \n\t  "``)
+        # is caught instead of being silently coerced to empty by
+        # ``.strip()``. Pre-fix this assertion was
+        # ``not streamed_content.strip()``, which would still pass
+        # under the exact regression we're guarding against — a
+        # self-defeating test. The new shape lists every raw
+        # ``delta.content`` value emitted on any chunk and asserts
+        # the list is empty; any non-null emission at all
+        # (whitespace, empty string, real text) is a regression.
+        #
+        # F-040: ``content: null`` is now an INTENTIONAL part of the
+        # streaming shape on reasoning-only deltas (so clients reading
+        # ``delta.content`` on the terminal chunk don't crash with a
+        # KeyError). The original test caught any presence of the
+        # ``content`` key including ``None``; we tighten the check to
+        # only flag actual *promotions* (a non-null value), which is
+        # the regression we care about here.
         content_values = [
             (choice.get("delta") or {}).get("content")
             for ev in events
             for choice in ev.get("choices", [])
             if "content" in (choice.get("delta") or {})
+            and (choice.get("delta") or {}).get("content") is not None
         ]
         assert content_values == [], (
             "#676 round-4 BLOCKING (streaming): whitespace-only "
             "accumulated reasoning must NOT promote to delta.content "
-            "on any SSE chunk; expected zero content emissions but "
-            f"got {content_values!r}"
+            "on any SSE chunk; expected zero non-null content emissions "
+            f"but got {content_values!r}"
         )
     finally:
         reset_config()

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -788,9 +788,7 @@ class ChatCompletionChunkDelta(BaseModel):
         is unchanged for non-reasoning paths.
         """
         d = handler(self)
-        if "content" not in d and (
-            "reasoning_content" in d or "tool_calls" in d
-        ):
+        if "content" not in d and ("reasoning_content" in d or "tool_calls" in d):
             d["content"] = None
         return d
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -13,7 +13,15 @@ import time
 import uuid
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    model_serializer,
+    model_validator,
+)
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -356,9 +364,51 @@ class AssistantMessage(BaseModel):
         """Add deprecated 'reasoning' alias for backward compatibility."""
         pass
 
+    @model_serializer(mode="wrap")
+    def _serialize_assistant_message(self, handler):
+        """Always emit ``content`` (and ``reasoning`` alias) on the wire.
+
+        Per OpenAI's ``chat.completion`` schema, ``message.content`` is a
+        REQUIRED field that is ``string`` or ``null`` — never absent. When
+        a reasoning model truncates inside ``<think>`` the parser yields
+        ``content=None`` and our callers serialize the response with
+        ``model_dump_json(exclude_none=True)``; pydantic then drops the
+        ``content`` key entirely and clients that read
+        ``resp["choices"][0]["message"]["content"]`` (the standard
+        OpenAI SDK pattern) crash with ``KeyError: 'content'``. This
+        wrap-mode serializer runs AFTER ``exclude_none`` pruning, so we
+        can put the field back as an explicit ``None`` (→ JSON ``null``)
+        regardless of how the parent was dumped.
+
+        Also forwards the deprecated ``reasoning`` alias for
+        backward-compat clients that read either field. (The legacy
+        ``model_dump`` override below covered direct ``.model_dump()``
+        calls but was bypassed when a parent's ``model_dump_json``
+        recursed — pydantic v2 routes JSON serialization through this
+        ``@model_serializer`` instead.)
+        """
+        d = handler(self)
+        # OpenAI contract: ``content`` is always present (string|null).
+        if "content" not in d:
+            d["content"] = None
+        if "reasoning_content" in d:
+            d["reasoning"] = d["reasoning_content"]
+        return d
+
     def model_dump(self, **kwargs) -> dict:
-        """Include 'reasoning' as alias of reasoning_content for clients expecting it."""
+        """Include 'reasoning' as alias of reasoning_content for clients expecting it.
+
+        Kept for callers that invoke ``.model_dump()`` directly (rather
+        than via a parent ``model_dump_json``). The wrap-mode
+        ``@model_serializer`` above already handles both paths, but this
+        override remains a defensive belt-and-braces for any external
+        caller relying on the historical behaviour.
+        """
         d = super().model_dump(**kwargs)
+        # Belt-and-braces: ensure ``content`` is always present, matching
+        # the OpenAI-spec invariant enforced by the wrap-mode serializer.
+        if "content" not in d:
+            d["content"] = None
         # Add backward-compat alias — clients may read either field
         if "reasoning_content" in d:
             d["reasoning"] = d["reasoning_content"]
@@ -713,6 +763,36 @@ class ChatCompletionChunkDelta(BaseModel):
     content: str | None = None
     reasoning_content: str | None = None
     tool_calls: list[dict] | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize_chunk_delta(self, handler):
+        """Ensure ``content`` is present on reasoning-only / terminal deltas.
+
+        Callers serialize streaming chunks with
+        ``model_dump_json(exclude_none=True)`` so per-token deltas stay
+        terse (most deltas carry exactly one of ``content`` /
+        ``reasoning_content`` / ``tool_calls``). When a generation
+        terminates mid-``<think>`` reasoning, the terminal delta carries
+        only ``reasoning_content`` plus a ``finish_reason`` on the
+        parent choice — and the missing ``content`` key crashes any
+        client that does ``chunk.choices[0].delta.content`` on the
+        terminal chunk (the standard OpenAI SDK pattern; see the
+        non-stream counterpart on ``AssistantMessage``).
+
+        Mirror the OpenAI on-the-wire shape: surface ``content: null``
+        on any delta that carries ``reasoning_content`` (or
+        ``tool_calls``) but no visible content, so the field is
+        addressable on every reasoning-bearing delta — including the
+        final one. Normal pure-content / pure-role / empty deltas keep
+        their current minimal shape, so the per-token streaming budget
+        is unchanged for non-reasoning paths.
+        """
+        d = handler(self)
+        if "content" not in d and (
+            "reasoning_content" in d or "tool_calls" in d
+        ):
+            d["content"] = None
+        return d
 
 
 class ChatCompletionChunkChoice(BaseModel):


### PR DESCRIPTION
## Summary

- F-040: ``choices[0].message.content`` field was missing (not even ``null``) when generation truncated mid-``<think>`` reasoning — universal client crash (every standard OpenAI SDK does ``resp["choices"][0]["message"]["content"]`` and gets ``KeyError: 'content'``).
- Add a wrap-mode ``@model_serializer`` to ``AssistantMessage`` so ``content`` is always present on the wire (``null`` when reasoning consumed the budget), even under ``model_dump_json(exclude_none=True)``. Also fixes the parallel streaming bug — terminal SSE delta now exposes ``content: null`` on reasoning-only / tool-call deltas; pure per-token deltas + empty terminal deltas stay minimal so the streaming budget for normal paths is unchanged.
- 6 regression tests in ``tests/test_api_models.py`` covering both shapes plus the lean / empty-delta paths.

## Repro (before)

```bash
curl -s http://127.0.0.1:8074/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "vibethinker-3b-8bit",
  "messages": [{"role": "user", "content": "What is the capital of Japan?"}],
  "max_tokens": 30
}'
# message: {role, reasoning_content}    ← no "content" key
# resp["choices"][0]["message"]["content"]   →   KeyError
```

## After

```json
"message": {
  "role": "assistant",
  "reasoning_content": "...",
  "content": null,
  "reasoning": "..."
}
```

Streaming terminal chunk now:

```
"delta": {"reasoning_content": "Hello", "content": null}, "finish_reason": "length"
```

## Test plan

- [x] ``tests/test_api_models.py`` — 87 pass (6 new F-040 regression tests covering both stream + non-stream shapes, plus lean / empty-delta invariants)
- [x] Updated ``tests/test_silent_drop_rescue_569.py`` #676 round-4 streaming guard to flag non-null content promotions only (``content: null`` is now an intentional part of the shape)
- [x] Wider sweep: 1900 pass, 9 skipped, 0 fail on all chat/chunk/assistant/stream/content/message/reasoning/sse-related tests
- [x] Manual repro on vibethinker-3b-8bit at port 8074 — non-stream + stream both verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)