### PR TITLE
fix(reasoning): close streaming multi-block <think> leak (F-100)

### DIFF
--- a/tests/test_streaming_reasoning_with_structured_output.py
+++ b/tests/test_streaming_reasoning_with_structured_output.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-100 regression: streaming + ``response_format=json_schema`` on
+reasoning models must split ``<think>…</think>`` blocks into
+``delta.reasoning_content`` even when the model autonomously re-enters
+reasoning by emitting a SECOND ``<think>`` opener AFTER the answer.
+
+Pre-fix repro (phi-4-mini-reasoning-4bit, stream=true, json_schema):
+
+    delta.content = '\n\n{"answer":4}<think>\nOkay let me see…'
+
+The literal ``<think>…</think>`` tags leaked into ``delta.content``
+(including SSE-split fragments like ``<th`` / ``ink`` / ``>\n``) instead
+of routing the second-block body to ``delta.reasoning_content``. Root
+cause: in **implicit mode** (chat template injected ``<think>`` so only
+``</think>`` appears in the output), ``_handle_implicit_think``'s
+``end_in_prev`` branch returned ``content=delta_text`` unconditionally
+— it had no awareness of the multi-block protocol that the explicit
+``<think>`` mode (``_handle_explicit_think → multi_block_after_close``)
+already implemented.
+
+Fix: in ``extract_reasoning_streaming`` Case 2 (implicit mode), once
+``end_in_prev=True`` we delegate to ``_handle_multi_block_after_close``
+— the same router that the explicit-mode path uses post-first-close.
+The fix also seeds ``_streaming_phase`` in the SSE-boundary recovery
+branches of ``_handle_explicit_think`` so a subsequent multi-block call
+inherits the correct phase rather than defaulting to "content".
+
+Symmetric with the non-streaming path's ``_sweep_residual_think_tags``
+which already handled multi-block output in the non-streaming
+``extract_reasoning`` (PR #722). The streaming path now matches that
+contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.reasoning import get_parser
+
+
+def _stream(parser, chunks: list[str]) -> tuple[str, str]:
+    """Replay ``chunks`` through ``parser.extract_reasoning_streaming``.
+
+    Returns ``(reasoning, content)`` as joined strings.
+    """
+    parser.reset_state()
+    accumulated = ""
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    for delta in chunks:
+        previous = accumulated
+        accumulated += delta
+        msg = parser.extract_reasoning_streaming(previous, accumulated, delta)
+        if msg is None:
+            continue
+        if msg.reasoning:
+            reasoning_parts.append(msg.reasoning)
+        if msg.content:
+            content_parts.append(msg.content)
+    return "".join(reasoning_parts), "".join(content_parts)
+
+
+@pytest.fixture(params=["qwen3", "deepseek_r1"])
+def parser(request):
+    return get_parser(request.param)()
+
+
+class TestImplicitModeMultiBlock:
+    """Implicit mode (chat template injects ``<think>``) — only
+    ``</think>`` appears in the output stream, then the model may emit a
+    SECOND autonomous ``<think>…</think>`` block after the answer.
+    """
+
+    def test_second_think_after_answer_routes_to_reasoning(self, parser):
+        """F-100 core repro: post-first-close, a second ``<think>`` opener
+        must route subsequent bytes to reasoning, NOT leak into content.
+        """
+        # Implicit mode: stream starts inside reasoning, then </think>,
+        # then JSON answer, then a SECOND <think> block.
+        chunks = [
+            "Okay let me think",
+            "</think>",
+            '{"answer":4}',
+            "<think>",
+            "double-checking",
+            "</think>",
+            "tail",
+        ]
+        reasoning, content = _stream(parser, chunks)
+        # First reasoning block + second reasoning block both in reasoning.
+        assert "Okay let me think" in reasoning
+        assert "double-checking" in reasoning
+        # JSON answer + post-second-block tail in content.
+        assert '{"answer":4}' in content
+        assert "tail" in content
+        # No literal tag bytes anywhere on either channel.
+        assert "<think>" not in content
+        assert "</think>" not in content
+        assert "<think>" not in reasoning
+        assert "</think>" not in reasoning
+
+    def test_split_second_open_tag_held_and_emitted_as_reasoning(self, parser):
+        """SSE-split second opener (``<th`` / ``ink`` / ``>\\n``) must be
+        withheld and the body routed to reasoning.
+        """
+        chunks = [
+            "first thought",
+            "</think>",
+            '{"answer":4}',
+            "<th",
+            "ink",
+            ">\n",
+            "second thought",
+            "</think>",
+            "trailing",
+        ]
+        reasoning, content = _stream(parser, chunks)
+        assert "second thought" in reasoning
+        assert "trailing" in content
+        # No partial-tag fragments in content.
+        assert "<th" not in content
+        assert "ink" not in content
+        # No structural-tag bytes survive on either side.
+        assert "<think>" not in content
+        assert "</think>" not in content
+
+    def test_split_second_close_tag_held_until_complete(self, parser):
+        """Second-block closer arriving split (``</`` / ``think`` / ``>``)
+        must withhold and flip back to content cleanly.
+        """
+        chunks = [
+            "first thought",
+            "</think>",
+            "answer",
+            "<think>",
+            "more thought",
+            "</",
+            "think",
+            ">",
+            "tail",
+        ]
+        reasoning, content = _stream(parser, chunks)
+        assert "more thought" in reasoning
+        assert "tail" in content
+        assert "<think>" not in content
+        assert "</think>" not in content
+
+
+class TestExplicitModeMultiBlockRegression:
+    """Explicit mode regression guard — keep the pre-F-100 behaviour for
+    streams where the model DOES emit the first ``<think>`` opener.
+    """
+
+    def test_split_first_open_then_multi_block(self, parser):
+        """Tokens: ``<`` ``think`` ``>`` … reasoning … ``</`` ``think`` ``>``
+        answer ``<think>`` second ``</think>`` tail.
+        """
+        chunks = [
+            "<",
+            "think",
+            ">",
+            "first",
+            "</",
+            "think",
+            ">",
+            "answer",
+            "<think>",
+            "second",
+            "</think>",
+            "tail",
+        ]
+        reasoning, content = _stream(parser, chunks)
+        assert "first" in reasoning
+        assert "second" in reasoning
+        assert "answer" in content
+        assert "tail" in content
+        assert "<think>" not in content
+        assert "</think>" not in content
+
+
+class TestSingleBlockUnchanged:
+    """Sanity check — single-block streams (the common case) keep their
+    pre-F-100 behaviour.
+    """
+
+    def test_implicit_single_block(self, parser):
+        chunks = ["thought ", "more", "</think>", "answer", " tail"]
+        reasoning, content = _stream(parser, chunks)
+        assert "thought" in reasoning
+        assert "more" in reasoning
+        assert "answer tail" in content
+        assert "</think>" not in content
+        assert "</think>" not in reasoning
+
+    def test_explicit_single_block(self, parser):
+        chunks = ["<think>", "thinking", "</think>", "answer"]
+        reasoning, content = _stream(parser, chunks)
+        assert "thinking" in reasoning
+        assert "answer" in content
+        assert "<think>" not in content
+        assert "</think>" not in content

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -256,6 +256,28 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # This handles when <think> was injected in the prompt
         if self.end_token in current_text:
             self._saw_any_tag = True
+            # F-100 (2026-06-19): in implicit mode, once we've already
+            # crossed the first ``</think>`` (``end_in_prev=True``) the
+            # model can re-enter reasoning by autonomously emitting a
+            # SECOND ``<think>`` opener after the answer (phi-4-mini-
+            # reasoning streams ``…JSON…<think>more thought</think>tail``
+            # under ``response_format=json_schema`` + ``stream=true``).
+            # The naive ``end_in_prev → content=delta_text`` fallback in
+            # ``_handle_implicit_think`` leaks the literal ``<think>``
+            # bytes (including SSE-split fragments like ``<th``, ``ink``,
+            # ``>\n``) into ``delta.content`` and routes the second
+            # block's body to content instead of reasoning. Delegate to
+            # the multi-block router — it already handles partial-tag
+            # withhold AND ``_streaming_phase`` flip on subsequent
+            # deltas, so the second block streams as reasoning and the
+            # following ``</think>`` flips cleanly back to content.
+            # Symmetric with the explicit-mode multi-block dispatch in
+            # ``_handle_explicit_think`` (``start_in_prev`` AND
+            # ``end_in_prev``).
+            if end_in_prev:
+                return self._handle_multi_block_after_close(
+                    previous_text, current_text, delta_text
+                )
             return self._handle_implicit_think(delta_text, end_in_prev, end_in_delta)
 
         # Case 3: No think tags seen yet
@@ -509,6 +531,15 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 # and reasoning_part is empty — OK.
                 if end_idx_cur < emitted_so_far:
                     reasoning_part = ""
+                # F-100: synchronise ``_streaming_phase`` with the
+                # post-close state so a SUBSEQUENT delta routed through
+                # the multi-block dispatch starts from the correct phase
+                # rather than inheriting whatever the SSE-boundary
+                # recovery branch left behind (a split-opener earlier in
+                # the same request would otherwise keep the phase at
+                # ``"reasoning"`` and leak post-``</think>`` bytes into
+                # ``reasoning_content``).
+                self._streaming_phase = "content"
                 return DeltaMessage(
                     reasoning=reasoning_part or None,
                     content=content_part or None,
@@ -591,6 +622,14 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 content_part = reasoning_part[end_idx + len(self.end_token) :]
                 reasoning_part = reasoning_part[:end_idx]
                 self._held_tag_suffix_len = 0
+                # F-100: synchronise ``_streaming_phase`` with the
+                # post-close state so a SUBSEQUENT delta routed through
+                # the multi-block dispatch (``start_in_prev AND
+                # end_in_prev`` after this) starts from the correct
+                # phase instead of defaulting to ``in_reasoning_prev =
+                # False``. We just emitted the close inside this delta;
+                # post-close state is ``content``.
+                self._streaming_phase = "content"
                 return DeltaMessage(
                     reasoning=reasoning_part or None,
                     content=content_part or None,
@@ -615,6 +654,16 @@ class BaseThinkingReasoningParser(ReasoningParser):
             reasoning_start_in_current = prev_len + tag_overlap
             keep = max(0, safe_end_in_current - reasoning_start_in_current)
             reasoning_part = reasoning_part[:keep]
+        # F-100: synchronise ``_streaming_phase`` with the just-opened
+        # block so a SUBSEQUENT delta routed through the multi-block
+        # dispatch (``start_in_prev AND end_in_prev`` after this) starts
+        # from the correct phase. We just emitted the opener inside this
+        # delta; post-opener state is ``reasoning``. Without this seed,
+        # ``_handle_multi_block_after_close`` falls back to
+        # ``in_reasoning_prev = False`` and the next-delta body of a
+        # second ``<think>`` block leaks into ``content`` (F-100 repro
+        # tail: ``Okay`` / ``second think`` after a split second opener).
+        self._streaming_phase = "reasoning"
         return DeltaMessage(reasoning=reasoning_part or None)
 
     def _handle_multi_block_after_close(


### PR DESCRIPTION
## Summary

- Closes **F-100**: streaming + `response_format=json_schema` on reasoning models leaked raw `<think>…</think>` tag bytes (including SSE-split fragments like `<th`, `ink`, `>\n`) into `delta.content` and routed second-block thoughts to content instead of `reasoning_content`. Non-streaming was unaffected — that path's `_sweep_residual_think_tags` (PR #722) already handled multi-block output.
- Root cause was a missing **multi-block dispatch in implicit mode**: `_handle_implicit_think`'s `end_in_prev` branch returned `content=delta_text` blindly, with no awareness that the model can autonomously emit a SECOND `<think>` opener after the answer. phi-4-mini-reasoning chains four to six `<think>...</think>` blocks before `max_tokens` hits when streaming with `json_schema`.
- Two-part fix in `BaseThinkingReasoningParser`:
  - **Case 2 (implicit mode)** of `extract_reasoning_streaming`: once `end_in_prev=True`, delegate to `_handle_multi_block_after_close` — same router the explicit path already uses post-first-close.
  - **Three branches of `_handle_explicit_think`** that previously left `_streaming_phase` stale now seed it: post-close (`"content"`), SSE-boundary split-opener with `end_in_delta` (`"content"`), and SSE-boundary split-opener trailing emit (`"reasoning"`). Without these seeds, subsequent multi-block calls inherited the wrong phase.

## Repro (phi-4-mini-reasoning-4bit on port 8094)

Pre-fix streaming output:
```
delta.content = '\n\n{"answer":4}<think>\nOkay let me see…'
```
3/3 reproductions on real server.

Post-fix streaming output (3/3 trials):
```
content_len=14, reasoning_len=1832
content = '\n\n{"answer":4}'
has_think_tag_in_content = False
```

Non-streaming unchanged (still works). Plain streaming without `json_schema` unchanged.

## Test plan

- [x] New regression suite `tests/test_streaming_reasoning_with_structured_output.py` (12 tests, parametrized over qwen3 + deepseek_r1): implicit-mode second-block, SSE-split second open/close tags, explicit-mode regression, single-block sanity. All pass.
- [x] Existing reasoning + streaming suites green: `test_reasoning_parser.py`, `test_reasoning_parsers.py`, `test_streaming_think_router.py`, `test_minimax_reasoning_parser.py`, `test_anthropic_streaming_reasoning.py`, `test_postprocessor.py`, `test_chat_streaming_guided.py`, `test_chat_streaming_spec.py`, `test_streaming_pipeline_integration.py` — 565 tests across these files, all passing.
- [x] Full unit-test run (excluding `mlx_vlm`-dependent infra): 6217 passed, 42 skipped, 7 xfailed; the 6 failures in `test_mllm_corrupt_image.py` are the pre-existing `mlx_vlm` import infra issue (not touched by this PR).
- [x] Live server probe: streaming + `response_format=json_schema` on phi-4-mini-reasoning-4bit, port 8094, 3/3 clean separation; non-streaming json_schema unchanged; plain streaming unchanged.

No version bump (user holds release).