### PR TITLE
fix(tool-logits): isinstance-guard 3 .get/.items sites (F-140 retires F-031)

### DIFF
--- a/tests/test_tool_logits_schema_guards.py
+++ b/tests/test_tool_logits_schema_guards.py
@@ -26,7 +26,6 @@ import pytest
 
 from vllm_mlx.api.tool_logits import _extract_param_schemas, validate_param_value
 
-
 # ---------------------------------------------------------------------------
 # F-140 known crash shapes — must NOT raise AttributeError
 # ---------------------------------------------------------------------------
@@ -49,19 +48,39 @@ F140_MALFORMED_SHAPES = [
     pytest.param([_tool(3.14)], id="parameters_float"),
     pytest.param([_tool(True)], id="parameters_bool"),
     pytest.param(
-        [{"type": "function", "function": {"name": "f", "parameters": {"properties": []}}}],
+        [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {"properties": []}},
+            }
+        ],
         id="properties_list",
     ),
     pytest.param(
-        [{"type": "function", "function": {"name": "f", "parameters": {"properties": "foo"}}}],
+        [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {"properties": "foo"}},
+            }
+        ],
         id="properties_string",
     ),
     pytest.param(
-        [{"type": "function", "function": {"name": "f", "parameters": {"properties": 42}}}],
+        [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {"properties": 42}},
+            }
+        ],
         id="properties_int",
     ),
     pytest.param(
-        [{"type": "function", "function": {"name": "f", "parameters": {"properties": None}}}],
+        [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {"properties": None}},
+            }
+        ],
         id="properties_null",
     ),
     # Structural variants — tool itself / function field is malformed.
@@ -133,7 +152,10 @@ def test_extract_skips_bad_tool_keeps_good_one():
 def test_extract_skips_bad_properties_keeps_good_tool():
     """``properties`` non-dict on one tool, good ``properties`` on another."""
     tools = [
-        {"type": "function", "function": {"name": "bad", "parameters": {"properties": []}}},
+        {
+            "type": "function",
+            "function": {"name": "bad", "parameters": {"properties": []}},
+        },
         {
             "type": "function",
             "function": {

--- a/tests/test_tool_logits_schema_guards.py
+++ b/tests/test_tool_logits_schema_guards.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for F-140 (retires F-031).
+
+Three unguarded ``.get()``/``.items()`` calls in
+``vllm_mlx/api/tool_logits.py`` at lines 42, 43, and 419 turned a wide
+family of malformed tool-schema shapes into an unmapped
+``AttributeError`` — surfacing as HTTP 500 (instead of a clean 400/422)
+and, on the route layer's older envelope, leaking the raw Python error
+text. F-031 was the narrowest subcase (``parameters: null``); F-140
+covers the full ``≥7`` known crash shapes including non-dict
+``parameters`` (list / scalar / string) and non-dict ``properties``.
+
+The fix shape: ``isinstance(_, dict)`` guards at the three call sites
+that previously assumed dict-shaped input. When the shape is wrong, the
+function skips that tool / returns an empty schema map cleanly — no
+exception leaves the helper.
+
+These tests don't boot the server (CI-cheap); they pin the helper-level
+contract so a regression can be caught without an integration harness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.api.tool_logits import _extract_param_schemas, validate_param_value
+
+
+# ---------------------------------------------------------------------------
+# F-140 known crash shapes — must NOT raise AttributeError
+# ---------------------------------------------------------------------------
+
+
+def _tool(parameters):
+    """Build a tool dict with the given ``parameters`` payload."""
+    return {"type": "function", "function": {"name": "f", "parameters": parameters}}
+
+
+# The seven shapes from the F-140 repro, plus three structural variants
+# (top-level tool not-a-dict, ``function`` not-a-dict, missing
+# ``function``).
+F140_MALFORMED_SHAPES = [
+    pytest.param([_tool(None)], id="parameters_null"),
+    pytest.param([_tool("foo")], id="parameters_string"),
+    pytest.param([_tool([])], id="parameters_empty_list"),
+    pytest.param([_tool([1, 2, 3])], id="parameters_nonempty_list"),
+    pytest.param([_tool(42)], id="parameters_int"),
+    pytest.param([_tool(3.14)], id="parameters_float"),
+    pytest.param([_tool(True)], id="parameters_bool"),
+    pytest.param(
+        [{"type": "function", "function": {"name": "f", "parameters": {"properties": []}}}],
+        id="properties_list",
+    ),
+    pytest.param(
+        [{"type": "function", "function": {"name": "f", "parameters": {"properties": "foo"}}}],
+        id="properties_string",
+    ),
+    pytest.param(
+        [{"type": "function", "function": {"name": "f", "parameters": {"properties": 42}}}],
+        id="properties_int",
+    ),
+    pytest.param(
+        [{"type": "function", "function": {"name": "f", "parameters": {"properties": None}}}],
+        id="properties_null",
+    ),
+    # Structural variants — tool itself / function field is malformed.
+    pytest.param(["not-a-dict"], id="tool_not_dict_str"),
+    pytest.param([42], id="tool_not_dict_int"),
+    pytest.param([None], id="tool_none"),
+    pytest.param([{"type": "function", "function": None}], id="function_none"),
+    pytest.param([{"type": "function", "function": "bogus"}], id="function_string"),
+    pytest.param([{"type": "function", "function": []}], id="function_list"),
+]
+
+
+@pytest.mark.parametrize("tools", F140_MALFORMED_SHAPES)
+def test_extract_param_schemas_tolerates_malformed_shapes(tools):
+    """Helper must return an empty schema map cleanly, never raise."""
+    result = _extract_param_schemas(tools)
+    assert result == {}, f"expected empty schemas for {tools!r}, got {result!r}"
+
+
+@pytest.mark.parametrize(
+    "bad_schema",
+    [
+        pytest.param(None, id="schema_none"),
+        pytest.param("foo", id="schema_string"),
+        pytest.param([], id="schema_empty_list"),
+        pytest.param([1, 2, 3], id="schema_nonempty_list"),
+        pytest.param(42, id="schema_int"),
+        pytest.param(3.14, id="schema_float"),
+        pytest.param(True, id="schema_bool"),
+    ],
+)
+def test_validate_param_value_tolerates_non_dict_schema(bad_schema):
+    """
+    ``validate_param_value`` ran ``schema.get("type", "")`` blindly at
+    line 419, raising ``AttributeError`` for the same family of shapes.
+    With the guard in place, treat non-dict schema as "no constraint"
+    and pass the value through as valid.
+    """
+    is_valid, err = validate_param_value('"hello"', bad_schema)
+    assert is_valid is True
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# Mixed-shape lists — partial malformation must not poison sibling entries
+# ---------------------------------------------------------------------------
+
+
+def test_extract_skips_bad_tool_keeps_good_one():
+    """
+    A malformed tool in position 0 must not prevent extraction of a
+    well-formed tool in position 1 — guards ``continue`` per-tool, they
+    don't ``return {}`` early.
+    """
+    tools = [
+        _tool(None),  # malformed — should be skipped
+        {
+            "type": "function",
+            "function": {
+                "name": "ok",
+                "parameters": {"properties": {"x": {"type": "string"}}},
+            },
+        },
+    ]
+    result = _extract_param_schemas(tools)
+    assert result == {"ok.x": {"type": "string"}}
+
+
+def test_extract_skips_bad_properties_keeps_good_tool():
+    """``properties`` non-dict on one tool, good ``properties`` on another."""
+    tools = [
+        {"type": "function", "function": {"name": "bad", "parameters": {"properties": []}}},
+        {
+            "type": "function",
+            "function": {
+                "name": "good",
+                "parameters": {"properties": {"y": {"type": "integer"}}},
+            },
+        },
+    ]
+    result = _extract_param_schemas(tools)
+    assert result == {"good.y": {"type": "integer"}}
+
+
+# ---------------------------------------------------------------------------
+# Sanity — the well-formed path still works after adding guards
+# ---------------------------------------------------------------------------
+
+
+def test_extract_well_formed_unchanged():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "properties": {
+                        "location": {"type": "string"},
+                        "units": {"type": "string", "enum": ["c", "f"]},
+                    }
+                },
+            },
+        }
+    ]
+    result = _extract_param_schemas(tools)
+    assert result == {
+        "get_weather.location": {"type": "string"},
+        "get_weather.units": {"type": "string", "enum": ["c", "f"]},
+    }
+
+
+def test_validate_well_formed_unchanged():
+    is_valid, err = validate_param_value('"celsius"', {"type": "string"})
+    assert is_valid is True
+    assert err is None
+
+    is_valid, err = validate_param_value("not-json", {"type": "integer"})
+    assert is_valid is False
+    assert err is not None

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -36,10 +36,25 @@ def _extract_param_schemas(tools: list[dict] | None) -> dict[str, dict]:
 
     schemas: dict[str, dict] = {}
     for tool in tools:
+        if not isinstance(tool, dict):
+            continue
         func = tool.get("function", tool)
+        if not isinstance(func, dict):
+            continue
         tool_name = func.get("name", "")
         params = func.get("parameters", {})
+        # Tolerate malformed tool schemas: ``parameters`` may legally be
+        # omitted (treated as no-args) but client JSON sometimes ships it
+        # as ``null``, a bare string, a list, or a number. Skip cleanly
+        # instead of letting ``params.get(...)`` raise ``AttributeError``
+        # — that bubbles up as an unmapped 500 and leaks raw Python error
+        # text. ``properties`` has the same exposure (F-140 / retires
+        # F-031).
+        if not isinstance(params, dict):
+            continue
         properties = params.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
         for param_name, param_schema in properties.items():
             key = f"{tool_name}.{param_name}"
             schemas[key] = param_schema
@@ -416,6 +431,13 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
     Returns:
         (is_valid, error_message) tuple.
     """
+    # Defensive guard: ``_extract_param_schemas`` may publish a non-dict
+    # entry when a future change to the extraction shape is bug-prone
+    # (e.g. earlier ``properties`` of mixed types reaching here as the
+    # leaf schema). Treat non-dict as "no constraint" rather than letting
+    # ``schema.get(...)`` raise ``AttributeError`` and 500. (F-140)
+    if not isinstance(schema, dict):
+        return True, None
     param_type = schema.get("type", "")
 
     # Try to parse as JSON first


### PR DESCRIPTION
## Summary
- Three unguarded `.get()`/`.items()` calls in `vllm_mlx/api/tool_logits.py` at lines 42/43/419 turned malformed `tools[].function.parameters` schemas (`null`, string, list, scalar, plus non-dict `properties` / leaf `schema`) into HTTP 500 raised by the global `Exception` handler. Pydantic models `function` as `dict` so anything that round-trips through JSON reaches the helper. F-031 is the narrowest subcase (`parameters: null`); F-140 is the universal fix.
- Add five `isinstance(_, dict)` guards — three at the spec-named sites plus two on `tool` / `function` themselves for symmetry — so every other shape becomes "skip cleanly", not "AttributeError".
- 28-case regression in `tests/test_tool_logits_schema_guards.py` covers all 7 F-140 shapes + 10 structural variants + mixed-list-doesn't-poison-siblings + well-formed-still-works. Existing `tests/test_tool_logits.py` (51 cases) unchanged.

## Test plan
- [x] `uv run pytest tests/test_tool_logits_schema_guards.py -v` — 28 passed
- [x] `uv run pytest tests/test_tool_logits.py -q` — 51 passed
- [x] Live repro on `llama3-3b-4bit` @ 127.0.0.1:8095 — all 6 curls return HTTP 200 (pre-fix produced 500)
- [x] Demonstrated pre-fix `AttributeError` on all 10 shapes against the unguarded helper

## Scope
- Tool-logits helpers only (`tool_logits.py:38-50`, `:431-438`). The wider `_inject_tools_into_messages` fallback in `utils/chat_template.py:334` has the same pattern but is out of F-140's stated scope and tracked separately.
- No pyproject.toml version bump (per task constraints).