### PR TITLE
fix(reasoning): drop reasoning_max_tokens overflow when real answer present (F-041)

### DIFF
--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -1003,6 +1003,88 @@ def test_f041_cap_below_cleaned_text_unchanged():
     assert cleaned == "answer"
 
 
+def test_f041_cap_with_tool_calls_drops_overflow():
+    """Codex r1 follow-up on F-041: ``tool_calls`` paths legitimately
+    ship ``content=""`` alongside the structured call payload (OpenAI
+    spec — the tool call IS the visible response, ``content`` is null).
+    Without the ``has_tool_calls`` gate the F-041 drop only fires when
+    ``cleaned_text`` is non-empty, so a tool-only response would still
+    route the over-cap reasoning into ``content``, polluting the
+    OpenAI-spec ``tool_calls`` response with the truncated thought
+    trace.
+
+    Repro shape: cleaned_text="" (tool parser stripped the call markup),
+    tool_calls=[{...}], engine_reasoning_text=long_trace,
+    reasoning_max_tokens=10. The F-041 plug must drop the overflow
+    regardless of cleaned_text being blank — the user's visible answer
+    is the tool call, not whatever bytes the legacy fallback would
+    re-route as content.
+    """
+    long_trace = "Reasoning about which tool to call. " * 50
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=long_trace + "<tool_call>get_weather()</tool_call>",
+        cleaned_text="",  # tool parser stripped the wire payload
+        tool_calls=[{"name": "get_weather", "arguments": "{}"}],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text=long_trace,
+        enable_thinking=None,
+        reasoning_max_tokens=10,  # 40 chars
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    # Tool call IS the visible response — content stays empty (the
+    # tool call payload travels via the ``tool_calls`` field).
+    assert cleaned == ""
+    # Defensive: over-cap reasoning must NOT bleed into the content
+    # field that ships alongside the tool call.
+    assert "tool to call" not in (cleaned or "")
+
+
+def test_f041_cap_with_tool_calls_no_reasoning_parser_drops_overflow():
+    """F-041 portability: the ``has_tool_calls`` gate also wires through
+    the no-reasoning-parser short-circuit (line 252-258) — gemma4 / non-
+    thinking-mode requests that hit the cap from a channel-routed
+    engine_reasoning_text still get the drop semantic."""
+    long_trace = "Some reasoning text. " * 50
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text="",
+        cleaned_text="",
+        tool_calls=[{"name": "do_thing", "arguments": "{}"}],
+        reasoning_parser=None,  # short-circuit path
+        engine_reasoning_text=long_trace,
+        enable_thinking=None,
+        reasoning_max_tokens=10,
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    assert cleaned == ""
+
+
+def test_f041_cap_empty_content_no_tool_calls_still_falls_back():
+    """F-041 negative control: when neither ``cleaned_text`` nor
+    ``tool_calls`` carry a visible payload (model emitted ONLY
+    reasoning, no tool call, no closed ``</think>``), the silent-drop-
+    guard fallback STILL fires and routes overflow into content. The
+    user opted into the cap but we don't want to silently drop the
+    whole response if it's the only thing the model produced — pin
+    that the ``has_tool_calls`` gate doesn't kill the fallback."""
+    long_trace = "Some reasoning text. " * 50
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text="",
+        cleaned_text="",
+        tool_calls=[],  # no tool calls
+        reasoning_parser=None,
+        engine_reasoning_text=long_trace,
+        enable_thinking=None,
+        reasoning_max_tokens=10,  # 40 chars
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    # Fallback fires — overflow surfaces as content so the response
+    # isn't empty.
+    assert len(cleaned) > 0
+
+
 def test_f041_qwen3_cap_with_closed_think_and_real_answer():
     """F-041 portability: the Qwen3 parser (used by
     ``qwen3-4b-thinking-2507-4bit`` and the wider Qwen3 thinking family)

--- a/tests/test_finalize_harmony_raw_text.py
+++ b/tests/test_finalize_harmony_raw_text.py
@@ -846,3 +846,186 @@ def test_qwen3_engine_routed_truncated_think_no_duplicate():
     assert not cleaned, (
         f"qwen3 engine-routed truncated <think> trace leaked: {cleaned!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# F-041 (2026-06-19): ``reasoning_max_tokens`` truncation must NOT leak the
+# overflow reasoning into ``content``.
+#
+# Bug class is the same as PR #722 (multi-block <think> sweep) but the leak
+# surface is the ``_apply_reasoning_cap`` overflow-into-cleaned_text
+# fallback, NOT the parser's tag-handling. Live vibethinker-3b-8bit repro:
+#
+#   reasoning_max_tokens=30, max_tokens=300, prompt="What is the capital of
+#   Japan?" → reasoning_content cut mid-word at 120 chars (30 * 4); content
+#   started with the REMAINDER of the reasoning trace ("answer succinctly,
+#   perhaps include some context. However, the instruction says: \"You are
+#   an intelligent assistant designed to write code...\"...") followed at
+#   the END by the actual answer "The capital of Japan is **Tokyo**." —
+#   the model's training-time system prompt + the truncated thought trace
+#   surfaced in the user-visible content channel BEFORE the real answer.
+#
+# The fix gates ``_apply_reasoning_cap`` on whether the parser produced a
+# real answer (closed ``<think>…</think>answer`` shape): when content is
+# non-empty the over-cap reasoning suffix is dropped; when content is
+# empty (model truncated mid-thought) the legacy don't-drop-bytes fallback
+# still routes overflow to content. Three plug sites cover the
+# representative paths VibeThinker / Qwen3 / DeepSeek-R1 / phi-4-mini-
+# reasoning hit in production:
+#
+#   1. ``_apply_reasoning_cap`` itself: drop overflow when cleaned_text is
+#      non-empty (covers the closed-``</think>`` + real-answer shape that
+#      the live repro hit).
+#   2. Engine-routed branch (gemma4 / harmony OutputRouter with structural
+#      ``<think>`` token stripping): use ``_truncate_reasoning_only`` when
+#      raw_text shows unclosed ``<think>`` regardless of cleaned_text gate.
+#   3. Parser-routed Case-4 fallback (``enable_thinking=True`` + no-tag
+#      output): use ``_truncate_reasoning_only`` instead of the legacy
+#      ``_apply_reasoning_cap`` fall-through (the Case-4 plug above blanks
+#      cleaned_text, which used to route the over-cap reasoning back in).
+# ---------------------------------------------------------------------------
+
+
+def test_f041_vibethinker_cap_with_closed_think_and_real_answer():
+    """F-041 live repro shape: model emitted ``<think>R</think>answer``
+    with a long reasoning trace; ``reasoning_max_tokens=30`` (120 chars)
+    truncates the trace; the over-cap suffix MUST NOT prepend into
+    ``content``. The parser produced ``content="The capital of Japan
+    is **Tokyo**."`` from the closed-think split — that real answer is
+    the user-visible payload, and the legacy
+    ``_apply_reasoning_cap`` prepend-overflow path would corrupt it
+    with ~500 chars of truncated thought trace."""
+    raw = (
+        "<think>Okay, the user is asking, what is the capital of Japan? "
+        + ("This is a knowledge question. " * 30)
+        + "</think>The capital of Japan is **Tokyo**."
+    )
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+        reasoning_max_tokens=30,  # 30 * 4 = 120 chars
+    )
+    # Reasoning capped at exactly 120 chars.
+    assert reasoning is not None
+    assert len(reasoning) == 120
+    # Real answer survives verbatim — no truncated thought trace
+    # prepended.
+    assert cleaned == "The capital of Japan is **Tokyo**."
+    # Defensive: the post-cap reasoning suffix MUST NOT appear in content.
+    assert "knowledge question" not in (cleaned or "")
+    assert "<think>" not in (cleaned or "")
+    assert "</think>" not in (cleaned or "")
+
+
+def test_f041_vibethinker_cap_case4_no_tags_truncated_thought():
+    """F-041 + #575 plug interaction: when chat template pre-injected
+    ``<think>`` (``enable_thinking=True``) and the model truncated
+    mid-thought emitting NO tags at all, the Case-4 fallback routes
+    the whole output to reasoning and blanks ``cleaned_text``. The cap
+    then USED TO fall through to ``_apply_reasoning_cap`` and prepend
+    the over-cap reasoning back into the blanked cleaned_text, shipping
+    the leaked thought trace as ``content``. The F-041 plug routes this
+    case through ``_truncate_reasoning_only`` so the overflow drops."""
+    # Long no-tag reasoning trace (chat-template pre-injected <think>,
+    # model continues the thought without emitting any structural tag).
+    raw = "Okay, the user is asking, what is the capital of Japan? " + (
+        "Let me think about this. " * 100
+    )
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=True,  # critical — triggers Case-4 fallback
+        reasoning_max_tokens=30,  # 120 chars
+    )
+    # Reasoning kept at the cap.
+    assert reasoning is not None
+    assert len(reasoning) == 120
+    # Content blanked — the over-cap reasoning suffix is dropped, not
+    # prepended back. Mirrors the streaming Case-3 contract: truncated
+    # mid-thought emits no visible content.
+    assert cleaned == ""
+    # Defensive: no fragment of the post-cap thought trace appears.
+    assert "Let me think" not in (cleaned or "")
+
+
+def test_f041_vibethinker_cap_engine_routed_truncated_no_content():
+    """F-041 engine-routed truncated-thought variant: OutputRouter
+    consumed the structural ``<think>`` token before reaching the
+    helper, so ``cleaned_text=""`` and ``engine_reasoning_text`` carries
+    the trace. The ``cleaned_text``-gated truncated_think plug above
+    misses this shape (cleaned_text is empty so the ``"<think>" in
+    cleaned_text`` check is False). The F-041 plug catches it by
+    checking ``raw_text`` for the unclosed ``<think>`` signal."""
+    # Model emitted unclosed <think> + long trace; engine OutputRouter
+    # consumed <think> token and routed the rest to reasoning_text;
+    # cleaned_text (from clean_output_text + router override) is "".
+    long_trace = "Let me think step by step about this. " * 100
+    raw = "<think>" + long_trace
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text="",  # router consumed <think>, no content channel
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text=long_trace,
+        enable_thinking=None,
+        reasoning_max_tokens=10,  # 40 chars
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 40
+    # Content empty — overflow dropped, not prepended.
+    assert cleaned == ""
+    assert "step by step" not in (cleaned or "")
+
+
+def test_f041_cap_below_cleaned_text_unchanged():
+    """F-041 negative control: when ``reasoning_text`` fits under the
+    cap, neither path fires and ``cleaned_text`` passes through verbatim
+    (no spurious drop). Pins that the F-041 plug only triggers on the
+    overflow path."""
+    raw = "<think>short</think>answer"
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=DeepSeekR1ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+        reasoning_max_tokens=100,  # 400 chars — way above "short" (5)
+    )
+    assert reasoning == "short"
+    assert cleaned == "answer"
+
+
+def test_f041_qwen3_cap_with_closed_think_and_real_answer():
+    """F-041 portability: the Qwen3 parser (used by
+    ``qwen3-4b-thinking-2507-4bit`` and the wider Qwen3 thinking family)
+    must also drop overflow when a real answer is present. The fix
+    lives in ``_apply_reasoning_cap`` — parser-agnostic by design —
+    but pinning Qwen3 explicitly so a future parser-specific override
+    can't silently regress."""
+    raw = (
+        "<think>Okay let me think about this question carefully. "
+        + ("Step by step analysis here. " * 30)
+        + "</think>The answer is **42**."
+    )
+    cleaned, reasoning = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=Qwen3ReasoningParser(),
+        engine_reasoning_text="",
+        enable_thinking=None,
+        reasoning_max_tokens=30,
+    )
+    assert reasoning is not None
+    assert len(reasoning) == 120
+    # Real answer survives.
+    assert cleaned == "The answer is **42**."
+    assert "Step by step" not in (cleaned or "")

--- a/tests/test_per_request_thinking_budget.py
+++ b/tests/test_per_request_thinking_budget.py
@@ -1053,7 +1053,28 @@ class TestFinalizeContentAndReasoningCap:
         assert cleaned == "hello"
         assert reasoning == "abc"
 
-    def test_cap_truncates_and_overflows_to_content(self):
+    def test_cap_truncates_and_drops_overflow_when_content_present(self):
+        """F-041 (2026-06-19): when ``cleaned_text`` already carries the
+        model's real answer (parser routed the post-``</think>`` final
+        content into it), the over-cap reasoning suffix MUST NOT be
+        prepended back into content — the user opted into the
+        ``reasoning_max_tokens`` cap as a hard contract, not as a
+        "drop reasoning then keep emitting it as content" hint.
+
+        The vibethinker live repro at ``reasoning_max_tokens=30``
+        (max_tokens=1500, finish=stop) shipped ~500 chars of post-cap
+        reasoning + the model's training-time system prompt as
+        ``content`` BEFORE the actual answer
+        ``"The capital of Japan is **Tokyo**."`` — exactly because
+        the previous codex round-11 BLOCKING design prepended overflow
+        regardless of whether the parser found a real answer.
+
+        Drop the overflow when the model gave us a real answer; the
+        empty-content fallback path
+        (``test_cap_truncates_and_overflows_to_content_empty_fallback``)
+        preserves the don't-silently-drop-bytes semantic for the case
+        where the model truncated mid-thought.
+        """
         cleaned, reasoning = _finalize_content_and_reasoning(
             raw_text="",
             cleaned_text="final answer",
@@ -1062,16 +1083,30 @@ class TestFinalizeContentAndReasoningCap:
             engine_reasoning_text="x" * 40,  # ≈ 10 tokens
             reasoning_max_tokens=2,  # cap ≈ 8 chars
         )
-        # First 8 chars stay as reasoning, the rest is PREPENDED to
-        # cleaned. Codex round-11 BLOCKING: the overflow bytes were
-        # emitted by the model BEFORE any post-``</think>`` final
-        # content, so appending them after ``cleaned_text`` would
-        # reorder time-ordered emission. Prepend preserves the source
-        # order AND matches the streaming pipeline (overflow emitted
-        # on the cap-crossing chunk, BEFORE any subsequent content
-        # delta).
         assert reasoning == "x" * 8
-        assert cleaned == "x" * 32 + "final answer"
+        # F-041: real answer preserved verbatim, over-cap reasoning
+        # suffix dropped — content stays clean.
+        assert cleaned == "final answer"
+
+    def test_cap_truncates_and_overflows_to_content_empty_fallback(self):
+        """F-041 (2026-06-19): when ``cleaned_text`` is empty (model
+        truncated mid-thought, never emitted a closed ``</think>`` or
+        a real answer), the over-cap reasoning overflow STILL surfaces
+        as content — the empty-content fallback so we don't silently
+        drop the whole response. Mirrors the streaming path semantic
+        for the no-real-answer case."""
+        cleaned, reasoning = _finalize_content_and_reasoning(
+            raw_text="",
+            cleaned_text="",
+            tool_calls=[],
+            reasoning_parser=None,
+            engine_reasoning_text="x" * 40,  # ≈ 10 tokens
+            reasoning_max_tokens=2,  # cap ≈ 8 chars
+        )
+        assert reasoning == "x" * 8
+        # Empty-content fallback: overflow surfaces as content so the
+        # client isn't left with a completely empty response.
+        assert cleaned == "x" * 32
 
     def test_cap_below_text_is_noop(self):
         # text fits comfortably under cap → no truncation

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -222,6 +222,30 @@ def _finalize_content_and_reasoning(
             return cleaned_text, _truncate_reasoning_only(
                 engine_reasoning_text, reasoning_max_tokens
             )
+        # F-041 (2026-06-19): the ``cleaned_text``-gated check above misses
+        # the case where the OutputRouter consumed the structural
+        # ``<think>`` token before it ever reached ``cleaned_text`` — the
+        # router emits ``content=None`` AND sets ``text=""`` (engine
+        # ``_route_tokens_for_channels`` lines 1588-1589), so the engine-
+        # routed branch falls through to ``_apply_reasoning_cap`` with
+        # ``cleaned_text=""``. With ``reasoning_max_tokens`` set, the cap
+        # then prepends the over-cap reasoning suffix back into
+        # ``cleaned_text`` (the empty-content fallback), shipping the
+        # truncated-thought trace into ``content``. Mirror the
+        # cleaned-text-gated truncated_think plug: when the engine routed
+        # reasoning AND ``raw_text`` shows an unclosed ``<think>`` (model
+        # was still mid-thought at ``finish_reason=length``), use the
+        # reasoning-only cap so the over-cap suffix is dropped rather
+        # than leaking into the user-visible answer channel.
+        if (
+            raw_text
+            and "<think>" in raw_text
+            and "</think>" not in raw_text
+            and not (cleaned_text and cleaned_text.strip())
+        ):
+            return cleaned_text or "", _truncate_reasoning_only(
+                engine_reasoning_text, reasoning_max_tokens
+            )
         return _apply_reasoning_cap(
             cleaned_text, engine_reasoning_text, reasoning_max_tokens
         )
@@ -363,6 +387,24 @@ def _finalize_content_and_reasoning(
         # MUST survive (codex R2 BLOCKING).
         if enable_thinking is True and first_parse_was_case4:
             cleaned_text = ""
+            # F-041 (2026-06-19): same rationale as the codex r3 P2 plug
+            # below for ``first_parse_was_truncated_think`` — when the
+            # chat template pre-injected ``<think>`` and the model was
+            # truncated mid-thought emitting NO tags at all, the
+            # accumulated text IS the thought trace. Letting it fall
+            # through to ``_apply_reasoning_cap`` would prepend the
+            # over-cap reasoning suffix back into the (now-blank)
+            # ``cleaned_text`` and ship the leaked thought trace as
+            # ``content``. Live VibeThinker repro at
+            # ``reasoning_max_tokens=30`` (max_tokens=200, finish=length):
+            # the Case-4 fallback routed the no-tag output to reasoning,
+            # the cap truncated to 120 chars, and the remaining
+            # ~500 chars of thought trace surfaced verbatim as
+            # ``content`` — the leak shape F-041 was filed against.
+            # Use the reasoning-only cap so the overflow is dropped.
+            return cleaned_text, _truncate_reasoning_only(
+                reasoning_text, reasoning_max_tokens
+            )
         # Truncated-``<think>`` plug (2026-06-17). Mirrors the #575
         # Case-4 plug above but fires on the explicit-start-no-end
         # signal independent of ``enable_thinking`` — see the
@@ -433,6 +475,26 @@ def _apply_reasoning_cap(
     of truth for "how many tokens does this text approximate" so the
     OpenAI usage block, the streaming SSE deltas, and this non-stream
     finalize all agree on a single token count.
+
+    F-041 (2026-06-19): the overflow-into-``cleaned_text`` reroute is
+    only meaningful when ``cleaned_text`` is empty — i.e. the parser
+    found no closed ``</think>`` so the model never produced a real
+    answer (we'd be silently dropping the whole response otherwise).
+    When the parser DID separate a real answer (closed
+    ``<think>…</think>answer`` split — the VibeThinker / Qwen3 /
+    DeepSeek-R1 family's typical wire shape), prepending the
+    over-cap reasoning bytes pollutes the user-visible answer with
+    the truncated thought trace. The vibethinker repro at
+    ``reasoning_max_tokens=30`` shipped the entire post-cap reasoning
+    suffix + the model's training-time system prompt into ``content``
+    BEFORE the actual answer ``"The capital of Japan is **Tokyo**."``
+    — exactly the leak shape PR #722 closed for the multi-block
+    ``<think>`` case. The user opting into a small reasoning cap
+    explicitly asked us to drop the reasoning past the cap; they did
+    not ask us to reclassify those bytes as content. Drop the
+    overflow in that case; preserve the prepend-into-content fallback
+    when ``cleaned_text`` is empty so we don't silently drop the whole
+    response when the model never emitted a closed ``</think>``.
     """
     if (
         reasoning_max_tokens is None
@@ -445,6 +507,14 @@ def _apply_reasoning_cap(
         return cleaned_text, reasoning_text
     overflow = reasoning_text[max_chars:]
     truncated = reasoning_text[:max_chars]
+    # F-041 plug: when ``cleaned_text`` already carries a real answer
+    # (parser routed the post-``</think>`` final content into it),
+    # the model gave us its visible answer — the user-requested cap
+    # is the contract, not a "best-effort don't-drop-bytes" hint, so
+    # drop the over-cap reasoning suffix rather than letting it bleed
+    # into the answer channel.
+    if cleaned_text and cleaned_text.strip():
+        return cleaned_text, truncated
     # Codex round-11 BLOCKING: prepend overflow rather than appending
     # it. In the source ordering, the overflow bytes were emitted by
     # the model BEFORE any post-``</think>`` final content. Appending

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -247,10 +247,18 @@ def _finalize_content_and_reasoning(
                 engine_reasoning_text, reasoning_max_tokens
             )
         return _apply_reasoning_cap(
-            cleaned_text, engine_reasoning_text, reasoning_max_tokens
+            cleaned_text,
+            engine_reasoning_text,
+            reasoning_max_tokens,
+            has_tool_calls=bool(tool_calls),
         )
     if reasoning_parser is None:
-        return _apply_reasoning_cap(cleaned_text, reasoning_text, reasoning_max_tokens)
+        return _apply_reasoning_cap(
+            cleaned_text,
+            reasoning_text,
+            reasoning_max_tokens,
+            has_tool_calls=bool(tool_calls),
+        )
     # #575 — thread the request-level ``enable_thinking`` so the
     # underlying ``BaseThinkingReasoningParser.extract_reasoning``
     # can apply its symmetric-with-streaming Case-4 fallback when
@@ -425,7 +433,12 @@ def _finalize_content_and_reasoning(
             return cleaned_text, _truncate_reasoning_only(
                 reasoning_text, reasoning_max_tokens
             )
-    return _apply_reasoning_cap(cleaned_text, reasoning_text, reasoning_max_tokens)
+    return _apply_reasoning_cap(
+        cleaned_text,
+        reasoning_text,
+        reasoning_max_tokens,
+        has_tool_calls=bool(tool_calls),
+    )
 
 
 def _truncate_reasoning_only(
@@ -462,6 +475,8 @@ def _apply_reasoning_cap(
     cleaned_text: str,
     reasoning_text: str | None,
     reasoning_max_tokens: int | None,
+    *,
+    has_tool_calls: bool = False,
 ) -> tuple[str, str | None]:
     """Truncate ``reasoning_text`` to the per-request cap and reroute
     the overflow into ``cleaned_text`` (upstream vLLM PR #20859
@@ -477,14 +492,16 @@ def _apply_reasoning_cap(
     finalize all agree on a single token count.
 
     F-041 (2026-06-19): the overflow-into-``cleaned_text`` reroute is
-    only meaningful when ``cleaned_text`` is empty — i.e. the parser
-    found no closed ``</think>`` so the model never produced a real
-    answer (we'd be silently dropping the whole response otherwise).
-    When the parser DID separate a real answer (closed
-    ``<think>…</think>answer`` split — the VibeThinker / Qwen3 /
-    DeepSeek-R1 family's typical wire shape), prepending the
-    over-cap reasoning bytes pollutes the user-visible answer with
-    the truncated thought trace. The vibethinker repro at
+    only meaningful when there is NO real visible payload — i.e. the
+    parser found no closed ``</think>`` AND no tool calls fired, so
+    the model never produced a user-visible answer (we'd be silently
+    dropping the whole response otherwise). When the response DOES
+    have a real payload (closed ``<think>…</think>answer`` split, OR
+    structured ``tool_calls`` — codex r1 follow-up: tool-only responses
+    legitimately ship ``content=""`` per the OpenAI spec, so an empty
+    ``cleaned_text`` alone isn't proof that the response is empty),
+    prepending the over-cap reasoning bytes pollutes the visible
+    payload with the truncated thought trace. The vibethinker repro at
     ``reasoning_max_tokens=30`` shipped the entire post-cap reasoning
     suffix + the model's training-time system prompt into ``content``
     BEFORE the actual answer ``"The capital of Japan is **Tokyo**."``
@@ -492,9 +509,9 @@ def _apply_reasoning_cap(
     ``<think>`` case. The user opting into a small reasoning cap
     explicitly asked us to drop the reasoning past the cap; they did
     not ask us to reclassify those bytes as content. Drop the
-    overflow in that case; preserve the prepend-into-content fallback
-    when ``cleaned_text`` is empty so we don't silently drop the whole
-    response when the model never emitted a closed ``</think>``.
+    overflow when a real payload exists; preserve the prepend-into-
+    content fallback only when both ``cleaned_text`` is empty AND no
+    tool calls fired (the model emitted nothing visible).
     """
     if (
         reasoning_max_tokens is None
@@ -507,13 +524,17 @@ def _apply_reasoning_cap(
         return cleaned_text, reasoning_text
     overflow = reasoning_text[max_chars:]
     truncated = reasoning_text[:max_chars]
-    # F-041 plug: when ``cleaned_text`` already carries a real answer
-    # (parser routed the post-``</think>`` final content into it),
+    # F-041 plug: when the response already carries a real visible
+    # payload (parser routed the post-``</think>`` final content into
+    # ``cleaned_text``, OR the tool parser surfaced structured
+    # ``tool_calls`` — the OpenAI-compat ``tool_choice`` paths
+    # legitimately ship ``content=""`` alongside ``tool_calls``),
     # the model gave us its visible answer — the user-requested cap
     # is the contract, not a "best-effort don't-drop-bytes" hint, so
     # drop the over-cap reasoning suffix rather than letting it bleed
-    # into the answer channel.
-    if cleaned_text and cleaned_text.strip():
+    # into ``content`` ahead of the answer / alongside the tool call.
+    has_visible_content = bool(cleaned_text and cleaned_text.strip())
+    if has_visible_content or has_tool_calls:
         return cleaned_text, truncated
     # Codex round-11 BLOCKING: prepend overflow rather than appending
     # it. In the source ordering, the overflow bytes were emitted by


### PR DESCRIPTION
## Summary
Live vibethinker-3b-8bit repro at `reasoning_max_tokens=30` shipped the post-cap reasoning suffix + the model's training-time system prompt into `content` BEFORE the actual answer ("The capital of Japan is **Tokyo**.") — the leak shape filed as **F-041**. Same bug class as PR #722 (multi-block `<think>` sweep) but the surface was `_apply_reasoning_cap`'s overflow-into-cleaned_text fallback, not parser tag handling.

Three plug sites in `vllm_mlx/service/helpers.py:_finalize_content_and_reasoning` cover the representative VibeThinker / Qwen3 / DeepSeek-R1 production shapes:

* **`_apply_reasoning_cap` core**: when `cleaned_text` is non-empty (parser produced a real answer via closed `<think>…</think>answer` split), drop the over-cap reasoning suffix rather than prepending it. Empty-content fallback preserved.
* **Engine-routed branch**: when OutputRouter consumed `<think>` before reaching the helper (cleaned_text="" + raw_text has unclosed `<think>`), use `_truncate_reasoning_only`.
* **Parser-routed Case-4 plug**: when chat-template-injected `<think>` triggers the no-tag fallback (the path the vibethinker live repro actually hits), route through `_truncate_reasoning_only` instead of the legacy `_apply_reasoning_cap` fall-through.

## Verification
Live on vibethinker-3b-8bit (port 8097):
- **Pre-fix**: 9/10 runs at `reasoning_max_tokens=30 + max_tokens=300` leaked the post-cap reasoning trace into content
- **Post-fix**: 0/10 leaks, reasoning capped at 120 chars, content contains ONLY the actual answer (or empty when model truncated mid-thought)

## Scope
Non-streaming only. Streaming has the same bug class via a different surface (parser state mutation after synthetic `</think>` flip misclassifies post-cap reasoning bytes as content directly, bypassing the overflow plug) — out of scope, tracked as F-041 streaming follow-up.

## Test plan
- [x] 5 new F-041 regression tests in `tests/test_finalize_harmony_raw_text.py`:
  - Closed-think with real answer (live repro shape)
  - Case-4 truncated thought with `enable_thinking=True`
  - Engine-routed truncated thought (cleaned_text="")
  - Below-cap negative control
  - Qwen3 portability
- [x] `tests/test_per_request_thinking_budget.py`: `test_cap_truncates_and_overflows_to_content` renamed to `_drops_overflow_when_content_present` with new contract, plus new `_empty_fallback` test pinning silent-drop-guard semantics
- [x] All 441 tests in reasoning / finalize / cap / postprocessor / streaming suites pass
- [x] Live repro verified clean on vibethinker-3b-8bit port 8097

🤖 Generated with [Claude Code](https://claude.com/claude-code)