### PR TITLE
fix(api): reject lone-surrogate codepoints in chat messages (F-130 + F-131)

### DIFF
--- a/tests/test_lone_surrogate_validator.py
+++ b/tests/test_lone_surrogate_validator.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for F-130 + F-131 (lone-surrogate input validator).
+
+Background
+----------
+``json.loads`` accepts ``"\\uD800"`` as a valid JSON string and binds it
+to a Python ``str`` carrying the unpaired surrogate codepoint U+D800.
+HuggingFace ``tokenizers`` then raises
+``TypeError: TextEncodeInput must be Union[TextInputSequence, …]`` deep
+inside the chat-template render, producing two distinct failure shapes
+depending on the lane:
+
+  * **F-130 (non-stream)** — HTTP 500 with the generic
+    ``"Internal server error"`` body. Tokenizer crash class.
+  * **F-131 (stream)** — HTTP 200 followed by an SSE ``data:`` chunk
+    carrying the raw Python ``TypeError`` text *and* the exception
+    class name. Status-code-then-content-type contract violation plus
+    info disclosure (HuggingFace-library fingerprinting).
+
+The route-layer scanner in ``_scan_messages_for_lone_surrogates`` runs
+BEFORE the streaming branch opens its ``StreamingResponse``, so both
+lanes return a clean 400 with a precise offset before any expensive
+work (tokenizer / engine / SSE generator) is invoked.
+
+These tests pin the validator on every message slot a client can
+populate and on the must-accept side-cases (paired surrogate emoji,
+control-code ASCII) so a future tokenizer / pydantic schema change
+cannot silently weaken the gate.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.service.helpers import (
+    _find_lone_surrogate,
+    _scan_messages_for_lone_surrogates,
+)
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# Unit: the codepoint scanner itself
+# ---------------------------------------------------------------------------
+
+
+class TestFindLoneSurrogate:
+    @pytest.mark.parametrize(
+        "s,expected_offset",
+        [
+            ("\uD800", 0),  # bare lone high
+            ("\uDFFF", 0),  # bare lone low (other end of range)
+            ("\uDC00", 0),  # bare lone low (lower end)
+            ("hello \uD800 world", 6),  # mid-string lone high
+            ("abc\uDFFFxyz", 3),  # mid-string lone low
+            ("\uD801\uD802", 0),  # two lone surrogates — first wins
+        ],
+    )
+    def test_detects_lone_surrogate(self, s: str, expected_offset: int):
+        assert _find_lone_surrogate(s) == expected_offset
+
+    @pytest.mark.parametrize(
+        "s",
+        [
+            "",  # empty
+            "hello world",  # pure ASCII
+            "café",  # latin-1
+            "日本語",  # CJK (BMP, no surrogates)
+            "abc\x00def",  # NUL — orthogonal to surrogates
+            "abc\x07def",  # BEL — control code, accept
+            "﻿",  # BOM
+            "😀",  # paired emoji → single astral codepoint after json.loads
+            "Hello 😀 World",  # paired emoji embedded
+            "👨‍👩‍👧‍👦",  # ZWJ family emoji
+        ],
+    )
+    def test_accepts_valid_unicode(self, s: str):
+        # The scanner returns ``None`` when the string is encodable as
+        # UTF-8 — including all paired surrogates (already coalesced
+        # into astral codepoints by ``json.loads``).
+        assert _find_lone_surrogate(s) is None
+        # Sanity: the accepted strings really do round-trip through
+        # UTF-8 — pins the contract the scanner exists to enforce.
+        s.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Unit: the message-walker (every slot)
+# ---------------------------------------------------------------------------
+
+
+def _msg(**kwargs) -> MagicMock:
+    """Tiny stand-in for a ``Message`` pydantic instance — attribute
+    access matches the real model surface but we don't need the full
+    schema for the walker (it only reads ``content`` /
+    ``tool_call_id`` / ``tool_calls`` / ``name``)."""
+    m = MagicMock(spec=["content", "tool_call_id", "tool_calls", "name"])
+    m.content = kwargs.get("content")
+    m.tool_call_id = kwargs.get("tool_call_id")
+    m.tool_calls = kwargs.get("tool_calls")
+    m.name = kwargs.get("name")
+    return m
+
+
+class TestScanMessagesForLoneSurrogates:
+    @pytest.mark.parametrize("role", ["system", "user", "assistant", "tool"])
+    def test_lone_surrogate_in_content_string(self, role):
+        """F-130: bare lone surrogate in any role's content string."""
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates([_msg(content="hi \uD800 there")])
+        assert ei.value.status_code == 400
+        assert "lone surrogate" in ei.value.detail
+        assert "U+D800" in ei.value.detail
+        assert "messages[0].content" in ei.value.detail
+
+    def test_lone_surrogate_in_tool_call_id(self):
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates(
+                [_msg(content="ok", tool_call_id="\uDC00abc")]
+            )
+        assert ei.value.status_code == 400
+        assert "messages[0].tool_call_id" in ei.value.detail
+
+    def test_lone_surrogate_in_name(self):
+        """``name`` is not declared on our Message model today, but the
+        walker still scans it via raw-dict access so future schema
+        widening doesn't quietly drop the gate."""
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates(
+                [{"role": "user", "content": "ok", "name": "u_\uD800"}]
+            )
+        assert ei.value.status_code == 400
+        assert "messages[0].name" in ei.value.detail
+
+    def test_lone_surrogate_in_tool_calls_arguments(self):
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates(
+                [
+                    _msg(
+                        content="ok",
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "search",
+                                    "arguments": '{"q":"\uD801"}',
+                                },
+                            }
+                        ],
+                    )
+                ]
+            )
+        assert ei.value.status_code == 400
+        assert "messages[0].tool_calls" in ei.value.detail
+
+    def test_lone_surrogate_in_multimodal_text_part(self):
+        """``content`` as ``list[ContentPart]``: the text part of a
+        multimodal message must be scanned recursively, otherwise the
+        gate is bypassed by VLM clients."""
+        from vllm_mlx.api.models import ContentPart
+
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates(
+                [_msg(content=[ContentPart(type="text", text="bad \uD800")])]
+            )
+        assert ei.value.status_code == 400
+        assert "messages[0].content" in ei.value.detail
+
+    def test_lone_surrogate_in_multimodal_dict_form(self):
+        """Same as above but ``content`` is a list of dicts — the form
+        that bypasses ContentPart validation on permissive client
+        envelopes."""
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates(
+                [_msg(content=[{"type": "text", "text": "bad \uDC00"}])]
+            )
+        assert ei.value.status_code == 400
+
+    def test_mid_string_offset_is_precise(self):
+        """The error message must surface the exact offset so a client
+        can locate the bad codepoint without re-scanning client-side."""
+        with pytest.raises(HTTPException) as ei:
+            _scan_messages_for_lone_surrogates([_msg(content="0123456\uD800tail")])
+        assert "at offset 7" in ei.value.detail
+
+    # ---- accept paths -------------------------------------------------------
+
+    def test_paired_surrogate_emoji_accepted(self):
+        """``"\\uD83D\\uDE00"`` (JSON) → coalesced into U+1F600 😀 by
+        ``json.loads``. Must NOT trigger the gate; this is the
+        regression check that the validator hasn't over-rejected
+        valid astral codepoints."""
+        # Simulate ``json.loads`` round-trip — the wire form of an
+        # emoji embeds two surrogates that collapse to a single
+        # codepoint in Python ``str``.
+        s = json.loads('"hi \\uD83D\\uDE00 there"')
+        assert len(s) == len("hi ") + 1 + len(" there")
+        _scan_messages_for_lone_surrogates([_msg(content=s)])  # no raise
+
+    def test_control_codes_accepted(self):
+        """Control codes (NUL/BEL/VT) are an orthogonal class — out of
+        scope for this PR (see F-134). The validator must not
+        accidentally swallow them while reaching for surrogates."""
+        _scan_messages_for_lone_surrogates([_msg(content="abc\x07def")])  # no raise
+
+    def test_empty_messages_list_noop(self):
+        """Empty list is a no-op — the role-validation block in the
+        chat route runs first and 400s on its own, but the scanner
+        must not crash on the edge case."""
+        _scan_messages_for_lone_surrogates([])  # no raise
+
+    def test_dict_message_form_walks(self):
+        """When a caller hands raw dicts (e.g. cloud-routing path), the
+        walker must still recurse — attribute-AND-dict access pattern."""
+        with pytest.raises(HTTPException):
+            _scan_messages_for_lone_surrogates(
+                [{"role": "user", "content": "hi \uD800"}]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration: the chat route returns 400 (not 500 / not SSE-200) on both
+# the non-stream and stream lanes BEFORE any engine work is invoked
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_config():
+    """Patch select fields on the global cfg singleton and restore on exit."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _build_chat_app(patch_cfg, monkeypatch):
+    from vllm_mlx.routes import chat as chat_route
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+
+    # If the validator passes, the route would try to call the mocked
+    # engine and fail downstream — but we only check the 400 path here,
+    # so ``raise_server_exceptions=False`` keeps the test deterministic.
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestChatRouteLoneSurrogate:
+    def test_non_stream_returns_400_before_engine_invoked(
+        self, patched_config, monkeypatch
+    ):
+        """F-130: a bare lone surrogate in the user message returns
+        400, NOT 500, and NEVER reaches the engine."""
+        from vllm_mlx.routes import chat as chat_route
+
+        # Trip-wire: if the engine is ever invoked, the test fails.
+        def _explode(*_a, **_kw):
+            raise AssertionError(
+                "engine should never be invoked when input has a lone surrogate"
+            )
+
+        client = _build_chat_app(patched_config, monkeypatch)
+        engine = chat_route.get_engine("stub-model")
+        engine.chat = _explode
+        engine.stream_chat = _explode
+
+        # ``httpx``'s ``json=`` arg refuses to serialize lone surrogates
+        # (it does ``json_dumps(..., ensure_ascii=False).encode("utf-8")``,
+        # which raises the same ``UnicodeEncodeError`` the route is
+        # defending against). Build the raw JSON body ourselves so the
+        # surrogate survives the wire as the ``\\uD800`` escape exactly
+        # as a malicious client would send it.
+        raw = b'{"model":"stub-model","messages":[{"role":"user","content":"\\uD800"}],"max_tokens":5}'
+        r = client.post(
+            "/v1/chat/completions",
+            content=raw,
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 400, r.text
+        body = r.json()
+        # OpenAI-style error envelope is the project convention; the
+        # detail message must surface the field and the codepoint.
+        assert "lone surrogate" in json.dumps(body)
+        assert "U+D800" in json.dumps(body)
+
+    def test_stream_returns_400_before_sse_opens(
+        self, patched_config, monkeypatch
+    ):
+        """F-131: stream=true with a lone surrogate must NOT open the
+        SSE stream. The pre-fix behavior was HTTP 200 followed by a
+        ``data:`` chunk carrying raw Python ``TypeError`` text — both
+        the status code AND the body contract were violated."""
+        from vllm_mlx.routes import chat as chat_route
+
+        def _explode(*_a, **_kw):
+            raise AssertionError(
+                "engine should never be invoked when input has a lone surrogate"
+            )
+
+        client = _build_chat_app(patched_config, monkeypatch)
+        engine = chat_route.get_engine("stub-model")
+        engine.stream_chat = _explode
+        engine.chat = _explode
+
+        # See note on the non-stream test above — pass raw JSON bytes
+        # so the lone surrogate survives the wire as the JSON escape.
+        raw = (
+            b'{"model":"stub-model","messages":[{"role":"user",'
+            b'"content":"\\uD800"}],"max_tokens":5,"stream":true}'
+        )
+        r = client.post(
+            "/v1/chat/completions",
+            content=raw,
+            headers={"Content-Type": "application/json"},
+        )
+        # Pre-fix: r.status_code == 200, body contained
+        # ``"TextEncodeInput must be"`` and ``"TypeError"`` strings.
+        assert r.status_code == 400, r.text
+        # The response is plain JSON (HTTPException), NOT SSE. Be
+        # explicit: a 400 with an SSE-style body would still be a
+        # protocol smell, even if it carried no Python error.
+        assert "text/event-stream" not in r.headers.get("content-type", "")
+        body = r.text
+        assert "lone surrogate" in body
+        # F-131 leak guard: regardless of status code, no Python-class
+        # exception names must appear in the response.
+        assert "TypeError" not in body
+        assert "TextEncodeInput" not in body

--- a/tests/test_lone_surrogate_validator.py
+++ b/tests/test_lone_surrogate_validator.py
@@ -32,15 +32,13 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from vllm_mlx.service.helpers import (
     _find_lone_surrogate,
     _scan_messages_for_lone_surrogates,
 )
-from fastapi import HTTPException
-
 
 # ---------------------------------------------------------------------------
 # Unit: the codepoint scanner itself
@@ -51,12 +49,12 @@ class TestFindLoneSurrogate:
     @pytest.mark.parametrize(
         "s,expected_offset",
         [
-            ("\uD800", 0),  # bare lone high
-            ("\uDFFF", 0),  # bare lone low (other end of range)
-            ("\uDC00", 0),  # bare lone low (lower end)
-            ("hello \uD800 world", 6),  # mid-string lone high
-            ("abc\uDFFFxyz", 3),  # mid-string lone low
-            ("\uD801\uD802", 0),  # two lone surrogates — first wins
+            ("\ud800", 0),  # bare lone high
+            ("\udfff", 0),  # bare lone low (other end of range)
+            ("\udc00", 0),  # bare lone low (lower end)
+            ("hello \ud800 world", 6),  # mid-string lone high
+            ("abc\udfffxyz", 3),  # mid-string lone low
+            ("\ud801\ud802", 0),  # two lone surrogates — first wins
         ],
     )
     def test_detects_lone_surrogate(self, s: str, expected_offset: int):
@@ -110,7 +108,7 @@ class TestScanMessagesForLoneSurrogates:
     def test_lone_surrogate_in_content_string(self, role):
         """F-130: bare lone surrogate in any role's content string."""
         with pytest.raises(HTTPException) as ei:
-            _scan_messages_for_lone_surrogates([_msg(content="hi \uD800 there")])
+            _scan_messages_for_lone_surrogates([_msg(content="hi \ud800 there")])
         assert ei.value.status_code == 400
         assert "lone surrogate" in ei.value.detail
         assert "U+D800" in ei.value.detail
@@ -119,7 +117,7 @@ class TestScanMessagesForLoneSurrogates:
     def test_lone_surrogate_in_tool_call_id(self):
         with pytest.raises(HTTPException) as ei:
             _scan_messages_for_lone_surrogates(
-                [_msg(content="ok", tool_call_id="\uDC00abc")]
+                [_msg(content="ok", tool_call_id="\udc00abc")]
             )
         assert ei.value.status_code == 400
         assert "messages[0].tool_call_id" in ei.value.detail
@@ -130,7 +128,7 @@ class TestScanMessagesForLoneSurrogates:
         widening doesn't quietly drop the gate."""
         with pytest.raises(HTTPException) as ei:
             _scan_messages_for_lone_surrogates(
-                [{"role": "user", "content": "ok", "name": "u_\uD800"}]
+                [{"role": "user", "content": "ok", "name": "u_\ud800"}]
             )
         assert ei.value.status_code == 400
         assert "messages[0].name" in ei.value.detail
@@ -147,7 +145,7 @@ class TestScanMessagesForLoneSurrogates:
                                 "type": "function",
                                 "function": {
                                     "name": "search",
-                                    "arguments": '{"q":"\uD801"}',
+                                    "arguments": '{"q":"\ud801"}',
                                 },
                             }
                         ],
@@ -165,7 +163,7 @@ class TestScanMessagesForLoneSurrogates:
 
         with pytest.raises(HTTPException) as ei:
             _scan_messages_for_lone_surrogates(
-                [_msg(content=[ContentPart(type="text", text="bad \uD800")])]
+                [_msg(content=[ContentPart(type="text", text="bad \ud800")])]
             )
         assert ei.value.status_code == 400
         assert "messages[0].content" in ei.value.detail
@@ -176,7 +174,7 @@ class TestScanMessagesForLoneSurrogates:
         envelopes."""
         with pytest.raises(HTTPException) as ei:
             _scan_messages_for_lone_surrogates(
-                [_msg(content=[{"type": "text", "text": "bad \uDC00"}])]
+                [_msg(content=[{"type": "text", "text": "bad \udc00"}])]
             )
         assert ei.value.status_code == 400
 
@@ -184,7 +182,7 @@ class TestScanMessagesForLoneSurrogates:
         """The error message must surface the exact offset so a client
         can locate the bad codepoint without re-scanning client-side."""
         with pytest.raises(HTTPException) as ei:
-            _scan_messages_for_lone_surrogates([_msg(content="0123456\uD800tail")])
+            _scan_messages_for_lone_surrogates([_msg(content="0123456\ud800tail")])
         assert "at offset 7" in ei.value.detail
 
     # ---- accept paths -------------------------------------------------------
@@ -218,7 +216,7 @@ class TestScanMessagesForLoneSurrogates:
         walker must still recurse — attribute-AND-dict access pattern."""
         with pytest.raises(HTTPException):
             _scan_messages_for_lone_surrogates(
-                [{"role": "user", "content": "hi \uD800"}]
+                [{"role": "user", "content": "hi \ud800"}]
             )
 
 
@@ -312,9 +310,7 @@ class TestChatRouteLoneSurrogate:
         assert "lone surrogate" in json.dumps(body)
         assert "U+D800" in json.dumps(body)
 
-    def test_stream_returns_400_before_sse_opens(
-        self, patched_config, monkeypatch
-    ):
+    def test_stream_returns_400_before_sse_opens(self, patched_config, monkeypatch):
         """F-131: stream=true with a lone surrogate must NOT open the
         SSE stream. The pre-fix behavior was HTTP 200 followed by a
         ``data:`` chunk carrying raw Python ``TypeError`` text — both

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -62,6 +62,7 @@ from ..service.helpers import (
     _resolve_model_name,
     _resolve_temperature,
     _resolve_top_p,
+    _scan_messages_for_lone_surrogates,
     _tool_use_required_named_suffix,
     _validate_model_name,
     _validate_tool_call_params,
@@ -468,6 +469,19 @@ async def _create_chat_completion_impl(
                 status_code=400,
                 detail=f"Invalid role '{msg.role}'. Must be one of: {', '.join(sorted(_valid_roles))}",
             )
+
+    # Reject lone-surrogate codepoints in any message-content slot
+    # (F-130 + F-131). ``json.loads`` accepts ``"\\uD800"`` as a valid
+    # JSON string and binds it to a Python ``str`` carrying the
+    # unpaired surrogate; HuggingFace ``tokenizers`` then raises
+    # ``TypeError: TextEncodeInput must be …`` deep inside the
+    # chat-template render, producing either a 500 (non-stream) or —
+    # WORSE — an HTTP 200 with the raw Python error text leaked in an
+    # SSE ``data:`` chunk (stream). The route-layer gate runs BEFORE
+    # the streaming branch opens its ``StreamingResponse``, so the
+    # SSE-leak path in F-131 is closed by construction (a 400 is
+    # returned before any byte of SSE is flushed).
+    _scan_messages_for_lone_surrogates(request.messages)
 
     # Validate n parameter (only n=1 supported)
     if request.n is not None and request.n > 1:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1231,6 +1231,142 @@ def _resolve_reasoning_enabled(model_name: str | None) -> bool:
     return cfg.reasoning_parser is not None or bool(cfg.reasoning_parser_name)
 
 
+# ── Unicode validation (F-130 / F-131) ─────────────────────────────
+
+
+def _find_lone_surrogate(s: str) -> int | None:
+    """Return the offset of the first lone surrogate codepoint in ``s``,
+    or ``None`` when the string is encodable as UTF-8.
+
+    A Python ``str`` is a sequence of Unicode codepoints; ``json.loads``
+    happily decodes ``"\\uD800"`` into a single-code-unit ``str``
+    carrying codepoint U+D800. That codepoint is RESERVED for the
+    high half of a UTF-16 surrogate pair and is not valid UTF-8 on its
+    own — every downstream consumer (HuggingFace ``tokenizers`` /
+    chat-template renderers / ``str.encode("utf-8")``) raises when
+    handed one. F-130 (non-stream 500) and F-131 (stream 200 + raw
+    Python error leak via SSE) are the same crash class surfacing on
+    different lanes; rejecting the payload at the JSON-input boundary
+    closes both at once.
+
+    Properly-paired surrogates from JSON ``\\uD83D\\uDE00`` are
+    coalesced by ``json.loads`` into a single astral codepoint
+    (U+1F600 😀, ``len(s)==1``) before the ``str`` reaches Python, so
+    valid emoji never hit this branch — we only catch the unpaired
+    case the spec leaves ambiguous.
+
+    Returning the offset (instead of just a bool) lets the caller
+    surface a precise location in the error message, matching the
+    diagnostic surface of the sibling ``max_tokens`` / ``top_p``
+    validators in the chat route.
+    """
+    for i, ch in enumerate(s):
+        cp = ord(ch)
+        # Surrogate range per Unicode 15.1 §3.8: high surrogates
+        # U+D800–U+DBFF, low surrogates U+DC00–U+DFFF. Any codepoint
+        # in the combined range that survived ``json.loads`` is by
+        # definition unpaired (paired surrogates from JSON are
+        # coalesced into the astral codepoint they encode).
+        if 0xD800 <= cp <= 0xDFFF:
+            return i
+    return None
+
+
+def _scan_messages_for_lone_surrogates(messages: list) -> None:
+    """Raise ``HTTPException(400)`` if any message slot carries a lone
+    surrogate codepoint (F-130 / F-131).
+
+    Covered slots — every string surface a client can populate that
+    eventually flows into the chat template / tokenizer:
+
+      * ``messages[i].content`` — plain string AND every ``text`` /
+        ``image_url.url`` / ``video_url.url`` / ``audio_url.url`` slot
+        of the multimodal ``list[ContentPart|dict]`` form
+      * ``messages[i].tool_call_id`` — tool-response messages
+      * ``messages[i].tool_calls[].function.name`` /
+        ``messages[i].tool_calls[].function.arguments`` /
+        ``messages[i].tool_calls[].id`` — assistant turns replaying
+        prior tool calls
+      * ``messages[i].name`` — OpenAI optional message author name
+
+    Running at the route layer (sibling to the ``_valid_roles`` /
+    ``max_tokens`` / ``top_p`` block) means the gate fires BEFORE the
+    streaming branch opens an SSE response, so F-131's
+    ``200 + data: chunk-with-Python-error`` leak cannot happen — the
+    client sees a clean 400 with the precise offset before any byte
+    of SSE is flushed.
+    """
+
+    def _check(value, path: str) -> None:
+        if isinstance(value, str):
+            offset = _find_lone_surrogate(value)
+            if offset is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid unicode in {path}: lone surrogate "
+                        f"codepoint U+{ord(value[offset]):04X} at offset "
+                        f"{offset} (surrogates must appear as paired "
+                        "high/low to encode an astral codepoint)."
+                    ),
+                )
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                _check(v, f"{path}.{k}" if isinstance(k, str) else path)
+        elif isinstance(value, list):
+            for j, item in enumerate(value):
+                _check(item, f"{path}[{j}]")
+        elif hasattr(value, "model_dump"):
+            # Pydantic ``BaseModel`` instance — e.g. ``ContentPart`` for
+            # multimodal messages, or ``ImageUrl`` / ``VideoUrl`` /
+            # ``AudioUrl`` nested URLs. Recurse via ``model_dump`` so the
+            # scan covers every string field without enumerating each
+            # pydantic class by hand (declared on ``api/models.py``).
+            # Without this branch, ``content=[ContentPart(text="\\uD801")]``
+            # bypasses the scan (the value is neither str/dict/list) and
+            # the lone surrogate falls through to the tokenizer crash —
+            # exactly the F-130 surface in the "multimodal text part"
+            # slot.
+            _check(value.model_dump(), path)
+
+    for i, msg in enumerate(messages):
+        # Pydantic Message or raw dict — normalize via attribute lookup.
+        # ``content`` may be str | list[ContentPart] | list[dict] | None;
+        # the recursive ``_check`` walks all three shapes uniformly.
+        content = msg.content if hasattr(msg, "content") else msg.get("content")
+        if content is not None:
+            _check(content, f"messages[{i}].content")
+
+        tcid = (
+            msg.tool_call_id
+            if hasattr(msg, "tool_call_id")
+            else (msg.get("tool_call_id") if isinstance(msg, dict) else None)
+        )
+        if tcid is not None:
+            _check(tcid, f"messages[{i}].tool_call_id")
+
+        # ``name`` is an OpenAI-spec optional message-author field. Not
+        # declared on our ``Message`` pydantic model today (silently
+        # dropped on parse), but client SDKs still send it and a
+        # future-proof scanner shouldn't depend on whether the field
+        # makes it past pydantic — check the raw dict form too.
+        name = (
+            msg.name
+            if hasattr(msg, "name") and getattr(msg, "name", None) is not None
+            else (msg.get("name") if isinstance(msg, dict) else None)
+        )
+        if name is not None:
+            _check(name, f"messages[{i}].name")
+
+        tcs = (
+            msg.tool_calls
+            if hasattr(msg, "tool_calls")
+            else (msg.get("tool_calls") if isinstance(msg, dict) else None)
+        )
+        if tcs:
+            _check(tcs, f"messages[{i}].tool_calls")
+
+
 def _validate_model_name(request_model: str) -> None:
     """Validate that the request model name matches a served model."""
     if request_model is None:
@@ -1592,11 +1728,28 @@ async def _disconnect_guard(
                 )
                 import json as _json
 
+                # F-131 belt-and-suspenders: never leak the raw Python
+                # exception message or class name through the SSE
+                # ``data:`` payload. Pre-fix, a tokenizer crash (e.g.
+                # the lone-surrogate ``TypeError``) surfaced inline in
+                # the stream as
+                # ``{"error":{"message":"Internal error during
+                # streaming: TextEncodeInput must be …","type":
+                # "TypeError"}}`` — useful for HuggingFace-library
+                # fingerprinting and breaking the OpenAI SSE contract
+                # (error payloads should not carry Python type names).
+                # The route-level ``_scan_messages_for_lone_surrogates``
+                # gate closes the primary path; this sanitization
+                # remains for any OTHER mid-stream exception so the
+                # ``200 + raw Python traceback in SSE`` shape can never
+                # surface from this entry point. The full exception is
+                # logged above with ``exc_info`` so operators retain
+                # the diagnostic detail server-side.
                 error_data = _json.dumps(
                     {
                         "error": {
-                            "message": f"Internal error during streaming: {exc}",
-                            "type": type(exc).__name__,
+                            "message": "Internal error during streaming",
+                            "type": "internal_error",
                         }
                     }
                 )


### PR DESCRIPTION
## Summary

A JSON message containing an unpaired surrogate codepoint (e.g. `"\uD800"`) decodes into a Python `str` that cannot be re-encoded as UTF-8. HuggingFace `tokenizers` raises `TypeError: TextEncodeInput must be Union[TextInputSequence, ...]` deep inside the chat-template render, producing two distinct crash shapes:

- **F-130 (non-stream, HIGH)** — HTTP **500** with `"Internal server error"`.
- **F-131 (stream, HIGH)** — HTTP **200**, then an SSE `data:` chunk leaking the raw Python `TypeError` text **and** the exception class name. Status-code + content-type contract violation + HuggingFace-library fingerprinting leak.

Same root-cause class; one PR closes both.

## Fix

- **`vllm_mlx/service/helpers.py`** — new `_scan_messages_for_lone_surrogates` recursively walks `content` (str / `list[ContentPart]` / `list[dict]`, including nested `text` / `image_url.url` / `video_url.url` / `audio_url.url`), `tool_call_id`, `name`, and `tool_calls[].function.{name,arguments}`. Lone surrogates in U+D800-U+DFFF surviving `json.loads` (which coalesces properly-paired surrogates into astral codepoints before they reach Python) raise `HTTPException(400)` with the precise offset.
- **`vllm_mlx/routes/chat.py`** — call the scanner from the existing validation block (sibling to `_valid_roles` / `max_tokens` / `top_p`), BEFORE the streaming branch opens its `StreamingResponse`. F-131's SSE-leak surface is closed by construction: the 400 returns before any byte of SSE is flushed.
- **`vllm_mlx/service/helpers.py::_disconnect_guard`** — belt-and-suspenders for any OTHER mid-stream exception: the SSE error payload no longer interpolates raw exception text / class name. Operators retain full detail via the existing `exc_info=True` server log.

## Repro (before + after, llama3-1b-4bit on :8085)

**F-130 non-stream**
```
# before: HTTP 500 {"error":{"message":"Internal server error"}}
# after:  HTTP 400 "Invalid unicode in messages[0].content: lone surrogate codepoint U+D800 at offset 0 ..."
```

**F-131 stream**
```
# before: HTTP 200 + SSE chunk: {"error":{"message":"Internal error during streaming: TextEncodeInput must be ...","type":"TypeError"}}
# after:  HTTP 400 (plain JSON; no SSE opens, no Python class name leaked)
```

## Test plan

- [x] Run new `tests/test_lone_surrogate_validator.py` (32 tests pass) — parametrized over every message slot (system/user/assistant/tool/name), bare AND mid-string lone surrogates (high + low ends), tool-call args, multimodal text part (ContentPart + raw dict), accept-paths (paired emoji, control codes, CJK, empty), and end-to-end chat-route assertions for both lanes with a trip-wire that fails if the mocked engine is ever invoked.
- [x] `pytest tests/test_api_validation_bundle.py` — no regression on existing route validators.
- [x] Live verify on `llama3-1b-4bit:8085` for F-130 + F-131 + multimodal text + tool_call_id + system slot + paired-emoji accept path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)