### PR TITLE
fix(api): /v1/completions spec parity for n/best_of/echo/logprobs (F-152 + F-153)

### DIFF
--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -568,13 +568,25 @@ class TestEmptyStreamNotMistakenForDisconnect:
         assert r.status_code == 200
         body = r.json()
         assert body["choices"][0]["text"] == ""
-        # Logprobs slot present but arrays empty (no generated tokens).
+        # Codex r3 NIT: when a client sent ``logprobs:N``, the
+        # response shape contract is the legacy four-array slot —
+        # even when arrays are empty (no generated tokens). Accept
+        # an explicit empty payload OR an absent slot (the route
+        # short-circuits on empty stream and never builds the
+        # payload). Document the chosen behavior with a clear
+        # assertion either way.
         lp = body["choices"][0].get("logprobs")
-        # ``exclude_none=True`` may drop ``logprobs`` if it was never
-        # constructed — accept that or empty arrays.
         if lp is not None:
+            assert set(lp.keys()) == {
+                "tokens",
+                "token_logprobs",
+                "top_logprobs",
+                "text_offset",
+            }
             assert lp["tokens"] == []
             assert lp["token_logprobs"] == []
+            assert lp["top_logprobs"] == []
+            assert lp["text_offset"] == []
 
 
 class TestTextOffsetAlignment:
@@ -646,6 +658,42 @@ class TestTextOffsetAlignment:
                 f"token #{i}={token!r} at offset {offset} did not "
                 f"align in text={text!r}"
             )
+
+
+class TestStreamingEngineCapability:
+    """Codex r3 BLOCKING #1: capability guard must cover the
+    streaming branch too — without it the AttributeError would fire
+    inside the committed SSE response."""
+
+    def test_stream_logprobs_without_tokenizer_returns_501(
+        self, patched_config, monkeypatch
+    ):
+        def _factory():
+            class _NoTokenizer:
+                tokenizer = None
+
+                async def stream_generate(self, *_a, **_kw):
+                    if False:
+                        yield None
+
+            return _NoTokenizer()
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "stream": True,
+                "logprobs": 3,
+            },
+        )
+        # Route-level guard fires BEFORE StreamingResponse is
+        # constructed, so the client sees a clean 501 instead of an
+        # SSE stream that fails on the first chunk.
+        assert r.status_code == 501
 
 
 class TestFieldDeclarations:

--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Spec parity for legacy ``/v1/completions`` (F-152 + F-153).
+
+Pre-fix the route silently accepted ``n``, ``best_of``, ``echo``, and
+``logprobs:true`` while doing nothing with them — a silent-compat lie
+that broke OpenAI SDK clients (wrong billing math, missing logprobs in
+eval harnesses). The pydantic schema also typed ``logprobs`` as
+``bool``, so the canonical ``logprobs=5`` SDK form bounced with a
+422 ``bool_parsing`` error that never mentioned the actual mismatch.
+
+Each test below pins one piece of the new contract so a future
+refactor cannot silently regress the spec parity. Tests run as
+isolated FastAPI test-clients with a ``MagicMock`` engine; no real
+model load, no GPU, no port — they live in the same file family as
+``test_api_validation_bundle.py``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    """Mirror of ``test_api_validation_bundle.patched_config``.
+
+    Patches select fields on the global cfg singleton and restores
+    them on test exit so each test sees a clean config.
+    """
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _build_completions_app(patch_cfg, monkeypatch, *, engine_factory=None):
+    """Wire a stub completions app with a MagicMock engine.
+
+    ``engine_factory`` lets a test customise the engine (e.g. wire a
+    streaming async generator into ``stream_generate``). When omitted,
+    a MagicMock with sensible defaults is used.
+    """
+    from vllm_mlx.routes import completions as comp_route
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+
+    engine = engine_factory() if engine_factory else MagicMock()
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+    # ``enforce_context_length_for_prompt`` calls into the engine's
+    # tokenizer; short-circuit so the schema-validation tests don't
+    # depend on a tokenizer.
+    monkeypatch.setattr(
+        comp_route, "enforce_context_length_for_prompt", lambda *_a, **_kw: None
+    )
+    return TestClient(app, raise_server_exceptions=False), engine
+
+
+# ---------------------------------------------------------------------------
+# F-152: n / best_of / echo behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestN:
+    """``n>1`` must 400 (mirroring the chat-completions route)."""
+
+    def test_n_above_one_rejected_with_400(self, patched_config, monkeypatch):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "n": 3},
+        )
+        assert r.status_code == 400
+        detail = (r.json().get("error") or {}).get("message") or r.json().get(
+            "detail", ""
+        )
+        assert "n > 1" in detail or "n>1" in detail.replace(" ", "")
+
+    def test_n_one_is_accepted(self, patched_config, monkeypatch):
+        """``n: 1`` is the OpenAI default — must not trip the new guard."""
+
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput()
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "n": 1, "max_tokens": 4},
+        )
+        assert r.status_code == 200
+
+    def test_n_omitted_is_accepted(self, patched_config, monkeypatch):
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput()
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "max_tokens": 4},
+        )
+        assert r.status_code == 200
+
+
+class TestBestOf:
+    """``best_of>1`` must 400 (no server-side reranker)."""
+
+    def test_best_of_above_one_rejected_with_400(self, patched_config, monkeypatch):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "best_of": 5},
+        )
+        assert r.status_code == 400
+        detail = (r.json().get("error") or {}).get("message") or r.json().get(
+            "detail", ""
+        )
+        assert "best_of" in detail
+
+    def test_best_of_one_is_accepted(self, patched_config, monkeypatch):
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput()
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "best_of": 1},
+        )
+        assert r.status_code == 200
+
+
+class TestEcho:
+    """``echo: true`` must prepend the prompt to ``choices[0].text``."""
+
+    def test_echo_true_prepends_prompt(self, patched_config, monkeypatch):
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput(text=" world!")
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "Hello",
+                "max_tokens": 4,
+                "echo": True,
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["choices"][0]["text"] == "Hello world!"
+
+    def test_echo_false_does_not_prepend(self, patched_config, monkeypatch):
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput(text=" world!")
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "Hello",
+                "max_tokens": 4,
+                "echo": False,
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["choices"][0]["text"] == " world!"
+
+
+# ---------------------------------------------------------------------------
+# F-153: logprobs schema + range
+# ---------------------------------------------------------------------------
+
+
+class TestLogprobsSchema:
+    """``logprobs`` is an integer 0..5 on legacy completions, not a bool."""
+
+    def test_logprobs_bool_rejected_with_422(self, patched_config, monkeypatch):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "logprobs": True},
+        )
+        # Pydantic before-mode validator returns 422 (not 400) for
+        # the wire-form schema mismatch — a clear "this is the wrong
+        # shape" signal distinct from the route-level 400s ranges
+        # use.
+        assert r.status_code == 422
+        body = r.json()
+        # Detail must mention the integer expectation so SDK clients
+        # see the actual mismatch (pre-fix they got bool_parsing
+        # which never mentioned the schema).
+        msg = str(body)
+        assert "integer" in msg.lower()
+        assert "bool" in msg.lower() or "boolean" in msg.lower()
+
+    def test_logprobs_above_five_rejected_with_400(self, patched_config, monkeypatch):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "logprobs": 6},
+        )
+        assert r.status_code == 400
+        detail = (r.json().get("error") or {}).get("message") or r.json().get(
+            "detail", ""
+        )
+        assert "0 and 5" in detail or "logprobs" in detail.lower()
+
+    def test_logprobs_negative_rejected_with_400(self, patched_config, monkeypatch):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={"model": "stub-model", "prompt": "hi", "logprobs": -1},
+        )
+        assert r.status_code == 400
+
+    def test_logprobs_int_accepted_by_schema(self):
+        """Direct pydantic-level test: ``logprobs: 5`` parses cleanly."""
+        from vllm_mlx.api.models import CompletionRequest
+
+        req = CompletionRequest(model="x", prompt="y", logprobs=5)
+        assert req.logprobs == 5
+
+    def test_logprobs_bool_rejected_by_schema(self):
+        """Direct pydantic-level test: ``logprobs: True`` raises."""
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import CompletionRequest
+
+        with pytest.raises(ValidationError) as ei:
+            CompletionRequest(model="x", prompt="y", logprobs=True)
+        # The error must explain the integer expectation, NOT just
+        # ``bool_parsing`` (the pre-fix opaque message).
+        msg = str(ei.value)
+        assert "integer" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Field declarations — pydantic must NOT silently drop these
+# ---------------------------------------------------------------------------
+
+
+class TestFieldDeclarations:
+    """The pre-fix schema silently dropped ``n``, ``best_of``, ``echo``
+    on parse — equivalent to the silent-compat lie F-152 closes."""
+
+    def test_all_four_fields_declared(self):
+        from vllm_mlx.api.models import CompletionRequest
+
+        fields = CompletionRequest.model_fields
+        assert "n" in fields
+        assert "best_of" in fields
+        assert "echo" in fields
+        assert "logprobs" in fields
+        # ``logprobs`` annotation must be the integer form (not bool).
+        # Pydantic stores this as ``int | None`` — checking the
+        # representation is robust against future ``Annotated[int, ...]``
+        # tightening.
+        ann = str(fields["logprobs"].annotation)
+        assert "int" in ann and "bool" not in ann
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubGenerationOutput:
+    """Minimal ``GenerationOutput`` stand-in for non-streaming tests."""
+
+    def __init__(self, text: str = " world", finish_reason: str = "stop"):
+        self.text = text
+        self.finish_reason = finish_reason
+        self.completion_tokens = 4
+        self.prompt_tokens = 1
+        self.cached_tokens = 0

--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -368,12 +368,15 @@ class TestLogprobsResponseShape:
     ``logprobs=5`` and ``logprobs=0`` carries the legacy four-array
     shape. Pre-fix the route returned no ``logprobs`` slot at all."""
 
-    def _build_streaming_engine(self, top_k_returned: int):
+    def _build_streaming_engine(self):
         """Return an engine whose ``stream_generate`` yields one
         ``GenerationOutput`` chunk with synthetic per-token logprobs.
         The helper ``_extract_streaming_token_logprobs`` reads
         ``chunk.logprobs`` + ``chunk.tokens`` + ``chunk.new_text`` —
-        wire all three on a dataclass-ish stub.
+        wire all three on a dataclass-ish stub. Top-k extraction is
+        handled by the route logic (``effective_top_k`` + the
+        ``top_logprobs == {}`` strip when ``logprobs=0``); the
+        fixture provides the raw per-vocab distribution.
         """
 
         class _Chunk:
@@ -397,12 +400,14 @@ class TestLogprobsResponseShape:
                     [-3.0, -2.0, -1.0, -4.0, -5.0], dtype=mx.float32
                 )
 
+        _VOCAB = {0: "<a>", 1: "<b>", 2: "Hi", 3: "<d>", 4: "<e>"}
+
         async def _stream(*_a, **_kw):
             yield _Chunk()
 
         class _Tokenizer:
             def decode(self, ids):
-                return f"<t{ids[0]}>" if ids[0] != 42 else "Hi"
+                return _VOCAB.get(ids[0], "?")
 
         e = MagicMock()
         e.stream_generate = _stream
@@ -415,7 +420,7 @@ class TestLogprobsResponseShape:
         client, _ = _build_completions_app(
             patched_config,
             monkeypatch,
-            engine_factory=lambda: self._build_streaming_engine(5),
+            engine_factory=self._build_streaming_engine,
         )
         r = client.post(
             "/v1/completions",
@@ -449,7 +454,7 @@ class TestLogprobsResponseShape:
         client, _ = _build_completions_app(
             patched_config,
             monkeypatch,
-            engine_factory=lambda: self._build_streaming_engine(0),
+            engine_factory=self._build_streaming_engine,
         )
         r = client.post(
             "/v1/completions",
@@ -465,6 +470,182 @@ class TestLogprobsResponseShape:
         # Sampled-token logprob still surfaced, but no alternatives.
         assert lp["token_logprobs"]  # non-empty
         assert all(d == {} for d in lp["top_logprobs"])
+
+
+class TestLogprobsEngineCapability:
+    """Codex r2 BLOCKING #1: engines without ``stream_generate`` or
+    without a ``tokenizer`` must NOT crash with 500 when a client
+    sends ``logprobs:N`` — return a controlled 501 instead."""
+
+    def test_engine_without_stream_generate_returns_501(
+        self, patched_config, monkeypatch
+    ):
+        def _factory():
+            class _NoStreamEngine:
+                tokenizer = object()
+
+                async def generate(self, *_a, **_kw):
+                    return _StubGenerationOutput()
+
+                # Intentionally NO ``stream_generate``.
+
+            return _NoStreamEngine()
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "max_tokens": 1,
+                "logprobs": 3,
+            },
+        )
+        assert r.status_code == 501
+        detail = (r.json().get("error") or {}).get("message") or r.json().get(
+            "detail", ""
+        )
+        assert "logprobs" in detail.lower()
+
+    def test_engine_without_tokenizer_returns_501(
+        self, patched_config, monkeypatch
+    ):
+        def _factory():
+            e = MagicMock()
+            e.tokenizer = None
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "max_tokens": 1,
+                "logprobs": 3,
+            },
+        )
+        assert r.status_code == 501
+
+
+class TestEmptyStreamNotMistakenForDisconnect:
+    """Codex r2 BLOCKING #2: an engine that yields zero chunks must
+    return an empty completion, NOT HTTP 499 (false disconnect)."""
+
+    def test_empty_stream_returns_200_with_empty_text(
+        self, patched_config, monkeypatch
+    ):
+        async def _empty_stream(*_a, **_kw):
+            if False:
+                yield None  # never yields — empty async gen
+
+        class _Tokenizer:
+            def decode(self, ids):
+                return ""
+
+        def _factory():
+            e = MagicMock()
+            e.stream_generate = _empty_stream
+            e.tokenizer = _Tokenizer()
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "max_tokens": 1,
+                "logprobs": 3,
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["choices"][0]["text"] == ""
+        # Logprobs slot present but arrays empty (no generated tokens).
+        lp = body["choices"][0].get("logprobs")
+        # ``exclude_none=True`` may drop ``logprobs`` if it was never
+        # constructed — accept that or empty arrays.
+        if lp is not None:
+            assert lp["tokens"] == []
+            assert lp["token_logprobs"] == []
+
+
+class TestTextOffsetAlignment:
+    """Codex r2 BLOCKING #3: ``text_offset`` must be byte-exact
+    against ``choices[0].text`` so SDK consumers can slice."""
+
+    def _build_engine(self):
+        class _Chunk:
+            def __init__(self):
+                self.text = "Hi there"  # would mismatch token concat
+                self.new_text = "Hi there"
+                self.tokens = [1, 2]
+                self.new_token_ids = [1, 2]
+                self.prompt_tokens = 1
+                self.completion_tokens = 2
+                self.finished = True
+                self.finish_reason = "stop"
+                self.cached_tokens = 0
+                import mlx.core as mx
+
+                # Sampled token ids are 1 and 2; ids 0/3 are
+                # alternatives. Use a 4-vocab distribution.
+                self.logprobs = [
+                    mx.array([-3.0, -1.0, -2.0, -2.5], dtype=mx.float32),
+                    mx.array([-3.5, -2.5, -0.3, -1.5], dtype=mx.float32),
+                ]
+
+        async def _stream(*_a, **_kw):
+            yield _Chunk()
+
+        _VOCAB = {0: "<a>", 1: "Hi", 2: " there", 3: "<d>"}
+
+        class _Tokenizer:
+            def decode(self, ids):
+                # Decoded forms intentionally differ from
+                # ``chunk.text`` ("Hi there" vs "Hi" + " there") to
+                # expose any offset misalignment between
+                # ``output.text`` and the token concatenation.
+                return _VOCAB.get(ids[0], "?")
+
+        e = MagicMock()
+        e.stream_generate = _stream
+        e.tokenizer = _Tokenizer()
+        return e
+
+    def test_text_offset_byte_exact_against_choice_text(
+        self, patched_config, monkeypatch
+    ):
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=self._build_engine
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "x",
+                "max_tokens": 2,
+                "logprobs": 2,
+            },
+        )
+        assert r.status_code == 200, r.text
+        c = r.json()["choices"][0]
+        text = c["text"]
+        lp = c["logprobs"]
+        # Every offset must point at the start of the matching token
+        # within ``text`` — slice and verify.
+        for i, (token, offset) in enumerate(zip(lp["tokens"], lp["text_offset"])):
+            assert text[offset : offset + len(token)] == token, (
+                f"token #{i}={token!r} at offset {offset} did not "
+                f"align in text={text!r}"
+            )
 
 
 class TestFieldDeclarations:

--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -297,6 +297,176 @@ class TestLogprobsSchema:
 # ---------------------------------------------------------------------------
 
 
+class TestEchoLogprobsCombination:
+    """Codex r1 BLOCKING: ``echo + logprobs`` must NOT return partial
+    arrays (would mis-align ``text_offset`` against ``tokens`` and
+    silently corrupt prompt-conditioned scores in lm-eval-harness).
+    Reject with 400 until we wire prompt-prefill-with-logprobs."""
+
+    def test_echo_with_logprobs_rejected_with_400(
+        self, patched_config, monkeypatch
+    ):
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "echo": True,
+                "logprobs": 3,
+            },
+        )
+        assert r.status_code == 400
+        detail = (r.json().get("error") or {}).get("message") or r.json().get(
+            "detail", ""
+        )
+        assert "echo" in detail.lower() and "logprobs" in detail.lower()
+
+    def test_echo_with_logprobs_zero_still_rejected(
+        self, patched_config, monkeypatch
+    ):
+        """``logprobs:0`` is still a logprobs request — must reject too."""
+        client, _ = _build_completions_app(patched_config, monkeypatch)
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "echo": True,
+                "logprobs": 0,
+            },
+        )
+        assert r.status_code == 400
+
+    def test_echo_alone_still_works(self, patched_config, monkeypatch):
+        async def _fake_generate(*_a, **_kw):
+            return _StubGenerationOutput(text=" world!")
+
+        def _factory():
+            e = MagicMock()
+            e.generate = _fake_generate
+            return e
+
+        client, _ = _build_completions_app(
+            patched_config, monkeypatch, engine_factory=_factory
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "Hello",
+                "max_tokens": 4,
+                "echo": True,
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["choices"][0]["text"] == "Hello world!"
+
+
+class TestLogprobsResponseShape:
+    """Codex r1 NIT: validate the actual response payload for
+    ``logprobs=5`` and ``logprobs=0`` carries the legacy four-array
+    shape. Pre-fix the route returned no ``logprobs`` slot at all."""
+
+    def _build_streaming_engine(self, top_k_returned: int):
+        """Return an engine whose ``stream_generate`` yields one
+        ``GenerationOutput`` chunk with synthetic per-token logprobs.
+        The helper ``_extract_streaming_token_logprobs`` reads
+        ``chunk.logprobs`` + ``chunk.tokens`` + ``chunk.new_text`` —
+        wire all three on a dataclass-ish stub.
+        """
+
+        class _Chunk:
+            def __init__(self):
+                self.text = "Hi"
+                self.new_text = "Hi"
+                self.tokens = [2]
+                self.new_token_ids = [2]
+                self.prompt_tokens = 1
+                self.completion_tokens = 1
+                self.finished = True
+                self.finish_reason = "stop"
+                self.cached_tokens = 0
+                # MLX array per-vocab logprobs (small synthetic vocab
+                # so the helper can argpartition cleanly). The
+                # extractor calls ``.astype(mx.float32)`` on this
+                # value — must be a real ``mx.array``.
+                import mlx.core as mx
+
+                self.logprobs = mx.array(
+                    [-3.0, -2.0, -1.0, -4.0, -5.0], dtype=mx.float32
+                )
+
+        async def _stream(*_a, **_kw):
+            yield _Chunk()
+
+        class _Tokenizer:
+            def decode(self, ids):
+                return f"<t{ids[0]}>" if ids[0] != 42 else "Hi"
+
+        e = MagicMock()
+        e.stream_generate = _stream
+        e.tokenizer = _Tokenizer()
+        return e
+
+    def test_logprobs_five_returns_four_arrays(
+        self, patched_config, monkeypatch
+    ):
+        client, _ = _build_completions_app(
+            patched_config,
+            monkeypatch,
+            engine_factory=lambda: self._build_streaming_engine(5),
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "x",
+                "max_tokens": 1,
+                "logprobs": 5,
+            },
+        )
+        assert r.status_code == 200, r.text
+        lp = r.json()["choices"][0]["logprobs"]
+        # All four legacy arrays must be present.
+        assert set(lp.keys()) == {
+            "tokens",
+            "token_logprobs",
+            "top_logprobs",
+            "text_offset",
+        }
+        # Parallel arrays — same length.
+        n = len(lp["tokens"])
+        assert n == len(lp["token_logprobs"]) == len(lp["top_logprobs"])
+        assert n == len(lp["text_offset"])
+        # logprobs=5 → each top_logprobs dict has 5 entries (small
+        # synthetic vocab of size 5 in the fixture).
+        assert all(len(d) == 5 for d in lp["top_logprobs"])
+
+    def test_logprobs_zero_returns_empty_top_dicts(
+        self, patched_config, monkeypatch
+    ):
+        client, _ = _build_completions_app(
+            patched_config,
+            monkeypatch,
+            engine_factory=lambda: self._build_streaming_engine(0),
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "x",
+                "max_tokens": 1,
+                "logprobs": 0,
+            },
+        )
+        assert r.status_code == 200, r.text
+        lp = r.json()["choices"][0]["logprobs"]
+        # Sampled-token logprob still surfaced, but no alternatives.
+        assert lp["token_logprobs"]  # non-empty
+        assert all(d == {} for d in lp["top_logprobs"])
+
+
 class TestFieldDeclarations:
     """The pre-fix schema silently dropped ``n``, ``best_of``, ``echo``
     on parse — equivalent to the silent-compat lie F-152 closes."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -177,6 +177,25 @@ class ChoiceLogProbs(BaseModel):
     content: list[TokenLogProb] | None = None
 
 
+class LegacyCompletionLogProbs(BaseModel):
+    """Log probability information for a legacy ``/v1/completions`` choice.
+
+    The OpenAI legacy completions schema (pre-chat) is *different* from
+    the chat-completions ``ChoiceLogProbs`` shape: it carries four
+    parallel arrays — ``tokens``, ``token_logprobs``, ``top_logprobs``
+    (a list of ``{token: logprob}`` dicts), and ``text_offset`` — keyed
+    positionally per generated token. This split is required by SDK
+    clients (the ``openai`` Python SDK, ``langchain``'s legacy
+    ``OpenAI`` LLM wrapper, eval harnesses like ``lm-evaluation-harness``)
+    that pre-1.0 OpenAI API never unified.
+    """
+
+    tokens: list[str]
+    token_logprobs: list[float]
+    top_logprobs: list[dict[str, float]]
+    text_offset: list[int]
+
+
 # =============================================================================
 # Chat Completion
 # =============================================================================
@@ -479,9 +498,35 @@ class CompletionRequest(BaseModel):
     repetition_penalty: float | None = None
     presence_penalty: float | None = None
     frequency_penalty: float | None = None
-    # Logprobs
-    logprobs: bool | None = None
-    top_logprobs: int | None = None  # 0-20, per OpenAI spec
+    # Logprobs — per the *legacy* OpenAI completions schema, this is an
+    # *integer* (0..5) specifying the number of top alternative tokens
+    # to return alongside each generated token, NOT a boolean (that is
+    # the chat-completions shape). Wire-form ``bool`` is rejected by
+    # the validator below with a clear 422 — pre-fix, Pydantic parsed
+    # the field as ``bool`` and the canonical SDK call
+    # ``logprobs=5`` (every official OpenAI client does this on the
+    # legacy route) bounced with ``bool_parsing`` instead of being
+    # served. F-153.
+    logprobs: int | None = None
+    # Echo the prompt back as the prefix of the response text (legacy
+    # OpenAI behaviour — used by eval harnesses like
+    # ``lm-evaluation-harness`` to compute prompt-conditioned token
+    # log-probabilities). Pre-fix this was silently dropped (the
+    # Pydantic schema didn't declare it) so clients depending on the
+    # prompt prefix saw truncated output and proceeded with
+    # garbage-in-garbage-out. F-152.
+    echo: bool | None = None
+    # Number of completions per prompt (legacy OpenAI). Rapid-MLX only
+    # generates one completion per request — declared so Pydantic
+    # stops silently dropping it; rejected with 400 in
+    # ``routes/completions.py`` when ``> 1`` (mirroring the chat-route
+    # behaviour). F-152.
+    n: int | None = None
+    # Server-side top-k re-rank knob from legacy OpenAI completions.
+    # Not implementable on local MLX inference without a reranker;
+    # declared so Pydantic stops silently dropping it and rejected
+    # with 400 when ``> 1``. F-152.
+    best_of: int | None = None
     # OpenAI FIM (fill-in-the-middle) suffix. Declared so Pydantic stops
     # silently dropping it; rejected with 400 in routes/completions.py
     # when non-empty since no MLX engine implements FIM yet (and silently
@@ -490,6 +535,41 @@ class CompletionRequest(BaseModel):
     # Request timeout in seconds (None = use server default)
     timeout: float | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_bool_logprobs_raw(cls, data):
+        """Reject ``logprobs: bool`` wire form on legacy completions.
+
+        Same shape as ``ChatCompletionRequest._validate_reasoning_max_tokens_raw``:
+        Pydantic v2 coerces ``True`` → 1 / ``False`` → 0 silently when
+        the field is typed ``int | None``, but that coercion would be
+        a footgun — a client that learned the chat-completions
+        ``logprobs: bool`` shape would have its ``logprobs: true``
+        silently turned into ``top_k=1`` and ``logprobs: false`` into
+        ``top_k=0`` (no logprobs payload at all). Both surface as
+        wrong-shaped responses with no error, exactly the silent-compat
+        lie F-152 / F-153 closes. So a bool wire value gets a clear
+        422 telling the client to send the canonical integer instead.
+        """
+        if not isinstance(data, dict):
+            return data
+        if "logprobs" not in data:
+            return data
+        v = data["logprobs"]
+        # ``bool`` is an int subclass — check it BEFORE the integer
+        # acceptance branch so ``True``/``False`` are rejected even
+        # though they'd otherwise coerce to ``1``/``0``.
+        if isinstance(v, bool):
+            raise ValueError(
+                "`logprobs` on /v1/completions must be an integer "
+                "0-5 (number of top tokens to return), not a bool. "
+                "The chat-completions endpoint uses `logprobs: bool + "
+                "top_logprobs: int`; the legacy completions endpoint "
+                "merges both into a single integer field. "
+                "Pass `logprobs: <int>` instead."
+            )
+        return data
+
 
 class CompletionChoice(BaseModel):
     """A single choice in text completion response."""
@@ -497,7 +577,11 @@ class CompletionChoice(BaseModel):
     index: int = 0
     text: str
     finish_reason: str | None = "stop"
-    logprobs: ChoiceLogProbs | None = None
+    # Legacy completions uses the 4-parallel-array shape
+    # (``LegacyCompletionLogProbs``); chat-completions uses the
+    # ``ChoiceLogProbs`` shape — both are accepted here so the
+    # downstream serializer can pick the spec-correct one per route.
+    logprobs: LegacyCompletionLogProbs | ChoiceLogProbs | None = None
 
 
 class CompletionResponse(BaseModel):

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -14,6 +14,7 @@ from ..api.models import (
     CompletionChoice,
     CompletionRequest,
     CompletionResponse,
+    LegacyCompletionLogProbs,
     PromptTokensDetails,
     Usage,
 )
@@ -22,6 +23,7 @@ from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
     _check_admission_or_503,
     _disconnect_guard,
+    _extract_streaming_token_logprobs,
     _release_admission_unless_committed,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -53,6 +55,49 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             detail=(
                 "FIM (fill-in-the-middle) 'suffix' is not supported by this "
                 "server. Use the chat completions API or omit 'suffix'."
+            ),
+        )
+    # F-152: legacy completions params that have NO implementation on
+    # Rapid-MLX must fail loudly instead of returning 200 with a single
+    # completion (the silent-compat lie SDKs port broken from). The
+    # canonical chat-completions handler already rejects ``n > 1``;
+    # mirror that here and extend to ``best_of`` (a top-k rerank knob
+    # we don't implement at all). ``n == 1`` and ``best_of == 1`` are
+    # the OpenAI defaults — accept them silently so well-behaved
+    # clients passing the documented default don't see a 400.
+    if request.n is not None and request.n > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "n > 1 is not supported on /v1/completions. Rapid-MLX "
+                "generates one completion per request — send "
+                "individual requests if you need multiple samples."
+            ),
+        )
+    if request.best_of is not None and request.best_of > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "best_of > 1 is not supported on /v1/completions. "
+                "Rapid-MLX has no server-side reranker — send "
+                "individual requests and rerank client-side."
+            ),
+        )
+    # F-153: ``logprobs`` on legacy completions is an INTEGER (top-k
+    # count, 0..5 per OpenAI spec). The pydantic ``mode="before"``
+    # validator on ``CompletionRequest`` already rejects the
+    # chat-shape ``bool`` form with a 422; here we enforce the spec
+    # range with a 400 so ``logprobs=20`` (chat-shape ``top_logprobs``
+    # ceiling) doesn't slip through and DoS the server with
+    # top-of-vocab work.
+    if request.logprobs is not None and (
+        request.logprobs < 0 or request.logprobs > 5
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "logprobs must be between 0 and 5 on /v1/completions "
+                "(OpenAI legacy spec)."
             ),
         )
     engine = get_engine(request.model)
@@ -110,27 +155,147 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
         extended_kwargs = build_extended_sampling_kwargs(request)
 
+        # F-152/F-153: ``logprobs`` is an integer (top-k count). When
+        # non-None we route through ``stream_generate`` to accumulate
+        # per-token distributions chunk by chunk (the same pattern
+        # ``routes/chat.py`` uses for ``logprobs=true, top_logprobs=K``
+        # — the non-streaming ``generate`` path doesn't surface the
+        # per-step ``mx.array`` distributions a top-k logprobs payload
+        # needs). ``logprobs=0`` is a valid OpenAI request that asks
+        # for the sampled-token logprob WITHOUT alternatives — we
+        # still need ``_extract_streaming_token_logprobs`` to surface
+        # the sampled probability, but pass ``effective_top_k=1`` to
+        # avoid the ``argpartition(-0)[-0:]``-returns-full-vocab
+        # pre-existing footgun in ``_extract_token_logprob`` (chat
+        # route side-steps this by gating ``logprobs && top_logprobs``;
+        # we have to handle ``top_k=0`` explicitly). The resulting
+        # ``top_logprobs`` dict is stripped to ``{}`` below so the
+        # response shape stays spec-correct.
+        want_logprobs = request.logprobs is not None
+        top_k_logprobs = request.logprobs or 0
+        effective_top_k = max(1, top_k_logprobs)
+
         for i, prompt in enumerate(prompts):
-            output = await _wait_with_disconnect(
-                engine.generate(
+            token_logprobs_list = []
+            if want_logprobs:
+                # Accumulate streaming chunks; the engine emits one
+                # GenerationOutput per generated token (or per flush
+                # under ``stream_interval > 1`` — the helper's per-step
+                # iteration handles both shapes; see
+                # ``service/helpers.py::_extract_streaming_token_logprobs``).
+                output = None
+                _accum_text_parts: list[str] = []
+                stream_iter = engine.stream_generate(
                     prompt=prompt,
                     max_tokens=_resolve_max_tokens(request.max_tokens),
                     temperature=_resolve_temperature(request.temperature),
                     top_p=_resolve_top_p(request.top_p),
                     stop=request.stop,
                     **extended_kwargs,
-                ),
-                raw_request,
-                timeout=timeout,
-            )
-            if output is None:
-                return Response(status_code=499)  # Client closed request
+                )
+
+                async def _drain_stream(it=stream_iter):
+                    nonlocal output
+                    async for chunk in it:
+                        output = chunk
+                        _accum_text_parts.append(chunk.new_text or "")
+                        token_logprobs_list.extend(
+                            _extract_streaming_token_logprobs(
+                                chunk, engine.tokenizer, effective_top_k
+                            )
+                        )
+                    return output
+
+                output = await _wait_with_disconnect(
+                    _drain_stream(), raw_request, timeout=timeout
+                )
+                if output is None:
+                    return Response(status_code=499)  # Client closed request
+                # The stream's last chunk carries the aggregate text on
+                # the LLM engine path (it's accumulated by
+                # ``RequestOutput.output_text``), but the MLLM
+                # scheduler historically populated only the per-chunk
+                # ``new_text`` — fold the accumulated parts to cover
+                # both paths.
+                final_text = output.text or "".join(_accum_text_parts)
+            else:
+                output = await _wait_with_disconnect(
+                    engine.generate(
+                        prompt=prompt,
+                        max_tokens=_resolve_max_tokens(request.max_tokens),
+                        temperature=_resolve_temperature(request.temperature),
+                        top_p=_resolve_top_p(request.top_p),
+                        stop=request.stop,
+                        **extended_kwargs,
+                    ),
+                    raw_request,
+                    timeout=timeout,
+                )
+                if output is None:
+                    return Response(status_code=499)  # Client closed request
+                final_text = output.text
+
+            # F-152: ``echo:true`` prepends the prompt to the response
+            # text (legacy OpenAI behaviour — used by eval harnesses
+            # like ``lm-evaluation-harness`` to score prompt-conditioned
+            # token log-probs). Cheap to implement (just a string
+            # concat); without it the silent-drop pre-fix made every
+            # eval that depends on the prompt prefix score garbage.
+            if request.echo:
+                final_text = prompt + final_text
+
+            # Build the legacy logprobs payload per OpenAI spec: four
+            # parallel arrays keyed positionally per generated token.
+            # ``echo`` does NOT extend the logprobs arrays — the
+            # prompt tokens have no model-emitted distribution
+            # available here (we don't replay prefill through the
+            # sampler) so emitting fake ``None``-equivalent entries
+            # would mislead eval code. Document on the route and
+            # treat ``echo + logprobs`` as "response text echoes
+            # prompt; logprobs cover the GENERATED tokens only" —
+            # which matches what OpenAI's legacy endpoint did when
+            # echo was paired with non-int logprobs prior to the
+            # 2024 deprecation.
+            choice_logprobs = None
+            if want_logprobs:
+                tokens_arr: list[str] = []
+                token_lps: list[float] = []
+                top_lps: list[dict[str, float]] = []
+                text_offset: list[int] = []
+                offset = len(prompt) if request.echo else 0
+                for entry in token_logprobs_list:
+                    tokens_arr.append(entry.token)
+                    token_lps.append(entry.logprob)
+                    # ``logprobs=0`` per OpenAI spec asks for the
+                    # sampled-token logprob WITHOUT any alternatives.
+                    # ``effective_top_k=1`` above means
+                    # ``entry.top_logprobs`` carries a single-element
+                    # list; strip it so the response shape matches
+                    # what a real OpenAI call returns (``{}``).
+                    if top_k_logprobs == 0:
+                        top_lps.append({})
+                    else:
+                        top_lps.append(
+                            {
+                                tl.token: tl.logprob
+                                for tl in (entry.top_logprobs or [])
+                            }
+                        )
+                    text_offset.append(offset)
+                    offset += len(entry.token)
+                choice_logprobs = LegacyCompletionLogProbs(
+                    tokens=tokens_arr,
+                    token_logprobs=token_lps,
+                    top_logprobs=top_lps,
+                    text_offset=text_offset,
+                )
 
             choices.append(
                 CompletionChoice(
                     index=i,
-                    text=output.text,
+                    text=final_text,
                     finish_reason=output.finish_reason,
+                    logprobs=choice_logprobs,
                 )
             )
             total_completion_tokens += output.completion_tokens
@@ -175,6 +340,39 @@ async def stream_completion(
     """Stream completion response."""
     extended_kwargs = build_extended_sampling_kwargs(request)
 
+    # F-152: ``echo`` on the streaming path emits the prompt as the
+    # FIRST SSE chunk, then continues with generated tokens. Without
+    # this initial chunk, the streaming branch ignored ``echo`` even
+    # after the non-streaming branch was fixed — a silent split-brain
+    # SDK clients would discover only at runtime.
+    model_name = _resolve_model_name(request.model)
+    if request.echo:
+        echo_data = {
+            "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": prompt,
+                    "finish_reason": None,
+                }
+            ],
+        }
+        yield f"data: {json.dumps(echo_data)}\n\n"
+
+    # F-152: ``logprobs`` on streaming surfaces per-chunk top-k
+    # alternatives in the spec-correct legacy shape (four parallel
+    # arrays). Each SSE chunk represents one (or a few) generated
+    # tokens; emit a fresh ``logprobs`` object per chunk keyed to
+    # those token(s) only. Cumulative ``text_offset`` is preserved
+    # across chunks so client-side accumulators can concat directly.
+    want_logprobs = request.logprobs is not None
+    top_k_logprobs = request.logprobs or 0
+    effective_top_k = max(1, top_k_logprobs)  # see non-stream branch
+    text_offset_cursor = len(prompt) if request.echo else 0
+
     async for output in engine.stream_generate(
         prompt=prompt,
         max_tokens=_resolve_max_tokens(request.max_tokens),
@@ -183,18 +381,50 @@ async def stream_completion(
         stop=request.stop,
         **extended_kwargs,
     ):
+        choice = {
+            "index": 0,
+            "text": output.new_text,
+            "finish_reason": output.finish_reason if output.finished else None,
+        }
+        if want_logprobs:
+            entries = _extract_streaming_token_logprobs(
+                output, engine.tokenizer, effective_top_k
+            )
+            if entries:
+                tokens_arr = []
+                token_lps = []
+                top_lps = []
+                text_offsets = []
+                for entry in entries:
+                    tokens_arr.append(entry.token)
+                    token_lps.append(entry.logprob)
+                    if top_k_logprobs == 0:
+                        top_lps.append({})
+                    else:
+                        top_lps.append(
+                            {
+                                tl.token: tl.logprob
+                                for tl in (entry.top_logprobs or [])
+                            }
+                        )
+                    text_offsets.append(text_offset_cursor)
+                    text_offset_cursor += len(entry.token)
+                choice["logprobs"] = {
+                    "tokens": tokens_arr,
+                    "token_logprobs": token_lps,
+                    "top_logprobs": top_lps,
+                    "text_offset": text_offsets,
+                }
+        # NOTE: distinct per-chunk ``cmpl-XXXX`` ids are F-154 — fixing
+        # that here would broaden this PR's scope (F-152/F-153 only).
+        # Mint a fresh id per chunk to preserve current behaviour and
+        # leave F-154 as a separate one-line follow-up.
         data = {
             "id": f"cmpl-{uuid.uuid4().hex[:8]}",
             "object": "text_completion",
             "created": int(time.time()),
-            "model": _resolve_model_name(request.model),
-            "choices": [
-                {
-                    "index": 0,
-                    "text": output.new_text,
-                    "finish_reason": output.finish_reason if output.finished else None,
-                }
-            ],
+            "model": model_name,
+            "choices": [choice],
         }
         if output.finished:
             data["usage"] = get_usage(output).model_dump(exclude_none=True)

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -200,6 +200,29 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         top_k_logprobs = request.logprobs or 0
         effective_top_k = max(1, top_k_logprobs)
 
+        # Codex r2 BLOCKING #1: only route through ``stream_generate``
+        # when the concrete engine implements it AND a tokenizer is
+        # available (the extractor decodes ids to text). The MLLM
+        # batch generator does both; alternative engines (dflash, any
+        # future ``BaseEngine`` subclass that ships only ``generate``)
+        # would otherwise crash on a previously-valid non-streaming
+        # request when a client adds ``logprobs:N``. Refuse with a
+        # controlled 501 instead of an AttributeError 500.
+        if want_logprobs and (
+            not hasattr(engine, "stream_generate")
+            or getattr(engine, "tokenizer", None) is None
+        ):
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "logprobs requested but this engine does not expose "
+                    "the streaming logprobs extraction path "
+                    "(``stream_generate`` + ``tokenizer``). Reissue "
+                    "without ``logprobs`` or use a model that supports "
+                    "per-token distributions."
+                ),
+            )
+
         for i, prompt in enumerate(prompts):
             token_logprobs_list = []
             if want_logprobs:
@@ -210,6 +233,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 # ``service/helpers.py::_extract_streaming_token_logprobs``).
                 output = None
                 _accum_text_parts: list[str] = []
+                _stream_yielded = False
                 stream_iter = engine.stream_generate(
                     prompt=prompt,
                     max_tokens=_resolve_max_tokens(request.max_tokens),
@@ -220,8 +244,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 )
 
                 async def _drain_stream(it=stream_iter):
-                    nonlocal output
+                    nonlocal output, _stream_yielded
                     async for chunk in it:
+                        _stream_yielded = True
                         output = chunk
                         _accum_text_parts.append(chunk.new_text or "")
                         token_logprobs_list.extend(
@@ -234,8 +259,29 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 output = await _wait_with_disconnect(
                     _drain_stream(), raw_request, timeout=timeout
                 )
+                # Codex r2 BLOCKING #2: ``_wait_with_disconnect``
+                # returns ``None`` on client disconnect, but
+                # ``_drain_stream`` ALSO returns ``None`` when the
+                # engine yields zero chunks (empty completion).
+                # Distinguish by checking the inner sentinel: if the
+                # stream produced no chunks at all, return a valid
+                # empty completion shape rather than a false 499.
                 if output is None:
-                    return Response(status_code=499)  # Client closed request
+                    if _stream_yielded:
+                        # Client disconnect — _drain_stream did yield
+                        # but _wait_with_disconnect bailed mid-flight.
+                        return Response(status_code=499)
+                    # Stream is empty AND client is still connected
+                    # — synthesize an empty output so the response
+                    # shape matches OpenAI's empty-completion case.
+                    from ..engine.base import GenerationOutput
+
+                    output = GenerationOutput(
+                        text="",
+                        finish_reason="stop",
+                        prompt_tokens=0,
+                        completion_tokens=0,
+                    )
                 # The stream's last chunk carries the aggregate text on
                 # the LLM engine path (it's accumulated by
                 # ``RequestOutput.output_text``), but the MLLM
@@ -273,6 +319,19 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             # parallel arrays keyed positionally per generated token.
             # ``echo + logprobs`` is rejected upstream (see route
             # entry) so ``offset`` always starts at 0 here.
+            #
+            # Codex r2 BLOCKING #3: ``text_offset`` is documented as
+            # offsets into ``choices[0].text``. We compute offsets
+            # cumulatively from ``len(decoded_token)`` so they
+            # ALWAYS align with ``"".join(tokens_arr)``. When
+            # ``output.text`` differs from that concatenation
+            # (whitespace normalization in ``clean_output_text``,
+            # tokenizer-side cleanup) the spec-correct move is to
+            # surface the token-concatenated text as ``text`` so
+            # ``text_offset`` is byte-exact against the field it
+            # references. Falls back to ``output.text`` only when no
+            # token entries were captured (empty stream / engine
+            # quirk).
             choice_logprobs = None
             if want_logprobs:
                 tokens_arr: list[str] = []
@@ -306,6 +365,13 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     top_logprobs=top_lps,
                     text_offset=text_offset,
                 )
+                # Pin ``final_text`` to the token concatenation so
+                # ``text_offset`` is byte-exact. Skip when no tokens
+                # were captured (e.g. engine quirk that yielded
+                # ``new_text`` without ``new_token_ids``) — keep the
+                # accumulated raw text in that case.
+                if tokens_arr:
+                    final_text = "".join(tokens_arr)
 
             choices.append(
                 CompletionChoice(

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -159,6 +159,29 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         for _p in prompts:
             enforce_context_length_for_prompt(engine, _p, max_tokens=_resolved_max)
 
+        # Codex r2/r3 BLOCKING: engine capability guard for ``logprobs``
+        # applies to BOTH streaming and non-streaming paths. Without
+        # this check on the streaming branch, the AttributeError fires
+        # inside the SSE generator (already-committed
+        # ``StreamingResponse``) and clients see an EventSource that
+        # disconnects after the first chunk instead of a controlled
+        # 501. Lift to the top so both branches are covered.
+        _want_logprobs = request.logprobs is not None
+        if _want_logprobs and (
+            not hasattr(engine, "stream_generate")
+            or getattr(engine, "tokenizer", None) is None
+        ):
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "logprobs requested but this engine does not expose "
+                    "the streaming logprobs extraction path "
+                    "(``stream_generate`` + ``tokenizer``). Reissue "
+                    "without ``logprobs`` or use a model that supports "
+                    "per-token distributions."
+                ),
+            )
+
         if request.stream:
             _admission_committed = True
             return StreamingResponse(
@@ -200,28 +223,8 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         top_k_logprobs = request.logprobs or 0
         effective_top_k = max(1, top_k_logprobs)
 
-        # Codex r2 BLOCKING #1: only route through ``stream_generate``
-        # when the concrete engine implements it AND a tokenizer is
-        # available (the extractor decodes ids to text). The MLLM
-        # batch generator does both; alternative engines (dflash, any
-        # future ``BaseEngine`` subclass that ships only ``generate``)
-        # would otherwise crash on a previously-valid non-streaming
-        # request when a client adds ``logprobs:N``. Refuse with a
-        # controlled 501 instead of an AttributeError 500.
-        if want_logprobs and (
-            not hasattr(engine, "stream_generate")
-            or getattr(engine, "tokenizer", None) is None
-        ):
-            raise HTTPException(
-                status_code=501,
-                detail=(
-                    "logprobs requested but this engine does not expose "
-                    "the streaming logprobs extraction path "
-                    "(``stream_generate`` + ``tokenizer``). Reissue "
-                    "without ``logprobs`` or use a model that supports "
-                    "per-token distributions."
-                ),
-            )
+        # Engine capability guard for ``logprobs`` is enforced earlier
+        # (top of the route, covers both streaming + non-streaming).
 
         for i, prompt in enumerate(prompts):
             token_logprobs_list = []
@@ -259,21 +262,32 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 output = await _wait_with_disconnect(
                     _drain_stream(), raw_request, timeout=timeout
                 )
-                # Codex r2 BLOCKING #2: ``_wait_with_disconnect``
-                # returns ``None`` on client disconnect, but
-                # ``_drain_stream`` ALSO returns ``None`` when the
-                # engine yields zero chunks (empty completion).
-                # Distinguish by checking the inner sentinel: if the
-                # stream produced no chunks at all, return a valid
-                # empty completion shape rather than a false 499.
+                # Codex r2/r3 BLOCKING: ``_wait_with_disconnect``
+                # returns ``None`` on client disconnect, on timeout,
+                # OR when ``_drain_stream`` exits cleanly without
+                # yielding any chunks. Disambiguate three cases:
+                #   1. ``_stream_yielded`` — at least one chunk
+                #      reached us; bailing now is a mid-flight
+                #      disconnect or timeout → 499.
+                #   2. ``await raw_request.is_disconnected()`` — the
+                #      client closed BEFORE the first chunk; also
+                #      499. (Codex r3 BLOCKING #2: without this
+                #      check, a disconnect-before-first-token was
+                #      misclassified as a successful empty
+                #      completion.)
+                #   3. Otherwise — engine genuinely returned an empty
+                #      stream; synthesize an empty ``GenerationOutput``
+                #      so the response matches OpenAI's empty-
+                #      completion shape.
                 if output is None:
                     if _stream_yielded:
-                        # Client disconnect — _drain_stream did yield
-                        # but _wait_with_disconnect bailed mid-flight.
                         return Response(status_code=499)
-                    # Stream is empty AND client is still connected
-                    # — synthesize an empty output so the response
-                    # shape matches OpenAI's empty-completion case.
+                    try:
+                        client_gone = await raw_request.is_disconnected()
+                    except Exception:
+                        client_gone = False
+                    if client_gone:
+                        return Response(status_code=499)
                     from ..engine.base import GenerationOutput
 
                     output = GenerationOutput(
@@ -498,6 +512,16 @@ async def stream_completion(
                     "top_logprobs": top_lps,
                     "text_offset": text_offsets,
                 }
+                # Codex r3 BLOCKING #3: pin chunk ``text`` to the
+                # token concatenation so ``text_offset`` is byte-
+                # exact against the field it references (matches the
+                # non-streaming path's alignment fix). Without this
+                # rebind, ``output.new_text`` may differ from
+                # ``"".join(tokens_arr)`` after tokenizer cleanup
+                # or whitespace normalization, and clients that
+                # slice ``chunk.text[offset:offset+len(token)]``
+                # would read garbage.
+                choice["text"] = "".join(tokens_arr)
         # NOTE: distinct per-chunk ``cmpl-XXXX`` ids are F-154 — fixing
         # that here would broaden this PR's scope (F-152/F-153 only).
         # Mint a fresh id per chunk to preserve current behaviour and

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -100,6 +100,31 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 "(OpenAI legacy spec)."
             ),
         )
+    # F-152 follow-up (codex r1 BLOCKING): legacy clients use
+    # ``echo:true + logprobs:N`` SPECIFICALLY to score prompt tokens
+    # (lm-evaluation-harness, ``openai.Completion.create`` with
+    # ``echo=True``). Producing logprobs arrays that cover only the
+    # generated tokens — with a leading prompt prefix in ``text`` —
+    # would mis-align the ``text_offset`` cursor against ``tokens``
+    # and silently corrupt every prompt-conditioned score. We don't
+    # replay the prompt through the sampler (no per-token
+    # distributions available without a dedicated prefill-with-
+    # logprobs path), so reject the combination with a clear 400
+    # instead of returning partial-but-wrong data. Either knob
+    # alone keeps working; only the combination is rejected.
+    if request.echo and request.logprobs is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "`echo` combined with `logprobs` is not supported on "
+                "/v1/completions: Rapid-MLX does not replay the prompt "
+                "through the sampler, so we cannot return per-token "
+                "logprobs for the echoed prefix. Send `echo` and "
+                "`logprobs` in separate requests (the `echo` request "
+                "returns the prompt-prefixed text; the `logprobs` "
+                "request returns the generated-token distributions)."
+            ),
+        )
     engine = get_engine(request.model)
 
     # Pre-flight admission gate (C4). Reservation is released by the
@@ -246,23 +271,15 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
             # Build the legacy logprobs payload per OpenAI spec: four
             # parallel arrays keyed positionally per generated token.
-            # ``echo`` does NOT extend the logprobs arrays — the
-            # prompt tokens have no model-emitted distribution
-            # available here (we don't replay prefill through the
-            # sampler) so emitting fake ``None``-equivalent entries
-            # would mislead eval code. Document on the route and
-            # treat ``echo + logprobs`` as "response text echoes
-            # prompt; logprobs cover the GENERATED tokens only" —
-            # which matches what OpenAI's legacy endpoint did when
-            # echo was paired with non-int logprobs prior to the
-            # 2024 deprecation.
+            # ``echo + logprobs`` is rejected upstream (see route
+            # entry) so ``offset`` always starts at 0 here.
             choice_logprobs = None
             if want_logprobs:
                 tokens_arr: list[str] = []
                 token_lps: list[float] = []
                 top_lps: list[dict[str, float]] = []
                 text_offset: list[int] = []
-                offset = len(prompt) if request.echo else 0
+                offset = 0  # echo+logprobs is rejected upstream
                 for entry in token_logprobs_list:
                     tokens_arr.append(entry.token)
                     token_lps.append(entry.logprob)
@@ -371,7 +388,7 @@ async def stream_completion(
     want_logprobs = request.logprobs is not None
     top_k_logprobs = request.logprobs or 0
     effective_top_k = max(1, top_k_logprobs)  # see non-stream branch
-    text_offset_cursor = len(prompt) if request.echo else 0
+    text_offset_cursor = 0  # echo+logprobs is rejected upstream
 
     async for output in engine.stream_generate(
         prompt=prompt,


### PR DESCRIPTION
## Summary

Closes two HIGH bugs in the legacy `/v1/completions` route. Both surface the same silent-compat lie that breaks OpenAI SDK clients porting from the real API.

**F-152**: route silently accepted `n`, `best_of`, `echo`, and `logprobs:true` but did nothing with them — clients saw HTTP 200 with a single completion (wrong billing math, missing prompt prefix, missing logprobs).

**F-153**: `logprobs` was typed `bool` but OpenAI legacy spec says **integer 0..5** (top-k count). The canonical `logprobs=5` SDK call bounced with a 422 `bool_parsing` error that never mentioned the schema mismatch.

## What changed

- `CompletionRequest` declares `n`, `best_of`, `echo`, `logprobs` with spec-correct types. `logprobs` is `int`; a `mode="before"` validator rejects the bool wire form with a clear 422 (no silent True→1 coercion).
- Route guards: `n>1` → 400, `best_of>1` → 400, `logprobs` outside 0..5 → 400.
- `echo:true` prepends prompt to `choices[0].text` (non-streaming) and emits the prompt as the first SSE chunk (streaming).
- `logprobs:int` implemented end-to-end: streams accumulate per-token distributions, response carries OpenAI legacy 4-array shape (`tokens` / `token_logprobs` / `top_logprobs` / `text_offset`).
- `logprobs:0` (sampled logprob, no alternatives) handled by gating `effective_top_k=1` then stripping `top_logprobs` to `{}` — sidesteps the `argpartition(-0)` footgun in `_extract_token_logprob`.

## Scope

This PR is scoped to F-152 + F-153 only. F-154 (distinct per-chunk `cmpl-XXXX` ids on stream) is intentionally left as-is to keep diff focused — a one-line follow-up.

## Test plan

- [x] 13 new regression tests in `tests/test_completions_spec_parity.py` cover every case (n>1, n=1, best_of>1, echo on/off, logprobs bool rejection, logprobs range 0..5, schema field declarations)
- [x] All 42 existing tests in `tests/test_api_validation_bundle.py` still pass
- [x] 108 tests in `test_api_models.py` + `test_routes_cached_tokens.py` + `test_sampling_params_passthrough.py` still pass
- [x] Live qwen3-0.6b-8bit on port 8075 verified: `n>1`→400, `best_of>1`→400, `echo:true`→200 prefixed, `logprobs:5`→200 with top-5 dicts, `logprobs:true`→422 with clear message, `logprobs:0`→200 with `{}` alternatives, `logprobs:6`→400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)