### PR TITLE
fix(api): stop raw Python AttributeError leaks in HTTP 400 body (F-013 + F-066)

### DIFF
--- a/tests/test_clean_error_messages.py
+++ b/tests/test_clean_error_messages.py
@@ -61,6 +61,38 @@ class TestResponseFormatValidation:
         assert "json_schema" in ei.value.detail
         assert "non-empty" in ei.value.detail
 
+    def test_json_schema_type_with_name_but_no_schema_raises_400(self):
+        """Codex r1 BLOCKING follow-up: ``{"type":"json_schema",
+        "json_schema":{"name":"r"}}`` has a non-empty outer dict but no
+        inner ``schema`` member, so the prior round of the gate let it
+        through and ``extract_json_schema_for_guided`` still bailed at
+        ``if not schema: return None`` — request proceeded with no
+        constraint. Now → 400 naming the missing inner member."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format(
+                {"type": "json_schema", "json_schema": {"name": "r"}}
+            )
+        assert ei.value.status_code == 400
+        assert "json_schema.schema" in ei.value.detail
+        assert "non-empty" in ei.value.detail
+
+    def test_json_schema_type_with_empty_schema_member_raises_400(self):
+        """Same shape as above but with ``schema:{}`` — an empty inner
+        schema is functionally equivalent to no schema at all."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format(
+                {
+                    "type": "json_schema",
+                    "json_schema": {"name": "r", "schema": {}},
+                }
+            )
+        assert ei.value.status_code == 400
+        assert "json_schema.schema" in ei.value.detail
+
     def test_json_schema_type_with_empty_dict_field_raises_400(self):
         """``response_format={"type":"json_schema","json_schema":{}}``
         used to be silently accepted as HTTP 200 — the empty schema dict

--- a/tests/test_clean_error_messages.py
+++ b/tests/test_clean_error_messages.py
@@ -366,7 +366,15 @@ class TestProcessImageInputDefenseInDepth:
     from the Anthropic / Responses adapters and from internal code
     paths where the schema-layer guard doesn't apply. The function's
     own ``isinstance(image, str)`` check raises a clean ValueError
-    instead of bubbling the raw ``startswith`` AttributeError."""
+    instead of bubbling the raw ``startswith`` AttributeError.
+
+    Critical preservation contract (codex r2): the existing dict
+    unwrapping at the top of ``process_image_input`` (``{"url": "..."}``
+    → ``url``) MUST still run before the type guard so valid
+    dict-shaped callers keep working — the guard only fires on the
+    POST-unwrap value, never on the original dict. Tests below pin
+    both branches.
+    """
 
     def test_int_image_raises_clean_value_error(self):
         from vllm_mlx.models.mllm import process_image_input
@@ -374,14 +382,58 @@ class TestProcessImageInputDefenseInDepth:
         with pytest.raises(ValueError) as ei:
             process_image_input(123)  # type: ignore[arg-type]
         assert "must be a string" in str(ei.value)
+        # Must surface the type name in the error for client debuggability
+        # (codex r2 NIT: prior assertion didn't pin the ``got X`` shape).
+        assert "got int" in str(ei.value)
         assert "startswith" not in str(ei.value)
 
     def test_dict_with_int_url_raises_clean_value_error(self):
-        """Dict-shape path: ``{"url": 123}`` unwraps to ``123`` and
-        then trips the new isinstance gate."""
+        """Dict-shape path: ``{"url": 123}`` is unwrapped at the
+        function's top (line ~525) to ``image = 123``, then the
+        type guard catches the non-string and raises. The error
+        message names the post-unwrap type (``int``), not ``dict``,
+        which is the load-bearing test (codex r2 BLOCKING)."""
         from vllm_mlx.models.mllm import process_image_input
 
         with pytest.raises(ValueError) as ei:
             process_image_input({"url": 123})  # type: ignore[arg-type]
         assert "must be a string" in str(ei.value)
+        assert "got int" in str(ei.value)
         assert "startswith" not in str(ei.value)
+
+    def test_dict_with_valid_string_url_still_processed(self):
+        """Codex r2 BLOCKING coverage: valid ``{"url": "<str>"}``
+        dict shape MUST still unwrap and proceed past the type guard.
+        The downstream call hits ``Path.exists()`` and raises
+        ``Cannot process image`` because the path is fake — that's
+        downstream behavior, not the type guard rejecting the dict."""
+        from vllm_mlx.models.mllm import process_image_input
+
+        # Pick a path that's <4096 chars and definitely doesn't exist
+        # — proves we got past the type guard into the body of the
+        # function.
+        with pytest.raises(ValueError) as ei:
+            process_image_input(
+                {"url": "/nonexistent/__rapid_mlx_test_path__.png"}
+            )
+        # The error must be the downstream "Cannot process image"
+        # marker (path not found), NOT the type guard's "must be a
+        # string" — proves the dict was unwrapped and the unwrapped
+        # string was accepted by the type guard.
+        assert "Cannot process image" in str(ei.value)
+        assert "must be a string" not in str(ei.value)
+
+    def test_nested_dict_url_unwrapped_correctly(self):
+        """The function also handles the nested ``{"url": {"url":
+        "..."}}`` shape (line ~527-528). Pin that the unwrap still
+        works through both levels."""
+        from vllm_mlx.models.mllm import process_image_input
+
+        with pytest.raises(ValueError) as ei:
+            process_image_input(
+                {"url": {"url": "/nonexistent/__nested_test__.png"}}
+            )
+        # Same as above — should fall through to the path-not-found
+        # error, not be caught by the type guard.
+        assert "Cannot process image" in str(ei.value)
+        assert "must be a string" not in str(ei.value)

--- a/tests/test_clean_error_messages.py
+++ b/tests/test_clean_error_messages.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for F-013 + F-066 — raw Python AttributeError /
+TypeError text used to leak into HTTP 400 response bodies for two
+distinct malformed-payload classes:
+
+* F-013: ``response_format={"type":"json_schema"}`` (missing inner
+  ``json_schema`` field) crashed inside ``build_json_system_prompt`` with
+  ``AttributeError: 'NoneType' object has no attribute 'get'`` — text
+  surfaced verbatim in the 400 body. Sister silent-200 cases
+  (``type:"xml"`` / ``type:""`` / ``{}`` / ``json_schema:{}``) were
+  silently accepted as unconstrained text generation.
+
+* F-066: ``image_url.url=123`` (or any non-string) crashed inside
+  ``process_image_input`` → ``is_base64_image`` with
+  ``AttributeError: 'int' object has no attribute 'startswith'`` — text
+  surfaced verbatim in the 400 body.
+
+Both share the same class: provider-side Python type errors leaking
+through ``except Exception → HTTPException(detail=str(e))`` paths
+without input-shape validation upstream. The fixes pin schema-layer
+and route-layer validators so the malformed payload is rejected before
+any Python ``getattr``/``startswith`` is attempted.
+"""
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# F-013: response_format validation (route-layer)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormatValidation:
+    """``_validate_response_format`` runs in
+    ``_create_chat_completion_impl`` BEFORE any code that might raise
+    ``AttributeError`` on a malformed payload. Each test pins one
+    F-013 reproduction case."""
+
+    def test_json_schema_type_without_field_raises_clean_400(self):
+        """The original raw-leak case. ``type:"json_schema"`` with no
+        ``json_schema`` field used to fall through to
+        ``build_json_system_prompt`` which called
+        ``rf_dict.get("json_schema", {}).get("schema", {})`` — the inner
+        ``.get`` raised ``AttributeError: 'NoneType' object has no
+        attribute 'get'`` because the field defaults to ``None``, not
+        ``{}``. Wrapped by ``except Exception: raise
+        HTTPException(detail=str(e))`` and the raw error string
+        surfaced in the response body."""
+        from vllm_mlx.service.helpers import _validate_response_format
+        from vllm_mlx.api.models import ResponseFormat
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format(ResponseFormat(type="json_schema"))
+        assert ei.value.status_code == 400
+        # Must NOT contain the raw Python AttributeError text.
+        assert "NoneType" not in ei.value.detail
+        assert "attribute" not in ei.value.detail
+        # Must contain the actionable hint.
+        assert "json_schema" in ei.value.detail
+        assert "non-empty" in ei.value.detail
+
+    def test_json_schema_type_with_empty_dict_field_raises_400(self):
+        """``response_format={"type":"json_schema","json_schema":{}}``
+        used to be silently accepted as HTTP 200 — the empty schema dict
+        passed the ``type == "json_schema"`` branch in
+        ``extract_json_schema_for_guided`` but its
+        ``json_schema_spec.get("schema", {})`` returned ``{}`` so the
+        function fell out at ``if not schema: return None`` and the
+        request proceeded with no structure enforcement."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format(
+                {"type": "json_schema", "json_schema": {}}
+            )
+        assert ei.value.status_code == 400
+        assert "non-empty" in ei.value.detail
+
+    def test_unknown_type_xml_raises_400(self):
+        """The F-013 silent-200 arm. ``type:"xml"`` used to fall
+        through ``build_json_system_prompt`` (which returns ``None``
+        for any non-listed type) and the request was treated as
+        unconstrained text — the client received plain prose with no
+        signal that their format choice was unsupported."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format({"type": "xml"})
+        assert ei.value.status_code == 400
+        assert "must be" in ei.value.detail
+        assert "json_object" in ei.value.detail
+        assert "json_schema" in ei.value.detail
+
+    def test_empty_string_type_raises_400(self):
+        """``type:""`` is a common client-side bug (env var unset →
+        empty string default). Used to silent-200 via the same path
+        as ``xml``."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format({"type": ""})
+        assert ei.value.status_code == 400
+        assert "must be" in ei.value.detail
+
+    def test_empty_response_format_dict_raises_400(self):
+        """``response_format={}`` — no ``type`` key at all. Used to
+        silent-200 because ``rf_dict.get("type", "text")`` returned
+        ``"text"`` and the route proceeded as unconstrained generation."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        with pytest.raises(HTTPException) as ei:
+            _validate_response_format({})
+        assert ei.value.status_code == 400
+        assert "type is required" in ei.value.detail
+
+    def test_valid_text_type_passes(self):
+        """``type:"text"`` is the documented default and is the
+        explicit value Pydantic assigns when no ``type`` is provided
+        to the typed path — must not raise."""
+        from vllm_mlx.service.helpers import _validate_response_format
+        from vllm_mlx.api.models import ResponseFormat
+
+        # Both shapes — dict and Pydantic — must pass.
+        _validate_response_format(ResponseFormat(type="text"))
+        _validate_response_format({"type": "text"})
+
+    def test_valid_json_object_passes(self):
+        """The OpenAI ``json_object`` JSON-mode shorthand."""
+        from vllm_mlx.service.helpers import _validate_response_format
+        from vllm_mlx.api.models import ResponseFormat
+
+        _validate_response_format(ResponseFormat(type="json_object"))
+        _validate_response_format({"type": "json_object"})
+
+    def test_valid_json_schema_with_spec_passes(self):
+        """A fully-specified ``json_schema`` request must still work —
+        the gate only fires on missing/empty inner ``json_schema``."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        _validate_response_format(
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "r",
+                    "schema": {"type": "object"},
+                },
+            }
+        )
+
+    def test_none_response_format_passes(self):
+        """``response_format`` is optional — ``None`` is the default
+        and must remain a no-op."""
+        from vllm_mlx.service.helpers import _validate_response_format
+
+        _validate_response_format(None)
+
+
+# ---------------------------------------------------------------------------
+# F-066: image_url.url type validation (schema layer)
+# ---------------------------------------------------------------------------
+
+
+class TestImageUrlTypeValidation:
+    """Non-string ``image_url.url`` payloads used to slip past the
+    schema layer because the Union ``ImageUrl | dict | str | None``
+    falls back to ``dict`` when the inner ``ImageUrl`` model rejects
+    a non-string ``url``. The dict shape then crashed inside
+    ``process_image_input`` → ``is_base64_image(123)`` with
+    ``AttributeError: 'int' object has no attribute 'startswith'``."""
+
+    def test_int_url_rejected_at_schema_layer(self):
+        """The F-066 repro: ``image_url.url=123``. Pydantic v2 raises
+        ValidationError (HTTP 422 at the FastAPI route layer)."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest(
+                model="x",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image_url", "image_url": {"url": 123}}
+                        ],
+                    }
+                ],
+            )
+        msg = str(ei.value)
+        assert "image_url.url must be a string" in msg
+        # Must NOT contain the raw Python AttributeError marker.
+        assert "startswith" not in msg
+        assert "'int' object" not in msg
+
+    @pytest.mark.parametrize(
+        "bad_url", [42, 3.14, [1, 2], {"a": "b"}, True]
+    )
+    def test_non_string_url_variants_rejected(self, bad_url):
+        """Coverage for the full set of JSON-encodable non-string
+        types a buggy client could send. All share the same
+        ``.startswith`` hazard at the parser layer — caught at the
+        schema instead."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest(
+                model="x",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": bad_url},
+                            }
+                        ],
+                    }
+                ],
+            )
+        assert "image_url.url must be a string" in str(ei.value)
+
+    def test_video_url_int_rejected(self):
+        """Sister field — ``video_url.url`` has the same parser
+        hazard (``process_video_input`` calls ``is_base64_video`` →
+        ``startswith``)."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest(
+                model="x",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "video_url", "video_url": {"url": 99}}
+                        ],
+                    }
+                ],
+            )
+        assert "video_url.url must be a string" in str(ei.value)
+
+    def test_audio_url_int_rejected(self):
+        """Sister field — ``audio_url.url`` shares the same shape."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest(
+                model="x",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "audio_url", "audio_url": {"url": 7}}
+                        ],
+                    }
+                ],
+            )
+        assert "audio_url.url must be a string" in str(ei.value)
+
+    def test_valid_string_url_dict_accepted(self):
+        """A well-typed dict-shape ``image_url`` must still parse —
+        the validator only rejects non-string ``url``."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/x.png"},
+                        }
+                    ],
+                }
+            ],
+        )
+        # Well-typed dict resolves to the Pydantic ContentPart variant
+        # (not the dict fallback), so the ``image_url`` field is the
+        # parsed ``ImageUrl`` model.
+        part = req.messages[0].content[0]
+        url = part.image_url.url if hasattr(part, "image_url") else part[
+            "image_url"
+        ]["url"]
+        assert url == "https://example.com/x.png"
+
+    def test_valid_string_url_shorthand_accepted(self):
+        """The OpenAI-compat ``image_url`` can also be a plain
+        string — that path bypasses the dict branch entirely and
+        must still parse."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": "https://example.com/x.png",
+                        }
+                    ],
+                }
+            ],
+        )
+        # The Pydantic ContentPart variant wins for well-typed input,
+        # so the ContentPart was constructed (not the dict-fallback).
+        assert req.messages[0].content[0].image_url == (
+            "https://example.com/x.png"
+        )
+
+    def test_valid_text_content_unaffected(self):
+        """The validator only runs on dict items with multimodal
+        fields — a pure-text content list must not be affected."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                }
+            ],
+        )
+        assert req.messages[0].content[0].text == "hello"
+
+
+class TestProcessImageInputDefenseInDepth:
+    """Belt-and-suspenders: ``process_image_input`` is also called
+    from the Anthropic / Responses adapters and from internal code
+    paths where the schema-layer guard doesn't apply. The function's
+    own ``isinstance(image, str)`` check raises a clean ValueError
+    instead of bubbling the raw ``startswith`` AttributeError."""
+
+    def test_int_image_raises_clean_value_error(self):
+        from vllm_mlx.models.mllm import process_image_input
+
+        with pytest.raises(ValueError) as ei:
+            process_image_input(123)  # type: ignore[arg-type]
+        assert "must be a string" in str(ei.value)
+        assert "startswith" not in str(ei.value)
+
+    def test_dict_with_int_url_raises_clean_value_error(self):
+        """Dict-shape path: ``{"url": 123}`` unwraps to ``123`` and
+        then trips the new isinstance gate."""
+        from vllm_mlx.models.mllm import process_image_input
+
+        with pytest.raises(ValueError) as ei:
+            process_image_input({"url": 123})  # type: ignore[arg-type]
+        assert "must be a string" in str(ei.value)
+        assert "startswith" not in str(ei.value)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -66,6 +66,41 @@ class ContentPart(BaseModel):
     video_url: VideoUrl | dict | str | None = None
     audio_url: AudioUrl | dict | str | None = None
 
+    @model_validator(mode="after")
+    def _validate_media_url_types(self) -> "ContentPart":
+        """Reject non-string ``url`` inside multimodal-content dicts (F-066).
+
+        The Union ``ImageUrl | dict | str | None`` falls back to ``dict``
+        when ``url`` is not a string (Pydantic can't coerce e.g. ``int``
+        into the strict-typed ``ImageUrl.url: str`` slot), so the
+        malformed payload used to slip past the schema layer and crash
+        deep inside ``process_image_input`` with
+        ``'int' object has no attribute 'startswith'`` — Python type-
+        error text leaked verbatim in the HTTP 400 body.
+
+        Catching it at the schema layer means the client sees a clean
+        ``image_url.url must be a string`` (mirrors the message pydantic
+        itself would produce if the union allowed only ``ImageUrl |
+        str``) — and the same check applies to the sister
+        ``video_url`` / ``audio_url`` slots whose URL parsers share the
+        same ``startswith`` hazard.
+        """
+        for field, label in (
+            ("image_url", "image_url.url"),
+            ("video_url", "video_url.url"),
+            ("audio_url", "audio_url.url"),
+        ):
+            value = getattr(self, field, None)
+            # Only the dict-fallback branch can carry a non-string ``url``
+            # — the Pydantic-typed ``ImageUrl`` / ``VideoUrl`` / ``AudioUrl``
+            # variants reject it at parse time, and the plain-``str``
+            # variant is trivially well-typed.
+            if isinstance(value, dict) and "url" in value:
+                url = value["url"]
+                if url is not None and not isinstance(url, str):
+                    raise ValueError(f"{label} must be a string")
+        return self
+
 
 # =============================================================================
 # Messages
@@ -89,6 +124,43 @@ class Message(BaseModel):
     tool_calls: list[dict] | None = None
     # For tool response messages (role="tool")
     tool_call_id: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_media_url_types(self) -> "Message":
+        """Reject non-string ``url`` inside multimodal-content payloads
+        (F-066).
+
+        The ``content`` union is ``list[ContentPart] | list[dict]`` —
+        Pydantic falls back to ``list[dict]`` when ContentPart-level
+        validation raises (e.g. ``image_url.url=123`` makes the inner
+        ``ImageUrl`` model reject, the ``dict`` arm accepts the raw
+        shape, and ``list[ContentPart]`` then fails the whole list so
+        Pydantic picks ``list[dict]``). The malformed payload used to
+        slip past the schema layer and crash deep inside
+        ``process_image_input`` with ``'int' object has no attribute
+        'startswith'`` — raw Python type-error text leaked verbatim in
+        the HTTP 400 body. Run the same check at the parent Message so
+        the dict-fallback path is also covered (the inner ContentPart
+        validator handles the ``list[ContentPart]`` arm — kept there so
+        direct ``ContentPart(...)`` construction in tests is also
+        protected).
+        """
+        if not isinstance(self.content, list):
+            return self
+        for item in self.content:
+            if not isinstance(item, dict):
+                continue
+            for field, label in (
+                ("image_url", "image_url.url"),
+                ("video_url", "video_url.url"),
+                ("audio_url", "audio_url.url"),
+            ):
+                value = item.get(field)
+                if isinstance(value, dict) and "url" in value:
+                    url = value["url"]
+                    if url is not None and not isinstance(url, str):
+                        raise ValueError(f"{label} must be a string")
+        return self
 
 
 # =============================================================================

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -531,6 +531,20 @@ def process_image_input(image: str | dict) -> str:
     if not image:
         raise ValueError("Empty image input")
 
+    # Belt-and-suspenders for F-066: the schema-layer validator in
+    # ``api/models.py`` rejects non-string ``image_url.url`` payloads
+    # before they reach this point, but the function is also called
+    # directly from the Anthropic / Responses adapters and from
+    # internal code paths where the type-check isn't repeated. Without
+    # this guard, ``is_base64_image(123)`` would raise
+    # ``AttributeError: 'int' object has no attribute 'startswith'``
+    # and the route's broad ``except Exception`` wrap would surface
+    # that raw Python error text in the HTTP 400 body.
+    if not isinstance(image, str):
+        raise ValueError(
+            f"image_url.url must be a string (got {type(image).__name__})"
+        )
+
     # Check if it's base64 FIRST (before Path.exists() which fails on long strings)
     if is_base64_image(image):
         return save_base64_image(image)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -65,6 +65,7 @@ from ..service.helpers import (
     _scan_messages_for_lone_surrogates,
     _tool_use_required_named_suffix,
     _validate_model_name,
+    _validate_response_format,
     _validate_tool_call_params,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
@@ -539,6 +540,18 @@ async def _create_chat_completion_impl(
             status_code=400,
             detail="logit_bias is not supported on this server",
         )
+
+    # Validate ``response_format`` shape BEFORE
+    # ``build_json_system_prompt`` is reached (F-013). Two bugs the gate
+    # closes: (a) ``type:"json_schema"`` with no ``json_schema`` field
+    # used to leak ``AttributeError: 'NoneType' object has no attribute
+    # 'get'`` in the 400 body via the broad ``except Exception`` at
+    # the call site; (b) unknown ``type`` values (``"xml"``,
+    # ``""``, ``{}``, ``type:"json_schema"`` with empty
+    # ``json_schema:{}``) were silently accepted as HTTP 200 with no
+    # structure enforcement — client received unconstrained prose
+    # without any signal.
+    _validate_response_format(request.response_format)
 
     # --- Detailed request logging ---
     n_msgs = len(request.messages)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -681,6 +681,93 @@ def _rescue_silent_drop_from_reasoning(
     return reasoning_text
 
 
+# OpenAI-spec closed enum for ``response_format.type``. Any value outside
+# this set used to be silently accepted (defaulted to "text" by
+# ``build_json_system_prompt``) so a client typo like ``"xml"`` or an
+# empty string returned HTTP 200 with no structure enforcement — the
+# client received plain prose instead of the JSON they asked for and had
+# no signal anything was wrong (F-013 silent-accept arm). The validator
+# below pins the enum + the ``json_schema``-requires-schema invariant so
+# malformed requests get a clean 400 BEFORE
+# ``build_json_system_prompt`` is reached (which used to leak the raw
+# Python ``AttributeError: 'NoneType' object has no attribute 'get'`` in
+# the 400 body — F-013 raw-leak arm).
+_VALID_RESPONSE_FORMAT_TYPES = ("text", "json_object", "json_schema")
+
+
+def _validate_response_format(response_format) -> None:
+    """Raise a clean HTTP 400 for malformed ``response_format`` payloads.
+
+    Pins three invariants the previous ``try/except`` in routes/chat.py
+    failed to enforce:
+
+    1. ``response_format.type`` must be one of ``text``,
+       ``json_object``, ``json_schema``. Any other value (``"xml"``,
+       ``""``, etc.) used to slip through to ``build_json_system_prompt``
+       which fell back to ``"text"`` semantics — client received no
+       structure enforcement and a misleading 200. Now → 400.
+    2. ``type:"json_schema"`` requires a non-empty ``json_schema``
+       field. Previously the missing field raised
+       ``AttributeError: 'NoneType' object has no attribute 'get'``
+       deep inside ``build_json_system_prompt`` which surfaced
+       verbatim in the 400 body (F-013 raw-leak arm). Now → clean
+       400 message naming the missing field.
+    3. Empty ``response_format={}`` used to fall through with no
+       ``type`` so ``rf_dict.get("type", "text")`` produced silent
+       "text" semantics — fine in isolation but indistinguishable from
+       a client bug that meant to send a real format. Now → clean
+       400 requiring ``type``.
+
+    Accepts either a Pydantic ``ResponseFormat`` instance or a raw
+    ``dict`` (the request field is declared as
+    ``ResponseFormat | dict | None`` so both shapes reach the route).
+    """
+    if response_format is None:
+        return
+
+    # Normalize to the shape we actually validate against.
+    if isinstance(response_format, dict):
+        rf_type = response_format.get("type")
+        # ``{}`` — no ``type`` key at all. Pydantic-typed path has a
+        # default of "text" so this branch is only the raw-dict shape.
+        if "type" not in response_format:
+            raise HTTPException(
+                status_code=400,
+                detail="response_format.type is required",
+            )
+        json_schema_field = response_format.get("json_schema")
+    else:
+        rf_type = getattr(response_format, "type", None)
+        json_schema_field = getattr(response_format, "json_schema", None)
+
+    if rf_type not in _VALID_RESPONSE_FORMAT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "response_format.type must be 'text', 'json_object', "
+                "or 'json_schema'"
+            ),
+        )
+
+    if rf_type == "json_schema":
+        # Treat None AND empty dict the same — both fail the "non-empty
+        # json_schema spec" contract. The raw-leak path was specifically
+        # ``json_schema=None`` (omitted entirely); the silent-200 path
+        # was ``json_schema={}`` (present but empty so
+        # ``json_schema_spec.get("schema", {})`` returned ``{}`` and
+        # ``extract_json_schema_for_guided`` then bailed out at the
+        # ``if not schema: return None`` guard — request proceeded with
+        # no constraint).
+        if not json_schema_field:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "response_format.type='json_schema' requires "
+                    "non-empty 'json_schema' field"
+                ),
+            )
+
+
 def _is_structured_output_requested(response_format) -> bool:
     """Codex round-2 BLOCKING on #676: shared predicate for "client
     asked for structured output" — used by BOTH the non-streaming

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -750,20 +750,41 @@ def _validate_response_format(response_format) -> None:
         )
 
     if rf_type == "json_schema":
-        # Treat None AND empty dict the same — both fail the "non-empty
-        # json_schema spec" contract. The raw-leak path was specifically
-        # ``json_schema=None`` (omitted entirely); the silent-200 path
-        # was ``json_schema={}`` (present but empty so
-        # ``json_schema_spec.get("schema", {})`` returned ``{}`` and
-        # ``extract_json_schema_for_guided`` then bailed out at the
-        # ``if not schema: return None`` guard — request proceeded with
-        # no constraint).
+        # Treat None / empty dict / missing-``schema``-member all the
+        # same — each fails the "non-empty json_schema spec" contract.
+        # The raw-leak path was specifically ``json_schema=None``
+        # (omitted entirely); the silent-200 path was either
+        # ``json_schema={}`` or ``json_schema={"name":"r"}`` (present
+        # but with no ``schema`` member — codex r1 BLOCKING) because
+        # ``extract_json_schema_for_guided`` then bails out at
+        # ``if not schema: return None`` and the request proceeds
+        # unconstrained. The Pydantic-typed ``ResponseFormatJsonSchema``
+        # branch declares ``schema_`` as a required field so the typed
+        # path already rejects this shape — the explicit check here
+        # closes the raw-dict arm (the ``ResponseFormat | dict`` union
+        # on the request field).
         if not json_schema_field:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "response_format.type='json_schema' requires "
                     "non-empty 'json_schema' field"
+                ),
+            )
+        # Extract the inner ``schema`` member through both shapes:
+        # raw dict (json_schema_field is a dict) and Pydantic
+        # ``ResponseFormatJsonSchema`` (the field is aliased to
+        # ``schema_`` to dodge the BaseModel.schema collision).
+        if isinstance(json_schema_field, dict):
+            inner_schema = json_schema_field.get("schema")
+        else:
+            inner_schema = getattr(json_schema_field, "schema_", None)
+        if not inner_schema:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "response_format.type='json_schema' requires "
+                    "'json_schema.schema' to be a non-empty object"
                 ),
             )
 


### PR DESCRIPTION
## Summary

Two MED bugs in the same class — raw Python `AttributeError` / `TypeError` text leaking verbatim into HTTP 400 response bodies — bundled with a unified clean-error mapping pattern.

**F-013** (`response_format` validation):
- `response_format={"type":"json_schema"}` (missing inner `json_schema` field) leaked `"'NoneType' object has no attribute 'get'"` from `build_json_system_prompt` via the route's broad `except Exception` wrap.
- Sister silent-200 arm: `{"type":"xml"}`, `{"type":""}`, `{}`, `{"type":"json_schema","json_schema":{}}` were all silently accepted as HTTP 200 with no structure enforcement.
- Fix: `_validate_response_format` in `service/helpers.py` invoked early in `_create_chat_completion_impl`. Pins OpenAI-spec closed enum (`text` / `json_object` / `json_schema`) and the `json_schema`-requires-non-empty-schema invariant on both Pydantic and raw-dict shapes.

**F-066** (`image_url.url` type validation):
- `image_url.url=123` (or any non-string) slipped past the `ImageUrl | dict | str | None` union (inner `ImageUrl` rejected → `dict` arm won) and crashed inside `process_image_input` → `is_base64_image(123)` with `"'int' object has no attribute 'startswith'"`.
- Fix: schema-layer `model_validator` on both `ContentPart` (direct construction + `list[ContentPart]` arm) and `Message` (the `list[dict]` fallback arm Pydantic picks when the inner ContentPart validator raises). Sister fields `video_url.url` and `audio_url.url` covered by the same check.
- Defense-in-depth: `process_image_input` also gets an `isinstance(image, str)` gate with a clean `ValueError` so Anthropic / Responses adapter call sites that bypass the schema layer are also protected.

## Before / After

### F-013

| Payload | Before | After |
|---|---|---|
| `{"type":"json_schema"}` | 400 `"Invalid response_format schema: 'NoneType' object has no attribute 'get'"` | 400 `"response_format.type='json_schema' requires non-empty 'json_schema' field"` |
| `{"type":"xml"}` | 200 (silent unconstrained) | 400 `"response_format.type must be 'text', 'json_object', or 'json_schema'"` |
| `{"type":""}` | 200 (silent unconstrained) | 400 same enum message |
| `{}` | 200 (silent unconstrained) | 400 `"response_format.type is required"` |
| `{"type":"json_schema","json_schema":{}}` | 200 (silent unconstrained) | 400 non-empty-schema message |

### F-066

| Payload | Before | After |
|---|---|---|
| `image_url.url=123` | 400 `"Failed to process image: 'int' object has no attribute 'startswith'"` | 422 `"image_url.url must be a string"` |
| `image_url.url=3.14` | 400 raw `float` AttributeError text | 422 same clean message |
| `image_url.url=[1,2,3]` | 400 raw `list` AttributeError text | 422 same clean message |
| `video_url.url=99` | 400 raw `__fspath__` TypeError text | 422 `"video_url.url must be a string"` |
| `audio_url.url=7` | 200 (silently dropped) | 422 `"audio_url.url must be a string"` |

Valid payloads (`{"type":"json_object"}`, `{"type":"json_schema","json_schema":{"name":"r","schema":{...}}}`, `image_url={"url":"data:image/png;base64,..."}`, `image_url="data:..."`) continue to work unchanged.

## Test plan

- [x] `tests/test_clean_error_messages.py` — 22 new regression tests covering all 6 F-013 shapes + 5 F-066 url-type variants + 3 sister-field url-type checks + 4 valid-payload cases + 2 defense-in-depth `process_image_input` tests
- [x] Live retest on qwen3-0.6b-8bit (F-013) — all 5 cases return clean 400, both valid `json_object` / full `json_schema` still 200
- [x] Live retest on qwen3-vl-2b-4bit (F-066) — all 5 type-mismatch variants return clean 422 with named field, base64 + string-shorthand image_url still 200
- [x] Full regression suite: 6373 passed, 19 skipped, 16 deselected, 7 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)