### PR TITLE
fix(tools): enforce tool_call param schema (F-141 scoped — enum/type/range/length)

### DIFF
--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -996,25 +996,38 @@ class TestValidateToolCallParams:
             self._make_tools(),
         )
 
-    def test_type_mismatch_no_crash(self):
+    def test_type_mismatch_raises_400(self):
+        """F-141: type violation now enforced as HTTPException(400)."""
+        from fastapi import HTTPException
+
         from vllm_mlx.server import _validate_tool_call_params
 
-        _validate_tool_call_params(
-            self._make_tool_calls(arguments='{"location": 123}'),
-            self._make_tools(properties={"location": {"type": "string"}}),
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(
+                self._make_tool_calls(arguments='{"location": 123}'),
+                self._make_tools(properties={"location": {"type": "string"}}),
+            )
+        assert exc_info.value.status_code == 400
+        assert "location" in exc_info.value.detail
 
-    def test_enum_violation_no_crash(self):
+    def test_enum_violation_raises_400(self):
+        """F-141: enum violation now enforced as HTTPException(400)."""
+        from fastapi import HTTPException
+
         from vllm_mlx.server import _validate_tool_call_params
 
-        _validate_tool_call_params(
-            self._make_tool_calls(arguments='{"unit": "kelvin"}'),
-            self._make_tools(
-                properties={
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                }
-            ),
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(
+                self._make_tool_calls(arguments='{"unit": "kelvin"}'),
+                self._make_tools(
+                    properties={
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    }
+                ),
+            )
+        assert exc_info.value.status_code == 400
+        assert "unit" in exc_info.value.detail
+        assert "kelvin" in exc_info.value.detail or "enum" in exc_info.value.detail
 
     def test_empty_tool_calls(self):
         from vllm_mlx.server import _validate_tool_call_params

--- a/tests/test_tool_param_enforcement.py
+++ b/tests/test_tool_param_enforcement.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for F-141 — scoped tool-param schema enforcement.
+
+Before this fix, ``_validate_tool_call_params`` (in
+``vllm_mlx/service/helpers.py``) was log-only: when the model emitted
+arguments that violated the declared JSON schema for a tool, the engine
+wrote a ``logger.warning(...)`` and returned the bad payload to the
+client as a normal 200. F-141 ports the validator to ENFORCEMENT: a
+schema violation now raises ``HTTPException(400)`` so the caller can
+react (retry / fallback / surface to user) instead of silently shipping
+a broken contract.
+
+Scope this PR (see TODO.md F-141 partial-fixed entry):
+
+  * ``enum``        — string value must be in the declared list
+  * ``type``        — strict pydantic-style int/float/str/bool/array/object
+  * ``minimum``     — numeric lower bound (integer / number)
+  * ``maximum``     — numeric upper bound (integer / number)
+  * ``minLength``   — string lower length bound
+  * ``maxLength``   — string upper length bound
+
+Explicitly DEFERRED (covered by the pass-through tests at the bottom
+of this file to lock the boundary — over-enforcing these would
+regress real-world tool schemas that ship loose ``pattern`` /
+``format`` hints):
+
+  * ``pattern``      — regex (TODO(F-141-followup))
+  * ``format``       — email/date-time/uuid (TODO(F-141-followup))
+  * ``multipleOf``   — TODO(F-141-followup)
+  * ``uniqueItems``  — TODO(F-141-followup)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from vllm_mlx.api.models import FunctionCall, ToolCall
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool(name: str, properties: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "parameters": {"type": "object", "properties": properties},
+        },
+    }
+
+
+def _call(name: str, arguments: str) -> ToolCall:
+    return ToolCall(
+        id="call_abc",
+        type="function",
+        function=FunctionCall(name=name, arguments=arguments),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enforcement — 4 violation classes that MUST 400
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcement:
+    """F-141 scoped fix — these four constraint classes are enforced."""
+
+    def test_enum_violation_raises_400(self):
+        """enum: model emits ``"purple"`` against ``enum:["red","green","blue"]``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_color",
+                {"color": {"type": "string", "enum": ["red", "green", "blue"]}},
+            )
+        ]
+        calls = [_call("set_color", '{"color": "purple"}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        # The detail must name the offending field so the client can
+        # surface a useful error to the end user.
+        assert "color" in exc_info.value.detail
+        assert "purple" in exc_info.value.detail or "enum" in exc_info.value.detail
+
+    def test_type_violation_raises_400(self):
+        """type: schema says ``integer``, model emits string ``"twentyfive"``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("set_age", {"age": {"type": "integer"}})]
+        calls = [_call("set_age", '{"age": "twentyfive"}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        assert "age" in exc_info.value.detail
+        assert "integer" in exc_info.value.detail.lower()
+
+    def test_range_violation_raises_400(self):
+        """minimum/maximum: ``score=200`` against ``maximum:100``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_score",
+                {"score": {"type": "integer", "minimum": 0, "maximum": 100}},
+            )
+        ]
+        calls = [_call("set_score", '{"score": 200}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        assert "score" in exc_info.value.detail
+        assert "maximum" in exc_info.value.detail or "100" in exc_info.value.detail
+
+    def test_min_below_floor_raises_400(self):
+        """Symmetric direction: ``score=-5`` against ``minimum:0``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_score",
+                {"score": {"type": "integer", "minimum": 0, "maximum": 100}},
+            )
+        ]
+        calls = [_call("set_score", '{"score": -5}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        assert "minimum" in exc_info.value.detail or "score" in exc_info.value.detail
+
+    def test_length_violation_raises_400(self):
+        """minLength: ``username="bob"`` (len 3) against ``minLength:5``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_username",
+                {"username": {"type": "string", "minLength": 5, "maxLength": 20}},
+            )
+        ]
+        calls = [_call("set_username", '{"username": "bob"}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        assert "username" in exc_info.value.detail
+        assert (
+            "minLength" in exc_info.value.detail
+            or "length" in exc_info.value.detail.lower()
+        )
+
+    def test_max_length_violation_raises_400(self):
+        """maxLength: 30-char username against ``maxLength:20``."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        long_name = "x" * 30
+        tools = [
+            _tool(
+                "set_username",
+                {"username": {"type": "string", "minLength": 1, "maxLength": 20}},
+            )
+        ]
+        calls = [_call("set_username", f'{{"username": "{long_name}"}}')]
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params(calls, tools)
+        assert exc_info.value.status_code == 400
+        assert "maxLength" in exc_info.value.detail or "20" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Valid baseline — must NOT raise (proves enforcement isn't over-zealous)
+# ---------------------------------------------------------------------------
+
+
+class TestValidPasses:
+    """A perfectly schema-conformant call must continue to succeed —
+    locks in the upper bound of enforcement so we don't silently start
+    rejecting good payloads."""
+
+    def test_valid_enum_passes(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_color",
+                {"color": {"type": "string", "enum": ["red", "green", "blue"]}},
+            )
+        ]
+        calls = [_call("set_color", '{"color": "red"}')]
+        _validate_tool_call_params(calls, tools)  # no raise
+
+    def test_valid_all_constraints_pass(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "register",
+                {
+                    "username": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 20,
+                    },
+                    "age": {"type": "integer", "minimum": 0, "maximum": 150},
+                    "role": {"type": "string", "enum": ["admin", "user"]},
+                },
+            )
+        ]
+        calls = [
+            _call(
+                "register",
+                '{"username": "alice", "age": 30, "role": "admin"}',
+            )
+        ]
+        _validate_tool_call_params(calls, tools)  # no raise
+
+    def test_boundary_inclusive_passes(self):
+        """JSON Schema ``minimum``/``maximum`` are inclusive."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_score",
+                {"score": {"type": "integer", "minimum": 0, "maximum": 100}},
+            )
+        ]
+        _validate_tool_call_params([_call("set_score", '{"score": 0}')], tools)
+        _validate_tool_call_params([_call("set_score", '{"score": 100}')], tools)
+
+
+# ---------------------------------------------------------------------------
+# Deferred — `pattern` and `format` MUST still pass-through (NOT enforced)
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredPassThrough:
+    """These constraint classes are intentionally left advisory in this
+    scoped PR. Locking the pass-through behaviour as a regression test
+    ensures a future tightening is a deliberate, reviewed change rather
+    than an accidental side-effect of touching ``validate_param_value``."""
+
+    def test_pattern_violation_does_not_raise(self):
+        """``pattern`` violations remain advisory (TODO(F-141-followup))."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "set_phone",
+                {"phone": {"type": "string", "pattern": "^[0-9]{3}-[0-9]{4}$"}},
+            )
+        ]
+        # "abc" clearly violates the regex; if we ever start enforcing
+        # `pattern` this test will need an explicit update.
+        _validate_tool_call_params([_call("set_phone", '{"phone": "abc"}')], tools)
+
+    def test_format_violation_does_not_raise(self):
+        """``format`` violations remain advisory (TODO(F-141-followup))."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool("set_email", {"email": {"type": "string", "format": "email"}})
+        ]
+        # "notanemail" is not an email; deferred.
+        _validate_tool_call_params(
+            [_call("set_email", '{"email": "notanemail"}')], tools
+        )
+
+    def test_multiple_of_violation_does_not_raise(self):
+        """``multipleOf`` deferred too — 7 is not a multiple of 3."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("step", {"n": {"type": "integer", "multipleOf": 3}})]
+        _validate_tool_call_params([_call("step", '{"n": 7}')], tools)

--- a/tests/test_tool_param_enforcement.py
+++ b/tests/test_tool_param_enforcement.py
@@ -37,7 +37,6 @@ from fastapi import HTTPException
 
 from vllm_mlx.api.models import FunctionCall, ToolCall
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -267,9 +266,7 @@ class TestDeferredPassThrough:
         """``format`` violations remain advisory (TODO(F-141-followup))."""
         from vllm_mlx.service.helpers import _validate_tool_call_params
 
-        tools = [
-            _tool("set_email", {"email": {"type": "string", "format": "email"}})
-        ]
+        tools = [_tool("set_email", {"email": {"type": "string", "format": "email"}})]
         # "notanemail" is not an email; deferred.
         _validate_tool_call_params(
             [_call("set_email", '{"email": "notanemail"}')], tools

--- a/tests/test_tool_param_enforcement.py
+++ b/tests/test_tool_param_enforcement.py
@@ -177,6 +177,44 @@ class TestEnforcement:
 
 
 # ---------------------------------------------------------------------------
+# Union types — `{"type": ["string", "null"]}` must be honoured
+# ---------------------------------------------------------------------------
+
+
+class TestUnionTypes:
+    """Codex round 2 BLOCKING on PR #736 — JSON-Schema lets ``type`` be
+    a list, e.g. ``{"type": ["string", "null"]}``. The original branch
+    tree skipped every check because ``param_type`` was a list, so an
+    integer slipped past for a string-or-null schema. These tests lock
+    the union-type path."""
+
+    def test_union_string_or_null_accepts_string(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("nick", {"name": {"type": ["string", "null"]}})]
+        _validate_tool_call_params([_call("nick", '{"name": "alice"}')], tools)
+
+    def test_union_string_or_null_accepts_null(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("nick", {"name": {"type": ["string", "null"]}})]
+        _validate_tool_call_params([_call("nick", '{"name": null}')], tools)
+
+    def test_union_string_or_null_rejects_integer(self):
+        """Integer should NOT match a ``["string", "null"]`` union."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("nick", {"name": {"type": ["string", "null"]}})]
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_tool_call_params([_call("nick", '{"name": 123}')], tools)
+        assert exc_info.value.status_code == 400
+        assert "name" in exc_info.value.detail
+        # Should mention the union members or the offending int type.
+        detail = exc_info.value.detail
+        assert "string" in detail or "null" in detail or "int" in detail
+
+
+# ---------------------------------------------------------------------------
 # Valid baseline — must NOT raise (proves enforcement isn't over-zealous)
 # ---------------------------------------------------------------------------
 

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -422,7 +422,14 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
     """
     Validate a parameter value against its JSON schema (lightweight).
 
-    Lightweight validation of a parameter value against its JSON schema.
+    Enforced constraints (F-141 scoped fix): ``type`` (strict — booleans
+    are NOT accepted for ``integer``/``number`` even though
+    ``isinstance(True, int)`` is True in Python), ``enum``, ``minimum`` /
+    ``maximum`` (numeric only), ``minLength`` / ``maxLength`` (string
+    only). Other JSON-schema keywords (``pattern``, ``format``,
+    ``multipleOf``, ``uniqueItems``, ``required``, ``oneOf``/``anyOf``,
+    ``additionalProperties``) are intentionally left pass-through and
+    tracked as a follow-up — see TODO below.
 
     Args:
         value: The parameter value string.
@@ -449,12 +456,17 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
             return True, None  # Bare strings are acceptable for string params
         return False, f"Invalid JSON value: {value!r}"
 
-    # Type check
+    # Type check (strict — exclude bool from integer/number; pydantic
+    # treats ``True``/``False`` as their own type, not as ``1``/``0``).
     if param_type == "string" and not isinstance(parsed, str):
         return False, f"Expected string, got {type(parsed).__name__}"
-    elif param_type == "integer" and not isinstance(parsed, int):
+    elif param_type == "integer" and (
+        not isinstance(parsed, int) or isinstance(parsed, bool)
+    ):
         return False, f"Expected integer, got {type(parsed).__name__}"
-    elif param_type == "number" and not isinstance(parsed, (int, float)):
+    elif param_type == "number" and (
+        not isinstance(parsed, (int, float)) or isinstance(parsed, bool)
+    ):
         return False, f"Expected number, got {type(parsed).__name__}"
     elif param_type == "boolean" and not isinstance(parsed, bool):
         return False, f"Expected boolean, got {type(parsed).__name__}"
@@ -466,5 +478,41 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
     # Enum check
     if "enum" in schema and parsed not in schema["enum"]:
         return False, f"Value {parsed!r} not in enum {schema['enum']}"
+
+    # Numeric range (only when the parsed value is actually numeric —
+    # the type-check branch above already rejected non-numeric values
+    # for declared ``integer``/``number`` types, but a schema may omit
+    # ``type`` and still carry ``minimum``/``maximum``).
+    if isinstance(parsed, (int, float)) and not isinstance(parsed, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and not isinstance(minimum, bool):
+            if parsed < minimum:
+                return False, f"Value {parsed} below minimum {minimum}"
+        maximum = schema.get("maximum")
+        if isinstance(maximum, (int, float)) and not isinstance(maximum, bool):
+            if parsed > maximum:
+                return False, f"Value {parsed} above maximum {maximum}"
+
+    # String length
+    if isinstance(parsed, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and not isinstance(min_length, bool):
+            if len(parsed) < min_length:
+                return (
+                    False,
+                    f"String length {len(parsed)} below minLength {min_length}",
+                )
+        max_length = schema.get("maxLength")
+        if isinstance(max_length, int) and not isinstance(max_length, bool):
+            if len(parsed) > max_length:
+                return (
+                    False,
+                    f"String length {len(parsed)} above maxLength {max_length}",
+                )
+
+    # TODO(F-141-followup): enforce pattern/format/multipleOf/uniqueItems.
+    # Deferred because regex/format implementations are non-trivial and
+    # the scoped fix targets the high-traffic constraints (enum/type/
+    # range/length). See TODO.md F-141 partial-fixed entry.
 
     return True, None

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -418,6 +418,45 @@ def create_tool_logits_processor(
     return None
 
 
+# JSON-Schema → Python type predicate. Booleans are explicitly excluded
+# from ``integer`` / ``number`` because Python treats ``True``/``False``
+# as ``int`` subclasses (``isinstance(True, int) is True``); JSON-Schema
+# and pydantic both consider them their own type.
+def _matches_single_json_type(parsed: object, t: str) -> bool:
+    if t == "string":
+        return isinstance(parsed, str)
+    if t == "integer":
+        return isinstance(parsed, int) and not isinstance(parsed, bool)
+    if t == "number":
+        return isinstance(parsed, (int, float)) and not isinstance(parsed, bool)
+    if t == "boolean":
+        return isinstance(parsed, bool)
+    if t == "array":
+        return isinstance(parsed, list)
+    if t == "object":
+        return isinstance(parsed, dict)
+    if t == "null":
+        return parsed is None
+    # Unknown type name — treat as no constraint (skip), matching the
+    # `allowed_types` normalisation in ``validate_param_value`` which
+    # already drops non-string entries.
+    return False
+
+
+def _value_matches_any_type(parsed: object, allowed_types: set[str]) -> bool:
+    """Return True if ``parsed`` matches at least one type in
+    ``allowed_types``.
+
+    Codex round 2 BLOCKING on PR #736 caught that the original
+    branch tree never visited union-typed schemas (``"type": [...]``).
+    Splitting the predicate into a single-type helper lets the union
+    case fall out as a simple ``any()`` over the set.
+    """
+    if not allowed_types:
+        return True  # No declared type → no constraint
+    return any(_matches_single_json_type(parsed, t) for t in allowed_types)
+
+
 def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
     """
     Validate a parameter value against its JSON schema (lightweight).
@@ -447,33 +486,53 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
         return True, None
     param_type = schema.get("type", "")
 
+    # JSON Schema lets ``type`` be either a single string or a list of
+    # strings (a "union" type — e.g. ``{"type": ["string", "null"]}``).
+    # Normalise to a set of allowed scalar names; an empty set means
+    # "no type constraint declared" (the schema may still carry an
+    # ``enum`` / range / length constraint which we honour below).
+    # Anything we don't recognise (e.g. a stray int that survived the
+    # F-140 guards upstream) is dropped from the allowed set so it
+    # doesn't accidentally permit every type — codex round 2 BLOCKING
+    # on PR #736 caught the original branch leaving union schemas
+    # unchecked.
+    if isinstance(param_type, str):
+        allowed_types: set[str] = {param_type} if param_type else set()
+    elif isinstance(param_type, list):
+        allowed_types = {t for t in param_type if isinstance(t, str)}
+    else:
+        allowed_types = set()
+
     # Try to parse as JSON first
     try:
         parsed = json.loads(value)
     except (json.JSONDecodeError, ValueError):
         # Not valid JSON — check if it's a bare string (common for string params)
-        if param_type == "string":
+        if "string" in allowed_types:
             return True, None  # Bare strings are acceptable for string params
         return False, f"Invalid JSON value: {value!r}"
 
     # Type check (strict — exclude bool from integer/number; pydantic
     # treats ``True``/``False`` as their own type, not as ``1``/``0``).
-    if param_type == "string" and not isinstance(parsed, str):
-        return False, f"Expected string, got {type(parsed).__name__}"
-    elif param_type == "integer" and (
-        not isinstance(parsed, int) or isinstance(parsed, bool)
-    ):
-        return False, f"Expected integer, got {type(parsed).__name__}"
-    elif param_type == "number" and (
-        not isinstance(parsed, (int, float)) or isinstance(parsed, bool)
-    ):
-        return False, f"Expected number, got {type(parsed).__name__}"
-    elif param_type == "boolean" and not isinstance(parsed, bool):
-        return False, f"Expected boolean, got {type(parsed).__name__}"
-    elif param_type == "array" and not isinstance(parsed, list):
-        return False, f"Expected array, got {type(parsed).__name__}"
-    elif param_type == "object" and not isinstance(parsed, dict):
-        return False, f"Expected object, got {type(parsed).__name__}"
+    # For union ``type`` ([...]) the value is valid if it matches ANY
+    # allowed type. ``allowed_types == set()`` means the schema omitted
+    # ``type`` entirely — we skip this branch and fall through to the
+    # enum / range / length checks. Unrecognised type names (anything
+    # outside the six JSON-schema scalars + ``"null"``) are ignored
+    # rather than silently permitting; if the schema lists ONLY
+    # unknown types we skip the type check entirely.
+    if allowed_types:
+        type_matches = _value_matches_any_type(parsed, allowed_types)
+        if not type_matches:
+            display = (
+                next(iter(allowed_types))
+                if len(allowed_types) == 1
+                else f"one of {sorted(allowed_types)}"
+            )
+            return (
+                False,
+                f"Expected {display}, got {type(parsed).__name__}",
+            )
 
     # Enum check
     if "enum" in schema and parsed not in schema["enum"]:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1643,7 +1643,25 @@ def _parse_tool_calls_with_parser(
 
 
 def _validate_tool_call_params(tool_calls: list, tools: list) -> None:
-    """Validate tool call parameter values against their schemas (post-generation)."""
+    """Validate tool call parameter values against their schemas (post-generation).
+
+    F-141 scoped fix: enforce JSON-schema constraints on the model's
+    emitted ``tool_calls[].function.arguments`` instead of merely
+    logging. When a violation is detected we raise ``HTTPException(400)``
+    so the caller can decide how to recover (retry with a stricter
+    prompt, fall back to text, etc.) rather than silently propagating a
+    schema-violating payload as a normal success. This matches the
+    OpenAI contract: when a ``tool_calls[i]`` is present, its arguments
+    are expected to satisfy the declared parameter schema.
+
+    Enforced today (intentionally narrow, see ``validate_param_value``):
+    ``type``, ``enum``, ``minimum``/``maximum``, ``minLength``/``maxLength``.
+    Deferred (TODO(F-141-followup)): ``pattern``, ``format``,
+    ``multipleOf``, ``uniqueItems``. Non-JSON ``arguments`` and non-dict
+    parsed args remain warn-only because they indicate a model/parser
+    issue rather than a schema violation, and the upstream parser layer
+    already surfaces them.
+    """
     from ..api.tool_logits import _extract_param_schemas, validate_param_value
 
     tool_defs = [t.model_dump() if hasattr(t, "model_dump") else t for t in tools]
@@ -1676,7 +1694,15 @@ def _validate_tool_call_params(tool_calls: list, tools: list) -> None:
                 continue
             is_valid, error = validate_param_value(json.dumps(param_value), schema)
             if not is_valid:
-                logger.warning(f"Tool call '{func_name}' param '{param_name}': {error}")
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Tool call '{func_name}' parameter '{param_name}' "
+                        f"violates declared schema: {error}. The model "
+                        "produced a schema-violating argument value; retry "
+                        "with a more constrained prompt or relax the schema."
+                    ),
+                )
 
 
 # ── Message helpers ────────────────────────────────────────────────

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -769,8 +769,7 @@ def _validate_response_format(response_format) -> None:
         raise HTTPException(
             status_code=400,
             detail=(
-                "response_format.type must be 'text', 'json_object', "
-                "or 'json_schema'"
+                "response_format.type must be 'text', 'json_object', or 'json_schema'"
             ),
         )
 


### PR DESCRIPTION
## Summary

- **F-141 scoped fix**: `_validate_tool_call_params` (in `vllm_mlx/service/helpers.py`) was log-only — when the model produced `tool_calls[].function.arguments` that violated the declared JSON schema, the engine wrote `logger.warning(...)` and returned the bad payload as a normal 200. OpenAI clients trusting the contract ("if a tool_call comes back, its arguments validate") silently received malformed arguments.
- This PR ports the validator to **enforcement** for the four high-traffic constraint classes: `enum`, `type` (strict pydantic-style — booleans are NOT accepted for `integer`/`number`), `minimum`/`maximum`, `minLength`/`maxLength`. Violations now raise `HTTPException(400)` with a detail naming the function + parameter + specific constraint.
- **Intentionally deferred** (`TODO(F-141-followup)`): `pattern`, `format`, `multipleOf`, `uniqueItems`. The regression test file locks the pass-through behaviour for these so a future tightening is deliberate.

## Repros against `llama3-3b-4bit` on port 8066 (before → after)

| Case | Request | Before | After |
|---|---|---|---|
| enum | `{"color":"purple"}` vs `["red","green","blue"]` | 200 (bad args) | **400** ("Value 'purple' not in enum [...]") |
| type | `{"age":"twentyfive"}` vs `{type:integer}` | 200 (bad args) | **400** ("Expected integer, got str") |
| range | `{"score":200}` vs `{maximum:100}` | 200 (bad args) | **400** ("Value 200 above maximum 100") |
| length | `{"username":"bob"}` vs `{minLength:5}` | 200 (bad args) | **400** ("String length 3 below minLength 5") |
| valid | `{"color":"red"}` (enum match) | 200 | 200 (unchanged) |
| deferred pattern | `{"phone":"abc"}` vs regex `^[0-9]{3}-[0-9]{4}$` | 200 | 200 (still advisory) |
| deferred format | `{"email":"notanemail"}` vs `format:email` | 200 | 200 (still advisory) |

## Files

- `vllm_mlx/api/tool_logits.py` — extend `validate_param_value` with `minimum`/`maximum`/`minLength`/`maxLength` + tighten int/number type check to exclude booleans + inline `TODO(F-141-followup)` for the deferred constraints.
- `vllm_mlx/service/helpers.py` — `_validate_tool_call_params` now raises `HTTPException(400)` instead of `logger.warning(...)`.
- `tests/test_tool_param_enforcement.py` — **NEW** 12-case regression suite: 6 violation classes raise 400, 3 valid baselines pass, 3 deferred classes (`pattern`/`format`/`multipleOf`) still pass-through.
- `tests/test_server_utils.py` — existing 2 no-crash tests (`test_type_mismatch_no_crash` / `test_enum_violation_no_crash`) flipped to assert `HTTPException(400)` to match the new contract.

## Test plan

- [x] `pytest tests/test_tool_logits.py tests/test_tool_logits_schema_guards.py tests/test_server_utils.py tests/test_tool_param_enforcement.py` — 170/170 pass
- [x] HTTP repro on `llama3-3b-4bit` port 8066 — all 4 violation classes return 400 with clear messages; valid request unchanged; deferred constraints still pass-through

## Out of scope (TODO follow-up)

- `pattern` (regex enforcement — needs catastrophic-backtracking guard)
- `format` (email/date-time/uuid validators)
- `multipleOf`, `uniqueItems`

NO version bump per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)