### PR TITLE
fix(security): gate /v1/cache/{export,import,info} on verify_internal_admin (F-180)

### DIFF
--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -48,13 +48,29 @@ def cache_client(monkeypatch, sandbox):
 
     app = FastAPI()
     app.include_router(router)
-    yield SimpleNamespace(client=TestClient(app), sandbox=sandbox)
+    # F-180: pin loopback as the TestClient origin so the
+    # ``verify_internal_admin`` loopback escape hatch resolves true. The
+    # default ``("testclient", 50000)`` host is NOT loopback and would 403
+    # every test once the cache router moved onto the admin gate.
+    yield SimpleNamespace(
+        client=TestClient(app, client=("127.0.0.1", 50000)),
+        sandbox=sandbox,
+    )
 
     reset_config()
 
 
 def _auth() -> dict:
-    return {"Authorization": "Bearer test-secret"}
+    """Auth headers for the cache router (F-180).
+
+    Bearer alone is no longer sufficient — the cache router now sits behind
+    ``verify_internal_admin``, which requires ``X-Rapid-MLX-Internal: true``
+    AND (because ``--api-key`` is configured in the fixture) a valid bearer.
+    """
+    return {
+        "Authorization": "Bearer test-secret",
+        "X-Rapid-MLX-Internal": "true",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -243,24 +259,35 @@ def test_manifest_from_dict_drops_unknown_fields(tmp_path):
     ],
 )
 def test_routes_require_auth(cache_client, method, path, body):
-    """No bearer → 401 on every route."""
+    """F-180: no ``X-Rapid-MLX-Internal`` header → 403 on every route.
+
+    Pre-F-180 these routes were on ``verify_api_key`` which returned 401 on
+    a missing bearer. Post-F-180 the header gate fires first and surfaces
+    as 403 even before the bearer check (auth-stage signals are distinct
+    so monitoring rules can grep them apart)."""
     client = cache_client.client
     if method == "post":
         resp = client.post(path, json=body)
     else:
         resp = client.get(path)
-    assert resp.status_code == 401, resp.text
+    assert resp.status_code == 403, resp.text
+    # The 403 detail must call out the missing header so an operator can
+    # diagnose the misconfiguration without grepping source.
+    body_json = resp.json()
+    detail = body_json.get("detail") or body_json.get("error", {}).get("message", "")
+    if isinstance(detail, dict):
+        detail = detail.get("message", "")
+    assert "X-Rapid-MLX-Internal" in detail, body_json
 
 
 def test_info_requires_auth_even_with_valid_manifest(cache_client):
     """An unauthenticated ``GET /v1/cache/info`` against a path with a
-    valid manifest must still return 401, not 200.
+    valid manifest must still 403 (F-180), not 200.
 
-    Codex round-3 NIT: the parametrized auth check uses an empty default
-    path, where auth-fires-before-handler is indistinguishable from
-    auth-fires-after-handler by 404 vs 401 ordering. With a real manifest
-    in place, a bypassed auth dependency would surface as a 200 — this
-    test catches that exact regression.
+    Codex round-3 NIT (original): with auth-fires-before-handler the empty
+    default path returns the same status as a missing-handler-output. With
+    a real manifest in place, a bypassed auth dependency would surface as
+    a 200 — this test catches that exact regression for the F-180 gate.
     """
     _write_export_root(
         cache_client.sandbox,
@@ -268,14 +295,21 @@ def test_info_requires_auth_even_with_valid_manifest(cache_client):
         Manifest(protocol_version=PROTOCOL_VERSION, model_id="x", entries=1),
     )
     resp = cache_client.client.get("/v1/cache/info?path=valid")
-    assert resp.status_code == 401
+    assert resp.status_code == 403
 
 
 def test_routes_reject_wrong_bearer(cache_client):
+    """With the internal header present but a wrong bearer, the api-key gate
+    fires (because ``cfg.api_key`` is set) and returns 401. Pre-F-180 this
+    test sent only the bearer; post-F-180 we must also send the header so
+    the request gets past the header gate to the bearer check."""
     resp = cache_client.client.post(
         "/v1/cache/export",
         json={},
-        headers={"Authorization": "Bearer wrong"},
+        headers={
+            "Authorization": "Bearer wrong",
+            "X-Rapid-MLX-Internal": "true",
+        },
     )
     assert resp.status_code == 401
 
@@ -286,15 +320,23 @@ def test_routes_reject_wrong_bearer(cache_client):
 
 
 def test_export_default_destination_returns_501(cache_client):
-    """No destination → uses sandbox root, then 501 with #476 link."""
+    """No destination → uses sandbox root, then 501 with the sanitized
+    F-180 envelope (no resolved-path leak, no tracking-URL leak)."""
     resp = cache_client.client.post("/v1/cache/export", json={}, headers=_auth())
     assert resp.status_code == 501
     detail = resp.json()["detail"]
-    assert "issue" in detail and "476" in detail["issue"]
-    assert detail["validated"]["protocol_version"] == PROTOCOL_VERSION
-    # Resolved destination must be inside the sandbox.
+    # F-180: minimal envelope, no operator-controlled fields.
+    assert detail == {
+        "error": {
+            "message": "not implemented",
+            "type": "not_implemented_error",
+            "code": None,
+        }
+    }
+    # The resolved destination must NOT appear anywhere in the body.
     sandbox_real = str(Path(cache_client.sandbox).resolve())
-    assert detail["validated"]["destination"].startswith(sandbox_real)
+    assert sandbox_real not in resp.text
+    assert "github.com" not in resp.text
 
 
 def test_export_rejects_path_traversal(cache_client):
@@ -447,7 +489,8 @@ def test_import_model_id_mismatch_returns_409(cache_client):
 
 
 def test_import_validated_request_returns_501(cache_client):
-    """All checks pass → 501 with the parsed manifest echoed back."""
+    """All checks pass → 501 with the sanitized F-180 envelope (no resolved
+    source path, no parsed-manifest echo, no tracking-URL leak)."""
     manifest = Manifest(
         protocol_version=PROTOCOL_VERSION,
         model_id="qwen3.5-9b-4bit",
@@ -466,9 +509,19 @@ def test_import_validated_request_returns_501(cache_client):
     )
     assert resp.status_code == 501
     detail = resp.json()["detail"]
-    assert detail["issue"].endswith("/476")
-    assert detail["validated"]["merge_strategy"] == "replace"
-    assert detail["validated"]["manifest"]["entries"] == 18
+    # F-180: minimal envelope, no operator-controlled fields.
+    assert detail == {
+        "error": {
+            "message": "not implemented",
+            "type": "not_implemented_error",
+            "code": None,
+        }
+    }
+    # Belt + braces: the resolved source dir and the model id must not surface.
+    sandbox_real = str(Path(cache_client.sandbox).resolve())
+    assert sandbox_real not in resp.text
+    assert "qwen3.5-9b-4bit" not in resp.text
+    assert "github.com" not in resp.text
 
 
 def test_import_rejects_path_traversal(cache_client):

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -33,11 +33,19 @@ from fastapi.testclient import TestClient
 # Routes that MUST require ``X-Rapid-MLX-Internal: true``. Parametrize over all
 # of them so a future addition to ``admin_router`` only needs an entry here to
 # get full unauth/auth/leak coverage.
+#
+# F-180: ``/v1/cache/{export,import,info}`` were originally on the
+# unauth-when-no-api-key ``cache`` router. They are now gated by the same
+# ``verify_internal_admin`` dep — pin that here so a future refactor splitting
+# the cache router doesn't silently drop the gate again.
 _DESTRUCTIVE_ROUTES = [
     ("POST", "/v1/cache/clear"),
     ("POST", "/v1/requests/some-request-id/cancel"),
     ("DELETE", "/v1/requests/some-request-id"),
     ("DELETE", "/v1/cache"),
+    ("POST", "/v1/cache/export"),
+    ("POST", "/v1/cache/import"),
+    ("GET", "/v1/cache/info"),
 ]
 
 
@@ -51,6 +59,7 @@ def client_factory():
     503-check guard in the route handlers.
     """
     from vllm_mlx.config import get_config
+    from vllm_mlx.routes.cache import router as cache_router
     from vllm_mlx.routes.health import admin_router, router
 
     cfg = get_config()
@@ -87,6 +96,10 @@ def client_factory():
         app = FastAPI()
         app.include_router(router)
         app.include_router(admin_router)
+        # F-180: ``cache_router`` carries the three sibling cache routes
+        # (export/import/info) that PR #728 missed. Mount it here so the
+        # _DESTRUCTIVE_ROUTES parametrize matrix can pin their auth shape.
+        app.include_router(cache_router)
         # ``TestClient(app, client=(host, port))`` injects the supplied
         # tuple into ``scope["client"]`` so ``request.client.host`` reads
         # back as ``host``. The default ``("testclient", 50000)`` is NOT
@@ -447,3 +460,87 @@ def test_cancel_500_error_path_does_not_leak_exception_detail(client_factory):
     assert "secret-snapshot" not in r.text
     assert "huggingface" not in r.text
     assert ".cache" not in r.text
+
+
+# ---------------------------------------------------------------------------
+# F-180 specific: cache export/import 501 envelope must not leak operator-
+# controlled disk paths or GitHub tracking URLs.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
+    """F-180: pre-fix, ``POST /v1/cache/export`` 501-stubbed back the resolved
+    sandbox destination — which expands to ``/Users/<USERNAME>/.cache/rapid-mlx/
+    cache_exports`` and leaks the operator's home dir / username. The fix
+    sanitizes the envelope to a minimal ``{"error": {...}}`` shape; the
+    resolved path stays in server logs only.
+    """
+    build, _ = client_factory
+    client = build(api_key=None)
+
+    r = client.post(
+        "/v1/cache/export",
+        headers={"X-Rapid-MLX-Internal": "true"},
+        json={},
+    )
+    assert r.status_code == 501, r.text
+    body = r.json()
+    # No resolved-path-shaped strings in the body.
+    assert "/Users/" not in r.text
+    assert ".cache" not in r.text
+    assert "rapid-mlx" not in r.text
+    assert "cache_exports" not in r.text
+    # No tracking-URL leak either (per test-loop8 finding).
+    assert "github.com" not in r.text
+    assert "issues/" not in r.text
+    # Minimal envelope shape.
+    detail = body.get("detail")
+    assert isinstance(detail, dict) and "error" in detail, body
+
+
+def test_cache_import_501_envelope_does_not_leak_operator_path(
+    client_factory, tmp_path, monkeypatch
+):
+    """F-180: same shape check for ``POST /v1/cache/import``. We point the
+    sandbox env at a tmp dir so we can hand-craft a manifest the route accepts,
+    then assert the resulting 501 body is path-free.
+    """
+    # Point the export sandbox at tmp_path so the resolved source / manifest
+    # path is under the test rig, not the operator's home dir.
+    monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(tmp_path))
+
+    # Hand-craft a valid manifest.json so import gets past the validation
+    # branches and into the 501 stub.
+    import json
+
+    from vllm_mlx.cache.protocol import PROTOCOL_VERSION
+
+    manifest = {
+        "protocol_version": PROTOCOL_VERSION,
+        "model_id": "test-model",
+        "entries": 0,
+        "total_bytes": 0,
+        "created_at": "2026-06-20T00:00:00Z",
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+    build, _ = client_factory
+    client = build(api_key=None)
+
+    r = client.post(
+        "/v1/cache/import",
+        headers={"X-Rapid-MLX-Internal": "true"},
+        json={"source": str(tmp_path)},
+    )
+    assert r.status_code == 501, r.text
+    body = r.json()
+    # No resolved-path-shaped strings.
+    assert str(tmp_path) not in r.text
+    assert "/Users/" not in r.text
+    assert "cache_exports" not in r.text
+    # No tracking-URL leak.
+    assert "github.com" not in r.text
+    assert "issues/" not in r.text
+    # Minimal envelope shape.
+    detail = body.get("detail")
+    assert isinstance(detail, dict) and "error" in detail, body

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -209,15 +209,21 @@ def _route_paths_with_auth(router):
     ``WebSocketRoute`` plumbing without dependency graphs).
 
     A route counts as auth-gated if it declares ANY dependency from the
-    ``verify_api_key*`` family — currently:
+    ``verify_api_key*`` family or the stricter ``verify_internal_admin``
+    family — currently:
 
     * ``verify_api_key`` — OpenAI-style bearer-token gate used by
-      chat/completions/embeddings/audio/cache/health/mcp/models/responses.
+      chat/completions/embeddings/audio/health/mcp/models/responses.
     * ``verify_api_key_or_x_api_key`` — same gate, additionally
       accepting Anthropic-native ``x-api-key`` header. Used by the
       ``/v1/messages*`` routes that mirror Anthropic's API shape.
+    * ``verify_internal_admin`` (F-180) — strictly stronger than
+      ``verify_api_key``: requires ``X-Rapid-MLX-Internal: true`` AND
+      either a valid api-key or a loopback caller. Used by the cache
+      router (export/import/info) and the health admin router (cache
+      clear, request cancel).
 
-    Both gates run BEFORE the route handler executes; either is
+    All gates run BEFORE the route handler executes; each is
     structurally equivalent for the bind→auth ordering invariant.
     """
     from vllm_mlx.middleware import auth as auth_mod
@@ -227,6 +233,10 @@ def _route_paths_with_auth(router):
         for name in dir(auth_mod)
         if name.startswith("verify_api_key")
     }
+    # F-180: ``verify_internal_admin`` is a strictly-stronger gate than
+    # ``verify_api_key`` — accept it under the same ordering invariant.
+    if hasattr(auth_mod, "verify_internal_admin"):
+        auth_funcs.add(auth_mod.verify_internal_admin)
     for r in router.routes:
         dep = getattr(r, "dependant", None)
         if dep is None:

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -16,8 +16,13 @@ fill in with the engine-level save/load body. Stub behavior:
   whitelisted path and returns it. Lets a peer instance (or oai-mlx) GC
   / inspect an export root without round-tripping a full import.
 
-Auth follows ``vllm_mlx.routes.health``'s ``router``: the bearer key is
-enforced when ``--api-key`` is set, no new header is invented.
+Auth (F-180): mirrors ``vllm_mlx.routes.health``'s ``admin_router`` — every
+route on this router is gated by ``verify_internal_admin``, the same dep
+PR #728 added to ``POST /v1/cache/clear`` for F-150 / F-151. Cache export
+roots reveal disk-layout information (operator home-dir, export sandbox
+path) and import drives engine state, so these are destructive control-plane
+routes and must NOT be reachable from an unauthenticated LAN client when
+``--api-key`` is unset — ``verify_api_key`` is a no-op in that posture.
 """
 
 from __future__ import annotations
@@ -38,21 +43,33 @@ from ..cache.protocol import (
     read_manifest,
     resolve_cache_dir,
 )
-from ..middleware.auth import verify_api_key
+from ..middleware.auth import verify_internal_admin
 
 logger = logging.getLogger(__name__)
 
-_ISSUE_URL = "https://github.com/raullenchai/Rapid-MLX/issues/476"
-_NOT_IMPLEMENTED_MSG = (
-    "engine integration pending; the wire contract (auth, path-whitelist, "
-    f"manifest schema v{PROTOCOL_VERSION}) is live — see {_ISSUE_URL}"
-)
+# F-180: 501 body must NOT echo operator-controlled context (export-root
+# path, issue URL) since the route is reachable pre-engine-integration —
+# sanitize the envelope. The tracking issue stays in source comments / logs
+# only. Mirrors the PR #728 "no model name in body" sanitization on cancel.
+_NOT_IMPLEMENTED_DETAIL = {
+    "error": {
+        "message": "not implemented",
+        "type": "not_implemented_error",
+        "code": None,
+    }
+}
 
 
+# F-180: ``verify_internal_admin`` (same dep PR #728 added to /v1/cache/clear).
+# ALWAYS requires ``X-Rapid-MLX-Internal: true`` even when ``--api-key`` is unset,
+# so an unauthenticated LAN client cannot probe the export sandbox layout
+# (501-body path leak) or call import with a chosen source path. When
+# ``--api-key`` IS configured the dep also requires a valid Bearer / x-api-key —
+# the internal-header is additive, not a bypass.
 router = APIRouter(
     prefix="/v1/cache",
     tags=["cache"],
-    dependencies=[Depends(verify_api_key)],
+    dependencies=[Depends(verify_internal_admin)],
 )
 
 
@@ -166,24 +183,17 @@ async def export_cache(req: ExportRequest):
     checks pass.
     """
     destination = _resolve_or_400(req.destination)
+    # F-180: keep the resolved destination in server logs only — don't echo it
+    # in the 501 body. The resolved path expands to the operator's home dir
+    # (``/Users/<USERNAME>/.cache/rapid-mlx/cache_exports``) which is both a
+    # username leak AND a sandbox-layout disclosure useful for a follow-up
+    # path-traversal probe.
     logger.info(
-        "cache/export: validated destination=%s max_bytes=%s — %s",
+        "cache/export: validated destination=%s max_bytes=%s — not implemented",
         destination,
         req.max_bytes,
-        _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(
-        status_code=501,
-        detail={
-            "message": _NOT_IMPLEMENTED_MSG,
-            "issue": _ISSUE_URL,
-            "validated": {
-                "destination": str(destination),
-                "max_bytes": req.max_bytes,
-                "protocol_version": PROTOCOL_VERSION,
-            },
-        },
-    )
+    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
 
 
 @router.post("/import", status_code=501)
@@ -221,25 +231,17 @@ async def import_cache(req: ImportRequest):
             ),
         )
 
+    # F-180: keep resolved source path + manifest contents in server logs only.
+    # The manifest may carry model_id / cache layout details the caller already
+    # provided — but the resolved ``source`` expands to the operator home-dir
+    # under the sandbox root, so echoing it in the body is a username leak.
     logger.info(
-        "cache/import: validated source=%s manifest=%s merge=%s — %s",
+        "cache/import: validated source=%s manifest=%s merge=%s — not implemented",
         source,
         manifest.model_id,
         req.merge_strategy,
-        _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(
-        status_code=501,
-        detail={
-            "message": _NOT_IMPLEMENTED_MSG,
-            "issue": _ISSUE_URL,
-            "validated": {
-                "source": str(source),
-                "merge_strategy": req.merge_strategy,
-                "manifest": manifest.to_dict(),
-            },
-        },
-    )
+    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
 
 
 @router.get("/info")


### PR DESCRIPTION
## Summary

PR #728 added `verify_internal_admin` to `POST /v1/cache/clear` and the destructive health-router routes for F-150 / F-151 — but missed the sibling cache routes mounted on `_cache_router` at `vllm_mlx/server.py:1041`:

- `POST /v1/cache/export`
- `POST /v1/cache/import`
- `GET  /v1/cache/info`

They stayed on `verify_api_key`, which is a no-op when `--api-key` is unset — so any LAN client could hit them. The `export` 501 stub also leaked the operator's resolved sandbox destination (`/Users/<USERNAME>/.cache/rapid-mlx/cache_exports` — a home-dir + sandbox-layout fingerprint) along with a GitHub tracking-URL (per test-loop8 finding).

## Fix shape — mirrors PR #728 exactly

- `vllm_mlx/routes/cache.py`: swap the router-level `dependencies=[Depends(verify_api_key)]` → `[Depends(verify_internal_admin)]`. Same import, same dep, same wiring as `admin_router` in `routes/health.py`. ALWAYS requires `X-Rapid-MLX-Internal: true` even when `--api-key` is unset; additionally requires a valid bearer / x-api-key when one is configured; never accepts proxied loopback callers (codex-r3 fix from PR #728 still applies because the dep is shared).
- Sanitize the 501 envelopes on `export_cache` / `import_cache`: replace the leaky `{"message": ..., "issue": GITHUB_URL, "validated": {...path..., ...manifest...}}` shape with a minimal `{"error": {"message": "not implemented", "type": "not_implemented_error", "code": null}}`. The resolved path + parsed manifest stay in server logs only — same posture PR #728 used to strip the model name from the cancel 200 envelope.

## Regression tests

- `tests/test_internal_route_auth.py`: extend `_DESTRUCTIVE_ROUTES` with the 3 cache routes and mount `cache_router` in the fixture — picks up the full 6-test parametrize matrix (missing header → 403, wrong value → 403, loopback OK without api-key, case-insensitive variants, header alone NOT enough with api-key, LAN-without-api-key → 403, LAN+valid-bearer → OK). Add two F-180-specific tests pinning the 501 envelope is path-free and URL-free for both export and import.
- `tests/test_cache_routes.py`: `_auth()` now includes the internal header, TestClient origin pinned to loopback, auth-rejection tests updated 401 → 403 (header gate fires first), 501-shape assertions updated to the sanitized envelope.
- `tests/test_server_auth_ordering.py`: `_route_paths_with_auth` accepts `verify_internal_admin` as a strictly-stronger gate so the bind→auth ordering invariant still holds for the cache router.

## Repro (Llama-3.2-1B-Instruct-4bit on :8065, no `--api-key`)

**BEFORE** (`93233e0`):

```
$ curl -sX POST http://127.0.0.1:8065/v1/cache/export -d '{}' -H 'Content-Type: application/json'
HTTP 501
{"detail":{"message":"engine integration pending; ...","issue":"https://github.com/raullenchai/Rapid-MLX/issues/476","validated":{"destination":"/Users/raullenstudio/.cache/rapid-mlx/cache_exports", ...}}}

$ curl -sX POST http://127.0.0.1:8065/v1/cache/import -d '{"source":"..."}' -H 'Content-Type: application/json'
HTTP 501  (same path + URL leak)

$ curl -s http://127.0.0.1:8065/v1/cache/info
HTTP 200  {"path":"/Users/raullenstudio/.cache/rapid-mlx/cache_exports", ...}
```

**AFTER** (this PR):

```
$ curl -sX POST http://127.0.0.1:8065/v1/cache/export -d '{}' -H 'Content-Type: application/json'
HTTP 403
{"error":{"message":"Forbidden: X-Rapid-MLX-Internal: true header required for control-plane routes", ...}}

$ curl -sX POST http://127.0.0.1:8065/v1/cache/export -d '{}' \
    -H 'Content-Type: application/json' -H 'X-Rapid-MLX-Internal: true'
HTTP 501
{"error":{"message":"not implemented","type":"not_implemented_error","code":null}}
```

(Operator path and tracking URL gone; same shape applies to the 3 routes.)

## No version bump

Security hotfix on the 0.7.41 line, same posture as PR #728.

## Test plan

- [x] `tests/test_internal_route_auth.py` — 57 cases pass (was 50; +7 from cache routes × 6 parametrize + 2 F-180 specific)
- [x] `tests/test_cache_routes.py` — 35 cases pass with updated auth headers + sanitized-envelope assertions
- [x] `tests/test_server_auth_ordering.py` — 13 cases pass with `verify_internal_admin` accepted by the static-dep gate
- [x] `tests/test_routes.py` + `tests/test_request_cancellation.py` — 62 cases (no regressions on the related health-router surface)
- [x] Manual repro on :8065 confirms BEFORE leak + AFTER sanitized envelope