### PR TITLE
fix(api): reject NaN/inf + out-of-range sampling params (F-011)

### DIFF
--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -143,6 +143,11 @@ def _build_chat_app(patch_cfg, monkeypatch):
 
 class TestChatValidation:
     def test_top_p_above_one_rejected(self, patched_config, monkeypatch):
+        """F-011: Pydantic schema enforces ``top_p ∈ (0, 1]`` via Field
+        bounds, so out-of-range values now 422 from the schema layer
+        instead of the route's legacy 400. Either code is a clean
+        rejection — pin both so a future cleanup that drops the dead
+        route guard doesn't trip the test."""
         client = _build_chat_app(patched_config, monkeypatch)
         r = client.post(
             "/v1/chat/completions",
@@ -152,11 +157,14 @@ class TestChatValidation:
                 "top_p": 2.0,
             },
         )
-        assert r.status_code == 400
-        assert "top_p" in r.json()["detail"]
+        assert r.status_code in (400, 422)
+        assert "top_p" in r.text
 
     def test_top_p_zero_rejected(self, patched_config, monkeypatch):
-        """0 is invalid per OpenAI spec — the valid range is (0, 1]."""
+        """0 is invalid per OpenAI spec — the valid range is (0, 1].
+
+        F-011 promoted the route's 400 to a Pydantic 422; either code
+        is a clean rejection."""
         client = _build_chat_app(patched_config, monkeypatch)
         r = client.post(
             "/v1/chat/completions",
@@ -166,8 +174,8 @@ class TestChatValidation:
                 "top_p": 0,
             },
         )
-        assert r.status_code == 400
-        assert "top_p" in r.json()["detail"]
+        assert r.status_code in (400, 422)
+        assert "top_p" in r.text
 
     def test_top_p_one_passes_validation(self, patched_config, monkeypatch):
         """1.0 is the OpenAI default and must not trigger the top_p

--- a/tests/test_sampling_validation.py
+++ b/tests/test_sampling_validation.py
@@ -1,0 +1,413 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-011: NaN / inf / out-of-range sampling-param rejection.
+
+Pre-fix, ``temperature=NaN``, ``top_p=NaN``,
+``presence_penalty=NaN``, ``frequency_penalty=NaN``,
+``presence_penalty=±10``, ``frequency_penalty=±10``, and
+``frequency_penalty=Infinity`` all returned HTTP 200 on
+``/v1/chat/completions`` and ``/v1/completions``:
+
+* ``temperature=NaN`` / ``top_p=NaN`` produced a silent burn —
+  ``choices[0].message.content=null`` with ``usage=0,0,0`` — and on
+  Metal Apple-silicon backends crashed the command buffer with a
+  ``kIOGPUCommandBufferCallbackErrorTimeout`` that killed the server
+  process. The client saw a clean 200.
+
+* penalty NaN/inf produced real output with mathematically
+  undefined logit shifts (NaN propagates through softmax; inf
+  collapses the distribution to a single token).
+
+* ``presence_penalty=10`` / ``frequency_penalty=-10`` exceeded the
+  OpenAI-spec ``[-2, 2]`` bound and produced equally-undefined
+  outputs because no range gate existed in the legacy route path.
+
+Root cause: the legacy route guard used ``not (0 < x <= 2)`` style
+range checks, which evaluate to ``False`` for NaN (every NaN
+comparison is False), so NaN slipped past. ``presence_penalty`` /
+``frequency_penalty`` had no range check at all in any route — the
+mlx-lm sampler accepted them unchecked.
+
+Fix shape (vllm_mlx/api/models.py):
+* Declare OpenAI-spec range bounds on the field itself via
+  ``Field(ge=..., le=...)`` so finite out-of-range values 422 from
+  the schema layer instead of the route layer.
+* Add a ``field_validator`` calling ``math.isfinite`` to catch
+  NaN/inf, which Field bounds skip.
+* Apply the same gates on BOTH ``ChatCompletionRequest`` and
+  ``CompletionRequest`` so the chat and legacy completions
+  endpoints close the gap identically.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Test-app fixtures: stub the engine on both routes so we hit only the
+# Pydantic-level validators (which run before the route handler).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_config():
+    """Patch the global config singleton and restore on teardown."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _stub_engine_cfg(patch_cfg):
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    return engine
+
+
+def _build_chat_client(patch_cfg, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import chat as chat_route
+
+    engine = _stub_engine_cfg(patch_cfg)
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+    # F-011: production wires the unified validation-error handler so
+    # a NaN/inf rejection never escapes as a 500 via the default
+    # FastAPI handler (which embeds the bad value in input_value and
+    # crashes on JSON serialization). Tests must wire the same shape.
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _build_completions_client(patch_cfg, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import completions as comp_route
+
+    engine = _stub_engine_cfg(patch_cfg)
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _base_chat_body() -> dict:
+    return {
+        "model": "stub-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 5,
+    }
+
+
+def _base_completion_body() -> dict:
+    return {
+        "model": "stub-model",
+        "prompt": "hi",
+        "max_tokens": 5,
+    }
+
+
+def _post_json_raw(client: TestClient, url: str, body: dict):
+    """POST a body that may contain non-JSON-compliant floats (NaN, inf).
+
+    httpx refuses to encode these via ``json=`` (it sets
+    ``allow_nan=False`` internally), but stdlib ``json.dumps`` happily
+    emits the ``NaN`` / ``Infinity`` / ``-Infinity`` tokens that
+    Python's parser AND FastAPI's request decoder accept. Using the
+    raw ``content=`` channel mirrors the bug repro exactly — clients
+    DO send these values on the wire (see F-011 production reports);
+    the server must reject them with a clean 4xx, not crash."""
+    payload = json.dumps(body)  # allow_nan=True by default
+    return client.post(
+        url,
+        content=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# The parametrized shape matrix.
+#
+# Each entry is a (field, wire-value) pair. We test every shape against
+# BOTH endpoints by parametrizing the endpoint builder + base body. The
+# wire values cover the three rejection classes:
+#
+#   * NaN / inf : Pydantic ``field_validator`` finite gate (or Field
+#     ``le=``/``ge=`` which happens to reject NaN because every NaN
+#     comparison is False — either gate is acceptable, both close the
+#     bug).
+#   * out-of-OpenAI-spec range : Field ``ge=`` / ``le=`` bound.
+#   * string ``"NaN"`` / ``"Infinity"`` : Pydantic coerces these to
+#     ``float`` non-finite values, then the same gates fire.
+# ---------------------------------------------------------------------------
+
+
+INVALID_SHAPES: list[tuple[str, object]] = [
+    # NaN — raw JSON token (json.loads non-strict mode) AND string form
+    ("temperature", float("nan")),
+    ("top_p", float("nan")),
+    ("presence_penalty", float("nan")),
+    ("frequency_penalty", float("nan")),
+    ("temperature", "NaN"),
+    ("top_p", "NaN"),
+    ("presence_penalty", "NaN"),
+    ("frequency_penalty", "NaN"),
+    # +inf / -inf
+    ("temperature", float("inf")),
+    ("top_p", float("inf")),
+    ("presence_penalty", float("inf")),
+    ("frequency_penalty", float("inf")),
+    ("frequency_penalty", "Infinity"),
+    ("presence_penalty", float("-inf")),
+    # Finite but out-of-OpenAI-spec range
+    ("temperature", 3.0),
+    ("temperature", -0.5),
+    ("top_p", 2.0),
+    ("top_p", 0),
+    ("presence_penalty", 10),
+    ("presence_penalty", -10),
+    ("frequency_penalty", 10),
+    ("frequency_penalty", -3.0),
+    # NaN on the auxiliary float fields too (passthrough to mlx-lm
+    # sampler would otherwise corrupt logits with no signal).
+    ("min_p", float("nan")),
+    ("repetition_penalty", float("nan")),
+    ("repetition_penalty", float("inf")),
+]
+
+
+@pytest.mark.parametrize("field,value", INVALID_SHAPES)
+def test_chat_invalid_sampling_param_rejected(
+    patched_config, monkeypatch, field, value
+):
+    """Every invalid sampling shape must be rejected with a clean 4xx
+    on the chat-completions endpoint — never silently accepted."""
+    client = _build_chat_client(patched_config, monkeypatch)
+    body = _base_chat_body()
+    body[field] = value
+    r = _post_json_raw(client, "/v1/chat/completions", body)
+    assert r.status_code in (400, 422), (
+        f"expected 400/422 for {field}={value!r}; "
+        f"got {r.status_code} body={r.text[:200]}"
+    )
+    # The error body must name the offending field so the client can
+    # fix the bug instead of guessing.
+    assert field in r.text, (
+        f"error body for {field}={value!r} missing field name; "
+        f"got {r.text[:200]}"
+    )
+
+
+@pytest.mark.parametrize("field,value", INVALID_SHAPES)
+def test_completions_invalid_sampling_param_rejected(
+    patched_config, monkeypatch, field, value
+):
+    """Same matrix on the legacy /v1/completions endpoint — the
+    schemas share the same gates by construction so the rejection
+    surface must be identical."""
+    client = _build_completions_client(patched_config, monkeypatch)
+    body = _base_completion_body()
+    body[field] = value
+    r = _post_json_raw(client, "/v1/completions", body)
+    assert r.status_code in (400, 422), (
+        f"expected 400/422 for {field}={value!r}; "
+        f"got {r.status_code} body={r.text[:200]}"
+    )
+    assert field in r.text, (
+        f"error body for {field}={value!r} missing field name; "
+        f"got {r.text[:200]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid baselines — every OpenAI-spec-canonical value must still 4xx-clean
+# (i.e. NOT be rejected by the new gate). The route stub returns 500 from
+# the MagicMock engine downstream, but the rejection — if any — must NOT
+# blame the sampling field we're checking.
+# ---------------------------------------------------------------------------
+
+
+VALID_SHAPES: list[tuple[str, float | int]] = [
+    ("temperature", 0.0),
+    ("temperature", 0.7),
+    ("temperature", 1.0),
+    ("temperature", 2.0),
+    ("top_p", 0.1),
+    ("top_p", 0.9),
+    ("top_p", 1.0),
+    ("presence_penalty", -2.0),
+    ("presence_penalty", -0.5),
+    ("presence_penalty", 0.0),
+    ("presence_penalty", 1.5),
+    ("presence_penalty", 2.0),
+    ("frequency_penalty", -2.0),
+    ("frequency_penalty", -0.5),
+    ("frequency_penalty", 0.0),
+    ("frequency_penalty", 1.5),
+    ("frequency_penalty", 2.0),
+    ("min_p", 0.0),
+    ("min_p", 0.05),
+    ("min_p", 1.0),
+    ("repetition_penalty", 1.0),
+    ("repetition_penalty", 1.5),
+]
+
+
+@pytest.mark.parametrize("field,value", VALID_SHAPES)
+def test_chat_valid_sampling_param_passes_validation(
+    patched_config, monkeypatch, field, value
+):
+    """A valid sampling value must NOT trigger the new gate. The
+    request may still 500 downstream (the mock engine doesn't honor
+    the route's full contract) — that's fine as long as the rejection
+    isn't blaming the field we set."""
+    client = _build_chat_client(patched_config, monkeypatch)
+    body = _base_chat_body()
+    body[field] = value
+    r = client.post("/v1/chat/completions", json=body)
+    if r.status_code in (400, 422):
+        assert field not in r.text, (
+            f"valid {field}={value!r} unexpectedly blamed in error: "
+            f"{r.text[:200]}"
+        )
+
+
+@pytest.mark.parametrize("field,value", VALID_SHAPES)
+def test_completions_valid_sampling_param_passes_validation(
+    patched_config, monkeypatch, field, value
+):
+    client = _build_completions_client(patched_config, monkeypatch)
+    body = _base_completion_body()
+    body[field] = value
+    r = client.post("/v1/completions", json=body)
+    if r.status_code in (400, 422):
+        assert field not in r.text, (
+            f"valid {field}={value!r} unexpectedly blamed in error: "
+            f"{r.text[:200]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pydantic-level unit checks — pin the validator behaviour directly so a
+# refactor of the route stack can't regress this even if the integration
+# tests above stop reaching the schema.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "temperature",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+        "presence_penalty",
+        "frequency_penalty",
+    ],
+)
+def test_chat_schema_rejects_nan_directly(field):
+    from vllm_mlx.api.models import ChatCompletionRequest
+
+    body = {
+        "model": "x",
+        "messages": [{"role": "user", "content": "hi"}],
+        field: float("nan"),
+    }
+    with pytest.raises(Exception):
+        ChatCompletionRequest.model_validate(body)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "temperature",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+        "presence_penalty",
+        "frequency_penalty",
+    ],
+)
+def test_completions_schema_rejects_nan_directly(field):
+    from vllm_mlx.api.models import CompletionRequest
+
+    body = {"model": "x", "prompt": "hi", field: float("nan")}
+    with pytest.raises(Exception):
+        CompletionRequest.model_validate(body)
+
+
+def test_chat_schema_accepts_default_none():
+    """All sampling fields default to ``None``; an empty request must
+    parse cleanly (no false positives from the new gates)."""
+    from vllm_mlx.api.models import ChatCompletionRequest
+
+    req = ChatCompletionRequest.model_validate(
+        {"model": "x", "messages": [{"role": "user", "content": "hi"}]}
+    )
+    assert req.temperature is None
+    assert req.top_p is None
+    assert req.presence_penalty is None
+    assert req.frequency_penalty is None
+    assert req.min_p is None
+    assert req.repetition_penalty is None
+
+
+def test_completions_schema_accepts_default_none():
+    from vllm_mlx.api.models import CompletionRequest
+
+    req = CompletionRequest.model_validate({"model": "x", "prompt": "hi"})
+    assert req.temperature is None
+    assert req.top_p is None
+    assert req.presence_penalty is None
+    assert req.frequency_penalty is None
+    assert req.min_p is None
+    assert req.repetition_penalty is None
+
+
+def test_reject_nonfinite_helper_directly():
+    """Module-level helper is shared by both schemas — pin its
+    behaviour explicitly so a refactor can't silently change it."""
+    from vllm_mlx.api.models import _reject_nonfinite_float
+
+    # Valid: None and finite numbers pass through unchanged.
+    assert _reject_nonfinite_float(None) is None
+    assert _reject_nonfinite_float(0.0) == 0.0
+    assert _reject_nonfinite_float(-1.5) == -1.5
+    assert _reject_nonfinite_float(2.0) == 2.0
+
+    # Invalid: NaN, +inf, -inf.
+    for bad in [float("nan"), float("inf"), float("-inf")]:
+        with pytest.raises(ValueError, match="finite"):
+            _reject_nonfinite_float(bad)
+        # math.isfinite mirror check — pins the invariant we rely on.
+        assert not math.isfinite(bad)

--- a/tests/test_sampling_validation.py
+++ b/tests/test_sampling_validation.py
@@ -48,7 +48,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-
 # ---------------------------------------------------------------------------
 # Test-app fixtures: stub the engine on both routes so we hit only the
 # Pydantic-level validators (which run before the route handler).
@@ -172,24 +171,46 @@ def _post_json_raw(client: TestClient, url: str, body: dict):
 # ---------------------------------------------------------------------------
 
 
-INVALID_SHAPES: list[tuple[str, object]] = [
-    # NaN — raw JSON token (json.loads non-strict mode) AND string form
+# Non-finite values — these are the F-011 silent-burn cases. All must
+# go through the project's unified ``invalid_request_error`` 400
+# envelope (production handler in
+# ``vllm_mlx.middleware.exception_handlers``). Asserting the precise
+# envelope shape here pins F-011 to its documented contract instead
+# of letting a future regression slip back into FastAPI's default
+# 422 path (codex round-1 BLOCKING #2).
+NONFINITE_SHAPES: list[tuple[str, object]] = [
+    # Raw JSON tokens (json.loads non-strict mode)
     ("temperature", float("nan")),
     ("top_p", float("nan")),
     ("presence_penalty", float("nan")),
     ("frequency_penalty", float("nan")),
-    ("temperature", "NaN"),
-    ("top_p", "NaN"),
-    ("presence_penalty", "NaN"),
-    ("frequency_penalty", "NaN"),
-    # +inf / -inf
     ("temperature", float("inf")),
     ("top_p", float("inf")),
     ("presence_penalty", float("inf")),
     ("frequency_penalty", float("inf")),
-    ("frequency_penalty", "Infinity"),
     ("presence_penalty", float("-inf")),
-    # Finite but out-of-OpenAI-spec range
+    # String wire forms (the F-011 bug repro uses these exactly)
+    ("temperature", "NaN"),
+    ("top_p", "NaN"),
+    ("presence_penalty", "NaN"),
+    ("frequency_penalty", "NaN"),
+    ("frequency_penalty", "Infinity"),
+    # NaN on auxiliary float sampling fields — would otherwise
+    # propagate into mlx-lm's logits processor with no signal.
+    ("min_p", float("nan")),
+    ("repetition_penalty", float("nan")),
+    ("repetition_penalty", float("inf")),
+]
+
+# Finite-but-out-of-OpenAI-spec-range values. These trip the Field
+# ``ge=``/``le=`` bounds (Pydantic 422) before the scrub validator
+# sees them, so the response is the 400 envelope produced by the
+# project's RequestValidationError handler converting the 422 path
+# down to the 400 contract. Either way the envelope shape + status
+# are identical to the non-finite case, but we keep the two matrices
+# split so a future regression on either path is pinpointed without
+# guesswork.
+OUT_OF_RANGE_SHAPES: list[tuple[str, object]] = [
     ("temperature", 3.0),
     ("temperature", -0.5),
     ("top_p", 2.0),
@@ -198,55 +219,93 @@ INVALID_SHAPES: list[tuple[str, object]] = [
     ("presence_penalty", -10),
     ("frequency_penalty", 10),
     ("frequency_penalty", -3.0),
-    # NaN on the auxiliary float fields too (passthrough to mlx-lm
-    # sampler would otherwise corrupt logits with no signal).
-    ("min_p", float("nan")),
-    ("repetition_penalty", float("nan")),
-    ("repetition_penalty", float("inf")),
 ]
 
+INVALID_SHAPES: list[tuple[str, object]] = NONFINITE_SHAPES + OUT_OF_RANGE_SHAPES
 
-@pytest.mark.parametrize("field,value", INVALID_SHAPES)
-def test_chat_invalid_sampling_param_rejected(
+
+def _assert_invalid_request_envelope(r, field: str, expected_status: int = 400) -> None:
+    """Assert the response matches the project's unified
+    ``invalid_request_error`` envelope (see
+    ``vllm_mlx.middleware.exception_handlers._validation_error_response``)
+    AND that the offending field name appears in the error message.
+
+    This is the production contract — pinning it precisely catches a
+    future cleanup that drops the custom handler and falls back to
+    FastAPI's default 422 path (which embeds ``input_value`` and
+    crashes on NaN serialization — exactly the F-011 secondary bug)."""
+    assert r.status_code == expected_status, (
+        f"expected {expected_status} for {field}; got {r.status_code} "
+        f"body={r.text[:200]}"
+    )
+    body = r.json()
+    assert isinstance(body, dict) and "error" in body, (
+        f"missing top-level ``error`` key in {field} response: {r.text[:200]}"
+    )
+    err = body["error"]
+    assert err.get("type") == "invalid_request_error", (
+        f"wrong error type for {field}: {err}"
+    )
+    assert err.get("code") == "invalid_request", f"wrong error code for {field}: {err}"
+    msg = err.get("message", "")
+    assert isinstance(msg, str) and field in msg, (
+        f"error message for {field} missing field name: {msg!r}"
+    )
+
+
+@pytest.mark.parametrize("field,value", NONFINITE_SHAPES)
+def test_chat_nonfinite_sampling_param_returns_invalid_request_400(
     patched_config, monkeypatch, field, value
 ):
-    """Every invalid sampling shape must be rejected with a clean 4xx
-    on the chat-completions endpoint — never silently accepted."""
+    """F-011 contract: NaN/inf wire values must return the project's
+    unified ``invalid_request_error`` 400 envelope on the chat
+    endpoint — NOT FastAPI's default 422 path (which would crash on
+    NaN serialization, the silent-burn cause F-011 closes)."""
     client = _build_chat_client(patched_config, monkeypatch)
     body = _base_chat_body()
     body[field] = value
     r = _post_json_raw(client, "/v1/chat/completions", body)
-    assert r.status_code in (400, 422), (
-        f"expected 400/422 for {field}={value!r}; "
-        f"got {r.status_code} body={r.text[:200]}"
-    )
-    # The error body must name the offending field so the client can
-    # fix the bug instead of guessing.
-    assert field in r.text, (
-        f"error body for {field}={value!r} missing field name; "
-        f"got {r.text[:200]}"
-    )
+    _assert_invalid_request_envelope(r, field)
 
 
-@pytest.mark.parametrize("field,value", INVALID_SHAPES)
-def test_completions_invalid_sampling_param_rejected(
+@pytest.mark.parametrize("field,value", NONFINITE_SHAPES)
+def test_completions_nonfinite_sampling_param_returns_invalid_request_400(
     patched_config, monkeypatch, field, value
 ):
-    """Same matrix on the legacy /v1/completions endpoint — the
-    schemas share the same gates by construction so the rejection
-    surface must be identical."""
+    """Same F-011 contract on the legacy /v1/completions endpoint —
+    the schemas share gates by construction, so the rejection
+    surface must be byte-for-byte identical."""
     client = _build_completions_client(patched_config, monkeypatch)
     body = _base_completion_body()
     body[field] = value
     r = _post_json_raw(client, "/v1/completions", body)
-    assert r.status_code in (400, 422), (
-        f"expected 400/422 for {field}={value!r}; "
-        f"got {r.status_code} body={r.text[:200]}"
-    )
-    assert field in r.text, (
-        f"error body for {field}={value!r} missing field name; "
-        f"got {r.text[:200]}"
-    )
+    _assert_invalid_request_envelope(r, field)
+
+
+@pytest.mark.parametrize("field,value", OUT_OF_RANGE_SHAPES)
+def test_chat_out_of_range_sampling_param_returns_invalid_request_400(
+    patched_config, monkeypatch, field, value
+):
+    """Finite-but-out-of-OpenAI-spec values must hit the same 400
+    envelope. The Field ``ge=``/``le=`` bound triggers a Pydantic
+    422 that the project's RequestValidationError handler converts
+    down to the documented 400 ``invalid_request_error`` shape."""
+    client = _build_chat_client(patched_config, monkeypatch)
+    body = _base_chat_body()
+    body[field] = value
+    r = _post_json_raw(client, "/v1/chat/completions", body)
+    _assert_invalid_request_envelope(r, field)
+
+
+@pytest.mark.parametrize("field,value", OUT_OF_RANGE_SHAPES)
+def test_completions_out_of_range_sampling_param_returns_invalid_request_400(
+    patched_config, monkeypatch, field, value
+):
+    client = _build_completions_client(patched_config, monkeypatch)
+    body = _base_completion_body()
+    body[field] = value
+    r = _post_json_raw(client, "/v1/completions", body)
+    _assert_invalid_request_envelope(r, field)
 
 
 # ---------------------------------------------------------------------------
@@ -283,38 +342,125 @@ VALID_SHAPES: list[tuple[str, float | int]] = [
 ]
 
 
+def _stub_chat_impl(monkeypatch) -> dict:
+    """Replace the chat route's inner dispatch with a sentinel that
+    records the parsed ``ChatCompletionRequest`` and returns a
+    deterministic 200. Asserting the stub was reached proves the
+    Pydantic schema accepted the request AND the route's
+    pre-engine validation block passed — closing the codex round-1
+    NIT where the previous "field not blamed in 400" check could
+    pass on any downstream 500."""
+    captured: dict = {"called": False, "request": None}
+
+    async def _impl(
+        request,
+        raw_request,
+        engine,
+        _commit_state,
+        _admission_acquired,
+    ):
+        captured["called"] = True
+        captured["request"] = request
+        # The outer route handler manages admission via these lists;
+        # mark committed so the finally-block release is a no-op and
+        # we don't trip the admission accounting in the engine stub.
+        _commit_state[0] = True
+        _admission_acquired[0] = False
+        return {
+            "id": "chatcmpl-stub",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "stub-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+
+    from vllm_mlx.routes import chat as chat_route
+
+    monkeypatch.setattr(chat_route, "_create_chat_completion_impl", _impl, raising=True)
+    return captured
+
+
+def _stub_completion_route(monkeypatch) -> dict:
+    """Same idea on the legacy /v1/completions endpoint — the route
+    body is one big handler so we monkeypatch the engine's
+    ``generate`` instead. The MagicMock baseline already does this,
+    but here we wire a deterministic async coroutine so the route
+    returns 200 and we can assert the request actually reached
+    engine dispatch."""
+    captured: dict = {"called": False, "request": None}
+
+    # Stub at the engine level — the route's pre-engine validation
+    # block has to pass for ``engine.generate`` to be invoked.
+    async def _generate(*args, **kwargs):
+        captured["called"] = True
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {
+            "text": "ok",
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "finish_reason": "stop",
+        }
+
+    return captured, _generate
+
+
 @pytest.mark.parametrize("field,value", VALID_SHAPES)
-def test_chat_valid_sampling_param_passes_validation(
+def test_chat_valid_sampling_param_reaches_route_dispatch(
     patched_config, monkeypatch, field, value
 ):
-    """A valid sampling value must NOT trigger the new gate. The
-    request may still 500 downstream (the mock engine doesn't honor
-    the route's full contract) — that's fine as long as the rejection
-    isn't blaming the field we set."""
+    """A valid sampling value must survive every gate and reach the
+    route's inner dispatch. We assert the dispatch stub was actually
+    invoked — that proves the request made it through Pydantic
+    schema validation AND the route-level guards (codex round-1
+    NIT)."""
     client = _build_chat_client(patched_config, monkeypatch)
+    captured = _stub_chat_impl(monkeypatch)
     body = _base_chat_body()
     body[field] = value
     r = client.post("/v1/chat/completions", json=body)
-    if r.status_code in (400, 422):
-        assert field not in r.text, (
-            f"valid {field}={value!r} unexpectedly blamed in error: "
-            f"{r.text[:200]}"
-        )
+    assert captured["called"], (
+        f"chat dispatch never invoked for {field}={value!r}; "
+        f"status={r.status_code} body={r.text[:200]}"
+    )
+    assert r.status_code == 200, (
+        f"valid {field}={value!r} rejected with {r.status_code}: {r.text[:200]}"
+    )
+    # And pin that the typed value survived to the request object
+    # exactly as sent — catches a future regression where the
+    # validator coerces or drops the field silently.
+    assert getattr(captured["request"], field) == pytest.approx(value)
 
 
 @pytest.mark.parametrize("field,value", VALID_SHAPES)
-def test_completions_valid_sampling_param_passes_validation(
+def test_completions_valid_sampling_param_parses_to_request(
     patched_config, monkeypatch, field, value
 ):
-    client = _build_completions_client(patched_config, monkeypatch)
+    """For the legacy completions endpoint we assert the schema
+    layer accepts the value by parsing it directly through
+    ``CompletionRequest.model_validate`` — the route's engine
+    plumbing is too entangled to stub cleanly here, and the chat
+    test above already pins "request reaches dispatch" for the
+    shared gate. The schema-level assert proves the value typed
+    cleanly through the Field bounds + finite check and survived
+    onto the model with the exact value we sent."""
+    from vllm_mlx.api.models import CompletionRequest
+
     body = _base_completion_body()
     body[field] = value
-    r = client.post("/v1/completions", json=body)
-    if r.status_code in (400, 422):
-        assert field not in r.text, (
-            f"valid {field}={value!r} unexpectedly blamed in error: "
-            f"{r.text[:200]}"
-        )
+    req = CompletionRequest.model_validate(body)
+    assert getattr(req, field) == pytest.approx(value)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -25,7 +25,6 @@ from pydantic import (
     model_validator,
 )
 
-
 # =============================================================================
 # Shared sampling-parameter validators (F-011)
 # =============================================================================
@@ -100,26 +99,46 @@ _FINITE_SAMPLING_FIELDS: tuple[str, ...] = (
 )
 
 
+_NONFINITE_PLACEHOLDER = "<non-finite>"
+
+
 def _scrub_nonfinite_sampling_raw(data):
-    """Pop NaN / ±inf sampling-param values out of the raw request
-    dict and raise a clean ``ValueError`` BEFORE Pydantic stores them.
+    """Replace NaN / ±inf sampling-param values with a JSON-safe
+    placeholder in the raw request dict, then raise ``ValueError``
+    so Pydantic emits a clean ``ValidationError``.
+
+    The mutate-then-raise dance matters because Pydantic captures the
+    raw ``data`` reference as ``input_value`` on the resulting
+    ``ValidationError`` — if NaN remains in the dict the downstream
+    ``starlette.JSONResponse`` (which uses ``json.dumps`` with
+    ``allow_nan=False`` by default) crashes serializing the error
+    body and the client sees a 500 instead of a 422. Replacing the
+    bad value with a string sentinel keeps the captured error body
+    JSON-safe AND preserves enough context for an operator reading
+    the log to see which field was bad. The production
+    ``_validation_error_response`` handler strips ``input`` from the
+    rendered body anyway (F-094/F-104), but this codepath also has
+    to survive a future cleanup that re-enables FastAPI's default
+    422 handler — codex round-1 BLOCKING #1.
 
     Wire forms covered:
       * raw JSON token ``NaN`` / ``Infinity`` / ``-Infinity`` (parsed
         by Python's stdlib json decoder, which is non-strict by
         default — every popular OpenAI client SDK plus ``requests``
-        emits these on the wire when the caller passes ``float('nan')``).
-      * String form ``"NaN"`` / ``"Infinity"`` / ``"-Infinity"`` (sent
-        by clients that defensively pre-stringify floats — the bug
+        emits these on the wire when the caller passes
+        ``float('nan')``).
+      * String form ``"NaN"`` / ``"Infinity"`` / ``"-Infinity"``
+        (clients that defensively pre-stringify floats — the bug
         repro under F-011 uses this form).
 
-    The string form is only checked case-insensitively against the
-    JSON spec tokens; any other string flows through untouched so
-    Pydantic still emits its native ``float_parsing`` 422 for
-    ``temperature: "hot"``.
+    The string form is matched case-insensitively against the JSON
+    spec tokens with an optional sign prefix; any other string flows
+    through untouched so Pydantic still emits its native
+    ``float_parsing`` 422 for ``temperature: "hot"``.
     """
     if not isinstance(data, dict):
         return data
+    bad_field: str | None = None
     for field in _FINITE_SAMPLING_FIELDS:
         if field not in data:
             continue
@@ -134,17 +153,18 @@ def _scrub_nonfinite_sampling_raw(data):
             continue
         if isinstance(v, (int, float)):
             if not math.isfinite(v):
-                raise ValueError(
-                    f"{field} must be a finite number (not NaN or inf)"
-                )
+                data[field] = _NONFINITE_PLACEHOLDER
+                bad_field = bad_field or field
             continue
         if isinstance(v, str):
             stripped = v.strip().lower().lstrip("+-")
             if stripped in ("nan", "inf", "infinity"):
-                raise ValueError(
-                    f"{field} must be a finite number (not NaN or inf)"
-                )
+                data[field] = _NONFINITE_PLACEHOLDER
+                bad_field = bad_field or field
+    if bad_field is not None:
+        raise ValueError(f"{bad_field} must be a finite number (not NaN or inf)")
     return data
+
 
 # =============================================================================
 # Content Types (for multimodal messages)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -9,6 +9,7 @@ These models define the request and response schemas for:
 - MCP (Model Context Protocol) integration
 """
 
+import math
 import time
 import uuid
 from typing import Literal
@@ -19,9 +20,131 @@ from pydantic import (
     Field,
     StrictInt,
     StrictStr,
+    field_validator,
     model_serializer,
     model_validator,
 )
+
+
+# =============================================================================
+# Shared sampling-parameter validators (F-011)
+# =============================================================================
+#
+# Range validators of the form ``not (0 < x <= 2)`` are False for NaN
+# because every comparison involving NaN returns False — so NaN slips
+# past as "valid" and is then handed to the sampler / Metal kernels.
+# Symptoms observed pre-fix on /v1/chat/completions and /v1/completions:
+#
+#   * ``temperature=NaN`` / ``top_p=NaN`` → HTTP 200 with
+#     ``choices[0].message.content=null`` + ``usage=0,0,0``; the Metal
+#     backend then aborts the command buffer with a GPU Timeout and the
+#     server process dies. Silent burn from the client's POV.
+#   * ``presence_penalty=±10`` / ``frequency_penalty=±10`` → HTTP 200
+#     with mathematically undefined logit shifts (OpenAI spec caps both
+#     at [-2, 2]).
+#   * ``presence_penalty=inf`` / ``frequency_penalty=inf`` → HTTP 200,
+#     same undefined-logit hazard.
+#
+# Fix shape: declare the OpenAI-spec range on the field itself (Field
+# ge=/le=) so Pydantic emits a 422 for finite out-of-range values, and
+# add a single ``field_validator`` that rejects NaN/inf. The
+# field-level Field bounds skip NaN (same comparison semantics as the
+# legacy in-route guard), so the finite check has to run separately —
+# Pydantic v2 invokes both gates per field, and either one failing
+# returns 422 with a clear "Input should be a finite number" / "Input
+# should be less than or equal to N" message.
+#
+# Range is OpenAI-spec-faithful:
+#   * temperature       : [0, 2]
+#   * top_p             : (0, 1]   — 0 disables sampling (illegal)
+#   * presence_penalty  : [-2, 2]
+#   * frequency_penalty : [-2, 2]
+#
+# Defined as module-level helpers so both ChatCompletionRequest and
+# CompletionRequest share the exact same logic — neither schema can
+# drift away from the other.
+
+
+def _reject_nonfinite_float(v: float | None) -> float | None:
+    """Reject NaN / ±inf on a sampling-parameter float field.
+
+    Returns ``None`` unchanged so the field's default-None semantics
+    are preserved. Raises ``ValueError`` (→ Pydantic 422) on any
+    non-finite value. Integer wire values that arrive as ``float``
+    (Pydantic coerces ``1`` → ``1.0`` on a ``float | None`` field) are
+    fine — ``math.isfinite`` handles them.
+    """
+    if v is None:
+        return None
+    if not math.isfinite(v):
+        raise ValueError("must be a finite number (not NaN or inf)")
+    return v
+
+
+# Fields that must reject NaN / ±inf BEFORE pydantic coerces them onto a
+# typed ``float | None`` slot. Pydantic v2's default ``ValidationError``
+# embeds ``input_value`` in the error dict; when the bad value is
+# ``float('nan')`` the downstream ``starlette.JSONResponse`` (which uses
+# stdlib ``json.dumps`` with ``allow_nan=False``) crashes mid-serialize
+# with ``ValueError: Out of range float values are not JSON compliant``
+# — meaning the client gets a 500 instead of a 422. We MUST sanitize
+# the raw dict before Pydantic ever sees the float so the error path
+# never carries a NaN payload. See F-011.
+_FINITE_SAMPLING_FIELDS: tuple[str, ...] = (
+    "temperature",
+    "top_p",
+    "min_p",
+    "repetition_penalty",
+    "presence_penalty",
+    "frequency_penalty",
+)
+
+
+def _scrub_nonfinite_sampling_raw(data):
+    """Pop NaN / ±inf sampling-param values out of the raw request
+    dict and raise a clean ``ValueError`` BEFORE Pydantic stores them.
+
+    Wire forms covered:
+      * raw JSON token ``NaN`` / ``Infinity`` / ``-Infinity`` (parsed
+        by Python's stdlib json decoder, which is non-strict by
+        default — every popular OpenAI client SDK plus ``requests``
+        emits these on the wire when the caller passes ``float('nan')``).
+      * String form ``"NaN"`` / ``"Infinity"`` / ``"-Infinity"`` (sent
+        by clients that defensively pre-stringify floats — the bug
+        repro under F-011 uses this form).
+
+    The string form is only checked case-insensitively against the
+    JSON spec tokens; any other string flows through untouched so
+    Pydantic still emits its native ``float_parsing`` 422 for
+    ``temperature: "hot"``.
+    """
+    if not isinstance(data, dict):
+        return data
+    for field in _FINITE_SAMPLING_FIELDS:
+        if field not in data:
+            continue
+        v = data[field]
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            # bool is an int subclass — let Pydantic's native rules
+            # decide (it currently coerces True/False to 1.0/0.0 onto
+            # ``float | None``; that's the historical contract and
+            # outside F-011's scope).
+            continue
+        if isinstance(v, (int, float)):
+            if not math.isfinite(v):
+                raise ValueError(
+                    f"{field} must be a finite number (not NaN or inf)"
+                )
+            continue
+        if isinstance(v, str):
+            stripped = v.strip().lower().lstrip("+-")
+            if stripped in ("nan", "inf", "infinity"):
+                raise ValueError(
+                    f"{field} must be a finite number (not NaN or inf)"
+                )
+    return data
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -284,8 +407,14 @@ class ChatCompletionRequest(BaseModel):
 
     model: str = "default"
     messages: list[Message]
-    temperature: float | None = None
-    top_p: float | None = None
+    # F-011: range bounds match OpenAI spec; the field-level Field
+    # constraints cover finite out-of-range values (Pydantic 422). NaN
+    # slips past Field bounds (every NaN comparison is False) so the
+    # ``_reject_nonfinite_sampling`` validator below catches it
+    # separately. Same gate applied to top_p / presence_penalty /
+    # frequency_penalty + their CompletionRequest twins.
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    top_p: float | None = Field(default=None, gt=0.0, le=1.0)
     max_tokens: int | None = None
     # OpenAI-canonical token cap since Sept 2024 (preferred over max_tokens for
     # reasoning models; newer SDKs >=1.45 send only this field). Normalized to
@@ -302,10 +431,16 @@ class ChatCompletionRequest(BaseModel):
     # mlx-lm sampler; repetition_penalty / presence_penalty / frequency_penalty
     # flow through to mlx-lm's make_logits_processors().
     top_k: int | None = None
-    min_p: float | None = None
+    min_p: float | None = Field(default=None, ge=0.0, le=1.0)
     repetition_penalty: float | None = None
-    presence_penalty: float | None = None
-    frequency_penalty: float | None = None
+    # F-011: presence_penalty / frequency_penalty are bounded [-2, 2] by
+    # OpenAI spec. Field bounds catch finite out-of-range values (e.g.
+    # ``presence_penalty=10`` previously HTTP 200'd as silent
+    # mathematically-undefined logit shifts); the
+    # ``_reject_nonfinite_sampling`` validator below catches NaN/inf,
+    # which Field bounds skip (NaN comparisons always return False).
+    presence_penalty: float | None = Field(default=None, ge=-2.0, le=2.0)
+    frequency_penalty: float | None = Field(default=None, ge=-2.0, le=2.0)
     # Tool calling
     tools: list[ToolDefinition] | None = None
     tool_choice: str | dict | None = None  # "auto", "none", or specific tool
@@ -358,6 +493,38 @@ class ChatCompletionRequest(BaseModel):
     reasoning_max_tokens: int | None = None
     # Number of completions (only n=1 supported)
     n: int | None = None
+
+    # F-011: NaN/inf scrub on the raw dict, BEFORE Pydantic coerces a
+    # bad value onto the typed float slot. Needed because (a) Field
+    # range bounds skip NaN (every NaN comparison is False) so they
+    # don't close the gap, and (b) even if we caught NaN at the
+    # field_validator layer the resulting Pydantic ValidationError
+    # would embed ``input_value=nan`` in the error dict — and
+    # starlette's ``JSONResponse`` then crashes serializing it with
+    # ``allow_nan=False``, turning a 422 into a 500. Sanitizing the
+    # raw dict avoids both pitfalls.
+    @model_validator(mode="before")
+    @classmethod
+    def _scrub_nonfinite_sampling(cls, data):
+        return _scrub_nonfinite_sampling_raw(data)
+
+    # Belt-and-braces: catches non-finite values that bypass the
+    # raw-dict path (e.g. ``ChatCompletionRequest(temperature=nan)``
+    # in-process). The Field range bounds also reject NaN as a side
+    # effect (NaN comparisons are False), but we wire the explicit
+    # finite check anyway so the field_validator-only path stays
+    # sound even if a future cleanup drops the Field bound.
+    @field_validator(
+        "temperature",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+        "presence_penalty",
+        "frequency_penalty",
+    )
+    @classmethod
+    def _reject_nonfinite_sampling(cls, v: float | None) -> float | None:
+        return _reject_nonfinite_float(v)
 
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
@@ -558,18 +725,22 @@ class CompletionRequest(BaseModel):
 
     model: str = "default"
     prompt: str | list[str]
-    temperature: float | None = None
-    top_p: float | None = None
+    # F-011: shared range bounds + NaN/inf reject — see
+    # ChatCompletionRequest for the rationale block. Field bounds
+    # mirror OpenAI spec; the ``_reject_nonfinite_sampling`` validator
+    # below catches NaN/inf, which Field bounds skip.
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    top_p: float | None = Field(default=None, gt=0.0, le=1.0)
     max_tokens: int | None = None
     stream: bool = False
     stop: list[str] | None = None
     # Extended OpenAI-compatible sampling parameters — see #355 + the
     # matching block on ChatCompletionRequest for wiring + caveats.
     top_k: int | None = None
-    min_p: float | None = None
+    min_p: float | None = Field(default=None, ge=0.0, le=1.0)
     repetition_penalty: float | None = None
-    presence_penalty: float | None = None
-    frequency_penalty: float | None = None
+    presence_penalty: float | None = Field(default=None, ge=-2.0, le=2.0)
+    frequency_penalty: float | None = Field(default=None, ge=-2.0, le=2.0)
     # Logprobs — per the *legacy* OpenAI completions schema, this is an
     # *integer* (0..5) specifying the number of top alternative tokens
     # to return alongside each generated token, NOT a boolean (that is
@@ -606,6 +777,26 @@ class CompletionRequest(BaseModel):
     suffix: str | None = None
     # Request timeout in seconds (None = use server default)
     timeout: float | None = None
+
+    # F-011: NaN/inf scrub + finite belt-and-braces, exactly mirroring
+    # ChatCompletionRequest. See the rationale block at the top of
+    # this module + the matching validators on the chat schema.
+    @model_validator(mode="before")
+    @classmethod
+    def _scrub_nonfinite_sampling(cls, data):
+        return _scrub_nonfinite_sampling_raw(data)
+
+    @field_validator(
+        "temperature",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+        "presence_penalty",
+        "frequency_penalty",
+    )
+    @classmethod
+    def _reject_nonfinite_sampling(cls, v: float | None) -> float | None:
+        return _reject_nonfinite_float(v)
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
## Summary

- F-011: ``temperature=NaN`` / ``top_p=NaN`` / penalty NaN+inf / penalty ±10 all returned HTTP 200 pre-fix because legacy range validators used ``not (0 < x <= 2)`` style, which is False for NaN (every NaN comparison is False). ``temperature=NaN`` / ``top_p=NaN`` produced a silent burn (``content=null, usage=0,0,0``) AND crashed the Metal command buffer (GPU Timeout → server SIGABRT). Penalty NaN/inf+ ±10 produced output with mathematically undefined logit shifts.
- Fix: declare OpenAI-spec range bounds on the typed ``Field`` (``temperature ∈ [0,2]``, ``top_p ∈ (0,1]``, ``min_p ∈ [0,1]``, ``presence_penalty/frequency_penalty ∈ [-2,2]``) + a ``model_validator(mode="before")`` that scrubs NaN/±inf (raw JSON tokens AND string wire forms) from the request dict BEFORE Pydantic coerces them. Sanitizing at the dict level avoids the secondary failure where ``ValidationError`` embeds ``input_value=nan`` and ``starlette.JSONResponse(allow_nan=False)`` then crashes serializing → 500 instead of 422. Belt-and-braces ``field_validator`` catches in-process construction. Identical gates on both ``ChatCompletionRequest`` and ``CompletionRequest``.
- 109 parametrized regression tests in ``tests/test_sampling_validation.py`` over both endpoints + 8+ shapes per endpoint covering NaN/inf wire forms + out-of-range + valid baselines + Pydantic-level unit checks.

## Test plan

- [x] BEFORE: 4 repros (``temperature="NaN"``, ``top_p="NaN"``, ``presence_penalty=10``, ``frequency_penalty="Infinity"``) → HTTP 200 (silent burn + Metal crash)
- [x] AFTER: 4 repros → HTTP 400 with ``invalid_request_error`` envelope citing the field
- [x] Valid baselines: ``temperature=0.7``, ``top_p=0.9``, ``presence_penalty=1.5``, ``frequency_penalty=-0.5`` → HTTP 200, real generation
- [x] Range edges: ``temperature ∈ {0, 2}``, ``top_p=1``, ``presence_penalty ∈ {-2, 2}`` → HTTP 200
- [x] Same matrix on ``/v1/completions`` → identical rejection / acceptance shape
- [x] ``pytest tests/test_sampling_validation.py tests/test_api_validation_bundle.py tests/test_sampling_params_passthrough.py tests/test_alias_recommended_sampling.py tests/test_sampler_fast_path.py tests/test_dense_sampler_fastpath.py tests/test_api_models.py tests/test_completions_spec_parity.py tests/test_chat_logprobs_channel_routing.py tests/test_lone_surrogate_validator.py tests/test_orphan_tool_validation.py -q`` → 362 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)