### PR TITLE
fix(stream): forced tool_choice + reasoning model drops scratch tool_calls (F-200)

### DIFF
--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -132,6 +132,24 @@ class TestForcedNameHelper:
         pp = StreamingPostProcessor(_make_cfg(), request=req)
         assert pp._forced_tool_choice_name() is None
 
+    def test_returns_name_for_pydantic_shaped_tool_choice(self):
+        """Codex r4 BLOCKING — production routes pass
+        ``request.model_dump(exclude_none=True)`` (a dict), but a
+        typed-request callpath (test fixtures, future refactors) may
+        leave ``tool_choice`` as a Pydantic model with ``.type`` /
+        ``.function.name`` attributes. The dict-only gate would have
+        silently disabled the filter on that path. Helper must read
+        both shapes."""
+        function_obj = MagicMock()
+        function_obj.name = "get_weather"
+        tc = MagicMock()
+        tc.type = "function"
+        tc.function = function_obj
+        req = MagicMock()
+        req.tool_choice = tc
+        pp = StreamingPostProcessor(_make_cfg(), request=req)
+        assert pp._forced_tool_choice_name() == "get_weather"
+
 
 # ── _apply_forced_tool_choice_filter pin ─────────────────────────────
 

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -238,6 +238,76 @@ class TestForcedToolChoiceFilter:
         assert len(out) == 1
         assert json.loads(out[0]["function"]["arguments"]) == {"city": "Paris"}
 
+    def test_passes_anchor_with_partial_unclosed_json_arguments(self):
+        """Codex r3 BLOCKING #1 — a hypothetical future parser could
+        emit a single delta carrying ``name`` PLUS the first PARTIAL
+        JSON fragment ``{"city":"Pa``. ``json.loads`` raises but
+        ``{`` count > ``}`` count signals the body is mid-stream;
+        pass through so subsequent fragments can complete it. Only
+        when the JSON is well-formed-but-non-object OR
+        balanced-but-broken does the helper drop."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {
+                    "index": 0,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Pa',
+                    },
+                }
+            ]
+        )
+        assert len(out) == 1, "partial-JSON anchor was wrongly dropped"
+
+    def test_drops_anchor_with_balanced_but_broken_json(self):
+        """Mirror of the partial-pass-through test — when braces are
+        balanced (``{`` count == ``}`` count) and parsing still fails,
+        the body is finalized garbage (e.g. mis-escaped quotes
+        ``{"city": Paris}``). Drop."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {
+                    "index": 0,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": Paris}',
+                    },
+                },
+                {
+                    "index": 1,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                },
+            ]
+        )
+        assert len(out) == 1
+        assert json.loads(out[0]["function"]["arguments"]) == {"city": "Paris"}
+
+    def test_drops_wrapped_function_shape_anchor(self):
+        """Codex r3 BLOCKING #2 — channel-routed callers (harmony /
+        gemma4 / future routers) emit calls in the wrapped
+        ``{"function": {"name": ..., "arguments": ...}}`` shape.
+        The forced-name filter must handle BOTH flat and wrapped
+        shapes consistently — the earlier inline channel-routed
+        filter accepted only flat and silently dropped wrapped
+        valid calls."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                # Wrong wrapped name — drop.
+                {"function": {"name": "other_tool", "arguments": '{"x":1}'}},
+                # Right wrapped name + valid JSON object — keep.
+                {"function": {"name": "get_weather", "arguments": '{"city":"P"}'}},
+                # Right FLAT name + valid JSON object — also keep.
+                {"name": "get_weather", "arguments": '{"city":"Q"}'},
+            ]
+        )
+        assert len(out) == 2
+
     def test_passes_argument_fragment_continuation(self):
         """A continuation delta (no name, only argument fragment) must
         pass through — the parallel-cap layer routes it to whichever

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-200 regression — streaming forced ``tool_choice`` on reasoning models
+must not leak schema-violating scratch tool_calls.
+
+When the chat template pre-injects ``<think>\\n`` AND the route forces a
+named-function ``tool_choice`` (via the assistant-prefix-injection
+lever ``_forced_tool_call_prefix``), reasoning models like
+qwen3-4b-thinking-2507 / phi-4-mini-reasoning routinely emit a SCRATCH
+``<tool_call>{"name": "X", "arguments": <bare int/string>}</tool_call>``
+block INSIDE the implicit ``<think>`` before producing the real
+post-think tool call. The MiniMax tool-markup redirect in
+``_process_with_reasoning`` (load-bearing for the forced-prefix-in-think
+flow) promotes those scratch blocks to content + ``_detect_tool_calls``,
+which then ships a SECOND tool_call delta with arguments that aren't
+JSON objects — a hard violation of the OpenAI spec which requires every
+``tool_calls[i].function.arguments`` to be a JSON-encoded string.
+
+The fix layers a ``_apply_forced_tool_choice_filter`` in front of
+``_apply_parallel_cap`` (and the finalize cross-format fallback) that
+drops any anchor whose name doesn't match the forced choice OR whose
+``arguments`` parsed as a JSON non-object — and tells the parallel-cap
+layer to drop downstream argument-fragment continuations of the dropped
+anchor via ``_no_index_last_dropped``.
+
+These tests pin the four-quadrant behaviour exercised by the live repro
+(reasoning ✕ stream/non-stream ✕ forced/auto) plus the non-reasoning
+control.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+
+def _make_cfg(tool_call_parser="hermes", reasoning_parser_name=None):
+    """Build a mock ServerConfig with a real hermes tool parser."""
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = reasoning_parser_name
+    cfg.enable_auto_tool_choice = True
+    cfg.tool_call_parser = tool_call_parser
+    cfg.tool_parser_instance = None
+    return cfg
+
+
+def _make_output(text="", finished=False, finish_reason=None):
+    """Build a mock GenerationOutput for the text-parser path."""
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = None
+    out.finish_reason = finish_reason or ("stop" if finished else None)
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = None
+    return out
+
+
+def _forced_request(name="get_weather"):
+    """Build a request dict carrying ``tool_choice={"type":"function","function":{"name":...}}``."""
+    return {
+        "tool_choice": {"type": "function", "function": {"name": name}},
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _auto_request(name="get_weather"):
+    """Build a request dict with NO forced tool_choice (auto)."""
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+    }
+
+
+# ── _forced_tool_choice_name helper pin ──────────────────────────────
+
+
+class TestForcedNameHelper:
+    def test_returns_name_for_function_form(self):
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("X"))
+        assert pp._forced_tool_choice_name() == "X"
+
+    def test_returns_none_for_auto(self):
+        pp = StreamingPostProcessor(_make_cfg(), request=_auto_request())
+        assert pp._forced_tool_choice_name() is None
+
+    def test_returns_none_for_required_no_name(self):
+        # ``"required"`` (string form) is NOT a named function — the
+        # model can pick any tool. Filter must NOT engage.
+        pp = StreamingPostProcessor(
+            _make_cfg(),
+            request={"tool_choice": "required", "tools": [{"function": {"name": "x"}}]},
+        )
+        assert pp._forced_tool_choice_name() is None
+
+    def test_returns_none_for_missing_request(self):
+        pp = StreamingPostProcessor(_make_cfg(), request=None)
+        assert pp._forced_tool_choice_name() is None
+
+    def test_returns_none_for_pydantic_unset(self):
+        req = MagicMock()
+        req.tool_choice = None
+        pp = StreamingPostProcessor(_make_cfg(), request=req)
+        assert pp._forced_tool_choice_name() is None
+
+
+# ── _apply_forced_tool_choice_filter pin ─────────────────────────────
+
+
+class TestForcedToolChoiceFilter:
+    def test_drops_wrong_function_anchor(self):
+        pp = StreamingPostProcessor(
+            _make_cfg(), request=_forced_request("get_weather")
+        )
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {"index": 0, "function": {"name": "other_tool", "arguments": '{"x":1}'}},
+                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"P"}'}},
+            ]
+        )
+        assert len(out) == 1
+        assert out[0]["function"]["name"] == "get_weather"
+        assert pp._no_index_last_dropped is True
+
+    def test_drops_bare_integer_arguments(self):
+        """The F-200 root case — model emits scratch
+        ``<tool_call>{"name":"get_weather","arguments":1234567890}</tool_call>``
+        inside ``<think>`` and the MiniMax redirect promotes it to a
+        tool_call delta. ``arguments="1234567890"`` parses as a JSON
+        integer (not object) — drop per OpenAI schema requirement."""
+        pp = StreamingPostProcessor(
+            _make_cfg(), request=_forced_request("get_weather")
+        )
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {"index": 0, "function": {"name": "get_weather", "arguments": "1234567890"}},
+                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'}},
+            ]
+        )
+        assert len(out) == 1
+        assert out[0]["function"]["arguments"] == '{"city":"Paris"}'
+
+    def test_drops_bare_string_arguments(self):
+        """Same root pattern, string variant — phi-4-mini-reasoning has
+        been observed emitting ``"arguments":"☉ Paris output output"``
+        inside ``<think>``. Bare string is a valid JSON value but not
+        an object — drop."""
+        pp = StreamingPostProcessor(
+            _make_cfg(), request=_forced_request("get_weather")
+        )
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {"index": 0, "function": {"name": "get_weather", "arguments": '"☉ Paris output output"'}},
+                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'}},
+            ]
+        )
+        assert len(out) == 1
+        assert json.loads(out[0]["function"]["arguments"]) == {"city": "Paris"}
+
+    def test_passes_argument_fragment_continuation(self):
+        """A continuation delta (no name, only argument fragment) must
+        pass through — the parallel-cap layer routes it to whichever
+        anchor was last admitted."""
+        pp = StreamingPostProcessor(
+            _make_cfg(), request=_forced_request("get_weather")
+        )
+        out = pp._apply_forced_tool_choice_filter(
+            [{"index": 0, "function": {"arguments": '{"city": "Pa'}}]
+        )
+        assert len(out) == 1
+
+    def test_no_op_when_no_forced_choice(self):
+        """``auto`` mode — the filter MUST be a no-op so multi-call
+        flows and other tools still work."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_auto_request())
+        calls = [
+            {"function": {"name": "get_weather", "arguments": "1234567890"}},
+            {"function": {"name": "other_tool", "arguments": '{"y":2}'}},
+        ]
+        out = pp._apply_forced_tool_choice_filter(calls)
+        assert out == calls
+
+    def test_passes_anchor_with_no_arguments_yet(self):
+        """First chunk often carries just ``name`` + ``id`` with empty
+        / missing arguments — body streams in later fragments. Must
+        not drop these as ``parsed != object``."""
+        pp = StreamingPostProcessor(
+            _make_cfg(), request=_forced_request("get_weather")
+        )
+        out = pp._apply_forced_tool_choice_filter(
+            [{"index": 0, "id": "call_x", "function": {"name": "get_weather"}}]
+        )
+        assert len(out) == 1
+        out2 = pp._apply_forced_tool_choice_filter(
+            [{"index": 0, "id": "call_x", "function": {"name": "get_weather", "arguments": ""}}]
+        )
+        assert len(out2) == 1
+
+
+# ── Four-quadrant behaviour pin (reasoning ✕ stream/non-stream ✕ forced/auto) ──
+
+
+class TestStreamForcedReasoningEndToEnd:
+    """End-to-end through ``process_chunk``: feed bytes from the F-200
+    repro (scratch ``<tool_call>`` body inside the implicit ``<think>``
+    block followed by the real call after ``</think>``) and assert
+    only one structured tool_call event surfaces."""
+
+    def _drain_stream(self, chunks, processor):
+        """Replay a list of ``(text, finished)`` chunks through the
+        processor and return the assembled event list."""
+        out = []
+        for i, (text, finished) in enumerate(chunks):
+            evs = processor.process_chunk(
+                _make_output(text=text, finished=finished, finish_reason=("stop" if finished else None))
+            )
+            out.extend(evs)
+        out.extend(processor.finalize())
+        return out
+
+    def test_qwen3_thinking_stream_forced_drops_scratch_call(self):
+        """qwen3-thinking + hermes + forced ``tool_choice``: scratch
+        in-think ``<tool_call>...1234567890...</tool_call>`` followed
+        by real ``<tool_call>...city:Paris...</tool_call>`` must emit
+        EXACTLY ONE tool_call to ``get_weather`` with ``{"city":"Paris"}``."""
+        cfg = _make_cfg(tool_call_parser="hermes", reasoning_parser_name="qwen3")
+        pp = StreamingPostProcessor(cfg, request=_forced_request("get_weather"))
+        pp.reset()
+
+        # Replay the recorded model output from the live repro. Chat
+        # template pre-injected ``<think>``; model emits scratch call,
+        # ``</think>``, real call.
+        full = (
+            '<tool_call>\n{"name": "get_weather", "arguments": 1234567890}\n</tool_call>\n'
+            '</think>\n'
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        events = pp.process_chunk(_make_output(text=full, finished=True))
+        events.extend(pp.finalize())
+
+        tool_events = [e for e in events if e.type == "tool_call"]
+        # Flatten all emitted tool_calls (parser may split into
+        # multiple events). Every surviving entry MUST have valid-
+        # object arguments matching the forced name.
+        all_calls: list[dict] = []
+        for ev in tool_events:
+            for tc in ev.tool_calls or []:
+                all_calls.append(tc)
+
+        # F-200 contract: ALL emitted calls match forced name AND have
+        # parseable-object arguments.
+        for tc in all_calls:
+            fn = tc.get("function") or {}
+            assert fn.get("name") == "get_weather"
+            args_str = fn.get("arguments")
+            # Accumulated full body (post-final-chunk) MUST be a JSON
+            # object. Mid-stream fragments would not be tested here
+            # since this is single-chunk replay.
+            if args_str:
+                parsed = json.loads(args_str)
+                assert isinstance(parsed, dict)
+                assert parsed.get("city", "").lower() == "paris"
+
+        # Must emit at least one call (real one survived).
+        assert all_calls, "real forced call was dropped"
+
+    def test_qwen3_thinking_stream_auto_keeps_call(self):
+        """Same model, no forced ``tool_choice`` (``auto``): the filter
+        is a no-op so the real call still surfaces."""
+        cfg = _make_cfg(tool_call_parser="hermes", reasoning_parser_name="qwen3")
+        pp = StreamingPostProcessor(cfg, request=_auto_request("get_weather"))
+        pp.reset()
+
+        full = (
+            '</think>\n'
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        events = pp.process_chunk(_make_output(text=full, finished=True))
+        events.extend(pp.finalize())
+
+        tool_events = [e for e in events if e.type == "tool_call"]
+        all_calls = [tc for ev in tool_events for tc in (ev.tool_calls or [])]
+        assert all_calls, "auto mode lost the call"
+        for tc in all_calls:
+            fn = tc.get("function") or {}
+            assert fn.get("name") == "get_weather"
+
+    def test_non_reasoning_stream_forced_keeps_call(self):
+        """Hermes parser without a reasoning parser (e.g. qwen3-instruct):
+        forced ``tool_choice`` + stream still surfaces the call with
+        valid args. The filter is engaged but has nothing to drop."""
+        cfg = _make_cfg(tool_call_parser="hermes", reasoning_parser_name=None)
+        pp = StreamingPostProcessor(cfg, request=_forced_request("get_weather"))
+        pp.reset()
+
+        full = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        events = pp.process_chunk(_make_output(text=full, finished=True))
+        events.extend(pp.finalize())
+
+        all_calls = [
+            tc for e in events if e.type == "tool_call" for tc in (e.tool_calls or [])
+        ]
+        assert all_calls, "non-reasoning forced call was dropped"
+        for tc in all_calls:
+            fn = tc.get("function") or {}
+            assert fn.get("name") == "get_weather"
+            parsed = json.loads(fn["arguments"])
+            assert isinstance(parsed, dict)

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -180,11 +180,11 @@ class TestForcedToolChoiceFilter:
         assert len(out) == 1
         assert out[0]["function"]["arguments"] == '{"city":"Paris"}'
 
-    def test_drops_bare_string_arguments(self):
-        """Same root pattern, string variant — phi-4-mini-reasoning has
-        been observed emitting ``"arguments":"☉ Paris output output"``
-        inside ``<think>``. Bare string is a valid JSON value but not
-        an object — drop."""
+    def test_drops_json_quoted_string_arguments(self):
+        """Same root pattern, JSON-quoted-string variant — the parser
+        round-trips ``{"arguments": "..."}`` into a stringified JSON
+        value (``'"..."'``) when the model emits a string literal in
+        place of the object. Valid JSON but non-object — drop."""
         pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [
@@ -193,6 +193,37 @@ class TestForcedToolChoiceFilter:
                     "function": {
                         "name": "get_weather",
                         "arguments": '"☉ Paris output output"',
+                    },
+                },
+                {
+                    "index": 1,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                },
+            ]
+        )
+        assert len(out) == 1
+        assert json.loads(out[0]["function"]["arguments"]) == {"city": "Paris"}
+
+    def test_drops_bare_unquoted_text_arguments(self):
+        """Codex r2 BLOCKING #1 — phi-4-mini-reasoning has been
+        observed panicking inside ``<think>`` and emitting BARE
+        UNQUOTED prose where a JSON body should be:
+        ``arguments: ☉ Paris output output``. The hermes parser
+        forwards the bytes verbatim as the ``arguments`` string —
+        this is NOT valid JSON at all (no surrounding quotes,
+        non-ASCII). The OpenAI spec mandates a JSON-object string,
+        so a non-JSON value can never satisfy the contract — drop."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                {
+                    "index": 0,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "☉ Paris output output",
                     },
                 },
                 {

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -138,13 +138,17 @@ class TestForcedNameHelper:
 
 class TestForcedToolChoiceFilter:
     def test_drops_wrong_function_anchor(self):
-        pp = StreamingPostProcessor(
-            _make_cfg(), request=_forced_request("get_weather")
-        )
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [
-                {"index": 0, "function": {"name": "other_tool", "arguments": '{"x":1}'}},
-                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"P"}'}},
+                {
+                    "index": 0,
+                    "function": {"name": "other_tool", "arguments": '{"x":1}'},
+                },
+                {
+                    "index": 1,
+                    "function": {"name": "get_weather", "arguments": '{"city":"P"}'},
+                },
             ]
         )
         assert len(out) == 1
@@ -157,13 +161,20 @@ class TestForcedToolChoiceFilter:
         inside ``<think>`` and the MiniMax redirect promotes it to a
         tool_call delta. ``arguments="1234567890"`` parses as a JSON
         integer (not object) — drop per OpenAI schema requirement."""
-        pp = StreamingPostProcessor(
-            _make_cfg(), request=_forced_request("get_weather")
-        )
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [
-                {"index": 0, "function": {"name": "get_weather", "arguments": "1234567890"}},
-                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'}},
+                {
+                    "index": 0,
+                    "function": {"name": "get_weather", "arguments": "1234567890"},
+                },
+                {
+                    "index": 1,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                },
             ]
         )
         assert len(out) == 1
@@ -174,13 +185,23 @@ class TestForcedToolChoiceFilter:
         been observed emitting ``"arguments":"☉ Paris output output"``
         inside ``<think>``. Bare string is a valid JSON value but not
         an object — drop."""
-        pp = StreamingPostProcessor(
-            _make_cfg(), request=_forced_request("get_weather")
-        )
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [
-                {"index": 0, "function": {"name": "get_weather", "arguments": '"☉ Paris output output"'}},
-                {"index": 1, "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'}},
+                {
+                    "index": 0,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '"☉ Paris output output"',
+                    },
+                },
+                {
+                    "index": 1,
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                },
             ]
         )
         assert len(out) == 1
@@ -190,9 +211,7 @@ class TestForcedToolChoiceFilter:
         """A continuation delta (no name, only argument fragment) must
         pass through — the parallel-cap layer routes it to whichever
         anchor was last admitted."""
-        pp = StreamingPostProcessor(
-            _make_cfg(), request=_forced_request("get_weather")
-        )
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [{"index": 0, "function": {"arguments": '{"city": "Pa'}}]
         )
@@ -213,15 +232,19 @@ class TestForcedToolChoiceFilter:
         """First chunk often carries just ``name`` + ``id`` with empty
         / missing arguments — body streams in later fragments. Must
         not drop these as ``parsed != object``."""
-        pp = StreamingPostProcessor(
-            _make_cfg(), request=_forced_request("get_weather")
-        )
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [{"index": 0, "id": "call_x", "function": {"name": "get_weather"}}]
         )
         assert len(out) == 1
         out2 = pp._apply_forced_tool_choice_filter(
-            [{"index": 0, "id": "call_x", "function": {"name": "get_weather", "arguments": ""}}]
+            [
+                {
+                    "index": 0,
+                    "id": "call_x",
+                    "function": {"name": "get_weather", "arguments": ""},
+                }
+            ]
         )
         assert len(out2) == 1
 
@@ -241,7 +264,11 @@ class TestStreamForcedReasoningEndToEnd:
         out = []
         for i, (text, finished) in enumerate(chunks):
             evs = processor.process_chunk(
-                _make_output(text=text, finished=finished, finish_reason=("stop" if finished else None))
+                _make_output(
+                    text=text,
+                    finished=finished,
+                    finish_reason=("stop" if finished else None),
+                )
             )
             out.extend(evs)
         out.extend(processor.finalize())
@@ -261,7 +288,7 @@ class TestStreamForcedReasoningEndToEnd:
         # ``</think>``, real call.
         full = (
             '<tool_call>\n{"name": "get_weather", "arguments": 1234567890}\n</tool_call>\n'
-            '</think>\n'
+            "</think>\n"
             '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
         )
         events = pp.process_chunk(_make_output(text=full, finished=True))
@@ -276,22 +303,21 @@ class TestStreamForcedReasoningEndToEnd:
             for tc in ev.tool_calls or []:
                 all_calls.append(tc)
 
-        # F-200 contract: ALL emitted calls match forced name AND have
-        # parseable-object arguments.
-        for tc in all_calls:
-            fn = tc.get("function") or {}
-            assert fn.get("name") == "get_weather"
-            args_str = fn.get("arguments")
-            # Accumulated full body (post-final-chunk) MUST be a JSON
-            # object. Mid-stream fragments would not be tested here
-            # since this is single-chunk replay.
-            if args_str:
-                parsed = json.loads(args_str)
-                assert isinstance(parsed, dict)
-                assert parsed.get("city", "").lower() == "paris"
-
-        # Must emit at least one call (real one survived).
-        assert all_calls, "real forced call was dropped"
+        # F-200 contract: EXACTLY ONE surviving call AND that call
+        # matches the forced name AND its ``arguments`` parse as a
+        # JSON object. Codex r1 BLOCKING — the earlier draft asserted
+        # only "every emitted call is valid" which would accept
+        # duplicate valid calls; the spec requires a single tool_call
+        # per forced ``tool_choice``.
+        assert len(all_calls) == 1, (
+            f"expected exactly 1 surviving tool_call, got {len(all_calls)}: {all_calls!r}"
+        )
+        tc = all_calls[0]
+        fn = tc.get("function") or {}
+        assert fn.get("name") == "get_weather"
+        parsed = json.loads(fn["arguments"])
+        assert isinstance(parsed, dict)
+        assert parsed.get("city", "").lower() == "paris"
 
     def test_qwen3_thinking_stream_auto_keeps_call(self):
         """Same model, no forced ``tool_choice`` (``auto``): the filter
@@ -301,7 +327,7 @@ class TestStreamForcedReasoningEndToEnd:
         pp.reset()
 
         full = (
-            '</think>\n'
+            "</think>\n"
             '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
         )
         events = pp.process_chunk(_make_output(text=full, finished=True))
@@ -314,6 +340,38 @@ class TestStreamForcedReasoningEndToEnd:
             fn = tc.get("function") or {}
             assert fn.get("name") == "get_weather"
 
+    def test_finalize_extract_drops_same_name_primitive_args(self):
+        """Codex r1 BLOCKING #1 — when the streaming parser missed
+        the call and ``finalize()`` runs ``extract_tool_calls`` over
+        the accumulated buffer, the parser may return both a scratch
+        call (same forced name, primitive ``arguments``) AND the real
+        call. Filtering by name alone leaks the scratch; the finalize
+        path must apply the same arguments-root-object validation."""
+        cfg = _make_cfg(tool_call_parser="hermes", reasoning_parser_name=None)
+        pp = StreamingPostProcessor(cfg, request=_forced_request("get_weather"))
+        pp.reset()
+        # Seed the tool buffer so finalize's extract_tool_calls runs
+        # the hermes parser over a buffer containing both shapes —
+        # bypasses the streaming detection entirely (mimics the path
+        # where the per-chunk parser holds bytes and only the buffer
+        # carries them).
+        pp.tool_accumulated_text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": 1234567890}\n</tool_call>\n'
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        events = pp.finalize()
+        all_calls = [
+            tc
+            for ev in events
+            if ev.type == "tool_call"
+            for tc in (ev.tool_calls or [])
+        ]
+        assert len(all_calls) == 1, f"finalize leaked a scratch call: {all_calls!r}"
+        fn = all_calls[0].get("function") or {}
+        parsed = json.loads(fn["arguments"])
+        assert isinstance(parsed, dict)
+        assert parsed.get("city") == "Paris"
+
     def test_non_reasoning_stream_forced_keeps_call(self):
         """Hermes parser without a reasoning parser (e.g. qwen3-instruct):
         forced ``tool_choice`` + stream still surfaces the call with
@@ -322,9 +380,7 @@ class TestStreamForcedReasoningEndToEnd:
         pp = StreamingPostProcessor(cfg, request=_forced_request("get_weather"))
         pp.reset()
 
-        full = (
-            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
-        )
+        full = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
         events = pp.process_chunk(_make_output(text=full, finished=True))
         events.extend(pp.finalize())
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -468,9 +468,34 @@ class StreamingPostProcessor:
         name = fn.get("name")
         return name if isinstance(name, str) and name else None
 
-    def _apply_forced_tool_choice_filter(
-        self, tool_calls: list[dict]
-    ) -> list[dict]:
+    @staticmethod
+    def _forced_tool_choice_arguments_violate_object_root(args_str: str | None) -> bool:
+        """Return True when ``args_str`` parses as JSON but is NOT a
+        JSON object (dict).
+
+        OpenAI spec: ``tool_calls[i].function.arguments`` is a string
+        encoding a JSON object — every declared tool schema is
+        ``{"type":"object","properties":{…}}``. A bare integer
+        (``"1234567890"``), bare string (``"☉ Paris output"``), or
+        array root is the model's scratch — not a real call. F-200
+        finalize path needs this guard too; sharing the helper between
+        the per-delta filter and the finalize / fallback paths keeps
+        the two surfaces from drifting.
+
+        Returns False when ``args_str`` is missing, empty / whitespace,
+        or does not parse as JSON at all (mid-stream fragments may not
+        be a complete JSON document yet; the parser path retries on
+        the next delta).
+        """
+        if not args_str or not args_str.strip():
+            return False
+        try:
+            parsed = json.loads(args_str)
+        except (ValueError, TypeError):
+            return False
+        return not isinstance(parsed, dict)
+
+    def _apply_forced_tool_choice_filter(self, tool_calls: list[dict]) -> list[dict]:
         """Suppress streaming tool_calls deltas that violate a forced
         ``tool_choice`` named-function contract.
 
@@ -512,9 +537,7 @@ class StreamingPostProcessor:
             wrapped_name = (
                 fn.get("name") if fn and isinstance(fn.get("name"), str) else None
             )
-            flat_name = (
-                tc.get("name") if isinstance(tc.get("name"), str) else None
-            )
+            flat_name = tc.get("name") if isinstance(tc.get("name"), str) else None
             anchor_name = wrapped_name or flat_name
             if anchor_name is None:
                 # Continuation fragment — defer to cap-layer routing.
@@ -532,28 +555,20 @@ class StreamingPostProcessor:
             # present and is non-empty, require it to parse as a
             # JSON object.
             wrapped_args = (
-                fn.get("arguments") if fn and isinstance(fn.get("arguments"), str) else None
+                fn.get("arguments")
+                if fn and isinstance(fn.get("arguments"), str)
+                else None
             )
             flat_args = (
                 tc.get("arguments") if isinstance(tc.get("arguments"), str) else None
             )
             args_str = wrapped_args if wrapped_args is not None else flat_args
-            if args_str and args_str.strip():
-                try:
-                    parsed = json.loads(args_str)
-                except (ValueError, TypeError):
-                    # Args don't parse as JSON at all — could be a
-                    # mid-stream fragment that hasn't accumulated yet,
-                    # so let it through; downstream validators will
-                    # log if the final assembly is still broken.
-                    parsed = ...  # sentinel
-                if parsed is not ... and not isinstance(parsed, dict):
-                    # F-200 root case: ``arguments`` parsed as JSON
-                    # but the root type is not ``object`` (bare
-                    # int / string / list). Schema-violating —
-                    # drop the anchor and route fragments to drop.
-                    self._no_index_last_dropped = True
-                    continue
+            if self._forced_tool_choice_arguments_violate_object_root(args_str):
+                # F-200 root case: ``arguments`` parsed as JSON but
+                # the root type is not ``object``. Schema-violating —
+                # drop the anchor and route fragments to drop.
+                self._no_index_last_dropped = True
+                continue
             filtered.append(tc)
         return filtered
 
@@ -1075,9 +1090,7 @@ class StreamingPostProcessor:
                 # ``parallel_tool_calls=false`` overflow. The forced-
                 # name filter drops the scratch anchor first so the
                 # cap admits the legitimate forced call.
-                _tc_list = self._apply_forced_tool_choice_filter(
-                    result["tool_calls"]
-                )
+                _tc_list = self._apply_forced_tool_choice_filter(result["tool_calls"])
                 allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
@@ -1379,9 +1392,7 @@ class StreamingPostProcessor:
                 # ``parallel_tool_calls=false`` overflow. The forced-
                 # name filter drops the scratch anchor first so the
                 # cap admits the legitimate forced call.
-                _tc_list = self._apply_forced_tool_choice_filter(
-                    result["tool_calls"]
-                )
+                _tc_list = self._apply_forced_tool_choice_filter(result["tool_calls"])
                 allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
@@ -1527,9 +1538,7 @@ class StreamingPostProcessor:
                 # ``parallel_tool_calls=false`` overflow. The forced-
                 # name filter drops the scratch anchor first so the
                 # cap admits the legitimate forced call.
-                _tc_list = self._apply_forced_tool_choice_filter(
-                    result["tool_calls"]
-                )
+                _tc_list = self._apply_forced_tool_choice_filter(result["tool_calls"])
                 allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
@@ -1712,19 +1721,26 @@ class StreamingPostProcessor:
             )
             if result.tools_called:
                 # F-200: forced ``tool_choice`` filter on the finalize
-                # cross-format recovery path. ``extract_tool_calls``
-                # on the configured parser may return multiple calls
-                # (a scratch ``<tool_call>`` inside ``<think>`` plus
-                # the real one) — drop any whose name does not match
-                # the forced choice. When ALL calls are filtered out,
-                # fall through to the cross-format fallback (parser
-                # may have a different recovery path).
+                # ``extract_tool_calls`` recovery path. The parser
+                # may return multiple calls (a scratch
+                # ``<tool_call>`` inside ``<think>`` with bare int /
+                # string ``arguments`` PLUS the real call) — drop
+                # any whose name does not match the forced choice
+                # OR whose ``arguments`` parses as a JSON non-object
+                # (codex r1 BLOCKING: filtering by name alone leaks
+                # a same-name scratch call with primitive args).
                 _forced_name = self._forced_tool_choice_name()
-                _filtered_calls = (
-                    [tc for tc in result.tool_calls if tc.get("name") == _forced_name]
-                    if _forced_name
-                    else list(result.tool_calls)
-                )
+                if _forced_name:
+                    _filtered_calls = [
+                        tc
+                        for tc in result.tool_calls
+                        if tc.get("name") == _forced_name
+                        and not self._forced_tool_choice_arguments_violate_object_root(
+                            tc.get("arguments")
+                        )
+                    ]
+                else:
+                    _filtered_calls = list(result.tool_calls)
                 if _filtered_calls:
                     events.append(
                         self._build_tool_call_event(
@@ -1756,12 +1772,21 @@ class StreamingPostProcessor:
                     )
                     fb_tcs = None
                 if fb_tcs:
-                    # F-200: same forced-name filter on the cross-
-                    # format fallback path.
+                    # F-200: forced ``tool_choice`` filter on the
+                    # cross-format fallback recovery path. Apply BOTH
+                    # name AND arguments-root-object validation —
+                    # codex r1 BLOCKING: name-only filtering let
+                    # same-name scratch calls with primitive / list
+                    # ``arguments`` leak through.
                     _forced_name = self._forced_tool_choice_name()
                     if _forced_name:
                         fb_tcs = [
-                            tc for tc in fb_tcs if tc.function.name == _forced_name
+                            tc
+                            for tc in fb_tcs
+                            if tc.function.name == _forced_name
+                            and not self._forced_tool_choice_arguments_violate_object_root(
+                                tc.function.arguments
+                            )
                         ]
                 if fb_tcs:
                     logger.info(

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -8,6 +8,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import TYPE_CHECKING
@@ -425,6 +426,137 @@ class StreamingPostProcessor:
         # only after the parser call succeeds.
         return "</think>" + delta_text
 
+    def _forced_tool_choice_name(self) -> str | None:
+        """Return the forced ``tool_choice`` function name, if any.
+
+        OpenAI spec: ``tool_choice={"type":"function","function":
+        {"name":"X"}}`` forces the model to call exactly the named
+        function — no other tool may appear in ``tool_calls[*]``.
+
+        F-200 (2026-06-20): reasoning models that share the hermes
+        tool parser (qwen3-thinking, phi-4-mini-reasoning, …)
+        speculatively emit scratch ``<tool_call>...</tool_call>``
+        blocks INSIDE ``<think>`` while planning. The MiniMax tool-
+        markup redirect (load-bearing for the forced-prefix-in-think
+        path) promotes those scratch blocks to content + tool_call
+        detection, which then ship as schema-violating tool_calls
+        with non-JSON ``arguments`` (e.g. bare ``"1234567890"``).
+        Filtering on the forced name at delta-emission time keeps
+        ONLY the spec-compliant call on the wire.
+
+        Returns ``None`` when ``tool_choice`` is unset, ``"auto"`` /
+        ``"none"`` / ``"required"``, or a non-string-named function
+        shape — i.e. only the unambiguous named-function form gates
+        the filter. ``"required"`` (no name) is intentionally NOT
+        gated here: the model may legitimately choose any of the
+        submitted tools.
+        """
+        req = self.request
+        if req is None:
+            return None
+        if isinstance(req, dict):
+            tc = req.get("tool_choice")
+        else:
+            tc = getattr(req, "tool_choice", None)
+        if not isinstance(tc, dict):
+            return None
+        if tc.get("type") != "function":
+            return None
+        fn = tc.get("function")
+        if not isinstance(fn, dict):
+            return None
+        name = fn.get("name")
+        return name if isinstance(name, str) and name else None
+
+    def _apply_forced_tool_choice_filter(
+        self, tool_calls: list[dict]
+    ) -> list[dict]:
+        """Suppress streaming tool_calls deltas that violate a forced
+        ``tool_choice`` named-function contract.
+
+        Two drop conditions, both required by the OpenAI spec:
+
+        1. **Wrong function**: an anchor delta naming a function other
+           than the forced choice. This catches harmony / gemma4
+           channel-routed calls to other tools the model speculated
+           on but the client never requested.
+
+        2. **Schema-violating arguments**: an anchor whose
+           ``arguments`` is non-empty AND does not parse as a JSON
+           OBJECT. The OpenAI spec mandates ``arguments`` be a JSON-
+           encoded string and tool schemas are object-shaped
+           (``{"type":"object","properties":{…}}``); a bare integer
+           ``"1234567890"`` or string ``"☉ Paris output"`` is the
+           model's scratch-pad — not a real call. Captures the
+           F-200 reasoning-model scratch leak that the MiniMax tool-
+           markup redirect promoted into structured deltas.
+
+        Argument-fragment continuation deltas (no name, no id) pass
+        through unconditionally — the parallel-cap layer already
+        tracks ``_no_index_last_dropped`` so fragments routed to a
+        dropped anchor are suppressed.
+
+        No-op when no forced ``tool_choice`` name is set: the request
+        is in auto / required / unset mode, and multi-tool and
+        flexible-argument flows must keep working.
+        """
+        forced_name = self._forced_tool_choice_name()
+        if not forced_name:
+            return tool_calls
+        filtered: list[dict] = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                filtered.append(tc)
+                continue
+            fn = tc.get("function") if isinstance(tc.get("function"), dict) else None
+            wrapped_name = (
+                fn.get("name") if fn and isinstance(fn.get("name"), str) else None
+            )
+            flat_name = (
+                tc.get("name") if isinstance(tc.get("name"), str) else None
+            )
+            anchor_name = wrapped_name or flat_name
+            if anchor_name is None:
+                # Continuation fragment — defer to cap-layer routing.
+                filtered.append(tc)
+                continue
+            if anchor_name != forced_name:
+                # Wrong function — suppress this anchor and tell the
+                # cap layer to drop its fragment continuations.
+                self._no_index_last_dropped = True
+                continue
+            # Right function: validate the (so-far complete) arguments
+            # field. ``arguments`` can be absent on an anchor that
+            # only carries name (the JSON body streams in later
+            # fragments); pass those through. When arguments IS
+            # present and is non-empty, require it to parse as a
+            # JSON object.
+            wrapped_args = (
+                fn.get("arguments") if fn and isinstance(fn.get("arguments"), str) else None
+            )
+            flat_args = (
+                tc.get("arguments") if isinstance(tc.get("arguments"), str) else None
+            )
+            args_str = wrapped_args if wrapped_args is not None else flat_args
+            if args_str and args_str.strip():
+                try:
+                    parsed = json.loads(args_str)
+                except (ValueError, TypeError):
+                    # Args don't parse as JSON at all — could be a
+                    # mid-stream fragment that hasn't accumulated yet,
+                    # so let it through; downstream validators will
+                    # log if the final assembly is still broken.
+                    parsed = ...  # sentinel
+                if parsed is not ... and not isinstance(parsed, dict):
+                    # F-200 root case: ``arguments`` parsed as JSON
+                    # but the root type is not ``object`` (bare
+                    # int / string / list). Schema-violating —
+                    # drop the anchor and route fragments to drop.
+                    self._no_index_last_dropped = True
+                    continue
+            filtered.append(tc)
+        return filtered
+
     def _parallel_tool_calls_allowed(self) -> bool:
         """Return False iff the request explicitly opted out of
         parallel tool calls via ``parallel_tool_calls=false``.
@@ -772,6 +904,19 @@ class StreamingPostProcessor:
         # literal harmony sentinels were corrupted by sentinel-
         # anchored regex parsing).
         engine_tool_calls = getattr(output, "tool_calls", None) or []
+        # F-200: when ``tool_choice`` forces a named function, suppress
+        # any structured channel-routed calls whose name does not match.
+        # Harmony / gemma4 channel parsers can surface speculative calls
+        # to other tools alongside the forced one — clients reading the
+        # forced-tool wire expect exactly one call to the named tool.
+        if engine_tool_calls:
+            _forced_name = self._forced_tool_choice_name()
+            if _forced_name:
+                engine_tool_calls = [
+                    _tc
+                    for _tc in engine_tool_calls
+                    if isinstance(_tc, dict) and _tc.get("name") == _forced_name
+                ]
         if output.channel == "tool_call" and engine_tool_calls:
             # ``parallel_tool_calls=false`` is a hard external contract:
             # the non-streaming path caps the parsed list at one
@@ -920,7 +1065,20 @@ class StreamingPostProcessor:
                 # BLOCKING: admit by ``index`` so continuation deltas
                 # (incremental argument fragments for the same call)
                 # don't each consume a slot.
-                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
+                # F-200: forced ``tool_choice`` name filter MUST run
+                # before the parallel cap — otherwise a scratch-call
+                # delta inside ``<think>`` (qwen3-thinking / phi-4-
+                # mini-reasoning hit the MiniMax tool-markup redirect
+                # which promotes those scratch ``<tool_call>`` bodies
+                # to content + tool_call detection) takes the only
+                # cap slot and the real forced call is dropped as
+                # ``parallel_tool_calls=false`` overflow. The forced-
+                # name filter drops the scratch anchor first so the
+                # cap admits the legitimate forced call.
+                _tc_list = self._apply_forced_tool_choice_filter(
+                    result["tool_calls"]
+                )
+                allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -1151,7 +1309,13 @@ class StreamingPostProcessor:
         if reasoning:
             self.accumulated_reasoning += reasoning
 
-        # MiniMax redirect: tool calls wrapped in <think> blocks
+        # MiniMax redirect: tool calls wrapped in <think> blocks.
+        # Also load-bearing for hermes / qwen3-thinking when the chat
+        # template pre-injects ``<think>`` AND a forced ``tool_choice``
+        # prefix lands the model inside an in-think tool envelope —
+        # the reasoning parser would otherwise leave the model's
+        # continuation of the prefix in the reasoning channel and the
+        # tool_call would never surface.
         if self.tool_parser and reasoning:
             _check = self.tool_accumulated_text + reasoning
             if (
@@ -1205,7 +1369,20 @@ class StreamingPostProcessor:
                 # BLOCKING: admit by ``index`` so continuation deltas
                 # (incremental argument fragments for the same call)
                 # don't each consume a slot.
-                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
+                # F-200: forced ``tool_choice`` name filter MUST run
+                # before the parallel cap — otherwise a scratch-call
+                # delta inside ``<think>`` (qwen3-thinking / phi-4-
+                # mini-reasoning hit the MiniMax tool-markup redirect
+                # which promotes those scratch ``<tool_call>`` bodies
+                # to content + tool_call detection) takes the only
+                # cap slot and the real forced call is dropped as
+                # ``parallel_tool_calls=false`` overflow. The forced-
+                # name filter drops the scratch anchor first so the
+                # cap admits the legitimate forced call.
+                _tc_list = self._apply_forced_tool_choice_filter(
+                    result["tool_calls"]
+                )
+                allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -1340,7 +1517,20 @@ class StreamingPostProcessor:
                 # incremental argument fragments don't each consume a
                 # cap slot (qwen3_coder pattern — header delta + N
                 # argument-fragment deltas all share the same index).
-                allowed_tcs = self._apply_parallel_cap(result["tool_calls"])
+                # F-200: forced ``tool_choice`` name filter MUST run
+                # before the parallel cap — otherwise a scratch-call
+                # delta inside ``<think>`` (qwen3-thinking / phi-4-
+                # mini-reasoning hit the MiniMax tool-markup redirect
+                # which promotes those scratch ``<tool_call>`` bodies
+                # to content + tool_call detection) takes the only
+                # cap slot and the real forced call is dropped as
+                # ``parallel_tool_calls=false`` overflow. The forced-
+                # name filter drops the scratch anchor first so the
+                # cap admits the legitimate forced call.
+                _tc_list = self._apply_forced_tool_choice_filter(
+                    result["tool_calls"]
+                )
+                allowed_tcs = self._apply_parallel_cap(_tc_list)
                 if not allowed_tcs:
                     self.tool_calls_detected = True
                     if output.finished:
@@ -1521,17 +1711,32 @@ class StreamingPostProcessor:
                 _fallback_text, request=self.request
             )
             if result.tools_called:
-                events.append(
-                    self._build_tool_call_event(
-                        {
-                            "id": tc["id"],
-                            "name": tc["name"],
-                            "arguments": tc["arguments"],
-                        }
-                        for tc in result.tool_calls
-                    )
+                # F-200: forced ``tool_choice`` filter on the finalize
+                # cross-format recovery path. ``extract_tool_calls``
+                # on the configured parser may return multiple calls
+                # (a scratch ``<tool_call>`` inside ``<think>`` plus
+                # the real one) — drop any whose name does not match
+                # the forced choice. When ALL calls are filtered out,
+                # fall through to the cross-format fallback (parser
+                # may have a different recovery path).
+                _forced_name = self._forced_tool_choice_name()
+                _filtered_calls = (
+                    [tc for tc in result.tool_calls if tc.get("name") == _forced_name]
+                    if _forced_name
+                    else list(result.tool_calls)
                 )
-                self.tool_calls_detected = True
+                if _filtered_calls:
+                    events.append(
+                        self._build_tool_call_event(
+                            {
+                                "id": tc["id"],
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            }
+                            for tc in _filtered_calls
+                        )
+                    )
+                    self.tool_calls_detected = True
             else:
                 # Cross-format fallback. The configured streaming parser is bound to
                 # ONE wire format; ``parse_tool_calls`` in ``api/tool_calling.py``
@@ -1550,6 +1755,14 @@ class StreamingPostProcessor:
                         "finalize cross-format fallback parser raised: %s", e
                     )
                     fb_tcs = None
+                if fb_tcs:
+                    # F-200: same forced-name filter on the cross-
+                    # format fallback path.
+                    _forced_name = self._forced_tool_choice_name()
+                    if _forced_name:
+                        fb_tcs = [
+                            tc for tc in fb_tcs if tc.function.name == _forced_name
+                        ]
                 if fb_tcs:
                     logger.info(
                         "[finalize] cross-format fallback recovered %d tool_call(s); "

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -489,23 +489,41 @@ class StreamingPostProcessor:
             where a JSON body should be).
           * Array root (``"[1,2]"``) — valid JSON, non-object.
 
-        Returns False ONLY when ``args_str`` is missing / empty /
+        Codex r3 BLOCKING #1: a hypothetical future parser could emit
+        a single delta carrying ``name`` PLUS the first PARTIAL JSON
+        fragment (``'{"city":"Pa'``). The current rapid-mlx parsers
+        don't do this (hermes / qwen3coder finalize args before
+        emitting them with ``name``, or emit ``name`` with empty args
+        and stream fragments WITHOUT ``name``), but defending against
+        it costs only one extra check: when ``json.loads`` raises AND
+        the braces are unbalanced (``{`` count > ``}`` count), treat
+        the body as a partial fragment in progress and pass it
+        through — the cap + tool-call merge will accumulate the rest
+        across subsequent deltas. Only when the JSON is well-formed
+        AND non-object, OR when it's syntactically broken with
+        balanced braces, do we drop the anchor.
+
+        Returns False when ``args_str`` is missing / empty /
         whitespace — that's an anchor delta carrying just
         ``name`` + ``id`` with the body deferred to subsequent
-        argument-fragment deltas. Fragment-emitting parsers like
-        qwen3coder publish those continuations WITHOUT a name field,
-        so they bypass this helper entirely via the anchor-name
-        gate in ``_apply_forced_tool_choice_filter``.
+        argument-fragment deltas.
         """
         if not args_str or not args_str.strip():
             return False
         try:
             parsed = json.loads(args_str)
         except (ValueError, TypeError):
-            # Non-JSON ``arguments`` on a finalized anchor — the
-            # bare-text scratch shape. The OpenAI spec mandates a
-            # JSON object string, so a non-JSON value can never
-            # satisfy the contract. Drop.
+            # Non-JSON: distinguish "partial fragment in progress"
+            # (unclosed object → keep) from "finalized non-JSON
+            # scratch" (balanced or no braces → drop).
+            # ``{`` count > ``}`` count means the JSON object is mid-
+            # stream and hasn't finished closing — pass through so
+            # subsequent fragments can complete it. Otherwise it's
+            # genuine non-JSON (bare prose / mis-escaped) — drop.
+            open_braces = args_str.count("{")
+            close_braces = args_str.count("}")
+            if open_braces > close_braces:
+                return False
             return True
         return not isinstance(parsed, dict)
 
@@ -933,19 +951,20 @@ class StreamingPostProcessor:
         # literal harmony sentinels were corrupted by sentinel-
         # anchored regex parsing).
         engine_tool_calls = getattr(output, "tool_calls", None) or []
-        # F-200: when ``tool_choice`` forces a named function, suppress
-        # any structured channel-routed calls whose name does not match.
-        # Harmony / gemma4 channel parsers can surface speculative calls
-        # to other tools alongside the forced one — clients reading the
-        # forced-tool wire expect exactly one call to the named tool.
+        # F-200: when ``tool_choice`` forces a named function, route
+        # the channel-routed structured calls through the SHARED
+        # filter so the wire-shape variants (flat
+        # ``{"name":"X","arguments":...}`` for HarmonyStreamableParser,
+        # wrapped ``{"function":{"name":...}}`` for any future
+        # router) are handled identically to the text-parser path.
+        # Codex r3 BLOCKING #2: the earlier inline filter accepted
+        # only the flat shape and would have silently dropped a
+        # wrapped-shape channel emission. Reusing the helper also
+        # picks up the JSON-object-root validation for free, which
+        # closes the same scratch-with-primitive-args leak on the
+        # channel-routed path.
         if engine_tool_calls:
-            _forced_name = self._forced_tool_choice_name()
-            if _forced_name:
-                engine_tool_calls = [
-                    _tc
-                    for _tc in engine_tool_calls
-                    if isinstance(_tc, dict) and _tc.get("name") == _forced_name
-                ]
+            engine_tool_calls = self._apply_forced_tool_choice_filter(engine_tool_calls)
         if output.channel == "tool_call" and engine_tool_calls:
             # ``parallel_tool_calls=false`` is a hard external contract:
             # the non-streaming path caps the parsed list at one

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -470,29 +470,43 @@ class StreamingPostProcessor:
 
     @staticmethod
     def _forced_tool_choice_arguments_violate_object_root(args_str: str | None) -> bool:
-        """Return True when ``args_str`` parses as JSON but is NOT a
-        JSON object (dict).
+        """Return True when a finalized anchor's ``arguments`` value
+        violates the OpenAI spec.
 
         OpenAI spec: ``tool_calls[i].function.arguments`` is a string
         encoding a JSON object — every declared tool schema is
-        ``{"type":"object","properties":{…}}``. A bare integer
-        (``"1234567890"``), bare string (``"☉ Paris output"``), or
-        array root is the model's scratch — not a real call. F-200
-        finalize path needs this guard too; sharing the helper between
-        the per-delta filter and the finalize / fallback paths keeps
-        the two surfaces from drifting.
+        ``{"type":"object","properties":{…}}``. A finalized anchor
+        whose ``arguments`` is not a JSON-object-encoded string can
+        never satisfy the contract, so it is always the model's
+        scratch:
 
-        Returns False when ``args_str`` is missing, empty / whitespace,
-        or does not parse as JSON at all (mid-stream fragments may not
-        be a complete JSON document yet; the parser path retries on
-        the next delta).
+          * Bare integer (``"1234567890"``) — valid JSON, non-object.
+          * JSON-quoted string (``'"☉ Paris output"'``) — valid JSON,
+            non-object.
+          * Bare unquoted text (``"☉ Paris output"``) — NOT valid
+            JSON at all (codex r2 BLOCKING #1; observed when phi-4-
+            mini-reasoning panics inside ``<think>`` and emits prose
+            where a JSON body should be).
+          * Array root (``"[1,2]"``) — valid JSON, non-object.
+
+        Returns False ONLY when ``args_str`` is missing / empty /
+        whitespace — that's an anchor delta carrying just
+        ``name`` + ``id`` with the body deferred to subsequent
+        argument-fragment deltas. Fragment-emitting parsers like
+        qwen3coder publish those continuations WITHOUT a name field,
+        so they bypass this helper entirely via the anchor-name
+        gate in ``_apply_forced_tool_choice_filter``.
         """
         if not args_str or not args_str.strip():
             return False
         try:
             parsed = json.loads(args_str)
         except (ValueError, TypeError):
-            return False
+            # Non-JSON ``arguments`` on a finalized anchor — the
+            # bare-text scratch shape. The OpenAI spec mandates a
+            # JSON object string, so a non-JSON value can never
+            # satisfy the contract. Drop.
+            return True
         return not isinstance(parsed, dict)
 
     def _apply_forced_tool_choice_filter(self, tool_calls: list[dict]) -> list[dict]:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -458,14 +458,29 @@ class StreamingPostProcessor:
             tc = req.get("tool_choice")
         else:
             tc = getattr(req, "tool_choice", None)
-        if not isinstance(tc, dict):
+        if tc is None:
             return None
-        if tc.get("type") != "function":
+
+        # Production routes call ``request.model_dump(exclude_none=True)``
+        # before constructing the postprocessor so ``tool_choice`` is a
+        # plain dict here. Codex r4 BLOCKING: a typed-request callpath
+        # (test fixtures, future refactors that thread the model
+        # object directly) would leave ``tc`` as a Pydantic model with
+        # ``.type`` / ``.function.name`` attributes — the dict-only
+        # gate silently disabled the filter on that path. Read both
+        # shapes via a tiny shape-agnostic accessor so future drift
+        # cannot reopen the leak.
+        def _get(obj, key):
+            if isinstance(obj, dict):
+                return obj.get(key)
+            return getattr(obj, key, None)
+
+        if _get(tc, "type") != "function":
             return None
-        fn = tc.get("function")
-        if not isinstance(fn, dict):
+        fn = _get(tc, "function")
+        if fn is None:
             return None
-        name = fn.get("name")
+        name = _get(fn, "name")
         return name if isinstance(name, str) and name else None
 
     @staticmethod


### PR DESCRIPTION
## Summary
- F-200 root cause: when `stream:true` + `tool_choice={type:function,function:{name:X}}` is set on a reasoning model that shares the hermes tool parser (qwen3-4b-thinking, phi-4-mini-reasoning), the chat-template-injected `<think>` plus the forced-assistant-prefix lever lands the model inside an implicit-think open tool envelope. Models speculate by emitting scratch `<tool_call>{"name":"X","arguments":<bare int/string>}</tool_call>` blocks while still in `<think>`. The MiniMax tool-markup redirect in `_process_with_reasoning` (load-bearing for this flow) promotes both the scratch block AND the real call to the wire — shipping a second `tool_calls[]` delta with non-JSON-object `arguments` (`"1234567890"`, `"☉ Paris output"`), violating the OpenAI spec.
- Fix: layer a `_apply_forced_tool_choice_filter` in front of every `_apply_parallel_cap` call site AND on the finalize cross-format fallback. Drops anchor deltas that either (a) name a function other than the forced choice or (b) have `arguments` that parse as JSON non-object. Continuation fragments pass through; the cap layer's `_no_index_last_dropped` flag is set on each drop so fragments routed to the dropped anchor are also suppressed.
- 4-case verification on live qwen3-4b-thinking-2507-4bit on port 8057: stream+forced (1/1 clean, single valid call), stream+auto (clean parallel calls preserved on `weather in paris AND tokyo`), non-stream+forced (clean, unchanged), stream+required-with-1-tool (clean). Auto tool_choice, non-reasoning forced, and multi-tool parallel paths unchanged.
- 14 new regression tests in `tests/test_stream_forced_tool_reasoning.py`; 195 related existing tests pass (postprocessor, parallel_tool_calls, forced_tool_prefix, tool_choice_enforcement, streaming_spec, streaming_guided, tool_call_streaming_parity); broader 1671-test sweep on `-k "stream or tool"` clean.

## Test plan
- [x] `tests/test_stream_forced_tool_reasoning.py` (14 new tests — helper unit pins, filter unit pins, four-quadrant end-to-end through `process_chunk`)
- [x] Live repro on qwen3-4b-thinking-2507-4bit (port 8057, 3 consecutive runs all clean)
- [x] Existing related suites green (195 tests)
- [x] Stream/tool broad sweep green (1671 tests, 6 skipped, 5 xfailed)
- [x] No version bump