### PR TITLE
fix(anthropic): wire _validate_tool_call_params into /v1/messages (F-220)

### DIFF
--- a/tests/test_anthropic_tool_param_validation.py
+++ b/tests/test_anthropic_tool_param_validation.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-220: ``_validate_tool_call_params`` is wired into ``/v1/messages``.
+
+PR #736 (F-141 scoped fix) added JSON-schema enforcement on the model's
+emitted ``tool_calls[].function.arguments`` for the OpenAI
+``/v1/chat/completions`` route — enum / type / minimum / maximum /
+minLength / maxLength violations turned into ``HTTPException(400)``.
+The Anthropic-flavored ``/v1/messages`` route bypassed the same
+validator, so the identical bad payload that 400-ed on
+``/v1/chat/completions`` came back as a 200 ``tool_use`` block carrying
+schema-violating arguments. This is the regression guard.
+
+Mirrors ``tests/test_tool_param_enforcement.py`` for the chat route
+but exercises the actual route handler so the cross-route adapter
+(``api/anthropic_adapter._convert_tool``) is included in the path.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.routes.anthropic import router
+
+
+class _StubTokenizer:
+    chat_template = ""
+
+
+class _ToolCallEngine:
+    """Stub engine that returns a pre-canned tool_calls structured payload.
+
+    The Anthropic non-stream branch reads ``output.tool_calls`` first
+    via ``getattr(output, "tool_calls", None)`` and feeds it into
+    ``_parse_tool_calls_with_parser`` as ``structured_tool_calls``. By
+    handing back a single tool_call whose ``arguments`` violate the
+    declared enum, we exercise the F-220 validator inline.
+    """
+
+    preserve_native_tool_format = False
+    tokenizer = _StubTokenizer()
+
+    def __init__(self, tool_calls_payload: list[dict]):
+        self._tool_calls = tool_calls_payload
+
+    async def chat(self, messages, **kwargs):  # noqa: ARG002
+        return SimpleNamespace(
+            text="",
+            raw_text="",
+            tool_calls=self._tool_calls,
+            prompt_tokens=10,
+            completion_tokens=5,
+            finish_reason="tool_calls",
+            reasoning_text="",
+        )
+
+    async def stream_chat(self, messages, **kwargs):  # noqa: ARG002
+        # Streaming variant: emit a single tool_call as a structured
+        # payload on the final delta. Mirrors how the real engine
+        # routers (HarmonyStreamingRouter) surface tool_calls.
+        yield SimpleNamespace(
+            new_text="",
+            prompt_tokens=10,
+            completion_tokens=1,
+            tool_calls=self._tool_calls,
+        )
+
+
+def _make_client(engine: _ToolCallEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+_PAINT_TOOL_SCHEMA = {
+    "name": "paint",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "color": {"type": "string", "enum": ["red", "blue"]},
+        },
+        "required": ["color"],
+    },
+}
+
+
+def _enum_violation_payload() -> list[dict]:
+    # Structured-tool-call payload as produced by HarmonyStreamingRouter:
+    # flat ``{name, arguments}`` dicts, NOT the wrapped OpenAI shape. See
+    # ``_parse_tool_calls_with_parser`` in ``service/helpers.py``.
+    return [{"name": "paint", "arguments": json.dumps({"color": "purple"})}]
+
+
+def _enum_ok_payload() -> list[dict]:
+    return [{"name": "paint", "arguments": json.dumps({"color": "red"})}]
+
+
+def test_messages_tool_enum_violation_returns_400():
+    """F-220: enum violation on /v1/messages is enforced as HTTP 400.
+
+    Pre-fix: 200 ``tool_use`` block with ``input.color == "purple"``.
+    Post-fix: 400 ``invalid_request_error`` with the canonical schema
+    violation message mirroring ``/v1/chat/completions``.
+    """
+    engine = _ToolCallEngine(_enum_violation_payload())
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "paint purple"}],
+            "tools": [_PAINT_TOOL_SCHEMA],
+            "tool_choice": {"type": "tool", "name": "paint"},
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    # The unit-test FastAPI app uses the default HTTPException renderer
+    # (``{"detail": "..."}``); the live server wraps it via the
+    # global exception handlers into ``{"error": {...}}``. Accept either
+    # representation here so the test stays agnostic to which layer of
+    # the production stack wraps the error envelope.
+    message = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "violates declared schema" in message, body
+    assert "purple" in message
+    assert "['red', 'blue']" in message
+
+
+def test_messages_tool_enum_ok_returns_200_with_tool_use():
+    """Negative control: a valid enum value still emits ``tool_use`` 200."""
+    engine = _ToolCallEngine(_enum_ok_payload())
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "paint red"}],
+            "tools": [_PAINT_TOOL_SCHEMA],
+            "tool_choice": {"type": "tool", "name": "paint"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    tool_uses = [b for b in body["content"] if b["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "paint"
+    assert tool_uses[0]["input"] == {"color": "red"}
+    assert body["stop_reason"] == "tool_use"
+
+
+def test_messages_stream_tool_enum_violation_emits_error_event():
+    """Streaming: headers are already sent so we cannot return 400 inline.
+
+    The fix surfaces the validation failure as an Anthropic
+    ``event: error`` SSE event with ``invalid_request_error`` and
+    suppresses the would-be ``tool_use`` blocks. The final
+    ``message_delta`` still fires with ``stop_reason="end_turn"`` so
+    well-behaved clients see a clean termination.
+    """
+    engine = _ToolCallEngine(_enum_violation_payload())
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "paint purple"}],
+            "tools": [_PAINT_TOOL_SCHEMA],
+            "tool_choice": {"type": "tool", "name": "paint"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+
+    raw = response.text
+    assert "event: error" in raw, raw
+    # The error event must carry the canonical schema-violation message
+    # so streaming clients see the SAME diagnostic the non-stream path
+    # would have returned as a 400 body.
+    assert "violates declared schema" in raw
+    assert "purple" in raw
+    assert "invalid_request_error" in raw
+
+    # No tool_use content_block_start should have been emitted — the
+    # violating call is dropped, not silently shipped as garbage.
+    assert '"type": "tool_use"' not in raw
+    # message_delta still fires with end_turn so the SSE protocol closes
+    # cleanly (no half-open stream).
+    assert '"stop_reason": "end_turn"' in raw

--- a/tests/test_response_format_strict_types.py
+++ b/tests/test_response_format_strict_types.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for F-103 — invalid ``response_format.type`` values
+and malformed inner ``json_schema`` payloads used to silently slip
+through the request-schema layer and HTTP 200 with no structure
+enforcement.
+
+The route-layer ``_validate_response_format`` helper in
+``vllm_mlx/service/helpers.py`` already covers the ``type`` enum and
+the "missing inner ``json_schema``" arm; this test file pins the
+remaining silent-200 surface the helper did NOT cover:
+
+* ``response_format.type`` = ``null`` / array / unknown string
+  (also covered by the route helper today; pinned here so a future
+  refactor that moves the gate into the schema layer alone keeps
+  the contract).
+* ``json_schema.schema`` is a non-dict (``42``, ``"hello"``,
+  ``[1,2]``). Previously the typed ``ResponseFormatJsonSchema`` arm
+  rejected these (schema_: dict), the Pydantic union fell back to
+  the bare-``dict`` arm, and the route helper's
+  ``if not json_schema_field.get("schema")`` check returned False
+  for any truthy value — so the request continued without
+  guided-generation enforcement. The desired contract: reject at
+  Pydantic-parse time with a clean 422 / 400 naming the actual
+  client-side type that was sent.
+
+Validation is wired as a ``@field_validator(mode="before")`` on
+``ChatCompletionRequest.response_format`` (and shared with
+``_validate_response_format_raw`` in ``vllm_mlx/api/models.py``)
+so the gate runs at FastAPI body-parse — never reaches any
+downstream code that could leak raw Python type errors.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    ResponseFormat,
+    _validate_response_format_raw,
+)
+
+# ---------------------------------------------------------------------------
+# Direct helper-level tests (cheap, no route invocation).
+# ---------------------------------------------------------------------------
+
+
+class TestValidateResponseFormatRaw:
+    """``_validate_response_format_raw`` is the shared dict-arm guard.
+    Each case pins one previously-silent-200 input shape."""
+
+    def test_none_flows_through(self):
+        assert _validate_response_format_raw(None) is None
+
+    def test_typed_instance_flows_through(self):
+        rf = ResponseFormat(type="json_object")
+        assert _validate_response_format_raw(rf) is rf
+
+    def test_bare_string_rejected(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _validate_response_format_raw("json")
+
+    def test_bare_list_rejected(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _validate_response_format_raw(["json"])
+
+    def test_missing_type_key_rejected(self):
+        with pytest.raises(ValueError, match="type is required"):
+            _validate_response_format_raw({})
+
+    def test_type_null_rejected(self):
+        with pytest.raises(ValueError, match="must be 'text'"):
+            _validate_response_format_raw({"type": None})
+
+    def test_type_unknown_string_rejected(self):
+        with pytest.raises(ValueError, match="must be 'text'"):
+            _validate_response_format_raw({"type": "xml"})
+
+    def test_type_array_rejected(self):
+        with pytest.raises(ValueError, match="must be 'text'"):
+            _validate_response_format_raw({"type": ["json_schema", "json_object"]})
+
+    def test_json_schema_type_missing_schema_field_rejected(self):
+        with pytest.raises(ValueError, match="non-empty 'json_schema' field"):
+            _validate_response_format_raw({"type": "json_schema"})
+
+    def test_json_schema_type_empty_dict_field_rejected(self):
+        with pytest.raises(ValueError, match="non-empty 'json_schema' field"):
+            _validate_response_format_raw({"type": "json_schema", "json_schema": {}})
+
+    @pytest.mark.parametrize(
+        "bad_schema, type_name",
+        [
+            (42, "int"),
+            ("hello", "str"),
+            ([1, 2], "list"),
+            (3.14, "float"),
+        ],
+    )
+    def test_json_schema_schema_not_a_dict_rejected(self, bad_schema, type_name):
+        """F-103 silent-200 closer. ``json_schema.schema`` of any
+        non-dict type used to fall through the bare-dict union arm and
+        be silently swallowed (downstream
+        ``extract_json_schema_for_guided`` bailed at the truthy-check
+        for ints/strings; truthy strings produced literal-in-prompt
+        garbage). Now → clean 422 naming the actual sent type."""
+        with pytest.raises(ValueError) as ei:
+            _validate_response_format_raw(
+                {
+                    "type": "json_schema",
+                    "json_schema": {"name": "x", "schema": bad_schema},
+                }
+            )
+        msg = str(ei.value)
+        assert "json_schema.schema must be an object" in msg
+        assert f"got {type_name}" in msg
+
+    def test_json_schema_empty_inner_schema_dict_rejected(self):
+        """``schema:{}`` is technically dict-shaped but unconstrained
+        in practice (matches anything) — mirror the typed arm's
+        rejection of empty inner schema."""
+        with pytest.raises(ValueError, match="non-empty object"):
+            _validate_response_format_raw(
+                {
+                    "type": "json_schema",
+                    "json_schema": {"name": "x", "schema": {}},
+                }
+            )
+
+    def test_json_schema_missing_name_rejected(self):
+        """Codex round-1 BLOCKING: the typed
+        ``ResponseFormatJsonSchema`` arm declares ``name: str`` as
+        required, but the bare-``dict`` union arm used to swallow
+        ``{"json_schema":{"schema":{...}}}`` silently — guided
+        generation then skipped its lookup and the request HTTP 200'd
+        unconstrained. Reject at the schema layer for parity."""
+        with pytest.raises(ValueError, match="name is required"):
+            _validate_response_format_raw(
+                {
+                    "type": "json_schema",
+                    "json_schema": {"schema": {"type": "object"}},
+                }
+            )
+
+    def test_json_schema_non_string_name_rejected(self):
+        with pytest.raises(ValueError, match="name is required"):
+            _validate_response_format_raw(
+                {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": 42,
+                        "schema": {"type": "object"},
+                    },
+                }
+            )
+
+    def test_valid_json_schema_passes(self):
+        value = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "r",
+                "schema": {"type": "object"},
+            },
+        }
+        assert _validate_response_format_raw(value) is value
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through ChatCompletionRequest (the field_validator hookup).
+# ---------------------------------------------------------------------------
+
+
+def _minimal_request(**overrides):
+    base = {
+        "model": "qwen3-0.6b-8bit",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestChatCompletionRequestResponseFormat:
+    """The ``@field_validator("response_format", mode="before")`` hookup
+    must reject every silent-200 shape before the Pydantic Union
+    resolves — i.e., a ``ValidationError`` must surface at parse
+    time, not a successful coercion to the bare-dict arm."""
+
+    @pytest.mark.parametrize(
+        "rf",
+        [
+            {"type": "xml"},
+            {"type": None},
+            {"type": ["json_schema", "json_object"]},
+            {"type": "json_schema"},
+            {"type": "json_schema", "json_schema": {}},
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "x", "schema": 42},
+            },
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "x", "schema": "hello"},
+            },
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "x", "schema": [1, 2]},
+            },
+        ],
+    )
+    def test_invalid_response_format_rejected(self, rf):
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest.model_validate(_minimal_request(response_format=rf))
+        msg = str(ei.value)
+        # Pydantic's default error body carries the field name plus our
+        # raised ``ValueError`` text — pin one or the other so a future
+        # error-shape change still has at least the field-name handle.
+        assert "response_format" in msg
+
+    @pytest.mark.parametrize(
+        "rf",
+        [
+            None,
+            {"type": "text"},
+            {"type": "json_object"},
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "r",
+                    "schema": {"type": "object"},
+                },
+            },
+            # Pydantic-typed instance also passes through.
+            ResponseFormat(type="text"),
+            ResponseFormat(type="json_object"),
+        ],
+    )
+    def test_valid_response_format_accepted(self, rf):
+        req = ChatCompletionRequest.model_validate(_minimal_request(response_format=rf))
+        # Sanity: the field is reachable, either as the typed model
+        # (Pydantic coerced the dict into ``ResponseFormat``), as
+        # the dict-arm fallback, or as ``None``.
+        if rf is None:
+            assert req.response_format is None
+        elif isinstance(rf, ResponseFormat):
+            # Typed input — Pydantic preserves the same instance shape.
+            assert isinstance(req.response_format, ResponseFormat)
+            assert req.response_format.type == rf.type
+        else:
+            # Dict input — typed arm wins for well-formed payloads.
+            assert isinstance(req.response_format, (ResponseFormat, dict))
+            # ``type`` is reachable either way.
+            rf_type = (
+                req.response_format.type
+                if isinstance(req.response_format, ResponseFormat)
+                else req.response_format.get("type")
+            )
+            assert rf_type == rf["type"]

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -350,6 +350,118 @@ class ResponseFormatJsonSchema(BaseModel):
         populate_by_name = True
 
 
+# F-103: legal ``response_format.type`` enum, kept in sync with the
+# route-layer ``_VALID_RESPONSE_FORMAT_TYPES`` in
+# ``vllm_mlx/service/helpers.py``. Defined at module scope so both
+# the typed ``ResponseFormat`` Pydantic model and the request-level
+# raw-dict guard share one source of truth.
+_VALID_RESPONSE_FORMAT_TYPES: tuple[str, ...] = (
+    "text",
+    "json_object",
+    "json_schema",
+)
+
+
+def _validate_response_format_raw(value):
+    """Reject malformed ``response_format`` dict payloads BEFORE the
+    typed ``ResponseFormat`` Pydantic arm is reached (F-103).
+
+    ``ChatCompletionRequest.response_format`` is declared as
+    ``ResponseFormat | dict | None`` so OpenAI-compat clients can send
+    the spec-shape directly without our typed model rejecting unknown
+    extension keys. The downside is Pydantic's Union coercion picks
+    the FIRST arm that parses — so when the typed arm rejects (e.g.
+    ``json_schema.schema=42`` because ``ResponseFormatJsonSchema``
+    declares ``schema_: dict``), the bare-``dict`` arm silently
+    swallows the same payload. That was the F-103 silent-200 hazard:
+
+      * ``{"type":"json_schema","json_schema":{"name":"x",
+         "schema":42}}`` (int) → fell through to the dict arm, then
+         ``extract_json_schema_for_guided`` bailed at
+         ``if not schema: return None`` (HTTP 200 with no constraint).
+      * Same with ``"schema":"hello"`` (string truthy → schema was
+         coerced into a string literal in the system prompt;
+         downstream JSON parsing produced garbage).
+
+    The route-layer ``_validate_response_format`` helper closes the
+    ``type``-enum and ``json_schema``-required arms; this validator
+    pins the inner ``json_schema.schema`` shape so the silent-200
+    arm becomes a clean 400 at parse time. Kept in models.py (not the
+    route helper) so the gate fires before any FastAPI dependency runs
+    — the resulting ``ValidationError`` surfaces as a Pydantic 400
+    with a structured ``detail`` body the existing
+    ``_validation_error_response`` handler already strips of
+    ``input``.
+    """
+    # ``None`` flows through (default — no structure enforcement).
+    if value is None:
+        return value
+    # If the value already parses as the typed model, the typed arm's
+    # own validators cover everything we need — pass through.
+    if isinstance(value, ResponseFormat):
+        return value
+    # Non-dict wire forms (string / list / int) — reject with a clean
+    # message; Pydantic's default union-fallback would otherwise
+    # produce a misleading error pointing at the wrong arm.
+    if not isinstance(value, dict):
+        raise ValueError("response_format must be an object with a 'type' field")
+    # From here we're on the dict arm. Mirror the route-layer enum
+    # rules + add the missing inner-``schema`` shape check.
+    if "type" not in value:
+        raise ValueError("response_format.type is required")
+    rf_type = value.get("type")
+    if rf_type not in _VALID_RESPONSE_FORMAT_TYPES:
+        raise ValueError(
+            "response_format.type must be 'text', 'json_object', or 'json_schema'"
+        )
+    if rf_type == "json_schema":
+        json_schema_field = value.get("json_schema")
+        if not json_schema_field:
+            raise ValueError(
+                "response_format.type='json_schema' requires "
+                "non-empty 'json_schema' field"
+            )
+        if not isinstance(json_schema_field, dict):
+            raise ValueError("response_format.json_schema must be an object")
+        # Mirror the typed ``ResponseFormatJsonSchema.name: str``
+        # required field on the dict arm — codex round-1 BLOCKING
+        # follow-up. The bare-dict union arm would otherwise swallow
+        # ``{"json_schema":{"schema":{...}}}`` (no ``name``) and the
+        # downstream guided-generation extractor skips its lookup
+        # silently, producing an unconstrained 200.
+        name_field = json_schema_field.get("name")
+        if not name_field or not isinstance(name_field, str):
+            raise ValueError(
+                "response_format.json_schema.name is required and must be a string"
+            )
+        inner_schema = json_schema_field.get("schema")
+        if inner_schema is None:
+            # Missing inner ``schema`` member; the route-layer helper
+            # already covers this, but mirroring here keeps the schema
+            # arm self-contained.
+            raise ValueError(
+                "response_format.type='json_schema' requires "
+                "'json_schema.schema' to be a non-empty object"
+            )
+        if not isinstance(inner_schema, dict):
+            # F-103 silent-200 closer: ``schema:42`` / ``schema:"hello"``
+            # / ``schema:[1,2]`` previously fell through the bare-dict
+            # union arm and produced HTTP 200 with no JSON-Schema
+            # enforcement. Now a clean Pydantic ``ValidationError``
+            # naming the actual type the client sent.
+            raise ValueError(
+                "response_format.json_schema.schema must be an object "
+                f"(got {type(inner_schema).__name__})"
+            )
+        if not inner_schema:
+            # Empty dict — also unconstrained, same hazard class.
+            raise ValueError(
+                "response_format.type='json_schema' requires "
+                "'json_schema.schema' to be a non-empty object"
+            )
+    return value
+
+
 class ResponseFormat(BaseModel):
     """
     Response format specification for structured output.
@@ -360,7 +472,12 @@ class ResponseFormat(BaseModel):
     - "json_schema": Forces JSON matching a specific schema
     """
 
-    type: str = "text"  # "text", "json_object", "json_schema"
+    # F-103: ``Literal`` so the typed arm of the
+    # ``ResponseFormat | dict`` union rejects unknown ``type`` values
+    # (``"xml"``, ``""``, etc.) at parse time. The dict arm is
+    # separately guarded by ``_validate_response_format_raw`` on the
+    # request model.
+    type: Literal["text", "json_object", "json_schema"] = "text"
     json_schema: ResponseFormatJsonSchema | None = None
 
 
@@ -527,6 +644,17 @@ class ChatCompletionRequest(BaseModel):
     @classmethod
     def _scrub_nonfinite_sampling(cls, data):
         return _scrub_nonfinite_sampling_raw(data)
+
+    # F-103: tighten ``response_format`` dict-arm validation so the
+    # silent-200 hazard (``json_schema.schema=42`` / ``"hello"``
+    # falling through the union to bare-dict) is rejected with a
+    # clean 422 at parse time. Runs on the raw value BEFORE the
+    # ``ResponseFormat | dict`` union resolves so the dict arm
+    # cannot swallow shapes the typed arm would reject.
+    @field_validator("response_format", mode="before")
+    @classmethod
+    def _validate_response_format(cls, v):
+        return _validate_response_format_raw(v)
 
     # Belt-and-braces: catches non-finite values that bypass the
     # raw-dict path (e.g. ``ChatCompletionRequest(temperature=nan)``

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -52,6 +52,7 @@ from ..service.helpers import (
     _resolve_temperature,
     _resolve_top_p,
     _validate_model_name,
+    _validate_tool_call_params,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
     enforce_context_length_for_messages,
@@ -309,6 +310,18 @@ async def create_anthropic_message(
         cleaned_text, tool_calls = _parse_tool_calls_with_parser(
             output.text, openai_request, structured_tool_calls=engine_tool_calls
         )
+
+        # F-220: enforce the same tool_call JSON-schema validation
+        # ``routes/chat.py:1651`` runs on the OpenAI ``/v1/chat/completions``
+        # route. The Anthropic adapter has already translated
+        # ``input_schema`` into the OpenAI ``function.parameters`` shape
+        # (see ``api/anthropic_adapter._convert_tool``), so we can reuse
+        # the same validator unchanged. Without this, an enum/type/range
+        # violation that returns HTTP 400 on chat-completions silently
+        # propagated through ``/v1/messages`` as a 200 ``tool_use`` block
+        # carrying schema-violating arguments.
+        if tool_calls and openai_request.tools:
+            _validate_tool_call_params(tool_calls, openai_request.tools)
 
         # Extract reasoning content via the same orchestration the OpenAI route
         # uses (chat.py). Skipping this is what #413 fixed — the Anthropic surface
@@ -1394,6 +1407,34 @@ async def _stream_anthropic_messages(
         openai_request,
         structured_tool_calls=accumulated_structured_tool_calls or None,
     )
+
+    # F-220: enforce JSON-schema validation on the model's emitted
+    # tool_call arguments. On the streaming branch, headers are already
+    # sent so a mid-stream ``HTTPException`` cannot be returned as a 400
+    # response. Instead, surface the validation error as an Anthropic
+    # SSE ``error`` event (``invalid_request_error``) and drop the
+    # offending tool_use blocks so the client can recover. Matches the
+    # non-stream branch's 400 contract in spirit while staying within
+    # the Anthropic streaming protocol.
+    tool_validation_error: str | None = None
+    if tool_calls and openai_request.tools:
+        try:
+            _validate_tool_call_params(tool_calls, openai_request.tools)
+        except HTTPException as exc:
+            tool_validation_error = (
+                exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            )
+            tool_calls = []
+
+    if tool_validation_error:
+        error_event = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": tool_validation_error,
+            },
+        }
+        yield f"event: error\ndata: {json.dumps(error_event)}\n\n"
 
     if tool_calls:
         for i, tc in enumerate(tool_calls):


### PR DESCRIPTION
## Summary

- PR #736 added tool-arg JSON-schema enforcement on `/v1/chat/completions` (enum/type/min/max/length → 400). The Anthropic-flavored `/v1/messages` route silently bypassed it.
- F-220 fix: thread the same `_validate_tool_call_params` into both the non-stream and stream paths of `routes/anthropic.py`.
- The adapter (`api/anthropic_adapter._convert_tool`) already translates `input_schema` → OpenAI `function.parameters`, so the existing validator is reused unchanged.

## Behavior change

| Surface | Before | After |
|---|---|---|
| `POST /v1/messages` (non-stream) with enum-violating tool_use | HTTP 200 with `tool_use` block carrying violating arg | HTTP 400 `invalid_request_error` with canonical schema-violation message (matches `/v1/chat/completions`) |
| `POST /v1/messages` (stream) | SSE 200 with `tool_use` content_block carrying violating arg | SSE 200 with `event: error` (`invalid_request_error`), violating tool_use suppressed, closes with `stop_reason=end_turn` |
| Valid enum value | HTTP 200 `tool_use` | HTTP 200 `tool_use` (unchanged) |

Stream branch can't return a 400 mid-response (headers already sent), so it surfaces the same diagnostic as an Anthropic-protocol error event.

## Test plan

- [x] Live repro on qwen3-0.6b-8bit, port 8058: `paint` with `enum:["red","blue"]` + arg `color="purple"` → before: 200 `tool_use`, after: 400 `violates declared schema`.
- [x] Negative control: `color="red"` still passes 200.
- [x] Stream variant: `event: error` emitted with canonical message.
- [x] Unit tests in `tests/test_anthropic_tool_param_validation.py` cover all three.
- [x] `tests/test_tool_param_enforcement.py` (32 tests) still pass — no regression on the chat-completions side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)