### PR TITLE
fix(models): /v1/models reports modality=image for VL aliases (F-067)

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -766,6 +766,88 @@ class TestModelsRoutes:
         finally:
             self._restore(orig)
 
+    # ----- F-067: modality reporting for VL models -----
+
+    def test_vl_alias_reports_image_modality(self):
+        """F-067 regression: aliases that resolve to a Vision-Language
+        checkpoint MUST advertise ``modality="image"`` on the wire so
+        downstream OpenAI-SDK clients know to send PNG/JPEG/etc. image
+        content shapes. Before the fix, all VL aliases (qwen3-vl-2b-4bit,
+        gemma-3n-*, qwen3-vl-4b-4bit) reported ``"text"`` because the
+        ``AliasProfile.modality`` field is an engine-routing
+        discriminator (``text`` = AR lane, ``text-diffusion`` = diffusion
+        lane) — the multimodal path is layered on top of the AR lane
+        via ``MLLMBatchGenerator`` and so keeps ``modality="text"``
+        internally. The route layer now derives the reported value from
+        ``is_mllm_model`` so VL aliases surface ``image`` to clients
+        without disturbing engine routing.
+        """
+        for vl_alias in (
+            "qwen3-vl-2b-4bit",
+            "qwen3-vl-4b-4bit",
+            "gemma-3n-e2b-4bit",
+            "gemma-3n-e4b-4bit",
+        ):
+            orig = self._set_config(
+                model_registry=None,
+                model_name=vl_alias,
+                model_alias=None,
+                api_key=None,
+            )
+            try:
+                client = TestClient(self._make_app())
+                r = client.get(f"/v1/models/{vl_alias}")
+                assert r.status_code == 200, (
+                    f"VL alias {vl_alias!r} should resolve"
+                )
+                body = r.json()
+                assert body["modality"] == "image", (
+                    f"F-067 regression: VL alias {vl_alias!r} reports "
+                    f"modality={body['modality']!r} (expected 'image')"
+                )
+            finally:
+                self._restore(orig)
+
+    def test_text_alias_still_reports_text_modality(self):
+        """Counterpart to F-067: a plain text LLM alias MUST keep
+        ``modality="text"`` so the detector doesn't over-trigger and
+        mislabel non-VL models as multimodal.
+        """
+        orig = self._set_config(
+            model_registry=None,
+            model_name="mlx-community/Qwen3.5-4B-MLX-4bit",
+            model_alias="qwen3.5-4b-4bit",
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/qwen3.5-4b-4bit")
+            assert r.status_code == 200
+            assert r.json()["modality"] == "text"
+        finally:
+            self._restore(orig)
+
+    def test_diffusion_alias_keeps_text_diffusion_modality(self):
+        """Counterpart to F-067: the text-diffusion routing
+        discriminator on diffusion-gemma-* must pass through unchanged
+        — the multimodal detector only kicks in when the profile
+        modality is the default ``text``, not for already-non-text
+        lanes that have their own dispatch.
+        """
+        orig = self._set_config(
+            model_registry=None,
+            model_name="diffusion-gemma-26b-4bit",
+            model_alias=None,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/diffusion-gemma-26b-4bit")
+            assert r.status_code == 200
+            assert r.json()["modality"] == "text-diffusion"
+        finally:
+            self._restore(orig)
+
 
 # ---------------------------------------------------------------------------
 # MCP routes

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -797,9 +797,7 @@ class TestModelsRoutes:
             try:
                 client = TestClient(self._make_app())
                 r = client.get(f"/v1/models/{vl_alias}")
-                assert r.status_code == 200, (
-                    f"VL alias {vl_alias!r} should resolve"
-                )
+                assert r.status_code == 200, f"VL alias {vl_alias!r} should resolve"
                 body = r.json()
                 assert body["modality"] == "image", (
                     f"F-067 regression: VL alias {vl_alias!r} reports "
@@ -807,6 +805,35 @@ class TestModelsRoutes:
                 )
             finally:
                 self._restore(orig)
+
+    def test_vl_alias_reports_image_modality_on_list_endpoint(self):
+        """F-067 regression on the LIST endpoint (the surface clients
+        actually consume on catalog pre-fetch). The per-id retrieval
+        test above pins the same field at the singleton endpoint;
+        this counterpart pins it on ``GET /v1/models`` so a future
+        refactor that fixes one path without the other is caught.
+        """
+        orig = self._set_config(
+            model_registry=None,
+            model_name="qwen3-vl-2b-4bit",
+            model_alias=None,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models")
+            assert r.status_code == 200
+            entries = r.json()["data"]
+            vl_entry = next((e for e in entries if e["id"] == "qwen3-vl-2b-4bit"), None)
+            assert vl_entry is not None, (
+                "qwen3-vl-2b-4bit must appear in the list endpoint"
+            )
+            assert vl_entry["modality"] == "image", (
+                f"F-067 list-endpoint regression: VL alias reports "
+                f"modality={vl_entry['modality']!r} (expected 'image')"
+            )
+        finally:
+            self._restore(orig)
 
     def test_text_alias_still_reports_text_modality(self):
         """Counterpart to F-067: a plain text LLM alias MUST keep

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -14,11 +14,49 @@ on ``qwen3.5-9b-4bit`` doesn't have to hand-tune sliders.
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..api.models import ModelInfo, ModelsResponse
+from ..api.utils import is_mllm_model
 from ..config import get_config
 from ..middleware.auth import verify_api_key
 from ..model_aliases import resolve_profile
 
 router = APIRouter()
+
+
+def _reported_modality(model_id: str, profile_modality: str) -> str:
+    """Return the modality the wire-level ``/v1/models`` should advertise.
+
+    ``AliasProfile.modality`` is an engine-routing discriminator:
+    ``text`` selects the AR ``BatchedEngine`` lane, ``text-diffusion``
+    selects the diffusion lane. Vision-Language aliases (qwen3-vl-*,
+    gemma-3n-*, etc.) deliberately keep ``modality="text"`` internally
+    because their language backbone IS routed through the AR lane —
+    the multimodal path is layered on top via ``MLLMBatchGenerator``,
+    not a separate engine. Reusing the routing discriminator as the
+    externally-reported modality therefore mislabels VL models as
+    text-only and downstream clients skip the image content shapes
+    they otherwise would have sent (F-067).
+
+    The fix derives the reported value from the same ``is_mllm_model``
+    detector the rest of the codebase already trusts to gate VLM
+    routing (see ``cli.py``/``server.py``: ``is_mllm=getattr(args,
+    "mllm", False) or is_mllm_model(args.model)``). This keeps engine
+    routing untouched while reporting an accurate capability hint on
+    the wire. Non-``text`` profile modalities (e.g. ``text-diffusion``)
+    bypass the detector entirely so existing dispatched lanes still
+    advertise their canonical value.
+    """
+    if profile_modality != "text":
+        return profile_modality
+    try:
+        if is_mllm_model(model_id):
+            return "image"
+    except Exception:  # noqa: BLE001
+        # ``is_mllm_model`` reads local config / HF cache; any IO or
+        # parse failure must NOT block ``/v1/models``. Fall back to
+        # the profile's declared modality so the endpoint stays
+        # available even when the cache layer is misbehaving.
+        pass
+    return profile_modality
 
 
 def _build_model_info(model_id: str) -> ModelInfo:
@@ -29,11 +67,18 @@ def _build_model_info(model_id: str) -> ModelInfo:
     HF path (``mlx-community/Qwen3.5-4B-MLX-4bit``); ``resolve_profile``
     handles both. Unknown ids (operator-supplied custom paths, models
     not yet in ``aliases.json``) get the OpenAI baseline shape with
-    every extension field at ``None``.
+    every extension field at ``None`` — except modality, which still
+    runs through the multimodal detector so an unregistered VLM repo
+    id still advertises ``image`` (F-067 layer fix covers raw HF paths
+    too, not just registered aliases).
     """
     profile = resolve_profile(model_id)
     if profile is None:
-        return ModelInfo(id=model_id)
+        try:
+            inferred = "image" if is_mllm_model(model_id) else None
+        except Exception:  # noqa: BLE001
+            inferred = None
+        return ModelInfo(id=model_id, modality=inferred)
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
     # back to a dict for JSON serialization. ``None`` stays ``None``
@@ -52,7 +97,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         is_moe=profile.is_moe,
         tool_call_parser=profile.tool_call_parser,
         reasoning_parser=profile.reasoning_parser,
-        modality=profile.modality,
+        modality=_reported_modality(model_id, profile.modality),
     )
 
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -74,11 +74,20 @@ def _build_model_info(model_id: str) -> ModelInfo:
     """
     profile = resolve_profile(model_id)
     if profile is None:
+        # Preserve the prior unknown-id wire shape (``ModelInfo(id=model_id)``
+        # with the schema-default ``modality``) and only override when the
+        # multimodal detector matches. Codex round-2 BLOCKING on PR #743
+        # flagged that passing ``modality=None`` explicitly is technically
+        # the same value today but would silently regress if
+        # ``ModelInfo.modality``'s default ever flipped from ``None``.
+        # Branch on the detector instead so the default path keeps using
+        # the schema default.
         try:
-            inferred = "image" if is_mllm_model(model_id) else None
+            if is_mllm_model(model_id):
+                return ModelInfo(id=model_id, modality="image")
         except Exception:  # noqa: BLE001
-            inferred = None
-        return ModelInfo(id=model_id, modality=inferred)
+            pass
+        return ModelInfo(id=model_id)
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
     # back to a dict for JSON serialization. ``None`` stays ``None``


### PR DESCRIPTION
## Summary
- Vision-Language aliases (qwen3-vl-2b-4bit, gemma-3n-e2b/e4b-4bit, qwen3-vl-4b-4bit) were advertising \`modality=\"text\"\` on \`/v1/models\` even though they accept image content shapes. Downstream OpenAI-SDK clients use this field to decide whether to send images, so VL models were silently mislabeled as text-only.
- Root cause: \`AliasProfile.modality\` doubles as the engine-routing discriminator (\`text\` -> AR BatchedEngine, \`text-diffusion\` -> DiffusionEngine). VL aliases keep \`modality=\"text\"\` internally because their language backbone runs through the AR lane — the multimodal path is layered on top via \`MLLMBatchGenerator\`. Reusing the routing field as the wire-level modality therefore mislabels them.
- Layer fix in \`vllm_mlx/routes/models.py\`: derive the reported value from the existing \`api.utils.is_mllm_model\` detector — same gate used by \`cli.py\` / \`server.py\` for VLM routing. Reported value flips to \`\"image\"\` when the detector matches; \`AliasProfile.modality\` and engine routing are untouched. \`text-diffusion\` bypasses the detector.

## Repro

\`\`\`bash
curl -s http://127.0.0.1:8047/v1/models | python3 -c \"import sys,json; d=json.load(sys.stdin); [print(m['id'], m.get('modality')) for m in d['data']]\"
# BEFORE: qwen3-vl-2b-4bit text
# AFTER:  qwen3-vl-2b-4bit image
\`\`\`

Unit-level verification (no model boot needed):
\`\`\`python
from vllm_mlx.routes.models import _build_model_info
for a in ['qwen3-vl-2b-4bit','gemma-3n-e2b-4bit','gemma-3n-e4b-4bit','qwen3-vl-4b-4bit']:
    print(a, _build_model_info(a).modality)  # -> image
print('qwen3-0.6b-8bit', _build_model_info('qwen3-0.6b-8bit').modality)  # -> text
print('diffusion-gemma-26b-4bit', _build_model_info('diffusion-gemma-26b-4bit').modality)  # -> text-diffusion
\`\`\`

## Test plan
- [x] \`pytest tests/test_routes.py::TestModelsRoutes\` (11 passed) — adds three regression tests: \`test_vl_alias_reports_image_modality\` (4 VL aliases), \`test_text_alias_still_reports_text_modality\`, \`test_diffusion_alias_keeps_text_diffusion_modality\`.
- [x] \`pytest tests/test_modality_field.py tests/test_model_aliases.py\` (44 passed) — engine-side modality contract unchanged.
- [x] Manual smoke on \`qwen3-0.6b-8bit @ 8047\` post-fix returns \`text\` (no over-trigger).

Layer-fix follow-up that would also be desirable: also expose the multimodal hint via a structured \`capabilities\` field rather than reusing the OpenAI \`modality\` string, so clients can distinguish vision-input from image-generation. Deferred — current fix is wire-compatible with the existing OpenAI shape.