### PR TITLE
fix(api): reject tool_choice='required' with empty/missing tools (F-034)

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -355,7 +355,23 @@ class TestAnthropicToOpenai:
         assert result.tools[0].function["name"] == "search"
 
     def test_tool_choice_conversion(self):
-        req = self._make_request(tool_choice={"type": "any"})
+        # Anthropic ``tool_choice: any`` only makes sense alongside a
+        # non-empty ``tools`` array — pre-F-034 the test passed without
+        # tools, but ``ChatCompletionRequest`` now (correctly) rejects
+        # ``tool_choice="required"`` with no tools at the schema layer.
+        # Anthropic's own spec rejects ``any`` without tools, so feeding
+        # a tool here brings the unit fixture in line with the real wire
+        # contract.
+        req = self._make_request(
+            tools=[
+                AnthropicToolDef(
+                    name="search",
+                    description="Search",
+                    input_schema={"type": "object"},
+                )
+            ],
+            tool_choice={"type": "any"},
+        )
         result = anthropic_to_openai(req)
         assert result.tool_choice == "required"
 

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -39,6 +39,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
 from vllm_mlx.routes.chat import _tool_call_name
 from vllm_mlx.routes.chat import router as chat_router
 
@@ -336,17 +337,27 @@ def test_tool_choice_function_missing_name_with_no_tools_returns_400():
 @pytest.mark.parametrize("tools_field", [None, []])
 def test_tool_choice_required_without_tools_returns_400(tools_field):
     """F-034: ``tool_choice="required"`` with ``tools`` absent or empty
-    must surface as a 4xx error — the request is unsatisfiable, since
+    must surface as HTTP 400 — the request is unsatisfiable, since
     "required" guarantees a tool_call but there is no tool to call.
     Pre-fix both cases silently 200'd as plain chat completions,
-    masking a client bug. The Pydantic ``ValueError`` raised in
-    ``ChatCompletionRequest._validate_tool_choice_against_tools``
-    surfaces as HTTP 400 via ``vllm_mlx.middleware.exception_handlers``
-    (Pydantic 422 → 400 OpenAI-shape envelope; same conversion the
-    F-011 reasoning_max_tokens / nonfinite-sampling validators rely on).
+    masking a client bug.
+
+    Wires the production OpenAI-shape exception middleware via
+    ``install_exception_handlers`` so the assertion pins the SAME wire
+    behavior the real serve binary returns (Pydantic ValidationError
+    -> 400 with ``error.type='invalid_request_error'`` envelope).
     """
     engine = _RecordingEngine()
-    client = _make_client(engine)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(chat_router)
+    client = TestClient(app)
     payload: dict[str, Any] = {
         "model": "test-model",
         "messages": [{"role": "user", "content": "hi"}],
@@ -356,14 +367,13 @@ def test_tool_choice_required_without_tools_returns_400(tools_field):
     if tools_field is not None:
         payload["tools"] = tools_field
     resp = client.post("/v1/chat/completions", json=payload)
-    # Direct Pydantic ValidationError surfaces as 422 from raw FastAPI;
-    # the OpenAI-shape middleware in the real serve binary rewrites to
-    # 400. This test harness mounts only the chat router (no middleware),
-    # so accept either — the contract being pinned is "non-200 plus the
-    # 'tool_choice=required requires non-empty tools' string".
-    assert resp.status_code in (400, 422), resp.text
-    assert "tool_choice='required'" in resp.text
-    assert "non-empty 'tools'" in resp.text
+    # Production wire contract: middleware rewrites the Pydantic 422
+    # into the OpenAI ``invalid_request_error`` 400 envelope.
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "tool_choice='required'" in body["error"]["message"]
+    assert "non-empty 'tools'" in body["error"]["message"]
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -333,6 +333,39 @@ def test_tool_choice_function_missing_name_with_no_tools_returns_400():
     assert resp.status_code == 400
 
 
+@pytest.mark.parametrize("tools_field", [None, []])
+def test_tool_choice_required_without_tools_returns_400(tools_field):
+    """F-034: ``tool_choice="required"`` with ``tools`` absent or empty
+    must surface as a 4xx error — the request is unsatisfiable, since
+    "required" guarantees a tool_call but there is no tool to call.
+    Pre-fix both cases silently 200'd as plain chat completions,
+    masking a client bug. The Pydantic ``ValueError`` raised in
+    ``ChatCompletionRequest._validate_tool_choice_against_tools``
+    surfaces as HTTP 400 via ``vllm_mlx.middleware.exception_handlers``
+    (Pydantic 422 → 400 OpenAI-shape envelope; same conversion the
+    F-011 reasoning_max_tokens / nonfinite-sampling validators rely on).
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    payload: dict[str, Any] = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_choice": "required",
+        "max_tokens": 32,
+    }
+    if tools_field is not None:
+        payload["tools"] = tools_field
+    resp = client.post("/v1/chat/completions", json=payload)
+    # Direct Pydantic ValidationError surfaces as 422 from raw FastAPI;
+    # the OpenAI-shape middleware in the real serve binary rewrites to
+    # 400. This test harness mounts only the chat router (no middleware),
+    # so accept either — the contract being pinned is "non-200 plus the
+    # 'tool_choice=required requires non-empty tools' string".
+    assert resp.status_code in (400, 422), resp.text
+    assert "tool_choice='required'" in resp.text
+    assert "non-empty 'tools'" in resp.text
+
+
 # ──────────────────────────────────────────────────────────────────
 # ``tool_choice="required"`` enforcement (#468)
 # ──────────────────────────────────────────────────────────────────

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -755,6 +755,28 @@ class ChatCompletionRequest(BaseModel):
                 }
         return self
 
+    # F-034: ``tool_choice="required"`` with no ``tools`` array (or with
+    # an explicit ``tools: []``) is a malformed request per the OpenAI
+    # spec — "required" means the model MUST emit a tool_call, which is
+    # impossible to satisfy when the tools surface is empty. Without this
+    # gate the request silently degrades to a plain chat completion (200),
+    # masking a client bug. Fires AFTER ``_normalize_legacy_functions`` so
+    # a legacy ``functions=[...]`` payload that has already been promoted
+    # to ``tools`` is exempt. The ``{type:"function",function:{name:X}}``
+    # named-tool shape is intentionally NOT mirrored here — the chat-route
+    # validator (``vllm_mlx/routes/chat.py`` ~L748) already 400s on that
+    # case with a more informative error referencing the missing function
+    # name; duplicating that check at the schema layer would just produce
+    # a less-helpful message.
+    @model_validator(mode="after")
+    def _validate_tool_choice_against_tools(self) -> "ChatCompletionRequest":
+        if self.tool_choice == "required" and not self.tools:
+            raise ValueError(
+                "tool_choice='required' requires a non-empty 'tools' array; "
+                "got tools=None or tools=[]."
+            )
+        return self
+
 
 class AssistantMessage(BaseModel):
     """Response message from the assistant."""

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -185,6 +185,15 @@ async def create_anthropic_message(
             openai_request = anthropic_to_openai(anthropic_request)
         except AnthropicOutputConfigError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except ValidationError as e:
+            # F-034 (and any future ``ChatCompletionRequest``-layer
+            # validator): the adapter constructs an OpenAI-shape request
+            # from the Anthropic body, and ``ChatCompletionRequest`` now
+            # rejects unsatisfiable combinations (e.g. ``tool_choice="required"``
+            # — Anthropic ``any`` — with no ``tools``). Surface as 400 with
+            # the validator's message instead of letting Pydantic crash
+            # the route into a 500.
+            raise HTTPException(status_code=400, detail=str(e))
 
         # Context-length pre-check — same DoS gate the chat/completions/
         # responses routes enforce. Render the prompt through the engine's

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -165,7 +165,16 @@ async def create_response(request: Request):
                 cfg_for_log.model_name,
             )
 
-        openai_request = responses_to_openai(responses_request)
+        # F-034 (and any future ``ChatCompletionRequest``-layer validator):
+        # the adapter materializes a fresh ``ChatCompletionRequest`` from
+        # the Responses body, which now rejects unsatisfiable combinations
+        # (e.g. ``tool_choice="required"`` with no ``tools``). Surface as
+        # 400 with the validator's message instead of letting Pydantic
+        # crash the route into a 500.
+        try:
+            openai_request = responses_to_openai(responses_request)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
         # Context-length pre-check — same DoS gate the chat/completions/
         # anthropic routes enforce. Runs BEFORE the stream branch so


### PR DESCRIPTION
## Summary

F-034: posting `tool_choice="required"` with `tools` absent or `tools=[]` silently returned 200 (the model just chatted). OpenAI spec: `"required"` means a tool_call MUST be present, so an empty tools surface makes the request unsatisfiable - should be 400.

Fix: add `_validate_tool_choice_against_tools` model_validator on `ChatCompletionRequest` (fires AFTER `_normalize_legacy_functions` so legacy `functions=[...]` payloads that get promoted to `tools` are exempt). The named-tool `{type:"function",function:{name:X}}` shape is intentionally left to the chat-route validator since it produces a more informative error referencing the missing function name.

Also wrap `responses_to_openai` / `anthropic_to_openai` call sites in a `ValidationError -> 400` catch so the new validator surfaces cleanly through both adapter routes instead of crashing into 500.

## Test plan

Verified on `qwen3-0.6b-8bit @ 127.0.0.1:8046`:

```
# Case A (tools missing)
curl -s -o /dev/null -w '%{http_code}\n' .../v1/chat/completions \
  -d '{"model":"qwen3-0.6b-8bit","messages":[...],"max_tokens":5,"tool_choice":"required"}'
# BEFORE: 200      AFTER: 400 "tool_choice='required' requires a non-empty 'tools' array; got tools=None or tools=[]."

# Case B (tools=[])
curl -s -o /dev/null -w '%{http_code}\n' .../v1/chat/completions \
  -d '{"model":"qwen3-0.6b-8bit","messages":[...],"tools":[],"max_tokens":5,"tool_choice":"required"}'
# BEFORE: 200      AFTER: 400 (same message)

# Sanity: tool_choice=required + valid tools     200 (unchanged)
```

- [x] Added `test_tool_choice_required_without_tools_returns_400` (parametrized over `tools=None`/`tools=[]`)
- [x] All 40 tests in `tests/test_chat_route_tool_choice_enforcement.py` pass
- [x] All ~1820 tool/anthropic/responses/api/request tests pass

Closes F-034.

Generated with [Claude Code](https://claude.com/claude-code)