### PR TITLE
fix(api): enforce OpenAI function.name regex on ToolDefinition (F-035 + F-146)

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -225,7 +225,9 @@ class TestToolCalling:
         covers the whole class.
         """
         with pytest.raises(ValidationError) as excinfo:
-            ToolDefinition(function={"name": bad_name, "parameters": {"type": "object"}})
+            ToolDefinition(
+                function={"name": bad_name, "parameters": {"type": "object"}}
+            )
         assert "function.name" in str(excinfo.value)
 
     def test_tool_definition_rejects_missing_name(self):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -200,6 +200,50 @@ class TestToolCalling:
         assert td.type == "function"
         assert td.function["name"] == "get_weather"
 
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "",  # F-035: empty string - hermes parser leaks <tool_call> to content
+            "a" * 65,  # F-146: >64 chars - exceeds OpenAI spec cap
+            "a" * 10000,  # F-146: 10k-char fuzz - context-window waster
+            "weather_\U0001f324",  # F-146: emoji - non-ASCII
+            "$(whoami)",  # F-146: shell metachars
+            "foo\nbar",  # F-146: control char (newline)
+            "foo bar",  # F-146: space
+            "foo.bar",  # F-146: dot
+            "foo/bar",  # F-146: slash
+        ],
+    )
+    def test_tool_definition_rejects_malformed_name(self, bad_name):
+        """F-035 / F-146: ``function.name`` must match the OpenAI spec
+        regex ``^[a-zA-Z0-9_-]{1,64}$``. Pre-fix the schema accepted
+        anything (typed as ``dict``), and empty / emoji / 10k-char /
+        shell-metachar names all 200'd - on hermes-parser models the
+        empty-name case leaked literal ``<tool_call>{"name":"",...}</tool_call>``
+        into ``content`` because the tool-call detector keyed off a
+        non-empty name. A single regex constraint at the schema layer
+        covers the whole class.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            ToolDefinition(function={"name": bad_name, "parameters": {"type": "object"}})
+        assert "function.name" in str(excinfo.value)
+
+    def test_tool_definition_rejects_missing_name(self):
+        """F-035 / F-146: ``function`` dict missing the ``name`` key is
+        also malformed - the OpenAI spec mandates ``name`` as required.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            ToolDefinition(function={"description": "no name", "parameters": {}})
+        assert "function.name" in str(excinfo.value)
+
+    def test_tool_definition_accepts_full_64_char_name(self):
+        """Boundary check - exactly 64 chars is the OpenAI spec maximum
+        and must pass cleanly. Guards against off-by-one regressions in
+        the regex bound."""
+        name = "a" * 64
+        td = ToolDefinition(function={"name": name, "parameters": {"type": "object"}})
+        assert td.function["name"] == name
+
 
 class TestResponseFormat:
     """Tests for structured output models."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -361,8 +361,10 @@ class ToolDefinition(BaseModel):
     @model_validator(mode="after")
     def _validate_function_name(self) -> "ToolDefinition":
         name = self.function.get("name") if isinstance(self.function, dict) else None
-        if name is None or not isinstance(name, str) or not _FUNCTION_NAME_PATTERN.match(
-            name
+        if (
+            name is None
+            or not isinstance(name, str)
+            or not _FUNCTION_NAME_PATTERN.match(name)
         ):
             raise ValueError(
                 "function.name must be a non-empty string of 1-64 characters "

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -10,6 +10,7 @@ These models define the request and response schemas for:
 """
 
 import math
+import re
 import time
 import uuid
 from typing import Literal
@@ -326,11 +327,49 @@ class ToolCall(BaseModel):
     function: FunctionCall
 
 
+# F-035 / F-146: OpenAI function-name spec — non-empty, ≤64 chars,
+# ASCII alphanumerics + ``_`` + ``-``. Same regex Anthropic and OpenAI
+# publish in their tool-definition schemas. Defined at module scope so
+# the request-level validator below and any future direct
+# ``ToolDefinition`` consumers share one source of truth. A single
+# constraint covers the whole space the F-035 / F-146 fuzz exposed
+# (empty / emoji / 10000-char / shell-metachar names all rejected).
+_FUNCTION_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
 class ToolDefinition(BaseModel):
     """Definition of a tool that can be called by the model."""
 
     type: str = "function"
     function: dict
+
+    # F-035 / F-146: reject malformed ``function.name`` at the schema
+    # layer. Pre-fix:
+    #   * ``name=""`` (F-035) - request 200'd; on hermes-parser models
+    #     the model emitted ``<tool_call>{"name":"",...}</tool_call>``
+    #     literally into ``content`` because the tool-call detector
+    #     keyed off a non-empty name field.
+    #   * ``name`` containing shell metacharacters / newlines (F-146)
+    #     - silently passed to the chat template; downstream parsers
+    #     either dropped the call or routed garbage into the tool-name
+    #     slot.
+    #   * ``name`` ≥10 KB (F-146) - accepted; ballooned the prompt and
+    #     wasted the context window.
+    # ``function`` is typed ``dict`` (legacy shape; the field accepts
+    # arbitrary OpenAI extensions) so the Pydantic v2 ``pattern=`` lever
+    # on ``Field`` isn't directly available - validate manually here.
+    @model_validator(mode="after")
+    def _validate_function_name(self) -> "ToolDefinition":
+        name = self.function.get("name") if isinstance(self.function, dict) else None
+        if name is None or not isinstance(name, str) or not _FUNCTION_NAME_PATTERN.match(
+            name
+        ):
+            raise ValueError(
+                "function.name must be a non-empty string of 1-64 characters "
+                "matching ^[a-zA-Z0-9_-]{1,64}$ (per OpenAI spec); got "
+                f"{name!r}."
+            )
+        return self
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

F-035 + F-146 family: pre-fix `tools[*].function.name` was typed as a bare `dict` so any value was accepted. Worst symptom (F-035): empty name on hermes-parser models 200'd with literal `<tool_call>{\"name\":\"\",...}</tool_call>` leaked into `content` because the tool-call detector keys off a non-empty name field. F-146 wave: emoji / 10k-char / shell-metachar / control-char / dot / slash / space all passed schema validation and reached the chat template.

Fix: add a `_validate_function_name` model_validator on `ToolDefinition` that enforces the OpenAI spec regex `^[a-zA-Z0-9_-]{1,64}$`. One constraint covers the entire fuzz surface.

## Test plan

Verified on `qwen3-0.6b-8bit @ 127.0.0.1:8046`:

```
# F-035 empty name
curl ... '{"tools":[{"type":"function","function":{"name":"","parameters":{"type":"object"}}}]}'
# BEFORE: 200 with leaked <tool_call>{"name":"",...}      AFTER: 400 "function.name must be a non-empty string of 1-64 chars matching ^[a-zA-Z0-9_-]{1,64}$"

# F-146 emoji          BEFORE: 200      AFTER: 400
# F-146 10000-char     BEFORE: 200      AFTER: 400
# F-146 shell-metachar BEFORE: 200      AFTER: 400
# Sanity: valid name   BEFORE: 200      AFTER: 200 (unchanged)
```

- [x] Added 9-case parametrized `test_tool_definition_rejects_malformed_name` (empty / 65-char / 10k-char / emoji / metachar / newline / space / dot / slash)
- [x] Added `test_tool_definition_rejects_missing_name` and `test_tool_definition_accepts_full_64_char_name` (boundary)
- [x] All ~6700 unit tests pass (only the pre-existing unrelated `test_no_hasattr_engine_guard[completions.py]` fails on origin/main too)

Closes F-035, addresses F-146.

Generated with [Claude Code](https://claude.com/claude-code)