### PR TITLE
fix(chat): tool_choice 400 hints case-insensitive match (F-145)

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -212,6 +212,80 @@ def test_tool_choice_specific_function_unknown_name_returns_400():
     assert "nonexistent_function" in resp.text
 
 
+def test_tool_choice_case_mismatch_surfaces_did_you_mean_hint():
+    """F-145 regression: a case-mismatched ``tool_choice.function.name``
+    must still 400 (OpenAI-parity, case-sensitive), but the error
+    message now appends a ``(did you mean 'X'? tool_choice is
+    case-sensitive)`` hint pointing at the tool whose name matches
+    case-insensitively. Without the hint, clients see only ``'X' which
+    is not present in the 'tools' array`` and have to diff their tool
+    list character-by-character to spot the case typo.
+    """
+    case_variant_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_Weather",  # capital W
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        },
+    ]
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "what's the weather?"}],
+            "tools": case_variant_tools,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},  # lowercase w
+            },
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+    # Canonical OpenAI-shape message preserved.
+    assert "get_weather" in resp.text
+    assert "not present in the 'tools' array" in resp.text
+    # F-145 hint surfaces the case-matching tool name AND explains why.
+    assert "get_Weather" in resp.text, "F-145 hint must name the case-matching tool"
+    assert "case-sensitive" in resp.text, (
+        "F-145 hint must explain the case-sensitivity surface"
+    )
+
+
+def test_tool_choice_no_case_match_omits_hint():
+    """F-145 counterpart: when there is NO case-insensitive match in
+    the tools array, the error message must NOT append a hint (so we
+    don't surface a misleading "did you mean" for an unrelated tool).
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "do something"}],
+            "tools": _TOOLS_FIXTURE,  # get_weather, get_time
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "completely_unrelated_tool"},
+            },
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 400
+    assert "completely_unrelated_tool" in resp.text
+    # No "did you mean" suffix when no case-insensitive match exists.
+    assert "did you mean" not in resp.text
+    assert "case-sensitive" not in resp.text
+
+
 def test_tool_choice_function_missing_name_returns_400():
     """``tool_choice: {type: function}`` with no ``function.name`` is
     malformed per OpenAI spec — return 400 explicitly rather than

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -770,11 +770,38 @@ async def _create_chat_completion_impl(
                 )
             filtered = [t for t in request.tools if t.function.get("name") == target]
             if not filtered:
+                # F-145: surface a case-insensitive match as a hint when
+                # one exists, so clients see "did you mean 'get_Weather'?"
+                # instead of having to diff their tool list character-by-
+                # character. OpenAI's API is case-sensitive too, but its
+                # error message is equally terse — the rapid-mlx hint is
+                # additive and OpenAI-shape-compatible (clients that ignore
+                # the suffix still see the canonical 400).
+                hint = ""
+                target_lower = target.lower() if isinstance(target, str) else ""
+                if target_lower:
+                    case_matches = [
+                        name
+                        for t in request.tools
+                        if isinstance((name := t.function.get("name")), str)
+                        and name.lower() == target_lower
+                    ]
+                    if case_matches:
+                        # ``case_matches[0]`` is deterministic — Pydantic
+                        # preserves request order on ``request.tools`` so
+                        # the hint points at the first matching definition.
+                        # We only ever surface ONE hint; if the request
+                        # somehow contains multiple case-variants of the
+                        # same name (duplicate tool names are silently
+                        # accepted today, see F-144), the first wins —
+                        # which is the same tool the prompt-time
+                        # filter would have picked anyway.
+                        hint = f" (did you mean {case_matches[0]!r}? tool_choice is case-sensitive)"
                 raise HTTPException(
                     status_code=400,
                     detail=(
                         f"tool_choice references function {target!r} which "
-                        "is not present in the 'tools' array"
+                        f"is not present in the 'tools' array{hint}"
                     ),
                 )
             request.tools = filtered


### PR DESCRIPTION
## Summary
- When a \`tool_choice\` specific-function name doesn't match any tool in the request's \`tools\` array, the 400 error was terse: \`tool_choice references function 'X' which is not present in the 'tools' array\`. The most common cause is a case typo (\`get_weather\` vs \`get_Weather\`) — clients had to diff their tool list character-by-character to spot the mismatch.
- Append a \`(did you mean 'X'? tool_choice is case-sensitive)\` hint when a case-insensitive match exists in the request's tools. Behavior stays case-sensitive (OpenAI parity), but the surface now explains WHY in the typo case.
- No hint when there's no case match — avoids misleading \"did you mean\" for an unrelated tool. Hint is additive; OpenAI-shape-strict clients that ignore the suffix still see the canonical 400.

## Repro
\`\`\`bash
# BEFORE
curl -sX POST http://127.0.0.1:8047/v1/chat/completions -H 'Content-Type: application/json' --data '{
  \"model\":\"qwen3-0.6b-8bit\",
  \"messages\":[{\"role\":\"user\",\"content\":\"weather?\"}],
  \"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_Weather\",\"parameters\":{\"type\":\"object\",\"properties\":{}}}}],
  \"tool_choice\":{\"type\":\"function\",\"function\":{\"name\":\"get_weather\"}}}'
# -> {\"error\":{\"message\":\"tool_choice references function 'get_weather' which is not present in the 'tools' array\"...}}

# AFTER
# -> {\"error\":{\"message\":\"tool_choice references function 'get_weather' which is not present in the 'tools' array (did you mean 'get_Weather'? tool_choice is case-sensitive)\"...}}
\`\`\`

## Test plan
- [x] \`pytest tests/test_chat_route_tool_choice_enforcement.py\` (42 passed) — adds two regression tests: case-mismatch with single tool surfaces hint, no-case-match path keeps the bare 400.
- [x] Manual smoke on \`qwen3-0.6b-8bit @ 8047\` — both repros above verified.
- [x] ruff check + ruff format clean.