### PR TITLE
fix(api): hint case-sensitivity on tool_choice name mismatch (F-145)

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -210,6 +210,50 @@ def test_tool_choice_specific_function_unknown_name_returns_400():
     )
     assert resp.status_code == 400
     assert "nonexistent_function" in resp.text
+    # F-145: a no-match name (no case-insensitive partner either) must
+    # NOT trigger the "Did you mean" hint - it would mislead the client
+    # into chasing a non-existent typo.
+    assert "Did you mean" not in resp.text
+
+
+def test_tool_choice_specific_function_case_mismatch_returns_400_with_hint():
+    """F-145: when ``tool_choice`` references a name whose ONLY difference
+    from a known tool is letter casing, the 400 must include a
+    "Did you mean '<X>'? names are case-sensitive" hint so the client
+    sees the fix without re-reading the request body. Pre-fix the 400
+    just said "not present in the 'tools' array" and the client had no
+    clue casing was the cause.
+    """
+    engine = _RecordingEngine()
+    client = _make_client(engine)
+    # Tool fixture has ``get_weather`` (lowercase w); request asks for
+    # ``get_Weather`` (capital W). Both names are otherwise identical.
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_Weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+            "max_tokens": 5,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "get_weather" in resp.text
+    # Hint pins both the suggested name and the case-sensitivity explanation.
+    assert "Did you mean 'get_Weather'" in resp.text
+    assert "case-sensitive" in resp.text
 
 
 def test_tool_choice_function_missing_name_returns_400():

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -770,13 +770,27 @@ async def _create_chat_completion_impl(
                 )
             filtered = [t for t in request.tools if t.function.get("name") == target]
             if not filtered:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"tool_choice references function {target!r} which "
-                        "is not present in the 'tools' array"
+                # F-145: tool names are case-sensitive (matches OpenAI).
+                # A bare 400 leaves the client guessing whether the typo
+                # is a missing tool or a casing mismatch — surface the
+                # case-insensitive match (if any) as an explicit hint so
+                # the fix is obvious without rereading the request body.
+                case_match = next(
+                    (
+                        t.function.get("name")
+                        for t in request.tools
+                        if isinstance(t.function.get("name"), str)
+                        and t.function.get("name", "").lower() == target.lower()
                     ),
+                    None,
                 )
+                msg = (
+                    f"tool_choice references function {target!r} which "
+                    "is not present in the 'tools' array"
+                )
+                if case_match is not None:
+                    msg += f". (Did you mean {case_match!r}? names are case-sensitive)"
+                raise HTTPException(status_code=400, detail=msg)
             request.tools = filtered
         elif tc == "none" and request.tools:
             request.tools = None


### PR DESCRIPTION
## Summary

F-145: when `tool_choice` references a function name that only differs from a known tool by letter casing, the 400 just said "not present in the 'tools' array" - technically correct (OpenAI is case-sensitive too) but the client had no way to know casing was the cause.

Fix: in `routes/chat.py` after the strict-equality lookup fails, do a secondary case-insensitive scan. If a name matches case-insensitively, append `(Did you mean '<X>'? names are case-sensitive)` to the existing 400 message. If no case-match exists the message is unchanged, so non-case typos never trigger a misleading hint.

## Test plan

Verified on `qwen3-0.6b-8bit @ 127.0.0.1:8046`:

```
# tool=get_Weather, tool_choice=get_weather (case mismatch)
curl ... '{"tools":[{"function":{"name":"get_Weather",...}}],"tool_choice":{"type":"function","function":{"name":"get_weather"}}}'
# BEFORE: 400 "tool_choice references function 'get_weather' which is not present in the 'tools' array"
# AFTER:  400 "tool_choice references function 'get_weather' which is not present in the 'tools' array. (Did you mean 'get_Weather'? names are case-sensitive)"

# tool=get_Weather, tool_choice=foo_bar (no case-match)
# BEFORE/AFTER: 400 "...not present in the 'tools' array" (no hint, unchanged)
```

- [x] Added `test_tool_choice_specific_function_case_mismatch_returns_400_with_hint`
- [x] Pinned negative branch in `test_tool_choice_specific_function_unknown_name_returns_400` - no-match name must NOT trigger the misleading hint
- [x] All 41 tests in `tests/test_chat_route_tool_choice_enforcement.py` pass

Closes F-145.

Generated with [Claude Code](https://claude.com/claude-code)