### PR TITLE
fix(completions): stream chunks share one cmpl-XXXX id (F-154)

### DIFF
--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -781,7 +781,26 @@ class TestStreamingCompletionIdStable:
         request start time. Clients that derive request latency from
         the first/last chunk timestamps would see jitter rather than
         a stable origin.
+
+        Codex round-1 BLOCKING on PR #752: a real-time test would
+        usually pass even against the pre-fix code because three
+        synthetic chunks generally fit inside a single integer second,
+        so ``int(time.time())`` returns the same value for each call.
+        Monkeypatch ``time.time`` to return a strictly-increasing
+        sequence (1000.0, 1001.0, 1002.0, ...) so every call yields a
+        distinct integer — if the production code calls ``time.time``
+        once per chunk we'd see 3 distinct timestamps; if it calls it
+        once per request we see 1. This makes the test actually
+        exercise the fix instead of accidentally passing on timing.
         """
+        from vllm_mlx.routes import completions as comp_route
+
+        _tick = iter(range(1000, 2000))
+
+        def _fake_time():
+            return float(next(_tick))
+
+        monkeypatch.setattr(comp_route.time, "time", _fake_time)
         client, _ = _build_completions_app(
             patched_config,
             monkeypatch,

--- a/tests/test_completions_spec_parity.py
+++ b/tests/test_completions_spec_parity.py
@@ -303,9 +303,7 @@ class TestEchoLogprobsCombination:
     silently corrupt prompt-conditioned scores in lm-eval-harness).
     Reject with 400 until we wire prompt-prefill-with-logprobs."""
 
-    def test_echo_with_logprobs_rejected_with_400(
-        self, patched_config, monkeypatch
-    ):
+    def test_echo_with_logprobs_rejected_with_400(self, patched_config, monkeypatch):
         client, _ = _build_completions_app(patched_config, monkeypatch)
         r = client.post(
             "/v1/completions",
@@ -322,9 +320,7 @@ class TestEchoLogprobsCombination:
         )
         assert "echo" in detail.lower() and "logprobs" in detail.lower()
 
-    def test_echo_with_logprobs_zero_still_rejected(
-        self, patched_config, monkeypatch
-    ):
+    def test_echo_with_logprobs_zero_still_rejected(self, patched_config, monkeypatch):
         """``logprobs:0`` is still a logprobs request — must reject too."""
         client, _ = _build_completions_app(patched_config, monkeypatch)
         r = client.post(
@@ -414,9 +410,7 @@ class TestLogprobsResponseShape:
         e.tokenizer = _Tokenizer()
         return e
 
-    def test_logprobs_five_returns_four_arrays(
-        self, patched_config, monkeypatch
-    ):
+    def test_logprobs_five_returns_four_arrays(self, patched_config, monkeypatch):
         client, _ = _build_completions_app(
             patched_config,
             monkeypatch,
@@ -448,9 +442,7 @@ class TestLogprobsResponseShape:
         # synthetic vocab of size 5 in the fixture).
         assert all(len(d) == 5 for d in lp["top_logprobs"])
 
-    def test_logprobs_zero_returns_empty_top_dicts(
-        self, patched_config, monkeypatch
-    ):
+    def test_logprobs_zero_returns_empty_top_dicts(self, patched_config, monkeypatch):
         client, _ = _build_completions_app(
             patched_config,
             monkeypatch,
@@ -509,9 +501,7 @@ class TestLogprobsEngineCapability:
         )
         assert "logprobs" in detail.lower()
 
-    def test_engine_without_tokenizer_returns_501(
-        self, patched_config, monkeypatch
-    ):
+    def test_engine_without_tokenizer_returns_501(self, patched_config, monkeypatch):
         def _factory():
             e = MagicMock()
             e.tokenizer = None
@@ -694,6 +684,125 @@ class TestStreamingEngineCapability:
         # constructed, so the client sees a clean 501 instead of an
         # SSE stream that fails on the first chunk.
         assert r.status_code == 501
+
+
+class TestStreamingCompletionIdStable:
+    """F-154 regression: every SSE chunk emitted by
+    ``stream_completion`` MUST share one ``cmpl-XXXX`` id (and one
+    ``created`` timestamp). Pre-fix the route minted a fresh
+    ``uuid.uuid4().hex[:8]`` per chunk, so client-side aggregators
+    that key on ``id`` to correlate chunks to a request treated each
+    chunk as a separate response and cross-chunk assembly was
+    impossible. ``/v1/chat/completions`` already shares one
+    ``chatcmpl-XXXX`` across chunks; this pins the legacy route to
+    parity with the OpenAI spec.
+    """
+
+    def _build_multichunk_engine(self):
+        class _Chunk:
+            def __init__(self, text, finished, finish_reason=None):
+                self.text = text
+                self.new_text = text
+                self.tokens = []
+                self.new_token_ids = []
+                self.prompt_tokens = 1
+                self.completion_tokens = 1
+                self.finished = finished
+                self.finish_reason = finish_reason
+                self.cached_tokens = 0
+                # ``logprobs`` is the route's signal to call
+                # ``_extract_streaming_token_logprobs`` — leave as None
+                # so the test exercises the no-logprobs branch (which
+                # is the surface the F-154 repro hits).
+                self.logprobs = None
+
+        async def _stream(*_a, **_kw):
+            yield _Chunk("hello", finished=False)
+            yield _Chunk(" there", finished=False)
+            yield _Chunk("!", finished=True, finish_reason="length")
+
+        e = MagicMock()
+        e.stream_generate = _stream
+        return e
+
+    def _parse_sse(self, body: str) -> list[dict]:
+        """Parse SSE ``data:`` lines into JSON, skipping ``[DONE]``."""
+        import json
+
+        chunks = []
+        for line in body.splitlines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: ") :].strip()
+            if payload == "[DONE]":
+                continue
+            chunks.append(json.loads(payload))
+        return chunks
+
+    def test_all_stream_chunks_share_one_completion_id(
+        self, patched_config, monkeypatch
+    ):
+        client, _ = _build_completions_app(
+            patched_config,
+            monkeypatch,
+            engine_factory=self._build_multichunk_engine,
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "max_tokens": 5,
+                "stream": True,
+            },
+        )
+        assert r.status_code == 200, r.text
+        chunks = self._parse_sse(r.text)
+        assert len(chunks) >= 2, f"expected multiple stream chunks, got {len(chunks)}"
+        ids = {c["id"] for c in chunks}
+        assert len(ids) == 1, (
+            f"F-154 regression: stream emitted distinct ids per chunk "
+            f"({len(ids)} unique across {len(chunks)} chunks): "
+            f"{sorted(ids)}"
+        )
+        # The shared id still follows the canonical ``cmpl-XXXX``
+        # prefix so OpenAI-shape-strict clients don't get surprised.
+        sole_id = next(iter(ids))
+        assert sole_id.startswith("cmpl-"), (
+            f"shared id must keep the OpenAI ``cmpl-`` prefix, got {sole_id!r}"
+        )
+
+    def test_all_stream_chunks_share_one_created_timestamp(
+        self, patched_config, monkeypatch
+    ):
+        """Counterpart to the id contract: ``created`` is also pinned
+        once per request. Pre-fix each chunk called ``int(time.time())``
+        again, so chunks straddling a second boundary disagreed on the
+        request start time. Clients that derive request latency from
+        the first/last chunk timestamps would see jitter rather than
+        a stable origin.
+        """
+        client, _ = _build_completions_app(
+            patched_config,
+            monkeypatch,
+            engine_factory=self._build_multichunk_engine,
+        )
+        r = client.post(
+            "/v1/completions",
+            json={
+                "model": "stub-model",
+                "prompt": "hi",
+                "max_tokens": 5,
+                "stream": True,
+            },
+        )
+        assert r.status_code == 200
+        chunks = self._parse_sse(r.text)
+        timestamps = {c["created"] for c in chunks}
+        assert len(timestamps) == 1, (
+            f"F-154 regression: stream emitted distinct ``created`` "
+            f"timestamps ({sorted(timestamps)}) — must share one start"
+        )
 
 
 class TestFieldDeclarations:

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -251,8 +251,15 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     async for chunk in it:
                         _stream_yielded = True
                         output = chunk
-                        _accum_text_parts.append(chunk.new_text or "")
-                        token_logprobs_list.extend(
+                        # B023 is a false positive here: the closure is
+                        # invoked synchronously inside the same loop
+                        # iteration via ``await _wait_with_disconnect``
+                        # below, so ``_accum_text_parts`` /
+                        # ``token_logprobs_list`` always reference the
+                        # current iteration's bindings. Suppress so the
+                        # ruff baseline stays clean.
+                        _accum_text_parts.append(chunk.new_text or "")  # noqa: B023
+                        token_logprobs_list.extend(  # noqa: B023
                             _extract_streaming_token_logprobs(
                                 chunk, engine.tokenizer, effective_top_k
                             )

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -91,9 +91,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     # range with a 400 so ``logprobs=20`` (chat-shape ``top_logprobs``
     # ceiling) doesn't slip through and DoS the server with
     # top-of-vocab work.
-    if request.logprobs is not None and (
-        request.logprobs < 0 or request.logprobs > 5
-    ):
+    if request.logprobs is not None and (request.logprobs < 0 or request.logprobs > 5):
         raise HTTPException(
             status_code=400,
             detail=(
@@ -368,10 +366,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         top_lps.append({})
                     else:
                         top_lps.append(
-                            {
-                                tl.token: tl.logprob
-                                for tl in (entry.top_logprobs or [])
-                            }
+                            {tl.token: tl.logprob for tl in (entry.top_logprobs or [])}
                         )
                     text_offset.append(offset)
                     offset += len(entry.token)
@@ -445,11 +440,22 @@ async def stream_completion(
     # after the non-streaming branch was fixed — a silent split-brain
     # SDK clients would discover only at runtime.
     model_name = _resolve_model_name(request.model)
+    # F-154: every SSE chunk in a single streamed completion shares
+    # one ``cmpl-XXXX`` id (per OpenAI legacy /v1/completions spec).
+    # Pre-fix this branch minted a fresh id at every yield point —
+    # client-side aggregators that key on ``id`` to correlate chunks
+    # to a request treated each chunk as a separate response, making
+    # cross-chunk assembly impossible. ``/v1/chat/completions``
+    # already shares one ``chatcmpl-XXXX`` across all chunks; this
+    # change brings the legacy route to parity. ``created`` is also
+    # captured once so all chunks report the same start timestamp.
+    completion_id = f"cmpl-{uuid.uuid4().hex[:8]}"
+    created_ts = int(time.time())
     if request.echo:
         echo_data = {
-            "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+            "id": completion_id,
             "object": "text_completion",
-            "created": int(time.time()),
+            "created": created_ts,
             "model": model_name,
             "choices": [
                 {
@@ -501,10 +507,7 @@ async def stream_completion(
                         top_lps.append({})
                     else:
                         top_lps.append(
-                            {
-                                tl.token: tl.logprob
-                                for tl in (entry.top_logprobs or [])
-                            }
+                            {tl.token: tl.logprob for tl in (entry.top_logprobs or [])}
                         )
                     text_offsets.append(text_offset_cursor)
                     text_offset_cursor += len(entry.token)
@@ -524,14 +527,14 @@ async def stream_completion(
                 # slice ``chunk.text[offset:offset+len(token)]``
                 # would read garbage.
                 choice["text"] = "".join(tokens_arr)
-        # NOTE: distinct per-chunk ``cmpl-XXXX`` ids are F-154 — fixing
-        # that here would broaden this PR's scope (F-152/F-153 only).
-        # Mint a fresh id per chunk to preserve current behaviour and
-        # leave F-154 as a separate one-line follow-up.
+        # F-154: reuse ``completion_id`` / ``created_ts`` minted once
+        # above so every chunk shares the same id+timestamp — matches
+        # the OpenAI legacy /v1/completions spec and brings parity with
+        # the ``/v1/chat/completions`` SSE path.
         data = {
-            "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+            "id": completion_id,
             "object": "text_completion",
-            "created": int(time.time()),
+            "created": created_ts,
             "model": model_name,
             "choices": [choice],
         }


### PR DESCRIPTION
## Summary
- Pre-fix every SSE chunk emitted by \`stream_completion\` minted a fresh \`cmpl-{uuid.uuid4().hex[:8]}\` and \`int(time.time())\` at every yield point. A 5-chunk streamed completion produced 5 distinct ids — client-side aggregators that key on \`id\` to correlate chunks to a request treated each chunk as a separate response and cross-chunk assembly was impossible.
- OpenAI spec for legacy \`/v1/completions\`: all chunks in a single streamed response share one \`id\` (and one \`created\` timestamp). \`/v1/chat/completions\` already does this with \`chatcmpl-XXXX\`; bringing the legacy route to parity.
- The fix is the one-line follow-up the original spec-parity PR explicitly deferred (see the NOTE at the old \`cmpl-{uuid...}\` site).

## Repro
\`\`\`bash
# BEFORE
curl -sN -X POST http://127.0.0.1:8047/v1/completions \\
  -H 'Content-Type: application/json' \\
  --data '{\"model\":\"qwen3-0.6b-8bit\",\"prompt\":\"hi\",\"max_tokens\":5,\"stream\":true}' \\
  | grep -o '\"id\": \"[^\"]*\"' | sort -u | wc -l
# -> 5 (distinct ids per chunk)

# AFTER
# -> 1 (single shared id, e.g. \"cmpl-f6ba908a\")
\`\`\`

## Test plan
- [x] \`pytest tests/test_completions_spec_parity.py\` (25 passed) — adds \`TestStreamingCompletionIdStable\` class with two regressions: all chunks share one id, all chunks share one \`created\` timestamp.
- [x] Manual smoke on \`qwen3-0.6b-8bit @ 8047\` — repro above confirms 1 unique id across all chunks.
- [x] ruff check + ruff format clean on touched files.