### PR TITLE
fix(api): reject bare-string image_url at schema layer (F-065)

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -8,6 +8,8 @@ from vllm_mlx/api/utils.py. No MLX dependency.
 
 import json
 
+import pytest
+
 from vllm_mlx.api.models import ContentPart, ImageUrl, Message
 from vllm_mlx.api.utils import (
     MLLM_PATTERNS,
@@ -574,18 +576,28 @@ class TestExtractMultimodalContent:
         processed, images, videos = extract_multimodal_content(messages)
         assert images == ["data:image/png;base64,abc"]
 
-    def test_multimodal_with_string_image_url(self):
-        messages = [
+    def test_multimodal_with_string_image_url_rejected(self):
+        """F-065: the bare-string ``image_url`` shorthand was
+        previously accepted at the Message layer and silently
+        dropped by the multimodal preprocessor. Per the new
+        OpenAI-spec contract the wire form must be the object
+        shape ``{"url": "..."}``; constructing a Message with
+        the bare-string form now raises ``ValidationError``
+        upfront so the silent-drop hazard is closed."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as ei:
             Message(
                 role="user",
                 content=[
                     {"type": "text", "text": "Look"},
-                    {"type": "image_url", "image_url": "https://example.com/img.png"},
+                    {
+                        "type": "image_url",
+                        "image_url": "https://example.com/img.png",
+                    },
                 ],
             )
-        ]
-        processed, images, videos = extract_multimodal_content(messages)
-        assert images == ["https://example.com/img.png"]
+        assert "image_url must be an object" in str(ei.value)
 
     def test_multimodal_with_video(self):
         messages = [
@@ -616,18 +628,23 @@ class TestExtractMultimodalContent:
         processed, images, videos = extract_multimodal_content(messages)
         assert videos == ["https://example.com/v.mp4"]
 
-    def test_multimodal_with_string_video_url(self):
-        messages = [
+    def test_multimodal_with_string_video_url_rejected(self):
+        """F-065 mirror surface: bare-string ``video_url`` was
+        also previously accepted and silently dropped. Now → 422."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as ei:
             Message(
                 role="user",
                 content=[
                     {"type": "text", "text": "Look"},
-                    {"type": "video_url", "video_url": "https://example.com/v.mp4"},
+                    {
+                        "type": "video_url",
+                        "video_url": "https://example.com/v.mp4",
+                    },
                 ],
             )
-        ]
-        processed, images, videos = extract_multimodal_content(messages)
-        assert videos == ["https://example.com/v.mp4"]
+        assert "video_url must be an object" in str(ei.value)
 
     def test_multiple_images(self):
         messages = [

--- a/tests/test_clean_error_messages.py
+++ b/tests/test_clean_error_messages.py
@@ -26,7 +26,6 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-
 # ---------------------------------------------------------------------------
 # F-013: response_format validation (route-layer)
 # ---------------------------------------------------------------------------
@@ -48,8 +47,8 @@ class TestResponseFormatValidation:
         ``{}``. Wrapped by ``except Exception: raise
         HTTPException(detail=str(e))`` and the raw error string
         surfaced in the response body."""
-        from vllm_mlx.service.helpers import _validate_response_format
         from vllm_mlx.api.models import ResponseFormat
+        from vllm_mlx.service.helpers import _validate_response_format
 
         with pytest.raises(HTTPException) as ei:
             _validate_response_format(ResponseFormat(type="json_schema"))
@@ -104,9 +103,7 @@ class TestResponseFormatValidation:
         from vllm_mlx.service.helpers import _validate_response_format
 
         with pytest.raises(HTTPException) as ei:
-            _validate_response_format(
-                {"type": "json_schema", "json_schema": {}}
-            )
+            _validate_response_format({"type": "json_schema", "json_schema": {}})
         assert ei.value.status_code == 400
         assert "non-empty" in ei.value.detail
 
@@ -151,8 +148,8 @@ class TestResponseFormatValidation:
         """``type:"text"`` is the documented default and is the
         explicit value Pydantic assigns when no ``type`` is provided
         to the typed path — must not raise."""
-        from vllm_mlx.service.helpers import _validate_response_format
         from vllm_mlx.api.models import ResponseFormat
+        from vllm_mlx.service.helpers import _validate_response_format
 
         # Both shapes — dict and Pydantic — must pass.
         _validate_response_format(ResponseFormat(type="text"))
@@ -160,8 +157,8 @@ class TestResponseFormatValidation:
 
     def test_valid_json_object_passes(self):
         """The OpenAI ``json_object`` JSON-mode shorthand."""
-        from vllm_mlx.service.helpers import _validate_response_format
         from vllm_mlx.api.models import ResponseFormat
+        from vllm_mlx.service.helpers import _validate_response_format
 
         _validate_response_format(ResponseFormat(type="json_object"))
         _validate_response_format({"type": "json_object"})
@@ -213,9 +210,7 @@ class TestImageUrlTypeValidation:
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "image_url", "image_url": {"url": 123}}
-                        ],
+                        "content": [{"type": "image_url", "image_url": {"url": 123}}],
                     }
                 ],
             )
@@ -225,9 +220,7 @@ class TestImageUrlTypeValidation:
         assert "startswith" not in msg
         assert "'int' object" not in msg
 
-    @pytest.mark.parametrize(
-        "bad_url", [42, 3.14, [1, 2], {"a": "b"}, True]
-    )
+    @pytest.mark.parametrize("bad_url", [42, 3.14, [1, 2], {"a": "b"}, True])
     def test_non_string_url_variants_rejected(self, bad_url):
         """Coverage for the full set of JSON-encodable non-string
         types a buggy client could send. All share the same
@@ -264,9 +257,7 @@ class TestImageUrlTypeValidation:
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "video_url", "video_url": {"url": 99}}
-                        ],
+                        "content": [{"type": "video_url", "video_url": {"url": 99}}],
                     }
                 ],
             )
@@ -282,9 +273,7 @@ class TestImageUrlTypeValidation:
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "audio_url", "audio_url": {"url": 7}}
-                        ],
+                        "content": [{"type": "audio_url", "audio_url": {"url": 7}}],
                     }
                 ],
             )
@@ -313,36 +302,49 @@ class TestImageUrlTypeValidation:
         # (not the dict fallback), so the ``image_url`` field is the
         # parsed ``ImageUrl`` model.
         part = req.messages[0].content[0]
-        url = part.image_url.url if hasattr(part, "image_url") else part[
-            "image_url"
-        ]["url"]
+        url = (
+            part.image_url.url
+            if hasattr(part, "image_url")
+            else part["image_url"]["url"]
+        )
         assert url == "https://example.com/x.png"
 
-    def test_valid_string_url_shorthand_accepted(self):
-        """The OpenAI-compat ``image_url`` can also be a plain
-        string — that path bypasses the dict branch entirely and
-        must still parse."""
+    def test_bare_string_image_url_rejected(self):
+        """F-065: the bare-string ``image_url`` shorthand was
+        previously accepted by the union arm
+        (``ImageUrl | dict | str | None``) and then silently
+        dropped by the multimodal preprocessor (which unwrapped
+        ``image["url"]`` from the dict shape but had no fallback
+        for the bare-string form). The model received only the
+        text and hallucinated ("the image is blank").
+
+        Per OpenAI spec the ``image_url`` slot MUST be an object
+        with a required ``url`` field; reject the bare-string form
+        at the schema layer with a clean 422 so the client sees
+        the actual mismatch instead of a silent-correctness bug.
+        """
+        from pydantic import ValidationError
+
         from vllm_mlx.api.models import ChatCompletionRequest
 
-        req = ChatCompletionRequest(
-            model="x",
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image_url",
-                            "image_url": "https://example.com/x.png",
-                        }
-                    ],
-                }
-            ],
-        )
-        # The Pydantic ContentPart variant wins for well-typed input,
-        # so the ContentPart was constructed (not the dict-fallback).
-        assert req.messages[0].content[0].image_url == (
-            "https://example.com/x.png"
-        )
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest(
+                model="x",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": "https://example.com/x.png",
+                            }
+                        ],
+                    }
+                ],
+            )
+        msg = str(ei.value)
+        assert "must be an object" in msg
+        assert "url" in msg
 
     def test_valid_text_content_unaffected(self):
         """The validator only runs on dict items with multimodal
@@ -413,9 +415,7 @@ class TestProcessImageInputDefenseInDepth:
         # — proves we got past the type guard into the body of the
         # function.
         with pytest.raises(ValueError) as ei:
-            process_image_input(
-                {"url": "/nonexistent/__rapid_mlx_test_path__.png"}
-            )
+            process_image_input({"url": "/nonexistent/__rapid_mlx_test_path__.png"})
         # The error must be the downstream "Cannot process image"
         # marker (path not found), NOT the type guard's "must be a
         # string" — proves the dict was unwrapped and the unwrapped
@@ -430,9 +430,7 @@ class TestProcessImageInputDefenseInDepth:
         from vllm_mlx.models.mllm import process_image_input
 
         with pytest.raises(ValueError) as ei:
-            process_image_input(
-                {"url": {"url": "/nonexistent/__nested_test__.png"}}
-            )
+            process_image_input({"url": {"url": "/nonexistent/__nested_test__.png"}})
         # Same as above — should fall through to the path-not-found
         # error, not be caught by the type guard.
         assert "Cannot process image" in str(ei.value)

--- a/tests/test_image_url_must_be_object.py
+++ b/tests/test_image_url_must_be_object.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for F-065 — bare-string ``image_url`` shorthand
+on a ``type:"image_url"`` content part used to silently slip past
+the schema layer and be dropped by the multimodal preprocessor.
+
+The wire-form pre-fix:
+    {"type":"image_url","image_url":"data:image/png;base64,..."}
+                                     ^ bare string, NOT spec-shape
+
+The OpenAI Chat Completions API requires
+    {"type":"image_url","image_url":{"url":"..."}}
+                                    ^^^^^^^^^^^^ object with required url
+i.e. an object with a required ``url`` slot. Pre-fix, the
+``ContentPart.image_url`` field accepted a bare string via the
+``ImageUrl | dict | str | None`` union, and the multimodal
+preprocessor unwrapped ``image["url"]`` only on the dict shape —
+the bare-string form silently dropped the image. The model
+received only the text and hallucinated ("the image is blank")
+on a multimodal model; on a text-only model the request 400'd at
+preprocess with a vague "model does not support image" message
+that never told the client the actual mismatch (shape, not
+modality).
+
+The fix:
+  * Reject bare-string ``image_url`` (resp. ``video_url`` /
+    ``audio_url``) at the ``ContentPart`` model_validator AND at
+    the parent ``Message`` model_validator (the dict-fallback
+    arm of ``list[ContentPart] | list[dict]``).
+  * Gate the reject on ``type``: only fire when the part type
+    advertises the media slot (``type=="image_url"`` for the
+    ``image_url`` field). A pure-text part that carries an
+    unrelated ``image_url:"..."`` slot (legacy / hand-rolled
+    clients) is NOT collaterally broken.
+  * Mirror the rule on ``video_url`` and ``audio_url`` so the
+    spec-shape contract is consistent across modalities.
+
+Validation happens BEFORE model dispatch, so port 8045 with a
+text-only model (qwen3-0.6b-8bit) is sufficient for the live
+repro — the schema layer fires before the preprocessor would
+get a chance to reject on modality grounds.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import ChatCompletionRequest, ContentPart
+
+
+class TestContentPartBareStringMediaRejected:
+    """Direct ``ContentPart`` construction tests — pins the
+    ContentPart-level model_validator contract."""
+
+    def test_bare_string_image_url_rejected(self):
+        with pytest.raises(ValidationError) as ei:
+            ContentPart(
+                type="image_url",
+                image_url="data:image/png;base64,iVBORw0KG...",
+            )
+        msg = str(ei.value)
+        assert "image_url must be an object" in msg
+        assert "url" in msg
+
+    def test_bare_string_video_url_rejected(self):
+        with pytest.raises(ValidationError) as ei:
+            ContentPart(
+                type="video_url",
+                video_url="https://example.com/vid.mp4",
+            )
+        msg = str(ei.value)
+        assert "video_url must be an object" in msg
+
+    def test_bare_string_audio_url_rejected(self):
+        with pytest.raises(ValidationError) as ei:
+            ContentPart(
+                type="audio_url",
+                audio_url="https://example.com/snd.mp3",
+            )
+        msg = str(ei.value)
+        assert "audio_url must be an object" in msg
+
+    def test_dict_shape_image_url_accepted(self):
+        """``image_url: {"url": "..."}`` is the spec-shape and must
+        continue to parse."""
+        part = ContentPart(
+            type="image_url",
+            image_url={"url": "data:image/png;base64,iVBORw0KG..."},
+        )
+        assert part.type == "image_url"
+        # Accept either ``ImageUrl`` model or raw dict (union may
+        # resolve either way depending on shape).
+        if isinstance(part.image_url, dict):
+            assert part.image_url["url"].startswith("data:image/png")
+        else:
+            assert part.image_url.url.startswith("data:image/png")
+
+    def test_typed_image_url_model_accepted(self):
+        """Passing an already-constructed ``ImageUrl`` instance is
+        also a legal wire form (in-process callers)."""
+        from vllm_mlx.api.models import ImageUrl
+
+        part = ContentPart(
+            type="image_url",
+            image_url=ImageUrl(url="https://example.com/x.png"),
+        )
+        assert part.image_url.url == "https://example.com/x.png"
+
+    def test_text_part_with_unrelated_image_url_string_unaffected(self):
+        """Codex-defensive: a content part of ``type:"text"`` that
+        happens to carry an unrelated ``image_url`` string slot
+        (legacy / hand-rolled clients that populate every slot) must
+        NOT be rejected — the validator is gated on ``type`` so it
+        only fires when the part actually advertises itself as the
+        media kind."""
+        part = ContentPart(
+            type="text",
+            text="hello",
+            image_url="https://example.com/should-be-ignored.png",
+        )
+        assert part.type == "text"
+        assert part.text == "hello"
+
+
+class TestChatCompletionRequestBareStringMediaRejected:
+    """End-to-end through ChatCompletionRequest — the Pydantic
+    ``Message.content`` union is ``list[ContentPart] | list[dict]``,
+    so a payload that fails ContentPart parsing CAN fall back to
+    ``list[dict]``. The parent ``Message._validate_media_url_types``
+    validator must also fire on the dict-fallback arm so the
+    bare-string hazard is closed end-to-end."""
+
+    def _build(self, content):
+        return {
+            "model": "qwen3-0.6b-8bit",
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": 5,
+        }
+
+    def test_bare_string_image_url_rejected_end_to_end(self):
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest.model_validate(
+                self._build(
+                    [
+                        {"type": "text", "text": "what color?"},
+                        {
+                            "type": "image_url",
+                            "image_url": ("data:image/png;base64,iVBORw0KG..."),
+                        },
+                    ]
+                )
+            )
+        msg = str(ei.value)
+        assert "image_url must be an object" in msg
+
+    def test_bare_string_video_url_rejected_end_to_end(self):
+        with pytest.raises(ValidationError) as ei:
+            ChatCompletionRequest.model_validate(
+                self._build(
+                    [
+                        {
+                            "type": "video_url",
+                            "video_url": "https://example.com/v.mp4",
+                        }
+                    ]
+                )
+            )
+        msg = str(ei.value)
+        assert "video_url must be an object" in msg
+
+    def test_dict_shape_image_url_accepted_end_to_end(self):
+        req = ChatCompletionRequest.model_validate(
+            self._build(
+                [
+                    {"type": "text", "text": "hi"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/x.png"},
+                    },
+                ]
+            )
+        )
+        part = req.messages[0].content[1]
+        # The well-typed dict resolves to the Pydantic ContentPart
+        # variant (with the inner ImageUrl model) for valid input.
+        if hasattr(part, "image_url"):
+            url = (
+                part.image_url.url
+                if hasattr(part.image_url, "url")
+                else part.image_url["url"]
+            )
+        else:
+            url = part["image_url"]["url"]
+        assert url == "https://example.com/x.png"
+
+    def test_text_only_content_unaffected(self):
+        """Sanity: a pure-text content list (single string OR
+        list of text parts) must still parse unchanged."""
+        req = ChatCompletionRequest.model_validate(self._build("hi there"))
+        assert req.messages[0].content == "hi there"
+
+        req2 = ChatCompletionRequest.model_validate(
+            self._build([{"type": "text", "text": "hi"}])
+        )
+        assert len(req2.messages[0].content) == 1

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -242,37 +242,66 @@ class ContentPart(BaseModel):
 
     @model_validator(mode="after")
     def _validate_media_url_types(self) -> "ContentPart":
-        """Reject non-string ``url`` inside multimodal-content dicts (F-066).
+        """Reject non-string ``url`` inside multimodal-content dicts (F-066)
+        AND reject the bare-string ``image_url`` shorthand when the part
+        ``type`` advertises a media payload (F-065).
 
-        The Union ``ImageUrl | dict | str | None`` falls back to ``dict``
-        when ``url`` is not a string (Pydantic can't coerce e.g. ``int``
-        into the strict-typed ``ImageUrl.url: str`` slot), so the
-        malformed payload used to slip past the schema layer and crash
-        deep inside ``process_image_input`` with
-        ``'int' object has no attribute 'startswith'`` — Python type-
-        error text leaked verbatim in the HTTP 400 body.
+        F-066 covered: ``image_url: dict`` with a non-string ``url`` slot
+        used to fall through the schema layer and crash inside
+        ``process_image_input`` with ``'int' object has no attribute
+        'startswith'``. The dict-arm check below pins that.
 
-        Catching it at the schema layer means the client sees a clean
-        ``image_url.url must be a string`` (mirrors the message pydantic
-        itself would produce if the union allowed only ``ImageUrl |
-        str``) — and the same check applies to the sister
-        ``video_url`` / ``audio_url`` slots whose URL parsers share the
-        same ``startswith`` hazard.
+        F-065 covered: the wire form
+        ``{"type":"image_url","image_url":"data:image/png;base64,..."}``
+        (bare string instead of the OpenAI-spec
+        ``{"url":"data:image/png;base64,..."}`` object) used to pass the
+        schema layer because the ``image_url`` union allowed a plain
+        ``str``. Downstream multimodal preprocessors then unwrapped the
+        dict-shape via ``image["url"]`` but had no fallback for the
+        bare-string form — on a text-only model the request 400'd at
+        preprocess time with a vague "model does not support image"
+        message, and on a multimodal model the image was silently
+        dropped (model received only the text and hallucinated
+        "image is blank"). Both surfaces are silent-correctness bugs
+        OpenAI-compat clients (the official SDK + LangChain serialize
+        the spec-shape, but a hand-rolled payload OR an SDK that
+        flattens the object to a string before posting hits this).
+        Reject at the schema layer with a clean 422 so the client
+        sees the actual mismatch.
+
+        Mirror the same rule on ``video_url`` and ``audio_url`` which
+        share the same OpenAI-spec object shape — same silent-drop
+        hazard if the bare-string shorthand were allowed on those
+        downstream parsers as well.
         """
         for field, label in (
-            ("image_url", "image_url.url"),
-            ("video_url", "video_url.url"),
-            ("audio_url", "audio_url.url"),
+            ("image_url", "image_url"),
+            ("video_url", "video_url"),
+            ("audio_url", "audio_url"),
         ):
             value = getattr(self, field, None)
-            # Only the dict-fallback branch can carry a non-string ``url``
-            # — the Pydantic-typed ``ImageUrl`` / ``VideoUrl`` / ``AudioUrl``
-            # variants reject it at parse time, and the plain-``str``
-            # variant is trivially well-typed.
+            if value is None:
+                continue
+            # F-065: bare-string shorthand is NOT the OpenAI-spec shape.
+            # Gate it on ``type`` so a content part with
+            # ``type:"text"`` that happens to carry an unrelated
+            # ``image_url:"..."`` slot (legacy / hand-rolled clients)
+            # is not collaterally broken — the validator only fires
+            # when the part is ACTUALLY advertising itself as that
+            # media type. Without this gate, code that flattens all
+            # parts through a generic ``ContentPart(**raw)`` could see
+            # surprise rejections.
+            if isinstance(value, str) and self.type == field:
+                raise ValueError(
+                    f"{label} must be an object with required field "
+                    f"'url' (got bare string; OpenAI-spec shape is "
+                    f'`{label}: {{"url": "..."}}`)'
+                )
+            # F-066: dict-arm non-string ``url`` slot.
             if isinstance(value, dict) and "url" in value:
                 url = value["url"]
                 if url is not None and not isinstance(url, str):
-                    raise ValueError(f"{label} must be a string")
+                    raise ValueError(f"{label}.url must be a string")
         return self
 
 
@@ -324,16 +353,26 @@ class Message(BaseModel):
         for item in self.content:
             if not isinstance(item, dict):
                 continue
-            for field, label in (
-                ("image_url", "image_url.url"),
-                ("video_url", "video_url.url"),
-                ("audio_url", "audio_url.url"),
-            ):
+            item_type = item.get("type")
+            for field in ("image_url", "video_url", "audio_url"):
                 value = item.get(field)
+                if value is None:
+                    continue
+                # F-065: bare-string ``image_url`` (etc.) on a part
+                # whose ``type`` advertises that media slot. Gated by
+                # ``type`` for the same back-compat rationale as the
+                # ContentPart-level validator.
+                if isinstance(value, str) and item_type == field:
+                    raise ValueError(
+                        f"{field} must be an object with required "
+                        f"field 'url' (got bare string; OpenAI-spec "
+                        f'shape is `{field}: {{"url": "..."}}`)'
+                    )
+                # F-066: dict-arm non-string ``url`` slot.
                 if isinstance(value, dict) and "url" in value:
                     url = value["url"]
                     if url is not None and not isinstance(url, str):
-                        raise ValueError(f"{label} must be a string")
+                        raise ValueError(f"{field}.url must be a string")
         return self
 
 


### PR DESCRIPTION
## Summary

F-065: bare-string ``image_url`` shorthand (``"image_url": "data:..."``) used to silently slip past the schema layer because the union allowed plain ``str``. The multimodal preprocessor unwrapped ``image["url"]`` only on the dict shape — the bare-string form was silently dropped on multimodal models (model hallucinated "image is blank") and 400'd with a vague modality message on text-only models.

### BEFORE → AFTER (port 8045 / qwen3-0.6b-8bit)
```
{"type":"image_url","image_url":"data:image/png;base64,..."}
BEFORE: 400 "Model does not support image" (wrong root cause)
AFTER:  400 "image_url must be an object with required field 'url'
              (got bare string; OpenAI-spec shape is `image_url: {\"url\": \"...\"}`)"

{"type":"image_url","image_url":{"url":"data:..."}}  (spec shape)
BEFORE: 400 / 200 (depends on model modality)
AFTER:  unchanged
```

### Fix
- Reject bare-string media slot at both ``ContentPart`` (typed-arm) AND parent ``Message`` (dict-fallback-arm) model_validators
- Gate reject on ``type`` — a part with ``type:"text"`` that happens to carry an unrelated ``image_url`` slot (legacy / hand-rolled clients) is not collaterally broken
- Mirror rule on ``video_url`` and ``audio_url`` (same OpenAI-spec object shape)
- Update F-066 test ``test_valid_string_url_shorthand_accepted`` → ``test_bare_string_image_url_rejected`` (inverted contract)
- 10-case regression test (``tests/test_image_url_must_be_object.py``)

## Test plan
- [x] ``pytest tests/test_image_url_must_be_object.py`` — 10 pass
- [x] ``pytest tests/test_clean_error_messages.py tests/test_api_models.py`` — 124 pass (no regressions)
- [x] ``pytest tests/test_chat_route_vlm_image.py tests/test_server.py tests/test_anthropic_adapter.py tests/test_video.py tests/test_text_only_media_gate.py`` — 132 pass
- [x] Manual curl repro on port 8045 confirms 400 with clean message

🤖 Generated with [Claude Code](https://claude.com/claude-code)