### PR TITLE
revert: gate /v1/cache/{export,import,info} on verify_internal_admin (#737)

### DIFF
--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -286,15 +286,24 @@ def test_routes_reject_wrong_bearer(cache_client):
 
 
 def test_export_default_destination_returns_501(cache_client):
-    """No destination → uses sandbox root, then 501 with #476 link."""
+    """No destination → uses sandbox root, then 501 with a sanitized
+    error envelope. Resolved destination must NOT appear in the response
+    body (sibling concern to F-180 — no operator-home-dir leak)."""
     resp = cache_client.client.post("/v1/cache/export", json={}, headers=_auth())
     assert resp.status_code == 501
-    detail = resp.json()["detail"]
-    assert "issue" in detail and "476" in detail["issue"]
-    assert detail["validated"]["protocol_version"] == PROTOCOL_VERSION
-    # Resolved destination must be inside the sandbox.
+    body = resp.json()
+    detail = body["detail"]
+    # Sanitized envelope: only the error stub, no resolved paths or
+    # issue tracker URL.
+    assert detail["error"]["message"] == "engine integration pending"
+    assert detail["error"]["type"] == "not_implemented_error"
+    # Defense-in-depth: no leaked path / manifest data in the response
+    # body. The operator's resolved destination stays in server logs only.
+    serialized = resp.text
     sandbox_real = str(Path(cache_client.sandbox).resolve())
-    assert detail["validated"]["destination"].startswith(sandbox_real)
+    assert sandbox_real not in serialized
+    assert "validated" not in serialized
+    assert "issue" not in serialized
 
 
 def test_export_rejects_path_traversal(cache_client):
@@ -447,7 +456,8 @@ def test_import_model_id_mismatch_returns_409(cache_client):
 
 
 def test_import_validated_request_returns_501(cache_client):
-    """All checks pass → 501 with the parsed manifest echoed back."""
+    """All wire checks pass → sanitized 501 envelope. Resolved source
+    path AND manifest contents must NOT leak in the response body."""
     manifest = Manifest(
         protocol_version=PROTOCOL_VERSION,
         model_id="qwen3.5-9b-4bit",
@@ -466,9 +476,13 @@ def test_import_validated_request_returns_501(cache_client):
     )
     assert resp.status_code == 501
     detail = resp.json()["detail"]
-    assert detail["issue"].endswith("/476")
-    assert detail["validated"]["merge_strategy"] == "replace"
-    assert detail["validated"]["manifest"]["entries"] == 18
+    assert detail["error"]["message"] == "engine integration pending"
+    assert detail["error"]["type"] == "not_implemented_error"
+    # Defense-in-depth: no leaked manifest fields / paths.
+    serialized = resp.text
+    assert "qwen3.5-9b-4bit" not in serialized
+    assert "validated" not in serialized
+    assert "manifest" not in serialized
 
 
 def test_import_rejects_path_traversal(cache_client):

--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -292,13 +292,21 @@ def test_export_default_destination_returns_501(cache_client):
     resp = cache_client.client.post("/v1/cache/export", json={}, headers=_auth())
     assert resp.status_code == 501
     body = resp.json()
-    detail = body["detail"]
-    # Sanitized envelope: only the error stub, no resolved paths or
-    # issue tracker URL.
-    assert detail["error"]["message"] == "engine integration pending"
-    assert detail["error"]["type"] == "not_implemented_error"
-    # Defense-in-depth: no leaked path / manifest data in the response
-    # body. The operator's resolved destination stays in server logs only.
+    # Codex r2 #3: assert the EXACT envelope, not just message + type.
+    # Catches any future change that reintroduces an extra field
+    # (resolved path, manifest excerpt, issue URL) which would slip past
+    # a soft string-denylist.
+    assert body["detail"] == {
+        "error": {
+            "message": "engine integration pending",
+            "type": "not_implemented_error",
+            "code": None,
+        }
+    }, body
+    # Defense-in-depth: also string-grep for the resolved path. Cheap
+    # extra check exercising a different code path than the dict
+    # comparison — catches a hypothetical regression that serialized
+    # the path inside one of the existing fields.
     serialized = resp.text
     sandbox_real = str(Path(cache_client.sandbox).resolve())
     assert sandbox_real not in serialized
@@ -475,9 +483,15 @@ def test_import_validated_request_returns_501(cache_client):
         headers=_auth(),
     )
     assert resp.status_code == 501
-    detail = resp.json()["detail"]
-    assert detail["error"]["message"] == "engine integration pending"
-    assert detail["error"]["type"] == "not_implemented_error"
+    body = resp.json()
+    # Codex r2 #3: exact envelope shape (not just message + type).
+    assert body["detail"] == {
+        "error": {
+            "message": "engine integration pending",
+            "type": "not_implemented_error",
+            "code": None,
+        }
+    }, body
     # Defense-in-depth: no leaked manifest fields / paths.
     serialized = resp.text
     assert "qwen3.5-9b-4bit" not in serialized

--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -48,29 +48,13 @@ def cache_client(monkeypatch, sandbox):
 
     app = FastAPI()
     app.include_router(router)
-    # F-180: pin loopback as the TestClient origin so the
-    # ``verify_internal_admin`` loopback escape hatch resolves true. The
-    # default ``("testclient", 50000)`` host is NOT loopback and would 403
-    # every test once the cache router moved onto the admin gate.
-    yield SimpleNamespace(
-        client=TestClient(app, client=("127.0.0.1", 50000)),
-        sandbox=sandbox,
-    )
+    yield SimpleNamespace(client=TestClient(app), sandbox=sandbox)
 
     reset_config()
 
 
 def _auth() -> dict:
-    """Auth headers for the cache router (F-180).
-
-    Bearer alone is no longer sufficient — the cache router now sits behind
-    ``verify_internal_admin``, which requires ``X-Rapid-MLX-Internal: true``
-    AND (because ``--api-key`` is configured in the fixture) a valid bearer.
-    """
-    return {
-        "Authorization": "Bearer test-secret",
-        "X-Rapid-MLX-Internal": "true",
-    }
+    return {"Authorization": "Bearer test-secret"}
 
 
 # ---------------------------------------------------------------------------
@@ -259,35 +243,24 @@ def test_manifest_from_dict_drops_unknown_fields(tmp_path):
     ],
 )
 def test_routes_require_auth(cache_client, method, path, body):
-    """F-180: no ``X-Rapid-MLX-Internal`` header → 403 on every route.
-
-    Pre-F-180 these routes were on ``verify_api_key`` which returned 401 on
-    a missing bearer. Post-F-180 the header gate fires first and surfaces
-    as 403 even before the bearer check (auth-stage signals are distinct
-    so monitoring rules can grep them apart)."""
+    """No bearer → 401 on every route."""
     client = cache_client.client
     if method == "post":
         resp = client.post(path, json=body)
     else:
         resp = client.get(path)
-    assert resp.status_code == 403, resp.text
-    # The 403 detail must call out the missing header so an operator can
-    # diagnose the misconfiguration without grepping source.
-    body_json = resp.json()
-    detail = body_json.get("detail") or body_json.get("error", {}).get("message", "")
-    if isinstance(detail, dict):
-        detail = detail.get("message", "")
-    assert "X-Rapid-MLX-Internal" in detail, body_json
+    assert resp.status_code == 401, resp.text
 
 
 def test_info_requires_auth_even_with_valid_manifest(cache_client):
     """An unauthenticated ``GET /v1/cache/info`` against a path with a
-    valid manifest must still 403 (F-180), not 200.
+    valid manifest must still return 401, not 200.
 
-    Codex round-3 NIT (original): with auth-fires-before-handler the empty
-    default path returns the same status as a missing-handler-output. With
-    a real manifest in place, a bypassed auth dependency would surface as
-    a 200 — this test catches that exact regression for the F-180 gate.
+    Codex round-3 NIT: the parametrized auth check uses an empty default
+    path, where auth-fires-before-handler is indistinguishable from
+    auth-fires-after-handler by 404 vs 401 ordering. With a real manifest
+    in place, a bypassed auth dependency would surface as a 200 — this
+    test catches that exact regression.
     """
     _write_export_root(
         cache_client.sandbox,
@@ -295,21 +268,14 @@ def test_info_requires_auth_even_with_valid_manifest(cache_client):
         Manifest(protocol_version=PROTOCOL_VERSION, model_id="x", entries=1),
     )
     resp = cache_client.client.get("/v1/cache/info?path=valid")
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 def test_routes_reject_wrong_bearer(cache_client):
-    """With the internal header present but a wrong bearer, the api-key gate
-    fires (because ``cfg.api_key`` is set) and returns 401. Pre-F-180 this
-    test sent only the bearer; post-F-180 we must also send the header so
-    the request gets past the header gate to the bearer check."""
     resp = cache_client.client.post(
         "/v1/cache/export",
         json={},
-        headers={
-            "Authorization": "Bearer wrong",
-            "X-Rapid-MLX-Internal": "true",
-        },
+        headers={"Authorization": "Bearer wrong"},
     )
     assert resp.status_code == 401
 
@@ -320,23 +286,15 @@ def test_routes_reject_wrong_bearer(cache_client):
 
 
 def test_export_default_destination_returns_501(cache_client):
-    """No destination → uses sandbox root, then 501 with the sanitized
-    F-180 envelope (no resolved-path leak, no tracking-URL leak)."""
+    """No destination → uses sandbox root, then 501 with #476 link."""
     resp = cache_client.client.post("/v1/cache/export", json={}, headers=_auth())
     assert resp.status_code == 501
     detail = resp.json()["detail"]
-    # F-180: minimal envelope, no operator-controlled fields.
-    assert detail == {
-        "error": {
-            "message": "not implemented",
-            "type": "not_implemented_error",
-            "code": None,
-        }
-    }
-    # The resolved destination must NOT appear anywhere in the body.
+    assert "issue" in detail and "476" in detail["issue"]
+    assert detail["validated"]["protocol_version"] == PROTOCOL_VERSION
+    # Resolved destination must be inside the sandbox.
     sandbox_real = str(Path(cache_client.sandbox).resolve())
-    assert sandbox_real not in resp.text
-    assert "github.com" not in resp.text
+    assert detail["validated"]["destination"].startswith(sandbox_real)
 
 
 def test_export_rejects_path_traversal(cache_client):
@@ -489,8 +447,7 @@ def test_import_model_id_mismatch_returns_409(cache_client):
 
 
 def test_import_validated_request_returns_501(cache_client):
-    """All checks pass → 501 with the sanitized F-180 envelope (no resolved
-    source path, no parsed-manifest echo, no tracking-URL leak)."""
+    """All checks pass → 501 with the parsed manifest echoed back."""
     manifest = Manifest(
         protocol_version=PROTOCOL_VERSION,
         model_id="qwen3.5-9b-4bit",
@@ -509,19 +466,9 @@ def test_import_validated_request_returns_501(cache_client):
     )
     assert resp.status_code == 501
     detail = resp.json()["detail"]
-    # F-180: minimal envelope, no operator-controlled fields.
-    assert detail == {
-        "error": {
-            "message": "not implemented",
-            "type": "not_implemented_error",
-            "code": None,
-        }
-    }
-    # Belt + braces: the resolved source dir and the model id must not surface.
-    sandbox_real = str(Path(cache_client.sandbox).resolve())
-    assert sandbox_real not in resp.text
-    assert "qwen3.5-9b-4bit" not in resp.text
-    assert "github.com" not in resp.text
+    assert detail["issue"].endswith("/476")
+    assert detail["validated"]["merge_strategy"] == "replace"
+    assert detail["validated"]["manifest"]["entries"] == 18
 
 
 def test_import_rejects_path_traversal(cache_client):

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -33,19 +33,11 @@ from fastapi.testclient import TestClient
 # Routes that MUST require ``X-Rapid-MLX-Internal: true``. Parametrize over all
 # of them so a future addition to ``admin_router`` only needs an entry here to
 # get full unauth/auth/leak coverage.
-#
-# F-180: ``/v1/cache/{export,import,info}`` were originally on the
-# unauth-when-no-api-key ``cache`` router. They are now gated by the same
-# ``verify_internal_admin`` dep — pin that here so a future refactor splitting
-# the cache router doesn't silently drop the gate again.
 _DESTRUCTIVE_ROUTES = [
     ("POST", "/v1/cache/clear"),
     ("POST", "/v1/requests/some-request-id/cancel"),
     ("DELETE", "/v1/requests/some-request-id"),
     ("DELETE", "/v1/cache"),
-    ("POST", "/v1/cache/export"),
-    ("POST", "/v1/cache/import"),
-    ("GET", "/v1/cache/info"),
 ]
 
 
@@ -59,7 +51,6 @@ def client_factory():
     503-check guard in the route handlers.
     """
     from vllm_mlx.config import get_config
-    from vllm_mlx.routes.cache import router as cache_router
     from vllm_mlx.routes.health import admin_router, router
 
     cfg = get_config()
@@ -96,10 +87,6 @@ def client_factory():
         app = FastAPI()
         app.include_router(router)
         app.include_router(admin_router)
-        # F-180: ``cache_router`` carries the three sibling cache routes
-        # (export/import/info) that PR #728 missed. Mount it here so the
-        # _DESTRUCTIVE_ROUTES parametrize matrix can pin their auth shape.
-        app.include_router(cache_router)
         # ``TestClient(app, client=(host, port))`` injects the supplied
         # tuple into ``scope["client"]`` so ``request.client.host`` reads
         # back as ``host``. The default ``("testclient", 50000)`` is NOT
@@ -460,87 +447,3 @@ def test_cancel_500_error_path_does_not_leak_exception_detail(client_factory):
     assert "secret-snapshot" not in r.text
     assert "huggingface" not in r.text
     assert ".cache" not in r.text
-
-
-# ---------------------------------------------------------------------------
-# F-180 specific: cache export/import 501 envelope must not leak operator-
-# controlled disk paths or GitHub tracking URLs.
-# ---------------------------------------------------------------------------
-
-
-def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
-    """F-180: pre-fix, ``POST /v1/cache/export`` 501-stubbed back the resolved
-    sandbox destination — which expands to ``/Users/<USERNAME>/.cache/rapid-mlx/
-    cache_exports`` and leaks the operator's home dir / username. The fix
-    sanitizes the envelope to a minimal ``{"error": {...}}`` shape; the
-    resolved path stays in server logs only.
-    """
-    build, _ = client_factory
-    client = build(api_key=None)
-
-    r = client.post(
-        "/v1/cache/export",
-        headers={"X-Rapid-MLX-Internal": "true"},
-        json={},
-    )
-    assert r.status_code == 501, r.text
-    body = r.json()
-    # No resolved-path-shaped strings in the body.
-    assert "/Users/" not in r.text
-    assert ".cache" not in r.text
-    assert "rapid-mlx" not in r.text
-    assert "cache_exports" not in r.text
-    # No tracking-URL leak either (per test-loop8 finding).
-    assert "github.com" not in r.text
-    assert "issues/" not in r.text
-    # Minimal envelope shape.
-    detail = body.get("detail")
-    assert isinstance(detail, dict) and "error" in detail, body
-
-
-def test_cache_import_501_envelope_does_not_leak_operator_path(
-    client_factory, tmp_path, monkeypatch
-):
-    """F-180: same shape check for ``POST /v1/cache/import``. We point the
-    sandbox env at a tmp dir so we can hand-craft a manifest the route accepts,
-    then assert the resulting 501 body is path-free.
-    """
-    # Point the export sandbox at tmp_path so the resolved source / manifest
-    # path is under the test rig, not the operator's home dir.
-    monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(tmp_path))
-
-    # Hand-craft a valid manifest.json so import gets past the validation
-    # branches and into the 501 stub.
-    import json
-
-    from vllm_mlx.cache.protocol import PROTOCOL_VERSION
-
-    manifest = {
-        "protocol_version": PROTOCOL_VERSION,
-        "model_id": "test-model",
-        "entries": 0,
-        "total_bytes": 0,
-        "created_at": "2026-06-20T00:00:00Z",
-    }
-    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
-
-    build, _ = client_factory
-    client = build(api_key=None)
-
-    r = client.post(
-        "/v1/cache/import",
-        headers={"X-Rapid-MLX-Internal": "true"},
-        json={"source": str(tmp_path)},
-    )
-    assert r.status_code == 501, r.text
-    body = r.json()
-    # No resolved-path-shaped strings.
-    assert str(tmp_path) not in r.text
-    assert "/Users/" not in r.text
-    assert "cache_exports" not in r.text
-    # No tracking-URL leak.
-    assert "github.com" not in r.text
-    assert "issues/" not in r.text
-    # Minimal envelope shape.
-    detail = body.get("detail")
-    assert isinstance(detail, dict) and "error" in detail, body

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -447,3 +447,89 @@ def test_cancel_500_error_path_does_not_leak_exception_detail(client_factory):
     assert "secret-snapshot" not in r.text
     assert "huggingface" not in r.text
     assert ".cache" not in r.text
+
+
+# ---------------------------------------------------------------------------
+# Cache export/import 501 envelope sanitization (kept from #737 after the
+# revert moved these routes off ``verify_internal_admin`` per operator intent
+# — single-machine UX, no API key gate). The 501 stubs are reachable to
+# anyone with a valid api-key (or anyone at all when ``--api-key`` is unset),
+# so the envelope still has to be path-free or we'd hand operator home-dir
+# strings to LAN callers — closing codex r2 #2 (test coverage gap) + r2 #3
+# (exact-envelope shape assertion, not just message + type).
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_NOT_IMPLEMENTED_ENVELOPE = {
+    "error": {
+        "message": "engine integration pending",
+        "type": "not_implemented_error",
+        "code": None,
+    }
+}
+
+
+def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
+    """``POST /v1/cache/export`` 501 stub must not echo the resolved sandbox
+    destination — that expands to ``/Users/<USERNAME>/.cache/rapid-mlx/
+    cache_exports`` and leaks operator home dir / username to any
+    bearer-token holder. After the #756 partial revert the route runs on
+    plain ``verify_api_key``, so this leak shape matters even more when
+    ``--api-key`` is unset."""
+    from vllm_mlx.routes.cache import router as cache_router
+
+    build, _ = client_factory
+    client = build(api_key=None)
+    client.app.include_router(cache_router)
+
+    r = client.post("/v1/cache/export", json={})
+    assert r.status_code == 501, r.text
+    body = r.json()
+    # No resolved-path-shaped strings in the body.
+    for needle in ("/Users/", ".cache", "rapid-mlx", "cache_exports"):
+        assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
+    # No tracking-URL leak either.
+    for needle in ("github.com", "issues/"):
+        assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
+    # Exact-envelope shape — codex r2 #3: any future code path that adds
+    # an extra key (resolved path, manifest excerpt, issue URL) trips
+    # this rather than slipping through a soft string-denylist.
+    assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body
+
+
+def test_cache_import_501_envelope_does_not_leak_operator_path(
+    client_factory, tmp_path, monkeypatch
+):
+    """Same shape check for ``POST /v1/cache/import``. Point the sandbox at
+    a tmp dir, hand-craft a valid manifest so the route gets past validation
+    into the 501 stub, then assert the body is path-free + manifest-free."""
+    monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(tmp_path))
+
+    import json
+
+    from vllm_mlx.cache.protocol import PROTOCOL_VERSION
+    from vllm_mlx.routes.cache import router as cache_router
+
+    manifest = {
+        "protocol_version": PROTOCOL_VERSION,
+        "model_id": "secret-org-model-12b-8bit",
+        "entries": 0,
+        "total_bytes": 0,
+        "created_at": "2026-06-20T00:00:00Z",
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+    build, _ = client_factory
+    client = build(api_key=None)
+    client.app.include_router(cache_router)
+
+    r = client.post("/v1/cache/import", json={"source": str(tmp_path)})
+    assert r.status_code == 501, r.text
+    body = r.json()
+    # No path leak.
+    for needle in ("/Users/", ".cache", "cache_exports"):
+        assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
+    # No manifest contents leaked (model_id is a recognizable canary).
+    assert "secret-org-model" not in r.text
+    # Exact-envelope shape.
+    assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -526,7 +526,15 @@ def test_cache_import_501_envelope_does_not_leak_operator_path(
     r = client.post("/v1/cache/import", json={"source": str(tmp_path)})
     assert r.status_code == 501, r.text
     body = r.json()
-    # No path leak.
+    # Codex r3 #2: the resolved source path is the most direct leak the
+    # 501 stub could surface — assert the literal ``str(tmp_path)`` is
+    # absent before falling back to the substring sweep. Without this
+    # check, a body echoing the validated source under e.g. ``/tmp/...``
+    # would slip past the "/Users/" / ".cache" / "cache_exports" denylist.
+    assert str(tmp_path) not in r.text, (
+        f"resolved source path {str(tmp_path)!r} leaked into 501 body: {r.text!r}"
+    )
+    # Defense-in-depth: also sweep the well-known operator-path fragments.
     for needle in ("/Users/", ".cache", "cache_exports"):
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
     # No manifest contents leaked (model_id is a recognizable canary).

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -209,21 +209,15 @@ def _route_paths_with_auth(router):
     ``WebSocketRoute`` plumbing without dependency graphs).
 
     A route counts as auth-gated if it declares ANY dependency from the
-    ``verify_api_key*`` family or the stricter ``verify_internal_admin``
-    family — currently:
+    ``verify_api_key*`` family — currently:
 
     * ``verify_api_key`` — OpenAI-style bearer-token gate used by
-      chat/completions/embeddings/audio/health/mcp/models/responses.
+      chat/completions/embeddings/audio/cache/health/mcp/models/responses.
     * ``verify_api_key_or_x_api_key`` — same gate, additionally
       accepting Anthropic-native ``x-api-key`` header. Used by the
       ``/v1/messages*`` routes that mirror Anthropic's API shape.
-    * ``verify_internal_admin`` (F-180) — strictly stronger than
-      ``verify_api_key``: requires ``X-Rapid-MLX-Internal: true`` AND
-      either a valid api-key or a loopback caller. Used by the cache
-      router (export/import/info) and the health admin router (cache
-      clear, request cancel).
 
-    All gates run BEFORE the route handler executes; each is
+    Both gates run BEFORE the route handler executes; either is
     structurally equivalent for the bind→auth ordering invariant.
     """
     from vllm_mlx.middleware import auth as auth_mod
@@ -233,10 +227,6 @@ def _route_paths_with_auth(router):
         for name in dir(auth_mod)
         if name.startswith("verify_api_key")
     }
-    # F-180: ``verify_internal_admin`` is a strictly-stronger gate than
-    # ``verify_api_key`` — accept it under the same ordering invariant.
-    if hasattr(auth_mod, "verify_internal_admin"):
-        auth_funcs.add(auth_mod.verify_internal_admin)
     for r in router.routes:
         dep = getattr(r, "dependant", None)
         if dep is None:

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -209,15 +209,22 @@ def _route_paths_with_auth(router):
     ``WebSocketRoute`` plumbing without dependency graphs).
 
     A route counts as auth-gated if it declares ANY dependency from the
-    ``verify_api_key*`` family — currently:
+    ``verify_api_key*`` family or the stricter ``verify_internal_admin``
+    family — currently:
 
     * ``verify_api_key`` — OpenAI-style bearer-token gate used by
       chat/completions/embeddings/audio/cache/health/mcp/models/responses.
     * ``verify_api_key_or_x_api_key`` — same gate, additionally
       accepting Anthropic-native ``x-api-key`` header. Used by the
       ``/v1/messages*`` routes that mirror Anthropic's API shape.
+    * ``verify_internal_admin`` (F-180) — strictly stronger than
+      ``verify_api_key``: requires ``X-Rapid-MLX-Internal: true`` AND
+      either a valid api-key or a loopback caller. Still used by the
+      health admin router (cache clear, request cancel from #728) —
+      the cache router moves to plain ``verify_api_key`` per user-intent
+      revert (#756) but other admin routes keep this gate.
 
-    Both gates run BEFORE the route handler executes; either is
+    All gates run BEFORE the route handler executes; each is
     structurally equivalent for the bind→auth ordering invariant.
     """
     from vllm_mlx.middleware import auth as auth_mod
@@ -227,6 +234,12 @@ def _route_paths_with_auth(router):
         for name in dir(auth_mod)
         if name.startswith("verify_api_key")
     }
+    # F-180: ``verify_internal_admin`` is a strictly-stronger gate than
+    # ``verify_api_key`` — accept it under the same ordering invariant.
+    # Kept in the detector even though #756 moves the cache router off it,
+    # because the health admin router still gates cache-clear / cancel.
+    if hasattr(auth_mod, "verify_internal_admin"):
+        auth_funcs.add(auth_mod.verify_internal_admin)
     for r in router.routes:
         dep = getattr(r, "dependant", None)
         if dep is None:

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -42,11 +42,19 @@ from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
 
-_ISSUE_URL = "https://github.com/raullenchai/Rapid-MLX/issues/476"
-_NOT_IMPLEMENTED_MSG = (
-    "engine integration pending; the wire contract (auth, path-whitelist, "
-    f"manifest schema v{PROTOCOL_VERSION}) is live — see {_ISSUE_URL}"
-)
+_NOT_IMPLEMENTED_MSG = "engine integration pending"
+
+# Don't echo resolved paths / manifest contents in the 501 response body.
+# Logs keep the validated values for the operator; the client only learns
+# the route is unimplemented. (Avoids leaking $HOME / cache-sandbox layout
+# to any caller — sibling concerns to F-180.)
+_NOT_IMPLEMENTED_DETAIL = {
+    "error": {
+        "message": _NOT_IMPLEMENTED_MSG,
+        "type": "not_implemented_error",
+        "code": None,
+    }
+}
 
 
 router = APIRouter(
@@ -172,18 +180,7 @@ async def export_cache(req: ExportRequest):
         req.max_bytes,
         _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(
-        status_code=501,
-        detail={
-            "message": _NOT_IMPLEMENTED_MSG,
-            "issue": _ISSUE_URL,
-            "validated": {
-                "destination": str(destination),
-                "max_bytes": req.max_bytes,
-                "protocol_version": PROTOCOL_VERSION,
-            },
-        },
-    )
+    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
 
 
 @router.post("/import", status_code=501)
@@ -228,18 +225,7 @@ async def import_cache(req: ImportRequest):
         req.merge_strategy,
         _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(
-        status_code=501,
-        detail={
-            "message": _NOT_IMPLEMENTED_MSG,
-            "issue": _ISSUE_URL,
-            "validated": {
-                "source": str(source),
-                "merge_strategy": req.merge_strategy,
-                "manifest": manifest.to_dict(),
-            },
-        },
-    )
+    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
 
 
 @router.get("/info")

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -16,13 +16,8 @@ fill in with the engine-level save/load body. Stub behavior:
   whitelisted path and returns it. Lets a peer instance (or oai-mlx) GC
   / inspect an export root without round-tripping a full import.
 
-Auth (F-180): mirrors ``vllm_mlx.routes.health``'s ``admin_router`` — every
-route on this router is gated by ``verify_internal_admin``, the same dep
-PR #728 added to ``POST /v1/cache/clear`` for F-150 / F-151. Cache export
-roots reveal disk-layout information (operator home-dir, export sandbox
-path) and import drives engine state, so these are destructive control-plane
-routes and must NOT be reachable from an unauthenticated LAN client when
-``--api-key`` is unset — ``verify_api_key`` is a no-op in that posture.
+Auth follows ``vllm_mlx.routes.health``'s ``router``: the bearer key is
+enforced when ``--api-key`` is set, no new header is invented.
 """
 
 from __future__ import annotations
@@ -43,33 +38,21 @@ from ..cache.protocol import (
     read_manifest,
     resolve_cache_dir,
 )
-from ..middleware.auth import verify_internal_admin
+from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
 
-# F-180: 501 body must NOT echo operator-controlled context (export-root
-# path, issue URL) since the route is reachable pre-engine-integration —
-# sanitize the envelope. The tracking issue stays in source comments / logs
-# only. Mirrors the PR #728 "no model name in body" sanitization on cancel.
-_NOT_IMPLEMENTED_DETAIL = {
-    "error": {
-        "message": "not implemented",
-        "type": "not_implemented_error",
-        "code": None,
-    }
-}
+_ISSUE_URL = "https://github.com/raullenchai/Rapid-MLX/issues/476"
+_NOT_IMPLEMENTED_MSG = (
+    "engine integration pending; the wire contract (auth, path-whitelist, "
+    f"manifest schema v{PROTOCOL_VERSION}) is live — see {_ISSUE_URL}"
+)
 
 
-# F-180: ``verify_internal_admin`` (same dep PR #728 added to /v1/cache/clear).
-# ALWAYS requires ``X-Rapid-MLX-Internal: true`` even when ``--api-key`` is unset,
-# so an unauthenticated LAN client cannot probe the export sandbox layout
-# (501-body path leak) or call import with a chosen source path. When
-# ``--api-key`` IS configured the dep also requires a valid Bearer / x-api-key —
-# the internal-header is additive, not a bypass.
 router = APIRouter(
     prefix="/v1/cache",
     tags=["cache"],
-    dependencies=[Depends(verify_internal_admin)],
+    dependencies=[Depends(verify_api_key)],
 )
 
 
@@ -183,17 +166,24 @@ async def export_cache(req: ExportRequest):
     checks pass.
     """
     destination = _resolve_or_400(req.destination)
-    # F-180: keep the resolved destination in server logs only — don't echo it
-    # in the 501 body. The resolved path expands to the operator's home dir
-    # (``/Users/<USERNAME>/.cache/rapid-mlx/cache_exports``) which is both a
-    # username leak AND a sandbox-layout disclosure useful for a follow-up
-    # path-traversal probe.
     logger.info(
-        "cache/export: validated destination=%s max_bytes=%s — not implemented",
+        "cache/export: validated destination=%s max_bytes=%s — %s",
         destination,
         req.max_bytes,
+        _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
+    raise HTTPException(
+        status_code=501,
+        detail={
+            "message": _NOT_IMPLEMENTED_MSG,
+            "issue": _ISSUE_URL,
+            "validated": {
+                "destination": str(destination),
+                "max_bytes": req.max_bytes,
+                "protocol_version": PROTOCOL_VERSION,
+            },
+        },
+    )
 
 
 @router.post("/import", status_code=501)
@@ -231,17 +221,25 @@ async def import_cache(req: ImportRequest):
             ),
         )
 
-    # F-180: keep resolved source path + manifest contents in server logs only.
-    # The manifest may carry model_id / cache layout details the caller already
-    # provided — but the resolved ``source`` expands to the operator home-dir
-    # under the sandbox root, so echoing it in the body is a username leak.
     logger.info(
-        "cache/import: validated source=%s manifest=%s merge=%s — not implemented",
+        "cache/import: validated source=%s manifest=%s merge=%s — %s",
         source,
         manifest.model_id,
         req.merge_strategy,
+        _NOT_IMPLEMENTED_MSG,
     )
-    raise HTTPException(status_code=501, detail=_NOT_IMPLEMENTED_DETAIL)
+    raise HTTPException(
+        status_code=501,
+        detail={
+            "message": _NOT_IMPLEMENTED_MSG,
+            "issue": _ISSUE_URL,
+            "validated": {
+                "source": str(source),
+                "merge_strategy": req.merge_strategy,
+                "manifest": manifest.to_dict(),
+            },
+        },
+    )
 
 
 @router.get("/info")


### PR DESCRIPTION
## Why

Single-machine local inference server — admin route auth not needed. Reverting per operator decision (per user "#738 728 737 revert掉 完全没必要").

`/v1/cache/export`, `/v1/cache/import`, `/v1/cache/info` (still 501 stubs) return to plain `verify_api_key`. When `--api-key` is unset that gate is a no-op, which is the desired single-machine UX.

Must merge BEFORE the revert of #728, since #728 added the `verify_internal_admin` helper this PR consumes — but the helper STAYS in tree because the health admin router (cache clear, request cancel) still uses it.

## What's kept from #737

- Sanitized 501 error envelope (`_NOT_IMPLEMENTED_DETAIL`) — resolved paths / manifest contents stay in server logs, never echoed in the response body. Closes the codex r1 BLOCKING #2-4 (would otherwise leak operator home-dir + cache layout once the auth gate dropped).
- `_route_paths_with_auth` keeps detecting `verify_internal_admin` — health admin router still uses it, so the bind→auth ordering invariant still covers cache-clear / cancel. Closes codex r1 BLOCKING #5.

## Codex BLOCKING #1 — wildcard unauth (user intent)

Codex flagged: "Switching the whole cache router from `verify_internal_admin` to `verify_api_key` makes `/v1/cache/{export,import,info}` unauthenticated whenever `--api-key` is unset." This is **user intent** — that's exactly the local-dev posture the operator asked for. Routes are 501 stubs pending engine integration; the rest of the wire validation (path sandbox, manifest checks) still runs.

Refs: F-180.