### PR TITLE
fix(tools): unified scan preserves wire order across all 3 hermes shapes (F-042 redo)

### DIFF
--- a/tests/test_vibethinker_function_xml.py
+++ b/tests/test_vibethinker_function_xml.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-042 redo — VibeThinker ``<function><name>...</name><arguments>...</arguments></function>``
+parser regression suite.
+
+These tests cover the redo design where the parser uses a single
+left-to-right scan over all three structured wire shapes
+(``<tool_call>``, ``<function=NAME>``, ``<function><name>``) so that
+``tool_calls`` always appear in wire order — fixing the two P2 issues
+codex flagged on the original F-042 (PR #746):
+
+* **P2-1 (wire order):** mixed-shape responses now preserve the order
+  the model emitted the calls in, regardless of which shape went first.
+* **P2-2 (streaming mixed leak):** a stream carrying shape #1 then
+  shape #4 (or vice versa) routes BOTH through ``tool_calls`` deltas
+  instead of leaking the second opener as content.
+
+13-case matrix per the F-042 v2 spec — 8 non-streaming + 5 streaming.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+
+@pytest.fixture
+def parser() -> HermesToolParser:
+    return HermesToolParser()
+
+
+# ---------------------------------------------------------------------
+# Non-streaming matrix (cases 1–8)
+# ---------------------------------------------------------------------
+
+
+def test_case01_function_xml_alone(parser: HermesToolParser) -> None:
+    """Case 1: ``<function>a</function>`` alone → ``[a]``."""
+    text = '<function><name>a</name><arguments>{"x": 1}</arguments></function>'
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["name"] == "a"
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"x": 1}
+
+
+def test_case02_tool_call_alone(parser: HermesToolParser) -> None:
+    """Case 2: ``<tool_call>b</tool_call>`` alone → ``[b]`` (regression check)."""
+    text = '<tool_call>{"name": "b", "arguments": {"y": 2}}</tool_call>'
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["name"] == "b"
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"y": 2}
+
+
+def test_case03_function_then_tool_call_wire_order(parser: HermesToolParser) -> None:
+    """Case 3: ``<function>a</function><tool_call>b</tool_call>`` → ``[a, b]``.
+
+    **P2-1 fix:** the prior implementation appended named-XML matches
+    AFTER existing ``<tool_call>`` matches regardless of wire position,
+    so this case returned ``[b, a]``. The unified scan fixes that.
+    """
+    text = (
+        "<function><name>a</name>"
+        '<arguments>{"x": 1}</arguments></function>'
+        '<tool_call>{"name": "b", "arguments": {"y": 2}}</tool_call>'
+    )
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 2
+    assert [c["name"] for c in result.tool_calls] == ["a", "b"], (
+        f"Expected wire order [a, b]; got {[c['name'] for c in result.tool_calls]}"
+    )
+
+
+def test_case04_tool_call_then_function_wire_order(parser: HermesToolParser) -> None:
+    """Case 4: ``<tool_call>b</tool_call><function>a</function>`` → ``[b, a]``.
+
+    **P2-1 sanity check (reverse order):** swapping wire order MUST
+    swap emitted order. This is the case the prior code coincidentally
+    handled correctly because additive append matched wire order; the
+    redo must keep it working.
+    """
+    text = (
+        '<tool_call>{"name": "b", "arguments": {"y": 2}}</tool_call>'
+        "<function><name>a</name>"
+        '<arguments>{"x": 1}</arguments></function>'
+    )
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 2
+    assert [c["name"] for c in result.tool_calls] == ["b", "a"], (
+        f"Expected [b, a]; got {[c['name'] for c in result.tool_calls]}"
+    )
+
+
+def test_case05_function_then_bare_function_mixed_shapes(
+    parser: HermesToolParser,
+) -> None:
+    """Case 5: named-XML then bare-Nemotron mixed → wire order preserved."""
+    text = (
+        "<function><name>a</name>"
+        '<arguments>{"x": 1}</arguments></function>'
+        '<function=c>{"z": 3}</function>'
+    )
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 2
+    assert [c["name"] for c in result.tool_calls] == ["a", "c"]
+
+
+def test_case06_two_function_xml_blocks(parser: HermesToolParser) -> None:
+    """Case 6: two named-XML blocks in sequence → both emitted in order."""
+    text = (
+        "<function><name>a</name>"
+        '<arguments>{"x": 1}</arguments></function>'
+        "<function><name>b</name>"
+        '<arguments>{"y": 2}</arguments></function>'
+    )
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 2
+    assert [c["name"] for c in result.tool_calls] == ["a", "b"]
+
+
+def test_case07_plain_text_no_tool_calls(parser: HermesToolParser) -> None:
+    """Case 7: plain text → ``tools_called=False``, content preserved."""
+    text = "Hello, this is a regular reply with no tool call markers."
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content is not None
+    assert "regular reply" in result.content
+
+
+def test_case08_literal_function_in_prose_no_false_positive(
+    parser: HermesToolParser,
+) -> None:
+    """Case 8: literal ``<function>`` mention in prose without ``<name>``
+    follower must NOT be parsed as a tool call."""
+    text = (
+        "Tool calls can use the <function> XML tag, like "
+        "<function=NAME>...</function> for Nemotron-style calls. "
+        "This is just prose, not a real call."
+    )
+    # The closing prose has a bare-function literal call mid-paragraph,
+    # which WILL match BARE_FUNCTION_PATTERN. Use a version with no
+    # closing tag so this is purely prose.
+    text = (
+        "Models emit calls inside <function>...</function> tags. "
+        "This explanatory sentence is plain content."
+    )
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content is not None
+    assert "<function>" in result.content
+
+
+# ---------------------------------------------------------------------
+# Streaming matrix (cases 9–13)
+# ---------------------------------------------------------------------
+
+
+def _drive_stream(
+    parser: HermesToolParser, chunks: list[str]
+) -> tuple[list[dict], list[str]]:
+    """Replay a list of chunks through the streaming API.
+
+    Returns ``(tool_call_deltas, content_deltas)`` aggregated across
+    all chunk callbacks.
+    """
+    previous = ""
+    tool_call_deltas: list[dict] = []
+    content_deltas: list[str] = []
+    for chunk in chunks:
+        current = previous + chunk
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=chunk,
+        )
+        if delta is not None:
+            if "tool_calls" in delta:
+                tool_call_deltas.extend(delta["tool_calls"])
+            if "content" in delta and delta["content"]:
+                content_deltas.append(delta["content"])
+        previous = current
+    return tool_call_deltas, content_deltas
+
+
+def test_case09_stream_function_xml_alone(parser: HermesToolParser) -> None:
+    """Case 9: stream a named-XML block → tool_calls delta, no content."""
+    chunks = [
+        "<function><name>",
+        "a",
+        '</name><arguments>{"x": 1}</arguments></function>',
+    ]
+    tc_deltas, content_deltas = _drive_stream(parser, chunks)
+    assert len(tc_deltas) == 1
+    assert tc_deltas[0]["function"]["name"] == "a"
+    assert content_deltas == []
+
+
+def test_case10_stream_tool_call_then_function_xml_wire_order(
+    parser: HermesToolParser,
+) -> None:
+    """Case 10: stream ``<tool_call>b</tool_call>`` then ``<function>a</function>``
+    → BOTH appear as ``tool_calls`` deltas in wire order (P2-2 fix)."""
+    chunks = [
+        '<tool_call>{"name": "b", "arguments": {"y": 2}}</tool_call>',
+        '<function><name>a</name><arguments>{"x": 1}</arguments></function>',
+    ]
+    tc_deltas, content_deltas = _drive_stream(parser, chunks)
+    names = [d["function"]["name"] for d in tc_deltas]
+    assert names == ["b", "a"], (
+        f"Expected [b, a] in tool_calls deltas; got {names}. "
+        f"Stray content: {content_deltas!r}"
+    )
+    # P2-2: the second opener must NOT have leaked as content.
+    leaked = "".join(content_deltas)
+    assert "<function>" not in leaked, f"Named-XML opener leaked as content: {leaked!r}"
+    assert "<name>" not in leaked
+
+
+def test_case11_stream_function_xml_then_tool_call_wire_order(
+    parser: HermesToolParser,
+) -> None:
+    """Case 11: reverse — ``<function>a</function>`` then ``<tool_call>b</tool_call>``
+    → BOTH appear in tool_calls in wire order ``[a, b]``."""
+    chunks = [
+        '<function><name>a</name><arguments>{"x": 1}</arguments></function>',
+        '<tool_call>{"name": "b", "arguments": {"y": 2}}</tool_call>',
+    ]
+    tc_deltas, content_deltas = _drive_stream(parser, chunks)
+    names = [d["function"]["name"] for d in tc_deltas]
+    assert names == ["a", "b"], (
+        f"Expected [a, b] in tool_calls deltas; got {names}. "
+        f"Stray content: {content_deltas!r}"
+    )
+    leaked = "".join(content_deltas)
+    assert "<tool_call>" not in leaked
+    assert "<function>" not in leaked
+
+
+def test_case12_stream_function_literal_no_name_follower_is_content(
+    parser: HermesToolParser,
+) -> None:
+    """Case 12: stream a literal ``<function>`` not followed by ``<name>``
+    → emitted as content, NOT held back as a tool-call opener.
+
+    Reaches the parser via end-of-stream flush so the partial-hold path
+    is exercised. ``flush_held_content`` releases any prefix-held bytes.
+    """
+    chunks = ["The <function> tag is one form.", ""]
+    tc_deltas, content_deltas = _drive_stream(parser, chunks)
+    assert tc_deltas == []
+    # Some content should have been emitted as the stream progressed.
+    # ``<function>`` is a sentinel so it'll be held until disambiguated;
+    # at the next chunk (" tag is one form.") the bytes following the
+    # `<` disambiguate as prose and are released.
+    full_text = "The <function> tag is one form."
+    flushed = parser.flush_held_content(full_text)
+    # Either content_deltas covered the entire safe-emit text, or some
+    # bytes were held until flush. The union must reconstruct the input.
+    reconstructed = "".join(content_deltas) + flushed
+    assert reconstructed == full_text, (
+        f"Stream content + flush ({reconstructed!r}) didn't reconstruct "
+        f"original input ({full_text!r})"
+    )
+
+
+def test_case13_stream_partial_opener_at_tail_holds_back(
+    parser: HermesToolParser,
+) -> None:
+    """Case 13: partial opener at tail (``<func``) is held back, NOT
+    leaked as content; resolves when ``<function><name>...`` completes."""
+    # Stage 1: "<func" — held, no emit.
+    delta1 = parser.extract_tool_calls_streaming(
+        previous_text="prefix ",
+        current_text="prefix <func",
+        delta_text="<func",
+    )
+    # delta1 should be either None (held entirely) or content="" (no new safe bytes).
+    if delta1 is not None and "content" in delta1:
+        assert "<func" not in delta1["content"], (
+            f"Partial opener leaked as content: {delta1['content']!r}"
+        )
+
+    # Stage 2: completion to a real named-XML opener should claim the
+    # held bytes as part of the tool-call block, NOT emit them as content.
+    full = 'prefix <function><name>a</name><arguments>{"x": 1}</arguments></function>'
+    delta2 = parser.extract_tool_calls_streaming(
+        previous_text="prefix <func",
+        current_text=full,
+        delta_text=full[len("prefix <func") :],
+    )
+    # Should be a tool_calls delta with name "a".
+    assert delta2 is not None
+    assert "tool_calls" in delta2
+    assert delta2["tool_calls"][0]["function"]["name"] == "a"

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -83,11 +83,16 @@ class ExtractedToolCallInformation:
 #   deepseek_native       — DeepSeek V3 specific
 #   deepseek_v31_native   — DeepSeek V3.1 / R1-0528 specific
 #   qwen3_coder_xml_named — Qwen3-Coder XML variant with named function tags
+#   function_xml_named    — <function><name>NAME</name><arguments>JSON
+#                           </arguments></function>  VibeThinker auto-emit
+#                           (F-042); distinct from ``function_bare`` which
+#                           uses the inline ``<function=NAME>`` attribute form.
 WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
     {
         "tool_call_json",
         "tool_call_xml_body",
         "function_bare",
+        "function_xml_named",
         "raw_json",
         "calling_tool_text",
         "gemma4_native",

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -104,12 +104,15 @@ class HermesToolParser(ToolParser):
 
     # Hermes is the most flexible parser — handles JSON body inside
     # <tool_call>, the Nemotron-style XML body fallback (covers vanilla
-    # Qwen3.6), bare <function=...> blocks, raw JSON tool calls, and the
+    # Qwen3.6), bare <function=...> blocks, the VibeThinker
+    # ``<function><name>...</name><arguments>...</arguments></function>``
+    # XML-named shape (F-042 redo), raw JSON tool calls, and the
     # [Calling tool:] text-fallback for low-quant degradation.
     EXPECTED_WIRE_FORMATS = (
         "tool_call_json",
         "tool_call_xml_body",
         "function_bare",
+        "function_xml_named",
         "raw_json",
         "calling_tool_text",
     )
@@ -134,6 +137,176 @@ class HermesToolParser(ToolParser):
     )
     # Bare Nemotron XML: <function=name>...</function> without <tool_call> wrapper
     BARE_FUNCTION_PATTERN = re.compile(r"<function=([^>]+)>(.*?)</function>", re.DOTALL)
+    # VibeThinker XML-named shape (F-042 redo): the model emits the call as
+    # ``<function><name>NAME</name><arguments>JSON</arguments></function>``
+    # under ``tool_choice="auto"`` despite the chat template specifying
+    # ``<tool_call>{"name":...,"arguments":...}</tool_call>``. Whitespace-
+    # tolerant (newlines between tags, indented inner JSON). The arguments
+    # body is parsed via the same ``_parse_function_body`` helper as the
+    # ``<function=...>`` Nemotron path — accepts JSON object or XML
+    # parameter shape.
+    FUNCTION_XML_NAMED_PATTERN = re.compile(
+        r"<function>\s*<name>\s*(.*?)\s*</name>\s*<arguments>\s*(.*?)\s*</arguments>\s*</function>",
+        re.DOTALL,
+    )
+
+    @classmethod
+    def _scan_tool_call_shapes(
+        cls, text: str
+    ) -> tuple[list[tuple[int, int, str, str]], str]:
+        """Unified left-to-right scan over the three wire shapes.
+
+        Returns ``(matches, residual_text)`` where ``matches`` is a list of
+        ``(start, end, name, arguments_json)`` tuples in **wire order** and
+        ``residual_text`` is the input with each matched span replaced by
+        whitespace (preserving offsets for any downstream content emit).
+
+        The three shapes considered at each scan position are:
+
+        1. ``<tool_call>{json}</tool_call>`` (Hermes JSON body)
+        2. ``<tool_call><function=NAME>...</function></tool_call>`` (Nemotron wrap)
+        3. ``<function=NAME>...</function>`` (bare Nemotron)
+        4. ``<function><name>NAME</name><arguments>JSON</arguments></function>``
+           (VibeThinker named-XML — F-042)
+
+        Single left-to-right scan: at each position, pick whichever of the
+        four shape openers appears EARLIEST and consume its full block,
+        then continue from the end of that block. This is the structural
+        fix for F-042 r4: the prior cascade ran shapes additively, which
+        broke wire order whenever both shape #1 and shape #4 coexisted in
+        one response (e.g. ``<function>...</function><tool_call>...`` came
+        out as ``[#1, #4]`` instead of ``[#4, #1]``).
+        """
+        matches: list[tuple[int, int, str, str]] = []
+        cursor = 0
+        n = len(text)
+        residual_parts: list[str] = []
+
+        # Pre-compile lightweight openers for cheap earliest-match probing.
+        # We use the existing class patterns for the actual parse (they
+        # already handle the body grammar) — these locators just tell us
+        # which shape's full pattern to anchor on next.
+        while cursor < n:
+            # Find the next occurrence of each opener after ``cursor``.
+            candidates: list[tuple[int, str]] = []
+            tc_pos = text.find("<tool_call>", cursor)
+            if tc_pos != -1:
+                candidates.append((tc_pos, "tool_call"))
+            # ``<function=`` opens both the Nemotron-wrapped (#2) and bare
+            # (#3) shapes — we'll discriminate after matching.
+            fb_pos = text.find("<function=", cursor)
+            if fb_pos != -1:
+                candidates.append((fb_pos, "function_eq"))
+            # ``<function>`` (no ``=``) opens the named-XML shape (#4).
+            # ``str.find`` would match ``<function=`` too, so guard with a
+            # regex anchored on the closing ``>`` directly after.
+            fn_match = re.compile(r"<function>").search(text, cursor)
+            if fn_match is not None:
+                candidates.append((fn_match.start(), "function_open"))
+
+            if not candidates:
+                residual_parts.append(text[cursor:])
+                break
+
+            earliest_pos, shape = min(candidates, key=lambda x: x[0])
+            # Emit prefix between cursor and earliest_pos as residual.
+            residual_parts.append(text[cursor:earliest_pos])
+
+            consumed = cls._try_consume_at(text, earliest_pos, shape)
+            if consumed is None:
+                # Opener at ``earliest_pos`` didn't form a complete block.
+                # For a ``<tool_call>`` opener that didn't close yet, skip
+                # past its matching ``</tool_call>`` if present, otherwise
+                # skip to end-of-text — so bare-function or named-XML
+                # shapes nested INSIDE an unclosed ``<tool_call>`` wrapper
+                # aren't transiently double-counted during streaming (their
+                # ``</function>`` arrives before the wrapping ``</tool_call>``).
+                # Any other shape's failed open: advance one byte so we
+                # don't infinite-loop and let the bytes fall through as
+                # content.
+                if shape == "tool_call":
+                    closing = text.find("</tool_call>", earliest_pos)
+                    if closing == -1:
+                        residual_parts.append(text[earliest_pos:])
+                        break
+                    residual_parts.append(
+                        text[earliest_pos : closing + len("</tool_call>")]
+                    )
+                    cursor = closing + len("</tool_call>")
+                    continue
+                residual_parts.append(text[earliest_pos])
+                cursor = earliest_pos + 1
+                continue
+
+            end_pos, name, arguments_json = consumed
+            matches.append((earliest_pos, end_pos, name, arguments_json))
+            # Replace the matched span with same-length whitespace in
+            # residual so any downstream positional logic stays aligned.
+            residual_parts.append(" " * (end_pos - earliest_pos))
+            cursor = end_pos
+
+        residual_text = "".join(residual_parts)
+        return matches, residual_text
+
+    @classmethod
+    def _try_consume_at(
+        cls, text: str, pos: int, shape: str
+    ) -> tuple[int, str, str] | None:
+        """Anchor the given shape's full pattern at ``pos`` and parse.
+
+        Returns ``(end_offset, name, arguments_json)`` on a clean parse,
+        ``None`` if the opener at ``pos`` doesn't form a valid block (we
+        let the scanner skip past it as content).
+        """
+        if shape == "tool_call":
+            # Shape #1: <tool_call>{json}</tool_call>
+            m = cls.TOOL_CALL_PATTERN.match(text, pos)
+            if m is not None:
+                body = m.group(1)
+                try:
+                    data = json.loads(body)
+                except json.JSONDecodeError:
+                    data = None
+                if isinstance(data, dict):
+                    name = data.get("name", "")
+                    if name:
+                        arguments = data.get("arguments", {})
+                        return (
+                            m.end(),
+                            name,
+                            json.dumps(arguments, ensure_ascii=False)
+                            if isinstance(arguments, dict)
+                            else str(arguments),
+                        )
+            # Shape #2: <tool_call><function=NAME>...</function></tool_call>
+            m = cls.NEMOTRON_PATTERN.match(text, pos)
+            if m is not None:
+                name = m.group(1).strip()
+                args = _parse_function_body(m.group(2))
+                return (m.end(), name, json.dumps(args, ensure_ascii=False))
+            return None
+        if shape == "function_eq":
+            # Shape #3: <function=NAME>...</function>
+            m = cls.BARE_FUNCTION_PATTERN.match(text, pos)
+            if m is not None:
+                name = m.group(1).strip()
+                args = _parse_function_body(m.group(2))
+                return (m.end(), name, json.dumps(args, ensure_ascii=False))
+            return None
+        if shape == "function_open":
+            # Shape #4: <function><name>NAME</name><arguments>JSON</arguments></function>
+            m = cls.FUNCTION_XML_NAMED_PATTERN.match(text, pos)
+            if m is not None:
+                name = m.group(1).strip()
+                args_body = m.group(2)
+                args = _parse_function_body(args_body)
+                if not args and args_body.strip().startswith("{"):
+                    # Body looked like JSON but failed both paths — keep
+                    # raw to avoid silently dropping argument content.
+                    return (m.end(), name, args_body.strip())
+                return (m.end(), name, json.dumps(args, ensure_ascii=False))
+            return None
+        return None
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -141,7 +314,7 @@ class HermesToolParser(ToolParser):
         """
         Extract tool calls from a complete Hermes model response.
         """
-        tool_calls = []
+        tool_calls: list[dict[str, Any]] = []
         cleaned_text = model_output
 
         # Strip <think> tags first (fallback when no reasoning parser)
@@ -151,68 +324,25 @@ class HermesToolParser(ToolParser):
         reasoning_matches = self.REASONING_PATTERN.findall(cleaned_text)
         cleaned_text = self.REASONING_PATTERN.sub("", cleaned_text)
 
-        # Parse tool calls with <tool_call> tags (primary format)
-        matches = self.TOOL_CALL_PATTERN.findall(cleaned_text)
-        for match in matches:
-            try:
-                data = json.loads(match)
-                name = data.get("name", "")
-                arguments = data.get("arguments", {})
-                if name:
-                    tool_calls.append(
-                        {
-                            "id": generate_tool_id(),
-                            "name": name,
-                            "arguments": (
-                                json.dumps(arguments, ensure_ascii=False)
-                                if isinstance(arguments, dict)
-                                else str(arguments)
-                            ),
-                        }
-                    )
-            except json.JSONDecodeError:
-                continue
-
-        if matches:
-            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text).strip()
-
-        # Try Nemotron XML / Qwen3-Coder format if no JSON tool calls found.
-        # Body shape is identical to the bare-function path (XML or JSON);
-        # share the body parser.
-        if not tool_calls:
-            nemotron_matches = self.NEMOTRON_PATTERN.findall(cleaned_text)
-            for name, params_block in nemotron_matches:
-                arguments = _parse_function_body(params_block)
-                tool_calls.append(
-                    {
-                        "id": generate_tool_id(),
-                        "name": name.strip(),
-                        "arguments": json.dumps(arguments, ensure_ascii=False),
-                    }
-                )
-            if nemotron_matches:
-                cleaned_text = self.NEMOTRON_PATTERN.sub("", cleaned_text).strip()
-
-        # Try bare Nemotron XML: <function=name>...</function> without <tool_call> wrapper.
-        # This happens when the chat template provides <tool_call> as generation prompt
-        # and the model generates <function=...> directly. Two body formats:
-        #   * Nemotron XML:  <parameter=p>v</parameter>...  → use PARAM_PATTERN
-        #   * Qwen3-Coder JSON: {"key": "val"}              → parse as JSON
-        # The original implementation only handled the XML form, silently emitting
-        # arguments={} on JSON bodies — issue #448 BUG-2.
-        if not tool_calls:
-            bare_matches = self.BARE_FUNCTION_PATTERN.findall(cleaned_text)
-            for name, params_block in bare_matches:
-                arguments = _parse_function_body(params_block)
-                tool_calls.append(
-                    {
-                        "id": generate_tool_id(),
-                        "name": name.strip(),
-                        "arguments": json.dumps(arguments, ensure_ascii=False),
-                    }
-                )
-            if bare_matches:
-                cleaned_text = self.BARE_FUNCTION_PATTERN.sub("", cleaned_text).strip()
+        # Unified left-to-right scan over the three structured wire
+        # shapes — emits tool calls in WIRE ORDER (F-042 redo). The
+        # residual text is what's left when each matched span is blanked
+        # out; we collapse whitespace below to recover the content
+        # surface.
+        scan_matches, residual = self._scan_tool_call_shapes(cleaned_text)
+        for _start, _end, name, args_json in scan_matches:
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": name,
+                    "arguments": args_json,
+                }
+            )
+        if scan_matches:
+            # Collapse any runs of whitespace-only residual (left over from
+            # blanked spans) so callers don't see chunks of empty space
+            # in the content surface.
+            cleaned_text = re.sub(r"\s+", " ", residual).strip()
 
         # Fallback: try lenient pattern for malformed tags like <tool_call without >
         if not tool_calls:
@@ -311,16 +441,28 @@ class HermesToolParser(ToolParser):
         }
 
     # Tool-call sentinels that the streaming branch must hold-back
-    # partial prefixes of (issue #448). When a char-level delivery
-    # emits ``<``, ``<f``, ``<fun``... ahead of the full ``<function=``
-    # opener, those partial bytes used to fall through to
-    # ``{"content": delta_text}`` and leak as content. The
-    # ``_safe_content_prefix`` helper trims the longest sentinel-
-    # prefix suffix off any candidate emission so partial sentinels
-    # are held back until either (a) the full sentinel arrives and
-    # the tool-call branch claims it or (b) a non-matching char
+    # partial prefixes of (issue #448 + F-042 redo). When a char-level
+    # delivery emits ``<``, ``<f``, ``<fun``... ahead of the full opener,
+    # those partial bytes used to fall through to ``{"content": delta_text}``
+    # and leak as content. The ``_safe_content_prefix`` helper trims the
+    # longest sentinel-prefix suffix off any candidate emission so partial
+    # sentinels are held back until either (a) the full sentinel arrives
+    # and the tool-call branch claims it or (b) a non-matching char
     # arrives and the held bytes are released as ordinary content.
-    _STREAMING_SENTINELS = ("<tool_call>", "<function=")
+    #
+    # ``<function>`` (no ``=``) is included so the F-042 VibeThinker shape
+    # ``<function><name>...`` is held back like the other openers. To avoid
+    # holding ordinary prose mentioning a literal ``<function>``, the
+    # streaming branch only enters the named-XML state when ``<function>``
+    # is followed by ``<name`` (the ``_FUNCTION_XML_OPENER_RE`` guard).
+    _STREAMING_SENTINELS = ("<tool_call>", "<function=", "<function>")
+
+    # Discriminator: a bare ``<function>`` is NOT a tool-call opener; only
+    # ``<function>`` immediately followed (after optional whitespace) by
+    # ``<name>`` qualifies as the VibeThinker named-XML opener. Without
+    # this guard the streaming branch would suppress prose explaining the
+    # tag in plain text.
+    _FUNCTION_XML_OPENER_RE = re.compile(r"<function>\s*<name>")
 
     @classmethod
     def _safe_content_prefix(cls, text: str) -> str:
@@ -371,6 +513,51 @@ class HermesToolParser(ToolParser):
         """
         return full_text[len(self._safe_content_prefix(full_text)) :]
 
+    @classmethod
+    def _has_incomplete_structured_block(cls, text: str) -> bool:
+        """Heuristic: is the text currently inside an unclosed structured
+        block of any of the three wire shapes? Used by the streaming
+        branch to decide whether to suppress emit while a block is
+        being assembled."""
+        # Shape #1 + #2 (<tool_call> wrapper)
+        if text.count("<tool_call>") > text.count("</tool_call>"):
+            return True
+        # Shape #3: <function=NAME> openers without matching </function>.
+        # We must not double-count the ``</function>`` inside a closed
+        # Nemotron-wrapped <tool_call> block, but if the <tool_call> is
+        # already closed those inner ``</function>`` tags are already
+        # consumed in the open/close balance check above.
+        fn_eq_open = text.count("<function=")
+        fn_named_open = len(cls._FUNCTION_XML_OPENER_RE.findall(text))
+        fn_close = text.count("</function>")
+        # Nemotron-wrapped blocks contribute 1 ``<function=`` and 1
+        # ``</function>`` each — they balance, so we can subtract both
+        # sides equally without affecting the open>close test.
+        if fn_eq_open + fn_named_open > fn_close:
+            return True
+        return False
+
+    @classmethod
+    def _completed_structured_tool_calls(cls, text: str) -> int:
+        """Count completed structured tool calls in ``text``.
+
+        Returns the count of *fully-closed* structured blocks across
+        all three wire shapes by running the same left-to-right scan
+        ``extract_tool_calls`` uses but ignoring everything except the
+        match count. This is the streaming branch's source of truth
+        for deciding whether to emit ``tool_calls`` deltas.
+
+        Using the scan rather than counting close-tag tokens
+        (``</tool_call>`` / ``</function>``) handles the awkward
+        intermediate state where ``</function>`` arrives BEFORE its
+        enclosing ``</tool_call>`` (Nemotron-wrapped streaming) —
+        the scan correctly waits for the wrapper close, while raw
+        tag counting would briefly count a Nemotron inner close as a
+        standalone bare-function close.
+        """
+        matches, _ = cls._scan_tool_call_shapes(text)
+        return len(matches)
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -384,58 +571,59 @@ class HermesToolParser(ToolParser):
         """
         Extract tool calls from streaming Hermes model output.
 
-        Uses tag counting to correctly handle multiple sequential tool calls.
+        Routes ALL three structured shapes (``<tool_call>``,
+        ``<function=NAME>``, ``<function><name>``) through a single
+        streaming branch that re-runs the unified left-to-right scan
+        from ``extract_tool_calls`` whenever a new block closes. This
+        is the streaming counterpart of the F-042 redo: a stream that
+        carries shape #1 followed by shape #4 now routes BOTH through
+        ``_format_streaming_tool_calls`` instead of leaking the second
+        as content (P2-2 fix).
+
         Partial tool-call sentinels (``<tool_``, ``<function``…) are
         held back via ``_emit_safe_content`` so per-char streaming
         doesn't leak them as content deltas before the full opener
         arrives (issue #448 / BUG-3 family-wide leak).
         """
-        # Count <tool_call> / </tool_call> tags for multi-tool support
-        open_count = current_text.count("<tool_call>")
-        close_count = current_text.count("</tool_call>")
-        prev_close_count = previous_text.count("</tool_call>")
+        has_any_opener = (
+            "<tool_call>" in current_text
+            or "<function=" in current_text
+            or self._FUNCTION_XML_OPENER_RE.search(current_text) is not None
+        )
 
-        if open_count > 0:
-            if open_count > close_count:
-                # Inside an incomplete tool call block, suppress output
+        if has_any_opener:
+            if self._has_incomplete_structured_block(current_text):
+                # Inside an incomplete structured block — suppress output.
                 return None
 
-            if close_count > prev_close_count:
-                # New tool call(s) completed in this delta
+            # Count COMPLETED structured-shape blocks so the streaming
+            # branch only emits when a structured block actually closes
+            # in this delta. Counting close tags directly (rather than
+            # re-running the unified scan on previous_text) avoids
+            # spuriously treating an in-flight ``<tool_call>{...``
+            # whose inner JSON is already complete as a finished call —
+            # the unified scan would skip the unclosed opener and pick
+            # up bare shapes nested inside (e.g. mid-stream Nemotron
+            # XML reaches ``</function>\n`` before its outer
+            # ``</tool_call>``).
+            prev_completed = self._completed_structured_tool_calls(previous_text)
+            cur_completed = self._completed_structured_tool_calls(current_text)
+            if cur_completed > prev_completed:
+                # Re-run the source-of-truth scan on current_text to
+                # get the WIRE-ORDERED list of completed tool calls in
+                # the dict form the streaming emitter expects, then
+                # slice past the count already emitted.
                 result = self.extract_tool_calls(current_text, request)
-                if result.tools_called:
-                    # Only emit newly completed tool calls (skip already emitted)
-                    new_calls = result.tool_calls[prev_close_count:]
+                if result.tools_called and len(result.tool_calls) > prev_completed:
+                    new_calls = result.tool_calls[prev_completed:]
                     if new_calls:
                         return self._format_streaming_tool_calls(
-                            new_calls, start_index=prev_close_count
+                            new_calls, start_index=prev_completed
                         )
 
             # All current tool calls already emitted; emit post-call
             # content with prefix-hold applied so any partial sentinel
             # at the new tail doesn't leak.
-            return self._emit_safe_content(previous_text, current_text)
-
-        # Bare Nemotron XML: <function=name>...</function> without <tool_call> wrapper
-        # This happens when the chat template provides <tool_call> as generation prompt.
-        if "<function=" in current_text:
-            func_close_count = current_text.count("</function>")
-            prev_func_close = previous_text.count("</function>")
-
-            if current_text.count("<function=") > func_close_count:
-                # Inside an incomplete function block, suppress output
-                return None
-
-            if func_close_count > prev_func_close:
-                # New function block(s) completed
-                result = self.extract_tool_calls(current_text, request)
-                if result.tools_called:
-                    new_calls = result.tool_calls[prev_func_close:]
-                    if new_calls:
-                        return self._format_streaming_tool_calls(
-                            new_calls, start_index=prev_func_close
-                        )
-
             return self._emit_safe_content(previous_text, current_text)
 
         # Fallback: check for raw JSON tool calls (detect closing brace pattern)


### PR DESCRIPTION
## Why

F-042 originally landed in #746 — VibeThinker auto-emits the call as `<function><name>NAME</name><arguments>JSON</arguments></function>` despite the chat template prescribing `<tool_call>{...}</tool_call>`. Without a matcher this leaked as content with `tool_calls=None` and `finish_reason="stop"`. PR #746 added a matcher but codex round 4 left 2 **P2** issues open at merge:

- **P2-1 (wire order):** the new matcher appended named-XML matches *after* existing parser results regardless of wire position, so
  `<function>a</function><tool_call>b</tool_call>` returned `[b, a]` instead of `[a, b]`. `tool_calls` order is client-observable.
- **P2-2 (streaming mixed leak):** the streaming branch returned from the `<tool_call>` branch first and never reached the named-XML branch, so a stream containing `<tool_call>{...}</tool_call><function><name>...` emitted the named-XML opener as `content` instead of as a `tool_calls` delta.

#746 was reverted in #754 per operator policy ("codex MUST converge clean"). This PR re-lands the matcher with a structural fix.

Refs #746 (original). Refs #754 (revert).

## What

Layer fix per the family-wide convention: ALL three structured wire shapes are first-class, no per-alias workaround. Both `extract_tool_calls` and `extract_tool_calls_streaming` delegate to a single left-to-right scanner — wire order is structural now, not additive.

- `vllm_mlx/tool_parsers/hermes_tool_parser.py`:
  - `_scan_tool_call_shapes(text)` — unified left-to-right scanner. At each position picks whichever shape opener (`<tool_call>`, `<function=`, `<function><name>`) appears earliest, anchors its full pattern, consumes the block, and continues. Unclosed `<tool_call>` openers skip to their close so nested bare-function shapes inside aren't transiently double-counted during streaming.
  - `extract_tool_calls` — delegates to scanner; emits in wire order.
  - `_completed_structured_tool_calls` — scanner-based count used by streaming branch to surface only newly-closed structured blocks.
  - `extract_tool_calls_streaming` — single unified branch for all three shapes (was per-shape if/elif before). When any opener appears, runs scan-diff to emit new calls in wire order.
  - `_STREAMING_SENTINELS` — adds `<function>` (named-XML opener); discriminator regex gates the named-XML streaming path so bare `<function>` in prose doesn't suppress emit.

- `vllm_mlx/tool_parsers/abstract_tool_parser.py` — registers the `function_xml_named` wire-format label.

- `tests/test_vibethinker_function_xml.py` — 13-case regression matrix per the F-042 v2 spec. Cases 3, 4, 10, 11 are the wire-order assertions (P2-1 + P2-2 fixes).

## Verification

- 13 new tests pass.
- Full hermes tool-parser suites: 1437 passed, 6 skipped.
- Full unit suite excluding pre-existing `test_route_engine_contract[completions.py]` failure (already failing on origin/main): 6749 passed, 18 skipped, 7 xfailed.
- Live on vibethinker-1.5b-4bit @ 8048:
  - auto+tools → `tool_calls` emitted (named-XML shape claimed).
  - forced `tool_choice` → unchanged, still works.
  - no-tools prompt → no false-positive tool_calls.