### PR TITLE
fix(tools): enforce pattern/format/multipleOf/uniqueItems (F-141a)

### DIFF
--- a/tests/test_tool_param_enforcement.py
+++ b/tests/test_tool_param_enforcement.py
@@ -281,38 +281,38 @@ class TestValidPasses:
 
 
 class TestDeferredPassThrough:
-    """These constraint classes are intentionally left advisory in this
-    scoped PR. Locking the pass-through behaviour as a regression test
-    ensures a future tightening is a deliberate, reviewed change rather
-    than an accidental side-effect of touching ``validate_param_value``."""
+    """Constraint classes still intentionally left advisory after the
+    F-141a follow-up. Locking the pass-through behaviour as regression
+    tests ensures a future tightening is a deliberate, reviewed change
+    rather than an accidental side-effect of touching
+    ``validate_param_value``.
 
-    def test_pattern_violation_does_not_raise(self):
-        """``pattern`` violations remain advisory (TODO(F-141-followup))."""
+    F-141a (PR following #736) flipped ``pattern`` / ``format`` /
+    ``multipleOf`` / ``uniqueItems`` to enforcement — those have moved
+    to ``tests/test_tool_param_enforcement_f141a.py``. The remaining
+    deferred set (``required``, ``oneOf``, ``anyOf``, ``allOf``,
+    ``additionalProperties``) still pass-through.
+    """
+
+    def test_required_missing_key_does_not_raise(self):
+        """``required`` violation: schema requires ``"x"`` but the model
+        emitted ``{}``. Compound semantics — deferred for now."""
         from vllm_mlx.service.helpers import _validate_tool_call_params
 
         tools = [
             _tool(
-                "set_phone",
-                {"phone": {"type": "string", "pattern": "^[0-9]{3}-[0-9]{4}$"}},
+                "f",
+                {"x": {"type": "string"}},
             )
         ]
-        # "abc" clearly violates the regex; if we ever start enforcing
-        # `pattern` this test will need an explicit update.
-        _validate_tool_call_params([_call("set_phone", '{"phone": "abc"}')], tools)
+        # Inject ``required`` into the parameters block.
+        tools[0]["function"]["parameters"]["required"] = ["x"]
+        _validate_tool_call_params([_call("f", "{}")], tools)
 
-    def test_format_violation_does_not_raise(self):
-        """``format`` violations remain advisory (TODO(F-141-followup))."""
+    def test_one_of_violation_does_not_raise(self):
+        """``oneOf`` (and ``anyOf`` / ``allOf``) violations remain
+        advisory — multi-branch schema traversal is a separate lift."""
         from vllm_mlx.service.helpers import _validate_tool_call_params
 
-        tools = [_tool("set_email", {"email": {"type": "string", "format": "email"}})]
-        # "notanemail" is not an email; deferred.
-        _validate_tool_call_params(
-            [_call("set_email", '{"email": "notanemail"}')], tools
-        )
-
-    def test_multiple_of_violation_does_not_raise(self):
-        """``multipleOf`` deferred too — 7 is not a multiple of 3."""
-        from vllm_mlx.service.helpers import _validate_tool_call_params
-
-        tools = [_tool("step", {"n": {"type": "integer", "multipleOf": 3}})]
-        _validate_tool_call_params([_call("step", '{"n": 7}')], tools)
+        tools = [_tool("f", {"x": {"oneOf": [{"const": "a"}, {"const": "b"}]}})]
+        _validate_tool_call_params([_call("f", '{"x": "c"}')], tools)

--- a/tests/test_tool_param_enforcement_f141a.py
+++ b/tests/test_tool_param_enforcement_f141a.py
@@ -25,9 +25,23 @@ uniqueItems: structural equality via JSON-canonical serialisation.
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException
 
-from vllm_mlx.api.models import FunctionCall, ToolCall
+# Linux CI runners don't ship MLX; ``vllm_mlx.service.helpers``
+# transitively imports it through the engine wiring. Skip cleanly so the
+# diff-aware targeted_tests step doesn't flag the whole file as
+# regressions. Same pattern as ``tests/test_audio_upload_size_limit.py``.
+pytest.importorskip(
+    "mlx.core",
+    reason="tool-arg validator helper imports transitively pull in mlx",
+)
+pytest.importorskip(
+    "mlx_lm",
+    reason="tool-arg validator helper imports transitively pull in mlx_lm",
+)
+
+from fastapi import HTTPException  # noqa: E402
+
+from vllm_mlx.api.models import FunctionCall, ToolCall  # noqa: E402
 
 
 def _tool(name: str, properties: dict) -> dict:

--- a/tests/test_tool_param_enforcement_f141a.py
+++ b/tests/test_tool_param_enforcement_f141a.py
@@ -312,3 +312,43 @@ class TestUniqueItemsEnforcement:
             )
         ]
         _validate_tool_call_params([_call("nums", '{"items": [1, 2, 3.5]}')], tools)
+
+    def test_large_distinct_integers_are_not_collapsed(self):
+        """codex r3 BLOCKING: ``float(9007199254740993) ==
+        float(9007199254740992)`` because IEEE-754 double can't
+        represent both. The canonical-key path must use ``Decimal``
+        so genuinely distinct large ints stay distinct."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "nums",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        # 2**53 and 2**53 + 1 — both exact ints, distinct values.
+        _validate_tool_call_params(
+            [_call("nums", '{"items": [9007199254740992, 9007199254740993]}')],
+            tools,
+        )
+
+
+class TestMultipleOfPrecision:
+    """codex r3 BLOCKING: ``math.isclose(..., rel_tol=0.0,
+    abs_tol=1e-9)`` so large non-multiples don't slip through on
+    relative-tolerance grounds."""
+
+    def test_large_non_multiple_is_rejected(self):
+        """``rel_tol`` default would have accepted this — pinning it
+        to 0.0 means the absolute tolerance is the only allowance."""
+        import json as _json
+
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "number", "multipleOf": 0.5}})]
+        # Far above the absolute tolerance, but the default relative
+        # tolerance (1e-9) was nearly enough to make this slip.
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params(
+                [_call("f", _json.dumps({"x": 10000000000.3}))], tools
+            )

--- a/tests/test_tool_param_enforcement_f141a.py
+++ b/tests/test_tool_param_enforcement_f141a.py
@@ -189,6 +189,29 @@ class TestFormatEnforcement:
             tools,
         )
 
+    def test_date_time_rejects_space_separator(self):
+        """codex r4 BLOCKING: JSON-schema ``format: date-time`` is RFC
+        3339 ``date-time``, whose grammar requires the literal ``T``
+        between date and time. ``datetime.fromisoformat`` happily
+        accepts the space-separated form (``"2024-01-15 10:30:00+00:00"``),
+        and the pre-fix ``" " in value`` short-circuit let it through.
+        Strict-RFC: space separator must be rejected."""
+        import json as _json
+
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "string", "format": "date-time"}})]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params(
+                [_call("f", _json.dumps({"x": "2024-01-15 10:30:00+00:00"}))],
+                tools,
+            )
+        # Sanity: same instant with ``T`` separator still passes.
+        _validate_tool_call_params(
+            [_call("f", _json.dumps({"x": "2024-01-15T10:30:00+00:00"}))],
+            tools,
+        )
+
 
 # ---------------------------------------------------------------------------
 # multipleOf enforcement

--- a/tests/test_tool_param_enforcement_f141a.py
+++ b/tests/test_tool_param_enforcement_f141a.py
@@ -154,6 +154,27 @@ class TestFormatEnforcement:
         tools = [_tool("f", {"x": {"type": "string", "format": "my-custom-format"}})]
         _validate_tool_call_params([_call("f", '{"x": "anything"}')], tools)
 
+    def test_date_time_requires_timezone_offset(self):
+        """codex r2 BLOCKING: RFC 3339 ``date-time`` requires a
+        timezone offset (``Z`` or ``±HH:MM``). A naive datetime
+        like ``2024-01-15T10:30:00`` (no tz) used to slip past
+        ``datetime.fromisoformat`` and pass as 200."""
+        import json as _json
+
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "string", "format": "date-time"}})]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params(
+                [_call("f", _json.dumps({"x": "2024-01-15T10:30:00"}))],
+                tools,
+            )
+        # +00:00 explicit offset must pass.
+        _validate_tool_call_params(
+            [_call("f", _json.dumps({"x": "2024-01-15T10:30:00+00:00"}))],
+            tools,
+        )
+
 
 # ---------------------------------------------------------------------------
 # multipleOf enforcement
@@ -263,3 +284,31 @@ class TestUniqueItemsEnforcement:
             )
         ]
         _validate_tool_call_params([_call("tags", '{"items": ["a", "a"]}')], tools)
+
+    def test_numerically_equal_int_and_float_count_as_duplicate(self):
+        """codex r2 BLOCKING: JSON-schema uniqueItems compares numeric
+        *value*, not representation. ``[1, 1.0]`` must be rejected as
+        a duplicate. Previously ``json.dumps`` keying made them
+        distinct and silently let it pass."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "nums",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params([_call("nums", '{"items": [1, 1.0]}')], tools)
+
+    def test_unique_numbers_pass(self):
+        """Negative control for the above."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "nums",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        _validate_tool_call_params([_call("nums", '{"items": [1, 2, 3.5]}')], tools)

--- a/tests/test_tool_param_enforcement_f141a.py
+++ b/tests/test_tool_param_enforcement_f141a.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-141a: extend tool-arg validator with ``pattern`` / ``format`` /
+``multipleOf`` / ``uniqueItems``.
+
+PR #736 (F-141 scoped) enforced ``enum`` / ``type`` / ``minimum`` /
+``maximum`` / ``minLength`` / ``maxLength`` by raising
+``HTTPException(400)`` on violation. ``pattern``, ``format``,
+``multipleOf`` and ``uniqueItems`` were deferred. F-141a closes that
+gap — these constraints now also escalate to a 400 with the same
+canonical "violates declared schema" envelope.
+
+Format scope (operator note): ``email`` / ``uri`` / ``uuid`` /
+``date`` / ``date-time``. Unknown ``format`` values pass through
+(advisory) to stay loose for real-world schemas.
+
+Pattern semantics: ``re.fullmatch``, not ``re.match`` — partial
+matches do not count.
+
+multipleOf: integer arithmetic for int values; ``math.isclose`` for
+float values so a 0.1-vs-0.3 float-drift case doesn't 400.
+
+uniqueItems: structural equality via JSON-canonical serialisation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from vllm_mlx.api.models import FunctionCall, ToolCall
+
+
+def _tool(name: str, properties: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "parameters": {"type": "object", "properties": properties},
+        },
+    }
+
+
+def _call(name: str, arguments: str) -> ToolCall:
+    return ToolCall(
+        id="call_abc",
+        type="function",
+        function=FunctionCall(name=name, arguments=arguments),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPatternEnforcement:
+    """``pattern`` (regex) — ``re.fullmatch`` per operator note."""
+
+    def test_pattern_violation_raises_400(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "book",
+                {"date": {"type": "string", "pattern": r"^\d{4}-\d{2}-\d{2}$"}},
+            )
+        ]
+        with pytest.raises(HTTPException) as exc:
+            _validate_tool_call_params([_call("book", '{"date": "tomorrow"}')], tools)
+        assert exc.value.status_code == 400
+        assert "does not match pattern" in exc.value.detail
+
+    def test_pattern_partial_match_is_rejected(self):
+        """``re.fullmatch``, not ``re.match`` — ``"2024-01-01x"`` must
+        still 400 even though the prefix matches the regex."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "book",
+                {"date": {"type": "string", "pattern": r"^\d{4}-\d{2}-\d{2}$"}},
+            )
+        ]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params(
+                [_call("book", '{"date": "2024-01-01x"}')], tools
+            )
+
+    def test_pattern_valid_passes(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "book",
+                {"date": {"type": "string", "pattern": r"^\d{4}-\d{2}-\d{2}$"}},
+            )
+        ]
+        _validate_tool_call_params([_call("book", '{"date": "2024-12-31"}')], tools)
+
+    def test_bogus_regex_in_schema_does_not_raise(self):
+        """If the *schema* ships an invalid regex (``[unclosed``), the
+        bug is the schema author's, not the model's. Fall back to
+        advisory pass-through rather than 400-ing on every call."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "string", "pattern": "[unclosed"}})]
+        _validate_tool_call_params([_call("f", '{"x": "anything"}')], tools)
+
+
+# ---------------------------------------------------------------------------
+# Format enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEnforcement:
+    """``format`` — narrow allow-list per operator scope."""
+
+    @pytest.mark.parametrize(
+        "fmt, bad, good",
+        [
+            ("email", "notanemail", "user@example.com"),
+            ("uri", "no scheme here", "https://example.com/path"),
+            (
+                "uuid",
+                "not-a-uuid",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ),
+            ("date", "tomorrow", "2024-01-15"),
+            ("date-time", "2024-01-15", "2024-01-15T10:30:00Z"),
+        ],
+    )
+    def test_format_enforced(self, fmt: str, bad: str, good: str):
+        """Each scoped format rejects the obvious bad value and
+        accepts the canonical good value."""
+        import json as _json
+
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "string", "format": fmt}})]
+
+        with pytest.raises(HTTPException) as exc:
+            _validate_tool_call_params([_call("f", _json.dumps({"x": bad}))], tools)
+        assert exc.value.status_code == 400
+        assert f"not a valid {fmt}" in exc.value.detail
+
+        # Good value must NOT raise.
+        _validate_tool_call_params([_call("f", _json.dumps({"x": good}))], tools)
+
+    def test_unknown_format_passes_through(self):
+        """Operator scope: unknown ``format`` values stay loose (200)
+        rather than 400-ing on every bespoke format hint in the wild."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "string", "format": "my-custom-format"}})]
+        _validate_tool_call_params([_call("f", '{"x": "anything"}')], tools)
+
+
+# ---------------------------------------------------------------------------
+# multipleOf enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleOfEnforcement:
+    """``multipleOf`` — integer / float."""
+
+    def test_int_multiple_of_violation_raises_400(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("step", {"n": {"type": "integer", "multipleOf": 3}})]
+        with pytest.raises(HTTPException) as exc:
+            _validate_tool_call_params([_call("step", '{"n": 7}')], tools)
+        assert exc.value.status_code == 400
+        assert "not a multiple of 3" in exc.value.detail
+
+    def test_int_multiple_of_pass(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("step", {"n": {"type": "integer", "multipleOf": 3}})]
+        _validate_tool_call_params([_call("step", '{"n": 9}')], tools)
+
+    def test_float_multiple_of_with_isclose_drift_pass(self):
+        """0.3 = 3 * 0.1 in math, but ``0.3 % 0.1 == 0.09999...`` in
+        float. Operator note: use ``math.isclose`` so this case passes."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "number", "multipleOf": 0.1}})]
+        _validate_tool_call_params([_call("f", '{"x": 0.3}')], tools)
+
+    def test_float_multiple_of_violation_raises(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "number", "multipleOf": 0.5}})]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params([_call("f", '{"x": 0.7}')], tools)
+
+    def test_zero_multiple_of_treated_as_advisory(self):
+        """``multipleOf: 0`` is invalid per JSON-schema. Bogus schema,
+        fall back to advisory rather than 400-ing every call."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [_tool("f", {"x": {"type": "integer", "multipleOf": 0}})]
+        _validate_tool_call_params([_call("f", '{"x": 5}')], tools)
+
+
+# ---------------------------------------------------------------------------
+# uniqueItems enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueItemsEnforcement:
+    """``uniqueItems`` — array dedup."""
+
+    def test_duplicate_strings_raises_400(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "tags",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        with pytest.raises(HTTPException) as exc:
+            _validate_tool_call_params(
+                [_call("tags", '{"items": ["a", "b", "a"]}')], tools
+            )
+        assert exc.value.status_code == 400
+        assert "uniqueItems" in exc.value.detail
+
+    def test_unique_strings_pass(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "tags",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        _validate_tool_call_params([_call("tags", '{"items": ["a", "b", "c"]}')], tools)
+
+    def test_structurally_equal_dicts_count_as_duplicate(self):
+        """JSON-schema uniqueItems uses structural equality, not Python
+        identity. ``{"a": 1}`` and ``{"a": 1}`` are duplicates."""
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "things",
+                {"items": {"type": "array", "uniqueItems": True}},
+            )
+        ]
+        with pytest.raises(HTTPException):
+            _validate_tool_call_params(
+                [_call("things", '{"items": [{"a": 1}, {"a": 1}]}')], tools
+            )
+
+    def test_unique_items_false_skips_check(self):
+        from vllm_mlx.service.helpers import _validate_tool_call_params
+
+        tools = [
+            _tool(
+                "tags",
+                {"items": {"type": "array", "uniqueItems": False}},
+            )
+        ]
+        _validate_tool_call_params([_call("tags", '{"items": ["a", "a"]}')], tools)

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -736,11 +736,15 @@ def _is_date_time(value: str) -> bool:
         dt = datetime.datetime.fromisoformat(candidate)
     except (ValueError, TypeError):
         return False
-    # RFC 3339 requires the ``T`` separator (or a space, per the
-    # spec's relaxation note) between date and time. ``fromisoformat``
-    # accepts a bare ``YYYY-MM-DD`` on 3.11+, which is the wrong
-    # format — date, not date-time. Require ``T`` or space.
-    if "T" not in value and " " not in value:
+    # codex r4 BLOCKING: JSON-schema ``date-time`` is RFC 3339 ``date-time``
+    # whose grammar requires the literal ``T`` separator between
+    # ``full-date`` and ``full-time``. The space form is a NOTE in the
+    # spec ("Applications that generate this format SHOULD use uppercase
+    # T") and is NOT part of the production rule we enforce here.
+    # ``fromisoformat`` accepts a bare ``YYYY-MM-DD`` on 3.11+ (wrong
+    # format — date, not date-time) and ``"2024-01-15 10:30:00+00:00"``
+    # (RFC-non-conformant separator), so reject both.
+    if "T" not in value:
         return False
     # codex r2 BLOCKING: RFC 3339 also requires a timezone offset (``Z``
     # or ``±HH:MM``). ``datetime.fromisoformat`` accepts a bare

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -642,16 +642,15 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
                         f"Value {parsed} is not a multiple of {multiple_of}",
                     )
 
-    # uniqueItems — for arrays. Items must be hashable for ``set()``
-    # to work; nested dicts / lists are skipped (the JSON-schema spec
-    # uses structural equality, which Python doesn't give us for free
-    # on lists/dicts without a deep-equal pass). We use a JSON-canonical
-    # serialisation per item so structurally equal dicts compare equal.
+    # uniqueItems — for arrays. JSON-schema uses *value* equality, not
+    # JSON-text equality, so we need a canonicalisation that respects
+    # number equality (``1`` and ``1.0`` are duplicates per spec) and
+    # nested-dict structural equality. codex r2 BLOCKING: the previous
+    # ``json.dumps`` keying treated ``1`` and ``1.0`` as different and
+    # let real duplicates through.
     if isinstance(parsed, list) and schema.get("uniqueItems") is True:
         try:
-            canonical = [
-                json.dumps(item, sort_keys=True, ensure_ascii=False) for item in parsed
-            ]
+            canonical = [_uniqueitems_canonical(item) for item in parsed]
         except TypeError:
             # Non-JSON-serialisable item somehow leaked in (parsed came
             # from ``json.loads``, so this is unreachable in practice
@@ -722,14 +721,22 @@ def _is_date_time(value: str) -> bool:
     # pre-3.11 Pythons, so swap it for ``+00:00`` first.
     candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
     try:
-        datetime.datetime.fromisoformat(candidate)
+        dt = datetime.datetime.fromisoformat(candidate)
     except (ValueError, TypeError):
         return False
     # RFC 3339 requires the ``T`` separator (or a space, per the
     # spec's relaxation note) between date and time. ``fromisoformat``
     # accepts a bare ``YYYY-MM-DD`` on 3.11+, which is the wrong
     # format — date, not date-time. Require ``T`` or space.
-    return "T" in value or " " in value
+    if "T" not in value and " " not in value:
+        return False
+    # codex r2 BLOCKING: RFC 3339 also requires a timezone offset (``Z``
+    # or ``±HH:MM``). ``datetime.fromisoformat`` accepts a bare
+    # ``2024-01-15T10:30:00`` as a naive datetime, which JSON-schema's
+    # ``date-time`` format does NOT permit. Reject naive results.
+    if dt.tzinfo is None:
+        return False
+    return True
 
 
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
@@ -741,3 +748,41 @@ _FORMAT_VALIDATORS: dict[str, Callable[[str], bool]] = {
     "date": _is_date,
     "date-time": _is_date_time,
 }
+
+
+def _uniqueitems_canonical(value: object) -> object:
+    """Build a hashable key for ``value`` that respects JSON-schema's
+    value-equality rules.
+
+    codex r2 BLOCKING fix: ``json.dumps`` keying made ``1`` and ``1.0``
+    distinct, but JSON-schema considers numerically-equal numbers as
+    duplicates. Walk the structure recursively, normalising every
+    numeric leaf to a ``float`` (with bools kept separate) and every
+    dict / list to a tuple that hashable ``set()`` can compare.
+    """
+    if isinstance(value, bool):
+        # Booleans are their own JSON type — keep separate from ints.
+        return ("bool", value)
+    if isinstance(value, (int, float)):
+        # Normalise int / float to a single canonical numeric form so
+        # ``1`` and ``1.0`` hash equal (per JSON-schema value equality).
+        # ``float`` is the lossy direction, but JSON-schema's
+        # ``uniqueItems`` rule explicitly compares numeric value, not
+        # representation.
+        return ("num", float(value))
+    if isinstance(value, str):
+        return ("str", value)
+    if value is None:
+        return ("null",)
+    if isinstance(value, list):
+        return ("arr", tuple(_uniqueitems_canonical(v) for v in value))
+    if isinstance(value, dict):
+        # Sort by key for structural-equality semantics regardless of
+        # JSON object key order.
+        return (
+            "obj",
+            tuple(sorted((k, _uniqueitems_canonical(v)) for k, v in value.items())),
+        )
+    # Unknown type — fall back to repr so ``set()`` still works without
+    # raising ``TypeError``. Practically unreachable from ``json.loads``.
+    return ("other", repr(value))

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -17,9 +17,13 @@ Usage:
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
+import math
 import re
+import uuid
+from collections.abc import Callable
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
@@ -569,9 +573,171 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
                     f"String length {len(parsed)} above maxLength {max_length}",
                 )
 
-    # TODO(F-141-followup): enforce pattern/format/multipleOf/uniqueItems.
-    # Deferred because regex/format implementations are non-trivial and
-    # the scoped fix targets the high-traffic constraints (enum/type/
-    # range/length). See TODO.md F-141 partial-fixed entry.
+    # F-141a: pattern / format / multipleOf / uniqueItems
+    #
+    # These were deferred from PR #736 (F-141 scoped). The follow-up
+    # set is intentionally narrow — only constraints with an
+    # unambiguous JSON-schema semantics. ``required``, ``oneOf``,
+    # ``anyOf``, ``additionalProperties`` are still deferred (compound
+    # semantics, multiple violation classes per call, schema-traversal
+    # rework).
+
+    # pattern — regex match (``re.fullmatch`` per operator note,
+    # NOT ``re.match`` which only anchors the start). Only string
+    # parsed values are checked; non-string parsed values fall
+    # through (the upstream ``type`` branch already rejected those
+    # when ``type:"string"`` was declared).
+    if isinstance(parsed, str):
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and pattern:
+            try:
+                if re.fullmatch(pattern, parsed) is None:
+                    return (
+                        False,
+                        f"String {parsed!r} does not match pattern {pattern!r}",
+                    )
+            except re.error:
+                # Bogus regex in the *schema* — fall back to advisory
+                # (the schema author is at fault, not the model).
+                pass
+
+    # format — best-effort, narrow allow-list. Unknown formats
+    # intentionally pass through as advisory (operator note:
+    # "reject unknown formats as 200 OK passthrough rather than
+    # 400, to stay loose"). Only string parsed values are checked.
+    if isinstance(parsed, str):
+        fmt = schema.get("format")
+        if isinstance(fmt, str) and fmt in _FORMAT_VALIDATORS:
+            if not _FORMAT_VALIDATORS[fmt](parsed):
+                return (
+                    False,
+                    f"String {parsed!r} is not a valid {fmt}",
+                )
+
+    # multipleOf — integer / float. ``value % multipleOf == 0`` for
+    # integers; ``math.isclose`` for floats (operator note) so a
+    # 0.1 + 0.2 == 0.3 float-drift case doesn't 400.
+    if isinstance(parsed, (int, float)) and not isinstance(parsed, bool):
+        multiple_of = schema.get("multipleOf")
+        if isinstance(multiple_of, (int, float)) and not isinstance(multiple_of, bool):
+            if multiple_of <= 0:
+                # JSON-schema requires multipleOf > 0; bogus schema,
+                # treat as advisory rather than 400.
+                pass
+            elif isinstance(parsed, int) and isinstance(multiple_of, int):
+                if parsed % multiple_of != 0:
+                    return (
+                        False,
+                        f"Value {parsed} is not a multiple of {multiple_of}",
+                    )
+            else:
+                # Float arithmetic — use ``math.isclose`` on the
+                # remainder. ``abs(parsed / multiple_of -
+                # round(parsed / multiple_of))`` is the canonical
+                # "distance to nearest multiple" measure.
+                quotient = parsed / multiple_of
+                if not math.isclose(quotient, round(quotient), abs_tol=1e-9):
+                    return (
+                        False,
+                        f"Value {parsed} is not a multiple of {multiple_of}",
+                    )
+
+    # uniqueItems — for arrays. Items must be hashable for ``set()``
+    # to work; nested dicts / lists are skipped (the JSON-schema spec
+    # uses structural equality, which Python doesn't give us for free
+    # on lists/dicts without a deep-equal pass). We use a JSON-canonical
+    # serialisation per item so structurally equal dicts compare equal.
+    if isinstance(parsed, list) and schema.get("uniqueItems") is True:
+        try:
+            canonical = [
+                json.dumps(item, sort_keys=True, ensure_ascii=False) for item in parsed
+            ]
+        except TypeError:
+            # Non-JSON-serialisable item somehow leaked in (parsed came
+            # from ``json.loads``, so this is unreachable in practice
+            # but defensive). Skip the uniqueness check.
+            canonical = None
+        if canonical is not None and len(set(canonical)) != len(canonical):
+            return False, f"Array {parsed!r} has duplicate items (uniqueItems)"
 
     return True, None
+
+
+# ---------------------------------------------------------------------
+# F-141a — narrow ``format`` validators.
+#
+# Per operator scope: ``email`` / ``uri`` / ``uuid`` / ``date`` /
+# ``date-time``. Unknown ``format`` values pass through (advisory) so
+# we stay loose for real-world schemas that ship bespoke format hints.
+# ---------------------------------------------------------------------
+
+
+def _is_email(value: str) -> bool:
+    # RFC 5321 / 5322 compliance is impossible without a real parser.
+    # Use a defensive regex: one ``@``, non-empty local part, non-empty
+    # domain part with at least one dot, no whitespace, no control
+    # chars. Mirrors what the openapi-style "loose email" check does.
+    if not value or len(value) > 254:
+        return False
+    if any(c.isspace() or ord(c) < 0x20 for c in value):
+        return False
+    return bool(_EMAIL_RE.fullmatch(value))
+
+
+def _is_uri(value: str) -> bool:
+    # Loose URI shape: ``scheme:rest`` with a non-empty scheme that
+    # starts with a letter and only contains letters / digits / ``+`` /
+    # ``-`` / ``.`` (RFC 3986 §3.1 scheme grammar). Doesn't validate
+    # the path / query — schema-level guards are best-effort.
+    if not value or any(c.isspace() for c in value):
+        return False
+    return bool(_URI_RE.match(value))
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        # ``UUID(str)`` accepts hyphenated 8-4-4-4-12, urn:uuid:..., and
+        # raw 32-char hex. JSON-schema's ``format: uuid`` is canonically
+        # the hyphenated form, so verify after a normalising round-trip.
+        u = uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return str(u) == value.lower().removeprefix("urn:uuid:")
+
+
+def _is_date(value: str) -> bool:
+    # JSON-schema ``date`` = RFC 3339 ``full-date`` = ``YYYY-MM-DD``.
+    try:
+        datetime.date.fromisoformat(value)
+    except (ValueError, TypeError):
+        return False
+    # ``fromisoformat`` accepts e.g. ``2024-01-01T00:00:00`` on Python
+    # 3.11+; reject anything carrying a time component.
+    return len(value) == 10 and value[4] == "-" and value[7] == "-"
+
+
+def _is_date_time(value: str) -> bool:
+    # JSON-schema ``date-time`` = RFC 3339 ``date-time``. ``Z`` is the
+    # UTC shorthand; ``datetime.fromisoformat`` doesn't accept it on
+    # pre-3.11 Pythons, so swap it for ``+00:00`` first.
+    candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        datetime.datetime.fromisoformat(candidate)
+    except (ValueError, TypeError):
+        return False
+    # RFC 3339 requires the ``T`` separator (or a space, per the
+    # spec's relaxation note) between date and time. ``fromisoformat``
+    # accepts a bare ``YYYY-MM-DD`` on 3.11+, which is the wrong
+    # format — date, not date-time. Require ``T`` or space.
+    return "T" in value or " " in value
+
+
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+_URI_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+\-.]*:")
+_FORMAT_VALIDATORS: dict[str, Callable[[str], bool]] = {
+    "email": _is_email,
+    "uri": _is_uri,
+    "uuid": _is_uuid,
+    "date": _is_date,
+    "date-time": _is_date_time,
+}

--- a/vllm_mlx/api/tool_logits.py
+++ b/vllm_mlx/api/tool_logits.py
@@ -635,8 +635,20 @@ def validate_param_value(value: str, schema: dict) -> tuple[bool, str | None]:
                 # remainder. ``abs(parsed / multiple_of -
                 # round(parsed / multiple_of))`` is the canonical
                 # "distance to nearest multiple" measure.
+                #
+                # codex r3 BLOCKING: the default ``rel_tol=1e-9`` lets
+                # large non-multiples through because the relative
+                # error stays small (e.g. ``quotient = 1e10 +
+                # epsilon`` rounds to ``1e10`` with relative drift
+                # well under 1e-9). Pin ``rel_tol=0.0`` so only the
+                # absolute tolerance applies, which is the operator's
+                # intent for "the model emitted a value that *should*
+                # be a multiple but is off by a few floating-point
+                # ulps".
                 quotient = parsed / multiple_of
-                if not math.isclose(quotient, round(quotient), abs_tol=1e-9):
+                if not math.isclose(
+                    quotient, round(quotient), rel_tol=0.0, abs_tol=1e-9
+                ):
                     return (
                         False,
                         f"Value {parsed} is not a multiple of {multiple_of}",
@@ -766,10 +778,21 @@ def _uniqueitems_canonical(value: object) -> object:
     if isinstance(value, (int, float)):
         # Normalise int / float to a single canonical numeric form so
         # ``1`` and ``1.0`` hash equal (per JSON-schema value equality).
-        # ``float`` is the lossy direction, but JSON-schema's
-        # ``uniqueItems`` rule explicitly compares numeric value, not
-        # representation.
-        return ("num", float(value))
+        #
+        # codex r3 BLOCKING: ``float(value)`` is lossy for large ints
+        # (``9007199254740992`` and ``9007199254740993`` collapse to
+        # the same float), so two genuinely distinct JSON integers
+        # would be falsely flagged as duplicates. Use ``Decimal`` to
+        # preserve the full numeric value while still hashing
+        # ``Decimal("1")`` and ``Decimal("1.0")`` equal (their
+        # internal coefficients differ but ``__hash__`` is computed
+        # from the numeric value).
+        from decimal import Decimal
+
+        # ``Decimal(str(value))`` is the round-trip-safe constructor
+        # — going through ``str`` preserves int exactness and reads
+        # float values at full ``repr`` precision.
+        return ("num", Decimal(str(value)))
     if isinstance(value, str):
         return ("str", value)
     if value is None:


### PR DESCRIPTION
## Summary

- PR #736 (F-141 scoped) enforced enum/type/min/max/length tool-arg constraints. F-141a closes the deferred follow-up: pattern, format, multipleOf, uniqueItems.
- Live-verified on qwen3-0.6b-8bit: `pattern` violation `{"date": "tomorrow"}` vs `^\d{4}-\d{2}-\d{2}$` → HTTP 400 with canonical "violates declared schema" envelope (was HTTP 200 before).

## Constraint semantics

| Constraint | Behavior |
|---|---|
| `pattern` | `re.fullmatch` (NOT `re.match`); bogus regex in schema → advisory |
| `format` | Narrow allow-list: `email` / `uri` / `uuid` / `date` / `date-time`; unknown formats stay advisory |
| `multipleOf` | Int arithmetic for ints, `math.isclose` for floats (0.1 drift case must pass); `multipleOf <= 0` advisory |
| `uniqueItems` | Structural equality via JSON-canonical serialisation (struct-equal dicts count as dupes) |

## Test plan

- [x] Live BEFORE/AFTER repro on port 8058 with `pattern`.
- [x] 19 new test cases in `tests/test_tool_param_enforcement_f141a.py`: 4 pattern, 6 format (5 enforced + 1 unknown-passthrough), 5 multipleOf, 4 uniqueItems.
- [x] `tests/test_tool_param_enforcement.py::TestDeferredPassThrough` now locks the *remaining* deferred set (`required` / `oneOf`) — 32 total tests pass on the existing file.
- [x] ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)