### PR TITLE
revert: gate destructive control-plane routes on verify_internal_admin (#728)

### DIFF
--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -275,8 +275,7 @@ def test_cache_import_501_envelope_does_not_leak_operator_path(
     # The resolved source path is the most direct leak the 501 stub
     # could surface — exact-string check before the substring sweep.
     assert str(tmp_path) not in r.text, (
-        f"resolved source path {str(tmp_path)!r} leaked into 501 body: "
-        f"{r.text!r}"
+        f"resolved source path {str(tmp_path)!r} leaked into 501 body: {r.text!r}"
     )
     for needle in ("/Users/", ".cache", "cache_exports"):
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -96,20 +96,23 @@ def client_factory():
 
 
 @pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_requires_bearer_when_api_key_configured(
+def test_destructive_route_requires_credential_when_api_key_configured(
     client_factory, method, path
 ):
     """When the operator sets ``--api-key``, the destructive routes still
-    require a matching Bearer / x-api-key — that's the plain
-    ``verify_api_key`` contract and the only auth gate left after the
-    #728 revert."""
+    require a matching credential — ``verify_api_key_or_x_api_key``
+    accepts EITHER ``Authorization: Bearer ...`` OR ``x-api-key`` (the
+    dual shape that the reverted ``verify_internal_admin`` also accepted,
+    so Anthropic-style clients hitting these routes don't break). Codex
+    r1 on PR #760: switching to plain ``verify_api_key`` here would have
+    silently dropped ``x-api-key`` callers."""
     build, _ = client_factory
     client = build(api_key="operator-secret")
 
-    no_bearer = client.request(method, path)
-    assert no_bearer.status_code == 401, (
-        f"{method} {path}: --api-key set but no bearer → expected 401, "
-        f"got {no_bearer.status_code}: {no_bearer.text}"
+    no_creds = client.request(method, path)
+    assert no_creds.status_code == 401, (
+        f"{method} {path}: --api-key set but no credential → expected 401, "
+        f"got {no_creds.status_code}: {no_creds.text}"
     )
 
     with_bearer = client.request(
@@ -120,6 +123,16 @@ def test_destructive_route_requires_bearer_when_api_key_configured(
     assert with_bearer.status_code not in (401, 403), (
         f"{method} {path}: valid bearer should pass, "
         f"got {with_bearer.status_code}: {with_bearer.text}"
+    )
+
+    with_x_api_key = client.request(
+        method,
+        path,
+        headers={"x-api-key": "operator-secret"},
+    )
+    assert with_x_api_key.status_code not in (401, 403), (
+        f"{method} {path}: valid x-api-key should pass (Anthropic shape), "
+        f"got {with_x_api_key.status_code}: {with_x_api_key.text}"
     )
 
 

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -1,25 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression coverage for F-150 / F-151 control-plane auth.
+"""Wire-level coverage for the destructive control-plane routes.
 
-Pre-fix, ``POST /v1/cache/clear`` and ``POST /v1/requests/{id}/cancel`` were
-reachable from any LAN client when ``--api-key`` was not configured (the
-default deployment): ``verify_api_key`` returns True the moment ``cfg.api_key``
-is unset, so the route group ran wide-open. An attacker could wipe the prefix
-cache every few seconds (DoS amplifier — every subsequent prompt is a cache
-miss) or fan out abort calls into the engine without ever proving they were
-the owner of the request.
+History: the F-150 / F-151 fixes (#728) gated ``POST /v1/cache/clear``,
+``POST /v1/requests/{id}/cancel``, the ``DELETE`` aliases, and
+``DELETE /v1/cache`` behind ``verify_internal_admin`` — an ``X-Rapid-MLX-
+Internal: true`` header plus loopback-or-api-key check. Per operator
+intent (single-machine UX, no API key gate), #728's auth bundle was
+reverted; these routes now run on plain ``verify_api_key`` (no-op when
+``--api-key`` is unset).
 
-The fix moves all destructive control-plane routes onto a dedicated
-``admin_router`` whose dependency is ``verify_internal_admin`` — that gate
-ALWAYS requires ``X-Rapid-MLX-Internal: true`` regardless of ``--api-key``
-state, and additionally requires a valid API key when one is configured.
+What stays from #728 and is pinned here:
 
-This file pins the gate's behaviour route-by-route so a future refactor that
-slips a destructive route back onto the unauthenticated ``router`` is caught
-in CI rather than at the next external pen test.
+* Cancel envelope sanitization — F-151 part 2. The success body must NOT
+  echo ``cfg.model_name``; the 404 path must NOT echo the request id;
+  the 500 path must NOT echo the engine exception text.
+* Cache export/import 501 envelope sanitization (added in the #756
+  partial revert) — resolved sandbox paths + manifest contents stay in
+  server logs only.
 
-Pattern mirrors trio's ``/internal/cookie-status`` (``X-Trio-Internal: true``)
-referenced in the F-150 / F-151 bug report.
+The auth-matrix tests from #728 (no-header → 403, wrong header → 403,
+LAN without api-key → 403) are gone because the auth gate is gone.
+The ``X-Rapid-MLX-Internal: true`` header is now harmless extra
+metadata; tests can pass it or not without changing behavior.
 """
 
 from __future__ import annotations
@@ -30,9 +32,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# Routes that MUST require ``X-Rapid-MLX-Internal: true``. Parametrize over all
-# of them so a future addition to ``admin_router`` only needs an entry here to
-# get full unauth/auth/leak coverage.
+# Destructive routes that still need leak-shape coverage. The cache router
+# is mounted separately in cache-specific tests; ``health.admin_router``
+# carries the cancel + cache-clear routes covered here.
 _DESTRUCTIVE_ROUTES = [
     ("POST", "/v1/cache/clear"),
     ("POST", "/v1/requests/some-request-id/cancel"),
@@ -43,12 +45,12 @@ _DESTRUCTIVE_ROUTES = [
 
 @pytest.fixture
 def client_factory():
-    """Yield ``(client, cfg)`` with a mock engine wired in.
+    """Yield ``(build, cfg)`` with a mock engine wired in.
 
-    The mock engine's ``abort_request`` returns True so the cancel route can
-    reach a 200 envelope (we check the F-151 leak shape from there). Cache
-    routes don't touch the engine for the happy path; the mock satisfies the
-    503-check guard in the route handlers.
+    The mock engine's ``abort_request`` returns True so the cancel route
+    can reach a 200 envelope (we check the F-151 leak shape from there).
+    Cache routes don't touch the engine for the happy path; the mock
+    satisfies the 503-check guard in the route handlers.
     """
     from vllm_mlx.config import get_config
     from vllm_mlx.routes.health import admin_router, router
@@ -62,37 +64,23 @@ def client_factory():
 
     engine = MagicMock()
     engine.abort_request = AsyncMock(return_value=True)
-    # ``clear_cache`` looks at ``engine._model._prompt_cache``; a spec=[]
-    # MagicMock makes ``hasattr(model, "_prompt_cache")`` return False so the
-    # handler takes the "no prompt cache to clear" branch and returns 200 with
-    # no engine mutation — exactly what we want for an auth-only test.
+    # ``clear_cache`` looks at ``engine._model._prompt_cache``; spec=[]
+    # makes ``hasattr(model, "_prompt_cache")`` return False so the
+    # handler takes the "no prompt cache to clear" branch and returns
+    # 200 with no engine mutation — exactly what we want for a wire test.
     engine._model = MagicMock(spec=[])
     cfg.engine = engine
-    # Use a repo-id-shaped name so the F-151 leak assertion can grep for the
-    # canonical pattern (org/model) rather than a generic word that might
-    # already appear in error envelopes.
+    # Repo-id-shaped name so the F-151 leak assertion can grep for the
+    # canonical pattern (``org/model``) rather than a generic word that
+    # might already appear in error envelopes.
     cfg.model_name = "mlx-community/secret-org-model-12b-8bit"
 
-    def build(api_key: str | None = None, client_host: str = "127.0.0.1") -> TestClient:
-        """Build a TestClient with a configurable origin host.
-
-        ``client_host`` defaults to ``127.0.0.1`` so the loopback branch
-        of ``verify_internal_admin`` resolves true — this lets tests
-        focus on the header gate without also having to thread an
-        operator api-key through every case. Tests that want to assert
-        the LAN-no-api-key 403 path pass ``client_host="10.0.0.5"`` or
-        similar (codex r1 BLOCKING fix).
-        """
+    def build(api_key: str | None = None) -> TestClient:
         cfg.api_key = api_key
         app = FastAPI()
         app.include_router(router)
         app.include_router(admin_router)
-        # ``TestClient(app, client=(host, port))`` injects the supplied
-        # tuple into ``scope["client"]`` so ``request.client.host`` reads
-        # back as ``host``. The default ``("testclient", 50000)`` is NOT
-        # loopback, so without overriding it the new loopback-required
-        # branch would reject every test — masking real bugs.
-        return TestClient(app, client=(client_host, 50000))
+        return TestClient(app)
 
     try:
         yield build, cfg
@@ -102,295 +90,71 @@ def client_factory():
         cfg.api_key = prev["api_key"]
 
 
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_rejects_missing_header(client_factory, method, path):
-    """F-150: no ``X-Rapid-MLX-Internal`` header → 403 even when ``--api-key``
-    is not configured.
+# ---------------------------------------------------------------------------
+# verify_api_key still gates when --api-key is set (sanity)
+# ---------------------------------------------------------------------------
 
-    Pre-fix this returned 200 (cache wipe / abort-on-arbitrary-id). The 403 is
-    the ASGI-level signal monitoring rules should alert on.
-    """
+
+@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
+def test_destructive_route_requires_bearer_when_api_key_configured(
+    client_factory, method, path
+):
+    """When the operator sets ``--api-key``, the destructive routes still
+    require a matching Bearer / x-api-key — that's the plain
+    ``verify_api_key`` contract and the only auth gate left after the
+    #728 revert."""
+    build, _ = client_factory
+    client = build(api_key="operator-secret")
+
+    no_bearer = client.request(method, path)
+    assert no_bearer.status_code == 401, (
+        f"{method} {path}: --api-key set but no bearer → expected 401, "
+        f"got {no_bearer.status_code}: {no_bearer.text}"
+    )
+
+    with_bearer = client.request(
+        method,
+        path,
+        headers={"Authorization": "Bearer operator-secret"},
+    )
+    assert with_bearer.status_code not in (401, 403), (
+        f"{method} {path}: valid bearer should pass, "
+        f"got {with_bearer.status_code}: {with_bearer.text}"
+    )
+
+
+@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
+def test_destructive_route_open_when_no_api_key(client_factory, method, path):
+    """When ``--api-key`` is unset (single-machine default), the routes
+    run wide open per the #728 revert. Pin this so a future tightening is
+    a conscious decision, not an accidental regression."""
     build, _ = client_factory
     client = build(api_key=None)
 
     r = client.request(method, path)
-
-    assert r.status_code == 403, (
-        f"{method} {path} should require X-Rapid-MLX-Internal: true even "
-        f"when --api-key is unset, got {r.status_code}: {r.text}"
-    )
-    assert "X-Rapid-MLX-Internal" in r.json()["detail"]
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_rejects_wrong_header_value(client_factory, method, path):
-    """The header must literally equal ``true`` (case-insensitive). A typo'd
-    or shell-default value like ``1`` / ``yes`` / empty MUST 403 — accepting
-    them would turn the gate into a no-op for any client that ships a default
-    truthy header injector."""
-    build, _ = client_factory
-    client = build(api_key=None)
-
-    for bad in ("1", "yes", "false", "", "TRUE_"):
-        r = client.request(method, path, headers={"X-Rapid-MLX-Internal": bad})
-        assert r.status_code == 403, (
-            f"{method} {path} accepted header value {bad!r}: {r.text}"
-        )
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_accepts_internal_header_when_no_api_key(
-    client_factory, method, path
-):
-    """F-150 happy path: ``X-Rapid-MLX-Internal: true`` + loopback caller is
-    sufficient when ``--api-key`` is not configured.
-
-    Per the codex r1 BLOCKING fix, the header alone is NOT enough — a LAN
-    caller still needs an api-key. Loopback is the dev-only escape hatch.
-    The fixture defaults ``client_host="127.0.0.1"`` so this test exercises
-    that branch. We only assert that the auth gate passes (status != 401/403).
-    Specific response shapes are validated in ``test_routes.py`` /
-    ``test_request_cancellation.py``.
-    """
-    build, _ = client_factory
-    client = build(api_key=None)
-
-    r = client.request(method, path, headers={"X-Rapid-MLX-Internal": "true"})
-
     assert r.status_code not in (401, 403), (
-        f"{method} {path} with valid internal header should pass auth, "
+        f"{method} {path}: no --api-key should NOT 401/403 after revert, "
         f"got {r.status_code}: {r.text}"
-    )
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_case_insensitive_header_value(client_factory, method, path):
-    """``True`` / ``TRUE`` are accepted (shells frequently uppercase by reflex).
-    Pin this so a future tightening doesn't break documented client code."""
-    build, _ = client_factory
-    client = build(api_key=None)
-
-    for variant in ("true", "True", "TRUE", " true "):
-        r = client.request(method, path, headers={"X-Rapid-MLX-Internal": variant})
-        assert r.status_code not in (401, 403), (
-            f"{method} {path} rejected variant {variant!r}: {r.text}"
-        )
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_requires_api_key_when_configured(
-    client_factory, method, path
-):
-    """When ``--api-key`` IS set, the internal header alone is NOT enough —
-    a valid Bearer token (or x-api-key) must accompany it. Without this, a
-    LAN attacker could bypass the operator's API-key gate just by adding the
-    internal header.
-    """
-    build, _ = client_factory
-    client = build(api_key="operator-secret")
-
-    # Internal header but no Bearer → 401 (API key required).
-    r = client.request(method, path, headers={"X-Rapid-MLX-Internal": "true"})
-    assert r.status_code == 401, (
-        f"{method} {path}: internal header should NOT bypass --api-key, "
-        f"got {r.status_code}: {r.text}"
-    )
-
-    # Both internal header AND valid Bearer → auth passes.
-    r = client.request(
-        method,
-        path,
-        headers={
-            "X-Rapid-MLX-Internal": "true",
-            "Authorization": "Bearer operator-secret",
-        },
-    )
-    assert r.status_code not in (401, 403), (
-        f"{method} {path}: internal header + valid bearer should pass, "
-        f"got {r.status_code}: {r.text}"
-    )
-
-    # Internal header AND valid x-api-key → also passes (Anthropic auth shape).
-    r = client.request(
-        method,
-        path,
-        headers={
-            "X-Rapid-MLX-Internal": "true",
-            "x-api-key": "operator-secret",
-        },
-    )
-    assert r.status_code not in (401, 403), (
-        f"{method} {path}: internal header + valid x-api-key should pass, "
-        f"got {r.status_code}: {r.text}"
-    )
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_rejects_lan_caller_without_api_key(
-    client_factory, method, path
-):
-    """Codex PR #728 round-1 BLOCKING: when ``--api-key`` is unset, a non-
-    loopback caller with the internal header MUST still 403.
-
-    Pre-codex-fix the header alone was sufficient. That left any LAN client
-    who read the open-source code able to send the header and wipe cache —
-    the header is not a secret, it's a "you meant this" signal. The
-    production posture is: operator sets ``--api-key`` → bearer required;
-    dev posture is: ``--api-key`` unset → loopback-only. There is no
-    "anonymous remote callers with the header" posture anymore.
-    """
-    build, _ = client_factory
-    # 10.x is the canonical "definitely not loopback" LAN range used by
-    # cloud / k8s test fixtures.
-    client = build(api_key=None, client_host="10.0.0.5")
-
-    r = client.request(method, path, headers={"X-Rapid-MLX-Internal": "true"})
-    assert r.status_code == 403, (
-        f"{method} {path}: LAN caller (10.0.0.5) with header but no --api-key "
-        f"should 403, got {r.status_code}: {r.text}"
-    )
-
-
-@pytest.mark.parametrize(("method", "path"), _DESTRUCTIVE_ROUTES)
-def test_destructive_route_accepts_lan_caller_with_valid_api_key(
-    client_factory, method, path
-):
-    """Cross-check the codex fix: a remote caller with the header AND a
-    valid bearer key (the production posture) still works. Otherwise the
-    fix would have made the routes effectively localhost-only, breaking
-    operators who run ``rapid-mlx`` behind a private VPN with ``--api-key``
-    set and want to hit the admin routes from their laptop.
-    """
-    build, _ = client_factory
-    client = build(api_key="operator-secret", client_host="10.0.0.5")
-
-    r = client.request(
-        method,
-        path,
-        headers={
-            "X-Rapid-MLX-Internal": "true",
-            "Authorization": "Bearer operator-secret",
-        },
-    )
-    assert r.status_code not in (401, 403), (
-        f"{method} {path}: LAN caller with valid api-key should pass, "
-        f"got {r.status_code}: {r.text}"
-    )
-
-
-def test_loopback_ipv6_is_recognised():
-    """``::1`` (canonical IPv6 loopback) is treated the same as 127.0.0.1.
-    Defends against a future refactor that switches to a string-equality
-    check and accidentally locks out callers binding on ``::1``."""
-    from vllm_mlx.middleware.auth import _is_loopback_client
-
-    # Build a minimal request-like object exposing ``.client.host`` and
-    # ``.headers.get(...)`` — both are consumed by ``_is_loopback_client``
-    # (codex r3 added the proxy-trail header check).
-    class _C:
-        def __init__(self, host: str) -> None:
-            self.host = host
-            self.port = 50000
-
-    class _H:
-        def __init__(self, headers: dict | None = None) -> None:
-            self._h = headers or {}
-
-        def get(self, name: str, default=None):
-            # Normalise to lower-case to match Starlette's case-insensitive
-            # header lookup — the production code passes already-lowered
-            # keys but a future caller might not.
-            return self._h.get(name.lower(), default)
-
-    class _R:
-        def __init__(self, host: str, headers: dict | None = None) -> None:
-            self.client = _C(host)
-            self.headers = _H(headers)
-
-    assert _is_loopback_client(_R("127.0.0.1")) is True
-    assert _is_loopback_client(_R("::1")) is True
-    assert _is_loopback_client(_R("localhost")) is True
-    # Bare IPv4-mapped-IPv6 form of loopback also resolves via is_loopback.
-    assert _is_loopback_client(_R("::ffff:127.0.0.1")) is True
-    # Anything in the 127.0.0.0/8 block.
-    assert _is_loopback_client(_R("127.0.0.42")) is True
-    # And anything outside is NOT loopback.
-    assert _is_loopback_client(_R("10.0.0.5")) is False
-    assert _is_loopback_client(_R("8.8.8.8")) is False
-    assert _is_loopback_client(_R("not-an-ip")) is False
-    # ``request.client`` may be None on some ASGI servers / test rigs.
-    assert _is_loopback_client(_R(None)) is False  # type: ignore[arg-type]
-
-
-def test_loopback_rejects_proxied_caller(client_factory):
-    """Codex PR #728 round-3 BLOCKING: a same-host reverse proxy (nginx
-    ``proxy_pass http://127.0.0.1:8000``) makes every external client look
-    like ``127.0.0.1``. The fix REJECTS any request carrying a proxy-trail
-    header, so a misconfigured deploy can't expose the admin routes via
-    its load balancer.
-
-    Each parametrised header is tested independently to pin which signals
-    we trust. The set is documented in ``_is_loopback_client``'s docstring.
-    """
-    build, _ = client_factory
-    client = build(api_key=None, client_host="127.0.0.1")
-
-    proxy_signals = [
-        {"X-Forwarded-For": "8.8.8.8"},
-        {"X-Forwarded-Host": "example.com"},
-        {"X-Forwarded-Proto": "https"},
-        {"Forwarded": 'for="8.8.8.8";proto=https'},
-        {"Via": "1.1 nginx-proxy"},
-        {"CF-Connecting-IP": "8.8.8.8"},
-        {"True-Client-IP": "8.8.8.8"},
-    ]
-    for extra in proxy_signals:
-        r = client.post(
-            "/v1/cache/clear",
-            headers={"X-Rapid-MLX-Internal": "true", **extra},
-        )
-        assert r.status_code == 403, (
-            f"Request with proxy signal {list(extra)[0]!r} should 403 "
-            f"even from 127.0.0.1, got {r.status_code}: {r.text}"
-        )
-
-
-def test_loopback_accepts_direct_caller_with_no_proxy_headers(client_factory):
-    """Cross-check: a direct loopback caller without any proxy-trail
-    headers still gets through. Otherwise the round-3 fix would have
-    accidentally locked out the dev-on-localhost path entirely.
-    """
-    build, _ = client_factory
-    client = build(api_key=None, client_host="127.0.0.1")
-
-    r = client.post(
-        "/v1/cache/clear",
-        headers={"X-Rapid-MLX-Internal": "true"},
-    )
-    assert r.status_code not in (401, 403), (
-        f"Direct loopback caller should pass, got {r.status_code}: {r.text}"
     )
 
 
 # ---------------------------------------------------------------------------
-# F-151 specific: cancel must not leak model_name and must 404 on unknown IDs
+# F-151: cancel must not leak model_name and must 404 on unknown IDs
+# (kept from #728 — these are real bugs unrelated to the auth gate)
 # ---------------------------------------------------------------------------
 
 
 def test_cancel_success_envelope_does_not_leak_model_name(client_factory):
-    """F-151 part 2: cancel response MUST NOT include ``model`` (or any other
-    server-side fingerprint of the loaded weights).
+    """F-151 part 2: cancel response MUST NOT include ``model`` (or any
+    other server-side fingerprint of the loaded weights).
 
-    The fixture configures ``cfg.model_name`` to a repo-id-shaped string —
-    if the route ever re-introduces an envelope field that echoes it, this
-    assertion catches the regression before merge."""
+    The fixture configures ``cfg.model_name`` to a repo-id-shaped string
+    — if the route ever re-introduces an envelope field that echoes it,
+    this assertion catches the regression before merge."""
     build, cfg = client_factory
     client = build(api_key=None)
 
-    r = client.post(
-        "/v1/requests/chatcmpl-real-id/cancel",
-        headers={"X-Rapid-MLX-Internal": "true"},
-    )
+    r = client.post("/v1/requests/chatcmpl-real-id/cancel")
     assert r.status_code == 200, r.text
     body = r.json()
     assert body == {
@@ -413,13 +177,9 @@ def test_cancel_unknown_id_returns_404_without_leak(client_factory):
     build, cfg = client_factory
     client = build(api_key=None)
 
-    # Tell the mock to behave as a post-fix scheduler for unknown IDs.
     cfg.engine.abort_request = AsyncMock(return_value=False)
 
-    r = client.post(
-        "/v1/requests/some-bogus-id/cancel",
-        headers={"X-Rapid-MLX-Internal": "true"},
-    )
+    r = client.post("/v1/requests/some-bogus-id/cancel")
     assert r.status_code == 404, r.text
     assert cfg.model_name not in r.text
     assert "mlx-community" not in r.text
@@ -427,8 +187,8 @@ def test_cancel_unknown_id_returns_404_without_leak(client_factory):
 
 def test_cancel_500_error_path_does_not_leak_exception_detail(client_factory):
     """F-151 part 3: when the engine raises during abort, the 500 envelope
-    MUST NOT echo the exception message — engine exceptions sometimes carry
-    the HF snapshot path / repo id."""
+    MUST NOT echo the exception message — engine exceptions sometimes
+    carry the HF snapshot path / repo id."""
     build, cfg = client_factory
     client = build(api_key=None)
 
@@ -438,25 +198,15 @@ def test_cancel_500_error_path_does_not_leak_exception_detail(client_factory):
         )
     )
 
-    r = client.post(
-        "/v1/requests/some-id/cancel",
-        headers={"X-Rapid-MLX-Internal": "true"},
-    )
+    r = client.post("/v1/requests/some-id/cancel")
     assert r.status_code == 500
-    # The leaked path components must not surface in the JSON envelope.
     assert "secret-snapshot" not in r.text
     assert "huggingface" not in r.text
     assert ".cache" not in r.text
 
 
 # ---------------------------------------------------------------------------
-# Cache export/import 501 envelope sanitization (kept from #737 after the
-# revert moved these routes off ``verify_internal_admin`` per operator intent
-# — single-machine UX, no API key gate). The 501 stubs are reachable to
-# anyone with a valid api-key (or anyone at all when ``--api-key`` is unset),
-# so the envelope still has to be path-free or we'd hand operator home-dir
-# strings to LAN callers — closing codex r2 #2 (test coverage gap) + r2 #3
-# (exact-envelope shape assertion, not just message + type).
+# Cache export/import 501 envelope sanitization (kept from #756)
 # ---------------------------------------------------------------------------
 
 
@@ -473,8 +223,8 @@ def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
     """``POST /v1/cache/export`` 501 stub must not echo the resolved sandbox
     destination — that expands to ``/Users/<USERNAME>/.cache/rapid-mlx/
     cache_exports`` and leaks operator home dir / username to any
-    bearer-token holder. After the #756 partial revert the route runs on
-    plain ``verify_api_key``, so this leak shape matters even more when
+    bearer-token holder. After the #728 revert the route runs on plain
+    ``verify_api_key``, so this leak shape matters even more when
     ``--api-key`` is unset."""
     from vllm_mlx.routes.cache import router as cache_router
 
@@ -485,24 +235,20 @@ def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
     r = client.post("/v1/cache/export", json={})
     assert r.status_code == 501, r.text
     body = r.json()
-    # No resolved-path-shaped strings in the body.
     for needle in ("/Users/", ".cache", "rapid-mlx", "cache_exports"):
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
-    # No tracking-URL leak either.
     for needle in ("github.com", "issues/"):
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
-    # Exact-envelope shape — codex r2 #3: any future code path that adds
-    # an extra key (resolved path, manifest excerpt, issue URL) trips
-    # this rather than slipping through a soft string-denylist.
     assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body
 
 
 def test_cache_import_501_envelope_does_not_leak_operator_path(
     client_factory, tmp_path, monkeypatch
 ):
-    """Same shape check for ``POST /v1/cache/import``. Point the sandbox at
-    a tmp dir, hand-craft a valid manifest so the route gets past validation
-    into the 501 stub, then assert the body is path-free + manifest-free."""
+    """Same shape check for ``POST /v1/cache/import``. Point the sandbox
+    at a tmp dir, hand-craft a valid manifest so the route gets past
+    validation into the 501 stub, then assert the body is path-free +
+    manifest-free."""
     monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(tmp_path))
 
     import json
@@ -526,18 +272,13 @@ def test_cache_import_501_envelope_does_not_leak_operator_path(
     r = client.post("/v1/cache/import", json={"source": str(tmp_path)})
     assert r.status_code == 501, r.text
     body = r.json()
-    # Codex r3 #2: the resolved source path is the most direct leak the
-    # 501 stub could surface — assert the literal ``str(tmp_path)`` is
-    # absent before falling back to the substring sweep. Without this
-    # check, a body echoing the validated source under e.g. ``/tmp/...``
-    # would slip past the "/Users/" / ".cache" / "cache_exports" denylist.
+    # The resolved source path is the most direct leak the 501 stub
+    # could surface — exact-string check before the substring sweep.
     assert str(tmp_path) not in r.text, (
-        f"resolved source path {str(tmp_path)!r} leaked into 501 body: {r.text!r}"
+        f"resolved source path {str(tmp_path)!r} leaked into 501 body: "
+        f"{r.text!r}"
     )
-    # Defense-in-depth: also sweep the well-known operator-path fragments.
     for needle in ("/Users/", ".cache", "cache_exports"):
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
-    # No manifest contents leaked (model_id is a recognizable canary).
     assert "secret-org-model" not in r.text
-    # Exact-envelope shape.
     assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -209,22 +209,20 @@ def _route_paths_with_auth(router):
     ``WebSocketRoute`` plumbing without dependency graphs).
 
     A route counts as auth-gated if it declares ANY dependency from the
-    ``verify_api_key*`` family or the stricter ``verify_internal_admin``
-    family — currently:
+    ``verify_api_key*`` family — currently:
 
     * ``verify_api_key`` — OpenAI-style bearer-token gate used by
       chat/completions/embeddings/audio/cache/health/mcp/models/responses.
     * ``verify_api_key_or_x_api_key`` — same gate, additionally
       accepting Anthropic-native ``x-api-key`` header. Used by the
       ``/v1/messages*`` routes that mirror Anthropic's API shape.
-    * ``verify_internal_admin`` (F-180) — strictly stronger than
-      ``verify_api_key``: requires ``X-Rapid-MLX-Internal: true`` AND
-      either a valid api-key or a loopback caller. Still used by the
-      health admin router (cache clear, request cancel from #728) —
-      the cache router moves to plain ``verify_api_key`` per user-intent
-      revert (#756) but other admin routes keep this gate.
 
-    All gates run BEFORE the route handler executes; each is
+    The historical ``verify_internal_admin`` gate (F-180) was reverted
+    in #728 / #756 per operator intent — single-machine UX, no API key
+    gate. If a future PR reintroduces it, add the dep back to the
+    ``auth_funcs`` set so the bind→auth ordering invariant covers it.
+
+    Both gates run BEFORE the route handler executes; either is
     structurally equivalent for the bind→auth ordering invariant.
     """
     from vllm_mlx.middleware import auth as auth_mod
@@ -234,12 +232,6 @@ def _route_paths_with_auth(router):
         for name in dir(auth_mod)
         if name.startswith("verify_api_key")
     }
-    # F-180: ``verify_internal_admin`` is a strictly-stronger gate than
-    # ``verify_api_key`` — accept it under the same ordering invariant.
-    # Kept in the detector even though #756 moves the cache router off it,
-    # because the health admin router still gates cache-clear / cancel.
-    if hasattr(auth_mod, "verify_internal_admin"):
-        auth_funcs.add(auth_mod.verify_internal_admin)
     for r in router.routes:
         dep = getattr(r, "dependant", None)
         if dep is None:

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -4,12 +4,11 @@
 import hashlib
 import hmac
 
-# ``ipaddress`` was already imported by the pre-existing ``_subnet_bucket``
-# rate-limit helper; ``verify_internal_admin`` / ``_is_loopback_client``
-# (PR #728) reuse it for the loopback check so a LAN caller can't probe
-# non-canonical loopback spellings (``::ffff:127.0.0.1``, ``127.0.0.42``)
-# past a hypothetical string-equality gate. Pinning the import in this diff
-# so future codex passes don't flag it as missing.
+# ``ipaddress`` is imported by ``_subnet_bucket`` (rate-limit helper) and
+# ``_is_loopback_client`` (kept as dead code for future control-plane
+# gates after #728 was reverted). Canonicalising via ``ipaddress`` is the
+# only safe way to identify loopback callers — string comparison misses
+# ``::ffff:127.0.0.1`` and IPv6 spellings.
 import ipaddress
 import logging
 import secrets
@@ -279,44 +278,18 @@ async def verify_api_key_or_x_api_key(
     return _verify_api_key_values(bearer_key, request.headers.get("x-api-key"))
 
 
-# Header gate for destructive control-plane routes that live on the main
-# bind (not a separate admin port). The F-150 root cause is that
-# ``verify_api_key`` returns True (open) when ``--api-key`` is not
-# configured, so ``/v1/cache/clear`` and ``/v1/requests/{id}/cancel`` were
-# reachable from any LAN client — wiping the prefix cache (DoS amplifier)
-# or firing abort calls into the engine with no proof of authorization.
-#
-# The fix is two-layered, evaluated in this order:
-#
-#   1. ALWAYS require the ``X-Rapid-MLX-Internal: true`` header. This blocks
-#      stray cross-site form POSTs, opportunistic scanners, and any client
-#      that doesn't know it's poking an internal route. Pattern mirrors
-#      trio's ``/internal/cookie-status`` (``X-Trio-Internal: true``).
-#
-#   2. ALSO require ONE of:
-#        a) a valid Bearer / x-api-key matching ``cfg.api_key``, OR
-#        b) the request is coming from loopback (127.0.0.1 / ::1 — i.e. the
-#           operator on the same host).
-#      Codex PR #728 round-1 BLOCKING: a hard-coded public header is not
-#      authentication; without (a) or (b) any LAN client who reads the
-#      open-source code can still send the header and wipe cache. (a) is
-#      the production posture (operator sets ``--api-key`` on the deploy);
-#      (b) is the dev-on-loopback escape hatch so ``curl localhost`` from
-#      the same machine still works.
-#
-# When ``cfg.api_key`` is configured (production), the only way to reach
-# these routes from a remote host is with both the header AND a valid
-# bearer/x-api-key — the loopback bypass is irrelevant. When ``cfg.api_key``
-# is unset, only loopback callers with the header get through; LAN
-# attackers are 403'd at step 1 if they don't know the header and 403'd at
-# step 2 if they do.
-_INTERNAL_HEADER_NAME = "X-Rapid-MLX-Internal"
-_INTERNAL_HEADER_EXPECTED = "true"
 # Loopback hosts the operator might appear under. We canonicalise via
 # ``ipaddress`` to catch ``::ffff:127.0.0.1`` and the various IPv6 spellings
 # of ``::1`` (``0000:0:0:0:0:0:0:1`` etc.) — a string-equality check would
 # miss those and let a remote attacker who controls DNS / a reverse proxy
 # forge ``127.0.0.1`` as a literal but fail any canonical form.
+#
+# Note: ``_is_loopback_client`` is kept as dead code in case a future PR
+# reintroduces a control-plane gate. The companion ``verify_internal_admin``
+# dependency was removed when operator-intent reverted #728 — single-machine
+# UX means the destructive routes run on plain ``verify_api_key`` (no-op
+# when ``--api-key`` unset). Cancel-envelope sanitization + scheduler
+# ``abort_request`` correctness from #728 are kept; only the auth gate goes.
 _LOOPBACK_LITERALS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
@@ -378,64 +351,8 @@ def _is_loopback_client(request: Request) -> bool:
         return False
 
 
-async def verify_internal_admin(
-    request: Request,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-):
-    """Gate for destructive control-plane routes (cache clear, request cancel).
-
-    Two-layer check (see module-level comment for rationale):
-
-    1. Header ``X-Rapid-MLX-Internal: true`` is ALWAYS required. Missing or
-       wrong value → 403.
-    2. Then EITHER a valid Bearer / x-api-key matching ``cfg.api_key`` OR
-       the request must originate from loopback. Neither → 403 when
-       ``cfg.api_key`` is unset (loopback-only mode), 401 when it IS set
-       (api-key required mode).
-
-    The 401-vs-403 split matches ``verify_api_key`` so monitoring rules that
-    grep for 401-on-control-plane keep working for the authenticated case.
-    """
-    header_value = request.headers.get(_INTERNAL_HEADER_NAME, "")
-    # Strict case-insensitive value match. We accept ``true`` / ``True`` /
-    # ``TRUE`` (some shells uppercase by reflex) but reject ``1``, ``yes``,
-    # empty string — anything that could be a typo'd misfire from an
-    # unrelated client middleware injecting a default header.
-    if header_value.strip().lower() != _INTERNAL_HEADER_EXPECTED:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"Forbidden: {_INTERNAL_HEADER_NAME}: "
-                f"{_INTERNAL_HEADER_EXPECTED} header required for "
-                "control-plane routes"
-            ),
-        )
-
-    bearer_key = credentials.credentials if credentials is not None else None
-    x_api_key = request.headers.get("x-api-key")
-    cfg = get_config()
-
-    if cfg.api_key is not None:
-        # Production posture: --api-key is set. The header gate above is
-        # informational; the real auth is the bearer/x-api-key check. A
-        # loopback caller still needs a valid key — otherwise an operator
-        # who curls from the same host could trip the route accidentally
-        # AND a local-privilege escalation (any other user on the box)
-        # would inherit admin access. Defer to the existing api-key check
-        # which raises 401 on miss/mismatch.
-        return _verify_api_key_values(bearer_key, x_api_key)
-
-    # Unauthenticated server posture: --api-key is unset. The only way
-    # through is loopback OR a valid api-key value (which can't exist when
-    # cfg.api_key is None — short-circuit). Reject any non-loopback caller
-    # with 403 (codex r1 BLOCKING fix). Logging is intentionally terse to
-    # avoid echoing attacker-controlled host strings at INFO level.
-    if _is_loopback_client(request):
-        return True
-    raise HTTPException(
-        status_code=403,
-        detail=(
-            "Forbidden: control-plane routes require either --api-key "
-            "configured or a loopback caller when --api-key is unset"
-        ),
-    )
+# ``verify_internal_admin`` removed per operator-intent revert of #728
+# (single-machine UX, no API key gate on cache-clear / request-cancel).
+# If a future PR needs to gate these routes again, reuse
+# ``_is_loopback_client`` above + the standard ``verify_api_key`` /
+# ``HTTPException`` pattern.

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -7,7 +7,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..config import get_config
-from ..middleware.auth import verify_api_key, verify_internal_admin
+from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +22,13 @@ probe_router = APIRouter()
 # live on ``admin_router`` below.
 router = APIRouter(dependencies=[Depends(verify_api_key)])
 
-# Destructive control-plane routes (F-150 / F-151 fix). ``verify_internal_admin``
-# ALWAYS requires ``X-Rapid-MLX-Internal: true`` even when ``--api-key`` is unset,
-# so an unauthenticated LAN client cannot wipe the prefix cache (DoS amplifier)
-# or fan out spurious abort calls. When ``--api-key`` IS configured the dep also
-# requires a valid Bearer / x-api-key — the internal-header is additive, not a
-# bypass.
-admin_router = APIRouter(dependencies=[Depends(verify_internal_admin)])
+# Destructive control-plane routes (cache clear, request cancel). Per the
+# operator-intent revert of #728, these run on plain ``verify_api_key`` —
+# single-machine UX means the prior ``verify_internal_admin`` gate (header
+# requirement) was friction for no benefit on the common deployment. The
+# cancel envelope sanitization + scheduler ``abort_request`` correctness
+# fix from #728 STAY — those are real bugs unrelated to the auth gate.
+admin_router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
 @probe_router.api_route("/", methods=["GET", "HEAD"])

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -7,7 +7,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..config import get_config
-from ..middleware.auth import verify_api_key
+from ..middleware.auth import verify_api_key, verify_api_key_or_x_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +23,16 @@ probe_router = APIRouter()
 router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 # Destructive control-plane routes (cache clear, request cancel). Per the
-# operator-intent revert of #728, these run on plain ``verify_api_key`` —
-# single-machine UX means the prior ``verify_internal_admin`` gate (header
-# requirement) was friction for no benefit on the common deployment. The
-# cancel envelope sanitization + scheduler ``abort_request`` correctness
-# fix from #728 STAY — those are real bugs unrelated to the auth gate.
-admin_router = APIRouter(dependencies=[Depends(verify_api_key)])
+# operator-intent revert of #728, these run on the Anthropic-compatible
+# ``verify_api_key_or_x_api_key`` gate — single-machine UX means the
+# prior ``verify_internal_admin`` header requirement was friction for no
+# benefit on the common deployment, but we keep the dual Bearer + x-api-key
+# acceptance that the removed gate had (codex r1 on PR #760: switching
+# to plain ``verify_api_key`` would drop ``x-api-key`` callers, breaking
+# Anthropic-style clients that hit these routes). The cancel envelope
+# sanitization + scheduler ``abort_request`` correctness fixes from #728
+# STAY — those are real bugs unrelated to the auth gate.
+admin_router = APIRouter(dependencies=[Depends(verify_api_key_or_x_api_key)])
 
 
 @probe_router.api_route("/", methods=["GET", "HEAD"])


### PR DESCRIPTION
## Why

Per operator intent (`#738 728 737 revert掉 完全没必要`) — rapid-mlx is a single-machine local inference server. The `verify_internal_admin` gate added in #728 (header `X-Rapid-MLX-Internal: true` + loopback-or-api-key) was friction for no benefit on the common deployment. Final piece of the three-revert bundle (#758 = CORS friendly default, #756 = cache router auth, this one = admin router auth).

## What stays from #728 (real bugs, NOT the auth gate)

- **Cancel envelope sanitization (F-151 part 2)** — 200 body drops `model` field; 404 path avoids echoing request id; 500 path drops engine exception text. `mlx-community/...` repo-id leak stays closed.
- **`Scheduler.abort_request` returns False for unknown ids (F-151 part 1)** — the route uses False as its 404 signal; attacker poking random ids gets truthful "not found" instead of fake `cancelled: true`.

## What goes

- `verify_internal_admin` helper + `_INTERNAL_HEADER_*` constants. `_is_loopback_client` kept as dead code in case a future PR reintroduces a control-plane gate.
- 7 auth-matrix parametrized tests in `test_internal_route_auth.py` (no-header → 403, wrong header → 403, LAN-without-api-key → 403). Cancel envelope + cache export/import envelope tests stay (F-151 + F-180 coverage, not auth coverage).
- `verify_internal_admin` entry in `_route_paths_with_auth` (`test_server_auth_ordering.py`) — no consumers left after #756 moved the cache router off it + this PR moves the admin router off it.

## Codex expected BLOCKING — user intent

Codex will flag that this makes destructive routes unauthenticated when `--api-key` unset. That's exactly the operator's intent — single-machine UX, no API key gate. Documented here per the convention from #755/#756.

## Tests

- 118/118 pass across `test_internal_route_auth.py`, `test_request_cancellation.py`, `test_routes.py`, `test_server_auth_ordering.py`, `test_batching.py`

Refs: F-150, F-151.

Final revert of the 3-PR bundle (#758 + #756 + #728). After this lands, cut 0.7.42.