### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.7.41"
+version = "0.8.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts **0.8.0** — minor version bump, not patch, because the 0.7.41 → 0.8.0 window contains intentionally user-visible behavior shifts that downstream callers should see in the version number:

### Default-posture changes (operator-intent)

- **#758 (CORS)** — default CORS changed from default-deny to default-wildcard (`*`). Browser frontends now work out of the box on the single-machine UX; multi-tenant operators still lock down via `RAPID_MLX_CORS_ALLOW_ORIGINS=https://your.app`.
- **#756 (cache router auth)** — `/v1/cache/{export,import,info}` moved off `verify_internal_admin` onto plain `verify_api_key` (no-op when `--api-key` unset).
- **#760 (admin router auth)** — `/v1/cache/clear` + `/v1/requests/{id}/cancel` + DELETE aliases moved off `verify_internal_admin` onto `verify_api_key_or_x_api_key` (preserves Anthropic `x-api-key` shape).

Real bugs from the security stack are **kept** even though the gates were removed: cancel envelope no longer leaks `model` / request-id / engine-exception text; scheduler `abort_request` returns False for unknown ids; cache 501 envelopes are path-free.

### F-fixes since 0.7.41

- **#716 / #720** — MLLM logprobs cross-thread `mx.new_stream` crash + 5 systematic integration fixes (tool_choice / stop / template-escape / logprobs / think-detection)
- **#709 / #715 / #718** — VibeThinker + diffusion-lane fixes
- **#732 / #733 / #752 / #753** — request body cap, completions n/best_of/echo/logprobs parity, stream cmpl-id, bare-string image_url rejection
- **#742 / #749 / #759** — F-220 Anthropic tool-arg validation, F-210 audio path-shaped model 404, F-141a pattern/format/multipleOf/uniqueItems enforcement
- **#754 / #757** — F-042 redo: unified scan over `<tool_call>` / `<function=>` / `<function><name><arguments>` preserves wire-order + streaming mixed

## Release SOP

Per the established pattern (`auto-release.yml` triggers on commit subject exact-match `chore: bump version to X.Y.Z`): bump lives in its own commit with no other changes, so the release pipeline (tag → GitHub Release → PyPI → Homebrew) fires automatically on merge.

## Tests

Just a version-string change; no behavior delta on top of what merged in #758 / #756 / #760 / #742 / #749 / #759.