### PR TITLE
fix(security): sanitize 403 sandbox-escape envelope (H-02)

### DIFF
--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -321,7 +321,11 @@ def test_export_rejects_path_traversal(cache_client):
         headers=_auth(),
     )
     assert resp.status_code == 403
-    assert "not allowed" in resp.json()["detail"]
+    # H-02: 403 body is sanitized — error.code identifies the failure
+    # mode, the caller-supplied path stays in server logs only.
+    detail = resp.json()["detail"]
+    assert detail["error"]["code"] == "sandbox_escape"
+    assert detail["error"]["type"] == "invalid_request_error"
 
 
 def test_export_rejects_absolute_outside(cache_client):

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -255,6 +255,61 @@ def test_cache_export_501_envelope_does_not_leak_operator_path(client_factory):
     assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body
 
 
+_EXPECTED_SANDBOX_ESCAPE_ENVELOPE = {
+    "error": {
+        "message": "destination must resolve under the cache-export sandbox",
+        "type": "invalid_request_error",
+        "code": "sandbox_escape",
+    }
+}
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "/tmp/foo",
+        "/",
+        "../../etc/passwd",
+        "/Users/x",
+        "/etc/passwd",
+    ],
+)
+def test_cache_export_403_sandbox_escape_does_not_leak_operator_path(
+    client_factory, destination
+):
+    """H-02: ``POST /v1/cache/export`` with an out-of-sandbox destination
+    returns 403, and the body must NOT echo the resolved sandbox root.
+
+    Pre-fix the 403 detail expanded ``InvalidExportPathError`` via
+    ``str(exc)``, which embeds ``/Users/<USERNAME>/.cache/rapid-mlx/
+    cache_exports`` — username + home-dir disclosure to any LAN caller
+    after the #756 auth-gate revert. Mirrors the strictness of the
+    sibling ``test_cache_export_501_envelope_does_not_leak_operator_path``
+    so a future regression at the same site is caught by the same
+    needles.
+    """
+    from pathlib import Path
+
+    from vllm_mlx.routes.cache import router as cache_router
+
+    build, _ = client_factory
+    client = build(api_key=None)
+    client.app.include_router(cache_router)
+
+    r = client.post("/v1/cache/export", json={"destination": destination})
+    assert r.status_code == 403, r.text
+    body = r.json()
+    # Belt + braces leak sweep — these are the substrings that the
+    # pre-fix envelope leaked verbatim. Same shape as the 501 test.
+    home = str(Path.home())
+    for needle in (home, "/Users/", ".cache", "rapid-mlx", "cache_exports"):
+        assert needle not in r.text, (
+            f"{needle!r} leaked into 403 sandbox-escape body for "
+            f"destination={destination!r}: {r.text!r}"
+        )
+    assert body.get("detail") == _EXPECTED_SANDBOX_ESCAPE_ENVELOPE, body
+
+
 def test_cache_import_501_envelope_does_not_leak_operator_path(
     client_factory, tmp_path, monkeypatch
 ):

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -56,6 +56,21 @@ _NOT_IMPLEMENTED_DETAIL = {
     }
 }
 
+# H-02: sandbox-escape 403 envelope. The underlying
+# ``InvalidExportPathError`` carries the caller-supplied path AND the
+# fully resolved sandbox root (``/Users/<username>/.cache/rapid-mlx/
+# cache_exports``). Echoing either to an unauthenticated caller leaks
+# the operator's home dir + username. Same treatment as the #756 501
+# envelope: generic wire message, full detail goes to the server log.
+_SANDBOX_ESCAPE_MSG = "destination must resolve under the cache-export sandbox"
+_SANDBOX_ESCAPE_DETAIL = {
+    "error": {
+        "message": _SANDBOX_ESCAPE_MSG,
+        "type": "invalid_request_error",
+        "code": "sandbox_escape",
+    }
+}
+
 
 router = APIRouter(
     prefix="/v1/cache",
@@ -124,13 +139,24 @@ class ImportRequest(BaseModel):
 
 
 def _resolve_or_400(caller_path: str | None) -> Path:
-    """Wrap ``resolve_cache_dir`` so path violations surface as 403."""
+    """Wrap ``resolve_cache_dir`` so path violations surface as 403.
+
+    H-02: ``InvalidExportPathError`` carries the caller-supplied path AND
+    the resolved sandbox root (which expands to ``/Users/<USERNAME>/.cache
+    /rapid-mlx/cache_exports`` on macOS). Both stay in the server log via
+    ``logger.warning`` — only the sanitized envelope reaches the wire.
+    """
     try:
         return resolve_cache_dir(caller_path)
     except InvalidExportPathError as exc:
         # 403 (not 400) because the request is well-formed JSON — what's
         # rejected is the *authorization* to write/read outside the sandbox.
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        logger.warning(
+            "cache: sandbox-escape rejected (caller_path=%r): %s",
+            caller_path,
+            exc,
+        )
+        raise HTTPException(status_code=403, detail=_SANDBOX_ESCAPE_DETAIL) from exc
 
 
 def _read_manifest_or_http(root: Path):


### PR DESCRIPTION
## Summary

Fixes **H-02** from `0.8TODO.md` ([HIGH severity, REVERT/NEW provenance](https://github.com/raullenchai/Rapid-MLX/blob/main/0.8TODO.md#h-02-revertnew--usersusername-path-leak-in-cacheexport-403-envelope)).

`POST /v1/cache/export -d '{"destination":"/tmp/foo"}'` against an unauthenticated rapid-mlx 0.8.0 returned `403 {"detail":"path '/tmp/foo' resolves outside sandbox /Users/<USERNAME>/.cache/rapid-mlx/cache_exports"}` — leaking the operator's home dir + username to any LAN caller.

PR #756 reverted the auth gate AND sanitized the **501** envelope (`_NOT_IMPLEMENTED_DETAIL`), but missed the **403** sandbox-escape path. This PR closes the same leak shape at the same site:

- New `_SANDBOX_ESCAPE_DETAIL` constant mirrors the 501 envelope shape — `error.type="invalid_request_error"`, `error.code="sandbox_escape"`, no path in `error.message`.
- `_resolve_or_400` now `logger.warning`s the raw `InvalidExportPathError` (including caller_path + resolved sandbox root) for ops debugging, and raises the sanitized envelope on the wire.
- New parametrized `test_cache_export_403_sandbox_escape_does_not_leak_operator_path` probes `/tmp/foo`, `/`, `../../etc/passwd`, `/Users/x`, `/etc/passwd` and asserts `$HOME` / `"/Users/"` / `".cache"` / `"rapid-mlx"` / `"cache_exports"` are all absent from `r.text` — same strictness as the sibling 501-envelope test.
- `tests/test_cache_routes.py::test_export_rejects_path_traversal` updated: was asserting `"not allowed" in resp.json()["detail"]` (which only passed because the raw exception string leaked through); now asserts `error.code == "sandbox_escape"`.

## Test plan

- [x] `pytest tests/test_internal_route_auth.py tests/test_cache_routes.py` — 53 passed (5 new sandbox-escape probes + existing coverage intact).
- [x] Reproduction via FastAPI `TestClient` against `vllm_mlx.routes.cache.router` — before-fix body contained the resolved sandbox path for all 5 probes; after-fix body is the generic envelope with no path component.
- [x] `ruff check` + `ruff format` clean on changed files.
- [x] `pr_validate` adversarial review (codex) — **codex r1 returned "No blocking issues found"** (`codex_review` step passed in 14.5s).

## pr_validate scorecard (PR #762)

| step | status | note |
|---|---|---|
| `fetch` | PASS | 3 files, +88/-3 LOC |
| `test_plan_check` | PASS | (after this edit) |
| `cl_description_quality` | PASS | |
| `codex_review` | PASS | **No blocking issues found — r1 converged** |
| `supply_chain` | PASS | |
| `lint` | PASS | |
| `targeted_tests` | PASS | 297/297 in 14 target files |
| `full_unit` | FAIL | **unrelated, pre-existing** — see below |
| `stress_e2e_bench` | FAIL | **unrelated, diffusion-gemma model quality** — see below |

### Known unrelated failures (do not block merge — same posture as the `full_unit` pytest-asyncio infra glitch the TODO calls out)

1. **`full_unit`** — 2/6798 failures, neither in code I touch:
   - `tests/test_batching_deterministic.py::TestBatchingPerformance::test_batched_faster_than_sequential` — perf flake (`Batched 120.1 tok/s vs sequential 173.8 tok/s = 0.69x` vs `0.70x` catastrophic-regression floor). Machine-load dependent; this PR is a 3-file route-helper sanitize with zero perf surface.
   - `tests/test_route_engine_contract.py::test_no_hasattr_engine_guard[completions.py]` — structural assertion that `vllm_mlx/routes/completions.py:170` should not use `hasattr(engine, 'stream_generate')`. Pre-existing on `main`; I never touch `completions.py`.

2. **`stress_e2e_bench`** — all flakes on the same model, `mlx-community/diffusiongemma-26B-A4B-it-4bit`, in the "Long generation" / "Plain message" / "System prompt" tests where the model emits empty content or only 5 chunks for an essay prompt. The other 3 families pass clean (qwen3.5 8/8, qwen3.6 8/8, gpt-oss-20b-harmony 8/8). This is a diffusion-gemma model-quality issue (empty content) — the failures bubble up as empty `FAIL:` strings in `agent-anthropic_sdk-mlx-community--diffusiongemma-26B-A4B-it-4bit.log`, not as wire errors. Cache-route handler is not exercised by any stress test (no `/v1/cache/*` traffic in `scripts/stress_test.py`).

## Out of scope / not changed

- No version bump (per H-02 fix scope; H-02 is a 0.8.0-window security gap, not a release-cutting feature).
- The protocol-layer `InvalidExportPathError` message itself (`vllm_mlx/cache/protocol.py`) is unchanged — internal callers still get the full diagnostic; only the HTTP wire surface is sanitized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)