### PR TITLE
fix(anthropic): scope F-220 tool-arg validation to the called tool (H-05)

### DIFF
--- a/tests/test_anthropic_tool_validation_scope.py
+++ b/tests/test_anthropic_tool_validation_scope.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-05: ``/v1/messages`` tool-arg validation scope.
+
+PR #742 (F-220) wired ``_validate_tool_call_params`` into ``/v1/messages``
+so a model emitting schema-violating tool arguments would 400 instead of
+silently returning a broken ``tool_use`` block. Sergei (r2) immediately
+hit a regression: with two tools defined and
+``tool_choice={"type":"tool","name":"get_weather"}``, the validator
+fired on the un-pinned tool (``lookup_zip``) and 400-ed the entire
+request — even though the user had pinned ``get_weather`` and the model
+DID emit a correct ``get_weather`` call alongside the bad
+``lookup_zip`` call.
+
+The fix has two parts:
+
+1. ``_validate_tool_call_params`` is refactored to per-call iteration:
+   for each emitted tool_call, find the matching tool spec by name and
+   validate that call's arguments against THAT spec only. Tool specs the
+   model did not call are never consulted. (See
+   ``service/helpers.py:_validate_tool_call_params``.)
+
+2. ``/v1/messages`` (both branches) drops tool_calls that don't match a
+   pinned ``tool_choice={"type":"tool","name":X}`` BEFORE running the
+   validator. This realises the user-visible contract: "you asked for
+   X, the response carries X" — and keeps the validator scoped to the
+   pinned tool even when the model emits extras. (See
+   ``routes/anthropic.py:_filter_tool_calls_by_tool_choice``.)
+
+These tests lock the five cases the H-05 ticket enumerates plus a
+regression for the original Sergei repro (two tools, pinned one,
+model defies the pin and fires both).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.routes.anthropic import router
+
+
+class _StubTokenizer:
+    chat_template = ""
+
+
+class _MultiCallEngine:
+    """Stub engine whose ``chat()`` returns a pre-canned tool_calls payload.
+
+    The Anthropic non-stream branch reads ``output.tool_calls`` first
+    via ``getattr(output, "tool_calls", None)`` and feeds it into
+    ``_parse_tool_calls_with_parser`` as ``structured_tool_calls`` —
+    bypassing the text-based parser entirely. By handing back a list
+    of pre-shaped ``{name, arguments}`` dicts we drive the route
+    through the same path a real harmony / structured-engine surface
+    would.
+    """
+
+    preserve_native_tool_format = False
+    tokenizer = _StubTokenizer()
+
+    def __init__(self, tool_calls_payload: list[dict] | None, text: str = ""):
+        self._tool_calls = tool_calls_payload
+        self._text = text
+
+    async def chat(self, messages, **kwargs):  # noqa: ARG002
+        return SimpleNamespace(
+            text=self._text,
+            raw_text=self._text,
+            tool_calls=self._tool_calls,
+            prompt_tokens=10,
+            completion_tokens=5,
+            finish_reason="tool_calls" if self._tool_calls else "stop",
+            reasoning_text="",
+        )
+
+    async def stream_chat(self, messages, **kwargs):  # noqa: ARG002
+        yield SimpleNamespace(
+            new_text=self._text,
+            prompt_tokens=10,
+            completion_tokens=1,
+            tool_calls=self._tool_calls,
+        )
+
+
+def _make_client(engine: _MultiCallEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+# Two-tool fixture: ``get_weather`` (open string ``location``) +
+# ``lookup_zip`` (strictly-typed ``zip`` with min/maxLength=5). The
+# ``lookup_zip`` schema is the one Sergei's repro tripped over — the
+# model emits an integer for ``zip`` instead of the declared string.
+_GET_WEATHER = {
+    "name": "get_weather",
+    "input_schema": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+    },
+}
+_LOOKUP_ZIP = {
+    "name": "lookup_zip",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "zip": {"type": "string", "minLength": 5, "maxLength": 5},
+        },
+        "required": ["zip"],
+    },
+}
+
+
+def _call(name: str, arguments: dict) -> dict:
+    """Flat ``{name, arguments}`` shape — matches harmony's
+    ``StreamableParser`` output and is what
+    ``_parse_tool_calls_with_parser`` wraps into ``ToolCall``."""
+    return {"name": name, "arguments": json.dumps(arguments)}
+
+
+def _post_messages(
+    client: TestClient, tool_choice=None, *, stream: bool = False
+) -> dict:
+    body = {
+        "model": "test-model",
+        "max_tokens": 32,
+        "stream": stream,
+        "messages": [{"role": "user", "content": "weather + zip lookup"}],
+        "tools": [_GET_WEATHER, _LOOKUP_ZIP],
+    }
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    return body
+
+
+# ---------------------------------------------------------------------------
+# H-05 scope tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_tool_choice_called_tool_args_ok_returns_200():
+    """Two tools declared, model calls ``get_weather`` correctly → 200.
+
+    The validator must not consult ``lookup_zip``'s schema because the
+    model never called it.
+    """
+    engine = _MultiCallEngine([_call("get_weather", {"location": "SF"})])
+    client = _make_client(engine)
+
+    response = client.post("/v1/messages", json=_post_messages(client))
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    tool_uses = [b for b in body["content"] if b["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
+    assert tool_uses[0]["input"] == {"location": "SF"}
+
+
+def test_no_tool_choice_called_tool_args_bad_returns_400_about_called_tool():
+    """Two tools, model calls ``get_weather`` with a schema-violating
+    argument → 400 about ``get_weather`` (NOT ``lookup_zip``).
+
+    Lock down: when the validator does fire, the error message must
+    name the tool the model actually called. Anything mentioning the
+    un-called tool would mean we leaked schema scope.
+    """
+    # ``location`` declared as string; emit an integer to trip the type check.
+    engine = _MultiCallEngine([_call("get_weather", {"location": 42})])
+    client = _make_client(engine)
+
+    response = client.post("/v1/messages", json=_post_messages(client))
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    message = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "get_weather" in message, message
+    assert "lookup_zip" not in message, message
+
+
+def test_no_tool_choice_text_only_no_validation_returns_200():
+    """Two tools declared, model emits text and no tool_use → no
+    validation, 200. Validator must not fire when ``tool_calls`` is
+    empty even if ``request.tools`` is non-empty.
+    """
+    engine = _MultiCallEngine(None, text="No tool needed for this.")
+    client = _make_client(engine)
+
+    response = client.post("/v1/messages", json=_post_messages(client))
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Either no tool_use blocks at all, or — with no tool_calls
+    # surfaced — Anthropic's normal text-content response.
+    assert not any(b["type"] == "tool_use" for b in body["content"])
+
+
+def test_tool_choice_pinned_called_tool_ok_returns_200():
+    """``tool_choice={type:tool,name:get_weather}`` + model calls
+    ``get_weather`` correctly → 200. Sergei's expected happy path.
+    """
+    engine = _MultiCallEngine([_call("get_weather", {"location": "SF"})])
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client, tool_choice={"type": "tool", "name": "get_weather"}
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    tool_uses = [b for b in body["content"] if b["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
+
+
+def test_tool_choice_pinned_called_tool_bad_args_returns_400_about_pinned_tool():
+    """``tool_choice={type:tool,name:get_weather}`` + model calls
+    ``get_weather`` with schema-violating arguments → 400 about
+    ``get_weather``. The pinned tool's own schema is still enforced.
+    """
+    engine = _MultiCallEngine([_call("get_weather", {"location": 42})])
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client, tool_choice={"type": "tool", "name": "get_weather"}
+        ),
+    )
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    message = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "get_weather" in message
+    assert "lookup_zip" not in message
+
+
+# ---------------------------------------------------------------------------
+# Sergei's original repro — model defies tool_choice and fires both tools.
+# Pre-fix this returned 400 about ``lookup_zip.zip``; post-fix the un-pinned
+# call is dropped and the user gets the pinned tool back at 200.
+# ---------------------------------------------------------------------------
+
+
+def test_sergei_repro_pinned_get_weather_model_emits_both_returns_200_with_pinned_only():
+    """The bug headline:
+
+      * ``tool_choice={"type":"tool","name":"get_weather"}``
+      * Model emits ``get_weather`` (good) + ``lookup_zip`` with an
+        integer ``zip`` (bad — string declared).
+
+    Pre-fix: 400 with detail "Tool call 'lookup_zip' parameter 'zip'
+    violates declared schema: Expected string, got int." (validation
+    leaked onto the un-pinned tool).
+
+    Post-fix: 200 with a single ``tool_use`` block for ``get_weather``.
+    The un-pinned ``lookup_zip`` call is dropped server-side and the
+    validator never sees its schema.
+    """
+    engine = _MultiCallEngine(
+        [
+            _call("get_weather", {"location": "SF"}),
+            _call("lookup_zip", {"zip": 941}),
+        ]
+    )
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client, tool_choice={"type": "tool", "name": "get_weather"}
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    tool_uses = [b for b in body["content"] if b["type"] == "tool_use"]
+    # Only the pinned tool survives; the un-pinned ``lookup_zip`` is dropped.
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
+    assert tool_uses[0]["input"] == {"location": "SF"}
+    assert body["stop_reason"] == "tool_use"
+
+
+def test_sergei_repro_streaming_pinned_get_weather_model_emits_both_returns_200_with_pinned_only():
+    """Streaming variant of the Sergei repro.
+
+    Pre-fix: SSE ``event: error`` with the lookup_zip schema-violation
+    message (the F-220 streaming branch routed the validator's
+    HTTPException through the error-event path).
+
+    Post-fix: the un-pinned lookup_zip is dropped before validation,
+    so the stream emits a clean ``tool_use`` content block for
+    ``get_weather`` and terminates with ``stop_reason=tool_use``.
+    """
+    engine = _MultiCallEngine(
+        [
+            _call("get_weather", {"location": "SF"}),
+            _call("lookup_zip", {"zip": 941}),
+        ]
+    )
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client,
+            tool_choice={"type": "tool", "name": "get_weather"},
+            stream=True,
+        ),
+    )
+
+    assert response.status_code == 200
+    raw = response.text
+    # No error event — the un-pinned call was dropped silently.
+    assert "event: error" not in raw, raw
+    # The pinned tool's content block IS emitted.
+    assert '"type": "tool_use"' in raw
+    assert "get_weather" in raw
+    # And the un-pinned tool's name MUST NOT survive into the stream
+    # (otherwise we'd be shipping the dropped call to the client).
+    assert "lookup_zip" not in raw, raw
+    assert '"stop_reason": "tool_use"' in raw
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the refactored ``_validate_tool_call_params`` so the
+# "per-call scope" property is locked at the helper boundary, independent
+# of the route plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _tool_def(name: str, properties: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "parameters": {"type": "object", "properties": properties},
+        },
+    }
+
+
+def test_validator_only_checks_called_tools_schema():
+    """Validator must not 400 on a non-called tool's bad-looking
+    schema. We pass two tools but the model only called the first
+    — the second tool's schema must be ignored entirely.
+    """
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.service.helpers import _validate_tool_call_params
+
+    tools = [
+        _tool_def("get_weather", {"location": {"type": "string"}}),
+        _tool_def(
+            "lookup_zip",
+            {"zip": {"type": "string", "minLength": 5, "maxLength": 5}},
+        ),
+    ]
+    calls = [
+        ToolCall(
+            id="c1",
+            type="function",
+            function=FunctionCall(name="get_weather", arguments='{"location": "SF"}'),
+        )
+    ]
+
+    # No exception — only ``get_weather``'s schema is consulted.
+    _validate_tool_call_params(calls, tools)
+
+
+def test_validator_called_unknown_tool_skips_validation():
+    """If the model calls a tool that isn't in the ``tools`` list at
+    all (parser hallucination), the validator skips it — there is no
+    schema to validate against, and the upstream parser layers own
+    that failure mode.
+    """
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.service.helpers import _validate_tool_call_params
+
+    tools = [_tool_def("get_weather", {"location": {"type": "string"}})]
+    calls = [
+        ToolCall(
+            id="c1",
+            type="function",
+            function=FunctionCall(name="ghost_tool", arguments='{"x": 1}'),
+        )
+    ]
+
+    _validate_tool_call_params(calls, tools)  # no raise
+
+
+def test_validator_multiple_calls_each_validated_against_own_schema():
+    """Two emitted calls to two different tools, both with valid args
+    → no raise. Locks that the per-call loop is using each call's own
+    tool spec rather than mixing schemas between calls.
+    """
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.service.helpers import _validate_tool_call_params
+
+    tools = [
+        _tool_def("get_weather", {"location": {"type": "string"}}),
+        _tool_def(
+            "lookup_zip",
+            {"zip": {"type": "string", "minLength": 5, "maxLength": 5}},
+        ),
+    ]
+    calls = [
+        ToolCall(
+            id="c1",
+            type="function",
+            function=FunctionCall(name="get_weather", arguments='{"location": "SF"}'),
+        ),
+        ToolCall(
+            id="c2",
+            type="function",
+            function=FunctionCall(name="lookup_zip", arguments='{"zip": "94105"}'),
+        ),
+    ]
+
+    _validate_tool_call_params(calls, tools)
+
+
+def test_validator_multiple_calls_bad_one_raises_about_bad_one_only():
+    """Same as above but the second call's args are bad. The 400 must
+    name the bad-call's tool, NOT mix names in the message.
+    """
+    from fastapi import HTTPException
+
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.service.helpers import _validate_tool_call_params
+
+    tools = [
+        _tool_def("get_weather", {"location": {"type": "string"}}),
+        _tool_def(
+            "lookup_zip",
+            {"zip": {"type": "string", "minLength": 5, "maxLength": 5}},
+        ),
+    ]
+    calls = [
+        ToolCall(
+            id="c1",
+            type="function",
+            function=FunctionCall(name="get_weather", arguments='{"location": "SF"}'),
+        ),
+        ToolCall(
+            id="c2",
+            type="function",
+            function=FunctionCall(name="lookup_zip", arguments='{"zip": 941}'),
+        ),
+    ]
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_tool_call_params(calls, tools)
+    assert exc_info.value.status_code == 400
+    assert "lookup_zip" in exc_info.value.detail
+    assert "get_weather" not in exc_info.value.detail

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -107,6 +107,84 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 
+def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
+    """Drop tool_use blocks that don't match a forced ``tool_choice``.
+
+    H-05: Anthropic ``tool_choice={"type":"tool","name":X}`` pins WHICH
+    tool the model must call. The Anthropic adapter has already
+    translated that into the OpenAI form
+    ``{"type":"function","function":{"name":X}}`` on
+    ``openai_request.tool_choice`` by the time we get here. Local
+    inference has no decoder-level constraint, so a small model can
+    happily defy the pin and emit a call to a different tool (the
+    Sergei repro hit qwen3.5-4b on a two-tool prompt where the model
+    fired BOTH the pinned tool AND the un-pinned one). Pre-fix, the
+    downstream JSON-schema validator (F-220) then 400-ed on the
+    un-pinned tool's argument schema — leaking validation across a
+    tool the user never asked for and silently breaking ``tool_choice``.
+
+    Policy: when the choice pins a specific tool, KEEP only the calls
+    to that tool and drop the rest with a warning. This matches the
+    user-visible expectation ("you asked for X, here is X") and keeps
+    the F-220 validator scoped to the pinned tool. ``"auto"`` /
+    ``"required"`` / ``"none"`` / unset shapes pass through unchanged
+    — only the explicit named-tool form has a defined "wrong tool"
+    case to filter.
+
+    Chat.py's named-function path 422s on the same mismatch (see
+    ``routes/chat.py:1665``). The two routes intentionally diverge
+    here: ``/v1/chat/completions`` mirrors OpenAI's strict contract,
+    while ``/v1/messages`` mirrors Anthropic's more forgiving
+    "deliver the pinned tool's call" contract — a 422 on an extra
+    call would surface a confusing error to clients that pinned the
+    very tool the response carries. The validator scope refactor in
+    ``_validate_tool_call_params`` ensures we never validate against
+    the dropped tool's schema even if a future change weakens this
+    filter.
+    """
+    if not tool_calls or not isinstance(tool_choice, dict):
+        return tool_calls or []
+    if tool_choice.get("type") != "function":
+        return tool_calls
+    target = (tool_choice.get("function") or {}).get("name")
+    if not target:
+        return tool_calls
+
+    def _name_of(tc) -> str | None:
+        # Three shapes survive into this point — see
+        # ``routes/chat.py:_tool_call_name`` for the catalogue. Inline
+        # here to avoid a cross-route import dependency from
+        # routes/chat.py into routes/anthropic.py.
+        if isinstance(tc, dict):
+            fn = tc.get("function")
+            if isinstance(fn, dict):
+                return fn.get("name")
+            if fn is not None:
+                return getattr(fn, "name", None)
+            return tc.get("name")
+        fn = getattr(tc, "function", None)
+        if fn is not None:
+            return getattr(fn, "name", None)
+        return getattr(tc, "name", None)
+
+    filtered = []
+    dropped: list[str] = []
+    for tc in tool_calls:
+        if _name_of(tc) == target:
+            filtered.append(tc)
+        else:
+            dropped.append(_name_of(tc) or "<unknown>")
+    if dropped:
+        logger.warning(
+            "tool_choice pinned %r but model also emitted calls to %s; "
+            "dropping the un-pinned calls so the response carries only the "
+            "pinned tool (Anthropic /v1/messages H-05 policy).",
+            target,
+            dropped,
+        )
+    return filtered
+
+
 @router.post(
     "/v1/messages",
     dependencies=[
@@ -319,6 +397,21 @@ async def create_anthropic_message(
         cleaned_text, tool_calls = _parse_tool_calls_with_parser(
             output.text, openai_request, structured_tool_calls=engine_tool_calls
         )
+
+        # H-05: tool_choice={"type":"tool","name":X} pins WHICH tool the
+        # model must call. Local inference can't decoder-enforce that,
+        # so a defiant model can fire an extra call to a different
+        # tool. Pre-fix, the F-220 validator below then 400-ed on the
+        # un-pinned tool's schema — Sergei's repro: pinned
+        # ``get_weather``, model fired ``get_weather`` AND
+        # ``lookup_zip``, 400 came back complaining about ``lookup_zip``.
+        # Drop the un-pinned calls FIRST so the validator only sees the
+        # pinned tool's call(s). See ``_filter_tool_calls_by_tool_choice``
+        # for the policy rationale vs chat.py's 422-on-mismatch.
+        if tool_calls and openai_request.tool_choice:
+            tool_calls = _filter_tool_calls_by_tool_choice(
+                tool_calls, openai_request.tool_choice
+            )
 
         # F-220: enforce the same tool_call JSON-schema validation
         # ``routes/chat.py:1651`` runs on the OpenAI ``/v1/chat/completions``
@@ -1416,6 +1509,15 @@ async def _stream_anthropic_messages(
         openai_request,
         structured_tool_calls=accumulated_structured_tool_calls or None,
     )
+
+    # H-05: same un-pinned-tool drop as the non-streaming branch —
+    # see the non-stream call site for the policy rationale. Run
+    # BEFORE validation so the F-220 enforcer never sees the dropped
+    # tool's schema-violating arguments.
+    if tool_calls and openai_request.tool_choice:
+        tool_calls = _filter_tool_calls_by_tool_choice(
+            tool_calls, openai_request.tool_choice
+        )
 
     # F-220: enforce JSON-schema validation on the model's emitted
     # tool_call arguments. On the streaming branch, headers are already

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1660,11 +1660,43 @@ def _validate_tool_call_params(tool_calls: list, tools: list) -> None:
     parsed args remain warn-only because they indicate a model/parser
     issue rather than a schema violation, and the upstream parser layer
     already surfaces them.
+
+    H-05 scope refactor: the iteration is strictly **per emitted call**.
+    For each ``tc`` we look up the tool spec by its ``function.name``
+    and validate the call's arguments against THAT spec's properties
+    only. Tool specs the model did not call are never consulted — this
+    makes "validate the called tool, not every declared tool" a
+    structural invariant of the function instead of an emergent
+    property of a keyed-schemas dict (which was functionally correct,
+    just less self-evident: a future change to ``_extract_param_schemas``
+    keying could silently re-introduce the cross-tool leak). A model
+    emitting a call to a function not in ``tools`` is treated as
+    schema-unknown (no constraint), mirroring the previous keyed-lookup
+    behaviour.
     """
     from ..api.tool_logits import _extract_param_schemas, validate_param_value
 
     tool_defs = [t.model_dump() if hasattr(t, "model_dump") else t for t in tools]
-    schemas = _extract_param_schemas(tool_defs)
+
+    # Per-tool index: name -> {param_name: schema}. Reuses
+    # ``_extract_param_schemas`` on a single-tool list so the schema
+    # normalisation logic (handles ``parameters`` being null /
+    # non-dict, ``properties`` being non-dict, etc.) stays in exactly
+    # one place. Strip the ``<name>.`` prefix from the keys so the
+    # per-call inner loop only does a ``param_name`` lookup against
+    # the tool we actually matched.
+    tool_by_name: dict[str, dict] = {}
+    for tool in tool_defs:
+        if not isinstance(tool, dict):
+            continue
+        func = tool.get("function", tool)
+        if not isinstance(func, dict):
+            continue
+        name = func.get("name", "")
+        if not name:
+            continue
+        scoped = _extract_param_schemas([tool])
+        tool_by_name[name] = {k.split(".", 1)[1]: v for k, v in scoped.items()}
 
     for tc in tool_calls:
         func = tc.function if hasattr(tc, "function") else tc.get("function", {})
@@ -1674,6 +1706,14 @@ def _validate_tool_call_params(tool_calls: list, tools: list) -> None:
             if hasattr(func, "arguments")
             else func.get("arguments", "{}")
         )
+
+        # Find the called tool's schema. If the model called a tool not
+        # in ``tools`` (parser hallucination), skip — the upstream
+        # tool_choice / parser layers own that case; we have no schema
+        # to validate against here.
+        called_tool_schemas = tool_by_name.get(func_name)
+        if called_tool_schemas is None:
+            continue
 
         try:
             args = json.loads(args_str)
@@ -1687,8 +1727,7 @@ def _validate_tool_call_params(tool_calls: list, tools: list) -> None:
             continue
 
         for param_name, param_value in args.items():
-            schema_key = f"{func_name}.{param_name}"
-            schema = schemas.get(schema_key)
+            schema = called_tool_schemas.get(param_name)
             if not schema:
                 continue
             is_valid, error = validate_param_value(json.dumps(param_value), schema)


### PR DESCRIPTION
## Summary

PR #742 (F-220) wired `_validate_tool_call_params` into `/v1/messages` so the same enum/type/range JSON-schema enforcement that 400s on `/v1/chat/completions` would also fire on the Anthropic surface. Sergei (r2) immediately hit a regression that this PR fixes.

## Sergei's repro (from `0.8TODO.md` H-05)

`POST /v1/messages` with two tools defined (`get_weather`, `lookup_zip`) and `tool_choice={"type":"tool","name":"get_weather"}` → 400 complaining about `lookup_zip.zip` schema.

Live reproduced against `mlx-community/Qwen3.5-4B-MLX-4bit`:

```
Tool call 'lookup_zip' parameter 'zip' violates declared schema:
Expected string, got int. The model produced a schema-violating argument
value; retry with a more constrained prompt or relax the schema.
```

The model fired calls to BOTH `get_weather` (correct) AND `lookup_zip` (with an integer `zip` instead of the declared string). The validator then 400-ed the entire response — even though the user had pinned `get_weather`, the response carried a perfectly valid `get_weather` call, and `lookup_zip` was an un-asked-for extra.

## Root cause — scope leak across two sites

1. **`_validate_tool_call_params` (`service/helpers.py`)** eagerly built a global `"<tool>.<param>" -> schema` dict over **all declared tools** and walked it via per-call key lookups. Functionally correct (the key-prefix isolates per tool) but the "validate only the called tool" property was an emergent invariant of dict keying, not a structural one.

2. **`routes/anthropic.py`** had no `tool_choice` enforcement — `chat.py` 422s on mismatched calls (`routes/chat.py:1665`), but the Anthropic adapter forwarded the full emitted list straight into the validator. An extra wrong-tool call that fails its own schema 400-ed the WHOLE request.

## Fix

- Refactor `_validate_tool_call_params` to a per-call loop: for each emitted `tool_call`, find the matching tool spec by name and validate that call's arguments against THAT spec only. Tool specs the model did not call are never consulted → scope is now structural, not emergent.
- Add `_filter_tool_calls_by_tool_choice` to `routes/anthropic.py` and run it BEFORE the validator on both branches (non-stream and stream). When `tool_choice={"type":"tool","name":X}` is set, drop tool_calls whose name isn't X with a warning. The user-visible contract: "you pinned X, you got X" — chat.py's 422-on-mismatch posture would surface a confusing error to clients that pinned the very tool the response already carries.

## Test plan

- [x] `tests/test_anthropic_tool_validation_scope.py` covers the five H-05 scope cases enumerated in the ticket
- [x] + Sergei's original two-tool defied-pin repro on both non-stream and stream branches
- [x] + 4 direct unit tests on `_validate_tool_call_params` so the structural scope invariant is locked at the helper boundary
- [x] All existing F-141 (`tests/test_tool_param_enforcement.py`, 14 tests) and F-220 (`tests/test_anthropic_tool_param_validation.py`, 3 tests) tests remain green
- [x] Broader sweep — 1346 anthropic/tool-related tests pass
- [x] Live verified on `mlx-community/Qwen3.5-4B-MLX-4bit` (port 8803): the exact two-tool + `tool_choice=get_weather` payload now returns 200 with a single `tool_use` block for `get_weather` across 3 consecutive runs (was deterministically 400 before this PR)
- [x] `ruff check` clean, `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)