### PR TITLE
style: ruff format mllm.py

### DIFF
--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -541,9 +541,7 @@ def process_image_input(image: str | dict) -> str:
     # and the route's broad ``except Exception`` wrap would surface
     # that raw Python error text in the HTTP 400 body.
     if not isinstance(image, str):
-        raise ValueError(
-            f"image_url.url must be a string (got {type(image).__name__})"
-        )
+        raise ValueError(f"image_url.url must be a string (got {type(image).__name__})")
 
     # Check if it's base64 FIRST (before Path.exists() which fails on long strings)
     if is_base64_image(image):


### PR DESCRIPTION
## Summary

`vllm_mlx/models/mllm.py` is format-dirty on `main` — one f-string wrap drift. Every PR opened today fails the CI \`lint\` job on this file. This unblocks #762 (H-02) and all in-flight HIGH/MED fix branches.

Drift came from a pre-existing commit where ruff format wasn't run before push.

## Test plan

- [x] \`ruff format --check vllm_mlx/models/mllm.py\` is clean post-fix.
- [x] No behavioral change — pure whitespace.