### PR TITLE
docs: SDK compat notes — base_url, delta.reasoning_content, usage, interleave (L-01/L-03/L-04/L-06)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -46,6 +46,29 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
+### Anthropic SDK (`/v1/messages`)
+
+The same server also speaks the Anthropic Messages API. **Important:** point
+`base_url` at the server root, **not** `…/v1` — the Anthropic SDK appends
+`/v1/messages` itself, so passing `…/v1` produces `404` on every request
+(L-01 in [SDK Compatibility Notes](../guides/sdk-compat.md#l-01--anthropic-sdk-base_url-must-not-include-v1)).
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="http://localhost:8000",   # no trailing /v1
+    api_key="not-needed",
+)
+
+message = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(message.content[0].text)
+```
+
 ## Option 3: Gradio Web UI
 
 A browser-based chat UI ships in the optional `[chat]` extra:
@@ -138,4 +161,5 @@ rapid-mlx serve devstral-24b-4bit \
 - [Embeddings Guide](../guides/embeddings.md) - Text embeddings
 - [Reasoning Models](../guides/reasoning.md) - Thinking models
 - [Tool Calling](../guides/tool-calling.md) - Function calling
+- [SDK Compatibility Notes](../guides/sdk-compat.md) - Where rapid-mlx deviates from OpenAI/Anthropic specs
 - [Supported Models](../reference/models.md) - Available models

--- a/docs/guides/ai-clients.md
+++ b/docs/guides/ai-clients.md
@@ -42,6 +42,13 @@ Base URL:  http://localhost:8000
 API Key:   not-needed
 ```
 
+> **Heads-up (L-01):** the Anthropic Python SDK silently appends
+> `/v1/messages` to whatever `base_url` you give it. If you pass
+> `http://localhost:8000/v1`, requests go to `/v1/v1/messages` and the
+> server returns `404`. Always pass the bare host (`http://localhost:8000`).
+> Full write-up in
+> [SDK Compatibility Notes — L-01](sdk-compat.md#l-01--anthropic-sdk-base_url-must-not-include-v1).
+
 ## Verified Compatible Clients
 
 These clients have been verified through automated integration tests

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -50,17 +50,34 @@ When reasoning parsing is enabled, the API response includes a `reasoning` field
 
 **Streaming response:**
 
-Chunks are sent separately for reasoning and content. During the reasoning phase, chunks have `reasoning` populated. When the model transitions to the final answer, chunks have `content` populated:
+Chunks are sent separately for reasoning and content. During the reasoning
+phase, chunks have `reasoning_content` (with a `reasoning` alias for
+backward compatibility) populated. When the model transitions to the final
+answer, chunks have `content` populated:
 
 ```json
-{"delta": {"reasoning": "Let me analyze"}}
-{"delta": {"reasoning": " this step by step."}}
-{"delta": {"reasoning": "\nFirst, I need to"}}
+{"delta": {"reasoning_content": "Let me analyze"}}
+{"delta": {"reasoning_content": " this step by step."}}
+{"delta": {"reasoning_content": "\nFirst, I need to"}}
 ...
 {"delta": {"content": "The prime"}}
 {"delta": {"content": " numbers less than 10"}}
 {"delta": {"content": " are: 2, 3, 5, 7."}}
 ```
+
+> **Note (L-03):** `delta.reasoning_content` is not part of the official
+> OpenAI Chat Completions streaming schema. The official `openai-python`
+> SDK tolerates the extra key (`chunk.choices[0].delta.model_extra` or
+> attribute access), but **strict / hand-rolled parsers may reject it**.
+> The naming intentionally mirrors the non-stream
+> `message.reasoning_content` field. See
+> [SDK Compatibility Notes — L-03](sdk-compat.md#l-03--streaming-deltareasoning_content-is-a-non-standard-openai-key).
+>
+> **Note (L-06):** Do not assume `reasoning_content` deltas fully
+> precede `content` deltas — they can interleave for many bytes after
+> the first `content` delta arrives. Buffer both streams separately and
+> join at the end. See
+> [SDK Compatibility Notes — L-06](sdk-compat.md#l-06--streaming-reasoning_content-and-content-deltas-interleave).
 
 ## Using with OpenAI SDK
 
@@ -265,3 +282,4 @@ curl http://localhost:8000/v1/chat/completions \
 - [Supported Models](../reference/models.md) - Models that support reasoning
 - [Server Configuration](server.md) - All server options
 - [CLI Reference](../reference/cli.md) - Command line options
+- [SDK Compatibility Notes](sdk-compat.md) - Non-standard streaming keys, `usage` chunk behavior, and other SDK gotchas

--- a/docs/guides/sdk-compat.md
+++ b/docs/guides/sdk-compat.md
@@ -109,7 +109,7 @@ across streaming and non-streaming makes client code symmetric.
 
 For chunk-by-chunk consumption patterns, see
 [Streaming with Reasoning](reasoning.md#streaming-with-reasoning) — and
-note the interleave caveat below in [L-06](#l-06--streaming-reasoning_content--content-deltas-interleave).
+note the interleave caveat below in [L-06](#l-06--streaming-reasoning_content-and-content-deltas-interleave).
 
 OpenAI reference for what the canonical schema actually contains:
 

--- a/docs/guides/sdk-compat.md
+++ b/docs/guides/sdk-compat.md
@@ -1,0 +1,273 @@
+# SDK Compatibility Notes
+
+This page collects small but important details about how rapid-mlx's
+OpenAI-compatible and Anthropic-compatible surfaces deviate from — or
+sit slightly outside of — the upstream specifications. None of these
+break common SDK usage in practice, but each has tripped at least one
+user during 0.7.x / 0.8.0 dogfooding. If you are debugging a strict-mode
+parser, building your own SDK wrapper, or pinning a vendored client to
+a specific schema, read through these before assuming you have hit a
+bug.
+
+Each entry is tagged with its tracking id (e.g. `L-01`) so you can grep
+back to the upstream issue list.
+
+---
+
+## L-01 — Anthropic SDK `base_url` must NOT include `/v1`
+
+When configuring the official [Anthropic Python SDK][anthropic-sdk]
+(or any port that follows the same URL conventions) against rapid-mlx,
+point it at the server root, **not** the `/v1` prefix.
+
+The SDK appends `/v1/messages` (or `/v1/messages/count_tokens`) to
+whatever `base_url` you give it. If you also supply `/v1`, the request
+goes to `/v1/v1/messages` and the server returns `404`.
+
+**Correct:**
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="http://localhost:8000",   # no trailing /v1
+    api_key="not-needed",
+)
+
+message = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Say hello"}],
+)
+print(message.content[0].text)
+```
+
+**Wrong (returns 404):**
+
+```python
+client = Anthropic(
+    base_url="http://localhost:8000/v1",   # SDK will append /v1/messages
+    api_key="not-needed",
+)
+```
+
+This is a property of the Anthropic SDK itself, not rapid-mlx — the
+same rule applies when pointing the SDK at any custom Messages-API
+backend. The OpenAI SDK has the opposite convention and **does**
+require the `/v1` suffix (it does not append a versioned segment).
+
+See also:
+
+- [Anthropic Python SDK source][anthropic-sdk] (`client.py` builds the URL by joining `base_url` with the route).
+- [Quick Start — OpenAI Server](../getting-started/quickstart.md#option-2-openai-compatible-server)
+- [AI Client Compatibility — Quick Configuration Pattern](ai-clients.md#quick-configuration-pattern)
+
+[anthropic-sdk]: https://github.com/anthropics/anthropic-sdk-python
+
+---
+
+## L-03 — Streaming `delta.reasoning_content` is a non-standard OpenAI key
+
+When you run a reasoning model (Qwen3, DeepSeek-R1, phi-4-mini-reasoning,
+VibeThinker, etc.) with `stream=true`, rapid-mlx emits an extra key in
+each SSE chunk's delta:
+
+```json
+{
+  "choices": [{
+    "index": 0,
+    "delta": {
+      "role": "assistant",
+      "reasoning_content": " step by step"
+    }
+  }]
+}
+```
+
+The official OpenAI Chat Completions streaming schema only defines
+`delta.role`, `delta.content`, `delta.tool_calls`, `delta.refusal`, and
+(very recently) `delta.function_call`. It does **not** define
+`delta.reasoning_content`.
+
+For us this is intentional: it mirrors the non-stream
+`message.reasoning_content` field that rapid-mlx already adds (also
+non-standard, but widely adopted by other reasoning-model providers
+like DeepSeek and Together AI). Keeping the field name identical
+across streaming and non-streaming makes client code symmetric.
+
+**What this means for SDK consumers:**
+
+- The official `openai-python` SDK tolerates unknown delta keys — it
+  exposes them via `chunk.choices[0].delta.model_extra` (or as
+  attribute access on lenient builds). No 4xx, no client crash.
+- **Strict parsers** — hand-rolled validators, code generators, or
+  SDKs that pin to a sealed schema (`additionalProperties: false`) —
+  may raise on this key. You will need to either pre-filter the chunks
+  or loosen the parser.
+- Treat any future "strict OpenAI delta" toggle as opt-in; we will
+  not change the default emission.
+
+For chunk-by-chunk consumption patterns, see
+[Streaming with Reasoning](reasoning.md#streaming-with-reasoning) — and
+note the interleave caveat below in [L-06](#l-06--streaming-reasoning_content--content-deltas-interleave).
+
+OpenAI reference for what the canonical schema actually contains:
+
+- [OpenAI Chat Completions — Streaming Reference][openai-stream-ref]
+
+[openai-stream-ref]: https://platform.openai.com/docs/api-reference/chat-streaming
+
+---
+
+## L-04 — Streaming emits `usage` in the last content chunk without `stream_options.include_usage`
+
+The OpenAI spec says token-usage data is only delivered on the wire
+when the client opts in with:
+
+```json
+{
+  "stream": true,
+  "stream_options": {"include_usage": true}
+}
+```
+
+When `include_usage` is `true`, OpenAI sends a **dedicated trailer
+chunk** after `finish_reason` is set, with an empty `choices` array
+and a populated `usage` object — followed by `data: [DONE]`.
+
+rapid-mlx currently does two things at once:
+
+1. **Always** embeds `usage` directly into the last content chunk
+   (the one that carries `finish_reason`), **regardless** of whether
+   `stream_options.include_usage` was set. This is non-spec.
+2. When `include_usage: true` **is** set, it additionally emits the
+   dedicated trailer chunk after the content chunk. This part **is**
+   spec-aligned.
+
+**What this means for clients:**
+
+- If you are using the official `openai-python` SDK to read
+  `chunk.usage`, you'll see usage data with or without
+  `include_usage`. Reading it works today.
+- For forward compatibility, **explicitly set
+  `stream_options.include_usage=True`** and rely on the dedicated
+  trailer chunk. We may gate the inline-on-last-content emission
+  behind the same opt-in flag in a future minor release to align with
+  the spec; clients that already opt in will be unaffected.
+- Strict parsers that disallow `usage` on a chunk with a non-empty
+  `choices` array will reject our current emission. The same parsers
+  will accept the trailer chunk fine, so opting in is the
+  forward-compatible workaround.
+
+Example of safe consumption (works on rapid-mlx today *and* on a
+spec-strict future):
+
+```python
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hi"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
+
+usage = None
+for chunk in stream:
+    if chunk.usage is not None:
+        usage = chunk.usage  # may be set on last content chunk OR trailer
+    if chunk.choices:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            print(delta.content, end="", flush=True)
+
+print(f"\nprompt_tokens={usage.prompt_tokens} completion_tokens={usage.completion_tokens}")
+```
+
+OpenAI reference:
+
+- [OpenAI Chat Completions — `stream_options.include_usage`][openai-stream-options]
+
+[openai-stream-options]: https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options
+
+---
+
+## L-06 — Streaming `reasoning_content` and `content` deltas interleave
+
+It is tempting to assume the stream is structured in two contiguous
+phases:
+
+> phase A — all `reasoning_content` deltas, then
+> phase B — all `content` deltas
+
+This holds for some prompts and some models, but it is **not
+guaranteed**, and you should not write code that depends on it. In
+production we have seen reasoning-model streams where, after the
+first `content` delta has already arrived, another ~7 KB of
+`reasoning_content` deltas continued to flow before the model went
+back to emitting `content`.
+
+This interleave mirrors the underlying token stream from the model
+(the `<think>` / `</think>` boundary in the raw output is what the
+parser uses to label each delta — and models can re-open thought
+blocks). It is intentional, and we will not flatten it on the server
+side.
+
+**Don't do this:**
+
+```python
+# WRONG — assumes reasoning_content fully precedes content
+seen_content = False
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.content:
+        seen_content = True
+    if getattr(delta, "reasoning_content", None):
+        if seen_content:
+            raise RuntimeError("reasoning after content?!")   # will fire on some models
+```
+
+**Do this instead — buffer both streams separately, join at
+`message_stop` / `[DONE]`:**
+
+```python
+reasoning_buf = []
+content_buf = []
+
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}],
+    stream=True,
+)
+
+for chunk in stream:
+    if not chunk.choices:
+        continue
+    delta = chunk.choices[0].delta
+    rc = getattr(delta, "reasoning_content", None)
+    if rc:
+        reasoning_buf.append(rc)
+    if delta.content:
+        content_buf.append(delta.content)
+
+reasoning = "".join(reasoning_buf)
+answer = "".join(content_buf)
+```
+
+For Anthropic SDK consumers on `/v1/messages`, the equivalent is to
+buffer `thinking` content blocks separately from `text` content blocks
+and join them at the `message_stop` event — the same interleave
+caveat applies.
+
+See also:
+
+- [Reasoning Models — Streaming with Reasoning](reasoning.md#streaming-with-reasoning)
+
+---
+
+## Quick reference
+
+| Tag | Surface | Symptom | Mitigation |
+|-----|---------|---------|------------|
+| **L-01** | Anthropic SDK | `404` on every request | `base_url="http://host:port"` — no `/v1` suffix |
+| **L-03** | OpenAI SDK / streaming | Strict parser rejects `delta.reasoning_content` | Loosen parser, or pre-filter chunks |
+| **L-04** | OpenAI SDK / streaming | `usage` arrives on last content chunk without opt-in | Opt in via `stream_options.include_usage=True` and read from trailer |
+| **L-06** | OpenAI / Anthropic streaming | `reasoning_content` deltas after first `content` delta | Buffer separately, join at end of stream |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ rapid-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 - [MCP & Tool Calling](guides/mcp-tools.md)
 - [Continuous Batching](guides/continuous-batching.md)
 - [AI Client Compatibility](guides/ai-clients.md)
+- [SDK Compatibility Notes](guides/sdk-compat.md)
 
 ### Reference
 - [CLI Commands](reference/cli.md)


### PR DESCRIPTION
## Summary

Pure docs PR — no code changes. Bundles four LOW-severity dogfooding
items from `0.8TODO.md` (L-01, L-03, L-04, L-06) into a new
[`docs/guides/sdk-compat.md`](docs/guides/sdk-compat.md) page, plus
small cross-links from the quickstart, the reasoning guide, the
AI-clients guide, and the docs index.

Each entry is tagged with its `L-XX` number so a future reader can grep
back to the TODO. Every section links out to the upstream spec
(OpenAI streaming reference) or vendor SDK (Anthropic Python SDK) where
applicable.

### What's documented

- **L-01 — Anthropic SDK `base_url` footgun.** The Anthropic SDK appends
  `/v1/messages` itself. Passing `base_url="http://host:port/v1"` yields
  `/v1/v1/messages` and a `404`. The new page makes the rule explicit
  and contrasts it with the OpenAI SDK's opposite convention; the
  quickstart now has a working Anthropic-SDK snippet; the AI-clients
  guide adds an inline heads-up next to its existing
  "Anthropic Base URL" recipe.
- **L-03 — Streaming `delta.reasoning_content` is non-standard OpenAI.**
  Documents that the key is intentional (mirrors the non-stream
  `message.reasoning_content`), is tolerated by `openai-python`, and
  may break strict / hand-rolled parsers. Adds an inline note in the
  reasoning guide's streaming section pointing at the full write-up.
- **L-04 — `usage` in last content chunk without `include_usage` opt-in.**
  Documents the current emission (inline on last content chunk + a
  spec-aligned trailer when opted in) and recommends clients explicitly
  set `stream_options.include_usage=True` for forward compatibility.
  Includes a reader snippet that works on both today's behavior and a
  spec-strict future.
- **L-06 — Streaming `reasoning_content` / `content` deltas interleave.**
  Documents the trap (the assumption that "all reasoning_content
  precedes all content" is false), shows a "don't" vs "do" code
  example, and notes the Anthropic-SDK equivalent (`thinking` vs
  `text` blocks). Adds an inline note in the reasoning guide.

### Files changed

- `docs/guides/sdk-compat.md` (new — main write-up for all four)
- `docs/getting-started/quickstart.md` (Anthropic SDK snippet + Next-Steps link)
- `docs/guides/ai-clients.md` (L-01 heads-up next to existing Anthropic recipe)
- `docs/guides/reasoning.md` (L-03 + L-06 inline notes in streaming section; Related link; fix `reasoning` -> `reasoning_content` in the canonical streaming JSON example)
- `docs/index.md` (new entry in the User Guides list)

### Worth flagging — possible follow-ups (NOT part of this PR)

While writing L-04 I noticed it is probably more actionable than just
documenting:

- **L-04 fix candidate:** the inline-on-last-content `usage` emission
  could be trivially gated on `stream_options.include_usage == True`
  with a one-line change, which would put us on the spec. Worth a
  separate small PR rather than bundling here. The doc is written so
  that future change is non-breaking for clients that already opt in.

L-01, L-03, L-06 are genuinely docs-only by nature (SDK behavior,
intentional schema choice, intentional model-output mirroring).

### TODO entries cited

From `0.8TODO.md`:

- **L-01 [PRE]** — Anthropic SDK `base_url` footgun
- **L-03 [PRE]** — Streaming `delta.reasoning_content` is a non-standard OpenAI key
- **L-04 [PRE]** — Streaming emits `usage` block in last content chunk without `stream_options.include_usage`
- **L-06 [PRE]** — Streaming `reasoning_content` / `content` deltas interleave, don't sequence

## Test plan

- [x] `docs/guides/sdk-compat.md` renders cleanly on GitHub (verified — fetched the rendered page and confirmed all four `L-0X-…` section anchors exist as `user-content-l-01--anthropic-sdk-base_url-must-not-include-v1`, `…l-03--streaming-deltareasoning_content-is-a-non-standard-openai-key`, `…l-04--streaming-emits-usage-in-the-last-content-chunk-without-stream_optionsinclude_usage`, `…l-06--streaming-reasoning_content-and-content-deltas-interleave`).
- [x] All cross-doc anchor links (`sdk-compat.md#l-0X-…` from quickstart, reasoning, ai-clients) match the rendered anchor ids above.
- [x] The Anthropic SDK snippet in the quickstart compiles and matches the existing working pattern in the README (`Anthropic(base_url="http://localhost:8000", api_key="not-needed")` + `client.messages.create(...)`).
- [x] `pr_validate` codex review — passes with no blocking issues (round 1: clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)