### PR TITLE
fix(anthropic): reject unknown tool_choice.type (M-03)

### DIFF
--- a/tests/test_anthropic_tool_choice_validation.py
+++ b/tests/test_anthropic_tool_choice_validation.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+M-03 (#742 follow-up): parse-time validation of ``tool_choice.type`` on
+``/v1/messages``.
+
+Before the fix, ``tool_choice={"type":"banana"}`` HTTP 200'd with plain
+text — the adapter's ``_convert_tool_choice`` fell through to
+``return "auto"`` and the request silently degraded to a no-forcing
+generation. This file pins the Anthropic-side schema contract:
+
+* Unknown ``type`` → 400 at schema parse, before the adapter runs.
+* ``type`` values from the public spec (``auto`` / ``any`` / ``tool``
+  / ``none``) → accepted.
+* ``type=="tool"`` without a non-empty ``name`` → 400.
+
+The validator lives on ``AnthropicRequest`` (api/anthropic_models.py),
+so the assertions here use the model directly (no HTTP fixture
+needed); the route already maps Pydantic ``ValidationError`` → 400
+(routes/anthropic.py L132-L135), so a model-level 422 IS the wire 400.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+
+
+def _base_request(**overrides):
+    """Minimum-valid Anthropic body; callers layer ``tool_choice`` on top."""
+    body = {
+        "model": "qwen3.5-4b-4bit",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Negative path — unknown / malformed tool_choice
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tool_choice_type_rejected():
+    """The M-03 repro: ``tool_choice={"type":"banana"}`` must 400."""
+    with pytest.raises(ValidationError) as exc_info:
+        AnthropicRequest(**_base_request(tool_choice={"type": "banana"}))
+    msg = str(exc_info.value)
+    assert "tool_choice.type" in msg
+    assert "banana" in msg
+
+
+@pytest.mark.parametrize(
+    "bad_type",
+    [
+        "function",  # OpenAI's word, NOT Anthropic's
+        "required",  # OpenAI's word for "any"
+        "TOOL",  # case-sensitive per spec
+        "",  # empty string
+        " auto",  # leading whitespace
+    ],
+)
+def test_other_unknown_tool_choice_types_rejected(bad_type):
+    """Verify the validator is strict-equality on the spec set, not
+    a substring / lowercase match. Catches the class of typos /
+    cross-API confusions (OpenAI-shape values landing on the
+    Anthropic surface) the M-03 gap silently absorbed."""
+    with pytest.raises(ValidationError):
+        AnthropicRequest(**_base_request(tool_choice={"type": bad_type}))
+
+
+def test_non_dict_tool_choice_rejected():
+    """``tool_choice`` MUST be an object per the Anthropic spec.
+    A string (OpenAI shape) should 400 with a clear shape error
+    rather than a downstream AttributeError when the adapter calls
+    ``.get("type")``."""
+    with pytest.raises(ValidationError) as exc_info:
+        AnthropicRequest(**_base_request(tool_choice="auto"))
+    assert "tool_choice" in str(exc_info.value)
+
+
+def test_tool_type_without_name_rejected():
+    """``{"type":"tool"}`` with no ``name`` is malformed per the
+    Anthropic spec. The Anthropic SDK enforces this client-side,
+    but a raw HTTP client could omit ``name`` and the adapter would
+    build ``function.name=""`` — let the route 400 here so the
+    error message points at the actual missing field."""
+    with pytest.raises(ValidationError) as exc_info:
+        AnthropicRequest(**_base_request(tool_choice={"type": "tool"}))
+    msg = str(exc_info.value)
+    assert "name" in msg
+
+
+def test_tool_type_with_empty_name_rejected():
+    """Whitespace-only ``name`` is the same hazard as missing ``name``."""
+    with pytest.raises(ValidationError):
+        AnthropicRequest(**_base_request(tool_choice={"type": "tool", "name": "   "}))
+
+
+def test_tool_type_with_non_string_name_rejected():
+    """A typo'd ``name: 42`` would otherwise coerce-or-skip silently."""
+    with pytest.raises(ValidationError):
+        AnthropicRequest(**_base_request(tool_choice={"type": "tool", "name": 42}))
+
+
+# ---------------------------------------------------------------------------
+# Positive path — every spec-legal shape must still pass parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "auto"},
+        {"type": "any"},
+        {"type": "none"},
+        {"type": "tool", "name": "search"},
+        # Spec-legal: extra keys are tolerated (Anthropic SDK adds e.g.
+        # ``disable_parallel_tool_use``); the validator must not be
+        # strict-keys.
+        {"type": "auto", "disable_parallel_tool_use": True},
+        {"type": "tool", "name": "search", "disable_parallel_tool_use": True},
+        # Empty dict — adapter defaults to "auto" (back-compat with
+        # TestConvertToolChoice.test_missing_type_defaults_to_auto).
+        {},
+        # Omitted entirely — null path.
+        None,
+    ],
+)
+def test_valid_tool_choice_shapes_accepted(tool_choice):
+    req = AnthropicRequest(**_base_request(tool_choice=tool_choice))
+    assert req.tool_choice == tool_choice
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: validation must NOT mutate the field
+# ---------------------------------------------------------------------------
+
+
+def test_validator_does_not_mutate_tool_choice():
+    """The validator is a gate, not a normalizer. The adapter and the
+    downstream chat route both read ``request.tool_choice`` as the
+    raw dict — silently rewriting it here would mask cross-layer
+    contract drift (and a future ``output_config`` may carry a
+    similarly-shaped struct we don't want to fold)."""
+    original = {"type": "tool", "name": "search", "extra": "preserved"}
+    req = AnthropicRequest(**_base_request(tool_choice=original))
+    assert req.tool_choice == original
+    assert req.tool_choice is not original  # Pydantic copies on construction

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -10,7 +10,7 @@ Claude Code to communicate with rapid-mlx.
 import uuid
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # =============================================================================
 # Request Models
@@ -164,6 +164,70 @@ class AnthropicRequest(BaseModel):
     # The adapter consults ``thinking.budget_tokens`` only when
     # ``output_config.effort`` is unset (newer surface wins).
     thinking: dict | None = None
+
+    # M-03 (#742 follow-up): the Anthropic Messages spec only accepts
+    # four ``tool_choice.type`` values — ``auto``, ``any``, ``tool``,
+    # ``none``. Without parse-time validation, unknown types like
+    # ``{"type": "banana"}`` silently fall through ``_convert_tool_choice``'s
+    # final ``return "auto"`` (anthropic_adapter.py L452) and the
+    # request HTTP 200s with plain text instead of the 400 the OpenAI
+    # route surfaces. The validator below mirrors the strict-Literal
+    # discipline ``AnthropicOutputConfig.effort`` already uses (codex
+    # round-6 NIT precedent): fail loud + fast at the schema boundary
+    # so a client typo can't silently degrade tool-forcing semantics.
+    #
+    # Pre-Pydantic-coercion so the ``dict`` type slot doesn't strip
+    # the keys we need to inspect, and so the typed ``tool_choice``
+    # field remains ``dict`` for the downstream adapter (which
+    # already calls ``.get("type")`` + ``.get("name")``). Keeping the
+    # field type unchanged means zero churn on the adapter and on
+    # the downstream chat route.
+    @field_validator("tool_choice", mode="before")
+    @classmethod
+    def _validate_tool_choice(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, dict):
+            raise ValueError(
+                "tool_choice must be an object with a 'type' field "
+                f"(got {type(v).__name__})."
+            )
+        # Match the Anthropic public spec — see
+        # https://docs.anthropic.com/en/api/messages#body-tool-choice.
+        # Includes ``none`` because the adapter (anthropic_adapter.py
+        # L449) already maps it through to OpenAI's ``"none"``; the
+        # existing TestConvertToolChoice.test_none_type test pins this.
+        # An entirely missing ``type`` key (``tool_choice={}``) is
+        # preserved as a no-op by the adapter (defaults to ``"auto"``,
+        # TestConvertToolChoice.test_missing_type_defaults_to_auto);
+        # only EXPLICITLY-set unknown values trip the gate so we
+        # don't tighten beyond M-03's wording.
+        allowed = ("auto", "any", "tool", "none")
+        if "type" not in v:
+            return v
+        choice_type = v["type"]
+        if choice_type not in allowed:
+            raise ValueError(
+                "tool_choice.type must be one of "
+                f"{list(allowed)} (got {choice_type!r}). "
+                "See https://docs.anthropic.com/en/api/messages."
+            )
+        # Anthropic's spec requires ``name`` on the forced-tool form.
+        # The Anthropic SDK enforces this client-side but a raw HTTP
+        # client can omit it; without this guard the adapter builds
+        # an OpenAI ``{"type":"function","function":{"name":""}}`` and
+        # the chat-route ``tool_choice with type='function' requires
+        # function.name`` 400 fires deep into the routing stack, with
+        # a less Anthropic-shape error message. Surface the contract
+        # at parse time so the message points at the right field.
+        if choice_type == "tool":
+            name = v.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(
+                    "tool_choice with type='tool' requires a non-empty "
+                    "string 'name' field."
+                )
+        return v
 
     @model_validator(mode="after")
     def _validate_thinking_budget(self) -> "AnthropicRequest":


### PR DESCRIPTION
## Summary

Closes M-03 from 0.8TODO.md (Sergei r2 repro).

`POST /v1/messages` with `tool_choice={"type":"banana"}` used to HTTP 200 with plain text — the adapter's `_convert_tool_choice` silently fell through to `return "auto"` (anthropic_adapter.py L452) and the request degraded to a free-form generation instead of surfacing a clean 400. Same client typo on the OpenAI surface is supposed to fail at the schema layer; this closes the schema-divergence.

## Fix

Add a `field_validator(mode="before")` on `AnthropicRequest.tool_choice`:

- Reject any `type` value outside the Anthropic public spec set (`auto` / `any` / `tool` / `none`) — strict equality, so `"function"` / `"required"` (OpenAI vocab) / `"TOOL"` / whitespace-prefixed values all 400.
- Reject `type=="tool"` without a non-empty string `name` (Anthropic SDK enforces client-side; raw HTTP clients can omit). Without this guard the adapter builds `function.name=""` and the chat-route 400 fires deep in the stack with a less Anthropic-shape message.
- Tolerate `tool_choice={}` and `tool_choice=None` so the existing `TestConvertToolChoice.test_missing_type_defaults_to_auto` contract holds. Only EXPLICITLY-set unknown `type` values trip the gate.

The route already maps `ValidationError` → 400 (routes/anthropic.py L132-L135), so the model-level validation surfaces as the wire 400 without any route changes.

## Repro

```bash
# Before
curl -X POST :8810/v1/messages -d '{"model":"qwen3.5-4b-4bit","max_tokens":16,"tool_choice":{"type":"banana"},"messages":[{"role":"user","content":"hi"}]}'
# → 200 OK + thinking block

# After
# → 400 {"error":{"message":"...tool_choice.type must be one of ['auto', 'any', 'tool', 'none'] (got 'banana')..."}}
```

Wire captures: `/tmp/m03-before.txt`, `/tmp/m03-after.txt`.

## Test plan

- [x] 19 new tests in `tests/test_anthropic_tool_choice_validation.py` — unknown types rejected (banana, OpenAI vocab confusion, case, whitespace), non-dict rejected, `type=tool` without `name` rejected, all spec-legal shapes accepted, extra keys preserved, validator does not mutate the field.
- [x] All 194 existing `test_anthropic_*` tests still pass.
- [x] `test_chat_route_tool_choice_enforcement.py` — unchanged, still passes.
- [x] Wire repro on running server: banana → 400, `{"type":"auto"}` → 200, `{"type":"tool"}` (no name) → 400.
- [x] `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)