### PR TITLE
fix(metrics): expose PFlash bypass + compressed-tokens counters (M-02)

### DIFF
--- a/tests/test_pflash_metrics.py
+++ b/tests/test_pflash_metrics.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Observability tests for PFlash-bypass counters (M-02 reframe).
+
+Background
+----------
+PFlash compression replaces the prompt with a position-shifted subsequence;
+the resulting ids do not share KV-positional semantics with the original
+prompt, so reusing prefix-cache entries computed for the uncompressed
+prefix would inject the wrong state into later requests. The scheduler is
+correct to bypass both the fetch (``scheduler.py`` ~2891) and the store
+(``scheduler.py`` ~3554) for compressed requests. The catch is that the
+existing ``rapid_mlx_prefix_cache_*`` series sees zero traffic on tiers
+where PFlash mode is forced to ``"always"`` (verified-tier aliases such as
+``qwen3.5-4b-4bit``) — they look frozen at ``hits=0/misses=1`` even though
+PFlash is doing meaningful work.
+
+This test suite locks in two new counters surfaced by
+``Scheduler.get_stats()`` and rendered by ``routes/metrics.py``:
+
+* ``rapid_mlx_pflash_bypass_total`` — N+= for every request that hit the
+  PFlash bypass.
+* ``rapid_mlx_pflash_compressed_tokens_total`` — cumulative
+  ``len(original) - len(compressed)`` across all bypassed requests.
+
+The scheduler counters are exercised by driving the real
+``Scheduler.add_request`` path through the same ``_compressing_config``
+fixture used by ``test_pflash_scheduler.py``. The metrics rendering is
+covered by injecting a fake ``engine.get_stats()`` into the FastAPI test
+client (same pattern as ``test_metrics_route.py``) — keeps the suite at
+unit-test speed and avoids the 2.5 GB Qwen3.5-4B download.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.pflash import PFlashConfig
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+# ---------------------------------------------------------------------------
+# Scheduler-side: counters accumulate on the PFlash bypass path
+# ---------------------------------------------------------------------------
+
+
+class _DummyTokenizer:
+    """Identity tokenizer — scheduler tests don't run the model.
+
+    Mirrors the helper used by ``test_pflash_scheduler.py`` so behaviour
+    stays in lockstep with the existing PFlash test suite.
+    """
+
+    eos_token_id = None
+
+    def encode(self, prompt):
+        if isinstance(prompt, str):
+            return [ord(char) for char in prompt]
+        return list(prompt)
+
+    def decode(self, token_ids):
+        return "".join(chr(token_id) for token_id in token_ids)
+
+
+def _make_scheduler(pflash_config: PFlashConfig) -> Scheduler:
+    return Scheduler(
+        model=object(),
+        tokenizer=_DummyTokenizer(),
+        config=SchedulerConfig(
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            pflash_config=pflash_config,
+        ),
+    )
+
+
+def _compressing_config() -> PFlashConfig:
+    """Forces compression on any prompt of length >= 1.
+
+    Same shape as the helper in ``test_pflash_scheduler.py`` so the
+    scheduler counters are exercised by the same code path that backs the
+    verified-tier ``"always"`` mode in production.
+    """
+    return PFlashConfig(
+        mode="always",
+        threshold=1,
+        keep_ratio=0.25,
+        min_keep_tokens=16,
+        sink_tokens=4,
+        tail_tokens=4,
+        block_size=4,
+    )
+
+
+def test_scheduler_counters_start_at_zero():
+    """Fresh scheduler exposes both counters at zero through ``get_stats``.
+
+    Operators dashboards rely on a stuck-at-zero counter being present
+    rather than absent — a missing series flips Prometheus panels to "no
+    data" and triggers spurious alerts after a deploy.
+    """
+    scheduler = _make_scheduler(PFlashConfig(mode="off"))
+    stats = scheduler.get_stats()
+    assert stats["pflash_bypass_count"] == 0
+    assert stats["pflash_compressed_tokens_dropped"] == 0
+
+
+def test_scheduler_bypass_counter_increments_per_compressed_request():
+    """Three PFlash-bypass requests advance ``bypass_count`` by 3.
+
+    Sanity check that the counter increments once per request that
+    actually engaged compression, not e.g. once per token or once per
+    batch step.
+    """
+    scheduler = _make_scheduler(_compressing_config())
+
+    for index in range(3):
+        request = Request(
+            f"req-bypass-{index}",
+            list(range(128)),
+            SamplingParams(max_tokens=4),
+        )
+        scheduler.add_request(request)
+        assert request.pflash_metadata is not None
+        assert request.pflash_metadata["compressed"] is True
+
+    stats = scheduler.get_stats()
+    assert stats["pflash_bypass_count"] == 3
+
+
+def test_scheduler_compressed_tokens_counter_matches_dropped_tokens():
+    """``compressed_tokens_dropped`` equals sum of (original - kept)."""
+    scheduler = _make_scheduler(_compressing_config())
+
+    dropped_expected = 0
+    for index in range(3):
+        original = list(range(128))
+        request = Request(
+            f"req-tokens-{index}",
+            original,
+            SamplingParams(max_tokens=4),
+        )
+        scheduler.add_request(request)
+        # ``model_prompt_tokens`` is the post-compression length.
+        # Recon: ``logical - kept`` is the operator-facing "dropped".
+        dropped_expected += len(original) - request.model_prompt_tokens
+
+    assert dropped_expected > 0  # sanity — the harness must be compressing
+    stats = scheduler.get_stats()
+    assert stats["pflash_compressed_tokens_dropped"] == dropped_expected
+
+
+def test_scheduler_counters_untouched_when_pflash_skips():
+    """PFlash skip paths (tools, integrity, threshold) leave counters at zero.
+
+    The bypass counter must reflect actual bypass events; a skipped
+    request still goes through ``compress_request_tokens`` but
+    ``metadata["compressed"]`` is False and the prefix cache fetch + store
+    paths run normally — counting it would mislead capacity planning.
+    """
+    scheduler = _make_scheduler(_compressing_config())
+
+    # Has tools → skipped with reason="tools".
+    scheduler.add_request(
+        Request(
+            "req-tools",
+            list(range(128)),
+            SamplingParams(max_tokens=4),
+            has_tools=True,
+        )
+    )
+    # Requires prompt integrity → skipped with reason="protected_prompt".
+    scheduler.add_request(
+        Request(
+            "req-protected",
+            list(range(128)),
+            SamplingParams(max_tokens=4),
+            requires_prompt_integrity=True,
+        )
+    )
+    # Threshold gate in auto mode → skipped with reason="threshold".
+    scheduler_auto = _make_scheduler(
+        PFlashConfig(mode="auto", threshold=10_000, keep_ratio=0.10)
+    )
+    scheduler_auto.add_request(
+        Request(
+            "req-short",
+            list(range(64)),
+            SamplingParams(max_tokens=4),
+        )
+    )
+
+    assert scheduler.get_stats()["pflash_bypass_count"] == 0
+    assert scheduler.get_stats()["pflash_compressed_tokens_dropped"] == 0
+    assert scheduler_auto.get_stats()["pflash_bypass_count"] == 0
+
+
+def test_scheduler_counters_zero_when_pflash_disabled():
+    """``mode="off"`` never triggers ``compress_request_tokens`` at all."""
+    scheduler = _make_scheduler(PFlashConfig(mode="off"))
+    scheduler.add_request(
+        Request("req-off", list(range(128)), SamplingParams(max_tokens=4))
+    )
+    stats = scheduler.get_stats()
+    assert stats["pflash_bypass_count"] == 0
+    assert stats["pflash_compressed_tokens_dropped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Route-side: counters surface in the /metrics Prometheus body
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def metrics_client():
+    """FastAPI TestClient mounting only the metrics router.
+
+    Mirrors ``test_metrics_route.metrics_client`` so the PFlash counters
+    are exercised through the same render path as every other series.
+    """
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+
+    cfg = reset_config()
+    cfg.model_name = "qwen3.5-4b"
+    _reset_accumulator_for_tests()
+
+    app = FastAPI()
+    app.include_router(router)
+    yield SimpleNamespace(client=TestClient(app), cfg=cfg)
+    reset_config()
+    _reset_accumulator_for_tests()
+
+
+def _fake_engine(stats: dict[str, Any]):
+    return SimpleNamespace(get_stats=lambda: stats)
+
+
+_PFLASH_STATS = {
+    "num_waiting": 0,
+    "num_running": 0,
+    "num_requests_processed": 3,
+    "total_prompt_tokens": 15000,
+    "total_completion_tokens": 12,
+    "steps_executed": 6,
+    "uptime_seconds": 9.0,
+    # Three identical 5K-token chats, ratio 0.25 → 1250 kept, 3750 dropped each.
+    "pflash_bypass_count": 3,
+    "pflash_compressed_tokens_dropped": 11_250,
+}
+
+
+def test_metrics_route_renders_pflash_bypass_counter(metrics_client):
+    """``rapid_mlx_pflash_bypass_total`` HELP/TYPE/value all present."""
+    metrics_client.cfg.engine = _fake_engine(_PFLASH_STATS)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "# HELP rapid_mlx_pflash_bypass_total" in body
+    assert "# TYPE rapid_mlx_pflash_bypass_total counter" in body
+    assert "rapid_mlx_pflash_bypass_total 3" in body
+
+
+def test_metrics_route_renders_pflash_compressed_tokens_counter(metrics_client):
+    """``rapid_mlx_pflash_compressed_tokens_total`` HELP/TYPE/value all present."""
+    metrics_client.cfg.engine = _fake_engine(_PFLASH_STATS)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "# HELP rapid_mlx_pflash_compressed_tokens_total" in body
+    assert "# TYPE rapid_mlx_pflash_compressed_tokens_total counter" in body
+    assert "rapid_mlx_pflash_compressed_tokens_total 11250" in body
+
+
+def test_metrics_route_renders_zero_when_pflash_keys_missing(metrics_client):
+    """Engines without PFlash render flat-line 0, not a missing series.
+
+    Older non-hybrid engines won't populate the keys at all. The route
+    must default to zero so dashboards stay stable rather than flipping
+    panels to "no data".
+    """
+    stats_without_pflash = {
+        "num_requests_processed": 1,
+        "total_prompt_tokens": 100,
+        "total_completion_tokens": 5,
+        "num_running": 0,
+        "num_waiting": 0,
+    }
+    metrics_client.cfg.engine = _fake_engine(stats_without_pflash)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_pflash_bypass_total 0" in body
+    assert "rapid_mlx_pflash_compressed_tokens_total 0" in body

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -332,6 +332,43 @@ def _render_prometheus(cfg: Any) -> str:
             monotonic = _cache_counter_accumulator.advance(metric_name, raw)
             lines.extend(_fmt_metric(metric_name, "counter", help_text, monotonic))
 
+    # ---- PFlash observability (M-02 reframe) ---------------------------
+    # When PFlash compression engages, the prompt skips the prefix-cache
+    # fetch + store paths entirely (the compressed sequence is a
+    # positional fiction — see ``compress_request_tokens`` in
+    # scheduler.py). Without these two counters, /metrics looks frozen
+    # at ``hits=0/misses=1`` on verified-tier aliases where PFlash is
+    # always-on, and operators conclude the prefix cache is broken.
+    # ``bypass_total`` counts requests that took the PFlash bypass;
+    # ``compressed_tokens_total`` is cumulative tokens dropped by the
+    # compressor (logical minus kept) and is the headline number for
+    # capacity planning.
+    #
+    # These come straight from the scheduler counters which only ever
+    # increment, so the sticky accumulator is not required.
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_pflash_bypass_total",
+            "counter",
+            (
+                "Requests where PFlash compression engaged and the "
+                "prefix-cache fetch/store was bypassed."
+            ),
+            int(_coerce_number(stats.get("pflash_bypass_count"))),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_pflash_compressed_tokens_total",
+            "counter",
+            (
+                "Cumulative prompt tokens dropped by PFlash compression "
+                "(logical minus kept) across all requests."
+            ),
+            int(_coerce_number(stats.get("pflash_compressed_tokens_dropped"))),
+        )
+    )
+
     # Prometheus requires a trailing newline.
     return "\n".join(lines) + "\n"
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1869,6 +1869,17 @@ class Scheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # PFlash observability (M-02 reframe). When PFlash compresses a
+        # prompt the request bypasses the prefix-cache fetch + store
+        # paths entirely (positional-fiction safety; see comment block
+        # near ``compress_request_tokens``). That bypass is correct but
+        # silences ``rapid_mlx_prefix_cache_*`` on PFlash-always tiers
+        # (e.g. verified-tier aliases), making /metrics look frozen at
+        # ``hits=0/misses=1``. These two counters let operators see
+        # PFlash is doing meaningful work even when the cache series
+        # stays flat. Observability only — bypass semantics unchanged.
+        self.pflash_bypass_count = 0
+        self.pflash_compressed_tokens_dropped = 0
 
         # Memory management: periodic mx.clear_cache() to free Metal command buffers
         # Lower interval = less VRAM spike during generation but slight throughput cost
@@ -2863,6 +2874,17 @@ class Scheduler:
             request.pflash_metadata = metadata
             if metadata["compressed"]:
                 pflash_compressed = True
+                # M-02: count every prompt that took the PFlash bypass
+                # so /metrics surfaces the work that prefix-cache
+                # counters can't (the compressed sequence skips both
+                # fetch and store — see the explanation block above).
+                # ``tokens_dropped`` = logical prompt length minus kept
+                # length, i.e. the saving operators want for capacity
+                # planning.
+                self.pflash_bypass_count += 1
+                self.pflash_compressed_tokens_dropped += max(
+                    0, len(original_tokens) - len(compressed_tokens)
+                )
                 request.original_prompt_token_ids = original_tokens
                 request.prompt_token_ids = compressed_tokens
                 request.model_prompt_tokens = len(compressed_tokens)
@@ -4023,6 +4045,16 @@ class Scheduler:
             "num_requests_processed": self.num_requests_processed,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
+            # M-02: PFlash observability counters. ``bypass_count`` is
+            # the number of requests where PFlash compression engaged
+            # and the prefix-cache fetch/store was skipped;
+            # ``compressed_tokens_dropped`` is the cumulative number of
+            # prompt tokens removed by the compressor (logical minus
+            # kept). Both default to zero on engines without PFlash so
+            # /metrics renders a flat-line 0 instead of an absent
+            # series.
+            "pflash_bypass_count": self.pflash_bypass_count,
+            "pflash_compressed_tokens_dropped": self.pflash_compressed_tokens_dropped,
         }
         # Include Metal memory stats
         try:


### PR DESCRIPTION
## Summary

M-02 (reframed) — observability gap, **not** a cache bug.

On verified-tier aliases (e.g. `mlx-community/Qwen3.5-4B-MLX-4bit`),
`pflash_tier=verified` flips PFlash mode to `"always"`
(`vllm_mlx/pflash.py:123`). Every request then takes the PFlash bypass:

- `vllm_mlx/scheduler.py:2891-2893` — prefix-cache `fetch` skipped.
- `vllm_mlx/scheduler.py:3554` — prefix-cache `store` skipped.

The bypass is **correct** — the compressed-token sequence is a positional
fiction, so reusing KV computed for the uncompressed prefix would inject
position-shifted state into a later request that shares the same sink
prefix (full rationale in the comment block above `compress_request_tokens`).

The downstream effect was that `/metrics` reads as
`rapid_mlx_prefix_cache_hits_total=0/misses_total=1` forever, so operators
conclude the prefix cache is broken when in fact PFlash is doing the work.
Recon report: `0.8TODO.md` M-02 recon section, file:lines all cited there.

This PR is **observability-only** — bypass / fetch / store semantics are
not touched. Two new scheduler counters are surfaced via
`Scheduler.get_stats()` and rendered as Prometheus counters in
`vllm_mlx/routes/metrics.py`:

- `rapid_mlx_pflash_bypass_total` — `++` per request that engaged PFlash compression.
- `rapid_mlx_pflash_compressed_tokens_total` — cumulative `len(original) - len(compressed)`.

Both default to zero on engines without PFlash so dashboards render a
flat-line `0` rather than a missing series (matches the existing Metal-
stats treatment in the same file).

### Touch points (mapped to recon citations)

- `vllm_mlx/scheduler.py:~1872` — counter init (right next to existing
  `num_requests_processed` / `total_prompt_tokens`).
- `vllm_mlx/scheduler.py:~2864` — increment inside the
  `metadata["compressed"]` branch — exactly the recon's location, after
  `compress_request_tokens` runs and before the original tokens are
  swapped out.
- `vllm_mlx/scheduler.py:~4026` — surface both counters in `get_stats()`.
- `vllm_mlx/routes/metrics.py:~334` — render block, analogous to the
  cache_stats block above (the recon called out line 305).

### Reproduction (`mlx-community/Qwen3.5-4B-MLX-4bit`, port 8815, two identical 8818-token chats)

Pre-fix (`/tmp/m02-before.txt`):

```
rapid_mlx_prefix_cache_hits_total 0
rapid_mlx_prefix_cache_misses_total 1
rapid_mlx_prefix_cache_evictions_total 0
rapid_mlx_prefix_cache_tokens_saved_total 0
# (no pflash counters)
```

Server log confirms PFlash engaged: `compressed 8818 -> 2304 tokens ratio=0.261`.

Post-fix (`/tmp/m02-after.txt`):

```
rapid_mlx_prefix_cache_hits_total 0      # unchanged — bypass is correct
rapid_mlx_prefix_cache_misses_total 1
rapid_mlx_prefix_cache_evictions_total 0
rapid_mlx_prefix_cache_tokens_saved_total 0
rapid_mlx_pflash_bypass_total 2          # NEW — one per chat
rapid_mlx_pflash_compressed_tokens_total 13028  # NEW — 2 × (8818 - 2304)
```

## Test plan

- [x] `tests/test_pflash_metrics.py` — 8/8 pass. Scheduler-side tests
      drive the real `Scheduler.add_request` PFlash bypass; route-side
      tests inject a fake `engine.get_stats()` (same pattern as
      `test_metrics_route.py`).
- [x] Three PFlash-bypass requests advance `pflash_bypass_count` by 3.
- [x] `pflash_compressed_tokens_dropped` equals sum of (original - kept).
- [x] PFlash skip paths (tools / integrity / threshold / `mode="off"`)
      leave both counters at zero — never miscount as bypass.
- [x] `rapid_mlx_pflash_bypass_total` / `_compressed_tokens_total` HELP +
      TYPE + value render in `/metrics`.
- [x] Engines without PFlash render flat-line `0` (no missing series).
- [x] Live `/metrics` repro on Qwen3.5-4B-MLX-4bit verified-tier: 2 chats
      → `bypass_total=2`, `compressed_tokens_total=13028`.
- [x] `tests/test_metrics_route.py tests/test_pflash_scheduler.py tests/test_pflash.py tests/test_pflash_engine.py tests/test_pflash_metrics.py` → 66/66 pass.
- [x] `ruff check` + `ruff format --check` clean on the three changed files.
- [x] Full suite (minus pre-existing diffusion/aiohttp/route-audit failures
      that reproduce on `origin/main`): 6866/6873 pass.

## Constraints respected

- Branch: `fix/m02-pflash-observability-counters`.
- No version bump, no global config writes.
- Bypass / fetch / store logic untouched — observability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)