### PR TITLE
fix(api): strip ```json fence in streaming response_format path (H-07)

### DIFF
--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -250,12 +250,17 @@ class TestJsonObjectFenceStripping:
         assert json.loads(joined) == [{"item": 1}, {"item": 2}]
 
     def test_trailing_newline_after_fence_suppressed(self):
-        """``\\n``` `` plus a trailing ``\\n`` — the trailing nl is dropped."""
+        """``\\n``` `` plus a trailing ``\\n`` — the trailing nl is dropped.
+
+        Codex r9 BLOCKING #2: assert byte-exact equality (not just
+        ``json.loads``) so a regression that leaks trailing whitespace
+        after the strip would fail. ``json.loads`` is permissive about
+        trailing whitespace and would silently pass."""
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=True)
         pp.reset()
         joined = _stream_chunks(pp, ['```json\n{"k": 1}\n```\n\n'])
-        assert json.loads(joined) == {"k": 1}
+        assert joined == '{"k": 1}'
 
     def test_long_preamble_past_scan_cap_does_not_leak(self):
         """Codex r3 BLOCKING: when the model emits >4KB of preamble
@@ -306,6 +311,56 @@ class TestJsonObjectFenceStripping:
             ],
         )
         assert joined == '{"answer": 42}'
+
+    def test_fenced_stream_post_root_close_prose_split_then_fence(self):
+        """Codex r9 BLOCKING #1: in fenced mode, bytes between the JSON
+        root close and the closing ``` ``` `` fence must NOT leak.
+
+        Scenario: chunk N ends ``{"k":1}\\nextra`` (root closes, then
+        extra prose still inside the fence body); chunk N+1 carries
+        the closing ``` ``` ``. The walker now LATCHES root-close,
+        holds all post-close bytes as tail, and drops them when the
+        fence terminator confirms. Without the latch ``\\nextra``
+        would land on the wire before the fence is seen and the
+        joined stream would be ``{"k":1}\\nextra`` (invalid JSON for
+        any client running ``json.loads`` on the concatenated
+        deltas)."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"k": 1}',
+                "\nextra",
+                "\n```",
+            ],
+        )
+        # Byte-exact: matches what the non-stream
+        # ``extract_json_from_response`` produces on the equivalent
+        # joined input — the wrapper prose is part of the fenced
+        # body and gets peeled along with the fence.
+        assert joined == '{"k": 1}'
+
+    def test_fenced_stream_post_root_close_prose_then_fence_same_chunk(self):
+        """Codex r9 BLOCKING #1 follow-up: post-root-close prose AND
+        the closing fence both arrive in the SAME later chunk.
+
+        Even though the walker sees the closing fence in this chunk,
+        the cut MUST be at root-close (not at fence_idx) so the
+        intervening prose is dropped. Without the ``cut = root_close_at``
+        rewrite the payload would include ``\\nextra``."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"k": 1}',
+                "\nextra\n```",
+            ],
+        )
+        assert joined == '{"k": 1}'
 
     def test_preamble_example_json_before_json_fence_wins_real_answer(self):
         """Codex r8 BLOCKING #1: re-anchor unconditionally when a

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -277,6 +277,36 @@ class TestJsonObjectFenceStripping:
         assert joined == '{"answer": 42}'
         assert "Let me think" not in joined
 
+    def test_preamble_with_non_json_fenced_example_then_json_fence(self):
+        """Codex r7 BLOCKING: a preamble that contains a NON-JSON
+        fenced code block (e.g. ``` ```python\\nx=1\\n``` ``) before
+        the actual ``` ```json\\n{...}\\n``` `` answer must NOT
+        anchor the scan on the python fence and lose the real JSON.
+
+        ``_find_json_fence_opener`` picks the LAST fence whose
+        payload begins with a JSON delimiter — language-tagged
+        blocks for python/bash/etc. don't match because their
+        payloads start with code, not ``{``/``[``."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # Feed everything as a single chunk so the scan phase has
+        # the complete preamble + fences visible.
+        joined = _stream_chunks(
+            pp,
+            [
+                "Here is the python example:\n"
+                "```python\n"
+                "x = 1\n"
+                "```\n"
+                "And here is the JSON answer:\n"
+                "```json\n"
+                '{"answer": 42}\n'
+                "```",
+            ],
+        )
+        assert joined == '{"answer": 42}'
+
     def test_nested_json_root_close_only_at_outermost(self):
         """Inner ``}``/``]`` must NOT trigger truncation — only the
         closing markdown fence ``` ``` `` does. JSON values with nested

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -100,8 +100,8 @@ class TestJsonObjectFenceStripping:
         joined = _stream_chunks(
             pp, ['```json\n{"name": "iPhone 15", "price": 799.99}\n```']
         )
-        assert json.loads(joined) == {"name": "iPhone 15", "price": 799.99}
-        assert "```" not in joined
+        # Byte-exact: matches what the non-stream path produces.
+        assert joined == '{"name": "iPhone 15", "price": 799.99}'
 
     def test_fence_split_across_token_boundaries(self):
         """Fence emitted token-by-token (realistic SSE granularity).
@@ -132,8 +132,7 @@ class TestJsonObjectFenceStripping:
             "```",
         ]
         joined = _stream_chunks(pp, chunks)
-        assert json.loads(joined) == {"name": "iPhone 15", "price": 799.99}
-        assert "```" not in joined
+        assert joined == '{"name": "iPhone 15", "price": 799.99}'
 
     def test_opening_fence_split_two_chunks(self):
         """Opening ``` ```json `` straddles chunks 1 and 2."""
@@ -148,11 +147,18 @@ class TestJsonObjectFenceStripping:
                 '`json\n{"k": 1}\n```',
             ],
         )
-        assert json.loads(joined) == {"k": 1}
-        assert "```" not in joined
+        assert joined == '{"k": 1}'
 
     def test_closing_fence_split_two_chunks(self):
-        """Closing ``` ``` `` straddles the last two chunks."""
+        """Closing ``` ``` `` straddles the last two chunks.
+
+        Codex r2 BLOCKING: assert byte-identical equality with the
+        non-stream output (bare ``{"k": 1}``). The earlier draft only
+        checked ``json.loads`` + no-backticks, which silently passed
+        even when a trailing ``\\n`` slipped onto the wire because
+        the suffix-hold released the newline before the next chunk's
+        backtick completed the fence.
+        """
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=True)
         pp.reset()
@@ -163,8 +169,45 @@ class TestJsonObjectFenceStripping:
                 "`",
             ],
         )
-        assert json.loads(joined) == {"k": 1}
-        assert "```" not in joined
+        # Exact byte equality with the non-stream shape — no leaked
+        # trailing newline, no leaked backticks.
+        assert joined == '{"k": 1}'
+
+    def test_closing_fence_newline_split_from_backticks(self):
+        """Codex r2 BLOCKING: closing fence split as ``\\n`` then
+        ``` ``` ``. The hold MUST cover the newline, otherwise
+        chunk 1's ``\\n`` lands on the wire before chunk 2's
+        backticks transition the state machine to ``done``."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"k": 1}',
+                "\n",
+                "```",
+            ],
+        )
+        assert joined == '{"k": 1}'
+
+    def test_closing_fence_newline_plus_two_backticks_split(self):
+        """Closing fence split as ``\\n```` `` then ``` ` ``.
+
+        Tests the case codex r2 specifically called out: chunk N ends
+        ``...}\\n``` ``; hold must include the ``\\n`` so the next
+        chunk's third backtick can close cleanly."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"k": 1}\n``',
+                "`\n",
+            ],
+        )
+        assert joined == '{"k": 1}'
 
     def test_bare_json_no_fence_passes_through(self):
         """Model returns bare ``{...}`` — NO fence anywhere.

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -214,6 +214,54 @@ class TestJsonObjectFenceStripping:
         joined = _stream_chunks(pp, ['```json\n{"k": 1}\n```\n\n'])
         assert json.loads(joined) == {"k": 1}
 
+    def test_triple_backticks_inside_json_string_preserved(self):
+        """Codex r1 BLOCKING: a JSON STRING VALUE containing literal
+        triple-backticks must NOT be truncated by the closing-fence
+        scanner. The state machine tracks JSON-string state via a
+        cheap ``"`` toggle, skipping fence detection inside string
+        literals. Mirrors a real-world response_format payload where
+        the model returns a code snippet as a string value."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # The JSON value carries the literal characters ``` ```python ```,
+        # a newline (encoded as ``\\n``), ``x``, another newline, and
+        # ``` ``` ``. All of this is INSIDE the string literal.
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"markdown": "',
+                "```python\\nx\\n```",
+                '"}\n```',
+            ],
+        )
+        # The fence-strip must have peeled the OUTER fence and left
+        # the inner triple-backticks alone.
+        assert json.loads(joined) == {"markdown": "```python\nx\n```"}
+
+    def test_bare_json_string_ends_with_backticks(self):
+        """Codex r1 BLOCKING #2: bare JSON whose final string value
+        legitimately ends with backticks must survive the finalize
+        flush. The earlier draft rstripped trailing backticks in
+        ``_flush_json_fence_tail`` at EOS, corrupting these payloads.
+
+        Stream the closing ``"}`` after the trailing backtick lands
+        in its own delta — exactly the chunk-boundary that fooled
+        the old flush."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '{"text": "look: `',
+                "`",
+                "`",
+                '"}',
+            ],
+        )
+        assert json.loads(joined) == {"text": "look: ```"}
+
 
 class TestJsonSchemaFenceStripping:
     """``response_format={"type":"json_schema",...}`` + stream=True."""
@@ -227,9 +275,7 @@ class TestJsonSchemaFenceStripping:
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=True)
         pp.reset()
-        joined = _stream_chunks(
-            pp, ['```json\n{"answer": 42, "valid": true}\n```']
-        )
+        joined = _stream_chunks(pp, ['```json\n{"answer": 42, "valid": true}\n```'])
         assert json.loads(joined) == {"answer": 42, "valid": True}
 
 
@@ -243,9 +289,7 @@ class TestNoResponseFormatPassThrough:
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=False)
         pp.reset()
-        joined = _stream_chunks(
-            pp, ["Here is some code:\n```python\nx = 1\n```"]
-        )
+        joined = _stream_chunks(pp, ["Here is some code:\n```python\nx = 1\n```"])
         # Fence must survive — no strip happened.
         assert "```python" in joined
         assert "x = 1" in joined

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -312,6 +312,42 @@ class TestJsonObjectFenceStripping:
         )
         assert joined == '{"answer": 42}'
 
+    def test_non_json_block_closer_then_bare_json_no_misclassification(self):
+        """Codex r10 BLOCKING: a preamble that contains a CLOSED
+        non-JSON code block (``` ```python\\nx\\n``` ``) followed by
+        BARE JSON (no fence) must NOT misclassify the python block's
+        CLOSING ``` ``` `` (which is then followed by ``\\n{``) as
+        an opening JSON fence.
+
+        Earlier ``_find_json_fence_opener`` walked every ``` ``` ``
+        and treated it as an opener if the next non-whitespace char
+        was ``{``/``[``. The python block's CLOSING ``` ``` `` met
+        that test (it sat before the bare ``{`` of the answer) and
+        was anchored on — which caused the JSON to be released
+        truncated. Fix: pair each fence with its matching closer and
+        skip past the closer before scanning the next fence."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # Note: NO ``` ```json `` wrapper anywhere — just an
+        # illustrative python block then bare JSON.
+        joined = _stream_chunks(
+            pp,
+            [
+                "Here is the python example:\n"
+                "```python\n"
+                "x = 1\n"
+                "```\n"
+                'And the answer: {"k": 1}'
+            ],
+        )
+        # Bare-JSON contract: only the JSON object is emitted (the
+        # existing ``_process_standard`` preamble strip already
+        # peels everything before the first ``{`` — the codex r10
+        # fix ensures the python closer is not anchored on, so the
+        # JSON survives intact).
+        assert joined == '{"k": 1}'
+
     def test_fenced_stream_post_root_close_prose_split_then_fence(self):
         """Codex r9 BLOCKING #1: in fenced mode, bytes between the JSON
         root close and the closing ``` ``` `` fence must NOT leak.

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -277,45 +277,10 @@ class TestJsonObjectFenceStripping:
         assert joined == '{"answer": 42}'
         assert "Let me think" not in joined
 
-    def test_trailing_prose_after_json_root_suppressed(self):
-        """Codex r5 BLOCKING: a fenced model output is not the only
-        wrapper shape — some models emit valid JSON followed by
-        explanatory prose with or without a triple-backtick code
-        block. ``response_format=json_object`` promises the client
-        ONLY the JSON object; the streaming state machine must
-        truncate at the closing brace of the JSON root, matching
-        the non-stream ``rfind('{') ... endswith('}')`` peel."""
-        cfg = _make_cfg()
-        pp = StreamingPostProcessor(cfg, json_mode=True)
-        pp.reset()
-        joined = _stream_chunks(
-            pp,
-            [
-                '{"k": 1}\nHere is some code:\n```python\nx = 1\n```',
-            ],
-        )
-        # Only the JSON root — no trailing prose, no fenced code.
-        assert joined == '{"k": 1}'
-
-    def test_trailing_prose_no_fence_after_json_root(self):
-        """Even without any closing fence at all, prose after the
-        JSON root must be suppressed."""
-        cfg = _make_cfg()
-        pp = StreamingPostProcessor(cfg, json_mode=True)
-        pp.reset()
-        joined = _stream_chunks(
-            pp,
-            [
-                '{"k": 1}',
-                "\n\nThat's the answer!",
-            ],
-        )
-        assert joined == '{"k": 1}'
-
     def test_nested_json_root_close_only_at_outermost(self):
-        """Bracket-depth tracking must NOT trigger on inner
-        ``}``/``]`` — only when depth returns to 0 (outermost root
-        closes)."""
+        """Inner ``}``/``]`` must NOT trigger truncation — only the
+        closing markdown fence ``` ``` `` does. JSON values with nested
+        objects and arrays must survive end-to-end."""
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=True)
         pp.reset()
@@ -330,6 +295,34 @@ class TestJsonObjectFenceStripping:
             "more": True,
         }
         assert joined == '{"outer": {"inner": [1, 2, 3]}, "more": true}'
+
+    def test_no_fence_no_truncation_matches_non_stream(self):
+        """Codex r6 BLOCKING: when the model emits JSON followed by
+        trailing prose (no fence wrapper at all), the streaming path
+        must NOT truncate at the root close — the non-stream
+        ``extract_json_from_response`` path also returns such inputs
+        UNCHANGED (its peel paths only fire on already-bare-JSON or
+        fenced inputs). The streaming path mirrors that pass-through
+        so client output is byte-equivalent."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '{"k": 1}',
+                "\n\nAnd more content the model emitted.",
+            ],
+        )
+        # Pass-through: matches what non-stream returns on the same
+        # text. Clients who want strict JSON-only must still call
+        # json.loads; this matches non-stream behaviour bit-for-bit.
+        from vllm_mlx.api.utils import extract_json_from_response
+
+        non_stream = extract_json_from_response(
+            '{"k": 1}\n\nAnd more content the model emitted.'
+        )
+        assert joined == non_stream
 
     def test_triple_backticks_inside_json_string_preserved(self):
         """Codex r1 BLOCKING: a JSON STRING VALUE containing literal

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -257,6 +257,26 @@ class TestJsonObjectFenceStripping:
         joined = _stream_chunks(pp, ['```json\n{"k": 1}\n```\n\n'])
         assert json.loads(joined) == {"k": 1}
 
+    def test_long_preamble_past_scan_cap_does_not_leak(self):
+        """Codex r3 BLOCKING: when the model emits >4KB of preamble
+        before the opening fence, the scan-cap fallback must NOT
+        release the preamble onto the wire. The contract for
+        json_mode is "suppress everything before the first
+        ``{``/``[``" regardless of preamble length — the cap is
+        about MEMORY (don't hold 100MB of history), not about
+        contract relaxation."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # 8KB of preamble (twice the scan cap), then the canonical
+        # fenced JSON.
+        preamble = "Let me think about this carefully. " * 250  # ~8.75 KB
+        chunks = [preamble, '```json\n{"answer": 42}\n```']
+        joined = _stream_chunks(pp, chunks)
+        # No preamble bytes, no fence — just the bare JSON.
+        assert joined == '{"answer": 42}'
+        assert "Let me think" not in joined
+
     def test_triple_backticks_inside_json_string_preserved(self):
         """Codex r1 BLOCKING: a JSON STRING VALUE containing literal
         triple-backticks must NOT be truncated by the closing-fence

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -277,6 +277,60 @@ class TestJsonObjectFenceStripping:
         assert joined == '{"answer": 42}'
         assert "Let me think" not in joined
 
+    def test_trailing_prose_after_json_root_suppressed(self):
+        """Codex r5 BLOCKING: a fenced model output is not the only
+        wrapper shape — some models emit valid JSON followed by
+        explanatory prose with or without a triple-backtick code
+        block. ``response_format=json_object`` promises the client
+        ONLY the JSON object; the streaming state machine must
+        truncate at the closing brace of the JSON root, matching
+        the non-stream ``rfind('{') ... endswith('}')`` peel."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '{"k": 1}\nHere is some code:\n```python\nx = 1\n```',
+            ],
+        )
+        # Only the JSON root — no trailing prose, no fenced code.
+        assert joined == '{"k": 1}'
+
+    def test_trailing_prose_no_fence_after_json_root(self):
+        """Even without any closing fence at all, prose after the
+        JSON root must be suppressed."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '{"k": 1}',
+                "\n\nThat's the answer!",
+            ],
+        )
+        assert joined == '{"k": 1}'
+
+    def test_nested_json_root_close_only_at_outermost(self):
+        """Bracket-depth tracking must NOT trigger on inner
+        ``}``/``]`` — only when depth returns to 0 (outermost root
+        closes)."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"outer": {"inner": [1, 2, 3]}, "more": true}\n```',
+            ],
+        )
+        assert json.loads(joined) == {
+            "outer": {"inner": [1, 2, 3]},
+            "more": True,
+        }
+        assert joined == '{"outer": {"inner": [1, 2, 3]}, "more": true}'
+
     def test_triple_backticks_inside_json_string_preserved(self):
         """Codex r1 BLOCKING: a JSON STRING VALUE containing literal
         triple-backticks must NOT be truncated by the closing-fence
@@ -337,24 +391,40 @@ class TestStreamEventMetadataPreservation:
 
     def test_metadata_preserved_on_content_event(self):
         """A content event with metadata must keep that metadata
-        after the fence-strip filter runs."""
+        after the fence-strip filter runs.
+
+        Codex r5 NIT: drive the state machine into ``"inside"``
+        through the public ``process_chunk`` surface so this test
+        exercises an already-in-stream rewrite (not the trivial
+        ``"scan"``-then-find-``{`` path which doesn't touch the
+        rewrite code path most of the time)."""
         from vllm_mlx.domain.events import StreamEvent
 
         cfg = _make_cfg()
         pp = StreamingPostProcessor(cfg, json_mode=True)
         pp.reset()
-        # Directly invoke the filter so we can inject metadata.
-        # First seed the state machine into "inside" so the content
-        # passes through.
+        # Drive state machine into ``"inside"`` and consume the
+        # opening ``{`` via the public process_chunk surface — this
+        # ensures we're testing the in-stream rewrite path that
+        # production deltas hit.
+        pp.process_chunk(_make_output('{"first": 0, '))
+        assert pp._json_fence_state == "inside"
+        # Now inject a synthesised content event WITH metadata and
+        # verify the filter pass preserves it. The content does NOT
+        # close the JSON root, so the filter walks the bytes through
+        # ``_guard_closing_fence`` and rewrites with ``dataclasses.replace``.
         ev = StreamEvent(
             type="content",
-            content='{"k": 1}',
+            content='"second": "value"',
             metadata={"prompt_tokens": 7, "completion_tokens": 3},
             tool_calls_detected=False,
         )
         out = pp._filter_events_for_json_fence([ev])
         assert len(out) == 1
         assert out[0].type == "content"
+        # Content survived (we're inside JSON, no fence here).
+        assert out[0].content == '"second": "value"'
+        # Metadata is the load-bearing assertion.
         assert out[0].metadata == {"prompt_tokens": 7, "completion_tokens": 3}
 
     def test_finish_event_fields_preserved(self):

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-07: streaming + json_mode must NOT leak ```json ... ``` markdown fence.
+
+The non-streaming chat response builder peels a markdown ``` ```json ```
+wrapper via ``extract_json_from_response`` (vllm_mlx/api/utils.py) AFTER
+assembling the full text. The streaming path concatenated raw model
+tokens WITHOUT the same scrub — joined SSE deltas decoded as
+``` ```json\\n{...}\\n``` ``` and ``json.loads`` failed for any SDK
+consumer assembling ``delta.content`` into a string.
+
+Marisol (0.8TODO r2 H-07) caught the regression: same prompt + same
+model + ``response_format={"type":"json_object"}`` + ``stream=True``
+produced fenced output while the non-stream path produced bare JSON.
+
+This test file pins the fence-strip state machine in
+``StreamingPostProcessor`` (see ``_apply_json_fence_strip``). Design
+rationale (state machine in delta builder, not post-join regex):
+
+  * Fence tokens are split across delta chunks. Tokenizers fragment
+    ``\\n``` `` arbitrarily ("``", "`json", "\\n"); a post-emission
+    regex would not help because we need to SUPPRESS bytes BEFORE
+    they reach the wire.
+  * The bare-JSON path (model returns ``{...}`` with no fence at all)
+    must pass through unchanged — we can't unconditionally buffer.
+  * Non-stream regression: the non-stream
+    ``extract_json_from_response`` path must keep peeling the fence
+    via its existing logic. We verify it still does.
+
+The tests below exercise the postprocessor directly with mocked
+``GenerationOutput`` chunks — the same surface area the live SSE route
+goes through (``stream_chat_completion`` -> ``processor.process_chunk``
+-> ``_filter_events_for_json_fence``).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from vllm_mlx.api.utils import extract_json_from_response
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+
+def _make_cfg(**overrides):
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = False
+    cfg.tool_call_parser = None
+    cfg.tool_parser_instance = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _make_output(
+    text="", finished=False, channel=None, finish_reason=None, tool_calls=None
+):
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = channel
+    out.finish_reason = finish_reason or ("stop" if finished else None)
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = tool_calls
+    return out
+
+
+def _stream_chunks(pp: StreamingPostProcessor, chunks: list[str]) -> str:
+    """Feed chunks one-by-one to the postprocessor, joining emitted content.
+
+    Mirrors what the SSE route does: every ``type="content"`` event
+    contributes to the joined ``delta.content`` string a client would
+    reassemble. Tool-call / reasoning / finish events are ignored for
+    fence-strip assertions — H-07 is strictly about the content channel.
+    """
+    joined = ""
+    for chunk in chunks:
+        for ev in pp.process_chunk(_make_output(chunk)):
+            if ev.type in ("content", "finish") and ev.content:
+                joined += ev.content
+    for ev in pp.finalize():
+        if ev.type == "content" and ev.content:
+            joined += ev.content
+    return joined
+
+
+class TestJsonObjectFenceStripping:
+    """``response_format={"type":"json_object"}`` + stream=True."""
+
+    def test_full_fence_single_chunk(self):
+        """Whole ``` ```json\\n{...}\\n``` `` arrives in one delta."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp, ['```json\n{"name": "iPhone 15", "price": 799.99}\n```']
+        )
+        assert json.loads(joined) == {"name": "iPhone 15", "price": 799.99}
+        assert "```" not in joined
+
+    def test_fence_split_across_token_boundaries(self):
+        """Fence emitted token-by-token (realistic SSE granularity).
+
+        The state machine MUST handle ``\\n```\\n`` being fragmented
+        across deltas — the tokenizer routinely splits the closing
+        fence into ``\\n``, ``` `` ``, ``json`` style pieces.
+        """
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # Realistic token-level fragmentation captured against
+        # Qwen3-0.6B-8bit during the H-07 repro.
+        chunks = [
+            "```",
+            "json",
+            "\n",
+            "{",
+            '"name"',
+            ": ",
+            '"iPhone 15"',
+            ", ",
+            '"price"',
+            ": ",
+            "799.99",
+            "}",
+            "\n",
+            "```",
+        ]
+        joined = _stream_chunks(pp, chunks)
+        assert json.loads(joined) == {"name": "iPhone 15", "price": 799.99}
+        assert "```" not in joined
+
+    def test_opening_fence_split_two_chunks(self):
+        """Opening ``` ```json `` straddles chunks 1 and 2."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # Backtick run lands in chunk 1; ``json\n`` + body land in chunk 2.
+        joined = _stream_chunks(
+            pp,
+            [
+                "``",
+                '`json\n{"k": 1}\n```',
+            ],
+        )
+        assert json.loads(joined) == {"k": 1}
+        assert "```" not in joined
+
+    def test_closing_fence_split_two_chunks(self):
+        """Closing ``` ``` `` straddles the last two chunks."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '```json\n{"k": 1}\n``',
+                "`",
+            ],
+        )
+        assert json.loads(joined) == {"k": 1}
+        assert "```" not in joined
+
+    def test_bare_json_no_fence_passes_through(self):
+        """Model returns bare ``{...}`` — NO fence anywhere.
+
+        The state machine must NOT introduce hold-back delays or
+        partial deltas on this path; bytes flow through end-to-end.
+        """
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                '{"name": ',
+                '"iPhone 15", ',
+                '"price": 799.99}',
+            ],
+        )
+        assert json.loads(joined) == {"name": "iPhone 15", "price": 799.99}
+        # No fence, no leak.
+        assert "```" not in joined
+
+    def test_fence_preceded_by_whitespace(self):
+        """Model emits whitespace before the opening fence."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(pp, ['\n\n```json\n{"k": 1}\n```\n'])
+        assert json.loads(joined) == {"k": 1}
+
+    def test_array_payload(self):
+        """JSON arrays must work too — the spec allows ``[...]`` root."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            ['```json\n[{"item": 1}, {"item": 2}]\n```'],
+        )
+        assert json.loads(joined) == [{"item": 1}, {"item": 2}]
+
+    def test_trailing_newline_after_fence_suppressed(self):
+        """``\\n``` `` plus a trailing ``\\n`` — the trailing nl is dropped."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(pp, ['```json\n{"k": 1}\n```\n\n'])
+        assert json.loads(joined) == {"k": 1}
+
+
+class TestJsonSchemaFenceStripping:
+    """``response_format={"type":"json_schema",...}`` + stream=True."""
+
+    def test_json_schema_fence_stripped(self):
+        """The strip applies to ``json_schema`` requests, not just
+        ``json_object`` — the route layer passes the same
+        ``json_mode=True`` flag for both ``json_object`` and
+        ``json_schema`` (see ``stream_chat_completion`` in
+        vllm_mlx/routes/chat.py around the ``json_mode=`` kwarg)."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp, ['```json\n{"answer": 42, "valid": true}\n```']
+        )
+        assert json.loads(joined) == {"answer": 42, "valid": True}
+
+
+class TestNoResponseFormatPassThrough:
+    """Streaming WITHOUT ``response_format`` MUST pass any ``` through."""
+
+    def test_fence_in_content_passes_through_when_json_mode_off(self):
+        """When the client did NOT request structured output, a model
+        that happens to emit ``` should reach the wire — it's plain
+        markdown content. The strip is gated on ``json_mode``."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=False)
+        pp.reset()
+        joined = _stream_chunks(
+            pp, ["Here is some code:\n```python\nx = 1\n```"]
+        )
+        # Fence must survive — no strip happened.
+        assert "```python" in joined
+        assert "x = 1" in joined
+
+    def test_fence_in_content_passes_through_no_json_mode_split(self):
+        """Same as above, but with the fence split across chunks."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=False)
+        pp.reset()
+        joined = _stream_chunks(pp, ["``", "`json\n{}\n``", "`"])
+        assert joined.count("```") == 2
+
+
+class TestNonStreamRegression:
+    """Non-stream fence-strip MUST keep working — H-07 is stream-only.
+
+    The non-stream chat response builder calls
+    ``extract_json_from_response`` to peel ``` ```json\\n{...}\\n``` ```.
+    These tests pin that the helper still peels the wrapper after the
+    streaming-side state machine landed.
+    """
+
+    def test_non_stream_helper_strips_fence(self):
+        wrapped = '```json\n{"name": "iPhone 15", "price": 799.99}\n```'
+        peeled = extract_json_from_response(wrapped)
+        assert json.loads(peeled) == {"name": "iPhone 15", "price": 799.99}
+
+    def test_non_stream_helper_passes_bare_json(self):
+        bare = '{"k": 1}'
+        peeled = extract_json_from_response(bare)
+        assert peeled == bare
+        assert json.loads(peeled) == {"k": 1}
+
+    def test_non_stream_helper_strips_bare_fence_no_json_lang_tag(self):
+        wrapped = '```\n{"k": 1}\n```'
+        peeled = extract_json_from_response(wrapped)
+        assert json.loads(peeled) == {"k": 1}
+
+
+class TestReasoningParserPath:
+    """When a reasoning parser is active, the fence-strip still applies.
+
+    The existing ``_json_preamble_buffer`` path is SKIPPED when a
+    reasoning parser is wired (vllm_mlx/service/postprocessor.py:
+    ``_process_standard`` gate ``not self.reasoning_parser``), so a
+    reasoning model emitting ``` ```json ``` after ``</think>`` would
+    previously leak the fence into ``delta.content``. The new state
+    machine in ``_filter_events_for_json_fence`` runs in the OUTER
+    ``process_chunk`` dispatcher and therefore covers the
+    reasoning-parser path too.
+    """
+
+    def test_reasoning_parser_path_strips_fence(self):
+        """Mock reasoning parser that routes everything to content
+        AFTER it sees ``</think>`` — same as the production
+        ``Qwen3ReasoningParser`` etc."""
+        parser = MagicMock()
+        emitted_content = []
+
+        def _fake_extract(prev, curr, delta):
+            # Strip ``<think>...</think>`` if present, route the rest
+            # to content. Mirrors the behaviour of the live reasoning
+            # parsers' streaming path.
+            msg = MagicMock()
+            msg.content = delta
+            msg.reasoning = None
+            emitted_content.append(delta)
+            return msg
+
+        parser.extract_reasoning_streaming.side_effect = _fake_extract
+
+        cfg = _make_cfg(reasoning_parser=parser)
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+
+        joined = _stream_chunks(pp, ['```json\n{"k": 1}\n```'])
+        assert json.loads(joined) == {"k": 1}
+        assert "```" not in joined

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -326,6 +326,59 @@ class TestJsonObjectFenceStripping:
         assert json.loads(joined) == {"text": "look: ```"}
 
 
+class TestStreamEventMetadataPreservation:
+    """Codex r4 BLOCKING #1: filter must preserve ALL StreamEvent fields.
+
+    The filter rewrites content but uses ``dataclasses.replace`` so
+    fields like ``metadata``, ``finish_reason``, ``tool_calls_detected``
+    survive. The earlier draft constructed a minimal
+    ``StreamEvent(type=..., content=...)`` and dropped everything else.
+    """
+
+    def test_metadata_preserved_on_content_event(self):
+        """A content event with metadata must keep that metadata
+        after the fence-strip filter runs."""
+        from vllm_mlx.domain.events import StreamEvent
+
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        # Directly invoke the filter so we can inject metadata.
+        # First seed the state machine into "inside" so the content
+        # passes through.
+        ev = StreamEvent(
+            type="content",
+            content='{"k": 1}',
+            metadata={"prompt_tokens": 7, "completion_tokens": 3},
+            tool_calls_detected=False,
+        )
+        out = pp._filter_events_for_json_fence([ev])
+        assert len(out) == 1
+        assert out[0].type == "content"
+        assert out[0].metadata == {"prompt_tokens": 7, "completion_tokens": 3}
+
+    def test_finish_event_fields_preserved(self):
+        """A finish event carrying finish_reason + tool_calls_detected
+        must keep them after the filter rewrites content."""
+        from vllm_mlx.domain.events import StreamEvent
+
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        ev = StreamEvent(
+            type="finish",
+            content='{"k": 1}',
+            finish_reason="stop",
+            tool_calls_detected=False,
+            metadata={"completion_tokens": 5},
+        )
+        out = pp._filter_events_for_json_fence([ev])
+        assert len(out) == 1
+        assert out[0].type == "finish"
+        assert out[0].finish_reason == "stop"
+        assert out[0].metadata == {"completion_tokens": 5}
+
+
 class TestJsonSchemaFenceStripping:
     """``response_format={"type":"json_schema",...}`` + stream=True."""
 

--- a/tests/test_response_format_streaming_fence_strip.py
+++ b/tests/test_response_format_streaming_fence_strip.py
@@ -307,6 +307,58 @@ class TestJsonObjectFenceStripping:
         )
         assert joined == '{"answer": 42}'
 
+    def test_preamble_example_json_before_json_fence_wins_real_answer(self):
+        """Codex r8 BLOCKING #1: re-anchor unconditionally when a
+        JSON-bearing fence opener is present in the scan buffer.
+
+        Earlier the scan path required ``fence_pos < json_start``
+        before re-anchoring — so a preamble that included an example
+        JSON BEFORE the fence (``Example: {"k":1}\\n```json\\n{...}``)
+        anchored on the example and lost the real answer."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        joined = _stream_chunks(
+            pp,
+            [
+                'Example shape: {"k": 1}\n'
+                "Now the real answer:\n"
+                "```json\n"
+                '{"answer": 42}\n'
+                "```",
+            ],
+        )
+        assert joined == '{"answer": 42}'
+
+    def test_bare_json_followed_by_markdown_fence_passes_through(self):
+        """Codex r8 BLOCKING #2: a bare, unfenced json-mode stream
+        that legitimately continues with markdown / code-fence text
+        AFTER the JSON root must NOT be truncated at the first ``` ``` ``.
+
+        The non-stream ``extract_json_from_response`` leaves unfenced
+        text alone; streaming has to match. The fix records whether an
+        opening fence was actually consumed in the scan phase and only
+        suppresses a closing markdown fence in that mode.
+
+        We assert the post-JSON markdown ``` ``` `` block survives in
+        the streamed output (the contract is "no truncation at a
+        non-fence-paired ``` ``` ``"). The exact non-stream output is
+        produced after a ``text.strip()``, so byte-equality isn't the
+        right oracle — we want the structural guarantee."""
+        cfg = _make_cfg()
+        pp = StreamingPostProcessor(cfg, json_mode=True)
+        pp.reset()
+        bare = '{"k": 1}\n\nHere\'s how I derived it:\n```python\nx = 1\n```\n'
+        joined = _stream_chunks(pp, [bare])
+
+        # JSON intact at the head.
+        assert joined.startswith('{"k": 1}')
+        # Post-JSON markdown survives — both the opener and the
+        # closer of the python fence are present.
+        assert "```python" in joined
+        assert "x = 1" in joined
+        assert joined.rstrip().endswith("```")
+
     def test_nested_json_root_close_only_at_outermost(self):
         """Inner ``}``/``]`` must NOT trigger truncation — only the
         closing markdown fence ``` ``` `` does. JSON values with nested

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -388,6 +388,14 @@ class StreamingPostProcessor:
         # continues with prose containing ``` ``` `` after the JSON
         # would have the prose truncated.
         self._json_fence_opener_consumed: bool = False
+        # Codex r9 BLOCKING #1: persistent flag — has the JSON root
+        # closed (depth returned to 0 from >0 at some point)? Once
+        # this latches in fenced mode, every byte after that point
+        # is wrapper/prose/whitespace/fence; we suppress all of it
+        # until the closing ``` ``` `` fence is confirmed. Without
+        # this latch a chunk boundary between root-close and the
+        # fence leaks the intervening bytes onto the wire.
+        self._json_root_closed: bool = False
 
         # Forced ``tool_choice`` assistant-prefix replay swallow (PR #716
         # codex r9 BLOCKING #1). When the route layer forces a function via
@@ -484,9 +492,15 @@ class StreamingPostProcessor:
     #   "inside" → "done"    when a closing ``` ``` `` is detected (with
     #                        the preceding ``\n`` also dropped).
     #
-    # Bounded buffers: ``_json_fence_buffer`` is capped at 4096 bytes
-    # — past that we give up on fence detection and pass content through
-    # raw rather than swallow the entire stream on a runaway preamble.
+    # Bounded buffers: ``_json_fence_buffer`` is capped at 4096 bytes.
+    # Codex r9 NIT: when the cap is exceeded the implementation TRIMS
+    # the buffer to the trailing ``_JSON_FENCE_SCAN_KEEP_SUFFIX`` bytes
+    # (just enough for a split opening fence to still be detected on
+    # the next chunk) and KEEPS scanning. Older preamble bytes are
+    # dropped from memory but NEVER released onto the wire — the
+    # json-mode contract is "suppress everything before the first
+    # ``{``/``[``" and runaway preambles do not relax that contract
+    # (codex r3 BLOCKING).
 
     # Max bytes to accumulate while scanning for the JSON start. Past
     # this point the buffer is trimmed to the last
@@ -701,7 +715,27 @@ class StreamingPostProcessor:
         # emit, e.g. the codex r6 #1 multi-value concern). The
         # contract: opening fence seen => terminator is the closing
         # fence, not the root close.
+        # Codex r9 BLOCKING #1: track the FIRST index at which the JSON
+        # root closes (depth returns from 1 to 0). For fenced-mode
+        # streams the contract is "emit the JSON object only" — bytes
+        # between the root close and the closing fence are
+        # wrapper / explanation that the non-stream
+        # ``extract_json_from_response`` strips along with the fence.
+        # We must NOT emit those bytes onto the wire as they arrive in
+        # an earlier chunk than the closing ``` ``` ``. Track the
+        # ROOT_CLOSE position so we can suppress everything from it
+        # onward when no fence is found in this chunk (the next chunk
+        # might carry both extra prose AND the fence — we hold both).
         fence_idx = -1
+        # Codex r9 BLOCKING #1: ``root_close_at`` tracks the FIRST
+        # index in ``combined`` at which the JSON root closed. When
+        # the persistent ``_json_root_closed`` latch is already set
+        # (from a PRIOR call's walker), every byte of ``combined`` is
+        # post-root-close — root_close_at = 0 so we suppress from the
+        # start. Otherwise we scan for the first depth-1→0
+        # transition and record its position+1 (the byte AFTER the
+        # closing brace/bracket).
+        root_close_at = 0 if self._json_root_closed else -1
         i = 0
         n = len(combined)
         while i < n:
@@ -726,7 +760,12 @@ class StreamingPostProcessor:
                 if c in "}]":
                     # Defensive clamp on negative depth (malformed
                     # unbalanced output).
+                    prev_depth = depth
                     depth = max(depth - 1, 0)
+                    if prev_depth == 1 and depth == 0 and root_close_at < 0:
+                        # First top-level close — record the position
+                        # right AFTER this closing brace/bracket.
+                        root_close_at = i + 1
                     i += 1
                     continue
                 # Triple-backtick OUTSIDE a JSON string AND OUTSIDE
@@ -744,12 +783,42 @@ class StreamingPostProcessor:
 
         if fence_idx >= 0:
             # Closing fence found at depth 0. Trim payload at the
-            # fence, dropping the immediately-preceding newline
-            # whitespace symmetric with the non-stream
-            # ``_strip_markdown_code_block`` peel.
-            payload = combined[:fence_idx].rstrip("\r\n")
+            # FIRST root close (codex r9 BLOCKING #1: drop any
+            # explanation prose between the JSON root and the fence,
+            # symmetric with the non-stream
+            # ``_strip_markdown_code_block`` peel), then drop the
+            # newline whitespace.
+            cut = root_close_at if 0 <= root_close_at <= fence_idx else fence_idx
+            payload = combined[:cut].rstrip("\r\n")
             self._json_fence_state = "done"
             return payload
+
+        # Codex r9 BLOCKING #1: in fenced mode, once the JSON root has
+        # closed we MUST suppress every byte after the close until the
+        # closing fence arrives. Otherwise a chunk-boundary like
+        # ``{"k":1}\nextra`` (chunk N) + ``` ``` `` (chunk N+1) leaks
+        # ``\nextra`` onto the wire before the fence terminator is
+        # seen — the joined stream would be ``{"k":1}\nextra``,
+        # invalid JSON for any client that runs ``json.loads`` on
+        # the assembled deltas. Emit only the bytes UP TO root close
+        # (the JSON object itself) and HOLD all post-close bytes as
+        # tail. The next call's walker re-examines the full
+        # tail+content buffer for the fence; the tail is bounded by
+        # one chunk's worth of post-close bytes per call.
+        if root_close_at >= 0:
+            head = combined[:root_close_at]
+            self._json_fence_tail = combined[root_close_at:]
+            # Snapshot flags AT the root-close boundary. ``head`` ends
+            # at depth 0 outside any string, so reset the snapshot to
+            # that baseline. The persistent ``_json_root_closed`` latch
+            # ensures the next call's walker treats ``combined``'s very
+            # first byte as already past the close — so any new
+            # post-close bytes are also held until the fence arrives.
+            self._json_fence_in_string = False
+            self._json_fence_string_escape = False
+            self._json_fence_bracket_depth = 0
+            self._json_root_closed = True
+            return head
 
         # No complete fence yet. Compute the minimum suffix-hold so the
         # NEXT chunk can still detect a fence that straddles the chunk
@@ -930,6 +999,15 @@ class StreamingPostProcessor:
         if self._json_fence_state == "done":
             # Closing fence detected; whatever sat in the tail belongs
             # AFTER the fence and is suppressed.
+            self._json_fence_tail = ""
+            return ""
+        # Codex r9 BLOCKING #1: in fenced mode, if the JSON root has
+        # closed but the closing ``` ``` `` never arrived (truncated
+        # stream / model stopped mid-fence), the held tail is
+        # post-root-close prose that the non-stream
+        # ``extract_json_from_response`` would have peeled. Drop it
+        # so the streaming bytes match the non-stream shape.
+        if self._json_fence_opener_consumed and self._json_root_closed:
             self._json_fence_tail = ""
             return ""
         tail = self._json_fence_tail
@@ -1529,6 +1607,7 @@ class StreamingPostProcessor:
         self._json_fence_string_escape = False
         self._json_fence_bracket_depth = 0
         self._json_fence_opener_consumed = False
+        self._json_root_closed = False
         # Forced-prefix swallow buffer reset to baseline. The route layer
         # re-seeds via ``seed_forced_assistant_prefix`` after ``reset()``
         # when the request carries ``forced_assistant_prefix``; without

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -316,6 +316,23 @@ class StreamingPostProcessor:
         # behavior of the original ``_guard_closing_fence``.
         self._json_fence_in_string: bool = False
         self._json_fence_string_escape: bool = False
+        # Bracket-depth tracker (running over emitted JSON body bytes
+        # only). Increments on ``{``/``[`` outside string literals,
+        # decrements on ``}``/``]``. The closing fence ``` ``` `` is
+        # only recognized when ``depth == 0`` — i.e. AFTER the
+        # top-level JSON root has fully closed. Without this, a
+        # response like
+        # ``{"k": 1}\nHere is code:\n```python\nx = 1\n``` ``
+        # would truncate at the FIRST triple-backtick after the JSON
+        # root and emit ``...\nHere is code:`` as content; with this,
+        # the fence still fires only at depth 0 (after ``}``) and the
+        # trailing markdown still gets suppressed AS the wrapper that
+        # json_mode promises to strip. The state lives on the
+        # instance because the walker re-scans ``combined`` from
+        # index 0 on every call and must resume with the depth value
+        # snapshotted at the start of the held tail. Codex r5
+        # BLOCKING.
+        self._json_fence_bracket_depth: int = 0
 
         # Forced ``tool_choice`` assistant-prefix replay swallow (PR #716
         # codex r9 BLOCKING #1). When the route layer forces a function via
@@ -534,9 +551,20 @@ class StreamingPostProcessor:
         # produces the correct flag state at every position.
         in_string = self._json_fence_in_string
         escape = self._json_fence_string_escape
+        depth = self._json_fence_bracket_depth
+        # ``json_root_closed_at`` records the index IMMEDIATELY AFTER
+        # the brace/bracket that closed the JSON root (depth returned
+        # to 0 from > 0). For json_mode the contract is "emit ONLY the
+        # JSON object", matching the non-stream
+        # ``extract_json_from_response`` shape. Everything after the
+        # closing brace is wrapper/explanation/fence/whitespace and
+        # gets suppressed — whether or not a triple-backtick follows.
+        # Codex r5 BLOCKING: the earlier draft only suppressed AT the
+        # first ``` ``` ``, leaving trailing prose like
+        # ``\nHere is code:`` on the wire.
+        json_root_closed_at = -1
         i = 0
         n = len(combined)
-        fence_idx = -1
         while i < n:
             c = combined[i]
             if escape:
@@ -551,17 +579,39 @@ class StreamingPostProcessor:
                 in_string = not in_string
                 i += 1
                 continue
-            # Look for ``` ``` `` outside string literals.
-            if not in_string and c == "`" and combined[i : i + 3] == "```":
-                fence_idx = i
-                break
+            if not in_string:
+                if c in "{[":
+                    depth += 1
+                    i += 1
+                    continue
+                if c in "}]":
+                    depth -= 1
+                    if depth <= 0:
+                        # JSON root just closed at index ``i`` (the
+                        # closing brace/bracket itself). Capture and
+                        # break — we'll truncate to ``combined[:i+1]``
+                        # (inclusive of the closing brace) below.
+                        # The non-stream path's
+                        # ``rfind('{') ... endswith('}')`` peel does
+                        # the same thing post-hoc. Defensive clamp on
+                        # negative depth (malformed unbalanced output)
+                        # — keep depth == 0 so subsequent processing
+                        # still treats the cursor as outside JSON.
+                        depth = 0
+                        json_root_closed_at = i
+                        break
+                    i += 1
+                    continue
             i += 1
 
-        if fence_idx >= 0:
-            payload = combined[:fence_idx]
-            payload = payload.rstrip("\r\n")
+        if json_root_closed_at >= 0:
+            # JSON root closed at this position. Emit through the
+            # closing brace; suppress everything after (wrapper
+            # explanation, closing fence, stray whitespace) — this
+            # is what the non-stream ``extract_json_from_response``
+            # peels do post-hoc, applied to streaming.
+            payload = combined[: json_root_closed_at + 1]
             self._json_fence_state = "done"
-            # Don't update the in-string flags — we're done.
             return payload
 
         # No complete fence yet. Compute the minimum suffix-hold so the
@@ -600,25 +650,27 @@ class StreamingPostProcessor:
             # Snapshot the END-of-buffer flags (== start of next chunk).
             self._json_fence_in_string = in_string
             self._json_fence_string_escape = escape
+            self._json_fence_bracket_depth = depth
             return combined
         if hold_len >= len(combined):
             # The whole buffer is suspicious tail. The flags at the
             # start of this tail are the snapshot we entered with —
-            # leave ``_json_fence_in_string`` / ``_string_escape``
-            # untouched (they already reflect that boundary).
+            # leave instance fields untouched (they already reflect
+            # that boundary).
             self._json_fence_tail = combined
             return ""
         emit = combined[:-hold_len]
         self._json_fence_tail = combined[-hold_len:]
         # Snapshot the flags AT the start of the held tail by
         # re-walking from the prior snapshot through ``emit``. Held
-        # tail will never include a quote (the hold chars are ``\\n``
-        # / ``\\r`` / ``` ` ``), so this is a defensive replay rather
-        # than load-bearing — but it keeps the next-chunk walker
-        # mechanically correct.
-        prior_in_string, prior_escape = (
+        # tail will never include a quote / brace (the hold chars
+        # are ``\\n`` / ``\\r`` / ``` ` ``), so this is a defensive
+        # replay rather than load-bearing — but it keeps the
+        # next-chunk walker mechanically correct.
+        prior_in_string, prior_escape, prior_depth = (
             self._json_fence_in_string,
             self._json_fence_string_escape,
+            self._json_fence_bracket_depth,
         )
         for c in emit:
             if prior_escape:
@@ -629,8 +681,15 @@ class StreamingPostProcessor:
                 continue
             if c == '"':
                 prior_in_string = not prior_in_string
+                continue
+            if not prior_in_string:
+                if c in "{[":
+                    prior_depth += 1
+                elif c in "}]":
+                    prior_depth = max(prior_depth - 1, 0)
         self._json_fence_in_string = prior_in_string
         self._json_fence_string_escape = prior_escape
+        self._json_fence_bracket_depth = prior_depth
         return emit
 
     def _filter_events_for_json_fence(
@@ -1331,6 +1390,7 @@ class StreamingPostProcessor:
         self._json_fence_tail = ""
         self._json_fence_in_string = False
         self._json_fence_string_escape = False
+        self._json_fence_bracket_depth = 0
         # Forced-prefix swallow buffer reset to baseline. The route layer
         # re-seeds via ``seed_forced_assistant_prefix`` after ``reset()``
         # when the request carries ``forced_assistant_prefix``; without

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -474,20 +474,51 @@ class StreamingPostProcessor:
         if state == "scan":
             self._json_fence_buffer += content
             buf = self._json_fence_buffer
-            # Look for the first JSON delimiter. Mirror
-            # ``_find_json_start``'s think-tag awareness so a reasoning
-            # parser that already routed think-content to the reasoning
-            # channel still works — and the rare case where the model
-            # emits a literal ``<think>{...}</think>{real}`` sequence
-            # is handled identically to the existing preamble path.
+            # Codex r6 BLOCKING #2: when an opening fence is present
+            # in the preamble, the REAL JSON answer starts AFTER the
+            # fence, not at the first ``{``/``[`` we see. A preamble
+            # like ``Example shape: {"k":...}\n```json\n{"answer":42}\n``` ``
+            # has TWO JSON delimiters; the first is illustrative
+            # content. Prefer the JSON delimiter that appears after
+            # the LAST opening fence in the preamble.
+            # Find the first JSON delimiter AND the first ``` ``` ``.
+            # The order matters: a fence BEFORE the JSON delimiter
+            # is the OPENING fence (we anchor search after it to
+            # skip an illustrative-example JSON in the preamble —
+            # codex r6 BLOCKING #2); a fence AFTER the first JSON
+            # delimiter (or no fence at all) is irrelevant to the
+            # scan-phase anchor — that's the closing fence (the
+            # ``_guard_closing_fence`` walker handles it later).
             json_start = _find_json_start(buf)
-            if json_start < 0:
-                # No JSON delimiter yet. If the buffer grew past the
-                # cap, drop the OLD bytes — but keep enough of the
-                # suffix to catch a fence-opener split across the
-                # boundary. Codex r3 BLOCKING: the earlier draft
-                # RELEASED the entire >4KB buffer raw, which leaked
-                # the preamble + opening fence onto the wire (the
+            fence_pos = buf.find("```")
+            if fence_pos >= 0 and (json_start < 0 or fence_pos < json_start):
+                # Opening fence in preamble. Re-anchor the JSON
+                # search to after the fence + optional ``json`` tag
+                # + whitespace, so an illustrative example JSON
+                # before the fence does NOT win.
+                search_from = fence_pos + 3
+                if buf[search_from : search_from + 4].lower() == "json":
+                    search_from += 4
+                while search_from < len(buf) and buf[search_from] in " \t\r\n":
+                    search_from += 1
+                rel_start = _find_json_start(buf[search_from:])
+                if rel_start < 0:
+                    # Opener seen but no JSON delimiter yet — keep
+                    # scanning. Apply the scan-cap trim if needed.
+                    if len(buf) > self._JSON_FENCE_SCAN_CAP:
+                        self._json_fence_buffer = buf[
+                            -self._JSON_FENCE_SCAN_KEEP_SUFFIX :
+                        ]
+                    return ""
+                json_start = search_from + rel_start
+            elif json_start < 0:
+                # No JSON delimiter AND no opening fence yet. Keep
+                # scanning. If the buffer grew past the cap, drop
+                # the OLD bytes — but keep enough of the suffix to
+                # catch a fence-opener split across the boundary.
+                # Codex r3 BLOCKING: the earlier draft RELEASED
+                # the entire >4KB buffer raw, which leaked the
+                # preamble + opening fence onto the wire (the
                 # opposite of what response_format=json_* requires).
                 # The contract for json_mode is "suppress everything
                 # before the first ``{``/``[``", and that contract
@@ -495,11 +526,14 @@ class StreamingPostProcessor:
                 if len(buf) > self._JSON_FENCE_SCAN_CAP:
                     self._json_fence_buffer = buf[-self._JSON_FENCE_SCAN_KEEP_SUFFIX :]
                 return ""
-            # Found the JSON start. Strip everything before it (preamble
-            # + opening fence). Symmetric with the non-stream
-            # ``extract_json_from_response`` ``rfind('{') ... endswith('}')``
-            # peel: bytes BEFORE the first ``{``/``[`` are the wrapper,
-            # and we are done with them.
+            # else: json_start is set; fence (if any) was AFTER the
+            # JSON delimiter — the ``_guard_closing_fence`` walker
+            # will suppress it. Found the JSON start. Strip everything
+            # before it (preamble + opening fence). Symmetric with the
+            # non-stream ``extract_json_from_response``'s
+            # ``rfind('{') ... endswith('}')`` peel: bytes BEFORE the
+            # first ``{``/``[`` are the wrapper, and we are done
+            # with them.
             payload = buf[json_start:]
             self._json_fence_state = "inside"
             self._json_fence_buffer = ""
@@ -562,7 +596,23 @@ class StreamingPostProcessor:
         # Codex r5 BLOCKING: the earlier draft only suppressed AT the
         # first ``` ``` ``, leaving trailing prose like
         # ``\nHere is code:`` on the wire.
-        json_root_closed_at = -1
+        # Walker tracks JSON-root close AND the closing ``` ``` ``
+        # fence. ``json_root_closed_at`` is the index of the brace
+        # that returned depth to 0 (top-level close). ``fence_idx``
+        # is the index of the FIRST ``` ``` `` that appears OUTSIDE
+        # a JSON string literal AND AT depth==0 (i.e. after the JSON
+        # root has fully closed). For the saw-open-fence path we
+        # truncate at fence_idx; if the buffer contains a root-close
+        # but no fence yet, we MUST continue holding (the model may
+        # still be emitting whitespace between root-close and the
+        # closing fence — that whitespace is suppressed regardless,
+        # but truncating at root-close would lose the chance to
+        # recognise a JSON value that contains a literal terminating
+        # ``}`` followed by more content the model still wants to
+        # emit, e.g. the codex r6 #1 multi-value concern). The
+        # contract: opening fence seen => terminator is the closing
+        # fence, not the root close.
+        fence_idx = -1
         i = 0
         n = len(combined)
         while i < n:
@@ -585,32 +635,30 @@ class StreamingPostProcessor:
                     i += 1
                     continue
                 if c in "}]":
-                    depth -= 1
-                    if depth <= 0:
-                        # JSON root just closed at index ``i`` (the
-                        # closing brace/bracket itself). Capture and
-                        # break — we'll truncate to ``combined[:i+1]``
-                        # (inclusive of the closing brace) below.
-                        # The non-stream path's
-                        # ``rfind('{') ... endswith('}')`` peel does
-                        # the same thing post-hoc. Defensive clamp on
-                        # negative depth (malformed unbalanced output)
-                        # — keep depth == 0 so subsequent processing
-                        # still treats the cursor as outside JSON.
-                        depth = 0
-                        json_root_closed_at = i
-                        break
+                    # Defensive clamp on negative depth (malformed
+                    # unbalanced output).
+                    depth = max(depth - 1, 0)
                     i += 1
                     continue
+                # Triple-backtick OUTSIDE a JSON string AND OUTSIDE
+                # the JSON body (depth==0). Codex r1 + r5 + r6
+                # combined: a backtick inside a string literal is
+                # value content, a backtick inside the structural
+                # body (between matched braces) is also content
+                # (e.g. JSON containing a stringified code block);
+                # the ONLY position that means "closing fence" is
+                # at depth 0 after the root has closed.
+                if c == "`" and depth == 0 and combined[i : i + 3] == "```":
+                    fence_idx = i
+                    break
             i += 1
 
-        if json_root_closed_at >= 0:
-            # JSON root closed at this position. Emit through the
-            # closing brace; suppress everything after (wrapper
-            # explanation, closing fence, stray whitespace) — this
-            # is what the non-stream ``extract_json_from_response``
-            # peels do post-hoc, applied to streaming.
-            payload = combined[: json_root_closed_at + 1]
+        if fence_idx >= 0:
+            # Closing fence found at depth 0. Trim payload at the
+            # fence, dropping the immediately-preceding newline
+            # whitespace symmetric with the non-stream
+            # ``_strip_markdown_code_block`` peel.
+            payload = combined[:fence_idx].rstrip("\r\n")
             self._json_fence_state = "done"
             return payload
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -66,25 +66,42 @@ def _json_fence_suffix_hold_len(text: str) -> int:
     Only chunks ending in ``\\n``, ``\\r``, or ``` ` `` pay a one-chunk
     delay so the state machine can decide whether the suffix becomes
     a fence.
+
+    Codex r2 BLOCKING: when the trailing suffix is ``\\n```` ``,
+    ``\\n```` ``, or ``\\n``` ``, the hold MUST include the leading
+    ``\\n`` together with the backticks. Otherwise the next chunk's
+    closing-fence completion swallows the backticks but the ``\\n``
+    is already on the wire, leaving the stream output ``...}\\n``
+    instead of the bare ``...}`` the non-stream path produces — a
+    deviation that breaks byte-identical equality with the non-stream
+    response shape.
     """
     if not text:
         return 0
-    # Look at the last 3 chars (max possible fence prefix worth holding).
-    # ``\\n``  +  one  +  two  backticks  is  3  chars;  ``  ``  `  `  alone
-    # is also up to 3.
-    tail3 = text[-3:]
-    # Case 1: text ends in 1, 2, or 3 backticks. Hold all of them — a
-    # 3rd backtick on the next chunk completes the fence.
-    if tail3 == "```":
-        return 3
-    if tail3.endswith("``"):
-        return 2
-    if tail3.endswith("`"):
-        return 1
-    # Case 2: text ends in a newline. Could be the start of ``\\n```\\n``.
-    # Hold ONE byte; if the next chunk starts with backtick we'll
-    # promote it on the combined re-scan.
-    if tail3.endswith("\n") or tail3.endswith("\r"):
+
+    # Walk from the right counting trailing backticks (up to 3).
+    trailing_backticks = 0
+    while trailing_backticks < 3 and trailing_backticks < len(text):
+        if text[-(trailing_backticks + 1)] == "`":
+            trailing_backticks += 1
+        else:
+            break
+
+    if trailing_backticks > 0:
+        # Hold ``trailing_backticks`` backticks AND any immediately
+        # preceding newline. The newline is part of the canonical
+        # closing fence ``\\n``` `` and must not slip onto the wire
+        # before the rest of the fence arrives.
+        pre = len(text) - trailing_backticks
+        if pre > 0 and text[pre - 1] in "\r\n":
+            return trailing_backticks + 1
+        return trailing_backticks
+
+    # No trailing backticks. A lone ``\\n`` at the end could be the
+    # start of ``\\n```\\n``; hold ONE byte. The next chunk's ``` ` ``
+    # will trigger the combined re-scan, and we'll re-evaluate the
+    # hold above with the backtick(s) appended.
+    if text[-1] in "\r\n":
         return 1
     return 0
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -376,6 +376,18 @@ class StreamingPostProcessor:
         # snapshotted at the start of the held tail. Codex r5
         # BLOCKING.
         self._json_fence_bracket_depth: int = 0
+        # Whether the scan phase actually consumed an opening
+        # ``` ```json `` (or bare ``` ``` `` wrapping JSON) fence.
+        # Codex r8 BLOCKING #2: ``_guard_closing_fence`` only
+        # suppresses a closing ``` ``` `` when an opening fence was
+        # consumed; bare-JSON streams (model returned ``{...}`` straight
+        # with no markdown wrapper) pass markdown content after the
+        # root close THROUGH UNCHANGED, mirroring the non-stream
+        # ``extract_json_from_response`` which leaves unfenced text
+        # alone. Without this gate, a model that legitimately
+        # continues with prose containing ``` ``` `` after the JSON
+        # would have the prose truncated.
+        self._json_fence_opener_consumed: bool = False
 
         # Forced ``tool_choice`` assistant-prefix replay swallow (PR #716
         # codex r9 BLOCKING #1). When the route layer forces a function via
@@ -534,7 +546,15 @@ class StreamingPostProcessor:
             # ``_guard_closing_fence`` walker handles it later).
             json_start = _find_json_start(buf)
             fence_pos = _find_json_fence_opener(buf)
-            if fence_pos >= 0 and (json_start < 0 or fence_pos < json_start):
+            # Codex r8 BLOCKING #1: re-anchor whenever a JSON-bearing
+            # fence opener exists ANYWHERE in the buffer — not only
+            # when ``fence_pos < json_start``. A preamble like
+            # ``Example: {"k":1}\n```json\n{"answer":42}\n``` `` has
+            # the example JSON BEFORE the fence; without unconditional
+            # re-anchoring we'd land on the example. ``_find_json_fence_opener``
+            # already requires the fence's payload to start with
+            # ``{``/``[``, so the candidate is reliable.
+            if fence_pos >= 0:
                 # Opening fence in preamble. Re-anchor the JSON
                 # search to after the fence + optional ``json`` tag
                 # + whitespace, so an illustrative example JSON
@@ -562,6 +582,13 @@ class StreamingPostProcessor:
                         ]
                     return ""
                 json_start = search_from + rel_start
+                # Codex r8 BLOCKING #2: record that an opening fence
+                # was actually consumed in the scan phase. The
+                # closing-fence walker uses this flag to decide
+                # whether to suppress a later ``` `` ``` — a bare-JSON
+                # stream (no opening fence) must pass markdown after
+                # the JSON root through unchanged.
+                self._json_fence_opener_consumed = True
             elif json_start < 0:
                 # No JSON delimiter AND no opening fence yet. Keep
                 # scanning. If the buffer grew past the cap, drop
@@ -619,6 +646,17 @@ class StreamingPostProcessor:
         # suffix as a single string.
         combined = self._json_fence_tail + content
         self._json_fence_tail = ""
+
+        # Codex r8 BLOCKING #2: bare-JSON streams (no opening fence
+        # consumed in the scan phase) must not have closing-fence
+        # detection or fence-tail hold applied. The non-stream
+        # ``extract_json_from_response`` leaves unfenced text alone;
+        # streaming has to match. Without this fast-path, a model
+        # that returns ``{...}\n\nHere's how I did it:\n```python...```
+        # would get truncated at the first ``` ``` ``. Flush any held
+        # tail and pass the rest through unchanged.
+        if not self._json_fence_opener_consumed:
+            return combined
 
         # Walk the buffer character-by-character, tracking JSON-string
         # state, so the FIRST ``` `` ` ``` we treat as a closing fence
@@ -1490,6 +1528,7 @@ class StreamingPostProcessor:
         self._json_fence_in_string = False
         self._json_fence_string_escape = False
         self._json_fence_bracket_depth = 0
+        self._json_fence_opener_consumed = False
         # Forced-prefix swallow buffer reset to baseline. The route layer
         # re-seeds via ``seed_forced_assistant_prefix`` after ``reset()``
         # when the request carries ``forced_assistant_prefix``; without
@@ -2169,6 +2208,23 @@ class StreamingPostProcessor:
                 json_start = _find_json_start(self._json_preamble_buffer)
                 if json_start >= 0:
                     self._json_preamble_stripped = True
+                    # Codex r8 BLOCKING #2: if the preamble we're about
+                    # to strip ends in an opening ``` ```json `` /
+                    # ``` ``` `` fence (whose payload IS the JSON we
+                    # just landed on), the downstream fence-walker
+                    # must know an opening fence WAS consumed so it
+                    # will suppress the matching closing fence.
+                    # Without this signal the bare-JSON pass-through
+                    # fast-path fires and the closing ``` ``` `` leaks
+                    # onto the wire. ``_find_json_fence_opener`` needs
+                    # the JSON delimiter visible to recognise the
+                    # fence's payload, so we run it over the FULL
+                    # buffer (preamble + JSON) and check whether the
+                    # found fence sits inside the about-to-be-stripped
+                    # preamble.
+                    fence_in_full = _find_json_fence_opener(self._json_preamble_buffer)
+                    if 0 <= fence_in_full < json_start:
+                        self._json_fence_opener_consumed = True
                     content = self._json_preamble_buffer[json_start:]
                 else:
                     return []

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -51,6 +51,49 @@ def _find_json_start(text: str) -> int:
     return -1
 
 
+def _find_json_fence_opener(text: str) -> int:
+    """Return the index of the OPENING JSON fence in ``text``, or -1.
+
+    Used by the H-07 scan phase to anchor the JSON-start search past
+    any preamble fences. The OPENING JSON fence is the last
+    triple-backtick whose payload starts (after an optional ``json``
+    language tag and whitespace) with ``{`` or ``[`` — i.e., the
+    fence whose body is actual JSON.
+
+    Codex r7 BLOCKING: a preamble may include NON-JSON fenced
+    examples (``\\n```python\\nx=1\\n``` ``) before the actual JSON
+    fence; the earlier ``buf.find("```")`` anchored on the python
+    fence and skipped the real ``` ```json `` opener. Scanning for
+    a fence whose payload begins with a JSON delimiter eliminates
+    that ambiguity — language-tagged code blocks (python, bash,
+    etc.) and string-content fences don't match.
+
+    Returns the index of the first backtick of the chosen fence,
+    or -1 if no JSON-bearing fence is found. Multiple matches: the
+    LAST one wins (preferring the most recent fence — the model is
+    most likely to wrap the FINAL answer).
+    """
+    best = -1
+    i = 0
+    n = len(text)
+    while i < n:
+        pos = text.find("```", i)
+        if pos < 0:
+            break
+        # Skip past the fence + optional ``json`` tag + whitespace.
+        cur = pos + 3
+        if text[cur : cur + 4].lower() == "json":
+            cur += 4
+        while cur < n and text[cur] in " \t\r\n":
+            cur += 1
+        # If the next non-whitespace char is a JSON delimiter, this
+        # fence opens a JSON block — eligible as the opener.
+        if cur < n and text[cur] in "{[":
+            best = pos
+        i = pos + 3
+    return best
+
+
 def _json_fence_suffix_hold_len(text: str) -> int:
     """Return how many trailing bytes of ``text`` MIGHT start a ``` fence.
 
@@ -490,12 +533,20 @@ class StreamingPostProcessor:
             # scan-phase anchor — that's the closing fence (the
             # ``_guard_closing_fence`` walker handles it later).
             json_start = _find_json_start(buf)
-            fence_pos = buf.find("```")
+            fence_pos = _find_json_fence_opener(buf)
             if fence_pos >= 0 and (json_start < 0 or fence_pos < json_start):
                 # Opening fence in preamble. Re-anchor the JSON
                 # search to after the fence + optional ``json`` tag
                 # + whitespace, so an illustrative example JSON
                 # before the fence does NOT win.
+                #
+                # Codex r7 BLOCKING: ``_find_json_fence_opener`` looks
+                # for the LAST ``` ```json `` (case-insensitive) before
+                # the first JSON delimiter, then falls back to a bare
+                # ``` ``` ``. This handles preambles that include
+                # NON-JSON fenced examples (``\\n```python\\n...\\n``` ``)
+                # before the real JSON fence — those earlier fences
+                # don't anchor the search.
                 search_from = fence_pos + 3
                 if buf[search_from : search_from + 4].lower() == "json":
                     search_from += 4

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -51,6 +51,44 @@ def _find_json_start(text: str) -> int:
     return -1
 
 
+def _json_fence_suffix_hold_len(text: str) -> int:
+    """Return how many trailing bytes of ``text`` MIGHT start a ``` fence.
+
+    Used by the H-07 streaming fence-strip state machine in
+    ``StreamingPostProcessor._guard_closing_fence``. A closing fence on
+    the wire is one of ``\\n```\\n``, ```\\n``, or ``` ``` `` alone; the
+    longest legitimate fence-prefix this function recognizes at a
+    chunk boundary is ``\\n`` + up to two backticks (the next chunk
+    would carry the third backtick to complete the fence).
+
+    Returns ``0`` (release everything) on the bare-JSON fast path —
+    chunks ending in ``}``, a digit, a quote, etc. flush immediately.
+    Only chunks ending in ``\\n``, ``\\r``, or ``` ` `` pay a one-chunk
+    delay so the state machine can decide whether the suffix becomes
+    a fence.
+    """
+    if not text:
+        return 0
+    # Look at the last 3 chars (max possible fence prefix worth holding).
+    # ``\\n``  +  one  +  two  backticks  is  3  chars;  ``  ``  `  `  alone
+    # is also up to 3.
+    tail3 = text[-3:]
+    # Case 1: text ends in 1, 2, or 3 backticks. Hold all of them — a
+    # 3rd backtick on the next chunk completes the fence.
+    if tail3 == "```":
+        return 3
+    if tail3.endswith("``"):
+        return 2
+    if tail3.endswith("`"):
+        return 1
+    # Case 2: text ends in a newline. Could be the start of ``\\n```\\n``.
+    # Hold ONE byte; if the next chunk starts with backtick we'll
+    # promote it on the combined re-scan.
+    if tail3.endswith("\n") or tail3.endswith("\r"):
+        return 1
+    return 0
+
+
 class StreamingPostProcessor:
     """Processes streaming engine output into StreamEvents.
 
@@ -221,6 +259,33 @@ class StreamingPostProcessor:
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
 
+        # JSON mode: ```json markdown-fence strip (H-07).
+        # The non-streaming chat response builder calls
+        # ``extract_json_from_response`` to peel a ```json\n{...}\n```
+        # wrapper off the model output when ``response_format`` is set so
+        # downstream clients see bare JSON. The streaming path concatenated
+        # raw model tokens without the same scrub — joined SSE deltas
+        # decoded as ```json\n{...}\n``` and ``json.loads`` failed for any
+        # SDK consumer assembling ``delta.content`` into a string.
+        #
+        # State machine (driven by ``_apply_json_fence_strip``) swallows an
+        # opening fence (with any leading whitespace / pre-JSON think
+        # content), passes the JSON body through, and suppresses a trailing
+        # closing fence. Active only when ``json_mode=True``; absent or
+        # ``"text"`` ``response_format`` leaves these fields cold and the
+        # state machine is a pass-through.
+        #
+        # ``_json_fence_state`` values:
+        #   "scan"   — pre-JSON: buffering until we see ``{``/``[`` or a
+        #              ``` fence. Holds bytes in ``_json_fence_buffer``.
+        #   "inside" — JSON body streaming. Holds a small tail in
+        #              ``_json_fence_tail`` to defer emission of bytes that
+        #              might be the start of a closing ``\n``` ``.
+        #   "done"   — closing fence consumed; suppress all further bytes.
+        self._json_fence_state: str = "scan"
+        self._json_fence_buffer: str = ""
+        self._json_fence_tail: str = ""
+
         # Forced ``tool_choice`` assistant-prefix replay swallow (PR #716
         # codex r9 BLOCKING #1). When the route layer forces a function via
         # the OpenAI ``tool_choice`` contract (#673), the chat-template
@@ -281,6 +346,258 @@ class StreamingPostProcessor:
         # that look at ``delta_text`` boundaries it leaks).
         self.tool_accumulated_text = prefix
         self._forced_prefix_pending = prefix
+
+    # ------------------------------------------------------------------
+    # H-07: ```json markdown-fence strip for streaming json_mode
+    # ------------------------------------------------------------------
+    #
+    # Mirrors the non-streaming ``extract_json_from_response`` behaviour
+    # (vllm_mlx/api/utils.py) on the SSE delta path. The non-stream
+    # response calls that helper after assembling the full text; the
+    # stream path concatenated raw tokens without any fence scrub, so
+    # joined ``delta.content`` parsed as ```json\n{...}\n``` and clients
+    # had to de-fence manually (H-07 / Marisol repro).
+    #
+    # Design: a per-instance state machine, NOT a post-join regex. Two
+    # constraints forced the state-machine shape:
+    #
+    # 1. Fence tokens are split across delta chunks. Tokenizers fragment
+    #    ``\n``` `` arbitrarily ("``", "`json", "\n"); a post-emission
+    #    regex would not help because we need to SUPPRESS bytes BEFORE
+    #    they reach the wire.
+    # 2. The bare-JSON path (model returns ``{...}`` with no fence at
+    #    all) must pass through unchanged — we can't unconditionally
+    #    buffer.
+    #
+    # No-op when ``json_mode`` is False (``response_format`` absent or
+    # ``"text"``); the gate sits inside ``_apply_json_fence_strip`` so
+    # all call sites can call it unconditionally.
+    #
+    # ``_json_fence_state`` transitions:
+    #   "scan"   → "inside"  when the first JSON delimiter (``{``/``[``)
+    #                        is seen, with any preceding ``` ```json ``` /
+    #                        ``` ``` `` / whitespace / think-content
+    #                        bytes suppressed.
+    #   "inside" → "done"    when a closing ``` ``` `` is detected (with
+    #                        the preceding ``\n`` also dropped).
+    #
+    # Bounded buffers: ``_json_fence_buffer`` is capped at 4096 bytes
+    # — past that we give up on fence detection and pass content through
+    # raw rather than swallow the entire stream on a runaway preamble.
+
+    # Max bytes to accumulate while scanning for the JSON start. Past
+    # this point the model clearly is NOT emitting an opening fence, so
+    # release the buffer rather than swallow arbitrary content. Sized
+    # generously vs. realistic fence variants (``\n\n```json\n``,
+    # ``Sure! Here:\n```json\n``); large preambles already lose to the
+    # ``_json_preamble_buffer`` path on the no-reasoning branch.
+    _JSON_FENCE_SCAN_CAP = 4096
+
+    def _apply_json_fence_strip(self, content: str) -> str:
+        """Strip ```json...``` markdown fence from streaming content.
+
+        See block comment above for design rationale. Returns the
+        bytes that are safe to emit on the wire RIGHT NOW; any
+        deferred tail bytes are held in ``self._json_fence_tail`` and
+        flushed by ``_flush_json_fence_tail`` at stream end.
+
+        No-op when ``json_mode`` is False — the call sites pass content
+        through unchanged in that case.
+        """
+        if not self.json_mode or not content:
+            return content
+
+        state = self._json_fence_state
+
+        if state == "done":
+            # Closing fence already consumed; any trailing model bytes
+            # (often a stray newline / whitespace before EOS) are
+            # suppressed so the joined stream stays parseable JSON.
+            return ""
+
+        if state == "scan":
+            self._json_fence_buffer += content
+            buf = self._json_fence_buffer
+            # Look for the first JSON delimiter. Mirror
+            # ``_find_json_start``'s think-tag awareness so a reasoning
+            # parser that already routed think-content to the reasoning
+            # channel still works — and the rare case where the model
+            # emits a literal ``<think>{...}</think>{real}`` sequence
+            # is handled identically to the existing preamble path.
+            json_start = _find_json_start(buf)
+            if json_start < 0:
+                # No JSON delimiter yet. If the buffer grew past the cap,
+                # we're clearly NOT in a fence scenario — release the
+                # buffer raw rather than swallow the entire stream.
+                if len(buf) > self._JSON_FENCE_SCAN_CAP:
+                    self._json_fence_state = "inside"
+                    self._json_fence_buffer = ""
+                    return self._guard_closing_fence(buf)
+                return ""
+            # Found the JSON start. Strip everything before it (preamble
+            # + opening fence). Symmetric with the non-stream
+            # ``extract_json_from_response`` ``rfind('{') ... endswith('}')``
+            # peel: bytes BEFORE the first ``{``/``[`` are the wrapper,
+            # and we are done with them.
+            payload = buf[json_start:]
+            self._json_fence_state = "inside"
+            self._json_fence_buffer = ""
+            return self._guard_closing_fence(payload)
+
+        # state == "inside" — pass content through, guarding against the
+        # closing fence.
+        return self._guard_closing_fence(content)
+
+    def _guard_closing_fence(self, content: str) -> str:
+        """Hold back the last few bytes that might start a closing ``` fence.
+
+        The streaming wire MUST suppress the trailing ``\\n```\\n``
+        before it lands in the SSE delta. Bytes that COULD be the
+        beginning of such a fence are held in ``_json_fence_tail`` and
+        only released once we know they are not a fence.
+
+        Tail-hold size is ``_JSON_FENCE_TAIL_HOLD`` so the typical
+        ``\\n```\\n`` / ``\\r\\n```\\r\\n`` patterns fit entirely in
+        the deferred buffer.
+
+        Bare-JSON streams pay no latency: ``_json_fence_suffix_hold_len``
+        returns 0 when the chunk does not end in a fence-prefix
+        character (``\\n`` / ``\\r`` / ``` ` ``), so a stream of
+        ``{"k": 1}`` chunks flushes immediately. Only chunks whose
+        last byte LOOKS like the start of a closing fence are
+        deferred — that one chunk's bytes are held until the next
+        chunk arrives or ``_flush_json_fence_tail`` runs in
+        ``finalize()``.
+        """
+        # Prepend any previously-held tail so we re-examine the full
+        # suffix as a single string.
+        combined = self._json_fence_tail + content
+        self._json_fence_tail = ""
+
+        # Fast path: scan from the LEFT for the closing fence marker.
+        # If we see ``` `` ` ``` at any position, the JSON body ends
+        # THERE (minus any immediately-preceding newline whitespace)
+        # and we transition to "done". The leftmost match wins:
+        # symmetric with the non-stream
+        # ``_strip_markdown_code_block`` regex which captures up to
+        # the FIRST closing fence (rare-but-real failure mode of a
+        # JSON string containing literal triple-backticks is shared
+        # with the non-stream path — out of scope here).
+        fence_idx = combined.find("```")
+        if fence_idx >= 0:
+            payload = combined[:fence_idx]
+            payload = payload.rstrip("\r\n")
+            self._json_fence_state = "done"
+            return payload
+
+        # No complete fence yet. Compute the minimum suffix-hold so the
+        # NEXT chunk can still detect a fence that straddles the chunk
+        # boundary. A closing fence on the wire is one of:
+        #
+        #   ``\\n```\\n``  (canonical)
+        #   ```\\n``       (no trailing newline; ``` could land at EOS)
+        #   ```            (fence-only line, no newlines)
+        #
+        # The longest prefix of any of these that could legitimately
+        # appear at the END of a non-fence emission is 4 bytes:
+        # ``\\n`` followed by up to two backticks (the next chunk would
+        # carry the third backtick to complete the fence). Anything
+        # longer than that we KNOW is real JSON body and can release
+        # immediately. Anything shorter that ends in ``\\n`` / ``` ` ```
+        # / ``` `` `` we hold; anything else we release wholesale.
+        #
+        # This keeps the bare-JSON path zero-latency: a chunk ending
+        # in ``}`` or a digit or a quote releases immediately. Only
+        # chunks ending in suspicious chars pay one chunk of latency.
+        hold_len = _json_fence_suffix_hold_len(combined)
+        if hold_len == 0:
+            return combined
+        if hold_len >= len(combined):
+            self._json_fence_tail = combined
+            return ""
+        emit = combined[:-hold_len]
+        self._json_fence_tail = combined[-hold_len:]
+        return emit
+
+    def _filter_events_for_json_fence(
+        self, events: list[StreamEvent]
+    ) -> list[StreamEvent]:
+        """Run ``_apply_json_fence_strip`` over a list of StreamEvents.
+
+        Walks the event list and rewrites every ``content`` field
+        (whether on a ``type="content"`` event or on a ``type="finish"``
+        event with merged content). When the strip pass empties the
+        content of a plain ``type="content"`` event, the event is
+        dropped — pristine ``content`` deltas with empty payload would
+        otherwise emit an empty SSE chunk.
+
+        No-op fast path when ``json_mode`` is False — caller treats the
+        list as already-filtered.
+        """
+        if not self.json_mode:
+            return events
+
+        filtered: list[StreamEvent] = []
+        for ev in events:
+            if ev.type == "content":
+                stripped = self._apply_json_fence_strip(ev.content or "")
+                if stripped:
+                    filtered.append(StreamEvent(type="content", content=stripped))
+                # else: fully suppressed (fence/preamble/closer) — drop.
+            elif ev.type == "finish":
+                # Finish events can carry merged content (the route's
+                # buffered-finish merge path). Strip it the same way,
+                # plus drain any held tail bytes so a bare-JSON-no-
+                # closing-fence stream still flushes the final chunk.
+                terminal = ev.content or ""
+                if terminal:
+                    terminal = self._apply_json_fence_strip(terminal)
+                # Drain the held tail (only meaningful for the
+                # bare-JSON-no-fence case where the JSON simply ends).
+                tail = self._flush_json_fence_tail()
+                if tail:
+                    terminal = (terminal or "") + tail
+                filtered.append(
+                    StreamEvent(
+                        type="finish",
+                        finish_reason=ev.finish_reason,
+                        content=terminal or None,
+                        reasoning=ev.reasoning,
+                        tool_calls=ev.tool_calls,
+                        tool_calls_detected=ev.tool_calls_detected,
+                    )
+                )
+            else:
+                # reasoning / tool_call / other event types: pass through.
+                filtered.append(ev)
+        return filtered
+
+    def _flush_json_fence_tail(self) -> str:
+        """Release any deferred tail bytes at stream end.
+
+        Called from ``finalize()`` so the bare-JSON path (model returned
+        ``{...}`` with NO closing fence) still flushes the final
+        ``_JSON_FENCE_TAIL_HOLD`` bytes that were held back in case
+        they were the start of a fence. Idempotent: clears the tail.
+        """
+        if not self.json_mode:
+            return ""
+        if self._json_fence_state == "done":
+            self._json_fence_tail = ""
+            return ""
+        tail = self._json_fence_tail
+        self._json_fence_tail = ""
+        if not tail:
+            return ""
+        # Defensive trim: a model that closed the stream mid-fence (rare,
+        # but possible when the engine hit ``max_tokens`` exactly at the
+        # ``` boundary) could leave a partial ``\\n``  or ``\\n``` `` in
+        # the tail. Drop trailing backticks and the newline immediately
+        # before them so the released suffix is still valid JSON.
+        stripped = tail.rstrip("`")
+        if stripped != tail:
+            stripped = stripped.rstrip("\r\n")
+        return stripped
 
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
@@ -863,6 +1180,14 @@ class StreamingPostProcessor:
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
+        # H-07: ```json fence-strip state machine — reset to baseline.
+        # ``_apply_json_fence_strip`` is a no-op when ``json_mode`` is
+        # False, but clearing the buffers keeps a reused processor
+        # instance (legacy singleton path) from carrying tail bytes into
+        # the next request.
+        self._json_fence_state = "scan"
+        self._json_fence_buffer = ""
+        self._json_fence_tail = ""
         # Forced-prefix swallow buffer reset to baseline. The route layer
         # re-seeds via ``seed_forced_assistant_prefix`` after ``reset()``
         # when the request carries ``forced_assistant_prefix``; without
@@ -943,14 +1268,28 @@ class StreamingPostProcessor:
 
         # Step 1: Separate content from reasoning
         if output.channel is not None:
-            return self._process_channel_routed(delta_text, output)
-        if self.reasoning_parser and self.enable_thinking is not False:
+            events = self._process_channel_routed(delta_text, output)
+        elif self.reasoning_parser and self.enable_thinking is not False:
             # When enable_thinking is explicitly False, the model is told to
             # skip thinking and answer directly. Bypass the reasoning parser
             # so its implicit-think heuristic doesn't reroute the answer to
             # reasoning_content.
-            return self._process_with_reasoning(delta_text, output)
-        return self._process_standard(delta_text, output)
+            events = self._process_with_reasoning(delta_text, output)
+        else:
+            events = self._process_standard(delta_text, output)
+
+        # H-07: ```json markdown-fence strip for streaming json_mode.
+        # The non-stream chat response builder peels the fence via
+        # ``extract_json_from_response`` AFTER assembling the full
+        # text; the stream path concatenated raw tokens without the
+        # same scrub. Filter content here, AFTER all reasoning / tool /
+        # sanitize passes have run so we only see the bytes that would
+        # land on the wire as ``delta.content``. No-op when
+        # ``json_mode`` is False — call sites in ``_filter_events_for_json_fence``
+        # short-circuit there. Tool-call deltas and reasoning_content
+        # are untouched (the fence only ever shows up in plain content
+        # for json_mode requests).
+        return self._filter_events_for_json_fence(events)
 
     def _process_channel_routed(
         self, delta_text: str, output: GenerationOutput
@@ -1878,6 +2217,21 @@ class StreamingPostProcessor:
             # downstream.
             if isinstance(held, str) and held:
                 events.append(StreamEvent(type="content", content=held))
+
+        # H-07: ```json fence-strip on the finalize event list AND flush
+        # any held tail. The route's "buffered_finish" merge path
+        # concatenates ``finalize()``-produced content events into the
+        # terminal SSE chunk; without the strip here the closing fence
+        # would survive on the last few bytes of the stream. The flush
+        # path also rescues the bare-JSON-no-fence stream: when the
+        # model returns ``{...}`` with no closing fence, the tail buffer
+        # at stream end holds the final few bytes that
+        # ``_guard_closing_fence`` held back "just in case". Drain them.
+        events = self._filter_events_for_json_fence(events)
+        if self.json_mode:
+            tail = self._flush_json_fence_tail()
+            if tail:
+                events.append(StreamEvent(type="content", content=tail))
 
         return events
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -285,6 +285,20 @@ class StreamingPostProcessor:
         self._json_fence_state: str = "scan"
         self._json_fence_buffer: str = ""
         self._json_fence_tail: str = ""
+        # Lightweight JSON-string awareness for fence detection.
+        # Tracks whether the cursor (running over emitted JSON body
+        # bytes only) is currently INSIDE a JSON ``"..."`` string
+        # literal — backticks inside a string literal are content, not
+        # fence markers, so we MUST skip them when looking for the
+        # closing ``` ``` ``. The flag flips on every unescaped ``"``
+        # we see in the streamed payload. The escape flag handles
+        # ``\\"`` so the next ``"`` does NOT flip the state.
+        #
+        # Codex r1 BLOCKING #1: without this, a valid JSON value like
+        # ``{"text": "```"}`` would be truncated by the leftmost-find
+        # behavior of the original ``_guard_closing_fence``.
+        self._json_fence_in_string: bool = False
+        self._json_fence_string_escape: bool = False
 
         # Forced ``tool_choice`` assistant-prefix replay swallow (PR #716
         # codex r9 BLOCKING #1). When the route layer forces a function via
@@ -474,20 +488,50 @@ class StreamingPostProcessor:
         combined = self._json_fence_tail + content
         self._json_fence_tail = ""
 
-        # Fast path: scan from the LEFT for the closing fence marker.
-        # If we see ``` `` ` ``` at any position, the JSON body ends
-        # THERE (minus any immediately-preceding newline whitespace)
-        # and we transition to "done". The leftmost match wins:
-        # symmetric with the non-stream
-        # ``_strip_markdown_code_block`` regex which captures up to
-        # the FIRST closing fence (rare-but-real failure mode of a
-        # JSON string containing literal triple-backticks is shared
-        # with the non-stream path — out of scope here).
-        fence_idx = combined.find("```")
+        # Walk the buffer character-by-character, tracking JSON-string
+        # state, so the FIRST ``` `` ` ``` we treat as a closing fence
+        # is actually OUTSIDE a string literal. Codex r1 BLOCKING #1:
+        # the previous leftmost-``find("```")`` truncated valid JSON
+        # whose VALUES happened to contain triple-backticks (e.g.
+        # ``{"markdown": "```python\\nx\\n```"}``).
+        #
+        # The walker starts from the per-instance snapshot of the
+        # (in_string, escape) flags taken at the held-tail boundary on
+        # the previous call. ``combined`` is structured as
+        # ``[previously-held tail] + [fresh content]`` and the snapshot
+        # is exactly the flag state AT the start of that previously-
+        # held tail — so the walker over ``combined`` from index 0
+        # produces the correct flag state at every position.
+        in_string = self._json_fence_in_string
+        escape = self._json_fence_string_escape
+        i = 0
+        n = len(combined)
+        fence_idx = -1
+        while i < n:
+            c = combined[i]
+            if escape:
+                escape = False
+                i += 1
+                continue
+            if c == "\\" and in_string:
+                escape = True
+                i += 1
+                continue
+            if c == '"':
+                in_string = not in_string
+                i += 1
+                continue
+            # Look for ``` ``` `` outside string literals.
+            if not in_string and c == "`" and combined[i : i + 3] == "```":
+                fence_idx = i
+                break
+            i += 1
+
         if fence_idx >= 0:
             payload = combined[:fence_idx]
             payload = payload.rstrip("\r\n")
             self._json_fence_state = "done"
+            # Don't update the in-string flags — we're done.
             return payload
 
         # No complete fence yet. Compute the minimum suffix-hold so the
@@ -498,25 +542,65 @@ class StreamingPostProcessor:
         #   ```\\n``       (no trailing newline; ``` could land at EOS)
         #   ```            (fence-only line, no newlines)
         #
-        # The longest prefix of any of these that could legitimately
-        # appear at the END of a non-fence emission is 4 bytes:
-        # ``\\n`` followed by up to two backticks (the next chunk would
-        # carry the third backtick to complete the fence). Anything
-        # longer than that we KNOW is real JSON body and can release
-        # immediately. Anything shorter that ends in ``\\n`` / ``` ` ```
-        # / ``` `` `` we hold; anything else we release wholesale.
+        # The longest prefix that could legitimately appear at the END
+        # of a non-fence emission is 4 bytes: ``\\n`` followed by up to
+        # two backticks (the next chunk would carry the third backtick
+        # to complete the fence). Anything longer than that we KNOW is
+        # real JSON body and can release immediately. Anything shorter
+        # that ends in ``\\n`` / ``` ` `` / ``` `` `` we hold; anything
+        # else we release wholesale.
         #
-        # This keeps the bare-JSON path zero-latency: a chunk ending
-        # in ``}`` or a digit or a quote releases immediately. Only
-        # chunks ending in suspicious chars pay one chunk of latency.
-        hold_len = _json_fence_suffix_hold_len(combined)
+        # Codex r1 BLOCKING #1 redux: when the trailing fence-prefix
+        # chars are INSIDE a JSON string literal (the running
+        # ``in_string`` flag from the walker says so), they can't be
+        # the start of a closing fence — release them too.
+        # At this point the walker advanced ``in_string`` / ``escape``
+        # to the END of the entire ``combined`` buffer (no fence found).
+        # We need to snapshot the flags as they were at the START of
+        # the soon-to-be-held tail (so the next chunk's walker can
+        # resume there). The held-tail length depends on whether we're
+        # inside a string literal: a trailing ``` ` `` / ``\\n`` inside
+        # a string can't begin a fence and should flush immediately.
+        if in_string:
+            hold_len = 0
+        else:
+            hold_len = _json_fence_suffix_hold_len(combined)
+
         if hold_len == 0:
+            # Snapshot the END-of-buffer flags (== start of next chunk).
+            self._json_fence_in_string = in_string
+            self._json_fence_string_escape = escape
             return combined
         if hold_len >= len(combined):
+            # The whole buffer is suspicious tail. The flags at the
+            # start of this tail are the snapshot we entered with —
+            # leave ``_json_fence_in_string`` / ``_string_escape``
+            # untouched (they already reflect that boundary).
             self._json_fence_tail = combined
             return ""
         emit = combined[:-hold_len]
         self._json_fence_tail = combined[-hold_len:]
+        # Snapshot the flags AT the start of the held tail by
+        # re-walking from the prior snapshot through ``emit``. Held
+        # tail will never include a quote (the hold chars are ``\\n``
+        # / ``\\r`` / ``` ` ``), so this is a defensive replay rather
+        # than load-bearing — but it keeps the next-chunk walker
+        # mechanically correct.
+        prior_in_string, prior_escape = (
+            self._json_fence_in_string,
+            self._json_fence_string_escape,
+        )
+        for c in emit:
+            if prior_escape:
+                prior_escape = False
+                continue
+            if c == "\\" and prior_in_string:
+                prior_escape = True
+                continue
+            if c == '"':
+                prior_in_string = not prior_in_string
+        self._json_fence_in_string = prior_in_string
+        self._json_fence_string_escape = prior_escape
         return emit
 
     def _filter_events_for_json_fence(
@@ -576,28 +660,30 @@ class StreamingPostProcessor:
         """Release any deferred tail bytes at stream end.
 
         Called from ``finalize()`` so the bare-JSON path (model returned
-        ``{...}`` with NO closing fence) still flushes the final
-        ``_JSON_FENCE_TAIL_HOLD`` bytes that were held back in case
-        they were the start of a fence. Idempotent: clears the tail.
+        ``{...}`` with NO closing fence) still flushes the final few
+        bytes that were held back in case they were the start of a
+        fence. Idempotent: clears the tail.
+
+        Codex r1 BLOCKING #2: flush the tail UNCHANGED unless the state
+        machine has already transitioned to ``"done"`` (closing fence
+        detected). The earlier draft rstripped backticks at EOS, which
+        would corrupt a valid bare JSON whose final string value
+        legitimately ends with backticks (``{"text":"```"}`` streamed
+        with the trailing ``\\"}`` arriving in the same chunk as a
+        leading ``` ` `` in the value). When ``state == "done"`` the
+        closing fence was already structurally detected and the tail
+        is dead bytes — we still drop them.
         """
         if not self.json_mode:
             return ""
         if self._json_fence_state == "done":
+            # Closing fence detected; whatever sat in the tail belongs
+            # AFTER the fence and is suppressed.
             self._json_fence_tail = ""
             return ""
         tail = self._json_fence_tail
         self._json_fence_tail = ""
-        if not tail:
-            return ""
-        # Defensive trim: a model that closed the stream mid-fence (rare,
-        # but possible when the engine hit ``max_tokens`` exactly at the
-        # ``` boundary) could leave a partial ``\\n``  or ``\\n``` `` in
-        # the tail. Drop trailing backticks and the newline immediately
-        # before them so the released suffix is still valid JSON.
-        stripped = tail.rstrip("`")
-        if stripped != tail:
-            stripped = stripped.rstrip("\r\n")
-        return stripped
+        return tail
 
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
@@ -1188,6 +1274,8 @@ class StreamingPostProcessor:
         self._json_fence_state = "scan"
         self._json_fence_buffer = ""
         self._json_fence_tail = ""
+        self._json_fence_in_string = False
+        self._json_fence_string_escape = False
         # Forced-prefix swallow buffer reset to baseline. The route layer
         # re-seeds via ``seed_forced_assistant_prefix`` after ``reset()``
         # when the request carries ``forced_assistant_prefix``; without

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -634,7 +634,7 @@ class StreamingPostProcessor:
         return emit
 
     def _filter_events_for_json_fence(
-        self, events: list[StreamEvent]
+        self, events: list[StreamEvent], *, drain_tail: bool = False
     ) -> list[StreamEvent]:
         """Run ``_apply_json_fence_strip`` over a list of StreamEvents.
 
@@ -645,45 +645,70 @@ class StreamingPostProcessor:
         dropped — pristine ``content`` deltas with empty payload would
         otherwise emit an empty SSE chunk.
 
+        Codex r4 BLOCKING #1: rewrites use ``dataclasses.replace`` so
+        all other ``StreamEvent`` fields the inner processors may have
+        attached (``metadata``, ``finish_reason``, ``tool_calls_detected``,
+        future fields) are preserved. The earlier draft constructed a
+        minimal ``StreamEvent(type=..., content=...)`` and dropped the
+        rest.
+
+        Codex r4 BLOCKING #2: when ``drain_tail=True`` (set by
+        ``finalize()``), any held tail bytes are merged into the
+        LAST emitted content/finish event in a single pass — avoids
+        emitting tail content AFTER a finish marker. When no such
+        event exists, the tail is appended as its own content event
+        at the END of the list (still before any terminal-finish
+        chunk the caller will assemble).
+
         No-op fast path when ``json_mode`` is False — caller treats the
         list as already-filtered.
         """
         if not self.json_mode:
             return events
 
+        from dataclasses import replace as _dc_replace
+
         filtered: list[StreamEvent] = []
         for ev in events:
             if ev.type == "content":
                 stripped = self._apply_json_fence_strip(ev.content or "")
                 if stripped:
-                    filtered.append(StreamEvent(type="content", content=stripped))
+                    filtered.append(_dc_replace(ev, content=stripped))
                 # else: fully suppressed (fence/preamble/closer) — drop.
             elif ev.type == "finish":
                 # Finish events can carry merged content (the route's
-                # buffered-finish merge path). Strip it the same way,
-                # plus drain any held tail bytes so a bare-JSON-no-
-                # closing-fence stream still flushes the final chunk.
+                # buffered-finish merge path). Strip it the same way.
+                # Tail draining happens BELOW (after the walk) so we
+                # don't double-drain if the caller also passed
+                # ``drain_tail=True``.
                 terminal = ev.content or ""
                 if terminal:
                     terminal = self._apply_json_fence_strip(terminal)
-                # Drain the held tail (only meaningful for the
-                # bare-JSON-no-fence case where the JSON simply ends).
-                tail = self._flush_json_fence_tail()
-                if tail:
-                    terminal = (terminal or "") + tail
-                filtered.append(
-                    StreamEvent(
-                        type="finish",
-                        finish_reason=ev.finish_reason,
-                        content=terminal or None,
-                        reasoning=ev.reasoning,
-                        tool_calls=ev.tool_calls,
-                        tool_calls_detected=ev.tool_calls_detected,
-                    )
-                )
+                filtered.append(_dc_replace(ev, content=terminal or None))
             else:
                 # reasoning / tool_call / other event types: pass through.
                 filtered.append(ev)
+
+        if drain_tail:
+            tail = self._flush_json_fence_tail()
+            if tail:
+                # Merge into the LAST content-bearing event in one pass
+                # (codex r4 BLOCKING #2 — avoid ordering finalize tail
+                # AFTER a finish event the inner branch emitted). Walk
+                # from the right; prefer ``finish`` (merges into the
+                # terminal SSE chunk), fall back to ``content`` (extends
+                # the last content delta), else append a new content
+                # event at the END.
+                merged = False
+                for i in range(len(filtered) - 1, -1, -1):
+                    if filtered[i].type in ("finish", "content"):
+                        prev = filtered[i].content or ""
+                        filtered[i] = _dc_replace(filtered[i], content=prev + tail)
+                        merged = True
+                        break
+                if not merged:
+                    filtered.append(StreamEvent(type="content", content=tail))
+
         return filtered
 
     def _flush_json_fence_tail(self) -> str:
@@ -2336,20 +2361,16 @@ class StreamingPostProcessor:
             if isinstance(held, str) and held:
                 events.append(StreamEvent(type="content", content=held))
 
-        # H-07: ```json fence-strip on the finalize event list AND flush
-        # any held tail. The route's "buffered_finish" merge path
-        # concatenates ``finalize()``-produced content events into the
-        # terminal SSE chunk; without the strip here the closing fence
-        # would survive on the last few bytes of the stream. The flush
-        # path also rescues the bare-JSON-no-fence stream: when the
-        # model returns ``{...}`` with no closing fence, the tail buffer
-        # at stream end holds the final few bytes that
-        # ``_guard_closing_fence`` held back "just in case". Drain them.
-        events = self._filter_events_for_json_fence(events)
-        if self.json_mode:
-            tail = self._flush_json_fence_tail()
-            if tail:
-                events.append(StreamEvent(type="content", content=tail))
+        # H-07: ```json fence-strip on the finalize event list AND
+        # drain any held tail in the SAME pass. The route's
+        # "buffered_finish" merge path concatenates
+        # ``finalize()``-produced content events into the terminal
+        # SSE chunk; without the strip here the closing fence would
+        # survive on the last few bytes of the stream. The single-
+        # pass drain (``drain_tail=True``) merges any held tail into
+        # the LAST content/finish event in this batch so JSON bytes
+        # never sit after a terminal marker (codex r4 BLOCKING #2).
+        events = self._filter_events_for_json_fence(events, drain_tail=True)
 
         return events
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -68,6 +68,15 @@ def _find_json_fence_opener(text: str) -> int:
     that ambiguity — language-tagged code blocks (python, bash,
     etc.) and string-content fences don't match.
 
+    Codex r10 BLOCKING: the scan must NOT look past the
+    matching CLOSING fence of a NON-JSON block. Otherwise a preamble
+    like ``\\n```python\\nx\\n```\\n{"k":1}`` would treat the python
+    block's closing ``` ``` `` (followed by ``\\n{`` in the next text)
+    as an opening JSON fence. We pair each ``` ``` `` with its
+    matching closer and skip past the closer before scanning the
+    next fence — only the OPENING fences can win, and only those
+    whose immediately-following payload begins with a JSON delimiter.
+
     Returns the index of the first backtick of the chosen fence,
     or -1 if no JSON-bearing fence is found. Multiple matches: the
     LAST one wins (preferring the most recent fence — the model is
@@ -82,7 +91,8 @@ def _find_json_fence_opener(text: str) -> int:
             break
         # Skip past the fence + optional ``json`` tag + whitespace.
         cur = pos + 3
-        if text[cur : cur + 4].lower() == "json":
+        is_json_tagged = text[cur : cur + 4].lower() == "json"
+        if is_json_tagged:
             cur += 4
         while cur < n and text[cur] in " \t\r\n":
             cur += 1
@@ -90,7 +100,13 @@ def _find_json_fence_opener(text: str) -> int:
         # fence opens a JSON block — eligible as the opener.
         if cur < n and text[cur] in "{[":
             best = pos
-        i = pos + 3
+        # Codex r10 BLOCKING: advance past the matching CLOSING
+        # fence so we don't treat its trailing whitespace + a later
+        # JSON delimiter as a fresh opener. If no closer exists yet
+        # (streaming: closer hasn't arrived), advance one char past
+        # the opener so we don't loop forever on the same position.
+        closer = text.find("```", pos + 3)
+        i = closer + 3 if closer >= 0 else pos + 3
     return best
 
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -417,12 +417,20 @@ class StreamingPostProcessor:
     # raw rather than swallow the entire stream on a runaway preamble.
 
     # Max bytes to accumulate while scanning for the JSON start. Past
-    # this point the model clearly is NOT emitting an opening fence, so
-    # release the buffer rather than swallow arbitrary content. Sized
-    # generously vs. realistic fence variants (``\n\n```json\n``,
-    # ``Sure! Here:\n```json\n``); large preambles already lose to the
-    # ``_json_preamble_buffer`` path on the no-reasoning branch.
+    # this point the buffer is trimmed to the last
+    # ``_JSON_FENCE_SCAN_KEEP_SUFFIX`` bytes — JUST enough to detect
+    # an opening fence split across the trim boundary — while older
+    # preamble bytes are dropped from the buffer. We never RELEASE the
+    # preamble onto the wire (codex r3 BLOCKING: doing so would leak
+    # the wrapper that the non-stream path strips); we just stop
+    # holding the entire history in memory.
     _JSON_FENCE_SCAN_CAP = 4096
+    # When the scan cap is hit, retain this many trailing bytes so
+    # a split ``...\\n``` `` opening fence can still be detected on
+    # the next chunk. ``"```json\n"`` is 8 bytes; 32 gives slack for
+    # rare opener variants like ``` ```json   \n ``` and is still
+    # negligible vs. the dropped 4KB.
+    _JSON_FENCE_SCAN_KEEP_SUFFIX = 32
 
     def _apply_json_fence_strip(self, content: str) -> str:
         """Strip ```json...``` markdown fence from streaming content.
@@ -457,13 +465,18 @@ class StreamingPostProcessor:
             # is handled identically to the existing preamble path.
             json_start = _find_json_start(buf)
             if json_start < 0:
-                # No JSON delimiter yet. If the buffer grew past the cap,
-                # we're clearly NOT in a fence scenario — release the
-                # buffer raw rather than swallow the entire stream.
+                # No JSON delimiter yet. If the buffer grew past the
+                # cap, drop the OLD bytes — but keep enough of the
+                # suffix to catch a fence-opener split across the
+                # boundary. Codex r3 BLOCKING: the earlier draft
+                # RELEASED the entire >4KB buffer raw, which leaked
+                # the preamble + opening fence onto the wire (the
+                # opposite of what response_format=json_* requires).
+                # The contract for json_mode is "suppress everything
+                # before the first ``{``/``[``", and that contract
+                # must hold regardless of preamble length.
                 if len(buf) > self._JSON_FENCE_SCAN_CAP:
-                    self._json_fence_state = "inside"
-                    self._json_fence_buffer = ""
-                    return self._guard_closing_fence(buf)
+                    self._json_fence_buffer = buf[-self._JSON_FENCE_SCAN_KEEP_SUFFIX :]
                 return ""
             # Found the JSON start. Strip everything before it (preamble
             # + opening fence). Symmetric with the non-stream


### PR DESCRIPTION
## Summary

Streaming chat completions with `response_format={"type":"json_object"}` (or `json_schema`) were leaking a `` ```json `` markdown fence around the JSON body. Concatenated SSE deltas decoded as `` ```json\n{...}\n``` `` and `json.loads(joined)` failed for any SDK consumer assembling `delta.content` into a string. The non-stream chat response builder already peels the fence via `extract_json_from_response` (vllm_mlx/api/utils.py); the stream path concatenated raw model tokens without the same scrub.

H-07 in `0.8TODO.md`, surfaced by **Marisol (r2)**.

## Repro (Qwen3-0.6B-8bit, port 8804)

```python
from openai import OpenAI
client = OpenAI(api_key="x", base_url="http://localhost:8804/v1")
stream = client.chat.completions.create(
    model="mlx-community/Qwen3-0.6B-8bit",
    messages=[{"role":"user","content":"Return JSON with name and price of iPhone 15"}],
    response_format={"type":"json_object"},
    stream=True,
)
joined = "".join(c.choices[0].delta.content or "" for c in stream)
```

- **Before** (origin/main): `joined == '```json\n{"name": "iPhone 15", "price": 799.99}\n```'`, `json.loads(joined)` raises.
- **After**: `joined == '{"name": "iPhone 15", "price": 799.99}'`, `json.loads(joined)` succeeds.

The non-stream path on the same prompt was always clean; the only regression was on `stream=True`.

## Design — state machine in the delta builder, NOT a post-join regex

Two constraints forced the state-machine shape:

1. **Fence tokens split across delta chunks.** Tokenizers fragment `` \n```\n `` arbitrarily (`` `` ``, `` `json ``, `\n`); a post-emission regex can't help because we need to SUPPRESS bytes BEFORE they reach the wire. A client that runs `json.loads` on every cumulative `joined` (streaming validators) needs each emitted byte to keep the buffer parseable.
2. **Bare-JSON path must pass through unchanged.** When the model returns `{...}` with no fence at all, we cannot unconditionally buffer — that would introduce a per-chunk delay even when nothing needs suppressing.

Implementation (vllm_mlx/service/postprocessor.py):

- New per-instance state machine with three states (`scan` → `inside` → `done`).
- Engaged only when `json_mode=True` (i.e. `response_format.type ∈ {"json_object","json_schema"}`); no-op otherwise so `response_format` absent leaves the existing behavior bit-identical.
- `_apply_json_fence_strip` runs at the OUTER `process_chunk` dispatcher via `_filter_events_for_json_fence`, so it covers all three internal paths (`_process_channel_routed`, `_process_with_reasoning`, `_process_standard`). The existing `_json_preamble_buffer` was gated on `not self.reasoning_parser`, so reasoning models in json_mode were doubly broken — now covered.
- `_guard_closing_fence` uses `_json_fence_suffix_hold_len` to defer only the trailing 0-3 bytes that LOOK like the start of a closing fence (`\n`, `` ` ``, `` `` ``, `` ``` ``). Chunks ending in `}`, a digit, a quote, etc. flush immediately — the bare-JSON path pays zero latency.
- **Codex r1 BLOCKING #1**: `_guard_closing_fence` now tracks JSON-string state (`"` toggle + `\"` escape) and skips `` ``` `` detection when inside a string literal, so `{"markdown":"```python\\nx\\n```"}` survives the outer fence strip.
- **Codex r1 BLOCKING #2**: `_flush_json_fence_tail` flushes held tail UNCHANGED unless the state machine has transitioned to `done` (closing fence detected). The earlier draft rstripped trailing backticks at EOS, which corrupted bare JSON whose final string value ended with backticks.
- `_flush_json_fence_tail` in `finalize()` drains any held tail at stream end (rescues the bare-JSON-no-closing-fence path).

## Test plan

- [x] Reproduced on origin/main: joined stream included `` ```json `` fence; `json.loads` failed (`/tmp/h07-before.txt`).
- [x] Post-fix live repro: joined stream is bare JSON, `json.loads` succeeds (`/tmp/h07-after.txt`).
- [x] New tests (`tests/test_response_format_streaming_fence_strip.py`, 17 cases):
  - [x] Stream + `json_object`: joined parses as JSON, no fence.
  - [x] Stream + `json_schema`: same.
  - [x] Fence split across two delta chunks (opening AND closing variants).
  - [x] Fence split token-by-token (realistic SSE granularity).
  - [x] Model returns bare JSON (no fence) under `json_object` — passes through unchanged.
  - [x] Stream WITHOUT `response_format`: any fence in content passes through unchanged.
  - [x] Reasoning-parser path strips the fence (previously broken — `_json_preamble_buffer` was skipped on this path).
  - [x] Non-stream `extract_json_from_response` regression (still peels fence, still passes bare JSON, still handles `` ``` ``-only fence).
  - [x] **Codex r1**: JSON string value containing literal triple-backticks survives (`{"markdown":"```python\\nx\\n```"}`).
  - [x] **Codex r1**: bare JSON whose final value ends with backticks survives finalize.
- [x] All 113 existing `test_postprocessor.py` tests pass unchanged.
- [x] Wider regression sweep (`test_chat_streaming_guided.py`, `test_streaming_reasoning_with_structured_output.py`, `test_structured_output.py`, `test_response_format_strict_types.py`, `test_silent_drop_rescue_569.py`, `test_streaming_simulator.py`, `test_clean_error_messages.py`): all pass.
- [x] Lint clean (`make lint`).
- [x] Live server smoke test (Qwen3-0.6B-8bit on :8804): stream + `json_object` returns bare JSON; non-stream regression unaffected; no-`response_format` stream passes fences through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)