### PR TITLE
fix(anthropic): 422 when tool_choice pins X but model emits zero X calls (H-05 follow-up)

### DIFF
--- a/tests/test_anthropic_tool_validation_scope.py
+++ b/tests/test_anthropic_tool_validation_scope.py
@@ -476,3 +476,194 @@ def test_validator_multiple_calls_bad_one_raises_about_bad_one_only():
     assert exc_info.value.status_code == 400
     assert "lookup_zip" in exc_info.value.detail
     assert "get_weather" not in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# PR #763 codex round-1 BLOCKING #1 — when ``tool_choice`` pins X but the
+# filter empties the call list (model emitted zero X calls), the route
+# MUST 422 instead of silently 200-ing with no tool_use. Two emit-shapes
+# of this failure mode:
+#
+#   * model emitted text only (count == 0): pin defied, text returned.
+#   * model emitted only wrong-tool calls (count > 0): pin defied, every
+#     call dropped by the filter.
+#
+# Both leave the user with no ``tool_use`` for the tool they pinned,
+# which violates the forced-tool contract.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_tool_model_emits_no_tool_calls_returns_422():
+    """``tool_choice={type:tool,name:get_weather}`` + model returns text
+    only → 422. Pre-fix, the route 200-ed with the text response and
+    the client had no ``tool_use`` for the pinned tool to act on.
+    """
+    engine = _MultiCallEngine(None, text="I can't help with weather right now.")
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client, tool_choice={"type": "tool", "name": "get_weather"}
+        ),
+    )
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    message = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "get_weather" in message
+    assert "no tool_calls" in message or "text response" in message
+
+
+def test_pinned_tool_model_emits_only_wrong_tool_returns_422():
+    """``tool_choice={type:tool,name:get_weather}`` + model fires only
+    ``lookup_zip`` → 422. The filter drops the un-pinned call and the
+    enforcer fires because no pinned-tool call survives.
+    """
+    engine = _MultiCallEngine([_call("lookup_zip", {"zip": "94105"})])
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client, tool_choice={"type": "tool", "name": "get_weather"}
+        ),
+    )
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    message = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "get_weather" in message
+    # The "model called something else" diagnostic mentions the original
+    # call count so the operator can distinguish defied-pin from no-call.
+    assert "1 call" in message or "none to" in message
+
+
+def test_pinned_tool_streaming_no_calls_emits_sse_error_event():
+    """Stream variant: pinned tool, model returned text only → SSE
+    ``event: error`` with the same diagnostic. Headers are already
+    sent so we cannot 422 the response; the error event is the
+    streaming surface's equivalent.
+    """
+    engine = _MultiCallEngine(None, text="I cannot help.")
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client,
+            tool_choice={"type": "tool", "name": "get_weather"},
+            stream=True,
+        ),
+    )
+
+    assert response.status_code == 200
+    raw = response.text
+    assert "event: error" in raw, raw
+    assert "invalid_request_error" in raw
+    assert "get_weather" in raw
+    # No tool_use must be shipped to the client — there was nothing
+    # valid to ship in the first place, and the error event already
+    # signalled "this stream is unrecoverable".
+    assert '"type": "tool_use"' not in raw, raw
+
+
+def test_pinned_tool_streaming_only_wrong_tool_emits_sse_error_and_no_tool_use():
+    """Stream variant: pinned tool, model fires only the wrong tool →
+    SSE error event AND no ``tool_use`` content_block for the wrong
+    tool (it was already filtered before the tool_use emit loop ran).
+
+    Locks PR #763 codex round-1 BLOCKING #2: the streaming branch must
+    NOT have shipped any ``tool_use`` content_block_start for the
+    dropped tool before the filter ran. The current code emits tool_use
+    SSE only AFTER ``_parse_tool_calls_with_parser`` (which sits AFTER
+    the filter call) — this test locks that ordering so a future
+    refactor that moves tool_use emission earlier into the
+    chunk-accumulation loop fails loudly.
+    """
+    engine = _MultiCallEngine([_call("lookup_zip", {"zip": "94105"})])
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client,
+            tool_choice={"type": "tool", "name": "get_weather"},
+            stream=True,
+        ),
+    )
+
+    assert response.status_code == 200
+    raw = response.text
+    assert "event: error" in raw, raw
+    assert "invalid_request_error" in raw
+    assert "get_weather" in raw
+    # Most importantly: the un-pinned tool name MUST NOT appear in any
+    # tool_use content_block — the filter dropped it before the emit
+    # loop. A pre-fix code path that streamed tool_use during
+    # accumulation would surface "lookup_zip" in a content_block_start
+    # event here.
+    assert '"type": "tool_use"' not in raw, raw
+    assert "lookup_zip" not in raw, raw
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the helpers added in PR #763 codex round-1.
+# ---------------------------------------------------------------------------
+
+
+def test_filter_returns_input_unchanged_for_non_named_tool_choice():
+    """``tool_choice="auto"`` / ``"required"`` / ``"none"`` / unset has
+    no defined "wrong tool" case. The filter must pass calls through
+    unchanged so the validator runs against the full set.
+    """
+    from vllm_mlx.routes.anthropic import _filter_tool_calls_by_tool_choice
+
+    calls = [_call("a", {}), _call("b", {})]
+    # ``None`` (unset).
+    assert _filter_tool_calls_by_tool_choice(calls, None) == calls
+    # ``"auto"`` (string form survives if a caller passed it through).
+    assert _filter_tool_calls_by_tool_choice(calls, "auto") == calls
+    # ``{"type":"function"}`` with no name → no target → passthrough.
+    assert _filter_tool_calls_by_tool_choice(calls, {"type": "function"}) == calls
+    # ``{"type":"function","function":{"name":""}}`` → no target.
+    assert (
+        _filter_tool_calls_by_tool_choice(
+            calls, {"type": "function", "function": {"name": ""}}
+        )
+        == calls
+    )
+
+
+def test_enforce_named_tool_choice_present_noop_for_non_named_choice():
+    """The enforcer must not raise when ``tool_choice`` doesn't pin a
+    specific tool — there's nothing to enforce. Locks against a future
+    bug where adding the enforcer would break ``tool_choice="auto"``
+    flows that the model resolved as text-only.
+    """
+    from vllm_mlx.routes.anthropic import _enforce_named_tool_choice_present
+
+    # No raise for ``None``, ``"auto"``, or a ``{"type":"function"}``
+    # shape without a name.
+    _enforce_named_tool_choice_present([], None, original_call_count=0)
+    _enforce_named_tool_choice_present([], "auto", original_call_count=0)
+    _enforce_named_tool_choice_present([], {"type": "function"}, original_call_count=0)
+
+
+def test_enforce_named_tool_choice_present_noop_when_pinned_call_survives():
+    """When the filter kept the pinned-tool call, the enforcer must
+    pass through silently — the contract is satisfied.
+    """
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.routes.anthropic import _enforce_named_tool_choice_present
+
+    pinned_call = ToolCall(
+        id="c1",
+        type="function",
+        function=FunctionCall(name="get_weather", arguments='{"location": "SF"}'),
+    )
+    _enforce_named_tool_choice_present(
+        [pinned_call],
+        {"type": "function", "function": {"name": "get_weather"}},
+        original_call_count=1,
+    )

--- a/tests/test_anthropic_tool_validation_scope.py
+++ b/tests/test_anthropic_tool_validation_scope.py
@@ -79,12 +79,26 @@ class _MultiCallEngine:
         )
 
     async def stream_chat(self, messages, **kwargs):  # noqa: ARG002
-        yield SimpleNamespace(
-            new_text=self._text,
-            prompt_tokens=10,
-            completion_tokens=1,
-            tool_calls=self._tool_calls,
-        )
+        # Emit text first (mirrors how a real streaming engine
+        # surfaces text tokens chunk-by-chunk before any tool_calls
+        # are finalised by the harmony parser). The route's chunk
+        # loop short-circuits with ``continue`` on any chunk that
+        # carries ``tool_calls``, so text + tool_calls must be on
+        # SEPARATE chunks for both paths to exercise.
+        if self._text:
+            yield SimpleNamespace(
+                new_text=self._text,
+                prompt_tokens=10,
+                completion_tokens=1,
+                tool_calls=None,
+            )
+        if self._tool_calls:
+            yield SimpleNamespace(
+                new_text="",
+                prompt_tokens=10,
+                completion_tokens=1,
+                tool_calls=self._tool_calls,
+            )
 
 
 def _make_client(engine: _MultiCallEngine) -> TestClient:
@@ -541,11 +555,21 @@ def test_pinned_tool_model_emits_only_wrong_tool_returns_422():
 
 def test_pinned_tool_streaming_no_calls_emits_sse_error_event():
     """Stream variant: pinned tool, model returned text only → SSE
-    ``event: error`` with the same diagnostic. Headers are already
-    sent so we cannot 422 the response; the error event is the
-    streaming surface's equivalent.
+    ``event: error`` with the same diagnostic AND no streamed text
+    deltas reach the wire BEFORE the error.
+
+    Headers are already sent so we cannot 422 the response; the
+    error event is the streaming surface's equivalent. The crucial
+    extra invariant (PR #771 codex round-2 BLOCKING #1) is that the
+    chunk loop's text deltas must NEVER have been emitted — the
+    pre-filter buffer drops them on the floor when enforcement
+    fires. Before the buffering fix, those deltas streamed to the
+    client BEFORE the error event, leaking a partial text payload
+    that violated the forced-tool contract (the client could surface
+    a half-formed "answer" the contract said wasn't allowed).
     """
-    engine = _MultiCallEngine(None, text="I cannot help.")
+    distinctive_text = "ANTHROPIC_TEXT_LEAK_CANARY_xyzzy"
+    engine = _MultiCallEngine(None, text=distinctive_text)
     client = _make_client(engine)
 
     response = client.post(
@@ -566,6 +590,16 @@ def test_pinned_tool_streaming_no_calls_emits_sse_error_event():
     # valid to ship in the first place, and the error event already
     # signalled "this stream is unrecoverable".
     assert '"type": "tool_use"' not in raw, raw
+    # PR #771 codex round-2 BLOCKING #1: the model's text response
+    # must NOT appear anywhere in the stream — neither as a
+    # ``text_delta`` chunk, a ``content_block_start`` of type
+    # ``text``, nor in the raw SSE payload. The distinctive text
+    # token above makes the leak detectable independent of how the
+    # delta is framed (single chunk, multiple chunks, escaped
+    # whitespace, etc.).
+    assert distinctive_text not in raw, raw
+    assert '"type": "text_delta"' not in raw, raw
+    assert '"type": "text"' not in raw, raw
 
 
 def test_pinned_tool_streaming_only_wrong_tool_emits_sse_error_and_no_tool_use():
@@ -667,3 +701,54 @@ def test_enforce_named_tool_choice_present_noop_when_pinned_call_survives():
         {"type": "function", "function": {"name": "get_weather"}},
         original_call_count=1,
     )
+
+
+def test_pinned_tool_streaming_text_replays_when_enforcement_passes():
+    """Happy-path buffer-replay regression: pinned tool, model emits
+    BOTH the pinned tool AND incidental text. The text must arrive
+    in the SSE stream (it's legitimate output adjacent to the
+    pinned-tool call), AND it must arrive AFTER the buffer-replay —
+    i.e. the order ``message_start`` → text content_block → tool_use
+    is preserved.
+
+    Locks the round-2 fix's "replay buffer on success" branch: a
+    naive implementation that dropped the buffer on every named
+    ``tool_choice`` would lose legitimate text output adjacent to a
+    correct pinned-tool call.
+    """
+    distinctive_text = "ANTHROPIC_STREAM_REPLAY_CANARY_42"
+    engine = _MultiCallEngine(
+        [_call("get_weather", {"location": "SF"})],
+        text=distinctive_text,
+    )
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json=_post_messages(
+            client,
+            tool_choice={"type": "tool", "name": "get_weather"},
+            stream=True,
+        ),
+    )
+
+    assert response.status_code == 200
+    raw = response.text
+    # No error — enforcement passed.
+    assert "event: error" not in raw, raw
+    # Both the text payload AND the pinned tool's tool_use must reach
+    # the client. The buffered text is replayed after the enforcement
+    # check, preserving streaming UX for legitimate adjacent text.
+    assert distinctive_text in raw, raw
+    assert '"type": "tool_use"' in raw
+    assert "get_weather" in raw
+    # Order check: the buffered text content_block_start/stop pair
+    # is replayed BEFORE the tool_use content_block_start. A reversed
+    # order would mean we leaked tool_use first then text — clients
+    # would see the tool result before the surrounding narration.
+    text_block_pos = raw.find(distinctive_text)
+    tool_use_pos = raw.find('"type": "tool_use"')
+    assert text_block_pos < tool_use_pos, (
+        f"text block at {text_block_pos} should precede tool_use at {tool_use_pos}"
+    )
+    assert '"stop_reason": "tool_use"' in raw

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -107,21 +107,57 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 
+def _named_tool_choice_target(tool_choice) -> str | None:
+    """Return the target tool name when ``tool_choice`` pins a specific
+    tool, else ``None``.
+
+    The Anthropic adapter has already translated
+    ``{"type":"tool","name":X}`` into the OpenAI form
+    ``{"type":"function","function":{"name":X}}`` on
+    ``openai_request.tool_choice`` by the time we get here. ``"auto"`` /
+    ``"required"`` / ``"none"`` / unset shapes return ``None`` — they
+    have no defined "wrong tool" case to filter or enforce.
+    """
+    if not isinstance(tool_choice, dict):
+        return None
+    if tool_choice.get("type") != "function":
+        return None
+    target = (tool_choice.get("function") or {}).get("name")
+    return target or None
+
+
+def _tool_call_name_anthropic(tc) -> str | None:
+    """Extract the function name from a tool_call entry regardless of
+    shape. Three real shapes survive into this point — see
+    ``routes/chat.py:_tool_call_name`` for the same catalogue. Inlined
+    here to avoid a cross-route import dependency from ``routes/chat.py``
+    into ``routes/anthropic.py``.
+    """
+    if isinstance(tc, dict):
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            return fn.get("name")
+        if fn is not None:
+            return getattr(fn, "name", None)
+        return tc.get("name")
+    fn = getattr(tc, "function", None)
+    if fn is not None:
+        return getattr(fn, "name", None)
+    return getattr(tc, "name", None)
+
+
 def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
     """Drop tool_use blocks that don't match a forced ``tool_choice``.
 
     H-05: Anthropic ``tool_choice={"type":"tool","name":X}`` pins WHICH
-    tool the model must call. The Anthropic adapter has already
-    translated that into the OpenAI form
-    ``{"type":"function","function":{"name":X}}`` on
-    ``openai_request.tool_choice`` by the time we get here. Local
-    inference has no decoder-level constraint, so a small model can
-    happily defy the pin and emit a call to a different tool (the
-    Sergei repro hit qwen3.5-4b on a two-tool prompt where the model
-    fired BOTH the pinned tool AND the un-pinned one). Pre-fix, the
-    downstream JSON-schema validator (F-220) then 400-ed on the
-    un-pinned tool's argument schema — leaking validation across a
-    tool the user never asked for and silently breaking ``tool_choice``.
+    tool the model must call. Local inference has no decoder-level
+    constraint, so a small model can happily defy the pin and emit a
+    call to a different tool (the Sergei repro hit qwen3.5-4b on a
+    two-tool prompt where the model fired BOTH the pinned tool AND the
+    un-pinned one). Pre-fix, the downstream JSON-schema validator
+    (F-220) then 400-ed on the un-pinned tool's argument schema —
+    leaking validation across a tool the user never asked for and
+    silently breaking ``tool_choice``.
 
     Policy: when the choice pins a specific tool, KEEP only the calls
     to that tool and drop the rest with a warning. This matches the
@@ -132,48 +168,36 @@ def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
     case to filter.
 
     Chat.py's named-function path 422s on the same mismatch (see
-    ``routes/chat.py:1665``). The two routes intentionally diverge
-    here: ``/v1/chat/completions`` mirrors OpenAI's strict contract,
-    while ``/v1/messages`` mirrors Anthropic's more forgiving
-    "deliver the pinned tool's call" contract — a 422 on an extra
-    call would surface a confusing error to clients that pinned the
-    very tool the response carries. The validator scope refactor in
-    ``_validate_tool_call_params`` ensures we never validate against
-    the dropped tool's schema even if a future change weakens this
-    filter.
+    ``routes/chat.py:1665``). The two routes intentionally diverge on
+    the "got pinned + extras" case: ``/v1/chat/completions`` mirrors
+    OpenAI's strict contract (422), while ``/v1/messages`` mirrors
+    Anthropic's more forgiving "deliver the pinned tool's call"
+    contract — a 422 on an extra call would surface a confusing error
+    to clients that pinned the very tool the response already
+    carries. They CONVERGE on the "got zero pinned calls" case, which
+    is handled by ``_enforce_named_tool_choice_present`` below (PR
+    #763 codex round-1 BLOCKING #1: a filter that emptied the list
+    plus a downstream "no tool_calls? end_turn." branch would 200
+    with no ``tool_use`` block at all, silently violating the
+    forced-tool contract).
+
+    The validator scope refactor in ``_validate_tool_call_params``
+    ensures we never validate against the dropped tool's schema even
+    if a future change weakens this filter.
     """
     if not tool_calls or not isinstance(tool_choice, dict):
         return tool_calls or []
-    if tool_choice.get("type") != "function":
-        return tool_calls
-    target = (tool_choice.get("function") or {}).get("name")
+    target = _named_tool_choice_target(tool_choice)
     if not target:
         return tool_calls
-
-    def _name_of(tc) -> str | None:
-        # Three shapes survive into this point — see
-        # ``routes/chat.py:_tool_call_name`` for the catalogue. Inline
-        # here to avoid a cross-route import dependency from
-        # routes/chat.py into routes/anthropic.py.
-        if isinstance(tc, dict):
-            fn = tc.get("function")
-            if isinstance(fn, dict):
-                return fn.get("name")
-            if fn is not None:
-                return getattr(fn, "name", None)
-            return tc.get("name")
-        fn = getattr(tc, "function", None)
-        if fn is not None:
-            return getattr(fn, "name", None)
-        return getattr(tc, "name", None)
 
     filtered = []
     dropped: list[str] = []
     for tc in tool_calls:
-        if _name_of(tc) == target:
+        if _tool_call_name_anthropic(tc) == target:
             filtered.append(tc)
         else:
-            dropped.append(_name_of(tc) or "<unknown>")
+            dropped.append(_tool_call_name_anthropic(tc) or "<unknown>")
     if dropped:
         logger.warning(
             "tool_choice pinned %r but model also emitted calls to %s; "
@@ -183,6 +207,59 @@ def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
             dropped,
         )
     return filtered
+
+
+def _enforce_named_tool_choice_present(
+    tool_calls,
+    tool_choice,
+    *,
+    original_call_count: int,
+) -> None:
+    """Raise 422 when ``tool_choice`` pinned a specific tool but no
+    matching tool_call survives.
+
+    PR #763 codex round-1 BLOCKING #1: ``_filter_tool_calls_by_tool_choice``
+    correctly drops un-pinned calls, but the downstream branch in
+    ``messages_endpoint`` treats ``tool_calls=[]`` as "model returned
+    text only → ``stop_reason=end_turn``". That is the wrong contract
+    when the client pinned a specific tool: an empty post-filter list
+    means EITHER the model emitted zero tool_calls at all (model
+    defied the pin entirely and answered as plain text) OR every
+    emitted call was to the wrong tool (model called something else
+    and we dropped them all). Both states violate the forced-tool
+    contract; clients that pinned ``X`` expect a ``tool_use`` block
+    for ``X`` and a 200 ``end_turn`` text response leaves them with
+    nothing to act on. Surface the failure explicitly so the caller
+    can retry / fall back instead of silently mis-routing.
+
+    Mirrors chat.py's ``tool_choice="required"`` no-call branch
+    (``routes/chat.py:1587``) which 422s with the same "local
+    inference cannot decoder-enforce" diagnostic. The streaming
+    branch uses the same body via an SSE ``event: error``.
+
+    ``original_call_count`` is the size of ``tool_calls`` BEFORE the
+    filter ran — we use it to disambiguate "model returned text"
+    (count == 0) from "model called the wrong tool(s) and the filter
+    emptied the list" (count > 0) in the error message.
+    """
+    target = _named_tool_choice_target(tool_choice)
+    if not target or tool_calls:
+        return
+    if original_call_count == 0:
+        detail = (
+            f"tool_choice pinned tool {target!r} but the model returned a text "
+            "response with no tool_calls. Local inference has no decoder-level "
+            "constraint; the system-prompt enforcement was insufficient for "
+            "this prompt. Retry with a more direct user message."
+        )
+    else:
+        detail = (
+            f"tool_choice pinned tool {target!r} but the model emitted "
+            f"{original_call_count} call(s), none to {target!r}. Local "
+            "inference cannot decoder-enforce a specific tool; retry with a "
+            "more direct user message."
+        )
+    raise HTTPException(status_code=422, detail=detail)
 
 
 @router.post(
@@ -407,10 +484,18 @@ async def create_anthropic_message(
         # ``lookup_zip``, 400 came back complaining about ``lookup_zip``.
         # Drop the un-pinned calls FIRST so the validator only sees the
         # pinned tool's call(s). See ``_filter_tool_calls_by_tool_choice``
-        # for the policy rationale vs chat.py's 422-on-mismatch.
-        if tool_calls and openai_request.tool_choice:
+        # for the policy rationale vs chat.py's 422-on-mismatch, and
+        # ``_enforce_named_tool_choice_present`` for the "filter dropped
+        # everything" guard added in PR #763 codex round-1.
+        original_call_count = len(tool_calls or [])
+        if openai_request.tool_choice:
             tool_calls = _filter_tool_calls_by_tool_choice(
-                tool_calls, openai_request.tool_choice
+                tool_calls or [], openai_request.tool_choice
+            )
+            _enforce_named_tool_choice_present(
+                tool_calls,
+                openai_request.tool_choice,
+                original_call_count=original_call_count,
             )
 
         # F-220: enforce the same tool_call JSON-schema validation
@@ -1514,10 +1599,39 @@ async def _stream_anthropic_messages(
     # see the non-stream call site for the policy rationale. Run
     # BEFORE validation so the F-220 enforcer never sees the dropped
     # tool's schema-violating arguments.
-    if tool_calls and openai_request.tool_choice:
+    #
+    # IMPORTANT (PR #763 codex round-1 BLOCKING #2 — confirm-and-lock):
+    # NO ``content_block_start`` for ``type=tool_use`` is emitted in the
+    # while-loop above. The structured tool-call payload is only
+    # collected into ``accumulated_structured_tool_calls`` (see the
+    # ``engine_tool_calls`` extend at the stream-chunk site), and the
+    # tool_use SSE events are emitted strictly below (after the
+    # filter + validation). If a future refactor moves tool_use deltas
+    # earlier in the stream, this filter MUST be re-applied at the
+    # earlier emission point or the dropped tool's content_block_start
+    # will reach the wire before we know to suppress it.
+    tool_choice_error: str | None = None
+    original_call_count_stream = len(tool_calls or [])
+    if openai_request.tool_choice:
         tool_calls = _filter_tool_calls_by_tool_choice(
-            tool_calls, openai_request.tool_choice
+            tool_calls or [], openai_request.tool_choice
         )
+        # Stream variant of ``_enforce_named_tool_choice_present``:
+        # headers are already on the wire so we can't 422 — surface
+        # the same diagnostic as an Anthropic ``event: error`` and
+        # close the stream with ``end_turn``. Mirrors how the F-220
+        # validation-failure branch below handles the same
+        # "headers-already-sent" constraint.
+        try:
+            _enforce_named_tool_choice_present(
+                tool_calls,
+                openai_request.tool_choice,
+                original_call_count=original_call_count_stream,
+            )
+        except HTTPException as exc:
+            tool_choice_error = (
+                exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            )
 
     # F-220: enforce JSON-schema validation on the model's emitted
     # tool_call arguments. On the streaming branch, headers are already
@@ -1537,15 +1651,27 @@ async def _stream_anthropic_messages(
             )
             tool_calls = []
 
-    if tool_validation_error:
+    # Emit a single SSE error event when either the tool_choice
+    # enforcement or the schema validator fired. Both classes are
+    # surfaced as ``invalid_request_error`` — they describe a
+    # client-actionable failure (retry / fall back / relax pin),
+    # whereas a true server failure would arrive via the route-level
+    # exception handler.
+    if tool_choice_error or tool_validation_error:
         error_event = {
             "type": "error",
             "error": {
                 "type": "invalid_request_error",
-                "message": tool_validation_error,
+                "message": tool_choice_error or tool_validation_error,
             },
         }
         yield f"event: error\ndata: {json.dumps(error_event)}\n\n"
+        # When the pinned-tool enforcement fires, the only emit-worthy
+        # output is the error event — drop any surviving tool_calls so
+        # the loop below doesn't ship a ``tool_use`` for a state the
+        # error event already marked unrecoverable.
+        if tool_choice_error:
+            tool_calls = []
 
     if tool_calls:
         for i, tc in enumerate(tool_calls):

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1024,6 +1024,52 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
+    # H-05 follow-up (PR #771 codex round-2 BLOCKING #1): when
+    # ``tool_choice`` pins a specific tool, the model is supposed to
+    # emit a ``tool_use`` for that tool. Local inference can't
+    # decoder-enforce that, so a defiant model can stream a TEXT
+    # response instead — and pre-fix, those text deltas were
+    # yielded chunk-by-chunk before we knew to reject the response.
+    # By the time the post-loop enforcement fired the SSE error event,
+    # the client had already received a partial text payload that
+    # violates the forced-tool contract.
+    #
+    # Fix: when a named ``tool_choice`` is set, BUFFER every
+    # content_block / thinking event produced inside the chunk loop
+    # (and the post-loop flushes) into ``pre_filter_buffer`` instead
+    # of yielding it. After the loop finishes we run the same filter +
+    # enforcement step the non-stream branch uses; on success we
+    # replay the buffer so streaming UX is preserved, on failure we
+    # drop the buffer and emit only the SSE error event so the
+    # forbidden text payload never reaches the wire. ``message_start``
+    # is yielded above this (clients use it to allocate the message
+    # frame) and ``message_delta`` / ``message_stop`` are yielded
+    # below the enforcement (they only describe the terminal state).
+    _pinned_tool_target = _named_tool_choice_target(
+        getattr(openai_request, "tool_choice", None)
+    )
+    _buffer_for_pinned_tool = _pinned_tool_target is not None
+    pre_filter_buffer: list[str] = []
+
+    def _capture(event: str) -> str | None:
+        """Either buffer ``event`` and return ``None``, or return
+        ``event`` unchanged.
+
+        When a named ``tool_choice`` is pinned, every chunk-loop
+        content event is appended to ``pre_filter_buffer`` and this
+        helper returns ``None`` so the caller's ``if ev is not None:
+        yield ev`` is a no-op. Otherwise the helper returns the
+        event unchanged and the caller yields it immediately —
+        preserving the original "one event in ⇒ one event out"
+        streaming semantics. ``async for`` constructs in Python 3.12
+        don't allow ``yield from`` against a sync generator helper,
+        so this returns a scalar rather than an iterator.
+        """
+        if _buffer_for_pinned_tool:
+            pre_filter_buffer.append(event)
+            return None
+        return event
+
     accumulated_text = ""
     accumulated_raw = ""
     # Structured tool calls surfaced by the engine's OutputRouter
@@ -1258,7 +1304,9 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        yield event
+                        ev = _capture(event)
+                        if ev is not None:
+                            yield ev
                 continue
 
             if reasoning_parser:
@@ -1413,7 +1461,9 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        yield event
+                        ev = _capture(event)
+                        if ev is not None:
+                            yield ev
                 continue
 
             # No reasoning_parser path — keep the existing think_router
@@ -1433,7 +1483,9 @@ async def _stream_anthropic_messages(
                     block_index,
                 )
                 for event in events:
-                    yield event
+                    ev = _capture(event)
+                    if ev is not None:
+                        yield ev
 
     # Flush remaining from both filters
     remaining = tool_filter.flush()
@@ -1451,7 +1503,9 @@ async def _stream_anthropic_messages(
             block_index,
         )
         for event in events:
-            yield event
+            ev = _capture(event)
+            if ev is not None:
+                yield ev
 
     if not reasoning_parser:
         flush_pieces = think_router.flush()
@@ -1462,11 +1516,18 @@ async def _stream_anthropic_messages(
                 block_index,
             )
             for event in events:
-                yield event
+                ev = _capture(event)
+                if ev is not None:
+                    yield ev
 
     # Close final content block
     if current_block_type is not None:
-        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+        ev = _capture(
+            f"event: content_block_stop\ndata: "
+            f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+        )
+        if ev is not None:
+            yield ev
         block_index += 1
 
     # Codex round-3 BLOCKING #2: if the reasoning cap latched on the
@@ -1532,14 +1593,18 @@ async def _stream_anthropic_messages(
                         [("text", filtered)], current_block_type, block_index
                     )
                     for event in events:
-                        yield event
+                        ev = _capture(event)
+                        if ev is not None:
+                            yield ev
         # Close any block we opened above before falling through to the
         # finalize_streaming path.
         if current_block_type is not None:
-            yield (
+            ev = _capture(
                 f"event: content_block_stop\ndata: "
                 f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
             )
+            if ev is not None:
+                yield ev
             block_index += 1
             current_block_type = None
 
@@ -1572,17 +1637,17 @@ async def _stream_anthropic_messages(
             content = strip_special_tokens(final_msg.content)
             if content:
                 accumulated_text = content
-                yield (
+                for raw_event in (
                     f"event: content_block_start\ndata: "
-                    f"{json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
-                )
-                delta_event = {
-                    "type": "content_block_delta",
-                    "index": block_index,
-                    "delta": {"type": "text_delta", "text": content},
-                }
-                yield f"event: content_block_delta\ndata: {json.dumps(delta_event)}\n\n"
-                yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+                    f"{json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n",
+                    f"event: content_block_delta\ndata: "
+                    f"{json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': 'text_delta', 'text': content}})}\n\n",
+                    f"event: content_block_stop\ndata: "
+                    f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n",
+                ):
+                    ev = _capture(raw_event)
+                    if ev is not None:
+                        yield ev
                 block_index += 1
 
     # Check for tool calls — prefer engine-surfaced structured payload
@@ -1651,6 +1716,28 @@ async def _stream_anthropic_messages(
             )
             tool_calls = []
 
+    # PR #771 codex round-2 BLOCKING #1: replay or drop the
+    # ``pre_filter_buffer`` we accumulated during the chunk loop.
+    # Until this point in the stream the only event yielded was the
+    # opening ``message_start``; every content_block / thinking event
+    # that the chunk loop produced sits in the buffer. We now know
+    # whether the enforcement passed:
+    #
+    #   * pass → replay the buffer so the streaming UX is preserved
+    #     (clients see the same text-delta cadence they would have
+    #     seen without the buffer). Tool_use blocks emit below.
+    #   * fail → drop the buffer so the would-be text response NEVER
+    #     reaches the wire. Only the SSE error event + the trailing
+    #     ``message_delta`` (end_turn) + ``message_stop`` follow.
+    #
+    # The buffer is unused when ``tool_choice`` is not a named pin —
+    # in that case the chunk loop yielded directly and ``pre_filter_buffer``
+    # is empty, so this block is a no-op on every non-pinned request.
+    if _buffer_for_pinned_tool and not (tool_choice_error or tool_validation_error):
+        for buffered_event in pre_filter_buffer:
+            yield buffered_event
+        pre_filter_buffer.clear()
+
     # Emit a single SSE error event when either the tool_choice
     # enforcement or the schema validator fired. Both classes are
     # surfaced as ``invalid_request_error`` — they describe a
@@ -1658,6 +1745,11 @@ async def _stream_anthropic_messages(
     # whereas a true server failure would arrive via the route-level
     # exception handler.
     if tool_choice_error or tool_validation_error:
+        # On the buffered path the buffer is intentionally NOT replayed
+        # — the would-be text payload that the chunk loop accumulated
+        # is precisely what the named ``tool_choice`` contract forbids.
+        # Drop it on the floor and surface only the error event.
+        pre_filter_buffer.clear()
         error_event = {
             "type": "error",
             "error": {


### PR DESCRIPTION
## Summary

Follow-up to PR #763. Codex round-1 reviewing the H-05 fix flagged a real gap: when `_filter_tool_calls_by_tool_choice` empties the call list entirely — either because the model returned text only or because EVERY emitted call was to the wrong tool — the route fell through to the "no tool_calls? end_turn." branch and 200-ed with no `tool_use` block at all. Clients that pinned a specific tool then got back nothing actionable, silently violating the forced-tool contract.

This PR addresses both codex round-1 BLOCKING findings:
- **#1 (legitimate gap)**: split the filter from a new `_enforce_named_tool_choice_present` guard that 422s on non-stream (mirrors chat.py's `tool_choice="required"` no-call branch) and emits an Anthropic SSE `event: error` on stream (mirrors the F-220 validation-failure SSE path that's already wired).
- **#2 (defensive lock)**: confirmed by code-trace that no `tool_use` content_block_start is emitted in the streaming chunk-accumulation loop above the filter — the filter runs before any tool_use SSE event leaves the wire. Added a defensive comment + a regression test that fails loudly if a future refactor moves tool_use emission into the chunk loop.

Also extracted `_named_tool_choice_target` and `_tool_call_name_anthropic` as small named helpers so "is this a named-tool pin?" + "what name did this call carry?" aren't re-implemented at every site.

## Test plan

- [x] Two new non-stream tests for the empty-pin failure: "model returned text only" + "model called only the wrong tool" — both must 422 with a diagnostic naming the pinned tool, and the two messages disambiguate the two failure modes
- [x] Two new stream tests mirroring above: SSE `event: error` + `invalid_request_error` + no `tool_use` block ever shipped for the dropped wrong-tool
- [x] Three unit tests on the new helpers: filter is a no-op for non-named `tool_choice` shapes (`None`, `"auto"`, `{"type":"function"}` without a name), enforcer is a no-op for those shapes too, enforcer is a no-op when the pinned call survived
- [x] 18 H-05 scope tests + 14 F-141 scoped enforcement tests + 3 F-220 wire-in tests = 35 tests in this surface pass
- [x] Broader 1376-test anthropic/tool sweep stays green
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)