### PR TITLE
test(pflash-metrics): assert compressed-tokens counter stays zero on threshold skip (M-02 codex follow-up)

### DIFF
--- a/tests/test_pflash_metrics.py
+++ b/tests/test_pflash_metrics.py
@@ -196,7 +196,12 @@ def test_scheduler_counters_untouched_when_pflash_skips():
 
     assert scheduler.get_stats()["pflash_bypass_count"] == 0
     assert scheduler.get_stats()["pflash_compressed_tokens_dropped"] == 0
+    # Threshold-skip path: BOTH counters must stay at zero. Asserting only
+    # ``pflash_bypass_count`` would let a regression that silently
+    # incremented ``pflash_compressed_tokens_dropped`` on threshold skips
+    # slip through unnoticed (codex review nit, M-02 PR).
     assert scheduler_auto.get_stats()["pflash_bypass_count"] == 0
+    assert scheduler_auto.get_stats()["pflash_compressed_tokens_dropped"] == 0
 
 
 def test_scheduler_counters_zero_when_pflash_disabled():


### PR DESCRIPTION
## Summary

Follow-up to the M-02 PR (#768, already merged). Codex review on #768
flagged a small test-coverage gap that landed in the squash before the
follow-up commit had a chance to be amended in:

> [NIT] `test_scheduler_counters_untouched_when_pflash_skips` claims the
> threshold skip leaves both counters at zero, but only asserts
> `scheduler_auto.get_stats()["pflash_bypass_count"]`, so a regression
> that increments `pflash_compressed_tokens_dropped` on threshold skips
> would still pass.

This PR tightens that assertion — adds the missing
`scheduler_auto.get_stats()["pflash_compressed_tokens_dropped"] == 0`
line and a comment explaining why.

## Test plan

- [x] `tests/test_pflash_metrics.py` — 8/8 pass.
- [x] No production-code changes; the prior PR #768 still owns the
      behaviour and the bypass / fetch / store logic is untouched.
- [x] Catches the exact regression codex called out: a stray increment
      of `pflash_compressed_tokens_dropped` on the threshold-skip path
      now fails the test instead of slipping through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)