### PR TITLE
fix(api): propagate F-061 stop matcher to /v1/completions and /v1/messages (H-03)

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -574,6 +574,60 @@ class TestOpenaiToAnthropic:
         result = openai_to_anthropic(resp, "default")
         assert result.stop_reason == "max_tokens"
 
+    # H-03 — matched_stop surface
+    def test_matched_stop_promotes_end_turn_to_stop_sequence(self):
+        """When the engine surfaces a matched stop string the adapter
+        must rewrite ``stop_reason="stop"`` (which would otherwise
+        map to ``end_turn``) to Anthropic's dedicated
+        ``stop_sequence`` value and populate the ``stop_sequence``
+        field verbatim. Pre-fix the adapter always emitted
+        ``end_turn`` with ``stop_sequence: None`` even when a stop
+        fired."""
+        resp = self._make_response(content="say ", finish_reason="stop")
+        result = openai_to_anthropic(resp, "default", matched_stop="END")
+        assert result.stop_reason == "stop_sequence"
+        assert result.stop_sequence == "END"
+
+    def test_matched_stop_none_keeps_end_turn(self):
+        """No matched stop means EOS / length / no-stop; the legacy
+        ``stop → end_turn`` mapping holds and ``stop_sequence`` stays
+        ``None``."""
+        resp = self._make_response(finish_reason="stop")
+        result = openai_to_anthropic(resp, "default", matched_stop=None)
+        assert result.stop_reason == "end_turn"
+        assert result.stop_sequence is None
+
+    def test_matched_stop_does_not_override_max_tokens(self):
+        """A length cap MUST still win — Anthropic's stop_reason
+        values are mutually exclusive, and the matched-stop rewrite
+        only applies to the ``end_turn`` bucket. Otherwise a request
+        that ran past max_tokens AND happened to also include the
+        stop bytes mid-output would be mis-classified."""
+        resp = self._make_response(finish_reason="length")
+        result = openai_to_anthropic(resp, "default", matched_stop="END")
+        assert result.stop_reason == "max_tokens"
+        # ``stop_sequence`` MUST stay None — Anthropic spec invariant:
+        # "stop_sequence is set iff stop_reason == 'stop_sequence'".
+        assert result.stop_sequence is None
+
+    def test_matched_stop_does_not_override_tool_use(self):
+        """Same invariant for the tool_use bucket: a tool_calls
+        finish must keep stop_reason='tool_use' even if a stop
+        string happened to surface earlier in the response."""
+        tc = ToolCall(
+            id="call_1",
+            type="function",
+            function=FunctionCall(name="search", arguments='{"q":"x"}'),
+        )
+        resp = self._make_response(
+            content="Calling.",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+        result = openai_to_anthropic(resp, "default", matched_stop="END")
+        assert result.stop_reason == "tool_use"
+        assert result.stop_sequence is None
+
     def test_response_has_id(self):
         resp = self._make_response()
         result = openai_to_anthropic(resp, "test-model")

--- a/tests/test_anthropic_stop_sequences.py
+++ b/tests/test_anthropic_stop_sequences.py
@@ -31,6 +31,12 @@ class _RecordingEngine:
     The point of the test isn't whether the model stops — it's that the
     request's ``stop_sequences`` reaches the engine. The previous bug was
     the route dropping the field silently.
+
+    H-03 extension: the stub can carry an arbitrary ``matched_stop`` so
+    we can pin the route's translation of the scheduler-pinned matched
+    bytes into Anthropic ``stop_reason="stop_sequence"`` +
+    ``stop_sequence: <str>``. ``None`` mirrors the legacy behaviour
+    (EOS / length / no-stop → ``stop_reason="end_turn"``).
     """
 
     preserve_native_tool_format = False
@@ -38,9 +44,10 @@ class _RecordingEngine:
     supports_guided_generation = False
     tokenizer = None
 
-    def __init__(self):
+    def __init__(self, matched_stop: str | None = None):
         self.chat_calls: list[dict[str, Any]] = []
         self.stream_calls: list[dict[str, Any]] = []
+        self._matched_stop = matched_stop
 
     def build_prompt(self, messages, tools=None, enable_thinking=None):
         return "PROMPT"
@@ -56,6 +63,7 @@ class _RecordingEngine:
             finished=True,
             finish_reason="stop",
             channel=None,
+            matched_stop=self._matched_stop,
         )
 
     async def stream_chat(self, messages, **kwargs):
@@ -69,6 +77,7 @@ class _RecordingEngine:
             finished=True,
             finish_reason="stop",
             channel=None,
+            matched_stop=self._matched_stop,
         )
 
 
@@ -160,3 +169,203 @@ def test_stop_sequences_none_when_omitted_non_stream():
     assert forwarded_stop is None, (
         f"omitted stop_sequences must forward as None; got {forwarded_stop!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# H-03: matched_stop must surface on the wire
+# ---------------------------------------------------------------------------
+#
+# Persona Sergei (r2) reported that ``messages.create(stop_sequences=["END"]
+# )`` returned ``stop_reason="end_turn"`` with ``stop_sequence`` absent —
+# even when the scheduler's stop-string trim DID fire. The matcher
+# (PR #716) landed at the scheduler layer, but ``/v1/messages`` had no
+# wire-level adapter for the Anthropic-specific ``stop_sequence``
+# surface, so the engine knew which stop fired but the response never
+# said so. The fix plumbs ``GenerationOutput.matched_stop`` through the
+# adapter; these tests pin the wire shape on both the non-stream and
+# streaming branches.
+
+
+def test_stop_sequence_surfaced_in_non_stream_response():
+    """When the engine reports a matched stop, the response must carry
+    ``stop_reason="stop_sequence"`` AND ``stop_sequence: <the matched
+    string>``. Persona Sergei's original repro: matched stop "END" →
+    pre-fix returned ``stop_reason="end_turn"``, ``stop_sequence`` field
+    silently dropped.
+    """
+    engine = _RecordingEngine(matched_stop="END")
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stop_sequences": ["END"],
+            "messages": [{"role": "user", "content": "say END"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stop_reason"] == "stop_sequence", (
+        f"matched user stop → ``stop_reason='stop_sequence'`` per Anthropic "
+        f"spec; got {body['stop_reason']!r}. Pre-fix the adapter mapped "
+        f"finish_reason='stop' to 'end_turn' unconditionally."
+    )
+    assert body["stop_sequence"] == "END", (
+        f"the matched stop bytes must surface verbatim in "
+        f"``stop_sequence``; got {body.get('stop_sequence')!r}"
+    )
+
+
+def test_stop_sequence_absent_when_no_user_stop_matched():
+    """EOS / length / no-stop terminations must still map to ``end_turn``
+    with ``stop_sequence: null`` — the H-03 fix must NOT regress the
+    default mapping."""
+    engine = _RecordingEngine(matched_stop=None)
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stop_reason"] == "end_turn"
+    # ``stop_sequence`` is excluded when None via ``exclude_none``; the
+    # legacy Anthropic SDK shape allows either omission or explicit
+    # null. Accept both.
+    assert body.get("stop_sequence") in (None,)
+
+
+def test_stop_sequence_surfaced_in_streaming_message_delta():
+    """The terminal SSE ``message_delta`` must carry the matched stop
+    bytes in ``delta.stop_sequence`` and set ``delta.stop_reason`` to
+    ``"stop_sequence"``. Pre-fix the streaming branch hard-coded
+    ``stop_sequence: None`` even when the engine reported a match.
+    """
+    engine = _RecordingEngine(matched_stop="END")
+    client = _make_client(engine)
+
+    saw_message_delta: list[dict] = []
+    with client.stream(
+        "POST",
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "stop_sequences": ["END"],
+            "messages": [{"role": "user", "content": "say END"}],
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        import json as _json
+
+        data_buffer: list[str] = []
+        last_event: str | None = None
+        for line in resp.iter_lines():
+            if line.startswith("event:"):
+                last_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:") and last_event == "message_delta":
+                payload = line[len("data:") :].strip()
+                if payload:
+                    try:
+                        saw_message_delta.append(_json.loads(payload))
+                    except Exception:
+                        data_buffer.append(payload)
+
+    assert saw_message_delta, "stream must include at least one message_delta event"
+    delta = saw_message_delta[-1]["delta"]
+    assert delta["stop_reason"] == "stop_sequence", (
+        f"stream terminal delta must report stop_reason='stop_sequence'; "
+        f"got {delta!r}. Pre-fix the streaming branch hard-coded "
+        f"stop_reason='end_turn'."
+    )
+    assert delta["stop_sequence"] == "END", (
+        f"the matched stop bytes must surface in delta.stop_sequence; "
+        f"got {delta!r}. Pre-fix the streaming branch hard-coded "
+        f"stop_sequence: null."
+    )
+
+
+def test_stop_sequence_streaming_falls_back_to_end_turn_when_no_match():
+    """Streaming parity for the no-match path: ``stop_reason='end_turn'``
+    + ``stop_sequence: null`` (the pre-fix default)."""
+    engine = _RecordingEngine(matched_stop=None)
+    client = _make_client(engine)
+
+    saw_message_delta: list[dict] = []
+    with client.stream(
+        "POST",
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        import json as _json
+
+        last_event: str | None = None
+        for line in resp.iter_lines():
+            if line.startswith("event:"):
+                last_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:") and last_event == "message_delta":
+                payload = line[len("data:") :].strip()
+                if payload:
+                    saw_message_delta.append(_json.loads(payload))
+
+    assert saw_message_delta
+    delta = saw_message_delta[-1]["delta"]
+    assert delta["stop_reason"] == "end_turn"
+    assert delta["stop_sequence"] is None
+
+
+def test_stop_sequence_multi_alternative_surfaces_first_match():
+    """When ``stop_sequences`` has multiple alternatives, the
+    ``stop_sequence`` field must echo whichever bytes the scheduler
+    actually matched — not the request's first alternative."""
+    engine = _RecordingEngine(matched_stop="ALSO_STOP")
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stop_sequences": ["NEVER_MATCHES", "ALSO_STOP", "WAY_DOWN"],
+            "messages": [{"role": "user", "content": "say ALSO_STOP"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["stop_reason"] == "stop_sequence"
+    assert body["stop_sequence"] == "ALSO_STOP"
+
+
+def test_stop_sequence_empty_list_does_not_force_stop_sequence_reason():
+    """Empty stop_sequences must behave like omitted — the matcher
+    cannot fire, so the response must NOT be reclassified to
+    ``stop_sequence``."""
+    engine = _RecordingEngine(matched_stop=None)
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stop_sequences": [],
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["stop_reason"] == "end_turn"

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1236,12 +1236,17 @@ class TestGenerationOutputFieldOrder:
             "reasoning_text",
             "tool_calls",
             "cached_tokens",
+            # H-03 appended ``matched_stop`` after ``cached_tokens``. New
+            # additions must keep growing this tail in chronological
+            # order — anything inserted MID-LIST silently rebinds
+            # positional construction for pre-v0.6.65 callers.
+            "matched_stop",
         ], (
             f"new GenerationOutput fields must be APPENDED in order "
-            f"(raw_text → reasoning_text → tool_calls → cached_tokens) "
-            f"to preserve positional-arg compatibility for the "
-            f"pre-v0.6.65 surface. Current trailing fields after "
-            f"``channel``: {appended}"
+            f"(raw_text → reasoning_text → tool_calls → cached_tokens "
+            f"→ matched_stop) to preserve positional-arg compatibility "
+            f"for the pre-v0.6.65 surface. Current trailing fields "
+            f"after ``channel``: {appended}"
         )
 
 

--- a/tests/test_stop_matcher_completions.py
+++ b/tests/test_stop_matcher_completions.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-03 regression: ``/v1/completions`` must honour ``stop``.
+
+The systematic stop-matcher landed in #716 lives at the scheduler layer
+(``Scheduler._process_batch_responses`` /
+``MLLMScheduler._process_batch_responses``) and is exercised by
+``tests/test_stop_string_enforcement.py`` already. What the user-reported
+H-03 surfaced is that the OpenAI legacy completions route had no
+end-to-end test asserting the wire surface: forward ``stop``, get
+``finish_reason="stop"``, payload does NOT contain the matched stop
+string.
+
+These tests pin the wire-level contract so a future refactor of the
+route (e.g. another spec-parity follow-up) cannot silently re-introduce
+the gap that personas Petra (r2) and Sergei (r2) reported. They sit at
+the route layer with a stub engine that mimics the scheduler's behaviour
+(``stop`` arrives → trimmed text + ``finish_reason="stop"``).
+
+The tests cover:
+  * non-stream + stream branches,
+  * the multi-alternative ``stop`` list,
+  * the empty-list ``stop`` no-op (used by SDKs as the default),
+  * end-to-end forwarding to ``engine.generate`` / ``engine.stream_generate``
+    so the kwarg never gets dropped at the route boundary.
+
+For the actual stop-trim semantics see
+``test_stop_string_enforcement.py`` (scheduler-layer) and
+``test_scheduler_stop_decoder_surface.py`` (incremental decoder).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+class _StubGenerationOutput:
+    """Minimal ``GenerationOutput`` stand-in for non-streaming tests."""
+
+    def __init__(
+        self,
+        text: str = "ok",
+        finish_reason: str = "stop",
+        matched_stop: str | None = None,
+    ):
+        self.text = text
+        self.finish_reason = finish_reason
+        self.completion_tokens = 1
+        self.prompt_tokens = 1
+        self.cached_tokens = 0
+        self.matched_stop = matched_stop
+
+
+class _StreamChunk:
+    """Minimal streaming chunk mimicking the engine's ``GenerationOutput``."""
+
+    def __init__(
+        self,
+        new_text: str,
+        finished: bool,
+        finish_reason: str | None,
+        text: str = "",
+        matched_stop: str | None = None,
+    ):
+        self.new_text = new_text
+        self.text = text
+        self.finished = finished
+        self.finish_reason = finish_reason
+        self.prompt_tokens = 1
+        self.completion_tokens = 1
+        self.cached_tokens = 0
+        self.matched_stop = matched_stop
+
+
+def _build_app(patch_cfg, monkeypatch, engine):
+    """Mount /v1/completions wired to ``engine``."""
+    from vllm_mlx.routes import completions as comp_route
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+    monkeypatch.setattr(
+        comp_route, "enforce_context_length_for_prompt", lambda *_a, **_kw: None
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class _RecordingEngine:
+    """Capture the kwargs passed to ``engine.generate`` / ``stream_generate``.
+
+    Non-streaming returns a stub ``GenerationOutput`` that mimics the
+    scheduler's stop-trim result. Streaming yields a short list of chunks
+    where the terminal chunk carries ``finish_reason="stop"`` — the
+    scheduler-side stop-string trim is exercised in
+    ``test_stop_string_enforcement.py``; here we pin the route wiring.
+    """
+
+    tokenizer = None
+
+    def __init__(
+        self,
+        *,
+        non_stream_text: str = "before",
+        non_stream_matched_stop: str | None = "STOP",
+        stream_chunks: list[_StreamChunk] | None = None,
+    ):
+        self.generate_calls: list[dict[str, Any]] = []
+        self.stream_calls: list[dict[str, Any]] = []
+        self._non_stream_text = non_stream_text
+        self._non_stream_matched_stop = non_stream_matched_stop
+        self._stream_chunks = stream_chunks or [
+            _StreamChunk(new_text="before", finished=False, finish_reason=None),
+            _StreamChunk(
+                new_text="",
+                finished=True,
+                finish_reason="stop",
+                text="before",
+                matched_stop="STOP",
+            ),
+        ]
+
+    async def generate(self, *_, **kwargs):
+        self.generate_calls.append(kwargs)
+        return _StubGenerationOutput(
+            text=self._non_stream_text,
+            finish_reason="stop",
+            matched_stop=self._non_stream_matched_stop,
+        )
+
+    async def stream_generate(self, *_, **kwargs):
+        self.stream_calls.append(kwargs)
+        for c in self._stream_chunks:
+            yield c
+
+
+def test_completions_non_stream_forwards_stop_to_engine(patched_config, monkeypatch):
+    engine = _RecordingEngine()
+    client = _build_app(patched_config, monkeypatch, engine)
+    r = client.post(
+        "/v1/completions",
+        json={
+            "model": "stub-model",
+            "prompt": "say before STOP after",
+            "max_tokens": 16,
+            "stop": ["STOP", "DONE"],
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert len(engine.generate_calls) == 1, "engine.generate not called"
+    forwarded = engine.generate_calls[0].get("stop")
+    assert forwarded == ["STOP", "DONE"], (
+        f"`stop` list must reach engine.generate; got {forwarded!r}"
+    )
+    body = r.json()
+    # The engine stub returns trimmed text already; the route must
+    # surface ``finish_reason="stop"`` on the choice.
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert "STOP" not in body["choices"][0]["text"]
+
+
+def test_completions_non_stream_omitted_stop_forwards_none(patched_config, monkeypatch):
+    """Sanity: omitting ``stop`` must not synthesize an empty list at the route."""
+    engine = _RecordingEngine(non_stream_matched_stop=None)
+    client = _build_app(patched_config, monkeypatch, engine)
+    r = client.post(
+        "/v1/completions",
+        json={"model": "stub-model", "prompt": "hi", "max_tokens": 4},
+    )
+    assert r.status_code == 200
+    assert engine.generate_calls[0].get("stop") is None, (
+        "omitted ``stop`` must forward as None — coercing it to ``[]`` "
+        "would mask a future regression where the engine starts treating "
+        "an empty list differently from None."
+    )
+
+
+def test_completions_non_stream_empty_stop_list_is_noop(patched_config, monkeypatch):
+    """Explicit empty-list ``stop`` is the legacy SDK default — must not 400."""
+    engine = _RecordingEngine(non_stream_matched_stop=None)
+    client = _build_app(patched_config, monkeypatch, engine)
+    r = client.post(
+        "/v1/completions",
+        json={
+            "model": "stub-model",
+            "prompt": "hi",
+            "max_tokens": 4,
+            "stop": [],
+        },
+    )
+    assert r.status_code == 200
+    assert engine.generate_calls[0].get("stop") == []
+
+
+def test_completions_stream_forwards_stop_to_engine(patched_config, monkeypatch):
+    engine = _RecordingEngine()
+    client = _build_app(patched_config, monkeypatch, engine)
+    with client.stream(
+        "POST",
+        "/v1/completions",
+        json={
+            "model": "stub-model",
+            "prompt": "say before STOP after",
+            "max_tokens": 16,
+            "stop": ["STOP"],
+            "stream": True,
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data:") and "[DONE]" not in line:
+                chunks.append(line)
+
+    assert len(engine.stream_calls) == 1
+    forwarded = engine.stream_calls[0].get("stop")
+    assert forwarded == ["STOP"], (
+        f"stream_generate must receive ``stop`` from the route; got {forwarded!r}"
+    )
+    # The terminal chunk must carry ``finish_reason="stop"`` and the
+    # response chunks must not echo the stop marker (scheduler-level
+    # trim is responsible — we only pin the wire-shape here).
+    assert any('"finish_reason": "stop"' in c for c in chunks), (
+        "streaming response must include a chunk with finish_reason='stop'; "
+        "Petra's H-03 repro showed finish_reason='length' with the stop "
+        "string still in the output."
+    )
+    joined_text = "".join(c for c in chunks)
+    assert "STOP" not in joined_text
+
+
+def test_completions_stop_multiple_alternatives_forwarded(patched_config, monkeypatch):
+    """The full alternation list must reach the engine — not just the first entry.
+
+    Pre-#716 the matcher iterated only on first-match; with multiple
+    alternatives a route that silently truncated to ``stop[:1]`` would
+    let the second alternative leak through.
+    """
+    engine = _RecordingEngine()
+    client = _build_app(patched_config, monkeypatch, engine)
+    r = client.post(
+        "/v1/completions",
+        json={
+            "model": "stub-model",
+            "prompt": "hello",
+            "max_tokens": 8,
+            "stop": ["\n\n", "def ", "END"],
+        },
+    )
+    assert r.status_code == 200
+    assert engine.generate_calls[0].get("stop") == ["\n\n", "def ", "END"]
+
+
+def test_completions_single_element_stop_list_forwarded(patched_config, monkeypatch):
+    """A single-entry ``stop`` list is the canonical SDK shape (the
+    Anthropic CLI, OpenAI SDK and Petra's IDE plugin all send the
+    list form). Pin that a one-element list still reaches the engine
+    intact — pre-#716 it would be silently dropped if the route ever
+    coerced the field to ``None`` for "empty-ish" inputs.
+    """
+    engine = _RecordingEngine()
+    client = _build_app(patched_config, monkeypatch, engine)
+    r = client.post(
+        "/v1/completions",
+        json={
+            "model": "stub-model",
+            "prompt": "hello",
+            "max_tokens": 8,
+            "stop": ["END"],
+        },
+    )
+    assert r.status_code == 200
+    forwarded = engine.generate_calls[0].get("stop")
+    assert forwarded == ["END"], (
+        f"single-element `stop` must reach the engine verbatim; got {forwarded!r}"
+    )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -163,6 +163,7 @@ def openai_to_anthropic(
     model: str,
     *,
     reasoning_enabled: bool = True,
+    matched_stop: str | None = None,
 ) -> AnthropicResponse:
     """
     Convert an OpenAI Chat Completions response to Anthropic Messages API format.
@@ -178,6 +179,14 @@ def openai_to_anthropic(
             models never emit a ``thinking`` block. Defaults to True so
             external callers that don't pass the flag keep their existing
             behavior (pre-issue #702).
+        matched_stop: H-03 — when a user-supplied ``stop_sequences`` entry
+            fired, the engine surfaces the matched string via
+            ``GenerationOutput.matched_stop``. The route passes it through
+            here so the response carries
+            ``stop_reason="stop_sequence"`` + ``stop_sequence: <str>`` per
+            Anthropic's public spec. ``None`` (the default) means EOS /
+            length / no-stop, and the legacy ``_convert_stop_reason``
+            mapping (``stop`` → ``end_turn``) applies.
 
     Returns:
         Anthropic Messages API response
@@ -264,6 +273,15 @@ def openai_to_anthropic(
                 )
 
         stop_reason = _convert_stop_reason(choice.finish_reason)
+        # H-03: when a user-supplied stop fired, override the generic
+        # "stop"→"end_turn" mapping with Anthropic's dedicated
+        # ``stop_sequence`` value. Tool/length finishes still win — a
+        # tool_calls finish_reason should not be reclassified just
+        # because the engine happened to also see a stop string in
+        # auxiliary text. Matches Anthropic's public spec where
+        # ``stop_sequence`` is mutually exclusive with the other reasons.
+        if matched_stop is not None and stop_reason == "end_turn":
+            stop_reason = "stop_sequence"
     else:
         stop_reason = "end_turn"
 
@@ -304,6 +322,12 @@ def openai_to_anthropic(
         model=model,
         content=content,
         stop_reason=stop_reason,
+        # H-03: only surface ``stop_sequence`` when the matched-stop
+        # rewrite actually took effect (``stop_reason == "stop_sequence"``).
+        # Carrying the matched bytes alongside an ``end_turn`` /
+        # ``max_tokens`` / ``tool_use`` reason would violate Anthropic's
+        # spec ("stop_sequence is set iff stop_reason == 'stop_sequence'").
+        stop_sequence=matched_stop if stop_reason == "stop_sequence" else None,
         usage=AnthropicUsage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -83,6 +83,20 @@ class GenerationOutput:
     # the prefix-cache path (guided generation, dflash speculative
     # server) — semantically "no cache hits", not "unknown".
     cached_tokens: int = 0
+    # H-03: when a user-supplied ``stop`` string fired (vs an EOS token
+    # or ``max_tokens`` cap), the scheduler/engine records the matched
+    # string here so route adapters can surface the precise reason.
+    # The Anthropic ``/v1/messages`` adapter maps this onto
+    # ``stop_reason="stop_sequence"`` + ``stop_sequence: <str>`` per the
+    # public spec; OpenAI ``/v1/completions`` and ``/v1/chat/
+    # completions`` keep ``finish_reason="stop"`` (a single bucket for
+    # both EOS and stop-string per OpenAI's wire spec) so the field is
+    # harmless to ignore on the OpenAI surface. ``None`` means "no
+    # user stop matched" — ``finish_reason`` was set by EOS, the
+    # length cap, or never fired. Appended LAST per the field-order
+    # note above to preserve positional constructor arg indices for
+    # pre-existing fields.
+    matched_stop: str | None = None
 
 
 class BaseEngine(ABC):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1043,6 +1043,9 @@ class BatchedEngine(BaseEngine):
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
+                # H-03: MLLM non-stream parity — propagate the matched
+                # stop string for the Anthropic adapter.
+                matched_stop=getattr(output, "matched_stop", None),
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -1128,6 +1131,13 @@ class BatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=structured_tool_calls,
             cached_tokens=output.cached_tokens,
+            # H-03: propagate the scheduler-pinned stop string so the
+            # Anthropic ``/v1/messages`` adapter can surface
+            # ``stop_reason="stop_sequence"`` + ``stop_sequence: <str>``.
+            # ``None`` for EOS / length / no-stop and harmless to ignore
+            # on the OpenAI surface (it already lumps stop+EOS under
+            # ``finish_reason="stop"``).
+            matched_stop=getattr(output, "matched_stop", None),
         )
 
     async def stream_generate(
@@ -1193,6 +1203,9 @@ class BatchedEngine(BaseEngine):
                     finished=output.finished,
                     finish_reason=output.finish_reason,
                     logprobs=output.logprobs,
+                    # H-03: MLLM stream parity — propagate the matched
+                    # stop string for the Anthropic adapter.
+                    matched_stop=getattr(output, "matched_stop", None),
                 )
             return
 
@@ -1264,6 +1277,9 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     logprobs=output.logprobs,
                     cached_tokens=output.cached_tokens,
+                    # H-03: text stream parity — propagate the matched
+                    # stop string for the Anthropic adapter.
+                    matched_stop=getattr(output, "matched_stop", None),
                 )
         finally:
             # Best-effort defensive abort. Codex r2 P1 #2 concern: this
@@ -1652,6 +1668,10 @@ class BatchedEngine(BaseEngine):
             channel=_channel_name(event.channel),
             tool_calls=tool_calls,
             cached_tokens=source.cached_tokens,
+            # H-03: preserve matched_stop through the router-wrapped
+            # streaming chunks so the terminal chunk still carries it
+            # for /v1/messages stop_sequence surfacing.
+            matched_stop=source.matched_stop,
         )
 
     def _routed_finish_sentinel(self, source: GenerationOutput) -> GenerationOutput:
@@ -1666,6 +1686,10 @@ class BatchedEngine(BaseEngine):
             logprobs=source.logprobs,
             channel=None,
             cached_tokens=source.cached_tokens,
+            # H-03: preserve matched_stop on the terminal sentinel so
+            # /v1/messages stop_sequence surfacing works on router-led
+            # streams (harmony / gemma4).
+            matched_stop=source.matched_stop,
         )
 
     def _finalize_output_router(

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -882,6 +882,15 @@ class EngineCore:
             completion_tokens=req_output.completion_tokens,
             cached_tokens=req_output.cached_tokens,
             logprobs=(prev_lp + new_lp) or None,
+            # H-03: prefer the newer step's matched_stop (the scheduler
+            # pins it exactly once on the chunk where the stop fires);
+            # fall back to the existing buffer so a stop that fired on a
+            # previous flush is not erased by a later step where the
+            # field is None. ``buf`` may be None on the first step.
+            matched_stop=(
+                req_output.matched_stop
+                or (buf.matched_stop if buf is not None else None)
+            ),
         )
 
     async def stream_outputs(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -656,6 +656,14 @@ class MLLMScheduler:
                 for stop_str in request.stop:
                     if stop_str and stop_str in decoded_so_far:
                         finish_reason = "stop"
+                        # H-03: pin WHICH user-supplied stop fired so
+                        # the Anthropic adapter can surface
+                        # ``stop_reason="stop_sequence"`` +
+                        # ``stop_sequence: <str>`` per the public spec.
+                        # Mirrors the text-scheduler companion change so
+                        # MLLM-backed ``/v1/messages`` traffic gets the
+                        # same surface as the text path.
+                        output.matched_stop = stop_str
                         # Trim output at stop string
                         idx = decoded_so_far.index(stop_str)
                         request.output_text = decoded_so_far[:idx]

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -150,6 +150,14 @@ class RequestOutputCollector:
             completion_tokens=new.completion_tokens,
             cached_tokens=new.cached_tokens,
             logprobs=new.logprobs,  # Use latest token's logprobs
+            # H-03: prefer the newer chunk's matched_stop (the scheduler
+            # pins it exactly once on the chunk where the stop fires);
+            # fall back to the existing buf so we never demote a
+            # previously-set value to None just because a later flush
+            # arrived after the stop already fired. Anthropic
+            # ``/v1/messages`` reads this on the FINAL output and would
+            # otherwise lose the stop_sequence signal under aggregation.
+            matched_stop=new.matched_stop or existing.matched_stop,
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -281,6 +281,20 @@ class RequestOutput:
     # effectiveness. Appended at the end of the dataclass so positional
     # constructor args for the pre-existing fields keep their indices.
     cached_tokens: int = 0
+    # H-03: when a user-supplied ``stop`` string fired (vs an EOS token
+    # or ``max_tokens`` cap), the scheduler records the matched string
+    # here so route adapters can surface the precise reason. The
+    # Anthropic ``/v1/messages`` surface maps this onto
+    # ``stop_reason="stop_sequence"`` + ``stop_sequence: <str>`` per the
+    # public Anthropic spec; OpenAI ``/v1/completions`` and
+    # ``/v1/chat/completions`` keep ``finish_reason="stop"`` (a single
+    # bucket for both EOS and stop-string per OpenAI's wire spec), so
+    # the field is harmless to ignore for the OpenAI surface. ``None``
+    # means "no user stop matched" — ``finish_reason`` was set by EOS,
+    # length cap, or never fired. Appended at the end of the dataclass
+    # so positional constructor args for the pre-existing fields keep
+    # their indices.
+    matched_stop: str | None = None
 
     @property
     def usage(self) -> dict[str, int]:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -614,6 +614,13 @@ async def create_anthropic_message(
             openai_response,
             cfg.model_name or anthropic_request.model,
             reasoning_enabled=_resolve_reasoning_enabled(anthropic_request.model),
+            # H-03: forward the engine-surfaced matched stop string so
+            # the response carries ``stop_reason="stop_sequence"`` +
+            # ``stop_sequence: <str>`` per Anthropic's public spec.
+            # ``getattr`` keeps the call defensive against engines that
+            # haven't been rebuilt against the new ``GenerationOutput``
+            # field (None → legacy ``stop`` → ``end_turn`` mapping).
+            matched_stop=getattr(output, "matched_stop", None),
         )
         return Response(
             content=anthropic_response.model_dump_json(exclude_none=True),
@@ -1097,6 +1104,15 @@ async def _stream_anthropic_messages(
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
+    # H-03: track the most-recently-surfaced ``matched_stop`` so the
+    # terminal ``message_delta`` can emit Anthropic's
+    # ``stop_reason="stop_sequence"`` + ``stop_sequence: <str>`` per the
+    # public spec. The scheduler pins this exactly once (on the chunk
+    # that fires the stop check) and downstream wrappers preserve it
+    # through to the terminal sentinel, so reading the latest non-None
+    # value is equivalent to "did any stop fire on this request?".
+    # Stays ``None`` for EOS / length / no-stop terminations.
+    stream_matched_stop: str | None = None
 
     current_block_type = None
     block_index = 0
@@ -1193,6 +1209,12 @@ async def _stream_anthropic_messages(
             completion_tokens = output.completion_tokens
         if hasattr(output, "cached_tokens") and output.cached_tokens:
             cached_tokens = output.cached_tokens
+        # H-03: latch the matched stop string from whichever chunk
+        # carries it. ``getattr`` keeps legacy mocks without the field
+        # working unchanged.
+        _chunk_matched_stop = getattr(output, "matched_stop", None)
+        if _chunk_matched_stop:
+            stream_matched_stop = _chunk_matched_stop
 
         # Capture engine-surfaced structured tool calls (HarmonyStreamingRouter
         # via openai-harmony's StreamableParser). The delta_text on these
@@ -1796,6 +1818,18 @@ async def _stream_anthropic_messages(
             yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': tool_index})}\n\n"
 
     stop_reason = "tool_use" if tool_calls else "end_turn"
+    # H-03: when a user-supplied ``stop_sequences`` entry fired (and the
+    # turn would otherwise have terminated normally with ``end_turn``),
+    # surface Anthropic's dedicated ``stop_sequence`` reason + populate
+    # the matched bytes — mirroring the non-stream adapter. Tool-use
+    # finishes still win: the model emitting a tool_call AND happening
+    # to also surface a stop string in auxiliary text should not be
+    # reclassified, matching Anthropic's mutually-exclusive
+    # ``stop_reason`` semantics.
+    stop_sequence: str | None = None
+    if stream_matched_stop is not None and stop_reason == "end_turn":
+        stop_reason = "stop_sequence"
+        stop_sequence = stream_matched_stop
 
     # Anthropic-side cache fields mirror what the non-streaming adapter
     # at ``api/anthropic_adapter.openai_to_anthropic`` produces. Per
@@ -1820,7 +1854,7 @@ async def _stream_anthropic_messages(
         usage_payload["cache_read_input_tokens"] = cached_tokens
     message_delta = {
         "type": "message_delta",
-        "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+        "delta": {"stop_reason": stop_reason, "stop_sequence": stop_sequence},
         "usage": usage_payload,
     }
     yield f"event: message_delta\ndata: {json.dumps(message_delta)}\n\n"

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3461,6 +3461,14 @@ class Scheduler:
                 for stop_str in stop_params:
                     if stop_str and stop_str in decoded_so_far:
                         finish_reason = "stop"
+                        # H-03: pin WHICH user-supplied stop fired so
+                        # the Anthropic adapter can surface
+                        # ``stop_reason="stop_sequence"`` +
+                        # ``stop_sequence: <str>`` per the public spec.
+                        # OpenAI's ``finish_reason="stop"`` bucket
+                        # already lumps EOS and stop-string together so
+                        # the OpenAI surface ignores this field.
+                        output.matched_stop = stop_str
                         idx = decoded_so_far.index(stop_str)
                         trimmed_total = decoded_so_far[:idx]
                         request.output_text = trimmed_total


### PR DESCRIPTION
## Summary
- **H-03** (`0.8TODO.md` HIGH tier) — Petra (r2, `/v1/completions`) and Sergei (r2, `/v1/messages`) reported `stop` / `stop_sequences` silently ignored. Investigation showed the scheduler-level matcher from #716 was actually firing on all three routes (text trimmed correctly), but `/v1/messages` had no wire-level adapter for the Anthropic `stop_sequence` field — the engine knew which stop fired and the response never said so.
- Fix plumbs the matched-stop bytes from the schedulers through `RequestOutput` / `GenerationOutput` / `EngineCore` aggregation / `RequestOutputCollector` aggregation / `BatchedEngine` (incl. router-wrapped streams) into `openai_to_anthropic` — which now emits `stop_reason="stop_sequence"` + `stop_sequence: <str>` per Anthropic's public spec. `/v1/messages` non-stream + stream both surface it; `/v1/completions` and `/v1/chat/completions` keep `finish_reason="stop"` (OpenAI lumps EOS and stop under one bucket per spec).
- One source of truth: matched_stop is pinned exactly once at the scheduler layer next to the existing #716 stop-string check; every downstream wrapper preserves it. No per-model logic; no route-local stop matcher.

## Repros (Qwen3-0.6B-4bit, port 8802)

**Sergei — `/v1/messages` non-stream**
```bash
curl -X POST .../v1/messages \
  -d '{"model":"...","max_tokens":150,"stop_sequences":["TESTSTOP"],
       "messages":[{"role":"user","content":"Output hello world TESTSTOP then more"}]}'
```
| | `stop_reason` | `stop_sequence` |
|---|---|---|
| before | `end_turn` | (absent) |
| after | `stop_sequence` | `TESTSTOP` |

**Sergei — `/v1/messages` streaming** — terminal `message_delta`:
- before: `{"stop_reason":"end_turn","stop_sequence":null}`
- after: `{"stop_reason":"stop_sequence","stop_sequence":"TESTSTOP"}`

**Petra — `/v1/completions`**
```bash
curl -X POST .../v1/completions \
  -d '{"prompt":"def fibonacci(n):","stop":["\n\n","def "],"max_tokens":64}'
```
Already trimming correctly post-#716 (`finish_reason="stop"`, no stop bytes in `text`). Pinned with new regression tests in `tests/test_stop_matcher_completions.py` so a future spec-parity refactor cannot silently drop the route-layer forwarding.

## Test plan
- [x] `tests/test_stop_matcher_completions.py` (new, 6 tests) — wire-level forwarding to `engine.generate` / `stream_generate`, multi-alternative stop list, empty stop, omitted stop, single-element list, non-stream + stream parity.
- [x] `tests/test_anthropic_stop_sequences.py` — extended from 3 → 9 tests covering matched-stop surfacing in both non-stream and stream `message_delta` events, multi-alternative match-vs-emitted, no-match fallback to `end_turn`, empty-list no-op.
- [x] `tests/test_anthropic_adapter.py` — 4 new unit tests on `openai_to_anthropic(..., matched_stop=...)` covering promotion to `stop_sequence`, None fallback, mutual exclusivity vs `max_tokens` and `tool_use`.
- [x] `tests/test_server_utils.py::TestGenerationOutputFieldOrder` updated to include `matched_stop` as the new trailing field (preserves the v0.6.65 positional-construction contract).
- [x] Full suite green (6819 passed, 19 skipped, 16 deselected, 7 xfailed) — 4 pre-existing unrelated failures (`test_event_loop` needs a live server; `test_no_out_of_band_routing` + `test_route_engine_contract` are pre-existing post-#767 / pre-existing in completions.py respectively).
- [x] `ruff check` + `ruff format` clean.
- [x] Live curl repros above on `mlx-community/Qwen3-0.6B-4bit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)