### PR TITLE
fix(api): reject unknown tool_choice shapes on /v1/chat/completions (H-16)

### DIFF
--- a/tests/test_openai_tool_choice_validation.py
+++ b/tests/test_openai_tool_choice_validation.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+H-16 (Pavel r3): parse-time validation of ``tool_choice`` on
+``/v1/chat/completions``.
+
+Before the fix, ``tool_choice={"foo":"bar"}`` (no ``type`` field) and
+``tool_choice={"type":"banana"}`` HTTP 200'd as a free-form chat
+completion — the typed ``str | dict`` union accepted the dict arm and
+the chat-route ``type=='function'`` guard (``vllm_mlx/routes/chat.py``
+L756) didn't match, so the request silently degraded with no tool
+forcing. PR #766 (M-03) closed the symmetric gap on ``/v1/messages``;
+this file pins the same contract for the OpenAI surface.
+
+The validator lives on ``ChatCompletionRequest`` (api/models.py), so
+the assertions here use the model directly (no HTTP fixture needed) —
+the global validation handler maps Pydantic ``ValidationError`` →
+400 ``invalid_request_error`` (middleware/exception_handlers.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import ChatCompletionRequest
+
+
+def _base_request(**overrides):
+    """Minimum-valid OpenAI body; callers layer ``tool_choice`` on top."""
+    body = {
+        "model": "qwen3-0.6b-8bit",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Negative path — unknown / malformed tool_choice
+# ---------------------------------------------------------------------------
+
+
+def test_no_type_field_object_rejected():
+    """The H-16 repro: ``tool_choice={"foo":"bar"}`` (no ``type``
+    field) must 400. Previously HTTP 200'd as a free-form chat
+    completion because the typed dict arm swallowed the shape and
+    the chat-route ``type=='function'`` guard didn't fire."""
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(**_base_request(tool_choice={"foo": "bar"}))
+    msg = str(exc_info.value)
+    assert "tool_choice" in msg
+    assert "type" in msg
+
+
+def test_unknown_object_type_rejected():
+    """``{"type":"banana"}`` — an unknown ``type`` value must 400 at
+    parse, not silently degrade."""
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(**_base_request(tool_choice={"type": "banana"}))
+    msg = str(exc_info.value)
+    assert "tool_choice" in msg
+    assert "banana" in msg
+
+
+@pytest.mark.parametrize(
+    "bad_type",
+    [
+        "tool",  # Anthropic's word, NOT OpenAI's
+        "any",  # Anthropic's word for "required"
+        "FUNCTION",  # case-sensitive per spec
+        "",  # empty string
+        " function",  # leading whitespace
+        "Function",
+        # The legacy bare-string ``"function"`` literal is allowed
+        # as a string-form tool_choice (route honors it at L1220),
+        # but NOT as an object's ``type``. Object form must be
+        # the canonical ``{"type":"function",...}``; a typo'd
+        # ``{"type":"Function"}`` is a separate hazard.
+    ],
+)
+def test_other_unknown_object_types_rejected(bad_type):
+    """Strict-equality on ``type`` — catches cross-API confusions
+    (Anthropic-shape values landing on the OpenAI surface) and
+    typos / case variants that the silent-degrade path used to
+    swallow."""
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(**_base_request(tool_choice={"type": bad_type}))
+
+
+@pytest.mark.parametrize(
+    "bad_string",
+    [
+        "banana",
+        "any",  # Anthropic's word
+        "tool",  # Anthropic's word
+        "AUTO",  # case-sensitive per spec
+        " required",  # leading whitespace
+        "Auto",
+        "",
+    ],
+)
+def test_unknown_strings_rejected(bad_string):
+    """The string form is closed-set: only ``none`` / ``auto`` /
+    ``required``. Reject anything else so a client typo or
+    cross-API confusion 400s instead of HTTP-200'ing as silent
+    free-form generation."""
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(**_base_request(tool_choice=bad_string))
+    msg = str(exc_info.value)
+    assert "tool_choice" in msg
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        42,
+        3.14,
+        [1, 2, 3],
+        ["function"],
+        # ``True`` would coerce-or-skip the union arms; flat reject.
+        True,
+        False,
+    ],
+)
+def test_non_string_non_object_rejected(bad_value):
+    """``tool_choice`` is either a string or an object — anything
+    else (numbers, lists, booleans) is malformed. Before the fix,
+    the pydantic union-attempt error leaked both arm names
+    (``tool_choice.str: ...; tool_choice.dict[any,any]: ...``);
+    after the fix, a single ``tool_choice`` ValueError points
+    at the field with a clean message."""
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(**_base_request(tool_choice=bad_value))
+    assert "tool_choice" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Positive path — every spec-legal shape must still pass parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("legal_string", ["none", "auto", "required"])
+def test_legal_strings_accepted(legal_string):
+    """The full OpenAI string-form set is accepted. ``"required"``
+    additionally requires a non-empty ``tools`` array (F-034) —
+    layer one on so the ``_validate_tool_choice_against_tools``
+    after-validator doesn't fire."""
+    req = ChatCompletionRequest(
+        **_base_request(
+            tool_choice=legal_string,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "ping", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+    )
+    assert req.tool_choice == legal_string
+
+
+def test_legacy_function_literal_accepted():
+    """Pre-2024 OpenAI SDKs sent ``tool_choice="function"`` (bare
+    string literal) to mean "force any function call" before the
+    dict form was added. The chat-route ``_forced_tool_choice``
+    gate (routes/chat.py L1212, codex r9 NIT #1 on #551) still
+    honors it — so the schema must let it pass to the route. Pin
+    by test_diffusion_engine.py::
+    test_engine_opts_out_blocks_legacy_function_literal_tool_choice
+    which would regress if we tightened to the modern triplet."""
+    req = ChatCompletionRequest(
+        **_base_request(
+            tool_choice="function",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "ping", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+    )
+    assert req.tool_choice == "function"
+
+
+def test_legal_object_form_accepted():
+    """``{"type":"function","function":{"name":"X"}}`` — the
+    canonical OpenAI named-tool form."""
+    tc = {"type": "function", "function": {"name": "ping"}}
+    req = ChatCompletionRequest(
+        **_base_request(
+            tool_choice=tc,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "ping", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+    )
+    assert req.tool_choice == tc
+
+
+def test_legal_object_form_with_extra_keys_accepted():
+    """Extra keys on the object form are tolerated — OpenAI's
+    contract is "extra keys ignored" (forward-compat). Mirror the
+    same wording M-03's validator uses on the Anthropic surface."""
+    tc = {
+        "type": "function",
+        "function": {"name": "ping"},
+        "extra": "preserved",
+    }
+    req = ChatCompletionRequest(
+        **_base_request(
+            tool_choice=tc,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "ping", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+    )
+    assert req.tool_choice == tc
+
+
+def test_omitted_tool_choice_accepted():
+    """Absent ``tool_choice`` (the most common case) — server picks
+    the default policy."""
+    req = ChatCompletionRequest(**_base_request())
+    assert req.tool_choice is None
+
+
+def test_explicit_null_tool_choice_accepted():
+    """``tool_choice=null`` (JSON null) — same semantics as
+    omission. Mirrors M-03's ``test_valid_tool_choice_shapes_accepted``
+    null entry."""
+    req = ChatCompletionRequest(**_base_request(tool_choice=None))
+    assert req.tool_choice is None
+
+
+# ---------------------------------------------------------------------------
+# Boundary: the route-level guard at chat.py L756 still owns
+# ``type=='function'`` without ``function.name`` (more informative
+# message including the F-145 case-insensitive name hint). The
+# schema validator must NOT pre-empt that path.
+# ---------------------------------------------------------------------------
+
+
+def test_function_type_without_name_passes_schema():
+    """``{"type":"function"}`` with no ``function`` field — schema
+    accepts (the route 400s with a more informative
+    ``tool_choice with type='function' requires function.name``
+    message). Mirrors the M-03 deferral discipline: don't duplicate
+    a downstream check that already produces a better message."""
+    tc = {"type": "function"}
+    req = ChatCompletionRequest(**_base_request(tool_choice=tc))
+    assert req.tool_choice == tc
+
+
+def test_function_type_with_empty_name_passes_schema():
+    """Same as above — empty ``function.name`` is the route's job.
+    Schema only catches the shapes the route silently accepts."""
+    tc = {"type": "function", "function": {"name": ""}}
+    req = ChatCompletionRequest(**_base_request(tool_choice=tc))
+    assert req.tool_choice == tc
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: validation must NOT mutate the field
+# ---------------------------------------------------------------------------
+
+
+def test_validator_does_not_mutate_tool_choice():
+    """The validator is a gate, not a normalizer. The chat route
+    reads ``request.tool_choice`` as the raw value — silently
+    rewriting it here would mask cross-layer contract drift.
+    Mirrors M-03's ``test_validator_does_not_mutate_tool_choice``."""
+    original = {
+        "type": "function",
+        "function": {"name": "ping"},
+        "extra": "preserved",
+    }
+    req = ChatCompletionRequest(
+        **_base_request(
+            tool_choice=original,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "ping", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+    )
+    assert req.tool_choice == original
+    assert req.tool_choice is not original  # Pydantic copies on construction

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -875,6 +875,101 @@ class ChatCompletionRequest(BaseModel):
         # codex round-2 BLOCKING gap stays open.
         return _reject_non_one_n(v)
 
+    # H-16 (Pavel r3): mirror M-03 (PR #766) onto the OpenAI surface.
+    # The OpenAI spec accepts these ``tool_choice`` shapes:
+    #
+    #   * string: ``"none"`` / ``"auto"`` / ``"required"``
+    #   * object: ``{"type": "function", "function": {"name": "<X>"}}``
+    #
+    # Plus the deprecated bare-string ``"function"`` literal that
+    # some pre-2024 OpenAI SDKs still send to mean "force any
+    # function call" (codex r9 NIT #1 on #551, pinned by
+    # test_diffusion_engine.py::
+    # test_engine_opts_out_blocks_legacy_function_literal_tool_choice).
+    # The route's ``_forced_tool_choice`` check (routes/chat.py
+    # L1212) honors it; the schema must let it through so the
+    # route layer can apply its 422.
+    #
+    # Without this validator, a typo'd object like
+    # ``tool_choice={"foo":"bar"}`` (no ``type`` field) or
+    # ``tool_choice={"type":"banana"}`` (unknown ``type``) silently
+    # falls through the typed ``str | dict`` union onto the dict arm,
+    # the chat-route ``type=='function'`` guard (routes/chat.py L756)
+    # doesn't match, and the request HTTP 200s as a free-form chat
+    # completion — masking the client bug and diverging from the
+    # Anthropic surface that PR #766 closed. Run BEFORE the typed
+    # union resolves so the union's individual arms cannot swallow
+    # shapes either arm alone would reject; mirror the M-03
+    # envelope (``invalid_request_error`` with the field name) by
+    # raising ``ValueError`` here — the global validation handler
+    # (middleware/exception_handlers.py) maps the resulting
+    # ``RequestValidationError`` to the canonical 400.
+    @field_validator("tool_choice", mode="before")
+    @classmethod
+    def _validate_tool_choice(cls, v):
+        # ``None`` / absent is the default — server picks the
+        # default policy (``"auto"`` when ``tools`` is set, else
+        # ``"none"``). Don't tighten beyond the M-03 wording.
+        if v is None:
+            return v
+        # String form: closed-set. Spec values plus the deprecated
+        # ``"function"`` legacy literal (kept because the route's
+        # forced-tool-choice gate at L1212 still honors it; codex
+        # r9 NIT #1 on #551). Reject unknown strings (``"banana"``,
+        # ``"any"`` / ``"tool"`` (Anthropic's words), case
+        # variants like ``"AUTO"``) so a cross-API confusion 400s
+        # at parse instead of silently degrading. Pydantic v2
+        # treats ``bool`` as an ``int`` subclass but ``isinstance(v,
+        # str)`` is False for bools, so no boolean-leak concern
+        # here.
+        allowed_strings = ("none", "auto", "required", "function")
+        if isinstance(v, str):
+            if v not in allowed_strings:
+                raise ValueError(
+                    "tool_choice string must be one of "
+                    f"{list(allowed_strings)} (got {v!r}). "
+                    "See https://platform.openai.com/docs/api-reference/"
+                    "chat/create#chat-create-tool_choice."
+                )
+            return v
+        # Object form: must carry ``type=="function"``. Anything
+        # else (no ``type`` field, unknown ``type`` value) is
+        # outside the spec. The route-level guard at chat.py L756
+        # already covers ``type=='function'`` without ``function.name``
+        # with a more descriptive 400 (including the F-145
+        # case-insensitive name hint), so we defer that arm to the
+        # route and only reject the shapes the route silently
+        # accepts (no ``type`` key, unknown ``type`` value).
+        if isinstance(v, dict):
+            if "type" not in v:
+                raise ValueError(
+                    "tool_choice object must have a 'type' field. Legal "
+                    "shapes: a string from "
+                    f"{list(allowed_strings)} or "
+                    "{'type': 'function', 'function': {'name': '<X>'}}."
+                )
+            choice_type = v["type"]
+            if choice_type != "function":
+                raise ValueError(
+                    "tool_choice.type must be 'function' for the object "
+                    f"form (got {choice_type!r}). Legal shapes: a string "
+                    f"from {list(allowed_strings)} or "
+                    "{'type': 'function', 'function': {'name': '<X>'}}."
+                )
+            return v
+        # Neither string nor dict — e.g. ``tool_choice=42``,
+        # ``tool_choice=[1,2]``, ``tool_choice=true``. Pydantic's
+        # union dispatch would surface a multi-line error blaming
+        # both arms ("tool_choice.str: Input should be a valid
+        # string; tool_choice.dict[any,any]: ..."); flatten it to
+        # a single human-readable message that names the field.
+        raise ValueError(
+            "tool_choice must be a string from "
+            f"{list(allowed_strings)} or an object "
+            "{'type': 'function', 'function': {'name': '<X>'}} "
+            f"(got {type(v).__name__})."
+        )
+
     # Belt-and-braces: catches non-finite values that bypass the
     # raw-dict path (e.g. ``ChatCompletionRequest(temperature=nan)``
     # in-process). The Field range bounds also reject NaN as a side


### PR DESCRIPTION
## Summary

Closes H-16 from 0.8TODO.md (Pavel r3 repro).

`POST /v1/chat/completions` with `tool_choice={"foo":"bar"}` (no `type` field) or `tool_choice={"type":"banana"}` used to HTTP 200 with a free-form chat reply — the typed `str | dict` union on `ChatCompletionRequest.tool_choice` swallowed the dict arm, the chat route's `type=="function"` guard (`vllm_mlx/routes/chat.py` L756) didn't match, and the request silently degraded with no tool forcing. M-03 / PR #766 closed the symmetric gap on the Anthropic surface; this closes the OpenAI surface to match.

## Fix

Mirror the M-03 `field_validator(mode="before")` pattern onto `ChatCompletionRequest.tool_choice`:

- **String form**: closed to `"none"` / `"auto"` / `"required"` per the OpenAI spec, plus the deprecated `"function"` bare-string literal that some pre-2024 SDKs still send (route's `_forced_tool_choice` gate at L1212 honors it; codex r9 NIT #1 on #551, pinned by `test_engine_opts_out_blocks_legacy_function_literal_tool_choice`). Reject `"any"` / `"tool"` (Anthropic vocab), case variants (`"AUTO"`), whitespace-prefixed values.
- **Object form**: must carry `type=="function"`. Reject objects with no `type` key (the H-16 root cause) and unknown `type` values (`"banana"`). The route-level guard at L756 still owns `type=="function"` without `function.name` because it surfaces a more informative message (including the F-145 case-insensitive name hint); the schema only rejects what the route silently accepts — mirrors the M-03 deferral discipline.
- **Non-string non-object** inputs (`42`, `[1,2]`, `True`) collapse to a single flat error message instead of pydantic's union-attempt multi-line shape that leaked both arm names.

The global `RequestValidationError` handler (`middleware/exception_handlers.py`) maps the resulting `ValidationError` to a canonical 400 with `invalid_request_error` envelope, matching the M-03 wire shape on `/v1/messages`.

## Repro (on Qwen3-0.6B-8bit @ :8906)

```bash
# Before
curl -X POST :8906/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"qwen3-0.6b-8bit","tool_choice":{"foo":"bar"},"messages":[{"role":"user","content":"hi"}]}'
# → HTTP 200 + free-form reasoning content (silent degrade)

# After
# → HTTP 400 {"error":{"message":"Invalid request body: tool_choice: Value error, tool_choice object must have a 'type' field. Legal shapes: a string from ['none', 'auto', 'required', 'function'] or {'type': 'function', 'function': {'name': '<X>'}}.","type":"invalid_request_error","code":"invalid_request","param":null}}
```

Wire captures: `/tmp/h16-before.txt`, `/tmp/h16-after.txt`.

## Test plan

- [x] 31 new tests in `tests/test_openai_tool_choice_validation.py` — object without `type` rejected, unknown `type` value rejected, unknown string rejected, non-string-non-object rejected, all OpenAI-spec shapes accepted (string × 3, object with name, legacy `"function"` literal, omitted, explicit null, extra-keys), validator does not mutate the field.
- [x] All 576 chat/openai-prefixed tests still pass (`pytest -k "openai or chat" --ignore=tests/integrations --ignore=tests/test_route_engine_contract.py` — the one `test_route_engine_contract` failure is pre-existing on `origin/main`, unrelated).
- [x] Pre-existing M-03 anthropic tool_choice tests still pass.
- [x] `test_engine_opts_out_blocks_legacy_function_literal_tool_choice` still passes (the route honors `tool_choice="function"`; schema must let it through).
- [x] Wire repro on running server: cases A/C/D/I/J → 400, cases E/F/G/H → 200; `{"type":"function"}` without `function.name` still 400 via route layer (L756) with the more informative message.
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)