### PR TITLE
fix(security): sanitize /v1/cache/info stub envelope (H-12)

### DIFF
--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -349,3 +349,124 @@ def test_cache_import_501_envelope_does_not_leak_operator_path(
         assert needle not in r.text, f"{needle!r} leaked into 501 body: {r.text!r}"
     assert "secret-org-model" not in r.text
     assert body.get("detail") == _EXPECTED_NOT_IMPLEMENTED_ENVELOPE, body
+
+
+# ---------------------------------------------------------------------------
+# H-12: /v1/cache/info envelope must not leak the resolved sandbox path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "/Users/",
+        ".cache",
+        "cache_exports",
+        "rapid-mlx",
+        "$HOME",
+    ],
+)
+def test_cache_info_does_not_leak_operator_path(
+    client_factory, tmp_path, monkeypatch, needle
+):
+    """H-12: ``GET /v1/cache/info`` returned ``{"path": str(root), ...}``
+    where ``root`` is the fully resolved sandbox subdirectory
+    (``/Users/<USERNAME>/.cache/rapid-mlx/cache_exports/<sub>`` on macOS).
+    Same shape as H-02 on a different cache endpoint — leaks the
+    operator's home dir + username to any LAN caller after the #756
+    auth-gate revert removed ``verify_internal_admin`` from this route.
+
+    Mimic the user-home-shaped sandbox so the substrings actually appear
+    in the resolved path even though ``tmp_path`` lives under ``/private
+    /var/folders/...``. Drop a valid manifest, then sweep the 200 body
+    for each leak needle (parametrized so a failure pinpoints which
+    substring leaked).
+    """
+    # Build a tmp sandbox whose absolute path contains every leak needle
+    # we care about — so a route that echoes ``str(root)`` would fail
+    # every parametrized case, not just the ones whose substring happens
+    # to land in the OS-provided ``tmp_path``.
+    sandbox = tmp_path / "Users" / "yuki" / ".cache" / "rapid-mlx" / "cache_exports"
+    sandbox.mkdir(parents=True)
+    monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(sandbox))
+
+    import json
+
+    from vllm_mlx.cache.protocol import PROTOCOL_VERSION
+    from vllm_mlx.routes.cache import router as cache_router
+
+    manifest = {
+        "protocol_version": PROTOCOL_VERSION,
+        "model_id": "secret-org-model-12b-8bit",
+        "entries": 0,
+        "total_bytes": 0,
+        "created_at": "2026-06-20T00:00:00Z",
+    }
+    (sandbox / "manifest.json").write_text(json.dumps(manifest))
+
+    build, _ = client_factory
+    client = build(api_key=None)
+    client.app.include_router(cache_router)
+
+    r = client.get("/v1/cache/info")
+    assert r.status_code == 200, r.text
+    assert needle not in r.text, (
+        f"{needle!r} leaked into /v1/cache/info 200 body: {r.text!r}"
+    )
+
+
+def test_cache_info_returns_canonical_shape_without_path_field(
+    client_factory, tmp_path, monkeypatch
+):
+    """H-12: positive contract pin. Post-fix the 200 envelope carries
+    ``protocol_version`` + ``manifest`` but NOT a top-level ``"path"``
+    field — the resolved sandbox root stays in the server log only.
+
+    The exact-string check on ``str(sandbox)`` catches a hypothetical
+    regression that serializes the path into a renamed field (e.g.
+    ``resolved_path``, ``root``, ``location``) which would slip past
+    the substring sweep when the tmp dir happens to live outside
+    ``/Users/``.
+    """
+    sandbox = tmp_path / "h12-canonical-shape"
+    sandbox.mkdir(parents=True)
+    monkeypatch.setenv("RAPID_MLX_CACHE_EXPORT_DIR", str(sandbox))
+
+    import json
+
+    from vllm_mlx.cache.protocol import PROTOCOL_VERSION
+    from vllm_mlx.routes.cache import router as cache_router
+
+    manifest = {
+        "protocol_version": PROTOCOL_VERSION,
+        "model_id": "secret-org-model-12b-8bit",
+        "entries": 7,
+        "total_bytes": 0,
+        "created_at": "2026-06-20T00:00:00Z",
+    }
+    (sandbox / "manifest.json").write_text(json.dumps(manifest))
+
+    build, _ = client_factory
+    client = build(api_key=None)
+    client.app.include_router(cache_router)
+
+    r = client.get("/v1/cache/info")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # H-12 wire-shape pin: top-level keys are exactly these two. A new
+    # field that re-introduces the path leak under a different name
+    # (``resolved_path``, ``root``, ``location``) trips this set check.
+    assert set(body.keys()) == {"protocol_version", "manifest"}, body
+    assert body["protocol_version"] == PROTOCOL_VERSION
+    # Manifest payload is intentionally preserved — the leak was the
+    # resolved sandbox root, NOT the manifest contents which the caller
+    # supplied / would receive on a full import.
+    assert body["manifest"]["model_id"] == "secret-org-model-12b-8bit"
+    assert body["manifest"]["entries"] == 7
+    # Belt + braces: the sandbox path is unique per test run and would
+    # not otherwise appear in the response. Catches a regression where
+    # the path field is renamed but still echoed.
+    assert str(sandbox) not in r.text, (
+        f"resolved root {str(sandbox)!r} leaked into /v1/cache/info "
+        f"200 body: {r.text!r}"
+    )

--- a/tests/test_internal_route_auth.py
+++ b/tests/test_internal_route_auth.py
@@ -363,7 +363,6 @@ def test_cache_import_501_envelope_does_not_leak_operator_path(
         ".cache",
         "cache_exports",
         "rapid-mlx",
-        "$HOME",
     ],
 )
 def test_cache_info_does_not_leak_operator_path(
@@ -380,7 +379,9 @@ def test_cache_info_does_not_leak_operator_path(
     in the resolved path even though ``tmp_path`` lives under ``/private
     /var/folders/...``. Drop a valid manifest, then sweep the 200 body
     for each leak needle (parametrized so a failure pinpoints which
-    substring leaked).
+    substring leaked). Codex r1 NIT: the needle list mirrors the H-02
+    sibling sweep — substrings that actually appear in the constructed
+    sandbox path, not unexpanded shell variables like ``$HOME``.
     """
     # Build a tmp sandbox whose absolute path contains every leak needle
     # we care about — so a route that echoes ``str(root)`` would fail

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -276,7 +276,16 @@ async def cache_info(path: str | None = None):
     root = _resolve_or_400(path)
     manifest = _read_manifest_or_http(root)
 
-    logger.info(
+    # Codex r1 follow-up: log at DEBUG (not INFO) so the resolved root
+    # only lands in operator logs when the operator explicitly opts in
+    # (RAPID_MLX_LOG_LEVEL=DEBUG or equivalent). Routine 200 traffic
+    # carries no path on the wire AND no path in the default log stream
+    # — but the breadcrumb is still there for ops who need to debug a
+    # peer-sync issue. Sibling concern: H-02's logger.warning on the
+    # 403 path is fine because that's an anomaly worth recording at
+    # default verbosity, whereas every successful info read shouldn't
+    # rewrite the sandbox path into the rolling log.
+    logger.debug(
         "cache/info: resolved root=%s model_id=%s entries=%s",
         root,
         manifest.model_id,

--- a/vllm_mlx/routes/cache.py
+++ b/vllm_mlx/routes/cache.py
@@ -14,7 +14,9 @@ fill in with the engine-level save/load body. Stub behavior:
   the wire-level contract is exercised today.
 * ``GET /v1/cache/info`` — fully implemented: reads the manifest at a
   whitelisted path and returns it. Lets a peer instance (or oai-mlx) GC
-  / inspect an export root without round-tripping a full import.
+  / inspect an export root without round-tripping a full import. H-12:
+  response carries ``protocol_version`` + ``manifest`` only — the
+  resolved sandbox root stays in the server log, never on the wire.
 
 Auth follows ``vllm_mlx.routes.health``'s ``router``: the bearer key is
 enforced when ``--api-key`` is set, no new header is invented.
@@ -261,12 +263,26 @@ async def cache_info(path: str | None = None):
     Returns the manifest dict so callers (peer instances, oai-mlx, ops
     tooling) can GC / route / version-gate without paying a full import.
     Path resolution follows the same sandbox rules as export/import.
+
+    H-12: pre-fix this handler echoed the resolved sandbox root back to
+    the caller in a top-level ``"path"`` field. ``str(root)`` expands to
+    ``/Users/<USERNAME>/.cache/rapid-mlx/cache_exports/<sub>`` on macOS
+    — same operator home-dir / username disclosure that H-02 fixed on
+    the 403 envelope. Same treatment here: keep the resolved root in
+    the server log only, omit it from the wire envelope. Callers that
+    need to dedupe by location already have the request-side ``path``
+    they supplied.
     """
     root = _resolve_or_400(path)
     manifest = _read_manifest_or_http(root)
 
+    logger.info(
+        "cache/info: resolved root=%s model_id=%s entries=%s",
+        root,
+        manifest.model_id,
+        manifest.entries,
+    )
     return {
-        "path": str(root),
         "protocol_version": PROTOCOL_VERSION,
         "manifest": manifest.to_dict(),
     }


### PR DESCRIPTION
## Summary

- `GET /v1/cache/info` echoed the resolved sandbox root back to the caller in a top-level `"path"` field. On macOS `str(root)` expands to `/Users/<USERNAME>/.cache/rapid-mlx/cache_exports/<sub>` — the same operator home-dir / username disclosure H-02 (#762) fixed on the 403 sandbox-escape envelope. After #756 reverted the `verify_internal_admin` gate on the cache routes, this leak reaches any LAN caller.
- Same treatment as H-02: drop the leaking field from the response, keep the resolved root in the server log only. The route stays implemented (manifest still returned) — going 501 here would regress the existing contract and break `test_info_returns_manifest`.
- New parametrized leak tests live alongside the H-02 tests in `tests/test_internal_route_auth.py` so the same needle sweep covers `/v1/cache/{export,info}`.

## Yuki r3 repro

Origin/main `GET /v1/cache/info` against a sandbox at `<tmp>/Users/yuki/.cache/rapid-mlx/cache_exports` with a valid manifest:

```
status: 200
body  : {"path":"/private/var/folders/.../Users/yuki/.cache/rapid-mlx/cache_exports","protocol_version":"1","manifest":{...,"model_id":"test","entries":0,...}}
leaks : ['/Users/', '.cache', 'rapid-mlx', 'cache_exports', '<full resolved path>']
```

Post-fix:

```
status: 200
body  : {"protocol_version":"1","manifest":{...,"model_id":"test","entries":0,...}}
leaks : []
```

Captured in `/tmp/h12-before.txt` and `/tmp/h12-after.txt`.

## H-02 precedent

PR #762 (squash `3e7e9ca`) introduced `_SANDBOX_ESCAPE_DETAIL` and a parametrized leak-sweep test that grep's `/Users/`, `.cache`, `rapid-mlx`, `cache_exports`. This PR re-uses the same needle set on the H-12 site (Yuki's repro shape) so a future regression at either endpoint is caught by the same shape of test.

## Implementation choice: implement-for-real (NOT 501)

The task description floated both options:
- **501-stub with sanitized envelope** (mirror cache/export precedent)
- **implement-for-real** with sanitized `path`

The route is already implemented — `tests/test_cache_routes.py::test_info_returns_manifest` exercises the happy 200 path and `vllm_mlx/routes/cache.py:15-17` documents it as "fully implemented: reads the manifest at a whitelisted path". The `model_id`/`entries`/`test` stub the task description quotes was actually the contents of a manifest the caller would have written, not a literal hardcoded stub — the leak is in the response envelope, not the data source.

Going 501 here would regress `test_info_returns_manifest` and remove a working capability. Instead the fix surgically drops the leaking `"path"` field and preserves `protocol_version` + `manifest`. The wire-shape pin in `test_cache_info_returns_canonical_shape_without_path_field` catches a regression that re-introduces the leak under a different field name (`resolved_path`, `root`, `location`).

## Test plan

- [x] Run `tests/test_internal_route_auth.py` and `tests/test_cache_routes.py` — all 59 pass.
- [x] Confirm pre-fix repro leaks all 5 needles (`/Users/`, `.cache`, `rapid-mlx`, `cache_exports`, resolved sandbox path) — `/tmp/h12-before.txt`.
- [x] Confirm post-fix repro: `leaks: []`, body carries only `protocol_version` + `manifest` — `/tmp/h12-after.txt`.
- [x] Confirm new tests `test_cache_info_does_not_leak_operator_path[/Users/]` fail against the un-fixed handler (stashed fix, re-ran the new tests — saw the expected AssertionError on the `/Users/` parametrization).
- [x] `ruff check vllm_mlx/routes/cache.py tests/test_internal_route_auth.py` — all checks pass.
- [x] `ruff format --check` — both files already formatted.
- [x] No change to `pyproject.toml` version (per task constraint).
- [x] No global config writes (per task constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)