### PR TITLE
fix(api): reject non-string text in content blocks (H-15)

### DIFF
--- a/tests/test_content_block_strict_types.py
+++ b/tests/test_content_block_strict_types.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for H-15 — non-string ``text`` (and image-source
+fields) on a content block used to slip past the schema layer and
+crash inside the prompt flattener with raw
+``TypeError: sequence item 0: expected str instance, X found``.
+
+Pre-fix surface (Daniela r3 repro):
+    POST /v1/chat/completions
+    {"messages":[{"role":"user","content":[
+        {"type":"text","text":[["deeply","nested"],"list"]}
+    ]}]}
+    → HTTP 500 ``{"error":{"message":"Internal server error"}}``
+      with a raw ``TypeError`` in the server log.
+
+Root cause: ``Message.content`` is declared as the union
+``str | list[ContentPart] | list[dict]``. When ``text`` is a
+non-string, the ``list[ContentPart]`` arm rejects (because
+``ContentPart.text`` is ``str | None``), and Pydantic falls back to
+the looser ``list[dict]`` arm — which silently accepts the
+malformed payload. ``_join_text_parts`` then crashes when it tries
+to ``"".join(...)`` the non-string ``text`` value.
+
+Shallow nesting (``text: 123`` / ``text: {"k": "v"}``) reproduces
+the same 500 — the dict-fallback path is shape-agnostic.
+
+Fix surface (covers both OpenAI- and Anthropic-flavoured routes):
+  * ``ContentPart`` gains an explicit ``_validate_text_type``
+    model_validator so direct construction errors name the field
+    cleanly (the ``str | None`` declaration alone surfaces as
+    Pydantic's raw ``string_type`` loc trail).
+  * ``Message._validate_media_url_types`` is extended to also
+    reject non-string ``text`` in the dict-fallback arm — this is
+    the path that actually escapes to ``_join_text_parts`` and
+    500s.
+  * ``AnthropicContentBlock`` gains a ``text`` field validator
+    plus an image-source string-check (the same H-15 shape applied
+    to ``source.data`` / ``source.url`` on Anthropic image blocks).
+
+Each rejection produces a 400 with a stable, field-named message:
+    ``content[].text must be a string (got <type>)``
+
+Live HTTP behaviour pinned via TestClient — the FastAPI route is
+constructed with the route-level handlers from
+``vllm_mlx.middleware.exception_handlers`` so the envelope-shape
+assertions match production.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from vllm_mlx.api.anthropic_models import AnthropicContentBlock, AnthropicRequest
+from vllm_mlx.api.models import ChatCompletionRequest, ContentPart, Message
+from vllm_mlx.middleware.exception_handlers import _validation_error_response
+
+# ---------------------------------------------------------------------------
+# Direct Pydantic construction — pins schema-layer rejection contract.
+# ---------------------------------------------------------------------------
+
+
+class TestContentPartTextStrictType:
+    """Direct ``ContentPart(text=…)`` construction must reject
+    non-string text with the named-field message."""
+
+    @pytest.mark.parametrize(
+        ("value", "type_name"),
+        [
+            ([["nested"]], "list"),
+            (123, "int"),
+            ({"k": "v"}, "dict"),
+            (12.3, "float"),
+            (True, "bool"),
+        ],
+    )
+    def test_non_string_text_rejected(self, value: Any, type_name: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ContentPart(type="text", text=value)
+        msg = str(exc_info.value)
+        # H-15 named-field message must be in the rejection.
+        assert "content[].text must be a string" in msg, msg
+
+    def test_string_text_accepted(self) -> None:
+        cp = ContentPart(type="text", text="hello")
+        assert cp.text == "hello"
+
+    def test_null_text_accepted(self) -> None:
+        # Backwards-compat: ``text=None`` is legal (empty no-op text part).
+        cp = ContentPart(type="text", text=None)
+        assert cp.text is None
+
+    def test_empty_string_text_accepted(self) -> None:
+        cp = ContentPart(type="text", text="")
+        assert cp.text == ""
+
+
+class TestMessageDictFallbackTextStrictType:
+    """``Message.content`` dict-fallback arm is the path that actually
+    leaked to ``_join_text_parts`` and 500'd pre-H-15. Pin the
+    rejection at the parent Message level so the live route surface
+    is covered (the route receives a ``Message`` after the union
+    resolves)."""
+
+    @pytest.mark.parametrize(
+        ("value", "type_name"),
+        [
+            ([["nested"]], "list"),
+            (123, "int"),
+            ({"k": "v"}, "dict"),
+        ],
+    )
+    def test_dict_fallback_non_string_text_rejected(
+        self, value: Any, type_name: str
+    ) -> None:
+        # Build a content list whose ``text`` value would force
+        # Pydantic into the ``list[dict]`` fallback arm.
+        with pytest.raises(ValidationError) as exc_info:
+            Message(
+                role="user",
+                content=[{"type": "text", "text": value}],
+            )
+        msg = str(exc_info.value)
+        assert "content[].text must be a string" in msg, msg
+        assert f"got {type_name}" in msg, msg
+
+    def test_null_text_accepted(self) -> None:
+        # ``text: null`` is a legal no-op (semantically equivalent to
+        # an absent text part).
+        m = Message(role="user", content=[{"type": "text", "text": None}])
+        part = m.content[0]
+        text = part["text"] if isinstance(part, dict) else part.text
+        assert text is None
+
+    def test_valid_text_accepted(self) -> None:
+        m = Message(role="user", content=[{"type": "text", "text": "ok"}])
+        part = m.content[0]
+        text = part["text"] if isinstance(part, dict) else part.text
+        assert text == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic content block — `text: str | None` already 422s, but the
+# H-15 fix adds an explicit field validator so the error message
+# names ``content[].text`` cleanly.
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicContentBlockTextStrictType:
+    @pytest.mark.parametrize(
+        ("value", "type_name"),
+        [
+            ([["nested"]], "list"),
+            (123, "int"),
+            ({"k": "v"}, "dict"),
+        ],
+    )
+    def test_non_string_text_rejected(self, value: Any, type_name: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicContentBlock(type="text", text=value)
+        msg = str(exc_info.value)
+        assert "content[].text must be a string" in msg, msg
+        assert f"got {type_name}" in msg, msg
+
+    def test_string_text_accepted(self) -> None:
+        block = AnthropicContentBlock(type="text", text="hi")
+        assert block.text == "hi"
+
+    def test_null_text_accepted(self) -> None:
+        block = AnthropicContentBlock(type="text", text=None)
+        assert block.text is None
+
+
+class TestAnthropicImageSourceStrictType:
+    """Pin string-typing on ``source.data`` / ``source.url`` (the
+    Anthropic-side equivalent of ``image_url.url``; F-066 sibling)."""
+
+    @pytest.mark.parametrize("key", ["data", "url"])
+    def test_non_string_source_field_rejected(self, key: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicContentBlock(
+                type="image",
+                source={"type": "base64", "media_type": "image/png", key: 123},
+            )
+        msg = str(exc_info.value)
+        assert f"image source.{key} must be a string" in msg, msg
+
+    def test_valid_source_accepted(self) -> None:
+        block = AnthropicContentBlock(
+            type="image",
+            source={
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgo=",
+            },
+        )
+        assert block.source["data"] == "iVBORw0KGgo="
+
+
+# ---------------------------------------------------------------------------
+# Top-level request models — covers both routes via the public-facing
+# parse surface (matches what FastAPI does).
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionRequestTextStrictType:
+    """``/v1/chat/completions`` body parse."""
+
+    @pytest.mark.parametrize(
+        ("text_value", "type_name"),
+        [
+            ([["deeply", "nested"], "list"], "list"),  # Daniela r3 shape
+            (123, "int"),
+            ({"nested": "obj"}, "dict"),
+        ],
+    )
+    def test_non_string_text_in_content_rejected(
+        self, text_value: Any, type_name: str
+    ) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(
+                model="default",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": text_value}],
+                    }
+                ],
+            )
+        msg = str(exc_info.value)
+        assert "content[].text must be a string" in msg, msg
+        assert f"got {type_name}" in msg, msg
+
+    def test_valid_text_content_accepted(self) -> None:
+        req = ChatCompletionRequest(
+            model="default",
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+        )
+        assert req.messages[0].content[0].text == "hello"
+
+    def test_valid_string_content_accepted(self) -> None:
+        # The ``content: str`` arm of the union must still work.
+        req = ChatCompletionRequest(
+            model="default",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        assert req.messages[0].content == "hello"
+
+    def test_multi_text_block_payload_accepted(self) -> None:
+        # Multiple text parts — a legal OpenAI-spec edge case.
+        req = ChatCompletionRequest(
+            model="default",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "first"},
+                        {"type": "text", "text": "second"},
+                    ],
+                }
+            ],
+        )
+        assert req.messages[0].content[0].text == "first"
+        assert req.messages[0].content[1].text == "second"
+
+    def test_image_url_non_string_url_still_rejected(self) -> None:
+        # F-066 already covered this; pin it here too so this test
+        # file owns the full content-block strict-typing contract.
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(
+                model="default",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": 123},
+                            }
+                        ],
+                    }
+                ],
+            )
+        msg = str(exc_info.value)
+        assert "image_url.url must be a string" in msg, msg
+
+
+class TestAnthropicRequestTextStrictType:
+    """``/v1/messages`` body parse."""
+
+    @pytest.mark.parametrize(
+        ("text_value", "type_name"),
+        [
+            ([["nested"]], "list"),
+            (123, "int"),
+            ({"nested": "obj"}, "dict"),
+        ],
+    )
+    def test_non_string_text_in_content_rejected(
+        self, text_value: Any, type_name: str
+    ) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicRequest(
+                model="claude-3-opus",
+                max_tokens=10,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": text_value}],
+                    }
+                ],
+            )
+        msg = str(exc_info.value)
+        assert "content[].text must be a string" in msg, msg
+        assert f"got {type_name}" in msg, msg
+
+    def test_valid_text_content_accepted(self) -> None:
+        req = AnthropicRequest(
+            model="claude-3-opus",
+            max_tokens=10,
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        )
+        assert req.messages[0].content[0].text == "hi"
+
+    def test_valid_string_content_accepted(self) -> None:
+        req = AnthropicRequest(
+            model="claude-3-opus",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert req.messages[0].content == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Live envelope shape — pins the 400 surface the client actually sees
+# on ``/v1/chat/completions``. Uses a minimal FastAPI app wired to the
+# canonical ``_validation_error_response`` so we don't depend on a
+# running model.
+# ---------------------------------------------------------------------------
+
+
+def _make_test_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(RequestValidationError)
+    async def _handler(_request, exc):  # noqa: ANN001
+        return _validation_error_response(exc)
+
+    @app.post("/v1/chat/completions")
+    async def _chat(req: ChatCompletionRequest):  # noqa: ARG001
+        return {"ok": True}
+
+    @app.post("/v1/messages")
+    async def _messages(req: AnthropicRequest):  # noqa: ARG001
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(_make_test_app())
+
+
+class TestLive400EnvelopeChatCompletions:
+    @pytest.mark.parametrize(
+        ("text_value", "type_name"),
+        [
+            ([["deeply", "nested"], "list"], "list"),
+            (123, "int"),
+            ({"nested": "obj"}, "dict"),
+        ],
+    )
+    def test_non_string_text_returns_400_clean_envelope(
+        self,
+        client: TestClient,
+        text_value: Any,
+        type_name: str,
+    ) -> None:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": text_value}],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        # OpenAI-shaped envelope (matches the canonical
+        # ``_validation_error_response`` output).
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "content[].text must be a string" in body["error"]["message"]
+        assert f"got {type_name}" in body["error"]["message"]
+        # No naked Python type-error text leaks (the H-15 surface).
+        assert "TypeError" not in body["error"]["message"]
+        assert "sequence item 0" not in body["error"]["message"]
+
+    def test_valid_text_passes_validation(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello"}],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_image_url_non_string_url_returns_400_clean(
+        self, client: TestClient
+    ) -> None:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": 123},
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert "image_url.url must be a string" in body["error"]["message"]
+
+
+class TestLive400EnvelopeAnthropicMessages:
+    @pytest.mark.parametrize(
+        ("text_value", "type_name"),
+        [
+            ([["nested"]], "list"),
+            (123, "int"),
+            ({"nested": "obj"}, "dict"),
+        ],
+    )
+    def test_non_string_text_returns_400_clean_envelope(
+        self,
+        client: TestClient,
+        text_value: Any,
+        type_name: str,
+    ) -> None:
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-3-opus",
+                "max_tokens": 10,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": text_value}],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "content[].text must be a string" in body["error"]["message"]
+        assert f"got {type_name}" in body["error"]["message"]
+        assert "TypeError" not in body["error"]["message"]

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -36,6 +36,54 @@ class AnthropicContentBlock(BaseModel):
     # image block
     source: dict | None = None
 
+    @field_validator("text", mode="before")
+    @classmethod
+    def _reject_non_string_text(cls, value: Any) -> Any:
+        """Reject non-string ``text`` with a clean, field-named error
+        message (H-15).
+
+        ``text: str | None`` already 422s on a non-string value, but
+        Pydantic's default message buries ``text`` under a
+        ``messages.0.content.str: Input should be a valid string`` loc
+        trail because the parent ``AnthropicMessage.content`` is a
+        ``str | list[AnthropicContentBlock]`` union (the str-arm fails
+        first, then the list-arm fails on ``text`` — two confusing
+        union errors). Run an explicit before-validator so the client
+        sees a single actionable message naming ``content[].text``
+        directly.
+        """
+        if value is None or isinstance(value, str):
+            return value
+        raise ValueError(
+            f"content[].text must be a string (got {type(value).__name__})"
+        )
+
+    @model_validator(mode="after")
+    def _validate_image_source_type(self) -> "AnthropicContentBlock":
+        """Reject non-string ``source.data`` / ``source.url`` (H-15
+        sibling).
+
+        Anthropic image blocks ship the payload inside ``source`` with
+        either ``{"type":"base64","media_type":"…","data":"…"}`` or
+        ``{"type":"url","url":"…"}``. ``source`` is declared ``dict``
+        (no inner schema) so a non-string ``data`` / ``url`` value
+        (e.g. a nested list — the same H-15 shape) used to fall through
+        the schema layer and surface as an uninformative downstream
+        error. Pin a string-typed check here for parity with the
+        OpenAI-side ``image_url.url`` rule (F-066) so the failure
+        names the field cleanly at the schema layer.
+        """
+        if self.type == "image" and isinstance(self.source, dict):
+            for key in ("data", "url"):
+                if key in self.source:
+                    val = self.source[key]
+                    if val is not None and not isinstance(val, str):
+                        raise ValueError(
+                            f"image source.{key} must be a string "
+                            f"(got {type(val).__name__})"
+                        )
+        return self
+
 
 class AnthropicMessage(BaseModel):
     """A message in an Anthropic conversation."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -328,6 +328,33 @@ class ContentPart(BaseModel):
     video_url: VideoUrl | dict | str | None = None
     audio_url: AudioUrl | dict | str | None = None
 
+    @field_validator("text", mode="before")
+    @classmethod
+    def _validate_text_type(cls, value):  # noqa: ANN001, ANN206
+        """Reject non-string ``text`` on a content part with a clean,
+        field-named error message (H-15).
+
+        ``text`` is declared ``str | None`` so direct ContentPart
+        construction already 422s on a non-string value — but Pydantic's
+        default ``string_type`` message buries ``text`` under a nested
+        loc trail. Run a ``mode="before"`` field validator so the error
+        surfaces a single actionable line naming ``content[].text``.
+
+        The dict-fallback escape (where ``Message.content`` falls back
+        to ``list[dict]`` because the ``list[ContentPart]`` arm rejected)
+        is pinned separately at the parent ``Message`` validator — see
+        ``Message._validate_media_url_types`` below. That's the path
+        that actually escaped to ``_join_text_parts`` pre-H-15 (and
+        500'd with raw ``TypeError``); the validator here keeps direct
+        ``ContentPart(...)`` construction (engine tests, the gradio
+        app, the speculative server) covered as well.
+        """
+        if value is None or isinstance(value, str):
+            return value
+        raise ValueError(
+            f"content[].text must be a string (got {type(value).__name__})"
+        )
+
     @model_validator(mode="after")
     def _validate_media_url_types(self) -> "ContentPart":
         """Reject non-string ``url`` inside multimodal-content dicts (F-066)
@@ -442,6 +469,23 @@ class Message(BaseModel):
             if not isinstance(item, dict):
                 continue
             item_type = item.get("type")
+            # H-15: dict-arm non-string ``text`` slot. The
+            # ``list[ContentPart] | list[dict]`` union falls back to
+            # ``list[dict]`` when the ContentPart arm rejects (e.g. a
+            # nested-list or dict ``text`` value fails the
+            # ``str | None`` declaration on ``ContentPart.text``), so
+            # the malformed payload used to slip past the schema layer
+            # and crash inside ``_join_text_parts`` with raw
+            # ``TypeError: sequence item 0: expected str instance, X
+            # found`` (HTTP 500). Pin it at this dict-fallback path so
+            # the client sees a clean 400 naming ``content[].text``.
+            if "text" in item:
+                text_value = item["text"]
+                if text_value is not None and not isinstance(text_value, str):
+                    raise ValueError(
+                        "content[].text must be a string "
+                        f"(got {type(text_value).__name__})"
+                    )
             for field in ("image_url", "video_url", "audio_url"):
                 value = item.get(field)
                 if value is None:


### PR DESCRIPTION
## Summary

Fixes H-15 from `0.8TODO.md` (Daniela r3) — a content-block payload
with a non-string `text` value (deeply nested list, int, dict) used
to slip past the schema layer on `/v1/chat/completions` and **500
with a raw `TypeError: sequence item 0: expected str instance, X
found`** inside the prompt flattener.

**Daniela r3 repro (pre-fix → HTTP 500):**

```bash
curl -X POST /v1/chat/completions -d '{
  "messages":[{"role":"user","content":[
    {"type":"text","text":[["deeply","nested"],"list"]}
  ]}]
}'
```

**Root cause:** `Message.content` is the union
`str | list[ContentPart] | list[dict]`. When `text` is non-string,
the `list[ContentPart]` arm rejects (`ContentPart.text` is
`str | None`), Pydantic falls back to `list[dict]`, and the
malformed payload reaches `_join_text_parts()` in
`vllm_mlx/utils/chat_template.py:302` which crashes on `"".join(...)`.

Shallow nesting (`text: 123` / `text: {...}`) reproduces the same
500 — the dict-fallback path is shape-agnostic.

### What changed

- **`ContentPart`**: `text` field validator rejects non-string with
  the named-field message `content[].text must be a string (got X)`.
- **`Message._validate_media_url_types`**: extended to reject
  non-string `text` in the dict-fallback arm — this is the path
  that actually escaped to `_join_text_parts` and 500'd.
- **`AnthropicContentBlock`**: mirror `text` validator + adds
  `source.data` / `source.url` string-typing (H-15 sibling; parity
  with the OpenAI-side `image_url.url` rule from F-066).

### Live verification (`/tmp/h15-before.txt` → `/tmp/h15-after.txt`)

| Input shape | Pre-fix | Post-fix |
|---|---|---|
| `text: [[nested]]` | 500 raw TypeError | 400 `content[].text must be a string (got list)` |
| `text: 123` | 500 raw TypeError | 400 `content[].text must be a string (got int)` |
| `text: {nested}` | 500 raw TypeError | 400 `content[].text must be a string (got dict)` |
| `text: "hello"` | 200 | 200 |
| `text: null` | 200 | 200 (empty no-op preserved) |
| Anthropic `text: [[nested]]` | 400 (cryptic) | 400 with named `content[].text` |
| `image_url.url: 123` (F-066) | 400 | 400 (unchanged) |

## Test plan

- [x] All 4 bad inputs (list / int / dict on OpenAI; list / int on Anthropic) return 400 with named-field message — no more naked `TypeError` in 500 body
- [x] `text: "hello"` (valid string) still returns 200
- [x] `text: null` still returns 200 (legal no-op text part)
- [x] Multi-block text payload (`[{text:"a"}, {text:"b"}]`) still returns 200
- [x] Pre-existing `image_url.url` rejection (F-066) unaffected — still 400 with `image_url.url must be a string`
- [x] Anthropic `image source.data: 123` returns 400 (new H-15 sibling)
- [x] `tests/test_content_block_strict_types.py` — 41 cases, all passing (direct ContentPart/Message construction, AnthropicContentBlock, top-level request models on both routes, live TestClient envelope shape)
- [x] Adjacent suites unaffected: `test_image_url_must_be_object.py`, `test_api_models.py`, `test_anthropic_models.py`, `test_clean_error_messages.py`, `test_anthropic_adapter.py`, `test_anthropic_tool_param_validation.py`, `test_paired_compat.py`, `test_chat_template_marker_sanitize.py`, `test_text_only_media_gate.py`, `test_chat_route_vlm_image.py`, `test_tool_result_content_array.py` — 397 passing across the cluster
- [x] Broader pytest sweep — 6915 passing; 4 pre-existing failures on `origin/main` (event-loop integration, contract tests unrelated to H-15) verified by `git stash && pytest` on origin/main
- [x] `ruff check` + `ruff format` clean on touched files
- [x] Live server reproduction on Qwen3-0.6B-8bit @ :8905 (Daniela r3 shape) confirms 500 → 400 transition

Refs: 0.8TODO.md H-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)