### PR TITLE
fix(scheduler): disconnect_guard force-aborts scheduler request on client close (C-01)

### DIFF
--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -214,22 +214,52 @@ async def test_no_holder_preserves_pre_c01_contract():
 
 
 @pytest.mark.asyncio
-async def test_generator_exit_path_also_force_aborts():
-    """When the consumer aborts the iteration via ``aclose()`` (the
-    ``GeneratorExit`` path — Starlette's StreamingResponse uses this
-    when it detects a write failure), the guard MUST also
-    force-abort even though the disconnect_task never fired.
+async def test_generator_exit_branch_force_aborts_before_finally(monkeypatch):
+    """C-01 codex r1 BLOCKING #1: pin the ``except GeneratorExit``
+    branch specifically (not just "abort happened somewhere").
 
-    Astrid r3 fingerprint: ``is_disconnected()`` may NEVER return
-    True even after the client RSTs, but uvicorn eventually
-    surfaces the dead socket via a write failure that propagates
-    back as ``GeneratorExit`` into the streaming generator. Catching
-    this path closes the second half of the runaway window.
+    The disconnect_guard now triggers force-abort from THREE places:
+    the explicit disconnect branch, the ``except GeneratorExit``
+    block, AND the ``finally`` belt-and-suspenders. A test that only
+    checks ``scheduler.aborts == [rid]`` would still pass if the
+    ``except GeneratorExit`` block were deleted, because ``finally``
+    would catch the case. This test discriminates by replacing
+    ``_force_abort_request`` with a wrapper that captures the calling
+    frame's local variable namespace — only the ``except GeneratorExit``
+    block (NOT ``finally``) accumulates ``chunk_count`` AND has yet to
+    cancel ``disconnect_task``. Asserting that the FIRST abort call
+    came from a frame WITHOUT ``finished_normally`` resolved/with
+    ``disconnect_task`` still live pins the branch specifically.
+
+    The Astrid r3 fingerprint: Starlette's StreamingResponse tears
+    down via ``aclose()`` (GeneratorExit into our wrapper) when uvicorn
+    detects a write failure to a dead socket — even though
+    ``is_disconnected()`` returned False the entire time. Catching the
+    branch here closes the second half of the runaway window.
     """
-    from vllm_mlx.service.helpers import _disconnect_guard
+    import inspect
+
+    from vllm_mlx.service import helpers as _helpers
 
     engine = _FakeEngine()
     holder: list[str | None] = ["req-runaway-xyz"]
+
+    # Record at which suite the abort fired. The except-GeneratorExit
+    # branch runs BEFORE the finally clause; we identify the calling
+    # frame by its source line via ``inspect``.
+    call_sites: list[str] = []
+    original = _helpers._force_abort_request
+
+    def _capturing_force_abort(eng, hld):
+        # Walk back to the disconnect_guard frame and capture which
+        # block we're in. The ``except GeneratorExit`` branch and the
+        # ``finally`` clause sit at distinct source lines in helpers.py.
+        frame = inspect.currentframe().f_back
+        if frame is not None:
+            call_sites.append(f"{frame.f_code.co_name}:line-{frame.f_lineno}")
+        return original(eng, hld)
+
+    monkeypatch.setattr(_helpers, "_force_abort_request", _capturing_force_abort)
 
     async def _gen():
         yield "data: chunk1\n\n"
@@ -239,7 +269,7 @@ async def test_generator_exit_path_also_force_aborts():
         await asyncio.sleep(30.0)
         yield "data: never\n\n"
 
-    agen = _disconnect_guard(
+    agen = _helpers._disconnect_guard(
         _gen(),
         _NeverDisconnectsRequest(),
         poll_interval=0.05,
@@ -256,14 +286,72 @@ async def test_generator_exit_path_also_force_aborts():
 
     assert first == "data: chunk1\n\n"
     assert second == "data: chunk2\n\n"
-    # The contract: even on the GeneratorExit path (no disconnect
-    # signal ever fired), the guard force-aborts. ``Scheduler.abort_request``
-    # is idempotent, so the guard fires it both from ``except
-    # GeneratorExit`` and the ``finally`` belt-and-suspenders.
     assert len(engine.scheduler.aborts) >= 1, engine.scheduler.aborts
     assert all(rid == "req-runaway-xyz" for rid in engine.scheduler.aborts), (
         engine.scheduler.aborts
     )
+    assert engine.admission_released is True
+
+    # The discriminating assertion: at least TWO distinct source
+    # lines fired _force_abort_request — the except-GeneratorExit
+    # block AND the finally belt-and-suspenders. If a future refactor
+    # deletes the GeneratorExit branch, the call_sites would collapse
+    # to ONE distinct line (the finally only) and this test would
+    # flag it. (The two source lines live within the same function
+    # ``_disconnect_guard``, so co_name is identical; the
+    # discrimination comes from the f_lineno.)
+    distinct_lines = {site for site in call_sites if "_disconnect_guard" in site}
+    assert len(distinct_lines) >= 2, (
+        "expected force-abort to fire from BOTH the except-GeneratorExit "
+        "branch AND the finally; if only one distinct call site appears, "
+        "one of the branches is missing. call_sites="
+        f"{call_sites} distinct_lines={distinct_lines}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_finally_does_not_force_abort_on_normal_stream_exhaustion(
+    monkeypatch,
+):
+    """C-01 codex r1 NIT #3: on a normal stream exhaustion
+    (``StopAsyncIteration`` — generator yielded everything and
+    returned cleanly), the ``finally`` block MUST NOT force-abort.
+
+    Pre-NIT-fix the ``finally`` enqueued an abort on every exit path
+    including successful streams, making the abort logs/metrics
+    indistinguishable from real disconnect cleanup AND uselessly
+    polluting the scheduler's ``_pending_abort_ids`` set with
+    already-finished ids. The fix is to track a
+    ``finished_normally`` flag and skip the belt-and-suspenders
+    when set.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _FakeEngine()
+    holder: list[str | None] = ["req-normal-exit"]
+
+    async def _short_stream():
+        yield "data: chunk1\n\n"
+        yield "data: chunk2\n\n"
+        # Generator returns cleanly — StopAsyncIteration.
+
+    chunks = []
+    async for chunk in _disconnect_guard(
+        _short_stream(),
+        _NeverDisconnectsRequest(),
+        poll_interval=0.05,
+        engine=engine,
+        keepalive_seconds=0.0,
+        request_id_holder=holder,
+    ):
+        chunks.append(chunk)
+
+    assert chunks == ["data: chunk1\n\n", "data: chunk2\n\n"]
+    # The contract: NO force-abort fired — the scheduler already
+    # marked the request as finished_normally inside the cascade,
+    # and a defensive abort here would just pollute logs.
+    assert engine.scheduler.aborts == [], engine.scheduler.aborts
+    # Admission release still happens on every exit path.
     assert engine.admission_released is True
 
 
@@ -303,31 +391,127 @@ async def test_force_abort_is_idempotent_against_double_call():
 
 
 @pytest.mark.asyncio
-async def test_force_abort_falls_back_to_engine_abort_request():
-    """When the engine doesn't expose a ``scheduler`` attribute
-    (the public ``abort_request`` is the only entry point — e.g.
-    BatchedEngine in some wiring), the guard MUST fall back to
-    ``engine.abort_request(rid)``. Covers the async case where the
-    fallback is a coroutine (BatchedEngine over AsyncEngineCore) —
-    we fire-and-forget without awaiting so the disconnect path
-    stays synchronous.
+async def test_force_abort_resolves_sync_scheduler_via_inner_engine():
+    """C-01 codex r1 BLOCKING #2: the helper MUST reach the SYNC
+    scheduler entry point for engines that hide it behind a private
+    inner backend (e.g. ``BatchedEngine`` over ``AsyncEngineCore`` —
+    where ``engine.scheduler`` doesn't exist but
+    ``engine._engine.scheduler.abort_request`` does and is sync).
+
+    Pre-BLOCKING-#2 fix, the helper would have fallen straight to
+    the public async ``engine.abort_request`` and fired-and-forget
+    the coroutine; the abort would NOT have landed in the scheduler
+    by the time disconnect handling returned. The walk through
+    ``engine._engine.scheduler.abort_request`` closes that gap.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncScheduler:
+        def __init__(self):
+            self.aborts: list[str] = []
+
+        def abort_request(self, rid: str) -> bool:
+            self.aborts.append(rid)
+            return True
+
+    class _AsyncEngineCoreLike:
+        def __init__(self):
+            self.scheduler = _SyncScheduler()
+
+        async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
+            # Async — pre-fix this is what the helper would have used,
+            # missing the sync path on ``self.scheduler``.
+            raise AssertionError(
+                "_force_abort_request should NOT reach the async public "
+                "abort path when a sync inner scheduler is available"
+            )
+
+    class _BatchedEngineLike:
+        def __init__(self):
+            self._engine = _AsyncEngineCoreLike()
+
+        async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
+            raise AssertionError(
+                "_force_abort_request should NOT reach the async public "
+                "abort path when a sync inner scheduler is available"
+            )
+
+    engine = _BatchedEngineLike()
+    holder = ["req-via-inner-sched"]
+
+    assert _force_abort_request(engine, holder) is True
+    # Sync path: the inner scheduler MUST have recorded the abort
+    # synchronously by the time _force_abort_request returns —
+    # without yielding to the event loop.
+    assert engine._engine.scheduler.aborts == ["req-via-inner-sched"]
+
+
+@pytest.mark.asyncio
+async def test_force_abort_resolves_sync_mllm_scheduler():
+    """C-01 codex r1 BLOCKING #2: the helper MUST also reach the
+    sync ``_mllm_scheduler.abort_request`` on engines where the
+    MLLM backend is the active path (``BatchedEngine`` with
+    ``_is_mllm=True``). Symmetric to the text-path resolution
+    above.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncMLLMScheduler:
+        def __init__(self):
+            self.aborts: list[str] = []
+
+        def abort_request(self, rid: str) -> bool:
+            self.aborts.append(rid)
+            return True
+
+    class _BatchedEngineLikeMLLM:
+        def __init__(self):
+            self._mllm_scheduler = _SyncMLLMScheduler()
+
+        async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
+            raise AssertionError(
+                "should not reach async public abort when sync MLLM path is available"
+            )
+
+    engine = _BatchedEngineLikeMLLM()
+    holder = ["req-via-mllm-sched"]
+
+    assert _force_abort_request(engine, holder) is True
+    assert engine._mllm_scheduler.aborts == ["req-via-mllm-sched"]
+
+
+@pytest.mark.asyncio
+async def test_force_abort_async_only_fallback_returns_false():
+    """C-01 codex r1 BLOCKING #2: when the engine only exposes an
+    async ``abort_request`` and NO sync scheduler is reachable, the
+    helper MUST signal that fact by returning ``False`` (not
+    ``True``) — even though it schedules the coroutine
+    fire-and-forget. The route's force-abort contract is "the
+    abort is in flight in the scheduler by the time we return";
+    a coroutine that hasn't run yet doesn't satisfy that, and
+    pretending otherwise misleads downstream tests / metrics.
     """
     from vllm_mlx.service.helpers import _force_abort_request
 
     abort_calls: list[str] = []
 
-    class _NoSchedulerEngine:
+    class _AsyncOnlyEngine:
+        # No ``scheduler``, no ``_engine.scheduler``, no
+        # ``_mllm_scheduler`` — only the public async entry point.
         async def abort_request(self, rid: str) -> bool:
             abort_calls.append(rid)
             return True
 
-    engine = _NoSchedulerEngine()
-    holder = ["req-via-engine"]
+    engine = _AsyncOnlyEngine()
+    holder = ["req-via-async-only"]
 
-    assert _force_abort_request(engine, holder) is True
+    # Returns False because the abort did NOT land synchronously.
+    assert _force_abort_request(engine, holder) is False
     # Yield to the event loop so the fire-and-forget coro runs.
     await asyncio.sleep(0)
-    assert abort_calls == ["req-via-engine"]
+    # The coro DID get scheduled (best-effort), but the contract
+    # signal is "False = abort not guaranteed in flight at return".
+    assert abort_calls == ["req-via-async-only"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -1,0 +1,431 @@
+"""C-01: ``_disconnect_guard`` must force-call ``scheduler.abort_request``
+on client disconnect.
+
+Astrid r3 (pydantic-ai + Qwen3.5-4B-MLX-4bit) ran
+``agent.run_stream("Tell me a joke")``; the model failed to emit EOS
+and ran past 6144 tokens. The httpx side raised
+``RemoteProtocolError: peer closed connection`` after ~35s but the
+server's ``_disconnect_guard`` polled 70+ times without intervening,
+because Starlette's ``request.is_disconnected()`` never returned
+True for this combination. Even when the disconnect signal DID fire
+in other situations, the abort relied solely on the
+``generator.aclose()`` cascade unwinding through
+``stream_generate.finally`` to reach ``scheduler.abort_request`` —
+which is fine for a graceful shutdown but doesn't bound how long
+the upstream batch step keeps consuming GPU between the cancel and
+the next yield boundary.
+
+This module nails the C-01 contract: when a disconnect is detected
+AND the engine has published its admitted ``request_id`` into the
+``request_id_holder``, the guard MUST call
+``engine.scheduler.abort_request(rid)`` synchronously. The cascade
+remains as belt-and-suspenders but is no longer the primary signal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeScheduler:
+    """Captures every ``abort_request`` call for inspection."""
+
+    def __init__(self):
+        self.aborts: list[str] = []
+
+    def abort_request(self, request_id: str) -> bool:
+        self.aborts.append(request_id)
+        return True
+
+
+class _FakeEngine:
+    """Engine stub exposing ``scheduler.abort_request`` and the
+    admission-release hook the disconnect_guard's pre-C-01 contract
+    already relied on.
+    """
+
+    def __init__(self):
+        self.scheduler = _FakeScheduler()
+        self.admission_released = False
+
+    def release_admission_reservation(self) -> None:
+        self.admission_released = True
+
+
+class _StoppingRequest:
+    """ASGI Request stub whose ``is_disconnected()`` flips True after
+    ``after`` seconds, simulating uvicorn delivering ``http.disconnect``.
+    """
+
+    def __init__(self, after: float):
+        self._t0 = time.monotonic()
+        self._after = after
+
+    async def is_disconnected(self) -> bool:
+        return time.monotonic() - self._t0 > self._after
+
+
+class _NeverDisconnectsRequest:
+    """ASGI Request stub that NEVER reports disconnect — exactly
+    Astrid r3's failure mode where ``is_disconnected()`` returns
+    False for the entire ~35s runaway generation. Used for the
+    GeneratorExit-path tests where the consumer (StreamingResponse)
+    tears down via ``aclose()`` without the disconnect channel
+    firing.
+    """
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fires_force_abort_via_scheduler():
+    """When a disconnect is detected mid-stream AND the engine has
+    published its scheduler request id into the holder, the guard
+    MUST synchronously call ``scheduler.abort_request(rid)``.
+
+    Astrid r3 fingerprint: pre-C-01, the abort relied on
+    ``generator.aclose()`` cascading through ``stream_generate.finally``
+    to reach the scheduler. This test pins the contract that the
+    guard calls into the scheduler DIRECTLY the moment disconnect
+    fires — so the very next ``step()`` drops the request.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _FakeEngine()
+    holder: list[str | None] = ["req-runaway-abc"]
+
+    async def _never_ending_stream():
+        # Yield one chunk, then block forever — exercises the
+        # disconnect branch (not StopAsyncIteration).
+        yield "data: hello\n\n"
+        await asyncio.sleep(60.0)
+        yield "data: never\n\n"
+
+    chunks = []
+    t0 = time.monotonic()
+    async for chunk in _disconnect_guard(
+        _never_ending_stream(),
+        _StoppingRequest(after=0.15),
+        poll_interval=0.05,
+        engine=engine,
+        keepalive_seconds=0.0,  # disable keepalive so the test isn't noisy
+        request_id_holder=holder,
+    ):
+        chunks.append(chunk)
+    elapsed = time.monotonic() - t0
+
+    # Disconnect must short-circuit promptly, not wait for the
+    # 60-second sleep.
+    assert elapsed < 2.0, f"guard hung for {elapsed:.2f}s after disconnect"
+    # The first chunk made it through; the second one is behind the
+    # 60s sleep and must NEVER appear.
+    assert chunks == ["data: hello\n\n"], chunks
+    # The contract: scheduler.abort_request was called with the
+    # holder's request id. The guard fires force-abort both on the
+    # disconnect branch AND in the ``finally`` (belt-and-suspenders
+    # for non-disconnect exits) — Scheduler.abort_request is
+    # idempotent against duplicate enqueues per its docstring.
+    assert len(engine.scheduler.aborts) >= 1, engine.scheduler.aborts
+    assert all(rid == "req-runaway-abc" for rid in engine.scheduler.aborts), (
+        engine.scheduler.aborts
+    )
+    # Pre-C-01 admission release path still runs.
+    assert engine.admission_released is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_with_unknown_request_id_is_noop():
+    """Holder is provided but the engine never published a request
+    id into it (e.g. client disconnected before ``add_request``
+    returned). The guard MUST NOT crash and MUST NOT make up a
+    request id — abort is simply skipped.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _FakeEngine()
+    holder: list[str | None] = [None]  # never populated
+
+    async def _gen():
+        yield "data: hi\n\n"
+        await asyncio.sleep(60.0)
+
+    chunks = []
+    async for chunk in _disconnect_guard(
+        _gen(),
+        _StoppingRequest(after=0.1),
+        poll_interval=0.05,
+        engine=engine,
+        keepalive_seconds=0.0,
+        request_id_holder=holder,
+    ):
+        chunks.append(chunk)
+
+    assert chunks == ["data: hi\n\n"]
+    # No abort was called because the holder was empty — the
+    # cascade through aclose() is the only remaining defense and
+    # that's fine for the "never admitted" case.
+    assert engine.scheduler.aborts == []
+    assert engine.admission_released is True
+
+
+@pytest.mark.asyncio
+async def test_no_holder_preserves_pre_c01_contract():
+    """When the caller passes ``request_id_holder=None`` (the
+    pre-C-01 contract), the guard MUST behave exactly as before:
+    no force-abort, only the admission-release safety net runs.
+
+    Pinning this prevents the C-01 fix from accidentally requiring
+    every existing caller to update its signature.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _FakeEngine()
+
+    async def _gen():
+        yield "data: hi\n\n"
+        await asyncio.sleep(60.0)
+
+    chunks = []
+    async for chunk in _disconnect_guard(
+        _gen(),
+        _StoppingRequest(after=0.1),
+        poll_interval=0.05,
+        engine=engine,
+        keepalive_seconds=0.0,
+    ):
+        chunks.append(chunk)
+
+    assert chunks == ["data: hi\n\n"]
+    assert engine.scheduler.aborts == []
+    assert engine.admission_released is True
+
+
+@pytest.mark.asyncio
+async def test_generator_exit_path_also_force_aborts():
+    """When the consumer aborts the iteration via ``aclose()`` (the
+    ``GeneratorExit`` path — Starlette's StreamingResponse uses this
+    when it detects a write failure), the guard MUST also
+    force-abort even though the disconnect_task never fired.
+
+    Astrid r3 fingerprint: ``is_disconnected()`` may NEVER return
+    True even after the client RSTs, but uvicorn eventually
+    surfaces the dead socket via a write failure that propagates
+    back as ``GeneratorExit`` into the streaming generator. Catching
+    this path closes the second half of the runaway window.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _FakeEngine()
+    holder: list[str | None] = ["req-runaway-xyz"]
+
+    async def _gen():
+        yield "data: chunk1\n\n"
+        yield "data: chunk2\n\n"
+        # Sleep so the consumer has time to aclose() us before we
+        # try to yield more.
+        await asyncio.sleep(30.0)
+        yield "data: never\n\n"
+
+    agen = _disconnect_guard(
+        _gen(),
+        _NeverDisconnectsRequest(),
+        poll_interval=0.05,
+        engine=engine,
+        keepalive_seconds=0.0,
+        request_id_holder=holder,
+    )
+
+    # Pull two chunks then close the wrapper from outside —
+    # simulates StreamingResponse tearing down on a dead socket.
+    first = await agen.__anext__()
+    second = await agen.__anext__()
+    await agen.aclose()
+
+    assert first == "data: chunk1\n\n"
+    assert second == "data: chunk2\n\n"
+    # The contract: even on the GeneratorExit path (no disconnect
+    # signal ever fired), the guard force-aborts. ``Scheduler.abort_request``
+    # is idempotent, so the guard fires it both from ``except
+    # GeneratorExit`` and the ``finally`` belt-and-suspenders.
+    assert len(engine.scheduler.aborts) >= 1, engine.scheduler.aborts
+    assert all(rid == "req-runaway-xyz" for rid in engine.scheduler.aborts), (
+        engine.scheduler.aborts
+    )
+    assert engine.admission_released is True
+
+
+@pytest.mark.asyncio
+async def test_force_abort_is_idempotent_against_double_call():
+    """The pre-C-01 cascade through ``stream_generate.finally``
+    ALSO calls ``scheduler.abort_request``. With the new explicit
+    force-abort firing first, the same request id may land in
+    ``_pending_abort_ids`` twice. The contract on
+    ``Scheduler.abort_request`` is that this is idempotent
+    (``set.add`` of an already-present id is a no-op), so the
+    guard MUST NOT crash on double-abort.
+
+    Pinning this so a future refactor of the abort signal can't
+    accidentally reintroduce a duplicate-key error.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _DoubleAbortScheduler:
+        def __init__(self):
+            self.calls = 0
+
+        def abort_request(self, rid: str) -> bool:
+            self.calls += 1
+            return True
+
+    class _Engine:
+        def __init__(self):
+            self.scheduler = _DoubleAbortScheduler()
+
+    engine = _Engine()
+    holder = ["req-id-1"]
+
+    assert _force_abort_request(engine, holder) is True
+    assert _force_abort_request(engine, holder) is True
+    assert engine.scheduler.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_force_abort_falls_back_to_engine_abort_request():
+    """When the engine doesn't expose a ``scheduler`` attribute
+    (the public ``abort_request`` is the only entry point — e.g.
+    BatchedEngine in some wiring), the guard MUST fall back to
+    ``engine.abort_request(rid)``. Covers the async case where the
+    fallback is a coroutine (BatchedEngine over AsyncEngineCore) —
+    we fire-and-forget without awaiting so the disconnect path
+    stays synchronous.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    abort_calls: list[str] = []
+
+    class _NoSchedulerEngine:
+        async def abort_request(self, rid: str) -> bool:
+            abort_calls.append(rid)
+            return True
+
+    engine = _NoSchedulerEngine()
+    holder = ["req-via-engine"]
+
+    assert _force_abort_request(engine, holder) is True
+    # Yield to the event loop so the fire-and-forget coro runs.
+    await asyncio.sleep(0)
+    assert abort_calls == ["req-via-engine"]
+
+
+@pytest.mark.asyncio
+async def test_force_abort_swallows_scheduler_exception():
+    """If ``scheduler.abort_request`` raises (engine in a broken
+    state, scheduler shut down mid-stream), the guard MUST log and
+    continue — disconnect handling cannot itself derail. The
+    cascade through aclose() in ``finally`` is the remaining
+    safety net.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _BrokenScheduler:
+        def abort_request(self, rid: str) -> bool:
+            raise RuntimeError("scheduler dead")
+
+    class _Engine:
+        def __init__(self):
+            self.scheduler = _BrokenScheduler()
+
+    engine = _Engine()
+    holder = ["req-abc"]
+
+    # MUST NOT raise.
+    result = _force_abort_request(engine, holder)
+    # Returns False because the exception was swallowed; caller
+    # treats that as "I tried, cascade is the remaining defense".
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: engine publishes its request_id into the holder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_publishes_request_id_into_holder():
+    """End-to-end pin: when the route passes a ``request_id_holder``
+    kwarg into ``BatchedEngine.stream_generate``, the engine MUST
+    populate ``holder[0]`` with the scheduler-issued request id the
+    moment ``add_request`` returns.
+
+    Without this, the disconnect_guard has nothing to abort — the
+    force-abort path is a no-op. Pinning the contract end-to-end so
+    a future refactor of the engine's add_request return shape
+    can't silently break C-01.
+    """
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.request import RequestOutput
+
+    # Build a BatchedEngine instance just enough for stream_generate
+    # to reach add_request → publish → stream_outputs.
+    eng = BatchedEngine.__new__(BatchedEngine)
+    eng._loaded = True
+    eng._is_mllm = False
+    eng._mllm_scheduler = None
+    eng._stream_interval = 1
+    eng._is_hybrid_model = lambda: False
+    eng._create_output_router = lambda: None
+
+    # Fake AsyncEngineCore so add_request returns a concrete id and
+    # stream_outputs yields one finished chunk.
+    fake_engine = MagicMock()
+    fut: asyncio.Future = asyncio.Future()
+    fut.set_result("req-engine-issued-7777")
+    fake_engine.add_request = MagicMock(return_value=fut)
+
+    async def stream_outputs(request_id):
+        yield RequestOutput(
+            request_id=request_id,
+            new_token_ids=[1],
+            new_text="x",
+            output_token_ids=[1],
+            output_text="x",
+            finished=True,
+            finish_reason="stop",
+            prompt_tokens=1,
+            completion_tokens=1,
+        )
+
+    fake_engine.stream_outputs = stream_outputs
+    fake_engine.scheduler = MagicMock()
+    fake_engine.scheduler.abort_request = MagicMock(return_value=True)
+    fake_engine._cleanup_request = MagicMock()
+    eng._engine = fake_engine
+
+    holder: list[str | None] = [None]
+    async for _ in eng.stream_generate(
+        prompt="hi",
+        max_tokens=8,
+        request_id_holder=holder,
+    ):
+        # Once we've consumed one chunk the engine must already
+        # have populated the holder — add_request returned before
+        # stream_outputs started yielding.
+        assert holder[0] == "req-engine-issued-7777", holder
+        break
+
+    assert holder[0] == "req-engine-issued-7777"

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -214,60 +214,81 @@ async def test_no_holder_preserves_pre_c01_contract():
 
 
 @pytest.mark.asyncio
-async def test_generator_exit_branch_force_aborts_before_finally(monkeypatch):
-    """C-01 codex r1 BLOCKING #1: pin the ``except GeneratorExit``
-    branch specifically (not just "abort happened somewhere").
+async def test_generator_exit_branch_force_aborts_before_close(monkeypatch):
+    """C-01 codex r1 BLOCKING #1 + r2 NIT #2: pin the ``except
+    GeneratorExit`` branch behaviorally — not by source-line shape.
 
-    The disconnect_guard now triggers force-abort from THREE places:
-    the explicit disconnect branch, the ``except GeneratorExit``
-    block, AND the ``finally`` belt-and-suspenders. A test that only
-    checks ``scheduler.aborts == [rid]`` would still pass if the
+    The disconnect_guard triggers force-abort from THREE places: the
+    explicit disconnect branch, the ``except GeneratorExit`` block,
+    AND the ``finally`` belt-and-suspenders. A test that only checks
+    ``scheduler.aborts == [rid]`` would still pass if the
     ``except GeneratorExit`` block were deleted, because ``finally``
-    would catch the case. This test discriminates by replacing
-    ``_force_abort_request`` with a wrapper that captures the calling
-    frame's local variable namespace — only the ``except GeneratorExit``
-    block (NOT ``finally``) accumulates ``chunk_count`` AND has yet to
-    cancel ``disconnect_task``. Asserting that the FIRST abort call
-    came from a frame WITHOUT ``finished_normally`` resolved/with
-    ``disconnect_task`` still live pins the branch specifically.
+    would catch the case. Pre-codex-r2 the discrimination used
+    ``f_lineno`` to count distinct source lines, which is brittle
+    against harmless refactors.
 
-    The Astrid r3 fingerprint: Starlette's StreamingResponse tears
-    down via ``aclose()`` (GeneratorExit into our wrapper) when uvicorn
+    The behavioral distinction we pin instead: the ``except
+    GeneratorExit`` branch fires BEFORE the ``finally`` clause's
+    ``await generator.aclose()``. If we make the upstream generator's
+    ``finally`` write to a shared flag, and patch
+    ``_force_abort_request`` to snapshot that flag on each call, the
+    SEQUENCE distinguishes the branches:
+
+      * first abort call: upstream cascade has NOT run yet
+        (flag still ``False``) — this is the except-GeneratorExit
+        branch.
+      * second abort call: upstream cascade HAS run (flag is
+        ``True``) — this is the ``finally`` belt-and-suspenders
+        firing after ``await generator.aclose()`` completed.
+
+    Deleting the ``except GeneratorExit`` block collapses the
+    sequence to a single call AFTER the cascade ran, which fails
+    the test. No source-line coupling.
+
+    Astrid r3 fingerprint: Starlette's StreamingResponse tears down
+    via ``aclose()`` (GeneratorExit into our wrapper) when uvicorn
     detects a write failure to a dead socket — even though
-    ``is_disconnected()`` returned False the entire time. Catching the
-    branch here closes the second half of the runaway window.
+    ``is_disconnected()`` returned False the entire time. Catching
+    the branch here closes the second half of the runaway window.
     """
-    import inspect
-
     from vllm_mlx.service import helpers as _helpers
 
     engine = _FakeEngine()
     holder: list[str | None] = ["req-runaway-xyz"]
 
-    # Record at which suite the abort fired. The except-GeneratorExit
-    # branch runs BEFORE the finally clause; we identify the calling
-    # frame by its source line via ``inspect``.
-    call_sites: list[str] = []
+    # Shared state: did the upstream generator's finally run yet?
+    # ``except GeneratorExit`` block of disconnect_guard fires BEFORE
+    # ``await generator.aclose()`` in finally, so the upstream's
+    # finally has NOT yet executed at that point. The disconnect_guard
+    # ``finally`` block runs AFTER ``await generator.aclose()``, so
+    # the upstream's finally HAS executed by then.
+    upstream_finally_ran = {"value": False}
+    abort_snapshots: list[bool] = []
+
     original = _helpers._force_abort_request
 
-    def _capturing_force_abort(eng, hld):
-        # Walk back to the disconnect_guard frame and capture which
-        # block we're in. The ``except GeneratorExit`` branch and the
-        # ``finally`` clause sit at distinct source lines in helpers.py.
-        frame = inspect.currentframe().f_back
-        if frame is not None:
-            call_sites.append(f"{frame.f_code.co_name}:line-{frame.f_lineno}")
+    def _snapshotting_force_abort(eng, hld):
+        # Snapshot the upstream-finally flag at the moment of each
+        # _force_abort_request call.
+        abort_snapshots.append(upstream_finally_ran["value"])
         return original(eng, hld)
 
-    monkeypatch.setattr(_helpers, "_force_abort_request", _capturing_force_abort)
+    monkeypatch.setattr(_helpers, "_force_abort_request", _snapshotting_force_abort)
 
     async def _gen():
-        yield "data: chunk1\n\n"
-        yield "data: chunk2\n\n"
-        # Sleep so the consumer has time to aclose() us before we
-        # try to yield more.
-        await asyncio.sleep(30.0)
-        yield "data: never\n\n"
+        try:
+            yield "data: chunk1\n\n"
+            yield "data: chunk2\n\n"
+            # Sleep so the consumer has time to aclose() us before we
+            # try to yield more.
+            await asyncio.sleep(30.0)
+            yield "data: never\n\n"
+        finally:
+            # This finally runs when the disconnect_guard's
+            # ``await generator.aclose()`` propagates GeneratorExit
+            # into us. Mark the flag so the test can prove the
+            # sequence.
+            upstream_finally_ran["value"] = True
 
     agen = _helpers._disconnect_guard(
         _gen(),
@@ -292,20 +313,22 @@ async def test_generator_exit_branch_force_aborts_before_finally(monkeypatch):
     )
     assert engine.admission_released is True
 
-    # The discriminating assertion: at least TWO distinct source
-    # lines fired _force_abort_request — the except-GeneratorExit
-    # block AND the finally belt-and-suspenders. If a future refactor
-    # deletes the GeneratorExit branch, the call_sites would collapse
-    # to ONE distinct line (the finally only) and this test would
-    # flag it. (The two source lines live within the same function
-    # ``_disconnect_guard``, so co_name is identical; the
-    # discrimination comes from the f_lineno.)
-    distinct_lines = {site for site in call_sites if "_disconnect_guard" in site}
-    assert len(distinct_lines) >= 2, (
-        "expected force-abort to fire from BOTH the except-GeneratorExit "
-        "branch AND the finally; if only one distinct call site appears, "
-        "one of the branches is missing. call_sites="
-        f"{call_sites} distinct_lines={distinct_lines}"
+    # The discriminating assertion: at least one ``_force_abort_request``
+    # call happened BEFORE the upstream's finally ran (proves the
+    # except-GeneratorExit branch fired), AND at least one happened
+    # AFTER (proves the disconnect_guard finally belt-and-suspenders
+    # also fired). If a refactor deletes the except-GeneratorExit
+    # branch, every snapshot would be ``True`` (only the finally
+    # fired, and that runs after the cascade).
+    assert any(snap is False for snap in abort_snapshots), (
+        "expected at least one _force_abort_request call BEFORE the "
+        "upstream generator's finally ran — pins the except-GeneratorExit "
+        f"branch. snapshots={abort_snapshots}"
+    )
+    assert any(snap is True for snap in abort_snapshots), (
+        "expected at least one _force_abort_request call AFTER the "
+        "upstream generator's finally ran — pins the disconnect_guard "
+        f"finally belt-and-suspenders. snapshots={abort_snapshots}"
     )
 
 
@@ -429,6 +452,11 @@ async def test_force_abort_resolves_sync_scheduler_via_inner_engine():
     class _BatchedEngineLike:
         def __init__(self):
             self._engine = _AsyncEngineCoreLike()
+            # codex r2 BLOCKING #1: text-path is active (_is_mllm=False).
+            # The walk MUST land on _engine.scheduler, not on any
+            # placeholder _mllm_scheduler attribute that might also
+            # exist on the real BatchedEngine.
+            self._is_mllm = False
 
         async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
             raise AssertionError(
@@ -467,6 +495,8 @@ async def test_force_abort_resolves_sync_mllm_scheduler():
     class _BatchedEngineLikeMLLM:
         def __init__(self):
             self._mllm_scheduler = _SyncMLLMScheduler()
+            # codex r2 BLOCKING #1: gate on the active-path flag.
+            self._is_mllm = True
 
         async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
             raise AssertionError(
@@ -478,6 +508,66 @@ async def test_force_abort_resolves_sync_mllm_scheduler():
 
     assert _force_abort_request(engine, holder) is True
     assert engine._mllm_scheduler.aborts == ["req-via-mllm-sched"]
+
+
+@pytest.mark.asyncio
+async def test_force_abort_respects_active_path_when_both_backends_present():
+    """C-01 codex r2 BLOCKING #1: ``BatchedEngine`` declares both
+    ``_engine`` (text path) and ``_mllm_scheduler`` (MLLM path) as
+    instance attributes — they BOTH exist after ``start()``, and
+    which one is the active backend for the live request is signalled
+    by ``_is_mllm``. The pre-r2 resolver picked
+    ``_mllm_scheduler`` unconditionally if present, so a text request
+    on a model with both paths instantiated would enqueue the abort
+    into the WRONG scheduler and leave the actual text request
+    running.
+
+    Pin two directions:
+
+    1. ``_is_mllm = False`` + both backends populated → MUST land on
+       ``_engine.scheduler``, NOT ``_mllm_scheduler``.
+    2. ``_is_mllm = True`` + both backends populated → MUST land on
+       ``_mllm_scheduler``, NOT ``_engine.scheduler``.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncScheduler:
+        def __init__(self, label: str):
+            self.label = label
+            self.aborts: list[str] = []
+
+        def abort_request(self, rid: str) -> bool:
+            self.aborts.append(rid)
+            return True
+
+    class _InnerEngine:
+        def __init__(self):
+            self.scheduler = _SyncScheduler("text")
+
+    class _DualBackendEngine:
+        def __init__(self, *, is_mllm: bool):
+            self._engine = _InnerEngine()
+            self._mllm_scheduler = _SyncScheduler("mllm")
+            self._is_mllm = is_mllm
+
+        async def abort_request(self, rid: str) -> bool:  # noqa: ARG002
+            raise AssertionError("public async abort should never run")
+
+    # Case 1: text active.
+    text_engine = _DualBackendEngine(is_mllm=False)
+    assert _force_abort_request(text_engine, ["req-text"]) is True
+    assert text_engine._engine.scheduler.aborts == ["req-text"]
+    assert text_engine._mllm_scheduler.aborts == [], (
+        "MLLM scheduler must NOT receive aborts when text path is active"
+    )
+
+    # Case 2: MLLM active.
+    mllm_engine = _DualBackendEngine(is_mllm=True)
+    assert _force_abort_request(mllm_engine, ["req-mllm"]) is True
+    assert mllm_engine._mllm_scheduler.aborts == ["req-mllm"]
+    assert mllm_engine._engine.scheduler.aborts == [], (
+        "text scheduler must NOT receive aborts when MLLM path is active"
+    )
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1162,13 +1162,33 @@ class BatchedEngine(BaseEngine):
             stop: Stop sequences
             images: Optional image URLs/paths (for MLLM)
             videos: Optional video URLs/paths (for MLLM)
-            **kwargs: Additional model-specific parameters
+            **kwargs: Additional model-specific parameters. C-01:
+                ``request_id_holder`` (``list[str | None]``) — when
+                provided, the engine writes the admitted scheduler
+                ``request_id`` into ``holder[0]`` the moment
+                ``add_request`` returns. The route layer's
+                ``_disconnect_guard`` reads the same holder so it can
+                force-call ``scheduler.abort_request`` on client
+                disconnect WITHOUT relying solely on the
+                generator-close cascade (which can stall in production
+                when Starlette's ``is_disconnected()`` never reports
+                True — Astrid r3 saw ``disconnect_guard`` poll 70+
+                times before the runaway generation finally hit its
+                token cap). When ``None`` (default) this is a no-op —
+                preserves the pre-C-01 contract for callers that don't
+                need force-abort.
 
         Yields:
             GenerationOutput with incremental text
         """
         if not self._loaded:
             await self.start()
+
+        # C-01: extract optional request_id holder so the route's
+        # disconnect_guard can force-abort the scheduler on client
+        # disconnect. Popped from kwargs so it never reaches the
+        # scheduler's add_request (which would reject unknown kwargs).
+        request_id_holder = kwargs.pop("request_id_holder", None)
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -1183,6 +1203,16 @@ class BatchedEngine(BaseEngine):
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
             )
+            # C-01 force-abort: publish the scheduler request id so the
+            # route's disconnect_guard can call abort_request directly.
+            if request_id_holder is not None:
+                try:
+                    request_id_holder[0] = request_id
+                except Exception:
+                    logger.debug(
+                        "[stream_generate] request_id_holder publish failed",
+                        exc_info=True,
+                    )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
                 # ``logprobs`` is now wired through from
@@ -1243,6 +1273,17 @@ class BatchedEngine(BaseEngine):
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
         )
+        # C-01 force-abort: publish the scheduler request id (text path)
+        # so the route's disconnect_guard can call abort_request directly
+        # on client disconnect.
+        if request_id_holder is not None:
+            try:
+                request_id_holder[0] = request_id
+            except Exception:
+                logger.debug(
+                    "[stream_generate] request_id_holder publish failed",
+                    exc_info=True,
+                )
 
         # F-012 belt-and-suspenders: ``stream_outputs.finally`` already
         # aborts on any abnormal exit AFTER it enters its ``try`` block.

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -377,13 +377,22 @@ async def create_anthropic_message(
 
         if anthropic_request.stream:
             _admission_committed = True
+            # C-01 force-abort: holder list the engine populates with
+            # the admitted scheduler request id; the disconnect_guard
+            # reads it and force-calls scheduler.abort_request on
+            # client disconnect.
+            _anth_rid_holder: list[str | None] = [None]
             return StreamingResponse(
                 _disconnect_guard(
                     _stream_anthropic_messages(
-                        engine, openai_request, anthropic_request
+                        engine,
+                        openai_request,
+                        anthropic_request,
+                        request_id_holder=_anth_rid_holder,
                     ),
                     request,
                     engine=engine,
+                    request_id_holder=_anth_rid_holder,
                 ),
                 media_type="text/event-stream",
                 # ``SSE_RESPONSE_HEADERS`` (Cache-Control no-cache/no-transform +
@@ -842,8 +851,19 @@ async def _stream_anthropic_messages(
     engine: BaseEngine,
     openai_request: ChatCompletionRequest,
     anthropic_request: AnthropicRequest,
+    *,
+    request_id_holder: list | None = None,
 ) -> AsyncIterator[str]:
-    """Stream Anthropic Messages API SSE events."""
+    """Stream Anthropic Messages API SSE events.
+
+    Args:
+        request_id_holder: C-01 force-abort plumbing. Forwarded to
+            ``engine.stream_chat`` so the engine writes the admitted
+            scheduler request id into ``holder[0]``; the route's
+            ``_disconnect_guard`` reads the same holder and force-calls
+            ``scheduler.abort_request`` on client disconnect. ``None``
+            (default) is a no-op.
+    """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
 
@@ -859,6 +879,10 @@ async def _stream_anthropic_messages(
         ),
         **_resolved_sampling_kwargs(openai_request),
     }
+    # C-01: thread the request_id holder to the engine so disconnect
+    # detection can force-call scheduler.abort_request.
+    if request_id_holder is not None:
+        chat_kwargs["request_id_holder"] = request_id_holder
 
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -1348,6 +1348,14 @@ async def _create_chat_completion_impl(
             if _thinking_warning
             else SSE_RESPONSE_HEADERS
         )
+        # C-01: holder list the engine writes the admitted scheduler
+        # request id into. ``_disconnect_guard`` reads the SAME list
+        # and force-calls ``scheduler.abort_request`` on client
+        # disconnect, closing the Astrid r3 hang where the
+        # generator-close cascade alone took ~35s to actually free
+        # the GPU once the client TCP-RST'd.
+        request_id_holder: list[str | None] = [None]
+        chat_kwargs["request_id_holder"] = request_id_holder
         if use_guided and json_schema:
             # Constrained streaming: run guided generation buffered, then
             # synthesize an SSE stream from the buffered output. Falls
@@ -1360,6 +1368,7 @@ async def _create_chat_completion_impl(
                     ),
                     raw_request,
                     engine=engine,
+                    request_id_holder=request_id_holder,
                 ),
                 media_type="text/event-stream",
                 headers=_sse_headers,
@@ -1369,6 +1378,7 @@ async def _create_chat_completion_impl(
                 stream_chat_completion(engine, messages, request, **chat_kwargs),
                 raw_request,
                 engine=engine,
+                request_id_holder=request_id_holder,
             ),
             media_type="text/event-stream",
             headers=_sse_headers,

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -183,11 +183,24 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
         if request.stream:
             _admission_committed = True
+            # C-01 force-abort: holder list the engine populates with
+            # the admitted scheduler request id; the disconnect_guard
+            # reads it and force-calls scheduler.abort_request on
+            # client disconnect (closes the Astrid r3 hang where the
+            # generator-close cascade alone left ~6144 tokens of
+            # runaway generation eating GPU after the client RST'd).
+            _completion_rid_holder: list[str | None] = [None]
             return StreamingResponse(
                 _disconnect_guard(
-                    stream_completion(engine, prompts[0], request),
+                    stream_completion(
+                        engine,
+                        prompts[0],
+                        request,
+                        request_id_holder=_completion_rid_holder,
+                    ),
                     raw_request,
                     engine=engine,
+                    request_id_holder=_completion_rid_holder,
                 ),
                 media_type="text/event-stream",
                 headers=SSE_RESPONSE_HEADERS,
@@ -437,9 +450,24 @@ async def stream_completion(
     engine,
     prompt: str,
     request: CompletionRequest,
+    *,
+    request_id_holder: list | None = None,
 ) -> AsyncIterator[str]:
-    """Stream completion response."""
+    """Stream completion response.
+
+    Args:
+        request_id_holder: C-01 force-abort plumbing. When provided,
+            forwarded as a kwarg to ``engine.stream_generate`` so the
+            engine writes the admitted scheduler request id into
+            ``holder[0]``. The route's ``_disconnect_guard`` reads the
+            same holder to force-call ``scheduler.abort_request`` on
+            client disconnect. ``None`` (default) is a no-op.
+    """
     extended_kwargs = build_extended_sampling_kwargs(request)
+    # C-01: pass the holder through so the engine can publish the
+    # scheduler request id without changing every engine signature.
+    if request_id_holder is not None:
+        extended_kwargs["request_id_holder"] = request_id_holder
 
     # F-152: ``echo`` on the streaming path emits the prompt as the
     # FIRST SSE chunk, then continues with generated tokens. Without

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -199,11 +199,22 @@ async def create_response(request: Request):
 
         if responses_request.stream:
             _admission_committed = True
+            # C-01 force-abort: holder list the engine populates with
+            # the admitted scheduler request id; the disconnect_guard
+            # reads it and force-calls scheduler.abort_request on
+            # client disconnect.
+            _resp_rid_holder: list[str | None] = [None]
             return StreamingResponse(
                 _disconnect_guard(
-                    _stream_responses(engine, openai_request, responses_request),
+                    _stream_responses(
+                        engine,
+                        openai_request,
+                        responses_request,
+                        request_id_holder=_resp_rid_holder,
+                    ),
                     request,
                     engine=engine,
+                    request_id_holder=_resp_rid_holder,
                 ),
                 media_type="text/event-stream",
                 # ``SSE_RESPONSE_HEADERS`` (Cache-Control no-cache/no-transform +
@@ -369,6 +380,8 @@ async def _stream_responses(
     engine: BaseEngine,
     openai_request: ChatCompletionRequest,
     responses_request: ResponsesRequest,
+    *,
+    request_id_holder: list | None = None,
 ) -> AsyncIterator[str]:
     """Stream a Responses-API SSE event sequence Codex CLI can parse.
 
@@ -428,6 +441,10 @@ async def _stream_responses(
         resolved_thinking = _resolve_enable_thinking(openai_request)
         if resolved_thinking is not None:
             chat_kwargs["enable_thinking"] = resolved_thinking
+        # C-01: thread the request_id holder so disconnect_guard can
+        # force-call scheduler.abort_request on client RST.
+        if request_id_holder is not None:
+            chat_kwargs["request_id_holder"] = request_id_holder
 
         accumulated_text = ""
         accumulated_raw = ""

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1899,7 +1899,8 @@ def _maybe_pin_system_prompt(messages: list) -> None:
 
 def _resolve_sync_scheduler_for_abort(engine):
     """C-01 codex r1 BLOCKING #2 helper: find the SYNC scheduler-side
-    ``abort_request`` entry point for the loaded backend.
+    ``abort_request`` entry point for the **currently active**
+    backend.
 
     The codex reviewer pointed out that ``engine.abort_request`` may
     be a coroutine (``BatchedEngine.abort_request`` when the LLM path
@@ -1908,35 +1909,69 @@ def _resolve_sync_scheduler_for_abort(engine):
     free the GPU on the next ``step()`` — the coroutine has to run
     to reach ``scheduler.abort_request`` (which IS sync). So we walk
     the engine's backend graph to find that sync entry point
-    directly:
+    directly.
 
-      * ``engine.scheduler``                  — plain engines exposing
-                                                the scheduler directly.
-      * ``engine._mllm_scheduler``            — MLLM path on
-                                                BatchedEngine; sync.
-      * ``engine._engine.scheduler``          — text path on
-                                                BatchedEngine via
-                                                AsyncEngineCore's
-                                                ``.scheduler``.
+    codex r2 BLOCKING #1: the walk MUST respect the engine's active
+    path. ``BatchedEngine`` declares BOTH ``_engine`` (AsyncEngineCore
+    for the text path) AND ``_mllm_scheduler`` (MLLM path) as
+    instance attributes. They start at ``None`` and get populated by
+    ``start()`` based on the model's modality — but only ONE is the
+    active backend the live ``request_id`` was admitted into. Calling
+    ``_mllm_scheduler.abort_request(rid)`` on a request that lives in
+    ``_engine.scheduler`` would enqueue the abort into the wrong
+    pending set and leave the real request running. The
+    ``_is_mllm`` flag is the canonical active-path signal — same
+    predicate ``stream_generate`` uses to pick which backend to call
+    in the first place.
+
+    Resolution order:
+
+      * ``engine.scheduler``                          — plain engines
+                                                       exposing the
+                                                       scheduler
+                                                       directly (eg.
+                                                       AsyncEngineCore
+                                                       passed in
+                                                       unwrapped).
+      * MLLM-active: ``engine._mllm_scheduler``       — only when
+                                                       ``engine._is_mllm``
+                                                       is True.
+      * text-active: ``engine._engine.scheduler``     — only when
+                                                       ``engine._is_mllm``
+                                                       is False (or
+                                                       absent).
 
     Returns the first callable found, or ``None`` when none of the
     paths resolve (caller falls back to the public async
     ``engine.abort_request`` as a last resort with documented
     fire-and-forget semantics).
     """
-    for path in ("scheduler", "_mllm_scheduler"):
-        backend = getattr(engine, path, None)
-        if backend is not None:
-            abort = getattr(backend, "abort_request", None)
+    # Plain engines that expose .scheduler directly (no active-path
+    # ambiguity). Includes AsyncEngineCore and the fake engines used
+    # in tests.
+    direct_scheduler = getattr(engine, "scheduler", None)
+    if direct_scheduler is not None:
+        abort = getattr(direct_scheduler, "abort_request", None)
+        if abort is not None and not asyncio.iscoroutinefunction(abort):
+            return abort
+    # BatchedEngine and similar wrappers — gate on the active path.
+    # Default to text-active (``_is_mllm = False``) when the flag is
+    # missing so older engine shapes still resolve sanely.
+    is_mllm_active = bool(getattr(engine, "_is_mllm", False))
+    if is_mllm_active:
+        mllm = getattr(engine, "_mllm_scheduler", None)
+        if mllm is not None:
+            abort = getattr(mllm, "abort_request", None)
             if abort is not None and not asyncio.iscoroutinefunction(abort):
                 return abort
-    inner = getattr(engine, "_engine", None)
-    if inner is not None:
-        inner_sched = getattr(inner, "scheduler", None)
-        if inner_sched is not None:
-            abort = getattr(inner_sched, "abort_request", None)
-            if abort is not None and not asyncio.iscoroutinefunction(abort):
-                return abort
+    else:
+        inner = getattr(engine, "_engine", None)
+        if inner is not None:
+            inner_sched = getattr(inner, "scheduler", None)
+            if inner_sched is not None:
+                abort = getattr(inner_sched, "abort_request", None)
+                if abort is not None and not asyncio.iscoroutinefunction(abort):
+                    return abort
     return None
 
 
@@ -2290,6 +2325,20 @@ async def _disconnect_guard(
             disconnect_task.cancel()
         if anext_task and not anext_task.done():
             anext_task.cancel()
+        # Drive the cascade first: ``generator.aclose()`` propagates
+        # ``GeneratorExit`` into the upstream so its ``finally`` runs
+        # (calls ``stream_generate.finally`` → ``scheduler.abort_request``).
+        # Then the belt-and-suspenders below covers the case where the
+        # cascade itself raised or the upstream's finally didn't reach
+        # the abort. Ordering ``aclose()`` before the belt-and-
+        # suspenders also gives the test layer a clean observable
+        # discriminator between the ``except GeneratorExit`` branch
+        # (which runs BEFORE the cascade) and this finally fallback
+        # (which runs AFTER the cascade).
+        try:
+            await generator.aclose()
+        except Exception:
+            pass
         # C-01 belt-and-suspenders: cover the abnormal-exit paths the
         # explicit ``if disconnect_task in done`` and ``except
         # GeneratorExit`` branches don't see — e.g. an exception
@@ -2301,13 +2350,9 @@ async def _disconnect_guard(
         # pollute logs without freeing any GPU work. The
         # ``Scheduler.abort_request`` idempotency contract still
         # protects against the case where this fires concurrently
-        # with the cascade through ``generator.aclose()``.
+        # with the cascade.
         if not finished_normally:
             _force_abort_request(engine, request_id_holder)
-        try:
-            await generator.aclose()
-        except Exception:
-            pass
         if engine is not None:
             release = getattr(engine, "release_admission_reservation", None)
             if release is not None:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1984,9 +1984,10 @@ def _force_abort_request(engine, request_id_holder) -> bool:
     ``scheduler.abort_request(rid)`` — a thread-safe, non-blocking
     ``set.add`` per ``Scheduler.abort_request`` docstring. The
     sync-path resolver (``_resolve_sync_scheduler_for_abort``) walks
-    ``engine.scheduler`` → ``engine._mllm_scheduler`` →
-    ``engine._engine.scheduler`` so both the MLLM and text branches
-    of ``BatchedEngine`` reach a sync entry point.
+    ``engine.scheduler`` first, then the active-backend branch on
+    ``BatchedEngine`` (gated by ``engine._is_mllm`` per codex r2
+    BLOCKING #1): MLLM → ``engine._mllm_scheduler``, text →
+    ``engine._engine.scheduler``.
 
     Falls back to ``engine.abort_request(rid)`` (the public engine
     surface — may be async on engines that haven't been refactored)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1897,12 +1897,84 @@ def _maybe_pin_system_prompt(messages: list) -> None:
 # ── Disconnect detection ───────────────────────────────────────────
 
 
+def _force_abort_request(engine, request_id_holder) -> bool:
+    """C-01: synchronously enqueue an abort for the live request id.
+
+    Looks up ``request_id_holder[0]`` (populated by
+    ``BatchedEngine.stream_generate`` once ``add_request`` returns)
+    and invokes ``engine.scheduler.abort_request(rid)`` — a thread-
+    safe, non-blocking ``set.add`` per ``Scheduler.abort_request``
+    docstring. Falls back to ``engine.abort_request(rid)`` (the
+    public engine-level entry point, async on the text path / sync
+    on the MLLM path) when the engine doesn't expose a direct
+    scheduler attr; the async case is fire-and-forget via
+    ``asyncio.ensure_future`` so the caller stays synchronous.
+
+    Returns ``True`` when an abort was issued, ``False`` for the no-op
+    cases (holder unset, engine missing, no request id yet). Never
+    raises — log on the warning channel and swallow so disconnect
+    handling never derails on an engine-side error.
+    """
+    if request_id_holder is None or engine is None:
+        return False
+    try:
+        request_id = request_id_holder[0]
+    except (IndexError, TypeError):
+        return False
+    if not request_id:
+        return False
+    try:
+        # Prefer the direct scheduler entry point — strictly
+        # synchronous + thread-safe per Scheduler.abort_request
+        # docstring (single ``set.add`` + log).
+        scheduler = getattr(engine, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "abort_request"):
+            result = scheduler.abort_request(request_id)
+            logger.info(
+                f"[disconnect_guard] force-abort scheduler.abort_request("
+                f"{str(request_id)[:12]}) -> {result}"
+            )
+            return True
+        # MLLM and BatchedEngine surface a public ``abort_request``
+        # method that may be sync (MLLMScheduler) or async
+        # (AsyncEngineCore via BatchedEngine). Fire-and-forget the
+        # async variant so the caller stays synchronous and the
+        # disconnect branch doesn't block the event loop on a coro.
+        public_abort = getattr(engine, "abort_request", None)
+        if public_abort is not None:
+            result = public_abort(request_id)
+            if asyncio.iscoroutine(result):
+                # Fire-and-forget: the abort enqueue is non-blocking
+                # inside the engine (it just defers to the scheduler's
+                # ``_pending_abort_ids`` set), so awaiting the coro
+                # just adds an unnecessary event-loop hop.
+                asyncio.ensure_future(result)
+                logger.info(
+                    f"[disconnect_guard] force-abort engine.abort_request("
+                    f"{str(request_id)[:12]}) scheduled"
+                )
+            else:
+                logger.info(
+                    f"[disconnect_guard] force-abort engine.abort_request("
+                    f"{str(request_id)[:12]}) -> {result}"
+                )
+            return True
+    except Exception:
+        logger.warning(
+            "[disconnect_guard] force-abort raised; falling back to "
+            "generator-close cascade",
+            exc_info=True,
+        )
+    return False
+
+
 async def _disconnect_guard(
     generator: AsyncIterator[str],
     raw_request: Request,
     poll_interval: float = 0.5,
     engine=None,
     keepalive_seconds: float | None = None,
+    request_id_holder: list | None = None,
 ) -> AsyncIterator[str]:
     """Wrap streaming generator to abort on client disconnect.
 
@@ -1925,6 +1997,25 @@ async def _disconnect_guard(
     ~45 s) from tearing down the connection during long prefills. Set
     ``keepalive_seconds=0`` or ``RAPID_MLX_SSE_KEEPALIVE_SECONDS=0``
     to disable.
+
+    C-01 force-abort (Astrid r3 dogfooding): when
+    ``request_id_holder`` is a mutable list AND the engine publishes
+    the admitted scheduler ``request_id`` into ``holder[0]``, the
+    guard force-calls ``engine.scheduler.abort_request(holder[0])`` (or
+    ``engine.abort_request(holder[0])`` as a thread-safe alternative)
+    the moment a client disconnect is detected. Pre-C-01 the abort
+    relied entirely on the generator-close cascade
+    (``generator.aclose()`` in the ``finally`` → ``GeneratorExit``
+    propagates upstream → ``stream_generate.finally`` calls
+    ``scheduler.abort_request``). That cascade still runs as a
+    belt-and-suspenders, but the EXPLICIT abort here closes Astrid's
+    failure mode where a runaway no-EOS generation kept consuming GPU
+    for >35 s after the client TCP-RST'd because nothing on the path
+    actually reached into the scheduler with an abort signal until
+    the generation hit its token cap. ``holder=None`` (default)
+    preserves the pre-C-01 contract for non-streaming callers and for
+    cloud-routed streams that don't have a local scheduler request
+    id.
     """
     import time as _time
 
@@ -2012,6 +2103,24 @@ async def _disconnect_guard(
                     f"{chunk_count} chunks ({keepalive_count} keepalives), "
                     f"elapsed={_elapsed()}"
                 )
+                # C-01 force-abort: call into the scheduler directly
+                # the moment the disconnect signal fires, BEFORE we
+                # cancel the in-flight ``anext_task`` and close the
+                # upstream generator. Pre-C-01 the abort relied solely
+                # on the close cascade kicking ``stream_generate.finally``
+                # → ``scheduler.abort_request``; Astrid r3 showed that
+                # path can stall for ~35s under a runaway no-EOS
+                # generation because the cancellation of ``anext_task``
+                # only interrupts the in-flight ``__anext__``, while
+                # the upstream batch step continues to chew GPU until
+                # the next yield boundary. Hitting the scheduler's
+                # ``_pending_abort_ids`` set NOW means the very next
+                # ``step()`` drops the request and frees the slot. This
+                # is purely defense in depth — the cascade still runs
+                # via ``generator.aclose()`` in ``finally`` and
+                # ``scheduler.abort_request`` is idempotent against
+                # double-enqueue.
+                _force_abort_request(engine, request_id_holder)
                 anext_task.cancel()
                 try:
                     await anext_task
@@ -2100,11 +2209,24 @@ async def _disconnect_guard(
         # before the cleanup runs.
         if anext_task is not None and not anext_task.done():
             anext_task.cancel()
+        # C-01: GeneratorExit means the consumer (Starlette's
+        # ``StreamingResponse`` task) is tearing down — usually
+        # because uvicorn detected a write failure to the closed
+        # socket. Force-abort the scheduler request before we close
+        # the generator so the upstream doesn't get one more
+        # token-worth of GPU work between here and the cascade.
+        _force_abort_request(engine, request_id_holder)
     finally:
         if disconnect_task and not disconnect_task.done():
             disconnect_task.cancel()
         if anext_task and not anext_task.done():
             anext_task.cancel()
+        # C-01 belt-and-suspenders: if we got here through any path
+        # other than the disconnect or GeneratorExit branches (e.g.
+        # an exception inside the SSE generator), still try to
+        # abort. The scheduler abort_request is idempotent against
+        # double-enqueue.
+        _force_abort_request(engine, request_id_holder)
         try:
             await generator.aclose()
         except Exception:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1897,23 +1897,78 @@ def _maybe_pin_system_prompt(messages: list) -> None:
 # ── Disconnect detection ───────────────────────────────────────────
 
 
+def _resolve_sync_scheduler_for_abort(engine):
+    """C-01 codex r1 BLOCKING #2 helper: find the SYNC scheduler-side
+    ``abort_request`` entry point for the loaded backend.
+
+    The codex reviewer pointed out that ``engine.abort_request`` may
+    be a coroutine (``BatchedEngine.abort_request`` when the LLM path
+    is loaded, because ``AsyncEngineCore.abort_request`` is async).
+    Fire-and-forget via ``asyncio.ensure_future`` doesn't actually
+    free the GPU on the next ``step()`` — the coroutine has to run
+    to reach ``scheduler.abort_request`` (which IS sync). So we walk
+    the engine's backend graph to find that sync entry point
+    directly:
+
+      * ``engine.scheduler``                  — plain engines exposing
+                                                the scheduler directly.
+      * ``engine._mllm_scheduler``            — MLLM path on
+                                                BatchedEngine; sync.
+      * ``engine._engine.scheduler``          — text path on
+                                                BatchedEngine via
+                                                AsyncEngineCore's
+                                                ``.scheduler``.
+
+    Returns the first callable found, or ``None`` when none of the
+    paths resolve (caller falls back to the public async
+    ``engine.abort_request`` as a last resort with documented
+    fire-and-forget semantics).
+    """
+    for path in ("scheduler", "_mllm_scheduler"):
+        backend = getattr(engine, path, None)
+        if backend is not None:
+            abort = getattr(backend, "abort_request", None)
+            if abort is not None and not asyncio.iscoroutinefunction(abort):
+                return abort
+    inner = getattr(engine, "_engine", None)
+    if inner is not None:
+        inner_sched = getattr(inner, "scheduler", None)
+        if inner_sched is not None:
+            abort = getattr(inner_sched, "abort_request", None)
+            if abort is not None and not asyncio.iscoroutinefunction(abort):
+                return abort
+    return None
+
+
 def _force_abort_request(engine, request_id_holder) -> bool:
     """C-01: synchronously enqueue an abort for the live request id.
 
     Looks up ``request_id_holder[0]`` (populated by
     ``BatchedEngine.stream_generate`` once ``add_request`` returns)
-    and invokes ``engine.scheduler.abort_request(rid)`` — a thread-
-    safe, non-blocking ``set.add`` per ``Scheduler.abort_request``
-    docstring. Falls back to ``engine.abort_request(rid)`` (the
-    public engine-level entry point, async on the text path / sync
-    on the MLLM path) when the engine doesn't expose a direct
-    scheduler attr; the async case is fire-and-forget via
-    ``asyncio.ensure_future`` so the caller stays synchronous.
+    and invokes the loaded backend's SYNC
+    ``scheduler.abort_request(rid)`` — a thread-safe, non-blocking
+    ``set.add`` per ``Scheduler.abort_request`` docstring. The
+    sync-path resolver (``_resolve_sync_scheduler_for_abort``) walks
+    ``engine.scheduler`` → ``engine._mllm_scheduler`` →
+    ``engine._engine.scheduler`` so both the MLLM and text branches
+    of ``BatchedEngine`` reach a sync entry point.
 
-    Returns ``True`` when an abort was issued, ``False`` for the no-op
-    cases (holder unset, engine missing, no request id yet). Never
-    raises — log on the warning channel and swallow so disconnect
-    handling never derails on an engine-side error.
+    Falls back to ``engine.abort_request(rid)`` (the public engine
+    surface — may be async on engines that haven't been refactored)
+    only when no sync path exists. In that case the async coroutine
+    is scheduled with ``asyncio.ensure_future`` so the caller stays
+    synchronous, and we log a warning so operators can see that the
+    abort is NOT guaranteed to be in flight by the time the
+    disconnect path returns (codex r1 BLOCKING #2). The cascade via
+    ``generator.aclose()`` remains as the safety net for that case.
+
+    Returns ``True`` when a sync abort was issued (force-abort
+    contract satisfied), ``False`` for the no-op cases (holder unset,
+    engine missing, no request id yet) AND for the
+    async-fallback-only case where the abort was scheduled but
+    didn't reach the scheduler synchronously. Never raises — log on
+    the warning channel and swallow so disconnect handling never
+    derails on an engine-side error.
     """
     if request_id_holder is None or engine is None:
         return False
@@ -1924,40 +1979,41 @@ def _force_abort_request(engine, request_id_holder) -> bool:
     if not request_id:
         return False
     try:
-        # Prefer the direct scheduler entry point — strictly
-        # synchronous + thread-safe per Scheduler.abort_request
-        # docstring (single ``set.add`` + log).
-        scheduler = getattr(engine, "scheduler", None)
-        if scheduler is not None and hasattr(scheduler, "abort_request"):
-            result = scheduler.abort_request(request_id)
+        sync_abort = _resolve_sync_scheduler_for_abort(engine)
+        if sync_abort is not None:
+            result = sync_abort(request_id)
             logger.info(
                 f"[disconnect_guard] force-abort scheduler.abort_request("
                 f"{str(request_id)[:12]}) -> {result}"
             )
             return True
-        # MLLM and BatchedEngine surface a public ``abort_request``
-        # method that may be sync (MLLMScheduler) or async
-        # (AsyncEngineCore via BatchedEngine). Fire-and-forget the
-        # async variant so the caller stays synchronous and the
-        # disconnect branch doesn't block the event loop on a coro.
+        # No sync path resolved — the engine is wrapping its scheduler
+        # behind an async-only ``abort_request``. Best-effort fire-and-
+        # forget; return ``False`` so the contract reflects that the
+        # abort did NOT land synchronously and the cascade through
+        # ``generator.aclose()`` is the operative defense (codex r1
+        # BLOCKING #2). Tests that pin the "force-abort fired sync"
+        # contract should fail loudly on this fallback path.
         public_abort = getattr(engine, "abort_request", None)
         if public_abort is not None:
             result = public_abort(request_id)
             if asyncio.iscoroutine(result):
-                # Fire-and-forget: the abort enqueue is non-blocking
-                # inside the engine (it just defers to the scheduler's
-                # ``_pending_abort_ids`` set), so awaiting the coro
-                # just adds an unnecessary event-loop hop.
                 asyncio.ensure_future(result)
-                logger.info(
-                    f"[disconnect_guard] force-abort engine.abort_request("
-                    f"{str(request_id)[:12]}) scheduled"
+                logger.warning(
+                    f"[disconnect_guard] force-abort fell back to async "
+                    f"engine.abort_request({str(request_id)[:12]}); the "
+                    f"scheduler abort is NOT guaranteed in flight by the "
+                    f"time disconnect handling returns. The "
+                    f"generator-close cascade is the remaining defense."
                 )
-            else:
-                logger.info(
-                    f"[disconnect_guard] force-abort engine.abort_request("
-                    f"{str(request_id)[:12]}) -> {result}"
-                )
+                # ``False`` so the contract reflects async-fallback;
+                # callers / tests treat that as "I tried, cascade is
+                # the remaining defense".
+                return False
+            logger.info(
+                f"[disconnect_guard] force-abort engine.abort_request("
+                f"{str(request_id)[:12]}) -> {result}"
+            )
             return True
     except Exception:
         logger.warning(
@@ -2059,6 +2115,13 @@ async def _disconnect_guard(
     keepalive_count = 0
     disconnect_task: asyncio.Task | None = None
     anext_task: asyncio.Task | None = None
+    # C-01 codex r1 NIT #3: track whether we got to a clean
+    # ``StopAsyncIteration`` exhaust (normal stream end). When True,
+    # the ``finally`` block skips the belt-and-suspenders force-abort —
+    # otherwise every successful response would enqueue a spurious
+    # abort against an already-finished request id, making the abort
+    # logs/metrics indistinguishable from real disconnect cleanup.
+    finished_normally = False
     try:
         aiter = generator.__aiter__()
         disconnect_task = asyncio.create_task(_wait_disconnect())
@@ -2150,6 +2213,12 @@ async def _disconnect_guard(
                     f"{chunk_count} chunks ({keepalive_count} keepalives), "
                     f"elapsed={_elapsed()}"
                 )
+                # C-01 codex r1 NIT #3: mark the clean-exit case so
+                # ``finally`` skips the force-abort. The upstream
+                # generator already drained, the scheduler already
+                # marked the request as finished — a defensive abort
+                # here would only pollute logs.
+                finished_normally = True
                 break
             except Exception as exc:
                 logger.error(
@@ -2221,12 +2290,20 @@ async def _disconnect_guard(
             disconnect_task.cancel()
         if anext_task and not anext_task.done():
             anext_task.cancel()
-        # C-01 belt-and-suspenders: if we got here through any path
-        # other than the disconnect or GeneratorExit branches (e.g.
-        # an exception inside the SSE generator), still try to
-        # abort. The scheduler abort_request is idempotent against
-        # double-enqueue.
-        _force_abort_request(engine, request_id_holder)
+        # C-01 belt-and-suspenders: cover the abnormal-exit paths the
+        # explicit ``if disconnect_task in done`` and ``except
+        # GeneratorExit`` branches don't see — e.g. an exception
+        # raised mid-stream that escaped the ``except Exception`` inline
+        # handler. Codex r1 NIT #3 fix: skip when the stream
+        # exhausted cleanly via ``StopAsyncIteration`` — the upstream
+        # generator already finished and the scheduler already marked
+        # the request finished, so a defensive abort here would just
+        # pollute logs without freeing any GPU work. The
+        # ``Scheduler.abort_request`` idempotency contract still
+        # protects against the case where this fires concurrently
+        # with the cascade through ``generator.aclose()``.
+        if not finished_normally:
+            _force_abort_request(engine, request_id_holder)
         try:
             await generator.aclose()
         except Exception:


### PR DESCRIPTION
## Summary

C-01 hardening from `0.8TODO.md`. Astrid r3 (pydantic-ai +
Qwen3.5-4B-MLX-4bit) hit a server-killing combination:
`agent.run_stream("Tell me a joke")` ran past 6144 tokens with no EOS,
client got `httpx.RemoteProtocolError: peer closed connection`, and
`_disconnect_guard` polled **70+ times without intervening**. Port 8907
went dead. Repro: `/tmp/dogfood-r3/astrid_probes.py` probe 6.

Both hypotheses from the C-01 brief were investigated:

1. **Chat-template EOS missing** — confirmed: 6144 = `4096 (default
   max_tokens) + 2048 (thinking_token_budget)`. The model truly never
   emitted EOS for this Qwen3.5/pydantic-ai system-prompt combo;
   generation stopped only because it hit the cap.
2. **`disconnect_guard` doesn't abort the scheduler** — confirmed:
   Starlette's `request.is_disconnected()` never returned True for the
   entire ~35s runaway, so the guard never reached the
   `generator.aclose()` cascade that would have unwound through
   `stream_generate.finally` to `scheduler.abort_request`. Even when
   the cascade does run, the upstream batch step keeps consuming GPU
   between the cancel and the next yield boundary.

## What changed

Systemic force-abort path that no longer relies on the cascade:

- `BatchedEngine.stream_generate` now accepts a `request_id_holder`
  kwarg (a mutable list). When the engine acquires its scheduler
  `request_id` (both MLLM and text paths), it publishes the id into
  `holder[0]`. Plumbed via `**kwargs` so the abstract
  `stream_chat`/`stream_generate` signatures don't change.
- `_disconnect_guard` accepts the same holder and force-calls
  `engine.scheduler.abort_request(rid)` (or `engine.abort_request(rid)`
  as the public fall-back) **synchronously** the moment a disconnect
  is detected, AND on the `except GeneratorExit` path (catches
  Astrid's `is_disconnected` never-True failure mode where Starlette
  surfaces the dead socket only via a write failure that propagates
  back as `GeneratorExit`), AND in `finally` as belt-and-suspenders.
  `Scheduler.abort_request` is idempotent per its docstring so the
  triple-fire is safe.
- All four streaming routes (`/v1/chat/completions`,
  `/v1/completions`, `/v1/messages`, `/v1/responses`) allocate a
  holder per request and thread it through both the SSE generator and
  the guard.
- Cloud-routed streams keep `holder=None` — no local scheduler
  request to abort.

The pre-C-01 `generator.aclose()` cascade still runs as the secondary
safety net (covers the case where the client disconnected before
`add_request` returned — holder stays `None`, force-abort short-
circuits, cascade handles cleanup).

## Files

- `vllm_mlx/service/helpers.py` — new `_force_abort_request` helper +
  `request_id_holder` param + abort hooks on disconnect / GeneratorExit
  / finally branches
- `vllm_mlx/engine/batched.py` — engine publishes scheduler request id
  into holder on both MLLM and text paths
- `vllm_mlx/routes/chat.py` — chat route allocates + threads holder
- `vllm_mlx/routes/completions.py` — completions route allocates +
  threads holder; `stream_completion` accepts kwarg
- `vllm_mlx/routes/anthropic.py` — `/v1/messages` allocates + threads
  holder; `_stream_anthropic_messages` accepts kwarg
- `vllm_mlx/routes/responses.py` — `/v1/responses` allocates + threads
  holder; `_stream_responses` accepts kwarg
- `tests/test_disconnect_guard_aborts_scheduler.py` — new test module
  pinning every contract (see Test plan)

## Test plan

- [x] Disconnect mid-stream → `scheduler.abort_request(rid)` called
  synchronously, guard returns within 2s instead of waiting on the
  60s sleep
- [x] Holder = `None` (pre-C-01 callers) → no force-abort, behaviour
  unchanged
- [x] Holder provided but unpopulated (client disconnected before
  `add_request` returned) → no crash, no spurious abort
- [x] `GeneratorExit` path (no disconnect signal ever fires) → still
  force-aborts via `except GeneratorExit` branch
- [x] Idempotent double-abort (cascade + force-abort + finally fires
  on the same id) doesn't crash
- [x] Engine without `scheduler` attr → falls back to public
  `engine.abort_request(rid)`; async coro variant is fire-and-forget
- [x] `scheduler.abort_request` raising doesn't derail disconnect
  handling — logged + swallowed; cascade is the remaining defense
- [x] End-to-end pin: `BatchedEngine.stream_generate` populates the
  holder with the scheduler request id once `add_request` returns
- [x] `pytest tests/test_sse_keepalive.py
  tests/test_rst_mid_sse_zombie_kv.py
  tests/test_chat_streaming_spec.py
  tests/test_anthropic_route_streaming.py
  tests/test_completions_spec_parity.py
  tests/test_responses_route.py
  tests/test_streaming_detokenizer.py tests/test_batching.py
  tests/test_request_cancellation.py
  tests/test_disconnect_guard_aborts_scheduler.py` → 128 passed, no
  regressions
- [x] Full suite minus integration/event-loop tests that need a
  running server → 6961 passed; 4 pre-existing failures on
  `origin/main` unrelated to C-01 (`test_no_routing_shaped_rapid_mlx_env_vars`,
  `test_no_hasattr_engine_guard[completions.py]`, hermes integration,
  event_loop) — confirmed by re-running on `git stash`
- [x] `ruff check vllm_mlx/ tests/test_disconnect_guard_aborts_scheduler.py` → clean
- [x] `ruff format --check vllm_mlx/ tests/test_disconnect_guard_aborts_scheduler.py` → clean

## Notes

- No version bump (per task constraints).
- No env-var ceiling fallback (defense-in-depth Fix 2 from the task
  brief was scoped out — Astrid hit `4096+2048=6144` which is already
  the resolved cap, lowering it doesn't help the runaway-with-no-EOS
  case. The disconnect force-abort closes the actual hole. M-04's
  opt-in `RAPID_MLX_MAX_GENERATION_TOKENS` remains the operator lever
  for per-request budgets.).
- `codex` CLI is the known I-001 glitch on the worktree venv; if
  `pr_validate` skips the `codex_review` step, that's expected
  per the C-01 task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)