### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` from `0.8.0` to `0.8.1` to ship the 0.8.x fix wave.

### What lands in 0.8.1

**CRIT (1)**
- C-01 — `_disconnect_guard` force-aborts scheduler request on client close (#777)

**HIGH (8 — 6 new this wave + 2 from prior batch)**
- H-02 — sanitize cache/export 403 path-leak (#762)
- H-03 — stop matcher on /v1/completions + /v1/messages (#773)
- H-05 + follow-up — F-220 tool-arg validation scope + 422 on empty-pin (#763, #771)
- H-07 — streaming response_format ` ```json ` fence-strip state machine (#769)
- H-10 — F-011 finite-range sweep across all sampling params (#778)
- H-11 — `seed` plumbed to per-request RNG state (#779)
- H-12 — sanitize `/v1/cache/info` path-leak (#775)
- H-15 — reject non-string `content[].text` (#776)
- H-16 — reject unknown `tool_choice` shapes on `/v1/chat/completions` (#774)

**MED**
- M-02 — PFlash bypass + compressed-tokens counters (#768, #772)
- M-03 — reject unknown `tool_choice.type` on `/v1/messages` (#766)
- M-04 — opt-in `RAPID_MLX_MAX_GENERATION_TOKENS` budget cap (#767)

**LOW**
- L-02 / L-05 / L-07 — CORS lockdown shape + `enable_thinking` warning header + `[vision]` extra (#770)
- L-01 / L-03 / L-04 / L-06 — SDK compat docs (#765)

### Verification

All 6 wave-2 fixes verified PASS on the wire against the local wheel built from HEAD `671582a`:

| ID | Status | Evidence |
|---|---|---|
| C-01 | ✅ | 3× mid-stream client close; scheduler aborted each; `/health` OK after |
| H-10 | ✅ | `repetition_penalty=-1.0` → 400; server healthy |
| H-11 | ✅ | 5× `seed=42` → byte-identical (sha `ac7867160068`); `seed=43` differs |
| H-12 | ✅ | `/v1/cache/info` body has no `/Users/`, `.cache`, `cache_exports` |
| H-15 | ✅ | non-string `text` → 400 with named-field error; server healthy |
| H-16 | ✅ | `{"foo":"bar"}` → 400; `"required"` → 200 |

Earlier wave (H-02 / H-03 / H-05 / H-07 / M-02 / M-03 / M-04 / L-02 / L-05 / L-07) verified in `/tmp/dogfood-r3/00-verification.md` (13/13 PASS).

## Test plan

- [x] Subject is exactly `chore: bump version to 0.8.1` so auto-release.yml fires.
- [x] Diff is pyproject-only (no other changes).
- [x] Verified 13/13 prior fixes + 6/6 new fixes pass on wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)