### PR TITLE
fix(api): reject image content blocks on text-only models (M-16)

### DIFF
--- a/tests/test_image_block_requires_vision_model.py
+++ b/tests/test_image_block_requires_vision_model.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression for M-16: text-only models silently accept image blocks.
+
+Bug (Quincy 0.8.1 dogfood)
+--------------------------
+``POST /v1/messages`` to a text-only model with an Anthropic ``image``
+content block returned HTTP 200 with the image silently dropped. The
+Anthropic adapter
+(``vllm_mlx/api/anthropic_adapter._convert_message_to_openai``) only
+forwards ``text``/``tool_use``/``tool_result`` blocks to the OpenAI-shape
+request — every other block type (``image``, ``document``) is silently
+discarded. The caller sees a confident-but-empty answer about the
+missing media.
+
+Fix
+---
+At the route boundary in ``vllm_mlx/routes/anthropic.py``, before the
+adapter runs, inspect every block in every message. If ``engine.is_mllm``
+is False and we see ``image`` or ``document``, raise HTTP 400 naming the
+model/incompatibility. Mirrors the same R9P1 guard the OpenAI
+``/v1/chat/completions`` route already enforces (``routes/chat.py``).
+
+Scope
+-----
+* ``/v1/messages`` (Anthropic): the new guard.
+* ``/v1/chat/completions`` (OpenAI): pre-existing guard already covers
+  ``image_url``/``image``; this file adds parity-style assertions so a
+  future refactor can't silently regress either surface.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.anthropic import router as anthropic_router
+from vllm_mlx.routes.chat import router as chat_router
+
+
+class _TextOnlyEngine:
+    """Minimal engine stub matching the text-only contract."""
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        return GenerationOutput(
+            text="ok",
+            new_text="ok",
+            tokens=[1],
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+class _VisionEngine(_TextOnlyEngine):
+    """Same stub but advertised as MLLM. Should accept image blocks
+    (passed through to the downstream multimodal pipeline)."""
+
+    is_mllm = True
+
+
+def _make_client(engine, *, include_anthropic: bool = True) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "text-only-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.tool_parser = None
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    if include_anthropic:
+        app.include_router(anthropic_router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    reset_config()
+
+
+# ----------------------------------------------------------------------
+# Anthropic surface: /v1/messages
+# ----------------------------------------------------------------------
+
+
+def test_anthropic_text_only_model_rejects_image_block():
+    """The bug repro: text-only model + image block => HTTP 400, not 200."""
+    client = _make_client(_TextOnlyEngine())
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBORw0KGgoAAAANSUhEUg==",
+                            },
+                        },
+                        {"type": "text", "text": "What is in this image?"},
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert "text-only-model" in detail
+    assert "image" in detail or "document" in detail
+
+
+def test_anthropic_text_only_model_rejects_document_block():
+    """Anthropic ``document`` blocks (PDFs) are also dropped silently
+    by the adapter; the guard must reject them too."""
+    client = _make_client(_TextOnlyEngine())
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": "JVBERi0xLjQK",
+                            },
+                        },
+                        {"type": "text", "text": "Summarise this pdf"},
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert "document" in detail
+
+
+def test_anthropic_vision_model_accepts_image_block():
+    """Sanity check: VLM-capable engine must NOT see a 400 — the route
+    must propagate the image block downstream."""
+    client = _make_client(_VisionEngine())
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBORw0KGgoAAAANSUhEUg==",
+                            },
+                        },
+                        {"type": "text", "text": "describe"},
+                    ],
+                }
+            ],
+        },
+    )
+    # We do not assert 200 strictly — downstream multimodal pipeline
+    # may itself reject the stub payload — but the route-level
+    # capability gate must NOT fire.
+    if resp.status_code == 400:
+        assert "does not support" not in resp.json().get("detail", ""), (
+            "VLM-capable engine wrongly triggered the text-only media gate"
+        )
+
+
+def test_anthropic_text_only_model_accepts_text_only_content():
+    """Sanity check: text-only model + text-only content => 200."""
+    client = _make_client(_TextOnlyEngine())
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_anthropic_text_only_model_accepts_string_content():
+    """The simple-string shape (most common) keeps working unchanged."""
+    client = _make_client(_TextOnlyEngine())
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {"role": "user", "content": "hi"},
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ----------------------------------------------------------------------
+# OpenAI surface: /v1/chat/completions (mirror)
+# ----------------------------------------------------------------------
+
+
+def test_openai_text_only_model_rejects_image_url_block():
+    """The pre-existing OpenAI-side guard must keep rejecting image_url
+    on text-only models. Pinned here so a refactor that drops it lights
+    up alongside the new Anthropic test."""
+    client = _make_client(_TextOnlyEngine(), include_anthropic=False)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/a.png"},
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "does not support" in resp.json()["detail"]
+
+
+def test_openai_text_only_model_accepts_text_only_content():
+    client = _make_client(_TextOnlyEngine(), include_anthropic=False)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "text-only-model",
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hi"}],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -333,6 +333,41 @@ async def create_anthropic_message(
                 cfg_for_log.model_name,
             )
 
+        # Reject image/document content blocks when the loaded model has
+        # no multimodal head (M-16). The Anthropic adapter
+        # (``anthropic_adapter._convert_message_to_openai``) only carries
+        # ``text``/``tool_use``/``tool_result`` blocks forward — every other
+        # block type (``image``, ``document``) is silently dropped. Without
+        # this guard the caller sees HTTP 200 with a hallucinated answer
+        # about the missing media (mirrors the OpenAI-route R9P1 fix in
+        # ``routes/chat.py``: text-only models never silently drop media).
+        cfg_pre = get_config()
+        # ``getattr`` default-True: tests with minimal engine stubs that
+        # never carry image blocks shouldn't trigger this guard, and the
+        # production engine always defines ``is_mllm``. Only a real
+        # text-only model (``is_mllm == False``) trips the rejection.
+        if getattr(engine, "is_mllm", True) is False:
+            for _msg in anthropic_request.messages:
+                _content = _msg.content
+                if not isinstance(_content, list):
+                    continue
+                for _block in _content:
+                    _block_type = (
+                        _block.type
+                        if hasattr(_block, "type")
+                        else (
+                            _block.get("type", "") if isinstance(_block, dict) else ""
+                        )
+                    )
+                    if _block_type in ("image", "document"):
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Model '{cfg_pre.model_name}' does not support "
+                                "image or document inputs."
+                            ),
+                        )
+
         # Convert Anthropic request -> OpenAI request. The adapter raises
         # ``AnthropicOutputConfigError`` (a ``ValueError`` subclass) on
         # malformed ``output_config`` payloads — backport of upstream vLLM


### PR DESCRIPTION
## Summary

Fixes M-16 (Quincy 0.8.1 dogfood `/tmp/dogfood-081/03-quincy.md`):
Anthropic `messages.create(...)` to a text-only model with an `image`
content block returned HTTP 200 with the image silently dropped — the
client thinks the image was processed and gets a confident-but-
hallucinated text answer about the missing media.

Root cause is in `vllm_mlx/api/anthropic_adapter._convert_message_to_openai`:
it only forwards `text` / `tool_use` / `tool_result` blocks to the
OpenAI-shape request that goes downstream. Every other Anthropic block
type (`image`, `document`) is silently discarded — no warning, no
error, no log line.

## Fix

Add a route-level capability guard in `vllm_mlx/routes/anthropic.py`
*before* adapter conversion. If `engine.is_mllm` is False and any
message carries an `image` or `document` block, raise HTTP 400 with
`"Model 'X' does not support image or document inputs."` — the same
"named-incompatibility" pattern the OpenAI `/v1/chat/completions`
route already uses for `image_url`/`image`/`video`/`audio_url`.

`getattr(engine, "is_mllm", True) is False` is deliberately
default-True: the production `BaseEngine` always sets the attribute;
the default-True fallback only matters for the minimal test stubs
under `tests/test_anthropic_*.py` that never carry image blocks and
whose engine doesn't define `is_mllm`. Only an explicitly text-only
engine trips the rejection.

## OpenAI parity

The OpenAI `/v1/chat/completions` route **already** enforces the
equivalent guard (`routes/chat.py`, R9P1 fix, with audio shapes added
in `tests/test_text_only_media_gate.py`). No code change needed on
that surface — the new test file asserts both surfaces in one place
so a future refactor can't silently regress either.

## Test plan

- [x] Added `tests/test_image_block_requires_vision_model.py` covering:
      text-only model + image block => 400 with named incompatibility;
      text-only model + document block => 400;
      text-only model + text-only blocks => 200 (control, both shapes);
      VLM-capable model + image block => no 400 from this gate;
      OpenAI parity: text-only model + image_url => 400;
      OpenAI parity: text-only model + text-only blocks => 200.
- [x] All 7 new tests pass.
- [x] Re-ran the full anthropic + media-gate suite (299 tests) — all pass.
- [x] Ruff check + format check clean on touched files.
- [x] Before-state repro captured in `/tmp/m16-before.txt`: adapter
      drops the image block, no error surfaces.
- [x] After-state repro captured in `/tmp/m16-after.txt`: 400, 400,
      200, 400 on the four target requests (Anthropic image,
      Anthropic document, Anthropic text-only control, OpenAI parity).

## Constraints

- No version bump (per ask).
- No global config writes.
- No changes to OpenAI route — existing guard already covers the gap.