### PR TITLE
fix(metrics): expose rapid_mlx_requests_cancelled_total counter (M-01)

### DIFF
--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -526,6 +526,25 @@ def test_disconnect_sub_counter_dedupes_per_request_id():
     assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
 
 
+def test_disconnect_sub_counter_silent_on_id_never_accepted_as_cancel():
+    """Codex r7 NIT #3: ``record_disconnect_abort`` must reject ids
+    that were never accepted by ``abort_request``, so the dashboard
+    invariant ``via_disconnect_total <= cancelled_total`` holds by
+    construction even on programmer error.
+
+    Pre-r7 the method incremented the sub-counter for any non-empty
+    id, so a buggy caller could push ``via_disconnect`` above
+    ``cancelled_total``. The lifetime ledger gate catches it.
+    """
+    scheduler = _make_scheduler()
+    # No ``abort_request("req-bogus")`` call — the id was never
+    # admitted into the lifetime ledger ``_cancelled_request_ids``.
+    scheduler.record_disconnect_abort("req-bogus")
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 0
+    assert stats["num_requests_cancelled_via_disconnect"] == 0
+
+
 def test_disconnect_sub_counter_silent_on_empty_request_id():
     """Empty string / None ``request_id`` is a no-op, not a crash.
 
@@ -954,6 +973,55 @@ async def test_force_abort_attribution_walks_production_batched_engine_shape():
     # But the attribution MUST still have landed — that's the bug
     # we're guarding against.
     assert engine._engine.engine.scheduler.disconnect_records == ["req-prod-shape"]
+
+
+def test_attribution_resolver_honors_is_mllm_before_direct_scheduler():
+    """Codex r7 BLOCKING #2: a dual-shaped engine exposing BOTH
+    ``engine.scheduler`` (text-path leftover) AND ``_mllm_scheduler``
+    (MLLM-path active) with ``_is_mllm=True`` must attribute the
+    disconnect to the MLLM scheduler — NOT the direct
+    ``engine.scheduler``.
+
+    Pre-r7-fix the resolver checked ``engine.scheduler`` FIRST and
+    short-circuited, mis-attributing every MLLM disconnect to the
+    text scheduler. The fix honors ``_is_mllm`` first; direct
+    ``engine.scheduler`` is only consulted as a fallback when the
+    flag is absent entirely.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncSched:
+        def __init__(self, name):
+            self.name = name
+            self.disconnect_records: list[str] = []
+
+        def abort_request(self, request_id: str) -> bool:
+            return True
+
+        def record_disconnect_abort(self, request_id: str) -> None:
+            self.disconnect_records.append(request_id)
+
+    class _DualShapedEngine:
+        """Both ``.scheduler`` (text leftover, e.g. a stale attribute
+        from a prior backend init) AND ``_mllm_scheduler`` populated;
+        the active backend is MLLM per ``_is_mllm=True``.
+        """
+
+        def __init__(self):
+            self.scheduler = _SyncSched("text-leftover")
+            self._mllm_scheduler = _SyncSched("mllm-active")
+            self._is_mllm = True
+
+        async def abort_request(self, request_id: str) -> bool:
+            return True
+
+    engine = _DualShapedEngine()
+    _force_abort_request(engine, ["req-mllm-active"])
+
+    # The MLLM scheduler MUST own the attribution.
+    assert engine._mllm_scheduler.disconnect_records == ["req-mllm-active"]
+    # The text-leftover scheduler MUST NOT be touched.
+    assert engine.scheduler.disconnect_records == []
 
 
 def test_force_abort_attribution_walks_active_backend():

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -199,20 +199,55 @@ def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
     assert scheduler.abort_request("req-reused") is True
     assert scheduler.get_stats()["num_requests_cancelled"] == 1
     scheduler._process_pending_aborts()
-    # The r3 fix: ``_cancelled_request_ids`` is empty for this id
-    # even though ``self.requests`` may still hold the finished
-    # ``Request`` object.
-    assert "req-reused" not in scheduler._cancelled_request_ids
+    # Codex r4 fix: the dedupe ledger MUST stay populated until the
+    # request actually leaves ``self.requests``. Otherwise a
+    # redundant ``abort_request`` arriving while the request is
+    # mid-cleanup would observe ``in self.requests`` AND an empty
+    # ledger and double-count the same lifetime.
+    assert "req-reused" in scheduler._cancelled_request_ids
     # Engine-core cleanup: remove the finished request from the
-    # scheduler's request map so the next admit doesn't collide.
+    # scheduler's request map; the discard of the dedupe ledger
+    # happens HERE per codex r4.
     scheduler.remove_finished_request("req-reused")
     assert "req-reused" not in scheduler.requests
+    assert "req-reused" not in scheduler._cancelled_request_ids
 
     # Second lifetime: distinct request, same id.
     _admit(scheduler, "req-reused")
     assert scheduler.abort_request("req-reused") is True
     # MUST count again — the new request is a distinct cancel.
     assert scheduler.get_stats()["num_requests_cancelled"] == 2
+
+
+def test_total_counter_does_not_double_count_redundant_abort_pre_cleanup():
+    """Codex r4 BLOCKING #1: between ``_do_abort_request`` and
+    ``remove_finished_request`` the request stays resident in
+    ``self.requests``. A redundant ``abort_request`` for the same id
+    in that window MUST NOT double-count.
+
+    Pre-r4-fix (codex r3): the dedupe ledger was cleared inside
+    ``_do_abort_request``, so the redundant call observed the
+    request still in ``self.requests`` AND an empty ledger and
+    incremented the counter a second time for the same lifetime.
+
+    Post-r4: the ledger is only cleared inside
+    ``remove_finished_request``, by which point the request has
+    truly left every admit predicate and a fresh ``abort_request``
+    can only land via a new admit (a distinct lifetime).
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-mid-cleanup")
+    scheduler.abort_request("req-mid-cleanup")
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+    # Simulate the executor running _do_abort_request — but NOT
+    # yet the engine_core remove_finished_request call. The
+    # request is mid-cleanup.
+    scheduler._process_pending_aborts()
+    assert "req-mid-cleanup" in scheduler.requests  # still resident
+
+    # Redundant abort in the cleanup window. MUST NOT increment.
+    assert scheduler.abort_request("req-mid-cleanup") is True
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
 
 
 def test_disconnect_subcounter_counts_reused_request_id_after_full_abort_cycle():
@@ -232,9 +267,10 @@ def test_disconnect_subcounter_counts_reused_request_id_after_full_abort_cycle()
     scheduler.record_disconnect_abort("req-disc-reused")
     assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
     scheduler._process_pending_aborts()
-    # Discarded by _do_abort_request.
-    assert "req-disc-reused" not in scheduler._disconnect_abort_ids
+    # Codex r4: still in ledger until remove_finished_request.
+    assert "req-disc-reused" in scheduler._disconnect_abort_ids
     scheduler.remove_finished_request("req-disc-reused")
+    assert "req-disc-reused" not in scheduler._disconnect_abort_ids
 
     # Second lifetime: distinct request reusing the id.
     _admit(scheduler, "req-disc-reused")
@@ -819,30 +855,57 @@ def test_force_abort_attribution_walks_active_backend():
 # ---------------------------------------------------------------------------
 
 
+class _RealSchedulerEngine:
+    """Engine stub that exposes a REAL ``Scheduler`` instance so the
+    end-to-end disconnect_guard tests pin the actual
+    ``get_stats()["num_requests_cancelled"]`` counter — not a fake
+    counter on a stub.
+
+    Codex r4 BLOCKING #3 fix: the earlier ``_CountingScheduler`` stub
+    only recorded method calls, so the test would still pass if
+    ``Scheduler.num_requests_cancelled`` never advanced. Driving the
+    real scheduler closes that gap — a regression that breaks the
+    counter wiring will now fail the assertion on
+    ``get_stats()``.
+    """
+
+    def __init__(self):
+        self.scheduler = _make_scheduler()
+
+
 @pytest.mark.asyncio
 async def test_three_aborted_streaming_requests_advance_counters_by_three():
     """Fire 3 streaming requests through ``_disconnect_guard`` and
     abort each via ``GeneratorExit``. The total counter and the
-    disconnect sub-counter both increment by 3.
+    disconnect sub-counter both increment by 3 on a REAL
+    ``Scheduler``.
 
     This is the headline behaviour Mei r0.8.1 / Yana r3 asked for:
     aborted streams MUST be visible in /metrics so operators see the
     cancel-rate. Pre-fix the counters didn't exist; post-fix the test
-    pins the +N contract.
+    pins the +N contract against the real scheduler's
+    ``get_stats()``.
+
+    Codex r4 BLOCKING #3: this test previously used a fake
+    ``_CountingScheduler`` and would have passed even if the real
+    scheduler counters never advanced. Replaced with
+    ``_RealSchedulerEngine`` so the assertion now pins the actual
+    Prometheus-facing counter.
     """
     from vllm_mlx.service.helpers import _disconnect_guard
 
-    engine = _Engine()
+    engine = _RealSchedulerEngine()
 
-    aborted_holders: list[list[str]] = []
+    # Admit three requests directly into the real scheduler so
+    # ``abort_request(rid)`` will pass the predicate.
+    for i in range(3):
+        _admit(engine.scheduler, f"req-stream-{i}")
+
     for i in range(3):
         holder = [f"req-stream-{i}"]
-        aborted_holders.append(holder)
 
         async def upstream():
             yield 'data: {"chunk":"hello"}\n\n'
-            # Wait long enough that GeneratorExit reaches us before
-            # the upstream exhausts naturally.
             await asyncio.sleep(60)
             yield "data: [DONE]\n\n"
 
@@ -860,32 +923,27 @@ async def test_three_aborted_streaming_requests_advance_counters_by_three():
         )
 
         # Pull one chunk then close — simulates Starlette tearing
-        # down the StreamingResponse mid-stream (Astrid r3 fingerprint).
+        # down the StreamingResponse mid-stream (Astrid r3
+        # fingerprint).
         agen = guard.__aiter__()
         await agen.__anext__()
         await agen.aclose()
 
-    # All three request_ids should be in the scheduler's abort list
-    # AND the disconnect-attribution list. De-dup guarantees one
-    # entry per id even when the helper fires from multiple branches.
-    accepted_aborts = sorted(set(engine.scheduler.aborts))
-    accepted_records = sorted(set(engine.scheduler.disconnect_records))
-    assert accepted_aborts == [
-        "req-stream-0",
-        "req-stream-1",
-        "req-stream-2",
-    ]
-    assert accepted_records == [
-        "req-stream-0",
-        "req-stream-1",
-        "req-stream-2",
-    ]
+    # The real scheduler's counters MUST have advanced by 3 each.
+    # If the wiring breaks (e.g. someone removes the
+    # ``_record_disconnect_abort_on_scheduler`` call, or the
+    # scheduler stops counting on accepted aborts), THIS is what
+    # catches it — not the side-channel attribute checks the
+    # stub-based version did.
+    stats = engine.scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 3, stats
+    assert stats["num_requests_cancelled_via_disconnect"] == 3, stats
 
 
 @pytest.mark.asyncio
 async def test_two_completed_streaming_requests_leave_counter_unchanged():
     """Streams that exhaust normally do NOT advance the cancellation
-    counters.
+    counters on a REAL ``Scheduler``.
 
     ``_disconnect_guard.finally`` has a ``finished_normally`` flag
     (codex r1 NIT #3 on PR #777) that skips the belt-and-suspenders
@@ -893,10 +951,15 @@ async def test_two_completed_streaming_requests_leave_counter_unchanged():
     ``StopAsyncIteration``. Without that gate the cancellation
     counter would tick once per completed request and the operator's
     "cancel rate" panel would look like "100% of traffic" — useless.
+
+    Codex r4 BLOCKING #3 same fix as the abort test above: drive a
+    real ``Scheduler`` so the counter assertion has bite.
     """
     from vllm_mlx.service.helpers import _disconnect_guard
 
-    engine = _Engine()
+    engine = _RealSchedulerEngine()
+    for i in range(2):
+        _admit(engine.scheduler, f"req-clean-{i}")
 
     for i in range(2):
         holder = [f"req-clean-{i}"]
@@ -925,9 +988,10 @@ async def test_two_completed_streaming_requests_leave_counter_unchanged():
         # Sanity: the consumer pulled the full stream.
         assert "[DONE]" in chunks[-1]
 
-    # Neither counter should have moved.
-    assert engine.scheduler.aborts == []
-    assert engine.scheduler.disconnect_records == []
+    # Neither counter should have moved on the REAL scheduler.
+    stats = engine.scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 0, stats
+    assert stats["num_requests_cancelled_via_disconnect"] == 0, stats
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -219,6 +219,80 @@ def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
     assert scheduler.get_stats()["num_requests_cancelled"] == 2
 
 
+def test_remove_finished_request_pops_and_discards_atomically():
+    """Codex r5 BLOCKING: ``remove_finished_request`` must perform
+    the ``self.requests.pop`` AND the dedupe-ledger discards
+    inside a single critical section so a concurrent
+    ``abort_request`` cannot observe ``request_id in self.requests``
+    AND an empty ledger.
+
+    Pre-r5-fix the discards happened under the lock but the pop
+    was outside, opening a window where a racing thread saw:
+      * ``request_id in self.requests``  (pop hadn't run yet)
+      * ``request_id not in _cancelled_request_ids`` (discard
+        already cleared it)
+    → double-count of the same request lifetime.
+
+    Test approach: monkeypatch ``self.requests.pop`` to verify the
+    lock is HELD across both ``pop`` and ``discard``. We can't
+    reliably exercise the race via real threads (the window is
+    microseconds), so we assert the ordering contract by tracking
+    when each operation runs relative to the lock state. A
+    regression that moves either operation out of the critical
+    section flips one of the assertions.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-atomic-cleanup")
+    scheduler.abort_request("req-atomic-cleanup")
+    scheduler._process_pending_aborts()
+    # Pre-state: ledger populated, request still resident.
+    assert "req-atomic-cleanup" in scheduler._cancelled_request_ids
+    assert "req-atomic-cleanup" in scheduler.requests
+
+    # Wrap ``self.requests`` and ``_cancelled_request_ids`` with
+    # observers that snapshot the lock state at each mutation.
+    # Can't monkeypatch ``dict.pop`` / ``set.discard`` directly
+    # (they're slot-defined read-only), so we replace the whole
+    # container with a subclass.
+    lock = scheduler._cancel_counter_lock
+
+    class _DictObserver(dict):
+        def __init__(self, src):
+            super().__init__(src)
+            self.pop_lock_states: list[bool] = []
+
+        def pop(self, *args, **kwargs):
+            self.pop_lock_states.append(lock.locked())
+            return super().pop(*args, **kwargs)
+
+    class _SetObserver(set):
+        def __init__(self, src):
+            super().__init__(src)
+            self.discard_lock_states: list[bool] = []
+
+        def discard(self, *args, **kwargs):
+            self.discard_lock_states.append(lock.locked())
+            return super().discard(*args, **kwargs)
+
+    scheduler.requests = _DictObserver(scheduler.requests)
+    scheduler._cancelled_request_ids = _SetObserver(scheduler._cancelled_request_ids)
+    scheduler._disconnect_abort_ids = _SetObserver(scheduler._disconnect_abort_ids)
+
+    scheduler.remove_finished_request("req-atomic-cleanup")
+
+    # Both operations must have observed the lock held — that's
+    # the codex r5 contract.
+    assert scheduler.requests.pop_lock_states == [True], (
+        scheduler.requests.pop_lock_states
+    )
+    assert scheduler._cancelled_request_ids.discard_lock_states == [True], (
+        scheduler._cancelled_request_ids.discard_lock_states
+    )
+    # Sanity: the actual cleanup happened.
+    assert "req-atomic-cleanup" not in scheduler.requests
+    assert "req-atomic-cleanup" not in scheduler._cancelled_request_ids
+
+
 def test_total_counter_does_not_double_count_redundant_abort_pre_cleanup():
     """Codex r4 BLOCKING #1: between ``_do_abort_request`` and
     ``remove_finished_request`` the request stays resident in

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -219,6 +219,85 @@ def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
     assert scheduler.get_stats()["num_requests_cancelled"] == 2
 
 
+def test_abort_request_revalidates_membership_under_lock():
+    """Codex r6 BLOCKING #1: ``abort_request`` MUST re-check
+    request membership INSIDE ``_cancel_counter_lock`` so that
+    ``remove_finished_request`` racing in (and popping
+    ``self.requests`` + clearing the ledger under the same lock)
+    can't leave ``abort_request`` to spuriously increment the
+    counter for an already-removed request.
+
+    Pre-r6-fix the predicate ran lock-free, so an abort that
+    observed the request alive could acquire the lock AFTER the
+    cleanup path ran and re-add the id to ``_pending_abort_ids``
+    + increment ``num_requests_cancelled``. Post-r6 the
+    membership check is inside the critical section.
+
+    Test approach: monkey the lock's ``__enter__`` to simulate
+    the racing ``remove_finished_request`` call THE MOMENT
+    ``abort_request`` acquires the lock — the request is removed
+    from ``self.requests`` BEFORE the inside-lock predicate
+    evaluates. Pre-r6 the abort had already committed to True
+    (predicate ran outside lock); post-r6 the inside-lock
+    predicate flips the result to False and the counter stays
+    at 0.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-stale-race")
+
+    # Wrap the lock with a class whose ``__enter__`` simulates the
+    # concurrent ``remove_finished_request`` racing in the moment
+    # ``abort_request`` acquires the lock. Pre-r6 fix the
+    # membership predicate ran outside the lock — it observed the
+    # request alive, then acquired the lock after this mutation,
+    # then re-added the id to ``_pending_abort_ids`` and bumped
+    # the counter (spurious). Post-r6 the predicate runs INSIDE
+    # the critical section and sees the cleared state.
+    real_lock = scheduler._cancel_counter_lock
+
+    class _RaceInjectingLock:
+        def __init__(self, inner):
+            self._inner = inner
+            self.injected = False
+
+        def __enter__(self):
+            self._inner.acquire()
+            # Inject ONCE per test, mirroring a single racing
+            # ``remove_finished_request`` running between this
+            # ``abort_request``'s predicate and lock acquire.
+            if not self.injected:
+                self.injected = True
+                scheduler.requests.pop("req-stale-race", None)
+                scheduler._cancelled_request_ids.discard("req-stale-race")
+                scheduler._disconnect_abort_ids.discard("req-stale-race")
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
+            return False
+
+        def locked(self):
+            return self._inner.locked()
+
+        def acquire(self, *args, **kwargs):
+            return self._inner.acquire(*args, **kwargs)
+
+        def release(self, *args, **kwargs):
+            return self._inner.release(*args, **kwargs)
+
+    scheduler._cancel_counter_lock = _RaceInjectingLock(real_lock)
+
+    # With the codex r6 fix the inside-lock predicate observes
+    # the cleared state and returns False; the counter does NOT
+    # advance.
+    result = scheduler.abort_request("req-stale-race")
+    assert result is False, (
+        "Pre-r6 fix would have returned True; the inside-lock "
+        "membership check must reject the stale id"
+    )
+    assert scheduler.get_stats()["num_requests_cancelled"] == 0
+
+
 def test_remove_finished_request_pops_and_discards_atomically():
     """Codex r5 BLOCKING: ``remove_finished_request`` must perform
     the ``self.requests.pop`` AND the dedupe-ledger discards

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -385,6 +385,188 @@ def test_force_abort_does_not_crash_when_record_method_absent():
 
 
 @pytest.mark.asyncio
+async def test_force_abort_async_fallback_does_not_attribute_on_false_result():
+    """Codex r1 BLOCKING #1: async-fallback path must await the abort
+    coroutine and skip the sub-counter when the eventual result is
+    False (unknown id rejected by the scheduler).
+
+    Pre-fix the helper called ``_record_disconnect_abort_on_scheduler``
+    immediately after ``asyncio.ensure_future(coro)`` without ever
+    inspecting ``coro``'s eventual result, so a stale holder with
+    a request_id that's already finished would leave the total
+    counter unchanged (correct — scheduler returned False) but tick
+    the via_disconnect sub-counter (wrong — would inflate the gap
+    operators rely on). The fix chains attribution on the awaited
+    coroutine result.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    records: list[str] = []
+
+    class _SyncScheduler:
+        def record_disconnect_abort(self, rid: str) -> None:
+            records.append(rid)
+
+    class _EngineCoreLike:
+        def __init__(self):
+            self.scheduler = _SyncScheduler()
+
+    class _AsyncEngineCoreLike:
+        def __init__(self):
+            self.engine = _EngineCoreLike()
+
+        async def abort_request(self, rid: str) -> bool:
+            # Scheduler-side rejection: the public abort returned
+            # False (unknown id / already finished). The sub-counter
+            # MUST NOT advance.
+            return False
+
+    class _BatchedEngineLike:
+        def __init__(self):
+            self._engine = _AsyncEngineCoreLike()
+            self._is_mllm = False
+
+        async def abort_request(self, rid: str) -> bool:
+            return await self._engine.abort_request(rid)
+
+    engine = _BatchedEngineLike()
+    holder = ["req-stale"]
+
+    fired = _force_abort_request(engine, holder)
+    # Let the chained awaiter run to completion.
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    # The helper returned False (async fallback path) AND no
+    # attribution landed because the coroutine returned False.
+    assert fired is False
+    assert records == []
+
+
+@pytest.mark.asyncio
+async def test_force_abort_async_fallback_attributes_on_true_result():
+    """Symmetric to the False case: async-fallback attribution DOES
+    fire when the awaited coroutine returns True.
+
+    This is the production text-path happy case (BatchedEngine over
+    AsyncEngineCore) — the abort is accepted by the underlying
+    scheduler, the total counter ticks, and the sub-counter
+    attributes the cause.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    records: list[str] = []
+
+    class _SyncScheduler:
+        def record_disconnect_abort(self, rid: str) -> None:
+            records.append(rid)
+
+    class _EngineCoreLike:
+        def __init__(self):
+            self.scheduler = _SyncScheduler()
+
+    class _AsyncEngineCoreLike:
+        def __init__(self):
+            self.engine = _EngineCoreLike()
+
+        async def abort_request(self, rid: str) -> bool:
+            return True  # scheduler accepted
+
+    class _BatchedEngineLike:
+        def __init__(self):
+            self._engine = _AsyncEngineCoreLike()
+            self._is_mllm = False
+
+        async def abort_request(self, rid: str) -> bool:
+            return await self._engine.abort_request(rid)
+
+    engine = _BatchedEngineLike()
+    holder = ["req-accepted"]
+
+    fired = _force_abort_request(engine, holder)
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    assert fired is False  # async-fallback returns False per contract
+    assert records == ["req-accepted"]
+
+
+def test_total_counter_atomic_against_concurrent_aborts():
+    """Codex r1 BLOCKING #2: concurrent ``abort_request`` calls for
+    the same id must not double-count.
+
+    Pre-fix the check-add-increment was not atomic: two threads
+    could both observe ``request_id not in _pending_abort_ids`` and
+    both bump the counter. With the lock the second thread sees the
+    first thread's add and skips the increment.
+
+    Uses a ``threading.Barrier`` to force all N threads into a hot
+    race rather than relying on luck — pre-fix this test would
+    catch the double-count in a small number of runs; with the lock
+    it's deterministic.
+    """
+    import threading as _threading
+
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-race")
+
+    n_threads = 32
+    barrier = _threading.Barrier(n_threads)
+    results: list[bool] = []
+    results_lock = _threading.Lock()
+
+    def race():
+        barrier.wait()
+        accepted = scheduler.abort_request("req-race")
+        with results_lock:
+            results.append(accepted)
+
+    threads = [_threading.Thread(target=race) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # All N threads return True (idempotent), but the counter must
+    # be exactly 1.
+    assert all(results)
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+
+def test_disconnect_subcounter_atomic_against_concurrent_records():
+    """Codex r1 BLOCKING #3: concurrent ``record_disconnect_abort``
+    calls for the same id must not double-count.
+
+    Pinning the helper-layer fire pattern: the disconnect_guard
+    invokes ``_force_abort_request`` from up to three branches
+    (disconnect / GeneratorExit / finally) which can be running on
+    different async tasks, each one potentially in a different
+    executor thread. Without the lock the set-membership / add /
+    increment sequence races and the sub-counter inflates.
+    """
+    import threading as _threading
+
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-race-disc")
+    scheduler.abort_request("req-race-disc")  # total = 1
+
+    n_threads = 32
+    barrier = _threading.Barrier(n_threads)
+
+    def race():
+        barrier.wait()
+        scheduler.record_disconnect_abort("req-race-disc")
+
+    threads = [_threading.Thread(target=race) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
+
+
+@pytest.mark.asyncio
 async def test_force_abort_attribution_walks_production_batched_engine_shape():
     """Production ``BatchedEngine`` over ``AsyncEngineCore`` hides the
     scheduler at ``engine._engine.engine.scheduler`` (one hop deeper

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -169,6 +169,50 @@ def test_total_counter_is_idempotent_against_double_enqueue():
     assert scheduler.get_stats()["num_requests_cancelled"] == 1
 
 
+def test_total_counter_dedupes_against_lifetime_ledger_not_pending_set():
+    """Codex r2 BLOCKING #1: the dedupe ledger must be a lifetime
+    set, not the drainable ``_pending_abort_ids``.
+
+    Pre-fix the dedupe used ``request_id in self._pending_abort_ids``.
+    ``_pending_abort_ids`` is drained every step via
+    ``_process_pending_aborts``; once drained, a later
+    ``abort_request(rid)`` for a still-resident request id (e.g.
+    while the request still lives in ``self.requests`` between the
+    first abort enqueue and the executor draining the pending set,
+    OR request_id reuse across distinct lifetimes) would see
+    ``already_pending=False`` again and double-count.
+
+    The new ledger ``_cancelled_request_ids`` is wiped only on
+    ``reset()`` (matching the prior drain treatment) and survives
+    individual abort drains.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-drain-race")
+
+    # First abort enqueues into _pending_abort_ids AND increments
+    # the counter via the new lifetime ledger.
+    assert scheduler.abort_request("req-drain-race") is True
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+    # Simulate the executor thread draining the pending set
+    # (``_process_pending_aborts`` pops every id). The lifetime
+    # ledger must NOT be touched.
+    scheduler._pending_abort_ids.clear()
+    # The request itself stays in ``self.requests`` until
+    # ``_do_abort_request`` runs — we don't simulate that here,
+    # because the failure mode codex flagged is the SECOND
+    # ``abort_request`` call landing while the request is still
+    # known (e.g. another abort source races with the drain).
+    assert "req-drain-race" in scheduler.requests
+
+    # Second abort_request for the same still-known id — passes the
+    # ``request_id in self.requests`` predicate. Pre-fix this would
+    # have bumped the counter again because the pending set was
+    # empty. Post-fix the lifetime ledger catches it.
+    assert scheduler.abort_request("req-drain-race") is True
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+
 def test_total_counter_survives_reset_unchanged():
     """``reset()`` clears in-flight aborts but NOT the lifetime counter.
 

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -476,6 +476,55 @@ def test_total_counter_dedupes_against_lifetime_ledger_not_pending_set():
     assert scheduler.get_stats()["num_requests_cancelled"] == 1
 
 
+def test_reset_clears_ledgers_after_abort_loop():
+    """Codex r8 BLOCKING #1: ``reset()`` MUST clear the
+    cancellation lifetime ledgers AFTER aborting every live
+    request, not before. Clearing before opens a window during
+    the abort loop where a concurrent ``record_disconnect_abort``
+    could either no-op (id discarded ahead of its lifetime
+    ending) or re-add the id after ``_do_abort_request`` runs
+    (the discard inside ``_do_abort_request`` would conflict).
+
+    Test approach: track the order of operations by patching
+    ``_do_abort_request`` to record when ``_cancelled_request_ids``
+    is empty. Pre-r8 the set is empty for every iteration of the
+    abort loop (cleared upfront); post-r8 the set still contains
+    the in-flight id (cleared after the loop).
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-reset-1")
+    _admit(scheduler, "req-reset-2")
+    scheduler.abort_request("req-reset-1")
+    scheduler.abort_request("req-reset-2")
+    # Pre-reset: both ids in the lifetime ledger.
+    assert "req-reset-1" in scheduler._cancelled_request_ids
+    assert "req-reset-2" in scheduler._cancelled_request_ids
+
+    # Track ledger state at the START of each _do_abort_request
+    # call during reset's loop.
+    ledger_snapshots: list[set[str]] = []
+    original_do_abort = scheduler._do_abort_request
+
+    def tracked_do_abort(rid):
+        ledger_snapshots.append(set(scheduler._cancelled_request_ids))
+        return original_do_abort(rid)
+
+    scheduler._do_abort_request = tracked_do_abort  # type: ignore[method-assign]
+
+    scheduler.reset()
+
+    # The abort loop must have observed a NON-EMPTY ledger on at
+    # least one iteration (pre-r8 fix it would be empty on every
+    # iteration because reset cleared it upfront).
+    assert any(snap for snap in ledger_snapshots), (
+        "reset() cleared the lifetime ledger BEFORE the abort loop ran; "
+        "concurrent record_disconnect_abort would have seen "
+        "inconsistent state. Snapshots: " + repr(ledger_snapshots)
+    )
+    # Post-reset: ledger is empty.
+    assert scheduler._cancelled_request_ids == set()
+
+
 def test_total_counter_survives_reset_unchanged():
     """``reset()`` clears in-flight aborts but NOT the lifetime counter.
 
@@ -1246,6 +1295,57 @@ def _fake_engine(stats: dict[str, Any]):
     return SimpleNamespace(get_stats=lambda: stats)
 
 
+def _assert_prom_counter(
+    body: str, metric_name: str, expected_value: int, help_substr: str | None = None
+) -> None:
+    """Codex r8 NIT #3: exact line-by-line assertion of a Prometheus
+    counter render (HELP, TYPE, sample), avoiding substring checks
+    that could match malformed duplicate lines.
+
+    The Prometheus text exposition format pins the line structure:
+      # HELP <name> <help_text>
+      # TYPE <name> <metric_type>
+      <name>[{labels}] <value>
+
+    We parse the body, look for those EXACT lines for the given
+    metric name, and assert (a) HELP appears exactly once, (b) TYPE
+    is ``counter`` exactly once, (c) the sample line is exactly
+    ``<name> <value>`` with the right value, and (d) the sample
+    appears exactly once. A malformed regression (duplicate series,
+    wrong type, missing newline) flips at least one of those
+    counts.
+    """
+    lines = body.splitlines()
+    help_lines = [line for line in lines if line.startswith(f"# HELP {metric_name} ")]
+    type_lines = [line for line in lines if line.startswith(f"# TYPE {metric_name} ")]
+    # Sample lines: the metric name MUST be followed by a space and
+    # the value (we don't render labels for these counters, so the
+    # ``{...}`` form is also a regression). Match by exact split,
+    # not substring.
+    sample_lines = [line for line in lines if line.split(" ", 1)[:1] == [metric_name]]
+
+    assert len(help_lines) == 1, (
+        f"Expected exactly one HELP line for {metric_name}, got {help_lines}"
+    )
+    assert len(type_lines) == 1, (
+        f"Expected exactly one TYPE line for {metric_name}, got {type_lines}"
+    )
+    assert type_lines[0].endswith(" counter"), (
+        f"Expected TYPE line to end with ' counter', got {type_lines[0]!r}"
+    )
+    assert len(sample_lines) == 1, (
+        f"Expected exactly one sample line for {metric_name}, got {sample_lines}"
+    )
+    assert sample_lines[0] == f"{metric_name} {expected_value}", (
+        f"Expected sample line {metric_name} {expected_value!r}, "
+        f"got {sample_lines[0]!r}"
+    )
+    if help_substr is not None:
+        assert help_substr in help_lines[0], (
+            f"Expected HELP line to contain {help_substr!r}, got {help_lines[0]!r}"
+        )
+
+
 _CANCEL_STATS = {
     "num_waiting": 0,
     "num_running": 0,
@@ -1260,13 +1360,20 @@ _CANCEL_STATS = {
 def test_metrics_route_renders_total_cancelled_counter(metrics_client):
     """``rapid_mlx_requests_cancelled_total`` HELP / TYPE / value all
     present and the value matches the scheduler stat.
+
+    Codex r8 NIT #3: assertion uses exact line-by-line parsing of
+    the Prometheus body so a malformed duplicate sample line
+    couldn't mask a regression.
     """
     metrics_client.cfg.engine = _fake_engine(_CANCEL_STATS)
     body = metrics_client.client.get("/metrics").text
 
-    assert "# HELP rapid_mlx_requests_cancelled_total" in body
-    assert "# TYPE rapid_mlx_requests_cancelled_total counter" in body
-    assert "rapid_mlx_requests_cancelled_total 5" in body
+    _assert_prom_counter(
+        body,
+        "rapid_mlx_requests_cancelled_total",
+        5,
+        help_substr="aborted via the scheduler abort path",
+    )
 
 
 def test_metrics_route_renders_disconnect_subcounter(metrics_client):
@@ -1276,9 +1383,12 @@ def test_metrics_route_renders_disconnect_subcounter(metrics_client):
     metrics_client.cfg.engine = _fake_engine(_CANCEL_STATS)
     body = metrics_client.client.get("/metrics").text
 
-    assert "# HELP rapid_mlx_requests_cancelled_via_disconnect_total" in body
-    assert "# TYPE rapid_mlx_requests_cancelled_via_disconnect_total counter" in body
-    assert "rapid_mlx_requests_cancelled_via_disconnect_total 3" in body
+    _assert_prom_counter(
+        body,
+        "rapid_mlx_requests_cancelled_via_disconnect_total",
+        3,
+        help_substr="attributed to client disconnect",
+    )
 
 
 def test_metrics_route_renders_zero_when_cancel_keys_missing(metrics_client):
@@ -1299,8 +1409,8 @@ def test_metrics_route_renders_zero_when_cancel_keys_missing(metrics_client):
     metrics_client.cfg.engine = _fake_engine(stats_without_cancel)
     body = metrics_client.client.get("/metrics").text
 
-    assert "rapid_mlx_requests_cancelled_total 0" in body
-    assert "rapid_mlx_requests_cancelled_via_disconnect_total 0" in body
+    _assert_prom_counter(body, "rapid_mlx_requests_cancelled_total", 0)
+    _assert_prom_counter(body, "rapid_mlx_requests_cancelled_via_disconnect_total", 0)
 
 
 def test_metrics_route_renders_zero_when_both_counters_zero(metrics_client):
@@ -1317,5 +1427,5 @@ def test_metrics_route_renders_zero_when_both_counters_zero(metrics_client):
     metrics_client.cfg.engine = _fake_engine(quiet_stats)
     body = metrics_client.client.get("/metrics").text
 
-    assert "rapid_mlx_requests_cancelled_total 0" in body
-    assert "rapid_mlx_requests_cancelled_via_disconnect_total 0" in body
+    _assert_prom_counter(body, "rapid_mlx_requests_cancelled_total", 0)
+    _assert_prom_counter(body, "rapid_mlx_requests_cancelled_via_disconnect_total", 0)

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -169,6 +169,80 @@ def test_total_counter_is_idempotent_against_double_enqueue():
     assert scheduler.get_stats()["num_requests_cancelled"] == 1
 
 
+def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
+    """Codex r3 BLOCKING #1: ``_cancelled_request_ids`` is an
+    ACTIVE-LIFETIME guard, not a process-lifetime ledger. Reusing the
+    same ``request_id`` for a NEW distinct request (after the prior
+    lifetime fully aborted AND was popped from ``self.requests``) MUST
+    increment the counter.
+
+    Pre-r3-fix the lifetime ledger persisted until ``reset()``, so
+    integrations that hash request_ids deterministically (or clients
+    that retry the same operation with a stable id) would silently
+    see their second cancel omitted from ``num_requests_cancelled``.
+    The r3 fix discards the id from BOTH dedupe ledgers inside
+    ``_do_abort_request`` so a future request with the same id
+    starts from a clean ledger.
+
+    Lifecycle: ``_do_abort_request`` clears the deduper but the text
+    scheduler keeps the ``Request`` object in ``self.requests`` until
+    a separate ``remove_finished_request`` call removes it (the
+    engine_core cleanup path). We drive that explicitly here to
+    mirror the production order — only AFTER the request is fully
+    out of the scheduler will the abort_request predicate take
+    the ``not in self.requests`` branch and require a fresh admit.
+    """
+    scheduler = _make_scheduler()
+
+    # First lifetime: admit, cancel, drain, cleanup.
+    _admit(scheduler, "req-reused")
+    assert scheduler.abort_request("req-reused") is True
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+    scheduler._process_pending_aborts()
+    # The r3 fix: ``_cancelled_request_ids`` is empty for this id
+    # even though ``self.requests`` may still hold the finished
+    # ``Request`` object.
+    assert "req-reused" not in scheduler._cancelled_request_ids
+    # Engine-core cleanup: remove the finished request from the
+    # scheduler's request map so the next admit doesn't collide.
+    scheduler.remove_finished_request("req-reused")
+    assert "req-reused" not in scheduler.requests
+
+    # Second lifetime: distinct request, same id.
+    _admit(scheduler, "req-reused")
+    assert scheduler.abort_request("req-reused") is True
+    # MUST count again — the new request is a distinct cancel.
+    assert scheduler.get_stats()["num_requests_cancelled"] == 2
+
+
+def test_disconnect_subcounter_counts_reused_request_id_after_full_abort_cycle():
+    """Codex r3 BLOCKING #2 symmetry: the via_disconnect sub-counter
+    must also re-count a reused ``request_id`` after the prior
+    lifetime completed.
+
+    Same rationale as the total counter — keeping the id in
+    ``_disconnect_abort_ids`` past the request's lifetime would
+    silently swallow attribution for the next distinct request.
+    """
+    scheduler = _make_scheduler()
+
+    # First lifetime: full cancel cycle with disconnect attribution.
+    _admit(scheduler, "req-disc-reused")
+    scheduler.abort_request("req-disc-reused")
+    scheduler.record_disconnect_abort("req-disc-reused")
+    assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
+    scheduler._process_pending_aborts()
+    # Discarded by _do_abort_request.
+    assert "req-disc-reused" not in scheduler._disconnect_abort_ids
+    scheduler.remove_finished_request("req-disc-reused")
+
+    # Second lifetime: distinct request reusing the id.
+    _admit(scheduler, "req-disc-reused")
+    scheduler.abort_request("req-disc-reused")
+    scheduler.record_disconnect_abort("req-disc-reused")
+    assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 2
+
+
 def test_total_counter_dedupes_against_lifetime_ledger_not_pending_set():
     """Codex r2 BLOCKING #1: the dedupe ledger must be a lifetime
     set, not the drainable ``_pending_abort_ids``.

--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -1,0 +1,736 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Observability tests for the M-01 cancelled-requests counter.
+
+Background
+----------
+Mei r0.8.1 and Yana r3 both flagged that ``/metrics`` reported
+``rapid_mlx_requests_processed_total = 0`` after fifty client-cancelled
+streaming requests. ``num_requests_processed`` deliberately excludes
+aborted requests (a request that never produced an EOS-bounded response
+shouldn't be billed as "completed"), so operators staring at the
+counter-of-record can't distinguish "model is idle" from "every caller
+is bailing out before EOS". That's the M-01 gap.
+
+The fix exposes two new scheduler counters via ``Scheduler.get_stats()``
+and ``Scheduler`` MLLM-twin, rendered as Prometheus counters in
+``routes/metrics.py``:
+
+* ``rapid_mlx_requests_cancelled_total`` — +1 per public-API abort the
+  scheduler accepted (client disconnect, explicit cancel route,
+  timeout, or internal abort), once per ``request_id`` irrespective of
+  how many idempotent re-enqueues fire.
+* ``rapid_mlx_requests_cancelled_via_disconnect_total`` — sub-counter
+  attributing the subset triggered through the disconnect_guard
+  ``_force_abort_request`` path, so the (total - disconnect) gap
+  surfaces explicit-cancel + timeout traffic for capacity planning.
+
+These are observability-only counters. ``Scheduler.abort_request`` and
+``_force_abort_request`` semantics are unchanged — the counters bolt on
+to existing returns. Defaults to zero on engines that never see an
+abort so dashboards never flip to "no data" after a deploy (mirrors the
+M-02 PFlash flat-line treatment).
+
+The tests below cover four behavioural surfaces:
+
+1. **Scheduler-side total counter** — increments once per accepted
+   abort, never on rejected unknown-id aborts, idempotent against
+   double-enqueue of the same id, and surfaced through ``get_stats``.
+2. **Scheduler-side disconnect sub-counter** — bumps only when
+   ``record_disconnect_abort`` is invoked, deduplicated by
+   ``_disconnect_abort_ids`` so the three-branch helper-layer fire
+   (disconnect + GeneratorExit + finally) attributes once per request.
+3. **End-to-end disconnect_guard** — `_force_abort_request` calls
+   `scheduler.abort_request` AND `scheduler.record_disconnect_abort`,
+   driving both counters to +N for N aborted requests. Three streaming
+   requests aborted via raw httpx aclose → counter = 3; two requests
+   that complete normally → counter unchanged.
+4. **Route-side Prometheus render** — both counters surface with
+   correct HELP/TYPE lines, zero-default when the keys are absent
+   (older engines), and stable monotonic values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers — real scheduler driven without the live model
+# ---------------------------------------------------------------------------
+
+
+class _DummyTokenizer:
+    eos_token_id = None
+
+    def encode(self, prompt):
+        if isinstance(prompt, str):
+            return [ord(c) for c in prompt]
+        return list(prompt)
+
+    def decode(self, token_ids):
+        return "".join(chr(t) for t in token_ids)
+
+
+def _make_scheduler() -> Scheduler:
+    """Build a real ``Scheduler`` against an identity tokenizer.
+
+    Mirrors the helper in ``test_pflash_metrics.py`` so the M-01
+    counters are exercised by the same scheduler entry points that
+    serve production traffic.
+    """
+    return Scheduler(
+        model=object(),
+        tokenizer=_DummyTokenizer(),
+        config=SchedulerConfig(
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+        ),
+    )
+
+
+def _admit(scheduler: Scheduler, request_id: str) -> None:
+    """Push a request into the scheduler so ``abort_request`` will
+    consider its ``request_id`` "known" via ``self.requests``.
+
+    The scheduler's abort gate returns False for an unknown id, so
+    every "abort that should count" must first appear in this dict.
+    """
+    request = Request(request_id, list(range(8)), SamplingParams(max_tokens=4))
+    scheduler.add_request(request)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler-side: total counter
+# ---------------------------------------------------------------------------
+
+
+def test_total_counter_starts_at_zero():
+    """Fresh scheduler exposes both counters at zero through ``get_stats``.
+
+    Dashboard panels treat an absent series as "no data" and trigger
+    spurious alerts after a deploy; we always want a flat-line zero
+    instead.
+    """
+    scheduler = _make_scheduler()
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 0
+    assert stats["num_requests_cancelled_via_disconnect"] == 0
+
+
+def test_total_counter_increments_once_per_accepted_abort():
+    """Three known request_ids aborted → counter = 3.
+
+    Sanity check that the counter advances per public-API abort, not
+    per token or per batch step.
+    """
+    scheduler = _make_scheduler()
+    for index in range(3):
+        request_id = f"req-{index}"
+        _admit(scheduler, request_id)
+        assert scheduler.abort_request(request_id) is True
+    assert scheduler.get_stats()["num_requests_cancelled"] == 3
+
+
+def test_total_counter_not_bumped_for_unknown_request_id():
+    """``abort_request`` returns False for unknown ids and the
+    counter does NOT advance.
+
+    F-151 hardening: an attacker who pokes random ids must not be
+    able to inflate the counter (it would be a free signal that
+    /metrics is observable; more importantly, it would corrupt the
+    series and trigger false alarms).
+    """
+    scheduler = _make_scheduler()
+    assert scheduler.abort_request("nonexistent-request-id") is False
+    assert scheduler.get_stats()["num_requests_cancelled"] == 0
+
+
+def test_total_counter_is_idempotent_against_double_enqueue():
+    """Two ``abort_request`` calls for the same id → counter = 1.
+
+    The scheduler is intentionally idempotent against double-enqueue
+    (``Scheduler.abort_request`` docstring) because the disconnect
+    guard fires from multiple branches per request. Without the de-dup
+    gate the counter would double-count every disconnect-triggered
+    abort.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-double")
+    assert scheduler.abort_request("req-double") is True
+    assert scheduler.abort_request("req-double") is True  # idempotent
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+
+def test_total_counter_survives_reset_unchanged():
+    """``reset()`` clears in-flight aborts but NOT the lifetime counter.
+
+    Prometheus counters MUST be monotonic — a step backward would be
+    interpreted as a process restart and corrupt rate() / increase()
+    calculations on the scraper side.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-pre-reset")
+    scheduler.abort_request("req-pre-reset")
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+    scheduler.reset()
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Scheduler-side: disconnect sub-counter
+# ---------------------------------------------------------------------------
+
+
+def test_disconnect_sub_counter_bumps_on_record_call():
+    """``record_disconnect_abort`` advances the sub-counter."""
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-disc")
+    scheduler.abort_request("req-disc")
+    scheduler.record_disconnect_abort("req-disc")
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 1
+    assert stats["num_requests_cancelled_via_disconnect"] == 1
+
+
+def test_disconnect_sub_counter_dedupes_per_request_id():
+    """Three ``record_disconnect_abort`` calls for the same id → sub = 1.
+
+    The disconnect_guard fires ``_force_abort_request`` from the
+    ``if disconnect_task in done`` branch, the ``except GeneratorExit``
+    branch, AND the ``finally`` belt-and-suspenders. Without the
+    per-id de-dup the sub-counter would over-count by up to 3x per
+    disconnect event.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-multi")
+    scheduler.abort_request("req-multi")
+    scheduler.record_disconnect_abort("req-multi")
+    scheduler.record_disconnect_abort("req-multi")
+    scheduler.record_disconnect_abort("req-multi")
+    assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
+
+
+def test_disconnect_sub_counter_silent_on_empty_request_id():
+    """Empty string / None ``request_id`` is a no-op, not a crash.
+
+    The disconnect_guard sometimes invokes ``_force_abort_request``
+    with an empty holder (engine cancelled before ``add_request``
+    returned). The helper must swallow that path silently rather than
+    propagate the no-op into the live disconnect flow.
+    """
+    scheduler = _make_scheduler()
+    scheduler.record_disconnect_abort("")
+    scheduler.record_disconnect_abort(None)  # type: ignore[arg-type]
+    assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 0
+
+
+def test_disconnect_sub_counter_decoupled_from_total():
+    """An explicit cancel (no disconnect attribution) leaves the
+    sub-counter at zero.
+
+    The total counter ticks on every accepted abort; the sub-counter
+    only ticks when ``_force_abort_request`` (disconnect path) was
+    the trigger. The (total - via_disconnect) gap is the operator's
+    signal for explicit-cancel + timeout traffic — if the sub-counter
+    were entangled with the total this gap would always be zero.
+    """
+    scheduler = _make_scheduler()
+    _admit(scheduler, "req-explicit")
+    scheduler.abort_request("req-explicit")  # explicit cancel route
+    # No ``record_disconnect_abort`` call.
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 1
+    assert stats["num_requests_cancelled_via_disconnect"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Helper-layer: _force_abort_request feeds both counters end-to-end
+# ---------------------------------------------------------------------------
+
+
+class _CountingScheduler:
+    """Real-shaped scheduler stand-in that records both the public-API
+    abort and the disconnect attribution call.
+
+    Lets the helper-layer test pin the exact contract between
+    ``_force_abort_request`` and the scheduler-side counters without
+    spinning up a full scheduler + tokenizer.
+    """
+
+    def __init__(self):
+        self.aborts: list[str] = []
+        self.disconnect_records: list[str] = []
+
+    def abort_request(self, request_id: str) -> bool:
+        self.aborts.append(request_id)
+        return True
+
+    def record_disconnect_abort(self, request_id: str) -> None:
+        self.disconnect_records.append(request_id)
+
+
+class _Engine:
+    """Engine stub that exposes ``scheduler`` directly (the simple
+    pre-BatchedEngine shape ``_resolve_sync_scheduler_for_abort``
+    matches first).
+    """
+
+    def __init__(self):
+        self.scheduler = _CountingScheduler()
+
+
+def test_force_abort_bumps_disconnect_subcounter():
+    """``_force_abort_request`` calls ``record_disconnect_abort``
+    once after a successful sync abort.
+
+    This is the contract that ties the helper-layer disconnect path
+    to the scheduler-side sub-counter; deleting the
+    ``_record_disconnect_abort_on_scheduler`` call would silently
+    drop the attribution and the operator's "via disconnect" series
+    would stay flat through real disconnects.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    engine = _Engine()
+    holder = ["req-disconnect"]
+
+    fired = _force_abort_request(engine, holder)
+
+    assert fired is True
+    assert engine.scheduler.aborts == ["req-disconnect"]
+    assert engine.scheduler.disconnect_records == ["req-disconnect"]
+
+
+def test_force_abort_does_not_record_when_sync_abort_rejected():
+    """If ``abort_request`` returned False (unknown id), the helper
+    must NOT call ``record_disconnect_abort``.
+
+    Pre-fix candidate bug: a helper that records unconditionally
+    would inflate the sub-counter every time a stale holder fires
+    through ``_force_abort_request`` (e.g. when the request finished
+    before the disconnect_guard tore down). The total counter is
+    already protected against this by ``Scheduler.abort_request``
+    returning False for unknown ids; the helper must propagate that
+    gate to the sub-counter or the two series will drift.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _RejectingScheduler:
+        def __init__(self):
+            self.disconnect_records: list[str] = []
+
+        def abort_request(self, request_id: str) -> bool:
+            return False  # unknown id — F-151 path
+
+        def record_disconnect_abort(self, request_id: str) -> None:
+            self.disconnect_records.append(request_id)
+
+    class _RejectingEngine:
+        def __init__(self):
+            self.scheduler = _RejectingScheduler()
+
+    engine = _RejectingEngine()
+    holder = ["req-unknown"]
+
+    fired = _force_abort_request(engine, holder)
+
+    # The sync abort entry returned False but the helper still
+    # returns True per its docstring (it DID dispatch). The
+    # sub-counter, however, must NOT advance.
+    assert fired is True
+    assert engine.scheduler.disconnect_records == []
+
+
+def test_force_abort_does_not_crash_when_record_method_absent():
+    """Older schedulers without ``record_disconnect_abort`` continue
+    to work — the helper swallows ``AttributeError`` silently and
+    the total counter alone keeps surfacing the abort.
+
+    Critical because the helper layer sits across a public API
+    surface that downstream forks / external schedulers depend on.
+    A regression here would break every non-rapid_mlx scheduler.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _LegacyScheduler:
+        def __init__(self):
+            self.aborts: list[str] = []
+
+        def abort_request(self, request_id: str) -> bool:
+            self.aborts.append(request_id)
+            return True
+
+        # NB: no record_disconnect_abort.
+
+    class _LegacyEngine:
+        def __init__(self):
+            self.scheduler = _LegacyScheduler()
+
+    engine = _LegacyEngine()
+    holder = ["req-legacy"]
+
+    fired = _force_abort_request(engine, holder)
+
+    assert fired is True
+    assert engine.scheduler.aborts == ["req-legacy"]
+
+
+@pytest.mark.asyncio
+async def test_force_abort_attribution_walks_production_batched_engine_shape():
+    """Production ``BatchedEngine`` over ``AsyncEngineCore`` hides the
+    scheduler at ``engine._engine.engine.scheduler`` (one hop deeper
+    than the abort resolver covers, because ``AsyncEngineCore`` wraps
+    ``EngineCore`` via ``self.engine``).
+
+    The attribution resolver MUST dig the extra hop or the
+    via_disconnect sub-counter stays flat through every real
+    production disconnect — which is the exact symptom Mei + Yana
+    flagged the cancel-rate counter for in the first place. A static
+    introspection / unit-test wins; the alternative is to ship the
+    fix and discover via dashboards two weeks later that the gap is
+    always 100% of total.
+
+    The production sync abort path falls through to the async
+    fallback (also covered by the helper now), but the attribution
+    must still land on the right scheduler so the (total -
+    via_disconnect) gap reflects reality.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncScheduler:
+        def __init__(self):
+            self.disconnect_records: list[str] = []
+            self._async_abort_calls: list[str] = []
+
+        def record_disconnect_abort(self, request_id: str) -> None:
+            self.disconnect_records.append(request_id)
+
+    class _EngineCoreLike:
+        """Mirrors the production ``EngineCore`` shape — owns the
+        scheduler directly."""
+
+        def __init__(self):
+            self.scheduler = _SyncScheduler()
+
+    class _AsyncEngineCoreLike:
+        """Production-shaped ``AsyncEngineCore`` — has ``.engine``
+        (the inner ``EngineCore``) but NO direct ``.scheduler``,
+        and exposes an ``async abort_request`` shim that lands on
+        ``self.engine.engine.abort_request`` in production. Crucially
+        the helper's sync-abort resolver returns ``None`` here, so
+        the async fallback fires (matching the production text path).
+        """
+
+        def __init__(self):
+            self.engine = _EngineCoreLike()
+
+        async def abort_request(self, request_id: str) -> bool:
+            # Production-fidelity: the async shim ultimately reaches
+            # ``self.engine.scheduler.abort_request`` (sync).
+            self.engine.scheduler._async_abort_calls.append(request_id)
+            return True
+
+    class _BatchedEngineLike:
+        def __init__(self):
+            self._engine = _AsyncEngineCoreLike()
+            self._is_mllm = False
+
+        async def abort_request(self, request_id: str) -> bool:
+            return await self._engine.abort_request(request_id)
+
+    engine = _BatchedEngineLike()
+    holder = ["req-prod-shape"]
+
+    fired = _force_abort_request(engine, holder)
+    # Drain the fire-and-forget task the helper queued via
+    # ``asyncio.ensure_future`` so the test doesn't trip the
+    # "Task was destroyed but it is pending" runtime warning. The
+    # production code intentionally fires-and-forgets (operators see
+    # the WARNING log) — the test owns the loop, so we drain.
+    await asyncio.sleep(0)
+
+    # The sync resolver returned None (no sync abort path), so the
+    # helper hits the async fallback branch and returns False per
+    # the docstring contract.
+    assert fired is False
+    # But the attribution MUST still have landed — that's the bug
+    # we're guarding against.
+    assert engine._engine.engine.scheduler.disconnect_records == ["req-prod-shape"]
+
+
+def test_force_abort_attribution_walks_active_backend():
+    """Cancel-attribution resolver respects ``_is_mllm`` like the abort
+    resolver — text-active engines record on ``_engine.scheduler``,
+    MLLM-active engines on ``_mllm_scheduler``.
+
+    The codex r2 BLOCKING #1 finding on PR #777 pinned this for the
+    abort resolver; the attribution resolver must follow the same
+    rule or it would bump the sub-counter on the wrong scheduler.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _SyncSched:
+        def __init__(self, name):
+            self.name = name
+            self.aborts: list[str] = []
+            self.disconnect_records: list[str] = []
+
+        def abort_request(self, request_id: str) -> bool:
+            self.aborts.append(request_id)
+            return True
+
+        def record_disconnect_abort(self, request_id: str) -> None:
+            self.disconnect_records.append(request_id)
+
+    class _Inner:
+        def __init__(self):
+            self.scheduler = _SyncSched("text")
+
+    class _DualEngine:
+        def __init__(self, is_mllm: bool):
+            self._is_mllm = is_mllm
+            self._engine = _Inner()
+            self._mllm_scheduler = _SyncSched("mllm")
+
+    # Text path
+    text_engine = _DualEngine(is_mllm=False)
+    _force_abort_request(text_engine, ["req-text"])
+    assert text_engine._engine.scheduler.disconnect_records == ["req-text"]
+    assert text_engine._mllm_scheduler.disconnect_records == []
+
+    # MLLM path
+    mllm_engine = _DualEngine(is_mllm=True)
+    _force_abort_request(mllm_engine, ["req-mllm"])
+    assert mllm_engine._mllm_scheduler.disconnect_records == ["req-mllm"]
+    assert mllm_engine._engine.scheduler.disconnect_records == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: streaming-route abort drives both counters via TestClient
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_three_aborted_streaming_requests_advance_counters_by_three():
+    """Fire 3 streaming requests through ``_disconnect_guard`` and
+    abort each via ``GeneratorExit``. The total counter and the
+    disconnect sub-counter both increment by 3.
+
+    This is the headline behaviour Mei r0.8.1 / Yana r3 asked for:
+    aborted streams MUST be visible in /metrics so operators see the
+    cancel-rate. Pre-fix the counters didn't exist; post-fix the test
+    pins the +N contract.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _Engine()
+
+    aborted_holders: list[list[str]] = []
+    for i in range(3):
+        holder = [f"req-stream-{i}"]
+        aborted_holders.append(holder)
+
+        async def upstream():
+            yield 'data: {"chunk":"hello"}\n\n'
+            # Wait long enough that GeneratorExit reaches us before
+            # the upstream exhausts naturally.
+            await asyncio.sleep(60)
+            yield "data: [DONE]\n\n"
+
+        class _NeverDisconnects:
+            async def is_disconnected(self) -> bool:
+                return False
+
+        guard = _disconnect_guard(
+            upstream(),
+            _NeverDisconnects(),
+            poll_interval=0.05,
+            engine=engine,
+            request_id_holder=holder,
+            keepalive_seconds=0,
+        )
+
+        # Pull one chunk then close — simulates Starlette tearing
+        # down the StreamingResponse mid-stream (Astrid r3 fingerprint).
+        agen = guard.__aiter__()
+        await agen.__anext__()
+        await agen.aclose()
+
+    # All three request_ids should be in the scheduler's abort list
+    # AND the disconnect-attribution list. De-dup guarantees one
+    # entry per id even when the helper fires from multiple branches.
+    accepted_aborts = sorted(set(engine.scheduler.aborts))
+    accepted_records = sorted(set(engine.scheduler.disconnect_records))
+    assert accepted_aborts == [
+        "req-stream-0",
+        "req-stream-1",
+        "req-stream-2",
+    ]
+    assert accepted_records == [
+        "req-stream-0",
+        "req-stream-1",
+        "req-stream-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_two_completed_streaming_requests_leave_counter_unchanged():
+    """Streams that exhaust normally do NOT advance the cancellation
+    counters.
+
+    ``_disconnect_guard.finally`` has a ``finished_normally`` flag
+    (codex r1 NIT #3 on PR #777) that skips the belt-and-suspenders
+    force-abort when the upstream drained cleanly via
+    ``StopAsyncIteration``. Without that gate the cancellation
+    counter would tick once per completed request and the operator's
+    "cancel rate" panel would look like "100% of traffic" — useless.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine = _Engine()
+
+    for i in range(2):
+        holder = [f"req-clean-{i}"]
+
+        async def upstream():
+            yield 'data: {"chunk":"a"}\n\n'
+            yield 'data: {"chunk":"b"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        class _NeverDisconnects:
+            async def is_disconnected(self) -> bool:
+                return False
+
+        guard = _disconnect_guard(
+            upstream(),
+            _NeverDisconnects(),
+            poll_interval=0.05,
+            engine=engine,
+            request_id_holder=holder,
+            keepalive_seconds=0,
+        )
+
+        chunks = []
+        async for chunk in guard:
+            chunks.append(chunk)
+        # Sanity: the consumer pulled the full stream.
+        assert "[DONE]" in chunks[-1]
+
+    # Neither counter should have moved.
+    assert engine.scheduler.aborts == []
+    assert engine.scheduler.disconnect_records == []
+
+
+# ---------------------------------------------------------------------------
+# Route-side: counters surface in the /metrics Prometheus body
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def metrics_client():
+    """FastAPI TestClient mounting only the metrics router.
+
+    Mirrors ``test_metrics_route.metrics_client`` and ``test_pflash_
+    metrics.metrics_client`` so the M-01 counters are exercised
+    through the same render path as every other series.
+    """
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+
+    cfg = reset_config()
+    cfg.model_name = "qwen3-0.6b"
+    _reset_accumulator_for_tests()
+
+    app = FastAPI()
+    app.include_router(router)
+    yield SimpleNamespace(client=TestClient(app), cfg=cfg)
+    reset_config()
+    _reset_accumulator_for_tests()
+
+
+def _fake_engine(stats: dict[str, Any]):
+    return SimpleNamespace(get_stats=lambda: stats)
+
+
+_CANCEL_STATS = {
+    "num_waiting": 0,
+    "num_running": 0,
+    "num_requests_processed": 0,
+    "total_prompt_tokens": 0,
+    "total_completion_tokens": 0,
+    "num_requests_cancelled": 5,
+    "num_requests_cancelled_via_disconnect": 3,
+}
+
+
+def test_metrics_route_renders_total_cancelled_counter(metrics_client):
+    """``rapid_mlx_requests_cancelled_total`` HELP / TYPE / value all
+    present and the value matches the scheduler stat.
+    """
+    metrics_client.cfg.engine = _fake_engine(_CANCEL_STATS)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "# HELP rapid_mlx_requests_cancelled_total" in body
+    assert "# TYPE rapid_mlx_requests_cancelled_total counter" in body
+    assert "rapid_mlx_requests_cancelled_total 5" in body
+
+
+def test_metrics_route_renders_disconnect_subcounter(metrics_client):
+    """``rapid_mlx_requests_cancelled_via_disconnect_total`` HELP /
+    TYPE / value all present and the value matches the scheduler stat.
+    """
+    metrics_client.cfg.engine = _fake_engine(_CANCEL_STATS)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "# HELP rapid_mlx_requests_cancelled_via_disconnect_total" in body
+    assert "# TYPE rapid_mlx_requests_cancelled_via_disconnect_total counter" in body
+    assert "rapid_mlx_requests_cancelled_via_disconnect_total 3" in body
+
+
+def test_metrics_route_renders_zero_when_cancel_keys_missing(metrics_client):
+    """Engines without the M-01 keys render flat-line zero rather than
+    omit the series.
+
+    Older non-rapid_mlx schedulers (downstream forks, custom backends)
+    may not populate the keys at all. Dashboards configured against
+    these series must not flip to "no data".
+    """
+    stats_without_cancel = {
+        "num_requests_processed": 1,
+        "total_prompt_tokens": 100,
+        "total_completion_tokens": 5,
+        "num_running": 0,
+        "num_waiting": 0,
+    }
+    metrics_client.cfg.engine = _fake_engine(stats_without_cancel)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_requests_cancelled_total 0" in body
+    assert "rapid_mlx_requests_cancelled_via_disconnect_total 0" in body
+
+
+def test_metrics_route_renders_zero_when_both_counters_zero(metrics_client):
+    """Quiet engine — both counters render at zero (not absent)."""
+    quiet_stats = {
+        "num_waiting": 0,
+        "num_running": 0,
+        "num_requests_processed": 0,
+        "total_prompt_tokens": 0,
+        "total_completion_tokens": 0,
+        "num_requests_cancelled": 0,
+        "num_requests_cancelled_via_disconnect": 0,
+    }
+    metrics_client.cfg.engine = _fake_engine(quiet_stats)
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_requests_cancelled_total 0" in body
+    assert "rapid_mlx_requests_cancelled_via_disconnect_total 0" in body

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -542,6 +542,14 @@ class MLLMScheduler:
 
         self._detokenizer_pool.pop(request_id, None)
 
+        # M-01 codex r3 BLOCKING #2: discard the active-lifetime
+        # dedupe ledgers so request_id reuse for a NEW distinct
+        # request counts correctly. See the same block in
+        # ``Scheduler._do_abort_request`` for the full rationale.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request_id)
+            self._disconnect_abort_ids.discard(request_id)
+
         # Do NOT write to output_queues here — this may run on the
         # executor thread where asyncio.Queue is not safe.  Mark for
         # signaling on the event loop thread via _distribute_outputs.

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -20,6 +20,7 @@ Architecture:
 
 import asyncio
 import logging
+import threading
 import time
 import uuid
 from collections import deque
@@ -253,6 +254,14 @@ class MLLMScheduler:
         # needs its own de-dup set instead of leaning on
         # ``_pending_abort_ids`` which drains every step.
         self._disconnect_abort_ids: set[str] = set()
+        # M-01 codex r1 BLOCKING #4/#5: same atomicity rationale as
+        # ``Scheduler._cancel_counter_lock`` — the check-add-increment
+        # for both the total and via_disconnect counters must be
+        # serialized across threads. MLLM-active engines reach this
+        # path from the same disconnect_guard multi-branch fire AND
+        # the explicit cancel route, so the concurrency surface is
+        # identical.
+        self._cancel_counter_lock = threading.Lock()
         # Aborted request IDs that need queue signaling (executor → event loop).
         self._aborted_queue_ids: set[str] = set()
 
@@ -443,15 +452,18 @@ class MLLMScheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
-            # M-01: count only when the id was NOT already pending —
-            # see ``Scheduler.abort_request`` for the de-dup rationale.
-            # Concurrent disconnect_guard + engine_core cleanup paths
-            # both enqueue the same id; without the gate the counter
-            # would double-count every disconnect-triggered abort.
-            already_pending = request_id in self._pending_abort_ids
-            self._pending_abort_ids.add(request_id)
-            if not already_pending:
-                self.num_requests_cancelled += 1
+            # M-01 codex r1 BLOCKING #4: serialize the
+            # check-add-increment under ``_cancel_counter_lock`` so
+            # concurrent abort callers (disconnect_guard's three
+            # branches + explicit /cancel + engine_core cleanup) can't
+            # both observe ``already_pending=False`` and double-count
+            # the same id. See ``Scheduler.abort_request`` for the
+            # full thread-safety rationale.
+            with self._cancel_counter_lock:
+                already_pending = request_id in self._pending_abort_ids
+                self._pending_abort_ids.add(request_id)
+                if not already_pending:
+                    self.num_requests_cancelled += 1
             logger.debug(f"Enqueued abort for request {request_id}")
             return True
         logger.debug("Rejected abort for unknown MLLM request_id")
@@ -463,12 +475,16 @@ class MLLMScheduler:
         Mirrors ``Scheduler.record_disconnect_abort`` so MLLM-active
         engines surface the same ``via_disconnect`` sub-counter on
         /metrics. See that method's docstring for the once-per-request
-        semantics and thread-safety contract.
+        semantics, lock-based atomicity contract (codex r1 BLOCKING
+        #5), and thread-safety guarantees.
         """
         try:
-            if request_id and request_id not in self._disconnect_abort_ids:
-                self._disconnect_abort_ids.add(request_id)
-                self.num_requests_cancelled_via_disconnect += 1
+            if not request_id:
+                return
+            with self._cancel_counter_lock:
+                if request_id not in self._disconnect_abort_ids:
+                    self._disconnect_abort_ids.add(request_id)
+                    self.num_requests_cancelled_via_disconnect += 1
         except Exception:  # pragma: no cover - belt-and-suspenders
             pass
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -544,33 +544,22 @@ class MLLMScheduler:
         if request is not None:
             request.status = RequestStatus.FINISHED_ABORTED
         self.finished_req_ids.add(request_id)
-        # M-01 codex r7 BLOCKING #1 analysis: MLLM's
-        # ``_do_abort_request`` does ``self.requests.pop`` itself
-        # (next line), so the active maps are ALREADY clean by the
-        # time we hit the dedupe-ledger discard below. Any
-        # concurrent ``abort_request`` racing through the inside-
-        # lock predicate (codex r6 fix) would observe
-        # ``request_id not in self.requests`` and return False
-        # before touching the ledger — so the discard
-        # placement here is race-safe. We keep it INSIDE
-        # ``_do_abort_request`` (rather than mirroring the text
-        # path's ``remove_finished_request`` indirection) because
-        # MLLM's lifecycle is intentionally in-line in this
-        # method, and the multiple pop sites (lines 805, 1216,
-        # 969) would otherwise need parallel discards. The
-        # text scheduler's ``remove_finished_request`` is the
-        # ONLY external-to-_do_abort_request pop boundary on
-        # that path; MLLM's analog doesn't exist as a single
-        # external entry point.
-        self.requests.pop(request_id, None)
 
-        self._detokenizer_pool.pop(request_id, None)
-
-        # M-01 codex r3 BLOCKING #2: discard the active-lifetime
-        # dedupe ledgers so request_id reuse for a NEW distinct
-        # request counts correctly. Atomic against the inside-
-        # lock predicate in ``abort_request`` (codex r6 fix).
+        # M-01 codex r8 BLOCKING #2: pop ``self.requests`` AND
+        # discard the cancellation lifetime ledgers under the SAME
+        # critical section. Pre-r8 the pop ran outside the lock,
+        # leaving a window where a concurrent ``abort_request``
+        # acquiring the lock could observe inconsistent state
+        # across ``self.requests`` / ``request_id_to_uid`` /
+        # ``running`` / ``_pending_abort_ids``. With both inside
+        # the lock, any concurrent abort-path predicate (codex r6
+        # fix: also inside the lock) sees a consistent
+        # transition — either everything pre-cleanup or
+        # everything post-cleanup. Detokenizer pool pop also
+        # joins the section for symmetric ordering.
         with self._cancel_counter_lock:
+            self.requests.pop(request_id, None)
+            self._detokenizer_pool.pop(request_id, None)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
 
@@ -1297,11 +1286,17 @@ class MLLMScheduler:
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
-        # M-01 codex r2: drop the cancellation lifetime ledgers
+        # M-01 codex r2/r8: drop the cancellation lifetime ledgers
         # alongside the in-flight state. The Prometheus counters
         # themselves are NOT zeroed (lifetime-cumulative contract).
-        self._cancelled_request_ids.clear()
-        self._disconnect_abort_ids.clear()
+        # Codex r8 BLOCKING #1 ordering: clear AFTER the abort loop
+        # so a concurrent ``record_disconnect_abort`` for an
+        # in-flight request can't interleave inconsistently, AND
+        # under the lock so the clear is atomic against any
+        # concurrent abort-path mutation.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.clear()
+            self._disconnect_abort_ids.clear()
 
         if self.batch_generator is not None:
             self.batch_generator.close()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -453,27 +453,27 @@ class MLLMScheduler:
         # running, or already pending abort (idempotent double-cancel). We
         # do NOT count ``finished_req_ids`` — the route contract is
         # "404 when already finished".
-        if (
-            request_id in self.requests
-            or request_id in self.request_id_to_uid
-            or request_id in self.running
-            or request_id in self._pending_abort_ids
-        ):
-            # M-01 codex r1 BLOCKING #4 + r2 BLOCKING #2: serialize
-            # the check-add-increment AND dedupe against the lifetime
-            # ledger ``_cancelled_request_ids`` rather than the
-            # drainable ``_pending_abort_ids``. See
-            # ``Scheduler.abort_request`` for the full rationale.
-            with self._cancel_counter_lock:
-                already_counted = request_id in self._cancelled_request_ids
-                self._cancelled_request_ids.add(request_id)
-                self._pending_abort_ids.add(request_id)
-                if not already_counted:
-                    self.num_requests_cancelled += 1
-            logger.debug(f"Enqueued abort for request {request_id}")
-            return True
-        logger.debug("Rejected abort for unknown MLLM request_id")
-        return False
+        # M-01 codex r1 BLOCKING #4 + r2 BLOCKING #2 + r6 BLOCKING #2:
+        # membership check AND check-add-increment serialized under
+        # the same lock to close the stale-admission race against
+        # ``_do_abort_request`` clearing the dedupe ledgers. See
+        # ``Scheduler.abort_request`` for the full rationale.
+        with self._cancel_counter_lock:
+            if not (
+                request_id in self.requests
+                or request_id in self.request_id_to_uid
+                or request_id in self.running
+                or request_id in self._pending_abort_ids
+            ):
+                logger.debug("Rejected abort for unknown MLLM request_id")
+                return False
+            already_counted = request_id in self._cancelled_request_ids
+            self._cancelled_request_ids.add(request_id)
+            self._pending_abort_ids.add(request_id)
+            if not already_counted:
+                self.num_requests_cancelled += 1
+        logger.debug(f"Enqueued abort for request {request_id}")
+        return True
 
     def record_disconnect_abort(self, request_id: str) -> None:
         """M-01: attribute a previously-accepted abort to client disconnect.

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -246,6 +246,13 @@ class MLLMScheduler:
         # Thread-safe set for deferred aborts (event loop → executor thread).
         # CPython GIL guarantees set.add() and set.pop() are atomic.
         self._pending_abort_ids: set[str] = set()
+        # M-01 codex r2 BLOCKING #2: lifetime de-dup ledger for the
+        # total cancellation counter. Mirror of
+        # ``Scheduler._cancelled_request_ids`` — see that comment for
+        # the rationale (TL;DR: ``_pending_abort_ids`` drains every
+        # step so it's the wrong ledger to dedupe a lifetime counter
+        # against).
+        self._cancelled_request_ids: set[str] = set()
         # M-01: once-per-request guard for the disconnect-cause
         # sub-counter. Mirrors ``Scheduler._disconnect_abort_ids`` —
         # the helper-layer ``_force_abort_request`` may fire two or
@@ -452,17 +459,16 @@ class MLLMScheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
-            # M-01 codex r1 BLOCKING #4: serialize the
-            # check-add-increment under ``_cancel_counter_lock`` so
-            # concurrent abort callers (disconnect_guard's three
-            # branches + explicit /cancel + engine_core cleanup) can't
-            # both observe ``already_pending=False`` and double-count
-            # the same id. See ``Scheduler.abort_request`` for the
-            # full thread-safety rationale.
+            # M-01 codex r1 BLOCKING #4 + r2 BLOCKING #2: serialize
+            # the check-add-increment AND dedupe against the lifetime
+            # ledger ``_cancelled_request_ids`` rather than the
+            # drainable ``_pending_abort_ids``. See
+            # ``Scheduler.abort_request`` for the full rationale.
             with self._cancel_counter_lock:
-                already_pending = request_id in self._pending_abort_ids
+                already_counted = request_id in self._cancelled_request_ids
+                self._cancelled_request_ids.add(request_id)
                 self._pending_abort_ids.add(request_id)
-                if not already_pending:
+                if not already_counted:
                     self.num_requests_cancelled += 1
             logger.debug(f"Enqueued abort for request {request_id}")
             return True
@@ -1259,6 +1265,11 @@ class MLLMScheduler:
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
+        # M-01 codex r2: drop the cancellation lifetime ledgers
+        # alongside the in-flight state. The Prometheus counters
+        # themselves are NOT zeroed (lifetime-cumulative contract).
+        self._cancelled_request_ids.clear()
+        self._disconnect_abort_ids.clear()
 
         if self.batch_generator is not None:
             self.batch_generator.close()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -483,11 +483,17 @@ class MLLMScheduler:
         /metrics. See that method's docstring for the once-per-request
         semantics, lock-based atomicity contract (codex r1 BLOCKING
         #5), and thread-safety guarantees.
+
+        Codex r7 NIT #3: gate on ``_cancelled_request_ids`` so the
+        ``via_disconnect_total <= cancelled_total`` dashboard
+        invariant holds by construction even on programmer error.
         """
         try:
             if not request_id:
                 return
             with self._cancel_counter_lock:
+                if request_id not in self._cancelled_request_ids:
+                    return
                 if request_id not in self._disconnect_abort_ids:
                     self._disconnect_abort_ids.add(request_id)
                     self.num_requests_cancelled_via_disconnect += 1
@@ -538,14 +544,32 @@ class MLLMScheduler:
         if request is not None:
             request.status = RequestStatus.FINISHED_ABORTED
         self.finished_req_ids.add(request_id)
+        # M-01 codex r7 BLOCKING #1 analysis: MLLM's
+        # ``_do_abort_request`` does ``self.requests.pop`` itself
+        # (next line), so the active maps are ALREADY clean by the
+        # time we hit the dedupe-ledger discard below. Any
+        # concurrent ``abort_request`` racing through the inside-
+        # lock predicate (codex r6 fix) would observe
+        # ``request_id not in self.requests`` and return False
+        # before touching the ledger — so the discard
+        # placement here is race-safe. We keep it INSIDE
+        # ``_do_abort_request`` (rather than mirroring the text
+        # path's ``remove_finished_request`` indirection) because
+        # MLLM's lifecycle is intentionally in-line in this
+        # method, and the multiple pop sites (lines 805, 1216,
+        # 969) would otherwise need parallel discards. The
+        # text scheduler's ``remove_finished_request`` is the
+        # ONLY external-to-_do_abort_request pop boundary on
+        # that path; MLLM's analog doesn't exist as a single
+        # external entry point.
         self.requests.pop(request_id, None)
 
         self._detokenizer_pool.pop(request_id, None)
 
         # M-01 codex r3 BLOCKING #2: discard the active-lifetime
         # dedupe ledgers so request_id reuse for a NEW distinct
-        # request counts correctly. See the same block in
-        # ``Scheduler._do_abort_request`` for the full rationale.
+        # request counts correctly. Atomic against the inside-
+        # lock predicate in ``abort_request`` (codex r6 fix).
         with self._cancel_counter_lock:
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -245,6 +245,14 @@ class MLLMScheduler:
         # Thread-safe set for deferred aborts (event loop → executor thread).
         # CPython GIL guarantees set.add() and set.pop() are atomic.
         self._pending_abort_ids: set[str] = set()
+        # M-01: once-per-request guard for the disconnect-cause
+        # sub-counter. Mirrors ``Scheduler._disconnect_abort_ids`` —
+        # the helper-layer ``_force_abort_request`` may fire two or
+        # three times per disconnect (disconnect branch + GeneratorExit
+        # branch + finally belt-and-suspenders) so the sub-counter
+        # needs its own de-dup set instead of leaning on
+        # ``_pending_abort_ids`` which drains every step.
+        self._disconnect_abort_ids: set[str] = set()
         # Aborted request IDs that need queue signaling (executor → event loop).
         self._aborted_queue_ids: set[str] = set()
 
@@ -261,6 +269,12 @@ class MLLMScheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # M-01: cancellation observability — mirror of the text-path
+        # scheduler counters so /metrics renders a stable series on
+        # MLLM-active engines. See ``Scheduler.__init__`` for the full
+        # rationale. Observability only — abort semantics unchanged.
+        self.num_requests_cancelled = 0
+        self.num_requests_cancelled_via_disconnect = 0
 
     def _get_stop_tokens(self) -> set[int]:
         """Get stop token IDs from tokenizer.
@@ -429,11 +443,34 @@ class MLLMScheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
+            # M-01: count only when the id was NOT already pending —
+            # see ``Scheduler.abort_request`` for the de-dup rationale.
+            # Concurrent disconnect_guard + engine_core cleanup paths
+            # both enqueue the same id; without the gate the counter
+            # would double-count every disconnect-triggered abort.
+            already_pending = request_id in self._pending_abort_ids
             self._pending_abort_ids.add(request_id)
+            if not already_pending:
+                self.num_requests_cancelled += 1
             logger.debug(f"Enqueued abort for request {request_id}")
             return True
         logger.debug("Rejected abort for unknown MLLM request_id")
         return False
+
+    def record_disconnect_abort(self, request_id: str) -> None:
+        """M-01: attribute a previously-accepted abort to client disconnect.
+
+        Mirrors ``Scheduler.record_disconnect_abort`` so MLLM-active
+        engines surface the same ``via_disconnect`` sub-counter on
+        /metrics. See that method's docstring for the once-per-request
+        semantics and thread-safety contract.
+        """
+        try:
+            if request_id and request_id not in self._disconnect_abort_ids:
+                self._disconnect_abort_ids.add(request_id)
+                self.num_requests_cancelled_via_disconnect += 1
+        except Exception:  # pragma: no cover - belt-and-suspenders
+            pass
 
     def _process_pending_aborts(self) -> None:
         """Drain and execute pending abort requests.
@@ -1161,6 +1198,14 @@ class MLLMScheduler:
             "num_requests_processed": self.num_requests_processed,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
+            # M-01: cancellation observability — mirror of the text
+            # scheduler stats so the same /metrics renderer surfaces a
+            # flat-line zero on MLLM-active engines that never see an
+            # abort. See ``Scheduler.get_stats`` for the full rationale.
+            "num_requests_cancelled": self.num_requests_cancelled,
+            "num_requests_cancelled_via_disconnect": (
+                self.num_requests_cancelled_via_disconnect
+            ),
         }
 
         if self.batch_generator is not None:

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -369,6 +369,46 @@ def _render_prometheus(cfg: Any) -> str:
         )
     )
 
+    # ---- Cancellation observability (M-01) -----------------------------
+    # ``rapid_mlx_requests_processed_total`` deliberately excludes aborted
+    # requests, so when fifty clients disconnect mid-stream the operator-
+    # facing series stays at zero with no way to distinguish "model idle"
+    # from "every request bailed". The total counter below ticks once per
+    # public-API abort the scheduler accepted (deduplicated against
+    # idempotent re-enqueues via ``_pending_abort_ids``), regardless of
+    # cause — client disconnect, explicit ``/v1/requests/{id}/cancel``
+    # route, timeout, or internal abort. The sub-counter attributes the
+    # subset triggered by the disconnect_guard force-abort path so the
+    # gap (total - via_disconnect) surfaces explicit-cancel + timeout
+    # traffic for capacity planning. Both default to zero on engines
+    # that never reach M-01 (mirrors the PFlash counters' flat-line
+    # treatment) so dashboards never flip to "no data" after a deploy.
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_requests_cancelled_total",
+            "counter",
+            (
+                "Cumulative requests aborted via the scheduler abort path "
+                "(client disconnect, explicit cancel route, timeout). "
+                "Disjoint from rapid_mlx_requests_processed_total which "
+                "only counts completed requests."
+            ),
+            int(_coerce_number(stats.get("num_requests_cancelled"))),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_requests_cancelled_via_disconnect_total",
+            "counter",
+            (
+                "Subset of rapid_mlx_requests_cancelled_total attributed "
+                "to client disconnect (force-abort fired from the "
+                "disconnect_guard streaming-route helper)."
+            ),
+            int(_coerce_number(stats.get("num_requests_cancelled_via_disconnect"))),
+        )
+    )
+
     # Prometheus requires a trailing newline.
     return "\n".join(lines) + "\n"
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -13,6 +13,7 @@ The scheduler follows vLLM's design with:
 
 import logging
 import os
+import threading
 import time
 from collections import OrderedDict, deque
 from dataclasses import dataclass, field
@@ -1873,6 +1874,20 @@ class Scheduler:
         # count by up to 3x per disconnect. Lives on the scheduler so
         # the lifetime matches the abort-tracking state next to it.
         self._disconnect_abort_ids: set[str] = set()
+        # M-01 codex r1 BLOCKING #2/#3: serialize the cancellation-
+        # counter mutations against the ``_pending_abort_ids`` /
+        # ``_disconnect_abort_ids`` membership checks. ``set.add`` and
+        # ``x in set`` are individually GIL-atomic, but the check-add-
+        # increment sequence is NOT — two threads calling
+        # ``abort_request(rid)`` concurrently can both observe
+        # ``already_pending=False`` and double-count the same
+        # request. The disconnect_guard fires from up to three branches
+        # per disconnect (potentially on different async tasks) and
+        # the explicit cancel route can race with engine_core's own
+        # cleanup-abort enqueue — both real concurrency surfaces. The
+        # lock cost is negligible (microseconds per abort), well below
+        # the existing per-step Metal latency.
+        self._cancel_counter_lock = threading.Lock()
 
         # Statistics
         self.num_requests_processed = 0
@@ -3105,20 +3120,23 @@ class Scheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
-            # M-01: count only when the id was NOT already pending —
-            # ``abort_request`` is intentionally idempotent (see the
-            # last branch of the predicate above), so concurrent
-            # disconnect-guard + engine_core cleanup paths both
-            # enqueue the same id and both return True. Counting on
-            # the True return without this gate would double-count
-            # every disconnect-triggered abort. ``set.add`` is GIL-
-            # atomic and the ``in`` check just above is consistent
-            # with the immediately-following ``add`` on CPython since
-            # we never yield between them.
-            already_pending = request_id in self._pending_abort_ids
-            self._pending_abort_ids.add(request_id)
-            if not already_pending:
-                self.num_requests_cancelled += 1
+            # M-01 codex r1 BLOCKING #2: the check-add-increment
+            # sequence MUST be atomic against concurrent callers.
+            # ``abort_request`` is intentionally idempotent — the
+            # disconnect_guard fires from multiple branches per
+            # disconnect, and engine_core's cleanup path can race
+            # with the explicit /cancel route. Counting on a True
+            # return without the lock would let two threads both
+            # observe ``already_pending=False`` for the same id and
+            # double-count. The lock spans only the
+            # set-membership + add + counter increment, so the
+            # surrounding ``in`` predicate evaluation (already done
+            # GIL-atomically per-set) remains lock-free.
+            with self._cancel_counter_lock:
+                already_pending = request_id in self._pending_abort_ids
+                self._pending_abort_ids.add(request_id)
+                if not already_pending:
+                    self.num_requests_cancelled += 1
             logger.info(
                 f"[abort_request] {request_id[:12]} enqueued for deferred abort"
             )
@@ -3130,19 +3148,35 @@ class Scheduler:
         """M-01: attribute a previously-accepted abort to client disconnect.
 
         Called by ``_force_abort_request`` (service/helpers.py) AFTER
-        the sync ``abort_request`` returned True, so the total counter
-        was already bumped exactly once on the public entry-point. The
-        ``request_id`` is recorded into the dedicated
-        ``_disconnect_abort_ids`` set so concurrent
-        disconnect-guard + finally belt-and-suspenders paths (both fire
-        the helper) only attribute once per request — matching the
-        once-per-request semantics of the total counter. Safe to call
-        from any thread (set.add is GIL-atomic), never raises.
+        the sync ``abort_request`` returned True (or the async fallback
+        scheduled the abort), so the total counter was already bumped
+        exactly once on the public entry-point. The ``request_id`` is
+        recorded into the dedicated ``_disconnect_abort_ids`` set so
+        concurrent disconnect-guard + finally belt-and-suspenders
+        paths (both fire the helper) only attribute once per request
+        — matching the once-per-request semantics of the total
+        counter.
+
+        Codex r1 BLOCKING #3: the check-add-increment sequence is
+        serialized against the same ``_cancel_counter_lock`` that
+        guards the total counter, because the disconnect_guard fires
+        from up to three branches per disconnect across potentially
+        different async tasks. Without the lock two threads could
+        both observe ``request_id not in _disconnect_abort_ids`` and
+        double-count the sub-counter. The lock cost is microseconds
+        per call, negligible against the existing disconnect-path
+        latency.
+
+        Safe to call from any thread, never raises. Empty / None ids
+        are no-ops.
         """
         try:
-            if request_id and request_id not in self._disconnect_abort_ids:
-                self._disconnect_abort_ids.add(request_id)
-                self.num_requests_cancelled_via_disconnect += 1
+            if not request_id:
+                return
+            with self._cancel_counter_lock:
+                if request_id not in self._disconnect_abort_ids:
+                    self._disconnect_abort_ids.add(request_id)
+                    self.num_requests_cancelled_via_disconnect += 1
         except Exception:  # pragma: no cover - belt-and-suspenders
             # Observability must never break a live disconnect path —
             # a counter that fails to advance is preferable to one

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3278,6 +3278,21 @@ class Scheduler:
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
 
+        # M-01 codex r3 BLOCKING #1: the dedupe ledgers
+        # ``_cancelled_request_ids`` / ``_disconnect_abort_ids`` are
+        # ACTIVE-LIFETIME guards, not process-lifetime. Keeping the
+        # id in the ledger after ``_do_abort_request`` has actually
+        # torn down the request would silently swallow the next
+        # cancel for a NEW distinct request that happens to reuse
+        # the same ``request_id`` (e.g. integrations that hash
+        # request_ids deterministically, or a client retrying the
+        # same operation). The lock-protected discard pair below
+        # keeps the codex r1 atomicity contract — discards are
+        # idempotent and only nominally cheap.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request_id)
+            self._disconnect_abort_ids.discard(request_id)
+
         # Flush Metal encoders after removing arrays from batch
         mx.clear_cache()
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3189,6 +3189,18 @@ class Scheduler:
         per call, negligible against the existing disconnect-path
         latency.
 
+        Codex r7 NIT #3: validate against ``_cancelled_request_ids``
+        BEFORE incrementing so a future caller (or a bug) that
+        records a disconnect for an id the scheduler never accepted
+        as a cancel cannot push the ``via_disconnect`` sub-counter
+        above the total. The contract is now "disconnect
+        attribution is only valid for ids the scheduler ALSO
+        accepted via ``abort_request``"; ids not in the lifetime
+        ledger silently no-op. This guarantees the dashboard
+        invariant ``via_disconnect_total <= cancelled_total`` holds
+        even on programmer error in callers that record without
+        first hitting the public abort path.
+
         Safe to call from any thread, never raises. Empty / None ids
         are no-ops.
         """
@@ -3196,6 +3208,13 @@ class Scheduler:
             if not request_id:
                 return
             with self._cancel_counter_lock:
+                # Codex r7 NIT #3: gate on the lifetime ledger so
+                # ``via_disconnect_total <= cancelled_total`` holds
+                # by construction. Callers MUST hit
+                # ``abort_request`` first; this method only
+                # attributes a previously-accepted abort.
+                if request_id not in self._cancelled_request_ids:
+                    return
                 if request_id not in self._disconnect_abort_ids:
                     self._disconnect_abort_ids.add(request_id)
                     self.num_requests_cancelled_via_disconnect += 1

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4344,23 +4344,24 @@ class Scheduler:
         return None
 
     def reset(self) -> None:
-        """Reset the scheduler state."""
+        """Reset the scheduler state.
+
+        M-01 codex r8 BLOCKING #1: the cancellation dedupe ledgers
+        (``_cancelled_request_ids`` / ``_disconnect_abort_ids``)
+        MUST be cleared AFTER the abort loop, not before. Clearing
+        before means a concurrent ``record_disconnect_abort`` for a
+        still-live in-flight request could either no-op (id removed
+        from ledger ahead of its lifetime ending) or, worse, re-add
+        the id after ``_do_abort_request`` runs (because that path
+        also does a discard, and the ``add`` came from
+        ``abort_request`` racing against the loop). Clearing AFTER
+        the abort loop AND under the lock means any concurrent
+        ``record_disconnect_abort`` either ran fully BEFORE reset
+        started (correct) or sees the cleared state and no-ops
+        (correct: the request is gone, attribution is meaningless).
+        """
         # Drain any pending deferred aborts
         self._pending_abort_ids.clear()
-        # M-01: drop the cancellation lifetime ledgers alongside the
-        # pending-aborts set. The counters themselves
-        # (``num_requests_cancelled`` /
-        # ``num_requests_cancelled_via_disconnect``) are NOT zeroed —
-        # they're lifetime-cumulative Prometheus counters and resetting
-        # them would make /metrics report a non-monotonic step change
-        # to scrapers. The sticky-counter accumulator in routes/metrics.py
-        # would then fold the apparent reset into a baseline, which is
-        # the right behaviour for the cache series but here we'd rather
-        # never trip it. Wiping the dedupe ledgers ahead of a model
-        # swap is safe because the request_ids they tracked are
-        # post-reset undefined behaviour anyway.
-        self._cancelled_request_ids.clear()
-        self._disconnect_abort_ids.clear()
 
         # Abort all requests directly (reset is synchronous)
         for request_id in list(self.requests.keys()):
@@ -4375,6 +4376,25 @@ class Scheduler:
         self._detokenizer_pool.clear()
         self._close_batch_generator()
         self._current_sampler_params = None
+
+        # M-01: drop the cancellation lifetime ledgers AFTER the
+        # tear-down loop completes. The counters themselves
+        # (``num_requests_cancelled`` /
+        # ``num_requests_cancelled_via_disconnect``) are NOT zeroed —
+        # they're lifetime-cumulative Prometheus counters and
+        # resetting them would make /metrics report a non-monotonic
+        # step change to scrapers. The sticky-counter accumulator in
+        # routes/metrics.py would then fold the apparent reset into
+        # a baseline, which is the right behaviour for the cache
+        # series but here we'd rather never trip it. Wiping the
+        # dedupe ledgers AFTER the abort loop is safe because the
+        # request_ids they tracked have all been torn down by then,
+        # and is correct against the codex r8 BLOCKING #1 race
+        # (clearing before reset's _do_abort_request loop ran would
+        # have re-opened the dedupe window during the tear-down).
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.clear()
+            self._disconnect_abort_ids.clear()
 
         # Clear caches
         if self.block_aware_cache is not None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4155,9 +4155,9 @@ class Scheduler:
     def remove_finished_request(self, request_id: str) -> Request | None:
         """Remove a finished request from tracking.
 
-        M-01 codex r4 BLOCKING #1: this is the canonical
-        request-leaves-scheduler boundary, so the cancellation
-        dedupe ledgers (``_cancelled_request_ids`` /
+        M-01 codex r4 BLOCKING #1 + codex r5 BLOCKING: this is the
+        canonical request-leaves-scheduler boundary, so the
+        cancellation dedupe ledgers (``_cancelled_request_ids`` /
         ``_disconnect_abort_ids``) are also discarded here. Before
         this method runs, a redundant ``abort_request`` for the
         same id would still pass the
@@ -4170,14 +4170,26 @@ class Scheduler:
         lifetime), which is exactly when the counter SHOULD tick
         again.
 
-        Discards are under the same lock as the abort_request
-        increment so the discard + future increment are linearly
-        ordered. Idempotent — re-entry is safe.
+        Codex r5 BLOCKING: the ``self.requests.pop`` AND the
+        ledger discards MUST happen under a single critical
+        section. Otherwise the window between "ledger discarded"
+        and "request popped" is a race where a concurrent
+        ``abort_request`` observes ``request_id in self.requests``
+        (still True) AND an empty ledger (because we just cleared
+        it) and double-counts the same lifetime. The pop is moved
+        INSIDE the lock and runs BEFORE the discard so any
+        concurrent ``abort_request`` either sees the id still in
+        ``self.requests`` AND in the ledger (no double-count, the
+        dedupe gate catches it) OR sees the id not in
+        ``self.requests`` (returns False per F-151).
+
+        Discards are idempotent — re-entry is safe.
         """
         with self._cancel_counter_lock:
+            popped = self.requests.pop(request_id, None)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
-        return self.requests.pop(request_id, None)
+        return popped
 
     def get_running_requests_info(self) -> list[dict[str, Any]]:
         """Per-request details for status endpoint."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1866,24 +1866,40 @@ class Scheduler:
         # Thread-safe set for deferred aborts (main thread → executor thread)
         # CPython GIL guarantees set.add() and `x in set` are atomic.
         self._pending_abort_ids: set[str] = set()
+        # M-01 codex r2 BLOCKING #1: lifetime de-dup set for the
+        # cancellation counter. ``_pending_abort_ids`` is the wrong
+        # ledger to dedupe against — it's a DEFERRED-ABORT QUEUE that
+        # gets drained on every step via ``_process_pending_aborts``.
+        # Once drained, a later ``abort_request(rid)`` for a request
+        # that's still resident (e.g. a sequence of cancel attempts
+        # while the request lives in ``running``, or request_id reuse
+        # across distinct lifetimes) would see ``already_pending=False``
+        # again and double-count. ``_cancelled_request_ids`` is a
+        # lifetime ledger — every id that has ever advanced the
+        # counter stays in it for the process lifetime. Memory is
+        # bounded by the cancel traffic (one ~36-byte uuid per cancel),
+        # which is the same scale as ``finished_req_ids`` and not a
+        # concern. The set is wiped only on ``reset()`` (matches the
+        # _pending_abort_ids treatment there).
+        self._cancelled_request_ids: set[str] = set()
         # M-01: once-per-request guard for the disconnect-cause
         # sub-counter. ``_force_abort_request`` calls
         # ``record_disconnect_abort`` from BOTH the disconnect branch
         # AND the GeneratorExit branch AND the finally belt-and-
         # suspenders; without this de-dup the sub-counter would over-
-        # count by up to 3x per disconnect. Lives on the scheduler so
-        # the lifetime matches the abort-tracking state next to it.
+        # count by up to 3x per disconnect. Lifetime ledger like
+        # ``_cancelled_request_ids`` above — never drained between
+        # cancels.
         self._disconnect_abort_ids: set[str] = set()
         # M-01 codex r1 BLOCKING #2/#3: serialize the cancellation-
-        # counter mutations against the ``_pending_abort_ids`` /
-        # ``_disconnect_abort_ids`` membership checks. ``set.add`` and
-        # ``x in set`` are individually GIL-atomic, but the check-add-
-        # increment sequence is NOT — two threads calling
-        # ``abort_request(rid)`` concurrently can both observe
-        # ``already_pending=False`` and double-count the same
-        # request. The disconnect_guard fires from up to three branches
-        # per disconnect (potentially on different async tasks) and
-        # the explicit cancel route can race with engine_core's own
+        # counter mutations against the dedupe-set membership checks.
+        # ``set.add`` and ``x in set`` are individually GIL-atomic,
+        # but the check-add-increment sequence is NOT — two threads
+        # calling ``abort_request(rid)`` concurrently can both observe
+        # ``already_counted=False`` and double-count the same request.
+        # The disconnect_guard fires from up to three branches per
+        # disconnect (potentially on different async tasks) and the
+        # explicit cancel route can race with engine_core's own
         # cleanup-abort enqueue — both real concurrency surfaces. The
         # lock cost is negligible (microseconds per abort), well below
         # the existing per-step Metal latency.
@@ -3120,22 +3136,24 @@ class Scheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
-            # M-01 codex r1 BLOCKING #2: the check-add-increment
-            # sequence MUST be atomic against concurrent callers.
-            # ``abort_request`` is intentionally idempotent — the
-            # disconnect_guard fires from multiple branches per
-            # disconnect, and engine_core's cleanup path can race
-            # with the explicit /cancel route. Counting on a True
-            # return without the lock would let two threads both
-            # observe ``already_pending=False`` for the same id and
-            # double-count. The lock spans only the
-            # set-membership + add + counter increment, so the
-            # surrounding ``in`` predicate evaluation (already done
-            # GIL-atomically per-set) remains lock-free.
+            # M-01 codex r1 BLOCKING #2 + r2 BLOCKING #1: the
+            # check-add-increment sequence MUST be atomic AND must
+            # dedupe against a lifetime ledger, not the drainable
+            # ``_pending_abort_ids``. The disconnect_guard fires
+            # ``_force_abort_request`` from up to three branches per
+            # disconnect, engine_core's cleanup path can race with
+            # the explicit /cancel route, AND a later abort for the
+            # same still-known request_id (between
+            # ``_process_pending_aborts`` drains) would re-tick the
+            # counter if we deduped against the pending set. The
+            # lock spans only the dedupe-membership + add +
+            # counter-increment so the surrounding ``in`` predicate
+            # remains lock-free.
             with self._cancel_counter_lock:
-                already_pending = request_id in self._pending_abort_ids
+                already_counted = request_id in self._cancelled_request_ids
+                self._cancelled_request_ids.add(request_id)
                 self._pending_abort_ids.add(request_id)
-                if not already_pending:
+                if not already_counted:
                     self.num_requests_cancelled += 1
             logger.info(
                 f"[abort_request] {request_id[:12]} enqueued for deferred abort"
@@ -4256,13 +4274,19 @@ class Scheduler:
         """Reset the scheduler state."""
         # Drain any pending deferred aborts
         self._pending_abort_ids.clear()
-        # M-01: drop the disconnect-cause de-dup set alongside the
+        # M-01: drop the cancellation lifetime ledgers alongside the
         # pending-aborts set. The counters themselves
         # (``num_requests_cancelled`` /
         # ``num_requests_cancelled_via_disconnect``) are NOT zeroed —
         # they're lifetime-cumulative Prometheus counters and resetting
         # them would make /metrics report a non-monotonic step change
-        # to scrapers.
+        # to scrapers. The sticky-counter accumulator in routes/metrics.py
+        # would then fold the apparent reset into a baseline, which is
+        # the right behaviour for the cache series but here we'd rather
+        # never trip it. Wiping the dedupe ledgers ahead of a model
+        # swap is safe because the request_ids they tracked are
+        # post-reset undefined behaviour anyway.
+        self._cancelled_request_ids.clear()
         self._disconnect_abort_ids.clear()
 
         # Abort all requests directly (reset is synchronous)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3130,37 +3130,41 @@ class Scheduler:
         # True so a double-cancel doesn't 404 the second caller). We do NOT
         # treat ``finished_req_ids`` as "known" because the abort would be
         # a no-op and the route contract is "404 when already finished".
-        if (
-            request_id in self.requests
-            or request_id in self.request_id_to_uid
-            or request_id in self.running
-            or request_id in self._pending_abort_ids
-        ):
-            # M-01 codex r1 BLOCKING #2 + r2 BLOCKING #1: the
-            # check-add-increment sequence MUST be atomic AND must
-            # dedupe against a lifetime ledger, not the drainable
-            # ``_pending_abort_ids``. The disconnect_guard fires
-            # ``_force_abort_request`` from up to three branches per
-            # disconnect, engine_core's cleanup path can race with
-            # the explicit /cancel route, AND a later abort for the
-            # same still-known request_id (between
-            # ``_process_pending_aborts`` drains) would re-tick the
-            # counter if we deduped against the pending set. The
-            # lock spans only the dedupe-membership + add +
-            # counter-increment so the surrounding ``in`` predicate
-            # remains lock-free.
-            with self._cancel_counter_lock:
-                already_counted = request_id in self._cancelled_request_ids
-                self._cancelled_request_ids.add(request_id)
-                self._pending_abort_ids.add(request_id)
-                if not already_counted:
-                    self.num_requests_cancelled += 1
-            logger.info(
-                f"[abort_request] {request_id[:12]} enqueued for deferred abort"
-            )
-            return True
-        logger.info("[abort_request] unknown request_id (rejected without enqueue)")
-        return False
+        # M-01 codex r1 BLOCKING #2 + r2 BLOCKING #1 + r6 BLOCKING #1:
+        # the membership check AND the check-add-increment sequence
+        # MUST be atomic together — checking ``request_id in
+        # self.requests`` outside the lock leaves a window where
+        # ``remove_finished_request`` can race in, pop ``self.requests``,
+        # clear the dedupe ledger, and let THIS path then re-add the id
+        # to ``_pending_abort_ids`` and increment ``num_requests_cancelled``
+        # for an already-removed request lifetime. By re-validating
+        # membership INSIDE the lock against the same maps
+        # ``remove_finished_request`` mutates (``self.requests``) and
+        # the abort-state maps (``request_id_to_uid`` / ``running`` /
+        # ``_pending_abort_ids``), we guarantee:
+        #   * any abort that passes the inside-lock predicate has a
+        #     live referent that can't be popped concurrently;
+        #   * the dedupe-ledger check + add + counter increment
+        #     remain serialized across all callers.
+        # The lock cost is negligible (microseconds per abort).
+        with self._cancel_counter_lock:
+            if not (
+                request_id in self.requests
+                or request_id in self.request_id_to_uid
+                or request_id in self.running
+                or request_id in self._pending_abort_ids
+            ):
+                logger.info(
+                    "[abort_request] unknown request_id (rejected without enqueue)"
+                )
+                return False
+            already_counted = request_id in self._cancelled_request_ids
+            self._cancelled_request_ids.add(request_id)
+            self._pending_abort_ids.add(request_id)
+            if not already_counted:
+                self.num_requests_cancelled += 1
+        logger.info(f"[abort_request] {request_id[:12]} enqueued for deferred abort")
+        return True
 
     def record_disconnect_abort(self, request_id: str) -> None:
         """M-01: attribute a previously-accepted abort to client disconnect.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1865,6 +1865,14 @@ class Scheduler:
         # Thread-safe set for deferred aborts (main thread → executor thread)
         # CPython GIL guarantees set.add() and `x in set` are atomic.
         self._pending_abort_ids: set[str] = set()
+        # M-01: once-per-request guard for the disconnect-cause
+        # sub-counter. ``_force_abort_request`` calls
+        # ``record_disconnect_abort`` from BOTH the disconnect branch
+        # AND the GeneratorExit branch AND the finally belt-and-
+        # suspenders; without this de-dup the sub-counter would over-
+        # count by up to 3x per disconnect. Lives on the scheduler so
+        # the lifetime matches the abort-tracking state next to it.
+        self._disconnect_abort_ids: set[str] = set()
 
         # Statistics
         self.num_requests_processed = 0
@@ -1881,6 +1889,22 @@ class Scheduler:
         # stays flat. Observability only — bypass semantics unchanged.
         self.pflash_bypass_count = 0
         self.pflash_compressed_tokens_dropped = 0
+        # Cancellation observability (M-01). ``num_requests_processed``
+        # deliberately excludes aborted requests, so operators staring at
+        # ``rapid_mlx_requests_processed_total = 0`` after fifty bailed-
+        # out clients can't tell whether the route is broken, the model
+        # is idle, or every caller is disconnecting before EOS. The total
+        # counter increments inside ``abort_request`` the moment a
+        # newly-known request_id transitions into the pending-abort set
+        # (idempotent re-enqueues do NOT double-count), so it reflects
+        # accepted public-API aborts irrespective of cause. The disconnect
+        # sub-counter is bumped separately by ``_force_abort_request`` in
+        # the disconnect-guard path via ``record_disconnect_abort`` so
+        # the (total - disconnect) gap surfaces explicit-cancel-route +
+        # timeout traffic. Both observability only — abort semantics are
+        # untouched.
+        self.num_requests_cancelled = 0
+        self.num_requests_cancelled_via_disconnect = 0
 
         # Memory management: periodic mx.clear_cache() to free Metal command buffers
         # Lower interval = less VRAM spike during generation but slight throughput cost
@@ -3081,13 +3105,50 @@ class Scheduler:
             or request_id in self.running
             or request_id in self._pending_abort_ids
         ):
+            # M-01: count only when the id was NOT already pending —
+            # ``abort_request`` is intentionally idempotent (see the
+            # last branch of the predicate above), so concurrent
+            # disconnect-guard + engine_core cleanup paths both
+            # enqueue the same id and both return True. Counting on
+            # the True return without this gate would double-count
+            # every disconnect-triggered abort. ``set.add`` is GIL-
+            # atomic and the ``in`` check just above is consistent
+            # with the immediately-following ``add`` on CPython since
+            # we never yield between them.
+            already_pending = request_id in self._pending_abort_ids
             self._pending_abort_ids.add(request_id)
+            if not already_pending:
+                self.num_requests_cancelled += 1
             logger.info(
                 f"[abort_request] {request_id[:12]} enqueued for deferred abort"
             )
             return True
         logger.info("[abort_request] unknown request_id (rejected without enqueue)")
         return False
+
+    def record_disconnect_abort(self, request_id: str) -> None:
+        """M-01: attribute a previously-accepted abort to client disconnect.
+
+        Called by ``_force_abort_request`` (service/helpers.py) AFTER
+        the sync ``abort_request`` returned True, so the total counter
+        was already bumped exactly once on the public entry-point. The
+        ``request_id`` is recorded into the dedicated
+        ``_disconnect_abort_ids`` set so concurrent
+        disconnect-guard + finally belt-and-suspenders paths (both fire
+        the helper) only attribute once per request — matching the
+        once-per-request semantics of the total counter. Safe to call
+        from any thread (set.add is GIL-atomic), never raises.
+        """
+        try:
+            if request_id and request_id not in self._disconnect_abort_ids:
+                self._disconnect_abort_ids.add(request_id)
+                self.num_requests_cancelled_via_disconnect += 1
+        except Exception:  # pragma: no cover - belt-and-suspenders
+            # Observability must never break a live disconnect path —
+            # a counter that fails to advance is preferable to one
+            # that escapes back through ``_force_abort_request`` and
+            # masks the abort in the caller's exception handler.
+            pass
 
     def _process_pending_aborts(self) -> None:
         """Drain and process pending abort requests. Called from executor thread."""
@@ -4114,6 +4175,20 @@ class Scheduler:
             # series.
             "pflash_bypass_count": self.pflash_bypass_count,
             "pflash_compressed_tokens_dropped": self.pflash_compressed_tokens_dropped,
+            # M-01: cancellation observability. ``num_requests_cancelled``
+            # is the total count of public-API aborts the scheduler
+            # accepted (one increment per unique request_id transitioning
+            # into ``_pending_abort_ids``). ``num_requests_cancelled_via_
+            # disconnect`` is the subset attributed to client disconnect
+            # via ``_force_abort_request``. Both default to zero on
+            # engines that never see traffic so /metrics stays at a
+            # flat-line series rather than an absent one. See the init
+            # comment for the rationale on why ``num_requests_processed``
+            # alone is insufficient.
+            "num_requests_cancelled": self.num_requests_cancelled,
+            "num_requests_cancelled_via_disconnect": (
+                self.num_requests_cancelled_via_disconnect
+            ),
         }
         # Include Metal memory stats
         try:
@@ -4147,6 +4222,14 @@ class Scheduler:
         """Reset the scheduler state."""
         # Drain any pending deferred aborts
         self._pending_abort_ids.clear()
+        # M-01: drop the disconnect-cause de-dup set alongside the
+        # pending-aborts set. The counters themselves
+        # (``num_requests_cancelled`` /
+        # ``num_requests_cancelled_via_disconnect``) are NOT zeroed —
+        # they're lifetime-cumulative Prometheus counters and resetting
+        # them would make /metrics report a non-monotonic step change
+        # to scrapers.
+        self._disconnect_abort_ids.clear()
 
         # Abort all requests directly (reset is synchronous)
         for request_id in list(self.requests.keys()):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3278,20 +3278,20 @@ class Scheduler:
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
 
-        # M-01 codex r3 BLOCKING #1: the dedupe ledgers
-        # ``_cancelled_request_ids`` / ``_disconnect_abort_ids`` are
-        # ACTIVE-LIFETIME guards, not process-lifetime. Keeping the
-        # id in the ledger after ``_do_abort_request`` has actually
-        # torn down the request would silently swallow the next
-        # cancel for a NEW distinct request that happens to reuse
-        # the same ``request_id`` (e.g. integrations that hash
-        # request_ids deterministically, or a client retrying the
-        # same operation). The lock-protected discard pair below
-        # keeps the codex r1 atomicity contract — discards are
-        # idempotent and only nominally cheap.
-        with self._cancel_counter_lock:
-            self._cancelled_request_ids.discard(request_id)
-            self._disconnect_abort_ids.discard(request_id)
+        # M-01 codex r4 BLOCKING #1: do NOT discard the dedupe
+        # ledgers here. The text scheduler intentionally keeps the
+        # ``Request`` object in ``self.requests`` between
+        # ``_do_abort_request`` and the later
+        # ``remove_finished_request`` call (engine_core cleanup),
+        # so ``abort_request`` would still observe
+        # ``request_id in self.requests`` and admit a redundant
+        # enqueue. Discarding the dedupe ledger HERE would let
+        # that redundant enqueue double-count the same request
+        # lifetime. The discard happens in ``remove_finished_request``
+        # instead — by which point the request has truly left every
+        # admit-able map and a fresh ``abort_request`` could only
+        # land via a new admit() with the same id (a distinct
+        # lifetime).
 
         # Flush Metal encoders after removing arrays from batch
         mx.clear_cache()
@@ -4153,7 +4153,30 @@ class Scheduler:
         return self.requests.get(request_id)
 
     def remove_finished_request(self, request_id: str) -> Request | None:
-        """Remove a finished request from tracking."""
+        """Remove a finished request from tracking.
+
+        M-01 codex r4 BLOCKING #1: this is the canonical
+        request-leaves-scheduler boundary, so the cancellation
+        dedupe ledgers (``_cancelled_request_ids`` /
+        ``_disconnect_abort_ids``) are also discarded here. Before
+        this method runs, a redundant ``abort_request`` for the
+        same id would still pass the
+        ``request_id in self.requests`` predicate — so the ledger
+        must stay populated to prevent double-counting that
+        redundant enqueue. After this method runs, ``request_id``
+        is no longer admit-able via the abort-path predicate, so
+        the only way a future ``abort_request(rid)`` can hit
+        ``True`` is through a fresh ``add_request`` (a distinct
+        lifetime), which is exactly when the counter SHOULD tick
+        again.
+
+        Discards are under the same lock as the abort_request
+        increment so the discard + future increment are linearly
+        ordered. Idempotent — re-entry is safe.
+        """
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request_id)
+            self._disconnect_abort_ids.discard(request_id)
         return self.requests.pop(request_id, None)
 
     def get_running_requests_info(self) -> list[dict[str, Any]]:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1997,6 +1997,102 @@ def _resolve_sync_scheduler_for_abort(engine):
     return None
 
 
+def _resolve_scheduler_for_cancel_attribution(engine):
+    """M-01: walk the engine backend graph and return the scheduler-side
+    object that exposes ``record_disconnect_abort``.
+
+    The cancel-attribution sub-counter lives on the same scheduler
+    where the public-API total counter lives, so the resolver must
+    follow the active-path gate (``_is_mllm``). We deliberately keep
+    this separate from ``_resolve_sync_scheduler_for_abort`` (which
+    gates on ``not iscoroutinefunction(abort_request)``) because the
+    sub-counter is a sync-only method wholly independent of the abort
+    path — re-using the abort resolver would skip schedulers that
+    expose a fine sync ``record_disconnect_abort`` but happen to have
+    an async ``abort_request`` shim.
+
+    Production text path walks one extra level versus the abort
+    resolver: ``BatchedEngine._engine`` is ``AsyncEngineCore`` (which
+    does NOT expose ``.scheduler`` directly) and the actual
+    ``Scheduler`` lives at ``BatchedEngine._engine.engine.scheduler``
+    (``AsyncEngineCore`` wraps ``EngineCore`` via ``self.engine``).
+    The abort resolver doesn't dig that deep because
+    ``AsyncEngineCore`` has its own async ``abort_request`` shim and
+    falls through to the public-async fallback — but the
+    attribution counter must NOT fall back because the sub-counter
+    only lives on ``Scheduler``. Without this extra hop the
+    via_disconnect series would stay flat through every real
+    production disconnect (Mei + Yana surfaced the cancel-rate
+    counter; the operator would still have no way to see whether
+    the bulk of cancels came from disconnect vs. timeout vs.
+    explicit /cancel).
+
+    Returns ``None`` if no scheduler in the active backend exposes
+    the method, in which case the helper-layer caller silently
+    no-ops (older schedulers without M-01 simply don't surface the
+    sub-counter, the total counter on the route side still defaults
+    to zero).
+    """
+    # 1) Direct ``engine.scheduler`` — plain engines, tests, fakes.
+    direct_scheduler = getattr(engine, "scheduler", None)
+    if direct_scheduler is not None:
+        record = getattr(direct_scheduler, "record_disconnect_abort", None)
+        if record is not None:
+            return record
+    # 2) Active-path gated walk on BatchedEngine.
+    is_mllm_active = bool(getattr(engine, "_is_mllm", False))
+    if is_mllm_active:
+        mllm = getattr(engine, "_mllm_scheduler", None)
+        if mllm is not None:
+            record = getattr(mllm, "record_disconnect_abort", None)
+            if record is not None:
+                return record
+    else:
+        inner = getattr(engine, "_engine", None)
+        if inner is not None:
+            # 2a) ``engine._engine.scheduler`` — matches the abort
+            # resolver shape (used by every test stub today).
+            inner_sched = getattr(inner, "scheduler", None)
+            if inner_sched is not None:
+                record = getattr(inner_sched, "record_disconnect_abort", None)
+                if record is not None:
+                    return record
+            # 2b) ``engine._engine.engine.scheduler`` — the production
+            # ``BatchedEngine`` over ``AsyncEngineCore`` shape. The
+            # extra hop is where AsyncEngineCore wraps EngineCore.
+            inner_engine = getattr(inner, "engine", None)
+            if inner_engine is not None:
+                deep_sched = getattr(inner_engine, "scheduler", None)
+                if deep_sched is not None:
+                    record = getattr(deep_sched, "record_disconnect_abort", None)
+                    if record is not None:
+                        return record
+    return None
+
+
+def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
+    """M-01 attribution helper — bumps the disconnect sub-counter on
+    whichever active-path scheduler owns this ``request_id``.
+
+    Wraps the resolver in a try/except so the cancel-attribution path
+    never leaks back into ``_force_abort_request``. The total counter
+    is already incremented inside ``Scheduler.abort_request`` the
+    moment the sync entry returns True, so failure of this attribution
+    helper at worst leaves the (total - disconnect) gap one larger
+    than reality — never breaks the abort itself.
+    """
+    try:
+        record = _resolve_scheduler_for_cancel_attribution(engine)
+        if record is not None:
+            record(request_id)
+    except Exception:  # pragma: no cover - belt-and-suspenders
+        logger.warning(
+            "[disconnect_guard] record_disconnect_abort raised; "
+            "via_disconnect sub-counter may under-count this abort",
+            exc_info=True,
+        )
+
+
 def _force_abort_request(engine, request_id_holder) -> bool:
     """C-01: synchronously enqueue an abort for the live request id.
 
@@ -2044,6 +2140,19 @@ def _force_abort_request(engine, request_id_holder) -> bool:
                 f"[disconnect_guard] force-abort scheduler.abort_request("
                 f"{str(request_id)[:12]}) -> {result}"
             )
+            # M-01: attribute the abort to client disconnect so
+            # ``rapid_mlx_requests_cancelled_via_disconnect_total`` ticks
+            # alongside the total. We bump only when the sync entry
+            # actually accepted the abort (``result == True``) — the
+            # scheduler returns False for unknown ids and we must not
+            # over-count those. The disconnect_guard fires
+            # ``_force_abort_request`` from up to three branches per
+            # disconnect (disconnect/GeneratorExit/finally), so the
+            # scheduler-side ``_disconnect_abort_ids`` set provides
+            # the once-per-request de-dup. Observability only — never
+            # let a counter-side error mask the actual abort.
+            if result:
+                _record_disconnect_abort_on_scheduler(engine, request_id)
             return True
         # No sync path resolved — the engine is wrapping its scheduler
         # behind an async-only ``abort_request``. Best-effort fire-and-
@@ -2064,6 +2173,24 @@ def _force_abort_request(engine, request_id_holder) -> bool:
                     f"time disconnect handling returns. The "
                     f"generator-close cascade is the remaining defense."
                 )
+                # M-01 attribution must fire on the async-fallback path
+                # too: ``BatchedEngine`` over ``AsyncEngineCore`` wraps
+                # the sync ``Scheduler.abort_request`` behind an async
+                # ``engine.abort_request`` shim, so the sync resolver
+                # returns ``None`` and we land here on the production
+                # default text path. The scheduler's
+                # ``_disconnect_abort_ids`` de-dup still pins the once-
+                # per-request semantics — calling
+                # ``record_disconnect_abort`` here is symmetric with the
+                # sync branch above. ``False`` is still returned because
+                # the abort itself isn't guaranteed in flight; the
+                # attribution counter ticks regardless because the
+                # eventual sync abort WILL reach the total counter via
+                # ``Scheduler.abort_request`` and we'd otherwise leave
+                # the via_disconnect sub-counter stuck at zero on every
+                # real-world disconnect (the bug Mei + Yana surfaced
+                # would only be HALF fixed).
+                _record_disconnect_abort_on_scheduler(engine, request_id)
                 # ``False`` so the contract reflects async-fallback;
                 # callers / tests treat that as "I tried, cascade is
                 # the remaining defense".
@@ -2072,6 +2199,11 @@ def _force_abort_request(engine, request_id_holder) -> bool:
                 f"[disconnect_guard] force-abort engine.abort_request("
                 f"{str(request_id)[:12]}) -> {result}"
             )
+            # Sync public-abort path (no coroutine to schedule) —
+            # attribute disconnect symmetric with the sync-scheduler
+            # branch above when the engine accepted the abort.
+            if result:
+                _record_disconnect_abort_on_scheduler(engine, request_id)
             return True
     except Exception:
         logger.warning(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2202,6 +2202,23 @@ def _force_abort_request(engine, request_id_holder) -> bool:
                         return
                     if accepted:
                         _record_disconnect_abort_on_scheduler(attribution_engine, rid)
+                    else:
+                        # Codex r2 NIT #3: surface the "abort coroutine
+                        # returned False" path to operators. Without
+                        # this log, a stale holder (request_id reused
+                        # or already finished by the time the
+                        # disconnect_guard fired) silently leaves the
+                        # ``via_disconnect`` sub-counter behind the
+                        # total, and the operator-facing
+                        # (total - via_disconnect) gap drifts with no
+                        # diagnostic trail. INFO-level — the sync
+                        # path also INFO-logs its rejected aborts.
+                        logger.info(
+                            "[disconnect_guard] async force-abort returned "
+                            "False for %s; via_disconnect sub-counter NOT "
+                            "advanced (stale holder / already finished?)",
+                            str(rid)[:12],
+                        )
 
                 asyncio.ensure_future(_await_and_record())
                 logger.warning(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2040,31 +2040,33 @@ def _resolve_disconnect_abort_recorder(engine):
     sub-counter, the total counter on the route side still defaults
     to zero).
     """
-    # 1) Direct ``engine.scheduler`` — plain engines, tests, fakes.
-    direct_scheduler = getattr(engine, "scheduler", None)
-    if direct_scheduler is not None:
-        recorder = getattr(direct_scheduler, "record_disconnect_abort", None)
-        if recorder is not None:
-            return recorder
-    # 2) Active-path gated walk on BatchedEngine.
-    is_mllm_active = bool(getattr(engine, "_is_mllm", False))
-    if is_mllm_active:
+    # M-01 codex r7 BLOCKING #2: when ``_is_mllm`` is set we MUST
+    # honor it before falling back to a direct ``engine.scheduler``
+    # — otherwise a dual-shaped engine (one that exposes
+    # ``.scheduler`` for the text path AND ``_mllm_scheduler`` for
+    # the MLLM path, depending on which backend is active) will
+    # mis-attribute disconnects to the text scheduler when the
+    # MLLM path is the live one. The check pattern is the same as
+    # the abort resolver's codex r2 BLOCKING #1 fix — active-path
+    # gate first, plain-engine fallback last.
+    is_mllm_flag = getattr(engine, "_is_mllm", None)
+    if is_mllm_flag is True:
         mllm = getattr(engine, "_mllm_scheduler", None)
         if mllm is not None:
             recorder = getattr(mllm, "record_disconnect_abort", None)
             if recorder is not None:
                 return recorder
-    else:
+    elif is_mllm_flag is False:
         inner = getattr(engine, "_engine", None)
         if inner is not None:
-            # 2a) ``engine._engine.scheduler`` — matches the abort
+            # ``engine._engine.scheduler`` — matches the abort
             # resolver shape (used by every test stub today).
             inner_sched = getattr(inner, "scheduler", None)
             if inner_sched is not None:
                 recorder = getattr(inner_sched, "record_disconnect_abort", None)
                 if recorder is not None:
                     return recorder
-            # 2b) ``engine._engine.engine.scheduler`` — the production
+            # ``engine._engine.engine.scheduler`` — the production
             # ``BatchedEngine`` over ``AsyncEngineCore`` shape. The
             # extra hop is where AsyncEngineCore wraps EngineCore.
             inner_engine = getattr(inner, "engine", None)
@@ -2074,6 +2076,15 @@ def _resolve_disconnect_abort_recorder(engine):
                     recorder = getattr(deep_sched, "record_disconnect_abort", None)
                     if recorder is not None:
                         return recorder
+    # Plain-engine fallback: only used when ``_is_mllm`` is absent
+    # (older / external engine shapes that pre-date BatchedEngine).
+    # Distinct from ``is_mllm_flag is False`` above, which means
+    # "explicitly text-active on a BatchedEngine".
+    direct_scheduler = getattr(engine, "scheduler", None)
+    if direct_scheduler is not None:
+        recorder = getattr(direct_scheduler, "record_disconnect_abort", None)
+        if recorder is not None:
+            return recorder
     return None
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2165,7 +2165,38 @@ def _force_abort_request(engine, request_id_holder) -> bool:
         if public_abort is not None:
             result = public_abort(request_id)
             if asyncio.iscoroutine(result):
-                asyncio.ensure_future(result)
+                # M-01 codex r1 BLOCKING #1: attribution MUST chain on
+                # the abort result, not fire-and-forget. Pre-fix this
+                # path called ``_record_disconnect_abort_on_scheduler``
+                # IMMEDIATELY after scheduling the coroutine, so a
+                # stale / unknown ``request_id`` (which makes
+                # ``Scheduler.abort_request`` return False and skip
+                # the total counter) would still tick the sub-counter
+                # — corrupting the (total - via_disconnect) gap
+                # operators rely on for cause attribution. The fix:
+                # wrap the coroutine in an awaiter that records ONLY
+                # after the awaited abort returns truthy. The
+                # ``ensure_future`` still keeps the disconnect path
+                # synchronous (we don't await it here), but the
+                # eventual coroutine resolution is now the gate for
+                # the sub-counter.
+                attribution_engine = engine
+
+                async def _await_and_record(coro=result, rid=request_id):
+                    try:
+                        accepted = await coro
+                    except Exception:  # pragma: no cover - belt-and-suspenders
+                        logger.warning(
+                            "[disconnect_guard] async force-abort raised; "
+                            "via_disconnect sub-counter NOT advanced for "
+                            f"{str(rid)[:12]}",
+                            exc_info=True,
+                        )
+                        return
+                    if accepted:
+                        _record_disconnect_abort_on_scheduler(attribution_engine, rid)
+
+                asyncio.ensure_future(_await_and_record())
                 logger.warning(
                     f"[disconnect_guard] force-abort fell back to async "
                     f"engine.abort_request({str(request_id)[:12]}); the "
@@ -2173,24 +2204,6 @@ def _force_abort_request(engine, request_id_holder) -> bool:
                     f"time disconnect handling returns. The "
                     f"generator-close cascade is the remaining defense."
                 )
-                # M-01 attribution must fire on the async-fallback path
-                # too: ``BatchedEngine`` over ``AsyncEngineCore`` wraps
-                # the sync ``Scheduler.abort_request`` behind an async
-                # ``engine.abort_request`` shim, so the sync resolver
-                # returns ``None`` and we land here on the production
-                # default text path. The scheduler's
-                # ``_disconnect_abort_ids`` de-dup still pins the once-
-                # per-request semantics — calling
-                # ``record_disconnect_abort`` here is symmetric with the
-                # sync branch above. ``False`` is still returned because
-                # the abort itself isn't guaranteed in flight; the
-                # attribution counter ticks regardless because the
-                # eventual sync abort WILL reach the total counter via
-                # ``Scheduler.abort_request`` and we'd otherwise leave
-                # the via_disconnect sub-counter stuck at zero on every
-                # real-world disconnect (the bug Mei + Yana surfaced
-                # would only be HALF fixed).
-                _record_disconnect_abort_on_scheduler(engine, request_id)
                 # ``False`` so the contract reflects async-fallback;
                 # callers / tests treat that as "I tried, cascade is
                 # the remaining defense".

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1997,9 +1997,16 @@ def _resolve_sync_scheduler_for_abort(engine):
     return None
 
 
-def _resolve_scheduler_for_cancel_attribution(engine):
-    """M-01: walk the engine backend graph and return the scheduler-side
-    object that exposes ``record_disconnect_abort``.
+def _resolve_disconnect_abort_recorder(engine):
+    """M-01: walk the engine backend graph and return the bound
+    ``record_disconnect_abort`` method of the active-path scheduler.
+
+    Codex r2 NIT: returns the BOUND METHOD, not the scheduler object,
+    so the call site stays one expression
+    (``recorder(rid)``) without having to know which attribute name
+    to look up. The name is honest about that — earlier draft was
+    ``_resolve_scheduler_for_cancel_attribution`` which suggested a
+    scheduler object would be returned.
 
     The cancel-attribution sub-counter lives on the same scheduler
     where the public-API total counter lives, so the resolver must
@@ -2036,17 +2043,17 @@ def _resolve_scheduler_for_cancel_attribution(engine):
     # 1) Direct ``engine.scheduler`` — plain engines, tests, fakes.
     direct_scheduler = getattr(engine, "scheduler", None)
     if direct_scheduler is not None:
-        record = getattr(direct_scheduler, "record_disconnect_abort", None)
-        if record is not None:
-            return record
+        recorder = getattr(direct_scheduler, "record_disconnect_abort", None)
+        if recorder is not None:
+            return recorder
     # 2) Active-path gated walk on BatchedEngine.
     is_mllm_active = bool(getattr(engine, "_is_mllm", False))
     if is_mllm_active:
         mllm = getattr(engine, "_mllm_scheduler", None)
         if mllm is not None:
-            record = getattr(mllm, "record_disconnect_abort", None)
-            if record is not None:
-                return record
+            recorder = getattr(mllm, "record_disconnect_abort", None)
+            if recorder is not None:
+                return recorder
     else:
         inner = getattr(engine, "_engine", None)
         if inner is not None:
@@ -2054,9 +2061,9 @@ def _resolve_scheduler_for_cancel_attribution(engine):
             # resolver shape (used by every test stub today).
             inner_sched = getattr(inner, "scheduler", None)
             if inner_sched is not None:
-                record = getattr(inner_sched, "record_disconnect_abort", None)
-                if record is not None:
-                    return record
+                recorder = getattr(inner_sched, "record_disconnect_abort", None)
+                if recorder is not None:
+                    return recorder
             # 2b) ``engine._engine.engine.scheduler`` — the production
             # ``BatchedEngine`` over ``AsyncEngineCore`` shape. The
             # extra hop is where AsyncEngineCore wraps EngineCore.
@@ -2064,9 +2071,9 @@ def _resolve_scheduler_for_cancel_attribution(engine):
             if inner_engine is not None:
                 deep_sched = getattr(inner_engine, "scheduler", None)
                 if deep_sched is not None:
-                    record = getattr(deep_sched, "record_disconnect_abort", None)
-                    if record is not None:
-                        return record
+                    recorder = getattr(deep_sched, "record_disconnect_abort", None)
+                    if recorder is not None:
+                        return recorder
     return None
 
 
@@ -2082,9 +2089,9 @@ def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
     than reality — never breaks the abort itself.
     """
     try:
-        record = _resolve_scheduler_for_cancel_attribution(engine)
-        if record is not None:
-            record(request_id)
+        recorder = _resolve_disconnect_abort_recorder(engine)
+        if recorder is not None:
+            recorder(request_id)
     except Exception:  # pragma: no cover - belt-and-suspenders
         logger.warning(
             "[disconnect_guard] record_disconnect_abort raised; "


### PR DESCRIPTION
## Summary

- **M-01 (Mei r0.8.1 + Yana r3)** flagged that `/metrics` reported `rapid_mlx_requests_processed_total = 0` after fifty cancelled streaming requests. `num_requests_processed` deliberately excludes aborted requests (a stream that never produced an EOS-bounded response shouldn't be billed as "completed"), so operators staring at the counter-of-record can't distinguish "model is idle" from "every caller is bailing out before EOS". This PR adds `rapid_mlx_requests_cancelled_total` plus a `rapid_mlx_requests_cancelled_via_disconnect_total` sub-counter for cause attribution.
- **Observability only** — `Scheduler.abort_request` and `_force_abort_request` semantics are unchanged. Counters bolt on to existing returns and dedupe via `_pending_abort_ids` / `_disconnect_abort_ids` so the concurrent multi-branch disconnect_guard fires count once per request.
- **Mirrors the M-02 PFlash precedent** from #768 / #772: init at `scheduler.py:1869`, increment at the abort site, expose via `get_stats()`, render in `routes/metrics.py`. Defaults to zero on engines without the keys so dashboards never flip to "no data" after a deploy.

## Reproduction

`mlx-community/Qwen3-0.6B-8bit`, port 8923, fire 5 streaming requests, abort each after 0.5s via `httpx.aclose`:

**pre-fix** `/metrics | grep cancel` → (no matches)
**post-fix** `/metrics | grep cancel` →
```
rapid_mlx_requests_cancelled_total 5
rapid_mlx_requests_cancelled_via_disconnect_total 5
```

After +1 normal completion the cancel counter is unchanged:
```
rapid_mlx_requests_processed_total 1
rapid_mlx_requests_cancelled_total 5
```

Artifacts: `/tmp/cancel-before.txt`, `/tmp/cancel-after.txt`.

## Wiring

- **`Scheduler.abort_request`** — bumps `num_requests_cancelled` only when the id transitioned from absent-from-pending to present (idempotent re-enqueue does NOT double-count).
- **`Scheduler.record_disconnect_abort(rid)`** — new sync method on both `Scheduler` and `MLLMScheduler`. Idempotent via `_disconnect_abort_ids` set so the three-branch helper fire (disconnect + GeneratorExit + finally) attributes once per request.
- **`_force_abort_request`** — calls `record_disconnect_abort` after the sync abort returns True, AND from the async-fallback branch (production text path lands there because `AsyncEngineCore` wraps `EngineCore` behind an async shim).
- **`_resolve_scheduler_for_cancel_attribution`** — walks the same `_is_mllm`-gated backend graph as the sync abort resolver, PLUS an extra hop through `engine._engine.engine.scheduler` to reach the production `BatchedEngine -> AsyncEngineCore -> EngineCore` shape. The abort resolver doesn't need that hop (it falls back to async-public); the attribution helper does or the via_disconnect series stays flat through every real production disconnect.

## Test plan

- [x] Total counter starts at zero (fresh scheduler)
- [x] Total counter increments once per accepted abort (3 known ids → +3)
- [x] Total counter does NOT bump on unknown ids (F-151 path — `abort_request` returns False)
- [x] Total counter idempotent against double-enqueue (same id twice → +1)
- [x] Total counter monotonic across `reset()` (Prometheus contract)
- [x] Disconnect sub-counter bumps on `record_disconnect_abort` call
- [x] Disconnect sub-counter dedupes per request_id (three-branch helper fire → +1)
- [x] Disconnect sub-counter silent on empty / None request_id
- [x] Disconnect sub-counter decoupled from total (explicit cancel → total +1, sub +0)
- [x] `_force_abort_request` bumps disconnect sub-counter end-to-end
- [x] `_force_abort_request` does NOT record on rejected abort (False return)
- [x] `_force_abort_request` survives schedulers without `record_disconnect_abort` (older forks)
- [x] Attribution resolver walks production `BatchedEngine -> AsyncEngineCore -> EngineCore` shape
- [x] Attribution resolver respects `_is_mllm` active-path gate (text vs MLLM)
- [x] End-to-end: 3 streaming aborts via real `_disconnect_guard` cascade → both counters +3
- [x] End-to-end: 2 normally-exhausted streams leave both counters unchanged (`finished_normally` flag)
- [x] Route-side: `rapid_mlx_requests_cancelled_total` HELP/TYPE/value all render
- [x] Route-side: `rapid_mlx_requests_cancelled_via_disconnect_total` HELP/TYPE/value all render
- [x] Route-side: flat-line zero when scheduler doesn't populate the keys (older engines)
- [x] Route-side: flat-line zero when both counters are zero (quiet engine)
- [x] Live reproduction with Qwen3-0.6B-8bit confirms +5 on 5 streaming aborts (`/tmp/cancel-after.txt`)

Co-authored sweeps green: `tests/test_cancelled_requests_metric.py` (20 tests), `tests/test_pflash_metrics.py` (8), `tests/test_disconnect_guard_aborts_scheduler.py` (12), `tests/test_metrics_route.py` (17), plus the broader scheduler/abort/cancel suite (167 tests).

Lint clean (`ruff check` + `ruff format --check`).

No version bump (observability-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)