### PR TITLE
fix(security): route /v1/messages + /v1/responses ValidationError through sanitized envelope (H-17)

### DIFF
--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -391,6 +391,7 @@ def anthropic_client(monkeypatch):
 
     from vllm_mlx.config import reset_config
     from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
     from vllm_mlx.routes.anthropic import router
 
     cfg = reset_config()
@@ -406,6 +407,12 @@ def anthropic_client(monkeypatch):
     rate_limiter._requests.clear()
 
     app = FastAPI()
+    # H-17: mirror production wiring — the route relies on the global
+    # ``pydantic.ValidationError`` handler to map malformed payloads to
+    # the sanitized 400 envelope. Without the install, manually-built
+    # ``AnthropicRequest(**body)`` raises the raw exception and bubbles
+    # to a 500.
+    install_exception_handlers(app)
     app.include_router(router)
     yield SimpleNamespace(client=TestClient(app), engine=cfg.engine)
 
@@ -476,9 +483,14 @@ class TestRouteOutputConfigSurface:
             json=_payload(output_config={"format": {"type": "regex", "schema": {}}}),
         )
         assert resp.status_code == 400
-        detail = resp.json()["detail"]
-        assert "json_schema" in detail
-        assert "/v1/messages" in detail
+        # H-17: production wires the canonical envelope via
+        # ``install_exception_handlers`` — the route's ``HTTPException``
+        # surfaces as ``{"error": {"message": ...}}``, not as the
+        # FastAPI default ``{"detail": ...}``. Fixture was updated to
+        # install the global handlers; assert the real shape here.
+        message = resp.json()["error"]["message"]
+        assert "json_schema" in message
+        assert "/v1/messages" in message
         # The engine must NOT have been invoked for a 400.
         assert anthropic_client.engine.calls == []
 
@@ -488,7 +500,9 @@ class TestRouteOutputConfigSurface:
             json=_payload(output_config={"format": {"type": "json_schema"}}),
         )
         assert resp.status_code == 400
-        assert "schema" in resp.json()["detail"]
+        # H-17: see ``test_unknown_format_type_returns_400`` — envelope
+        # shape is the canonical ``error.message`` once handlers wire.
+        assert "schema" in resp.json()["error"]["message"]
         assert anthropic_client.engine.calls == []
 
     def test_invalid_schema_type_returns_400(self, anthropic_client):

--- a/tests/test_no_pydantic_error_leak.py
+++ b/tests/test_no_pydantic_error_leak.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-17 — Pydantic ``ValidationError`` text must not leak from
+``/v1/messages`` or ``/v1/responses``.
+
+Pre-fix repro (Rhea r0.8.1 audit):
+
+    POST /v1/responses
+    {"model":"x","messages":[],"FOO_BAR_INJECTED":"<attacker_pwned>"}
+
+    HTTP/1.1 400
+    {"error":{"message":"1 validation error for ResponsesRequest\\ninput\\n"
+              "  Field required [type=missing, input_value={..., 'FOO_BAR_"
+              "INJECTED': '<attacker_pwned>'}, input_type=dict]\\n    For "
+              "further information visit https://errors.pydantic.dev/2.13/"
+              "v/missing","type":"invalid_request_error","code":null,
+              "param":null}}
+
+The body leaks **three things at once**:
+
+1. The pinned Pydantic version (``errors.pydantic.dev/2.13/...``) — a
+   dependency-fingerprint vector that helps an attacker target
+   known-CVE Pydantic releases against this binary.
+2. The internal request-model class name (``ResponsesRequest``,
+   ``AnthropicRequest``, ``ChatCompletionRequest``) — code structure
+   recon.
+3. The attacker-controlled ``input_value`` echoed verbatim inside
+   ``[input_value=..., input_type=dict]`` — a stored-XSS-style
+   reflection vector (chat clients render error messages) and a
+   side-channel for any secret the attacker probes by including it
+   in a body field that fails validation.
+
+The systemic fix routes raw :class:`pydantic.ValidationError` through
+the same sanitized envelope ``/v1/chat/completions`` uses, via a new
+``@app.exception_handler(PydanticValidationError)`` in
+``middleware/exception_handlers.py``. The per-route
+``try: M(**body) except ValidationError: raise HTTPException(detail=str(e))``
+patches in ``routes/anthropic.py`` and ``routes/responses.py`` were
+deleted so the exception bubbles to the global handler.
+
+This module exercises the public surface end-to-end (TestClient
+against both routers + the installed exception handlers) and asserts
+both directions:
+
+* The 400 envelope MUST NOT contain ``pydantic``, ``ValidationError``,
+  the pinned version, the request-model class name, the
+  ``input_value=...`` echo, ``errors.pydantic.dev``, or any
+  attacker-supplied sentinel.
+* The 400 envelope MUST contain the canonical OpenAI error shape with
+  ``error.type == "invalid_request_error"`` and
+  ``error.code == "invalid_request"`` so legitimate clients can still
+  programmatically distinguish bad-input from rate-limit or auth
+  errors.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ── Lightweight engine stubs (same shape as test_exception_handlers) ─
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def encode(self, text: str) -> list[int]:
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str = ""
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+    tool_calls: list | None = None
+
+
+class _Engine:
+    preserve_native_tool_format = False
+
+    def __init__(self) -> None:
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):  # noqa: ARG002
+        return _GenerationOutput(text="hello", prompt_tokens=3, completion_tokens=1)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.anthropic",
+    "vllm_mlx.routes.responses",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "anthropic"),
+    ("vllm_mlx.routes", "responses"),
+)
+_MISSING = object()
+
+
+def _install_lightweight_engine_modules(monkeypatch) -> None:
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+def _build_app(monkeypatch, *, with_handlers: bool = True):
+    """Lightweight FastAPI app mounting /v1/messages + /v1/responses.
+
+    Mirrors :func:`tests.test_exception_handlers._build_app` — kept
+    local rather than imported so this regression is fully isolated
+    from the F-160/F-161/F-162 fixtures (the H-17 fix MUST stand on
+    its own even if the older fixture file is renamed).
+    """
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    cfg.api_key = None
+    cfg.engine = _Engine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    if with_handlers:
+        from vllm_mlx.middleware.exception_handlers import (
+            install_exception_handlers,
+        )
+
+        install_exception_handlers(app)
+    app.include_router(anthropic_router)
+    app.include_router(responses_router)
+
+    def teardown():
+        reset_config()
+        rate_limiter.enabled = False
+        rate_limiter.requests_per_minute = 60
+        rate_limiter._requests.clear()
+        for name, previous in previous_modules.items():
+            if previous is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        for (module_name, attr), previous in previous_attrs.items():
+            module = sys.modules.get(module_name)
+            if module is None:
+                continue
+            if previous is _MISSING:
+                if hasattr(module, attr):
+                    delattr(module, attr)
+            else:
+                setattr(module, attr, previous)
+
+    return app, cfg, teardown
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app, cfg, teardown = _build_app(monkeypatch, with_handlers=True)
+    try:
+        yield SimpleNamespace(client=TestClient(app), cfg=cfg)
+    finally:
+        teardown()
+
+
+# ── Bad-payload matrix ──────────────────────────────────────────────
+#
+# Cases chosen to hit each Pydantic v2 error class that would normally
+# emit the leaky default ``str(e)`` shape:
+#
+# * ``malformed-body``  — body parses to a non-dict (Pydantic's
+#   ``model_type`` error). The route's ``M(**body)`` itself raises
+#   ``TypeError`` for non-dict; we test the *list* case which goes
+#   through ``M(*body)``-style unpacking only when it's a dict, so we
+#   actually pass a dict that fails ``model_validator``.
+# * ``type-violation``  — ``messages: "not-a-list"`` triggers
+#   Pydantic's ``list_type`` error. Pre-fix leaked
+#   ``input_value='not-a-list'``.
+# * ``missing-required`` — drop the required ``model`` / ``input`` /
+#   ``max_tokens`` field. Pre-fix leaked ``input_value={'messages':
+#   ...}`` which echoes the whole body.
+# * ``extra-strict-injection`` — include an attacker-controlled extra
+#   field. Pre-fix the body echo in ``input_value=...`` carried the
+#   sentinel verbatim — clearest demonstration of the secret-bounce
+#   vector.
+
+_ATTACKER_SENTINEL = "<H17_ATTACKER_SENTINEL_pwned>"
+
+# Each entry: (case_id, /v1/messages body, /v1/responses body).
+# We keep separate per-endpoint bodies because the two request models
+# disagree on which fields are required (Anthropic needs ``max_tokens``;
+# Responses needs ``input`` instead of ``messages``). Reusing one body
+# would silently make one endpoint pass for the wrong reason.
+_BAD_BODIES = [
+    (
+        "type-violation",
+        {"model": "test-model", "messages": "not-a-list", "max_tokens": 10},
+        {"model": "test-model", "input": 12345, "max_output_tokens": 10},
+    ),
+    (
+        "missing-required-field",
+        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}]},
+    ),
+    (
+        "extra-strict-injection",
+        {
+            "messages": [{"role": "user", "content": "x"}],
+            # leave out required ``model`` + ``max_tokens`` so the
+            # attacker sentinel ends up in Pydantic's body echo on the
+            # legacy path.
+            "FOO_BAR_INJECTED": _ATTACKER_SENTINEL,
+        },
+        {
+            "messages": [{"role": "user", "content": "x"}],
+            "FOO_BAR_INJECTED": _ATTACKER_SENTINEL,
+        },
+    ),
+    (
+        "nested-type-violation",
+        {
+            "model": "test-model",
+            "max_tokens": 10,
+            # Each message must be a dict; passing an int per element
+            # trips the inner validator and the original ``str(e)``
+            # would have echoed the int back inside ``input_value=12345``.
+            "messages": [12345],
+        },
+        {
+            "model": "test-model",
+            # ``input`` is required for ResponsesRequest. Passing an
+            # int for the field hits the union-discriminator validator
+            # and the legacy path echoed the int in ``input_value=...``.
+            "input": 12345,
+            "max_output_tokens": 10,
+        },
+    ),
+]
+
+
+_LEAK_NEEDLES = (
+    # 1. Dependency-fingerprint vector — Pydantic help URLs include the
+    #    pinned major.minor version.
+    "errors.pydantic.dev",
+    # 2. Pinned Pydantic version (rapid-mlx v0.8.1 ships 2.13.x). Wider
+    #    than ``errors.pydantic.dev/2.13`` so a future upgrade to 2.14
+    #    doesn't silently make this test pass on a still-leaking 2.13
+    #    binary.
+    "pydantic",
+    # 3. The standard Pydantic v2 ``str(ValidationError)`` preamble.
+    "validation error for",
+    # 4. The ``[type=..., input_value=..., input_type=...]`` annotation
+    #    Pydantic appends per error — carries the attacker echo.
+    "input_value",
+    # 5. Internal request-model class names — code-structure recon.
+    "AnthropicRequest",
+    "ResponsesRequest",
+    "ChatCompletionRequest",
+)
+
+
+@pytest.mark.parametrize("case_id, msgs_body, resp_body", _BAD_BODIES)
+def test_messages_no_pydantic_leak(client, case_id, msgs_body, resp_body):
+    """H-17 — /v1/messages must sanitize Pydantic ValidationError."""
+    response = client.client.post("/v1/messages", json=msgs_body)
+    body_text = response.text.lower()
+    err = response.json().get("error")
+    assert response.status_code == 400, (
+        f"[{case_id}] /v1/messages expected 400; got {response.status_code} "
+        f"body={response.text!r}"
+    )
+    assert err is not None, f"[{case_id}] missing top-level 'error' object"
+    # Canonical envelope shape — clients programmatically rely on these.
+    assert err["type"] == "invalid_request_error", (
+        f"[{case_id}] error.type={err['type']!r}"
+    )
+    assert err["code"] == "invalid_request", f"[{case_id}] error.code={err['code']!r}"
+    assert "message" in err, f"[{case_id}] envelope missing message"
+    assert err["message"].startswith("Invalid request body:"), (
+        f"[{case_id}] message must start with canonical prefix; got {err['message']!r}"
+    )
+
+    # Defence-in-depth: no leak strings anywhere in the body (case-
+    # insensitive).
+    for needle in _LEAK_NEEDLES:
+        assert needle.lower() not in body_text, (
+            f"[{case_id}] /v1/messages leaked {needle!r} in 400 envelope; "
+            f"body={response.text!r}"
+        )
+    # Attacker-supplied sentinel must not bounce.
+    assert _ATTACKER_SENTINEL not in response.text, (
+        f"[{case_id}] /v1/messages echoed attacker sentinel; body={response.text!r}"
+    )
+
+
+@pytest.mark.parametrize("case_id, msgs_body, resp_body", _BAD_BODIES)
+def test_responses_no_pydantic_leak(client, case_id, msgs_body, resp_body):
+    """H-17 — /v1/responses must sanitize Pydantic ValidationError."""
+    response = client.client.post("/v1/responses", json=resp_body)
+    body_text = response.text.lower()
+    err = response.json().get("error")
+    assert response.status_code == 400, (
+        f"[{case_id}] /v1/responses expected 400; got {response.status_code} "
+        f"body={response.text!r}"
+    )
+    assert err is not None, f"[{case_id}] missing top-level 'error' object"
+    assert err["type"] == "invalid_request_error", (
+        f"[{case_id}] error.type={err['type']!r}"
+    )
+    assert err["code"] == "invalid_request", f"[{case_id}] error.code={err['code']!r}"
+    assert "message" in err, f"[{case_id}] envelope missing message"
+    assert err["message"].startswith("Invalid request body:"), (
+        f"[{case_id}] message must start with canonical prefix; got {err['message']!r}"
+    )
+
+    for needle in _LEAK_NEEDLES:
+        assert needle.lower() not in body_text, (
+            f"[{case_id}] /v1/responses leaked {needle!r} in 400 envelope; "
+            f"body={response.text!r}"
+        )
+    assert _ATTACKER_SENTINEL not in response.text, (
+        f"[{case_id}] /v1/responses echoed attacker sentinel; body={response.text!r}"
+    )
+
+
+# ── Defence-in-depth: the global handler covers the raw Pydantic ─────
+# ``ValidationError`` even when no route is involved (a future endpoint
+# that builds its model manually inherits the fix automatically).
+
+
+def test_global_handler_routes_raw_pydantic_validation_error(monkeypatch):
+    """A throwaway endpoint that raises raw ``pydantic.ValidationError``
+    must get the same sanitized 400 envelope as the route fix targets.
+
+    This makes the regression structural: the fix isn't ``/v1/messages``
+    + ``/v1/responses`` -specific, it's the global handler.
+    """
+    from pydantic import BaseModel
+
+    app, _cfg, teardown = _build_app(monkeypatch, with_handlers=True)
+    try:
+
+        class _Inner(BaseModel):
+            field_x: int
+
+        @app.post("/__h17_probe__")
+        async def _probe(req):  # noqa: ARG001
+            body = await req.json()
+            # Manual construction — the same anti-pattern messages /
+            # responses use. Raises pydantic.ValidationError directly.
+            return _Inner(**body)
+
+        client = TestClient(app)
+        response = client.post("/__h17_probe__", json={"field_x": "not-an-int"})
+        assert response.status_code == 400, response.text
+        err = response.json()["error"]
+        assert err["type"] == "invalid_request_error"
+        assert err["code"] == "invalid_request"
+        assert err["message"].startswith("Invalid request body:")
+        # Same sanitization on the probe path.
+        body_text = response.text.lower()
+        for needle in ("pydantic", "validation error for", "input_value"):
+            assert needle.lower() not in body_text, (
+                f"global handler leaked {needle!r}; body={response.text!r}"
+            )
+    finally:
+        teardown()
+
+
+# ── Pre-fix-state guard: assert the legacy ``str(e)`` shape NEVER ─────
+# returns by hitting a known-leak input with the production handler
+# installed. The negation is what the H-17 fix bought us; lock it in.
+
+
+def test_pre_fix_leak_no_longer_reproduces(client):
+    """Negative control — the exact byte sequence Rhea's repro lifted
+    from r0.8.1 must not appear in any 400 envelope shape."""
+    rhea_repro_body = {
+        "messages": [{"role": "user", "content": "x"}],
+        "FOO_BAR_INJECTED": _ATTACKER_SENTINEL,
+    }
+    for path in ("/v1/messages", "/v1/responses"):
+        response = client.client.post(path, json=rhea_repro_body)
+        # The pre-fix body literally contained:
+        #   "1 validation error for ResponsesRequest"
+        #   "[type=missing, input_value={'messages': ..."
+        #   "https://errors.pydantic.dev/2.13/v/missing"
+        # Lock each substring out.
+        assert "1 validation error for" not in response.text, response.text
+        assert "errors.pydantic.dev" not in response.text, response.text
+        assert "[type=missing" not in response.text, response.text
+        assert _ATTACKER_SENTINEL not in response.text, response.text
+        # And the canonical envelope is still there.
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        # JSON-encoding sanity: response must be valid JSON.
+        json.loads(response.text)

--- a/tests/test_no_pydantic_error_leak.py
+++ b/tests/test_no_pydantic_error_leak.py
@@ -52,8 +52,6 @@ both directions:
   errors.
 """
 
-from __future__ import annotations
-
 import json
 import sys
 import types
@@ -378,6 +376,101 @@ def test_responses_no_pydantic_leak(client, case_id, msgs_body, resp_body):
     )
 
 
+# ── H-17 round-2 (codex): attacker sentinel inside a KEY name ────────
+
+
+def test_attacker_key_in_loc_is_collapsed(monkeypatch):
+    """Codex H-17 round-2 finding: the original sanitizer joined the
+    full ``loc`` tuple into the 400 message verbatim. Pydantic v2
+    puts attacker-controlled dict keys / JSON-pointer escapes / extra-
+    forbid field names directly into ``loc``, so a body like
+    ``{"tags": {"<attacker_pwned>": "x"}}`` against a schema that
+    types ``tags`` as ``dict[str, int]`` would reflect the sentinel
+    in the 400 envelope even though the value was harmless.
+
+    Wires a throwaway endpoint with a ``dict[str, int]`` field, posts
+    an attacker-controlled key, and asserts the sentinel does NOT
+    appear anywhere in the envelope while the canonical shape still
+    surfaces. Uses :func:`_build_app` so the global handler install is
+    exercised end-to-end.
+    """
+    from fastapi import Request as _FastAPIRequest
+    from pydantic import BaseModel
+
+    app, _cfg, teardown = _build_app(monkeypatch, with_handlers=True)
+    try:
+
+        class _KeyEcho(BaseModel):
+            # ``dict[str, int]`` triggers per-key validation, so a bad
+            # value bubbles the key into ``loc``.
+            tags: dict[str, int]
+
+        @app.post("/__h17_key_probe__")
+        async def _probe(req: _FastAPIRequest):
+            body = await req.json()
+            return _KeyEcho(**body)
+
+        client = TestClient(app)
+        evil_key = "<H17_KEY_SENTINEL_pwned>"
+        response = client.post(
+            "/__h17_key_probe__",
+            json={"tags": {evil_key: "not-an-int"}},
+        )
+        assert response.status_code == 400, response.text
+        assert evil_key not in response.text, (
+            f"loc echoed attacker-controlled key: {response.text!r}"
+        )
+        # Envelope shape still canonical.
+        err = response.json()["error"]
+        assert err["type"] == "invalid_request_error"
+        assert err["code"] == "invalid_request"
+        assert err["message"].startswith("Invalid request body:")
+        # Sanitized placeholder shows up in place of the dangerous key.
+        assert "<key>" in err["message"], (
+            f"expected sanitized <key> placeholder; got {err['message']!r}"
+        )
+    finally:
+        teardown()
+
+
+def test_attacker_extra_field_name_is_collapsed(monkeypatch):
+    """Sibling of the dict-key test, but for ``ConfigDict(extra=
+    "forbid")`` schemas: Pydantic puts the rejected extra-field NAME
+    into ``loc[0]``. An attacker who can pick the field name
+    (``POST {"<sentinel>": 1, ...}``) would otherwise see it echoed in
+    the 400 envelope on any forbid-extras model wired to this handler.
+    """
+    from fastapi import Request as _FastAPIRequest
+    from pydantic import BaseModel, ConfigDict
+
+    app, _cfg, teardown = _build_app(monkeypatch, with_handlers=True)
+    try:
+
+        class _Strict(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            x: int
+
+        @app.post("/__h17_extra_probe__")
+        async def _probe(req: _FastAPIRequest):
+            body = await req.json()
+            return _Strict(**body)
+
+        client = TestClient(app)
+        evil_field = "<H17_EXTRA_FIELD_pwned>"
+        response = client.post(
+            "/__h17_extra_probe__", json={"x": 1, evil_field: "anything"}
+        )
+        assert response.status_code == 400, response.text
+        assert evil_field not in response.text, (
+            f"extra-field name echoed: {response.text!r}"
+        )
+        err = response.json()["error"]
+        assert err["type"] == "invalid_request_error"
+        assert err["code"] == "invalid_request"
+    finally:
+        teardown()
+
+
 # ── Defence-in-depth: the global handler covers the raw Pydantic ─────
 # ``ValidationError`` even when no route is involved (a future endpoint
 # that builds its model manually inherits the fix automatically).
@@ -390,6 +483,7 @@ def test_global_handler_routes_raw_pydantic_validation_error(monkeypatch):
     This makes the regression structural: the fix isn't ``/v1/messages``
     + ``/v1/responses`` -specific, it's the global handler.
     """
+    from fastapi import Request as _FastAPIRequest
     from pydantic import BaseModel
 
     app, _cfg, teardown = _build_app(monkeypatch, with_handlers=True)
@@ -399,7 +493,7 @@ def test_global_handler_routes_raw_pydantic_validation_error(monkeypatch):
             field_x: int
 
         @app.post("/__h17_probe__")
-        async def _probe(req):  # noqa: ARG001
+        async def _probe(req: _FastAPIRequest):
             body = await req.json()
             # Manual construction — the same anti-pattern messages /
             # responses use. Raises pydantic.ValidationError directly.

--- a/tests/test_no_pydantic_error_leak.py
+++ b/tests/test_no_pydantic_error_leak.py
@@ -503,6 +503,72 @@ def test_attacker_extra_field_name_is_collapsed(monkeypatch, evil_field):
         teardown()
 
 
+# ── H-17 round-3 (codex): operator logs must NOT carry attacker bytes ─
+
+
+def test_pydantic_handler_log_does_not_leak_attacker_input(monkeypatch, caplog):
+    """Codex H-17 round-3 BLOCKING: the WARNING log path added for
+    NIT #4 must not write the raw ``ValidationError`` to the log
+    (``exc_info=exc`` or ``str(exc)``) — Pydantic's text form embeds
+    ``input_value=...`` which carries attacker-supplied bytes. An
+    attacker can pivot secrets from a request body into the
+    operator's log pipeline by stuffing them into a field that fails
+    validation.
+
+    Send a malformed body with a sentinel and assert the captured log
+    records contain only sanitized metadata (error ``type`` codes and
+    sanitized ``loc``), never the sentinel and never the leaky
+    Pydantic strings.
+    """
+    from fastapi import Request as _FastAPIRequest
+    from pydantic import BaseModel
+
+    app, _cfg, teardown = _build_app(monkeypatch, with_handlers=True)
+    try:
+
+        class _Inner(BaseModel):
+            field_x: int
+
+        @app.post("/__h17_log_probe__")
+        async def _probe(req: _FastAPIRequest):
+            body = await req.json()
+            return _Inner(**body)
+
+        sentinel = "H17_LOG_SENTINEL_pwned_secret_value"
+        client = TestClient(app)
+
+        with caplog.at_level("WARNING", logger="rapid_mlx.exception_handlers"):
+            response = client.post("/__h17_log_probe__", json={"field_x": sentinel})
+
+        assert response.status_code == 400
+        # The handler must emit at least one log line (the operator-
+        # visibility WARNING).
+        assert any(
+            "pydantic.ValidationError" in r.getMessage() for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+        # No log line may carry the attacker sentinel — neither in the
+        # main message, the args, nor the exc_info traceback (which
+        # codex round-3 BLOCKING said must not be set).
+        for record in caplog.records:
+            joined = record.getMessage() + " " + repr(record.args)
+            if record.exc_info:
+                import traceback as _tb
+
+                joined += "".join(_tb.format_exception(*record.exc_info))
+            assert sentinel not in joined, (
+                f"WARNING log leaked attacker sentinel: {joined!r}"
+            )
+            # Sanity: the leaky Pydantic strings stay out of the log too.
+            assert "input_value=" not in joined, (
+                f"WARNING log leaked pydantic input_value=: {joined!r}"
+            )
+            assert "errors.pydantic.dev" not in joined, (
+                f"WARNING log leaked pydantic.dev help URL: {joined!r}"
+            )
+    finally:
+        teardown()
+
+
 # ── Defence-in-depth: the global handler covers the raw Pydantic ─────
 # ``ValidationError`` even when no route is involved (a future endpoint
 # that builds its model manually inherits the fix automatically).

--- a/tests/test_no_pydantic_error_leak.py
+++ b/tests/test_no_pydantic_error_leak.py
@@ -379,20 +379,35 @@ def test_responses_no_pydantic_leak(client, case_id, msgs_body, resp_body):
 # ── H-17 round-2 (codex): attacker sentinel inside a KEY name ────────
 
 
-def test_attacker_key_in_loc_is_collapsed(monkeypatch):
-    """Codex H-17 round-2 finding: the original sanitizer joined the
-    full ``loc`` tuple into the 400 message verbatim. Pydantic v2
-    puts attacker-controlled dict keys / JSON-pointer escapes / extra-
-    forbid field names directly into ``loc``, so a body like
-    ``{"tags": {"<attacker_pwned>": "x"}}`` against a schema that
-    types ``tags`` as ``dict[str, int]`` would reflect the sentinel
-    in the 400 envelope even though the value was harmless.
+# Codex H-17 round-2 (PR #784 review BLOCKING #2 + #3): exercise the
+# loc-sanitizer across the full byte shape an attacker can choose for
+# a dict key or an extra-forbid field name. The original sanitizer's
+# identifier-shape regex passed valid-identifier sentinels (e.g.
+# ``AWS_SECRET_ACCESS_KEY``) through verbatim; the current sanitizer
+# collapses **every** string ``loc`` component, so all of these must
+# be reflected back as ``<field>`` regardless of byte shape.
+_ATTACKER_KEY_SHAPES = [
+    "AWS_SECRET_ACCESS_KEY",  # valid Python identifier, all caps
+    "h17_key_sentinel_pwned",  # valid Python identifier, all lower
+    "H17KeySentinelPwnedCamel",  # valid Python identifier, camel
+    "<H17_KEY_SENTINEL_pwned>",  # punctuation-bracketed (round-1 only)
+    "X-Forwarded-For",  # contains dashes, header-shaped
+    "../../etc/passwd",  # path-traversal probe
+    "a" * 256,  # oversized identifier
+]
 
-    Wires a throwaway endpoint with a ``dict[str, int]`` field, posts
-    an attacker-controlled key, and asserts the sentinel does NOT
-    appear anywhere in the envelope while the canonical shape still
-    surfaces. Uses :func:`_build_app` so the global handler install is
-    exercised end-to-end.
+
+@pytest.mark.parametrize("evil_key", _ATTACKER_KEY_SHAPES)
+def test_attacker_key_in_loc_is_collapsed(monkeypatch, evil_key):
+    """Codex H-17 round-2 BLOCKING #1: Pydantic v2 puts attacker-
+    controlled dict keys directly into ``loc`` for ``dict[str, T]``
+    fields. The round-1 identifier regex let identifier-shaped keys
+    (e.g. ``AWS_SECRET_ACCESS_KEY``) pass through, still leaking a
+    side-channel for any attacker who can stage a bad value under a
+    chosen key. The current sanitizer must collapse **every** string
+    ``loc`` component regardless of shape — this test parametrizes
+    over identifier-shaped, punctuation-bracketed, dashed, and
+    oversized sentinels and asserts the envelope never reflects them.
     """
     from fastapi import Request as _FastAPIRequest
     from pydantic import BaseModel
@@ -411,14 +426,13 @@ def test_attacker_key_in_loc_is_collapsed(monkeypatch):
             return _KeyEcho(**body)
 
         client = TestClient(app)
-        evil_key = "<H17_KEY_SENTINEL_pwned>"
         response = client.post(
             "/__h17_key_probe__",
             json={"tags": {evil_key: "not-an-int"}},
         )
         assert response.status_code == 400, response.text
         assert evil_key not in response.text, (
-            f"loc echoed attacker-controlled key: {response.text!r}"
+            f"loc echoed attacker-controlled key {evil_key!r}: {response.text!r}"
         )
         # Envelope shape still canonical.
         err = response.json()["error"]
@@ -426,19 +440,34 @@ def test_attacker_key_in_loc_is_collapsed(monkeypatch):
         assert err["code"] == "invalid_request"
         assert err["message"].startswith("Invalid request body:")
         # Sanitized placeholder shows up in place of the dangerous key.
-        assert "<key>" in err["message"], (
-            f"expected sanitized <key> placeholder; got {err['message']!r}"
+        assert "<field>" in err["message"], (
+            f"expected sanitized <field> placeholder; got {err['message']!r}"
         )
     finally:
         teardown()
 
 
-def test_attacker_extra_field_name_is_collapsed(monkeypatch):
-    """Sibling of the dict-key test, but for ``ConfigDict(extra=
-    "forbid")`` schemas: Pydantic puts the rejected extra-field NAME
-    into ``loc[0]``. An attacker who can pick the field name
-    (``POST {"<sentinel>": 1, ...}``) would otherwise see it echoed in
-    the 400 envelope on any forbid-extras model wired to this handler.
+# Codex H-17 round-2 BLOCKING #3: extra-forbid field names also need
+# to be tested with identifier-shaped sentinels; the round-1 regex
+# would have admitted them.
+_ATTACKER_EXTRA_FIELD_SHAPES = [
+    "AWS_SECRET_ACCESS_KEY",
+    "h17_extra_field_pwned",
+    "H17ExtraFieldPwnedCamel",
+    "<H17_EXTRA_FIELD_pwned>",
+    "X-Sensitive-Header",
+    "Z" * 256,
+]
+
+
+@pytest.mark.parametrize("evil_field", _ATTACKER_EXTRA_FIELD_SHAPES)
+def test_attacker_extra_field_name_is_collapsed(monkeypatch, evil_field):
+    """``ConfigDict(extra="forbid")`` puts the rejected field NAME into
+    ``loc[0]``. An attacker who can pick the field name would
+    otherwise see it echoed verbatim. Parametrize over the same shape
+    matrix as the dict-key test so an identifier-shaped extra field
+    (``AWS_SECRET_ACCESS_KEY=...``) is exercised explicitly per codex
+    round-2 BLOCKING #3.
     """
     from fastapi import Request as _FastAPIRequest
     from pydantic import BaseModel, ConfigDict
@@ -456,17 +485,20 @@ def test_attacker_extra_field_name_is_collapsed(monkeypatch):
             return _Strict(**body)
 
         client = TestClient(app)
-        evil_field = "<H17_EXTRA_FIELD_pwned>"
         response = client.post(
             "/__h17_extra_probe__", json={"x": 1, evil_field: "anything"}
         )
         assert response.status_code == 400, response.text
         assert evil_field not in response.text, (
-            f"extra-field name echoed: {response.text!r}"
+            f"extra-field name {evil_field!r} echoed: {response.text!r}"
         )
         err = response.json()["error"]
         assert err["type"] == "invalid_request_error"
         assert err["code"] == "invalid_request"
+        # Sanitized placeholder shows up where the field name used to.
+        assert "<field>" in err["message"], (
+            f"expected <field> placeholder; got {err['message']!r}"
+        )
     finally:
         teardown()
 

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -129,6 +129,7 @@ def responses_client(monkeypatch):
 
     from vllm_mlx.config import reset_config
     from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
     from vllm_mlx.routes.responses import router
 
     cfg = reset_config()
@@ -142,6 +143,13 @@ def responses_client(monkeypatch):
     rate_limiter._requests.clear()
 
     app = FastAPI()
+    # H-17: mirror production wiring — the route relies on the global
+    # ``pydantic.ValidationError`` handler to map bad bodies to the
+    # sanitized 400 envelope. The earlier fixture omitted handler
+    # install and the route's now-removed per-route ``try/except`` was
+    # producing the 400 instead, which masked the leak this fixture is
+    # meant to gate against.
+    install_exception_handlers(app)
     app.include_router(router)
     yield SimpleNamespace(
         client=TestClient(app),
@@ -194,7 +202,13 @@ class TestResponsesAuth:
         response = client.post("/v1/responses", json=_payload())
 
         assert response.status_code == 401
-        assert response.json()["detail"] == "API key required"
+        # H-17: fixture now installs the global exception handlers
+        # (mirror production). Auth ``HTTPException(detail="...")`` is
+        # wrapped in the canonical OpenAI envelope by
+        # ``_http_error_response`` — assert the new shape, not the raw
+        # FastAPI default ``{"detail": "..."}`` that fixture-less tests
+        # would have seen.
+        assert response.json()["error"]["message"] == "API key required"
         assert engine.calls == []
 
     def test_rejects_invalid_bearer(self, responses_client):
@@ -349,7 +363,10 @@ class TestStatelessGate:
         )
 
         assert response.status_code == 400
-        assert "previous_response_id" in response.json()["detail"]
+        # H-17: fixture installs the global exception handlers (mirror
+        # production), so the route's ``HTTPException`` is wrapped in
+        # the canonical OpenAI envelope by ``_http_error_response``.
+        assert "previous_response_id" in response.json()["error"]["message"]
         # Engine must not have been called.
         assert engine.calls == []
 

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json as _json
 import logging
-import re
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
@@ -47,32 +46,32 @@ from starlette.responses import JSONResponse
 
 logger = logging.getLogger("rapid_mlx.exception_handlers")
 
-# H-17 round-2 (codex): Pydantic v2 puts attacker-controlled dict
-# keys, JSON-pointer-style indices, and (with ``extra="forbid"``)
-# arbitrary extra-field names directly into the ``loc`` tuple of every
-# error it raises. The original sanitizer joined those components
-# verbatim into the 400 envelope — so a request body like
-# ``{"metadata": {"<attacker_pwned>": 12345}}`` against any schema
-# that types ``metadata`` as ``dict[str, int]`` would bounce the
-# sentinel right back to the caller. Lock the surface down: a ``loc``
-# component is allowed through only if it's a positional list index
-# (int) or a strict Python-style identifier from the schema itself.
-# Anything else collapses to ``<key>`` so the envelope still tells the
-# caller "the error was here" without echoing the dangerous bytes.
-_SAFE_LOC_KEY = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]{0,63}\Z")
-
 
 def _sanitize_loc(loc: tuple) -> str:
     """Collapse a Pydantic ``loc`` tuple to a safe dotted path.
 
     Drops the synthetic ``"body"`` prefix FastAPI prepends. Keeps
-    positional indices (``int``) and short Python-style identifiers
-    (≤64 chars, ``[A-Za-z_][A-Za-z0-9_]*``) — these are schema-
-    determined and safe to surface. Replaces anything else (Unicode,
-    punctuation, whitespace, oversized strings — all attacker-
-    controlled signals) with the placeholder ``<key>`` so the envelope
-    still carries enough shape to be actionable without reflecting
-    user input.
+    positional indices (``int``) as-is — they come from list/sequence
+    positions and the attacker can't inject arbitrary bytes there.
+    Replaces **every** string component with the placeholder
+    ``<field>`` so attacker-controlled bytes are never reflected:
+
+    * Pydantic v2 puts dict keys (``dict[str, T]`` types), JSON-
+      pointer-style indices, and (with ``ConfigDict(extra="forbid")``)
+      the rejected extra-field NAME directly into ``loc`` —
+      indistinguishable from the schema-owned field names at the
+      string level. Codex H-17 round-2 BLOCKING #1 caught that any
+      shape-based whitelist (e.g. identifier regex) still leaks
+      identifier-shaped attacker bytes like ``AWS_SECRET_ACCESS_KEY``.
+    * Schema-owned field names are public API surface anyway, so
+      losing them in the envelope costs at most an informational
+      hint; the validator message itself ("Field required", "Input
+      should be a valid list", ...) already conveys the failure mode.
+
+    Net effect: the 400 still carries actionable structure (e.g.
+    ``<field>.0.<field>: Input should be a valid integer``) and the
+    Pydantic error message, without echoing a single byte the caller
+    chose.
     """
     parts: list[str] = []
     for raw in loc:
@@ -81,12 +80,12 @@ def _sanitize_loc(loc: tuple) -> str:
         if isinstance(raw, int):
             parts.append(str(raw))
             continue
-        if isinstance(raw, str) and _SAFE_LOC_KEY.match(raw):
-            parts.append(raw)
-            continue
-        # Attacker-supplied dict key, JSON-pointer escape, oversized
-        # extra-field name, etc. Collapse to a fixed placeholder.
-        parts.append("<key>")
+        # All string components — whether schema-owned or attacker-
+        # supplied — collapse to a constant placeholder. The Pydantic
+        # error MESSAGE ("Field required", etc.) is schema-determined
+        # and is still surfaced separately, so we lose only the
+        # field-name hint, never any byte the attacker can choose.
+        parts.append("<field>")
     return ".".join(parts)
 
 
@@ -235,7 +234,7 @@ def install_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(PydanticValidationError)
     async def _pydantic_validation_handler(
-        request: Request,  # noqa: ARG001
+        request: Request,
         exc: PydanticValidationError,
     ):
         # H-17: routes that build a Pydantic model manually
@@ -247,6 +246,22 @@ def install_exception_handlers(app: FastAPI) -> None:
         # bound bodies so the model class name, the pinned pydantic
         # version (``errors.pydantic.dev/2.13/...``), and the attacker-
         # supplied ``input_value`` stay out of the response body.
+        #
+        # Codex H-17 round-2 NIT #4: a global handler converts every
+        # internal Pydantic bug into a client 400, which can mask
+        # server-side defects. Log at WARNING with the request path so
+        # operators can spot "this 400 actually came from a server-
+        # side response-model construction failure". The exception
+        # text (which contains the leaky details) goes only to the log
+        # — never to the client.
+        logger.warning(
+            "pydantic.ValidationError on %s %s — %d error(s); "
+            "response body is the sanitized H-17 envelope",
+            request.method,
+            request.url.path,
+            len(exc.errors()),
+            exc_info=exc,
+        )
         return _validation_error_response(exc)
 
     @app.exception_handler(Exception)

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -19,6 +19,18 @@ Fixes covered:
 * F-094 / F-104 mitigation — the default FastAPI 422 echoes the
   offending value verbatim in ``detail[*].input``. We collapse to a
   400 with no value echo and strip the pydantic.dev help URL (F-163).
+* H-17 — ``/v1/messages`` and ``/v1/responses`` construct their
+  Pydantic request models manually (``AnthropicRequest(**body)`` /
+  ``ResponsesRequest(**body)``) instead of binding them as FastAPI
+  body parameters, so the resulting :class:`pydantic.ValidationError`
+  never reached ``RequestValidationError``. The previous per-route
+  ``raise HTTPException(status_code=400, detail=str(e))`` patches
+  echoed the full Pydantic message — leaking the model class name,
+  the pinned pydantic version (``errors.pydantic.dev/2.13/...``),
+  and attacker-controlled ``input_value`` blobs. The dedicated
+  ``pydantic.ValidationError`` handler below routes both routes
+  through the same sanitized 400 envelope used by ``/v1/chat/
+  completions`` and ``/v1/completions``.
 """
 
 from __future__ import annotations
@@ -28,6 +40,7 @@ import logging
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError as PydanticValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import JSONResponse
 
@@ -55,12 +68,21 @@ def _decode_error_response(exc: _json.JSONDecodeError) -> JSONResponse:
     )
 
 
-def _validation_error_response(exc: RequestValidationError) -> JSONResponse:
+def _validation_error_response(
+    exc: RequestValidationError | PydanticValidationError,
+) -> JSONResponse:
     """Build the 400 envelope for Pydantic body-validation failures.
 
     Strips ``detail[*].input`` (F-094 / F-104 secret-bounce vector)
     and drops the pydantic.dev help URL (F-163). Surfaces only the
     location + message so clients still get an actionable hint.
+
+    Accepts both the FastAPI-wrapped :class:`RequestValidationError`
+    (raised when a Pydantic model is bound as a FastAPI body parameter)
+    and the raw :class:`pydantic.ValidationError` (raised when a route
+    constructs the request model manually — e.g. ``/v1/messages`` and
+    ``/v1/responses``). Both expose the same ``.errors()`` shape, so a
+    single sanitizer covers both code paths (H-17).
     """
     details = []
     for err in exc.errors():
@@ -163,6 +185,22 @@ def install_exception_handlers(app: FastAPI) -> None:
     ):
         return _validation_error_response(exc)
 
+    @app.exception_handler(PydanticValidationError)
+    async def _pydantic_validation_handler(
+        request: Request,  # noqa: ARG001
+        exc: PydanticValidationError,
+    ):
+        # H-17: routes that build a Pydantic model manually
+        # (``AnthropicRequest(**body)`` on /v1/messages,
+        # ``ResponsesRequest(**body)`` on /v1/responses, plus the
+        # adapter-layer ``ChatCompletionRequest`` constructions inside
+        # those routes) raise the raw ``pydantic.ValidationError``.
+        # Route it through the same sanitized envelope as the FastAPI-
+        # bound bodies so the model class name, the pinned pydantic
+        # version (``errors.pydantic.dev/2.13/...``), and the attacker-
+        # supplied ``input_value`` stay out of the response body.
+        return _validation_error_response(exc)
+
     @app.exception_handler(Exception)
     async def _generic_handler(request: Request, exc: Exception):
         # Re-route the specific subclasses in case a TaskGroup /
@@ -172,6 +210,8 @@ def install_exception_handlers(app: FastAPI) -> None:
         if isinstance(exc, _json.JSONDecodeError):
             return _decode_error_response(exc)
         if isinstance(exc, RequestValidationError):
+            return _validation_error_response(exc)
+        if isinstance(exc, PydanticValidationError):
             return _validation_error_response(exc)
         if isinstance(exc, StarletteHTTPException):
             return _http_error_response(exc)

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -128,7 +128,7 @@ def _validation_error_response(
 
     The ``loc`` is run through :func:`_sanitize_loc` so attacker-
     controlled dict keys / extra-field names (codex H-17 round-2
-    finding) collapse to ``<key>`` instead of being echoed verbatim
+    finding) collapse to ``<field>`` instead of being echoed verbatim
     in the 400 message.
     """
     details = []
@@ -249,18 +249,33 @@ def install_exception_handlers(app: FastAPI) -> None:
         #
         # Codex H-17 round-2 NIT #4: a global handler converts every
         # internal Pydantic bug into a client 400, which can mask
-        # server-side defects. Log at WARNING with the request path so
-        # operators can spot "this 400 actually came from a server-
-        # side response-model construction failure". The exception
-        # text (which contains the leaky details) goes only to the log
-        # — never to the client.
+        # server-side defects. Log at WARNING with sanitized metadata
+        # so operators can spot "this 400 actually came from a server-
+        # side response-model construction failure".
+        #
+        # Codex H-17 round-3 BLOCKING: do NOT pass the raw exception
+        # (``exc_info=exc`` or ``str(exc)``) — its string form embeds
+        # ``input_value=...`` which can carry attacker-supplied
+        # secrets, and this PR is explicitly preventing that
+        # reflection. Operator log lines must be sanitized too;
+        # otherwise an attacker can stuff secrets into a body field
+        # and pivot them into the operator's log pipeline. We surface
+        # only the per-error ``type`` codes (``missing``,
+        # ``int_parsing``, ``extra_forbidden``, …) and the sanitized
+        # ``loc`` path — both schema-determined.
+        sanitized = [
+            {
+                "type": err.get("type", "validation_error"),
+                "loc": _sanitize_loc(tuple(err.get("loc", ()))),
+            }
+            for err in exc.errors()
+        ]
         logger.warning(
-            "pydantic.ValidationError on %s %s — %d error(s); "
-            "response body is the sanitized H-17 envelope",
+            "pydantic.ValidationError on %s %s — %d sanitized error(s): %s",
             request.method,
             request.url.path,
-            len(exc.errors()),
-            exc_info=exc,
+            len(sanitized),
+            sanitized,
         )
         return _validation_error_response(exc)
 

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
+import re
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
@@ -45,6 +46,48 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import JSONResponse
 
 logger = logging.getLogger("rapid_mlx.exception_handlers")
+
+# H-17 round-2 (codex): Pydantic v2 puts attacker-controlled dict
+# keys, JSON-pointer-style indices, and (with ``extra="forbid"``)
+# arbitrary extra-field names directly into the ``loc`` tuple of every
+# error it raises. The original sanitizer joined those components
+# verbatim into the 400 envelope — so a request body like
+# ``{"metadata": {"<attacker_pwned>": 12345}}`` against any schema
+# that types ``metadata`` as ``dict[str, int]`` would bounce the
+# sentinel right back to the caller. Lock the surface down: a ``loc``
+# component is allowed through only if it's a positional list index
+# (int) or a strict Python-style identifier from the schema itself.
+# Anything else collapses to ``<key>`` so the envelope still tells the
+# caller "the error was here" without echoing the dangerous bytes.
+_SAFE_LOC_KEY = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]{0,63}\Z")
+
+
+def _sanitize_loc(loc: tuple) -> str:
+    """Collapse a Pydantic ``loc`` tuple to a safe dotted path.
+
+    Drops the synthetic ``"body"`` prefix FastAPI prepends. Keeps
+    positional indices (``int``) and short Python-style identifiers
+    (≤64 chars, ``[A-Za-z_][A-Za-z0-9_]*``) — these are schema-
+    determined and safe to surface. Replaces anything else (Unicode,
+    punctuation, whitespace, oversized strings — all attacker-
+    controlled signals) with the placeholder ``<key>`` so the envelope
+    still carries enough shape to be actionable without reflecting
+    user input.
+    """
+    parts: list[str] = []
+    for raw in loc:
+        if raw == "body":
+            continue
+        if isinstance(raw, int):
+            parts.append(str(raw))
+            continue
+        if isinstance(raw, str) and _SAFE_LOC_KEY.match(raw):
+            parts.append(raw)
+            continue
+        # Attacker-supplied dict key, JSON-pointer escape, oversized
+        # extra-field name, etc. Collapse to a fixed placeholder.
+        parts.append("<key>")
+    return ".".join(parts)
 
 
 def _decode_error_response(exc: _json.JSONDecodeError) -> JSONResponse:
@@ -83,10 +126,15 @@ def _validation_error_response(
     constructs the request model manually — e.g. ``/v1/messages`` and
     ``/v1/responses``). Both expose the same ``.errors()`` shape, so a
     single sanitizer covers both code paths (H-17).
+
+    The ``loc`` is run through :func:`_sanitize_loc` so attacker-
+    controlled dict keys / extra-field names (codex H-17 round-2
+    finding) collapse to ``<key>`` instead of being echoed verbatim
+    in the 400 message.
     """
     details = []
     for err in exc.errors():
-        loc = ".".join(str(p) for p in err.get("loc", ()) if p != "body")
+        loc = _sanitize_loc(tuple(err.get("loc", ())))
         msg = err.get("msg", "validation error")
         details.append(f"{loc}: {msg}" if loc else msg)
     summary = "; ".join(details) or "Invalid request body"

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -9,7 +9,6 @@ from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
-from pydantic import ValidationError
 
 from ..api.anthropic_adapter import (
     AnthropicOutputConfigError,
@@ -280,14 +279,14 @@ async def create_anthropic_message(
     """
     body = await request.json()
     # ``AnthropicRequest`` is constructed manually (not as a FastAPI body
-    # parameter), so Pydantic ``ValidationError`` would otherwise surface
-    # as a generic 500. Catch it explicitly to give clients a 400 with
-    # the actual validation detail — matches the ergonomics of the
-    # ``output_config`` 400 path below (PR #42396 backport).
-    try:
-        anthropic_request = AnthropicRequest(**body)
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    # parameter). The raw :class:`pydantic.ValidationError` it can raise
+    # is now caught by the global ``_pydantic_validation_handler`` in
+    # ``middleware.exception_handlers`` (H-17), which routes it through
+    # the same sanitized 400 envelope used by ``/v1/chat/completions``.
+    # Letting the exception bubble keeps the model class name, the
+    # pinned pydantic version (``errors.pydantic.dev/2.13/...``), and
+    # the attacker-supplied ``input_value`` out of the response body.
+    anthropic_request = AnthropicRequest(**body)
 
     if not (anthropic_request.model or "").startswith(("claude-", "gpt-")):
         _validate_model_name(anthropic_request.model)
@@ -337,18 +336,17 @@ async def create_anthropic_message(
         # ``AnthropicOutputConfigError`` (a ``ValueError`` subclass) on
         # malformed ``output_config`` payloads — backport of upstream vLLM
         # PR #42396; map directly to HTTP 400 with the adapter's message.
+        # F-034: ``anthropic_to_openai`` constructs a ``ChatCompletionRequest``
+        # which now rejects unsatisfiable combinations (e.g.
+        # ``tool_choice="required"`` — Anthropic ``any`` — with no
+        # ``tools``). The resulting :class:`pydantic.ValidationError` is
+        # caught by the global ``_pydantic_validation_handler`` (H-17)
+        # so we no longer wrap it in ``str(e)`` here — that wrapping was
+        # the source of the H-17 leak (model class name + pydantic
+        # version + attacker ``input_value`` echo).
         try:
             openai_request = anthropic_to_openai(anthropic_request)
         except AnthropicOutputConfigError as e:
-            raise HTTPException(status_code=400, detail=str(e))
-        except ValidationError as e:
-            # F-034 (and any future ``ChatCompletionRequest``-layer
-            # validator): the adapter constructs an OpenAI-shape request
-            # from the Anthropic body, and ``ChatCompletionRequest`` now
-            # rejects unsatisfiable combinations (e.g. ``tool_choice="required"``
-            # — Anthropic ``any`` — with no ``tools``). Surface as 400 with
-            # the validator's message instead of letting Pydantic crash
-            # the route into a 500.
             raise HTTPException(status_code=400, detail=str(e))
 
         # Context-length pre-check — same DoS gate the chat/completions/

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -22,7 +22,6 @@ from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
-from pydantic import ValidationError
 
 from ..api.models import (
     AssistantMessage,
@@ -111,18 +110,15 @@ async def create_response(request: Request):
     """
     body = await request.json()
     # ``ResponsesRequest`` is constructed manually (not as a FastAPI body
-    # parameter), so Pydantic ``ValidationError`` would otherwise surface
-    # as a generic 500. Catch it explicitly to give clients a 400 with
-    # the actual validation detail — matches the same pattern in
-    # ``routes/anthropic.py``. Codex bundled-review finding on the
-    # v0.7.32 release bundle: #685's strict ``reasoning_max_tokens``
-    # ``model_validator(mode="before")`` now raises on bad input
-    # (``0``, ``true``, ``"100"``), and without this catch a malformed
-    # client request would 500 here instead of 400.
-    try:
-        responses_request = ResponsesRequest(**body)
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    # parameter). The raw :class:`pydantic.ValidationError` it can raise
+    # is now caught by the global ``_pydantic_validation_handler`` in
+    # ``middleware.exception_handlers`` (H-17), which routes it through
+    # the same sanitized 400 envelope used by ``/v1/chat/completions``.
+    # The earlier per-route ``HTTPException(detail=str(e))`` leaked the
+    # model class name (``ResponsesRequest``), the pinned pydantic
+    # version (``errors.pydantic.dev/2.13/...``), and any attacker-
+    # supplied ``input_value`` blob — see Rhea r0.8.1 audit.
+    responses_request = ResponsesRequest(**body)
 
     # Statelessness gate — see module docstring. Codex CLI does not set
     # this field; clients that DO use it would get silent prompt loss
@@ -168,13 +164,12 @@ async def create_response(request: Request):
         # F-034 (and any future ``ChatCompletionRequest``-layer validator):
         # the adapter materializes a fresh ``ChatCompletionRequest`` from
         # the Responses body, which now rejects unsatisfiable combinations
-        # (e.g. ``tool_choice="required"`` with no ``tools``). Surface as
-        # 400 with the validator's message instead of letting Pydantic
-        # crash the route into a 500.
-        try:
-            openai_request = responses_to_openai(responses_request)
-        except ValidationError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+        # (e.g. ``tool_choice="required"`` with no ``tools``). The
+        # resulting :class:`pydantic.ValidationError` bubbles to the
+        # global ``_pydantic_validation_handler`` (H-17) which routes
+        # it through the sanitized 400 envelope — no more ``str(e)``
+        # echo that leaked the model class name and pydantic version.
+        openai_request = responses_to_openai(responses_request)
 
         # Context-length pre-check — same DoS gate the chat/completions/
         # anthropic routes enforce. Runs BEFORE the stream branch so


### PR DESCRIPTION
## Summary

Rhea r0.8.1 audit (H-17, HIGH, NEW) caught that `/v1/messages` and `/v1/responses` leak raw Pydantic `ValidationError` text in their 400 envelopes:

* Pinned Pydantic version (`errors.pydantic.dev/2.13/v/...`) — dependency-fingerprint vector for CVE-targeting.
* Internal request-model class names (`AnthropicRequest`, `ResponsesRequest`, `ChatCompletionRequest`) — code recon.
* Attacker-controlled `input_value` echoed verbatim — secret-bounce vector + stored-reflection in chat clients that render error messages.

Both routes build their Pydantic models manually (`AnthropicRequest(**body)` / `ResponsesRequest(**body)`) outside FastAPI body binding, so they bypassed the `RequestValidationError` handler installed by the M-10 envelope sweep (`F-160` / `F-161` / `F-162` / `F-165` in PR #735, `F-013` / `F-066` in PR #734). The per-route `try: M(**body) except ValidationError: raise HTTPException(detail=str(e))` patches papered over the 500-on-bad-body, but the `str(e)` leaks everything Pydantic v2 packs into its error string.

### Systemic fix

1. **`middleware/exception_handlers.py`** — register a global `@app.exception_handler(pydantic.ValidationError)` that reuses the existing `_validation_error_response` sanitizer (already strips `input` echo + the `errors.pydantic.dev` URL — both `ValidationError` and `RequestValidationError` expose the same `.errors()` shape).
2. **`routes/anthropic.py` + `routes/responses.py`** — delete the per-route `try/except ValidationError` patches. The exception now bubbles to the global handler.
3. **`tests/test_no_pydantic_error_leak.py`** — parametrized regression covering both endpoints across (type-violation, missing-required-field, extra-strict-injection with attacker sentinel, nested-type-violation), asserting the 400 body never contains `pydantic` / `ValidationError` / `2.13` / class names / `input_value` / `errors.pydantic.dev` / the attacker sentinel, and always contains the canonical `error.type` / `error.code` shape. Plus a structural test (throwaway endpoint raising raw `ValidationError`) so future routes inherit the fix automatically.
4. **Fixture parity** — `tests/test_responses_route.py` + `tests/test_anthropic_output_config.py` were not installing the global handlers, so the now-removed per-route try/except was the only thing producing a 400 for them. Mirror production: install `install_exception_handlers` in both fixtures. Three pre-existing tests that asserted on the FastAPI-default `response.json()["detail"]` shape now assert the canonical `response.json()["error"]["message"]` shape that production actually returns.

### Repro evidence (Rhea r0.8.1, this PR)

Pre-fix probe on the lightweight test harness with `install_exception_handlers` already wired:

```
[/v1/responses] case=extra-strict
{"error":{"message":"1 validation error for ResponsesRequest\ninput\n
  Field required [type=missing, input_value={'model':'test-model', ...
  'FOO_BAR_INJECTED': '<H17_ATTACKER_SENTINEL_pwned>'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing",
  "type":"invalid_request_error","code":null,"param":null}}
```

Post-fix on the same input:

```
{"error":{"message":"Invalid request body: input: Field required",
  "type":"invalid_request_error","code":"invalid_request","param":null}}
```

Live-server probe (Qwen3-0.6B-8bit on `:8920`, `/tmp/h17-live-after.txt`) confirmed the production wiring routes through the new handler with zero leaks across `/v1/messages` and `/v1/responses` malformed payloads.

## Test plan

- [x] Pre-fix repro on lightweight harness — 6 of 8 bad inputs leak (`/tmp/h17-before.txt`)
- [x] Post-fix repro on lightweight harness — 0 leaks across 8 inputs (`/tmp/h17-after.txt`)
- [x] Live-server probe on `:8920` with Qwen3-0.6B-8bit — sanitized envelope on every malformed payload (`/tmp/h17-live-after.txt`)
- [x] `tests/test_no_pydantic_error_leak.py` — 10 tests, all green
- [x] `tests/test_exception_handlers.py` — 27 tests, all green (no regression on F-160/F-161/F-162)
- [x] `tests/test_responses_route.py` — 22 tests, all green (fixture now mirrors production)
- [x] `tests/test_anthropic_output_config.py` — 26 tests, all green
- [x] Wider anthropic/responses/messages sweep — 459 tests, 0 failures
- [x] `ruff check` + `ruff format` on all touched files — clean
- [x] No version bump
- [x] No global config writes

Closes H-17.