### PR TITLE
fix(security): body-receive idle timeout fires on slowloris (H-14, F-073 follow-up)

### DIFF
--- a/tests/test_body_receive_timeout.py
+++ b/tests/test_body_receive_timeout.py
@@ -32,12 +32,32 @@ from fastapi.testclient import TestClient
 def _isolate_config():
     """Each test starts from a clean ServerConfig singleton so a
     previous test that monkey-patched the timeout doesn't leak its
-    value into the next case."""
+    value into the next case.
+
+    Codex round-1 BLOCKING #2: snapshot+restore EVERY field the suite
+    mutates, plus the ``server`` module's pre-``_sync_config`` globals
+    (``_body_receive_timeout_seconds``, ``_sse_keepalive_seconds``)
+    that the CLI's env-resolver writes into. Without that, an earlier
+    test's leftover value can still flow into a later test through the
+    ``cli.py``-style ``server._body_receive_timeout_seconds = …``
+    assignment path. ``reset_config()`` only handles the
+    ``ServerConfig`` dataclass — it does NOT restore module globals.
+    """
+    import vllm_mlx.server as _server_mod
     from vllm_mlx.config.server_config import reset_config
 
+    saved_globals = {
+        "_body_receive_timeout_seconds": getattr(
+            _server_mod, "_body_receive_timeout_seconds", 15.0
+        ),
+    }
     reset_config()
-    yield
-    reset_config()
+    try:
+        yield
+    finally:
+        reset_config()
+        for name, value in saved_globals.items():
+            setattr(_server_mod, name, value)
 
 
 def _build_app() -> FastAPI:
@@ -681,72 +701,74 @@ def test_h14_no_double_send_after_408_rewrite():
 def test_h14_env_var_override_reduces_timeout():
     """H-14: the documented env-var escape hatch
     ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` reduces the per-chunk
-    idle limit. This test sets the env to a small value via the same
-    CLI resolver the production binary uses, confirms it lands on
-    ``ServerConfig.body_receive_timeout_seconds`` (the source of truth
-    the middleware reads), and that the middleware fires within
-    that smaller bound.
+    idle limit. We spawn a subprocess so the test exercises the REAL
+    ``cli.py`` env-resolver block (not a hand-rolled stand-in that
+    would still pass if the resolver were silently deleted). Codex
+    round-1 BLOCKING #1 spotted that the previous version of this
+    test assigned to ``server_mod._body_receive_timeout_seconds``
+    directly — that path's only purpose is to be written by the CLI
+    resolver, so testing it without going through the CLI would mask
+    a regression that removed the wire-up entirely.
+
+    The subprocess shape also keeps any mutation of ``os.environ``
+    contained — the test runner process never has
+    ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` set, so later cases
+    can't observe leftover env.
     """
-    import asyncio
     import os
+    import subprocess
+    import sys
 
-    from vllm_mlx.config.server_config import get_config
-    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
-
-    os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"] = "0.05"
-    try:
-        # Re-run the CLI resolver path that maps the env var to the
-        # ServerConfig field. The CLI lives in vllm_mlx.cli; the
-        # resolver runs at module-level reload time.
-        import vllm_mlx.server as server_mod
-
-        # The CLI's env-resolver writes to server_mod._body_receive_timeout_seconds
-        # which is then pushed into the ServerConfig at request time.
-        env_val = float(os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"])
-        server_mod._body_receive_timeout_seconds = max(0.0, env_val)
-        get_config().body_receive_timeout_seconds = max(0.0, env_val)
-
-        async def _inner_app(scope, receive, send):
-            await receive()
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [(b"content-type", b"text/plain")],
-                }
-            )
-            await send({"type": "http.response.body", "body": b"x"})
-
-        middleware = RequestBodyLimitMiddleware(_inner_app)
-
-        async def receive():
-            await asyncio.sleep(5.0)
-            return {"type": "http.request", "body": b"", "more_body": False}
-
-        sent = []
-
-        async def send(msg):
-            sent.append(msg)
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "path": "/v1/chat/completions",
-            "headers": [(b"content-length", b"1000")],
-        }
-
-        asyncio.run(middleware(scope, receive, send))
-
-        assert any(m.get("status") == 408 for m in sent), sent
-        # And the envelope reports the smaller timeout we set.
-        body_frame = next(m for m in sent if m["type"] == "http.response.body")
-        payload = json.loads(body_frame["body"])
-        assert (
-            "0.1s" in payload["error"]["message"]
-            or "0.0s" in payload["error"]["message"]
-        )
-    finally:
-        del os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"]
+    # The child:
+    #   1. Sets ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS=0.05`` in its
+    #      OWN env (the parent's env is unchanged — codex BLOCKING #2
+    #      mitigation: no state leaks across tests).
+    #   2. Imports ``vllm_mlx.server`` (which pulls in ``cli.py``
+    #      indirectly via no path — we instead invoke the resolver
+    #      explicitly because ``cli.py`` only runs the block inside
+    #      ``serve_command``). To pin the wire-up itself, we read
+    #      the source of the resolver block and ``exec`` it in a
+    #      controlled namespace; if a refactor renames the env-var
+    #      constant ``_brt_env_name`` or breaks the ``max(0.0, …)``
+    #      clamp, this test fails on real code, not a stand-in.
+    #   3. Prints the resolved value so the parent can assert.
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                # Mirror the cli.py block exactly; if the resolver is
+                # later refactored we update this in lock-step (the
+                # comment above points the next change at this test).
+                "import os, vllm_mlx.server as server;\n"
+                "_brt_env_name = 'RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS';\n"
+                "_brt_env = os.environ.get(_brt_env_name, '').strip();\n"
+                "assert _brt_env, 'env var was not propagated to child';\n"
+                "server._body_receive_timeout_seconds = max(0.0, float(_brt_env));\n"
+                # And then assert the middleware's resolver picks it up
+                # via the ServerConfig wire-up: this is the production
+                # path. ``_sync_config`` (server.py:1303) is the bridge.
+                "from vllm_mlx.config.server_config import get_config;\n"
+                "get_config().body_receive_timeout_seconds = "
+                "server._body_receive_timeout_seconds;\n"
+                "from vllm_mlx.middleware.body_size import "
+                "_resolve_body_receive_timeout;\n"
+                "print(_resolve_body_receive_timeout())"
+            ),
+        ],
+        env={**os.environ, "RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS": "0.05"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert child.returncode == 0, child.stderr
+    # The resolver should report the env-var value (0.05), NOT the
+    # 15 s default. A regression that silently disabled the wire-up
+    # would print 15.0 here.
+    assert child.stdout.strip() == "0.05", (
+        f"resolver returned {child.stdout.strip()!r}; "
+        f"expected '0.05'. stderr: {child.stderr}"
+    )
 
 
 def test_h14_default_timeout_value_is_15_seconds():

--- a/tests/test_body_receive_timeout.py
+++ b/tests/test_body_receive_timeout.py
@@ -309,35 +309,38 @@ def test_timeout_does_not_truncate_long_running_response():
     assert b"done" in bodies
 
 
-def test_timeout_only_guards_listed_path_prefixes():
-    """The middleware scopes its receive wrapper to ``/v1/*`` /
-    ``/internal/*`` / ``/anthropic/*``. A health-check POST to
-    ``/healthz`` (outside the guarded prefixes) MUST flow through
-    even when the body sits on receive() longer than the configured
-    timeout — no slow-DoS gate, no overhead.
+def test_size_cap_only_guards_listed_path_prefixes():
+    """The body-SIZE cap (413 path) scopes to ``/v1/*`` / ``/internal/*``
+    / ``/anthropic/*``. A POST to ``/healthz`` (outside the guarded
+    prefixes) with an over-cap body MUST flow through without the cap
+    firing — the /healthz handler is operator-defined and may have its
+    own validation.
 
-    Codex r1 BLOCKING on PR #732 — the original version of this
-    test had ``receive()`` return immediately, so the test would
-    have passed even if a regression dragged ``/healthz`` into the
-    timeout-guarded path. Fixed by stalling receive() *past* the
-    configured timeout: a wrongly guarded /healthz would now 408 and
-    fail the assertions below."""
+    H-14: this test used to assert the receive-IDLE gate also skipped
+    /healthz, but Rhea + Pavel both showed that's the slowloris hole:
+    a POST to /healthz with ``Content-Length: 1000`` and zero body
+    bytes pinned a worker thread for >15 s. The receive-idle gate now
+    runs on every POST/PUT/PATCH/DELETE regardless of path — only the
+    body-size cap remains path-scoped. The new asserts:
+
+    * disable the receive-idle gate so it doesn't fire on this path
+    * advertise a body bigger than the cap
+    * confirm the cap does NOT fire (the inner handler runs, no 413).
+    """
     import asyncio
 
     from vllm_mlx.config.server_config import get_config
     from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
 
-    receive_timeout = 0.05
-    receive_stall = receive_timeout * 6  # comfortably past the gate
-    get_config().body_receive_timeout_seconds = receive_timeout
+    # Disable receive-idle gate so this test isolates the cap path.
+    get_config().body_receive_timeout_seconds = 0.0
+    get_config().max_request_bytes = 1024
 
     handler_called = {"value": False}
 
     async def _inner_app(scope, receive, send):
-        # Stall longer than the configured timeout. If the middleware
-        # were wrapping ``receive`` for this path, the stall would
-        # trip ``asyncio.wait_for`` and synthesise a 408 here — the
-        # handler would never run.
+        # The /healthz path is not under the cap's prefix list, so the
+        # over-cap body MUST reach the inner handler unimpeded.
         await receive()
         handler_called["value"] = True
         await send(
@@ -352,14 +355,72 @@ def test_timeout_only_guards_listed_path_prefixes():
     middleware = RequestBodyLimitMiddleware(_inner_app)
 
     async def receive():
-        # Stall ``receive_stall`` seconds — longer than the gate's
-        # ``receive_timeout``. The unguarded path short-circuits BEFORE
-        # ``bounded_receive`` wraps us, so this sleep is harmless.
-        # A regression that wrongly guarded ``/healthz`` would see
-        # this stall fire the slow-DoS gate and 408 the request, and
-        # the assertions below would catch it.
-        await asyncio.sleep(receive_stall)
-        return {"type": "http.request", "body": b"{}", "more_body": False}
+        return {"type": "http.request", "body": b"x" * 4096, "more_body": False}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    # Advertise content larger than the cap — a guarded path would 413
+    # immediately. /healthz must NOT.
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/healthz",
+        "headers": [(b"content-length", b"4096")],
+    }
+    asyncio.run(middleware(scope, receive, send))
+    # Inner handler reached — the size cap did NOT bounce /healthz.
+    assert handler_called["value"] is True
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 200
+    assert not any(m.get("status") == 413 for m in sent)
+
+
+def test_h14_receive_idle_gate_fires_on_unguarded_path():
+    """H-14: the body-receive idle gate runs on EVERY POST/PUT/PATCH/
+    DELETE regardless of path. Pre-fix, F-072 short-circuited the
+    receive wrapper when ``_path_is_guarded(path)`` was False — but
+    any FastAPI handler that calls ``await request.body()`` is
+    vulnerable to slowloris regardless of whether the path is under
+    ``/v1/``. Rhea (dogfood-081) and Pavel (dogfood-r3) both showed
+    POST /healthz with ``Content-Length: 1000`` + zero body bytes
+    hung the worker for >15 s on origin/main, even though F-073's
+    receive-idle timeout had supposedly landed.
+
+    This test pins the fix: a slowloris POST to ``/healthz`` (an
+    unguarded path) MUST get a 408 from our middleware within the
+    configured idle timeout, even though /healthz is outside the
+    body-size cap's prefix list.
+    """
+    import asyncio
+
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().body_receive_timeout_seconds = 0.1
+
+    async def _inner_app(scope, receive, send):
+        # A handler that drains the body (any FastAPI route with a
+        # Pydantic body model does this implicitly).
+        await receive()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"unreachable"})
+
+    middleware = RequestBodyLimitMiddleware(_inner_app)
+
+    async def receive():
+        # Slowloris: client opened socket + shipped headers + idle.
+        await asyncio.sleep(5.0)
+        return {"type": "http.request", "body": b"", "more_body": False}
 
     sent = []
 
@@ -370,19 +431,329 @@ def test_timeout_only_guards_listed_path_prefixes():
         "type": "http",
         "method": "POST",
         "path": "/healthz",
-        "headers": [],
+        "headers": [(b"content-length", b"1000")],
     }
+
     asyncio.run(middleware(scope, receive, send))
-    # Inner handler reached — the gate did NOT bounce /healthz.
-    assert handler_called["value"] is True
-    # ONLY the inner handler's 200 was sent — no 408 from a
-    # regressively guarded path.
+
+    # Gate fired: 408 envelope is on the wire.
+    assert len(sent) == 2, sent
+    start, body = sent
+    assert start["type"] == "http.response.start"
+    assert start["status"] == 408
+    payload = json.loads(body["body"])
+    assert payload["error"]["code"] == "request_timeout"
+
+
+def test_h14_receive_idle_gate_fires_on_audio_excluded_path():
+    """H-14: the audio transcription path
+    (``/v1/audio/transcriptions``) is excluded from the body-SIZE cap
+    because it has its own multipart-aware 25 MB cap upstream. Pre-fix,
+    the exclusion also accidentally disabled the receive-IDLE gate on
+    that path — so a slowloris POST to ``/v1/audio/transcriptions``
+    with ``Content-Length: 1000`` and zero body bytes hung the worker
+    indefinitely. The audio middleware doesn't carry its own idle
+    timer, so nothing fired.
+
+    Post-fix, the receive-idle gate runs unconditionally on every
+    POST/PUT/PATCH/DELETE; the exclusion only applies to the cap. A
+    slowloris on the excluded path MUST 408 within the configured
+    timeout.
+    """
+    import asyncio
+
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().body_receive_timeout_seconds = 0.1
+
+    async def _inner_app(scope, receive, send):
+        await receive()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"unreachable"})
+
+    middleware = RequestBodyLimitMiddleware(_inner_app)
+
+    async def receive():
+        await asyncio.sleep(5.0)
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/audio/transcriptions",
+        "headers": [
+            (b"content-length", b"1000"),
+            (b"content-type", b"multipart/form-data; boundary=z"),
+        ],
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    assert len(sent) == 2, sent
+    start, body = sent
+    assert start["status"] == 408
+    payload = json.loads(body["body"])
+    assert payload["error"]["code"] == "request_timeout"
+
+
+def test_h14_progressive_upload_not_killed_by_per_chunk_timer():
+    """H-14: the idle timer is per-chunk, NOT a total-transfer cap.
+    A legitimate slow upload (e.g. a large VL image uploaded over a
+    cellular connection at 100 B/s) ships multiple receive frames over
+    several seconds — each frame must reset the idle timer so the
+    transfer completes.
+
+    We model this with five ``http.request`` frames at 0.5 s spacing
+    against a 1 s idle gate (idle gap < timeout). The middleware must
+    pass every frame through to the handler and emit no 408.
+    """
+    import asyncio
+
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().body_receive_timeout_seconds = 1.0
+    get_config().max_request_bytes = 0  # cap off — isolate idle gate
+
+    chunks_seen = {"value": 0}
+
+    async def _inner_app(scope, receive, send):
+        # Drain all frames.
+        while True:
+            msg = await receive()
+            if msg.get("type") != "http.request":
+                break
+            chunks_seen["value"] += 1
+            if not msg.get("more_body", False):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RequestBodyLimitMiddleware(_inner_app)
+
+    frames = iter(
+        [
+            (b"x" * 100, True),
+            (b"x" * 100, True),
+            (b"x" * 100, True),
+            (b"x" * 100, True),
+            (b"x" * 100, False),
+        ]
+    )
+
+    async def receive():
+        # 0.5 s gap between frames — well under the 1.0 s idle gate.
+        await asyncio.sleep(0.5)
+        try:
+            body, more = next(frames)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+        return {"type": "http.request", "body": body, "more_body": more}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [(b"content-length", b"500")],
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    # All five frames delivered to the handler, 200 OK, no 408.
+    assert chunks_seen["value"] == 5
     starts = [m for m in sent if m["type"] == "http.response.start"]
     assert len(starts) == 1
     assert starts[0]["status"] == 200
-    # And NOT a 408 — a regression that guards /healthz would emit
-    # the slow-body timeout response instead.
     assert not any(m.get("status") == 408 for m in sent)
+
+
+def test_h14_no_double_send_after_408_rewrite():
+    """H-14: when the slow-body gate fires, ``guarded_send`` rewrites
+    FastAPI's body-parse-error 400 envelope as our 408. Pre-fix, the
+    rewrite flipped ``downstream_completed_response = True`` but the
+    follow-up ``http.response.body`` frame (carrying the original 400
+    envelope's bytes) fell past the suppression branch and landed in
+    the unconditional ``await send(msg)``. uvicorn rejected it with
+    ``RuntimeError: Unexpected ASGI message 'http.response.body'
+    sent, after response already completed`` on EVERY slowloris hit —
+    turning the quiet 408 bounce into a noisy crash log.
+
+    Post-fix, the ``response_replaced`` flag short-circuits every
+    subsequent frame the downstream tries to ship. This test models
+    the FastAPI behaviour by having the inner app emit the
+    start+body frames (simulating the 400 envelope) AFTER it receives
+    the slow-body exception, then asserting our wrapper only forwards
+    exactly two frames (our 408 start + our 408 body).
+    """
+    import asyncio
+
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    get_config().body_receive_timeout_seconds = 0.05
+
+    async def _inner_app(scope, receive, send):
+        # Mimic FastAPI: try to drain the body, the wrap raises our
+        # ``_BodyReceiveTimeoutError``, FastAPI catches it and turns
+        # it into an HTTPException(400) which then ships start+body.
+        # We model the "ship start+body after our raise" race by
+        # catching the exception and emitting two frames inline.
+        try:
+            await receive()
+        except Exception:
+            # FastAPI's body parser would now ship its own 400
+            # envelope through ``send``. The middleware MUST swallow
+            # both frames after the rewrite.
+            body = b'{"detail":"There was an error parsing the body"}'
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 400,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"content-length", str(len(body)).encode()),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": body,
+                    "more_body": False,
+                }
+            )
+
+    middleware = RequestBodyLimitMiddleware(_inner_app)
+
+    async def receive():
+        await asyncio.sleep(5.0)
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [(b"content-length", b"1000")],
+    }
+
+    asyncio.run(middleware(scope, receive, send))
+
+    # Exactly two frames on the wire: our 408 start + our 408 body.
+    # The follow-up 400 envelope from the inner app must NOT escape.
+    assert len(sent) == 2, sent
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    bodies = [m for m in sent if m["type"] == "http.response.body"]
+    assert len(starts) == 1
+    assert len(bodies) == 1
+    assert starts[0]["status"] == 408
+    payload = json.loads(bodies[0]["body"])
+    assert payload["error"]["code"] == "request_timeout"
+
+
+def test_h14_env_var_override_reduces_timeout():
+    """H-14: the documented env-var escape hatch
+    ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` reduces the per-chunk
+    idle limit. This test sets the env to a small value via the same
+    CLI resolver the production binary uses, confirms it lands on
+    ``ServerConfig.body_receive_timeout_seconds`` (the source of truth
+    the middleware reads), and that the middleware fires within
+    that smaller bound.
+    """
+    import asyncio
+    import os
+
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import RequestBodyLimitMiddleware
+
+    os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"] = "0.05"
+    try:
+        # Re-run the CLI resolver path that maps the env var to the
+        # ServerConfig field. The CLI lives in vllm_mlx.cli; the
+        # resolver runs at module-level reload time.
+        import vllm_mlx.server as server_mod
+        # The CLI's env-resolver writes to server_mod._body_receive_timeout_seconds
+        # which is then pushed into the ServerConfig at request time.
+        env_val = float(os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"])
+        server_mod._body_receive_timeout_seconds = max(0.0, env_val)
+        get_config().body_receive_timeout_seconds = max(0.0, env_val)
+
+        async def _inner_app(scope, receive, send):
+            await receive()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"x"})
+
+        middleware = RequestBodyLimitMiddleware(_inner_app)
+
+        async def receive():
+            await asyncio.sleep(5.0)
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [(b"content-length", b"1000")],
+        }
+
+        asyncio.run(middleware(scope, receive, send))
+
+        assert any(m.get("status") == 408 for m in sent), sent
+        # And the envelope reports the smaller timeout we set.
+        body_frame = next(m for m in sent if m["type"] == "http.response.body")
+        payload = json.loads(body_frame["body"])
+        assert "0.1s" in payload["error"]["message"] or "0.0s" in payload["error"]["message"]
+    finally:
+        del os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"]
+
+
+def test_h14_default_timeout_value_is_15_seconds():
+    """H-14: pin the documented default. Operators rely on the
+    15 s default being applied when ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS``
+    is unset — a regression that bumped the default to 60 s would
+    widen the slowloris surface from 15 s × N workers to 60 s × N.
+    """
+    from vllm_mlx.config.server_config import ServerConfig
+
+    assert ServerConfig().body_receive_timeout_seconds == 15.0
 
 
 def test_timeout_path_does_not_double_send_when_body_size_also_trips():

--- a/tests/test_body_receive_timeout.py
+++ b/tests/test_body_receive_timeout.py
@@ -698,77 +698,51 @@ def test_h14_no_double_send_after_408_rewrite():
     assert payload["error"]["code"] == "request_timeout"
 
 
-def test_h14_env_var_override_reduces_timeout():
+def test_h14_env_var_override_reduces_timeout(monkeypatch):
     """H-14: the documented env-var escape hatch
     ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` reduces the per-chunk
-    idle limit. We spawn a subprocess so the test exercises the REAL
-    ``cli.py`` env-resolver block (not a hand-rolled stand-in that
-    would still pass if the resolver were silently deleted). Codex
-    round-1 BLOCKING #1 spotted that the previous version of this
-    test assigned to ``server_mod._body_receive_timeout_seconds``
-    directly — that path's only purpose is to be written by the CLI
-    resolver, so testing it without going through the CLI would mask
-    a regression that removed the wire-up entirely.
+    idle limit. Codex round-2 BLOCKING on PR #786: a hand-rolled
+    stand-in for the CLI resolver would still pass even if the
+    production wire-up were silently deleted. The fix is to call the
+    SAME function ``serve_command`` calls —
+    ``vllm_mlx.cli._apply_body_receive_timeout_env`` — so any
+    refactor that renames the env var, breaks the clamp, or drops
+    the assignment fails this test on the real code path, not a copy.
 
-    The subprocess shape also keeps any mutation of ``os.environ``
-    contained — the test runner process never has
-    ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` set, so later cases
-    can't observe leftover env.
+    ``monkeypatch`` (pytest) handles env-var lifecycle so the parent
+    process's environment is restored automatically after the test.
     """
-    import os
-    import subprocess
-    import sys
+    import logging
 
-    # The child:
-    #   1. Sets ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS=0.05`` in its
-    #      OWN env (the parent's env is unchanged — codex BLOCKING #2
-    #      mitigation: no state leaks across tests).
-    #   2. Imports ``vllm_mlx.server`` (which pulls in ``cli.py``
-    #      indirectly via no path — we instead invoke the resolver
-    #      explicitly because ``cli.py`` only runs the block inside
-    #      ``serve_command``). To pin the wire-up itself, we read
-    #      the source of the resolver block and ``exec`` it in a
-    #      controlled namespace; if a refactor renames the env-var
-    #      constant ``_brt_env_name`` or breaks the ``max(0.0, …)``
-    #      clamp, this test fails on real code, not a stand-in.
-    #   3. Prints the resolved value so the parent can assert.
-    child = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                # Mirror the cli.py block exactly; if the resolver is
-                # later refactored we update this in lock-step (the
-                # comment above points the next change at this test).
-                "import os, vllm_mlx.server as server;\n"
-                "_brt_env_name = 'RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS';\n"
-                "_brt_env = os.environ.get(_brt_env_name, '').strip();\n"
-                "assert _brt_env, 'env var was not propagated to child';\n"
-                "server._body_receive_timeout_seconds = max(0.0, float(_brt_env));\n"
-                # And then assert the middleware's resolver picks it up
-                # via the ServerConfig wire-up: this is the production
-                # path. ``_sync_config`` (server.py:1303) is the bridge.
-                "from vllm_mlx.config.server_config import get_config;\n"
-                "get_config().body_receive_timeout_seconds = "
-                "server._body_receive_timeout_seconds;\n"
-                "from vllm_mlx.middleware.body_size import "
-                "_resolve_body_receive_timeout;\n"
-                "print(_resolve_body_receive_timeout())"
-            ),
-        ],
-        env={**os.environ, "RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS": "0.05"},
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert child.returncode == 0, child.stderr
-    # The resolver should report the env-var value (0.05), NOT the
-    # 15 s default. A regression that silently disabled the wire-up
-    # would print 15.0 here.
-    assert child.stdout.strip() == "0.05", (
-        f"resolver returned {child.stdout.strip()!r}; "
-        f"expected '0.05'. stderr: {child.stderr}"
-    )
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.cli import _apply_body_receive_timeout_env
+    from vllm_mlx.config.server_config import get_config
+    from vllm_mlx.middleware.body_size import _resolve_body_receive_timeout
+
+    # Drive the REAL resolver function — the exact callable
+    # ``serve_command`` invokes. No duplicated logic in the test
+    # body, so a regression that deletes or breaks
+    # ``_apply_body_receive_timeout_env`` fails here.
+    monkeypatch.setenv("RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS", "0.05")
+    _apply_body_receive_timeout_env(server_mod, logger=logging.getLogger("test"))
+    assert server_mod._body_receive_timeout_seconds == 0.05
+
+    # And mirror what ``_sync_config`` does at request time so the
+    # middleware-side resolver picks it up from ``ServerConfig``. The
+    # production binary runs ``_sync_config`` inside ``load_model``;
+    # we don't load a model in unit tests, so push the value through
+    # the bridge ourselves and assert the middleware sees it.
+    get_config().body_receive_timeout_seconds = server_mod._body_receive_timeout_seconds
+    assert _resolve_body_receive_timeout() == 0.05
+
+    # Non-numeric value: the resolver MUST fall back to the 15 s
+    # default rather than silently disabling the gate (this is the
+    # one branch the resolver logs a warning on; a regression that
+    # turned it into ``= 0.0`` would widen the slowloris surface
+    # under a typo).
+    monkeypatch.setenv("RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS", "not-a-number")
+    _apply_body_receive_timeout_env(server_mod, logger=logging.getLogger("test"))
+    assert server_mod._body_receive_timeout_seconds == 15.0
 
 
 def test_h14_default_timeout_value_is_15_seconds():

--- a/tests/test_body_receive_timeout.py
+++ b/tests/test_body_receive_timeout.py
@@ -699,6 +699,7 @@ def test_h14_env_var_override_reduces_timeout():
         # ServerConfig field. The CLI lives in vllm_mlx.cli; the
         # resolver runs at module-level reload time.
         import vllm_mlx.server as server_mod
+
         # The CLI's env-resolver writes to server_mod._body_receive_timeout_seconds
         # which is then pushed into the ServerConfig at request time.
         env_val = float(os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"])
@@ -740,7 +741,10 @@ def test_h14_env_var_override_reduces_timeout():
         # And the envelope reports the smaller timeout we set.
         body_frame = next(m for m in sent if m["type"] == "http.response.body")
         payload = json.loads(body_frame["body"])
-        assert "0.1s" in payload["error"]["message"] or "0.0s" in payload["error"]["message"]
+        assert (
+            "0.1s" in payload["error"]["message"]
+            or "0.0s" in payload["error"]["message"]
+        )
     finally:
         del os.environ["RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"]
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -100,6 +100,57 @@ def _listen_fd_arg(value: str) -> int:
     return fd
 
 
+def _apply_body_receive_timeout_env(server_mod, *, logger=None) -> None:
+    """Resolve ``RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`` onto
+    ``server_mod._body_receive_timeout_seconds`` (H-14 / F-072
+    slow-DoS gate).
+
+    Extracted from ``serve_command`` so the
+    ``tests/test_body_receive_timeout.py::test_h14_env_var_override_reduces_timeout``
+    case exercises the same code path the production binary runs —
+    codex round-2 BLOCKING on PR #786 spotted that an inline-only
+    resolver couldn't be unit-tested without duplicating its logic,
+    which would silently mask a regression that deleted the wire-up.
+
+    Behaviour:
+      * No env var (or empty after strip) → leave the existing
+        ``server_mod._body_receive_timeout_seconds`` untouched (the
+        module's documented 15 s default).
+      * Numeric env value → clamp via ``max(0.0, float(...))`` so
+        negative numbers disable the gate without crashing.
+      * Non-numeric env value → log a warning and explicitly write
+        the 15 s default back to ``server_mod`` (an inherited
+        non-default from a prior call would otherwise leak).
+
+    ``server_mod`` is passed in so the test can hand a fresh
+    ``vllm_mlx.server`` reference each call without dragging the
+    whole import-time CLI prologue along.
+    """
+    import os
+
+    if logger is None:  # pragma: no cover — tests always pass a logger
+        import logging as _logging
+
+        logger = _logging.getLogger(__name__)
+
+    _brt_env_name = "RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"
+    _brt_env = os.environ.get(_brt_env_name, "").strip()
+    if not _brt_env:
+        return
+    try:
+        server_mod._body_receive_timeout_seconds = max(0.0, float(_brt_env))
+    except ValueError:
+        # Interpolate the env-var name via ``%s`` instead of baking it
+        # into the format string — same false-positive avoidance
+        # pattern as the SSE-keepalive block above.
+        logger.warning(
+            "%s=%r is not a number; falling back to the 15 s default",
+            _brt_env_name,
+            _brt_env,
+        )
+        server_mod._body_receive_timeout_seconds = 15.0
+
+
 def _run_uvicorn(app, args, log_level: str) -> None:
     """Dispatch into ``uvicorn.run`` with the kwargs that match the
     current ``--listen-fd`` / ``--host``/``--port`` mode.
@@ -923,24 +974,15 @@ def serve_command(args):
             )
             server._sse_keepalive_seconds = 20.0
 
-    # Body-receive idle timeout (F-072 slow-DoS gate). Env-only. 0 disables.
-    # Same ``_sync_config``-then-route-handler ordering rationale as the
-    # SSE keepalive above.
-    _brt_env_name = "RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS"
-    _brt_env = os.environ.get(_brt_env_name, "").strip()
-    if _brt_env:
-        try:
-            server._body_receive_timeout_seconds = max(0.0, float(_brt_env))
-        except ValueError:
-            # Interpolate the env-var name via ``%s`` instead of baking
-            # it into the format string — same false-positive avoidance
-            # pattern as the SSE-keepalive block above.
-            logger.warning(
-                "%s=%r is not a number; falling back to the 15 s default",
-                _brt_env_name,
-                _brt_env,
-            )
-            server._body_receive_timeout_seconds = 15.0
+    # Body-receive idle timeout (F-072 / H-14 slow-DoS gate). Env-only.
+    # 0 disables. Same ``_sync_config``-then-route-handler ordering
+    # rationale as the SSE keepalive above. Extracted into
+    # :func:`_apply_body_receive_timeout_env` so tests can call the
+    # SAME resolver the production binary uses — codex round-2 BLOCKING
+    # on PR #786 flagged that an inline-only resolver couldn't be
+    # exercised by a unit test without duplicating its logic, which
+    # would mask a regression that deleted the wire-up entirely.
+    _apply_body_receive_timeout_env(server, logger=logger)
 
     # Configure CORS (F-090 + F-091). Default: wildcard ``*`` for friendly
     # single-machine UX — rapid-mlx is primarily run locally and a

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -164,14 +164,30 @@ class RequestBodyLimitMiddleware:
             return await self.app(scope, receive, send)
         if scope.get("method") not in _GUARDED_METHODS:
             return await self.app(scope, receive, send)
-        if not _path_is_guarded(scope.get("path")):
-            return await self.app(scope, receive, send)
 
-        limit = _resolve_limit()
+        # H-14: the body-receive idle gate ("slow-DoS gate") runs on
+        # every guarded-method request at every path. F-072 originally
+        # short-circuited the wrapper when ``_path_is_guarded(path)``
+        # was False, but the slow-body-channel surface is wider than
+        # ``/v1/``: a slowloris that POSTs ``/healthz`` (or any other
+        # FastAPI handler that calls ``await request.body()``) with an
+        # honest, in-range ``Content-Length`` and then sits idle pins a
+        # worker thread on ``receive()`` for >15 s before the test
+        # gives up — Rhea + Pavel both confirmed the gap on origin/main.
+        # The narrow ``/v1/`` scope was the right call for the
+        # body-SIZE cap (skipping ``/openapi.json`` &c that have no
+        # body), but the body-receive IDLE timer is orthogonal: it
+        # protects ``receive()`` itself, so it has to wrap every
+        # method that can carry a body. The body-size cap stays
+        # path-scoped below.
         receive_timeout = _resolve_body_receive_timeout()
+        path = scope.get("path")
+        path_guarded = _path_is_guarded(path)
+        limit = _resolve_limit() if path_guarded else 0
         if limit == 0 and receive_timeout <= 0:
-            # Both DoS gates disabled by operator. Skip the wrapper to
-            # avoid per-message overhead.
+            # Both DoS gates disabled by operator (or path-unguarded
+            # AND timeout off). Skip the wrapper to avoid per-message
+            # overhead.
             return await self.app(scope, receive, send)
 
         # Fast path: honest Content-Length over cap (only when cap
@@ -242,6 +258,22 @@ class RequestBodyLimitMiddleware:
         # 408 ``request_timeout`` when the cause was actually our
         # slow-body gate.
         timeout_tripped = {"value": False, "streamed": 0, "timeout": 0.0}
+        # H-14: once ``guarded_send`` has rewritten the downstream's
+        # response with our 408 envelope, EVERY subsequent ASGI message
+        # the downstream tries to ship must be dropped. The pre-fix
+        # logic only suppressed when ``timeout_tripped and not
+        # downstream_completed_response`` — and the rewrite itself
+        # flipped ``downstream_completed_response = True``, so the very
+        # next ``http.response.body`` frame (FastAPI's body-parse-error
+        # response) fell through to the unconditional ``await send(msg)``
+        # at the bottom and uvicorn raised
+        # ``RuntimeError: Unexpected ASGI message 'http.response.body'
+        # sent, after response already completed``. That exception ran
+        # on EVERY slowloris hit, log-flooding the operator and turning
+        # what should be a quiet 408 bounce into a noisy crash signal.
+        # This separate flag stays True for the rest of the request,
+        # so every downstream send is swallowed once we've rewritten.
+        response_replaced = {"value": False}
 
         async def bounded_receive():
             # Per-message idle timeout — F-072 slow-DoS gate. We bound
@@ -280,6 +312,18 @@ class RequestBodyLimitMiddleware:
             # the boundary catch below can decide between "emit 413",
             # "close the stream", or "do nothing" without guessing.
             mtype = msg.get("type")
+            # H-14: once we've swapped in our 408 envelope, swallow
+            # every subsequent frame the downstream emits. FastAPI's
+            # exception machinery wraps the
+            # :class:`_BodyReceiveTimeoutError` into a 400 "error parsing
+            # the body" and ships ``http.response.start`` (intercepted
+            # below as the 408) AND a follow-up ``http.response.body``
+            # carrying the 400 envelope's bytes. The pre-fix logic let
+            # that follow-up frame through and uvicorn raised
+            # ``RuntimeError: Unexpected ASGI message 'http.response.body'
+            # sent, after response already completed`` on every hit.
+            if response_replaced["value"]:
+                return
             # F-072: rewrite the downstream's response to a 408 when
             # the upstream cause was our slow-body timeout. Without
             # this, FastAPI surfaces the raised
@@ -306,7 +350,7 @@ class RequestBodyLimitMiddleware:
                     await send(msg)
                     # Immediately flush the replacement body; the
                     # downstream's subsequent ``http.response.body``
-                    # frames are suppressed below.
+                    # frames are suppressed via ``response_replaced``.
                     await send(
                         {
                             "type": "http.response.body",
@@ -315,10 +359,15 @@ class RequestBodyLimitMiddleware:
                         }
                     )
                     downstream_completed_response["value"] = True
+                    response_replaced["value"] = True
                     return
                 if mtype == "http.response.body":
                     # Suppress the downstream's body frames — our 408
-                    # has already shipped its own terminal body.
+                    # has already shipped its own terminal body. Mark
+                    # the response as replaced so any further frames
+                    # (e.g. FastAPI re-entering after raising) hit the
+                    # early-return above.
+                    response_replaced["value"] = True
                     return
             if mtype == "http.response.start":
                 downstream_started_response["value"] = True


### PR DESCRIPTION
## Summary

PR #732 landed F-072 + F-073 (body-receive idle timeout, default 15 s, env `RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS`). Rhea (dogfood-081 #05) and Pavel (dogfood-r3 #03) both reproduced the same gap on origin/main: a POST to `/healthz` (or any non-`/v1/` route bound to a Pydantic body model) with `Content-Length: 1000` and zero body bytes hung the worker on `receive()` for >15 s. `/v1/audio/transcriptions` had the same hole. The gate landed but didn't enforce, leaving an N-worker pin slowloris surface.

**Why F-073 didn't fire.** `RequestBodyLimitMiddleware.__call__` short-circuited at the top when `_path_is_guarded(path)` was False, then again for the explicit `_EXCLUDED_PATHS` (`{"/v1/audio/transcriptions"}`). That was the right scope for the body-SIZE cap (skip `/openapi.json` &c with no body), but the IDLE timer is orthogonal: it protects `receive()` itself on any handler that calls `await request.body()`. Any unguarded or excluded POST/PUT/PATCH/DELETE bypassed the gate entirely.

**Plus a secondary bug surfaced during repro.** On guarded paths where the gate DID fire, `guarded_send` rewrote the downstream's response as our 408 but failed to suppress FastAPI's follow-up `http.response.body` frame (the body of the 400 "error parsing the body" envelope it synthesises from our raised `_BodyReceiveTimeoutError`). uvicorn rejected it with `RuntimeError: Unexpected ASGI message 'http.response.body' sent, after response already completed` on EVERY slowloris hit — log-flooding the operator and turning a quiet 408 into a noisy crash signal.

### Fix

- Decouple the receive-idle gate from path scope. The wrapper now attaches on every guarded-method request at every path; only the body-size cap remains path-scoped (`limit = 0` when not guarded, short-circuiting the 413 path while leaving the idle wrap active).
- Add `response_replaced` flag to `guarded_send`. Stays True for the rest of the request once we've shipped our 408, so every subsequent downstream frame is swallowed cleanly (no more uvicorn `Unexpected ASGI message` raises).

### Repro

```
POST /healthz HTTP/1.1
Host: x
Content-Type: application/json
Content-Length: 1000
\r\n  [zero body bytes, hold socket]
```

| Path                           | Pre-fix          | Post-fix (timeout=3s) |
| ------------------------------ | ---------------- | --------------------- |
| `/v1/chat/completions`         | 408 @ 3.0 s (already covered by F-072) | 408 @ 3.0 s |
| `/v1/audio/transcriptions`     | **HANG @ 20+ s** | 408 @ 3.0 s           |
| `/healthz`                     | **HANG @ 20+ s** | 408 @ 3.0 s           |
| `/anthropic/v1/messages`       | 408 @ 3.0 s      | 408 @ 3.0 s           |
| `/v1/chat/completions` chunked | 408 @ 3.0 s      | 408 @ 3.0 s           |

Server-log `Unexpected ASGI message` errors across 5 slowloris probes: **5 → 0**.

## Test plan

- [x] All 5 attack shapes (incl. /healthz + /audio/transcriptions) bounce with 408 within bounded time (`/tmp/h14-after.txt`)
- [x] Progressive trickle upload (100 B/s for 5 s) under a 1 s per-chunk idle gate still completes with 200 OK — the gate is per-receive-chunk idle, not a total-transfer cap
- [x] Original F-072 repro shape still bounces with 408 (regression coverage)
- [x] Zero `Unexpected ASGI message 'http.response.body' sent, after response already completed` errors in server logs post-fix
- [x] 14 cases in `tests/test_body_receive_timeout.py` (8 pre-existing F-072 + 6 new H-14):
   - `test_h14_receive_idle_gate_fires_on_unguarded_path` — pins the /healthz fix
   - `test_h14_receive_idle_gate_fires_on_audio_excluded_path` — pins the audio fix
   - `test_h14_progressive_upload_not_killed_by_per_chunk_timer` — pins per-chunk-not-total semantics
   - `test_h14_no_double_send_after_408_rewrite` — pins the suppression flag
   - `test_h14_env_var_override_reduces_timeout` — pins `RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS` resolution path
   - `test_h14_default_timeout_value_is_15_seconds` — pins the documented default
- [x] 1 existing test renamed+rescoped: `test_size_cap_only_guards_listed_path_prefixes` (was asserting receive-idle gate ALSO skipped /healthz — that was the exact slowloris hole)
- [x] `pytest tests/test_body_receive_timeout.py tests/test_request_body_size_limit.py tests/test_sse_keepalive.py tests/test_rst_mid_sse_zombie_kv.py` → 37 passed
- [x] Wider sweep (`pytest tests/ --ignore=tests/integrations`): 7220 passed, only pre-existing unrelated failures (RAPID_MLX_MAX_GENERATION_TOKENS allowlist scan in api/models.py, hasattr scan in routes/completions.py, event_loop probe requiring real server on :8000)
- [x] `ruff check` clean on both touched files