### PR TITLE
chore: bump version to 0.8.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.1"
+version = "0.8.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Rolls up four wave-3 fixes shipped post-0.8.1:

| ID | PR | Squash | Severity | One-liner |
|---|---|---|---|---|
| M-16 | #782 | `1f43a48` | MED | Reject image content blocks on text-only models (Anthropic was silently dropping images) |
| H-14 | #786 | `effccdd` | HIGH | Body-receive idle timeout fires on slowloris (Content-Length mismatch + close hang) |
| H-17 | #784 | `0af7e5e` | HIGH | Sanitize Pydantic ValidationError envelope on /v1/messages + /v1/responses (pinned Pydantic version, internal class names, attacker-echoed input_value) |
| M-01 | #783 | `929c969` | MED | Expose `rapid_mlx_requests_cancelled_total` + `_via_disconnect_total` Prometheus counters (atomic under `_cancel_counter_lock`, 9 codex rounds) |

## Test plan

- [x] Subject is exactly `chore: bump version to 0.8.2` (auto-release.yml needs this regex)
- [x] pyproject.toml bump is the only diff
- [x] Branched off fresh `origin/main` (HEAD `929c969`)

## Post-merge verification (tracked, not gating)

- auto-release.yml fires on merge → creates `v0.8.2` tag + GitHub release
- publish.yml fires on tag → PyPI `rapid-mlx==0.8.2`
- Homebrew formula auto-bumps via the `chore: bump version to 0.8.2` subject
- 5-10 personas dogfood the fresh PyPI 0.8.2 wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)