### PR TITLE
fix(routes): honor stream_options.include_usage=false at SSE final-chunk emit (D-SSE-USAGE)

### DIFF
--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -321,7 +321,7 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     assert any_usage_key2 == [], (
         f"no SSE chunk may carry the usage KEY when include_usage is "
         f"unset; got {len(any_usage_key2)} chunk(s) with the key "
-        f"(includes regressions to ``\"usage\": null``)"
+        f'(includes regressions to ``"usage": null``)'
     )
 
 

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -317,10 +317,11 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     assert usage_only_events2 == [], (
         "no dedicated usage chunk when include_usage is unset"
     )
-    any_usage2 = [e for e in events2 if e.get("usage")]
-    assert any_usage2 == [], (
-        f"no SSE chunk may carry a usage block when include_usage is "
-        f"unset; got {len(any_usage2)} chunk(s) with usage"
+    any_usage_key2 = [e for e in events2 if "usage" in e]
+    assert any_usage_key2 == [], (
+        f"no SSE chunk may carry the usage KEY when include_usage is "
+        f"unset; got {len(any_usage_key2)} chunk(s) with the key "
+        f"(includes regressions to ``\"usage\": null``)"
     )
 
 

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -232,9 +232,10 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     double-count tokens. DeepSeek review caught this on first pass; a
     later refactor that re-introduces the duplication trips this gate.
 
-    When ``include_usage`` is False (default), usage stays on the finish
-    chunk so basic clients still receive token counts. The two pin
-    assertions below lock both branches.
+    When ``include_usage`` is False / unset (D-SSE-USAGE, v0.8.2),
+    usage MUST be absent from EVERY chunk including the finish chunk —
+    per the OpenAI streaming spec. The two pin assertions below lock
+    both branches.
     """
     engine = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
     client = _make_client(engine)
@@ -282,9 +283,11 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
         f"all SSE chunks must share one created timestamp; saw {created_values}"
     )
 
-    # include_usage default-False branch: usage stays on the finish chunk
-    # (legacy behavior — bare clients that don't set the flag still get
-    # token counts in the final delta).
+    # include_usage default-False branch (D-SSE-USAGE, v0.8.2):
+    # ``usage`` MUST be absent from EVERY chunk including the finish
+    # chunk. Pre-fix the finish chunk carried a populated usage block
+    # under the "legacy bare-client accommodation" — LangChain /
+    # AI-SDK / vercel-ai-stream parsers double-counted as a result.
     engine2 = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
     client2 = _make_client(engine2)
     resp2 = client2.post(
@@ -307,12 +310,17 @@ def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     ]
     usage_only_events2 = [e for e in events2 if not e.get("choices") and e.get("usage")]
     assert len(finish_events2) == 1
-    assert finish_events2[0].get("usage") is not None, (
-        "finish chunk MUST carry usage when include_usage is unset — "
-        "matches the legacy stream_chat_completion behavior"
+    assert finish_events2[0].get("usage") is None, (
+        "finish chunk MUST NOT carry usage when include_usage is unset — "
+        "OpenAI streaming spec requires opt-in via stream_options"
     )
     assert usage_only_events2 == [], (
         "no dedicated usage chunk when include_usage is unset"
+    )
+    any_usage2 = [e for e in events2 if e.get("usage")]
+    assert any_usage2 == [], (
+        f"no SSE chunk may carry a usage block when include_usage is "
+        f"unset; got {len(any_usage2)} chunk(s) with usage"
     )
 
 

--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -266,11 +266,15 @@ def test_non_guided_streaming_omits_usage_when_include_usage_unset():
     assert usage_only_events == [], (
         "no dedicated usage chunk when include_usage is unset"
     )
-    # Stronger: NO chunk anywhere may carry a usage block.
-    any_usage = [e for e in events if e.get("usage")]
-    assert any_usage == [], (
-        f"no SSE chunk may carry a usage block when include_usage is "
-        f"unset; got {len(any_usage)} chunk(s) with usage"
+    # Stronger: the ``usage`` KEY must be absent from every chunk —
+    # a regression that serializes ``"usage": null`` would slip past a
+    # truthiness check but is itself non-spec for the unset path
+    # (codex review caught the same gap in
+    # ``test_stream_include_usage_honored.py``).
+    any_usage_key = [e for e in events if "usage" in e]
+    assert any_usage_key == [], (
+        f"no SSE chunk may carry the usage KEY when include_usage is "
+        f"unset; got {len(any_usage_key)} chunk(s) with the key"
     )
 
 

--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -18,8 +18,17 @@ that the 2026-05-20 ≥20B onboarding sweep caught on qwen3.5-35b-8bit
    True, the finish chunk AND the dedicated trailing chunk both carried
    the same usage payload, double-counting tokens for aggregating
    clients. Fixed by setting ``usage=None`` on the finish chunk when
-   ``include_usage`` is True; legacy (``include_usage`` unset) keeps
-   usage on the finish chunk for bare clients.
+   ``include_usage`` is True.
+
+3. **D-SSE-USAGE (v0.8.2)** — when ``stream_options.include_usage`` is
+   False / unset, the finish chunk still carried a populated ``usage``
+   block. Per the OpenAI streaming spec, ``usage`` is opt-in and MUST
+   be omitted from every chunk unless the caller passes
+   ``include_usage=true``. LangChain / AI-SDK / vercel-ai-stream
+   parsers double-count token totals when the field appears on
+   non-opt-in streams. The old "usage on finish chunk for bare clients"
+   accommodation has been removed — see
+   ``tests/test_stream_include_usage_honored.py`` for the full matrix.
 
 Bug A (streaming tool-parser coverage gap) is pinned by
 ``test_streaming_tool_fallback_catches_non_canonical_format``: the
@@ -219,11 +228,16 @@ def test_non_guided_streaming_usage_only_in_dedicated_chunk_when_include_usage_t
     )
 
 
-def test_non_guided_streaming_usage_stays_on_finish_chunk_by_default():
-    """Defensive: clients that DON'T set ``include_usage`` rely on the
-    legacy behavior of receiving usage on the finish chunk. The Bug B
-    fix only applies when ``include_usage=True``; the default path must
-    stay backwards-compatible.
+def test_non_guided_streaming_omits_usage_when_include_usage_unset():
+    """D-SSE-USAGE regression: when ``stream_options`` is omitted (or
+    ``include_usage=false``), the OpenAI streaming spec requires the
+    ``usage`` field to be absent from EVERY SSE chunk — not just the
+    dedicated trailing one. Pre-v0.8.2 the finish chunk carried a
+    populated ``usage`` block on bare requests, which LangChain /
+    AI-SDK / vercel-ai-stream parsers treated as the canonical totals
+    AND then double-counted when a downstream proxy upgraded the
+    request with ``include_usage=true`` and the dedicated chunk also
+    landed.
     """
     engine = _PlainStreamEngine(deltas=["one", " two."])
     client = _make_client(engine)
@@ -245,12 +259,18 @@ def test_non_guided_streaming_usage_stays_on_finish_chunk_by_default():
     usage_only_events = [e for e in events if not e.get("choices") and e.get("usage")]
 
     assert len(finish_events) == 1
-    assert finish_events[0].get("usage") is not None, (
-        "finish chunk MUST carry usage when include_usage is unset — "
-        "matches legacy behavior for bare clients"
+    assert finish_events[0].get("usage") is None, (
+        "finish chunk MUST NOT carry usage when include_usage is unset — "
+        "OpenAI streaming spec requires opt-in via stream_options"
     )
     assert usage_only_events == [], (
         "no dedicated usage chunk when include_usage is unset"
+    )
+    # Stronger: NO chunk anywhere may carry a usage block.
+    any_usage = [e for e in events if e.get("usage")]
+    assert any_usage == [], (
+        f"no SSE chunk may carry a usage block when include_usage is "
+        f"unset; got {len(any_usage)} chunk(s) with usage"
     )
 
 

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -260,10 +260,11 @@ def test_chat_streaming_without_include_usage_omits_usage_block_entirely():
     assert finish_events[0].get("usage") is None, (
         "finish chunk MUST NOT carry usage when include_usage is unset"
     )
-    any_usage = [e for e in events if e.get("usage")]
-    assert any_usage == [], (
-        f"no SSE chunk may carry a usage block when include_usage is "
-        f"unset; got {len(any_usage)} chunk(s) with usage"
+    any_usage_key = [e for e in events if "usage" in e]
+    assert any_usage_key == [], (
+        f"no SSE chunk may carry the usage KEY when include_usage is "
+        f"unset; got {len(any_usage_key)} chunk(s) with the key "
+        f"(includes regressions to ``\"usage\": null``)"
     )
 
 

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -226,11 +226,18 @@ def test_chat_streaming_with_include_usage_carries_cached_tokens_in_dedicated_ch
     assert details["cached_tokens"] == 128
 
 
-def test_chat_streaming_without_include_usage_carries_cached_tokens_on_finish_chunk():
-    """Without ``stream_options.include_usage``, bare clients still
-    expect usage on the finish chunk (legacy behavior). The new
-    ``cached_tokens`` field must survive the same route through the
-    ``Usage(...)`` inline constructor as the existing fields do.
+def test_chat_streaming_without_include_usage_omits_usage_block_entirely():
+    """D-SSE-USAGE regression: when the caller does NOT pass
+    ``stream_options.include_usage=true``, the OpenAI streaming spec
+    requires the ``usage`` field (including its ``cached_tokens``
+    subfield) to be absent from every SSE chunk. Pre-v0.8.2 the finish
+    chunk carried a populated ``usage`` block — encoded here as the
+    accommodation for "legacy bare clients" — which LangChain /
+    AI-SDK / vercel-ai-stream parsers double-counted. The new contract
+    is opt-in: clients that want cached_tokens on the streaming wire
+    must pass ``include_usage=true`` and read the dedicated trailing
+    chunk (covered by
+    ``test_chat_streaming_with_include_usage_carries_cached_tokens_in_dedicated_chunk``).
     """
     engine = _CacheReportingChatEngine(prompt_tokens=200, cached_tokens=128)
     client = _make_chat_client(engine)
@@ -250,13 +257,14 @@ def test_chat_streaming_without_include_usage_carries_cached_tokens_on_finish_ch
         e for e in events for c in e.get("choices", []) if c.get("finish_reason")
     ]
     assert len(finish_events) == 1
-    usage = finish_events[0].get("usage")
-    assert usage is not None, (
-        "finish chunk must carry usage when include_usage is unset"
+    assert finish_events[0].get("usage") is None, (
+        "finish chunk MUST NOT carry usage when include_usage is unset"
     )
-    details = usage.get("prompt_tokens_details")
-    assert details is not None
-    assert details["cached_tokens"] == 128
+    any_usage = [e for e in events if e.get("usage")]
+    assert any_usage == [], (
+        f"no SSE chunk may carry a usage block when include_usage is "
+        f"unset; got {len(any_usage)} chunk(s) with usage"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -264,9 +272,10 @@ def test_chat_streaming_without_include_usage_carries_cached_tokens_on_finish_ch
 # ---------------------------------------------------------------------------
 
 
-def test_completions_streaming_final_chunk_omits_null_detail_fields():
-    """Pin the wire shape of the streaming ``/v1/completions`` final
-    usage chunk: with no cache hit and no reasoning split, the JSON
+def test_completions_streaming_dedicated_usage_chunk_omits_null_detail_fields():
+    """Pin the wire shape of the streaming ``/v1/completions`` dedicated
+    usage chunk (emitted only when ``include_usage=true`` per
+    D-SSE-USAGE): with no cache hit and no reasoning split, the JSON
     payload's ``usage`` block must NOT carry literal ``null``
     ``prompt_tokens_details`` or ``completion_tokens_details`` keys.
     ``model_dump(exclude_none=True)`` drops them; bare ``model_dump()``
@@ -285,6 +294,7 @@ def test_completions_streaming_final_chunk_omits_null_detail_fields():
             "prompt": "Hello",
             "max_tokens": 32,
             "stream": True,
+            "stream_options": {"include_usage": True},
         },
     )
     assert resp.status_code == 200, resp.text
@@ -305,10 +315,11 @@ def test_completions_streaming_final_chunk_omits_null_detail_fields():
     assert usage["total_tokens"] == 202
 
 
-def test_completions_streaming_final_chunk_includes_cached_tokens_when_hit():
-    """Sibling assertion: when there IS a cache hit, the streaming
-    final usage chunk DOES include ``prompt_tokens_details`` with the
-    populated count — `exclude_none=True` only suppresses null
+def test_completions_streaming_dedicated_usage_chunk_includes_cached_tokens_when_hit():
+    """Sibling assertion: when there IS a cache hit AND the caller
+    opted in via ``stream_options.include_usage=true``, the streaming
+    dedicated usage chunk DOES include ``prompt_tokens_details`` with
+    the populated count — `exclude_none=True` only suppresses null
     fields, not populated ones.
     """
     engine = _CacheReportingCompletionEngine(prompt_tokens=200, cached_tokens=128)
@@ -321,6 +332,7 @@ def test_completions_streaming_final_chunk_includes_cached_tokens_when_hit():
             "prompt": "Hello",
             "max_tokens": 32,
             "stream": True,
+            "stream_options": {"include_usage": True},
         },
     )
     assert resp.status_code == 200, resp.text

--- a/tests/test_routes_cached_tokens.py
+++ b/tests/test_routes_cached_tokens.py
@@ -264,7 +264,7 @@ def test_chat_streaming_without_include_usage_omits_usage_block_entirely():
     assert any_usage_key == [], (
         f"no SSE chunk may carry the usage KEY when include_usage is "
         f"unset; got {len(any_usage_key)} chunk(s) with the key "
-        f"(includes regressions to ``\"usage\": null``)"
+        f'(includes regressions to ``"usage": null``)'
     )
 
 

--- a/tests/test_stream_include_usage_honored.py
+++ b/tests/test_stream_include_usage_honored.py
@@ -178,9 +178,13 @@ def _dedicated_usage_chunks(events: list[dict]) -> list[dict]:
 
 
 def test_chat_stream_omits_usage_when_include_usage_false():
-    """``stream_options.include_usage=false`` → no ``usage`` field on
-    any chunk, anywhere. Pre-fix the finish chunk carried a populated
-    ``usage`` block here, double-counting on aggregating clients.
+    """``stream_options.include_usage=false`` → the ``usage`` KEY must
+    be absent from every chunk (not just present-but-null). Codex
+    review caught that a truthiness check would let a regression
+    re-serialize ``"usage": null`` and still pass — explicit key
+    absence is the spec-compliant gate. Pre-fix the finish chunk
+    carried a populated ``usage`` block here, double-counting on
+    aggregating clients.
     """
     client = _make_chat_client(_PlainChatEngine())
     resp = client.post(
@@ -195,10 +199,11 @@ def test_chat_stream_omits_usage_when_include_usage_false():
     )
     assert resp.status_code == 200, resp.text
     events = _parse_sse(resp.text)
-    chunks_with_usage = [e for e in events if e.get("usage")]
-    assert chunks_with_usage == [], (
-        f"include_usage=false MUST emit zero usage chunks; got "
-        f"{len(chunks_with_usage)}: {chunks_with_usage!r}"
+    chunks_with_usage_key = [e for e in events if "usage" in e]
+    assert chunks_with_usage_key == [], (
+        f"include_usage=false MUST omit the usage KEY from every "
+        f"chunk (not just emit null); got {len(chunks_with_usage_key)} "
+        f"chunk(s) with the key: {chunks_with_usage_key!r}"
     )
 
 
@@ -206,7 +211,9 @@ def test_chat_stream_omits_usage_when_stream_options_absent():
     """``stream_options`` omitted entirely → same contract as
     ``include_usage=false`` (the OpenAI default). Pre-fix this was the
     common bug surface — most clients omit ``stream_options`` and got
-    a populated ``usage`` on the finish chunk anyway.
+    a populated ``usage`` on the finish chunk anyway. Asserts KEY
+    absence (not truthiness) so a serializer regression to
+    ``"usage": null`` would still trip the gate.
     """
     client = _make_chat_client(_PlainChatEngine())
     resp = client.post(
@@ -220,10 +227,11 @@ def test_chat_stream_omits_usage_when_stream_options_absent():
     )
     assert resp.status_code == 200, resp.text
     events = _parse_sse(resp.text)
-    chunks_with_usage = [e for e in events if e.get("usage")]
-    assert chunks_with_usage == [], (
-        f"omitted stream_options MUST emit zero usage chunks; got "
-        f"{len(chunks_with_usage)}: {chunks_with_usage!r}"
+    chunks_with_usage_key = [e for e in events if "usage" in e]
+    assert chunks_with_usage_key == [], (
+        f"omitted stream_options MUST omit the usage KEY from every "
+        f"chunk (not just emit null); got {len(chunks_with_usage_key)} "
+        f"chunk(s) with the key: {chunks_with_usage_key!r}"
     )
 
 
@@ -270,10 +278,12 @@ def test_chat_stream_emits_dedicated_usage_chunk_when_include_usage_true():
 
 def test_completions_stream_omits_usage_when_include_usage_false():
     """Sibling of the chat test: legacy ``/v1/completions`` must also
-    honor ``stream_options.include_usage=false`` and omit the field
-    from every SSE chunk. Pre-fix the schema didn't even declare
-    ``stream_options`` so the field was silently dropped — the
-    finish-chunk-build unconditionally attached usage.
+    honor ``stream_options.include_usage=false`` and omit the ``usage``
+    KEY entirely from every SSE chunk. Pre-fix the schema didn't even
+    declare ``stream_options`` so the field was silently dropped —
+    the finish-chunk-build unconditionally attached usage. Asserts
+    KEY absence (not truthiness) so a regression to ``"usage": null``
+    still trips the gate (codex review finding).
     """
     client = _make_completions_client(_PlainCompletionsEngine())
     resp = client.post(
@@ -288,17 +298,21 @@ def test_completions_stream_omits_usage_when_include_usage_false():
     )
     assert resp.status_code == 200, resp.text
     events = _parse_sse(resp.text)
-    chunks_with_usage = [e for e in events if e.get("usage")]
-    assert chunks_with_usage == [], (
-        f"completions include_usage=false MUST emit zero usage chunks; "
-        f"got {len(chunks_with_usage)}: {chunks_with_usage!r}"
+    chunks_with_usage_key = [e for e in events if "usage" in e]
+    assert chunks_with_usage_key == [], (
+        f"completions include_usage=false MUST omit the usage KEY from "
+        f"every chunk (not just emit null); got "
+        f"{len(chunks_with_usage_key)} chunk(s) with the key: "
+        f"{chunks_with_usage_key!r}"
     )
 
 
 def test_completions_stream_omits_usage_when_stream_options_absent():
     """Most common shape: bare ``/v1/completions`` streaming request
-    with no ``stream_options``. Must emit zero usage chunks per
-    OpenAI spec.
+    with no ``stream_options``. The ``usage`` KEY must be absent from
+    every chunk per OpenAI spec — asserts key absence (not truthiness)
+    so a regression to ``"usage": null`` still trips the gate
+    (codex review finding).
     """
     client = _make_completions_client(_PlainCompletionsEngine())
     resp = client.post(
@@ -312,10 +326,12 @@ def test_completions_stream_omits_usage_when_stream_options_absent():
     )
     assert resp.status_code == 200, resp.text
     events = _parse_sse(resp.text)
-    chunks_with_usage = [e for e in events if e.get("usage")]
-    assert chunks_with_usage == [], (
-        f"omitted stream_options on completions MUST emit zero usage "
-        f"chunks; got {len(chunks_with_usage)}: {chunks_with_usage!r}"
+    chunks_with_usage_key = [e for e in events if "usage" in e]
+    assert chunks_with_usage_key == [], (
+        f"omitted stream_options on completions MUST omit the usage "
+        f"KEY from every chunk (not just emit null); got "
+        f"{len(chunks_with_usage_key)} chunk(s) with the key: "
+        f"{chunks_with_usage_key!r}"
     )
 
 

--- a/tests/test_stream_include_usage_honored.py
+++ b/tests/test_stream_include_usage_honored.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-SSE-USAGE regression matrix: ``stream_options.include_usage`` is
+honored at the SSE chunk-emit site across every OpenAI-compatible
+streaming route.
+
+Pre-v0.8.2 the SSE final delta on both ``/v1/chat/completions`` and
+``/v1/completions`` carried a populated ``usage`` block regardless of
+what the caller passed in ``stream_options``. The OpenAI streaming
+spec says ``usage`` is opt-in:
+
+    "If set, an additional chunk will be streamed before the data:
+    [DONE] message. The usage field on this chunk shows the token
+    usage statistics for the entire request, and the choices field
+    will always be an empty array."
+
+LangChain, AI-SDK, and the vercel-ai-stream parser double-count token
+totals when ``usage`` appears on chunks the spec does not allow — the
+parser treats the finish-chunk total as canonical AND adds the
+dedicated trailing chunk's total on top of it.
+
+This file pins the contract at the route-level chunk emitter (not in
+each model parser) so the fix is parser-independent and survives any
+future model-family addition. 6 confirmed-affected parser families
+(qwen3-reasoning, qwen3.5-4b, llama3-1b, llama3-3b, gemma3-1b,
+glm4.7) are all gated through the same emitter — the unit tests
+below exercise the chunk-build site with mock engines, but the fix
+applies uniformly to every parser family because the gate sits BELOW
+the parser layer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.routes.completions import router as completions_router
+
+# ---------------------------------------------------------------------------
+# Mock engines
+# ---------------------------------------------------------------------------
+
+
+class _PlainChatEngine:
+    """Mock streaming chat engine. Emits N text deltas; the final
+    ``GenerationOutput`` carries ``finished=True`` and a finish_reason.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, deltas: list[str] | None = None) -> None:
+        self._deltas = deltas or ["Hello", " world", "."]
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        accumulated = ""
+        for i, delta in enumerate(self._deltas):
+            accumulated += delta
+            is_last = i == len(self._deltas) - 1
+            yield GenerationOutput(
+                text=accumulated,
+                new_text=delta,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                channel=None,
+            )
+
+
+class _PlainCompletionsEngine:
+    """Mock streaming legacy-completions engine — parallels
+    ``_PlainChatEngine`` but exposes ``stream_generate`` to match the
+    route's expected signature.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, deltas: list[str] | None = None) -> None:
+        self._deltas = deltas or ["foo", "bar", "baz"]
+
+    async def stream_generate(self, prompt, **kwargs):
+        accumulated = ""
+        for i, delta in enumerate(self._deltas):
+            accumulated += delta
+            is_last = i == len(self._deltas) - 1
+            yield GenerationOutput(
+                text=accumulated,
+                new_text=delta,
+                prompt_tokens=3,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="stop" if is_last else None,
+                channel=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_client(engine: _PlainChatEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _make_completions_client(engine: _PlainCompletionsEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    app.include_router(completions_router)
+    return TestClient(app)
+
+
+def _parse_sse(text: str) -> list[dict]:
+    """Parse SSE ``data:`` lines, excluding the ``[DONE]`` sentinel.
+
+    Surfaces ``json.JSONDecodeError`` rather than silently swallowing —
+    a regression that corrupts an intermediate chunk should fail the
+    test, not be hidden by the trailing valid chunk.
+    """
+    events: list[dict] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            continue
+        payload = stripped.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        events.append(json.loads(payload))
+    return events
+
+
+def _finish_chunks(events: list[dict]) -> list[dict]:
+    """Chunks whose first ``choice`` carries a ``finish_reason``."""
+    out: list[dict] = []
+    for e in events:
+        for c in e.get("choices", []) or []:
+            if c.get("finish_reason"):
+                out.append(e)
+                break
+    return out
+
+
+def _dedicated_usage_chunks(events: list[dict]) -> list[dict]:
+    """Chunks with empty ``choices`` and a populated ``usage`` — the
+    OpenAI-spec dedicated trailing usage chunk.
+    """
+    return [e for e in events if not e.get("choices") and e.get("usage")]
+
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+def test_chat_stream_omits_usage_when_include_usage_false():
+    """``stream_options.include_usage=false`` → no ``usage`` field on
+    any chunk, anywhere. Pre-fix the finish chunk carried a populated
+    ``usage`` block here, double-counting on aggregating clients.
+    """
+    client = _make_chat_client(_PlainChatEngine())
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream_options": {"include_usage": False},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+    chunks_with_usage = [e for e in events if e.get("usage")]
+    assert chunks_with_usage == [], (
+        f"include_usage=false MUST emit zero usage chunks; got "
+        f"{len(chunks_with_usage)}: {chunks_with_usage!r}"
+    )
+
+
+def test_chat_stream_omits_usage_when_stream_options_absent():
+    """``stream_options`` omitted entirely → same contract as
+    ``include_usage=false`` (the OpenAI default). Pre-fix this was the
+    common bug surface — most clients omit ``stream_options`` and got
+    a populated ``usage`` on the finish chunk anyway.
+    """
+    client = _make_chat_client(_PlainChatEngine())
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+    chunks_with_usage = [e for e in events if e.get("usage")]
+    assert chunks_with_usage == [], (
+        f"omitted stream_options MUST emit zero usage chunks; got "
+        f"{len(chunks_with_usage)}: {chunks_with_usage!r}"
+    )
+
+
+def test_chat_stream_emits_dedicated_usage_chunk_when_include_usage_true():
+    """``stream_options.include_usage=true`` → exactly one dedicated
+    trailing chunk with empty ``choices`` and populated ``usage``. The
+    finish chunk carries ``usage=null`` (serialized away by
+    ``exclude_none=True``) so aggregating clients DO NOT double-count.
+    """
+    client = _make_chat_client(_PlainChatEngine())
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream_options": {"include_usage": True},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+
+    finish = _finish_chunks(events)
+    dedicated = _dedicated_usage_chunks(events)
+    assert len(finish) == 1, f"expected exactly one finish chunk; got {len(finish)}"
+    assert finish[0].get("usage") is None, (
+        "finish chunk MUST NOT carry usage when include_usage=true "
+        "(double-emission breaks aggregating clients)"
+    )
+    assert len(dedicated) == 1, (
+        f"expected exactly one dedicated usage chunk; got {len(dedicated)}"
+    )
+    usage = dedicated[0]["usage"]
+    assert usage["prompt_tokens"] >= 1
+    assert usage["completion_tokens"] >= 1
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# /v1/completions
+# ---------------------------------------------------------------------------
+
+
+def test_completions_stream_omits_usage_when_include_usage_false():
+    """Sibling of the chat test: legacy ``/v1/completions`` must also
+    honor ``stream_options.include_usage=false`` and omit the field
+    from every SSE chunk. Pre-fix the schema didn't even declare
+    ``stream_options`` so the field was silently dropped — the
+    finish-chunk-build unconditionally attached usage.
+    """
+    client = _make_completions_client(_PlainCompletionsEngine())
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "stream": True,
+            "max_tokens": 16,
+            "stream_options": {"include_usage": False},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+    chunks_with_usage = [e for e in events if e.get("usage")]
+    assert chunks_with_usage == [], (
+        f"completions include_usage=false MUST emit zero usage chunks; "
+        f"got {len(chunks_with_usage)}: {chunks_with_usage!r}"
+    )
+
+
+def test_completions_stream_omits_usage_when_stream_options_absent():
+    """Most common shape: bare ``/v1/completions`` streaming request
+    with no ``stream_options``. Must emit zero usage chunks per
+    OpenAI spec.
+    """
+    client = _make_completions_client(_PlainCompletionsEngine())
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "stream": True,
+            "max_tokens": 16,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+    chunks_with_usage = [e for e in events if e.get("usage")]
+    assert chunks_with_usage == [], (
+        f"omitted stream_options on completions MUST emit zero usage "
+        f"chunks; got {len(chunks_with_usage)}: {chunks_with_usage!r}"
+    )
+
+
+def test_completions_stream_emits_dedicated_usage_chunk_when_include_usage_true():
+    """``/v1/completions`` with ``include_usage=true`` emits exactly
+    one dedicated trailing chunk shaped like the OpenAI streaming
+    spec: empty ``choices``, populated ``usage``. Brings parity with
+    the chat-completions route.
+    """
+    client = _make_completions_client(_PlainCompletionsEngine())
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "stream": True,
+            "max_tokens": 16,
+            "stream_options": {"include_usage": True},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+
+    # The trailing usage chunk has ``"choices": []`` and a populated
+    # ``usage`` block. The earlier per-token chunks have populated
+    # ``choices`` and NO usage.
+    dedicated = [e for e in events if e.get("choices") == [] and e.get("usage")]
+    assert len(dedicated) == 1, (
+        f"expected exactly one dedicated usage chunk on completions; "
+        f"got {len(dedicated)} (full event list: {events!r})"
+    )
+    usage = dedicated[0]["usage"]
+    assert usage["prompt_tokens"] >= 1
+    assert usage["completion_tokens"] >= 1
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+    # The earlier per-token chunks MUST NOT carry usage.
+    per_token = [e for e in events if e.get("choices") and e.get("usage")]
+    assert per_token == [], (
+        f"per-token chunks MUST NOT carry usage; got {len(per_token)} "
+        f"that did: {per_token!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "body"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        ),
+        (
+            "/v1/completions",
+            {
+                "model": "test-model",
+                "prompt": "hi",
+                "stream": True,
+                "max_tokens": 16,
+            },
+        ),
+    ],
+)
+def test_no_usage_in_per_token_chunks_when_include_usage_true(endpoint, body):
+    """OpenAI spec: per-token chunks MAY carry ``"usage": null`` (or
+    omit the field entirely — ``exclude_none=True`` makes the wire
+    representation identical). They MUST NOT carry a populated usage
+    block. Holds across both endpoints.
+    """
+    body = dict(body, stream_options={"include_usage": True})
+    if endpoint == "/v1/chat/completions":
+        client = _make_chat_client(_PlainChatEngine())
+    else:
+        client = _make_completions_client(_PlainCompletionsEngine())
+    resp = client.post(endpoint, json=body)
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse(resp.text)
+    per_token_with_usage = [
+        e for e in events if e.get("choices") and e.get("usage") is not None
+    ]
+    assert per_token_with_usage == [], (
+        f"{endpoint}: per-token chunks must not carry a populated "
+        f"usage block when include_usage=true; got {len(per_token_with_usage)}"
+    )

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1581,6 +1581,14 @@ class CompletionRequest(BaseModel):
     top_p: float | None = Field(default=None, gt=0.0, le=1.0)
     max_tokens: int | None = None
     stream: bool = False
+    # OpenAI streaming-spec parity (D-SSE-USAGE): legacy ``/v1/completions``
+    # also accepts ``stream_options.include_usage`` to opt in to a
+    # dedicated trailing usage chunk on SSE responses. Pre-fix this
+    # field was silently dropped, so the only behavior was the
+    # non-compliant "usage attached to finish chunk" that breaks
+    # LangChain / AI-SDK accumulators (same root cause as the
+    # chat-route bug). Default ``None`` ⇒ no usage on the wire.
+    stream_options: StreamOptions | None = None
     stop: list[str] | None = None
     # Extended OpenAI-compatible sampling parameters — see #355 + the
     # matching block on ChatCompletionRequest for wiring + caveats.

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -73,7 +73,6 @@ from ..service.helpers import (
     enable_thinking_warning_header,
     enforce_context_length_for_messages,
     get_engine,
-    get_usage,
 )
 
 logger = logging.getLogger(__name__)
@@ -2053,16 +2052,17 @@ async def stream_chat_completion(
                                 finish_reason=event.finish_reason,
                             )
                         ],
-                        # Usage placement: when ``stream_options.include_usage``
-                        # is True, usage MUST appear ONLY in the dedicated
-                        # trailing chunk per the OpenAI streaming spec.
-                        # Without ``include_usage``, legacy clients expect it
-                        # on the finish chunk.
-                        usage=(
-                            None
-                            if include_usage
-                            else (get_usage(output) if output.finished else None)
-                        ),
+                        # Usage placement (OpenAI streaming spec, D-SSE-USAGE):
+                        # ``usage`` MUST appear ONLY when the caller opted
+                        # in via ``stream_options.include_usage=true``,
+                        # and then ONLY in the dedicated trailing chunk
+                        # (this finish chunk carries ``null`` so it
+                        # serializes as ``"usage": null`` per spec). When
+                        # ``include_usage`` is false / unset, the field
+                        # is omitted from every chunk — LangChain /
+                        # AI-SDK / vercel-ai-stream parsers double-count
+                        # token totals when usage shows up unexpectedly.
+                        usage=None,
                     )
                     _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
                     logger.info(f"[SSE-TC] {_tc_sse.strip()[:300]}")
@@ -2275,12 +2275,11 @@ async def stream_chat_completion(
                         logprobs=_build_chunk_logprobs(finish_output),
                     )
                 ],
-                # See "Usage placement" note on the tool_call branch.
-                usage=(
-                    None
-                    if include_usage
-                    else (get_usage(finish_output) if finish_output.finished else None)
-                ),
+                # See "Usage placement" note on the tool_call branch
+                # (D-SSE-USAGE). When ``include_usage`` is false / unset
+                # the field is omitted from this terminal chunk; the
+                # dedicated trailing usage chunk is suppressed too.
+                usage=None,
             )
             yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"
         elif fallback_tool_calls or finalize_content:
@@ -2504,31 +2503,20 @@ async def stream_chat_completion_guided(
         # engine emits (DeepSeek pr_validate round 3 finding).
         finish_reason = getattr(output, "finish_reason", None)
 
-        # Final chunk with finish_reason. Usage placement:
+        # Final chunk with finish_reason. Usage placement
+        # (OpenAI streaming spec, D-SSE-USAGE):
         #  - When ``stream_options.include_usage`` is True, usage MUST
-        #    appear ONLY in the dedicated usage chunk below (per the
-        #    OpenAI spec; emitting it in both places would have clients
-        #    that aggregate usage double-count). DeepSeek review caught
-        #    the duplication on first pass.
-        #  - When False, attach usage to the finish chunk so a client
-        #    that doesn't set ``include_usage`` still receives token
-        #    counts in the final delta (matches the legacy behavior of
-        #    ``stream_chat_completion`` and the non-streaming response
-        #    shape).
-        finish_usage = (
-            None
-            if include_usage
-            else Usage(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-                prompt_tokens_details=(
-                    PromptTokensDetails(cached_tokens=cached_tokens)
-                    if cached_tokens
-                    else None
-                ),
-            )
-        )
+        #    appear ONLY in the dedicated usage chunk below (this finish
+        #    chunk carries ``null`` so it serializes consistently per
+        #    spec; emitting it in both places had clients that
+        #    aggregate usage double-count).
+        #  - When False / unset, the field is omitted from EVERY chunk.
+        #    The legacy behavior of attaching usage to the finish chunk
+        #    when ``include_usage`` was unset was the D-SSE-USAGE bug:
+        #    LangChain / AI-SDK / vercel-ai-stream parsers double-count
+        #    token totals when usage appears on chunks the spec does
+        #    not allow. Clients that want usage MUST opt in.
+        finish_usage = None
         # ``created`` must be passed explicitly: the SSE prefix-style
         # chunks above already share ``_sse_created`` (computed once at
         # the top of the helper). ``ChatCompletionChunk.created`` has

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -513,6 +513,14 @@ async def stream_completion(
     effective_top_k = max(1, top_k_logprobs)  # see non-stream branch
     text_offset_cursor = 0  # echo+logprobs is rejected upstream
 
+    # D-SSE-USAGE: capture the engine-reported usage from the final
+    # ``GenerationOutput`` so the dedicated trailing usage chunk (only
+    # emitted when ``stream_options.include_usage=true``) can read it
+    # AFTER the per-token loop has finished. Pre-fix this code attached
+    # usage to the finish chunk unconditionally — see comment further
+    # down at the chunk-build site.
+    _final_usage = None
+
     async for output in engine.stream_generate(
         prompt=prompt,
         max_tokens=_resolve_max_tokens(request.max_tokens),
@@ -573,8 +581,36 @@ async def stream_completion(
             "model": model_name,
             "choices": [choice],
         }
+        # D-SSE-USAGE: capture usage from the engine but DO NOT attach
+        # it to this finish chunk — the OpenAI streaming spec says
+        # ``usage`` is opt-in via ``stream_options.include_usage=true``
+        # and, when opted in, MUST appear ONLY on a dedicated trailing
+        # chunk with empty ``choices``. Pre-fix this branch ALWAYS
+        # attached usage to the finish chunk, double-counting on
+        # aggregating clients (LangChain / AI-SDK / vercel-ai-stream).
         if output.finished:
-            data["usage"] = get_usage(output).model_dump(exclude_none=True)
+            _final_usage = get_usage(output)
         yield f"data: {json.dumps(data)}\n\n"
+
+    # Dedicated trailing usage chunk (OpenAI spec — empty ``choices``,
+    # populated ``usage``). Only emitted when the caller opted in via
+    # ``stream_options.include_usage=true``; otherwise the field is
+    # omitted from the wire entirely. Mirrors the trailing usage chunk
+    # on ``/v1/chat/completions`` so SDK shape is identical across
+    # both endpoints.
+    if (
+        _final_usage is not None
+        and request.stream_options is not None
+        and request.stream_options.include_usage
+    ):
+        usage_data = {
+            "id": completion_id,
+            "object": "text_completion",
+            "created": created_ts,
+            "model": model_name,
+            "choices": [],
+            "usage": _final_usage.model_dump(exclude_none=True),
+        }
+        yield f"data: {json.dumps(usage_data)}\n\n"
 
     yield "data: [DONE]\n\n"


### PR DESCRIPTION
## Summary

D-SSE-USAGE (P1, parser-independent): the SSE final delta on
`/v1/chat/completions` and `/v1/completions` was emitting a populated
`usage` block regardless of `stream_options.include_usage`. The
OpenAI streaming spec says `usage` is opt-in: when `include_usage` is
`false` / unset, the field MUST be absent from every chunk; when
`true`, exactly one dedicated trailing chunk with `choices: []`
carries the totals.

The pre-fix "legacy bare-client accommodation" (attach usage to the
finish chunk when `include_usage` was unset) breaks LangChain /
AI-SDK / vercel-ai-stream stream parsers, which double-count when
usage appears on chunks the spec does not allow.

Root cause sits at the route-level chunk emitter (BELOW the parser
layer), so the fix is parser-independent and applies uniformly across
6 confirmed-affected parser families:

- qwen3-reasoning
- qwen3.5-4b
- llama3-1b
- llama3-3b
- gemma3-1b
- glm4.7

## Changes

- **`routes/chat.py`** — tool_call branch, finish-chunk branch, and
  the guided-generation finish-chunk branch all set `usage=None`
  unconditionally. The dedicated trailing usage chunk is still gated
  on `include_usage=true` (unchanged). Drops the now-unused
  `get_usage` import.
- **`routes/completions.py`** — stop attaching usage to the per-token
  finish chunk; capture the engine-reported usage and only emit it as
  a dedicated trailing chunk (`choices: []`, populated `usage`) when
  `stream_options.include_usage=true`. Same shape as
  `/v1/chat/completions` for SDK parity.
- **`api/models.py`** — declare `stream_options: StreamOptions | None`
  on `CompletionRequest` so the field stops being silently dropped
  (was the upstream reason `/v1/completions` had no way to opt out).
- **`tests/test_stream_include_usage_honored.py`** (new) — parser-
  independent matrix exercising 3 stream_options shapes
  (`include_usage=false`, omitted, `include_usage=true`) across both
  endpoints, plus a parametrized assertion that per-token chunks
  never carry usage when `include_usage=true`.
- Pre-existing tests that pinned the buggy "usage on finish chunk for
  bare clients" behavior have been updated to assert the
  spec-compliant contract:
  - `tests/test_chat_streaming_spec.py`
  - `tests/test_chat_streaming_guided.py`
  - `tests/test_routes_cached_tokens.py` (chat + completions sides)

## Scope notes

- `/v1/messages` (Anthropic) and `/v1/responses` are out of scope:
  they follow their own protocols (`message_delta` + usage events)
  and do not key on `stream_options.include_usage`.

## Live verification on `qwen3-0.6b-8bit`

| Case | Before | After |
|---|---|---|
| `include_usage=false` | 1 usage block on finish chunk | 0 usage blocks |
| `stream_options` omitted | 1 usage block on finish chunk | 0 usage blocks |
| `include_usage=true` | dedicated chunk only | dedicated chunk only (unchanged) |

Saved traces: `/tmp/d-sse-usage-before.txt`, `/tmp/d-sse-usage-after.txt`.

## Test plan

- [x] New regression matrix `tests/test_stream_include_usage_honored.py` (8 tests) passes
- [x] Updated `tests/test_chat_streaming_spec.py` passes
- [x] Updated `tests/test_chat_streaming_guided.py` passes
- [x] Updated `tests/test_routes_cached_tokens.py` passes
- [x] Touched + adjacent regression sweep (156 tests) passes
- [x] Streaming-related sweep (`-k "streaming or stream_ or _stream or test_usage"`, 861 tests) passes
- [x] `ruff check` clean across all touched files
- [x] Live `rapid-mlx serve qwen3-0.6b-8bit` reproduction confirms fix on all 3 stream_options shapes
- [x] Live `/v1/completions` exercise with real model confirms parser-independent fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)