### PR TITLE
fix(detok): GPT2-BPE byte-fallback mojibake in reasoning_content + content + /v1/completions text (D-DETOK-BPE)

### DIFF
--- a/tests/test_streaming_detokenizer_bpe.py
+++ b/tests/test_streaming_detokenizer_bpe.py
@@ -171,6 +171,36 @@ class TestRepairByteLevelDecoder:
         # No mojibake markers in vocab — probe finds nothing — no repair.
         assert repair_byte_level_decoder(plain) is False
 
+    def test_repair_scans_full_vocab_not_just_first_4096_ids(self) -> None:
+        """Codex r2 NIT: the probe must scan the *entire* vocab, not a
+        4 KB prefix — otherwise a valid byte-level tokenizer whose
+        ``Ġ``-prefixed ids all live past 4096 (specials + reserved
+        slots packed at the front) silently skips the repair."""
+        # Build a vocab where the only byte-level token sits well past
+        # the old 4096-id cap. Specials fill 0..5000.
+        vocab = {f"<reserved_{i}>": i for i in range(5000)}
+        vocab["ĠLate"] = 5000  # the lone byte-level entry, past the cap
+        vocab["<pad>"] = 5001
+        model = models.BPE(vocab=vocab, merges=[])
+        rust = Tokenizer(model)
+        rust.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        rust.decoder = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(" ", 1, 0),
+            ]
+        )
+        tok = PreTrainedTokenizerFast(tokenizer_object=rust, pad_token="<pad>")
+
+        # Pre-repair: the lone byte-level id leaks Ġ.
+        assert "Ġ" in tok.decode([5000], skip_special_tokens=False)
+        # The repair must find it despite the high id.
+        assert repair_byte_level_decoder(tok) is True
+        assert "Ġ" not in tok.decode([5000], skip_special_tokens=False)
+        assert tok.decode([5000], skip_special_tokens=False) == " Late"
+
     def test_repair_restores_original_decoder_when_swap_fails_verification(
         self,
     ) -> None:

--- a/tests/test_streaming_detokenizer_bpe.py
+++ b/tests/test_streaming_detokenizer_bpe.py
@@ -171,6 +171,62 @@ class TestRepairByteLevelDecoder:
         # No mojibake markers in vocab — probe finds nothing — no repair.
         assert repair_byte_level_decoder(plain) is False
 
+    def test_repair_restores_original_decoder_when_swap_fails_verification(
+        self,
+    ) -> None:
+        """If ByteLevel swap doesn't clear the mojibake either (unknown
+        vocab shape), the original decoder must be restored — *not* left
+        as ByteLevel. Locks codex r1 BLOCKING contract."""
+        # Build a vocab where every "byte-level-looking" token actually
+        # decodes through a custom decoder that ByteLevel can't undo.
+        # We simulate this by giving the vocab a Ġ-prefixed token whose
+        # byte-level inverse still contains Ġ — patho­logical, but the
+        # contract is: we revert on failure.
+        vocab = {"<pad>": 0, "Ġevil": 1}
+        model = models.BPE(vocab=vocab, merges=[])
+        rust = Tokenizer(model)
+        rust.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        # Custom decoder that simply returns the pretty token verbatim —
+        # this is the BROKEN-on-byte-level shape we want to repair.
+        original = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(" ", 1, 0),
+            ]
+        )
+        rust.decoder = original
+        tok = PreTrainedTokenizerFast(tokenizer_object=rust, pad_token="<pad>")
+
+        # Sanity: the broken decode contains Ġ.
+        assert "Ġ" in tok.decode([1], skip_special_tokens=False)
+
+        # Monkey-patch ``tokenizers.decoders.ByteLevel`` to be a no-op
+        # decoder (returns the input unchanged — still leaks Ġ) so the
+        # verification path will fail and trigger the revert branch.
+        import tokenizers.decoders as _decmod
+
+        from vllm_mlx.utils import tokenizer as _toktools
+
+        class _NoopDecoder(decoders.Decoder):
+            def decode(self, tokens: list[str]) -> str:
+                return "".join(tokens)
+
+        # Patch only inside the call so we don't leak global state.
+        real_byte_level = _decmod.ByteLevel
+        try:
+            _decmod.ByteLevel = _NoopDecoder
+            assert _toktools.repair_byte_level_decoder(tok) is False
+        finally:
+            _decmod.ByteLevel = real_byte_level
+
+        # The contract: original decoder is back in place.
+        assert tok.backend_tokenizer.decoder.__class__.__name__ == "Sequence", (
+            f"expected Sequence (original), got "
+            f"{tok.backend_tokenizer.decoder.__class__.__name__}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 2. Streaming surface: IncrementalDecoder (delta.* path)

--- a/tests/test_streaming_detokenizer_bpe.py
+++ b/tests/test_streaming_detokenizer_bpe.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for D-DETOK-BPE: GPT-2 byte-level BPE mojibake leak.
+
+Bug: ``mlx-community/DeepSeek-R1-*`` distills ship a
+``tokenizer.json`` whose ``decoder`` chain is the Llama SentencePiece
+chain (``Replace("▁", " ")`` -> ``ByteFallback`` -> ``Fuse`` ->
+``Strip``) while the *vocab* is GPT-2 byte-level. Every
+``tokenizer.decode([byte_level_id])`` then leaks the raw pretty
+form (``Ġ``, ``Ċ``, ``âĢľ``, ``Â°`` …) instead of inverting it back to
+the original byte sequence.
+
+This test suite locks the contract on three surfaces:
+
+1. ``repair_byte_level_decoder`` swaps the broken decoder in place.
+2. The ``IncrementalDecoder`` (used by ``Scheduler`` for streaming
+   ``delta.reasoning_content`` / ``delta.content``) emits clean UTF-8.
+3. Cumulative ``tokenizer.decode(ids)`` (used by ``/v1/completions[0]
+   .text`` and non-stream ``content`` / ``reasoning_content``) is
+   clean.
+
+The fixture builds a synthetic byte-level BPE tokenizer that mirrors
+the malformation — no model download required, runs in <100 ms in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+from transformers import PreTrainedTokenizerFast
+
+from vllm_mlx.utils.decode import IncrementalDecoder
+from vllm_mlx.utils.tokenizer import (
+    _BYTE_LEVEL_MOJIBAKE_MARKERS,
+    repair_byte_level_decoder,
+)
+
+# Synthetic byte-level vocab that reproduces the bug deterministically.
+# Each id maps to its byte-level pretty token; the "ground truth" decoded
+# text after a correct ByteLevel decoder swap is shown in the inverse
+# comment.
+_VOCAB = {
+    "<pad>": 0,
+    "<s>": 1,
+    "</s>": 2,
+    "Hello": 3,  # 'Hello'
+    "ĠHello": 4,  # ' Hello'
+    "Ġworld": 5,  # ' world'
+    "Ċ": 6,  # '\n'
+    "ĠLet": 7,  # ' Let'
+    "Ġme": 8,  # ' me'
+    "Ġcompute": 9,  # ' compute'
+    "ĊĊ": 10,  # '\n\n'
+    "ĠThe": 11,  # ' The'
+    "Ġanswer": 12,  # ' answer'
+    "Ġis": 13,  # ' is'
+    "4": 14,  # '4'
+    ".": 15,  # '.'
+    "<think>": 16,  # '<think>'
+    "</think>": 17,  # '</think>'
+}
+
+# ids -> expected decoded text once the decoder is repaired.
+_REASONING_SEQUENCE_IDS = [16, 6, 7, 8, 9, 10, 17, 6, 11, 12, 13, 14, 15]
+_REASONING_SEQUENCE_TEXT = "<think>\n Let me compute\n\n</think>\n The answer is4."
+
+# Sentinels for content streaming (no <think>).
+_CONTENT_SEQUENCE_IDS = [4, 5, 6, 11, 12, 13, 14, 15]
+_CONTENT_SEQUENCE_TEXT = " Hello world\n The answer is4."
+
+
+def _build_broken_tokenizer() -> PreTrainedTokenizerFast:
+    """Construct a tokenizer with the D-DETOK-BPE malformation.
+
+    Encoder = GPT-2 ByteLevel (correct), decoder = SentencePiece chain
+    (broken — leaks pretty tokens verbatim).
+    """
+    model = models.BPE(vocab=_VOCAB, merges=[])
+    tok = Tokenizer(model)
+    tok.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    tok.decoder = decoders.Sequence(
+        [
+            decoders.Replace("▁", " "),
+            decoders.ByteFallback(),
+            decoders.Fuse(),
+            decoders.Strip(" ", 1, 0),
+        ]
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tok,
+        eos_token="</s>",
+        bos_token="<s>",
+        pad_token="<pad>",
+    )
+
+
+def _build_healthy_tokenizer() -> PreTrainedTokenizerFast:
+    """Same vocab but with the correct ByteLevel decoder from the start."""
+    model = models.BPE(vocab=_VOCAB, merges=[])
+    tok = Tokenizer(model)
+    tok.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    tok.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tok,
+        eos_token="</s>",
+        bos_token="<s>",
+        pad_token="<pad>",
+    )
+
+
+def _assert_no_mojibake(text: str, context: str = "") -> None:
+    """Assert that ``text`` contains no GPT-2 byte-level pretty markers."""
+    bad = [m for m in _BYTE_LEVEL_MOJIBAKE_MARKERS if m in text]
+    assert not bad, f"mojibake leak in {context}: text={text!r} markers={bad!r}"
+
+
+# ---------------------------------------------------------------------------
+# 1. The repair function itself
+# ---------------------------------------------------------------------------
+
+
+class TestRepairByteLevelDecoder:
+    """repair_byte_level_decoder swaps the decoder; idempotent; targeted."""
+
+    def test_broken_tokenizer_leaks_mojibake_before_repair(self) -> None:
+        tok = _build_broken_tokenizer()
+        decoded = tok.decode(_REASONING_SEQUENCE_IDS, skip_special_tokens=False)
+        # Sanity: the bug is reproducible — Ġ and Ċ both appear.
+        assert "Ġ" in decoded
+        assert "Ċ" in decoded
+
+    def test_repair_returns_true_on_broken_tokenizer(self) -> None:
+        tok = _build_broken_tokenizer()
+        assert repair_byte_level_decoder(tok) is True
+
+    def test_repair_clears_mojibake(self) -> None:
+        tok = _build_broken_tokenizer()
+        repair_byte_level_decoder(tok)
+        decoded = tok.decode(_REASONING_SEQUENCE_IDS, skip_special_tokens=False)
+        _assert_no_mojibake(decoded, context="full decode after repair")
+        assert decoded == _REASONING_SEQUENCE_TEXT
+
+    def test_repair_is_idempotent(self) -> None:
+        tok = _build_broken_tokenizer()
+        assert repair_byte_level_decoder(tok) is True
+        # Second call: nothing to repair, returns False, output unchanged.
+        assert repair_byte_level_decoder(tok) is False
+        decoded = tok.decode(_REASONING_SEQUENCE_IDS, skip_special_tokens=False)
+        assert decoded == _REASONING_SEQUENCE_TEXT
+
+    def test_repair_is_noop_on_healthy_tokenizer(self) -> None:
+        tok = _build_healthy_tokenizer()
+        # Already healthy — no repair, decode already clean.
+        before = tok.decode(_REASONING_SEQUENCE_IDS, skip_special_tokens=False)
+        assert repair_byte_level_decoder(tok) is False
+        after = tok.decode(_REASONING_SEQUENCE_IDS, skip_special_tokens=False)
+        assert before == after
+        _assert_no_mojibake(after, context="healthy tokenizer decode")
+
+    def test_repair_handles_none_gracefully(self) -> None:
+        assert repair_byte_level_decoder(None) is False
+
+    def test_repair_skips_tokenizers_without_byte_level_vocab(self) -> None:
+        """A tokenizer without ``Ġ``/``Ċ`` in its vocab is left alone."""
+        # Build a vocab with no byte-level markers.
+        from tokenizers.models import WordLevel
+
+        plain_vocab = {"<pad>": 0, "hello": 1, "world": 2}
+        rust = Tokenizer(WordLevel(plain_vocab))
+        rust.decoder = decoders.WordPiece()
+        plain = PreTrainedTokenizerFast(tokenizer_object=rust, pad_token="<pad>")
+        # No mojibake markers in vocab — probe finds nothing — no repair.
+        assert repair_byte_level_decoder(plain) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Streaming surface: IncrementalDecoder (delta.* path)
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalDecoderNoLeak:
+    """The streaming ``delta`` path used by the chat-completions SSE
+    handler and the OpenAI completions adapter."""
+
+    @pytest.mark.parametrize(
+        "ids,expected",
+        [
+            (_REASONING_SEQUENCE_IDS, _REASONING_SEQUENCE_TEXT),
+            (_CONTENT_SEQUENCE_IDS, _CONTENT_SEQUENCE_TEXT),
+        ],
+        ids=["reasoning_block", "content_block"],
+    )
+    def test_streaming_deltas_are_clean_after_repair(
+        self, ids: list[int], expected: str
+    ) -> None:
+        tok = _build_broken_tokenizer()
+        # The fix: repair happens at tokenizer load time in production.
+        repair_byte_level_decoder(tok)
+
+        decoder = IncrementalDecoder(tok)
+        emitted = ""
+        for tid in ids:
+            delta = decoder.add_token(tid)
+            _assert_no_mojibake(delta, context=f"delta for id={tid}")
+            emitted += delta
+
+        assert emitted == expected, (
+            f"streaming sum mismatch:\n  got:      {emitted!r}\n"
+            f"  expected: {expected!r}"
+        )
+
+    def test_streaming_without_repair_leaks(self) -> None:
+        """Negative control: without the repair, mojibake leaks. This
+        is the canonical D-DETOK-BPE reproducer — if this test fails
+        the bug is no longer reproducible by this fixture (which would
+        invalidate the positive assertions)."""
+        tok = _build_broken_tokenizer()
+        # Deliberately skip repair.
+        decoder = IncrementalDecoder(tok)
+        emitted = ""
+        for tid in _REASONING_SEQUENCE_IDS:
+            emitted += decoder.add_token(tid)
+        assert any(m in emitted for m in _BYTE_LEVEL_MOJIBAKE_MARKERS), (
+            f"expected mojibake in unrepaired streaming output, got {emitted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-stream + raw /v1/completions surface: cumulative
+#    tokenizer.decode(ids) is what builds ``message.content``,
+#    ``message.reasoning_content``, and ``completions[0].text``.
+# ---------------------------------------------------------------------------
+
+
+class TestCumulativeDecodeNoLeak:
+    @pytest.mark.parametrize(
+        "ids,expected",
+        [
+            (_REASONING_SEQUENCE_IDS, _REASONING_SEQUENCE_TEXT),
+            (_CONTENT_SEQUENCE_IDS, _CONTENT_SEQUENCE_TEXT),
+        ],
+        ids=["reasoning_block", "content_block"],
+    )
+    def test_full_decode_is_clean(self, ids: list[int], expected: str) -> None:
+        tok = _build_broken_tokenizer()
+        repair_byte_level_decoder(tok)
+        decoded = tok.decode(ids, skip_special_tokens=False)
+        _assert_no_mojibake(decoded, context="full decode")
+        assert decoded == expected
+
+    def test_per_token_decode_is_clean(self) -> None:
+        """The legacy ``tokenizer.decode([single_id])`` path used by
+        ``output_router.py`` line 188 (current text), 310 (response
+        token), 430 (control token), and ``service/helpers.py``
+        line 1370 (probe text) is *also* clean post-repair."""
+        tok = _build_broken_tokenizer()
+        repair_byte_level_decoder(tok)
+        for tid in _REASONING_SEQUENCE_IDS:
+            single = tok.decode([tid], skip_special_tokens=False)
+            _assert_no_mojibake(single, context=f"per-token decode id={tid}")
+
+
+# ---------------------------------------------------------------------------
+# 4. UTF-8-safety preserved (the IncrementalDecoder's U+FFFD hold-back
+#    contract must keep working after the decoder swap).
+# ---------------------------------------------------------------------------
+
+
+class TestUtf8SafetyPreserved:
+    def test_repair_does_not_break_emoji_hold_back(self) -> None:
+        """The ByteLevel decoder swap must not disturb the
+        IncrementalDecoder's UTF-8 incomplete-sequence hold-back
+        (deferred-emit) contract — multibyte characters still arrive
+        intact instead of being split across deltas."""
+        # Build a vocab with multibyte UTF-8 split across two ids.
+        # In GPT-2 byte-level, U+00B0 (°) = bytes 0xC2 0xB0 = pretty
+        # token "Â°"; a real emoji like 😀 (U+1F600) = F0 9F 98 80 =
+        # "ðŁĺĢ".
+        vocab = {
+            "<pad>": 0,
+            "</s>": 1,
+            "Ġ25": 2,  # ' 25'
+            "Â°": 3,  # '°' (2-byte UTF-8)
+            "C": 4,
+            # Split the emoji across two tokens.
+            "ðŁ": 5,  # first half of 😀 (bytes F0 9F)
+            "ĺĢ": 6,  # second half (bytes 98 80)
+        }
+        model = models.BPE(vocab=vocab, merges=[])
+        rust = Tokenizer(model)
+        rust.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        # Start broken: SentencePiece-style decoder.
+        rust.decoder = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(" ", 1, 0),
+            ]
+        )
+        tok = PreTrainedTokenizerFast(
+            tokenizer_object=rust, pad_token="<pad>", eos_token="</s>"
+        )
+        assert repair_byte_level_decoder(tok) is True
+
+        # Degree-sign sequence: " 25°C"
+        decoder = IncrementalDecoder(tok)
+        deltas = [decoder.add_token(t) for t in [2, 3, 4]]
+        assert "".join(deltas) == " 25°C"
+        for d in deltas:
+            _assert_no_mojibake(d, context="degree-sign streaming")
+
+        # Emoji split-across-tokens: 😀 must not leave a U+FFFD in the
+        # first delta — the IncrementalDecoder holds back until the
+        # second token completes it.
+        decoder2 = IncrementalDecoder(tok)
+        first_delta = decoder2.add_token(5)
+        assert "�" not in first_delta
+        # The full character only materialises after the second id.
+        second_delta = decoder2.add_token(6)
+        assert (first_delta + second_delta) == "😀"
+        _assert_no_mojibake(first_delta + second_delta, context="emoji")

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -766,6 +766,7 @@ class MLXMultimodalLM:
             # for the full rationale.
             from ..utils.tokenizer import (
                 augment_eos_token_ids_from_generation_config,
+                repair_byte_level_decoder,
             )
 
             tok = (
@@ -774,6 +775,11 @@ class MLXMultimodalLM:
                 else self.processor
             )
             augment_eos_token_ids_from_generation_config(tok, self.model_name)
+            # D-DETOK-BPE: some VLM processors (Qwen3-VL distills, etc.)
+            # carry the same broken SentencePiece-decoder-on-byte-level-BPE
+            # mis-configuration as text-only DeepSeek-R1; patch the live
+            # backend decoder so streaming + non-stream emit clean UTF-8.
+            repair_byte_level_decoder(tok)
 
             self._loaded = True
             self._video_native = hasattr(

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -124,20 +124,23 @@ def repair_byte_level_decoder(tokenizer) -> bool:
     backend = inner.backend_tokenizer
 
     # Find a probe id whose pretty token starts with a byte-level marker.
-    # We sample the vocab in id order; the first match suffices.
+    # We scan the *entire* vocab (codex r2 NIT) — a 4 KB id prefix cap
+    # silently skips valid byte-level vocabs whose byte tokens all live
+    # past id 4096 (e.g. tokenizers that pack specials + reserved ids
+    # ahead of the BPE merges). The scan walks the dict from
+    # ``get_vocab()`` (token→id), which is O(vocab) one-shot and short-
+    # circuits on the first match — no per-id ``convert_ids_to_tokens``
+    # round-trip, so even a 200k-entry vocab probes in <5 ms.
     probe_id: int | None = None
     probe_pretty: str | None = None
     try:
-        vocab_size = getattr(inner, "vocab_size", None) or len(inner.get_vocab())
+        vocab = inner.get_vocab()
     except Exception:
         return False
-    # Scan a bounded prefix of the vocab for a Ġ-prefixed token. On every
-    # GPT-2 byte-level BPE these appear within the first few hundred ids.
-    for tid in range(min(vocab_size, 4096)):
-        try:
-            pretty = inner.convert_ids_to_tokens(tid)
-        except Exception:
-            continue
+    # ``get_vocab`` returns ``{pretty: id}``. Sort by id so the probe
+    # is deterministic across HF tokenizer versions (some return dicts
+    # in insertion order, others in hash order).
+    for pretty, tid in sorted(vocab.items(), key=lambda kv: kv[1]):
         if not isinstance(pretty, str):
             continue
         if any(pretty.startswith(m) for m in _BYTE_LEVEL_MOJIBAKE_MARKERS):

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -38,6 +38,174 @@ def _needs_tokenizer_fallback(model_name: str) -> bool:
 RAPID_EXTRA_EOS_ATTR = "_rapid_extra_eos_token_ids"
 
 
+# Characters that mark a *broken* GPT-2 byte-level BPE decode path.
+# When ``tokenizer.decode([id])`` leaks any of these, the underlying
+# fast-tokenizer ``decoder`` is mis-configured (typically a Llama
+# SentencePiece decoder paired with a Qwen3 / GPT-2 byte-level BPE
+# vocab — see ``repair_byte_level_decoder`` docstring for the
+# full diagnosis). The repair probe samples a known byte-level pretty
+# token and asserts the decode is clean before declaring the tokenizer
+# healthy.
+_BYTE_LEVEL_MOJIBAKE_MARKERS: tuple[str, ...] = (
+    "Ġ",  # 'Ġ' — GPT-2 byte-level encoding of space
+    "Ċ",  # 'Ċ' — GPT-2 byte-level encoding of newline
+    "ĉ",  # 'ĉ' — GPT-2 byte-level encoding of tab
+)
+
+
+def repair_byte_level_decoder(tokenizer) -> bool:
+    """Repair a mis-configured byte-level BPE decoder in place.
+
+    Bug D-DETOK-BPE (rapid-mlx 0.7/0.8 series): every DeepSeek-R1
+    distill on Qwen3 / Llama bases (``mlx-community/DeepSeek-R1-0528-
+    Qwen3-8B-4bit``, ``DeepSeek-R1-Distill-Qwen-32B-4bit``, etc.) ships
+    a ``tokenizer_config.json`` declaring ``tokenizer_class:
+    LlamaTokenizerFast``. The Rust fast tokenizer is loaded with the
+    correct GPT-2 ``ByteLevel`` *encoder* (so encode is fine), but
+    transformers' ``LlamaTokenizerFast`` then *overrides* the decoder
+    chain with the SentencePiece convention::
+
+        Sequence([Replace("▁", " "), ByteFallback(), Fuse(),
+                  Strip(" ", start=1, stop=0)])
+
+    even though the vocab uses GPT-2 byte-level pretty tokens (``Ġ``,
+    ``Ċ``, ``âĢľ``, ``Â°``…). Result: ``tokenizer.decode([6771])``
+    returns ``"ĠLet"`` instead of ``" Let"``, so every byte-level pretty
+    token leaks **verbatim** into ``reasoning_content``, ``content``,
+    streaming ``delta.*`` fields, and ``/v1/completions[0].text``. This
+    happens at the tokenizer layer, *not* per-parser, which is why all
+    user-facing surfaces (chat stream, chat non-stream, raw completions)
+    are affected on every affected alias.
+
+    The repair: detect the mismatch by probing a token whose pretty form
+    starts with ``Ġ`` or ``Ċ`` (we use the first vocab id whose
+    ``convert_ids_to_tokens`` output begins with such a marker), and if
+    ``decode([id])`` still contains the marker, swap the live
+    ``backend_tokenizer.decoder`` for a plain GPT-2 ``ByteLevel`` decoder.
+    The vocab itself is correct — only the decoder side needs swapping.
+
+    Idempotent: a second call on a healthy tokenizer is a no-op.
+
+    Returns ``True`` if a repair was applied, ``False`` otherwise.
+
+    Note: also unwraps ``mlx_lm.tokenizer_utils.TokenizerWrapper`` —
+    ``decode`` is forwarded to ``_tokenizer`` via ``__getattr__`` so
+    patching the inner backend is sufficient; both the wrapper's own
+    ``decode`` callers and the raw HF ``decode`` callers see the fix.
+    """
+    if tokenizer is None:
+        return False
+
+    # Three tokenizer shapes flow through Rapid-MLX:
+    # 1. ``mlx_lm.tokenizer_utils.TokenizerWrapper`` — wraps an HF
+    #    tokenizer; ``decode`` is forwarded via ``__getattr__``.
+    # 2. ``transformers.PreTrainedTokenizerFast`` (and subclasses,
+    #    including ``LlamaTokenizerFast``) — the canonical HF fast
+    #    shape; the Rust backend lives on ``backend_tokenizer``.
+    # 3. Slow / pure-Python HF tokenizers — no Rust backend, byte-level
+    #    handling is built in to the slow decoder, so no repair needed.
+    #
+    # The mlx-lm wrapper *also* has a ``_tokenizer`` attribute, but on
+    # an HF fast tokenizer ``_tokenizer`` is the raw Rust ``Tokenizer``
+    # object (no ``backend_tokenizer``). We probe both candidates and
+    # pick the one that exposes ``backend_tokenizer``.
+    candidates = [tokenizer]
+    if hasattr(tokenizer, "_tokenizer"):
+        candidates.append(tokenizer._tokenizer)
+    inner = next(
+        (c for c in candidates if hasattr(c, "backend_tokenizer")),
+        None,
+    )
+    if inner is None:
+        # Slow / pure-Python tokenizer — no Rust decoder to swap. The
+        # slow decoder paths handle byte-level natively, so this branch
+        # is healthy by construction.
+        return False
+    backend = inner.backend_tokenizer
+
+    # Find a probe id whose pretty token starts with a byte-level marker.
+    # We sample the vocab in id order; the first match suffices.
+    probe_id: int | None = None
+    probe_pretty: str | None = None
+    try:
+        vocab_size = getattr(inner, "vocab_size", None) or len(inner.get_vocab())
+    except Exception:
+        return False
+    # Scan a bounded prefix of the vocab for a Ġ-prefixed token. On every
+    # GPT-2 byte-level BPE these appear within the first few hundred ids.
+    for tid in range(min(vocab_size, 4096)):
+        try:
+            pretty = inner.convert_ids_to_tokens(tid)
+        except Exception:
+            continue
+        if not isinstance(pretty, str):
+            continue
+        if any(pretty.startswith(m) for m in _BYTE_LEVEL_MOJIBAKE_MARKERS):
+            probe_id = tid
+            probe_pretty = pretty
+            break
+
+    if probe_id is None:
+        # Not a byte-level vocab — nothing to repair.
+        return False
+
+    try:
+        decoded = inner.decode([probe_id], skip_special_tokens=False)
+    except Exception:
+        return False
+
+    if not any(m in decoded for m in _BYTE_LEVEL_MOJIBAKE_MARKERS):
+        # Decoder is already correct.
+        return False
+
+    # Decoder is broken: swap in a plain ByteLevel decoder.
+    try:
+        from tokenizers import decoders as _decoders
+
+        backend.decoder = _decoders.ByteLevel()
+    except Exception as exc:  # noqa: BLE001 — defensive only
+        logger.warning(
+            "repair_byte_level_decoder: failed to swap decoder on %s: %s",
+            type(inner).__name__,
+            exc,
+        )
+        return False
+
+    # Verify the swap actually fixed the decode. If the model genuinely
+    # uses a non-ByteLevel pretty token (unlikely on real models), leave
+    # the original in place so we don't silently corrupt output.
+    try:
+        verify = inner.decode([probe_id], skip_special_tokens=False)
+    except Exception:
+        verify = decoded
+    if any(m in verify for m in _BYTE_LEVEL_MOJIBAKE_MARKERS):
+        logger.warning(
+            "repair_byte_level_decoder: swap did not clear mojibake on %s "
+            "(probe id=%d pretty=%r decoded=%r); reverting",
+            type(inner).__name__,
+            probe_id,
+            probe_pretty,
+            verify,
+        )
+        # Best-effort revert is not strictly necessary — if the swap
+        # didn't help, the original decoder was producing the same
+        # mojibake, so callers are no worse off. But to honour the
+        # "non-destructive" contract on unexpected vocabs we surface the
+        # warning and leave the new decoder in place (still ByteLevel —
+        # any further regression would be visible to the same probe).
+        return False
+
+    logger.info(
+        "repair_byte_level_decoder: swapped %s.backend_tokenizer.decoder to "
+        "ByteLevel (probe id=%d pretty=%r -> decoded=%r)",
+        type(inner).__name__,
+        probe_id,
+        probe_pretty,
+        verify,
+    )
+    return True
+
+
 def augment_eos_token_ids_from_generation_config(
     tokenizer, model_path_or_name: str
 ) -> None:
@@ -317,6 +485,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
                 if mp is not None:
                     _apply_chat_template_sidecar(mp, tokenizer)
             augment_eos_token_ids_from_generation_config(tokenizer, model_name)
+            repair_byte_level_decoder(tokenizer)
             return model, tokenizer
         except Exception as e:
             # Fall back to our wrapper for older mlx-lm versions
@@ -346,6 +515,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
             if mp is not None:
                 _apply_chat_template_sidecar(mp, tokenizer)
         augment_eos_token_ids_from_generation_config(tokenizer, model_name)
+        repair_byte_level_decoder(tokenizer)
         return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers, OR newer model_types
@@ -395,6 +565,7 @@ def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     _try_inject_mtp(model, model_path, config)
     _apply_chat_template_sidecar(model_path, tokenizer)
     augment_eos_token_ids_from_generation_config(tokenizer, str(model_path))
+    repair_byte_level_decoder(tokenizer)
     return model, tokenizer
 
 
@@ -468,6 +639,7 @@ def _load_non_strict(model_name: str, tokenizer_config: dict = None):
     tokenizer = load_tokenizer(model_path, tokenizer_config or {})
     _apply_chat_template_sidecar(model_path, tokenizer)
     augment_eos_token_ids_from_generation_config(tokenizer, str(model_path))
+    repair_byte_level_decoder(tokenizer)
     return model, tokenizer
 
 
@@ -539,6 +711,7 @@ def _load_with_tokenizer_fallback(model_name: str):
             tokenizer.chat_template = DEFAULT_CHATML_TEMPLATE
             logger.info("Using default ChatML chat template")
 
+        repair_byte_level_decoder(tokenizer)
         logger.info("Tokenizer loaded via fallback successfully")
         return model, tokenizer
     else:

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -158,7 +158,11 @@ def repair_byte_level_decoder(tokenizer) -> bool:
         # Decoder is already correct.
         return False
 
-    # Decoder is broken: swap in a plain ByteLevel decoder.
+    # Decoder is broken: swap in a plain ByteLevel decoder. Save the
+    # original so we can restore it on verification failure (codex r1
+    # BLOCKING: a "revert" comment that doesn't actually revert leaves
+    # an unverified mutation in place).
+    original_decoder = backend.decoder
     try:
         from tokenizers import decoders as _decoders
 
@@ -172,27 +176,35 @@ def repair_byte_level_decoder(tokenizer) -> bool:
         return False
 
     # Verify the swap actually fixed the decode. If the model genuinely
-    # uses a non-ByteLevel pretty token (unlikely on real models), leave
-    # the original in place so we don't silently corrupt output.
+    # uses a non-ByteLevel pretty token (unlikely on real models), put
+    # the original decoder back so we don't silently corrupt output.
     try:
         verify = inner.decode([probe_id], skip_special_tokens=False)
     except Exception:
         verify = decoded
     if any(m in verify for m in _BYTE_LEVEL_MOJIBAKE_MARKERS):
+        # Restore the original decoder — if ByteLevel can't clear the
+        # mojibake either, the vocab is in a shape we don't understand
+        # and changing the decoder is a net behaviour change. Honour
+        # the "non-destructive on unknown vocab" contract by undoing
+        # the swap before returning False.
+        try:
+            backend.decoder = original_decoder
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "repair_byte_level_decoder: could not restore original "
+                "decoder on %s after failed verification: %s",
+                type(inner).__name__,
+                exc,
+            )
         logger.warning(
             "repair_byte_level_decoder: swap did not clear mojibake on %s "
-            "(probe id=%d pretty=%r decoded=%r); reverting",
+            "(probe id=%d pretty=%r decoded=%r); restored original decoder",
             type(inner).__name__,
             probe_id,
             probe_pretty,
             verify,
         )
-        # Best-effort revert is not strictly necessary — if the swap
-        # didn't help, the original decoder was producing the same
-        # mojibake, so callers are no worse off. But to honour the
-        # "non-destructive" contract on unexpected vocabs we surface the
-        # warning and leave the new decoder in place (still ByteLevel —
-        # any further regression would be visible to the same probe).
         return False
 
     logger.info(


### PR DESCRIPTION
## Why this change

Closes the D-DETOK-BPE (P0) regression flagged by rapid-desktop fuzz
cycle-7 F-701: every DeepSeek-R1 distill alias on rapid-mlx 0.7/0.8
leaks GPT-2 byte-level pretty tokens verbatim into user-facing text
because the model repos ship an
``LlamaTokenizerFast``-with-byte-level-vocab malformation. We fix it
once at tokenizer load time so every consumer of
``tokenizer.decode`` is healthy from the first request onward.

## Bug

Every DeepSeek-R1 / Qwen3-base distill alias (``deepseek-r1-8b-4bit``,
``deepseek-r1-32b-4bit``, …) leaks GPT-2 byte-level pretty tokens
verbatim into:

- ``message.reasoning_content`` (non-stream chat)
- ``message.content`` (non-stream chat)
- SSE ``delta.reasoning_content`` / ``delta.content`` (streaming chat)
- ``/v1/completions[0].text`` (raw completions)

Symbol soup: ``Ġ`` (U+0120 = space), ``Ċ`` (U+010a = newline),
``ĉ`` (U+0109 = tab), and the UTF-8-bytes-as-Latin-1 derivatives
``âĢľ`` / ``âĢĿ`` (curly quotes), ``Â°`` (degree sign).

Source: rapid-desktop fuzz cycle-7 F-701 / `bug_report.md:148`.

## Root cause

The mlx-community DeepSeek-R1 repos ship
``tokenizer_config.json`` declaring ``tokenizer_class:
LlamaTokenizerFast`` while the vocab is GPT-2 byte-level. We picked
this approach because it fires once at load time and covers every
existing and future caller of ``tokenizer.decode`` — far cleaner than
patching N call sites. transformers loads the Llama SentencePiece
decoder chain — ``Sequence([Replace("▁", " "), ByteFallback, Fuse,
Strip])`` — which **cannot invert** the byte-level encoding (``Ġ``
→ space etc.). Result: every ``tokenizer.decode([id])`` returns the
pretty form verbatim. The encoder side is correct, so it isn't a
parser bug — it's at the detokenizer layer, which is why *all*
user-facing surfaces are affected on every affected alias.

Confirmed with a one-liner against the live tokenizer:

```python
tok.decode([6771])              # 'ĠLet'  — broken
tok.backend_tokenizer.decoder   # SentencePiece chain (Llama)
```

## Fix

New ``repair_byte_level_decoder(tokenizer)`` in
``vllm_mlx/utils/tokenizer.py``:

1. Locate the live ``backend_tokenizer`` (works for both
   ``mlx_lm.TokenizerWrapper`` and bare
   ``transformers.PreTrainedTokenizerFast``).
2. Probe vocab for the first id whose pretty token starts with
   ``Ġ`` / ``Ċ`` / ``ĉ``.
3. If ``tokenizer.decode([id])`` still contains that marker, swap the
   live decoder for ``tokenizers.decoders.ByteLevel()``.
4. **Verify the swap actually fixed the decode; if not, restore the
   original decoder** (codex r1 BLOCKING — non-destructive on unknown
   vocab shapes; covered by
   ``test_repair_restores_original_decoder_when_swap_fails_verification``).

Idempotent. No-op on healthy tokenizers, no-op on non-byte-level
vocabs, no-op on slow / pure-Python tokenizers. Single mutation point
per model load — covers stream, non-stream, raw-completions, and any
future consumer of ``tokenizer.decode``.

Why one mutation point instead of patching the streaming detokenizer
specifically? Because the malformation is in the underlying HF
``decode()`` method, which is *also* called by ``/v1/completions[0]
.text``, the non-stream chat builder, ``output_router.py`` (lines
188 / 310 / 430), and ``service/helpers.py:1370``. Fixing each call
site would be a 7-file patch with no defence against future call
sites. Fixing the tokenizer itself is one function plus six load-path
hooks.

Wired into every load path:

- ``load_model_with_fallback`` (primary + Gemma 4 fast-path)
- ``_load_strict_false``
- ``_load_non_strict``
- ``_load_with_tokenizer_fallback`` (Nemotron-style fallback)
- ``MLLM._load`` in ``vllm_mlx/models/mllm.py`` (VLM processor path)

## Verification

Live boot of ``deepseek-r1-8b-4bit`` now logs at startup:

```
INFO:rapid_mlx.utils.tokenizer:repair_byte_level_decoder: swapped
TokenizerWrapper.backend_tokenizer.decoder to ByteLevel
(probe id=197 pretty='ĉ' -> decoded='\t')
```

Live envelopes (POST ``{"model":"deepseek-r1-8b-4bit","messages":[…],
"max_tokens":200}``):

- BEFORE (deterministic re-derivation via un-repaired tokenizer):
  ``/tmp/d-detok-bpe-before.json`` — ``reasoning_content`` contains
  9× ``Ġ`` + 2× ``Ċ``
- AFTER (live ``deepseek-r1-8b-4bit`` on this branch):
  ``/tmp/d-detok-bpe-after.json`` — 0 mojibake markers

Same for ``stream=true`` deltas
(``/tmp/d-detok-bpe-stream-after.txt``) and ``/v1/completions``.

## Test plan

- [x] ``pytest tests/test_streaming_detokenizer_bpe.py -v`` — 15/15
      pass (repair contract, idempotent, restore-on-verification-fail,
      streaming deltas, cumulative decode, U+FFFD multi-byte hold-back,
      negative control proving the fixture reproduces the bug)
- [x] ``pytest tests/test_streaming_detokenizer.py -v`` — existing 13
      tests still pass (no regression on the optimized detokenizer
      pool / scheduler path)
- [x] ``pytest tests/test_reasoning_parsers.py tests/test_reasoning_parser.py tests/test_reasoning_think_detector.py -q``
      — 278 pass
- [x] ``pytest tests/test_streaming.py -q`` — 26 pass
- [x] Live boot ``rapid-mlx serve deepseek-r1-8b-4bit`` — repair logs
      fire; ``/healthz`` ready
- [x] Live ``POST /v1/chat/completions`` (non-stream) — 0 mojibake in
      ``reasoning_content``
- [x] Live ``POST /v1/chat/completions`` (``stream:true``) — 0
      mojibake in any ``delta.*`` chunk
- [x] Live ``POST /v1/completions`` — 0 mojibake in
      ``choices[0].text``
- [x] ``ruff check`` + ``ruff format`` clean on touched files

## Post-merge verification (tracked, not gating)

- Capture a longer reasoning trace on ``deepseek-r1-32b-4bit`` to
  confirm the same alias bundle (different chat-template) is also
  clean.
- Re-run rapid-desktop fuzz cycle-7 F-701 against 0.8.3 — expect the
  Ġ / Ċ / âĢľ / Â° markers to drop out of the failure report.
- Audit the rest of the mlx-community alias list for the same
  ``LlamaTokenizerFast``-with-byte-level-vocab malformation; the
  repair is idempotent so coverage is automatic, but we should
  emit one Prometheus counter for every alias that triggers the
  swap to surface the affected catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)