### PR TITLE
fix(harmony): route analysis-channel buffer to reasoning_content on cut-short finalize (D-HARMONY-LEAK)

### DIFF
--- a/tests/test_harmony_finalize.py
+++ b/tests/test_harmony_finalize.py
@@ -602,44 +602,155 @@ def test_streaming_harmony_cut_short_does_not_leak_into_content_stop():
     )
 
 
-# ── Codex r1 BLOCKING #2 pin: tool-call-detected stream gate ─────────
+# ── Codex r1/r2 BLOCKING pin: tool-call-detected stream gate ─────────
 
 
-def test_streaming_synthetic_raw_excludes_tool_call_detected_state():
-    """Codex r1 BLOCKING #2: the streaming ``harmony_cut_short``
-    detection at chat.py looks for "active HarmonyReasoningParser AND
-    accumulated_reasoning non-empty AND accumulated_text empty". That
-    shape ALSO matches a tool-call-only stream where the parallel-
-    tool-calls cap dropped every commentary entry
-    (``processor.tool_calls_detected`` set on the cap-exhaust path
-    but ``fallback_tool_calls`` may arrive empty and
+def test_production_helper_skips_synthetic_raw_when_tool_calls_detected():
+    """Codex r1 BLOCKING #2 + r2 BLOCKING: the streaming chat route's
+    ``harmony_cut_short`` predicate looks for "active
+    HarmonyReasoningParser AND accumulated_reasoning non-empty AND
+    accumulated_text empty". That shape ALSO matches a tool-call-only
+    stream where the parallel-tool-calls cap dropped every commentary
+    entry (``processor.tool_calls_detected`` set on the cap-exhaust
+    path but ``fallback_tool_calls`` may arrive empty and
     ``finish_event.finish_reason`` may take a non-``"tool_calls"``
     value on the buffered-finish-gate path). Plumbing
     ``processor.tool_calls_detected`` into the harmony_cut_short
     predicate prevents misclassifying a tool-call-detected stream as
-    analysis-without-final and accidentally narrowing the helper's
-    surface for that case. Pin the predicate directly so future
-    refactors of the streaming call site preserve the gate.
+    analysis-without-final.
+
+    Codex r2 BLOCKING (PR #794) caught the earlier shape of this test
+    re-implementing the predicate locally — that hid any drift if the
+    route stopped consulting ``tool_calls_detected``. The production
+    predicate is now a module-level helper
+    ``vllm_mlx.routes.chat._is_harmony_cut_short_stream`` and the
+    route imports + invokes it directly. This test imports the SAME
+    code object, so dropping the ``tool_calls_detected`` argument
+    from the route would break this test immediately.
     """
     from vllm_mlx.reasoning.harmony_parser import HarmonyReasoningParser
+    from vllm_mlx.routes.chat import _is_harmony_cut_short_stream
 
-    # Mirror the actual streaming-callsite predicate composition.
     rp = HarmonyReasoningParser()
-    accumulated_reasoning = "still thinking"
-    accumulated_text = ""
-
-    def _harmony_cut_short(*, tool_calls_detected: bool) -> bool:
-        rp_is_harmony = type(rp).__name__ == "HarmonyReasoningParser"
-        return bool(
-            rp_is_harmony
-            and accumulated_reasoning
-            and not accumulated_text
-            and not tool_calls_detected
-        )
-
     # No tool-call detected: gate fires (harmony cut-short → suppress).
-    assert _harmony_cut_short(tool_calls_detected=False) is True
-    # Tool-call detected (even with no fallback_tool_calls surfaced):
-    # gate does NOT fire — the stream is structurally a tool-call
-    # response, not an analysis-only truncation.
-    assert _harmony_cut_short(tool_calls_detected=True) is False
+    assert (
+        _is_harmony_cut_short_stream(
+            rp,
+            accumulated_reasoning="still thinking",
+            accumulated_text="",
+            tool_calls_detected=False,
+        )
+        is True
+    )
+    # Tool-call detected: gate does NOT fire — the stream is
+    # structurally a tool-call response, not an analysis-only
+    # truncation.
+    assert (
+        _is_harmony_cut_short_stream(
+            rp,
+            accumulated_reasoning="still thinking",
+            accumulated_text="",
+            tool_calls_detected=True,
+        )
+        is False
+    )
+    # Reasoning-parser absent (non-harmony families) — gate never fires.
+    assert (
+        _is_harmony_cut_short_stream(
+            None,
+            accumulated_reasoning="still thinking",
+            accumulated_text="",
+            tool_calls_detected=False,
+        )
+        is False
+    )
+    # Content was streamed — gate never fires (we already have the
+    # answer; rescue's happy-path early-exit handles it).
+    assert (
+        _is_harmony_cut_short_stream(
+            rp,
+            accumulated_reasoning="thought",
+            accumulated_text="The answer is 42.",
+            tool_calls_detected=False,
+        )
+        is False
+    )
+
+
+def test_streaming_route_imports_production_harmony_predicate():
+    """Codex r2 BLOCKING: belt-and-suspenders — the streaming chat
+    route's body must reference the production
+    ``_is_harmony_cut_short_stream`` symbol at the synthetic_raw
+    decision point, not duplicate its logic inline. If a future
+    refactor inlines the predicate again, this regression test
+    triggers and the codex r1/r2 fix-cycle's drift hazard is caught
+    before merge.
+    """
+    import inspect
+
+    from vllm_mlx.routes import chat as chat_module
+
+    # The stream_chat_completion function specifically must use the
+    # helper (the helper's own definition also has the symbol, but we
+    # care about the route consuming it, not just defining it).
+    stream_src = inspect.getsource(chat_module.stream_chat_completion)
+    assert "_is_harmony_cut_short_stream(" in stream_src, (
+        "stream_chat_completion must invoke the harmony cut-short "
+        "predicate via the module-level helper, not inline a "
+        "reimplementation"
+    )
+
+
+def test_streaming_route_call_site_passes_tool_calls_detected_arg():
+    """Codex r2 BLOCKING (PR #794): static-import pin that the route's
+    invocation of ``_is_harmony_cut_short_stream`` actually passes
+    ``processor.tool_calls_detected`` through, not a hard-coded
+    ``False`` or a different field. Together with the helper-level
+    unit test above (which proves the helper itself honours the
+    ``tool_calls_detected`` argument), this closes the static-drift
+    gap codex r2 flagged — the production predicate is consulted AND
+    the route feeds it the right argument.
+
+    An end-to-end TestClient drive of the cap-exhaust path requires
+    the full streaming postprocessor configuration the production
+    server runs (tool_call_parser, model_registry, channel-routed
+    capability probe), which is heavy to fake. The two-layer pin
+    (helper unit + AST inspection of the call site) is the minimal
+    discrimination that fails on either drift.
+    """
+    import ast
+    import inspect
+
+    from vllm_mlx.routes import chat as chat_module
+
+    stream_src = inspect.getsource(chat_module.stream_chat_completion)
+    tree = ast.parse(stream_src)
+
+    # Find every call to _is_harmony_cut_short_stream and confirm
+    # exactly one of the args is ``processor.tool_calls_detected``.
+    matches: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else (func.attr if isinstance(func, ast.Attribute) else None)
+            )
+            if name == "_is_harmony_cut_short_stream":
+                matches.append(node)
+    assert matches, "stream_chat_completion must invoke _is_harmony_cut_short_stream"
+    for call in matches:
+        passed_attrs = []
+        for arg in list(call.args) + [kw.value for kw in call.keywords]:
+            if (
+                isinstance(arg, ast.Attribute)
+                and isinstance(arg.value, ast.Name)
+                and arg.value.id == "processor"
+            ):
+                passed_attrs.append(arg.attr)
+        assert "tool_calls_detected" in passed_attrs, (
+            "D-HARMONY-LEAK r2 BLOCKING: route must pass "
+            "processor.tool_calls_detected to _is_harmony_cut_short_stream; "
+            f"call site passed processor.{passed_attrs!r}"
+        )

--- a/tests/test_harmony_finalize.py
+++ b/tests/test_harmony_finalize.py
@@ -1,0 +1,596 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-HARMONY-LEAK (2026-06-21) regression tests.
+
+The gpt-oss family (and any Harmony-encoding tokenizer) emits
+
+    <|channel|>analysis<|message|>…<|end|>
+    <|channel|>final<|message|>…<|return|>
+
+as the wire contract for a complete reasoning-then-answer turn. When
+generation is cut short BEFORE the final-channel opener appears
+(``max_tokens`` mid-analysis OR a ``stop`` string matching mid-
+analysis), the engine correctly routes the analysis bytes into
+``reasoning_content`` and leaves ``content`` empty — exactly the
+silent-drop shape the issue-#569 rescue
+(``_rescue_silent_drop_from_reasoning``) was designed to fix.
+
+But on Harmony, the analysis body is NOT the model's final answer.
+Promoting it to ``content`` ships the SAME bytes in both fields
+(``content == reasoning_content`` mojibake) — the bug filed as
+D-HARMONY-LEAK in the cycle-2 fuzz-perf P0 sweep.
+
+The fix adds a harmony-channel-shape gate to the rescue: when
+``raw_text`` shows an analysis-channel opener but NO final-channel
+opener AND no ``<|call|>`` (commentary tool call), the rescue does
+NOT fire, regardless of ``finish_reason`` (length / stop / other).
+The gate is symmetric across the streaming and non-streaming surfaces
+— the streaming call site synthesises a harmony-marked ``raw_text``
+when the active reasoning parser is the ``HarmonyReasoningParser`` and
+the model never reached the content channel so the helper's gate fires
+uniformly across both paths.
+
+This file exercises:
+
+* Unit tests for the rescue helper's new harmony gate (length cut,
+  stop-string match, happy path with full close, truncation mid-final,
+  truncation mid-commentary tool call).
+* Token-level checks against ``HarmonyStreamingRouter.feed_sequence``
+  so the engine-side split contract stays pinned (analysis-only →
+  ``content=None`` / ``reasoning=<analysis>``; mid-final →
+  ``content=<partial>``; happy path → both populated).
+* Regressions for the existing #569 rescue (gemma-4 stuck-thought
+  shape) and the VibeThinker ``<think>`` gate so the new harmony gate
+  is additive, not replacing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.service.helpers import _rescue_silent_drop_from_reasoning
+
+# ── Unit tests: the rescue helper's new harmony gate ─────────────────
+
+
+def test_rescue_skipped_when_harmony_cut_short_finish_length():
+    """``max_tokens=20`` cut mid-analysis on gpt-oss-20b-mxfp4-q8.
+
+    Live repro: POST chat with ``max_tokens=20`` → finish_reason=length,
+    raw_text carries ``<|channel|>analysis<|message|>…`` and never
+    reaches ``<|channel|>final<|message|>``. The engine populated
+    ``reasoning_text`` with the analysis body and left ``content`` empty.
+    Pre-fix, the rescue surfaced the analysis trace as ``content`` —
+    ``content == reasoning_content`` mojibake. Post-fix, the harmony-
+    shape gate suppresses the rescue so ``content`` stays ``None``.
+    """
+    raw = "<|channel|>analysis<|message|>Let me think step by step. 17 * 23 ="
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="Let me think step by step. 17 * 23 =",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        "D-HARMONY-LEAK: rescue must NOT fire on harmony cut short "
+        f"mid-analysis; got rescued={rescued!r}"
+    )
+
+
+def test_rescue_skipped_when_harmony_cut_short_finish_stop():
+    """``stop:["Mars"]`` match mid-analysis.
+
+    Live repro: POST chat with a prompt that mentions Mars and
+    ``stop=["Mars"]`` → finish_reason=stop, raw_text carries
+    ``<|channel|>analysis<|message|>…`` ending just before the
+    stop-string token. The engine populated ``reasoning_text`` and
+    left ``content`` empty. Pre-fix, the rescue fired (its ``length``
+    gate didn't match) and surfaced the analysis prefix as content.
+    Post-fix, the harmony gate is finish_reason-agnostic and
+    suppresses the rescue.
+    """
+    raw = "<|channel|>analysis<|message|>Let me think about "
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="Let me think about ",
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        "D-HARMONY-LEAK: rescue must NOT fire on harmony cut short "
+        f"by stop-string mid-analysis; got rescued={rescued!r}"
+    )
+
+
+def test_rescue_fires_on_happy_path_with_final_channel_present():
+    """Counter-test: when the model reached the final channel and
+    emitted content, ``final_content`` is non-empty. The rescue's
+    happy-path early-exit (``if final_content and final_content.strip()``)
+    returns it as-is — the harmony gate is irrelevant here.
+    """
+    raw = (
+        "<|channel|>analysis<|message|>17 * 23 = 391.<|end|>"
+        "<|channel|>final<|message|>The answer is 391.<|return|>"
+    )
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content="The answer is 391.",
+        reasoning_text="17 * 23 = 391.",
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text=raw,
+    )
+    assert rescued == "The answer is 391.", (
+        "happy path must propagate final-channel content unchanged; "
+        f"got rescued={rescued!r}"
+    )
+
+
+def test_rescue_fires_on_truncation_mid_final_channel():
+    """Counter-test: truncation mid-FINAL channel must NOT mistakenly
+    suppress the rescue. The engine's router populates ``content`` with
+    the partial final-channel bytes; the rescue's happy-path early-
+    exit returns it as-is. The harmony gate (analysis present, final
+    absent) does not fire because ``<|channel|>final<|message|>`` IS
+    in raw_text.
+    """
+    raw = (
+        "<|channel|>analysis<|message|>Brief thought.<|end|>"
+        "<|channel|>final<|message|>The ans is"
+    )
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content="The ans is",
+        reasoning_text="Brief thought.",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    assert rescued == "The ans is", (
+        "mid-final truncation must surface the partial final content; "
+        f"got rescued={rescued!r}"
+    )
+
+
+def test_rescue_skipped_when_harmony_cut_short_finish_unknown():
+    """The harmony gate is finish_reason-agnostic. A caller that
+    doesn't thread ``finish_reason`` (legacy or non-streaming early-
+    return path) still gets the suppression — the discriminator is the
+    raw_text channel state, not the wire finish signal.
+    """
+    raw = "<|channel|>analysis<|message|>still thinking"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="still thinking",
+        tool_calls=None,
+        finish_reason=None,
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        f"D-HARMONY-LEAK gate must be finish_reason-agnostic; got rescued={rescued!r}"
+    )
+
+
+def test_rescue_suppressed_on_commentary_tool_call_in_progress():
+    """Counter-test: when ``<|call|>`` is present in raw_text but
+    ``tool_calls`` was not surfaced (e.g. router upstream parsed the
+    call but downstream dropped due to a separate gate), the harmony
+    gate should still suppress — the model emitted a structural tool
+    call, not a final answer. The tool-call branch above the gate
+    already returns ``final_content`` (None) when ``tool_calls`` is
+    populated; this counter pins the marker-only path.
+    """
+    raw = (
+        "<|channel|>analysis<|message|>need weather<|end|>"
+        '<|channel|>commentary to=functions.get_weather<|message|>{"city":"SF"}<|call|>'
+    )
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="need weather",
+        tool_calls=None,  # parser dropped the call somewhere downstream
+        finish_reason="stop",
+        raw_text=raw,
+    )
+    # raw_text carries ``<|call|>`` so the harmony gate's "no tool
+    # call" sub-condition is False — but the rescue would normally
+    # fire here. After the fix, the helper's check is:
+    #   analysis present AND final absent AND <|call|> absent
+    # → ``<|call|>`` present means the gate does NOT fire; the rescue
+    # surfaces reasoning. This matches the pre-fix behaviour for the
+    # rare "parser-dropped-call" path so we don't accidentally
+    # regress an unrelated edge case.
+    assert rescued == "need weather"
+
+
+# ── Existing #569 / VibeThinker rescue still fire — additive gate ────
+
+
+def test_rescue_still_fires_for_gemma4_stuck_thought_no_harmony_markers():
+    """Counter-test: the original #569 failure (gemma-4 stuck inside
+    ``<|channel>thought\\n…`` — note ``<|channel>`` not ``<|channel|>``,
+    a DIFFERENT marker family) does NOT match the harmony gate's
+    marker substring. The rescue still fires.
+    """
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="The user wants weather for SF",
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text="The user wants weather for SF",  # no harmony markers
+    )
+    assert rescued == "The user wants weather for SF", (
+        "gemma-4 #569 rescue must still fire when no harmony markers "
+        f"are present; got rescued={rescued!r}"
+    )
+
+
+def test_rescue_still_skipped_for_vibethinker_truncated_think():
+    """Counter-test: the 2026-06-17 VibeThinker gate
+    (``finish_reason=length`` + raw_text starts with ``<think>`` + no
+    ``</think>``) still suppresses — the new harmony gate is
+    additive, not replacing.
+    """
+    raw = "<think>The user wants to compute 17 * 23. Step 1: 17 * 20"
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=None,
+        reasoning_text="The user wants to compute 17 * 23. Step 1: 17 * 20",
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        "VibeThinker truncated-<think> gate must still suppress; "
+        f"got rescued={rescued!r}"
+    )
+
+
+# ── Engine-router-level pin: HarmonyStreamingRouter.feed_sequence ────
+
+
+@pytest.fixture(scope="module")
+def harmony_router():
+    """Build a real ``HarmonyStreamingRouter`` against the upstream
+    harmony encoding's vocab. Skips if ``openai-harmony`` isn't
+    installed in the test environment.
+    """
+    openai_harmony = pytest.importorskip("openai_harmony")
+    from openai_harmony import HarmonyEncodingName, load_harmony_encoding
+
+    from vllm_mlx.output_router import TokenMap
+    from vllm_mlx.output_router_harmony import HarmonyStreamingRouter
+
+    enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+
+    def _eid(s: str) -> int:
+        ids = enc.encode(s, allowed_special="all")
+        assert len(ids) == 1, (s, ids)
+        return ids[0]
+
+    class _FakeHarmonyTokenizer:
+        name_or_path = "mlx-community/gpt-oss-20b-mxfp4-q8"
+
+        def encode(self, s, add_special_tokens=False):
+            return enc.encode(s, allowed_special="none")
+
+        def decode(self, ids):
+            return enc.decode(ids)
+
+    tm = TokenMap(
+        format_tag="harmony",
+        harmony_channel=_eid("<|channel|>"),
+        harmony_message=_eid("<|message|>"),
+        harmony_call=_eid("<|call|>"),
+        harmony_end=_eid("<|end|>"),
+        harmony_return=_eid("<|return|>"),
+        harmony_start=_eid("<|start|>"),
+        harmony_constrain=_eid("<|constrain|>"),
+    )
+    router = HarmonyStreamingRouter(tm, _FakeHarmonyTokenizer())
+    return enc, router
+
+
+def _encode_assistant(enc, body: str) -> list[int]:
+    return enc.encode(body, allowed_special="all")
+
+
+def test_router_emits_reasoning_only_on_cut_short_mid_analysis(harmony_router):
+    """Engine-side pin: feed an analysis-channel prefix with no close,
+    no final, no call. The router must surface
+    ``content=None, reasoning=<analysis-body>`` so the chat route's
+    downstream split has the right inputs to suppress the rescue.
+    """
+    enc, router = harmony_router
+    router.reset()
+    body = (
+        "<|start|>assistant<|channel|>analysis<|message|>"
+        "Let me think step by step. 17 * 23 ="
+    )
+    routed = router.feed_sequence(_encode_assistant(enc, body))
+    assert routed["content"] is None
+    assert routed["reasoning"] == "Let me think step by step. 17 * 23 ="
+    assert routed["tool_calls"] is None
+
+
+def test_router_emits_partial_content_on_cut_short_mid_final(harmony_router):
+    """Engine-side pin: feed analysis + an unclosed final channel.
+    The router must surface ``content=<partial-final>,
+    reasoning=<analysis>`` so the rescue's happy-path early-exit fires
+    and the partial final answer ships unchanged.
+    """
+    enc, router = harmony_router
+    router.reset()
+    body = (
+        "<|start|>assistant<|channel|>analysis<|message|>"
+        "Brief thought.<|end|>"
+        "<|start|>assistant<|channel|>final<|message|>The ans is"
+    )
+    routed = router.feed_sequence(_encode_assistant(enc, body))
+    assert routed["content"] == "The ans is"
+    assert routed["reasoning"] == "Brief thought."
+    assert routed["tool_calls"] is None
+
+
+def test_router_emits_both_on_happy_path_full_close(harmony_router):
+    """Engine-side pin: feed a fully-closed analysis-then-final
+    sequence. Both channels populated; the rescue's happy-path early-
+    exit returns the final content unchanged.
+    """
+    enc, router = harmony_router
+    router.reset()
+    body = (
+        "<|start|>assistant<|channel|>analysis<|message|>"
+        "17 * 23 = 391.<|end|>"
+        "<|start|>assistant<|channel|>final<|message|>"
+        "The answer is 391.<|return|>"
+    )
+    routed = router.feed_sequence(_encode_assistant(enc, body))
+    assert routed["content"] == "The answer is 391."
+    assert routed["reasoning"] == "17 * 23 = 391."
+    assert routed["tool_calls"] is None
+
+
+# ── End-to-end: helper + rescue chain on engine-routed harmony input ──
+
+
+def test_end_to_end_harmony_cut_short_keeps_content_null():
+    """End-to-end: simulate the engine path for gpt-oss cut short
+    mid-analysis. The chat route's ``_finalize_content_and_reasoning``
+    + ``_rescue_silent_drop_from_reasoning`` chain must yield
+    ``content=None`` (or empty) with ``reasoning_content`` populated.
+
+    This pins the wire contract D-HARMONY-LEAK exposed: clients should
+    detect "model ran out of budget before producing an answer" via
+    ``finish_reason`` plus the empty content — never via byte-
+    identical ``content == reasoning_content``.
+    """
+    from vllm_mlx.service.helpers import _finalize_content_and_reasoning
+
+    raw = "<|channel|>analysis<|message|>Let me think step by step. 17 * 23 ="
+    engine_reasoning = "Let me think step by step. 17 * 23 ="
+
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text="",  # engine routed analysis away from content
+        tool_calls=None,
+        reasoning_parser=None,
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+        reasoning_max_tokens=None,
+    )
+
+    # helper preserves the engine split (no reasoning_max_tokens cap).
+    assert reasoning_text == engine_reasoning
+    assert cleaned_text == ""
+
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=cleaned_text or None,
+        reasoning_text=reasoning_text,
+        tool_calls=None,
+        finish_reason="length",
+        raw_text=raw,
+    )
+    # The fix: rescue is suppressed; content stays None even though
+    # reasoning is populated.
+    assert rescued is None, (
+        "end-to-end D-HARMONY-LEAK: chat route's content slot must "
+        f"stay None for harmony cut-short; got {rescued!r}"
+    )
+
+
+def test_end_to_end_harmony_stop_match_keeps_content_null():
+    """End-to-end: ``stop:["Mars"]`` match mid-analysis. Same shape as
+    length cut from the helper chain's perspective — the rescue's gate
+    suppresses regardless of finish_reason.
+    """
+    from vllm_mlx.service.helpers import _finalize_content_and_reasoning
+
+    raw = "<|channel|>analysis<|message|>Let me think about "
+    engine_reasoning = "Let me think about "
+
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text="",
+        tool_calls=None,
+        reasoning_parser=None,
+        engine_reasoning_text=engine_reasoning,
+        enable_thinking=None,
+        reasoning_max_tokens=None,
+    )
+
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content=cleaned_text or None,
+        reasoning_text=reasoning_text,
+        tool_calls=None,
+        finish_reason="stop",
+        raw_text=raw,
+    )
+    assert rescued is None, (
+        "stop-string match mid-analysis must NOT promote reasoning "
+        f"to content; got {rescued!r}"
+    )
+
+
+# ── Streaming surface: SSE terminal-chunk gate for harmony ───────────
+
+
+class _HarmonyReasoningOnlyStreamEngine:
+    """Streaming engine mimicking gpt-oss cut short mid-analysis.
+
+    Emits channel-routed reasoning-only deltas — same shape the
+    ``HarmonyStreamingRouter`` produces when feeding through
+    ``_stream_with_output_router`` on a generation that ends before a
+    final-channel transition. Used to drive the chat route's SSE
+    pipeline via ``TestClient`` so the streaming D-HARMONY-LEAK gate
+    can be exercised without booting a real model server.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, reasoning_deltas: list[str], finish_reason: str = "length"):
+        self._deltas = reasoning_deltas
+        self._finish_reason = finish_reason
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def stream_chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        accumulated_reasoning = ""
+        for i, delta in enumerate(self._deltas):
+            accumulated_reasoning += delta
+            is_last = i == len(self._deltas) - 1
+            yield GenerationOutput(
+                text="",
+                new_text=delta,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason=self._finish_reason if is_last else None,
+                channel="reasoning",
+                reasoning_text=accumulated_reasoning,
+            )
+
+
+def _parse_sse(text: str) -> list[dict]:
+    import json as _json
+
+    events = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            events.append(_json.loads(payload))
+        except _json.JSONDecodeError:
+            continue
+    return events
+
+
+def _drive_streaming_harmony(finish_reason: str) -> list[dict]:
+    """Drive the chat route's SSE path with a HarmonyReasoningParser
+    wired as ``cfg.reasoning_parser`` so the streaming D-HARMONY-LEAK
+    synthetic_raw injection at ``routes/chat.py`` fires.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.reasoning.harmony_parser import HarmonyReasoningParser
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    cfg.engine = _HarmonyReasoningOnlyStreamEngine(
+        reasoning_deltas=[
+            "Let me think step by step. ",
+            "17 * 23 = ",
+        ],
+        finish_reason=finish_reason,
+    )
+    cfg.model_name = "gpt-oss-20b-mxfp4-q8"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = HarmonyReasoningParser()
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-oss-20b-mxfp4-q8",
+                "stream": True,
+                "max_tokens": 20,
+                "messages": [
+                    {"role": "user", "content": "Compute 17*23 step by step."}
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        return _parse_sse(resp.text)
+    finally:
+        reset_config()
+
+
+def test_streaming_harmony_cut_short_does_not_leak_into_content_length():
+    """SSE streaming surface, ``finish_reason=length``: the terminal
+    chunk's ``delta.content`` MUST stay empty / None when the engine
+    emitted only reasoning-channel deltas and the active parser is
+    ``HarmonyReasoningParser``. Pre-fix the rescue would promote the
+    accumulated reasoning to content, shipping byte-identical
+    content + reasoning_content. Post-fix the streaming call site's
+    harmony synthetic_raw injection makes the helper's gate fire and
+    no SSE chunk carries reasoning prose in ``delta.content``.
+    """
+    events = _drive_streaming_harmony("length")
+    assert events, "expected at least one SSE chunk"
+
+    streamed_content = ""
+    streamed_reasoning = ""
+    for ev in events:
+        for choice in ev.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                streamed_content += delta["content"]
+            if delta.get("reasoning_content"):
+                streamed_reasoning += delta["reasoning_content"]
+
+    assert not streamed_content, (
+        "D-HARMONY-LEAK (streaming, length): no SSE chunk may surface "
+        "reasoning as delta.content; "
+        f"got streamed_content={streamed_content!r}"
+    )
+    # The reasoning trace must still flow on the reasoning channel
+    # so debug / operator visibility into the cut-short state holds.
+    assert "17 * 23" in streamed_reasoning, (
+        "reasoning_content must still surface during the loop; "
+        f"got reasoning={streamed_reasoning!r}"
+    )
+
+
+def test_streaming_harmony_cut_short_does_not_leak_into_content_stop():
+    """SSE streaming surface, ``finish_reason=stop``: same contract as
+    the length case — the harmony gate is finish_reason-agnostic. A
+    stop-string matching mid-analysis must NOT promote the analysis
+    prefix to ``delta.content`` on the terminal chunk.
+    """
+    events = _drive_streaming_harmony("stop")
+    assert events
+
+    streamed_content = ""
+    for ev in events:
+        for choice in ev.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                streamed_content += delta["content"]
+
+    assert not streamed_content, (
+        "D-HARMONY-LEAK (streaming, stop): no SSE chunk may surface "
+        "reasoning as delta.content; "
+        f"got streamed_content={streamed_content!r}"
+    )

--- a/tests/test_harmony_finalize.py
+++ b/tests/test_harmony_finalize.py
@@ -170,14 +170,24 @@ def test_rescue_skipped_when_harmony_cut_short_finish_unknown():
     )
 
 
-def test_rescue_suppressed_on_commentary_tool_call_in_progress():
-    """Counter-test: when ``<|call|>`` is present in raw_text but
-    ``tool_calls`` was not surfaced (e.g. router upstream parsed the
-    call but downstream dropped due to a separate gate), the harmony
-    gate should still suppress — the model emitted a structural tool
-    call, not a final answer. The tool-call branch above the gate
-    already returns ``final_content`` (None) when ``tool_calls`` is
-    populated; this counter pins the marker-only path.
+def test_rescue_suppressed_on_commentary_tool_call_marker_only():
+    """Codex r1 BLOCKING #1 counter-test: when ``<|call|>`` is present
+    in raw_text but ``tool_calls`` is None (parser failed to extract
+    the structured call — malformed args, downstream filter dropped
+    the entry, the helper was invoked by a third-party caller that
+    doesn't thread the parsed-calls list), the harmony gate must
+    STILL suppress the rescue. Promoting the analysis body to
+    ``content`` in this state would leak ``reasoning_content`` bytes
+    onto the user-visible channel, which is the exact mojibake
+    D-HARMONY-LEAK exists to prevent.
+
+    The helper's contract: analysis-present + final-absent suppresses
+    REGARDLESS of ``<|call|>`` presence. The earlier
+    ``if tool_calls:`` branch already preserves successfully-parsed
+    tool calls (it returns the original ``final_content`` before
+    reaching this gate). The two branches are independent — a parsed
+    call short-circuits early; an unparsed-but-marker-present call
+    falls into this gate, which still refuses to leak the analysis.
     """
     raw = (
         "<|channel|>analysis<|message|>need weather<|end|>"
@@ -190,15 +200,11 @@ def test_rescue_suppressed_on_commentary_tool_call_in_progress():
         finish_reason="stop",
         raw_text=raw,
     )
-    # raw_text carries ``<|call|>`` so the harmony gate's "no tool
-    # call" sub-condition is False — but the rescue would normally
-    # fire here. After the fix, the helper's check is:
-    #   analysis present AND final absent AND <|call|> absent
-    # → ``<|call|>`` present means the gate does NOT fire; the rescue
-    # surfaces reasoning. This matches the pre-fix behaviour for the
-    # rare "parser-dropped-call" path so we don't accidentally
-    # regress an unrelated edge case.
-    assert rescued == "need weather"
+    assert rescued is None, (
+        "D-HARMONY-LEAK BLOCKING #1: harmony gate must suppress even "
+        "when <|call|> is present but tool_calls is empty; "
+        f"got rescued={rescued!r}"
+    )
 
 
 # ── Existing #569 / VibeThinker rescue still fire — additive gate ────
@@ -594,3 +600,46 @@ def test_streaming_harmony_cut_short_does_not_leak_into_content_stop():
         "reasoning as delta.content; "
         f"got streamed_content={streamed_content!r}"
     )
+
+
+# ── Codex r1 BLOCKING #2 pin: tool-call-detected stream gate ─────────
+
+
+def test_streaming_synthetic_raw_excludes_tool_call_detected_state():
+    """Codex r1 BLOCKING #2: the streaming ``harmony_cut_short``
+    detection at chat.py looks for "active HarmonyReasoningParser AND
+    accumulated_reasoning non-empty AND accumulated_text empty". That
+    shape ALSO matches a tool-call-only stream where the parallel-
+    tool-calls cap dropped every commentary entry
+    (``processor.tool_calls_detected`` set on the cap-exhaust path
+    but ``fallback_tool_calls`` may arrive empty and
+    ``finish_event.finish_reason`` may take a non-``"tool_calls"``
+    value on the buffered-finish-gate path). Plumbing
+    ``processor.tool_calls_detected`` into the harmony_cut_short
+    predicate prevents misclassifying a tool-call-detected stream as
+    analysis-without-final and accidentally narrowing the helper's
+    surface for that case. Pin the predicate directly so future
+    refactors of the streaming call site preserve the gate.
+    """
+    from vllm_mlx.reasoning.harmony_parser import HarmonyReasoningParser
+
+    # Mirror the actual streaming-callsite predicate composition.
+    rp = HarmonyReasoningParser()
+    accumulated_reasoning = "still thinking"
+    accumulated_text = ""
+
+    def _harmony_cut_short(*, tool_calls_detected: bool) -> bool:
+        rp_is_harmony = type(rp).__name__ == "HarmonyReasoningParser"
+        return bool(
+            rp_is_harmony
+            and accumulated_reasoning
+            and not accumulated_text
+            and not tool_calls_detected
+        )
+
+    # No tool-call detected: gate fires (harmony cut-short → suppress).
+    assert _harmony_cut_short(tool_calls_detected=False) is True
+    # Tool-call detected (even with no fallback_tool_calls surfaced):
+    # gate does NOT fire — the stream is structurally a tool-call
+    # response, not an analysis-only truncation.
+    assert _harmony_cut_short(tool_calls_detected=True) is False

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2209,11 +2209,44 @@ async def stream_chat_completion(
                         processor.accumulated_reasoning + processor.accumulated_text
                     )
                 )
-                synthetic_raw = (
-                    "<think>" + processor.accumulated_reasoning
-                    if saw_open_no_close
-                    else processor.accumulated_reasoning or ""
+                # D-HARMONY-LEAK (2026-06-21): harmony-streaming mirror
+                # of the truncated-``<think>`` synthetic raw above. On
+                # gpt-oss / Harmony streaming, the engine token-routes
+                # via ``OutputRouter`` so ``output.channel="reasoning"``
+                # arrives in the postprocessor pre-split — the literal
+                # ``<|channel|>analysis<|message|>`` opener is consumed
+                # as a state transition by ``HarmonyStreamingRouter``
+                # and never lands in ``accumulated_reasoning``. The
+                # streaming counterpart of the bug: when generation
+                # cuts short before a final channel emerges (max_tokens
+                # mid-analysis OR a stop string matching mid-analysis),
+                # ``accumulated_text`` stays empty and the rescue would
+                # promote the analysis trace to ``delta.content`` —
+                # shipping byte-identical content + reasoning_content
+                # to the client. Synthesise a harmony-marked raw_text
+                # so the helper's new harmony-shape gate (analysis
+                # marker present, final marker absent, no ``<|call|>``)
+                # fires uniformly across both the streaming and non-
+                # streaming surfaces. Gated on the parser type so the
+                # synthetic only fires for Harmony — gemma-4 / qwen
+                # families still rely on their existing rescue paths.
+                rp_is_harmony = (
+                    type(rp).__name__ == "HarmonyReasoningParser" if rp else False
                 )
+                harmony_cut_short = bool(
+                    rp_is_harmony
+                    and processor.accumulated_reasoning
+                    and not processor.accumulated_text
+                )
+                if harmony_cut_short:
+                    synthetic_raw = (
+                        "<|channel|>analysis<|message|>"
+                        + processor.accumulated_reasoning
+                    )
+                elif saw_open_no_close:
+                    synthetic_raw = "<think>" + processor.accumulated_reasoning
+                else:
+                    synthetic_raw = processor.accumulated_reasoning or ""
                 # PR #715 bundle, fuzz finding C: streaming Case-4
                 # mirror of the non-streaming detection. When the
                 # parser never saw a ``<think>``/``</think>`` token

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2225,11 +2225,29 @@ async def stream_chat_completion(
                 # shipping byte-identical content + reasoning_content
                 # to the client. Synthesise a harmony-marked raw_text
                 # so the helper's new harmony-shape gate (analysis
-                # marker present, final marker absent, no ``<|call|>``)
-                # fires uniformly across both the streaming and non-
-                # streaming surfaces. Gated on the parser type so the
-                # synthetic only fires for Harmony — gemma-4 / qwen
-                # families still rely on their existing rescue paths.
+                # marker present, final marker absent) fires uniformly
+                # across both the streaming and non-streaming surfaces.
+                # Gated on the parser type so the synthetic only fires
+                # for Harmony — gemma-4 / qwen families still rely on
+                # their existing rescue paths.
+                #
+                # Codex r1 BLOCKING #2: the empty-content + non-empty-
+                # reasoning shape ALSO matches a tool-call-only stream
+                # where the parallel-tool-calls cap dropped every
+                # commentary entry (``tool_calls_detected=True`` set on
+                # the cap-exhaust path but ``fallback_tool_calls`` may
+                # arrive empty and ``finish_event.finish_reason`` may
+                # be something other than ``"tool_calls"`` on the
+                # router-cap path before the buffered-finish gate
+                # fires). Plumb ``processor.tool_calls_detected``
+                # through so a commentary-call stream is not
+                # misclassified as analysis-without-final and
+                # accidentally suppressed via the harmony gate —
+                # tool-call-only responses legitimately ship
+                # ``content=None`` per the OpenAI spec and the gate
+                # would only change zero-byte output here, but
+                # honouring the explicit channel signal keeps the
+                # synthetic_raw discrimination accurate.
                 rp_is_harmony = (
                     type(rp).__name__ == "HarmonyReasoningParser" if rp else False
                 )
@@ -2237,6 +2255,7 @@ async def stream_chat_completion(
                     rp_is_harmony
                     and processor.accumulated_reasoning
                     and not processor.accumulated_text
+                    and not processor.tool_calls_detected
                 )
                 if harmony_cut_short:
                     synthetic_raw = (

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -234,6 +234,50 @@ def _synthesize_forced_tool_call(name: str, arguments: str = "{}"):
     )
 
 
+def _is_harmony_cut_short_stream(
+    reasoning_parser,
+    accumulated_reasoning: str,
+    accumulated_text: str,
+    tool_calls_detected: bool,
+) -> bool:
+    """D-HARMONY-LEAK gate predicate, factored for direct test reuse.
+
+    Returns True when the streaming postprocessor state matches the
+    harmony "analysis without final" cut-short shape: an active
+    ``HarmonyReasoningParser`` saw reasoning tokens, no content
+    tokens have been streamed, AND no commentary tool call was
+    detected on any chunk. The streaming chat route uses this to
+    decide whether to synthesise a harmony-marked ``raw_text`` so the
+    shared rescue helper's gate fires uniformly across the streaming
+    and non-streaming surfaces.
+
+    Codex r1 BLOCKING #2 (PR #794): plumbing ``tool_calls_detected``
+    keeps a tool-call-only stream from being misclassified as
+    analysis-without-final — the cap-exhaust path in
+    ``StreamingPostProcessor._process_channel_routed`` sets
+    ``tool_calls_detected=True`` even when ``fallback_tool_calls``
+    arrives empty, and a wrongly-fired harmony gate there would not
+    suppress visible bytes but WOULD lose the channel-state signal
+    for any future caller that gates on the synthetic raw shape.
+
+    Codex r2 BLOCKING (PR #794): extracted to a module-level helper
+    so ``tests/test_harmony_finalize.py`` exercises the SAME code
+    object the streaming chat route uses, not a local re-implementation
+    of the predicate.
+    """
+    rp_is_harmony = (
+        type(reasoning_parser).__name__ == "HarmonyReasoningParser"
+        if reasoning_parser is not None
+        else False
+    )
+    return bool(
+        rp_is_harmony
+        and accumulated_reasoning
+        and not accumulated_text
+        and not tool_calls_detected
+    )
+
+
 def _engine_supports_channel_routed_tool_calls(engine) -> bool:
     """Probe whether the engine's tokenizer yields a channel-routed
     streaming path that can emit structured tool calls without a text
@@ -2248,14 +2292,11 @@ async def stream_chat_completion(
                 # would only change zero-byte output here, but
                 # honouring the explicit channel signal keeps the
                 # synthetic_raw discrimination accurate.
-                rp_is_harmony = (
-                    type(rp).__name__ == "HarmonyReasoningParser" if rp else False
-                )
-                harmony_cut_short = bool(
-                    rp_is_harmony
-                    and processor.accumulated_reasoning
-                    and not processor.accumulated_text
-                    and not processor.tool_calls_detected
+                harmony_cut_short = _is_harmony_cut_short_stream(
+                    rp,
+                    processor.accumulated_reasoning,
+                    processor.accumulated_text,
+                    processor.tool_calls_detected,
                 )
                 if harmony_cut_short:
                     synthetic_raw = (

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -703,6 +703,42 @@ def _rescue_silent_drop_from_reasoning(
         return final_content
     if finish_reason == "length" and reasoning_is_case4:
         return final_content
+    # D-HARMONY-LEAK (2026-06-21): harmony-channel analog of the
+    # truncated-``<think>`` gate above. The gpt-oss family (and any
+    # Harmony-encoding tokenizer) emits ``<|channel|>analysis<|message|>
+    # …<|end|><|channel|>final<|message|>…<|return|>`` as the wire
+    # contract for a complete reasoning-then-answer turn — the
+    # ``<|channel|>analysis<|message|>`` opener is the analysis-channel
+    # start marker and ``<|channel|>final<|message|>`` is the
+    # final-channel start marker (the user-visible answer). When
+    # generation is cut short BEFORE the final-channel opener appears
+    # (max_tokens cut mid-analysis OR ``stop:["X"]`` matched a stop-
+    # string that happens to land in the analysis body), the engine
+    # has correctly routed the analysis bytes into ``reasoning_text``
+    # and left ``content`` empty — exactly the silent-drop shape this
+    # rescue was designed to fix. But the analysis body is NOT the
+    # model's final answer, so promoting it to ``content`` ships the
+    # SAME bytes in both fields (``content == reasoning_content``
+    # mojibake) — the bug filed as D-HARMONY-LEAK. Gate the rescue
+    # on the harmony state machine: when raw_text shows an analysis-
+    # channel opener but NO final-channel opener AND no ``<|call|>``
+    # (tool call terminator), we are structurally mid-state-machine
+    # and the rescue must NOT fire. The gate is finish_reason-
+    # AGNOSTIC because both repros (max_tokens=length AND stop-string
+    # match=stop) produce the same broken shape — letting the rescue
+    # fire on either would re-leak the analysis body into ``content``.
+    # When the model DID reach the final channel (final-marker
+    # present), control already returned through the happy-path
+    # early-exit above, so no override is needed for that case. When
+    # the model emitted a commentary tool call (``<|call|>``), the
+    # ``tool_calls`` branch above already suppressed the rescue.
+    if (
+        raw_text
+        and "<|channel|>analysis<|message|>" in raw_text
+        and "<|channel|>final<|message|>" not in raw_text
+        and "<|call|>" not in raw_text
+    ):
+        return final_content
     return reasoning_text
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -721,22 +721,33 @@ def _rescue_silent_drop_from_reasoning(
     # SAME bytes in both fields (``content == reasoning_content``
     # mojibake) — the bug filed as D-HARMONY-LEAK. Gate the rescue
     # on the harmony state machine: when raw_text shows an analysis-
-    # channel opener but NO final-channel opener AND no ``<|call|>``
-    # (tool call terminator), we are structurally mid-state-machine
-    # and the rescue must NOT fire. The gate is finish_reason-
-    # AGNOSTIC because both repros (max_tokens=length AND stop-string
-    # match=stop) produce the same broken shape — letting the rescue
-    # fire on either would re-leak the analysis body into ``content``.
-    # When the model DID reach the final channel (final-marker
-    # present), control already returned through the happy-path
-    # early-exit above, so no override is needed for that case. When
-    # the model emitted a commentary tool call (``<|call|>``), the
-    # ``tool_calls`` branch above already suppressed the rescue.
+    # channel opener but NO final-channel opener, we are structurally
+    # mid-state-machine and the rescue must NOT fire. The gate is
+    # finish_reason-AGNOSTIC because both repros (max_tokens=length
+    # AND stop-string match=stop) produce the same broken shape —
+    # letting the rescue fire on either would re-leak the analysis
+    # body into ``content``.
+    #
+    # Codex r1 BLOCKING #1: an earlier revision exempted any raw_text
+    # carrying ``<|call|>`` (commentary tool-call terminator) under
+    # the assumption the upstream ``tool_calls`` branch would catch
+    # it. That assumption is unsafe — if the tool-call parser failed
+    # to extract a structured call (malformed args, downstream filter
+    # dropping the entry, ``tool_calls`` not threaded into this
+    # helper at all by a third-party caller), the analysis body
+    # would still leak as user-visible content. Suppress the rescue
+    # for ANY harmony "analysis without final" state and rely on the
+    # earlier ``if tool_calls:`` branch to preserve parsed tool
+    # calls — that branch already returns the original
+    # ``final_content`` so a populated ``tool_calls`` list never
+    # reaches this point. When the model DID reach the final channel
+    # (final-marker present), control already returned through the
+    # happy-path early-exit above, so no override is needed for that
+    # case.
     if (
         raw_text
         and "<|channel|>analysis<|message|>" in raw_text
         and "<|channel|>final<|message|>" not in raw_text
-        and "<|call|>" not in raw_text
     ):
         return final_content
     return reasoning_text


### PR DESCRIPTION
## Summary

- **D-HARMONY-LEAK (P0, cycle-2 fuzz-perf)**: gpt-oss-20b-mxfp4-q8 (and every Harmony alias) returns byte-identical \`content == reasoning_content\` whenever generation is cut short before the final channel — \`max_tokens=20\` mid-analysis OR \`stop:["X"]\` matching mid-analysis.
- **Root cause**: \`_rescue_silent_drop_from_reasoning\` (the #569 silent-drop bridge) had a \`<think>\`-specific gate for VibeThinker but no analog for Harmony's channel state machine. When the engine routed analysis tokens into \`reasoning_text\` and left \`content\` empty, the rescue treated it as a silent drop and promoted the analysis trace to \`content\` — exactly the mojibake the bug report flagged.
- **Fix**: extend the rescue helper with a harmony-shape gate — when \`raw_text\` carries \`<|channel|>analysis<|message|>\` but no \`<|channel|>final<|message|>\` AND no \`<|call|>\`, the model never reached the user-visible channel and the rescue must NOT fire (regardless of \`finish_reason\`). The streaming call site synthesises a harmony-marked \`raw_text\` when the active reasoning parser is \`HarmonyReasoningParser\` and no content has been streamed so the gate fires uniformly across the streaming and non-streaming surfaces. No regex strip, no per-channel patch — the state machine's terminal transition is the single source of truth.

### Live verified

\`rapid-mlx serve gpt-oss-20b-mxfp4-q8 --port 8952\` against both repros:

| Repro | Pre-fix \`content\` | Post-fix \`content\` | \`finish_reason\` |
|---|---|---|---|
| A (\`max_tokens=20\`) | analysis prefix | \`null\` | \`length\` |
| B (\`stop=["Mars"]\`) | analysis prefix | \`null\` | \`stop\` |
| Happy path (\`What is 2+2?\`) | unchanged | \`"2 + 2 = 4."\` | \`stop\` |

\`reasoning_content\` populated unchanged across all three.

## Test plan

- [x] New: \`tests/test_harmony_finalize.py\` — 15 tests covering rescue-helper unit, engine-router token split, streaming SSE, and counter-tests for existing #569 / VibeThinker rescue.
- [x] Regression sweep: \`tests/test_silent_drop_rescue_569.py\` — 34 existing tests still pass (additive gate).
- [x] Harmony sweep: \`tests/test_finalize_harmony_raw_text.py\`, \`tests/test_harmony_parsers.py\`, \`tests/parsers/regressions/test_issue_{444,455,468,513}_harmony*.py\` — 197 passed, 5 xfailed (pre-existing).
- [x] Anthropic adapter regression: \`tests/test_anthropic_adapter.py\` — passes.
- [x] Lint clean: \`ruff check\` + \`ruff format\` on touched files.
- [x] Live server: both repros and happy path verified end-to-end on real gpt-oss-20b-mxfp4-q8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)