### PR TITLE
fix(tools): recognize DeepSeek-V3 fullwidth-pipe tool-call markers (D-DSV31)

### DIFF
--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -450,8 +450,44 @@ class TestV3Streaming:
         # Internal cache size matches the emitted block count — proof
         # that we minted exactly one ID per block, not one per delta.
         assert len(parser._streamed_v3_ids) == 3
-        # And the cache content matches what we emitted.
-        assert parser._streamed_v3_ids == ids
+        # The cache content matches what we emitted, keyed by absolute
+        # block index. Order of values mirrors emission order because
+        # the three blocks are V3 indices 0/1/2.
+        assert parser._streamed_v3_ids == {0: ids[0], 1: ids[1], 2: ids[2]}
+
+    def test_v31_then_v3_does_not_re_emit_v3_block(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r4 BLOCKING: a V3.1 block before a V3 block puts the
+        V3 block at absolute index 1, but ``_streamed_v3_ids`` records
+        only V3 emissions — so a positional ``idx < len(...)`` boundary
+        would re-emit the V3 block on every subsequent delta because
+        ``len(_streamed_v3_ids)`` stays at 1 while the V3 block's
+        absolute index is also 1.
+
+        The dict-keyed cache makes this structurally impossible: once
+        index 1 is in the cache, it's skipped on every later scan.
+        """
+        payload = _envelope(
+            _v31_block("first_call", '{"a": 1}'),
+            _v3_block("second_call", '{"b": 2}'),
+        )
+
+        events = self._feed(parser, payload, chunk_size=12)
+
+        # Count emissions of the V3 block (``second_call``).
+        v3_emissions = 0
+        for ev in events:
+            if not ev or "tool_calls" not in ev:
+                continue
+            for call in ev["tool_calls"]:
+                if call.get("function", {}).get("name") == "second_call":
+                    v3_emissions += 1
+
+        assert v3_emissions == 1, (
+            f"V3 block at absolute index 1 was emitted {v3_emissions} "
+            f"times — index-keyed cache failed to dedupe."
+        )
 
     def test_v31_tool_named_with_function_prefix_streams_normally(
         self, parser: DeepSeekV31ToolParser

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -455,6 +455,67 @@ class TestV3Streaming:
         # the three blocks are V3 indices 0/1/2.
         assert parser._streamed_v3_ids == {0: ids[0], 1: ids[1], 2: ids[2]}
 
+    def test_malformed_block_before_v3_block_does_not_shift_indices(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r5 BLOCKING-1: ``extract_tool_calls`` skips malformed
+        blocks, so correlating ``enumerate(result.tool_calls)`` with
+        block-position classification would shift V3 indices and
+        mis-key ``_streamed_v3_ids``.
+
+        We construct an envelope with [malformed, V3] and confirm the
+        V3 block is emitted exactly once at the absolute wire index
+        ``1`` — not at the parsed index ``0`` (which is what the bug
+        would produce).
+        """
+        # Block 0: malformed (no <sep>). Block 1: valid V3.
+        malformed_block = f"{C_OPEN}no_sep_here{C_CLOSE}"
+        v3_block_b = _v3_block("get_weather", '{"city": "Tokyo"}')
+        payload = f"{TC_OPEN}{malformed_block}{v3_block_b}{TC_CLOSE}"
+
+        events = self._feed(parser, payload, chunk_size=12)
+
+        v3_emissions = []
+        for ev in events:
+            if not ev or "tool_calls" not in ev:
+                continue
+            for call in ev["tool_calls"]:
+                if call.get("function", {}).get("name") == "get_weather":
+                    v3_emissions.append(call)
+
+        assert len(v3_emissions) == 1, (
+            f"V3 block emitted {len(v3_emissions)} times "
+            f"(want 1) — malformed block likely shifted indices."
+        )
+        assert v3_emissions[0]["index"] == 1, (
+            f"V3 block emitted at index {v3_emissions[0]['index']} "
+            f"(want 1) — index correlated against parsed-call list "
+            f"instead of wire-block position."
+        )
+        # And the cache is keyed by ABSOLUTE wire index (1), not by
+        # parsed-call index (0).
+        assert 1 in parser._streamed_v3_ids
+        assert 0 not in parser._streamed_v3_ids
+
+    def test_v3_block_at_index_zero_advances_current_tool_id(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r5 BLOCKING-2 (edge case): when a V3 block emits at
+        absolute index 0, ``current_tool_id`` must be advanced from
+        ``-1`` to ``0`` so the legacy delta machine doesn't later
+        treat block 0 as an unadvanced V3.1 state.
+        """
+        payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
+
+        # Drive the stream all the way through.
+        self._feed(parser, payload, chunk_size=12)
+
+        assert parser.current_tool_id >= 0, (
+            f"current_tool_id={parser.current_tool_id} after a V3 "
+            f"block at index 0 closed — must have advanced from -1 to >=0."
+        )
+        assert 0 in parser._streamed_v3_ids
+
     def test_v31_then_v3_does_not_re_emit_v3_block(
         self, parser: DeepSeekV31ToolParser
     ) -> None:

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -29,9 +29,11 @@ exact parser instance the server uses for that checkpoint.
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
 from vllm_mlx.tool_parsers import ToolParserManager
 from vllm_mlx.tool_parsers.deepseekv31_tool_parser import DeepSeekV31ToolParser
 
@@ -567,6 +569,95 @@ class TestV3Streaming:
             f"V3.1 stream lost its name event — V3 suppression may "
             f"have hijacked the empty-body intermediate state. Events: "
             f"{events!r}"
+        )
+
+
+# --------------------------------------------------------------------
+# Integration: V3 streaming through the real ``StreamingPostProcessor``
+# finalize path. Confirms the suppression + finalize composition
+# actually delivers a ``tool_call`` event to clients — i.e. it would
+# fail if the parser-level suppression worked but the postprocessor's
+# fallback gate didn't pick the V3 calls up at end-of-stream.
+# (codex r9 BLOCKING-3: parser-only tests can't prove this.)
+# --------------------------------------------------------------------
+def _make_postprocessor_cfg() -> MagicMock:
+    """Mock ServerConfig minimally configured to route through the
+    ``deepseek_v31`` tool parser path."""
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = True
+    cfg.tool_call_parser = "deepseek_v31"
+    cfg.tool_parser_instance = None
+    return cfg
+
+
+def _make_generation_output(
+    text: str, finished: bool = False, finish_reason: str | None = None
+) -> MagicMock:
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = None
+    out.finish_reason = finish_reason or ("stop" if finished else None)
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = None
+    return out
+
+
+class TestV3StreamingIntegration:
+    """End-to-end through ``StreamingPostProcessor`` (codex r9)."""
+
+    def test_v3_payload_emits_tool_call_via_finalize(self) -> None:
+        """Drive a V3-shaped payload through the real postprocessor
+        chunk-by-chunk and confirm ``finalize()`` emits a
+        ``tool_call`` event with ``name="get_weather"``. Pins the
+        suppression + fallback composition end-to-end.
+        """
+        cfg = _make_postprocessor_cfg()
+        pp = StreamingPostProcessor(cfg, tools_requested=True)
+        pp.reset()
+
+        payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
+
+        # Stream in mid-sized chunks. None of these should emit a
+        # ``tool_call`` event — the parser-level suppression returns
+        # ``None`` for every V3 delta.
+        all_events = []
+        for i in range(0, len(payload), 16):
+            chunk = payload[i : i + 16]
+            is_last = i + 16 >= len(payload)
+            output = _make_generation_output(
+                chunk,
+                finished=is_last,
+                finish_reason="tool_calls" if is_last else None,
+            )
+            all_events.extend(pp.process_chunk(output))
+
+        all_events.extend(pp.finalize())
+
+        # Collect tool_call events from the full event stream.
+        tool_call_events = [e for e in all_events if e.type == "tool_call"]
+        assert tool_call_events, (
+            f"No tool_call event emitted end-to-end. Events: "
+            f"{[(e.type, getattr(e, 'tool_calls', None)) for e in all_events]!r}"
+        )
+        # Aggregate names across emitted events (finalize may emit
+        # one event with multiple calls).
+        names = []
+        for ev in tool_call_events:
+            for tc in ev.tool_calls or []:
+                names.append(tc.get("function", {}).get("name") or tc.get("name"))
+        assert "get_weather" in names, (
+            f"V3 finalize path lost the real tool name. Names: {names!r}"
+        )
+        # And the leaked V3 type tag must NEVER appear.
+        assert "function" not in names, (
+            f"V3 type-tag leaked into the final tool_call event. Names: {names!r}"
         )
 
 

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -334,11 +334,21 @@ class TestMalformedGraceful:
 
 
 # --------------------------------------------------------------------
-# Streaming — V3 short-circuit emits one well-formed tool_call event
-# per closed block instead of leaking mid-stream ``name="function"``
-# deltas. The legacy V3.1 streaming path remains delta-based and is
-# covered by ``test_upstream_regression.TestDeepSeekV31UpstreamStreaming``;
-# here we pin only the V3 short-circuit behaviour.
+# Streaming — V3 streams suppress mid-stream emission and defer the
+# tool-call emission to the postprocessor's end-of-stream finalize
+# path (``service/postprocessor.py``: "Fallback tool call detection"),
+# which calls ``extract_tool_calls`` on the cumulative buffer.
+#
+# Why: the legacy delta machine would otherwise leak ``name="function"``
+# mid-stream for V3 bodies. After several rounds of attempted
+# delta-by-delta short-circuits each composed badly with malformed
+# blocks / mixed V3+V3.1 envelopes / delta boundaries, the conservative
+# contract is: do not attempt to stream V3 — let the closed-buffer
+# extract handle it as a one-shot event. This matches how other
+# wrapped-format parsers (GLM-4.7, Seed-OSS) already behave.
+#
+# V3.1 streaming is unchanged and covered by
+# ``test_upstream_regression.TestDeepSeekV31UpstreamStreaming``.
 # --------------------------------------------------------------------
 class TestV3Streaming:
     def _feed(
@@ -362,172 +372,68 @@ class TestV3Streaming:
             prev = cur
         return results
 
-    def test_v3_block_emits_single_complete_tool_call_on_close(
+    def _no_streamed_tool_calls(self, events: list[dict | None]) -> None:
+        """Assert no mid-stream ``tool_calls`` event leaked from the
+        streaming path for a V3 payload."""
+        for ev in events:
+            if not ev:
+                continue
+            assert "tool_calls" not in ev, (
+                f"V3 stream leaked a mid-stream tool_calls event: {ev!r}. "
+                f"V3 streams must defer emission to the postprocessor "
+                f"end-of-stream finalize path."
+            )
+
+    def test_v3_stream_emits_no_mid_stream_tool_calls(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """No ``name="function"`` deltas — only one fully-resolved
-        ``tool_calls`` event when the block's ``<call_end>`` arrives."""
+        """Single V3 block: streaming path returns no ``tool_calls``
+        events (in particular: NO ``name="function"`` deltas).
+        Emission is deferred to the postprocessor's end-of-stream
+        finalize, which calls ``extract_tool_calls`` and gets the
+        correct ``name="get_weather"``.
+        """
         payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
 
         events = self._feed(parser, payload, chunk_size=12)
+        self._no_streamed_tool_calls(events)
 
-        tool_events = [e for e in events if e and "tool_calls" in e]
-        assert len(tool_events) == 1, (
-            f"expected exactly one tool_calls event, got {len(tool_events)}: "
-            f"{tool_events!r}"
-        )
-        tc_list = tool_events[0]["tool_calls"]
-        assert len(tc_list) == 1
-        tc = tc_list[0]
-        assert tc["function"]["name"] == "get_weather"
-        assert json.loads(tc["function"]["arguments"]) == {"city": "Tokyo"}
-        # Index sequence starts at 0 for the first tool call.
-        assert tc["index"] == 0
+        # And the non-streaming extract on the cumulative text emits
+        # the correct call — confirming the postprocessor's finalize
+        # path will produce the right tool_call.
+        result = parser.extract_tool_calls(payload)
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"city": "Tokyo"}
 
-        # And no event ever leaked ``name="function"`` (the bug shape).
-        for ev in events:
-            if not ev or "tool_calls" not in ev:
-                continue
-            for call in ev["tool_calls"]:
-                assert call.get("function", {}).get("name") != "function", (
-                    f"V3 type-tag leaked into streaming name: {ev!r}"
-                )
-
-    def test_parallel_v3_blocks_emit_per_block(
+    def test_v3_parallel_stream_emits_no_mid_stream_tool_calls(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """Two V3 blocks → two distinct tool_calls deltas with
-        ascending indices."""
+        """Multiple V3 blocks: still no mid-stream emission. Finalize
+        path produces all the calls in one shot."""
         payload = _envelope(
             _v3_block("get_weather", '{"city": "Tokyo"}'),
             _v3_block("get_time", '{"tz": "UTC"}'),
-        )
-
-        events = self._feed(parser, payload, chunk_size=24)
-
-        emitted_names = []
-        emitted_indices = []
-        for ev in events:
-            if not ev or "tool_calls" not in ev:
-                continue
-            for call in ev["tool_calls"]:
-                emitted_names.append(call["function"]["name"])
-                emitted_indices.append(call["index"])
-
-        assert emitted_names == ["get_weather", "get_time"]
-        assert emitted_indices == [0, 1]
-
-    def test_parallel_v3_blocks_emit_distinct_ids(
-        self, parser: DeepSeekV31ToolParser
-    ) -> None:
-        """Each emitted block gets exactly one stable ID (codex r1
-        BLOCKING: the cumulative re-parse must not re-mint IDs for
-        previously emitted blocks).
-
-        We inspect the IDs in emission order — they must all be
-        distinct, and the parser's internal ID cache should record
-        exactly one ID per emitted block (no churn from re-parsing
-        the cumulative text on later deltas).
-        """
-        payload = _envelope(
-            _v3_block("get_weather", '{"city": "Tokyo"}'),
-            _v3_block("get_time", '{"tz": "UTC"}'),
-            _v3_block("search", '{"q": "x"}'),
         )
 
         events = self._feed(parser, payload, chunk_size=18)
+        self._no_streamed_tool_calls(events)
 
-        ids: list[str] = []
-        for ev in events:
-            if not ev or "tool_calls" not in ev:
-                continue
-            for call in ev["tool_calls"]:
-                ids.append(call["id"])
+        result = parser.extract_tool_calls(payload)
+        assert len(result.tool_calls) == 2
+        assert [c["name"] for c in result.tool_calls] == ["get_weather", "get_time"]
 
-        assert len(ids) == 3
-        # Distinct IDs per block.
-        assert len(set(ids)) == 3
-        # Internal cache size matches the emitted block count — proof
-        # that we minted exactly one ID per block, not one per delta.
-        assert len(parser._streamed_v3_ids) == 3
-        # The cache content matches what we emitted, keyed by absolute
-        # block index. Order of values mirrors emission order because
-        # the three blocks are V3 indices 0/1/2.
-        assert parser._streamed_v3_ids == {0: ids[0], 1: ids[1], 2: ids[2]}
-
-    def test_malformed_block_before_v3_block_does_not_shift_indices(
+    def test_v31_then_v3_v3_part_does_not_stream_v31_part_does(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """codex r5 BLOCKING-1: ``extract_tool_calls`` skips malformed
-        blocks, so correlating ``enumerate(result.tool_calls)`` with
-        block-position classification would shift V3 indices and
-        mis-key ``_streamed_v3_ids``.
-
-        We construct an envelope with [malformed, V3] and confirm the
-        V3 block is emitted exactly once at the absolute wire index
-        ``1`` — not at the parsed index ``0`` (which is what the bug
-        would produce).
-        """
-        # Block 0: malformed (no <sep>). Block 1: valid V3.
-        malformed_block = f"{C_OPEN}no_sep_here{C_CLOSE}"
-        v3_block_b = _v3_block("get_weather", '{"city": "Tokyo"}')
-        payload = f"{TC_OPEN}{malformed_block}{v3_block_b}{TC_CLOSE}"
-
-        events = self._feed(parser, payload, chunk_size=12)
-
-        v3_emissions = []
-        for ev in events:
-            if not ev or "tool_calls" not in ev:
-                continue
-            for call in ev["tool_calls"]:
-                if call.get("function", {}).get("name") == "get_weather":
-                    v3_emissions.append(call)
-
-        assert len(v3_emissions) == 1, (
-            f"V3 block emitted {len(v3_emissions)} times "
-            f"(want 1) — malformed block likely shifted indices."
-        )
-        assert v3_emissions[0]["index"] == 1, (
-            f"V3 block emitted at index {v3_emissions[0]['index']} "
-            f"(want 1) — index correlated against parsed-call list "
-            f"instead of wire-block position."
-        )
-        # And the cache is keyed by ABSOLUTE wire index (1), not by
-        # parsed-call index (0).
-        assert 1 in parser._streamed_v3_ids
-        assert 0 not in parser._streamed_v3_ids
-
-    def test_v3_block_at_index_zero_advances_current_tool_id(
-        self, parser: DeepSeekV31ToolParser
-    ) -> None:
-        """codex r5 BLOCKING-2 (edge case): when a V3 block emits at
-        absolute index 0, ``current_tool_id`` must be advanced from
-        ``-1`` to ``0`` so the legacy delta machine doesn't later
-        treat block 0 as an unadvanced V3.1 state.
-        """
-        payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
-
-        # Drive the stream all the way through.
-        self._feed(parser, payload, chunk_size=12)
-
-        assert parser.current_tool_id >= 0, (
-            f"current_tool_id={parser.current_tool_id} after a V3 "
-            f"block at index 0 closed — must have advanced from -1 to >=0."
-        )
-        assert 0 in parser._streamed_v3_ids
-
-    def test_v31_then_v3_does_not_re_emit_v3_block(
-        self, parser: DeepSeekV31ToolParser
-    ) -> None:
-        """codex r4 BLOCKING: a V3.1 block before a V3 block puts the
-        V3 block at absolute index 1, but ``_streamed_v3_ids`` records
-        only V3 emissions — so a positional ``idx < len(...)`` boundary
-        would re-emit the V3 block on every subsequent delta because
-        ``len(_streamed_v3_ids)`` stays at 1 while the V3 block's
-        absolute index is also 1.
-
-        The dict-keyed cache makes this structurally impossible: once
-        index 1 is in the cache, it's skipped on every later scan.
+        """Mixed envelope [V3.1, V3]: once V3 is detected in cumulative
+        text, the suppression engages and streaming returns ``None``.
+        The V3.1 block before V3 will have already been streamed by the
+        legacy delta machine (its emissions happen before V3 arrives).
+        Finalize then re-parses the cumulative text and emits both —
+        the postprocessor reconciles via ``tool_calls_detected`` (out
+        of scope for this parser-level test). We assert: no V3-shape
+        ``name="function"`` deltas reach the wire from streaming.
         """
         payload = _envelope(
             _v31_block("first_call", '{"a": 1}'),
@@ -536,32 +442,22 @@ class TestV3Streaming:
 
         events = self._feed(parser, payload, chunk_size=12)
 
-        # Count emissions of the V3 block (``second_call``).
-        v3_emissions = 0
         for ev in events:
             if not ev or "tool_calls" not in ev:
                 continue
             for call in ev["tool_calls"]:
-                if call.get("function", {}).get("name") == "second_call":
-                    v3_emissions += 1
-
-        assert v3_emissions == 1, (
-            f"V3 block at absolute index 1 was emitted {v3_emissions} "
-            f"times — index-keyed cache failed to dedupe."
-        )
+                assert call.get("function", {}).get("name") != "function", (
+                    f"V3 type-tag leaked into a streaming name: {call!r}"
+                )
 
     def test_v31_tool_named_with_function_prefix_streams_normally(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """codex r3 BLOCKING-1: a V3.1 tool whose name *starts* with
-        ``f`` / ``fun`` / ``function_lookup`` (i.e. a prefix of the V3
-        type-tag-plus-sep marker) must not be hijacked by the V3
-        short-circuit.
-
-        After the previous design briefly buffered any open block
-        whose body was a strict prefix of ``function<sep>``, this test
-        documents the fix: V3 buffering ONLY engages once the literal
-        ``function<sep>`` is in the body.
+        """A V3.1 tool named ``function_lookup`` (whose name is a
+        prefix of the V3 type-tag-plus-sep marker) must NOT trip the
+        V3 suppression. ``_cumulative_has_v3_block`` anchors on the
+        literal ``function<sep>`` byte sequence — ``function_lookup``
+        never reaches that exact prefix.
         """
         payload = _envelope(_v31_block("function_lookup", '{"q": "x"}'))
 
@@ -577,72 +473,21 @@ class TestV3Streaming:
         ]
         assert "function_lookup" in names, (
             f"V3.1 tool 'function_lookup' was hijacked by the V3 "
-            f"short-circuit. Events: {events!r}"
+            f"suppression. Events: {events!r}"
         )
 
-    def test_v3_block_close_with_immediate_next_open(
+    def test_v31_stream_empty_block_body_does_not_trigger_v3_suppression(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """codex r3 BLOCKING-2: a delta that closes one V3 block and
-        also opens the next block (with an empty body so far) must
-        still emit the closed V3 call. The closed-block scan runs
-        before the open-block inspection, so the empty trailing open
-        body doesn't mask the just-closed V3.
-        """
-        # Two V3 blocks back-to-back; choose a chunk size that places
-        # the first block's <call_end> AND the second block's
-        # <call_begin> in the SAME delta with an empty body after the
-        # second begin.
-        block_a = _v3_block("get_weather", '{"city": "Tokyo"}')
-        block_b = _v3_block("get_time", '{"tz": "UTC"}')
-        payload = _envelope(block_a, block_b)
-
-        # Pick a chunk_size that makes the close-of-A + start-of-B land
-        # in one delta. The exact value depends on payload geometry —
-        # iterate small sizes and assert at least one chunking
-        # produces a valid emission of both blocks.
-        for chunk_size in (5, 7, 9, 11, 13, 17):
-            p = DeepSeekV31ToolParser()
-            events = self._feed(p, payload, chunk_size=chunk_size)
-            names = [
-                call["function"]["name"]
-                for ev in events
-                if ev and "tool_calls" in ev
-                for call in ev["tool_calls"]
-            ]
-            if names == ["get_weather", "get_time"]:
-                break
-        else:
-            raise AssertionError(
-                "No chunk size emitted both V3 blocks — closed-V3 "
-                "recovery may not survive a delta that closes one "
-                "block and opens the next."
-            )
-
-    def test_v31_stream_empty_block_body_does_not_trigger_v3_short_circuit(
-        self, parser: DeepSeekV31ToolParser
-    ) -> None:
-        """codex r1 BLOCKING: ``"".startswith(...)`` is True for every
-        string, so without an explicit non-empty body guard the V3
-        short-circuit would hijack a V3.1 stream that ended right after
-        ``<call_begin>`` (no body byte yet) and silently swallow the
-        delta instead of letting the legacy delta state machine
-        initialize.
-
-        We replay a V3.1 payload one character at a time and confirm
-        the legacy path eventually emits a fully-streamed V3.1 call —
-        i.e. the V3 short-circuit did NOT hijack the empty-body
-        intermediate state.
+        """``"".startswith(...)`` is True for every string — a V3.1
+        stream that ended right after ``<call_begin>`` (no body byte
+        yet) must NOT trip V3 suppression and silently swallow the
+        legacy delta machine's emissions.
         """
         payload = _envelope(_v31_block("get_weather", '{"city": "Paris"}'))
 
         events = self._feed(parser, payload, chunk_size=1)
 
-        # The V3.1 streaming path emits the name event first, then
-        # arguments deltas, then nothing (V3.1's existing delta
-        # contract). What we care about for this regression: SOMETHING
-        # got emitted with name="get_weather" — the V3 short-circuit
-        # didn't swallow the whole stream.
         names_emitted = [
             call.get("function", {}).get("name")
             for ev in events
@@ -651,7 +496,7 @@ class TestV3Streaming:
             if call.get("function", {}).get("name")
         ]
         assert "get_weather" in names_emitted, (
-            f"V3.1 stream lost its name event — V3 short-circuit may "
+            f"V3.1 stream lost its name event — V3 suppression may "
             f"have hijacked the empty-body intermediate state. Events: "
             f"{events!r}"
         )

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -284,6 +284,54 @@ class TestMalformedGraceful:
         assert len(result.tool_calls) == 2
         assert [c["name"] for c in result.tool_calls] == ["get_weather", "get_time"]
 
+    def test_v3_anchored_body_with_broken_fence_does_not_mis_emit_function(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r2 BLOCKING: a body that anchors as V3 (starts with
+        ``function<sep>``) but doesn't contain a parseable
+        ``\\n``\\`\\`\\`json…`` fence MUST NOT fall through to the V3.1
+        ``NAME<sep>ARGS`` split.
+
+        That fallthrough would emit ``name="function"`` with the real
+        tool name embedded in ``arguments`` — i.e. recreate the exact
+        production failure mode D-DSV31 was filed for.
+        """
+        # V3 anchor, no fence at all (just ``function<sep>get_weather``
+        # then nothing JSON-ish). Must NOT emit ``name="function"``.
+        payload = (
+            f"{TC_OPEN}{C_OPEN}function{SEP}get_weather is the name{C_CLOSE}{TC_CLOSE}"
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        for tc in result.tool_calls:
+            assert tc["name"] != "function", (
+                f"V3-anchored malformed body leaked into V3.1 split: {tc!r}"
+            )
+
+    def test_v3_anchored_body_with_recoverable_partial_fence(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """V3 anchor + name + opening JSON fence + body but no closing
+        fence (truncated mid-args): the bounded recovery should pick up
+        the name and pass the body through as args, rather than
+        emitting ``name="function"``.
+        """
+        payload = (
+            f"{TC_OPEN}{C_OPEN}function{SEP}get_weather\n"
+            f'```json\n{{"city": "Tokyo"'
+            f"{C_CLOSE}{TC_CLOSE}"
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        # If we extracted anything, the name MUST be the real tool
+        # name — never the literal ``function`` type tag.
+        for tc in result.tool_calls:
+            assert tc["name"] == "get_weather", (
+                f"V3 partial-fence recovery wrong name: {tc!r}"
+            )
+
 
 # --------------------------------------------------------------------
 # Streaming — V3 short-circuit emits one well-formed tool_call event

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -453,6 +453,75 @@ class TestV3Streaming:
         # And the cache content matches what we emitted.
         assert parser._streamed_v3_ids == ids
 
+    def test_v31_tool_named_with_function_prefix_streams_normally(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r3 BLOCKING-1: a V3.1 tool whose name *starts* with
+        ``f`` / ``fun`` / ``function_lookup`` (i.e. a prefix of the V3
+        type-tag-plus-sep marker) must not be hijacked by the V3
+        short-circuit.
+
+        After the previous design briefly buffered any open block
+        whose body was a strict prefix of ``function<sep>``, this test
+        documents the fix: V3 buffering ONLY engages once the literal
+        ``function<sep>`` is in the body.
+        """
+        payload = _envelope(_v31_block("function_lookup", '{"q": "x"}'))
+
+        events = self._feed(parser, payload, chunk_size=1)
+
+        # The legacy V3.1 path must have emitted the real name.
+        names = [
+            call.get("function", {}).get("name")
+            for ev in events
+            if ev and "tool_calls" in ev
+            for call in ev["tool_calls"]
+            if call.get("function", {}).get("name")
+        ]
+        assert "function_lookup" in names, (
+            f"V3.1 tool 'function_lookup' was hijacked by the V3 "
+            f"short-circuit. Events: {events!r}"
+        )
+
+    def test_v3_block_close_with_immediate_next_open(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r3 BLOCKING-2: a delta that closes one V3 block and
+        also opens the next block (with an empty body so far) must
+        still emit the closed V3 call. The closed-block scan runs
+        before the open-block inspection, so the empty trailing open
+        body doesn't mask the just-closed V3.
+        """
+        # Two V3 blocks back-to-back; choose a chunk size that places
+        # the first block's <call_end> AND the second block's
+        # <call_begin> in the SAME delta with an empty body after the
+        # second begin.
+        block_a = _v3_block("get_weather", '{"city": "Tokyo"}')
+        block_b = _v3_block("get_time", '{"tz": "UTC"}')
+        payload = _envelope(block_a, block_b)
+
+        # Pick a chunk_size that makes the close-of-A + start-of-B land
+        # in one delta. The exact value depends on payload geometry —
+        # iterate small sizes and assert at least one chunking
+        # produces a valid emission of both blocks.
+        for chunk_size in (5, 7, 9, 11, 13, 17):
+            p = DeepSeekV31ToolParser()
+            events = self._feed(p, payload, chunk_size=chunk_size)
+            names = [
+                call["function"]["name"]
+                for ev in events
+                if ev and "tool_calls" in ev
+                for call in ev["tool_calls"]
+            ]
+            if names == ["get_weather", "get_time"]:
+                break
+        else:
+            raise AssertionError(
+                "No chunk size emitted both V3 blocks — closed-V3 "
+                "recovery may not survive a delta that closes one "
+                "block and opens the next."
+            )
+
     def test_v31_stream_empty_block_body_does_not_trigger_v3_short_circuit(
         self, parser: DeepSeekV31ToolParser
     ) -> None:

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -423,17 +423,22 @@ class TestV3Streaming:
         assert len(result.tool_calls) == 2
         assert [c["name"] for c in result.tool_calls] == ["get_weather", "get_time"]
 
-    def test_v31_then_v3_v3_part_does_not_stream_v31_part_does(
+    def test_mixed_v31_then_v3_stream_no_function_leak(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """Mixed envelope [V3.1, V3]: once V3 is detected in cumulative
-        text, the suppression engages and streaming returns ``None``.
-        The V3.1 block before V3 will have already been streamed by the
-        legacy delta machine (its emissions happen before V3 arrives).
-        Finalize then re-parses the cumulative text and emits both —
-        the postprocessor reconciles via ``tool_calls_detected`` (out
-        of scope for this parser-level test). We assert: no V3-shape
-        ``name="function"`` deltas reach the wire from streaming.
+        """Mixed envelope [V3.1, V3]: documented known limitation
+        (parser docstring, codex r7) — the postprocessor's finalize
+        fallback gates on ``not tool_calls_detected``, so a V3.1 block
+        streamed first would prevent finalize from reconciling the
+        suppressed V3 block. Mixed envelopes don't occur in practice
+        on released DeepSeek checkpoints (each chat template emits a
+        single body shape per envelope).
+
+        What we DO require: even in a mixed-envelope stream, the V3
+        block must not leak ``name="function"`` mid-stream. The
+        suppression engages the moment the V3 anchor arrives, so any
+        legacy-machine emission for the V3 block is short-circuited
+        before the type tag becomes the streamed name.
         """
         payload = _envelope(
             _v31_block("first_call", '{"a": 1}'),
@@ -449,6 +454,17 @@ class TestV3Streaming:
                 assert call.get("function", {}).get("name") != "function", (
                     f"V3 type-tag leaked into a streaming name: {call!r}"
                 )
+
+        # Non-streaming extract on the same payload still produces
+        # both calls correctly — the parser itself isn't lossy on
+        # mixed envelopes; the limitation lives in the streaming +
+        # postprocessor contract.
+        result = parser.extract_tool_calls(payload)
+        assert len(result.tool_calls) == 2
+        assert [c["name"] for c in result.tool_calls] == [
+            "first_call",
+            "second_call",
+        ]
 
     def test_v31_tool_named_with_function_prefix_streams_normally(
         self, parser: DeepSeekV31ToolParser

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -309,6 +309,58 @@ class TestMalformedGraceful:
                 f"V3-anchored malformed body leaked into V3.1 split: {tc!r}"
             )
 
+    def test_literal_marker_text_before_envelope_does_not_misparse(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r8 BLOCKING-1: a response that mentions
+        ``<｜tool▁call▁begin｜>`` as literal content (e.g. in a docs
+        explanation) and later happens to contain
+        ``<｜tool▁calls▁begin｜>`` MUST NOT have the literal text
+        treated as a tool call. The block scanner is bounded to the
+        outer envelope.
+        """
+        # Literal mention in plain content, then a real envelope with
+        # a real tool call.
+        prose = (
+            "Here's how DeepSeek tool calls work: "
+            f"the format uses {C_OPEN}NAME{SEP}ARGS{C_CLOSE}. For example:\n\n"
+        )
+        real_call = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
+        payload = prose + real_call
+
+        result = parser.extract_tool_calls(payload)
+
+        # Exactly ONE tool call (the real one inside the envelope),
+        # not multiple from the literal markers in prose.
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_envelope_with_truncated_trailing_block_preserves_text(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r8 BLOCKING-2: a response with [valid V3 block,
+        truncated trailing block] must surface the truncated text in
+        ``content`` rather than silently dropping it. Without
+        preservation the user loses the model's partial output.
+        """
+        good_block = _v3_block("get_weather", '{"city": "Tokyo"}')
+        truncated_tail = f"{C_OPEN}function{SEP}get_time\n```json\n{{"  # no close
+        payload = f"{TC_OPEN}{good_block}{truncated_tail}"
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        # The truncated trailing text MUST appear somewhere in content
+        # so the caller has access to it.
+        assert result.content is not None
+        assert "get_time" in result.content, (
+            f"Truncated trailing block text dropped from content. "
+            f"content={result.content!r}"
+        )
+
     def test_v3_anchored_body_with_recoverable_partial_fence(
         self, parser: DeepSeekV31ToolParser
     ) -> None:

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -369,6 +369,79 @@ class TestV3Streaming:
         assert emitted_names == ["get_weather", "get_time"]
         assert emitted_indices == [0, 1]
 
+    def test_parallel_v3_blocks_emit_distinct_ids(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """Each emitted block gets exactly one stable ID (codex r1
+        BLOCKING: the cumulative re-parse must not re-mint IDs for
+        previously emitted blocks).
+
+        We inspect the IDs in emission order — they must all be
+        distinct, and the parser's internal ID cache should record
+        exactly one ID per emitted block (no churn from re-parsing
+        the cumulative text on later deltas).
+        """
+        payload = _envelope(
+            _v3_block("get_weather", '{"city": "Tokyo"}'),
+            _v3_block("get_time", '{"tz": "UTC"}'),
+            _v3_block("search", '{"q": "x"}'),
+        )
+
+        events = self._feed(parser, payload, chunk_size=18)
+
+        ids: list[str] = []
+        for ev in events:
+            if not ev or "tool_calls" not in ev:
+                continue
+            for call in ev["tool_calls"]:
+                ids.append(call["id"])
+
+        assert len(ids) == 3
+        # Distinct IDs per block.
+        assert len(set(ids)) == 3
+        # Internal cache size matches the emitted block count — proof
+        # that we minted exactly one ID per block, not one per delta.
+        assert len(parser._streamed_v3_ids) == 3
+        # And the cache content matches what we emitted.
+        assert parser._streamed_v3_ids == ids
+
+    def test_v31_stream_empty_block_body_does_not_trigger_v3_short_circuit(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """codex r1 BLOCKING: ``"".startswith(...)`` is True for every
+        string, so without an explicit non-empty body guard the V3
+        short-circuit would hijack a V3.1 stream that ended right after
+        ``<call_begin>`` (no body byte yet) and silently swallow the
+        delta instead of letting the legacy delta state machine
+        initialize.
+
+        We replay a V3.1 payload one character at a time and confirm
+        the legacy path eventually emits a fully-streamed V3.1 call —
+        i.e. the V3 short-circuit did NOT hijack the empty-body
+        intermediate state.
+        """
+        payload = _envelope(_v31_block("get_weather", '{"city": "Paris"}'))
+
+        events = self._feed(parser, payload, chunk_size=1)
+
+        # The V3.1 streaming path emits the name event first, then
+        # arguments deltas, then nothing (V3.1's existing delta
+        # contract). What we care about for this regression: SOMETHING
+        # got emitted with name="get_weather" — the V3 short-circuit
+        # didn't swallow the whole stream.
+        names_emitted = [
+            call.get("function", {}).get("name")
+            for ev in events
+            if ev and "tool_calls" in ev
+            for call in ev["tool_calls"]
+            if call.get("function", {}).get("name")
+        ]
+        assert "get_weather" in names_emitted, (
+            f"V3.1 stream lost its name event — V3 short-circuit may "
+            f"have hijacked the empty-body intermediate state. Events: "
+            f"{events!r}"
+        )
+
 
 # --------------------------------------------------------------------
 # Argument-body passthrough contract.

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -363,28 +363,37 @@ class TestMalformedGraceful:
             f"content={result.content!r}"
         )
 
-    def test_v3_anchored_body_with_recoverable_partial_fence(
+    def test_v3_anchored_body_with_partial_fence_drops_block(
         self, parser: DeepSeekV31ToolParser
     ) -> None:
-        """V3 anchor + name + opening JSON fence + body but no closing
-        fence (truncated mid-args): the bounded recovery should pick up
-        the name and pass the body through as args, rather than
-        emitting ``name="function"``.
+        """codex r10 BLOCKING-1: V3-anchored bodies with an incomplete
+        fenced-JSON body are DROPPED entirely (no tool call emitted).
+        The previous bounded recovery could emit a tool call with
+        truncated / non-JSON arguments which would then reach
+        downstream tool execution.
+
+        Pin the explicit contract:
+          * ``tools_called`` is False.
+          * No tool calls in the result.
+          * The malformed text survives in ``content`` so the caller
+            can decide whether to display or retry (codex r8 BLOCKING-2).
         """
         payload = (
             f"{TC_OPEN}{C_OPEN}function{SEP}get_weather\n"
-            f'```json\n{{"city": "Tokyo"'
+            f'```json\n{{"city": "Tokyo"'  # no closing fence, no `}`
             f"{C_CLOSE}{TC_CLOSE}"
         )
 
         result = parser.extract_tool_calls(payload)
 
-        # If we extracted anything, the name MUST be the real tool
-        # name — never the literal ``function`` type tag.
-        for tc in result.tool_calls:
-            assert tc["name"] == "get_weather", (
-                f"V3 partial-fence recovery wrong name: {tc!r}"
-            )
+        assert not result.tools_called, (
+            f"Partial-fence V3 body must NOT emit a tool call. "
+            f"Got: {result.tool_calls!r}"
+        )
+        assert result.tool_calls == []
+        # Raw text passes through so the caller can surface it.
+        assert result.content is not None
+        assert "get_weather" in result.content
 
 
 # --------------------------------------------------------------------

--- a/tests/test_deepseek_v3_tool_parser.py
+++ b/tests/test_deepseek_v3_tool_parser.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+D-DSV31 regression: DeepSeek V3 wire-format support in the
+``deepseek_v31`` parser.
+
+DeepSeek-R1-0528-Qwen3-8B's chat_template.jinja was inherited from
+DeepSeek-V3 and emits the V3 "function-typed, JSON-fenced" tool-call
+body shape:
+
+    <｜tool▁calls▁begin｜>
+    <｜tool▁call▁begin｜>function<｜tool▁sep｜>NAME
+    ```json
+    {ARGS}
+    ```<｜tool▁call▁end｜>
+    <｜tool▁calls▁end｜>
+
+The original ``deepseek_v31`` parser only recognised the V3.1 thinking
+channel shape (``<call_begin>NAME<sep>ARGS<call_end>``) and
+mis-parsed the V3 shape as ``name="function"`` /
+``arguments="NAME\\n```json\\n{...}\\n```"``. This file pins the
+auto-detect behaviour.
+
+Why these tests use the DeepSeekV31ToolParser directly and not the
+``deepseek`` alias: ``deepseek-r1-8b-4bit`` in ``aliases.json`` is
+configured with ``tool_call_parser: deepseek_v31``, so this is the
+exact parser instance the server uses for that checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers import ToolParserManager
+from vllm_mlx.tool_parsers.deepseekv31_tool_parser import DeepSeekV31ToolParser
+
+# Wire-format building blocks — all fullwidth pipes (U+FF5C), exactly as
+# the DeepSeek chat template emits them. We construct payloads from
+# these primitives so the tests double as documentation of the wire
+# format the parser is contracted against.
+TC_OPEN = "<｜tool▁calls▁begin｜>"
+TC_CLOSE = "<｜tool▁calls▁end｜>"
+C_OPEN = "<｜tool▁call▁begin｜>"
+C_CLOSE = "<｜tool▁call▁end｜>"
+SEP = "<｜tool▁sep｜>"
+
+
+def _v3_block(name: str, args_json: str) -> str:
+    """Construct a single V3-format tool-call block body."""
+    return f"{C_OPEN}function{SEP}{name}\n```json\n{args_json}\n```{C_CLOSE}"
+
+
+def _v31_block(name: str, args_body: str) -> str:
+    """Construct a single V3.1-format tool-call block body."""
+    return f"{C_OPEN}{name}{SEP}{args_body}{C_CLOSE}"
+
+
+def _envelope(*blocks: str, prefix: str = "") -> str:
+    """Wrap one-or-more blocks in the outer ``<calls_begin>`` envelope."""
+    return f"{prefix}{TC_OPEN}{''.join(blocks)}{TC_CLOSE}"
+
+
+@pytest.fixture
+def parser() -> DeepSeekV31ToolParser:
+    return DeepSeekV31ToolParser()
+
+
+# --------------------------------------------------------------------
+# Verify wire-format primitives are constructed with the *correct*
+# fullwidth-pipe Unicode codepoint (U+FF5C) — not the ASCII pipe — and
+# match what the real chat_template.jinja emits. Catches accidental
+# normalisation of the test data itself.
+# --------------------------------------------------------------------
+def test_wire_format_primitives_use_fullwidth_pipe() -> None:
+    for s in (TC_OPEN, TC_CLOSE, C_OPEN, C_CLOSE, SEP):
+        assert "｜" in s, f"{s!r} missing fullwidth pipe"
+        assert "|" not in s, f"{s!r} leaked ASCII pipe"
+
+
+# --------------------------------------------------------------------
+# Routing: aliases.json points ``deepseek-r1-8b-4bit`` at the
+# ``deepseek_v31`` parser. Confirm the registry lookup the server
+# performs (``ToolParserManager.get_tool_parser("deepseek_v31")``)
+# returns this fixed class — i.e. the bug fix actually reaches the
+# request path the server uses for that alias.
+# --------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["deepseek_v31", "deepseek_r1_0528"])
+def test_registry_lookup_returns_fixed_parser(name: str) -> None:
+    cls = ToolParserManager.get_tool_parser(name)
+    assert cls is DeepSeekV31ToolParser
+
+
+# --------------------------------------------------------------------
+# V3 wire format — the D-DSV31 P0 case.
+# --------------------------------------------------------------------
+class TestV3WireFormat:
+    """Direct V3-shaped payloads: ``function<sep>NAME\\n```json\\n{...}\\n```\\n``."""
+
+    def test_single_v3_tool_call(self, parser: DeepSeekV31ToolParser) -> None:
+        payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called, "V3-shaped payload must trigger tools_called"
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        # The bug: name == "function" and arguments started with "get_weather\n```json…"
+        assert tc["name"] == "get_weather", (
+            f"V3 type-tag leak: parser returned name={tc['name']!r}"
+        )
+        assert json.loads(tc["arguments"]) == {"city": "Tokyo"}
+
+    def test_parallel_v3_tool_calls(self, parser: DeepSeekV31ToolParser) -> None:
+        """N V3 blocks in one envelope must produce N tool calls."""
+        payload = _envelope(
+            _v3_block("get_weather", '{"city": "Tokyo"}'),
+            _v3_block("get_time", '{"tz": "UTC"}'),
+            _v3_block("search", '{"q": "deepseek"}'),
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 3
+        names = [c["name"] for c in result.tool_calls]
+        assert names == ["get_weather", "get_time", "search"]
+        # Pin all three argument bodies — protects against any "one
+        # block swallows the next" greedy-regex regression.
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"city": "Tokyo"}
+        assert json.loads(result.tool_calls[1]["arguments"]) == {"tz": "UTC"}
+        assert json.loads(result.tool_calls[2]["arguments"]) == {"q": "deepseek"}
+
+    def test_v3_with_leading_content(self, parser: DeepSeekV31ToolParser) -> None:
+        """Reasoning text before the envelope must be preserved as content."""
+        payload = _envelope(
+            _v3_block("get_weather", '{"city": "Tokyo"}'),
+            prefix="Let me check the weather. ",
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        assert result.content == "Let me check the weather. "
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_v3_arguments_with_nested_braces(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """Nested JSON inside the fenced body must not confuse the fence detector."""
+        args = '{"filter": {"city": "Tokyo", "tags": ["a", "b"]}, "limit": 10}'
+        payload = _envelope(_v3_block("search", args))
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        assert json.loads(result.tool_calls[0]["arguments"]) == json.loads(args)
+
+
+# --------------------------------------------------------------------
+# V3.1 wire format — regression: pre-existing behaviour must hold.
+# --------------------------------------------------------------------
+class TestV31WireFormat:
+    """Plain ``NAME<sep>ARGS`` body — the original V3.1 thinking-channel shape."""
+
+    def test_single_v31_tool_call(self, parser: DeepSeekV31ToolParser) -> None:
+        payload = _envelope(_v31_block("get_weather", '{"city": "Paris"}'))
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"city": "Paris"}
+
+    def test_parallel_v31_tool_calls(self, parser: DeepSeekV31ToolParser) -> None:
+        payload = _envelope(
+            _v31_block("f1", '{"a": 1}'),
+            _v31_block("f2", '{"b": 2}'),
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        assert len(result.tool_calls) == 2
+        assert [c["name"] for c in result.tool_calls] == ["f1", "f2"]
+
+    def test_v31_with_tool_named_function_is_not_misclassified(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """A V3.1 tool literally named ``function_lookup`` (or anything
+        starting with ``function``) must NOT be sniffed as V3.
+
+        The V3 sniffer anchors on ``function<sep>`` — the separator
+        immediately after the literal type tag — so this only fires
+        when the V3 type tag is present.
+        """
+        payload = _envelope(_v31_block("function_lookup", '{"q": "x"}'))
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tool_calls[0]["name"] == "function_lookup"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"q": "x"}
+
+
+# --------------------------------------------------------------------
+# Mixed-shape envelope — V3 and V3.1 blocks coexisting within one
+# outer ``<calls_begin>`` envelope. Not seen in any single checkpoint
+# today but the block-wise sniffer is supposed to handle them per-block.
+# --------------------------------------------------------------------
+def test_mixed_v3_and_v31_blocks(parser: DeepSeekV31ToolParser) -> None:
+    payload = _envelope(
+        _v3_block("get_weather", '{"city": "Tokyo"}'),
+        _v31_block("get_time", '{"tz": "UTC"}'),
+    )
+
+    result = parser.extract_tool_calls(payload)
+
+    assert result.tools_called
+    assert len(result.tool_calls) == 2
+    assert result.tool_calls[0]["name"] == "get_weather"
+    assert result.tool_calls[1]["name"] == "get_time"
+
+
+# --------------------------------------------------------------------
+# Malformed payloads — must not raise, must not silently consume content.
+# --------------------------------------------------------------------
+class TestMalformedGraceful:
+    def test_no_envelope_passes_through(self, parser: DeepSeekV31ToolParser) -> None:
+        text = "Just plain reasoning, no tools here."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == text
+
+    def test_truncated_block_falls_back_to_content(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """Outer ``<calls_begin>`` present but the block never closes."""
+        payload = f"prefix {TC_OPEN}{C_OPEN}function{SEP}get_weather\n```json\n{{"
+
+        result = parser.extract_tool_calls(payload)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        # Full text passes through — caller can decide what to do with
+        # the unfinished generation rather than the parser silently
+        # dropping everything after the begin marker.
+        assert result.content == payload
+
+    def test_envelope_with_no_blocks(self, parser: DeepSeekV31ToolParser) -> None:
+        """``<calls_begin>...<calls_end>`` with nothing inside."""
+        payload = f"{TC_OPEN}{TC_CLOSE}"
+
+        result = parser.extract_tool_calls(payload)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == payload
+
+    def test_block_missing_separator(self, parser: DeepSeekV31ToolParser) -> None:
+        """Block envelope but no ``<sep>`` — un-parseable body."""
+        payload = f"{TC_OPEN}{C_OPEN}garbage_no_sep_here{C_CLOSE}{TC_CLOSE}"
+
+        result = parser.extract_tool_calls(payload)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        # No usable calls extracted; envelope-present payload passes
+        # through so the caller can surface or strip it as needed.
+        assert result.content == payload
+
+    def test_one_good_one_bad_block(self, parser: DeepSeekV31ToolParser) -> None:
+        """A malformed block must not invalidate sibling good blocks."""
+        payload = _envelope(
+            _v3_block("get_weather", '{"city": "Tokyo"}'),
+            f"{C_OPEN}no_sep_here{C_CLOSE}",
+            _v3_block("get_time", '{"tz": "UTC"}'),
+        )
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tools_called
+        # The bad block in the middle is dropped; good blocks survive.
+        assert len(result.tool_calls) == 2
+        assert [c["name"] for c in result.tool_calls] == ["get_weather", "get_time"]
+
+
+# --------------------------------------------------------------------
+# Streaming — V3 short-circuit emits one well-formed tool_call event
+# per closed block instead of leaking mid-stream ``name="function"``
+# deltas. The legacy V3.1 streaming path remains delta-based and is
+# covered by ``test_upstream_regression.TestDeepSeekV31UpstreamStreaming``;
+# here we pin only the V3 short-circuit behaviour.
+# --------------------------------------------------------------------
+class TestV3Streaming:
+    def _feed(
+        self, parser: DeepSeekV31ToolParser, payload: str, chunk_size: int = 8
+    ) -> list[dict | None]:
+        """Replay ``payload`` through ``extract_tool_calls_streaming``
+        in fixed-size chunks. Returns the per-delta return values so
+        tests can assert what was emitted at each step.
+        """
+        results: list[dict | None] = []
+        prev = ""
+        for i in range(0, len(payload), chunk_size):
+            delta = payload[i : i + chunk_size]
+            cur = prev + delta
+            r = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=delta,
+            )
+            results.append(r)
+            prev = cur
+        return results
+
+    def test_v3_block_emits_single_complete_tool_call_on_close(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """No ``name="function"`` deltas — only one fully-resolved
+        ``tool_calls`` event when the block's ``<call_end>`` arrives."""
+        payload = _envelope(_v3_block("get_weather", '{"city": "Tokyo"}'))
+
+        events = self._feed(parser, payload, chunk_size=12)
+
+        tool_events = [e for e in events if e and "tool_calls" in e]
+        assert len(tool_events) == 1, (
+            f"expected exactly one tool_calls event, got {len(tool_events)}: "
+            f"{tool_events!r}"
+        )
+        tc_list = tool_events[0]["tool_calls"]
+        assert len(tc_list) == 1
+        tc = tc_list[0]
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "Tokyo"}
+        # Index sequence starts at 0 for the first tool call.
+        assert tc["index"] == 0
+
+        # And no event ever leaked ``name="function"`` (the bug shape).
+        for ev in events:
+            if not ev or "tool_calls" not in ev:
+                continue
+            for call in ev["tool_calls"]:
+                assert call.get("function", {}).get("name") != "function", (
+                    f"V3 type-tag leaked into streaming name: {ev!r}"
+                )
+
+    def test_parallel_v3_blocks_emit_per_block(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """Two V3 blocks → two distinct tool_calls deltas with
+        ascending indices."""
+        payload = _envelope(
+            _v3_block("get_weather", '{"city": "Tokyo"}'),
+            _v3_block("get_time", '{"tz": "UTC"}'),
+        )
+
+        events = self._feed(parser, payload, chunk_size=24)
+
+        emitted_names = []
+        emitted_indices = []
+        for ev in events:
+            if not ev or "tool_calls" not in ev:
+                continue
+            for call in ev["tool_calls"]:
+                emitted_names.append(call["function"]["name"])
+                emitted_indices.append(call["index"])
+
+        assert emitted_names == ["get_weather", "get_time"]
+        assert emitted_indices == [0, 1]
+
+
+# --------------------------------------------------------------------
+# Argument-body passthrough contract.
+#
+# Upstream vLLM emits the model's argument bytes verbatim (modulo
+# leading/trailing whitespace) — see
+# ``tests/test_upstream_regression.py::TestDeepSeekV31UpstreamNonStreaming``.
+# JSON-canonicalisation is the caller's job; doing it here would break
+# bytes-equal regression assertions.
+# --------------------------------------------------------------------
+class TestArgumentBytesPassthrough:
+    def test_valid_json_args_passed_through_verbatim(
+        self, parser: DeepSeekV31ToolParser
+    ) -> None:
+        """Args body bytes survive end-to-end (no canonicalisation)."""
+        args = '{   "k"  :  1  }'
+        payload = _envelope(_v3_block("f", args))
+
+        result = parser.extract_tool_calls(payload)
+
+        # Bytes match modulo the leading/trailing whitespace strip that
+        # ``_parse_block_body`` applies; the inner spaces survive.
+        assert result.tool_calls[0]["arguments"] == args
+        # And the body is still loadable when the caller wants.
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"k": 1}
+
+    def test_non_json_args_passed_through(self, parser: DeepSeekV31ToolParser) -> None:
+        """Non-JSON args body (a quirky V3.1 free-form payload) is
+        passed through verbatim — we don't try to manufacture JSON we
+        didn't receive."""
+        payload = _envelope(_v31_block("explain", "free-form text body"))
+
+        result = parser.extract_tool_calls(payload)
+
+        assert result.tool_calls[0]["arguments"] == "free-form text body"

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -289,40 +289,50 @@ class DeepSeekV31ToolParser(ToolParser):
     # -----------------------------------------------------------------
     @classmethod
     def _cumulative_has_v3_block(cls, model_output: str) -> bool:
-        """Return ``True`` if any block (open or closed) in the
-        cumulative text has a V3-shaped body (starts with the literal
-        ``function<｜tool▁sep｜>`` type-tag-plus-separator).
+        """Return ``True`` if any block (open or closed) WITHIN the
+        outer ``<tool_calls_begin>`` envelope has a V3-shaped body
+        (starts with the literal ``function<｜tool▁sep｜>``
+        type-tag-plus-separator).
 
         Called every streaming delta. Once this returns ``True``, the
         streaming path stops emitting and defers to the postprocessor's
         end-of-stream ``extract_tool_calls`` fallback — see the
         streaming gate comment in ``extract_tool_calls_streaming``.
+
+        codex r9 BLOCKING-1: like ``_iter_block_bodies``, this scanner
+        MUST be bounded to ``_envelope_bounds()`` so literal marker
+        text in streamed plain content can't suppress normal V3.1
+        streaming.
         """
-        if cls.TOOL_CALL_START not in model_output:
+        bounds = cls._envelope_bounds(model_output)
+        if bounds is None:
             return False
+        inner_start, inner_end = bounds
         v3_marker = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
-        # Scan every open/closed block body in order. We can't use
-        # ``_iter_block_bodies`` because that scanner skips
-        # not-yet-closed trailing blocks — for V3 detection we want
-        # the open trailing body too, since that's where the V3 type
-        # tag arrives first.
-        pos = 0
+        # Scan every open/closed block body in order, but only inside
+        # the outer envelope. The open trailing body inside the
+        # envelope is the most important case because that's where
+        # the V3 type tag arrives first mid-stream.
+        pos = inner_start
         start_len = len(cls.TOOL_CALL_START)
         end_len = len(cls.TOOL_CALL_END)
-        while True:
-            start = model_output.find(cls.TOOL_CALL_START, pos)
+        while pos < inner_end:
+            start = model_output.find(cls.TOOL_CALL_START, pos, inner_end)
             if start == -1:
                 return False
             body_start = start + start_len
-            end = model_output.find(cls.TOOL_CALL_END, body_start)
+            end = model_output.find(cls.TOOL_CALL_END, body_start, inner_end)
             body = (
-                model_output[body_start:end] if end != -1 else model_output[body_start:]
+                model_output[body_start:end]
+                if end != -1
+                else model_output[body_start:inner_end]
             )
             if body.lstrip("\n").startswith(v3_marker):
                 return True
             if end == -1:
                 return False
             pos = end + end_len
+        return False
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -470,18 +480,17 @@ class DeepSeekV31ToolParser(ToolParser):
         # streaming. V3.1 streams are unchanged (legacy delta machine
         # still runs).
         #
-        # Known limitation (codex r7): a *mixed* V3.1+V3 envelope —
-        # where the legacy machine streams a V3.1 block FIRST (setting
-        # ``tool_calls_detected = True`` on the postprocessor) BEFORE
-        # the V3 block opens — would lose the V3 block, because the
-        # postprocessor's finalize fallback gates on
-        # ``not tool_calls_detected``. This is a postprocessor
-        # contract limitation, not something a parser-only fix can
-        # address. Mixed envelopes are not produced by any released
-        # DeepSeek checkpoint; the chat templates for both V3 and
-        # V3.1 emit a single body shape per envelope. See
-        # ``test_mixed_v3_and_v31_blocks`` for the NON-streaming
-        # (correct) behaviour on mixed payloads.
+        # Streaming contract for mixed V3.1+V3 envelopes (codex
+        # r7/r9): NOT SUPPORTED in this parser. If a stream contains
+        # both V3.1 and V3 blocks in the same envelope, the postprocessor
+        # ``tool_calls_detected`` gate prevents the finalize-path
+        # fallback from reconciling the V3 block once an earlier V3.1
+        # block has already emitted. Released DeepSeek chat templates
+        # (V3, V3.1, R1, R1-0528) emit a SINGLE body shape per
+        # envelope so this case doesn't arise in practice. The
+        # non-streaming ``extract_tool_calls`` path handles mixed
+        # envelopes correctly (see ``test_mixed_v3_and_v31_blocks``)
+        # for completeness.
         # ----------------------------------------------------------------
         if self._cumulative_has_v3_block(current_text):
             return None

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -192,9 +192,19 @@ class DeepSeekV31ToolParser(ToolParser):
         """Parse one ``<call_begin>...<call_end>`` body into ``(name, args)``.
 
         Tries V3 (fenced JSON) first when the body starts with the
-        ``function<sep>`` type-tag prefix; falls back to V3.1 (plain
-        ``NAME<sep>ARGS``) otherwise. Returns ``None`` if the body is
-        not parseable in either shape.
+        ``function<sep>`` type-tag prefix; otherwise the V3.1 (plain
+        ``NAME<sep>ARGS``) shape. Returns ``None`` if the body is not
+        parseable in the claimed shape.
+
+        Critically (codex r2 BLOCKING): a body that anchors as V3 must
+        NOT silently fall through to the V3.1 split — that path would
+        emit ``name="function"`` with the real tool name embedded in
+        ``arguments``, recreating the exact production failure mode
+        we're patching. If the V3 anchor matches but neither V3 regex
+        does, the body is malformed; we attempt one bounded recovery
+        (look for the inner JSON between ``\\`\\`\\`json`` and any
+        terminator) and return ``None`` if that fails so the caller
+        drops the block.
         """
         body = body.strip("\n")
         if body.startswith(f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"):
@@ -203,10 +213,27 @@ class DeepSeekV31ToolParser(ToolParser):
             )
             if m is not None:
                 return m.group("name").strip(), m.group("args").strip()
-            # Body claimed V3 (``function<sep>...``) but didn't close
-            # with a JSON fence — fall through to the V3.1 shape, which
-            # also matches ``function<sep>RAW_ARGS`` and recovers a
-            # usable name+args pair even when the fence was lost.
+            # V3 anchor but malformed fence. Try one bounded recovery:
+            # the body shape is ``function<sep>NAME\n``\`\`\`json\n…``
+            # — split off the type-tag-plus-sep and look for the name
+            # terminator (``\n``\`\`\`json``). If both halves
+            # materialise we recover; otherwise the block is unparseable
+            # and we return ``None`` to drop it (NOT fall through to
+            # the V3.1 ``name=function`` mis-split).
+            v3_prefix = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
+            tail = body[len(v3_prefix) :]
+            fence_idx = tail.find("\n```json")
+            if fence_idx <= 0:
+                return None
+            name = tail[:fence_idx].strip()
+            args_part = tail[fence_idx + len("\n```json") :].lstrip("\n")
+            # Strip any trailing ``\`\`\`` fence the model produced.
+            if args_part.endswith("```"):
+                args_part = args_part[: -len("```")].rstrip("\n")
+            args = args_part.strip()
+            if not name:
+                return None
+            return name, args
 
         sep_idx = body.find(cls.TOOL_SEP)
         if sep_idx == -1:
@@ -215,14 +242,6 @@ class DeepSeekV31ToolParser(ToolParser):
         args = body[sep_idx + len(cls.TOOL_SEP) :].strip()
         if not name:
             return None
-        # If a V3-shaped body lost its closing fence but the args body
-        # still contains ```json\n…``` markers, recover the inner JSON
-        # rather than passing the fenced wrapper as the arg string.
-        if args.startswith("```json"):
-            inner = args[len("```json") :].lstrip("\n")
-            if inner.endswith("```"):
-                inner = inner[: -len("```")].rstrip("\n")
-            args = inner.strip()
         return name, args
 
     def extract_tool_calls(

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -396,6 +396,19 @@ class DeepSeekV31ToolParser(ToolParser):
         # contract until a model emerges that actually demands V3
         # streaming. V3.1 streams are unchanged (legacy delta machine
         # still runs).
+        #
+        # Known limitation (codex r7): a *mixed* V3.1+V3 envelope —
+        # where the legacy machine streams a V3.1 block FIRST (setting
+        # ``tool_calls_detected = True`` on the postprocessor) BEFORE
+        # the V3 block opens — would lose the V3 block, because the
+        # postprocessor's finalize fallback gates on
+        # ``not tool_calls_detected``. This is a postprocessor
+        # contract limitation, not something a parser-only fix can
+        # address. Mixed envelopes are not produced by any released
+        # DeepSeek checkpoint; the chat templates for both V3 and
+        # V3.1 emit a single body shape per envelope. See
+        # ``test_mixed_v3_and_v31_blocks`` for the NON-streaming
+        # (correct) behaviour on mixed payloads.
         # ----------------------------------------------------------------
         if self._cumulative_has_v3_block(current_text):
             return None

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -124,13 +124,21 @@ class DeepSeekV31ToolParser(ToolParser):
         self.streamed_args_for_tool: list[str] = []
 
         # IDs we have already emitted on the streaming V3 short-circuit
-        # path. We re-parse the cumulative text every time a block
-        # closes (so any newly-closed block is included), but we MUST
-        # NOT regenerate the IDs of blocks we have already announced —
+        # path, keyed by ABSOLUTE block index in the cumulative parse.
+        # We re-parse the cumulative text every time a block closes (so
+        # any newly-closed block is included), and we MUST NOT
+        # regenerate IDs for blocks we have already announced —
         # downstream clients track tool calls by ID and seeing the same
         # block under a new ID on every subsequent delta would corrupt
         # their state (codex r1 BLOCKING).
-        self._streamed_v3_ids: list[str] = []
+        #
+        # Must be keyed by absolute index, NOT a positional list:
+        # ``_streamed_v3_ids`` records ONLY V3 emissions; a V3.1 block
+        # in front of a V3 block makes the absolute index of the V3
+        # block 1 while ``len(_streamed_v3_ids)`` is 0 — a positional
+        # ``idx < len(...)`` would then re-emit the V3 block on every
+        # subsequent delta (codex r4 BLOCKING).
+        self._streamed_v3_ids: dict[int, str] = {}
 
         # V3.1 streaming regex (unchanged). V3-shaped streaming
         # arrives through the same regex because both shapes share the
@@ -277,12 +285,16 @@ class DeepSeekV31ToolParser(ToolParser):
         is_v3_index = self._classify_block_shapes(current_text)
 
         # Walk the parsed calls; for any index whose block is V3-shaped
-        # AND hasn't been emitted yet, queue it for emission.
+        # AND hasn't been emitted yet, queue it for emission. Emission
+        # state is tracked by ABSOLUTE block index keyed in
+        # ``_streamed_v3_ids`` — NOT by positional length — because
+        # ``_streamed_v3_ids`` records only V3 emissions and the
+        # cumulative parse interleaves V3 and V3.1 blocks (codex r4).
         to_emit: list[tuple[int, dict[str, Any]]] = []
         for idx, tc in enumerate(result.tool_calls):
             if idx >= len(is_v3_index) or not is_v3_index[idx]:
                 continue
-            if idx < len(self._streamed_v3_ids):
+            if idx in self._streamed_v3_ids:
                 continue
             to_emit.append((idx, tc))
 
@@ -292,7 +304,7 @@ class DeepSeekV31ToolParser(ToolParser):
         emitted: list[dict[str, Any]] = []
         for abs_idx, tc in to_emit:
             tc_id = tc["id"]
-            self._streamed_v3_ids.append(tc_id)
+            self._streamed_v3_ids[abs_idx] = tc_id
             # Keep ``current_tool_id`` advanced past this index so the
             # legacy machine doesn't try to re-emit the same block as
             # V3.1 on a subsequent delta. We're a bit defensive: if the
@@ -403,7 +415,7 @@ class DeepSeekV31ToolParser(ToolParser):
             self.streamed_args_for_tool = []
             self.current_tool_id = -1
             self.prev_tool_call_arr = []
-            self._streamed_v3_ids = []
+            self._streamed_v3_ids = {}
 
         current_token_ids = current_token_ids or []
         previous_token_ids = previous_token_ids or []

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -244,6 +244,87 @@ class DeepSeekV31ToolParser(ToolParser):
             return None
         return name, args
 
+    # -----------------------------------------------------------------
+    # Streaming helper — closed-V3 block recovery (codex r3 BLOCKING-2)
+    # -----------------------------------------------------------------
+    def _maybe_emit_closed_v3_blocks(
+        self, current_text: str, request: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Scan the cumulative streamed text for closed V3-shaped blocks
+        that have not yet been announced via ``_streamed_v3_ids``. If
+        any exist, emit them now as a one-shot ``tool_calls`` delta and
+        return that delta. Otherwise return ``None`` and let the legacy
+        streaming path run.
+
+        Why this lives at the top of streaming dispatch: a single
+        delta may both close a V3 block AND open a non-V3-yet block,
+        in which case the open-block sniffer would miss the closed V3
+        (it only inspects the latest body). The cumulative scan catches
+        it regardless of what the next block is doing.
+        """
+        # ``extract_tool_calls`` runs the same block-wise scanner used
+        # for non-streaming parses, so it sees all closed blocks. We
+        # use index correlation: ``_streamed_v3_ids`` records the IDs
+        # of every block we've already emitted (in order), so any
+        # parsed call past ``len(_streamed_v3_ids)`` is unannounced.
+        result = self.extract_tool_calls(current_text, request)
+        if not result.tools_called:
+            return None
+
+        # Find the V3-shaped block indices in the cumulative text so we
+        # only short-circuit for V3 blocks; V3.1 blocks continue to use
+        # the legacy delta machine for token-by-token emission.
+        is_v3_index = self._classify_block_shapes(current_text)
+
+        # Walk the parsed calls; for any index whose block is V3-shaped
+        # AND hasn't been emitted yet, queue it for emission.
+        to_emit: list[tuple[int, dict[str, Any]]] = []
+        for idx, tc in enumerate(result.tool_calls):
+            if idx >= len(is_v3_index) or not is_v3_index[idx]:
+                continue
+            if idx < len(self._streamed_v3_ids):
+                continue
+            to_emit.append((idx, tc))
+
+        if not to_emit:
+            return None
+
+        emitted: list[dict[str, Any]] = []
+        for abs_idx, tc in to_emit:
+            tc_id = tc["id"]
+            self._streamed_v3_ids.append(tc_id)
+            # Keep ``current_tool_id`` advanced past this index so the
+            # legacy machine doesn't try to re-emit the same block as
+            # V3.1 on a subsequent delta. We're a bit defensive: if the
+            # legacy path already advanced past this index (e.g. a
+            # V3.1 block sat in front of a V3 block), we don't rewind.
+            if abs_idx > self.current_tool_id:
+                self.current_tool_id = abs_idx
+            emitted.append(
+                {
+                    "index": abs_idx,
+                    "id": tc_id,
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["arguments"],
+                    },
+                }
+            )
+        return {"tool_calls": emitted}
+
+    @classmethod
+    def _classify_block_shapes(cls, model_output: str) -> list[bool]:
+        """Return ``[is_v3_per_block]`` for every CLOSED block, in
+        order. Open trailing blocks are not included — they have no
+        determined shape until ``<call_end>`` arrives.
+        """
+        out: list[bool] = []
+        v3_marker = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
+        for body in cls._iter_block_bodies(model_output):
+            out.append(body.lstrip("\n").startswith(v3_marker))
+        return out
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
@@ -338,102 +419,59 @@ class DeepSeekV31ToolParser(ToolParser):
             return {"content": delta_text}
 
         # ----------------------------------------------------------------
-        # V3-shape streaming short-circuit (D-DSV31 follow-on).
+        # V3-shape streaming gate (D-DSV31 follow-on).
         #
-        # The legacy streaming path captures ``name<sep>args`` from the
-        # currently-open block via a single regex — that emits
-        # ``name="function"`` mid-stream for V3 bodies because the literal
-        # ``function`` type tag *is* what arrives first. The cleanest
-        # incremental fix without rewriting the entire delta state
-        # machine: when ANY block in the current envelope is (or could
-        # become) V3-shaped, buffer silently until the block closes,
-        # then emit the fully resolved name+args as a single one-shot
-        # tool_call event via the non-streaming ``extract_tool_calls``
-        # path. Clients receive a well-formed call instead of a hot
-        # stream of garbage deltas.
+        # The legacy delta machine captures ``name<sep>args`` from the
+        # currently-open block via a single regex — that would emit
+        # ``name="function"`` mid-stream for V3 bodies because the
+        # literal ``function`` type tag *is* what arrives first.
         #
-        # Activation criteria for buffering an OPEN block:
-        #   * a ``<call_begin>`` is open (more begins than ends)
-        #   * the open body either already matches ``function<sep>`` or
-        #     is consistent with becoming V3 (body is a prefix of the V3
-        #     type-tag-plus-sep marker). The prefix-match keeps us out of
-        #     the legacy path BEFORE it bumps ``current_tool_id`` on the
-        #     first ``<call_begin>`` delta, which would otherwise desync
-        #     the close-emission below.
+        # The gate has two responsibilities, applied in order:
+        #
+        #   A. Detect V3 in any CLOSED block via the cumulative
+        #      non-streaming parser. If a V3 block has closed but
+        #      hasn't yet been announced (tracked by
+        #      ``self._streamed_v3_ids``), emit it now. This handles
+        #      the "delta closes a V3 block and also opens an empty
+        #      next block" case (codex r3 BLOCKING-2): the V3 detection
+        #      lives in the closed-block scan, not in inspection of
+        #      the latest possibly-open body.
+        #
+        #   B. For the currently-OPEN block: buffer silently only when
+        #      V3 is *confirmed* by the body starting with
+        #      ``function<｜tool▁sep｜>`` (the V3 type tag + separator).
+        #      We do NOT buffer on a mere prefix-could-become-V3 because
+        #      a V3.1 tool whose name happens to start with ``f``,
+        #      ``fun``, ``function_lookup`` etc. would otherwise be
+        #      swallowed (codex r3 BLOCKING-1) and the legacy state
+        #      machine never gets to advance ``current_tool_id``.
+        #
+        # The closed-V3-emit path runs first because it must fire even
+        # when the *latest* (possibly empty) block isn't V3-confirmed
+        # but a previously-closed block was V3.
         # ----------------------------------------------------------------
         cur_start_count = current_text.count(self.TOOL_CALL_START)
         cur_end_count = current_text.count(self.TOOL_CALL_END)
-
-        # Body of the most-recent block (may still be open).
-        latest_body = ""
-        if cur_start_count > 0:
-            tail = current_text.split(self.TOOL_CALL_START)[-1]
-            latest_body = tail.split(self.TOOL_CALL_END)[0]
-        latest_body_stripped = latest_body.lstrip("\n")
         v3_marker = f"{_V3_TYPE_TAG}{self.TOOL_SEP}"
 
-        # Confirmed V3 once the type-tag-plus-sep is in the body.
-        is_v3_confirmed = latest_body_stripped.startswith(v3_marker)
-        # Ambiguous prefix while the body has at least one character but
-        # is still a strict prefix of ``function<sep>``. We require >=1
-        # body character (codex r1 BLOCKING — every string starts with
-        # ``""`` so the empty-body case would otherwise hijack legitimate
-        # V3.1 streams that ended right after ``<call_begin>`` and
-        # haven't yet emitted a single body byte).
-        body_could_be_v3 = (
-            not is_v3_confirmed
-            and cur_end_count < cur_start_count  # block still open
-            and 0 < len(latest_body_stripped) < len(v3_marker)
-            and v3_marker.startswith(latest_body_stripped)
-        )
+        # --- A. Closed V3 block recovery ---
+        # Scan the closed blocks for V3-shaped bodies; emit any whose
+        # absolute index hasn't been streamed yet.
+        closed_v3_emit = self._maybe_emit_closed_v3_blocks(current_text, request)
+        if closed_v3_emit is not None:
+            return closed_v3_emit
 
-        if is_v3_confirmed or body_could_be_v3:
-            # Block still open → buffer silently.
-            if cur_end_count < cur_start_count:
+        # --- B. Open-block confirmed-V3 buffer ---
+        # Latest (possibly open) block body.
+        is_block_open = cur_end_count < cur_start_count
+        if is_block_open:
+            tail = current_text.split(self.TOOL_CALL_START)[-1]
+            open_body = tail.split(self.TOOL_CALL_END)[0].lstrip("\n")
+            if open_body.startswith(v3_marker):
+                # V3 confirmed in open block — silently buffer. The
+                # closed-V3 path will emit it once <call_end> lands in
+                # a later delta.
                 return None
-            # At least one block closed. Run the canonical non-streaming
-            # extract on the cumulative text and emit any closed-block
-            # tool calls we haven't announced yet. ``current_tool_id``
-            # tracks the highest already-emitted index (-1 = none).
-            prev_end_count = previous_text.count(self.TOOL_CALL_END)
-            newly_closed = cur_end_count - prev_end_count
-            if newly_closed <= 0:
-                return None
-            result = self.extract_tool_calls(current_text, request)
-            if not result.tools_called:
-                return None
-            start_idx = self.current_tool_id + 1
-            tail_calls = result.tool_calls[start_idx : start_idx + newly_closed]
-            if not tail_calls:
-                return None
-            # Stable IDs across re-parses (codex r1 BLOCKING):
-            # ``extract_tool_calls`` generates a fresh ``call_xxxx`` ID
-            # every invocation, but we re-invoke it every time a block
-            # closes — so previously-emitted blocks would get new IDs on
-            # later deltas. Cache the IDs we have already announced and
-            # only mint a new ID when the parsed list grows past what
-            # we've previously cached.
-            emitted: list[dict[str, Any]] = []
-            for i, tc in enumerate(tail_calls):
-                absolute_idx = start_idx + i
-                if absolute_idx < len(self._streamed_v3_ids):
-                    tc_id = self._streamed_v3_ids[absolute_idx]
-                else:
-                    tc_id = tc["id"]
-                    self._streamed_v3_ids.append(tc_id)
-                emitted.append(
-                    {
-                        "index": absolute_idx,
-                        "id": tc_id,
-                        "type": "function",
-                        "function": {
-                            "name": tc["name"],
-                            "arguments": tc["arguments"],
-                        },
-                    }
-                )
-            self.current_tool_id += len(tail_calls)
-            return {"tool_calls": emitted}
 
         delta_text = delta_text.replace(self.TOOL_CALLS_START, "").replace(
             self.TOOL_CALLS_END, ""

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -1,13 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-DeepSeek V3.1 tool call parser for rapid-mlx.
+DeepSeek V3 / V3.1 / R1-0528 tool call parser for rapid-mlx.
 
-Ported from vLLM upstream (vllm/tool_parsers/deepseekv31_tool_parser.py).
+Originally ported from vLLM upstream
+(vllm/tool_parsers/deepseekv31_tool_parser.py) targeting the V3.1
+"thinking-channel" body format:
 
-Format (different from V3 — no ```json``` code fence, no "function" type tag):
-  <｜tool▁calls▁begin｜>
-  <｜tool▁call▁begin｜>NAME<｜tool▁sep｜>ARGS<｜tool▁call▁end｜>
-  <｜tool▁calls▁end｜>
+    <｜tool▁calls▁begin｜>
+    <｜tool▁call▁begin｜>NAME<｜tool▁sep｜>ARGS<｜tool▁call▁end｜>
+    <｜tool▁calls▁end｜>
+
+Real-world checkpoints (incl. DeepSeek-R1-0528-Qwen3-8B, whose
+``chat_template.jinja`` was inherited from DeepSeek-V3) emit the V3
+"function-typed, JSON-fenced" body shape instead:
+
+    <｜tool▁calls▁begin｜>
+    <｜tool▁call▁begin｜>function<｜tool▁sep｜>NAME
+    ```json
+    {ARGS}
+    ```<｜tool▁call▁end｜>
+    <｜tool▁calls▁end｜>
+
+Both shapes share the *outer* envelope (``<｜tool▁calls▁begin｜>`` /
+``<｜tool▁calls▁end｜>``) and the *block* envelope (``<｜tool▁call▁begin｜>``
+/ ``<｜tool▁call▁end｜>``) plus the ``<｜tool▁sep｜>`` separator — only the
+body inside each ``<call_begin>...<call_end>`` block differs.
+
+D-DSV31 (0.8.2 P0): the original V3.1-only regex matched
+``function<sep>NAME\\n```json\\n{...}\\n```<end>`` as
+``name="function"``, ``arguments="NAME\\n```json\\n{...}\\n```"`` — i.e.
+the type tag became the function name and the real name + fenced JSON
+became the arguments string. Downstream OpenAI clients then attempted to
+invoke a tool literally named ``function`` with garbage arguments.
+
+Fix: parse each ``<call_begin>...<call_end>`` block with explicit
+format auto-detection on the block body. The block-wise scanner walks
+the outer envelope as a state machine instead of relying on a single
+greedy regex over the full payload — that's what makes parallel /
+malformed payloads parse correctly rather than collapsing into one
+mis-shaped match.
 """
 
 import logging
@@ -29,20 +60,43 @@ def _generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
+# Body shape inside a single <call_begin>...<call_end> block.
+#
+# V3 (DeepSeek-V3, DeepSeek-R1-0528-Qwen3-8B, and any checkpoint whose
+# chat template inherits V3's "function-typed, JSON-fenced" tool-call
+# emission):
+#
+#     function<｜tool▁sep｜>NAME\n```json\n{...}\n```
+#
+# V3.1 (DeepSeek V3.1 thinking-channel):
+#
+#     NAME<｜tool▁sep｜>{...}
+#
+# We detect V3 by checking whether the body starts with the literal
+# ``function`` type tag *followed by* the separator (anchored, no
+# regex needed) — that's what the V3 chat template always emits and
+# what V3.1 never emits. Without that anchor a V3.1 tool literally
+# named ``function_lookup`` would be misclassified.
+_V3_TYPE_TAG = "function"
+
+
 @ToolParserManager.register_module(["deepseek_v31", "deepseek_r1_0528"])
 class DeepSeekV31ToolParser(ToolParser):
     """
-    Tool call parser for DeepSeek V3.1 and R1-0528 models.
+    Tool call parser for DeepSeek V3 / V3.1 / R1-0528 models.
 
-    Uses the same unicode special tokens as V3 but with a simpler format:
-    <｜tool▁call▁begin｜>NAME<｜tool▁sep｜>ARGS<｜tool▁call▁end｜>
-    (no "function" type prefix, no ```json``` fencing)
+    Auto-detects both wire shapes (see module docstring) — a single
+    parser covers every DeepSeek alias whose chat template emits the
+    shared ``<｜tool▁calls▁begin｜>`` envelope, regardless of whether
+    the body inside each block uses the V3 ``function<sep>NAME\\n\\`\\`\\`json
+    {...}\\`\\`\\`\\n`` shape or the V3.1 ``NAME<sep>{...}`` shape.
 
-    Used when --enable-auto-tool-choice --tool-call-parser deepseek_v31 are set.
+    Used when --enable-auto-tool-choice --tool-call-parser deepseek_v31
+    (or the V3 aliases) are set.
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
-    EXPECTED_WIRE_FORMATS = ("deepseek_v31_native",)
+    EXPECTED_WIRE_FORMATS = ("deepseek_native", "deepseek_v31_native")
 
     TOOL_CALLS_START = "<｜tool▁calls▁begin｜>"
     TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
@@ -50,17 +104,32 @@ class DeepSeekV31ToolParser(ToolParser):
     TOOL_CALL_END = "<｜tool▁call▁end｜>"
     TOOL_SEP = "<｜tool▁sep｜>"
 
+    # V3 body: "function<sep>NAME\n```json\n{...}\n```"
+    # The fenced JSON block is greedy-but-bounded by ``\n\`\`\``` at the end.
+    _V3_BODY_REGEX = re.compile(
+        r"^function<｜tool▁sep｜>(?P<name>.*?)\n```json\n(?P<args>.*?)\n```\s*$",
+        re.DOTALL,
+    )
+    # V3 body with a tolerant trailing fence (some checkpoints omit the
+    # newline before the closing fence, e.g. ``...}```<call_end>``).
+    _V3_BODY_REGEX_TOLERANT = re.compile(
+        r"^function<｜tool▁sep｜>(?P<name>.*?)\n```json\n(?P<args>.*?)```\s*$",
+        re.DOTALL,
+    )
+
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
 
         self.current_tool_name_sent: bool = False
         self.streamed_args_for_tool: list[str] = []
 
-        self.tool_call_regex = re.compile(
-            r"<｜tool▁call▁begin｜>(?P<function_name>.*?)<｜tool▁sep｜>"
-            r"(?P<function_arguments>.*?)<｜tool▁call▁end｜>",
-            re.DOTALL,
-        )
+        # V3.1 streaming regex (unchanged). V3-shaped streaming
+        # arrives through the same regex because both shapes share the
+        # ``NAME<sep>...`` skeleton; the V3 "function" type tag plus
+        # JSON fence become part of the staged ``arguments`` buffer
+        # mid-stream and are only resolved into the correct ``name`` /
+        # ``arguments`` split once the closing ``<call_end>`` lands and
+        # the non-streaming ``extract_tool_calls`` path runs.
         self.stream_tool_call_portion_regex = re.compile(
             r"(?P<function_name>.*)<｜tool▁sep｜>(?P<function_arguments>.*)",
             re.DOTALL,
@@ -75,6 +144,78 @@ class DeepSeekV31ToolParser(ToolParser):
         self.tool_call_start_token_id = self.vocab.get(self.TOOL_CALL_START)
         self.tool_call_end_token_id = self.vocab.get(self.TOOL_CALL_END)
 
+    # -----------------------------------------------------------------
+    # Block-wise scanner — the structural fix for D-DSV31
+    # -----------------------------------------------------------------
+    @classmethod
+    def _iter_block_bodies(cls, model_output: str) -> list[str]:
+        """Yield the body text between each ``<call_begin>`` /
+        ``<call_end>`` pair, in order.
+
+        Uses a forward-scanning state machine (find next ``<call_begin>``,
+        find the *matching* ``<call_end>``) rather than a single greedy
+        regex. This is what makes parallel calls parse as N entries
+        instead of one over-greedy match, and what makes a truncated
+        trailing block ignored rather than swallowing the rest of the
+        payload.
+        """
+        bodies: list[str] = []
+        pos = 0
+        start_len = len(cls.TOOL_CALL_START)
+        end_len = len(cls.TOOL_CALL_END)
+        while True:
+            start = model_output.find(cls.TOOL_CALL_START, pos)
+            if start == -1:
+                break
+            body_start = start + start_len
+            end = model_output.find(cls.TOOL_CALL_END, body_start)
+            if end == -1:
+                # Truncated block — drop and stop (caller emits the
+                # leading text as content). Matches the "malformed →
+                # graceful no-op" contract.
+                break
+            bodies.append(model_output[body_start:end])
+            pos = end + end_len
+        return bodies
+
+    @classmethod
+    def _parse_block_body(cls, body: str) -> tuple[str, str] | None:
+        """Parse one ``<call_begin>...<call_end>`` body into ``(name, args)``.
+
+        Tries V3 (fenced JSON) first when the body starts with the
+        ``function<sep>`` type-tag prefix; falls back to V3.1 (plain
+        ``NAME<sep>ARGS``) otherwise. Returns ``None`` if the body is
+        not parseable in either shape.
+        """
+        body = body.strip("\n")
+        if body.startswith(f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"):
+            m = cls._V3_BODY_REGEX.match(body) or cls._V3_BODY_REGEX_TOLERANT.match(
+                body
+            )
+            if m is not None:
+                return m.group("name").strip(), m.group("args").strip()
+            # Body claimed V3 (``function<sep>...``) but didn't close
+            # with a JSON fence — fall through to the V3.1 shape, which
+            # also matches ``function<sep>RAW_ARGS`` and recovers a
+            # usable name+args pair even when the fence was lost.
+
+        sep_idx = body.find(cls.TOOL_SEP)
+        if sep_idx == -1:
+            return None
+        name = body[:sep_idx].strip()
+        args = body[sep_idx + len(cls.TOOL_SEP) :].strip()
+        if not name:
+            return None
+        # If a V3-shaped body lost its closing fence but the args body
+        # still contains ```json\n…``` markers, recover the inner JSON
+        # rather than passing the fenced wrapper as the arg string.
+        if args.startswith("```json"):
+            inner = args[len("```json") :].lstrip("\n")
+            if inner.endswith("```"):
+                inner = inner[: -len("```")].rstrip("\n")
+            args = inner.strip()
+        return name, args
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
@@ -84,22 +225,46 @@ class DeepSeekV31ToolParser(ToolParser):
             )
 
         try:
-            matches = self.tool_call_regex.findall(model_output)
-            tool_calls = []
-            for func_name, func_args in matches:
+            tool_calls: list[dict[str, Any]] = []
+            for body in self._iter_block_bodies(model_output):
+                parsed = self._parse_block_body(body)
+                if parsed is None:
+                    # Malformed block — skip, don't poison the rest of
+                    # the envelope. Matches the "malformed → graceful"
+                    # contract exercised by the test suite.
+                    continue
+                name, args = parsed
                 tool_calls.append(
                     {
                         "id": _generate_tool_id(),
-                        "name": func_name.strip(),
-                        "arguments": func_args.strip(),
+                        "name": name,
+                        # Args body passes through verbatim. The
+                        # upstream vLLM contract is bytes-equal
+                        # passthrough — downstream JSON canonicalisation
+                        # is the caller's job (and changing the bytes
+                        # here breaks ``tests/test_upstream_regression``).
+                        "arguments": args,
                     }
                 )
 
-            content = model_output[: model_output.find(self.TOOL_CALLS_START)]
+            if tool_calls:
+                # Tool calls fired — content is anything strictly before
+                # the outer begin marker (V3.1 semantics).
+                content = model_output[: model_output.find(self.TOOL_CALLS_START)]
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=content if content else None,
+                )
+
+            # Outer envelope present but nothing parsed (truncated /
+            # malformed). Pass the full model output through as content
+            # so callers see the raw text rather than silently dropping
+            # everything after ``<call_begin>``. Mirrors the V3 parser's
+            # "no match" behaviour and the test suite's malformed
+            # graceful-passthrough contract.
             return ExtractedToolCallInformation(
-                tools_called=len(tool_calls) > 0,
-                tool_calls=tool_calls,
-                content=content if content else None,
+                tools_called=False, tool_calls=[], content=model_output
             )
         except Exception:
             logger.exception("Error in extracting tool call from response.")
@@ -142,6 +307,88 @@ class DeepSeekV31ToolParser(ToolParser):
 
         if not has_tool_start:
             return {"content": delta_text}
+
+        # ----------------------------------------------------------------
+        # V3-shape streaming short-circuit (D-DSV31 follow-on).
+        #
+        # The legacy streaming path captures ``name<sep>args`` from the
+        # currently-open block via a single regex — that emits
+        # ``name="function"`` mid-stream for V3 bodies because the literal
+        # ``function`` type tag *is* what arrives first. The cleanest
+        # incremental fix without rewriting the entire delta state
+        # machine: when ANY block in the current envelope is (or could
+        # become) V3-shaped, buffer silently until the block closes,
+        # then emit the fully resolved name+args as a single one-shot
+        # tool_call event via the non-streaming ``extract_tool_calls``
+        # path. Clients receive a well-formed call instead of a hot
+        # stream of garbage deltas.
+        #
+        # Activation criteria for buffering an OPEN block:
+        #   * a ``<call_begin>`` is open (more begins than ends)
+        #   * the open body either already matches ``function<sep>`` or
+        #     is consistent with becoming V3 (body is a prefix of the V3
+        #     type-tag-plus-sep marker). The prefix-match keeps us out of
+        #     the legacy path BEFORE it bumps ``current_tool_id`` on the
+        #     first ``<call_begin>`` delta, which would otherwise desync
+        #     the close-emission below.
+        # ----------------------------------------------------------------
+        cur_start_count = current_text.count(self.TOOL_CALL_START)
+        cur_end_count = current_text.count(self.TOOL_CALL_END)
+
+        # Body of the most-recent block (may still be open).
+        latest_body = ""
+        if cur_start_count > 0:
+            tail = current_text.split(self.TOOL_CALL_START)[-1]
+            latest_body = tail.split(self.TOOL_CALL_END)[0]
+        latest_body_stripped = latest_body.lstrip("\n")
+        v3_marker = f"{_V3_TYPE_TAG}{self.TOOL_SEP}"
+
+        # Confirmed V3 once the type-tag-plus-sep is in the body.
+        is_v3_confirmed = latest_body_stripped.startswith(v3_marker)
+        # Ambiguous prefix while the body is shorter than ``function<sep>``
+        # and still a prefix of it. We buffer in this state because
+        # committing to either path now would force a re-emission later.
+        body_could_be_v3 = (
+            not is_v3_confirmed
+            and cur_end_count < cur_start_count  # block still open
+            and len(latest_body_stripped) < len(v3_marker)
+            and v3_marker.startswith(latest_body_stripped)
+        )
+
+        if is_v3_confirmed or body_could_be_v3:
+            # Block still open → buffer silently.
+            if cur_end_count < cur_start_count:
+                return None
+            # At least one block closed. Run the canonical non-streaming
+            # extract on the cumulative text and emit any closed-block
+            # tool calls we haven't emitted yet. ``current_tool_id``
+            # tracks the highest already-emitted index (-1 = none).
+            prev_end_count = previous_text.count(self.TOOL_CALL_END)
+            newly_closed = cur_end_count - prev_end_count
+            if newly_closed <= 0:
+                return None
+            result = self.extract_tool_calls(current_text, request)
+            if not result.tools_called:
+                return None
+            start_idx = self.current_tool_id + 1
+            tail_calls = result.tool_calls[start_idx : start_idx + newly_closed]
+            if not tail_calls:
+                return None
+            self.current_tool_id += len(tail_calls)
+            return {
+                "tool_calls": [
+                    {
+                        "index": start_idx + i,
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": {
+                            "name": tc["name"],
+                            "arguments": tc["arguments"],
+                        },
+                    }
+                    for i, tc in enumerate(tail_calls)
+                ],
+            }
 
         delta_text = delta_text.replace(self.TOOL_CALLS_START, "").replace(
             self.TOOL_CALLS_END, ""

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -253,27 +253,16 @@ class DeepSeekV31ToolParser(ToolParser):
             )
             if m is not None:
                 return m.group("name").strip(), m.group("args").strip()
-            # V3 anchor but malformed fence. Try one bounded recovery:
-            # the body shape is ``function<sep>NAME\n``\`\`\`json\n…``
-            # — split off the type-tag-plus-sep and look for the name
-            # terminator (``\n``\`\`\`json``). If both halves
-            # materialise we recover; otherwise the block is unparseable
-            # and we return ``None`` to drop it (NOT fall through to
-            # the V3.1 ``name=function`` mis-split).
-            v3_prefix = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
-            tail = body[len(v3_prefix) :]
-            fence_idx = tail.find("\n```json")
-            if fence_idx <= 0:
-                return None
-            name = tail[:fence_idx].strip()
-            args_part = tail[fence_idx + len("\n```json") :].lstrip("\n")
-            # Strip any trailing ``\`\`\`` fence the model produced.
-            if args_part.endswith("```"):
-                args_part = args_part[: -len("```")].rstrip("\n")
-            args = args_part.strip()
-            if not name:
-                return None
-            return name, args
+            # V3-anchored but neither fenced-JSON regex matched. Drop
+            # the block entirely (return ``None``) rather than trying a
+            # bounded recovery: a partial recovery can emit a tool call
+            # with truncated / non-JSON arguments (e.g. ``{"city":
+            # "Tokyo"`` with no closing brace), which would then reach
+            # downstream tool execution (codex r10 BLOCKING). The
+            # malformed block's raw text is preserved as ``content``
+            # by ``extract_tool_calls`` (codex r8 BLOCKING-2), so the
+            # caller can decide whether to display or retry.
+            return None
 
         sep_idx = body.find(cls.TOOL_SEP)
         if sep_idx == -1:

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -269,73 +269,68 @@ class DeepSeekV31ToolParser(ToolParser):
         in which case the open-block sniffer would miss the closed V3
         (it only inspects the latest body). The cumulative scan catches
         it regardless of what the next block is doing.
+
+        Indexing contract (codex r5 BLOCKING): emission indices are
+        ABSOLUTE block positions in the wire envelope (every
+        ``<call_begin>...<call_end>`` pair counts, including malformed
+        ones that ``extract_tool_calls`` drops). Decoupling our
+        position counter from the parsed-call list is what protects
+        against a malformed block shifting subsequent V3 indices.
         """
-        # ``extract_tool_calls`` runs the same block-wise scanner used
-        # for non-streaming parses, so it sees all closed blocks. We
-        # use index correlation: ``_streamed_v3_ids`` records the IDs
-        # of every block we've already emitted (in order), so any
-        # parsed call past ``len(_streamed_v3_ids)`` is unannounced.
-        result = self.extract_tool_calls(current_text, request)
-        if not result.tools_called:
+        # Walk closed-block bodies in their ORIGINAL positions and
+        # parse each one inline. This is the same scanner
+        # ``extract_tool_calls`` uses, but we keep the block index
+        # stable even when ``_parse_block_body`` returns ``None`` for a
+        # malformed block — we just don't emit that block. The legacy
+        # non-streaming path is free to renumber, but a streaming
+        # parser's emission indices must match the wire positions so
+        # ``_streamed_v3_ids`` keys remain stable across deltas.
+        bodies = self._iter_block_bodies(current_text)
+        if not bodies:
             return None
 
-        # Find the V3-shaped block indices in the cumulative text so we
-        # only short-circuit for V3 blocks; V3.1 blocks continue to use
-        # the legacy delta machine for token-by-token emission.
-        is_v3_index = self._classify_block_shapes(current_text)
-
-        # Walk the parsed calls; for any index whose block is V3-shaped
-        # AND hasn't been emitted yet, queue it for emission. Emission
-        # state is tracked by ABSOLUTE block index keyed in
-        # ``_streamed_v3_ids`` — NOT by positional length — because
-        # ``_streamed_v3_ids`` records only V3 emissions and the
-        # cumulative parse interleaves V3 and V3.1 blocks (codex r4).
-        to_emit: list[tuple[int, dict[str, Any]]] = []
-        for idx, tc in enumerate(result.tool_calls):
-            if idx >= len(is_v3_index) or not is_v3_index[idx]:
+        v3_marker = f"{_V3_TYPE_TAG}{self.TOOL_SEP}"
+        to_emit: list[tuple[int, str, str]] = []
+        for abs_idx, body in enumerate(bodies):
+            if abs_idx in self._streamed_v3_ids:
                 continue
-            if idx in self._streamed_v3_ids:
+            stripped = body.lstrip("\n")
+            if not stripped.startswith(v3_marker):
+                # V3.1 (or unrecognised) — leave to legacy delta machine.
                 continue
-            to_emit.append((idx, tc))
+            parsed = self._parse_block_body(body)
+            if parsed is None:
+                # V3-anchored but malformed: don't emit and don't
+                # confuse the legacy machine either — the
+                # non-streaming finalize path will surface the raw
+                # text as content.
+                continue
+            name, args = parsed
+            to_emit.append((abs_idx, name, args))
 
         if not to_emit:
             return None
 
         emitted: list[dict[str, Any]] = []
-        for abs_idx, tc in to_emit:
-            tc_id = tc["id"]
+        for abs_idx, name, args in to_emit:
+            tc_id = f"call_{uuid.uuid4().hex[:8]}"
             self._streamed_v3_ids[abs_idx] = tc_id
-            # Keep ``current_tool_id`` advanced past this index so the
-            # legacy machine doesn't try to re-emit the same block as
-            # V3.1 on a subsequent delta. We're a bit defensive: if the
-            # legacy path already advanced past this index (e.g. a
-            # V3.1 block sat in front of a V3 block), we don't rewind.
-            if abs_idx > self.current_tool_id:
-                self.current_tool_id = abs_idx
+            # Advance ``current_tool_id`` past the just-emitted V3
+            # block (codex r5 BLOCKING: use ``max(...)`` to cover the
+            # ``abs_idx=0, current_tool_id=-1`` edge case explicitly).
+            self.current_tool_id = max(self.current_tool_id, abs_idx)
             emitted.append(
                 {
                     "index": abs_idx,
                     "id": tc_id,
                     "type": "function",
                     "function": {
-                        "name": tc["name"],
-                        "arguments": tc["arguments"],
+                        "name": name,
+                        "arguments": args,
                     },
                 }
             )
         return {"tool_calls": emitted}
-
-    @classmethod
-    def _classify_block_shapes(cls, model_output: str) -> list[bool]:
-        """Return ``[is_v3_per_block]`` for every CLOSED block, in
-        order. Open trailing blocks are not included — they have no
-        determined shape until ``<call_end>`` arrives.
-        """
-        out: list[bool] = []
-        v3_marker = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
-        for body in cls._iter_block_bodies(model_output):
-            out.append(body.lstrip("\n").startswith(v3_marker))
-        return out
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -148,35 +148,84 @@ class DeepSeekV31ToolParser(ToolParser):
     # Block-wise scanner — the structural fix for D-DSV31
     # -----------------------------------------------------------------
     @classmethod
+    def _envelope_bounds(cls, model_output: str) -> tuple[int, int] | None:
+        """Locate the outer ``<tool_calls_begin>...<tool_calls_end>``
+        envelope and return ``(inner_start, inner_end)`` pointing at
+        the substring strictly between the two markers. If the
+        envelope hasn't fully arrived (no closing marker), the inner
+        end is the length of the string — the caller can still scan
+        the partially-complete inner region for in-progress blocks.
+
+        Returns ``None`` if the outer ``<tool_calls_begin>`` is not
+        present at all.
+
+        codex r8 BLOCKING-1: block scanning MUST be bounded to the
+        outer envelope. Otherwise a response that mentions
+        ``<｜tool▁call▁begin｜>`` as literal content (e.g. quoted
+        documentation) and later happens to contain
+        ``<｜tool▁calls▁begin｜>`` could have the literal content
+        treated as a tool call.
+        """
+        outer_start = model_output.find(cls.TOOL_CALLS_START)
+        if outer_start == -1:
+            return None
+        inner_start = outer_start + len(cls.TOOL_CALLS_START)
+        outer_end = model_output.find(cls.TOOL_CALLS_END, inner_start)
+        inner_end = outer_end if outer_end != -1 else len(model_output)
+        return (inner_start, inner_end)
+
+    @classmethod
     def _iter_block_bodies(cls, model_output: str) -> list[str]:
         """Yield the body text between each ``<call_begin>`` /
-        ``<call_end>`` pair, in order.
+        ``<call_end>`` pair found INSIDE the outer
+        ``<tool_calls_begin>...<tool_calls_end>`` envelope, in order.
 
         Uses a forward-scanning state machine (find next ``<call_begin>``,
         find the *matching* ``<call_end>``) rather than a single greedy
         regex. This is what makes parallel calls parse as N entries
         instead of one over-greedy match, and what makes a truncated
         trailing block ignored rather than swallowing the rest of the
-        payload.
+        payload. The outer-envelope bound prevents literal marker text
+        in plain content from getting misparsed as tool calls
+        (codex r8 BLOCKING-1).
         """
+        bounds = cls._envelope_bounds(model_output)
+        if bounds is None:
+            return []
+        inner_start, inner_end = bounds
         bodies: list[str] = []
-        pos = 0
+        pos = inner_start
         start_len = len(cls.TOOL_CALL_START)
         end_len = len(cls.TOOL_CALL_END)
-        while True:
-            start = model_output.find(cls.TOOL_CALL_START, pos)
+        while pos < inner_end:
+            start = model_output.find(cls.TOOL_CALL_START, pos, inner_end)
             if start == -1:
                 break
             body_start = start + start_len
-            end = model_output.find(cls.TOOL_CALL_END, body_start)
+            end = model_output.find(cls.TOOL_CALL_END, body_start, inner_end)
             if end == -1:
-                # Truncated block — drop and stop (caller emits the
-                # leading text as content). Matches the "malformed →
-                # graceful no-op" contract.
+                # Truncated trailing block within the envelope — drop
+                # and stop. Matches the "malformed → graceful no-op"
+                # contract.
                 break
             bodies.append(model_output[body_start:end])
             pos = end + end_len
         return bodies
+
+    @classmethod
+    def _has_any_open_or_unparsed_block(cls, model_output: str) -> bool:
+        """True if there are ``<call_begin>`` markers inside the
+        envelope that ``_iter_block_bodies`` did NOT pair with a
+        ``<call_end>`` (truncated trailing block) — used by
+        ``extract_tool_calls`` to decide whether to preserve content
+        for callers (codex r8 BLOCKING-2).
+        """
+        bounds = cls._envelope_bounds(model_output)
+        if bounds is None:
+            return False
+        inner_start, inner_end = bounds
+        inner = model_output[inner_start:inner_end]
+        return inner.count(cls.TOOL_CALL_START) > inner.count(cls.TOOL_CALL_END)
 
     @classmethod
     def _parse_block_body(cls, body: str) -> tuple[str, str] | None:
@@ -284,13 +333,16 @@ class DeepSeekV31ToolParser(ToolParser):
             )
 
         try:
+            bodies = self._iter_block_bodies(model_output)
             tool_calls: list[dict[str, Any]] = []
-            for body in self._iter_block_bodies(model_output):
+            had_malformed = False
+            for body in bodies:
                 parsed = self._parse_block_body(body)
                 if parsed is None:
-                    # Malformed block — skip, don't poison the rest of
-                    # the envelope. Matches the "malformed → graceful"
-                    # contract exercised by the test suite.
+                    # Malformed block — skip emission but note the
+                    # presence so we can surface the model's text to
+                    # the caller below (codex r8 BLOCKING-2).
+                    had_malformed = True
                     continue
                 name, args = parsed
                 tool_calls.append(
@@ -306,10 +358,31 @@ class DeepSeekV31ToolParser(ToolParser):
                     }
                 )
 
+            # Detect truncated trailing blocks (``<call_begin>`` without
+            # a matching ``<call_end>`` inside the envelope) — these
+            # are also "malformed" for content-preservation purposes
+            # but ``_iter_block_bodies`` silently dropped them above.
+            has_truncated = self._has_any_open_or_unparsed_block(model_output)
+
             if tool_calls:
-                # Tool calls fired — content is anything strictly before
-                # the outer begin marker (V3.1 semantics).
-                content = model_output[: model_output.find(self.TOOL_CALLS_START)]
+                prefix_content = model_output[
+                    : model_output.find(self.TOOL_CALLS_START)
+                ]
+                # codex r8 BLOCKING-2: when ANY block was malformed or
+                # truncated, surface the post-envelope/raw text so the
+                # caller can decide whether to display it. Otherwise
+                # we lose model output. The "clean envelope" case
+                # (every block parsed cleanly) preserves the prefix-only
+                # content as before — V3.1 semantics.
+                if had_malformed or has_truncated:
+                    # Surface the prefix + everything from the envelope
+                    # onward (the model's raw text). This is verbose,
+                    # but the alternative (dropping it) loses data.
+                    # Callers that want only the prefix can detect the
+                    # envelope markers in ``content`` themselves.
+                    content = model_output
+                else:
+                    content = prefix_content
                 return ExtractedToolCallInformation(
                     tools_called=True,
                     tool_calls=tool_calls,

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -123,23 +123,6 @@ class DeepSeekV31ToolParser(ToolParser):
         self.current_tool_name_sent: bool = False
         self.streamed_args_for_tool: list[str] = []
 
-        # IDs we have already emitted on the streaming V3 short-circuit
-        # path, keyed by ABSOLUTE block index in the cumulative parse.
-        # We re-parse the cumulative text every time a block closes (so
-        # any newly-closed block is included), and we MUST NOT
-        # regenerate IDs for blocks we have already announced —
-        # downstream clients track tool calls by ID and seeing the same
-        # block under a new ID on every subsequent delta would corrupt
-        # their state (codex r1 BLOCKING).
-        #
-        # Must be keyed by absolute index, NOT a positional list:
-        # ``_streamed_v3_ids`` records ONLY V3 emissions; a V3.1 block
-        # in front of a V3 block makes the absolute index of the V3
-        # block 1 while ``len(_streamed_v3_ids)`` is 0 — a positional
-        # ``idx < len(...)`` would then re-emit the V3 block on every
-        # subsequent delta (codex r4 BLOCKING).
-        self._streamed_v3_ids: dict[int, str] = {}
-
         # V3.1 streaming regex (unchanged). V3-shaped streaming
         # arrives through the same regex because both shapes share the
         # ``NAME<sep>...`` skeleton; the V3 "function" type tag plus
@@ -253,84 +236,44 @@ class DeepSeekV31ToolParser(ToolParser):
         return name, args
 
     # -----------------------------------------------------------------
-    # Streaming helper — closed-V3 block recovery (codex r3 BLOCKING-2)
+    # Streaming helper — V3 presence sniffer.
     # -----------------------------------------------------------------
-    def _maybe_emit_closed_v3_blocks(
-        self, current_text: str, request: dict[str, Any] | None
-    ) -> dict[str, Any] | None:
-        """Scan the cumulative streamed text for closed V3-shaped blocks
-        that have not yet been announced via ``_streamed_v3_ids``. If
-        any exist, emit them now as a one-shot ``tool_calls`` delta and
-        return that delta. Otherwise return ``None`` and let the legacy
-        streaming path run.
+    @classmethod
+    def _cumulative_has_v3_block(cls, model_output: str) -> bool:
+        """Return ``True`` if any block (open or closed) in the
+        cumulative text has a V3-shaped body (starts with the literal
+        ``function<｜tool▁sep｜>`` type-tag-plus-separator).
 
-        Why this lives at the top of streaming dispatch: a single
-        delta may both close a V3 block AND open a non-V3-yet block,
-        in which case the open-block sniffer would miss the closed V3
-        (it only inspects the latest body). The cumulative scan catches
-        it regardless of what the next block is doing.
-
-        Indexing contract (codex r5 BLOCKING): emission indices are
-        ABSOLUTE block positions in the wire envelope (every
-        ``<call_begin>...<call_end>`` pair counts, including malformed
-        ones that ``extract_tool_calls`` drops). Decoupling our
-        position counter from the parsed-call list is what protects
-        against a malformed block shifting subsequent V3 indices.
+        Called every streaming delta. Once this returns ``True``, the
+        streaming path stops emitting and defers to the postprocessor's
+        end-of-stream ``extract_tool_calls`` fallback — see the
+        streaming gate comment in ``extract_tool_calls_streaming``.
         """
-        # Walk closed-block bodies in their ORIGINAL positions and
-        # parse each one inline. This is the same scanner
-        # ``extract_tool_calls`` uses, but we keep the block index
-        # stable even when ``_parse_block_body`` returns ``None`` for a
-        # malformed block — we just don't emit that block. The legacy
-        # non-streaming path is free to renumber, but a streaming
-        # parser's emission indices must match the wire positions so
-        # ``_streamed_v3_ids`` keys remain stable across deltas.
-        bodies = self._iter_block_bodies(current_text)
-        if not bodies:
-            return None
-
-        v3_marker = f"{_V3_TYPE_TAG}{self.TOOL_SEP}"
-        to_emit: list[tuple[int, str, str]] = []
-        for abs_idx, body in enumerate(bodies):
-            if abs_idx in self._streamed_v3_ids:
-                continue
-            stripped = body.lstrip("\n")
-            if not stripped.startswith(v3_marker):
-                # V3.1 (or unrecognised) — leave to legacy delta machine.
-                continue
-            parsed = self._parse_block_body(body)
-            if parsed is None:
-                # V3-anchored but malformed: don't emit and don't
-                # confuse the legacy machine either — the
-                # non-streaming finalize path will surface the raw
-                # text as content.
-                continue
-            name, args = parsed
-            to_emit.append((abs_idx, name, args))
-
-        if not to_emit:
-            return None
-
-        emitted: list[dict[str, Any]] = []
-        for abs_idx, name, args in to_emit:
-            tc_id = f"call_{uuid.uuid4().hex[:8]}"
-            self._streamed_v3_ids[abs_idx] = tc_id
-            # Advance ``current_tool_id`` past the just-emitted V3
-            # block (codex r5 BLOCKING: use ``max(...)`` to cover the
-            # ``abs_idx=0, current_tool_id=-1`` edge case explicitly).
-            self.current_tool_id = max(self.current_tool_id, abs_idx)
-            emitted.append(
-                {
-                    "index": abs_idx,
-                    "id": tc_id,
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "arguments": args,
-                    },
-                }
+        if cls.TOOL_CALL_START not in model_output:
+            return False
+        v3_marker = f"{_V3_TYPE_TAG}{cls.TOOL_SEP}"
+        # Scan every open/closed block body in order. We can't use
+        # ``_iter_block_bodies`` because that scanner skips
+        # not-yet-closed trailing blocks — for V3 detection we want
+        # the open trailing body too, since that's where the V3 type
+        # tag arrives first.
+        pos = 0
+        start_len = len(cls.TOOL_CALL_START)
+        end_len = len(cls.TOOL_CALL_END)
+        while True:
+            start = model_output.find(cls.TOOL_CALL_START, pos)
+            if start == -1:
+                return False
+            body_start = start + start_len
+            end = model_output.find(cls.TOOL_CALL_END, body_start)
+            body = (
+                model_output[body_start:end] if end != -1 else model_output[body_start:]
             )
-        return {"tool_calls": emitted}
+            if body.lstrip("\n").startswith(v3_marker):
+                return True
+            if end == -1:
+                return False
+            pos = end + end_len
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -410,7 +353,6 @@ class DeepSeekV31ToolParser(ToolParser):
             self.streamed_args_for_tool = []
             self.current_tool_id = -1
             self.prev_tool_call_arr = []
-            self._streamed_v3_ids = {}
 
         current_token_ids = current_token_ids or []
         previous_token_ids = previous_token_ids or []
@@ -433,52 +375,30 @@ class DeepSeekV31ToolParser(ToolParser):
         # ``name="function"`` mid-stream for V3 bodies because the
         # literal ``function`` type tag *is* what arrives first.
         #
-        # The gate has two responsibilities, applied in order:
+        # Design decision: instead of trying to interleave V3 and V3.1
+        # emissions through the legacy delta machine (codex r3/r4/r5/r6
+        # discovered escalating composition bugs around malformed
+        # blocks, mixed V3/V3.1 envelopes, and delta boundaries), we
+        # SUPPRESS streaming emissions entirely once a V3-confirmed
+        # body is seen ANYWHERE in the cumulative text. The
+        # postprocessor's end-of-stream fallback path (see
+        # ``vllm_mlx/service/postprocessor.py`` "Fallback tool call
+        # detection") calls ``extract_tool_calls`` on the cumulative
+        # buffer when ``tool_calls_detected`` was never flipped — that
+        # path runs the now-fixed block-wise scanner and emits a
+        # well-formed one-shot ``tool_call`` event per block.
         #
-        #   A. Detect V3 in any CLOSED block via the cumulative
-        #      non-streaming parser. If a V3 block has closed but
-        #      hasn't yet been announced (tracked by
-        #      ``self._streamed_v3_ids``), emit it now. This handles
-        #      the "delta closes a V3 block and also opens an empty
-        #      next block" case (codex r3 BLOCKING-2): the V3 detection
-        #      lives in the closed-block scan, not in inspection of
-        #      the latest possibly-open body.
-        #
-        #   B. For the currently-OPEN block: buffer silently only when
-        #      V3 is *confirmed* by the body starting with
-        #      ``function<｜tool▁sep｜>`` (the V3 type tag + separator).
-        #      We do NOT buffer on a mere prefix-could-become-V3 because
-        #      a V3.1 tool whose name happens to start with ``f``,
-        #      ``fun``, ``function_lookup`` etc. would otherwise be
-        #      swallowed (codex r3 BLOCKING-1) and the legacy state
-        #      machine never gets to advance ``current_tool_id``.
-        #
-        # The closed-V3-emit path runs first because it must fire even
-        # when the *latest* (possibly empty) block isn't V3-confirmed
-        # but a previously-closed block was V3.
+        # Tradeoff: V3 streams don't see incremental token-by-token
+        # ``function.arguments`` deltas — clients receive one
+        # ``tool_call`` event per call at end-of-stream. This matches
+        # how other "wrapped" parsers (GLM-4.7, Seed-OSS) already
+        # behave for their wrapper formats and is the conservative
+        # contract until a model emerges that actually demands V3
+        # streaming. V3.1 streams are unchanged (legacy delta machine
+        # still runs).
         # ----------------------------------------------------------------
-        cur_start_count = current_text.count(self.TOOL_CALL_START)
-        cur_end_count = current_text.count(self.TOOL_CALL_END)
-        v3_marker = f"{_V3_TYPE_TAG}{self.TOOL_SEP}"
-
-        # --- A. Closed V3 block recovery ---
-        # Scan the closed blocks for V3-shaped bodies; emit any whose
-        # absolute index hasn't been streamed yet.
-        closed_v3_emit = self._maybe_emit_closed_v3_blocks(current_text, request)
-        if closed_v3_emit is not None:
-            return closed_v3_emit
-
-        # --- B. Open-block confirmed-V3 buffer ---
-        # Latest (possibly open) block body.
-        is_block_open = cur_end_count < cur_start_count
-        if is_block_open:
-            tail = current_text.split(self.TOOL_CALL_START)[-1]
-            open_body = tail.split(self.TOOL_CALL_END)[0].lstrip("\n")
-            if open_body.startswith(v3_marker):
-                # V3 confirmed in open block — silently buffer. The
-                # closed-V3 path will emit it once <call_end> lands in
-                # a later delta.
-                return None
+        if self._cumulative_has_v3_block(current_text):
+            return None
 
         delta_text = delta_text.replace(self.TOOL_CALLS_START, "").replace(
             self.TOOL_CALLS_END, ""

--- a/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseekv31_tool_parser.py
@@ -123,6 +123,15 @@ class DeepSeekV31ToolParser(ToolParser):
         self.current_tool_name_sent: bool = False
         self.streamed_args_for_tool: list[str] = []
 
+        # IDs we have already emitted on the streaming V3 short-circuit
+        # path. We re-parse the cumulative text every time a block
+        # closes (so any newly-closed block is included), but we MUST
+        # NOT regenerate the IDs of blocks we have already announced —
+        # downstream clients track tool calls by ID and seeing the same
+        # block under a new ID on every subsequent delta would corrupt
+        # their state (codex r1 BLOCKING).
+        self._streamed_v3_ids: list[str] = []
+
         # V3.1 streaming regex (unchanged). V3-shaped streaming
         # arrives through the same regex because both shapes share the
         # ``NAME<sep>...`` skeleton; the V3 "function" type tag plus
@@ -294,6 +303,7 @@ class DeepSeekV31ToolParser(ToolParser):
             self.streamed_args_for_tool = []
             self.current_tool_id = -1
             self.prev_tool_call_arr = []
+            self._streamed_v3_ids = []
 
         current_token_ids = current_token_ids or []
         previous_token_ids = previous_token_ids or []
@@ -345,13 +355,16 @@ class DeepSeekV31ToolParser(ToolParser):
 
         # Confirmed V3 once the type-tag-plus-sep is in the body.
         is_v3_confirmed = latest_body_stripped.startswith(v3_marker)
-        # Ambiguous prefix while the body is shorter than ``function<sep>``
-        # and still a prefix of it. We buffer in this state because
-        # committing to either path now would force a re-emission later.
+        # Ambiguous prefix while the body has at least one character but
+        # is still a strict prefix of ``function<sep>``. We require >=1
+        # body character (codex r1 BLOCKING — every string starts with
+        # ``""`` so the empty-body case would otherwise hijack legitimate
+        # V3.1 streams that ended right after ``<call_begin>`` and
+        # haven't yet emitted a single body byte).
         body_could_be_v3 = (
             not is_v3_confirmed
             and cur_end_count < cur_start_count  # block still open
-            and len(latest_body_stripped) < len(v3_marker)
+            and 0 < len(latest_body_stripped) < len(v3_marker)
             and v3_marker.startswith(latest_body_stripped)
         )
 
@@ -361,7 +374,7 @@ class DeepSeekV31ToolParser(ToolParser):
                 return None
             # At least one block closed. Run the canonical non-streaming
             # extract on the cumulative text and emit any closed-block
-            # tool calls we haven't emitted yet. ``current_tool_id``
+            # tool calls we haven't announced yet. ``current_tool_id``
             # tracks the highest already-emitted index (-1 = none).
             prev_end_count = previous_text.count(self.TOOL_CALL_END)
             newly_closed = cur_end_count - prev_end_count
@@ -374,21 +387,34 @@ class DeepSeekV31ToolParser(ToolParser):
             tail_calls = result.tool_calls[start_idx : start_idx + newly_closed]
             if not tail_calls:
                 return None
-            self.current_tool_id += len(tail_calls)
-            return {
-                "tool_calls": [
+            # Stable IDs across re-parses (codex r1 BLOCKING):
+            # ``extract_tool_calls`` generates a fresh ``call_xxxx`` ID
+            # every invocation, but we re-invoke it every time a block
+            # closes — so previously-emitted blocks would get new IDs on
+            # later deltas. Cache the IDs we have already announced and
+            # only mint a new ID when the parsed list grows past what
+            # we've previously cached.
+            emitted: list[dict[str, Any]] = []
+            for i, tc in enumerate(tail_calls):
+                absolute_idx = start_idx + i
+                if absolute_idx < len(self._streamed_v3_ids):
+                    tc_id = self._streamed_v3_ids[absolute_idx]
+                else:
+                    tc_id = tc["id"]
+                    self._streamed_v3_ids.append(tc_id)
+                emitted.append(
                     {
-                        "index": start_idx + i,
-                        "id": tc["id"],
+                        "index": absolute_idx,
+                        "id": tc_id,
                         "type": "function",
                         "function": {
                             "name": tc["name"],
                             "arguments": tc["arguments"],
                         },
                     }
-                    for i, tc in enumerate(tail_calls)
-                ],
-            }
+                )
+            self.current_tool_id += len(tail_calls)
+            return {"tool_calls": emitted}
 
         delta_text = delta_text.replace(self.TOOL_CALLS_START, "").replace(
             self.TOOL_CALLS_END, ""


### PR DESCRIPTION
## Bug (D-DSV31, P0)

`deepseek_v31` tool parser did NOT match what DeepSeek-R1-0528-Qwen3-8B actually emits. Its `chat_template.jinja` was inherited from DeepSeek-V3 and produces the V3 fenced-JSON tool-call body shape:

```
<｜tool▁calls▁begin｜>
<｜tool▁call▁begin｜>function<｜tool▁sep｜>NAME
` ` `json
{ARGS}
` ` `<｜tool▁call▁end｜>
<｜tool▁calls▁end｜>
```

`aliases.json` points `deepseek-r1-8b-4bit` at the `deepseek_v31` parser. The parser's V3.1-only regex greedily matched `function<sep>NAME\n` `\`\`\`` `json\n{...}\n` `\`\`\`` `<end>` as `name="function"`, `arguments="NAME\n` `\`\`\`` `json\n{...}\n` `\`\`\`` `"` — the type tag became the function name and the real name + fenced JSON became the args string. Downstream OpenAI clients then attempted to invoke a tool literally named `function` with garbage arguments.

### Repro (unit, before fix)

```python
from vllm_mlx.tool_parsers.deepseekv31_tool_parser import DeepSeekV31ToolParser
raw = ('<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       'get_weather\n```json\n{"city": "Tokyo"}\n```<｜tool▁call▁end｜>'
       '<｜tool▁calls▁end｜>')
DeepSeekV31ToolParser().extract_tool_calls(raw)
# tool_calls=[{'name': 'function',
#              'arguments': 'get_weather\n```json\n{"city": "Tokyo"}\n```'}]
```

Captured at `/tmp/d-dsv31-before.json`.

## Fix (Option B — block-wise scanner with body auto-detect)

The `deepseek_v31` parser now recognizes both wire shapes. Implementation choice:

- **Single parser, two body shapes.** The outer envelope (`<calls_begin>` / `<calls_end>`) and block envelope (`<call_begin>` / `<call_end>`) are shared between V3 and V3.1. Only the body inside each block differs (V3: `function<sep>NAME\n` `\`\`\`` `json\n{...}\n` `\`\`\``; V3.1: `NAME<sep>ARGS`). One parser per family with per-block sniffing is cleaner than splitting into two parser classes.
- **State machine, not regex band-aid.** A forward-scanning scanner (`_iter_block_bodies`) bounded to `_envelope_bounds()` finds each `<call_begin>` / `<call_end>` pair in order rather than relying on a greedy regex over the whole payload. This is what makes parallel calls parse as N entries instead of one over-greedy match, what makes a truncated trailing block drop cleanly rather than swallow the rest of the payload, and what prevents literal marker text in plain content from being misparsed as a tool call.
- **Body classifier (`_parse_block_body`)** anchors on `function<sep>` at the body start — that's what the V3 chat template always emits and what V3.1 never emits. A V3.1 tool literally named `function_lookup` is not misclassified because the V3 sniffer requires the type-tag immediately followed by the separator.
- **Strict V3 parsing — no partial recovery.** A V3-anchored body that fails both the strict and tolerant fenced-JSON regex is dropped entirely (return `None`). The raw text passes through in `content` so the caller can decide. Avoids emitting tool calls with truncated / non-JSON arguments that would reach downstream tool execution.
- **V3 streaming suppression.** Once any V3-confirmed body appears inside the envelope, `extract_tool_calls_streaming` returns `None` for every delta. The postprocessor's end-of-stream "Fallback tool call detection" path then calls the now-fixed `extract_tool_calls` on the cumulative buffer and emits a well-formed one-shot `tool_call` event per V3 block. V3.1 streams are entirely unchanged. (Note: mixed V3.1+V3 envelopes in a single stream are documented as NOT SUPPORTED — released DeepSeek chat templates never produce them.)
- **Registration left at `["deepseek_v31", "deepseek_r1_0528"]`.** The pre-existing `DeepSeekToolParser` (registered as `deepseek` / `deepseek_v3` / `deepseek_r1`) is unchanged — only the V3.1 alias group is widened to also handle V3. This keeps the change surgical: every alias the bug affects (`deepseek-r1-8b-4bit`) is routed through the fixed code path; no other model's parser routing is touched.
- **Argument body passthrough.** The upstream vLLM contract is bytes-equal passthrough of the args body — no JSON canonicalization. This preserves `tests/test_upstream_regression.py::TestDeepSeekV31UpstreamNonStreaming`'s `{"x":1}` exact-bytes assertion.

## Test plan

New test file: `tests/test_deepseek_v3_tool_parser.py` (28 tests).

- [x] Wire-format primitives use fullwidth-pipe U+FF5C (not ASCII)
- [x] Registry lookup `ToolParserManager.get_tool_parser("deepseek_v31"|"deepseek_r1_0528")` returns `DeepSeekV31ToolParser` (the alias paths actually reach the fix)
- [x] **V3 single tool call** — `name="get_weather"`, `arguments='{"city": "Tokyo"}'` (the P0 case)
- [x] **V3 parallel** — 3 blocks → 3 distinct calls in order, each with correct name + args
- [x] V3 with leading reasoning content preserved
- [x] V3 with nested JSON args (filter, tags array) — fence detector not confused
- [x] V3.1 single + parallel — regression: pre-existing shape still works
- [x] V3.1 tool named `function_lookup` NOT misclassified as V3 (anchored sniffer)
- [x] Mixed V3 + V3.1 blocks in one envelope → both parse per-block (non-streaming)
- [x] Malformed: no-envelope passthrough / truncated / envelope-no-blocks / missing-sep / one-good-one-bad parallel
- [x] V3-anchored body with broken fence does NOT mis-emit `name="function"`
- [x] V3-anchored body with partial fence DROPS the block (no truncated-JSON args reach downstream)
- [x] Literal `<call_begin>` marker text in prose before envelope does not misparse
- [x] Envelope with truncated trailing block preserves the raw text in `content`
- [x] Args bytes pass through verbatim (upstream contract: `'{   "k"  :  1  }'` survives)
- [x] **Streaming V3** — zero mid-stream `tool_calls` events (no `name="function"` leak); non-streaming extract produces correct names
- [x] **Streaming V3 integration** — drive V3 payload through real `StreamingPostProcessor` chunk-by-chunk; `finalize()` emits `tool_call` event with `name="get_weather"` (NOT `"function"`)
- [x] Streaming V3.1 `function_lookup` (V3 type-tag-prefix collision) streams normally
- [x] Streaming V3.1 single-char chunked — empty-body intermediate state does NOT trip V3 suppression
- [x] All 1208 tool-parser / streaming / regression tests pass (`pytest -k "deepseek or tool_parser or tool_parsers or native_tool or streaming or postprocessor"`)
- [x] `ruff check + ruff format` clean on touched files
- [x] **codex adversarial review converged (PR validate r11): 0 BLOCKING findings** (after 10 rounds addressing envelope-bounded scanning, stable IDs, mixed-envelope contract, malformed block handling, integration testing, and partial-fence drop semantics)

### Post-merge verification (tracked, not gating)

Live-server end-to-end repro on `deepseek-r1-8b-4bit` was attempted but produces unreliable output for verification because (a) the model at 4-bit + temp=0 often emits fenced-JSON OUTSIDE the DeepSeek-native envelope rather than inside it, and (b) D-DETOK-BPE (a separate documented bug) is still leaking raw BPE markers (`Ġ`, `Ċ`) into `content`. The bug fix is verified end-to-end at the unit/integration level via the parser interface the server's `helpers.py:1667` calls (`parser.extract_tool_calls(output_text, request_dict)`) AND via the integration test that drives the real `StreamingPostProcessor`. Once D-DETOK-BPE lands, a live server-level smoke test can confirm the request-response cycle. The before-envelope is at `/tmp/d-dsv31-before.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)