### PR TITLE
fix(metrics): wire M-01 sub-counter on prod AsyncEngineCore shape + fix 2x over-count race (D-M01-DEAD + D-M01-2X)

### DIFF
--- a/tests/test_cancelled_requests_metric.py
+++ b/tests/test_cancelled_requests_metric.py
@@ -170,27 +170,23 @@ def test_total_counter_is_idempotent_against_double_enqueue():
 
 
 def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
-    """Codex r3 BLOCKING #1: ``_cancelled_request_ids`` is an
-    ACTIVE-LIFETIME guard, not a process-lifetime ledger. Reusing the
-    same ``request_id`` for a NEW distinct request (after the prior
-    lifetime fully aborted AND was popped from ``self.requests``) MUST
-    increment the counter.
+    """``_cancelled_request_ids`` is an ACTIVE-LIFETIME guard, not a
+    process-lifetime ledger. Reusing the same ``request_id`` for a
+    NEW distinct request (after the prior lifetime fully aborted)
+    MUST increment the counter.
 
-    Pre-r3-fix the lifetime ledger persisted until ``reset()``, so
-    integrations that hash request_ids deterministically (or clients
-    that retry the same operation with a stable id) would silently
-    see their second cancel omitted from ``num_requests_cancelled``.
-    The r3 fix discards the id from BOTH dedupe ledgers inside
-    ``_do_abort_request`` so a future request with the same id
-    starts from a clean ledger.
-
-    Lifecycle: ``_do_abort_request`` clears the deduper but the text
-    scheduler keeps the ``Request`` object in ``self.requests`` until
-    a separate ``remove_finished_request`` call removes it (the
-    engine_core cleanup path). We drive that explicitly here to
-    mirror the production order — only AFTER the request is fully
-    out of the scheduler will the abort_request predicate take
-    the ``not in self.requests`` branch and require a fresh admit.
+    D-M01-2X (0.8.2 dogfood) update: the lifetime boundary that
+    clears the dedupe ledger moved from ``remove_finished_request``
+    to ``add_request``. The OLD boundary opened a multi-branch race
+    where the disconnect_guard's three force-abort fires (or the
+    deferred async-fallback coroutine) could re-enter
+    ``scheduler.abort_request`` AFTER ``_cleanup_request`` had
+    wiped the ledger but BEFORE ``_pending_abort_ids`` drained,
+    double-counting the same lifetime. Three PyPI 0.8.2 personas
+    independently reported the 2x over-count fingerprint. Moving
+    the clear to fresh-admit preserves the reuse semantics (this
+    test) while keeping the ledger lifetime-persistent across the
+    abort+cleanup window.
     """
     scheduler = _make_scheduler()
 
@@ -199,21 +195,27 @@ def test_total_counter_counts_reused_request_id_after_full_abort_cycle():
     assert scheduler.abort_request("req-reused") is True
     assert scheduler.get_stats()["num_requests_cancelled"] == 1
     scheduler._process_pending_aborts()
-    # Codex r4 fix: the dedupe ledger MUST stay populated until the
-    # request actually leaves ``self.requests``. Otherwise a
-    # redundant ``abort_request`` arriving while the request is
-    # mid-cleanup would observe ``in self.requests`` AND an empty
-    # ledger and double-count the same lifetime.
+    # Dedupe ledger stays populated past _do_abort_request — that's
+    # the long-standing codex r4 invariant.
     assert "req-reused" in scheduler._cancelled_request_ids
-    # Engine-core cleanup: remove the finished request from the
-    # scheduler's request map; the discard of the dedupe ledger
-    # happens HERE per codex r4.
+    # Engine-core cleanup pops self.requests but the dedupe ledger
+    # now persists past remove_finished_request (D-M01-2X fix). The
+    # ledger is the lifetime-cumulative dedupe; clearing it inside
+    # ``remove_finished_request`` was what opened the 0.8.2 dogfood
+    # race surface.
     scheduler.remove_finished_request("req-reused")
     assert "req-reused" not in scheduler.requests
-    assert "req-reused" not in scheduler._cancelled_request_ids
+    assert "req-reused" in scheduler._cancelled_request_ids, (
+        "ledger MUST persist past remove_finished_request — see "
+        "Scheduler.remove_finished_request docstring for the race"
+    )
 
-    # Second lifetime: distinct request, same id.
+    # Second lifetime: distinct request, same id. Fresh add_request
+    # clears the ledger entry for this id under the same lock that
+    # abort_request re-validates against, so the new lifetime
+    # starts from a clean dedupe state.
     _admit(scheduler, "req-reused")
+    assert "req-reused" not in scheduler._cancelled_request_ids
     assert scheduler.abort_request("req-reused") is True
     # MUST count again — the new request is a distinct cancel.
     assert scheduler.get_stats()["num_requests_cancelled"] == 2
@@ -298,27 +300,19 @@ def test_abort_request_revalidates_membership_under_lock():
     assert scheduler.get_stats()["num_requests_cancelled"] == 0
 
 
-def test_remove_finished_request_pops_and_discards_atomically():
-    """Codex r5 BLOCKING: ``remove_finished_request`` must perform
-    the ``self.requests.pop`` AND the dedupe-ledger discards
-    inside a single critical section so a concurrent
-    ``abort_request`` cannot observe ``request_id in self.requests``
-    AND an empty ledger.
+def test_remove_finished_request_pops_under_lock():
+    """``remove_finished_request`` must perform the
+    ``self.requests.pop`` inside the cancellation lock so concurrent
+    ``abort_request`` callers see a consistent transition (id either
+    fully resident or fully gone).
 
-    Pre-r5-fix the discards happened under the lock but the pop
-    was outside, opening a window where a racing thread saw:
-      * ``request_id in self.requests``  (pop hadn't run yet)
-      * ``request_id not in _cancelled_request_ids`` (discard
-        already cleared it)
-    → double-count of the same request lifetime.
-
-    Test approach: monkeypatch ``self.requests.pop`` to verify the
-    lock is HELD across both ``pop`` and ``discard``. We can't
-    reliably exercise the race via real threads (the window is
-    microseconds), so we assert the ordering contract by tracking
-    when each operation runs relative to the lock state. A
-    regression that moves either operation out of the critical
-    section flips one of the assertions.
+    D-M01-2X (0.8.2 dogfood) update: the dedupe-ledger discard moved
+    OUT of this method — it's now lifetime-persistent and cleared
+    at fresh ``add_request``. See
+    ``Scheduler.remove_finished_request`` docstring for the
+    multi-branch race repro. The pop staying under the lock is
+    still the codex r5 atomicity contract — only the discard
+    moved.
     """
     scheduler = _make_scheduler()
     _admit(scheduler, "req-atomic-cleanup")
@@ -328,11 +322,6 @@ def test_remove_finished_request_pops_and_discards_atomically():
     assert "req-atomic-cleanup" in scheduler._cancelled_request_ids
     assert "req-atomic-cleanup" in scheduler.requests
 
-    # Wrap ``self.requests`` and ``_cancelled_request_ids`` with
-    # observers that snapshot the lock state at each mutation.
-    # Can't monkeypatch ``dict.pop`` / ``set.discard`` directly
-    # (they're slot-defined read-only), so we replace the whole
-    # container with a subclass.
     lock = scheduler._cancel_counter_lock
 
     class _DictObserver(dict):
@@ -344,32 +333,19 @@ def test_remove_finished_request_pops_and_discards_atomically():
             self.pop_lock_states.append(lock.locked())
             return super().pop(*args, **kwargs)
 
-    class _SetObserver(set):
-        def __init__(self, src):
-            super().__init__(src)
-            self.discard_lock_states: list[bool] = []
-
-        def discard(self, *args, **kwargs):
-            self.discard_lock_states.append(lock.locked())
-            return super().discard(*args, **kwargs)
-
     scheduler.requests = _DictObserver(scheduler.requests)
-    scheduler._cancelled_request_ids = _SetObserver(scheduler._cancelled_request_ids)
-    scheduler._disconnect_abort_ids = _SetObserver(scheduler._disconnect_abort_ids)
 
     scheduler.remove_finished_request("req-atomic-cleanup")
 
-    # Both operations must have observed the lock held — that's
-    # the codex r5 contract.
+    # The pop must have observed the lock held — codex r5 atomicity.
     assert scheduler.requests.pop_lock_states == [True], (
         scheduler.requests.pop_lock_states
     )
-    assert scheduler._cancelled_request_ids.discard_lock_states == [True], (
-        scheduler._cancelled_request_ids.discard_lock_states
-    )
-    # Sanity: the actual cleanup happened.
+    # Sanity: the actual cleanup happened on the request map.
     assert "req-atomic-cleanup" not in scheduler.requests
-    assert "req-atomic-cleanup" not in scheduler._cancelled_request_ids
+    # D-M01-2X: ledger is lifetime-persistent, NOT cleared by
+    # remove_finished_request.
+    assert "req-atomic-cleanup" in scheduler._cancelled_request_ids
 
 
 def test_total_counter_does_not_double_count_redundant_abort_pre_cleanup():
@@ -404,13 +380,15 @@ def test_total_counter_does_not_double_count_redundant_abort_pre_cleanup():
 
 
 def test_disconnect_subcounter_counts_reused_request_id_after_full_abort_cycle():
-    """Codex r3 BLOCKING #2 symmetry: the via_disconnect sub-counter
-    must also re-count a reused ``request_id`` after the prior
-    lifetime completed.
+    """The via_disconnect sub-counter must re-count a reused
+    ``request_id`` after the prior lifetime completed (symmetry
+    with the total counter).
 
-    Same rationale as the total counter — keeping the id in
-    ``_disconnect_abort_ids`` past the request's lifetime would
-    silently swallow attribution for the next distinct request.
+    D-M01-2X (0.8.2 dogfood) update: the dedupe-clear boundary moved
+    from ``remove_finished_request`` to ``add_request``. The ledger
+    now persists past cleanup (plugging the multi-branch race) and
+    is wiped on fresh admit (preserving the reuse semantics this
+    test pins).
     """
     scheduler = _make_scheduler()
 
@@ -420,13 +398,16 @@ def test_disconnect_subcounter_counts_reused_request_id_after_full_abort_cycle()
     scheduler.record_disconnect_abort("req-disc-reused")
     assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 1
     scheduler._process_pending_aborts()
-    # Codex r4: still in ledger until remove_finished_request.
     assert "req-disc-reused" in scheduler._disconnect_abort_ids
     scheduler.remove_finished_request("req-disc-reused")
-    assert "req-disc-reused" not in scheduler._disconnect_abort_ids
+    # D-M01-2X: ledger persists past cleanup.
+    assert "req-disc-reused" in scheduler._disconnect_abort_ids
 
-    # Second lifetime: distinct request reusing the id.
+    # Second lifetime: distinct request reusing the id. Fresh admit
+    # wipes the dedupe ledgers for that id, so the new lifetime
+    # starts clean and the sub-counter advances.
     _admit(scheduler, "req-disc-reused")
+    assert "req-disc-reused" not in scheduler._disconnect_abort_ids
     scheduler.abort_request("req-disc-reused")
     scheduler.record_disconnect_abort("req-disc-reused")
     assert scheduler.get_stats()["num_requests_cancelled_via_disconnect"] == 2

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-M01-DEAD + D-M01-2X regression: pin counter behaviour on the
+PRODUCTION ``BatchedEngine`` over ``AsyncEngineCore`` shape.
+
+Background
+----------
+0.8.2 dogfood (3 independent personas) reported on PyPI 0.8.2:
+
+* **D-M01-DEAD**: ``rapid_mlx_requests_cancelled_via_disconnect_total``
+  NEVER increments under real client disconnect on the production
+  ``rapid-mlx serve`` engine shape, even though
+  ``[disconnect_guard] force-abort`` warnings fire every time.
+* **D-M01-2X**: ``rapid_mlx_requests_cancelled_total`` over-counts 2x
+  on every BatchedEngine disconnect — 20 ticks for 10 actual aborts.
+
+PR #783's 9 rounds of codex review covered SYNTHETIC engine shapes
+(``engine.scheduler`` directly, or ``engine._engine.scheduler`` one
+hop deep). The real production shape is ``BatchedEngine._engine`` →
+``AsyncEngineCore.engine`` → ``EngineCore.scheduler`` — TWO hops past
+``_engine``, where ``AsyncEngineCore`` does NOT expose ``.scheduler``
+directly. The previous tests under
+``tests/test_disconnect_guard_aborts_scheduler.py`` and
+``tests/test_cancelled_requests_metric.py`` did NOT reproduce this
+shape, so the resolvers + dedupe-ledger race went uncaught.
+
+The two root causes
+-------------------
+1. ``_resolve_sync_scheduler_for_abort`` only walked one hop past
+   ``engine._engine`` and missed the production deep path. Result:
+   ``_force_abort_request`` falls into the async fallback every time,
+   logs the "force-abort fell back to async" warning, and never
+   reaches the sync scheduler entry directly.
+
+2. ``Scheduler.remove_finished_request`` discarded the lifetime
+   ledgers (``_cancelled_request_ids`` and ``_disconnect_abort_ids``)
+   when called by ``EngineCore._cleanup_request``. The deferred
+   ``_await_and_record`` coroutine that runs after the async fallback
+   then sees a wiped ledger and:
+     * RE-INCREMENTS the total counter on the second
+       ``scheduler.abort_request`` call (the id is still in
+       ``_pending_abort_ids`` so the membership check passes, but
+       ``already_counted`` reads False from the cleared ledger),
+       producing the 2x over-count.
+     * The disconnect sub-counter then NO-OPS because
+       ``record_disconnect_abort`` runs AFTER ``_cleanup_request`` has
+       wiped ``_cancelled_request_ids``, so the lifetime-ledger gate
+       at the top of ``record_disconnect_abort`` silently returns.
+
+The tests below build the EXACT production engine shape with stubbed
+mlx-step internals and pin both invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyTokenizer:
+    """Identity tokenizer good enough for Scheduler.add_request."""
+
+    eos_token_id = None
+
+    def encode(self, prompt):
+        if isinstance(prompt, str):
+            return [ord(c) for c in prompt]
+        return list(prompt)
+
+    def decode(self, token_ids):
+        return "".join(chr(t) for t in token_ids)
+
+
+def _make_scheduler() -> Scheduler:
+    return Scheduler(
+        model=object(),
+        tokenizer=_DummyTokenizer(),
+        config=SchedulerConfig(
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+        ),
+    )
+
+
+def _admit(scheduler: Scheduler, request_id: str) -> None:
+    """Stage a request so ``abort_request`` finds it in ``self.requests``."""
+    request = Request(
+        request_id=request_id,
+        prompt=[42],
+        sampling_params=SamplingParams(max_tokens=128),
+    )
+    scheduler.add_request(request)
+
+
+class _EngineCoreLike:
+    """Mimics ``EngineCore`` for the production shape: exposes
+    ``.scheduler`` and re-implements ``abort_request`` + ``_cleanup_request``
+    EXACTLY as the production version does.
+
+    The production sequence — ``self.scheduler.abort_request(rid)``
+    followed by ``self._cleanup_request(rid)`` (which calls
+    ``self.scheduler.remove_finished_request(rid)``) — is what races
+    the deferred attribution helper. We mirror it byte-for-byte so the
+    pin is faithful.
+    """
+
+    def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
+
+    async def abort_request(self, request_id: str) -> bool:
+        result = self.scheduler.abort_request(request_id)
+        self._cleanup_request(request_id)
+        return result
+
+    def _cleanup_request(self, request_id: str) -> None:
+        self.scheduler.remove_finished_request(request_id)
+
+
+class _AsyncEngineCoreLike:
+    """Mimics ``AsyncEngineCore``: wraps an ``EngineCore``-like as
+    ``self.engine`` and forwards ``abort_request``. Does NOT expose
+    ``.scheduler`` directly — that's the production gap PR #783 missed.
+    """
+
+    def __init__(self, engine_core: _EngineCoreLike):
+        self.engine = engine_core
+
+    async def abort_request(self, request_id: str) -> bool:
+        return await self.engine.abort_request(request_id)
+
+
+class _BatchedEngineLike:
+    """Mimics ``BatchedEngine`` over ``AsyncEngineCore``: exposes
+    ``_engine`` (the AsyncEngineCore) and the ``_is_mllm`` flag.
+    Does NOT expose ``.scheduler`` directly.
+
+    The public ``abort_request`` mirrors ``BatchedEngine.abort_request``
+    — async, awaitable, routes through ``self._engine.abort_request``.
+    """
+
+    def __init__(self, async_engine_core: _AsyncEngineCoreLike):
+        self._engine = async_engine_core
+        self._mllm_scheduler = None
+        self._is_mllm = False
+
+    async def abort_request(self, request_id: str) -> bool:
+        return await self._engine.abort_request(request_id)
+
+
+# ---------------------------------------------------------------------------
+# D-M01-DEAD: via_disconnect sub-counter advances on prod shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disconnect_subcounter_advances_on_prod_engine_shape():
+    """``rapid_mlx_requests_cancelled_via_disconnect_total`` MUST
+    increment by exactly 1 per disconnect-driven abort on the
+    production ``BatchedEngine`` over ``AsyncEngineCore`` shape.
+
+    Pre-fix repro: PR #783's resolvers couldn't reach the deep
+    scheduler from the sync abort path, so ``_force_abort_request``
+    fell into the async fallback. The deferred coroutine ran
+    ``EngineCore.abort_request`` which called ``scheduler.abort_request``
+    AND ``_cleanup_request`` (wiping the lifetime ledger). The
+    attribution helper that runs AFTER the coroutine then sees an
+    empty ledger and the gate at the top of
+    ``record_disconnect_abort`` silently returns. The dogfood
+    fingerprint: ``via_disconnect_total`` stays flat-zero through
+    every real client disconnect.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    scheduler = _make_scheduler()
+    engine_core = _EngineCoreLike(scheduler)
+    async_core = _AsyncEngineCoreLike(engine_core)
+    engine = _BatchedEngineLike(async_core)
+
+    request_id = "req-prod-shape-dead"
+    _admit(scheduler, request_id)
+
+    holder = [request_id]
+    # Fire the force-abort exactly the way disconnect_guard does.
+    _force_abort_request(engine, holder)
+    # Allow the deferred async coroutine (if any) to run.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled_via_disconnect"] == 1, (
+        "D-M01-DEAD: via_disconnect sub-counter did not advance on "
+        f"production engine shape — got {stats}"
+    )
+    # Invariant: via_disconnect <= total always holds.
+    assert (
+        stats["num_requests_cancelled_via_disconnect"]
+        <= stats["num_requests_cancelled"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-M01-2X: total counter increments exactly once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_total_counter_no_2x_overcount_on_prod_shape():
+    """``rapid_mlx_requests_cancelled_total`` MUST advance by exactly
+    1 per abort on the production engine shape — not 2 (or more).
+
+    Pre-fix repro: the disconnect_guard fires ``_force_abort_request``
+    from up to three branches. Under the async fallback each fire
+    schedules a ``_await_and_record`` coroutine. The coroutine calls
+    ``scheduler.abort_request`` AND ``_cleanup_request``. The cleanup
+    wipes ``_cancelled_request_ids``, so the NEXT
+    ``scheduler.abort_request`` (from another fire branch, or from
+    ``stream_outputs.finally``) sees an empty ledger and re-counts.
+    The dogfood fingerprint: 10 aborts → 20 ticks.
+
+    The pin: ONE id, multiple force-abort fires (mirroring the
+    three-branch helper), total counter advances by exactly 1.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    scheduler = _make_scheduler()
+    engine_core = _EngineCoreLike(scheduler)
+    async_core = _AsyncEngineCoreLike(engine_core)
+    engine = _BatchedEngineLike(async_core)
+
+    request_id = "req-prod-shape-2x"
+    _admit(scheduler, request_id)
+
+    holder = [request_id]
+    # disconnect_guard fires _force_abort_request from BOTH the
+    # disconnect branch AND the finally belt-and-suspenders. Replay
+    # the same two-fire pattern here.
+    _force_abort_request(engine, holder)
+    _force_abort_request(engine, holder)
+    # Drain whatever ensure_future coroutines were scheduled.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 1, (
+        "D-M01-2X: total counter over-counted on production engine "
+        f"shape — got {stats}"
+    )
+    assert stats["num_requests_cancelled_via_disconnect"] == 1
+    # Invariant: via_disconnect <= total always holds.
+    assert (
+        stats["num_requests_cancelled_via_disconnect"]
+        <= stats["num_requests_cancelled"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Combined: 10 aborts on the prod shape → 10 / 10, not 20 / 0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
+    """End-to-end repro of the dogfood numbers: 10 distinct client
+    disconnects on the production engine shape yield
+    ``cancelled_total=10`` AND ``cancelled_via_disconnect_total=10``
+    — not the 0.8.2 ``20 / 0`` shape three personas observed.
+    """
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    scheduler = _make_scheduler()
+    engine_core = _EngineCoreLike(scheduler)
+    async_core = _AsyncEngineCoreLike(engine_core)
+    engine = _BatchedEngineLike(async_core)
+
+    for i in range(10):
+        rid = f"req-disc-{i}"
+        _admit(scheduler, rid)
+        holder = [rid]
+        # Two fires per disconnect to match disconnect_guard's branches
+        # (disconnect + finally).
+        _force_abort_request(engine, holder)
+        _force_abort_request(engine, holder)
+
+    # Drain the deferred coroutines.
+    for _ in range(30):
+        await asyncio.sleep(0)
+
+    stats = scheduler.get_stats()
+    assert stats["num_requests_cancelled"] == 10, (
+        f"expected 10 aborts, got {stats}"
+    )
+    assert stats["num_requests_cancelled_via_disconnect"] == 10, (
+        f"expected 10 disconnect-attributed aborts, got {stats}"
+    )
+    assert (
+        stats["num_requests_cancelled_via_disconnect"]
+        <= stats["num_requests_cancelled"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolver coverage — production engine shape is recognised
+# ---------------------------------------------------------------------------
+
+
+def test_sync_scheduler_resolver_finds_deep_prod_path():
+    """The sync-abort resolver MUST find the deep production
+    scheduler at ``engine._engine.engine.scheduler``. Without this,
+    every disconnect falls into the async fallback and pays the
+    ``_await_and_record`` race tax.
+    """
+    from vllm_mlx.service.helpers import _resolve_sync_scheduler_for_abort
+
+    scheduler = _make_scheduler()
+    engine_core = _EngineCoreLike(scheduler)
+    async_core = _AsyncEngineCoreLike(engine_core)
+    engine = _BatchedEngineLike(async_core)
+
+    abort = _resolve_sync_scheduler_for_abort(engine)
+    assert abort is not None, (
+        "sync abort resolver returned None for production engine shape — "
+        "every disconnect will fall into the async fallback"
+    )
+    # Must be the actual scheduler.abort_request, not the engine's
+    # async public method.
+    assert abort == scheduler.abort_request
+
+
+def test_disconnect_recorder_resolver_finds_deep_prod_path():
+    """The attribution resolver MUST find the deep production
+    scheduler at ``engine._engine.engine.scheduler`` and return its
+    bound ``record_disconnect_abort`` method.
+    """
+    from vllm_mlx.service.helpers import _resolve_disconnect_abort_recorder
+
+    scheduler = _make_scheduler()
+    engine_core = _EngineCoreLike(scheduler)
+    async_core = _AsyncEngineCoreLike(engine_core)
+    engine = _BatchedEngineLike(async_core)
+
+    recorder = _resolve_disconnect_abort_recorder(engine)
+    assert recorder is not None, (
+        "disconnect-abort recorder resolver returned None for production "
+        "engine shape — sub-counter will stay flat-zero through every "
+        "real disconnect"
+    )
+    assert recorder == scheduler.record_disconnect_abort
+
+
+# ---------------------------------------------------------------------------
+# Logging guard: future engine-shape changes do not silently regress
+# ---------------------------------------------------------------------------
+
+
+def test_unresolved_engine_shape_logs_explicit_warning(caplog):
+    """When neither resolver finds a recorder, the helper layer MUST
+    emit an explicit WARNING so the next engine-shape change cannot
+    silently regress the sub-counter again — which is precisely how
+    D-M01-DEAD escaped PR #783's 9 codex rounds.
+    """
+    import logging
+
+    from vllm_mlx.service.helpers import _record_disconnect_abort_on_scheduler
+
+    class _NakedEngine:
+        # No .scheduler, no _engine, no _mllm_scheduler — the future
+        # shape that PR #783's resolvers would silently no-op on.
+        _is_mllm = False
+
+    caplog.set_level(logging.WARNING, logger="vllm_mlx.service.helpers")
+    _record_disconnect_abort_on_scheduler(_NakedEngine(), "req-naked")
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "record_disconnect_abort" in messages.lower() or (
+        "via_disconnect" in messages.lower()
+    ), (
+        "expected WARNING log when the engine shape exposes no "
+        f"recorder; got records: {[r.getMessage() for r in caplog.records]}"
+    )

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -215,17 +215,22 @@ async def test_total_counter_no_2x_overcount_on_prod_shape():
     """``rapid_mlx_requests_cancelled_total`` MUST advance by exactly
     1 per abort on the production engine shape — not 2 (or more).
 
-    Pre-fix repro: the disconnect_guard fires ``_force_abort_request``
-    from up to three branches. Under the async fallback each fire
-    schedules a ``_await_and_record`` coroutine. The coroutine calls
-    ``scheduler.abort_request`` AND ``_cleanup_request``. The cleanup
-    wipes ``_cancelled_request_ids``, so the NEXT
-    ``scheduler.abort_request`` (from another fire branch, or from
-    ``stream_outputs.finally``) sees an empty ledger and re-counts.
-    The dogfood fingerprint: 10 aborts → 20 ticks.
+    Pre-fix repro fingerprint: the disconnect_guard
+    ``_force_abort_request`` reaches the scheduler via one path,
+    and ``EngineCore.stream_outputs.finally`` reaches it via a
+    SECOND path (``scheduler.abort_request`` + ``_cleanup_request``
+    →  ``remove_finished_request``). Pre-fix the cleanup wiped the
+    lifetime ledger, so the SECOND public abort entry observed an
+    empty ledger and double-counted the same lifetime. The dogfood
+    fingerprint: 10 aborts → 20 ticks.
 
-    The pin: ONE id, multiple force-abort fires (mirroring the
-    three-branch helper), total counter advances by exactly 1.
+    The pin replays the EXACT production sequence: one
+    ``_force_abort_request`` (the helper) followed by the
+    ``EngineCore.abort_request`` path (sync ``scheduler.abort_request``
+    + ``_cleanup_request``). Codex r10 BLOCKING: each fire path
+    MUST be modelled distinctly — calling ``_force_abort_request``
+    twice with the same holder doesn't exercise the
+    "two independent abort entries" race the dogfood data captures.
     """
     from vllm_mlx.service.helpers import _force_abort_request
 
@@ -238,19 +243,51 @@ async def test_total_counter_no_2x_overcount_on_prod_shape():
     _admit(scheduler, request_id)
 
     holder = [request_id]
-    # disconnect_guard fires _force_abort_request from BOTH the
-    # disconnect branch AND the finally belt-and-suspenders. Replay
-    # the same two-fire pattern here.
-    _force_abort_request(engine, holder)
-    _force_abort_request(engine, holder)
-    # Drain whatever ensure_future coroutines were scheduled.
-    for _ in range(10):
+    # Path 1: disconnect_guard fires _force_abort_request. With the
+    # D-M01-DEAD resolver fix this lands SYNC on the deep prod
+    # scheduler — scheduler.abort_request returns True, counter ticks
+    # to 1, ledger now carries the id.
+    fired = _force_abort_request(engine, holder)
+    assert fired is True, (
+        "_force_abort_request must resolve to the sync deep prod "
+        "scheduler — falling back to async fallback is the pre-fix shape"
+    )
+    # Drain any deferred coroutines scheduled by the helper.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert scheduler.get_stats()["num_requests_cancelled"] == 1
+
+    # Path 2: EngineCore.stream_outputs.finally explicitly calls
+    # ``scheduler.abort_request`` then ``_cleanup_request`` — this is
+    # the OTHER abort entry that races the helper in production. Pre-
+    # fix the cleanup wiped the ledger here, so this second entry's
+    # ``already_counted`` check returned False and the counter ticked
+    # to 2 (the dogfood "20/0" shape). Post-fix the ledger is
+    # lifetime-persistent and the second entry is correctly dedup'd.
+    second_result = scheduler.abort_request(request_id)
+    # ``stream_outputs.finally`` then calls ``_cleanup_request`` →
+    # ``remove_finished_request`` (we drive it explicitly here so the
+    # ledger-clear semantic is what's actually under test, not
+    # whether _cleanup_request fired).
+    scheduler.remove_finished_request(request_id)
+    # Drain any further deferred coroutines.
+    for _ in range(5):
         await asyncio.sleep(0)
 
     stats = scheduler.get_stats()
+    # The contract: even though TWO independent public-API abort
+    # paths each ran sync against the scheduler (one from the
+    # disconnect_guard helper, one from EngineCore's cleanup), the
+    # lifetime-persistent ledger dedupes them and the counter is
+    # exactly 1.
     assert stats["num_requests_cancelled"] == 1, (
-        f"D-M01-2X: total counter over-counted on production engine shape — got {stats}"
+        f"D-M01-2X: two distinct public-API abort paths must "
+        f"dedupe to a single counter tick; got {stats} "
+        f"(second_result={second_result})"
     )
+    # via_disconnect was attributed by the helper path; the
+    # stream_outputs.finally path is NOT a disconnect path so the
+    # sub-counter stays at 1, not 2.
     assert stats["num_requests_cancelled_via_disconnect"] == 1
     # Invariant: via_disconnect <= total always holds.
     assert (
@@ -270,6 +307,14 @@ async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
     disconnects on the production engine shape yield
     ``cancelled_total=10`` AND ``cancelled_via_disconnect_total=10``
     — not the 0.8.2 ``20 / 0`` shape three personas observed.
+
+    Each iteration models BOTH abort paths the disconnect
+    actually traverses in production: (1) the disconnect_guard
+    helper's force-abort, AND (2) ``EngineCore.stream_outputs.finally``
+    invoking ``scheduler.abort_request`` + ``_cleanup_request``.
+    These run on different async surfaces in production; here we
+    drive them sequentially so the lifetime-ledger dedupe contract
+    is the only thing keeping the counter from ticking to 20.
     """
     from vllm_mlx.service.helpers import _force_abort_request
 
@@ -281,18 +326,25 @@ async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
     for i in range(10):
         rid = f"req-disc-{i}"
         _admit(scheduler, rid)
-        holder = [rid]
-        # Two fires per disconnect to match disconnect_guard's branches
-        # (disconnect + finally).
-        _force_abort_request(engine, holder)
-        _force_abort_request(engine, holder)
+        # Path 1: helper force-abort (sync to deep prod scheduler).
+        assert _force_abort_request(engine, [rid]) is True
+        # Path 2: stream_outputs.finally cleanup sequence — direct
+        # scheduler.abort_request followed by remove_finished_request
+        # (the EngineCore._cleanup_request equivalent). Pre-fix this
+        # second path is what drove the counter to 2N because the
+        # cleanup wiped the dedupe ledger.
+        scheduler.abort_request(rid)
+        scheduler.remove_finished_request(rid)
 
-    # Drain the deferred coroutines.
+    # Drain any deferred coroutines.
     for _ in range(30):
         await asyncio.sleep(0)
 
     stats = scheduler.get_stats()
-    assert stats["num_requests_cancelled"] == 10, f"expected 10 aborts, got {stats}"
+    assert stats["num_requests_cancelled"] == 10, (
+        f"expected 10 aborts (lifetime-persistent ledger dedupes the "
+        f"two abort paths per disconnect); got {stats}"
+    )
     assert stats["num_requests_cancelled_via_disconnect"] == 10, (
         f"expected 10 disconnect-attributed aborts, got {stats}"
     )
@@ -370,18 +422,27 @@ def test_unresolved_engine_shape_logs_explicit_warning(caplog):
     """
     import logging
 
+    from vllm_mlx.service import helpers as _helpers
     from vllm_mlx.service.helpers import _record_disconnect_abort_on_scheduler
 
-    class _NakedEngineXYZ:
+    # Use a name unique to this test so the once-per-engine-type
+    # dedupe in the helper doesn't suppress us due to a previous
+    # test's stub class.
+    class _NakedEngineForWarningTest:
         # No .scheduler, no _engine, no _mllm_scheduler — the future
         # shape that PR #783's resolvers would silently no-op on.
         _is_mllm = False
+
+    # Reset the once-per-engine-type dedupe so the warning is
+    # guaranteed to fire even under repeated test runs.
+    with _helpers._unresolved_engine_lock:
+        _helpers._unresolved_engine_logged.discard("_NakedEngineForWarningTest")
 
     # Capture WARNING from whatever logger the helpers module ends up
     # bound to (rapid-mlx aliases ``vllm_mlx`` → ``rapid_mlx`` on the
     # logging tree, see runtime/__init__.py).
     caplog.set_level(logging.WARNING)
-    _record_disconnect_abort_on_scheduler(_NakedEngineXYZ(), "req-naked")
+    _record_disconnect_abort_on_scheduler(_NakedEngineForWarningTest(), "req-naked")
 
     warning_records = [rec for rec in caplog.records if rec.levelname == "WARNING"]
     assert warning_records, (
@@ -396,7 +457,44 @@ def test_unresolved_engine_shape_logs_explicit_warning(caplog):
     # The engine type name is part of the actionable signal — it's
     # how an operator knows WHICH backend shape the resolvers don't
     # yet recognise.
-    assert "_NakedEngineXYZ" in combined, combined
+    assert "_NakedEngineForWarningTest" in combined, combined
     # The "via_disconnect" diagnostic identifies WHICH metric will
     # under-count, so dashboards can flag a sticky warning.
     assert "via_disconnect" in combined, combined
+
+
+def test_unresolved_engine_warning_dedupes_per_engine_type(caplog):
+    """Codex r10 NIT: the unresolved-engine warning is rate-limited
+    to once-per-engine-type so it does not drown the log under
+    sustained cancel traffic. Repeat calls for the SAME engine type
+    emit DEBUG, not WARNING.
+    """
+    import logging
+
+    from vllm_mlx.service import helpers as _helpers
+    from vllm_mlx.service.helpers import _record_disconnect_abort_on_scheduler
+
+    class _NakedEngineForDedupeTest:
+        _is_mllm = False
+
+    # Reset for a clean slate.
+    with _helpers._unresolved_engine_lock:
+        _helpers._unresolved_engine_logged.discard("_NakedEngineForDedupeTest")
+
+    caplog.set_level(logging.DEBUG)
+    # First call: fires the WARNING.
+    _record_disconnect_abort_on_scheduler(_NakedEngineForDedupeTest(), "req-1")
+    # Subsequent calls: suppressed to DEBUG.
+    for i in range(5):
+        _record_disconnect_abort_on_scheduler(
+            _NakedEngineForDedupeTest(), f"req-{i + 2}"
+        )
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    # Exactly one warning, despite 6 calls. The dedupe contract is
+    # what stops a sustained disconnect storm from drowning logs.
+    assert len(warnings) == 1, (
+        f"expected exactly 1 warning across 6 unresolved-engine calls "
+        f"for the same engine type; got {len(warnings)}: "
+        f"{[r.getMessage() for r in warnings]}"
+    )

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -355,6 +355,60 @@ async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
 
 
 # ---------------------------------------------------------------------------
+# MLLM twin: verify the same lifetime-persistent ledger contract holds
+# ---------------------------------------------------------------------------
+
+
+def test_mllm_scheduler_admit_below_cap_does_not_attributeerror_on_lock():
+    """Codex r12 BLOCKING follow-up: ``MLLMScheduler.add_request``
+    now acquires ``self._cancel_counter_lock`` to do the
+    lifetime-ledger clear + commit under one critical section. The
+    constructor MUST initialise this lock or the first multimodal
+    request raises ``AttributeError`` and breaks every MLLM admit.
+
+    Drive a below-cap admit through ``add_request`` against a stub
+    that mimics the bare scheduler state (no real model needed)
+    and assert the lock + commit path completes without
+    AttributeError. A future refactor that drops the constructor's
+    ``_cancel_counter_lock = threading.Lock()`` line fails here.
+    """
+    import threading
+
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+    sched = MLLMScheduler.__new__(MLLMScheduler)
+    # Mirror the constructor's ``_cancel_counter_lock`` /
+    # ``_cancelled_request_ids`` / ``_disconnect_abort_ids`` /
+    # ``_pending_abort_ids`` / ``requests`` / ``waiting`` init,
+    # exactly as the real ``__init__`` does. The minimal stub is
+    # sufficient to drive ``add_request`` past the ledger clear +
+    # commit critical section. Anything missing here would raise
+    # AttributeError BEFORE the cap-check vs after; pinning that
+    # add_request reaches the commit line is the contract.
+    sched._cancel_counter_lock = threading.Lock()
+    sched._cancelled_request_ids = set()
+    sched._disconnect_abort_ids = set()
+    sched._pending_abort_ids = set()
+    sched.config = MLLMSchedulerConfig(max_concurrent_requests=4)
+    sched.requests = {}
+    sched.waiting = []
+
+    # Call into the real add_request with a stub prompt — minimal
+    # prompt is enough to reach the commit line; we don't care
+    # whether the downstream processing succeeds, only that the
+    # admission gate + ledger clear + commit ran without
+    # AttributeError on the lock.
+    request_id = sched.add_request(prompt="hi", request_id="req-mllm-smoke")
+    assert request_id == "req-mllm-smoke"
+    assert "req-mllm-smoke" in sched.requests
+    assert sched.requests["req-mllm-smoke"] is not None
+    # The lifetime ledger MUST be empty at this point (the clear
+    # ran, no abort has fired yet).
+    assert "req-mllm-smoke" not in sched._cancelled_request_ids
+    assert "req-mllm-smoke" not in sched._disconnect_abort_ids
+
+
+# ---------------------------------------------------------------------------
 # Resolver coverage — production engine shape is recognised
 # ---------------------------------------------------------------------------
 

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -434,9 +434,11 @@ def test_unresolved_engine_shape_logs_explicit_warning(caplog):
         _is_mllm = False
 
     # Reset the once-per-engine-type dedupe so the warning is
-    # guaranteed to fire even under repeated test runs.
+    # guaranteed to fire even under repeated test runs. Uses the
+    # same (module, qualname) key the helper consults.
+    dedupe_key = _helpers._unresolved_engine_dedupe_key(_NakedEngineForWarningTest)
     with _helpers._unresolved_engine_lock:
-        _helpers._unresolved_engine_logged.discard("_NakedEngineForWarningTest")
+        _helpers._unresolved_engine_logged.discard(dedupe_key)
 
     # Capture WARNING from whatever logger the helpers module ends up
     # bound to (rapid-mlx aliases ``vllm_mlx`` → ``rapid_mlx`` on the
@@ -463,6 +465,58 @@ def test_unresolved_engine_shape_logs_explicit_warning(caplog):
     assert "via_disconnect" in combined, combined
 
 
+def test_unresolved_engine_warning_keyed_by_module_qualname(caplog):
+    """Codex r11 NIT: the dedupe ledger MUST key on
+    ``(module, qualname)``, not the leaf class name, so two
+    different unresolved engine classes that happen to share a leaf
+    name (e.g. nested vs. top-level, or two modules each defining
+    ``BatchedEngine``) each get their own actionable warning.
+
+    Build two distinct classes with the same leaf name by
+    monkey-patching ``__qualname__`` so they share ``__name__`` but
+    differ in qualified identity. Both MUST warn.
+    """
+    import logging
+
+    from vllm_mlx.service import helpers as _helpers
+    from vllm_mlx.service.helpers import _record_disconnect_abort_on_scheduler
+
+    class _SameLeafA:
+        _is_mllm = False
+
+    class _SameLeafB:
+        _is_mllm = False
+
+    # Force a leaf-name collision so a leaf-keyed dedupe would
+    # incorrectly suppress one of the warnings.
+    _SameLeafA.__name__ = "BatchedEngineCollision"
+    _SameLeafB.__name__ = "BatchedEngineCollision"
+
+    # Reset both dedupe slots.
+    key_a = _helpers._unresolved_engine_dedupe_key(_SameLeafA)
+    key_b = _helpers._unresolved_engine_dedupe_key(_SameLeafB)
+    with _helpers._unresolved_engine_lock:
+        _helpers._unresolved_engine_logged.discard(key_a)
+        _helpers._unresolved_engine_logged.discard(key_b)
+
+    assert key_a != key_b, (
+        f"dedupe key collision: {key_a} == {key_b} — qualnames "
+        "should differ even when __name__ matches"
+    )
+
+    caplog.set_level(logging.WARNING)
+    _record_disconnect_abort_on_scheduler(_SameLeafA(), "req-a")
+    _record_disconnect_abort_on_scheduler(_SameLeafB(), "req-b")
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 2, (
+        "Two unresolved engine classes with the same leaf name MUST "
+        "each get their own actionable warning, not be silenced by a "
+        f"leaf-keyed dedupe. Got {len(warnings)}: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+
+
 def test_unresolved_engine_warning_dedupes_per_engine_type(caplog):
     """Codex r10 NIT: the unresolved-engine warning is rate-limited
     to once-per-engine-type so it does not drown the log under
@@ -478,8 +532,9 @@ def test_unresolved_engine_warning_dedupes_per_engine_type(caplog):
         _is_mllm = False
 
     # Reset for a clean slate.
+    dedupe_key = _helpers._unresolved_engine_dedupe_key(_NakedEngineForDedupeTest)
     with _helpers._unresolved_engine_lock:
-        _helpers._unresolved_engine_logged.discard("_NakedEngineForDedupeTest")
+        _helpers._unresolved_engine_logged.discard(dedupe_key)
 
     caplog.set_level(logging.DEBUG)
     # First call: fires the WARNING.

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -249,8 +249,7 @@ async def test_total_counter_no_2x_overcount_on_prod_shape():
 
     stats = scheduler.get_stats()
     assert stats["num_requests_cancelled"] == 1, (
-        "D-M01-2X: total counter over-counted on production engine "
-        f"shape — got {stats}"
+        f"D-M01-2X: total counter over-counted on production engine shape — got {stats}"
     )
     assert stats["num_requests_cancelled_via_disconnect"] == 1
     # Invariant: via_disconnect <= total always holds.
@@ -293,9 +292,7 @@ async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
         await asyncio.sleep(0)
 
     stats = scheduler.get_stats()
-    assert stats["num_requests_cancelled"] == 10, (
-        f"expected 10 aborts, got {stats}"
-    )
+    assert stats["num_requests_cancelled"] == 10, f"expected 10 aborts, got {stats}"
     assert stats["num_requests_cancelled_via_disconnect"] == 10, (
         f"expected 10 disconnect-attributed aborts, got {stats}"
     )
@@ -364,22 +361,42 @@ def test_unresolved_engine_shape_logs_explicit_warning(caplog):
     emit an explicit WARNING so the next engine-shape change cannot
     silently regress the sub-counter again — which is precisely how
     D-M01-DEAD escaped PR #783's 9 codex rounds.
+
+    Codex r10 NIT: assert the stable, actionable fragments of the
+    warning (the leading tag, the "no recorder found" diagnostic,
+    AND the engine type name) rather than a loose substring — so a
+    future refactor that accidentally degrades the warning to a
+    generic message still fails this test loudly.
     """
     import logging
 
     from vllm_mlx.service.helpers import _record_disconnect_abort_on_scheduler
 
-    class _NakedEngine:
+    class _NakedEngineXYZ:
         # No .scheduler, no _engine, no _mllm_scheduler — the future
         # shape that PR #783's resolvers would silently no-op on.
         _is_mllm = False
 
-    caplog.set_level(logging.WARNING, logger="vllm_mlx.service.helpers")
-    _record_disconnect_abort_on_scheduler(_NakedEngine(), "req-naked")
-    messages = " ".join(rec.getMessage() for rec in caplog.records)
-    assert "record_disconnect_abort" in messages.lower() or (
-        "via_disconnect" in messages.lower()
-    ), (
-        "expected WARNING log when the engine shape exposes no "
-        f"recorder; got records: {[r.getMessage() for r in caplog.records]}"
+    # Capture WARNING from whatever logger the helpers module ends up
+    # bound to (rapid-mlx aliases ``vllm_mlx`` → ``rapid_mlx`` on the
+    # logging tree, see runtime/__init__.py).
+    caplog.set_level(logging.WARNING)
+    _record_disconnect_abort_on_scheduler(_NakedEngineXYZ(), "req-naked")
+
+    warning_records = [rec for rec in caplog.records if rec.levelname == "WARNING"]
+    assert warning_records, (
+        "expected at least one WARNING-level record when the engine "
+        f"shape exposes no recorder; got: {[r.getMessage() for r in caplog.records]}"
     )
+    # The combined warning text MUST carry the stable diagnostic
+    # fragments operators / dashboards key on.
+    combined = " ".join(rec.getMessage() for rec in warning_records)
+    assert "[disconnect_guard]" in combined, combined
+    assert "no record_disconnect_abort recorder" in combined, combined
+    # The engine type name is part of the actionable signal — it's
+    # how an operator knows WHICH backend shape the resolvers don't
+    # yet recognise.
+    assert "_NakedEngineXYZ" in combined, combined
+    # The "via_disconnect" diagnostic identifies WHICH metric will
+    # under-count, so dashboards can flag a sticky warning.
+    assert "via_disconnect" in combined, combined

--- a/tests/test_disconnect_counter_prod_shape.py
+++ b/tests/test_disconnect_counter_prod_shape.py
@@ -360,48 +360,74 @@ async def test_ten_disconnects_on_prod_shape_yield_ten_ten():
 
 
 def test_mllm_scheduler_admit_below_cap_does_not_attributeerror_on_lock():
-    """Codex r12 BLOCKING follow-up: ``MLLMScheduler.add_request``
-    now acquires ``self._cancel_counter_lock`` to do the
+    """Codex r12 + r13 BLOCKING: ``MLLMScheduler.add_request`` now
+    acquires ``self._cancel_counter_lock`` to do the
     lifetime-ledger clear + commit under one critical section. The
     constructor MUST initialise this lock or the first multimodal
     request raises ``AttributeError`` and breaks every MLLM admit.
 
-    Drive a below-cap admit through ``add_request`` against a stub
-    that mimics the bare scheduler state (no real model needed)
-    and assert the lock + commit path completes without
-    AttributeError. A future refactor that drops the constructor's
-    ``_cancel_counter_lock = threading.Lock()`` line fails here.
+    Run the REAL ``__init__`` (with stub model + processor) so a
+    future refactor that drops the constructor's
+    ``_cancel_counter_lock = threading.Lock()`` line fails loudly
+    on this regression test. Codex r13 BLOCKING called out the
+    prior version of this test which bypassed the constructor and
+    manually installed the lock — that defeated the point of
+    testing the constructor invariant.
     """
-    import threading
-
     from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
 
-    sched = MLLMScheduler.__new__(MLLMScheduler)
-    # Mirror the constructor's ``_cancel_counter_lock`` /
-    # ``_cancelled_request_ids`` / ``_disconnect_abort_ids`` /
-    # ``_pending_abort_ids`` / ``requests`` / ``waiting`` init,
-    # exactly as the real ``__init__`` does. The minimal stub is
-    # sufficient to drive ``add_request`` past the ledger clear +
-    # commit critical section. Anything missing here would raise
-    # AttributeError BEFORE the cap-check vs after; pinning that
-    # add_request reaches the commit line is the contract.
-    sched._cancel_counter_lock = threading.Lock()
-    sched._cancelled_request_ids = set()
-    sched._disconnect_abort_ids = set()
-    sched._pending_abort_ids = set()
-    sched.config = MLLMSchedulerConfig(max_concurrent_requests=4)
-    sched.requests = {}
-    sched.waiting = []
+    class _StubProcessor:
+        # MLLMScheduler._get_stop_tokens consults
+        # ``processor.tokenizer.added_tokens_decoder``; a single
+        # method-shaped stub keeps the constructor path live without
+        # pulling in a real HF tokenizer.
+        class _Tok:
+            eos_token_id = None
+            added_tokens_decoder: dict = {}
 
-    # Call into the real add_request with a stub prompt — minimal
-    # prompt is enough to reach the commit line; we don't care
-    # whether the downstream processing succeeds, only that the
-    # admission gate + ledger clear + commit ran without
-    # AttributeError on the lock.
+            def encode(self, _prompt, **_kw):
+                return [42]
+
+            def decode(self, _ids, **_kw):
+                return ""
+
+            def convert_tokens_to_ids(self, _t):
+                return None
+
+        tokenizer = _Tok()
+
+    class _StubModel:
+        # MultimodalProcessor / MLLMScheduler read ``model.config`` —
+        # a bare object with attribute access via getattr is enough.
+        class _Cfg:
+            image_token_index = None
+
+        config = _Cfg()
+
+    # REAL constructor — this is what codex r13 demanded. If the
+    # constructor's `_cancel_counter_lock = threading.Lock()` line
+    # is ever dropped, the ``add_request`` call below raises
+    # AttributeError on the lock acquisition and this test fails
+    # loudly.
+    sched = MLLMScheduler(
+        model=_StubModel(),
+        processor=_StubProcessor(),
+        config=MLLMSchedulerConfig(max_concurrent_requests=4),
+    )
+
+    # Constructor-invariant pin: the lock MUST be present and a
+    # real Lock before any admit runs.
+    assert hasattr(sched, "_cancel_counter_lock"), (
+        "MLLMScheduler.__init__ MUST initialise _cancel_counter_lock"
+    )
+    assert hasattr(sched._cancel_counter_lock, "acquire")
+
+    # Below-cap admit through the REAL add_request so the
+    # lock-acquired ledger-clear + commit critical section runs end
+    # to end.
     request_id = sched.add_request(prompt="hi", request_id="req-mllm-smoke")
     assert request_id == "req-mllm-smoke"
     assert "req-mllm-smoke" in sched.requests
-    assert sched.requests["req-mllm-smoke"] is not None
     # The lifetime ledger MUST be empty at this point (the clear
     # ran, no abort has fired yet).
     assert "req-mllm-smoke" not in sched._cancelled_request_ids

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -402,17 +402,6 @@ class MLLMScheduler:
                 f"(currently {len(self.requests)} in-flight)"
             )
 
-        # D-M01-2X (0.8.2 dogfood) follow-up: mirror the text-path
-        # ``Scheduler.add_request`` ledger clear. The cancellation
-        # dedupe ledgers are now lifetime-persistent across
-        # ``_do_abort_request`` to plug the disconnect_guard
-        # multi-branch race; clearing them at fresh admit (after
-        # admission control passes) preserves the request_id-reuse
-        # counting semantics.
-        with self._cancel_counter_lock:
-            self._cancelled_request_ids.discard(request_id)
-            self._disconnect_abort_ids.discard(request_id)
-
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -430,7 +419,24 @@ class MLLMScheduler:
             video_max_frames=video_max_frames,
         )
 
-        self.requests[request_id] = request
+        # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
+        # mirror the text-path ``Scheduler.add_request`` ledger
+        # clear, gated on the same critical section as the
+        # ``self.requests[...] = request`` commit. Earlier clears
+        # would erase the prior lifetime's dedupe even when
+        # ``SamplingParams(...)``, ``MLLMRequest(...)``, or any
+        # other request-construction step subsequently raised —
+        # re-opening the double-count window for the OLD
+        # lifetime should a late ``abort_request`` arrive between
+        # the failed admit and the next successful one. The
+        # ledgers are otherwise lifetime-persistent across the
+        # abort+cleanup window; see
+        # ``Scheduler.remove_finished_request`` docstring for the
+        # multi-branch race repro the persistence plugs.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request_id)
+            self._disconnect_abort_ids.discard(request_id)
+            self.requests[request_id] = request
         self.waiting.append(request)
 
         logger.debug(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -402,6 +402,17 @@ class MLLMScheduler:
                 f"(currently {len(self.requests)} in-flight)"
             )
 
+        # D-M01-2X (0.8.2 dogfood) follow-up: mirror the text-path
+        # ``Scheduler.add_request`` ledger clear. The cancellation
+        # dedupe ledgers are now lifetime-persistent across
+        # ``_do_abort_request`` to plug the disconnect_guard
+        # multi-branch race; clearing them at fresh admit (after
+        # admission control passes) preserves the request_id-reuse
+        # counting semantics.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request_id)
+            self._disconnect_abort_ids.discard(request_id)
+
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -545,23 +556,22 @@ class MLLMScheduler:
             request.status = RequestStatus.FINISHED_ABORTED
         self.finished_req_ids.add(request_id)
 
-        # M-01 codex r8 BLOCKING #2: pop ``self.requests`` AND
-        # discard the cancellation lifetime ledgers under the SAME
-        # critical section. Pre-r8 the pop ran outside the lock,
-        # leaving a window where a concurrent ``abort_request``
-        # acquiring the lock could observe inconsistent state
-        # across ``self.requests`` / ``request_id_to_uid`` /
-        # ``running`` / ``_pending_abort_ids``. With both inside
-        # the lock, any concurrent abort-path predicate (codex r6
-        # fix: also inside the lock) sees a consistent
-        # transition — either everything pre-cleanup or
-        # everything post-cleanup. Detokenizer pool pop also
-        # joins the section for symmetric ordering.
+        # D-M01-2X + D-M01-DEAD (0.8.2 dogfood): do NOT discard the
+        # dedupe ledgers — keep them lifetime-persistent. Mirrors
+        # the same fix applied to ``Scheduler.remove_finished_request``
+        # in the text path. See that docstring for the full repro of
+        # the disconnect_guard multi-branch fire race that wiping
+        # these ledgers opens up. The MLLM path has the SAME race
+        # surface (disconnect_guard fires from up to three branches,
+        # each may invoke ``abort_request`` against the MLLM
+        # scheduler) — so keeping the ledger persistent here is
+        # required for the dashboard invariant
+        # ``via_disconnect_total <= cancelled_total`` and the
+        # "exactly one tick per abort" contract that three personas
+        # independently observed broken on PyPI 0.8.2.
         with self._cancel_counter_lock:
             self.requests.pop(request_id, None)
             self._detokenizer_pool.pop(request_id, None)
-            self._cancelled_request_ids.discard(request_id)
-            self._disconnect_abort_ids.discard(request_id)
 
         # Do NOT write to output_queues here — this may run on the
         # executor thread where asyncio.Queue is not safe.  Mark for

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2923,6 +2923,26 @@ class Scheduler:
                 f"(currently {len(self.requests)} in-flight)"
             )
 
+        # D-M01-2X (0.8.2 dogfood) follow-up: the cancellation dedupe
+        # ledgers are LIFETIME-PERSISTENT to plug the
+        # disconnect_guard multi-branch race (see
+        # ``remove_finished_request`` docstring for the repro). To
+        # preserve request_id-reuse counting semantics (a fresh
+        # admit with a previously-cancelled id legitimately starts
+        # a new lifetime that SHOULD be counted on cancel), we
+        # explicitly clear that id from BOTH ledgers right after
+        # admission control passes — under the same lock that
+        # ``abort_request`` re-validates against, so a concurrent
+        # late abort for the prior lifetime can't observe an
+        # inconsistent transition. Without this, deterministic
+        # integrations that reuse request_ids would silently see
+        # their second cancel omitted from the counter. Placed
+        # AFTER the admission gate so capped admits do not wipe
+        # the prior lifetime's ledger.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request.request_id)
+            self._disconnect_abort_ids.discard(request.request_id)
+
         # Tokenize if needed
         if request.prompt_token_ids is None:
             if isinstance(request.prompt, str):
@@ -4178,40 +4198,72 @@ class Scheduler:
     def remove_finished_request(self, request_id: str) -> Request | None:
         """Remove a finished request from tracking.
 
-        M-01 codex r4 BLOCKING #1 + codex r5 BLOCKING: this is the
-        canonical request-leaves-scheduler boundary, so the
-        cancellation dedupe ledgers (``_cancelled_request_ids`` /
-        ``_disconnect_abort_ids``) are also discarded here. Before
-        this method runs, a redundant ``abort_request`` for the
-        same id would still pass the
-        ``request_id in self.requests`` predicate — so the ledger
-        must stay populated to prevent double-counting that
-        redundant enqueue. After this method runs, ``request_id``
-        is no longer admit-able via the abort-path predicate, so
-        the only way a future ``abort_request(rid)`` can hit
-        ``True`` is through a fresh ``add_request`` (a distinct
-        lifetime), which is exactly when the counter SHOULD tick
-        again.
+        D-M01-2X + D-M01-DEAD (0.8.2 dogfood): this method MUST
+        NOT discard ``_cancelled_request_ids`` /
+        ``_disconnect_abort_ids``. Those are LIFETIME ledgers — the
+        ``__init__`` comment block explicitly documents them as
+        "every id that has ever advanced the counter stays in it
+        for the process lifetime" with memory bounded by cancel
+        traffic.
 
-        Codex r5 BLOCKING: the ``self.requests.pop`` AND the
-        ledger discards MUST happen under a single critical
-        section. Otherwise the window between "ledger discarded"
-        and "request popped" is a race where a concurrent
-        ``abort_request`` observes ``request_id in self.requests``
-        (still True) AND an empty ledger (because we just cleared
-        it) and double-counts the same lifetime. The pop is moved
-        INSIDE the lock and runs BEFORE the discard so any
-        concurrent ``abort_request`` either sees the id still in
-        ``self.requests`` AND in the ledger (no double-count, the
-        dedupe gate catches it) OR sees the id not in
-        ``self.requests`` (returns False per F-151).
+        Why the prior discard was a regression
+        --------------------------------------
+        On the production ``BatchedEngine`` over ``AsyncEngineCore``
+        shape, an aborted request follows this sequence:
 
-        Discards are idempotent — re-entry is safe.
+          1. ``stream_outputs.finally`` (or the deferred
+             ``_await_and_record`` coroutine) calls
+             ``scheduler.abort_request(rid)`` → adds to
+             ``_cancelled_request_ids``, increments
+             ``num_requests_cancelled``, queues into
+             ``_pending_abort_ids``. Returns True.
+          2. ``EngineCore._cleanup_request`` calls THIS method →
+             previously discarded both ledgers. ``_pending_abort_ids``
+             still contains the id (it's drained on the executor
+             thread by ``_process_pending_aborts``).
+          3. The other branch's ``scheduler.abort_request(rid)``
+             (the disconnect_guard fires from up to three places,
+             the async-fallback coroutine adds a fourth)
+             re-enters the public abort. The membership predicate
+             ``request_id in self._pending_abort_ids`` still
+             evaluates True, so the abort is accepted. The
+             ``already_counted`` read on the WIPED
+             ``_cancelled_request_ids`` returns False, and the
+             counter increments AGAIN — the 2x over-count.
+          4. ``record_disconnect_abort`` then runs through the gate
+             ``request_id not in self._cancelled_request_ids`` —
+             which AGAIN reads from the wiped ledger and silently
+             returns. ``via_disconnect_total`` stays flat-zero
+             through every real disconnect — D-M01-DEAD.
+
+        The fix: leave the ledgers populated for the process
+        lifetime. Membership in ``_cancelled_request_ids`` is now
+        a true "this id has already advanced the counter once"
+        marker that survives ``_cleanup_request`` AND any number
+        of redundant abort calls from the disconnect_guard's
+        multi-branch fire pattern. The only paths that clear them
+        are ``reset()`` / ``deep_reset()`` — see the codex r8
+        BLOCKING #1 comment block in ``reset()`` for why those
+        clear AFTER the abort loop.
+
+        Memory: one ~36-byte uuid per cancel, same scale as
+        ``finished_req_ids`` (which also persists across
+        ``_cleanup_request``). The PR #783 docstring claim that
+        "the only way a future ``abort_request(rid)`` can hit
+        True is through a fresh ``add_request``" was wrong: the
+        ``_pending_abort_ids`` membership branch passes True for
+        the entire window between abort enqueue and
+        executor-thread drain, opening exactly this race.
+
+        Returns the popped Request (or None if already gone).
         """
+        # Pop under the lock so a concurrent ``abort_request`` either
+        # observes the id present in ``self.requests`` (admits, hits
+        # the lifetime ledger, dedupes — no double count) or absent
+        # AND with all admission predicates ruling it out (returns
+        # False per F-151). The ledgers stay populated indefinitely.
         with self._cancel_counter_lock:
             popped = self.requests.pop(request_id, None)
-            self._cancelled_request_ids.discard(request_id)
-            self._disconnect_abort_ids.discard(request_id)
         return popped
 
     def get_running_requests_info(self) -> list[dict[str, Any]]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2923,26 +2923,6 @@ class Scheduler:
                 f"(currently {len(self.requests)} in-flight)"
             )
 
-        # D-M01-2X (0.8.2 dogfood) follow-up: the cancellation dedupe
-        # ledgers are LIFETIME-PERSISTENT to plug the
-        # disconnect_guard multi-branch race (see
-        # ``remove_finished_request`` docstring for the repro). To
-        # preserve request_id-reuse counting semantics (a fresh
-        # admit with a previously-cancelled id legitimately starts
-        # a new lifetime that SHOULD be counted on cancel), we
-        # explicitly clear that id from BOTH ledgers right after
-        # admission control passes — under the same lock that
-        # ``abort_request`` re-validates against, so a concurrent
-        # late abort for the prior lifetime can't observe an
-        # inconsistent transition. Without this, deterministic
-        # integrations that reuse request_ids would silently see
-        # their second cancel omitted from the counter. Placed
-        # AFTER the admission gate so capped admits do not wipe
-        # the prior lifetime's ledger.
-        with self._cancel_counter_lock:
-            self._cancelled_request_ids.discard(request.request_id)
-            self._disconnect_abort_ids.discard(request.request_id)
-
         # Tokenize if needed
         if request.prompt_token_ids is None:
             if isinstance(request.prompt, str):
@@ -3115,8 +3095,30 @@ class Scheduler:
             request.cache_hit_type = "miss"
             request.remaining_tokens = request.prompt_token_ids
 
-        # Add to tracking
-        self.requests[request.request_id] = request
+        # Add to tracking. D-M01-2X (0.8.2 dogfood, codex r10
+        # BLOCKING follow-up): the cancellation dedupe ledgers
+        # (``_cancelled_request_ids`` / ``_disconnect_abort_ids``)
+        # are LIFETIME-PERSISTENT across the
+        # abort+cleanup window (see ``remove_finished_request``
+        # docstring for the multi-branch race repro). Clearing
+        # them at fresh admit preserves the request_id-reuse
+        # counting semantics — but the clear MUST run atomically
+        # with the ``self.requests[...] = request`` commit, NOT
+        # earlier in this method. An earlier clear (e.g. right
+        # after the admission gate) would erase the prior
+        # lifetime's dedupe even if tokenization / cache lookup /
+        # PFlash compression subsequently raised, opening a
+        # double-count window for the OLD lifetime should a late
+        # ``abort_request`` arrive between the failed admit and
+        # the next successful one. By gating the clear on the
+        # same critical section as the actual commit, every
+        # exception path between admission and tracking leaves
+        # the ledger intact and the prior lifetime's dedupe
+        # stays effective.
+        with self._cancel_counter_lock:
+            self._cancelled_request_ids.discard(request.request_id)
+            self._disconnect_abort_ids.discard(request.request_id)
+            self.requests[request.request_id] = request
         self.waiting.append(request)
 
         logger.debug(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -13,6 +13,7 @@ import hashlib
 import inspect
 import json
 import logging
+import threading
 import uuid
 from collections.abc import AsyncIterator
 
@@ -2119,6 +2120,19 @@ def _resolve_disconnect_abort_recorder(engine):
     return None
 
 
+# M-01 / D-M01-DEAD: once-per-engine-type ledger for the unresolved-
+# engine warning. Without this dedupe, an operator running on an
+# engine shape the resolvers don't yet recognise would see one
+# warning per ABORT — at 1 cancel/second that's 86,400 warnings/day,
+# enough to drown the disconnect_guard log signal entirely. The
+# warning is informational ("which backend shape do the resolvers
+# need to learn") so once-per-engine-type is the right cardinality.
+# Bounded by the number of distinct engine classes in the process,
+# typically 1.
+_unresolved_engine_logged: set[str] = set()
+_unresolved_engine_lock = threading.Lock()
+
+
 def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
     """M-01 attribution helper — bumps the disconnect sub-counter on
     whichever active-path scheduler owns this ``request_id``.
@@ -2136,26 +2150,40 @@ def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
     catching that the production ``BatchedEngine`` over
     ``AsyncEngineCore`` shape exposed no recorder — three personas
     independently observed flat-zero ``via_disconnect_total`` on
-    PyPI 0.8.2. The explicit WARNING below ensures the next
-    engine-shape change cannot silently regress the sub-counter
-    again: an operator will see the unresolved-engine warning in
-    logs the moment any abort path hits a shape neither resolver
-    recognises.
+    PyPI 0.8.2. The WARNING below (rate-limited to once-per-engine-
+    type so it doesn't drown the log under sustained cancel traffic)
+    ensures the next engine-shape change cannot silently regress the
+    sub-counter again. The high-cardinality ``request_id`` is logged
+    at DEBUG only — codex r10 NIT.
     """
     try:
         recorder = _resolve_disconnect_abort_recorder(engine)
         if recorder is None:
-            logger.warning(
-                "[disconnect_guard] no record_disconnect_abort recorder "
-                "found on engine type=%s — via_disconnect sub-counter "
-                "WILL NOT advance for %s. This indicates an unrecognised "
-                "engine shape; the resolvers in "
-                "_resolve_disconnect_abort_recorder + "
-                "_resolve_sync_scheduler_for_abort must learn the new "
-                "backend graph.",
-                type(engine).__name__,
-                str(request_id)[:12] if request_id else request_id,
-            )
+            engine_type = type(engine).__name__
+            should_warn = False
+            with _unresolved_engine_lock:
+                if engine_type not in _unresolved_engine_logged:
+                    _unresolved_engine_logged.add(engine_type)
+                    should_warn = True
+            if should_warn:
+                logger.warning(
+                    "[disconnect_guard] no record_disconnect_abort recorder "
+                    "found on engine type=%s — via_disconnect sub-counter "
+                    "WILL NOT advance for aborts routed through this engine. "
+                    "This indicates an unrecognised engine shape; the "
+                    "resolvers in _resolve_disconnect_abort_recorder + "
+                    "_resolve_sync_scheduler_for_abort must learn the new "
+                    "backend graph. Further occurrences for this engine "
+                    "type will be suppressed at DEBUG.",
+                    engine_type,
+                )
+            else:
+                logger.debug(
+                    "[disconnect_guard] no recorder for engine type=%s "
+                    "(request_id=%s) — warning already emitted",
+                    engine_type,
+                    str(request_id)[:12] if request_id else request_id,
+                )
             return
         recorder(request_id)
     except Exception:  # pragma: no cover - belt-and-suspenders

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2129,8 +2129,25 @@ def _resolve_disconnect_abort_recorder(engine):
 # need to learn") so once-per-engine-type is the right cardinality.
 # Bounded by the number of distinct engine classes in the process,
 # typically 1.
-_unresolved_engine_logged: set[str] = set()
+_unresolved_engine_logged: set[tuple[str, str]] = set()
 _unresolved_engine_lock = threading.Lock()
+
+
+def _unresolved_engine_dedupe_key(engine_cls: type) -> tuple[str, str]:
+    """Codex r11 NIT: dedupe by the fully-qualified class identity
+    so two distinct unresolved engine classes that happen to share
+    a leaf name (e.g. ``mod_a.BatchedEngine`` vs.
+    ``mod_b.BatchedEngine``) do NOT suppress each other's warning.
+    ``__qualname__`` covers nested classes; pairing with
+    ``__module__`` makes the key bijective with the class identity
+    for any sensibly-defined production class. Falling back to the
+    class object itself for stragglers (lambda-defined / no
+    qualname) would also work but a tuple is cheaper to hash and
+    easier to inspect in a heap dump.
+    """
+    module = getattr(engine_cls, "__module__", "<unknown>") or "<unknown>"
+    qualname = getattr(engine_cls, "__qualname__", engine_cls.__name__)
+    return (module, qualname)
 
 
 def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
@@ -2159,11 +2176,16 @@ def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
     try:
         recorder = _resolve_disconnect_abort_recorder(engine)
         if recorder is None:
-            engine_type = type(engine).__name__
+            engine_cls = type(engine)
+            dedupe_key = _unresolved_engine_dedupe_key(engine_cls)
+            # Display name is "module.qualname" so the operator log
+            # carries the full backend identity, not a leaf name that
+            # might collide across modules.
+            engine_display = f"{dedupe_key[0]}.{dedupe_key[1]}"
             should_warn = False
             with _unresolved_engine_lock:
-                if engine_type not in _unresolved_engine_logged:
-                    _unresolved_engine_logged.add(engine_type)
+                if dedupe_key not in _unresolved_engine_logged:
+                    _unresolved_engine_logged.add(dedupe_key)
                     should_warn = True
             if should_warn:
                 logger.warning(
@@ -2175,13 +2197,13 @@ def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
                     "_resolve_sync_scheduler_for_abort must learn the new "
                     "backend graph. Further occurrences for this engine "
                     "type will be suppressed at DEBUG.",
-                    engine_type,
+                    engine_display,
                 )
             else:
                 logger.debug(
                     "[disconnect_guard] no recorder for engine type=%s "
                     "(request_id=%s) — warning already emitted",
-                    engine_type,
+                    engine_display,
                     str(request_id)[:12] if request_id else request_id,
                 )
             return

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1989,11 +1989,42 @@ def _resolve_sync_scheduler_for_abort(engine):
     else:
         inner = getattr(engine, "_engine", None)
         if inner is not None:
+            # ``engine._engine.scheduler`` — synthetic test-stub shape
+            # where AsyncEngineCore-like is stubbed with a direct
+            # ``.scheduler`` attribute. Kept for back-compat with the
+            # existing pre-D-M01 test corpus.
             inner_sched = getattr(inner, "scheduler", None)
             if inner_sched is not None:
                 abort = getattr(inner_sched, "abort_request", None)
                 if abort is not None and not asyncio.iscoroutinefunction(abort):
                     return abort
+            # D-M01-DEAD (0.8.2 dogfood): the PRODUCTION ``rapid-mlx
+            # serve`` shape is ``BatchedEngine._engine`` →
+            # ``AsyncEngineCore.engine`` → ``EngineCore.scheduler``.
+            # ``AsyncEngineCore`` does NOT expose ``.scheduler``
+            # directly — its scheduler lives behind ``self.engine``
+            # which is an ``EngineCore``. Without this extra hop the
+            # sync resolver returns ``None`` on every real production
+            # engine and ``_force_abort_request`` falls into the
+            # async fallback. That fallback awaits
+            # ``EngineCore.abort_request`` which interleaves
+            # ``scheduler.abort_request`` + ``_cleanup_request``
+            # (which wipes the lifetime ledger), racing the
+            # attribution helper and causing the 2x over-count +
+            # flat-zero via_disconnect sub-counter that three
+            # 0.8.2 personas independently reported.
+            #
+            # Mirror the same deep-path walk
+            # ``_resolve_disconnect_abort_recorder`` already does so
+            # the sync abort and the attribution call resolve to the
+            # SAME ``Scheduler`` instance on every backend shape.
+            inner_engine = getattr(inner, "engine", None)
+            if inner_engine is not None:
+                deep_sched = getattr(inner_engine, "scheduler", None)
+                if deep_sched is not None:
+                    abort = getattr(deep_sched, "abort_request", None)
+                    if abort is not None and not asyncio.iscoroutinefunction(abort):
+                        return abort
     return None
 
 
@@ -2098,11 +2129,35 @@ def _record_disconnect_abort_on_scheduler(engine, request_id) -> None:
     moment the sync entry returns True, so failure of this attribution
     helper at worst leaves the (total - disconnect) gap one larger
     than reality — never breaks the abort itself.
+
+    D-M01-DEAD (0.8.2 dogfood): the previous implementation silently
+    no-op'd when ``_resolve_disconnect_abort_recorder`` returned
+    ``None``. That swallow-with-no-log let PR #783 ship without
+    catching that the production ``BatchedEngine`` over
+    ``AsyncEngineCore`` shape exposed no recorder — three personas
+    independently observed flat-zero ``via_disconnect_total`` on
+    PyPI 0.8.2. The explicit WARNING below ensures the next
+    engine-shape change cannot silently regress the sub-counter
+    again: an operator will see the unresolved-engine warning in
+    logs the moment any abort path hits a shape neither resolver
+    recognises.
     """
     try:
         recorder = _resolve_disconnect_abort_recorder(engine)
-        if recorder is not None:
-            recorder(request_id)
+        if recorder is None:
+            logger.warning(
+                "[disconnect_guard] no record_disconnect_abort recorder "
+                "found on engine type=%s — via_disconnect sub-counter "
+                "WILL NOT advance for %s. This indicates an unrecognised "
+                "engine shape; the resolvers in "
+                "_resolve_disconnect_abort_recorder + "
+                "_resolve_sync_scheduler_for_abort must learn the new "
+                "backend graph.",
+                type(engine).__name__,
+                str(request_id)[:12] if request_id else request_id,
+            )
+            return
+        recorder(request_id)
     except Exception:  # pragma: no cover - belt-and-suspenders
         logger.warning(
             "[disconnect_guard] record_disconnect_abort raised; "


### PR DESCRIPTION
## Summary
- **D-M01-DEAD**: `rapid_mlx_requests_cancelled_via_disconnect_total` NEVER advanced on the production `BatchedEngine` over `AsyncEngineCore` engine shape — three independent personas reported this on PyPI 0.8.2 ("force-abort fires every time but the metric stays flat-zero").
- **D-M01-2X**: `rapid_mlx_requests_cancelled_total` over-counted 2x on every disconnect — 20 ticks for 10 actual aborts.

Both root-caused at the boundary and fixed in one PR. Single live-server probe (`rapid-mlx serve qwen3-0.6b-8bit` + 10 raw-socket RST disconnects) confirms before-fix `cancelled=20 / via_disconnect=0` becomes after-fix `cancelled=10 / via_disconnect=10`.

### Root causes

1. **`_resolve_sync_scheduler_for_abort` (vllm_mlx/service/helpers.py)** walked one hop past `engine._engine` and missed the production deep path. `_force_abort_request` then fell into the async fallback every time (the `[disconnect_guard] force-abort fell back to async` warning was the smoking gun), and the deferred `_await_and_record` coroutine raced `EngineCore._cleanup_request`. PR #783's 9 codex rounds covered SYNTHETIC stubs only — the actual production shape (`BatchedEngine._engine` → `AsyncEngineCore.engine` → `EngineCore.scheduler`) was never built in any test. Fix: extended the resolver to walk the deep path, mirroring what `_resolve_disconnect_abort_recorder` already did.
2. **`Scheduler.remove_finished_request` (vllm_mlx/scheduler.py)** wiped the lifetime dedupe ledgers (`_cancelled_request_ids` and `_disconnect_abort_ids`). Sequence: `stream_outputs.finally` → `scheduler.abort_request` → `_cleanup_request` → `remove_finished_request` → ledger wiped. The deferred async-fallback coroutine then re-entered `scheduler.abort_request`. The id was still in `_pending_abort_ids` so the membership check passed; `already_counted` read False from the wiped ledger → counter incremented AGAIN (2x over-count). `record_disconnect_abort` gated on the same wiped ledger → silently no-op'd (flat-zero `via_disconnect`). Fix: ledgers are now LIFETIME-PERSISTENT — wiped only on fresh `add_request` (preserves request_id-reuse counting, the clear runs under the same lock as the `self.requests[...] = request` commit so admit-side exceptions never erase the prior lifetime) and on `reset()`/`deep_reset()`. Same fix mirrored on `MLLMScheduler`.

Plus two **guardrails**:
- `_record_disconnect_abort_on_scheduler` now logs an explicit WARNING when no recorder is resolved (PR #783's silent `try/except` swallow was what let D-M01-DEAD ship). The warning is rate-limited to once-per-engine-type, keyed on `(module, qualname)` so leaf-name collisions don't suppress each other.
- The unresolved-engine warning logs at WARNING the first time per engine type and DEBUG thereafter, so a sustained cancel storm on an unrecognised engine shape can't drown the disconnect_guard log signal.

### Tests
- **NEW** `tests/test_disconnect_counter_prod_shape.py` (9 cases): builds the EXACT `BatchedEngine(AsyncEngineCore(EngineCore(Scheduler)))` shape and pins both the resolver coverage and the 10-disconnect end-to-end dogfood numbers, plus the warning dedupe contracts and the MLLMScheduler `_cancel_counter_lock` constructor invariant.
- `tests/test_cancelled_requests_metric.py`: 3 existing tests updated to reflect the lifetime-persistent ledger contract (ledger persists past `remove_finished_request`, cleared at fresh `add_request`).

## Test plan
- [x] New `tests/test_disconnect_counter_prod_shape.py` (9 cases) all pass — pin the resolver coverage, the 10-disconnect end-to-end dogfood numbers, the warning dedupe contract, and the MLLMScheduler lock constructor invariant
- [x] `tests/test_cancelled_requests_metric.py` (33 cases) all pass — 3 updated to the new lifetime-persistent ledger contract
- [x] `tests/test_disconnect_guard_aborts_scheduler.py` (12 cases) all pass — no regression on existing C-01 contract
- [x] `tests/test_request_cancellation.py` (9 cases) all pass
- [x] `tests/test_embeddings_timeout_admission.py` (32 cases) all pass — verified the admission gate still fires BEFORE the ledger clear; `MLLMScheduler.add_request` lock-acquired path validated end-to-end
- [x] Live verification: `rapid-mlx serve qwen3-0.6b-8bit` + 10 raw-socket RST disconnects → `cancelled_total=10`, `via_disconnect_total=10` (was `20 / 0` on 0.8.2)
- [x] `ruff check` + `ruff format` clean across all modified files
- [x] Codex review converged: 5 rounds (r10 BLOCKING → r11 BLOCKING → r12 BLOCKING → r13 BLOCKING → r14 clean). Each round's findings addressed with the named regression test or surgical fix
- [x] Full sweep: ~6952 pass / 11 pre-existing fails (sampling-param, prometheus_client, mllm corrupt-image, anthropic env), unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)