### PR TITLE
fix(embeddings): guard --embedding-model behind extras + 400 on /v1/embeddings without configured model (H-08 + H-09)

### DIFF
--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -257,7 +257,11 @@ def _build_embed_app(patch_cfg, monkeypatch, embed_return):
     engine.embed.return_value = embed_return
     patch_cfg(
         embedding_engine=engine,
-        embedding_model_locked=None,
+        # H-09 route guard rejects requests when no embedding model is
+        # configured. These dimension/base64 tests aren't exercising the
+        # guard — they only want the success path — so configure a
+        # wildcard lock that matches the test's ``model="any"`` POST.
+        embedding_model_locked="any",
         api_key=None,
     )
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -166,6 +166,7 @@ class TestEmbeddingsEndpoint:
     def test_batch_input_preserves_order(self, client):
         """Test batch embedding returns vectors with correct indices."""
         import vllm_mlx.server as srv
+        from vllm_mlx.config import get_config
 
         texts = ["first", "second", "third"]
         mock_engine = MagicMock()
@@ -177,8 +178,20 @@ class TestEmbeddingsEndpoint:
         ]
         mock_engine.count_tokens.return_value = 9
 
+        cfg = get_config()
         original = srv._embedding_engine
+        original_locked = srv._embedding_model_locked
+        cfg_original_engine = cfg.embedding_engine
+        cfg_original_locked = cfg.embedding_model_locked
         srv._embedding_engine = mock_engine
+        # H-09: the route now requires the embedding model to be
+        # configured (i.e. the server was started with
+        # --embedding-model). Set BOTH the server global AND the cfg
+        # mirror so the route's bridge branch doesn't reset to a
+        # stale value from a prior test that left cfg set.
+        srv._embedding_model_locked = "test-embed"
+        cfg.embedding_engine = mock_engine
+        cfg.embedding_model_locked = "test-embed"
         try:
             resp = client.post(
                 "/v1/embeddings",
@@ -186,6 +199,9 @@ class TestEmbeddingsEndpoint:
             )
         finally:
             srv._embedding_engine = original
+            srv._embedding_model_locked = original_locked
+            cfg.embedding_engine = cfg_original_engine
+            cfg.embedding_model_locked = cfg_original_locked
 
         assert resp.status_code == 200
         body = resp.json()
@@ -199,12 +215,20 @@ class TestEmbeddingsEndpoint:
     def test_empty_input_returns_400(self, client):
         """Test that empty input list returns 400 error."""
         import vllm_mlx.server as srv
+        from vllm_mlx.config import get_config
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-embed"
 
+        cfg = get_config()
         original = srv._embedding_engine
+        original_locked = srv._embedding_model_locked
+        cfg_original_engine = cfg.embedding_engine
+        cfg_original_locked = cfg.embedding_model_locked
         srv._embedding_engine = mock_engine
+        srv._embedding_model_locked = "test-embed"
+        cfg.embedding_engine = mock_engine
+        cfg.embedding_model_locked = "test-embed"
         try:
             resp = client.post(
                 "/v1/embeddings",
@@ -212,50 +236,76 @@ class TestEmbeddingsEndpoint:
             )
         finally:
             srv._embedding_engine = original
+            srv._embedding_model_locked = original_locked
+            cfg.embedding_engine = cfg_original_engine
+            cfg.embedding_model_locked = cfg_original_locked
 
         assert resp.status_code == 400
 
-    def test_model_hot_swap(self, client):
-        """Test that requesting a different model triggers reload."""
+    def test_model_hot_swap_disabled_when_unlocked(self, client):
+        """H-09: hot-swap is gone — without --embedding-model, every
+        ``/v1/embeddings`` request is rejected with 400.
+
+        Pre-fix the route would call ``load_embedding_model`` on
+        ``request.model`` (typically the chat model, since no embedding
+        model was configured) and silently return chat-model hidden
+        states as if they were embeddings. The new guard refuses to do
+        that — callers must explicitly configure the embedding model at
+        startup.
+        """
         import vllm_mlx.server as srv
+        from vllm_mlx.config import get_config
 
         mock_engine = MagicMock()
         mock_engine.model_name = "old-model"
-        mock_engine.embed.return_value = [[0.1]]
-        mock_engine.count_tokens.return_value = 1
 
+        cfg = get_config()
         original = srv._embedding_engine
+        original_locked = srv._embedding_model_locked
+        cfg_original_engine = cfg.embedding_engine
+        cfg_original_locked = cfg.embedding_model_locked
         srv._embedding_engine = mock_engine
+        srv._embedding_model_locked = None  # not configured
+        cfg.embedding_engine = mock_engine
+        cfg.embedding_model_locked = None
 
         try:
             with patch("vllm_mlx.embedding.EmbeddingEngine") as mock_cls:
-                new_engine = MagicMock()
-                new_engine.model_name = "new-model"
-                new_engine.embed.return_value = [[0.9]]
-                new_engine.count_tokens.return_value = 1
-                mock_cls.return_value = new_engine
-
                 resp = client.post(
                     "/v1/embeddings",
                     json={"model": "new-model", "input": "test"},
                 )
-                assert resp.status_code == 200
-                mock_cls.assert_called_once_with("new-model")
-                new_engine.load.assert_called_once()
+                # Hot-swap path is gone; route 400s without touching
+                # the engine class.
+                assert resp.status_code == 400
+                mock_cls.assert_not_called()
+                body = resp.json()
+                msg = body["error"]["message"]
+                assert "embeddings model not configured" in msg
+                assert "rapid-mlx[embeddings]" in msg
         finally:
             srv._embedding_engine = original
+            srv._embedding_model_locked = original_locked
+            cfg.embedding_engine = cfg_original_engine
+            cfg.embedding_model_locked = cfg_original_locked
 
     def test_model_locked_rejects_different_model(self, client):
         """Test that a locked embedding model rejects requests for different models."""
         import vllm_mlx.server as srv
+        from vllm_mlx.config import get_config
 
         mock_engine = MagicMock()
         mock_engine.model_name = "locked-model"
 
+        cfg = get_config()
         original_engine = srv._embedding_engine
         original_locked = srv._embedding_model_locked
+        cfg_original_engine = cfg.embedding_engine
+        cfg_original_locked = cfg.embedding_model_locked
         srv._embedding_engine = mock_engine
         srv._embedding_model_locked = "locked-model"
+        cfg.embedding_engine = mock_engine
+        cfg.embedding_model_locked = "locked-model"
 
         try:
             resp = client.post(
@@ -272,6 +322,8 @@ class TestEmbeddingsEndpoint:
         finally:
             srv._embedding_engine = original_engine
             srv._embedding_model_locked = original_locked
+            cfg.embedding_engine = cfg_original_engine
+            cfg.embedding_model_locked = cfg_original_locked
 
 
 # =============================================================================

--- a/tests/test_embeddings_extra_guard.py
+++ b/tests/test_embeddings_extra_guard.py
@@ -22,7 +22,6 @@ were trying to avoid). Pin that here too.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -56,22 +55,21 @@ class TestEmbeddingsExtraProbe:
     def test_probe_returns_false_when_missing(self, monkeypatch):
         """When ``mlx_embeddings`` is not importable the probe returns
         False — the caller then surfaces the install hint. Simulated
-        by poisoning ``sys.modules`` with a sentinel that raises on
-        attribute access, which is how ``importlib`` reports an
-        unimportable module without us having to actually uninstall
-        the package in CI."""
+        by patching ``importlib.util.find_spec`` to report the
+        top-level package as missing, which is exactly the signal the
+        probe's new ``find_spec``-based implementation reads (codex
+        nit closure: don't mask broken-installed-package errors
+        behind the missing-extra hint)."""
+        import importlib.util as _ilu
 
-        # Drop any cached module and forbid re-import.
-        monkeypatch.delitem(sys.modules, "mlx_embeddings", raising=False)
+        real_find_spec = _ilu.find_spec
 
-        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+        def _fake_find_spec(name, *args, **kwargs):
+            if name == "mlx_embeddings":
+                return None
+            return real_find_spec(name, *args, **kwargs)
 
-        def _fake_import(name, *args, **kwargs):
-            if name == "mlx_embeddings" or name.startswith("mlx_embeddings."):
-                raise ImportError("simulated: extras not installed")
-            return real_import(name, *args, **kwargs)
-
-        monkeypatch.setattr("builtins.__import__", _fake_import)
+        monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
         from vllm_mlx.embedding import mlx_embeddings_available
 
         assert mlx_embeddings_available() is False
@@ -82,16 +80,16 @@ class TestEmbeddingsExtraProbe:
         message must name the ``[embeddings]`` extra and the
         ``rapid-mlx`` install command verbatim so the user can copy-
         paste the fix."""
-        monkeypatch.delitem(sys.modules, "mlx_embeddings", raising=False)
+        import importlib.util as _ilu
 
-        real_import = __import__
+        real_find_spec = _ilu.find_spec
 
-        def _fake_import(name, *args, **kwargs):
-            if name == "mlx_embeddings" or name.startswith("mlx_embeddings."):
-                raise ImportError("simulated: extras not installed")
-            return real_import(name, *args, **kwargs)
+        def _fake_find_spec(name, *args, **kwargs):
+            if name == "mlx_embeddings":
+                return None
+            return real_find_spec(name, *args, **kwargs)
 
-        monkeypatch.setattr("builtins.__import__", _fake_import)
+        monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
         from vllm_mlx.embedding import require_mlx_embeddings_or_exit
 
         with pytest.raises(SystemExit) as exc:
@@ -134,9 +132,8 @@ class TestEmbeddingsExtraProbe:
                     # Indented — inside a function/method, that's the
                     # lazy-import form we want.
                     continue
-                if (
-                    stripped.startswith("import mlx_embeddings")
-                    or stripped.startswith("from mlx_embeddings")
+                if stripped.startswith("import mlx_embeddings") or stripped.startswith(
+                    "from mlx_embeddings"
                 ):
                     offenders.append(f"{path.relative_to(pkg_root)}:{lineno}: {line}")
         assert not offenders, (
@@ -359,11 +356,7 @@ class TestModelsListEmbeddingCapability:
 
     def test_retrieve_embedding_model_by_id(self, monkeypatch):
         """Per-id retrieval also surfaces the configured embedding
-        model — desktop hydrates per-model state from this path.
-        Uses a slash-free id so FastAPI's path matcher accepts the
-        ``/v1/models/{id}`` route as-is (HF paths with slashes work in
-        production behind a URL-encoder; the routing semantics under
-        test here are about lookup, not about path serialization)."""
+        model — desktop hydrates per-model state from this path."""
         embed_id = "all-minilm-embed"
         client, restore = self._mount_models_app(
             monkeypatch, embedding_model_locked=embed_id
@@ -376,3 +369,51 @@ class TestModelsListEmbeddingCapability:
         body = r.json()
         assert body["id"] == embed_id
         assert "embedding" in body.get("capabilities", [])
+
+    def test_retrieve_embedding_model_by_hf_path_id(self, monkeypatch):
+        """Codex R1 BLOCKER closure: the configured embedding model is
+        almost always a Hugging Face repo id containing ``/`` (e.g.
+        ``mlx-community/all-MiniLM-L6-v2-4bit``). The
+        ``/v1/models/{model_id:path}`` route must match the raw HF id
+        without forcing clients to URL-encode the slash — every other
+        rapid-mlx endpoint accepts the bare HF id. Pin the production
+        URL shape callers actually use against the production lookup."""
+        embed_id = "mlx-community/all-MiniLM-L6-v2-4bit"
+        client, restore = self._mount_models_app(
+            monkeypatch, embedding_model_locked=embed_id
+        )
+        try:
+            # Raw HF id with slash — no URL-encoding. This is the
+            # production wire shape (rapid-desktop and the curl
+            # examples in the README both send it this way).
+            r = client.get(f"/v1/models/{embed_id}")
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == embed_id
+        assert "embedding" in body.get("capabilities", [])
+
+    def test_list_models_includes_hf_path_embedding_id(self, monkeypatch):
+        """Companion to the per-id test: with a slash-containing
+        embedding model configured, the listing also surfaces it with
+        the ``"embedding"`` capability tag. Catches the case where
+        ``_append`` or the lookup walks a different code path for
+        slash-containing ids than alias-shaped ids."""
+        embed_id = "mlx-community/all-MiniLM-L6-v2-4bit"
+        client, restore = self._mount_models_app(
+            monkeypatch, embedding_model_locked=embed_id
+        )
+        try:
+            r = client.get("/v1/models")
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        ids = [e["id"] for e in body["data"]]
+        assert embed_id in ids, (
+            f"Configured HF-path embedding id {embed_id} missing from /v1/models"
+        )
+        for entry in body["data"]:
+            if entry["id"] == embed_id:
+                assert "embedding" in entry.get("capabilities", [])

--- a/tests/test_embeddings_extra_guard.py
+++ b/tests/test_embeddings_extra_guard.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-08 + H-09 regression tests — embeddings flag/route guards.
+
+Two bugs, shared embedding surface, one PR:
+
+* **H-08**: ``--embedding-model`` was advertised in the CLI help but
+  ``mlx_embeddings`` lives behind the ``[embeddings]`` extra, so the
+  base install crashed with a raw ``ModuleNotFoundError`` traceback as
+  soon as a user passed the flag. Probe at flag-parse time, exit 2
+  with an install hint on stderr.
+* **H-09**: ``/v1/embeddings`` without ``--embedding-model`` silently
+  loaded the *chat* model name through ``mlx_embeddings.load()`` and
+  returned its pooled hidden states as if they were real embeddings —
+  silent-wrong vectors that get stuffed into vector stores. Route
+  entry now 400s with the canonical envelope + the same install hint.
+
+The probe is a lazy ``import mlx_embeddings`` inside
+``vllm_mlx.embedding.mlx_embeddings_available`` — the base install must
+never see a top-level import of ``mlx_embeddings`` (that's the bug we
+were trying to avoid). Pin that here too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# H-08 — CLI probe
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingsExtraProbe:
+    """``require_mlx_embeddings_or_exit`` is the systemic fix for H-08.
+
+    When ``mlx_embeddings`` isn't importable, the CLI ``serve`` path
+    must exit 2 with the install hint on stderr instead of letting the
+    ``ModuleNotFoundError`` bubble out of the engine load path.
+    """
+
+    def test_probe_returns_true_when_installed(self):
+        """Sanity: when the extra IS installed (the CI default for the
+        embeddings suite), the probe returns True and the CLI is free
+        to load. Skip cleanly if the extra isn't installed in this
+        environment so the test suite stays portable."""
+        pytest.importorskip("mlx_embeddings")
+        from vllm_mlx.embedding import mlx_embeddings_available
+
+        assert mlx_embeddings_available() is True
+
+    def test_probe_returns_false_when_missing(self, monkeypatch):
+        """When ``mlx_embeddings`` is not importable the probe returns
+        False — the caller then surfaces the install hint. Simulated
+        by poisoning ``sys.modules`` with a sentinel that raises on
+        attribute access, which is how ``importlib`` reports an
+        unimportable module without us having to actually uninstall
+        the package in CI."""
+
+        # Drop any cached module and forbid re-import.
+        monkeypatch.delitem(sys.modules, "mlx_embeddings", raising=False)
+
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "mlx_embeddings" or name.startswith("mlx_embeddings."):
+                raise ImportError("simulated: extras not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _fake_import)
+        from vllm_mlx.embedding import mlx_embeddings_available
+
+        assert mlx_embeddings_available() is False
+
+    def test_require_or_exit_bails_with_install_hint(self, monkeypatch, capsys):
+        """The CLI helper prints an actionable install hint to stderr
+        and exits 2 — argparse's conventional usage-error code. The
+        message must name the ``[embeddings]`` extra and the
+        ``rapid-mlx`` install command verbatim so the user can copy-
+        paste the fix."""
+        monkeypatch.delitem(sys.modules, "mlx_embeddings", raising=False)
+
+        real_import = __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "mlx_embeddings" or name.startswith("mlx_embeddings."):
+                raise ImportError("simulated: extras not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _fake_import)
+        from vllm_mlx.embedding import require_mlx_embeddings_or_exit
+
+        with pytest.raises(SystemExit) as exc:
+            require_mlx_embeddings_or_exit()
+        assert exc.value.code == 2
+
+        err = capsys.readouterr().err
+        assert "--embedding-model" in err
+        assert "[embeddings]" in err
+        assert "pip install 'rapid-mlx[embeddings]'" in err
+
+    def test_require_or_exit_noop_when_installed(self):
+        """Sanity: when the extra IS installed the CLI helper returns
+        silently — no stderr, no exit. Pinned so a future refactor that
+        accidentally turns the probe into ``not is_available`` is
+        caught immediately."""
+        pytest.importorskip("mlx_embeddings")
+        from vllm_mlx.embedding import require_mlx_embeddings_or_exit
+
+        # Returns None without raising.
+        assert require_mlx_embeddings_or_exit() is None
+
+    def test_mlx_embeddings_not_imported_at_module_top_level(self):
+        """The whole point of H-08: ``mlx_embeddings`` must NOT be
+        imported at module top level by any rapid-mlx source file.
+        Source-grep the package — if a future refactor moves a
+        top-level ``import mlx_embeddings`` into ``embedding.py`` (or
+        anywhere else), the base install starts crashing on import.
+
+        Allow ``import mlx_embeddings`` ONLY when it appears indented
+        (inside a function / method) — that's the lazy form. Top-level
+        bare ``import mlx_embeddings`` / ``from mlx_embeddings import``
+        is the failure mode."""
+        pkg_root = Path(__file__).resolve().parents[1] / "vllm_mlx"
+        offenders = []
+        for path in pkg_root.rglob("*.py"):
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.lstrip()
+                if stripped != line:
+                    # Indented — inside a function/method, that's the
+                    # lazy-import form we want.
+                    continue
+                if (
+                    stripped.startswith("import mlx_embeddings")
+                    or stripped.startswith("from mlx_embeddings")
+                ):
+                    offenders.append(f"{path.relative_to(pkg_root)}:{lineno}: {line}")
+        assert not offenders, (
+            "Top-level ``import mlx_embeddings`` found — H-08 regression: "
+            "the base install (no [embeddings] extra) will crash on import. "
+            "Move the import inside the function that needs it.\n"
+            + "\n".join(offenders)
+        )
+
+
+# ---------------------------------------------------------------------------
+# H-09 — /v1/embeddings route guard
+# ---------------------------------------------------------------------------
+
+
+def _build_embed_app(monkeypatch, engine, *, embedding_model_locked):
+    """Mount the embeddings router with a stubbed engine and the
+    chosen lock state. Mirrors the helper in
+    ``tests/test_embeddings_timeout_admission.py`` but exposes the
+    lock as a parameter so each test can pick the success vs guard
+    path explicitly. Installs the OpenAI-shaped exception handlers
+    so the 400 envelope matches the production wire shape (the same
+    wrappers ``server.app`` mounts)."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import embeddings as emb_route
+
+    app = FastAPI()
+    app.include_router(emb_route.router)
+    install_exception_handlers(app)
+
+    cfg = get_config()
+    saved = {
+        "embedding_engine": cfg.embedding_engine,
+        "embedding_model_locked": cfg.embedding_model_locked,
+        "api_key": cfg.api_key,
+    }
+    cfg.embedding_engine = engine
+    cfg.embedding_model_locked = embedding_model_locked
+    cfg.api_key = None
+
+    # Also override the server globals so the route's "bridge" branch
+    # (cfg→server fallback) doesn't reset our locked value.
+    import vllm_mlx.server as srv
+
+    saved_srv = {
+        "_embedding_engine": srv._embedding_engine,
+        "_embedding_model_locked": srv._embedding_model_locked,
+    }
+    srv._embedding_engine = engine
+    srv._embedding_model_locked = embedding_model_locked
+
+    monkeypatch.setattr(
+        "vllm_mlx.server.load_embedding_model",
+        lambda *_a, **_kw: None,
+        raising=False,
+    )
+
+    def _restore():
+        for k, v in saved.items():
+            setattr(cfg, k, v)
+        for k, v in saved_srv.items():
+            setattr(srv, k, v)
+
+    return TestClient(app), _restore
+
+
+class TestEmbeddingsRouteGuard:
+    """H-09: ``POST /v1/embeddings`` must 400 when no embedding model
+    is configured. Previously the route silently re-used the chat
+    model as if it were an embedding model — vectors shaped right
+    (1024-dim for Qwen3-0.6B) but semantically meaningless."""
+
+    def test_unconfigured_server_returns_400(self, monkeypatch):
+        engine = MagicMock()
+        client, restore = _build_embed_app(
+            monkeypatch, engine, embedding_model_locked=None
+        )
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "qwen3-0.6b-8bit", "input": "hello"},
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, r.text
+        body = r.json()
+        # Canonical OpenAI-shaped envelope.
+        assert "error" in body
+        msg = body["error"]["message"]
+        assert "embeddings model not configured" in msg
+        # Install hint is the actionable bit — must be in the envelope.
+        assert "pip install 'rapid-mlx[embeddings]'" in msg
+        # The engine must NOT have been touched — guard fires before
+        # any model load (no silent chat-model fallback).
+        engine.embed.assert_not_called()
+        engine.embed_tokens.assert_not_called()
+
+    def test_configured_server_returns_200(self, monkeypatch):
+        """Sanity: when an embedding model IS configured, the route
+        returns 200 with the engine's vectors. Smoke test only — value
+        equality is exercised by the dedicated engine tests."""
+        engine = MagicMock()
+        engine.model_name = "stub-embed"
+        engine.embed.return_value = [[0.5, 0.5, 0.5, 0.5]]
+        engine.count_tokens.return_value = 3
+        client, restore = _build_embed_app(
+            monkeypatch, engine, embedding_model_locked="stub-embed"
+        )
+        try:
+            r = client.post(
+                "/v1/embeddings",
+                json={"model": "stub-embed", "input": "hello"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["data"][0]["embedding"] == [0.5, 0.5, 0.5, 0.5]
+        engine.embed.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# H-09 — /v1/models capability advertisement
+# ---------------------------------------------------------------------------
+
+
+class TestModelsListEmbeddingCapability:
+    """``/v1/models`` must not lie about which entries are embedding-
+    capable. When no embedding model is configured, NO entry carries
+    ``"embedding"`` in ``capabilities`` — the route guard already
+    400s ``/v1/embeddings``, so advertising the chat model as
+    embedding-capable would mislead the desktop client into thinking
+    the path works."""
+
+    def _mount_models_app(self, monkeypatch, *, embedding_model_locked):
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes import models as models_route
+
+        app = FastAPI()
+        app.include_router(models_route.router)
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "model_name",
+                "model_alias",
+                "model_registry",
+                "embedding_model_locked",
+                "api_key",
+            )
+        }
+        cfg.model_name = "mlx-community/Qwen3-0.6B-8bit"
+        cfg.model_alias = "qwen3-0.6b-8bit"
+        cfg.model_registry = None
+        cfg.embedding_model_locked = embedding_model_locked
+        cfg.api_key = None
+
+        import vllm_mlx.server as srv
+
+        saved_srv = {"_embedding_model_locked": srv._embedding_model_locked}
+        srv._embedding_model_locked = embedding_model_locked
+
+        def _restore():
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+            for k, v in saved_srv.items():
+                setattr(srv, k, v)
+
+        return TestClient(app), _restore
+
+    def test_no_embedding_model_no_capability_tag(self, monkeypatch):
+        """When no embedding model is configured, no entry in
+        ``/v1/models`` carries ``"embedding"`` in its capabilities.
+        Don't lie."""
+        client, restore = self._mount_models_app(
+            monkeypatch, embedding_model_locked=None
+        )
+        try:
+            r = client.get("/v1/models")
+        finally:
+            restore()
+        assert r.status_code == 200
+        body = r.json()
+        for entry in body["data"]:
+            caps = entry.get("capabilities", [])
+            assert "embedding" not in caps, (
+                f"Model {entry['id']} advertises embedding capability "
+                "but no embedding model is configured. /v1/embeddings would 400."
+            )
+
+    def test_configured_embedding_model_carries_capability(self, monkeypatch):
+        """When an embedding model IS configured, exactly that id
+        carries the ``"embedding"`` capability tag — and it appears in
+        the listing alongside the chat model."""
+        embed_id = "mlx-community/all-MiniLM-L6-v2-4bit"
+        client, restore = self._mount_models_app(
+            monkeypatch, embedding_model_locked=embed_id
+        )
+        try:
+            r = client.get("/v1/models")
+        finally:
+            restore()
+        assert r.status_code == 200
+        body = r.json()
+
+        ids = [e["id"] for e in body["data"]]
+        assert embed_id in ids, (
+            f"Configured embedding model {embed_id} missing from /v1/models"
+        )
+
+        for entry in body["data"]:
+            caps = entry.get("capabilities", [])
+            if entry["id"] == embed_id:
+                assert "embedding" in caps
+            else:
+                assert "embedding" not in caps
+
+    def test_retrieve_embedding_model_by_id(self, monkeypatch):
+        """Per-id retrieval also surfaces the configured embedding
+        model — desktop hydrates per-model state from this path.
+        Uses a slash-free id so FastAPI's path matcher accepts the
+        ``/v1/models/{id}`` route as-is (HF paths with slashes work in
+        production behind a URL-encoder; the routing semantics under
+        test here are about lookup, not about path serialization)."""
+        embed_id = "all-minilm-embed"
+        client, restore = self._mount_models_app(
+            monkeypatch, embedding_model_locked=embed_id
+        )
+        try:
+            r = client.get(f"/v1/models/{embed_id}")
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == embed_id
+        assert "embedding" in body.get("capabilities", [])

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -172,7 +172,13 @@ def _build_embed_app(monkeypatch, engine):
         "api_key": cfg.api_key,
     }
     cfg.embedding_engine = engine
-    cfg.embedding_model_locked = None
+    # H-09 (route guard) requires the embedding model to be configured.
+    # These tests use ``model="any"`` so accept anything by locking the
+    # route to a wildcard token that's then rejected only on the
+    # mismatch branch — the test's own POSTs all use ``"any"`` so they
+    # pass the lock check. Setting None here would now 400 at the
+    # route guard instead of exercising the path under test.
+    cfg.embedding_model_locked = "any"
     cfg.api_key = None
 
     monkeypatch.setattr(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -994,7 +994,10 @@ class TestEmbeddingsRoutes:
 
         with (
             patch.object(get_config(), "embedding_engine", mock_emb_engine),
-            patch.object(get_config(), "embedding_model_locked", None),
+            # H-09 route guard requires an embedding model to be
+            # configured before accepting requests; match the test's
+            # request model so we exercise the success path.
+            patch.object(get_config(), "embedding_model_locked", "test-embed"),
             patch("vllm_mlx.server.load_embedding_model"),
             patch.object(get_config(), "api_key", None),
             patch("vllm_mlx.middleware.auth.check_rate_limit", return_value=None),
@@ -1022,7 +1025,10 @@ class TestEmbeddingsRoutes:
 
         with (
             patch.object(get_config(), "embedding_engine", mock_emb_engine),
-            patch.object(get_config(), "embedding_model_locked", None),
+            # H-09: configure the lock so the route accepts the
+            # ``model="test-embed"`` POST instead of 400ing under the
+            # new guard.
+            patch.object(get_config(), "embedding_model_locked", "test-embed"),
             patch("vllm_mlx.server.load_embedding_model"),
             patch.object(get_config(), "api_key", None),
             patch("vllm_mlx.middleware.auth.check_rate_limit", return_value=None),

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1857,6 +1857,16 @@ class ModelInfo(BaseModel):
     # dispatches on this — populating from the server lets us drop
     # the desktop-side hard-coded modality map in a future release.
     modality: str | None = None
+    # Capability tags advertised on the wire. Currently used to mark
+    # the configured embedding model with ``"embedding"`` so clients
+    # can discover which entry is wired to ``/v1/embeddings`` without
+    # heuristics on the model id. H-09 sub-fix: when no embedding
+    # model is configured at startup, NO entry carries ``"embedding"``
+    # — the server used to silently fall back to chat-model hidden
+    # states, so listing the chat model as embedding-capable was a
+    # lie the desktop happily believed. Empty list (rather than
+    # ``None``) means "we've thought about it; nothing applies".
+    capabilities: list[str] = Field(default_factory=list)
 
 
 class ModelsResponse(BaseModel):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1186,6 +1186,15 @@ def serve_command(args):
 
     # Pre-load embedding model if specified
     if args.embedding_model:
+        # H-08 guard: ``--embedding-model`` is advertised in serve --help
+        # but ``mlx_embeddings`` lives behind the ``[embeddings]`` extra.
+        # Probe here so the user gets a clear install hint on stderr +
+        # ``sys.exit(2)`` instead of a raw ``ModuleNotFoundError`` deep
+        # inside the engine load path. Lazy import — base install stays
+        # ``mlx_embeddings``-free.
+        from .embedding import require_mlx_embeddings_or_exit
+
+        require_mlx_embeddings_or_exit()
         print(f"Pre-loading embedding model: {args.embedding_model}")
         server.load_embedding_model(args.embedding_model, lock=True)
         print(f"Embedding model loaded: {args.embedding_model}")
@@ -4977,7 +4986,11 @@ Examples:
         "--embedding-model",
         type=str,
         default=None,
-        help="Pre-load an embedding model at startup (e.g. mlx-community/embeddinggemma-300m-6bit)",
+        help=(
+            "Pre-load an embedding model at startup (e.g. "
+            "mlx-community/embeddinggemma-300m-6bit). Requires the "
+            "[embeddings] extra: pip install 'rapid-mlx[embeddings]'."
+        ),
     )
     # PFlash long-prompt prefill compression (#287). Off by default; see
     # vllm_mlx/pflash.py for the design and the prefix-cache bypass.

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -7,11 +7,62 @@ for the OpenAI-compatible /v1/embeddings endpoint.
 """
 
 import logging
+import sys
 import time
 
 import mlx.core as mx
 
 logger = logging.getLogger(__name__)
+
+# Canonical install-hint copy. Shared between the CLI startup probe
+# (H-08) and the ``/v1/embeddings`` route guard (H-09) so the user sees
+# the same actionable line no matter which surface tripped the guard.
+EMBEDDINGS_EXTRA_INSTALL_HINT = (
+    "Install with: pip install 'rapid-mlx[embeddings]'"
+)
+
+
+def mlx_embeddings_available() -> bool:
+    """Probe whether ``mlx_embeddings`` is importable.
+
+    Lazy import — keeps the base install (without the ``[embeddings]``
+    extra) free of ``mlx_embeddings`` at module top-level. Callers
+    decide what to do when ``False``:
+
+    * CLI startup (:mod:`vllm_mlx.cli`, :mod:`vllm_mlx.server`) calls
+      :func:`require_mlx_embeddings_or_exit` when ``--embedding-model``
+      is passed so the user gets a clear install hint on stderr and
+      ``sys.exit(2)`` — H-08 fix.
+    * The ``/v1/embeddings`` route (:mod:`vllm_mlx.routes.embeddings`)
+      raises a 400 with the same hint when no embedding model is
+      configured — H-09 fix.
+    """
+    try:
+        import mlx_embeddings  # noqa: F401  (probe only)
+    except ImportError:
+        return False
+    return True
+
+
+def require_mlx_embeddings_or_exit() -> None:
+    """CLI-side guard: bail out cleanly when ``--embedding-model`` is
+    passed but the ``[embeddings]`` extra isn't installed.
+
+    H-08: previously the server crashed deep inside
+    :meth:`EmbeddingEngine.load` with a raw ``ModuleNotFoundError``
+    traceback because the help text advertises ``--embedding-model``
+    while ``mlx_embeddings`` lives behind the ``[embeddings]`` extra.
+    Probe at flag-parse time and exit ``2`` (the conventional argparse
+    usage-error code) with an actionable hint to stderr.
+    """
+    if mlx_embeddings_available():
+        return
+    print(
+        "error: --embedding-model requires the [embeddings] extra. "
+        + EMBEDDINGS_EXTRA_INSTALL_HINT,
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 
 class EmbeddingEngine:

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -17,17 +17,23 @@ logger = logging.getLogger(__name__)
 # Canonical install-hint copy. Shared between the CLI startup probe
 # (H-08) and the ``/v1/embeddings`` route guard (H-09) so the user sees
 # the same actionable line no matter which surface tripped the guard.
-EMBEDDINGS_EXTRA_INSTALL_HINT = (
-    "Install with: pip install 'rapid-mlx[embeddings]'"
-)
+EMBEDDINGS_EXTRA_INSTALL_HINT = "Install with: pip install 'rapid-mlx[embeddings]'"
 
 
 def mlx_embeddings_available() -> bool:
     """Probe whether ``mlx_embeddings`` is importable.
 
-    Lazy import — keeps the base install (without the ``[embeddings]``
-    extra) free of ``mlx_embeddings`` at module top-level. Callers
-    decide what to do when ``False``:
+    Uses :func:`importlib.util.find_spec` so we only answer "no" for
+    the specific case the install hint is meant to address — the
+    top-level ``mlx_embeddings`` package isn't installed. A broken
+    transitive dependency raising ``ImportError`` deep inside the
+    package surfaces as the real exception (not masked behind the
+    "install the extra" hint), making misdiagnosis less likely
+    (codex review nit on PR #800).
+
+    Lazy resolution — keeps the base install (without the
+    ``[embeddings]`` extra) free of ``mlx_embeddings`` at module
+    top-level. Callers decide what to do when ``False``:
 
     * CLI startup (:mod:`vllm_mlx.cli`, :mod:`vllm_mlx.server`) calls
       :func:`require_mlx_embeddings_or_exit` when ``--embedding-model``
@@ -37,11 +43,9 @@ def mlx_embeddings_available() -> bool:
       raises a 400 with the same hint when no embedding model is
       configured — H-09 fix.
     """
-    try:
-        import mlx_embeddings  # noqa: F401  (probe only)
-    except ImportError:
-        return False
-    return True
+    import importlib.util
+
+    return importlib.util.find_spec("mlx_embeddings") is not None
 
 
 def require_mlx_embeddings_or_exit() -> None:

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -29,6 +29,7 @@ router = APIRouter()
 )
 async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
     """Create embeddings for the given input text(s)."""
+    from ..embedding import EMBEDDINGS_EXTRA_INSTALL_HINT
     from ..server import load_embedding_model
 
     cfg = get_config()
@@ -42,6 +43,26 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
 
         if _embedding_model_locked is not None:
             cfg.embedding_model_locked = _embedding_model_locked
+
+    # H-09 guard: when the server was started WITHOUT --embedding-model,
+    # the route used to call ``load_embedding_model(request.model)`` and
+    # — if ``mlx_embeddings.load()`` happened to succeed on the chat-
+    # model repo — return a 200 with the chat model's pooled hidden
+    # states as if they were embeddings. Silent-wrong: callers stuff
+    # the garbage vector into a vector store and only notice weeks
+    # later when retrieval quality cratered. Fail loud instead — 400
+    # with the canonical envelope and the same install hint the CLI
+    # probe (H-08) prints, so the user sees the same actionable line
+    # regardless of which surface tripped the guard.
+    if cfg.embedding_model_locked is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "embeddings model not configured; start server with "
+                "--embedding-model <model> (requires [embeddings] extra). "
+                + EMBEDDINGS_EXTRA_INSTALL_HINT
+            ),
+        )
 
     try:
         model_name = request.model

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -59,6 +59,34 @@ def _reported_modality(model_id: str, profile_modality: str) -> str:
     return profile_modality
 
 
+def _embedding_capabilities(model_id: str) -> list[str]:
+    """Return capability tags for ``model_id``.
+
+    H-09 sub-fix: only the explicitly-configured embedding model is
+    tagged ``"embedding"``. When the server boots without
+    ``--embedding-model``, the route guard rejects ``/v1/embeddings``
+    requests with a 400, so advertising any chat-model id as
+    embedding-capable would be lying to the client.
+
+    Reads from ``ServerConfig.embedding_model_locked`` first and falls
+    back to the ``server._embedding_model_locked`` global so the
+    capability shows up even before ``_sync_config`` has bridged the
+    value (mirrors the same bridge the embeddings route uses).
+    """
+    cfg = get_config()
+    locked = cfg.embedding_model_locked
+    if locked is None:
+        try:
+            from ..server import _embedding_model_locked as _server_locked
+
+            locked = _server_locked
+        except Exception:  # noqa: BLE001
+            locked = None
+    if locked is not None and model_id == locked:
+        return ["embedding"]
+    return []
+
+
 def _build_model_info(model_id: str) -> ModelInfo:
     """Construct a ``ModelInfo`` for ``model_id``, filling vendor
     extension fields from the alias registry when the id resolves.
@@ -72,6 +100,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
     id still advertises ``image`` (F-067 layer fix covers raw HF paths
     too, not just registered aliases).
     """
+    capabilities = _embedding_capabilities(model_id)
     profile = resolve_profile(model_id)
     if profile is None:
         # Preserve the prior unknown-id wire shape (``ModelInfo(id=model_id)``
@@ -84,10 +113,12 @@ def _build_model_info(model_id: str) -> ModelInfo:
         # the schema default.
         try:
             if is_mllm_model(model_id):
-                return ModelInfo(id=model_id, modality="image")
+                return ModelInfo(
+                    id=model_id, modality="image", capabilities=capabilities
+                )
         except Exception:  # noqa: BLE001
             pass
-        return ModelInfo(id=model_id)
+        return ModelInfo(id=model_id, capabilities=capabilities)
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
     # back to a dict for JSON serialization. ``None`` stays ``None``
@@ -107,6 +138,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         tool_call_parser=profile.tool_call_parser,
         reasoning_parser=profile.reasoning_parser,
         modality=_reported_modality(model_id, profile.modality),
+        capabilities=capabilities,
     )
 
 
@@ -121,16 +153,42 @@ async def list_models() -> ModelsResponse:
     cfg = get_config()
 
     models = []
+    seen_ids: set[str] = set()
+
+    def _append(info: ModelInfo) -> None:
+        if info.id in seen_ids:
+            return
+        seen_ids.add(info.id)
+        models.append(info)
+
     if cfg.model_registry:
         for entry in cfg.model_registry.list_entries():
-            models.append(_build_model_info(entry.model_name))
+            _append(_build_model_info(entry.model_name))
             for alias in sorted(entry.aliases):
                 if alias != entry.model_name:
-                    models.append(_build_model_info(alias))
+                    _append(_build_model_info(alias))
     elif cfg.model_name:
-        models.append(_build_model_info(cfg.model_name))
+        _append(_build_model_info(cfg.model_name))
         if cfg.model_alias and cfg.model_alias != cfg.model_name:
-            models.append(_build_model_info(cfg.model_alias))
+            _append(_build_model_info(cfg.model_alias))
+
+    # Surface the dedicated embedding model id (when configured) so
+    # clients discover the ``/v1/embeddings``-capable id from the same
+    # ``/v1/models`` listing. H-09 sub-fix: when no embedding model is
+    # configured the route guard already 400s on ``/v1/embeddings``,
+    # so nothing is added here — capability advertisement matches
+    # actual behavior.
+    locked = cfg.embedding_model_locked
+    if locked is None:
+        try:
+            from ..server import _embedding_model_locked as _server_locked
+
+            locked = _server_locked
+        except Exception:  # noqa: BLE001
+            locked = None
+    if locked:
+        _append(_build_model_info(locked))
+
     return ModelsResponse(data=models)
 
 
@@ -147,5 +205,18 @@ async def retrieve_model(model_id: str) -> ModelInfo:
     if cfg.model_registry and model_id in cfg.model_registry:
         return _build_model_info(model_id)
     if model_id in (cfg.model_name, cfg.model_alias):
+        return _build_model_info(model_id)
+    # The dedicated embedding model id is addressable too so callers
+    # can hydrate per-model state from ``/v1/models/{id}`` without
+    # extra wire heuristics.
+    locked = cfg.embedding_model_locked
+    if locked is None:
+        try:
+            from ..server import _embedding_model_locked as _server_locked
+
+            locked = _server_locked
+        except Exception:  # noqa: BLE001
+            locked = None
+    if locked and model_id == locked:
         return _build_model_info(model_id)
     raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -192,13 +192,21 @@ async def list_models() -> ModelsResponse:
     return ModelsResponse(data=models)
 
 
-@router.get("/v1/models/{model_id}", dependencies=[Depends(verify_api_key)])
+@router.get("/v1/models/{model_id:path}", dependencies=[Depends(verify_api_key)])
 async def retrieve_model(model_id: str) -> ModelInfo:
     """Retrieve a specific model by ID.
 
     Same vendor-extension shape as `/v1/models` for callers that
     only want the profile for the active alias (rapid-desktop's
     SamplingConfig-bootstrap path).
+
+    Uses Starlette's ``:path`` converter so HF-style ids containing
+    ``/`` (e.g. ``mlx-community/all-MiniLM-L6-v2-4bit``) match the
+    route without forcing clients to URL-encode the slash — every
+    other rapid-mlx endpoint accepts the bare HF id, this one
+    should too. Slashes in alias ids are still safe: the lookup is
+    a string-equality match against the registry / cfg, not a path
+    parse.
     """
     cfg = get_config()
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1636,7 +1636,11 @@ Examples:
         "--embedding-model",
         type=str,
         default=None,
-        help="Pre-load an embedding model at startup (e.g. mlx-community/all-MiniLM-L6-v2-4bit)",
+        help=(
+            "Pre-load an embedding model at startup (e.g. "
+            "mlx-community/all-MiniLM-L6-v2-4bit). Requires the "
+            "[embeddings] extra: pip install 'rapid-mlx[embeddings]'."
+        ),
     )
     parser.add_argument(
         "--default-temperature",
@@ -1789,6 +1793,15 @@ Examples:
         logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")
 
     # Pre-load embedding model if specified
+    if args.embedding_model:
+        # H-08 guard: probe before the engine import path so an opaque
+        # ``ModuleNotFoundError`` traceback is replaced with an
+        # actionable install hint on stderr + ``sys.exit(2)``. Lazy
+        # import — the base install must not pin ``mlx_embeddings`` at
+        # module top-level.
+        from .embedding import require_mlx_embeddings_or_exit
+
+        require_mlx_embeddings_or_exit()
     load_embedding_model(args.embedding_model, lock=True)
 
     # Build a SchedulerConfig so user-supplied flags on this standalone entry


### PR DESCRIPTION
## Summary

Two bugs on the embeddings surface, one PR.

### H-08 [PRE] — `--embedding-model` crash without `[embeddings]` extra

The serve CLI advertises `--embedding-model` in `--help` but `mlx-embeddings` lives behind the `[embeddings]` extra, so the base install crashed at startup with a raw `ModuleNotFoundError` traceback as soon as a user passed the flag. Hard onboarding kill.

**Pre-fix repro** (worktree venv, no `[embeddings]` extra):
```
$ rapid-mlx serve qwen3-0.6b-8bit --embedding-model mlx-community/all-MiniLM-L6-v2-4bit --port 8962
...
File ".../vllm_mlx/embedding.py", line 36, in load
    from mlx_embeddings import load
ModuleNotFoundError: No module named 'mlx_embeddings'
```

**Post-fix:**
```
$ rapid-mlx serve qwen3-0.6b-8bit --embedding-model mlx-community/all-MiniLM-L6-v2-4bit --port 8962
...
error: --embedding-model requires the [embeddings] extra. Install with: pip install 'rapid-mlx[embeddings]'
$ echo $?
2
```

### H-09 [PRE] — `/v1/embeddings` silent-wrong without `--embedding-model`

When `--embedding-model` was unset but the user POSTed to `/v1/embeddings`, the route called `load_embedding_model(request.model)` and — if `mlx_embeddings.load()` happened to load the chat-model id — returned the chat model's pooled hidden states as if they were real embeddings. Silent-wrong 1024-dim vectors that get stuffed into a vector store and only surface weeks later as retrieval-quality cratering.

**Pre-fix repro** (server started without `--embedding-model`):
```
$ curl -X POST /v1/embeddings -d '{"model":"mlx-community/Qwen3-0.6B-8bit","input":"hello"}'
HTTP 200
{"object":"list","data":[{"index":0,"embedding":[0.073,0.179,-0.001,...]}],"model":"...","usage":{...}}
# 1024-dim vector — pulled out of qwen3 0.6B's hidden states, NOT an embedding
```

**Post-fix:**
```
$ curl -X POST /v1/embeddings -d '{"model":"mlx-community/Qwen3-0.6B-8bit","input":"hello"}'
HTTP 400
{"error":{"message":"embeddings model not configured; start server with --embedding-model <model> (requires [embeddings] extra). Install with: pip install 'rapid-mlx[embeddings]'","type":"invalid_request_error","code":null,"param":null}}
```

### Capability-listing sub-fix

`/v1/models` now advertises a `capabilities` field. When no embedding model is configured, no entry carries `"embedding"` — the route guard already 400s `/v1/embeddings`, so listing the chat model as embedding-capable would mislead the desktop client. When `--embedding-model` is set, that id is added to `/v1/models` alongside the chat model with `capabilities=["embedding"]`.

## Systemic, not band-aid

- **Lazy `import mlx_embeddings`** inside a function in `vllm_mlx/embedding.py` — base install still has zero top-level `mlx_embeddings` references (pinned by a new source-grep regression test).
- **Probe + install hint** shared between CLI and route (one constant, one helper).
- **Route-entry guard** is the single decision point — no silent fallback path.

## Install hint copy block

> `error: --embedding-model requires the [embeddings] extra. Install with: pip install 'rapid-mlx[embeddings]'`

Same copy appears in:
- The CLI probe (stderr, exit 2)
- The `/v1/embeddings` 400 body
- The `--embedding-model` help text in both `vllm_mlx/cli.py` and `vllm_mlx/server.py`

## Test plan

- [x] H-08: probe returns `True` with the extra installed
- [x] H-08: probe returns `False` when `import mlx_embeddings` is monkeypatched to raise
- [x] H-08: `require_mlx_embeddings_or_exit` exits 2 with install hint on stderr when probe fails
- [x] H-08: `require_mlx_embeddings_or_exit` no-ops when probe passes
- [x] H-08: source-grep regression test — package-wide ban on top-level `import mlx_embeddings`
- [x] H-09: `POST /v1/embeddings` with no `--embedding-model` returns 400 with canonical envelope; engine never touched
- [x] H-09: `POST /v1/embeddings` with `--embedding-model` configured returns 200 with real engine vectors
- [x] H-09: `GET /v1/models` lists no `"embedding"` capability when no model is configured
- [x] H-09: `GET /v1/models` tags exactly the configured embedding-model id with `"embedding"` capability
- [x] H-09: `GET /v1/models/{id}` resolves the configured embedding-model id
- [x] Existing `tests/test_embeddings.py`, `tests/test_embeddings_timeout_admission.py`, `tests/test_api_validation_bundle.py`, `tests/test_routes.py` updated to set `embedding_model_locked` so they exercise the success path through the new guard
- [x] Live server end-to-end: re-ran both H-08 and H-09 repros with the fix applied
- [x] Lint clean (`ruff check`)
- [x] No regression vs `b25e3af` baseline (same set of 53 failing tests outside the embeddings/cli/models surface, all unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)