### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.2"
+version = "0.8.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bumps rapid-mlx 0.8.2 → 0.8.3. Ships the 10 wave-3 fixes merged since 0.8.2:

| PR | Bug | One-line |
|---|---|---|
| #793 | D-DETOK-BPE | GPT2-BPE byte-fallback mojibake repair via `ByteLevel()` decoder swap |
| #792 | D-SSE-USAGE | `stream_options.include_usage=false` honoured at SSE final-chunk emit |
| #794 | D-HARMONY-LEAK | Harmony cut-short routes analysis to `reasoning_content` (not `content`) |
| #796 | D-M01-PROD | `cancelled_via_disconnect_total` wired on prod AsyncEngineCore; 2x over-count race fixed |
| #795 | D-DSV31 | DeepSeek-V3 fullwidth-pipe tool-call markers parsed |
| #798 | D-RECUR-FRAMEWORK | iterative tool-schema walk + body-depth guard + RecursionError handler |
| #797 | D-METAL | `--gpu-memory-utilization` enforced at admission + pressure prefix-cache eviction |
| #802 | H-01 | length-cut mid-think sentinel notice in `content` (env opt-out) |
| #801 | H-06 | `response_format: json_schema strict=true` enforced via outlines |
| #800 | H-08 + H-09 | `--embedding-model` extras probe + `/v1/embeddings` 400 guard + `/v1/models` capability truth |

## Out of release

- **PR #799 D-STOP-THINK** intentionally NOT in this release — codex review is in confirmed oscillation between suppression and casual-stop rescue invariants (16 rounds; the two cannot be simultaneously satisfied at finalize time). Awaiting operator decision (see https://github.com/raullenchai/Rapid-MLX/pull/799#issuecomment-4763218932).

## Test plan

- [x] `pyproject.toml` bumped to `0.8.3`
- [x] Commit subject matches release SOP: `chore: bump version to 0.8.3`
- [x] Single-file diff (no other changes co-committed)

## Post-merge verification (tracked, not gating)

- PyPI publish: https://pypi.org/project/rapid-mlx/0.8.3/
- Homebrew formula auto-bump PR on `homebrew-rapid-mlx`
- `pip install rapid-mlx==0.8.3` smoke (use `--index-url https://pypi.org/simple/` if JSON propagation lags)
- `rapid-mlx serve qwen3-0.6b-8bit` boots without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)