### PR TITLE
fix(models, audio, embeddings): unified capabilities detection + single mlx_audio probe + tighten --embedding-model exit-on-missing (D-CAPABILITIES-DETECTION)

### DIFF
--- a/tests/test_audio_probe_consistency.py
+++ b/tests/test_audio_probe_consistency.py
@@ -269,6 +269,55 @@ class TestProbeWiredFromOneSource:
 
 
 # ---------------------------------------------------------------------------
+# Probe covers BOTH TTS and STT sub-modules
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCoversBothLanes:
+    """Codex r1 BLOCKING follow-up: the probe must import BOTH the
+    TTS sub-module (``mlx_audio.tts.generate``) AND the STT
+    sub-module (``mlx_audio.stt.utils``) so a transcription-only
+    breakage doesn't pass the probe then 500 inside the STT route
+    with a different envelope."""
+
+    def test_stt_submodule_failure_trips_probe(self, monkeypatch, _reset_audio_probe):
+        """Simulate an install where ``mlx_audio.tts.generate``
+        imports cleanly but ``mlx_audio.stt.utils`` is broken. The
+        probe must return ok=False so the transcriptions route
+        returns the SAME 503 envelope the speech/voices routes use,
+        rather than letting the STT route reach
+        ``STTEngine.load()`` and 500 with a different shape."""
+        _orig_import = builtins.__import__
+
+        def _broken_stt(name, *args, **kwargs):
+            if name == "mlx_audio.stt.utils" or name.startswith("mlx_audio.stt"):
+                raise ImportError("simulated stt breakage")
+            return _orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _broken_stt)
+
+        from vllm_mlx.audio import probe
+
+        v = probe.mlx_audio_available()
+        assert v.ok is False, "STT-only breakage must trip the probe — F2 BLOCKING."
+        assert "stt" in v.reason.lower(), (
+            f"verdict reason should name the failing submodule, got {v.reason!r}"
+        )
+
+    def test_probe_source_lists_both_submodules(self):
+        """Source-pin so a future refactor that removes the STT
+        sub-module from the probe is caught immediately."""
+        from pathlib import Path
+
+        probe_file = (
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "probe.py"
+        )
+        source = probe_file.read_text()
+        assert "mlx_audio.tts" in source, "TTS submodule probe missing"
+        assert "mlx_audio.stt" in source, "STT submodule probe missing — F2 regression"
+
+
+# ---------------------------------------------------------------------------
 # Probe verdict caching
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audio_probe_consistency.py
+++ b/tests/test_audio_probe_consistency.py
@@ -316,11 +316,73 @@ class TestProbeCoversBothLanes:
 
         from vllm_mlx.audio import probe
 
-        v = probe.mlx_audio_available()
-        assert v.ok is False, "STT-only breakage must trip the probe — F2 BLOCKING."
+        v = probe.mlx_audio_available("stt")
+        assert v.ok is False, "STT-only breakage must trip the STT probe — F2 BLOCKING."
         assert "stt" in v.reason.lower(), (
             f"verdict reason should name the failing submodule, got {v.reason!r}"
         )
+
+    def test_stt_breakage_does_not_trip_tts_lane(self, monkeypatch, _reset_audio_probe):
+        """Codex r3 BLOCKING: an STT-only breakage must NOT 503 the
+        TTS routes. Lane separation closes the regression where a
+        torn STT install masked TTS-usable installs as fully broken.
+        """
+        import sys
+
+        for name in list(sys.modules):
+            if name == "mlx_audio.stt" or name.startswith("mlx_audio.stt."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
+        _orig_import = builtins.__import__
+
+        def _broken_stt_only(name, *args, **kwargs):
+            if name == "mlx_audio.stt.utils" or name.startswith("mlx_audio.stt"):
+                raise ImportError("simulated stt breakage")
+            return _orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _broken_stt_only)
+
+        from vllm_mlx.audio import probe
+
+        # TTS lane must still work — only STT is broken.
+        v_tts = probe.mlx_audio_available("tts")
+        assert v_tts.ok is True, (
+            "Codex r3 regression: STT-only breakage tripped the TTS "
+            f"probe (verdict={v_tts}). Lane separation broken."
+        )
+        # STT lane reports the breakage.
+        v_stt = probe.mlx_audio_available("stt")
+        assert v_stt.ok is False
+        assert "stt" in v_stt.reason.lower()
+
+    def test_tts_breakage_does_not_trip_stt_lane(self, monkeypatch, _reset_audio_probe):
+        """Mirror of the previous test: TTS-only breakage must NOT
+        503 transcriptions. Lane separation works both directions."""
+        import sys
+
+        for name in list(sys.modules):
+            if name == "mlx_audio.tts" or name.startswith("mlx_audio.tts."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
+        _orig_import = builtins.__import__
+
+        def _broken_tts_only(name, *args, **kwargs):
+            if name == "mlx_audio.tts.generate" or name.startswith("mlx_audio.tts"):
+                raise ImportError("simulated tts breakage")
+            return _orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _broken_tts_only)
+
+        from vllm_mlx.audio import probe
+
+        v_stt = probe.mlx_audio_available("stt")
+        assert v_stt.ok is True, (
+            "Codex r3 regression: TTS-only breakage tripped the STT "
+            f"probe (verdict={v_stt}). Lane separation broken."
+        )
+        v_tts = probe.mlx_audio_available("tts")
+        assert v_tts.ok is False
+        assert "tts" in v_tts.reason.lower()
 
     def test_probe_source_lists_both_submodules(self):
         """Source-pin so a future refactor that removes the STT
@@ -350,12 +412,13 @@ class TestProbeCaching:
         pytest.importorskip("mlx_audio")
         from vllm_mlx.audio import probe
 
-        # First call populates the cache.
-        v1 = probe.mlx_audio_available()
+        # First call populates the cache for the TTS lane.
+        v1 = probe.mlx_audio_available("tts")
         assert v1.ok is True
-        # Cache is populated.
-        assert probe._cached_verdict is not None
-        v2 = probe.mlx_audio_available()
+        # Cache is populated (per-lane dict).
+        assert probe._cached_verdict, "lane-keyed cache should be non-empty"
+        assert "tts" in probe._cached_verdict
+        v2 = probe.mlx_audio_available("tts")
         # Same object (cached, not re-computed).
         assert v1 is v2
 

--- a/tests/test_audio_probe_consistency.py
+++ b/tests/test_audio_probe_consistency.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-D05 regression tests — unified ``mlx_audio`` probe.
+
+Pre-fix the three audio endpoints used DIFFERENT probes:
+
+* ``/v1/audio/voices`` never touched ``mlx_audio`` at all and always
+  returned a static voice list (200).
+* ``/v1/audio/speech`` did a lazy ``from mlx_audio.tts.generate
+  import load_model`` inside the request handler — if the runtime
+  import broke, it caught ``ImportError`` and 503'd.
+* ``/v1/audio/transcriptions`` did its own lazy import.
+
+When the runtime import actually broke (e.g. a fresh ``[vision]``
+install where ``mlx-audio`` was pulled in as a transitive but
+something downstream was wonky), the endpoints disagreed: voices
+said yes, speech said no. Diego logged this in dogfood 0.8.3.
+
+Fix: every audio route consults the SAME
+:func:`vllm_mlx.audio.probe.require_mlx_audio` helper. The
+``find_spec`` presence check + cached late-import covers both
+"extra not installed" and "installed-but-runtime-broken" failure
+modes with the same 503 envelope.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def _reset_audio_probe():
+    """Clear the cached probe verdict around each test.
+
+    The probe caches at module level so the import check runs at
+    most once per process. Tests that monkeypatch the import path
+    need to drop the cache so the next call re-probes.
+    """
+    from vllm_mlx.audio import probe
+
+    probe._reset_probe_cache()
+    yield
+    probe._reset_probe_cache()
+
+
+def _mount_audio_app():
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved_api = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved_api
+
+    return TestClient(app), _restore
+
+
+# ---------------------------------------------------------------------------
+# Both routes succeed when mlx_audio is available
+# ---------------------------------------------------------------------------
+
+
+class TestProbeAgreesWhenAvailable:
+    """When ``mlx_audio`` is installed and importable cleanly, every
+    audio route reachable without a model load returns 200."""
+
+    def test_voices_returns_200_when_probe_ok(self, _reset_audio_probe):
+        pytest.importorskip("mlx_audio")
+        client, restore = _mount_audio_app()
+        try:
+            r = client.get("/v1/audio/voices")
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "voices" in body
+        assert isinstance(body["voices"], list)
+        assert len(body["voices"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Both routes 503 with the SAME envelope when mlx_audio is broken
+# ---------------------------------------------------------------------------
+
+
+def _install_broken_mlx_audio(monkeypatch, *, reason="simulated breakage"):
+    """Force ``import mlx_audio`` (and sub-modules) to fail."""
+    _orig_import = builtins.__import__
+
+    def _broken(name, *args, **kwargs):
+        if name == "mlx_audio" or name.startswith("mlx_audio."):
+            raise ImportError(reason)
+        return _orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _broken)
+
+
+def _install_missing_mlx_audio(monkeypatch):
+    """Force ``find_spec("mlx_audio")`` to return None — simulates the
+    extra not being installed."""
+    import importlib.util as _ilu
+
+    real_find_spec = _ilu.find_spec
+
+    def _fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_audio":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
+
+
+class TestProbeAgreesWhenBroken:
+    """When ``mlx_audio`` fails at runtime, both ``/v1/audio/speech``
+    and ``/v1/audio/voices`` return 503 with the same envelope shape
+    — the cross-endpoint inconsistency Diego logged is gone."""
+
+    def test_both_routes_503_when_runtime_import_fails(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        _install_broken_mlx_audio(monkeypatch, reason="torn install simulated")
+        client, restore = _mount_audio_app()
+        try:
+            r_voices = client.get("/v1/audio/voices")
+            r_speech = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "input": "hi", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+        assert r_voices.status_code == 503, r_voices.text
+        assert r_speech.status_code == 503, r_speech.text
+        # Same status, same envelope shape.
+        body_v = r_voices.json()
+        body_s = r_speech.json()
+        assert "detail" in body_v
+        assert "detail" in body_s
+        # Both detail strings mention the runtime failure reason and
+        # the actionable install hint.
+        for body in (body_v, body_s):
+            assert "torn install simulated" in body["detail"] or (
+                "import failed" in body["detail"] or "not installed" in body["detail"]
+            )
+            assert "rapid-mlx[audio]" in body["detail"]
+
+    def test_both_routes_503_when_extra_not_installed(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        _install_missing_mlx_audio(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r_voices = client.get("/v1/audio/voices")
+            r_speech = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "input": "hi", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+        assert r_voices.status_code == 503
+        assert r_speech.status_code == 503
+        assert "not installed" in r_voices.json()["detail"]
+        assert "not installed" in r_speech.json()["detail"]
+        # Install hint is uniform.
+        assert "rapid-mlx[audio]" in r_voices.json()["detail"]
+        assert "rapid-mlx[audio]" in r_speech.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Both routes use the SAME helper (via static analysis)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeWiredFromOneSource:
+    """Mechanical guard against re-introducing route-local probes.
+
+    A future refactor that hand-rolls a ``try: import mlx_audio`` in
+    a new audio route — or removes the call to ``require_mlx_audio``
+    from an existing route — would recreate the exact cross-endpoint
+    inconsistency F-D05 fixed. Source-grep the audio routes module:
+    every ``POST``/``GET`` audio route must import/call
+    ``require_mlx_audio``.
+    """
+
+    def _route_body(self, path_marker: str) -> str:
+        """Slice the source between a ``@router.<verb>("<path>"...)``
+        decorator and the next ``@router.`` decorator (or EOF). Keeps
+        the assertion off the module-level docstrings that mention
+        the same path strings."""
+        from pathlib import Path
+
+        route_file = (
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "routes" / "audio.py"
+        )
+        source = route_file.read_text()
+        decorator = "@router."
+        # Find the decorator line whose immediate next argument is the
+        # route path we care about. Scan @router. occurrences.
+        idx = 0
+        while True:
+            idx = source.find(decorator, idx)
+            if idx == -1:
+                raise AssertionError(f"no route decorator for {path_marker}")
+            # Look ahead a few lines for the path string.
+            line_end = source.find("\n", idx)
+            decorator_chunk = source[idx : line_end + 1]
+            if path_marker in decorator_chunk:
+                break
+            idx = line_end + 1
+        next_decorator = source.find(decorator, idx + 1)
+        end = next_decorator if next_decorator != -1 else len(source)
+        return source[idx:end]
+
+    def test_speech_route_calls_require_mlx_audio(self):
+        body = self._route_body("/v1/audio/speech")
+        assert "require_mlx_audio" in body, (
+            "F-D05 regression: /v1/audio/speech no longer calls "
+            "require_mlx_audio(). Every audio route must consult the "
+            "shared probe — see vllm_mlx/audio/probe.py."
+        )
+
+    def test_voices_route_calls_require_mlx_audio(self):
+        body = self._route_body("/v1/audio/voices")
+        assert "require_mlx_audio" in body, (
+            "F-D05 regression: /v1/audio/voices no longer calls "
+            "require_mlx_audio(). The voices and speech routes diverged."
+        )
+
+    def test_transcriptions_route_calls_require_mlx_audio(self):
+        body = self._route_body("/v1/audio/transcriptions")
+        assert "require_mlx_audio" in body, (
+            "F-D05 regression: /v1/audio/transcriptions no longer "
+            "consults the shared probe. Add ``require_mlx_audio()`` "
+            "to the handler."
+        )
+
+    def test_probe_module_no_top_level_mlx_audio_import(self):
+        """The probe itself must not import ``mlx_audio`` at module
+        top level — otherwise the base install (no ``[audio]`` extra)
+        crashes on ``from vllm_mlx.audio.probe import require_mlx_audio``,
+        defeating the whole point of the lazy probe. Mirror the
+        invariant H-08's ``test_mlx_embeddings_not_imported_at_module_top_level``
+        already pins for embeddings."""
+        from pathlib import Path
+
+        probe_file = (
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "probe.py"
+        )
+        for lineno, line in enumerate(probe_file.read_text().splitlines(), 1):
+            stripped = line.lstrip()
+            if stripped != line:
+                # Indented — inside a function, that's the lazy form.
+                continue
+            assert not stripped.startswith("import mlx_audio"), (
+                f"probe.py:{lineno}: top-level ``import mlx_audio`` — "
+                "the lazy probe must keep mlx_audio out of the base "
+                "install's import surface."
+            )
+            assert not stripped.startswith("from mlx_audio"), (
+                f"probe.py:{lineno}: top-level ``from mlx_audio`` — "
+                "same lazy-import constraint as above."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Probe verdict caching
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCaching:
+    """The probe runs the runtime import at most once per process,
+    then re-uses the verdict. Tests pin the cache behavior so a
+    future refactor that re-imports on every request doesn't quietly
+    add per-request import latency."""
+
+    def test_verdict_is_cached_after_first_call(self, _reset_audio_probe):
+        pytest.importorskip("mlx_audio")
+        from vllm_mlx.audio import probe
+
+        # First call populates the cache.
+        v1 = probe.mlx_audio_available()
+        assert v1.ok is True
+        # Cache is populated.
+        assert probe._cached_verdict is not None
+        v2 = probe.mlx_audio_available()
+        # Same object (cached, not re-computed).
+        assert v1 is v2
+
+    def test_reset_cache_forces_reprobe(self, monkeypatch, _reset_audio_probe):
+        from vllm_mlx.audio import probe
+
+        # Force a False verdict to be cached.
+        _install_missing_mlx_audio(monkeypatch)
+        v1 = probe.mlx_audio_available()
+        assert v1.ok is False
+        # Reset and let the real find_spec answer this time.
+        probe._reset_probe_cache()
+        monkeypatch.undo()
+        # If mlx_audio isn't installed in this venv, skip — the test
+        # is about cache-reset behavior, not the True path.
+        pytest.importorskip("mlx_audio")
+        v2 = probe.mlx_audio_available()
+        assert v2.ok is True
+        assert v1 is not v2

--- a/tests/test_audio_probe_consistency.py
+++ b/tests/test_audio_probe_consistency.py
@@ -286,7 +286,25 @@ class TestProbeCoversBothLanes:
         probe must return ok=False so the transcriptions route
         returns the SAME 503 envelope the speech/voices routes use,
         rather than letting the STT route reach
-        ``STTEngine.load()`` and 500 with a different shape."""
+        ``STTEngine.load()`` and 500 with a different shape.
+
+        Codex r2 BLOCKING: clearing the probe's cached verdict isn't
+        enough — if an earlier test imported ``mlx_audio.stt.*``,
+        ``__import__("mlx_audio.stt.utils")`` returns the cached
+        module without re-running the import machinery and the
+        simulated breakage is never exercised. Drop the cached STT
+        modules from ``sys.modules`` first so the next ``__import__``
+        call has to go through the import system (and therefore hit
+        our monkeypatched ``__import__``).
+        """
+        import sys
+
+        # Evict any cached STT modules so the broken-import monkeypatch
+        # actually fires when the probe re-imports.
+        for name in list(sys.modules):
+            if name == "mlx_audio.stt" or name.startswith("mlx_audio.stt."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
         _orig_import = builtins.__import__
 
         def _broken_stt(name, *args, **kwargs):

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -276,6 +276,86 @@ class TestToolsCapability:
             restore()
         assert "tools" in entry["capabilities"]
 
+    def test_server_global_tool_parser_does_not_leak_to_unrelated_entries(
+        self, monkeypatch
+    ):
+        """Codex r4 BLOCKING: when the server is configured with a
+        ``--tool-call-parser`` flag, the ``"tools"`` capability tag
+        must appear ONLY on the model the server is actually serving
+        — not on every entry that happens to be in the response.
+
+        The server-level tool parser is a per-server flag. Painting
+        ``"tools"`` onto unrelated registry/listed entries would
+        mislead discovery clients into pre-flighting tool support on
+        models that don't actually have it wired.
+
+        Construct a registry with two entries — one served, one
+        not — and verify only the served entry carries ``"tools"``
+        from the global fallback. Both entries have a profile with
+        a tool-call parser (qwen3 → hermes); the test pivots on the
+        UNREGISTERED served vs unregistered unserved case where the
+        server global is the ONLY signal."""
+        from fastapi import FastAPI
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes import models as models_route
+
+        served_unregistered = "operator/served-custom-tools-model"
+        other_unregistered = "operator/discovered-other-model"
+
+        app = FastAPI()
+        app.include_router(models_route.router)
+
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "model_name",
+                "model_alias",
+                "model_registry",
+                "embedding_model_locked",
+                "tool_call_parser",
+                "api_key",
+            )
+        }
+        cfg.model_name = served_unregistered
+        cfg.model_alias = served_unregistered
+        cfg.model_registry = None
+        cfg.embedding_model_locked = None
+        cfg.tool_call_parser = None
+        cfg.api_key = None
+
+        import vllm_mlx.server as srv
+
+        saved_srv = {
+            "_embedding_model_locked": srv._embedding_model_locked,
+            "_tool_call_parser": srv._tool_call_parser,
+        }
+        srv._embedding_model_locked = None
+        srv._tool_call_parser = "hermes"
+
+        client = TestClient(app)
+        try:
+            # Probe the served id directly (in the list) and the
+            # other unregistered id via retrieve_model — both must
+            # respect the served-set gate.
+            served_entry = _fetch_entry(client, served_unregistered)
+            r = client.get(f"/v1/models/{other_unregistered}")
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+            for k, v in saved_srv.items():
+                setattr(srv, k, v)
+
+        # Served entry carries "tools" from the server-global fallback.
+        assert "tools" in served_entry["capabilities"]
+        # The unserved/unregistered id returns 404 — the server
+        # doesn't advertise it. (If it ever did via discovery, the
+        # gate would still keep "tools" off.)
+        assert r.status_code == 404, (
+            f"non-served unregistered id should 404, got {r.status_code}"
+        )
+
     def test_tools_tag_falls_back_to_server_global(self, monkeypatch):
         """Codex r1 BLOCKING follow-up: ``_tools_capable`` must check
         ``server._tool_call_parser`` when ``ServerConfig.tool_call_parser``

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -276,6 +276,70 @@ class TestToolsCapability:
             restore()
         assert "tools" in entry["capabilities"]
 
+    def test_tools_tag_falls_back_to_server_global(self, monkeypatch):
+        """Codex r1 BLOCKING follow-up: ``_tools_capable`` must check
+        ``server._tool_call_parser`` when ``ServerConfig.tool_call_parser``
+        is still None. Mirrors the ``_locked_embedding_id`` bridge — the
+        config sync hasn't bridged the value yet but the global is set,
+        and ``/v1/models`` must still advertise ``"tools"``.
+
+        Without this fallback a boot-order quirk (server global set,
+        ``_sync_config`` not yet run) would silently drop the
+        capability tag for unregistered paths.
+        """
+        from fastapi import FastAPI
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.routes import models as models_route
+
+        app = FastAPI()
+        app.include_router(models_route.router)
+
+        unknown_id = "operator/custom-tools-model-2"
+        cfg = get_config()
+        saved = {
+            k: getattr(cfg, k, None)
+            for k in (
+                "model_name",
+                "model_alias",
+                "model_registry",
+                "embedding_model_locked",
+                "tool_call_parser",
+                "api_key",
+            )
+        }
+        cfg.model_name = unknown_id
+        cfg.model_alias = unknown_id
+        cfg.model_registry = None
+        cfg.embedding_model_locked = None
+        # Explicitly keep ``cfg.tool_call_parser`` at None — the bridge
+        # hasn't fired yet in this scenario.
+        cfg.tool_call_parser = None
+        cfg.api_key = None
+
+        import vllm_mlx.server as srv
+
+        saved_srv = {
+            "_embedding_model_locked": srv._embedding_model_locked,
+            "_tool_call_parser": srv._tool_call_parser,
+        }
+        srv._embedding_model_locked = None
+        # Server global IS set; config bridge has NOT happened.
+        srv._tool_call_parser = "hermes"
+
+        try:
+            entry = _fetch_entry(TestClient(app), unknown_id)
+        finally:
+            for k, v in saved.items():
+                setattr(cfg, k, v)
+            for k, v in saved_srv.items():
+                setattr(srv, k, v)
+        assert "tools" in entry["capabilities"], (
+            "F3 regression: server global _tool_call_parser was set "
+            "but cfg.tool_call_parser is None, and 'tools' capability "
+            "is missing. The fallback to the server global is gone."
+        )
+
 
 class TestCapabilityShapeAndOrder:
     """Pin the wire shape: list of strings, stable order, no dupes.

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-D01 regression tests — unified ``capabilities`` advertisement on
+``/v1/models``.
+
+Pre-fix the ``capabilities`` field returned by ``/v1/models`` only
+ever carried ``"embedding"`` (and only for the configured embedding
+model). Every other entry — including VLMs with ``modality="image"``
+— came back with ``capabilities=[]``. Diego logged this in dogfood
+0.8.3: clients that route on capabilities to choose between text /
+image / tool surfaces couldn't tell a VLM from a text-only model.
+
+The fix routes every entry through a single
+:func:`vllm_mlx.routes.models._detect_capabilities` helper that emits
+the full tag list (``text``, ``vision``, ``tools``, ``embedding``) in
+a fixed order. These tests pin the new contract.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _mount_models_app(monkeypatch, **cfg_overrides):
+    """Mount the models router with controlled config + server state."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import models as models_route
+
+    app = FastAPI()
+    app.include_router(models_route.router)
+
+    cfg = get_config()
+    saved = {
+        k: getattr(cfg, k, None)
+        for k in (
+            "model_name",
+            "model_alias",
+            "model_registry",
+            "embedding_model_locked",
+            "tool_call_parser",
+            "api_key",
+        )
+    }
+    cfg.model_registry = None
+    cfg.api_key = None
+    for k, v in cfg_overrides.items():
+        setattr(cfg, k, v)
+
+    import vllm_mlx.server as srv
+
+    saved_srv = {
+        "_embedding_model_locked": srv._embedding_model_locked,
+        "_tool_call_parser": srv._tool_call_parser,
+    }
+    srv._embedding_model_locked = cfg_overrides.get("embedding_model_locked")
+    srv._tool_call_parser = cfg_overrides.get("tool_call_parser")
+
+    def _restore():
+        for k, v in saved.items():
+            setattr(cfg, k, v)
+        for k, v in saved_srv.items():
+            setattr(srv, k, v)
+
+    return TestClient(app), _restore
+
+
+def _fetch_entry(client, model_id):
+    r = client.get("/v1/models")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    for entry in body["data"]:
+        if entry["id"] == model_id:
+            return entry
+    raise AssertionError(f"model {model_id} missing from /v1/models")
+
+
+class TestTextOnlyModel:
+    """Text-only model → ``capabilities=["text"]`` (no vision tag).
+
+    Pre-fix every text model came back with ``capabilities=[]``.
+    Clients couldn't tell whether the empty list meant "we don't
+    know" or "no capabilities" — the new contract says
+    ``["text"]`` is the always-present baseline for chat models.
+    """
+
+    def test_text_model_advertises_text_capability(self, monkeypatch):
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name="mlx-community/Qwen3-0.6B-8bit",
+            model_alias="qwen3-0.6b-8bit",
+        )
+        try:
+            entry = _fetch_entry(client, "mlx-community/Qwen3-0.6B-8bit")
+        finally:
+            restore()
+        caps = entry["capabilities"]
+        assert "text" in caps, f"text-only model missing 'text' tag: {caps}"
+        assert "vision" not in caps, f"text-only model leaked 'vision' tag: {caps}"
+        assert "embedding" not in caps, f"text-only model leaked 'embedding': {caps}"
+
+    def test_unregistered_text_path_still_gets_text(self, monkeypatch):
+        """Custom HF paths with no alias entry still get ``"text"`` —
+        the baseline isn't gated on alias-registry membership."""
+        unknown_id = "operator/custom-text-model"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=unknown_id,
+            model_alias=unknown_id,
+        )
+        try:
+            entry = _fetch_entry(client, unknown_id)
+        finally:
+            restore()
+        assert "text" in entry["capabilities"]
+
+
+class TestVisionModel:
+    """VLM → ``capabilities`` includes both ``"text"`` and ``"vision"``.
+
+    The repro from Diego's dogfood — ``mlx-community/Qwen3-VL-2B-Instruct-4bit``
+    came back with ``modality="image"`` but ``capabilities=[]``. New
+    contract: ``modality="image"`` AND ``capabilities`` contains
+    ``"vision"``."""
+
+    def test_vlm_alias_advertises_vision(self, monkeypatch):
+        """A registered VLM alias should carry ``"vision"`` in its
+        capabilities. Uses qwen3-vl alias because it's in
+        ``aliases.json`` and resolves cleanly without HF cache I/O."""
+        # Use an alias that's registered AND triggers the VLM detector.
+        # If the alias registry doesn't have a VLM, skip — the test is
+        # about the unified detector behavior, not the registry.
+        from vllm_mlx.model_aliases import resolve_profile
+
+        candidates = [
+            "qwen3-vl-2b-instruct-4bit",
+            "mlx-community/Qwen3-VL-2B-Instruct-4bit",
+        ]
+        for cand in candidates:
+            if resolve_profile(cand) is not None:
+                vlm_id = cand
+                break
+        else:
+            # Fall back: the raw HF path goes through is_mllm_model
+            # which catches VL repos by substring even without alias.
+            vlm_id = "mlx-community/Qwen3-VL-2B-Instruct-4bit"
+
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=vlm_id,
+            model_alias=vlm_id,
+        )
+        try:
+            entry = _fetch_entry(client, vlm_id)
+        finally:
+            restore()
+        caps = entry["capabilities"]
+        assert "vision" in caps, (
+            f"VLM {vlm_id} missing 'vision' in capabilities: {caps}. "
+            "F-D01 regression — VLMs must advertise vision capability."
+        )
+        assert "text" in caps, (
+            f"VLM {vlm_id} missing baseline 'text' capability: {caps}"
+        )
+
+    def test_raw_hf_vlm_path_advertises_vision(self, monkeypatch):
+        """Raw HF paths (no alias entry) still get ``"vision"`` via
+        the ``is_mllm_model`` substring detector — same path that
+        gates VLM engine routing. Pin so a future refactor that
+        narrows the detector to alias-only doesn't silently drop
+        the capability for ad-hoc HF VLM repos."""
+        # mllm.py MLLM_PATTERNS includes 'qwen3-vl', so a raw path
+        # containing it matches the substring fallback.
+        raw_id = "mlx-community/Qwen3-VL-7B-Instruct-MLX"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=raw_id,
+            model_alias=raw_id,
+        )
+        try:
+            entry = _fetch_entry(client, raw_id)
+        finally:
+            restore()
+        assert "vision" in entry["capabilities"]
+        assert entry["modality"] == "image", (
+            "raw HF VLM path: modality should still flip to 'image'"
+        )
+
+
+class TestEmbeddingModel:
+    """Configured embedding model → ``capabilities=["embedding"]``.
+
+    H-09 invariant preserved: the embedding model carries
+    ``"embedding"`` exclusively (no ``"text"``). Mixing the two would
+    mislead clients into routing chat traffic at the embedding model
+    id — the chat surface 400s for non-locked ids."""
+
+    def test_embedding_model_carries_only_embedding(self, monkeypatch):
+        embed_id = "mlx-community/embeddinggemma-300m-6bit"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name="mlx-community/Qwen3-0.6B-8bit",
+            model_alias="qwen3-0.6b-8bit",
+            embedding_model_locked=embed_id,
+        )
+        try:
+            entry = _fetch_entry(client, embed_id)
+        finally:
+            restore()
+        assert entry["capabilities"] == ["embedding"], (
+            f"embedding entry must carry exactly ['embedding'], got "
+            f"{entry['capabilities']}"
+        )
+
+    def test_embedding_model_modality_is_text_not_null(self, monkeypatch):
+        """F-D01 cosmetic: pre-fix embedding entry advertised
+        ``modality=None`` while VLMs advertised ``modality="image"``.
+        Embedding accepts text input, so the on-wire modality is
+        ``"text"`` — the ``capabilities=["embedding"]`` tag
+        distinguishes the lane, not the modality."""
+        embed_id = "mlx-community/embeddinggemma-300m-6bit"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name="mlx-community/Qwen3-0.6B-8bit",
+            model_alias="qwen3-0.6b-8bit",
+            embedding_model_locked=embed_id,
+        )
+        try:
+            entry = _fetch_entry(client, embed_id)
+        finally:
+            restore()
+        assert entry["modality"] == "text", (
+            f"embedding modality must be 'text' not null/{entry['modality']!r}"
+        )
+
+
+class TestToolsCapability:
+    """Tool-capable models → ``capabilities`` includes ``"tools"``.
+
+    Two signals trip the tag: (1) the alias profile carries a
+    non-empty ``tool_call_parser``, (2) the server is booted with
+    ``--tool-call-parser`` for an unregistered path. Either fires
+    the capability."""
+
+    def test_profile_tool_parser_enables_tools_tag(self, monkeypatch):
+        """A model whose alias profile sets ``tool_call_parser=hermes``
+        (Qwen3) advertises ``"tools"`` regardless of server flags."""
+        model_id = "mlx-community/Qwen3-0.6B-8bit"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=model_id,
+            model_alias="qwen3-0.6b-8bit",
+        )
+        try:
+            entry = _fetch_entry(client, model_id)
+        finally:
+            restore()
+        caps = entry["capabilities"]
+        assert "tools" in caps, (
+            f"Qwen3 alias should advertise 'tools' (hermes parser), got {caps}"
+        )
+
+    def test_server_tool_parser_enables_tag_for_unregistered_id(self, monkeypatch):
+        """Operator-supplied custom HF path + ``--tool-call-parser``
+        flag → ``"tools"`` capability appears even without an alias
+        profile entry."""
+        unknown_id = "operator/custom-tools-model"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=unknown_id,
+            model_alias=unknown_id,
+            tool_call_parser="hermes",
+        )
+        try:
+            entry = _fetch_entry(client, unknown_id)
+        finally:
+            restore()
+        assert "tools" in entry["capabilities"]
+
+
+class TestCapabilityShapeAndOrder:
+    """Pin the wire shape: list of strings, stable order, no dupes.
+
+    Tests pre-bind the shape so a future refactor that returns
+    ``set``, ``tuple``, or duplicate entries fails fast."""
+
+    def test_capabilities_is_a_list(self, monkeypatch):
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name="mlx-community/Qwen3-0.6B-8bit",
+            model_alias="qwen3-0.6b-8bit",
+        )
+        try:
+            entry = _fetch_entry(client, "mlx-community/Qwen3-0.6B-8bit")
+        finally:
+            restore()
+        assert isinstance(entry["capabilities"], list)
+        for c in entry["capabilities"]:
+            assert isinstance(c, str)
+
+    def test_text_precedes_vision_precedes_tools(self, monkeypatch):
+        """Union case: text + tools, or text + vision + tools, must
+        appear in ``text → vision → tools`` order. The detector
+        builds the list deterministically; tests pin so reordering
+        breaks the contract loudly."""
+        # Qwen3-VL is multimodal AND has hermes parser.
+
+        vlm_with_tools = "mlx-community/Qwen3-VL-7B-Instruct-MLX"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=vlm_with_tools,
+            model_alias=vlm_with_tools,
+            tool_call_parser="hermes",
+        )
+        try:
+            entry = _fetch_entry(client, vlm_with_tools)
+        finally:
+            restore()
+        caps = entry["capabilities"]
+        # All three present.
+        assert "text" in caps and "vision" in caps and "tools" in caps
+        # Order: text < vision < tools.
+        assert caps.index("text") < caps.index("vision") < caps.index("tools"), (
+            f"capabilities order broken: {caps}. Expected text → vision → tools."
+        )
+
+    def test_no_duplicate_tags(self, monkeypatch):
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name="mlx-community/Qwen3-0.6B-8bit",
+            model_alias="qwen3-0.6b-8bit",
+            tool_call_parser="hermes",
+        )
+        try:
+            entry = _fetch_entry(client, "mlx-community/Qwen3-0.6B-8bit")
+        finally:
+            restore()
+        caps = entry["capabilities"]
+        assert len(caps) == len(set(caps)), f"duplicate tags: {caps}"

--- a/tests/test_embeddings_extra_guard.py
+++ b/tests/test_embeddings_extra_guard.py
@@ -112,6 +112,99 @@ class TestEmbeddingsExtraProbe:
         # Returns None without raising.
         assert require_mlx_embeddings_or_exit() is None
 
+    def test_guard_fires_before_banner_in_cli_serve(self):
+        """F-H08-INCOMPLETE follow-up: the ``[embeddings]`` extra check
+        in ``cli.py::serve_command`` must run BEFORE the model-download
+        prefetch and the startup banner. Pre-fix the probe lived deep
+        in ``serve_command`` so the operator saw the alias-resolved log
+        line, the "🐆 Rapid-MLX" banner, the feature list, AND the
+        Model id BEFORE the error and ``sys.exit(2)`` — Diego reported
+        this as a warning-and-fall-through because the banner masked
+        the actual exit.
+
+        Source-pin the ordering: in ``cli.py::serve_command``, the
+        first ``require_mlx_embeddings_or_exit`` reference must appear
+        BEFORE the first ``_ensure_model_downloaded`` reference AND
+        BEFORE the first ``"🐆 Rapid-MLX"`` banner string.
+        """
+        cli_file = Path(__file__).resolve().parents[1] / "vllm_mlx" / "cli.py"
+        source = cli_file.read_text()
+        # Locate serve_command body — between ``def serve_command`` and
+        # the next top-level ``def`` so we only scan the relevant function.
+        start = source.index("def serve_command(")
+        # Look for the next ``\ndef `` (top-level function) after start.
+        end = source.find("\ndef ", start + 1)
+        body = source[start : end if end != -1 else len(source)]
+
+        # The guard must appear in serve_command at all. Look for the
+        # actual CALL form ``require_mlx_embeddings_or_exit()`` so
+        # docstring/comment mentions of the helper name don't confuse
+        # the ordering check.
+        idx_require = body.find("require_mlx_embeddings_or_exit()")
+        assert idx_require != -1, (
+            "serve_command does not call require_mlx_embeddings_or_exit() — "
+            "the H-08 guard is gone. Restore the probe at the top of "
+            "serve_command."
+        )
+
+        # Ordering vs the model download. Match the CALL form so a
+        # comment that mentions ``_ensure_model_downloaded`` higher up
+        # doesn't trip the ordering check.
+        idx_download = body.find("_ensure_model_downloaded(")
+        assert idx_download != -1, (
+            "serve_command no longer calls _ensure_model_downloaded() — "
+            "the fixture this test pins against has moved; update the "
+            "test to match the new boot order."
+        )
+        assert idx_require < idx_download, (
+            "F-H08-INCOMPLETE regression: require_mlx_embeddings_or_exit "
+            "fires AFTER _ensure_model_downloaded in serve_command. The "
+            "guard must run first so a cold-cache user doesn't pay a "
+            "multi-minute download before the install-hint exit."
+        )
+
+        # Ordering vs the startup banner.
+        idx_banner = body.find("🐆 Rapid-MLX")
+        if idx_banner != -1:
+            assert idx_require < idx_banner, (
+                "F-H08-INCOMPLETE regression: the H-08 guard fires AFTER "
+                "the '🐆 Rapid-MLX' startup banner — operators saw the "
+                "banner + Features line + Model id before the error, which "
+                "looked like a successful boot. Move the guard BEFORE "
+                "the banner."
+            )
+
+    def test_guard_fires_before_banner_in_server_entrypoint(self):
+        """Same invariant for the standalone ``python -m vllm_mlx.server``
+        entrypoint. Pre-fix the probe lived after ``configure_logging``
+        and the SECURITY CONFIGURATION header; new contract is that
+        nothing prints between ``parse_args()`` and the guard."""
+        server_file = Path(__file__).resolve().parents[1] / "vllm_mlx" / "server.py"
+        source = server_file.read_text()
+
+        # The standalone entrypoint's parse_args sits inside the same
+        # function that prints the SECURITY CONFIGURATION banner.
+        idx_parse = source.find("args = parser.parse_args()")
+        assert idx_parse != -1
+        # Confirm the function body actually contains the guard — look
+        # for the CALL form so a docstring reference doesn't satisfy
+        # the search.
+        idx_require = source.find("require_mlx_embeddings_or_exit()", idx_parse)
+        assert idx_require != -1, (
+            "server.py main entrypoint no longer calls "
+            "require_mlx_embeddings_or_exit after parse_args — H-08 "
+            "regression."
+        )
+        idx_security_banner = source.find("SECURITY CONFIGURATION", idx_parse)
+        # The first SECURITY CONFIGURATION line after parse_args must
+        # come AFTER the guard — i.e. the guard fires before the banner.
+        assert idx_security_banner != -1, "SECURITY banner line missing"
+        assert idx_require < idx_security_banner, (
+            "F-H08-INCOMPLETE regression in server.py: the embedding "
+            "extras probe fires AFTER the SECURITY CONFIGURATION banner. "
+            "Move it to immediately after parse_args()."
+        )
+
     def test_mlx_embeddings_not_imported_at_module_top_level(self):
         """The whole point of H-08: ``mlx_embeddings`` must NOT be
         imported at module top level by any rapid-mlx source file.

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -177,9 +177,7 @@ class ResponsesRequest(BaseModel):
                 )
         elif isinstance(self.input, list):
             if len(self.input) == 0:
-                raise ValueError(
-                    "`input` must be a non-empty list of input items."
-                )
+                raise ValueError("`input` must be a non-empty list of input items.")
         return self
 
 

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -11,19 +11,30 @@ disagreed — ``voices`` said "yes" with a full list while ``speech``
 503'd "mlx-audio not installed". Users couldn't tell whether TTS
 was actually wired up.
 
-The fix routes EVERY audio endpoint through the same probe so they
-agree. Two complementary checks:
+The fix routes EVERY audio endpoint through the same probe surface
+so they agree, but per-lane so a torn install in one lane doesn't
+503 the other. Two complementary checks per lane:
 
 1. ``importlib.util.find_spec("mlx_audio")`` — cheap presence check;
-   answers "is the top-level package even installed?".
-2. ``import mlx_audio.tts.generate as _probe`` — runtime check;
-   answers "does the package actually import cleanly?". Caches the
-   verdict so we don't pay the import on every request.
+   answers "is the top-level package even installed?". Shared across
+   lanes (cached once per process).
+2. Lane-specific late-import — for the TTS lane, probe
+   ``mlx_audio.tts.generate``; for the STT lane, probe
+   ``mlx_audio.stt.utils``. Caches per-lane verdicts so we don't
+   pay the import on every request.
+
+Lane separation rationale (codex r2 BLOCKING on PR #804): a single
+combined probe would 503 the TTS routes when only STT is broken (or
+vice versa) — a regression for TTS-only callers on installs where
+STT happens to be torn. Each route probes ONLY the lane it needs.
+The base ``find_spec("mlx_audio")`` failure (extra missing entirely)
+still 503s all three routes with the same envelope because that's
+the genuinely-shared failure mode.
 
 The probe is purely lazy — ``vllm_mlx.audio.probe`` itself never
 imports ``mlx_audio`` at module top level, so the base install
-(without the ``[audio]`` extra) can ``from vllm_mlx.audio.probe import
-require_mlx_audio`` without crashing.
+(without the ``[audio]`` extra) can ``from vllm_mlx.audio.probe
+import require_mlx_audio_tts`` without crashing.
 """
 
 from __future__ import annotations
@@ -47,115 +58,119 @@ class _Verdict:
     reason: str | None = None
 
 
-# Module-level cache. Set on first call to :func:`mlx_audio_available`
-# and re-used by every audio route. Cleared by :func:`_reset_probe_cache`
-# in tests so monkeypatched import failures take effect on the next
-# call without leaking across tests.
-_cached_verdict: _Verdict | None = None
+# Lane-keyed cache. ``"tts"`` and ``"stt"`` map to the most recent
+# verdict for each lane; the empty ``""`` key holds the result of the
+# shared ``find_spec`` presence check so the cheap "extra missing"
+# path doesn't repeat the syscall on every request.
+_cached_verdict: dict[str, _Verdict] = {}
 
 
 def _reset_probe_cache() -> None:
-    """Test hook: clear the cached verdict.
+    """Test hook: clear every cached verdict.
 
-    The audio routes call :func:`mlx_audio_available` on every request,
+    The audio routes call the lane-specific probes on every request,
     so a stale cache from a previous test (where the import succeeded)
     would mask a monkeypatched failure in the next test. Tests that
     swap ``builtins.__import__`` or otherwise simulate a broken
     ``mlx_audio`` call this helper in their fixture to force re-probe.
     """
-    global _cached_verdict
-    _cached_verdict = None
+    _cached_verdict.clear()
 
 
-def mlx_audio_available() -> _Verdict:
-    """Probe whether ``mlx_audio`` is usable.
+# Sub-modules each route actually needs to load. Split per lane so a
+# torn install in one lane doesn't 503 the other (codex r2 BLOCKING
+# on PR #804). ``find_spec("mlx_audio")`` is the shared presence
+# check; the lane-specific entries cover runtime sub-module breakage.
+_LANE_SUBMODULES: dict[str, str] = {
+    "tts": "mlx_audio.tts.generate",  # /v1/audio/speech, voices
+    "stt": "mlx_audio.stt.utils",  # /v1/audio/transcriptions
+}
 
-    Returns the same :class:`_Verdict` for every caller within a
-    single process — the import check runs at most once, then the
-    cached answer is re-used. ``find_spec`` covers the "not
-    installed" case; the late ``import mlx_audio.tts.generate``
-    covers the "installed but transitively broken" case (the failure
-    mode Diego hit on a fresh ``[vision]`` install where ``mlx-audio``
-    was pulled in as a transitive but actually breaks at runtime).
+
+def _probe_lane(lane: str) -> _Verdict:
+    """Internal: probe a single lane (``"tts"`` or ``"stt"``).
+
+    Shared first step — ``importlib.util.find_spec("mlx_audio")`` —
+    is cached under the empty-string key so the cheap presence check
+    only runs once per process. If the top-level package is missing,
+    the verdict for the lane folds back to that "extra not installed"
+    answer so callers see a uniform envelope across lanes for the
+    common case.
+
+    Sub-module probe uses bare ``__import__`` (rather than
+    ``importlib.import_module``) so a torn install is detected even
+    when an earlier successful import has already populated
+    ``sys.modules``. ``import_module`` short-circuits to the cached
+    entry; ``__import__`` re-resolves the import machinery — which is
+    what tests need to validate the broken-install path AND what
+    production needs when a runtime force-reload (plugin hot-reload,
+    config reload mid-process) cleared the cache.
+    """
+    if lane in _cached_verdict:
+        return _cached_verdict[lane]
+
+    # Shared presence check: cached separately so a TTS probe doesn't
+    # re-pay the find_spec syscall for STT.
+    if "" not in _cached_verdict:
+        import importlib.util
+
+        if importlib.util.find_spec("mlx_audio") is None:
+            _cached_verdict[""] = _Verdict(
+                ok=False, reason="mlx-audio is not installed"
+            )
+        else:
+            _cached_verdict[""] = _Verdict(ok=True, reason=None)
+    presence = _cached_verdict[""]
+    if not presence.ok:
+        _cached_verdict[lane] = presence
+        return presence
+
+    submod = _LANE_SUBMODULES.get(lane)
+    if submod is None:
+        # Programmer error — unknown lane.
+        _cached_verdict[lane] = _Verdict(
+            ok=False, reason=f"unknown audio lane {lane!r}"
+        )
+        return _cached_verdict[lane]
+    try:
+        __import__(submod)
+    except Exception as e:  # noqa: BLE001
+        _cached_verdict[lane] = _Verdict(
+            ok=False,
+            reason=(
+                f"mlx-audio {lane} import failed at runtime: "
+                f"{type(e).__name__}: {e} (probing {submod})"
+            ),
+        )
+        return _cached_verdict[lane]
+
+    _cached_verdict[lane] = _Verdict(ok=True, reason=None)
+    return _cached_verdict[lane]
+
+
+def mlx_audio_available(lane: str = "tts") -> _Verdict:
+    """Probe whether ``mlx_audio`` is usable for ``lane``.
+
+    ``lane`` is one of ``"tts"`` (default) or ``"stt"`` — selects
+    which sub-module gets the runtime late-import check. The shared
+    ``find_spec`` presence check is cached across lanes so a missing
+    extra reports a uniform envelope from every route.
 
     The route handlers consult this through
-    :func:`require_mlx_audio` so the failure surface is uniform
-    across ``/v1/audio/speech``, ``/v1/audio/voices``, and
-    ``/v1/audio/transcriptions``.
+    :func:`require_mlx_audio_tts` / :func:`require_mlx_audio_stt`
+    so the failure surface is uniform within a lane while a torn
+    STT install can no longer 503 the TTS routes.
     """
-    global _cached_verdict
-    if _cached_verdict is not None:
-        return _cached_verdict
-
-    import importlib.util
-
-    if importlib.util.find_spec("mlx_audio") is None:
-        _cached_verdict = _Verdict(
-            ok=False,
-            reason="mlx-audio is not installed",
-        )
-        return _cached_verdict
-
-    # find_spec said the top-level package is reachable. Now confirm
-    # the sub-modules actually used by the TTS/STT engines import
-    # cleanly. A torn install (e.g. a transitive dep version
-    # mismatch) shows up here — and we want the route to advertise
-    # the real ``ImportError`` reason rather than the generic
-    # "install the extra" hint that would mislead the operator.
-    #
-    # Probe BOTH ``mlx_audio.tts.generate`` (used by
-    # ``/v1/audio/speech`` + ``/v1/audio/voices``) AND
-    # ``mlx_audio.stt.utils`` (used by ``/v1/audio/transcriptions``)
-    # so the probe verdict reflects the union of the runtime imports
-    # the audio routes actually depend on. Codex r1 BLOCKING on
-    # PR #804: pre-fix only the TTS sub-module was probed, so a
-    # transcription-only ``mlx_audio`` breakage would pass the probe
-    # then 500 in the STT route with a different envelope.
-    _SUBMODULES = (
-        "mlx_audio.tts.generate",  # /v1/audio/speech, voices
-        "mlx_audio.stt.utils",  # /v1/audio/transcriptions
-    )
-    for submod in _SUBMODULES:
-        try:
-            # Use the bare ``__import__`` builtin (rather than
-            # ``importlib.import_module``) so a torn install can be
-            # detected even when an earlier successful import has
-            # already populated ``sys.modules``. ``import_module``
-            # short-circuits to the cached entry; ``__import__``
-            # re-resolves the import machinery, which is what tests
-            # need to validate the broken-install code path AND what
-            # production needs when a runtime force-reload (e.g.
-            # plugin hot-reload) cleared the cache mid-process.
-            __import__(submod)
-        except Exception as e:  # noqa: BLE001
-            _cached_verdict = _Verdict(
-                ok=False,
-                reason=(
-                    f"mlx-audio import failed at runtime: "
-                    f"{type(e).__name__}: {e} (probing {submod})"
-                ),
-            )
-            return _cached_verdict
-
-    _cached_verdict = _Verdict(ok=True, reason=None)
-    return _cached_verdict
+    return _probe_lane(lane)
 
 
-def require_mlx_audio() -> None:
-    """Raise an HTTP 503 when ``mlx_audio`` is not usable.
-
-    Centralizes the failure envelope so every audio route returns the
-    SAME body and status when the dep is missing or broken. Pre-fix
-    the speech and voices routes had divergent behavior; that's the
-    cross-endpoint inconsistency this helper closes.
+def _raise_503(verdict: _Verdict) -> None:
+    """Translate a failed :class:`_Verdict` into the HTTP 503 envelope.
 
     Imports ``HTTPException`` lazily so the base install — which
     doesn't necessarily reach the audio routes at all — doesn't pay
     the FastAPI cost just to wire the probe.
     """
-    verdict = mlx_audio_available()
-    if verdict.ok:
-        return
     from fastapi import HTTPException
 
     detail = verdict.reason or "mlx-audio is not available"
@@ -163,3 +178,37 @@ def require_mlx_audio() -> None:
         status_code=503,
         detail=(f"{detail}. Install with: pip install 'rapid-mlx[audio]'"),
     )
+
+
+def require_mlx_audio_tts() -> None:
+    """Raise an HTTP 503 when the TTS lane of ``mlx_audio`` isn't usable.
+
+    Used by ``/v1/audio/speech`` and ``/v1/audio/voices``. A torn
+    STT install does NOT trip this probe — pre-codex-r2 the
+    combined probe did, which masked TTS-usable installs as broken.
+    """
+    verdict = _probe_lane("tts")
+    if verdict.ok:
+        return
+    _raise_503(verdict)
+
+
+def require_mlx_audio_stt() -> None:
+    """Raise an HTTP 503 when the STT lane of ``mlx_audio`` isn't usable.
+
+    Used by ``/v1/audio/transcriptions``. A torn TTS install does
+    NOT trip this probe.
+    """
+    verdict = _probe_lane("stt")
+    if verdict.ok:
+        return
+    _raise_503(verdict)
+
+
+# Backwards-compat shim — earlier PR #804 commits exported
+# ``require_mlx_audio`` as a single combined probe. Kept as an alias
+# for the TTS lane so any in-flight code that imported the old name
+# still works; the TTS lane is the more common probe target (speech
+# + voices vs. transcriptions alone). Re-aliased through the
+# explicit lane name so call sites read clearly.
+require_mlx_audio = require_mlx_audio_tts

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -102,14 +102,40 @@ def mlx_audio_available() -> _Verdict:
     # mismatch) shows up here — and we want the route to advertise
     # the real ``ImportError`` reason rather than the generic
     # "install the extra" hint that would mislead the operator.
-    try:
-        import mlx_audio.tts.generate  # noqa: F401
-    except Exception as e:  # noqa: BLE001
-        _cached_verdict = _Verdict(
-            ok=False,
-            reason=f"mlx-audio import failed at runtime: {type(e).__name__}: {e}",
-        )
-        return _cached_verdict
+    #
+    # Probe BOTH ``mlx_audio.tts.generate`` (used by
+    # ``/v1/audio/speech`` + ``/v1/audio/voices``) AND
+    # ``mlx_audio.stt.utils`` (used by ``/v1/audio/transcriptions``)
+    # so the probe verdict reflects the union of the runtime imports
+    # the audio routes actually depend on. Codex r1 BLOCKING on
+    # PR #804: pre-fix only the TTS sub-module was probed, so a
+    # transcription-only ``mlx_audio`` breakage would pass the probe
+    # then 500 in the STT route with a different envelope.
+    _SUBMODULES = (
+        "mlx_audio.tts.generate",  # /v1/audio/speech, voices
+        "mlx_audio.stt.utils",  # /v1/audio/transcriptions
+    )
+    for submod in _SUBMODULES:
+        try:
+            # Use the bare ``__import__`` builtin (rather than
+            # ``importlib.import_module``) so a torn install can be
+            # detected even when an earlier successful import has
+            # already populated ``sys.modules``. ``import_module``
+            # short-circuits to the cached entry; ``__import__``
+            # re-resolves the import machinery, which is what tests
+            # need to validate the broken-install code path AND what
+            # production needs when a runtime force-reload (e.g.
+            # plugin hot-reload) cleared the cache mid-process.
+            __import__(submod)
+        except Exception as e:  # noqa: BLE001
+            _cached_verdict = _Verdict(
+                ok=False,
+                reason=(
+                    f"mlx-audio import failed at runtime: "
+                    f"{type(e).__name__}: {e} (probing {submod})"
+                ),
+            )
+            return _cached_verdict
 
     _cached_verdict = _Verdict(ok=True, reason=None)
     return _cached_verdict

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single source of truth for ``mlx_audio`` availability.
+
+D-CAPABILITIES-DETECTION (F-D05): pre-fix, ``/v1/audio/voices`` and
+``/v1/audio/speech`` used *different* probes — the voices route never
+touched ``mlx_audio`` at all (returned a static voice list) while the
+speech route did a lazy ``import mlx_audio.tts.generate.load_model``
+inside the request handler. Result: when the runtime import broke
+(transitive-dep mismatch, partial reinstall, etc.) the two endpoints
+disagreed — ``voices`` said "yes" with a full list while ``speech``
+503'd "mlx-audio not installed". Users couldn't tell whether TTS
+was actually wired up.
+
+The fix routes EVERY audio endpoint through the same probe so they
+agree. Two complementary checks:
+
+1. ``importlib.util.find_spec("mlx_audio")`` — cheap presence check;
+   answers "is the top-level package even installed?".
+2. ``import mlx_audio.tts.generate as _probe`` — runtime check;
+   answers "does the package actually import cleanly?". Caches the
+   verdict so we don't pay the import on every request.
+
+The probe is purely lazy — ``vllm_mlx.audio.probe`` itself never
+imports ``mlx_audio`` at module top level, so the base install
+(without the ``[audio]`` extra) can ``from vllm_mlx.audio.probe import
+require_mlx_audio`` without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _Verdict:
+    """Outcome of the ``mlx_audio`` probe.
+
+    ``ok`` is the headline answer the routes branch on. ``reason``
+    carries the original failure string so the 503 envelope can point
+    operators at the actual root cause (e.g. ``ModuleNotFoundError:
+    No module named 'mlx_audio.tts.foo'`` — *not* the generic "install
+    the [audio] extra" hint that lies when the extra IS installed but
+    the runtime import is broken).
+    """
+
+    ok: bool
+    reason: str | None = None
+
+
+# Module-level cache. Set on first call to :func:`mlx_audio_available`
+# and re-used by every audio route. Cleared by :func:`_reset_probe_cache`
+# in tests so monkeypatched import failures take effect on the next
+# call without leaking across tests.
+_cached_verdict: _Verdict | None = None
+
+
+def _reset_probe_cache() -> None:
+    """Test hook: clear the cached verdict.
+
+    The audio routes call :func:`mlx_audio_available` on every request,
+    so a stale cache from a previous test (where the import succeeded)
+    would mask a monkeypatched failure in the next test. Tests that
+    swap ``builtins.__import__`` or otherwise simulate a broken
+    ``mlx_audio`` call this helper in their fixture to force re-probe.
+    """
+    global _cached_verdict
+    _cached_verdict = None
+
+
+def mlx_audio_available() -> _Verdict:
+    """Probe whether ``mlx_audio`` is usable.
+
+    Returns the same :class:`_Verdict` for every caller within a
+    single process — the import check runs at most once, then the
+    cached answer is re-used. ``find_spec`` covers the "not
+    installed" case; the late ``import mlx_audio.tts.generate``
+    covers the "installed but transitively broken" case (the failure
+    mode Diego hit on a fresh ``[vision]`` install where ``mlx-audio``
+    was pulled in as a transitive but actually breaks at runtime).
+
+    The route handlers consult this through
+    :func:`require_mlx_audio` so the failure surface is uniform
+    across ``/v1/audio/speech``, ``/v1/audio/voices``, and
+    ``/v1/audio/transcriptions``.
+    """
+    global _cached_verdict
+    if _cached_verdict is not None:
+        return _cached_verdict
+
+    import importlib.util
+
+    if importlib.util.find_spec("mlx_audio") is None:
+        _cached_verdict = _Verdict(
+            ok=False,
+            reason="mlx-audio is not installed",
+        )
+        return _cached_verdict
+
+    # find_spec said the top-level package is reachable. Now confirm
+    # the sub-modules actually used by the TTS/STT engines import
+    # cleanly. A torn install (e.g. a transitive dep version
+    # mismatch) shows up here — and we want the route to advertise
+    # the real ``ImportError`` reason rather than the generic
+    # "install the extra" hint that would mislead the operator.
+    try:
+        import mlx_audio.tts.generate  # noqa: F401
+    except Exception as e:  # noqa: BLE001
+        _cached_verdict = _Verdict(
+            ok=False,
+            reason=f"mlx-audio import failed at runtime: {type(e).__name__}: {e}",
+        )
+        return _cached_verdict
+
+    _cached_verdict = _Verdict(ok=True, reason=None)
+    return _cached_verdict
+
+
+def require_mlx_audio() -> None:
+    """Raise an HTTP 503 when ``mlx_audio`` is not usable.
+
+    Centralizes the failure envelope so every audio route returns the
+    SAME body and status when the dep is missing or broken. Pre-fix
+    the speech and voices routes had divergent behavior; that's the
+    cross-endpoint inconsistency this helper closes.
+
+    Imports ``HTTPException`` lazily so the base install — which
+    doesn't necessarily reach the audio routes at all — doesn't pay
+    the FastAPI cost just to wire the probe.
+    """
+    verdict = mlx_audio_available()
+    if verdict.ok:
+        return
+    from fastapi import HTTPException
+
+    detail = verdict.reason or "mlx-audio is not available"
+    raise HTTPException(
+        status_code=503,
+        detail=(f"{detail}. Install with: pip install 'rapid-mlx[audio]'"),
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -747,6 +747,26 @@ def serve_command(args):
     import os
     import sys
 
+    # F-H08-INCOMPLETE: the ``[embeddings]`` extra-required guard MUST
+    # fire first thing in ``serve_command`` — before
+    # ``prompt_upgrade_if_available`` (which may exit 0 on user
+    # decline), before ``_ensure_model_downloaded`` (which can take
+    # minutes on a cold cache), and well before the startup banner
+    # gets printed. Pre-fix the check lived deeper in the function so
+    # the operator saw the alias-resolved log line, the startup banner,
+    # the feature list, AND the model id BEFORE the
+    # "requires the [embeddings] extra" error and ``sys.exit(2)``,
+    # which read as a successful boot followed by a mysterious failure
+    # — Diego logged this as a warning-and-fall-through bug because
+    # the banner masked the actual exit. Hoisting the probe to the
+    # very top of ``serve_command`` puts the error first, with no
+    # banner output before it. ``mlx_embeddings`` import stays lazy so
+    # the base install (no ``[embeddings]`` extra) keeps booting.
+    if getattr(args, "embedding_model", None):
+        from .embedding import require_mlx_embeddings_or_exit
+
+        require_mlx_embeddings_or_exit()
+
     # Interactive auto-upgrade prompt — when serve runs interactively and a
     # newer release is available, ask once before booting the model. Honors
     # RAPID_MLX_DISABLE_VERSION_CHECK, CI=1, and non-TTY stdin. Cached
@@ -1186,12 +1206,12 @@ def serve_command(args):
 
     # Pre-load embedding model if specified
     if args.embedding_model:
-        # H-08 guard: ``--embedding-model`` is advertised in serve --help
-        # but ``mlx_embeddings`` lives behind the ``[embeddings]`` extra.
-        # Probe here so the user gets a clear install hint on stderr +
-        # ``sys.exit(2)`` instead of a raw ``ModuleNotFoundError`` deep
-        # inside the engine load path. Lazy import — base install stays
-        # ``mlx_embeddings``-free.
+        # H-08 guard already fired at the top of ``serve_command``
+        # (F-H08-INCOMPLETE fix) — by the time we get here ``mlx_embeddings``
+        # is importable. Re-probe defensively as a belt-and-braces:
+        # cheap, and any caller that synthesizes an ``args`` namespace
+        # and jumps straight into the load path still gets the same
+        # install-hint exit code instead of a raw ``ModuleNotFoundError``.
         from .embedding import require_mlx_embeddings_or_exit
 
         require_mlx_embeddings_or_exit()

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -444,14 +444,14 @@ async def create_transcription(
         else (response_format_query if response_format_query is not None else "json")
     )
 
-    # F-D05: single audio dep probe — same envelope as
-    # ``/v1/audio/speech`` and ``/v1/audio/voices``. Fires BEFORE we
-    # spool any upload bytes so a broken ``mlx_audio`` install rejects
-    # cheaply (no temp file, no read loop). Catches both "extra not
-    # installed" and "installed-but-runtime-broken" failure modes.
-    from ..audio.probe import require_mlx_audio
+    # F-D05: STT-lane audio dep probe — same envelope as the TTS
+    # lane shares. Fires BEFORE we spool any upload bytes so a broken
+    # ``mlx_audio.stt`` install rejects cheaply (no temp file, no
+    # read loop). Codex r3 BLOCKING: probe the STT lane SPECIFICALLY
+    # so a torn TTS install doesn't 503 transcriptions and vice versa.
+    from ..audio.probe import require_mlx_audio_stt
 
-    require_mlx_audio()
+    require_mlx_audio_stt()
 
     # Resolve / validate the requested model BEFORE draining the upload.
     # Previously every failure mode (unknown alias, missing mlx-audio,
@@ -548,14 +548,17 @@ async def create_speech(
     """
     global _tts_engine
 
-    # Single audio dep probe (F-D05). Fires BEFORE the lazy TTSEngine
-    # import — if mlx_audio is missing or broken at runtime, every
-    # audio route now returns the SAME 503 envelope with the actual
-    # failure reason embedded so operators can distinguish "missing
-    # extra" from "torn install".
-    from ..audio.probe import require_mlx_audio
+    # TTS-lane audio dep probe (F-D05 + codex r3 BLOCKING). Fires
+    # BEFORE the lazy TTSEngine import — if the TTS sub-module of
+    # mlx_audio is missing or broken at runtime, both ``/v1/audio/
+    # speech`` and ``/v1/audio/voices`` return the SAME 503 envelope
+    # with the actual failure reason embedded. A torn STT lane does
+    # NOT 503 this route — the lane separation closes the codex r3
+    # regression where a broken STT install would mask TTS-usable
+    # installs as fully broken.
+    from ..audio.probe import require_mlx_audio_tts
 
-    require_mlx_audio()
+    require_mlx_audio_tts()
 
     try:
         from ..audio.tts import TTSEngine
@@ -621,11 +624,12 @@ async def list_voices(model: str = "kokoro"):
     # future refactor that hoists an ``import mlx_audio`` to the top
     # of ``audio/tts.py`` (e.g. for type hints) can't accidentally
     # bypass the shared 503 envelope by failing at the route's import
-    # statement before ``require_mlx_audio`` even runs. Codex r1
-    # BLOCKING on PR #804.
-    from ..audio.probe import require_mlx_audio
+    # statement before the probe even runs. Codex r1 BLOCKING on
+    # PR #804. Codex r3 follow-up: probe the TTS lane SPECIFICALLY so
+    # a torn STT install doesn't 503 voice listing.
+    from ..audio.probe import require_mlx_audio_tts
 
-    require_mlx_audio()
+    require_mlx_audio_tts()
 
     from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -444,6 +444,15 @@ async def create_transcription(
         else (response_format_query if response_format_query is not None else "json")
     )
 
+    # F-D05: single audio dep probe — same envelope as
+    # ``/v1/audio/speech`` and ``/v1/audio/voices``. Fires BEFORE we
+    # spool any upload bytes so a broken ``mlx_audio`` install rejects
+    # cheaply (no temp file, no read loop). Catches both "extra not
+    # installed" and "installed-but-runtime-broken" failure modes.
+    from ..audio.probe import require_mlx_audio
+
+    require_mlx_audio()
+
     # Resolve / validate the requested model BEFORE draining the upload.
     # Previously every failure mode (unknown alias, missing mlx-audio,
     # bad audio bytes) collapsed into a 500 "could not open/decode
@@ -527,8 +536,26 @@ async def create_speech(
     speed: float = 1.0,
     response_format: str = "wav",
 ):
-    """Generate speech from text (OpenAI TTS API compatible)."""
+    """Generate speech from text (OpenAI TTS API compatible).
+
+    F-D05: probe ``mlx_audio`` availability through the shared
+    :func:`vllm_mlx.audio.probe.require_mlx_audio` helper so this
+    route's 503 envelope matches ``/v1/audio/voices`` and
+    ``/v1/audio/transcriptions``. Pre-fix each audio route hand-rolled
+    its own check; the voices route never probed at all, the speech
+    route only saw the ImportError, and operators couldn't tell from
+    one endpoint that the others were also broken.
+    """
     global _tts_engine
+
+    # Single audio dep probe (F-D05). Fires BEFORE the lazy TTSEngine
+    # import — if mlx_audio is missing or broken at runtime, every
+    # audio route now returns the SAME 503 envelope with the actual
+    # failure reason embedded so operators can distinguish "missing
+    # extra" from "torn install".
+    from ..audio.probe import require_mlx_audio
+
+    require_mlx_audio()
 
     try:
         from ..audio.tts import TTSEngine
@@ -555,10 +582,21 @@ async def create_speech(
         )
         return Response(content=audio_bytes, media_type=content_type)
 
-    except ImportError:
+    except HTTPException:
+        # Preserve probe-emitted 503 (and any other explicit status)
+        # rather than collapsing into the generic 500 catch-all below.
+        raise
+    except ImportError as e:
+        # Defense in depth: if a future refactor introduces an import
+        # path the probe doesn't cover (or the cached verdict is stale
+        # in some edge case), still surface a meaningful 503 instead
+        # of leaking a stack trace through the catch-all 500.
         raise HTTPException(
             status_code=503,
-            detail="mlx-audio not installed. Install with: pip install mlx-audio",
+            detail=(
+                f"mlx-audio import failed at runtime: {e}. "
+                "Install with: pip install 'rapid-mlx[audio]'"
+            ),
         )
     except Exception as e:
         logger.error(f"TTS generation failed: {e}")
@@ -567,8 +605,19 @@ async def create_speech(
 
 @router.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])
 async def list_voices(model: str = "kokoro"):
-    """List available voices for a TTS model."""
+    """List available voices for a TTS model.
+
+    F-D05: gates on the same :func:`require_mlx_audio` probe that
+    ``/v1/audio/speech`` uses so callers can't get a 200 with a
+    voice list while the very next ``speech`` call 503s on the same
+    server. Pre-fix the voices route returned a static list without
+    touching ``mlx_audio`` at all, so it advertised TTS-capability
+    even when the engine wouldn't load.
+    """
+    from ..audio.probe import require_mlx_audio
     from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
+
+    require_mlx_audio()
 
     if "kokoro" in model.lower():
         return {"voices": KOKORO_VOICES}

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -614,10 +614,20 @@ async def list_voices(model: str = "kokoro"):
     touching ``mlx_audio`` at all, so it advertised TTS-capability
     even when the engine wouldn't load.
     """
+    # Probe FIRST, then import anything that depends on mlx_audio
+    # transitively. Pre-fix this ordering wasn't a problem because
+    # ``vllm_mlx.audio.tts`` doesn't import ``mlx_audio`` at module
+    # level — but pinning the order in the route handler means a
+    # future refactor that hoists an ``import mlx_audio`` to the top
+    # of ``audio/tts.py`` (e.g. for type hints) can't accidentally
+    # bypass the shared 503 envelope by failing at the route's import
+    # statement before ``require_mlx_audio`` even runs. Codex r1
+    # BLOCKING on PR #804.
     from ..audio.probe import require_mlx_audio
-    from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
 
     require_mlx_audio()
+
+    from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
 
     if "kokoro" in model.lower():
         return {"voices": KOKORO_VOICES}

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -206,29 +206,58 @@ def _is_vlm(model_id: str, profile_modality: str | None) -> bool:
         return False
 
 
-def _tools_capable(profile_tool_parser: str | None) -> bool:
+def _is_served_model(model_id: str) -> bool:
+    """Return True when ``model_id`` is the (or one of the) model(s)
+    the server is currently serving.
+
+    The server-level tool parser flag (``--tool-call-parser`` or the
+    auto-detected value) applies ONLY to the model the server is
+    actually serving — it's a per-server flag, not a per-registry
+    setting. Without this guard a single configured parser would
+    paint ``"tools"`` onto every entry returned by ``/v1/models``,
+    including unrelated registry / discovery entries the parser
+    isn't wired for. Codex r4 BLOCKING on PR #804.
+
+    Multi-model serve (``model_registry``) lists every served entry;
+    membership in the registry is the served-set. Single-model serve
+    uses ``model_name`` / ``model_alias``. Both surfaces are
+    consulted because the registry is set on multi-model serve only.
+    """
+    cfg = get_config()
+    if cfg.model_registry is not None:
+        try:
+            return model_id in cfg.model_registry
+        except Exception:  # noqa: BLE001
+            return False
+    return model_id in {cfg.model_name, cfg.model_alias} - {None}
+
+
+def _tools_capable(model_id: str, profile_tool_parser: str | None) -> bool:
     """Return True when ``model_id`` exposes a tool-call surface.
 
-    Combines three signals (any of which flips ``"tools"`` on):
+    Two-tier decision:
 
-    * The alias profile carries a non-empty ``tool_call_parser``
-      (qwen, hermes, mistral, …) — set in ``aliases.json`` for the
-      tool-capable families. Authoritative for registered aliases.
-    * ``ServerConfig.tool_call_parser`` (the bridged value
-      ``_sync_config`` plumbs from the server-level global). Covers
-      raw HF paths the operator wired tools onto with a CLI flag,
-      once the config bridge has run.
-    * ``server._tool_call_parser`` (the live server global).
-      Mirrors the ``_locked_embedding_id`` fallback so the
-      capability shows up even before ``_sync_config`` has bridged
-      the value — same reason the embedding fallback exists. Codex
-      r1 BLOCKING on PR #804: pre-fix only ``cfg.tool_call_parser``
-      was checked, so a boot order that updated only the server
-      global (e.g. before the first ``_sync_config``) would silently
-      omit the ``"tools"`` capability on ``/v1/models``.
+    * **Per-entry alias signal** — the alias profile carries a
+      non-empty ``tool_call_parser`` (qwen, hermes, mistral, …) set
+      in ``aliases.json`` for the tool-capable families. This is
+      authoritative for every registered alias regardless of which
+      model the server is currently serving — discovery clients
+      use it to pre-flight tool-call support on aliases they're
+      considering switching to.
+    * **Server-global fallback** — ``ServerConfig.tool_call_parser``
+      OR ``vllm_mlx.server._tool_call_parser``. ONLY applied when
+      ``model_id`` IS the currently served model (or one of them in
+      multi-model serve). Without this gate a single configured
+      parser would paint ``"tools"`` onto every unrelated registry
+      entry — codex r4 BLOCKING on PR #804. The dual read (config +
+      server global) mirrors :func:`_locked_embedding_id`'s
+      bridge-order fallback so the capability shows up even before
+      ``_sync_config`` has plumbed the value.
     """
     if profile_tool_parser:
         return True
+    if not _is_served_model(model_id):
+        return False
     cfg = get_config()
     if getattr(cfg, "tool_call_parser", None):
         return True
@@ -281,7 +310,7 @@ def _detect_capabilities(
     caps: list[str] = ["text"]
     if _is_vlm(model_id, profile_modality):
         caps.append("vision")
-    if _tools_capable(profile_tool_parser):
+    if _tools_capable(model_id, profile_tool_parser):
         caps.append("tools")
     return caps
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -150,14 +150,8 @@ def _reported_modality(model_id: str, profile_modality: str) -> str:
     return profile_modality
 
 
-def _embedding_capabilities(model_id: str) -> list[str]:
-    """Return capability tags for ``model_id``.
-
-    H-09 sub-fix: only the explicitly-configured embedding model is
-    tagged ``"embedding"``. When the server boots without
-    ``--embedding-model``, the route guard rejects ``/v1/embeddings``
-    requests with a 400, so advertising any chat-model id as
-    embedding-capable would be lying to the client.
+def _locked_embedding_id() -> str | None:
+    """Return the configured embedding model id, if any.
 
     Reads from ``ServerConfig.embedding_model_locked`` first and falls
     back to the ``server._embedding_model_locked`` global so the
@@ -166,16 +160,134 @@ def _embedding_capabilities(model_id: str) -> list[str]:
     """
     cfg = get_config()
     locked = cfg.embedding_model_locked
-    if locked is None:
-        try:
-            from ..server import _embedding_model_locked as _server_locked
+    if locked is not None:
+        return locked
+    try:
+        from ..server import _embedding_model_locked as _server_locked
 
-            locked = _server_locked
-        except Exception:  # noqa: BLE001
-            locked = None
+        return _server_locked
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _is_vlm(model_id: str, profile_modality: str | None) -> bool:
+    """Return True when ``model_id`` accepts image input.
+
+    Single source of truth for VLM detection on the wire. Combines
+    two signals:
+
+    * ``profile_modality != "text"`` — explicit alias registration
+      (``aliases.json``) wins when the profile flags a non-text
+      modality. Catches diffusion / audio / future modalities the
+      raw HF-id heuristic can't see.
+    * :func:`vllm_mlx.api.utils.is_mllm_model` — the same detector
+      ``cli.py`` and ``server.py`` use to route requests through
+      ``MLLMBatchGenerator``. Covers VLM aliases that internally
+      keep ``modality="text"`` (their language backbone IS the AR
+      lane; the multimodal path layers on top — see
+      :func:`_reported_modality`) and raw HF VLM repos that have no
+      alias entry yet.
+
+    Any exception inside ``is_mllm_model`` (corrupt local config,
+    HF cache I/O failure) collapses to ``False`` so the
+    ``/v1/models`` endpoint stays available — losing the ``"vision"``
+    capability tag is far less harmful than 500'ing the whole listing.
+    """
+    if profile_modality is not None and profile_modality != "text":
+        # Non-text profile modalities are authoritative (e.g.
+        # ``image``, ``text-diffusion``). The wire-reported modality
+        # may still flip to ``image`` via ``_reported_modality``
+        # below, but the capability tag is decided independently.
+        if profile_modality == "image":
+            return True
+    try:
+        return bool(is_mllm_model(model_id))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _tools_capable(profile_tool_parser: str | None) -> bool:
+    """Return True when ``model_id`` exposes a tool-call surface.
+
+    Combines two signals:
+
+    * The alias profile carries a non-empty ``tool_call_parser``
+      (qwen, hermes, mistral, …) — set in ``aliases.json`` for the
+      tool-capable families. Authoritative for registered aliases.
+    * Server-level ``_tool_call_parser`` is set (via
+      ``--tool-call-parser`` or auto-detection during boot). Covers
+      raw HF paths the operator wired tools onto with a CLI flag.
+
+    Either signal flips the ``"tools"`` capability on. Reading the
+    server global through ``get_config()`` keeps the import surface
+    flat — no late ``vllm_mlx.server`` import needed in the common
+    path.
+    """
+    if profile_tool_parser:
+        return True
+    cfg = get_config()
+    return bool(getattr(cfg, "tool_call_parser", None))
+
+
+def _detect_capabilities(
+    model_id: str,
+    profile_modality: str | None = None,
+    profile_tool_parser: str | None = None,
+) -> list[str]:
+    """Compute the ``capabilities`` tag list for ``model_id``.
+
+    F-D01: pre-fix only the configured embedding model carried a tag
+    (``"embedding"``) — every other entry returned ``[]`` even when
+    it accepted image input or exposed a tool-call surface.
+    Downstream clients that route on capabilities couldn't tell a VLM
+    from a text-only model from the wire.
+
+    The unified detector emits the full set in a stable order:
+
+    * ``"embedding"`` — exactly when this id is the
+      ``--embedding-model`` locked at startup. The chat surface is
+      still 400'd by the embeddings route guard for non-locked ids
+      (H-09), so we don't combine ``"text"`` with ``"embedding"``.
+    * ``"text"`` — every non-embedding model accepts text input.
+    * ``"vision"`` — :func:`_is_vlm` returns True (profile flags
+      ``image`` or :func:`is_mllm_model` matches).
+    * ``"tools"`` — :func:`_tools_capable` returns True (alias
+      profile has a parser, or the server is running with one).
+
+    Order is fixed: ``text → vision → tools`` (or just
+    ``["embedding"]`` for the embedding entry). Tests pin this so
+    a future addition (e.g. ``"audio"``) is a deliberate, reviewed
+    change rather than a silent reordering.
+    """
+    locked = _locked_embedding_id()
     if locked is not None and model_id == locked:
+        # H-09 invariant preserved: the embedding model carries
+        # ``"embedding"`` exclusively. Combining it with ``"text"``
+        # would mislead clients into routing chat traffic at the
+        # embedding model id — the chat surface is not wired.
         return ["embedding"]
-    return []
+
+    caps: list[str] = ["text"]
+    if _is_vlm(model_id, profile_modality):
+        caps.append("vision")
+    if _tools_capable(profile_tool_parser):
+        caps.append("tools")
+    return caps
+
+
+def _reported_modality_for_embedding(locked_id: str) -> str:
+    """Return the ``modality`` field for the embedding entry.
+
+    F-D01 cosmetic fix: pre-fix the embedding entry advertised
+    ``modality=None`` while VLMs advertised ``modality="image"``.
+    Clients reading ``modality`` to distinguish lanes saw a
+    three-way (text / image / null) shape instead of the documented
+    text / image / embedding axis. Embedding models accept text
+    input, so the on-wire modality is ``"text"`` — the
+    ``capabilities=["embedding"]`` tag is what distinguishes the
+    lane, not the modality.
+    """
+    return "text"
 
 
 def _build_model_info(model_id: str) -> ModelInfo:
@@ -186,12 +298,12 @@ def _build_model_info(model_id: str) -> ModelInfo:
     HF path (``mlx-community/Qwen3.5-4B-MLX-4bit``); ``resolve_profile``
     handles both. Unknown ids (operator-supplied custom paths, models
     not yet in ``aliases.json``) get the OpenAI baseline shape with
-    every extension field at ``None`` — except modality, which still
-    runs through the multimodal detector so an unregistered VLM repo
-    id still advertises ``image`` (F-067 layer fix covers raw HF paths
-    too, not just registered aliases).
+    every extension field at ``None`` — except modality and
+    capabilities, which still run through the detectors so an
+    unregistered VLM repo id still advertises ``image`` modality
+    plus the ``"vision"`` capability tag (F-D01 + F-067 layer fix
+    covers raw HF paths too, not just registered aliases).
     """
-    capabilities = _embedding_capabilities(model_id)
     profile = resolve_profile(model_id)
     # ``context_window`` is engine-derived (not profile-derived) so it
     # surfaces even for unregistered operator-supplied ids when an
@@ -199,6 +311,40 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # failures fall through to ``None`` and the client uses its own
     # per-family fallback. See ``_resolve_context_window`` docstring.
     context_window = _resolve_context_window(model_id)
+
+    locked = _locked_embedding_id()
+    if locked is not None and model_id == locked:
+        # The embedding entry: ``capabilities=["embedding"]`` plus an
+        # explicit ``modality="text"`` (F-D01 cosmetic — pre-fix this
+        # came back as ``null`` and clients couldn't tell embedding
+        # apart from "unset" on the wire). Pass through the
+        # ``context_window`` so embedding entries also carry the
+        # engine-advertised cap (PR #808 contract) when an engine is
+        # actually loaded for the embedding id.
+        if profile is None:
+            return ModelInfo(
+                id=model_id,
+                modality=_reported_modality_for_embedding(locked),
+                capabilities=["embedding"],
+                context_window=context_window,
+            )
+        sampling = (
+            dict(profile.recommended_sampling)
+            if profile.recommended_sampling is not None
+            else None
+        )
+        return ModelInfo(
+            id=model_id,
+            recommended_sampling=sampling,
+            is_hybrid=profile.is_hybrid,
+            is_moe=profile.is_moe,
+            tool_call_parser=profile.tool_call_parser,
+            reasoning_parser=profile.reasoning_parser,
+            modality=_reported_modality_for_embedding(locked),
+            capabilities=["embedding"],
+            context_window=context_window,
+        )
+
     if profile is None:
         # Preserve the prior unknown-id wire shape (``ModelInfo(id=model_id)``
         # with the schema-default ``modality``) and only override when the
@@ -208,6 +354,9 @@ def _build_model_info(model_id: str) -> ModelInfo:
         # ``ModelInfo.modality``'s default ever flipped from ``None``.
         # Branch on the detector instead so the default path keeps using
         # the schema default.
+        capabilities = _detect_capabilities(
+            model_id, profile_modality=None, profile_tool_parser=None
+        )
         try:
             if is_mllm_model(model_id):
                 return ModelInfo(
@@ -233,6 +382,11 @@ def _build_model_info(model_id: str) -> ModelInfo:
         dict(profile.recommended_sampling)
         if profile.recommended_sampling is not None
         else None
+    )
+    capabilities = _detect_capabilities(
+        model_id,
+        profile_modality=profile.modality,
+        profile_tool_parser=profile.tool_call_parser,
     )
     return ModelInfo(
         id=model_id,
@@ -283,14 +437,7 @@ async def list_models() -> ModelsResponse:
     # configured the route guard already 400s on ``/v1/embeddings``,
     # so nothing is added here — capability advertisement matches
     # actual behavior.
-    locked = cfg.embedding_model_locked
-    if locked is None:
-        try:
-            from ..server import _embedding_model_locked as _server_locked
-
-            locked = _server_locked
-        except Exception:  # noqa: BLE001
-            locked = None
+    locked = _locked_embedding_id()
     if locked:
         _append(_build_model_info(locked))
 
@@ -322,14 +469,7 @@ async def retrieve_model(model_id: str) -> ModelInfo:
     # The dedicated embedding model id is addressable too so callers
     # can hydrate per-model state from ``/v1/models/{id}`` without
     # extra wire heuristics.
-    locked = cfg.embedding_model_locked
-    if locked is None:
-        try:
-            from ..server import _embedding_model_locked as _server_locked
-
-            locked = _server_locked
-        except Exception:  # noqa: BLE001
-            locked = None
+    locked = _locked_embedding_id()
     if locked and model_id == locked:
         return _build_model_info(model_id)
     raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -209,24 +209,35 @@ def _is_vlm(model_id: str, profile_modality: str | None) -> bool:
 def _tools_capable(profile_tool_parser: str | None) -> bool:
     """Return True when ``model_id`` exposes a tool-call surface.
 
-    Combines two signals:
+    Combines three signals (any of which flips ``"tools"`` on):
 
     * The alias profile carries a non-empty ``tool_call_parser``
       (qwen, hermes, mistral, …) — set in ``aliases.json`` for the
       tool-capable families. Authoritative for registered aliases.
-    * Server-level ``_tool_call_parser`` is set (via
-      ``--tool-call-parser`` or auto-detection during boot). Covers
-      raw HF paths the operator wired tools onto with a CLI flag.
-
-    Either signal flips the ``"tools"`` capability on. Reading the
-    server global through ``get_config()`` keeps the import surface
-    flat — no late ``vllm_mlx.server`` import needed in the common
-    path.
+    * ``ServerConfig.tool_call_parser`` (the bridged value
+      ``_sync_config`` plumbs from the server-level global). Covers
+      raw HF paths the operator wired tools onto with a CLI flag,
+      once the config bridge has run.
+    * ``server._tool_call_parser`` (the live server global).
+      Mirrors the ``_locked_embedding_id`` fallback so the
+      capability shows up even before ``_sync_config`` has bridged
+      the value — same reason the embedding fallback exists. Codex
+      r1 BLOCKING on PR #804: pre-fix only ``cfg.tool_call_parser``
+      was checked, so a boot order that updated only the server
+      global (e.g. before the first ``_sync_config``) would silently
+      omit the ``"tools"`` capability on ``/v1/models``.
     """
     if profile_tool_parser:
         return True
     cfg = get_config()
-    return bool(getattr(cfg, "tool_call_parser", None))
+    if getattr(cfg, "tool_call_parser", None):
+        return True
+    try:
+        from ..server import _tool_call_parser as _server_tool_parser
+
+        return bool(_server_tool_parser)
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _detect_capabilities(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1694,6 +1694,20 @@ Examples:
     )
 
     args = parser.parse_args()
+
+    # F-H08-INCOMPLETE: the ``[embeddings]`` extra-required guard MUST
+    # fire BEFORE logging configuration and the security/banner side
+    # effects below. Pre-fix on this entrypoint the probe ran AFTER the
+    # parser-init log lines and the security summary, then the user
+    # saw "error: --embedding-model requires the [embeddings] extra"
+    # interleaved with banner output and exit-2 — Diego logged this
+    # as a warning-and-fall-through. Hoisting the probe puts the
+    # error first with nothing else on stderr/stdout before it.
+    if getattr(args, "embedding_model", None):
+        from .embedding import require_mlx_embeddings_or_exit
+
+        require_mlx_embeddings_or_exit()
+
     uvicorn_log_level = configure_logging(args.log_level)
 
     # Set global configuration
@@ -1792,17 +1806,18 @@ Examples:
         _reasoning_parser_name = args.reasoning_parser
         logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")
 
-    # Pre-load embedding model if specified
+    # Pre-load embedding model if specified. The H-08 guard already
+    # fired at the top of this function (F-H08-INCOMPLETE fix); by the
+    # time we reach this point either ``args.embedding_model`` is None
+    # or ``mlx_embeddings`` is importable. Re-probe defensively as
+    # belt-and-braces: cheap, and any caller that synthesizes args and
+    # jumps in here still gets the install-hint exit instead of a raw
+    # ``ModuleNotFoundError``.
     if args.embedding_model:
-        # H-08 guard: probe before the engine import path so an opaque
-        # ``ModuleNotFoundError`` traceback is replaced with an
-        # actionable install hint on stderr + ``sys.exit(2)``. Lazy
-        # import — the base install must not pin ``mlx_embeddings`` at
-        # module top-level.
         from .embedding import require_mlx_embeddings_or_exit
 
         require_mlx_embeddings_or_exit()
-    load_embedding_model(args.embedding_model, lock=True)
+        load_embedding_model(args.embedding_model, lock=True)
 
     # Build a SchedulerConfig so user-supplied flags on this standalone entry
     # (`python -m vllm_mlx.server` / `mise run`) reach the engine. Pre-0.6.52


### PR DESCRIPTION
## Summary

Three related capabilities/detection bugs from Diego dogfood 0.8.3, all systemic single-source-of-truth fixes:

- **F-D01** — VLM `/v1/models` returned `capabilities=[]` even with `modality="image"`. Single `_detect_capabilities` helper now emits `text`/`vision`/`tools`/`embedding` in a fixed order based on the alias profile + `is_mllm_model` detector + server-level tool parser.
- **F-D05** — `/v1/audio/voices`=200 but `/v1/audio/speech`=503 on the same install. New `vllm_mlx/audio/probe.py` is the single probe (`find_spec` + cached late-import) consulted by all three audio routes; they now return identical 503 envelopes with the actual failure reason embedded.
- **F-H08-INCOMPLETE** — `--embedding-model` without `[embeddings]` printed the install hint AFTER the startup banner. Hoisted the `require_mlx_embeddings_or_exit` probe to be the first statement in `serve_command` (and immediately after `parse_args()` in the standalone `python -m vllm_mlx.server` entrypoint), before `_ensure_model_downloaded` and before any banner output.

## Test plan

- [x] `tests/test_capabilities_field.py` — 11 tests cover text-only / VLM / embedding / tools / union ordering / no-duplicates
- [x] `tests/test_audio_probe_consistency.py` — 9 tests cover both routes returning same 503 envelope on broken/missing mlx_audio, source-grep guard that every audio route calls `require_mlx_audio`, probe-cache behavior
- [x] `tests/test_embeddings_extra_guard.py` extended with source-pin tests that the H-08 guard fires BEFORE `_ensure_model_downloaded` and BEFORE the startup banner in both `cli.py` and `server.py` entrypoints
- [x] Live verification: VLM `/v1/models` now returns `capabilities=["text","vision","tools"]`; `/v1/audio/{voices,speech}` both 503 with identical envelope on broken `mlx_audio`; `rapid-mlx serve qwen3-0.6b-8bit --embedding-model bogus` in a no-`[embeddings]` venv exits 2 with the hint as the first stderr line and no `🐆 Rapid-MLX` banner output
- [x] `ruff check` + `ruff format --check` clean
- [x] No regressions in `tests/test_modality_field.py`, `tests/test_api_models.py`, `tests/test_audio*.py`, `tests/test_embeddings*.py` (180 passed, 5 unrelated skips)
- [x] Lazy-import invariant preserved: base install (no `[vision]`/`[audio]`/`[embeddings]`) never sees a top-level `mlx_audio` / `mlx_vlm` / `mlx_embeddings` import — verified by existing `test_mlx_embeddings_not_imported_at_module_top_level` plus the new audio-probe mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)