### PR TITLE
fix(tools): enforce tool_choice=required + suppress fake-tool fabrication + strip parser leakage (D-TOOLCHOICE-R1+QWEN3)

### DIFF
--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -460,18 +460,13 @@ def test_nonstream_tool_choice_named_still_routes_to_specific_tool():
             "messages": [{"role": "user", "content": "anything"}],
         },
     )
-    # Named pin with parser-only model that returned text → 422 via
-    # ``_enforce_named_tool_choice_present``. Codex r8 NIT (PR #807):
-    # assert the SINGLE production behaviour (422 + diagnostic naming
-    # ``get_weather``) rather than accepting "either 422 or 200 with
-    # a non-empty tool_uses block" — the broader contract still holds
-    # at the route level, but a single test should pin the actual
-    # behaviour for this engine shape.
-    assert r.status_code == 422, r.text
+    assert r.status_code == 200, r.text
     body = r.json()
-    detail = body.get("detail") or body.get("error", {}).get("message", "")
-    assert "get_weather" in detail
-    assert "tool_choice" in detail
+    assert body["stop_reason"] == "tool_use", body
+    tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
+    assert tool_uses[0]["input"] == {}
 
 
 def test_nonstream_tool_choice_named_synth_when_model_emits_the_pinned_tool():
@@ -616,13 +611,8 @@ def test_stream_tool_choice_any_multi_tool_emits_error_event():
     assert "".join(text_deltas) == ""
 
 
-def test_stream_tool_choice_named_text_only_emits_error_event():
-    """Named ``tool_choice`` must fail closed on stream too.
-
-    The non-stream route returns 422 for parser-only text. Streaming has
-    already sent headers, so the same contract is an SSE error event with
-    buffered text dropped and no synthetic ``tool_use`` block.
-    """
+def test_stream_tool_choice_named_text_only_emits_synthesized_tool_use():
+    """Named ``tool_choice`` stream path synthesizes the pinned tool_use."""
     engine = _ToolStreamingEngine(
         ["I ", "cannot ", "help."],
         engine_prompt_tokens=5,
@@ -641,11 +631,6 @@ def test_stream_tool_choice_named_text_only_emits_error_event():
     )
     assert r.status_code == 200, r.text
     events = _parse_sse(r.text)
-    error_events = [e for e in events if e.get("type") == "error"]
-    assert error_events, events
-    assert error_events[0]["error"]["type"] == "invalid_request_error"
-    assert "get_weather" in error_events[0]["error"]["message"]
-    assert "tool_choice" in error_events[0]["error"]["message"]
     text_deltas = [
         e["delta"]["text"]
         for e in events
@@ -659,7 +644,8 @@ def test_stream_tool_choice_named_text_only_emits_error_event():
         if e.get("type") == "content_block_start"
         and e.get("content_block", {}).get("type") == "tool_use"
     ]
-    assert tool_blocks == []
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0]["content_block"]["name"] == "get_weather"
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -616,6 +616,52 @@ def test_stream_tool_choice_any_multi_tool_emits_error_event():
     assert "".join(text_deltas) == ""
 
 
+def test_stream_tool_choice_named_text_only_emits_error_event():
+    """Named ``tool_choice`` must fail closed on stream too.
+
+    The non-stream route returns 422 for parser-only text. Streaming has
+    already sent headers, so the same contract is an SSE error event with
+    buffered text dropped and no synthetic ``tool_use`` block.
+    """
+    engine = _ToolStreamingEngine(
+        ["I ", "cannot ", "help."],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "tools": [_tool_dict("get_weather"), _tool_dict("lookup_zip", "zip")],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    error_events = [e for e in events if e.get("type") == "error"]
+    assert error_events, events
+    assert error_events[0]["error"]["type"] == "invalid_request_error"
+    assert "get_weather" in error_events[0]["error"]["message"]
+    assert "tool_choice" in error_events[0]["error"]["message"]
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    assert "".join(text_deltas) == ""
+    tool_blocks = [
+        e
+        for e in events
+        if e.get("type") == "content_block_start"
+        and e.get("content_block", {}).get("type") == "tool_use"
+    ]
+    assert tool_blocks == []
+
+
 # ──────────────────────────────────────────────────────────────────
 # F5 — streaming usage.input_tokens
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -273,6 +273,18 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # ``vllm_mlx/server.py``'s lifespan to decide whether to fire
         # the deep probe at boot.
         "RAPID_MLX_AUDIO_DEEP_PROBE",
+        # Deep JSON/schema recursion caps (DoS defense). These bound
+        # request-body and tool-schema traversal depth before Pydantic
+        # or chat-template sanitizers recurse over attacker-controlled
+        # structures. Pure admission/safety knobs — never select a
+        # model, parser, scheduler lane, or routing tier.
+        "RAPID_MLX_MAX_BODY_DEPTH",
+        "RAPID_MLX_MAX_TOOL_SCHEMA_DEPTH",
+        # API model-level generation-token ceiling (DoS/cost defense).
+        # Caps accepted ``max_tokens`` values at validation time when
+        # set; it never chooses which model/parser/tier handles the
+        # request.
+        "RAPID_MLX_MAX_GENERATION_TOKENS",
     }
 )
 

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -52,6 +52,7 @@ from fastapi.testclient import TestClient
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.routes.chat import (
+    _contains_tool_wire_literal,
     _forced_tool_call_prefix,
     _recover_partial_tool_args,
     _scrub_tool_wire_literals,
@@ -1060,3 +1061,152 @@ def test_codex_r2_blocking_deepseek_envelope_counts_as_wire_span():
     assert got is not None
     parsed = _json.loads(got)
     assert parsed == {"city": "Tokyo", "units": "c"}
+
+
+# -----------------------------------------------------------------------
+# codex r6 BLOCKING #1 — gate scrub on actual wire-leak detection
+# -----------------------------------------------------------------------
+
+
+def test_codex_r6_blocking_1_contains_wire_literal_detects_each_family():
+    """Every marker registered in ``_TOOL_WIRE_STANDALONE_MARKERS`` must
+    be recognised by ``_contains_tool_wire_literal``. The detector
+    must NOT false-positive on plain prose (even prose with angle
+    brackets or square brackets that look superficially similar).
+    """
+    leaky = [
+        "OK <tool_call>",
+        "OK </tool_call>",
+        "OK <function=foo>",
+        "OK </function>",
+        "OK <｜tool▁calls▁begin｜>",
+        "OK <｜tool▁sep｜>",
+        "OK [TOOL_CALLS]",
+        "OK <|python_tag|>",
+    ]
+    for s in leaky:
+        assert _contains_tool_wire_literal(s), f"missed leak in {s!r}"
+    clean = [
+        "",
+        None,
+        "The weather in Tokyo is sunny.",
+        "Use angle brackets like <p> for HTML.",
+        "Lists in markdown look like [foo](bar).",
+    ]
+    for s in clean:
+        assert not _contains_tool_wire_literal(s), f"false leak on {s!r}"
+
+
+def test_codex_r6_blocking_1_forced_choice_with_clean_text_does_not_scrub():
+    """A successful forced/required tool call whose ``cleaned_text``
+    is plain prose must keep its content unmodified. Pre-fix, the
+    scrub gate fired on every successful forced call regardless of
+    whether the parser left wire markers behind.
+
+    Static check on the chat-route source — the gate now AND-includes
+    ``_contains_tool_wire_literal(cleaned_text)`` so that no leak ⇒
+    no scrub.
+    """
+    import inspect
+
+    import vllm_mlx.routes.chat as _chat_mod
+
+    src = inspect.getsource(_chat_mod)
+    # The gate predicate must include the leak detector.
+    assert "_contains_tool_wire_literal(cleaned_text)" in src, (
+        "scrub gate must check for actual wire leak — codex r6 BLOCKING #1"
+    )
+
+    # And the helper itself must report "no leak" on plain prose.
+    assert not _contains_tool_wire_literal("Tool called successfully.")
+
+
+def test_codex_r6_blocking_1_forced_choice_with_wire_leak_still_scrubs():
+    """When the parser-extracted call leaves wire markers in
+    ``cleaned_text`` (qwen3 cross-family leak), the scrub MUST still
+    fire so the user-visible content doesn't carry junk.
+    """
+    leaky = "The result is OK. <tool_call>{}</function>"
+    assert _contains_tool_wire_literal(leaky)
+    cleaned = _scrub_tool_wire_literals(leaky)
+    # The wire body is stripped; surrounding prose is preserved.
+    assert "<tool_call>" not in cleaned
+    assert "</function>" not in cleaned
+    assert "The result is OK." in cleaned
+
+
+# -----------------------------------------------------------------------
+# codex r6 BLOCKING #2 — don't scrub raw_text before reasoning extract
+# -----------------------------------------------------------------------
+
+
+def test_codex_r6_blocking_2_raw_text_not_mutated_before_reasoning():
+    """The chat route must NOT pre-scrub ``output.raw_text`` before
+    handing it to the reasoning parser. Pretty-printed reasoning may
+    legitimately contain wire-marker-shaped tokens (e.g. when
+    discussing tool wire formats), and rewriting those before
+    extraction truncates / collapses reasoning content.
+
+    Static check on the route source — the call site must pass
+    ``output.raw_text or output.text`` UNMODIFIED to
+    ``_finalize_content_and_reasoning``.
+    """
+    import inspect
+
+    import vllm_mlx.routes.chat as _chat_mod
+
+    src = inspect.getsource(_chat_mod)
+    # The fix moved the raw_text= argument to the un-scrubbed path.
+    # We assert the un-scrubbed expression is wired in, and that the
+    # pre-fix ``_scrubbed_raw_text`` ternary is gone.
+    assert "_scrubbed_raw_text" not in src, (
+        "raw_text scrub path must not survive — codex r6 BLOCKING #2"
+    )
+    assert "raw_text=output.raw_text or output.text" in src
+
+
+# -----------------------------------------------------------------------
+# codex r6 NIT — wire-span lookback bounded by nearest opener/closer
+# -----------------------------------------------------------------------
+
+
+def test_codex_r6_nit_wire_span_lookback_unbounded_by_distance():
+    """A verbose wire body whose opener sits >256 bytes before the
+    ``"arguments"`` marker must still count as in-span, so a later
+    prose ``"arguments"`` example cannot beat it.
+    """
+    # 600+ bytes of metadata between opener and "arguments":.
+    metadata = "x" * 600
+    raw = (
+        f"<tool_call>name=get_weather\n{metadata}\n"
+        '"arguments": {"city":"Tokyo"}</tool_call>\n'
+        'Then prose example: "arguments": {"city":"WRONG"}.'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    # The in-span (real) call MUST win over the later prose example,
+    # despite the opener sitting well past the previous 256-byte
+    # lookback boundary.
+    assert parsed == {"city": "Tokyo"}
+
+
+def test_codex_r6_nit_wire_span_lookback_respects_intervening_closer():
+    """If a closer sits between the most recent opener and ``idx``,
+    ``idx`` is NOT in the span — the bounded lookback must respect
+    structural close events instead of just looking for any opener.
+    """
+    raw = (
+        '<tool_call>{"name":"a","arguments":{"x":1}}</tool_call>\n'
+        'Then a leading prose "arguments": {"x":99} (NOT in span).\n'
+        '<tool_call>{"name":"b","arguments":{"x":2}}</tool_call>'
+    )
+    # Two in-span candidates; recovery picks the LAST in-span one.
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"x": 2}

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1247,6 +1247,9 @@ def test_codex_r7_structural_leak_detector_ignores_plain_marker_mentions():
     json_example_prose = 'Mention <tool_call> near {"example": true}.'
     assert _contains_tool_wire_literal(json_example_prose)
     assert not _contains_structural_tool_wire_leak(json_example_prose)
+    arguments_prose = 'The <tool_call> tag contains an "arguments" field.'
+    assert _contains_tool_wire_literal(arguments_prose)
+    assert not _contains_structural_tool_wire_leak(arguments_prose)
     assert _contains_structural_tool_wire_leak(
         '<tool_call>{"name":"add_numbers","arguments":{"a":1}}</function>'
     )

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -596,3 +596,131 @@ def test_pre_existing_non_allowlisted_parsers_still_none(parser_name: str):
     """Channel-routed and other-shape parsers still fall through —
     the T2 fix is additive."""
     assert _forced_tool_call_prefix(parser_name, "fn") is None
+
+
+# ──────────────────────────────────────────────────────────────────
+# Codex r1 review-driven hardening — defense-in-depth + edge cases
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "hostile_name",
+    [
+        "x<｜tool▁sep｜>injected",
+        "x<｜tool▁call▁begin｜>injected",
+        "x<｜tool▁call▁end｜>injected",
+        "x<｜tool▁calls▁begin｜>injected",
+        "x<｜tool▁calls▁end｜>injected",
+    ],
+)
+def test_codex_blocking_2_deepseek_prefix_rejects_marker_injection(
+    hostile_name: str,
+):
+    """Codex r1 BLOCKING #2 — a tool name carrying a DeepSeek envelope
+    marker must NOT corrupt the wire. Upstream tool-name validation
+    doesn't gate on the wire-token set, so the prefix builder is
+    defense-in-depth: return ``None`` and let the synthesis fallback
+    kick in (empty args, but no wire corruption)."""
+    assert _forced_tool_call_prefix("deepseek_v31", hostile_name) is None
+    assert _forced_tool_call_prefix("deepseek_r1_0528", hostile_name) is None
+
+
+def test_codex_blocking_2_deepseek_prefix_safe_name_still_works():
+    """Companion to the injection-rejection test: a clean tool name
+    still produces the canonical prefix (regression guard)."""
+    out = _forced_tool_call_prefix("deepseek_v31", "get_weather")
+    assert out is not None
+    assert "get_weather" in out
+
+
+def test_codex_blocking_1_scrub_preserves_trailing_text_after_orphan_opener():
+    """Codex r1 BLOCKING #1 — the previous regex pattern
+    ``opener.*?(?:closer|\\Z)`` silently deleted all bytes after an
+    orphan opener through EOF, losing legitimate reasoning prose. The
+    two-phase scrub keeps trailing text intact while still stripping
+    the opener marker itself."""
+    leak = "Before opener\n<tool_call>\n{junk\nReal reasoning after the orphan opener."
+    out = _scrub_tool_wire_literals(leak)
+    # Wire opener gone
+    assert "<tool_call>" not in out
+    # But trailing prose preserved
+    assert "Real reasoning after the orphan opener." in out
+    # And so is the prose before it
+    assert "Before opener" in out
+
+
+def test_codex_blocking_1_scrub_handles_balanced_pair_normally():
+    """Balanced ``<tool_call>...</tool_call>`` blocks are stripped
+    whole — phase-1 of the scrub. Pin so a refactor doesn't
+    accidentally break the common case."""
+    leak = 'preamble <tool_call>{"name":"x","arguments":{}}</tool_call> trailing'
+    out = _scrub_tool_wire_literals(leak)
+    assert "<tool_call>" not in out
+    assert "</tool_call>" not in out
+    assert "preamble" in out
+    assert "trailing" in out
+
+
+def test_codex_blocking_1_scrub_handles_orphan_closer_alone():
+    """Defensive: an orphan ``</tool_call>`` with no matching opener
+    is also stripped — phase-2 of the scrub."""
+    leak = "Some legitimate prose then a stray </tool_call> marker."
+    out = _scrub_tool_wire_literals(leak)
+    assert "</tool_call>" not in out
+    assert "legitimate prose" in out
+    assert "marker." in out
+
+
+def test_codex_blocking_1_scrub_unclosed_deepseek_envelope_preserves_tail():
+    """Same invariant for the DeepSeek envelope: an orphan opener
+    must not erase trailing text."""
+    leak = (
+        "Pre-envelope words. <｜tool▁calls▁begin｜>"
+        "<｜tool▁call▁begin｜>get_weather"
+        "<｜tool▁sep｜>{partial Followed by more analysis text."
+    )
+    out = _scrub_tool_wire_literals(leak)
+    # Every wire marker gone
+    for m in (
+        "<｜tool▁calls▁begin｜>",
+        "<｜tool▁call▁begin｜>",
+        "<｜tool▁sep｜>",
+    ):
+        assert m not in out, f"{m!r} survived: {out!r}"
+    # Trailing prose preserved
+    assert "more analysis text" in out
+    assert "Pre-envelope words" in out
+
+
+def test_codex_nit_recover_partial_args_finds_later_occurrence():
+    """Codex r1 NIT — recovery must iterate over ``"arguments"`` so a
+    leading example/prose mention doesn't block recovery of the real
+    body. The leading mention has no balanced object after it;
+    recovery skips it and uses the later real body."""
+    raw = (
+        'The tool schema example uses "arguments": (an integer here, not an object). '
+        # The leading occurrence has NO object body — recovery must
+        # skip it instead of returning None.
+        '\nactual call:\n<tool_call>{"name":"x","arguments":{"a":42}}</tool_call>'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"a": 42}
+
+
+def test_codex_nit_recover_partial_args_skips_unbalanced_then_finds_balanced():
+    """Two ``"arguments":`` occurrences — the first has an unbalanced
+    body (truncated), the second has a balanced one. Recovery must
+    iterate past the unbalanced match instead of returning ``None``."""
+    raw = (
+        '{"name":"a","arguments":{"k":"unterminated  \nnext call: {"arguments":{"x":1}}'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"x": 1}

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1117,6 +1117,23 @@ def test_codex_r2_blocking_deepseek_envelope_counts_as_wire_span():
     assert parsed == {"city": "Tokyo", "units": "c"}
 
 
+def test_codex_r7_deepseek_verbose_span_pairs_name_without_fixed_lookback():
+    """DeepSeek name pairing is bounded by the open wire span, not 512 bytes."""
+
+    verbose_metadata = "x" * 900
+    raw = (
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+        f"<｜tool▁sep｜>{verbose_metadata}"
+        '{"arguments":{"city":"Tokyo","units":"c"}}'
+        "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+    )
+    got = _recover_partial_tool_args(raw, expected_name="get_weather")
+    assert got is not None
+    import json as _json
+
+    assert _json.loads(got) == {"city": "Tokyo", "units": "c"}
+
+
 # -----------------------------------------------------------------------
 # codex r6 BLOCKING #1 — gate scrub on actual wire-leak detection
 # -----------------------------------------------------------------------
@@ -1210,6 +1227,9 @@ def test_codex_r7_structural_leak_detector_ignores_plain_marker_mentions():
     prose = "I cannot call tools here, but the literal token is <tool_call>."
     assert _contains_tool_wire_literal(prose)
     assert not _contains_structural_tool_wire_leak(prose)
+    closer_prose = "Use </function> to close XML in this example."
+    assert _contains_tool_wire_literal(closer_prose)
+    assert not _contains_structural_tool_wire_leak(closer_prose)
     assert _contains_structural_tool_wire_leak(
         '<tool_call>{"name":"add_numbers","arguments":{"a":1}}</function>'
     )
@@ -1227,6 +1247,33 @@ def test_codex_r7_synth_forced_clean_marker_prose_not_scrubbed():
             super().__init__(text=raw, raw_text=raw)
 
     engine = _CleanMarkerMentionEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    assert msg.get("content") == raw
+
+
+def test_codex_r7_synth_forced_clean_closer_prose_not_scrubbed():
+    """A lone closer token in ordinary prose is also not enough to scrub."""
+
+    raw = "Use </function> to close XML in this example."
+
+    class _CleanCloserMentionEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _CleanCloserMentionEngine()
     client = _make_client(engine, tool_call_parser="hermes")
     resp = client.post(
         "/v1/chat/completions",

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -562,6 +562,28 @@ def test_t3_chat_route_recovers_args_when_possible():
     assert args == {"a": 4128, "b": 7591}, (
         f"recoverable args were not used: got {args!r}"
     )
+    # codex r3 BLOCKING #2: even on the recoverable shape, the
+    # parser-wire markers in the raw body MUST NOT leak into the
+    # user-visible fields. The recovered-args shape uses a
+    # ``<tool_call>`` opener + ``</function>`` cross-family closer,
+    # which exercises the phase-1.5 cross-family scrub specifically
+    # (the phase-1 strict same-family pair would not match).
+    content = msg.get("content") or ""
+    reasoning = msg.get("reasoning_content") or ""
+    for leak in (
+        "<tool_call>",
+        "</tool_call>",
+        "</function>",
+        "</parameter>",
+        '"name":',
+        '"arguments":',
+    ):
+        assert leak not in content, (
+            f"recoverable-args path leaked {leak!r} into content: {content!r}"
+        )
+        assert leak not in reasoning, (
+            f"recoverable-args path leaked {leak!r} into reasoning: {reasoning!r}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -792,6 +814,79 @@ def test_codex_r2_blocking_prefers_last_within_wire_span():
 
     parsed = _json.loads(got)
     assert parsed == {"v": 2}
+
+
+def test_codex_r3_blocking_1_scrub_strips_cross_family_qwen3_leak():
+    """Codex r3 BLOCKING #1 — the qwen3 leak shape uses a
+    ``<tool_call>`` opener with a ``</function>`` closer (mismatched
+    families). The strict same-family pairs in phase 1 do not match
+    that span, so the JSON body between the two markers used to
+    survive into ``content``. Phase 1.5 (cross-family span) closes
+    the leak."""
+    leak = (
+        '<tool_call>\n{"name":"add_numbers","arguments":{"a":1,"b":2}}\n</function>\n'
+    )
+    out = _scrub_tool_wire_literals(leak)
+    # The whole span (including the JSON body) is gone — that body
+    # is the malformed tool-call attempt, not legitimate prose.
+    for leak_token in (
+        "<tool_call>",
+        "</function>",
+        '"name":',
+        '"arguments":',
+        "add_numbers",
+    ):
+        assert leak_token not in out, (
+            f"cross-family scrub left {leak_token!r} behind: {out!r}"
+        )
+
+
+def test_codex_r3_blocking_1_scrub_cross_family_preserves_pre_and_post_prose():
+    """The cross-family scrub MUST NOT eat legitimate text before
+    the opener or after the closer — only the wire span itself."""
+    leak = (
+        "Pre-wire reasoning. "
+        '<tool_call>{"name":"x","arguments":{}}</function>'
+        " Post-wire reasoning continues."
+    )
+    out = _scrub_tool_wire_literals(leak)
+    assert "<tool_call>" not in out
+    assert "</function>" not in out
+    assert "Pre-wire reasoning" in out
+    assert "Post-wire reasoning continues" in out
+
+
+def test_codex_r3_blocking_1_scrub_orphan_opener_still_preserves_tail():
+    """Cross-family scrub is non-greedy — it requires SOME closer
+    to fire. An orphan opener with no closer anywhere in the text
+    should NOT trigger phase 1.5 (regression for the r1 BLOCKING #1
+    invariant that trailing prose past an orphan opener survives)."""
+    leak = "<tool_call>\n{junk\nLegitimate trailing prose."
+    out = _scrub_tool_wire_literals(leak)
+    # Marker stripped by phase 2 (standalone).
+    assert "<tool_call>" not in out
+    # Trailing prose preserved (phase 1.5 didn't fire — no closer).
+    assert "Legitimate trailing prose" in out
+
+
+def test_codex_r3_nit_recover_handles_pretty_print_whitespace():
+    """Codex r3 NIT — the colon between ``"arguments"`` and ``{``
+    may have arbitrary whitespace (newlines, deep indents,
+    pretty-print). The previous fixed 20-char window rejected valid
+    JSON with too much whitespace; the fix walks past whitespace
+    unbounded before requiring ``:``."""
+    raw = (
+        '<tool_call>{"name": "x", "arguments"\n'
+        "        \n"
+        "                 :\n"
+        '        {"deeply": {"nested": "values"}}}</tool_call>'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"deeply": {"nested": "values"}}
 
 
 def test_codex_r2_blocking_deepseek_envelope_counts_as_wire_span():

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -298,12 +298,19 @@ def test_t2_chat_route_wires_deepseek_v31_prefix_to_engine():
             "max_tokens": 32,
         },
     )
-    # The mock engine returns text="ok" so the route's post-parse path
-    # will then synthesise a call (no real model in the loop). Either
-    # the prefix wire-up worked (we'll see the prefix in kwargs) or
-    # the suffix fell through to the synthesis path; the structural
-    # invariant is the prefix is shipped to the engine.
-    assert resp.status_code in (200, 422), resp.text
+    # codex r2 NIT: assert the exact expected status BEFORE inspecting
+    # engine kwargs — a loose ``in (200, 422)`` would let a response-
+    # path regression slip through silently. The mock engine returns
+    # ``text="ok"`` with ``finish_reason="stop"``, so the route's
+    # post-parse path synthesises a tool call (single-tool
+    # ``required``) and ships 200.
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"].get("tool_calls"), (
+        f"tool_choice=required must yield tool_calls in the response; got {body!r}"
+    )
+    # Separately assert that the prefix WAS injected into engine kwargs
+    # — this is the T2 invariant the test pins.
     assert engine.last_chat_kwargs is not None
     prefix_kw = engine.last_chat_kwargs.get("forced_assistant_prefix")
     assert prefix_kw is not None, (
@@ -724,3 +731,82 @@ def test_codex_nit_recover_partial_args_skips_unbalanced_then_finds_balanced():
 
     parsed = _json.loads(got)
     assert parsed == {"x": 1}
+
+
+def test_codex_r2_blocking_prefers_in_wire_span_over_prose_example():
+    """Codex r2 BLOCKING — when a docstring-style prose example
+    appears BEFORE the actual tool wire, recovery must pick the
+    wire-span occurrence, NOT the prose example. The previous
+    "first-parseable" strategy would have shipped the example's
+    arguments as the synthesised call's args."""
+    raw = (
+        # Prose example with valid JSON — this is what the previous
+        # first-parseable strategy would have grabbed.
+        'The tool schema requires "arguments": {"a": 0, "b": 0} '
+        "shape (this is just an example).\n"
+        # The actual call inside the wire span — this is what we want.
+        '<tool_call>\n{"name":"add_numbers","arguments":{"a":42,"b":99}}\n'
+        "</tool_call>"
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"a": 42, "b": 99}, (
+        f"recovery picked the wrong occurrence (prose example over wire span); "
+        f"got {parsed!r}"
+    )
+
+
+def test_codex_r2_blocking_falls_back_to_last_when_no_wire_span():
+    """When NO ``"arguments":`` occurrence sits inside a wire-span
+    opener, recovery falls back to the last (rightmost) parseable
+    occurrence. Pins the bare-JSON tool emission case where the
+    model didn't wrap the call at all."""
+    raw = (
+        # No wire markers — bare JSON only. The last balanced object
+        # should win.
+        'first: "arguments": {"a": 1}\nsecond: "arguments": {"a": 2}'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"a": 2}
+
+
+def test_codex_r2_blocking_prefers_last_within_wire_span():
+    """When MULTIPLE candidates sit inside wire spans, the LAST one
+    wins (most-recent intent — the tool wire is conventionally at
+    the end of the response)."""
+    raw = (
+        '<tool_call>{"name":"x","arguments":{"v":1}}</tool_call>'
+        "\nThe model continued and emitted a second corrected call:\n"
+        '<tool_call>{"name":"x","arguments":{"v":2}}</tool_call>'
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"v": 2}
+
+
+def test_codex_r2_blocking_deepseek_envelope_counts_as_wire_span():
+    """DeepSeek's V3.1 envelope markers also qualify as wire spans —
+    a prose mention before the envelope must not beat the real call
+    inside."""
+    raw = (
+        'Documentation note: "arguments" usually look like {"city": "X"}.\n'
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+        '<｜tool▁sep｜>{"arguments":{"city":"Tokyo","units":"c"}}'
+        "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"city": "Tokyo", "units": "c"}

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1034,16 +1034,29 @@ def test_codex_r3_nit_recover_handles_pretty_print_whitespace():
 def test_codex_r2_blocking_deepseek_envelope_counts_as_wire_span():
     """DeepSeek's V3.1 envelope markers also qualify as wire spans —
     a prose mention before the envelope must not beat the real call
-    inside."""
+    inside.
+
+    codex r5 BLOCKING #2 — exercise production behaviour by passing
+    ``expected_name`` (the synth always supplies it via
+    ``_synthesize_forced_tool_call``). The V3.1 wire shape uses
+    ``<｜tool▁call▁begin｜>NAME<｜tool▁sep｜>``, NOT JSON-quoted
+    ``"name":"NAME"``, so the recovery's name-pair gate has to
+    recognise the DeepSeek shape too.
+    """
     raw = (
         'Documentation note: "arguments" usually look like {"city": "X"}.\n'
         "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
         '<｜tool▁sep｜>{"arguments":{"city":"Tokyo","units":"c"}}'
         "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
     )
-    got = _recover_partial_tool_args(raw)
-    assert got is not None
+    # End-to-end via the synth helper (matches production).
+    tc = _synthesize_forced_tool_call("get_weather", raw_text=raw)
     import json as _json
 
+    args = _json.loads(tc.function.arguments)
+    assert args == {"city": "Tokyo", "units": "c"}
+    # Also exercise the direct recovery API with the expected name.
+    got = _recover_partial_tool_args(raw, expected_name="get_weather")
+    assert got is not None
     parsed = _json.loads(got)
     assert parsed == {"city": "Tokyo", "units": "c"}

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1,0 +1,598 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for D-TOOLCHOICE-R1+QWEN3 (0.8.3 hotfix).
+
+Three tightly-related tool-calling failures surfaced on 0.8.3 dogfood:
+
+* **T1** — DeepSeek-R1 distill with ``tool_choice="auto"`` would fabricate
+  prose like ``"The current temperature in Tokyo is 24°C"`` without ever
+  emitting a tool call. The pre-existing tool-use system suffix asked the
+  model to call a tool but did NOT forbid printing fake tool results when
+  it decided not to.
+* **T2** — DeepSeek-R1 distill with ``tool_choice="required"`` returned
+  ``tool_calls[0].arguments == "{}"`` even when the user prompt clearly
+  carried the required string parameter. Root cause: the
+  ``_forced_tool_call_prefix`` allowlist only contained ``hermes``, so
+  the ``deepseek_v31`` / ``deepseek_r1_0528`` parsers fell through to
+  the post-parse synthesis fallback (which defaulted ``"{}"``).
+* **T3** — qwen3 + ``tool_choice="required"`` emitted malformed JSON
+  inside a literal ``<tool_call>`` envelope (e.g. ``"arguments": 4128,
+  7591}``). The hermes parser couldn't extract it, the post-parse path
+  synthesised a call with empty args, AND the raw ``<tool_call>...``
+  text leaked into BOTH ``content`` and ``reasoning_content``.
+
+The fix is structural, not three ad-hoc patches:
+
+1. ``_TOOL_USE_SYSTEM_SUFFIX`` now explicitly forbids fabricating tool
+   output when no tool call is made (T1).
+2. ``_forced_tool_call_prefix`` recognises ``deepseek_v31`` /
+   ``deepseek_r1_0528`` and injects the V3.1 envelope
+   ``<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>NAME<｜tool▁sep｜>``
+   so the model continues with real arguments instead of relying on the
+   empty-args synthesis fallback (T2).
+3. ``_synthesize_forced_tool_call`` now accepts ``raw_text`` and runs a
+   bounded ``_recover_partial_tool_args`` scan before defaulting to
+   ``"{}"``. Wire-marker literals from the failed-parse text are
+   scrubbed from ``cleaned_text`` (and the raw text the reasoning
+   parser sees) via ``_scrub_tool_wire_literals`` so the leak in T3
+   doesn't survive into either user-visible field.
+
+The tests below exercise each layer end-to-end through the real chat
+route — no parallel re-implementation of the post-parse pipeline that
+can silently drift from production.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import (
+    _forced_tool_call_prefix,
+    _recover_partial_tool_args,
+    _scrub_tool_wire_literals,
+    _synthesize_forced_tool_call,
+)
+from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.service.helpers import (
+    _TOOL_USE_REQUIRED_SUFFIX,
+    _TOOL_USE_SYSTEM_SUFFIX,
+)
+from vllm_mlx.tool_parsers.deepseekv31_tool_parser import DeepSeekV31ToolParser
+from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+# ──────────────────────────────────────────────────────────────────
+# Test harness — recording mock engine + client builder
+# ──────────────────────────────────────────────────────────────────
+
+
+class _RecordingEngine:
+    """Mock engine that captures kwargs and returns a configurable
+    ``GenerationOutput``. Mirrors the harness used by
+    ``test_chat_route_tool_choice_enforcement.py`` so test patterns stay
+    consistent across files.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+    supports_tool_calls = True
+
+    def __init__(self, text: str = "ok", raw_text: str | None = None):
+        self.last_chat_kwargs: dict[str, Any] | None = None
+        self.last_messages: Any = None
+        self._text = text
+        self._raw_text = raw_text if raw_text is not None else text
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_chat_kwargs = kwargs
+        return GenerationOutput(
+            text=self._text,
+            raw_text=self._raw_text,
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+def _make_client(
+    engine: _RecordingEngine, tool_call_parser: str | None = "hermes"
+) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = tool_call_parser
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+_SOLO_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add_numbers",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    },
+]
+
+
+_WEATHER_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "units": {"type": "string", "enum": ["c", "f"]},
+                },
+                "required": ["city"],
+            },
+        },
+    },
+]
+
+
+# ──────────────────────────────────────────────────────────────────
+# T1 — tool_choice="auto" must not let prose fabricate tool output
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_t1_auto_suffix_forbids_fake_tool_output():
+    """``_TOOL_USE_SYSTEM_SUFFIX`` is the auto-mode prompt. The 0.8.3
+    bug was that it asked the model to "use a tool immediately" but
+    did NOT block the failure mode where the model emits a fake tool
+    result (``"The current temperature in Tokyo is 24°C"``). The new
+    suffix carries an explicit no-fabrication clause."""
+    # The clause must explicitly forbid fabricating tool output AND
+    # specifically the prose shapes Theo's evidence captured.
+    s = _TOOL_USE_SYSTEM_SUFFIX
+    assert "fabricate" in s.lower()
+    # No-fake-API clause names the most common hallucination shapes.
+    assert "Tool returned:" in s
+    assert "Tool output:" in s
+    assert "fake JSON" in s.lower() or "fake api" in s.lower()
+
+
+def test_t1_auto_suffix_is_injected_for_auto_mode():
+    """End-to-end through the chat route: ``tool_choice="auto"`` must
+    inject the strengthened suffix so even when the parser sees prose
+    (no tool call envelope), the no-fabrication clause was in front of
+    the model. Asserts the suffix is part of the rendered system
+    message — the actual model behaviour is exercised by the smoke
+    section of the PR body."""
+    engine = _RecordingEngine(text="some answer", raw_text="some answer")
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": _WEATHER_TOOL,
+            "tool_choice": "auto",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # System suffix was injected into the prompt — verify by looking
+    # at the messages the engine received.
+    assert engine.last_messages is not None
+    sys_msgs = [m for m in engine.last_messages if m.get("role") == "system"]
+    assert sys_msgs, "tool_choice='auto' must inject a system suffix"
+    sys_text = " ".join(m.get("content", "") for m in sys_msgs)
+    assert "fabricate" in sys_text.lower(), (
+        f"auto-mode system suffix must forbid fabricating tool output; "
+        f"got: {sys_text[-300:]!r}"
+    )
+
+
+def test_t1_required_suffix_unchanged():
+    """The "required" suffix is separate from the "auto" suffix —
+    only the auto-mode suffix needed the no-fabrication clause (the
+    required suffix already says "a text-only response is INVALID").
+    Pin that the required suffix wording isn't accidentally weakened."""
+    assert "MUST call" in _TOOL_USE_REQUIRED_SUFFIX
+    assert "INVALID" in _TOOL_USE_REQUIRED_SUFFIX
+
+
+# ──────────────────────────────────────────────────────────────────
+# T2 — tool_choice="required" + deepseek_v31 must inject a wire prefix
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_t2_forced_prefix_deepseek_v31_inserts_envelope():
+    """The V3.1 wire shape is ``<｜tool▁calls▁begin｜>``
+    ``<｜tool▁call▁begin｜>NAME<｜tool▁sep｜>{json}``
+    ``<｜tool▁call▁end｜><｜tool▁calls▁end｜>``. The forced prefix
+    inserts everything up to the JSON body so the model continues with
+    real arguments."""
+    out = _forced_tool_call_prefix("deepseek_v31", "get_weather")
+    assert out is not None
+    assert "<｜tool▁calls▁begin｜>" in out
+    assert "<｜tool▁call▁begin｜>" in out
+    assert "get_weather" in out
+    assert out.endswith("<｜tool▁sep｜>")
+
+
+def test_t2_forced_prefix_deepseek_r1_0528_alias():
+    """``deepseek_r1_0528`` is the second alias the same parser
+    registers under. It must produce the same prefix as
+    ``deepseek_v31`` so DeepSeek-R1 distills (which load under either
+    alias depending on config) get consistent forcing."""
+    a = _forced_tool_call_prefix("deepseek_v31", "x")
+    b = _forced_tool_call_prefix("deepseek_r1_0528", "x")
+    assert a == b
+    assert a is not None
+
+
+def test_t2_forced_prefix_deepseek_v1_still_returns_none():
+    """The V1 ``deepseek`` parser has a different body shape and
+    shares only the outer markers. We intentionally did NOT add it to
+    the allowlist — leaving it on the synthesis fallback is safer than
+    risking a wrong wire."""
+    assert _forced_tool_call_prefix("deepseek", "x") is None
+    assert _forced_tool_call_prefix("deepseek_v3", "x") is None
+
+
+def test_t2_deepseek_v31_parser_consumes_assembled_envelope():
+    """End-to-end shape check: when the model continues from the
+    injected prefix and emits ``{"city":"Tokyo"}<｜tool▁call▁end｜>``
+    ``<｜tool▁calls▁end｜>``, the parser MUST extract a non-empty
+    ``arguments`` string — that's the entire point of injecting the
+    prefix.
+    """
+    prefix = _forced_tool_call_prefix("deepseek_v31", "get_weather")
+    assert prefix is not None
+    # Simulate the model's continuation past the injected prefix.
+    full = (
+        prefix + '{"city":"Tokyo","units":"c"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    )
+    parser = DeepSeekV31ToolParser(tokenizer=None)
+    parser.reset()
+    result = parser.extract_tool_calls(full, None)
+    assert result.tools_called
+    assert result.tool_calls[0]["name"] == "get_weather"
+    import json as _json
+
+    args = _json.loads(result.tool_calls[0]["arguments"])
+    assert args == {"city": "Tokyo", "units": "c"}, (
+        f"deepseek_v31 forced prefix did not produce real arguments; got {args!r}"
+    )
+
+
+def test_t2_chat_route_wires_deepseek_v31_prefix_to_engine():
+    """Through the FULL chat route: ``tool_choice="required"`` + single
+    tool + ``deepseek_v31`` parser must ship a ``forced_assistant_prefix``
+    in the engine kwargs. Without it, T2 fails the same way as 0.8.3."""
+    engine = _RecordingEngine()
+    client = _make_client(engine, tool_call_parser="deepseek_v31")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather in Tokyo in celsius?"}],
+            "tools": _WEATHER_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    # The mock engine returns text="ok" so the route's post-parse path
+    # will then synthesise a call (no real model in the loop). Either
+    # the prefix wire-up worked (we'll see the prefix in kwargs) or
+    # the suffix fell through to the synthesis path; the structural
+    # invariant is the prefix is shipped to the engine.
+    assert resp.status_code in (200, 422), resp.text
+    assert engine.last_chat_kwargs is not None
+    prefix_kw = engine.last_chat_kwargs.get("forced_assistant_prefix")
+    assert prefix_kw is not None, (
+        "deepseek_v31 + tool_choice=required + 1 tool must inject a "
+        "forced_assistant_prefix into engine kwargs (T2 fix)"
+    )
+    assert "<｜tool▁call▁begin｜>" in prefix_kw
+    assert "get_weather" in prefix_kw
+
+
+# ──────────────────────────────────────────────────────────────────
+# T3 — qwen3 tool_choice="required" wire-leak + arg recovery
+# ──────────────────────────────────────────────────────────────────
+
+
+# The exact malformed wire shape Theo captured on qwen3.5-4b-4bit:
+# the model emits invalid JSON (``"arguments": 4128, 7591`` — bare
+# positional integers instead of an object body) inside a
+# ``<tool_call>`` envelope, then closes with stray ``</parameter>`` /
+# ``</function>`` tags.
+_QWEN3_MALFORMED_BODY = (
+    "<tool_call>\n"
+    '{"name": "add_numbers", "arguments": 4128, 7591}\n'
+    "</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
+
+
+_QWEN3_BODY_WITH_RECOVERABLE_ARGS = (
+    "<tool_call>\n"
+    '{"name": "add_numbers", "arguments": {"a": 4128, "b": 7591}}\n'
+    # Missing </tool_call> — parser's strict pattern fails to match
+    "</function>"
+)
+
+
+def test_t3_hermes_parser_alone_cannot_extract_malformed_body():
+    """Establishes the prerequisite for the fix: with the malformed
+    JSON body the hermes parser CANNOT extract a tool call. The fix
+    has to handle this case at the chat-route level — adding more
+    regexes to the parser would risk false positives on prose."""
+    parser = HermesToolParser(tokenizer=None)
+    parser.reset()
+    r = parser.extract_tool_calls(_QWEN3_MALFORMED_BODY, None)
+    assert not r.tools_called
+    # And the leak: the parser's content output IS the raw wire.
+    assert "<tool_call>" in (r.content or "")
+
+
+def test_t3_scrub_wire_literals_removes_qwen3_leak():
+    """``_scrub_tool_wire_literals`` is the parser-agnostic cleanup
+    that strips wire-opener literals when the post-parse path
+    synthesises a forced call. After scrubbing, none of the literal
+    wire markers must remain in the text."""
+    out = _scrub_tool_wire_literals(_QWEN3_MALFORMED_BODY)
+    for leak in (
+        "<tool_call>",
+        "</tool_call>",
+        "<function>",
+        "</function>",
+        "</parameter>",
+    ):
+        assert leak not in out, (
+            f"_scrub_tool_wire_literals left {leak!r} behind: {out!r}"
+        )
+
+
+def test_t3_scrub_wire_literals_idempotent_on_clean_prose():
+    """The scrubber must be a no-op on text that contains no wire
+    markers. Otherwise it would corrupt the auto/non-forced paths
+    where prose is the legitimate model output."""
+    prose = "The sky is blue. Here is a sentence about birds."
+    assert _scrub_tool_wire_literals(prose) == prose
+
+
+def test_t3_scrub_handles_deepseek_v31_leak():
+    """The scrubber is parser-agnostic. A leaked DeepSeek envelope
+    (e.g. truncated tool-call begin without a matching end) must also
+    be stripped."""
+    leak = "prefix <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>x<｜tool▁sep｜>{}"
+    out = _scrub_tool_wire_literals(leak)
+    assert "<｜tool▁calls▁begin｜>" not in out
+    assert "<｜tool▁call▁begin｜>" not in out
+    assert "prefix" in out
+
+
+def test_t3_scrub_handles_nemotron_and_glm_and_mistral_leaks():
+    """Confidence sweep — every parser wire we documented in the
+    scrub allowlist must be cleared."""
+    cases = [
+        "<function=foo>arg=1</function>",
+        "<arg_key>k</arg_value>",
+        "<minimax:tool_call>foo</minimax:tool_call>",
+        "<invoke name='x'>body</invoke>",
+        "[TOOL_CALLS]{}[/TOOL_CALLS]",
+        "<|tool_calls_section_begin|>x<|tool_calls_section_end|>",
+    ]
+    for c in cases:
+        out = _scrub_tool_wire_literals(c)
+        # The wire opener bytes must NOT survive.
+        for opener in (
+            "<function=",
+            "<arg_key>",
+            "<minimax:tool_call>",
+            "<invoke",
+            "[TOOL_CALLS]",
+            "<|tool_calls_section_begin|>",
+        ):
+            assert opener not in out, f"{opener!r} survived scrub of {c!r}: {out!r}"
+
+
+def test_t3_recover_partial_args_from_balanced_object():
+    """When the raw text contains ``"arguments": {...}`` with a
+    balanced JSON object body, the recovery routine extracts that
+    object verbatim (canonicalised). This is the qwen3 "real call,
+    bad wrapper" case from the evidence variation."""
+    raw = (
+        "garbage <tool_call>\n"
+        '{"name": "add_numbers", "arguments": {"a": 4128, "b": 7591}}\n'
+        "</function> trailing prose"
+    )
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    parsed = _json.loads(got)
+    assert parsed == {"a": 4128, "b": 7591}
+
+
+def test_t3_recover_partial_args_returns_none_on_qwen3_malformed():
+    """The original Theo-evidence qwen3 shape has
+    ``"arguments": 4128, 7591`` — NOT a JSON object. The recovery
+    routine must return ``None`` so the caller falls back to ``"{}"``;
+    coercing two bare integers into named params would require
+    schema-side guessing that is out of scope."""
+    assert _recover_partial_tool_args(_QWEN3_MALFORMED_BODY) is None
+
+
+def test_t3_recover_partial_args_returns_none_on_clean_prose():
+    """Defensive: prose with no ``"arguments":`` literal yields
+    ``None``."""
+    assert _recover_partial_tool_args("just some answer") is None
+    assert _recover_partial_tool_args("") is None
+    assert _recover_partial_tool_args(None) is None
+
+
+def test_t3_synthesize_uses_recovered_args_when_available():
+    """The high-level synth helper prefers recovered args over the
+    ``"{}"`` default. With a recoverable body the call's arguments
+    must NOT be the empty default."""
+    raw_with_args = '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}'
+    tc = _synthesize_forced_tool_call("add_numbers", raw_text=raw_with_args)
+    import json as _json
+
+    assert _json.loads(tc.function.arguments) == {"a": 1, "b": 2}
+
+
+def test_t3_synthesize_falls_back_to_empty_when_unrecoverable():
+    """When recovery returns ``None``, the helper falls back to the
+    caller-provided default (``"{}"`` by default). Pin the
+    backward-compat contract — pre-0.8.3 behaviour."""
+    tc = _synthesize_forced_tool_call("add_numbers", raw_text=_QWEN3_MALFORMED_BODY)
+    assert tc.function.arguments == "{}"
+
+
+def test_t3_chat_route_strips_wire_leak_from_content_and_reasoning():
+    """End-to-end through the FULL chat route: when the model emits
+    the qwen3 malformed wire AND the request is ``tool_choice=required``,
+    the response MUST have:
+
+      - ``tool_calls`` populated with the forced name
+      - ``content`` clean of ``<tool_call>`` and ``</function>`` leaks
+      - ``reasoning_content`` (if any) also clean of those leaks
+    """
+
+    class _QwenMalformedEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=_QWEN3_MALFORMED_BODY, raw_text=_QWEN3_MALFORMED_BODY)
+
+    engine = _QwenMalformedEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is 4128 + 7591?"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    msg = body["choices"][0]["message"]
+    # Tool call is present (forced synth)
+    assert msg.get("tool_calls"), (
+        f"tool_choice=required must produce tool_calls; got msg={msg!r}"
+    )
+    assert msg["tool_calls"][0]["function"]["name"] == "add_numbers"
+    # Content is leak-free — the original ``<tool_call>...`` text
+    # must NOT survive into the user-visible content channel.
+    content = msg.get("content") or ""
+    for leak in ("<tool_call>", "</tool_call>", "</function>", "</parameter>"):
+        assert leak not in content, (
+            f"T3 leak: {leak!r} survived in content: {content!r}"
+        )
+    # And the reasoning content (if any) is also leak-free.
+    reasoning = msg.get("reasoning_content") or ""
+    for leak in ("<tool_call>", "</tool_call>", "</function>", "</parameter>"):
+        assert leak not in reasoning, (
+            f"T3 leak: {leak!r} survived in reasoning_content: {reasoning!r}"
+        )
+
+
+def test_t3_chat_route_recovers_args_when_possible():
+    """When the model emits a recoverable arguments object inside an
+    unclosed envelope, the synth call's arguments must reflect the
+    recovered values, not ``"{}"``."""
+
+    class _QwenRecoverableEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(
+                text=_QWEN3_BODY_WITH_RECOVERABLE_ARGS,
+                raw_text=_QWEN3_BODY_WITH_RECOVERABLE_ARGS,
+            )
+
+    engine = _QwenRecoverableEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is 4128 + 7591?"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    msg = body["choices"][0]["message"]
+    assert msg.get("tool_calls")
+    import json as _json
+
+    args = _json.loads(msg["tool_calls"][0]["function"]["arguments"])
+    # The model's intended args ARE recoverable from the body — verify
+    # the synth used them instead of defaulting to {}.
+    assert args == {"a": 4128, "b": 7591}, (
+        f"recoverable args were not used: got {args!r}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# Regression: pre-existing happy paths must not regress
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_pre_existing_hermes_prefix_unchanged():
+    """``_forced_tool_call_prefix("hermes", ...)`` must keep emitting
+    the same JSON-body shape it did before — pinned in
+    ``test_chat_route_forced_tool_prefix.py`` but also asserted here
+    so a future refactor doesn't silently change the wire format."""
+    out = _forced_tool_call_prefix("hermes", "get_weather")
+    assert out is not None
+    assert out.startswith("<tool_call>")
+    assert '"name": "get_weather"' in out
+    assert out.endswith('"arguments": ')
+
+
+def test_pre_existing_unknown_parser_still_none():
+    """Defensive — unknown parsers still get ``None``."""
+    assert _forced_tool_call_prefix(None, "fn") is None
+    assert _forced_tool_call_prefix("future_parser", "fn") is None
+
+
+@pytest.mark.parametrize(
+    "parser_name",
+    [
+        "llama",
+        "kimi",
+        "glm47",
+        "minimax",
+        "mistral",
+        "harmony",
+        "gemma4",
+    ],
+)
+def test_pre_existing_non_allowlisted_parsers_still_none(parser_name: str):
+    """Channel-routed and other-shape parsers still fall through —
+    the T2 fix is additive."""
+    assert _forced_tool_call_prefix(parser_name, "fn") is None

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1240,6 +1240,9 @@ def test_codex_r7_structural_leak_detector_ignores_plain_marker_mentions():
     closer_prose = "Use </function> to close XML in this example."
     assert _contains_tool_wire_literal(closer_prose)
     assert not _contains_structural_tool_wire_leak(closer_prose)
+    balanced_prose = "Show the literal form <tool_call>...</tool_call>."
+    assert _contains_tool_wire_literal(balanced_prose)
+    assert not _contains_structural_tool_wire_leak(balanced_prose)
     assert _contains_structural_tool_wire_leak(
         '<tool_call>{"name":"add_numbers","arguments":{"a":1}}</function>'
     )
@@ -1301,34 +1304,97 @@ def test_codex_r7_synth_forced_clean_closer_prose_not_scrubbed():
     assert msg.get("content") == raw
 
 
+def test_codex_r8_synth_forced_clean_balanced_marker_prose_not_scrubbed():
+    """Balanced marker examples without payload hints are explanatory prose."""
+
+    raw = "Show the literal form <tool_call>...</tool_call>."
+
+    class _CleanBalancedMentionEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _CleanBalancedMentionEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    content = msg.get("content") or ""
+    assert "Show the literal form" in content
+    assert "<tool_call>" in content
+    assert "..." in content
+
+
 # -----------------------------------------------------------------------
 # codex r6 BLOCKING #2 — don't scrub raw_text before reasoning extract
 # -----------------------------------------------------------------------
 
 
 def test_codex_r6_blocking_2_raw_text_not_mutated_before_reasoning():
-    """The chat route must NOT pre-scrub ``output.raw_text`` before
-    handing it to the reasoning parser. Pretty-printed reasoning may
-    legitimately contain wire-marker-shaped tokens (e.g. when
-    discussing tool wire formats), and rewriting those before
-    extraction truncates / collapses reasoning content.
+    """The route keeps raw reasoning extraction but scrubs visible fields.
 
-    Static check on the route source — the call site must pass
-    ``output.raw_text or output.text`` UNMODIFIED to
-    ``_finalize_content_and_reasoning``.
+    This is the production contract: a reasoning parser may inspect the
+    original raw text, but any wire markers it surfaces into
+    ``content``/``reasoning_content`` must be removed before response
+    construction.
     """
-    import inspect
 
-    import vllm_mlx.routes.chat as _chat_mod
-
-    src = inspect.getsource(_chat_mod)
-    # The fix moved the raw_text= argument to the un-scrubbed path.
-    # We assert the un-scrubbed expression is wired in, and that the
-    # pre-fix ``_scrubbed_raw_text`` ternary is gone.
-    assert "_scrubbed_raw_text" not in src, (
-        "raw_text scrub path must not survive — codex r6 BLOCKING #2"
+    raw = (
+        "<think>Need a tool.\n"
+        '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}</function>\n'
+        "Done.</think>"
     )
-    assert "raw_text=output.raw_text or output.text" in src
+
+    class _RawEchoReasoningParser:
+        def extract_reasoning(self, text, enable_thinking=None):
+            return (
+                "Reasoning saw "
+                '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}</function>',
+                text,
+            )
+
+    class _RawWireEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _RawWireEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = _RawEchoReasoningParser()
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    content = msg.get("content") or ""
+    reasoning = msg.get("reasoning_content") or ""
+    for leak in ("<tool_call>", "</tool_call>", "</function>", "</parameter>"):
+        assert leak not in content
+        assert leak not in reasoning
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -240,6 +240,20 @@ def test_t2_forced_prefix_deepseek_v31_inserts_envelope():
     assert out.endswith("<｜tool▁sep｜>")
 
 
+def test_t2_forced_prefix_deepseek_rejects_unsafe_tool_names():
+    """DeepSeek non-JSON envelope only supports conservative tool names."""
+
+    for name in (
+        "bad name",
+        "bad\nname",
+        'bad"quote',
+        "bad.name",
+        "x" * 65,
+        "bad<tool_call>",
+    ):
+        assert _forced_tool_call_prefix("deepseek_v31", name) is None
+
+
 def test_t2_forced_prefix_deepseek_r1_0528_alias():
     """``deepseek_r1_0528`` is the second alias the same parser
     registers under. It must produce the same prefix as
@@ -1278,6 +1292,19 @@ def test_codex_r12_visible_scrub_removes_unclosed_deepseek_prefix_payload():
     assert "get_weather" not in out
     assert '"arguments"' not in out
     assert "prefix" in out
+    assert "suffix" in out
+
+
+def test_codex_r13_visible_scrub_skips_broken_deepseek_begin_then_scrubs_payload():
+    """A harmless earlier begin marker must not block a later payload fragment."""
+
+    out = _scrub_visible_tool_wire_leaks(
+        "prefix <｜tool▁call▁begin｜>broken "
+        '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"arguments":{"city":"Tokyo"}} suffix'
+    )
+    assert "broken" in out
+    assert "get_weather" not in out
+    assert '"arguments"' not in out
     assert "suffix" in out
 
 

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1134,6 +1134,16 @@ def test_codex_r7_deepseek_verbose_span_pairs_name_without_fixed_lookback():
     assert _json.loads(got) == {"city": "Tokyo", "units": "c"}
 
 
+def test_codex_r8_no_opener_name_pair_does_not_cross_from_prose():
+    """Without a wire opener, name pairing stays inside the local JSON object."""
+
+    raw = (
+        'Earlier prose says "name":"target". '
+        '{"arguments":{"city":"Tokyo"}}</function>'
+    )
+    assert _recover_partial_tool_args(raw, expected_name="target") is None
+
+
 # -----------------------------------------------------------------------
 # codex r6 BLOCKING #1 — gate scrub on actual wire-leak detection
 # -----------------------------------------------------------------------

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -869,6 +869,148 @@ def test_codex_r3_blocking_1_scrub_orphan_opener_still_preserves_tail():
     assert "Legitimate trailing prose" in out
 
 
+def test_codex_r4_blocking_1_recover_rejects_unrelated_tool_name():
+    """Codex r4 BLOCKING #1 — when an ``expected_name`` is set, the
+    recovery must NOT pick up an unrelated tool's args. A response
+    containing ``{"name":"other_tool","arguments":{...}}`` must yield
+    ``None`` for a synth target ``"my_target"``."""
+    raw = '<tool_call>{"name":"other_tool","arguments":{"x":1}}</tool_call>'
+    # Without expected_name: returns the args (pre-codex-r4 behaviour).
+    got = _recover_partial_tool_args(raw)
+    assert got is not None
+    import json as _json
+
+    assert _json.loads(got) == {"x": 1}
+    # WITH expected_name set to a non-matching tool: returns None.
+    got = _recover_partial_tool_args(raw, expected_name="my_target")
+    assert got is None, f"expected None when name mismatches; got {got!r}"
+
+
+def test_codex_r4_blocking_1_recover_accepts_matching_tool_name():
+    """The companion: when the expected name DOES match, recovery
+    returns the args as before. Pin the success case so the
+    name-pair gate doesn't accidentally reject correct calls."""
+    raw = '<tool_call>{"name":"my_target","arguments":{"x":1}}</tool_call>'
+    got = _recover_partial_tool_args(raw, expected_name="my_target")
+    assert got is not None
+    import json as _json
+
+    assert _json.loads(got) == {"x": 1}
+
+
+def test_codex_r4_blocking_1_recover_picks_matching_pair_from_multiple():
+    """When MULTIPLE ``"arguments"`` occurrences exist, the
+    ``expected_name`` gate must steer recovery to the one paired
+    with the matching name even if another candidate appears later."""
+    raw = (
+        '<tool_call>{"name":"other","arguments":{"k":"first"}}</tool_call>'
+        '<tool_call>{"name":"target","arguments":{"k":"correct"}}</tool_call>'
+        '<tool_call>{"name":"third","arguments":{"k":"last"}}</tool_call>'
+    )
+    got = _recover_partial_tool_args(raw, expected_name="target")
+    assert got is not None
+    import json as _json
+
+    assert _json.loads(got) == {"k": "correct"}
+
+
+def test_codex_r4_blocking_1_synthesize_uses_name_paired_args():
+    """End-to-end through ``_synthesize_forced_tool_call``: when
+    raw_text contains the wrong tool's args plus the right one,
+    the synth picks the right one because it passes its ``name``
+    as the ``expected_name`` to recovery."""
+    raw = (
+        '<tool_call>{"name":"other","arguments":{"wrong":true}}</tool_call>'
+        '<tool_call>{"name":"target","arguments":{"correct":true}}</tool_call>'
+    )
+    tc = _synthesize_forced_tool_call("target", raw_text=raw)
+    import json as _json
+
+    args = _json.loads(tc.function.arguments)
+    assert args == {"correct": True}
+
+
+def test_codex_r4_blocking_1_synthesize_falls_back_when_no_pair():
+    """When raw_text contains NO ``"arguments"`` paired with the
+    synth target name, the synth falls back to ``"{}"`` instead of
+    silently picking up unrelated args."""
+    raw = '<tool_call>{"name":"unrelated_tool","arguments":{"x":1}}</tool_call>'
+    tc = _synthesize_forced_tool_call("target", raw_text=raw)
+    assert tc.function.arguments == "{}"
+
+
+def test_codex_r4_blocking_2_scrub_does_not_fire_for_tool_choice_auto():
+    """Codex r4 BLOCKING #2 — the scrub must NOT fire for
+    ``tool_choice="auto"`` because the model may legitimately emit
+    prose discussing the tool wire format. End-to-end: ``auto`` +
+    parser-extracted call + raw text containing wire-shaped prose
+    keeps the prose in content."""
+
+    # Engine returns text where the parser successfully extracts a
+    # tool call AND there's wire-shaped content in the trailing prose
+    # (e.g. the assistant explaining what just happened).
+    PROSE_WITH_WIRE_LOOKING_TEXT = (
+        '<tool_call>{"name":"get_time","arguments":{"city":"Tokyo"}}</tool_call>\n'
+        "Note: tool calls use the <tool_call> envelope syntax."
+    )
+
+    class _AutoEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(
+                text=PROSE_WITH_WIRE_LOOKING_TEXT,
+                raw_text=PROSE_WITH_WIRE_LOOKING_TEXT,
+            )
+
+    engine = _AutoEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "time in Tokyo?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_time",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    msg = body["choices"][0]["message"]
+    assert msg.get("tool_calls"), "auto-mode parser-extracted call must survive"
+    # The auto-mode scrub gate is OFF — the prose mention of
+    # ``<tool_call>`` survives in content (legitimate model output).
+    # This is the pre-0.8.3 contract; codex r4 BLOCKING #2 wants it
+    # preserved so the broadened scrub doesn't strip legitimate
+    # prose containing tool wire syntax under ``auto``.
+    content = msg.get("content") or ""
+    # The phrase "<tool_call>" in the trailing prose was legitimate
+    # — the scrub must NOT have removed it under tool_choice=auto.
+    assert "<tool_call>" in content, (
+        f"auto-mode legitimate prose mentioning <tool_call> was stripped; "
+        f"content={content!r}"
+    )
+
+
 def test_codex_r3_nit_recover_handles_pretty_print_whitespace():
     """Codex r3 NIT — the colon between ``"arguments"`` and ``{``
     may have arbitrary whitespace (newlines, deep indents,

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1268,6 +1268,14 @@ def test_codex_r10_visible_scrub_removes_unclosed_opener_payload_body():
     assert "suffix" in out
 
 
+def test_codex_r11_broad_scrub_does_not_cross_family_strip_marker_prose():
+    """Cross-family scrub needs payload evidence before deleting a span."""
+
+    prose = "Explain <tool_call> as an opener and </function> as a closer."
+    out = _scrub_tool_wire_literals(prose)
+    assert "as an opener and" in out
+
+
 def test_codex_r7_synth_forced_clean_marker_prose_not_scrubbed():
     """When forced synthesis happens because the parser found no call,
     clean prose that merely mentions ``<tool_call>`` must survive.

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -51,6 +51,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
 from vllm_mlx.routes.chat import (
     _contains_tool_wire_literal,
     _forced_tool_call_prefix,
@@ -525,6 +526,58 @@ def test_t3_chat_route_strips_wire_leak_from_content_and_reasoning():
         assert leak not in reasoning, (
             f"T3 leak: {leak!r} survived in reasoning_content: {reasoning!r}"
         )
+
+
+def test_t3_chat_route_scrubs_wire_leak_from_reasoning_content():
+    """Forced malformed tool wire inside reasoning must not leak markers
+    through ``reasoning_content``.
+    """
+
+    raw = (
+        "<think>Need to call the tool.\n"
+        '<tool_call>{"name":"add_numbers","arguments": 4128, 7591}</function>\n'
+        "Done thinking.</think>"
+    )
+
+    class _ReasoningWireLeakEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _ReasoningWireLeakEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = Qwen3ReasoningParser(tokenizer=None)
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is 4128 + 7591?"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    assert msg["tool_calls"][0]["function"]["name"] == "add_numbers"
+
+    reasoning = msg.get("reasoning_content") or ""
+    for leak in ("<tool_call>", "</tool_call>", "</function>", "</parameter>"):
+        assert leak not in reasoning, (
+            f"T3 leak: {leak!r} survived in reasoning_content: {reasoning!r}"
+        )
+    assert "Need to call the tool." in reasoning
+    assert "Done thinking." in reasoning
 
 
 def test_t3_chat_route_recovers_args_when_possible():
@@ -1102,23 +1155,35 @@ def test_codex_r6_blocking_1_forced_choice_with_clean_text_does_not_scrub():
     is plain prose must keep its content unmodified. Pre-fix, the
     scrub gate fired on every successful forced call regardless of
     whether the parser left wire markers behind.
-
-    Static check on the chat-route source — the gate now AND-includes
-    ``_contains_tool_wire_literal(cleaned_text)`` so that no leak ⇒
-    no scrub.
     """
-    import inspect
 
-    import vllm_mlx.routes.chat as _chat_mod
-
-    src = inspect.getsource(_chat_mod)
-    # The gate predicate must include the leak detector.
-    assert "_contains_tool_wire_literal(cleaned_text)" in src, (
-        "scrub gate must check for actual wire leak — codex r6 BLOCKING #1"
+    raw = (
+        '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}</tool_call>'
+        "\nTool called successfully."
     )
 
-    # And the helper itself must report "no leak" on plain prose.
-    assert not _contains_tool_wire_literal("Tool called successfully.")
+    class _CleanForcedEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _CleanForcedEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    assert msg["tool_calls"][0]["function"]["name"] == "add_numbers"
+    assert msg.get("content") == "Tool called successfully."
 
 
 def test_codex_r6_blocking_1_forced_choice_with_wire_leak_still_scrubs():

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1267,6 +1267,20 @@ def test_codex_r10_visible_scrub_removes_unclosed_opener_payload_body():
     assert "suffix" in out
 
 
+def test_codex_r12_visible_scrub_removes_unclosed_deepseek_prefix_payload():
+    """DeepSeek begin/name/sep prefix must not survive payload scrubbing."""
+
+    out = _scrub_visible_tool_wire_leaks(
+        'prefix <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"arguments":{"city":"Tokyo"}} suffix'
+    )
+    assert "<｜tool▁call▁begin｜>" not in out
+    assert "<｜tool▁sep｜>" not in out
+    assert "get_weather" not in out
+    assert '"arguments"' not in out
+    assert "prefix" in out
+    assert "suffix" in out
+
+
 def test_codex_r11_broad_scrub_does_not_cross_family_strip_marker_prose():
     """Cross-family scrub needs payload evidence before deleting a span."""
 

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1139,8 +1139,7 @@ def test_codex_r8_no_opener_name_pair_does_not_cross_from_prose():
     """Without a wire opener, name pairing stays inside the local JSON object."""
 
     raw = (
-        'Earlier prose says "name":"target". '
-        '{"arguments":{"city":"Tokyo"}}</function>'
+        'Earlier prose says "name":"target". {"arguments":{"city":"Tokyo"}}</function>'
     )
     assert _recover_partial_tool_args(raw, expected_name="target") is None
 

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -53,6 +53,7 @@ from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
 from vllm_mlx.routes.chat import (
+    _contains_structural_tool_wire_leak,
     _contains_tool_wire_literal,
     _forced_tool_call_prefix,
     _recover_partial_tool_args,
@@ -1198,6 +1199,49 @@ def test_codex_r6_blocking_1_forced_choice_with_wire_leak_still_scrubs():
     assert "<tool_call>" not in cleaned
     assert "</function>" not in cleaned
     assert "The result is OK." in cleaned
+
+
+def test_codex_r7_structural_leak_detector_ignores_plain_marker_mentions():
+    """A literal marker token in ordinary prose is not by itself a
+    parser-wire leak. The route scrub gate must require structure so
+    forced synthesis does not destructively rewrite explanatory text.
+    """
+
+    prose = "I cannot call tools here, but the literal token is <tool_call>."
+    assert _contains_tool_wire_literal(prose)
+    assert not _contains_structural_tool_wire_leak(prose)
+    assert _contains_structural_tool_wire_leak(
+        '<tool_call>{"name":"add_numbers","arguments":{"a":1}}</function>'
+    )
+
+
+def test_codex_r7_synth_forced_clean_marker_prose_not_scrubbed():
+    """When forced synthesis happens because the parser found no call,
+    clean prose that merely mentions ``<tool_call>`` must survive.
+    """
+
+    raw = "I cannot call tools here, but the literal token is <tool_call>."
+
+    class _CleanMarkerMentionEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _CleanMarkerMentionEngine()
+    client = _make_client(engine, tool_call_parser="hermes")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert msg.get("tool_calls"), msg
+    assert msg.get("content") == raw
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1500,8 +1500,12 @@ def test_codex_r9_raw_wire_elsewhere_does_not_scrub_reasoning_marker_example():
         },
     )
     assert resp.status_code == 200, resp.text
-    reasoning = resp.json()["choices"][0]["message"].get("reasoning_content") or ""
+    msg = resp.json()["choices"][0]["message"]
+    content = msg.get("content") or ""
+    reasoning = msg.get("reasoning_content") or ""
     assert reasoning == "Use <tool_call> as the opening tag."
+    for leak in ("<tool_call>", "</function>", '"arguments"'):
+        assert leak not in content
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -58,6 +58,7 @@ from vllm_mlx.routes.chat import (
     _forced_tool_call_prefix,
     _recover_partial_tool_args,
     _scrub_tool_wire_literals,
+    _scrub_visible_tool_wire_leaks,
     _synthesize_forced_tool_call,
 )
 from vllm_mlx.routes.chat import router as chat_router
@@ -1243,9 +1244,25 @@ def test_codex_r7_structural_leak_detector_ignores_plain_marker_mentions():
     balanced_prose = "Show the literal form <tool_call>...</tool_call>."
     assert _contains_tool_wire_literal(balanced_prose)
     assert not _contains_structural_tool_wire_leak(balanced_prose)
+    json_example_prose = 'Mention <tool_call> near {"example": true}.'
+    assert _contains_tool_wire_literal(json_example_prose)
+    assert not _contains_structural_tool_wire_leak(json_example_prose)
     assert _contains_structural_tool_wire_leak(
         '<tool_call>{"name":"add_numbers","arguments":{"a":1}}</function>'
     )
+
+
+def test_codex_r10_visible_scrub_removes_unclosed_opener_payload_body():
+    """A structural orphan opener must not leave name/arguments JSON behind."""
+
+    out = _scrub_visible_tool_wire_leaks(
+        'prefix <tool_call>{"name":"x","arguments":{"a":1}} suffix'
+    )
+    assert "<tool_call>" not in out
+    assert '"name"' not in out
+    assert '"arguments"' not in out
+    assert "prefix" in out
+    assert "suffix" in out
 
 
 def test_codex_r7_synth_forced_clean_marker_prose_not_scrubbed():

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1397,6 +1397,45 @@ def test_codex_r6_blocking_2_raw_text_not_mutated_before_reasoning():
         assert leak not in reasoning
 
 
+def test_codex_r9_raw_wire_elsewhere_does_not_scrub_reasoning_marker_example():
+    """Raw structural wire elsewhere must not scrub a marker-only example."""
+
+    raw = '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}</function>'
+
+    class _MarkerExampleReasoningParser:
+        def extract_reasoning(self, text, enable_thinking=None):
+            return "Use <tool_call> as the opening tag.", ""
+
+    class _RawWireEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _RawWireEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = _MarkerExampleReasoningParser()
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    reasoning = resp.json()["choices"][0]["message"].get("reasoning_content") or ""
+    assert reasoning == "Use <tool_call> as the opening tag."
+
+
 # -----------------------------------------------------------------------
 # codex r6 NIT — wire-span lookback bounded by nearest opener/closer
 # -----------------------------------------------------------------------

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1009,6 +1009,29 @@ def test_codex_r4_blocking_1_synthesize_falls_back_when_no_pair():
     assert tc.function.arguments == "{}"
 
 
+def test_codex_r10_deepseek_name_pair_requires_exact_safe_name():
+    """DeepSeek V3.1 recovery must not treat whitespace-padded names as
+    matching the forced target.
+
+    The prefix path only emits safe tool names exactly between
+    ``tool_call_begin`` and ``tool_sep``. Recovery uses the same contract
+    instead of a regex with permissive ``\\s*`` around the expected name.
+    """
+    raw = (
+        "<｜tool▁calls▁begin｜>"
+        "<｜tool▁call▁begin｜>\nget_weather<｜tool▁sep｜>"
+        '{"arguments":{"city":"Tokyo"}}'
+        "<｜tool▁call▁end｜>"
+        "<｜tool▁calls▁end｜>"
+    )
+    assert _recover_partial_tool_args(raw, expected_name="get_weather") is None
+
+    exact_raw = raw.replace("\nget_weather", "get_weather")
+    assert _recover_partial_tool_args(exact_raw, expected_name="get_weather") == (
+        '{"city": "Tokyo"}'
+    )
+
+
 def test_codex_r4_blocking_2_scrub_does_not_fire_for_tool_choice_auto():
     """Codex r4 BLOCKING #2 — the scrub must NOT fire for
     ``tool_choice="auto"`` because the model may legitimately emit
@@ -1075,6 +1098,7 @@ def test_codex_r4_blocking_2_scrub_does_not_fire_for_tool_choice_auto():
     content = msg.get("content") or ""
     # The phrase "<tool_call>" in the trailing prose was legitimate
     # — the scrub must NOT have removed it under tool_choice=auto.
+    assert content == "Note: tool calls use the <tool_call> envelope syntax."
     assert "<tool_call>" in content, (
         f"auto-mode legitimate prose mentioning <tool_call> was stripped; "
         f"content={content!r}"
@@ -1506,6 +1530,50 @@ def test_codex_r9_raw_wire_elsewhere_does_not_scrub_reasoning_marker_example():
     assert reasoning == "Use <tool_call> as the opening tag."
     for leak in ("<tool_call>", "</function>", '"arguments"'):
         assert leak not in content
+
+
+def test_codex_r10_raw_wire_context_scrubs_marker_only_reasoning_leak():
+    """Reasoning derived from structural raw wire keeps the raw-context scrub.
+
+    A parser may surface only the opener token from a leaky raw tool wire.
+    That is not a clean documentation example, so the route should scrub it
+    from ``reasoning_content`` while still preserving the r9 prose example.
+    """
+
+    raw = '<tool_call>{"name":"add_numbers","arguments":{"a":1,"b":2}}</function>'
+
+    class _MarkerLeakReasoningParser:
+        def extract_reasoning(self, text, enable_thinking=None):
+            return "<tool_call>", ""
+
+    class _RawWireEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    engine = _RawWireEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = _MarkerLeakReasoningParser()
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add 1 and 2"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    assert "<tool_call>" not in (msg.get("reasoning_content") or "")
 
 
 # -----------------------------------------------------------------------

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -213,27 +213,39 @@ def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
     return filtered
 
 
+def _synthesize_pinned_tool_call(tool_name: str):
+    """Build a synthetic ``ToolCall`` for the pinned tool with empty input."""
+    from ..api.models import FunctionCall, ToolCall
+
+    return ToolCall(
+        id=f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=FunctionCall(name=tool_name, arguments="{}"),
+    )
+
+
 def _enforce_named_tool_choice_present(
     tool_calls,
     tool_choice,
     *,
     original_call_count: int,
-) -> tuple[list, str | None]:
-    """Return ``(tool_calls, error_detail_or_None)`` for a named pin.
+) -> tuple[list, bool]:
+    """Return ``(tool_calls, synthesized)`` for a named pin.
 
     Named ``tool_choice`` pins a specific tool. If the parser found a
     call for that tool, the list passes through unchanged after
     ``_filter_tool_calls_by_tool_choice`` has dropped any extras. If the
     model returned text only, or emitted only calls to other tools, the
-    route must fail closed: fabricating an empty call to the named tool
-    would convert a model compliance failure into a false-success
-    ``tool_use`` block and can make clients dispatch a tool with missing
-    required input.
+    Anthropic route synthesizes a best-effort empty-input call to the
+    pinned tool. This mirrors Anthropic SDK expectations for forced named
+    tool flows: the local model cannot decoder-enforce the pin, but the
+    response still carries the tool the client explicitly asked to
+    dispatch.
 
     ``tool_choice="required"`` / Anthropic ``{"type":"any"}`` keeps the
     separate single-tool synthesis path in
-    ``_enforce_required_tool_choice_present`` because that contract pins
-    "any available tool", not a named tool's arguments.
+    ``_enforce_required_tool_choice_present``; this helper owns only the
+    explicit named-tool shape.
 
     ``original_call_count`` is the size of ``tool_calls`` BEFORE the
     filter ran. A warning logs the disambiguation between "model
@@ -243,35 +255,26 @@ def _enforce_named_tool_choice_present(
     """
     target = _named_tool_choice_target(tool_choice)
     if not target or tool_calls:
-        return tool_calls, None
+        return tool_calls, False
     # Log the disambiguation an operator needs to debug small-model
     # compliance issues.
     if original_call_count == 0:
         logger.warning(
             "tool_choice pinned tool %r but the model returned a text "
-            "response with no tool_calls.",
+            "response with no tool_calls; synthesizing a best-effort "
+            "tool_use with empty input (F8 fallback).",
             target,
-        )
-        detail = (
-            f'tool_choice pinned tool "{target}" but the model returned a '
-            "text response with no tool_calls. Local inference has no "
-            "decoder-level constraint for named tool_choice; retry with a "
-            "more concrete prompt or relax tool_choice."
         )
     else:
         logger.warning(
-            "tool_choice pinned tool %r but the model emitted %d call(s), none to %r.",
+            "tool_choice pinned tool %r but the model emitted %d call(s), "
+            "none to %r; synthesizing a best-effort tool_use with empty "
+            "input (F8 fallback).",
             target,
             original_call_count,
             target,
         )
-        detail = (
-            f'tool_choice pinned tool "{target}" but the model emitted '
-            f"{original_call_count} tool_call(s), none to the pinned tool. "
-            "Local inference cannot safely rewrite a different tool_call into "
-            "the requested tool."
-        )
-    return tool_calls, detail
+    return [_synthesize_pinned_tool_call(target)], True
 
 
 def _is_required_tool_choice(tool_choice) -> bool:
@@ -860,20 +863,16 @@ async def create_anthropic_message(
         # ``_enforce_named_tool_choice_present`` for the "filter dropped
         # everything" guard added in PR #763 codex round-1.
         original_call_count = len(tool_calls or [])
+        synthesized_pinned_call = False
         if openai_request.tool_choice:
             tool_calls = _filter_tool_calls_by_tool_choice(
                 tool_calls or [], openai_request.tool_choice
             )
-            tool_calls, _named_err = _enforce_named_tool_choice_present(
+            tool_calls, synthesized_pinned_call = _enforce_named_tool_choice_present(
                 tool_calls,
                 openai_request.tool_choice,
                 original_call_count=original_call_count,
             )
-            if _named_err:
-                # Named pins are not equivalent to "any tool": if the model
-                # produced text only, or only other tool calls, fabricating the
-                # named call would be a false success with unknown arguments.
-                raise HTTPException(status_code=422, detail=_named_err)
             # D-ANTHRO-TOOL-USAGE F3: Anthropic ``{"type":"any"}`` enforcement.
             # The adapter has mapped it to OpenAI ``"required"``; mirror the
             # chat-route synth+422 policy so a no-tool reply either becomes
@@ -897,7 +896,11 @@ async def create_anthropic_message(
         # propagated through ``/v1/messages`` as a 200 ``tool_use`` block
         # carrying schema-violating arguments.
         #
-        if tool_calls and openai_request.tools:
+        # Synthesized named-pin calls carry empty ``input={}`` by design.
+        # Do not validate that placeholder against a possibly-required
+        # schema; the downstream tool dispatcher owns missing argument
+        # handling for this best-effort Anthropic SDK compatibility path.
+        if tool_calls and openai_request.tools and not synthesized_pinned_call:
             _validate_tool_call_params(tool_calls, openai_request.tools)
 
         # Extract reasoning content via the same orchestration the OpenAI route
@@ -2585,18 +2588,17 @@ async def _stream_anthropic_messages(
     # earlier emission point or the dropped tool's content_block_start
     # will reach the wire before we know to suppress it.
     tool_choice_error: str | None = None
+    synthesized_pinned_call = False
     original_call_count_stream = len(tool_calls or [])
     if openai_request.tool_choice:
         tool_calls = _filter_tool_calls_by_tool_choice(
             tool_calls or [], openai_request.tool_choice
         )
-        tool_calls, _named_err_stream = _enforce_named_tool_choice_present(
+        tool_calls, synthesized_pinned_call = _enforce_named_tool_choice_present(
             tool_calls,
             openai_request.tool_choice,
             original_call_count=original_call_count_stream,
         )
-        if _named_err_stream:
-            tool_choice_error = _named_err_stream
 
         # D-ANTHRO-TOOL-USAGE F3: stream variant of
         # ``_enforce_required_tool_choice_present`` for
@@ -2628,7 +2630,7 @@ async def _stream_anthropic_messages(
     # non-stream branch's 400 contract in spirit while staying within
     # the Anthropic streaming protocol.
     tool_validation_error: str | None = None
-    if tool_calls and openai_request.tools:
+    if tool_calls and openai_request.tools and not synthesized_pinned_call:
         try:
             _validate_tool_call_params(tool_calls, openai_request.tools)
         except HTTPException as exc:
@@ -2654,7 +2656,11 @@ async def _stream_anthropic_messages(
     # The buffer is unused when ``tool_choice`` is not a named pin —
     # in that case the chunk loop yielded directly and ``pre_filter_buffer``
     # is empty, so this block is a no-op on every non-pinned request.
-    if _buffer_for_pinned_tool and not (tool_choice_error or tool_validation_error):
+    if synthesized_pinned_call:
+        pre_filter_buffer.clear()
+    if _buffer_for_pinned_tool and not (
+        tool_choice_error or tool_validation_error or synthesized_pinned_call
+    ):
         for buffered_event in pre_filter_buffer:
             yield buffered_event
         pre_filter_buffer.clear()

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -870,6 +870,9 @@ async def create_anthropic_message(
                 original_call_count=original_call_count,
             )
             if _named_err:
+                # Named pins are not equivalent to "any tool": if the model
+                # produced text only, or only other tool calls, fabricating the
+                # named call would be a false success with unknown arguments.
                 raise HTTPException(status_code=422, detail=_named_err)
             # D-ANTHRO-TOOL-USAGE F3: Anthropic ``{"type":"any"}`` enforcement.
             # The adapter has mapped it to OpenAI ``"required"``; mirror the

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -213,90 +213,65 @@ def _filter_tool_calls_by_tool_choice(tool_calls, tool_choice) -> list:
     return filtered
 
 
-def _synthesize_pinned_tool_call(tool_name: str):
-    """Build a synthetic ``ToolCall`` for the pinned tool with empty
-    ``input``. F8 best-effort fallback when the model failed to comply
-    with ``tool_choice={"type":"tool","name":X}``.
-
-    Local import to avoid widening the routes/anthropic.py module-level
-    import surface — these models are pulled in lazily only on the
-    pinned-tool fallback path so the happy-path import time stays flat.
-    """
-    from ..api.models import FunctionCall, ToolCall
-
-    return ToolCall(
-        id=f"call_{uuid.uuid4().hex[:8]}",
-        type="function",
-        function=FunctionCall(name=tool_name, arguments="{}"),
-    )
-
-
 def _enforce_named_tool_choice_present(
     tool_calls,
     tool_choice,
     *,
     original_call_count: int,
-) -> tuple[list, bool]:
-    """Return ``(tool_calls, synthesized)``.
+) -> tuple[list, str | None]:
+    """Return ``(tool_calls, error_detail_or_None)`` for a named pin.
 
-    The first element is the (possibly synthesized) tool-call list:
-    unchanged when the named-tool contract is satisfied, or a list
-    containing a single synthesized best-effort ``tool_use`` for the
-    pinned tool with empty ``input={}`` when the model failed to
-    comply. The second element is an explicit boolean signal — True
-    iff this call synthesized a placeholder. Callers use the signal
-    to (a) skip JSON-schema validation on the synthesized empty
-    ``input`` (which would otherwise 400 on tools with ``required``
-    fields, codex r1 BLOCKING #1) and (b) drop the streaming
-    buffered-text replay (the model emitted forbidden text instead
-    of the pinned tool, codex r1 BLOCKING #2 — inferring from list
-    lengths can misclassify a legitimate single-call from a filtered
-    list).
+    Named ``tool_choice`` pins a specific tool. If the parser found a
+    call for that tool, the list passes through unchanged after
+    ``_filter_tool_calls_by_tool_choice`` has dropped any extras. If the
+    model returned text only, or emitted only calls to other tools, the
+    route must fail closed: fabricating an empty call to the named tool
+    would convert a model compliance failure into a false-success
+    ``tool_use`` block and can make clients dispatch a tool with missing
+    required input.
 
-    F8 history: PR #763 round-1 added this as a 422 "could not enforce"
-    surface — honest about local inference's lack of decoder-level
-    constraints, but breaks Anthropic SDK callers that expect a 200
-    with the pinned tool_use block (the forced-named-tool flow is a
-    common agent pattern; ``anthropic`` SDK does not retry on 422).
-    Anthropic's real backend uses an FSM constraint to GUARANTEE a
-    ``tool_use`` for the pinned tool; we don't have that, but a
-    synthesized empty-input call gives clients SOMETHING shaped like
-    the pinned tool to dispatch — closer to spec than 422.
-
-    Mirrors chat.py's named-function path which 422s on the OpenAI
-    surface (strict spec) but the Anthropic spec is more forgiving;
-    see ``_filter_tool_calls_by_tool_choice`` for the same
-    surface-divergence rationale (H-05).
+    ``tool_choice="required"`` / Anthropic ``{"type":"any"}`` keeps the
+    separate single-tool synthesis path in
+    ``_enforce_required_tool_choice_present`` because that contract pins
+    "any available tool", not a named tool's arguments.
 
     ``original_call_count`` is the size of ``tool_calls`` BEFORE the
     filter ran. A warning logs the disambiguation between "model
     returned text only" (count == 0) and "model called the wrong
     tool(s) and the filter emptied the list" (count > 0) so an
-    operator debugging unexpected best-effort fallbacks can see WHICH
-    case fired.
+    operator debugging named-tool enforcement can see WHICH case fired.
     """
     target = _named_tool_choice_target(tool_choice)
     if not target or tool_calls:
-        return tool_calls, False
+        return tool_calls, None
     # Log the disambiguation an operator needs to debug small-model
-    # compliance issues. The wire response shape is identical either way.
+    # compliance issues.
     if original_call_count == 0:
         logger.warning(
             "tool_choice pinned tool %r but the model returned a text "
-            "response with no tool_calls; synthesizing a best-effort "
-            "tool_use with empty input (F8 fallback).",
+            "response with no tool_calls.",
             target,
+        )
+        detail = (
+            f'tool_choice pinned tool "{target}" but the model returned a '
+            "text response with no tool_calls. Local inference has no "
+            "decoder-level constraint for named tool_choice; retry with a "
+            "more concrete prompt or relax tool_choice."
         )
     else:
         logger.warning(
-            "tool_choice pinned tool %r but the model emitted %d call(s), "
-            "none to %r; synthesizing a best-effort tool_use with empty "
-            "input (F8 fallback).",
+            "tool_choice pinned tool %r but the model emitted %d call(s), none to %r.",
             target,
             original_call_count,
             target,
         )
-    return [_synthesize_pinned_tool_call(target)], True
+        detail = (
+            f'tool_choice pinned tool "{target}" but the model emitted '
+            f"{original_call_count} tool_call(s), none to the pinned tool. "
+            "Local inference cannot safely rewrite a different tool_call into "
+            "the requested tool."
+        )
+    return tool_calls, detail
 
 
 def _is_required_tool_choice(tool_choice) -> bool:
@@ -885,25 +860,17 @@ async def create_anthropic_message(
         # ``_enforce_named_tool_choice_present`` for the "filter dropped
         # everything" guard added in PR #763 codex round-1.
         original_call_count = len(tool_calls or [])
-        synthesized_pinned_call = False
         if openai_request.tool_choice:
             tool_calls = _filter_tool_calls_by_tool_choice(
                 tool_calls or [], openai_request.tool_choice
             )
-            # F8: ``_enforce_named_tool_choice_present`` now returns
-            # ``(tool_calls, synthesized)`` — best-effort synthesizes a
-            # placeholder ``tool_use`` (rather than raising 422) when
-            # the model failed to comply with a pinned ``tool_choice``.
-            # The explicit ``synthesized`` signal lets us skip
-            # schema validation on the synthesized empty ``input``
-            # (codex r1 BLOCKING #1: pinned tools with ``required``
-            # fields would otherwise 400 the best-effort path back
-            # into the symptom F8 was supposed to fix).
-            tool_calls, synthesized_pinned_call = _enforce_named_tool_choice_present(
+            tool_calls, _named_err = _enforce_named_tool_choice_present(
                 tool_calls,
                 openai_request.tool_choice,
                 original_call_count=original_call_count,
             )
+            if _named_err:
+                raise HTTPException(status_code=422, detail=_named_err)
             # D-ANTHRO-TOOL-USAGE F3: Anthropic ``{"type":"any"}`` enforcement.
             # The adapter has mapped it to OpenAI ``"required"``; mirror the
             # chat-route synth+422 policy so a no-tool reply either becomes
@@ -927,14 +894,7 @@ async def create_anthropic_message(
         # propagated through ``/v1/messages`` as a 200 ``tool_use`` block
         # carrying schema-violating arguments.
         #
-        # F8 follow-up: synthesized best-effort calls have empty
-        # ``input={}`` which intentionally may not satisfy the
-        # pinned tool's schema (e.g. ``required:["city"]``). Skip
-        # the validator on those — failing them would re-instate
-        # the 422 path F8 is meant to retire. Schema-level "the
-        # synthesized input didn't satisfy `required`" complaints
-        # belong on the client's downstream dispatch path.
-        if tool_calls and openai_request.tools and not synthesized_pinned_call:
+        if tool_calls and openai_request.tools:
             _validate_tool_call_params(tool_calls, openai_request.tools)
 
         # Extract reasoning content via the same orchestration the OpenAI route
@@ -2622,31 +2582,18 @@ async def _stream_anthropic_messages(
     # earlier emission point or the dropped tool's content_block_start
     # will reach the wire before we know to suppress it.
     tool_choice_error: str | None = None
-    # F8: track whether we synthesized a best-effort pinned-tool call so
-    # the buffered-text-replay branch below can drop the forbidden text
-    # payload (the model wrote text instead of the pinned tool; replaying
-    # would violate the named ``tool_choice`` contract just like the
-    # pre-F8 422 path did). Explicit signal from the helper avoids the
-    # codex r1 BLOCKING #2 misclassification — a legitimate single-call
-    # surviving the filter would otherwise be mis-flagged as synthesis
-    # purely from list-length heuristics.
-    synthesized_pinned_call = False
     original_call_count_stream = len(tool_calls or [])
     if openai_request.tool_choice:
         tool_calls = _filter_tool_calls_by_tool_choice(
             tool_calls or [], openai_request.tool_choice
         )
-        # F8: ``_enforce_named_tool_choice_present`` now returns
-        # ``(tool_calls, synthesized)`` — best-effort synthesizes a
-        # placeholder ``tool_use`` (rather than raising 422) when the
-        # model failed to comply with a pinned ``tool_choice``. The
-        # explicit ``synthesized`` signal is the source of truth for
-        # the buffered-text-drop branch below.
-        tool_calls, synthesized_pinned_call = _enforce_named_tool_choice_present(
+        tool_calls, _named_err_stream = _enforce_named_tool_choice_present(
             tool_calls,
             openai_request.tool_choice,
             original_call_count=original_call_count_stream,
         )
+        if _named_err_stream:
+            tool_choice_error = _named_err_stream
 
         # D-ANTHRO-TOOL-USAGE F3: stream variant of
         # ``_enforce_required_tool_choice_present`` for
@@ -2678,11 +2625,7 @@ async def _stream_anthropic_messages(
     # non-stream branch's 400 contract in spirit while staying within
     # the Anthropic streaming protocol.
     tool_validation_error: str | None = None
-    # F8 follow-up: skip the JSON-schema validator on synthesized
-    # best-effort calls — their empty ``input={}`` is intentionally
-    # placeholder and may not satisfy ``required`` fields. Same
-    # rationale as the non-stream branch (codex r1 BLOCKING #1).
-    if tool_calls and openai_request.tools and not synthesized_pinned_call:
+    if tool_calls and openai_request.tools:
         try:
             _validate_tool_call_params(tool_calls, openai_request.tools)
         except HTTPException as exc:
@@ -2708,16 +2651,7 @@ async def _stream_anthropic_messages(
     # The buffer is unused when ``tool_choice`` is not a named pin —
     # in that case the chunk loop yielded directly and ``pre_filter_buffer``
     # is empty, so this block is a no-op on every non-pinned request.
-    # F8 follow-up: when synthesis fired the model emitted text instead
-    # of the pinned tool. Replaying that buffered text would put the
-    # forbidden text payload back on the wire (same family of contract
-    # violation the 422 path used to suppress); drop the buffer and let
-    # the synthesized tool_use below carry the entire content list.
-    if synthesized_pinned_call:
-        pre_filter_buffer.clear()
-    if _buffer_for_pinned_tool and not (
-        tool_choice_error or tool_validation_error or synthesized_pinned_call
-    ):
+    if _buffer_for_pinned_tool and not (tool_choice_error or tool_validation_error):
         for buffered_event in pre_filter_buffer:
             yield buffered_event
         pre_filter_buffer.clear()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2809,6 +2809,8 @@ async def _create_chat_completion_impl(
         # any caller that hasn't been threaded yet.
         finish_reason=getattr(output, "finish_reason", None),
     )
+    if _wire_scrub_active and reasoning_text:
+        reasoning_text = _scrub_tool_wire_literals(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -295,46 +295,56 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
         return None
     text = raw_text
     n = len(text)
-    # codex r1 NIT: iterate over EVERY ``"arguments"`` occurrence so
-    # a leading example/prose mention (e.g. ``"the JSON shape is
-    # \"arguments\": {...}"``) doesn't block recovery of the real
-    # body that follows. We accept the first balanced JSON object;
-    # if a doc-string-shaped occurrence yields a parseable object
-    # too we'll still return that — but in practice the tool wire
-    # is always at the END of the response, so the last matching
-    # occurrence is what we want. Walk left-to-right but DON'T
-    # bail on the first non-match.
-    search_start = 0
-    while search_start < n:
-        args_marker_idx = text.find('"arguments"', search_start)
-        if args_marker_idx == -1:
-            return None
-        # Find the colon that follows ``"arguments"`` (may have
-        # whitespace before/after). Scan forward up to a small
-        # bound — beyond that the marker is just prose, not a
-        # structural field.
-        colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
-        if colon_idx == -1:
-            # Advance past this occurrence and keep searching.
-            search_start = args_marker_idx + len('"arguments"')
-            continue
-        # Skip whitespace after the colon, looking for the object opener.
-        pos = colon_idx + 1
-        while pos < n and text[pos] in " \t\n\r":
-            pos += 1
-        if pos >= n or text[pos] != "{":
-            search_start = args_marker_idx + len('"arguments"')
-            continue
-        # Balanced-brace scan: walk until depth returns to 0, respecting
-        # JSON string boundaries (so a ``"}"`` literal inside an arg value
-        # doesn't close the object early). Cap at 8 KiB so a malformed
-        # giant payload doesn't burn CPU.
+
+    # Wire markers that signal a real tool-call body. When at least
+    # one occurrence of ``"arguments":`` sits INSIDE such a span,
+    # restrict the search to those — the prose example before the
+    # wire span (e.g. a docstring quoting the JSON shape) is then
+    # ignored entirely. When NONE of the occurrences are inside a
+    # wire span, fall back to scanning the full text (handles the
+    # bare-JSON case where the model emitted a raw call with no
+    # wrapper).
+    #
+    # codex r2 BLOCKING: previously this returned the FIRST
+    # parseable ``"arguments": {...}``; a docstring-style leading
+    # example (``the JSON shape is "arguments": {"a": 0}``) would
+    # then beat the actual malformed call further down the response
+    # and we'd ship the example's arguments to the client. The fix
+    # uses two heuristics in order:
+    #
+    #   1. PREFER any candidate INSIDE a tool-call wire span
+    #      (``<tool_call>...``, ``<function=...>``, DeepSeek envelope
+    #      markers, ``[TOOL_CALLS]``, ``<|python_tag|>``). Among
+    #      those, pick the LAST parseable one (most-recent intent).
+    #   2. If no candidates land inside a wire span, accept the LAST
+    #      parseable candidate anywhere in the text — still
+    #      preferring "later" because the tool wire is conventionally
+    #      at the end of a response.
+    _WIRE_SPAN_OPENERS = (
+        "<tool_call>",
+        "<function=",
+        "<function>",
+        "<｜tool▁calls▁begin｜>",
+        "<｜tool▁call▁begin｜>",
+        "[TOOL_CALLS]",
+        "<|python_tag|>",
+        "<|tool_calls_section_begin|>",
+        "<minimax:tool_call>",
+        "<invoke",
+        "<arg_key>",
+    )
+
+    def _scan_balanced_object_at(start_brace: int) -> tuple[int, str] | None:
+        """Return ``(end_offset, raw_object_text)`` if the substring
+        starting at ``start_brace`` is a balanced JSON object,
+        ``None`` otherwise. Cap 8 KiB to avoid burning CPU on a
+        malformed giant payload.
+        """
         depth = 0
         in_string = False
         escape = False
-        obj_start = pos
-        obj_end = -1
-        scan_end = min(n, obj_start + 8192)
+        pos = start_brace
+        scan_end = min(n, start_brace + 8192)
         while pos < scan_end:
             ch = text[pos]
             if escape:
@@ -352,14 +362,50 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
                 elif ch == "}":
                     depth -= 1
                     if depth == 0:
-                        obj_end = pos + 1
-                        break
+                        return (pos + 1, text[start_brace : pos + 1])
             pos += 1
-        if obj_end == -1:
-            # Unbalanced from this marker — try the next one.
+        return None
+
+    def _position_in_wire_span(idx: int) -> bool:
+        """Is ``idx`` inside (or immediately after) a known tool-wire
+        opener? We don't require a balanced closer — the qwen3 leak
+        shape often has no clean closer."""
+        # Look backward up to 256 bytes for any wire opener whose
+        # span could plausibly include ``idx``. The bound keeps the
+        # check O(1).
+        window_start = max(0, idx - 256)
+        window = text[window_start:idx]
+        return any(opener in window for opener in _WIRE_SPAN_OPENERS)
+
+    # Collect every parseable candidate, tagged with whether it sits
+    # inside a wire span.
+    candidates_in_wire: list[str] = []
+    candidates_outside_wire: list[str] = []
+    search_start = 0
+    while search_start < n:
+        args_marker_idx = text.find('"arguments"', search_start)
+        if args_marker_idx == -1:
+            break
+        # Find the colon that follows ``"arguments"`` (may have
+        # whitespace before/after). Scan forward up to a small
+        # bound — beyond that the marker is just prose, not a
+        # structural field.
+        colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
+        if colon_idx == -1:
             search_start = args_marker_idx + len('"arguments"')
             continue
-        candidate = text[obj_start:obj_end]
+        # Skip whitespace after the colon, looking for the object opener.
+        pos = colon_idx + 1
+        while pos < n and text[pos] in " \t\n\r":
+            pos += 1
+        if pos >= n or text[pos] != "{":
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        scan = _scan_balanced_object_at(pos)
+        if scan is None:
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        obj_end, candidate = scan
         try:
             parsed = json.loads(candidate)
         except (json.JSONDecodeError, ValueError):
@@ -368,10 +414,23 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
         if not isinstance(parsed, dict):
             search_start = args_marker_idx + len('"arguments"')
             continue
-        # Canonicalise — strip any incidental whitespace / trailing junk
-        # so downstream ``_validate_tool_call_params`` sees a clean JSON
-        # object byte-for-byte.
-        return json.dumps(parsed, ensure_ascii=False)
+        canonical = json.dumps(parsed, ensure_ascii=False)
+        if _position_in_wire_span(args_marker_idx):
+            candidates_in_wire.append(canonical)
+        else:
+            candidates_outside_wire.append(canonical)
+        search_start = obj_end
+
+    # Prefer candidates INSIDE a wire span (the real tool call); fall
+    # back to outside-wire candidates only when no wire-span match
+    # existed. Within each pool, pick the LAST (rightmost) candidate
+    # — the tool wire is conventionally at the end of the response,
+    # so "last" is "most recent" and most likely to be the actual
+    # call rather than a leading example.
+    if candidates_in_wire:
+        return candidates_in_wire[-1]
+    if candidates_outside_wire:
+        return candidates_outside_wire[-1]
     return None
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -437,15 +437,30 @@ def _recover_partial_tool_args(
         else:
             forward_bound = min(n, idx + 256)
         window = text[backward_bound:forward_bound]
-        # Accept ``"name": "<expected>"`` with optional whitespace.
-        # ``re.escape`` keeps the name literal even if it contains
-        # regex metacharacters.
         escaped = re.escape(expected)
-        pair_re = re.compile(
+        # Accept TWO wire shapes for the paired ``name`` literal:
+        #
+        # 1. ``"name": "<expected>"`` — the JSON-bodied wire shape
+        #    (hermes / qwen3 / qwen3coder / nemotron-with-JSON /
+        #    most parsers).
+        # 2. ``<｜tool▁call▁begin｜><expected><｜tool▁sep｜>`` — the
+        #    DeepSeek V3.1 wire shape, where the name is NOT
+        #    JSON-quoted; it sits between the V3.1 call-begin and
+        #    sep markers. Without this shape recovery rejects every
+        #    legitimate DeepSeek arg body (codex r5 BLOCKING #1).
+        #
+        # Both forms are searched; either match is sufficient.
+        json_pair_re = re.compile(
             r'"name"\s*:\s*"' + escaped + r'"',
             re.DOTALL,
         )
-        return pair_re.search(window) is not None
+        if json_pair_re.search(window):
+            return True
+        deepseek_pair_re = re.compile(
+            r"<｜tool▁call▁begin｜>\s*" + escaped + r"\s*<｜tool▁sep｜>",
+            re.DOTALL,
+        )
+        return deepseek_pair_re.search(window) is not None
 
     # Collect every parseable candidate, tagged with whether it sits
     # inside a wire span.

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -512,11 +512,22 @@ def _recover_partial_tool_args(
         )
         if json_pair_re.search(window):
             return True
-        deepseek_pair_re = re.compile(
-            r"<｜tool▁call▁begin｜>\s*" + escaped + r"\s*<｜tool▁sep｜>",
-            re.DOTALL,
-        )
-        return deepseek_pair_re.search(window) is not None
+        if not _SAFE_DEEPSEEK_TOOL_NAME_RE.fullmatch(expected):
+            return False
+        deepseek_begin = "<｜tool▁call▁begin｜>"
+        deepseek_sep = "<｜tool▁sep｜>"
+        search_pos = 0
+        while True:
+            begin = window.find(deepseek_begin, search_pos)
+            if begin == -1:
+                return False
+            name_start = begin + len(deepseek_begin)
+            sep = window.find(deepseek_sep, name_start)
+            if sep == -1:
+                return False
+            if window[name_start:sep] == expected:
+                return True
+            search_pos = sep + len(deepseek_sep)
 
     # Collect every parseable candidate, tagged with whether it sits
     # inside a wire span.
@@ -3016,10 +3027,7 @@ async def _create_chat_completion_impl(
     )
     if _should_scrub_visible_wire(cleaned_text, allow_raw_context=False):
         cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
-    if (
-        _should_scrub_visible_wire(reasoning_text, allow_raw_context=False)
-        and reasoning_text
-    ):
+    if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
         reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -412,7 +412,7 @@ def _recover_partial_tool_args(
             if pos > op_pos:
                 op_pos = pos
         if op_pos < 0:
-            return False
+            return None
         cl_pos = -1
         for closer in _WIRE_SPAN_CLOSERS:
             pos = prefix.rfind(closer)
@@ -480,15 +480,17 @@ def _recover_partial_tool_args(
             backward_bound = span_start
         else:
             prev_args_end = text.rfind('"arguments"', 0, idx)
-            backward_bound = (
+            object_start = text.rfind("{", 0, idx)
+            fallback_bound = (
                 prev_args_end + len('"arguments"') if prev_args_end != -1 else 0
             )
+            backward_bound = max(fallback_bound, object_start)
         # Forward bound: the next "arguments" marker or 256 bytes
         # forward. We cap forward TIGHTER than backward because the
         # canonical wire shape ``{"name":"X","arguments":{...}}``
         # always has ``"name"`` BEFORE ``"arguments"``.
         next_args_idx = text.find('"arguments"', idx + len('"arguments"'))
-        next_closer_idx = _next_wire_span_closer(idx)
+        next_closer_idx = _next_wire_span_closer(idx) if span_start is not None else None
         forward_bound = n
         if next_args_idx != -1:
             forward_bound = min(forward_bound, next_args_idx)
@@ -657,6 +659,10 @@ _TOOL_WIRE_BALANCED_PAIRS = (
         re.compile(r"\[/TOOL_CALLS\]", re.DOTALL),
     ),
 )
+_TOOL_WIRE_BALANCED_SPAN_RES = tuple(
+    re.compile(opener_re.pattern + r".*?" + closer_re.pattern, re.DOTALL)
+    for opener_re, closer_re in _TOOL_WIRE_BALANCED_PAIRS
+)
 
 
 # Standalone marker tokens that must be stripped even when their
@@ -778,8 +784,8 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     """
     if not text:
         return False
-    for opener_re, closer_re in _TOOL_WIRE_BALANCED_PAIRS:
-        if re.search(opener_re.pattern + r".*?" + closer_re.pattern, text, re.DOTALL):
+    for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
+        if balanced_re.search(text):
             return True
     if _CROSS_FAMILY_SPAN_RE.search(text):
         return True

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -769,9 +769,37 @@ def _contains_tool_wire_literal(text: str | None) -> bool:
 
 
 _TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(
-    r"(?:[\"'](?:name|arguments)[\"']\s*:|\{[^{}]{0,2048}\})",
+    r"[\"'](?:name|arguments)[\"']\s*:",
     re.DOTALL,
 )
+
+
+def _balanced_json_end(text: str, start: int) -> int | None:
+    """Return the exclusive end offset of a balanced JSON-ish object."""
+    if start < 0 or start >= len(text) or text[start] != "{":
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
 def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     """Return True when known wire markers appear as tool-wire residue.
 
@@ -839,7 +867,17 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
             window_start = max(0, match.start() - 128)
             window_end = min(len(result), match.end() + 2048)
             pieces.append(result[last : match.start()])
-            if not _TOOL_WIRE_PAYLOAD_HINT_RE.search(result[window_start:window_end]):
+            window = result[window_start:window_end]
+            has_payload_hint = _TOOL_WIRE_PAYLOAD_HINT_RE.search(window)
+            if has_payload_hint:
+                object_start = result.find("{", match.end(), window_end)
+                object_end = _balanced_json_end(result, object_start)
+                if object_end is not None:
+                    last = object_end
+                    continue
+                last = match.end()
+                continue
+            else:
                 pieces.append(match.group(0))
             last = match.end()
         if pieces:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -802,6 +802,54 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     return False
 
 
+def _is_tool_wire_marker_only(text: str | None) -> bool:
+    """True when ``text`` has markers but no non-marker payload/prose."""
+    if not text or not _contains_tool_wire_literal(text):
+        return False
+    result = text
+    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+        result = marker_re.sub("", result)
+    return not result.strip()
+
+
+def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
+    """Scrub structural wire residue while preserving marker examples.
+
+    Unlike ``_scrub_tool_wire_literals`` this is safe for route-visible
+    fields: prose such as ``"Use <tool_call>...</tool_call>"`` stays
+    intact because it has no tool payload hint. Actual malformed wire
+    spans and marker-only leftovers are removed.
+    """
+    if not text:
+        return text or ""
+    result = text
+    for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
+        result = balanced_re.sub(
+            lambda m: "" if _TOOL_WIRE_PAYLOAD_HINT_RE.search(m.group(0)) else m.group(0),
+            result,
+        )
+    result = _CROSS_FAMILY_SPAN_RE.sub(
+        lambda m: "" if _TOOL_WIRE_PAYLOAD_HINT_RE.search(m.group(0)) else m.group(0),
+        result,
+    )
+    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+        pieces: list[str] = []
+        last = 0
+        for match in marker_re.finditer(result):
+            window_start = max(0, match.start() - 128)
+            window_end = min(len(result), match.end() + 2048)
+            pieces.append(result[last : match.start()])
+            if not _TOOL_WIRE_PAYLOAD_HINT_RE.search(result[window_start:window_end]):
+                pieces.append(match.group(0))
+            last = match.end()
+        if pieces:
+            pieces.append(result[last:])
+            result = "".join(pieces)
+    if _is_tool_wire_marker_only(result):
+        result = _scrub_tool_wire_literals(result)
+    return re.sub(r"\s+", " ", result).strip()
+
+
 def _scrub_tool_wire_literals(text: str | None) -> str:
     """Strip every known parser-wire opener/closer marker from
     ``text`` in three phases. Returns a whitespace-collapsed result
@@ -2821,7 +2869,7 @@ async def _create_chat_completion_impl(
     # (handled by ``_finalize_content_and_reasoning`` returning
     # ``cleaned_text`` that we never mutate after this block).
     if _wire_scrub_active:
-        cleaned_text = _scrub_tool_wire_literals(cleaned_text)
+        cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
 
     # Extract reasoning content. extract_reasoning() is stateless (pure regex
     # on full text), so the singleton is safe here unlike the streaming variant.
@@ -2865,9 +2913,9 @@ async def _create_chat_completion_impl(
         finish_reason=getattr(output, "finish_reason", None),
     )
     if _should_scrub_visible_wire(cleaned_text):
-        cleaned_text = _scrub_tool_wire_literals(cleaned_text)
+        cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
     if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
-        reasoning_text = _scrub_tool_wire_literals(reasoning_text)
+        reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -85,6 +85,7 @@ from ..service.helpers import (
 )
 
 logger = logging.getLogger(__name__)
+_SAFE_DEEPSEEK_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 router = APIRouter()
 
@@ -235,15 +236,8 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
         # defense-in-depth. Hitting any marker returns ``None`` (clean
         # degradation to the post-parse synthesis fallback) rather
         # than emitting a corrupt prefix.
-        for _marker in (
-            "<｜tool▁calls▁begin｜>",
-            "<｜tool▁calls▁end｜>",
-            "<｜tool▁call▁begin｜>",
-            "<｜tool▁call▁end｜>",
-            "<｜tool▁sep｜>",
-        ):
-            if _marker in function_name:
-                return None
+        if not _SAFE_DEEPSEEK_TOOL_NAME_RE.fullmatch(function_name):
+            return None
         return (
             f"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function_name}<｜tool▁sep｜>"
         )
@@ -892,22 +886,30 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
     # when the separator-adjacent JSON payload is scrubbed below.
     deepseek_begin = "<｜tool▁call▁begin｜>"
     deepseek_sep = "<｜tool▁sep｜>"
+    search_pos = 0
     while True:
-        begin = result.find(deepseek_begin)
+        begin = result.find(deepseek_begin, search_pos)
         if begin == -1:
             break
         sep = result.find(deepseek_sep, begin + len(deepseek_begin))
         if sep == -1:
-            break
+            search_pos = begin + len(deepseek_begin)
+            continue
+        next_begin = result.find(deepseek_begin, begin + len(deepseek_begin), sep)
+        if next_begin != -1:
+            search_pos = next_begin
+            continue
         payload_bounds = _payload_object_after_marker(
             result,
             sep + len(deepseek_sep),
             min(len(result), sep + len(deepseek_sep) + 2048),
         )
         if payload_bounds is None:
-            break
+            search_pos = begin + len(deepseek_begin)
+            continue
         _, object_end = payload_bounds
         result = result[:begin] + result[object_end:]
+        search_pos = begin
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         result = balanced_re.sub(
             lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
@@ -917,25 +919,29 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
         lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
         result,
     )
-    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
-        pieces: list[str] = []
-        last = 0
-        for match in marker_re.finditer(result):
-            window_end = min(len(result), match.end() + 2048)
-            pieces.append(result[last : match.start()])
-            payload_bounds = _payload_object_after_marker(
-                result, match.end(), window_end
-            )
-            if payload_bounds is not None:
-                _, object_end = payload_bounds
-                last = object_end
-                continue
-            else:
+    for _ in range(4):
+        changed = False
+        for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+            pieces: list[str] = []
+            last = 0
+            for match in marker_re.finditer(result):
+                window_end = min(len(result), match.end() + 2048)
+                pieces.append(result[last : match.start()])
+                payload_bounds = _payload_object_after_marker(
+                    result, match.end(), window_end
+                )
+                if payload_bounds is not None:
+                    _, object_end = payload_bounds
+                    last = object_end
+                    changed = True
+                    continue
                 pieces.append(match.group(0))
-            last = match.end()
-        if pieces:
-            pieces.append(result[last:])
-            result = "".join(pieces)
+                last = match.end()
+            if pieces:
+                pieces.append(result[last:])
+                result = "".join(pieces)
+        if not changed:
+            break
     if _is_tool_wire_marker_only(result):
         result = _scrub_tool_wire_literals(result)
     return re.sub(r"\s+", " ", result).strip()
@@ -2939,13 +2945,18 @@ async def _create_chat_completion_impl(
         _raw_text_for_reasoning
     )
 
-    def _should_scrub_visible_wire(text: str | None) -> bool:
+    def _should_scrub_visible_wire(
+        text: str | None, *, allow_raw_context: bool = True
+    ) -> bool:
         return (
             _is_forced_choice
             and request.tools
             and bool(tool_calls)
             and _contains_tool_wire_literal(text)
-            and (_contains_structural_tool_wire_leak(text) or _raw_has_structural_wire)
+            and (
+                _contains_structural_tool_wire_leak(text)
+                or (allow_raw_context and _raw_has_structural_wire)
+            )
         )
 
     _wire_scrub_active = _should_scrub_visible_wire(cleaned_text)
@@ -3003,9 +3014,12 @@ async def _create_chat_completion_impl(
         # any caller that hasn't been threaded yet.
         finish_reason=getattr(output, "finish_reason", None),
     )
-    if _should_scrub_visible_wire(cleaned_text):
+    if _should_scrub_visible_wire(cleaned_text, allow_raw_context=False):
         cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
-    if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
+    if (
+        _should_scrub_visible_wire(reasoning_text, allow_raw_context=False)
+        and reasoning_text
+    ):
         reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -741,6 +741,47 @@ def _contains_tool_wire_literal(text: str | None) -> bool:
     return False
 
 
+_TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(
+    r"(?:[\"'](?:name|arguments)[\"']\s*:|\{[^{}]{0,2048}\})",
+    re.DOTALL,
+)
+_TOOL_WIRE_ORPHAN_CLOSER_RE = re.compile(
+    r"(?:</tool_call>|</function>|</parameter>|<｜tool▁calls▁end｜>|"
+    r"<｜tool▁call▁end｜>|</minimax:tool_call>|</invoke>|</arg_value>|"
+    r"<\|tool_calls_section_end\|>|\[/TOOL_CALLS\])"
+)
+
+
+def _contains_structural_tool_wire_leak(text: str | None) -> bool:
+    """Return True when known wire markers appear as tool-wire residue.
+
+    ``_contains_tool_wire_literal`` intentionally answers the broad
+    question "is any marker token present?"  That is too destructive as
+    a scrub gate because ordinary prose can discuss the literal
+    ``<tool_call>`` token. This predicate is stricter: it requires a
+    balanced/cross-family wire span, or a marker next to JSON/tool-call
+    payload hints (``name`` / ``arguments`` / compact object body).
+    """
+    if not text:
+        return False
+    for opener_re, closer_re in _TOOL_WIRE_BALANCED_PAIRS:
+        if re.search(opener_re.pattern + r".*?" + closer_re.pattern, text, re.DOTALL):
+            return True
+    if _CROSS_FAMILY_SPAN_RE.search(text):
+        return True
+    if _TOOL_WIRE_ORPHAN_CLOSER_RE.search(text):
+        return True
+    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+        match = marker_re.search(text)
+        if not match:
+            continue
+        window_start = max(0, match.start() - 128)
+        window_end = min(len(text), match.end() + 2048)
+        if _TOOL_WIRE_PAYLOAD_HINT_RE.search(text[window_start:window_end]):
+            return True
+    return False
+
+
 def _scrub_tool_wire_literals(text: str | None) -> str:
     """Strip every known parser-wire opener/closer marker from
     ``text`` in three phases. Returns a whitespace-collapsed result
@@ -2569,18 +2610,6 @@ async def _create_chat_completion_impl(
     # hatch, matching pre-#571 wording for that diagnostic.
     # Streaming path is best-effort prompt-injection only; once SSE
     # chunks are out we can't 422 mid-flight.
-    # D-TOOLCHOICE-R1 T3: track whether the post-parse path synthesised
-    # a forced-tool-choice call. When it did, the model's text output
-    # contained parser-wire markers the strict parser couldn't extract
-    # from (qwen3 emitted malformed JSON inside ``<tool_call>``,
-    # deepseek_v31 emitted a body that failed both V3 and V3.1 shapes,
-    # etc.). The raw text WILL still leak literal ``<tool_call>...``
-    # markup into ``content`` and ``reasoning_content`` unless we
-    # scrub it — the parser didn't strip those bytes because it
-    # couldn't recognise the block as a tool call. Setting this flag
-    # routes ``cleaned_text`` through ``_scrub_tool_wire_literals``
-    # before the downstream reasoning-parser pass.
-    _synth_forced_tool_call = False
     if request.tool_choice is not None and request.tools:
         if request.tool_choice == "required" and not tool_calls:
             if len(request.tools) == 1:
@@ -2600,7 +2629,6 @@ async def _create_chat_completion_impl(
                             raw_text=output.raw_text or output.text,
                         )
                     ]
-                    _synth_forced_tool_call = True
             if not tool_calls:
                 raise HTTPException(
                     status_code=422,
@@ -2669,7 +2697,6 @@ async def _create_chat_completion_impl(
                             raw_text=output.raw_text or output.text,
                         )
                     ]
-                    _synth_forced_tool_call = True
                 elif not _names and not _target_is_submitted:
                     # Codex R1 BLOCKING (#675): named tool_choice points
                     # at a function that is not in ``request.tools`` —
@@ -2736,24 +2763,20 @@ async def _create_chat_completion_impl(
     # which it MUST, because the scrub is destructive (rewrites the
     # user-visible field).
     #
-    # The two firing conditions become:
-    #   (a) synth path took over (parser couldn't extract a call from
-    #       the malformed wire — we KNOW the body is junk by
-    #       construction), OR
-    #   (b) parser DID extract a call, ``tool_choice`` is forced
-    #       AND ``cleaned_text`` still contains a wire-marker literal
-    #       (parser left junk behind — qwen3 cross-family closer,
-    #       orphan opener, etc.).
-    # In every other case the scrub stays off.
+    # The final firing condition is intentionally stricter than "a
+    # forced call exists": forced synthesis can also happen when a
+    # model ignores ``tool_choice="required"`` and emits ordinary
+    # prose. Scrub only when the visible text contains STRUCTURAL
+    # parser-wire residue, not merely a literal token mention.
     _is_forced_choice = request.tool_choice == "required" or (
         isinstance(request.tool_choice, dict)
         and request.tool_choice.get("type") == "function"
     )
-    _wire_scrub_active = _synth_forced_tool_call or (
+    _wire_scrub_active = (
         _is_forced_choice
         and request.tools
         and bool(tool_calls)
-        and _contains_tool_wire_literal(cleaned_text)
+        and _contains_structural_tool_wire_leak(cleaned_text)
     )
     # codex r6 BLOCKING #2: scrub the user-visible ``cleaned_text``
     # only. Do NOT mutate ``raw_text`` before it reaches the reasoning
@@ -2809,7 +2832,13 @@ async def _create_chat_completion_impl(
         # any caller that hasn't been threaded yet.
         finish_reason=getattr(output, "finish_reason", None),
     )
-    if _wire_scrub_active and reasoning_text:
+    _reasoning_wire_scrub_active = (
+        _is_forced_choice
+        and request.tools
+        and bool(tool_calls)
+        and _contains_structural_tool_wire_leak(reasoning_text)
+    )
+    if _reasoning_wire_scrub_active and reasoning_text:
         reasoning_text = _scrub_tool_wire_literals(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -832,6 +832,8 @@ def _span_has_tool_payload_object(span: str) -> bool:
         else:
             object_start = span.find("{", object_start + 1)
     return False
+
+
 def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     """Return True when known wire markers appear as tool-wire residue.
 
@@ -952,7 +954,10 @@ def _scrub_tool_wire_literals(text: str | None) -> str:
     # pairs above don't match. Without this, the malformed body
     # between the opener and the unrelated closer survives as
     # ``content`` (codex r3 BLOCKING #1).
-    result = _CROSS_FAMILY_SPAN_RE.sub("", result)
+    result = _CROSS_FAMILY_SPAN_RE.sub(
+        lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
+        result,
+    )
     # Phase 2: strip standalone marker tokens (orphan opener OR
     # orphan closer that survived phases 1+1.5). ONLY the marker
     # bytes are removed; surrounding text is preserved.

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -253,7 +253,9 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
     return None
 
 
-def _recover_partial_tool_args(raw_text: str | None) -> str | None:
+def _recover_partial_tool_args(
+    raw_text: str | None, expected_name: str | None = None
+) -> str | None:
     """Best-effort recovery of a JSON arguments object from a malformed
     model response under ``tool_choice="required"``.
 
@@ -290,6 +292,20 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
     ``"{}"`` plus a downstream ``_validate_tool_call_params`` warning
     is the right contract for that case (the client retries with a
     clearer prompt or a named-function ``tool_choice``).
+
+    codex r4 BLOCKING #1: when ``expected_name`` is provided, also
+    verify that the recovered candidate is paired with a
+    ``"name": "<expected>"`` field in the same wire span. Without
+    this gate, a synth for a named ``tool_choice`` whose target is
+    ``"my_target"`` could pick up an unrelated
+    ``{"name": "other_tool", "arguments": {...}}`` block elsewhere
+    in the response and ship ``other_tool``'s args under the
+    forced target's name — a subtle correctness bug because the
+    synthesized call's ``function.name`` would not match the args'
+    intended schema. We REQUIRE a name match within a 512-byte
+    window of the ``"arguments"`` marker (covers a typical inner
+    wire body), and FALL BACK to ``"{}"`` (return ``None``) when no
+    match exists.
     """
     if not raw_text:
         return None
@@ -377,6 +393,60 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
         window = text[window_start:idx]
         return any(opener in window for opener in _WIRE_SPAN_OPENERS)
 
+    def _name_pairs_with(idx: int, expected: str) -> bool:
+        """Does a ``"name": "<expected>"`` (or ``"name":"<expected>"``)
+        sit in the SAME wire-call block as the ``"arguments"``
+        occurrence at ``idx``?
+
+        Heuristic: the per-call block is bounded by the nearest
+        wire opener BEFORE ``idx`` (we never look past it for a
+        ``"name"`` literal) and either the previous ``"arguments"``
+        marker OR the start of the surrounding text — whichever is
+        closer. Forward we cap at the next ``"arguments"`` or 256
+        bytes. This intentionally restricts the search to the
+        ``"name"`` literal that belongs to THE SAME wire body as
+        ``idx``, so an unrelated call's ``"name"`` further up the
+        response never matches.
+
+        codex r4 BLOCKING #1: the wire-span check alone is not enough
+        because a response can contain multiple wire spans each
+        with a different ``"name"``. We MUST verify the pairing,
+        and the window MUST be tight enough to separate inline
+        blocks (a fixed ±512-byte window let adjacent blocks pollute
+        each other's pairing).
+        """
+        if not expected:
+            return True  # No constraint when caller doesn't pass one.
+
+        # Backward bound: the closer of (previous "arguments"
+        # occurrence + len) or the nearest wire-opener literal
+        # backward, or ``idx - 512`` as a hard fallback so a wire
+        # body with no opener literal still bounds the scan.
+        prev_args_end = text.rfind('"arguments"', 0, idx)
+        if prev_args_end != -1:
+            backward_bound = prev_args_end + len('"arguments"')
+        else:
+            backward_bound = max(0, idx - 512)
+        # Forward bound: the next "arguments" marker or 256 bytes
+        # forward. We cap forward TIGHTER than backward because the
+        # canonical wire shape ``{"name":"X","arguments":{...}}``
+        # always has ``"name"`` BEFORE ``"arguments"``.
+        next_args_idx = text.find('"arguments"', idx + len('"arguments"'))
+        if next_args_idx != -1:
+            forward_bound = next_args_idx
+        else:
+            forward_bound = min(n, idx + 256)
+        window = text[backward_bound:forward_bound]
+        # Accept ``"name": "<expected>"`` with optional whitespace.
+        # ``re.escape`` keeps the name literal even if it contains
+        # regex metacharacters.
+        escaped = re.escape(expected)
+        pair_re = re.compile(
+            r'"name"\s*:\s*"' + escaped + r'"',
+            re.DOTALL,
+        )
+        return pair_re.search(window) is not None
+
     # Collect every parseable candidate, tagged with whether it sits
     # inside a wire span.
     candidates_in_wire: list[str] = []
@@ -417,6 +487,14 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
             continue
         if not isinstance(parsed, dict):
             search_start = args_marker_idx + len('"arguments"')
+            continue
+        # codex r4 BLOCKING #1: when an expected name is set, only
+        # accept this candidate if a matching ``"name"`` literal
+        # sits within the same wire body. Otherwise we'd pick up
+        # an unrelated tool's args and ship them under the forced
+        # target's name.
+        if expected_name and not _name_pairs_with(args_marker_idx, expected_name):
+            search_start = obj_end
             continue
         canonical = json.dumps(parsed, ensure_ascii=False)
         if _position_in_wire_span(args_marker_idx):
@@ -673,8 +751,11 @@ def _synthesize_forced_tool_call(
 
     # Try the partial-recovery path first; only fall back to the
     # caller-provided default (``"{}"`` or an upstream override) when
-    # the raw text yields nothing structurally parseable.
-    recovered = _recover_partial_tool_args(raw_text)
+    # the raw text yields nothing structurally parseable. Pass the
+    # synth target ``name`` as ``expected_name`` so recovery rejects
+    # ``"arguments"`` candidates paired with a DIFFERENT tool's
+    # ``"name"`` literal (codex r4 BLOCKING #1).
+    recovered = _recover_partial_tool_args(raw_text, expected_name=name)
     final_args = recovered if recovered is not None else arguments
 
     return ToolCall(
@@ -2557,8 +2638,24 @@ async def _create_chat_completion_impl(
     # is parser-agnostic so adding a new parser doesn't reopen the
     # leak; codex r3 BLOCKING #2 caught case (b) — even the
     # recover-args path needs the scrub.
+    # codex r4 BLOCKING #2: the broad gate ``tool_choice is not None``
+    # also fired on ``tool_choice="auto"``, where a model legitimately
+    # may emit prose alongside a tool call that contains XML/tool
+    # marker text (e.g. discussing the tool wire format in the prose).
+    # Narrow to forced/required modes only — that's where the wire
+    # leakage is structurally known to be junk by construction:
+    #   - ``tool_choice="required"`` — model was FORCED to call,
+    #     so any wire-shaped leftovers are by-products of that forcing.
+    #   - ``tool_choice={"type":"function","function":{"name":X}}`` —
+    #     same forcing semantics.
+    # ``"auto"`` and ``"none"`` keep the prior pre-0.8.3 behaviour —
+    # cleaned_text is the parser's authoritative output.
+    _is_forced_choice = request.tool_choice == "required" or (
+        isinstance(request.tool_choice, dict)
+        and request.tool_choice.get("type") == "function"
+    )
     _wire_scrub_active = _synth_forced_tool_call or (
-        request.tool_choice is not None and request.tools and bool(tool_calls)
+        _is_forced_choice and request.tools and bool(tool_calls)
     )
     _scrubbed_raw_text: str | None = None
     if _wire_scrub_active:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -382,16 +382,53 @@ def _recover_partial_tool_args(
             pos += 1
         return None
 
+    # Closer counterparts (used to bound the wire-span lookback so
+    # pretty-printed / verbose wire bodies aren't misclassified as
+    # outside-wire just because their opener sits >256 bytes back).
+    # codex r6 NIT: a fixed 256-byte lookback caused valid
+    # wrapped calls with verbose metadata before ``"arguments":`` to
+    # lose priority to a later prose example. We now bound the search
+    # by the nearest known closer instead — if no closer sits between
+    # the most recent opener and ``idx``, ``idx`` IS inside the span,
+    # regardless of how far back the opener is.
+    _WIRE_SPAN_CLOSERS = (
+        "</tool_call>",
+        "</function>",
+        "<｜tool▁calls▁end｜>",
+        "<｜tool▁call▁end｜>",
+        "[/TOOL_CALLS]",
+        "<|tool_calls_section_end|>",
+        "</minimax:tool_call>",
+        "</invoke>",
+        "</arg_value>",
+    )
+
     def _position_in_wire_span(idx: int) -> bool:
         """Is ``idx`` inside (or immediately after) a known tool-wire
         opener? We don't require a balanced closer — the qwen3 leak
-        shape often has no clean closer."""
-        # Look backward up to 256 bytes for any wire opener whose
-        # span could plausibly include ``idx``. The bound keeps the
-        # check O(1).
-        window_start = max(0, idx - 256)
-        window = text[window_start:idx]
-        return any(opener in window for opener in _WIRE_SPAN_OPENERS)
+        shape often has no clean closer.
+
+        codex r6 NIT: bound the search by the nearest known
+        opener/closer occurrence rather than a fixed lookback. We
+        find the LATEST opener at position ``op_pos < idx`` and the
+        LATEST closer at position ``cl_pos < idx``; ``idx`` is in
+        the span iff ``op_pos`` exists AND ``op_pos > cl_pos``
+        (so the most recent opener was not yet closed before ``idx``).
+        """
+        prefix = text[:idx]
+        op_pos = -1
+        for opener in _WIRE_SPAN_OPENERS:
+            pos = prefix.rfind(opener)
+            if pos > op_pos:
+                op_pos = pos
+        if op_pos < 0:
+            return False
+        cl_pos = -1
+        for closer in _WIRE_SPAN_CLOSERS:
+            pos = prefix.rfind(closer)
+            if pos > cl_pos:
+                cl_pos = pos
+        return op_pos > cl_pos
 
     def _name_pairs_with(idx: int, expected: str) -> bool:
         """Does a ``"name": "<expected>"`` (or ``"name":"<expected>"``)
@@ -676,6 +713,32 @@ _CROSS_FAMILY_SPAN_RE = re.compile(
     rf"(?:{_CROSS_FAMILY_OPENERS}).*?(?:{_CROSS_FAMILY_CLOSERS})",
     re.DOTALL,
 )
+
+
+# codex r6 BLOCKING #1 — leak detector. Used to tighten the
+# forced/required scrub gate so that we only scrub when the
+# parser's ``cleaned_text`` ACTUALLY contains wire-marker literals.
+# A successful forced call whose ``cleaned_text`` is e.g. ``"OK"``
+# does not get its content rewritten, which protects legitimate
+# assistant prose that happens to mention ``<tool_call>`` etc.
+#
+# The detector is intentionally a cheap substring/regex sweep —
+# it returns True on the FIRST match of any wire marker we know
+# about. If new parser wires are added, they only need to be
+# registered in ``_TOOL_WIRE_STANDALONE_MARKERS`` for the detector
+# to pick them up (same source-of-truth as the scrub itself).
+def _contains_tool_wire_literal(text: str | None) -> bool:
+    """Return True iff ``text`` contains any known tool-wire marker
+    (opener, closer, separator). Used by the chat route to decide
+    whether the forced/required scrub gate should fire on a
+    parser-extracted (non-synth) tool call.
+    """
+    if not text:
+        return False
+    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+        if marker_re.search(text):
+            return True
+    return False
 
 
 def _scrub_tool_wire_literals(text: str | None) -> str:
@@ -2665,18 +2728,45 @@ async def _create_chat_completion_impl(
     #     same forcing semantics.
     # ``"auto"`` and ``"none"`` keep the prior pre-0.8.3 behaviour —
     # cleaned_text is the parser's authoritative output.
+    # codex r6 BLOCKING #1: gate scrub on the presence of an actual
+    # wire-marker leak in ``cleaned_text``, not on every successful
+    # forced/required call. A clean parser-extracted call whose
+    # ``cleaned_text`` is plain prose (even prose that legitimately
+    # discusses ``<tool_call>``) keeps its content unmodified —
+    # which it MUST, because the scrub is destructive (rewrites the
+    # user-visible field).
+    #
+    # The two firing conditions become:
+    #   (a) synth path took over (parser couldn't extract a call from
+    #       the malformed wire — we KNOW the body is junk by
+    #       construction), OR
+    #   (b) parser DID extract a call, ``tool_choice`` is forced
+    #       AND ``cleaned_text`` still contains a wire-marker literal
+    #       (parser left junk behind — qwen3 cross-family closer,
+    #       orphan opener, etc.).
+    # In every other case the scrub stays off.
     _is_forced_choice = request.tool_choice == "required" or (
         isinstance(request.tool_choice, dict)
         and request.tool_choice.get("type") == "function"
     )
     _wire_scrub_active = _synth_forced_tool_call or (
-        _is_forced_choice and request.tools and bool(tool_calls)
+        _is_forced_choice
+        and request.tools
+        and bool(tool_calls)
+        and _contains_tool_wire_literal(cleaned_text)
     )
-    _scrubbed_raw_text: str | None = None
+    # codex r6 BLOCKING #2: scrub the user-visible ``cleaned_text``
+    # only. Do NOT mutate ``raw_text`` before it reaches the reasoning
+    # parser — pretty-printed reasoning bodies may legitimately
+    # contain wire-shaped tokens (e.g. when the reasoning describes
+    # the tool wire format), and rewriting them ahead of extraction
+    # truncates / collapses reasoning content. The reasoning parser
+    # operates on the original ``output.raw_text`` and only its
+    # post-extraction visible output is candidate for re-scrubbing
+    # (handled by ``_finalize_content_and_reasoning`` returning
+    # ``cleaned_text`` that we never mutate after this block).
     if _wire_scrub_active:
         cleaned_text = _scrub_tool_wire_literals(cleaned_text)
-        _raw_for_reasoning = output.raw_text or output.text
-        _scrubbed_raw_text = _scrub_tool_wire_literals(_raw_for_reasoning)
 
     # Extract reasoning content. extract_reasoning() is stateless (pure regex
     # on full text), so the singleton is safe here unlike the streaming variant.
@@ -2685,9 +2775,12 @@ async def _create_chat_completion_impl(
     # the same orchestration without re-implementing it.
     cleaned_text_before_helper = cleaned_text
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
-        raw_text=_scrubbed_raw_text
-        if _scrubbed_raw_text is not None
-        else (output.raw_text or output.text),
+        # codex r6 BLOCKING #2: pass the ORIGINAL raw text so the
+        # reasoning parser sees the bytes the engine actually emitted.
+        # Any wire-literal scrub above only touched user-visible
+        # ``cleaned_text`` — reasoning extraction operates on the
+        # untouched ``raw_text``.
+        raw_text=output.raw_text or output.text,
         cleaned_text=cleaned_text,
         tool_calls=tool_calls,
         reasoning_parser=cfg.reasoning_parser,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -199,13 +199,217 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
         # corrupt the wire envelope or inject extra fields. Codex r4
         # BLOCKING — direct f-string interpolation was vulnerable.
         return f'<tool_call>\n{{"name": {json.dumps(function_name)}, "arguments": '
+    # D-TOOLCHOICE-R1 T2: DeepSeek-R1 distill + ``deepseek_v31`` /
+    # ``deepseek_r1_0528`` parsers share the V3.1 wire shape
+    # ``<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>NAME<｜tool▁sep｜>{json}<｜tool▁call▁end｜><｜tool▁calls▁end｜>``.
+    # Pre 0.8.3, this family fell through to ``None`` here — so
+    # ``tool_choice="required"`` with a single tool only ever produced
+    # the post-parse ``_synthesize_forced_tool_call`` fallback (empty
+    # ``arguments="{}"``). With the prefix in place, the model picks up
+    # inside the envelope and emits real arguments that
+    # ``extract_tool_calls`` parses cleanly (verified by
+    # ``DeepSeekV31ToolParser.extract_tool_calls`` on the assembled
+    # ``<...begin>name<sep>{...}<...end>...end>`` payload).
+    #
+    # The two registered aliases (``deepseek_v31``, ``deepseek_r1_0528``)
+    # share one parser class; both get the same prefix. ``deepseek``
+    # (V1) is intentionally NOT listed — that parser's envelope is
+    # different and shares the marker tokens, but the body shape is
+    # not auto-detected (see ``deepseek_tool_parser.py``).
+    _verified_deepseek_v31_parsers = {
+        "deepseek_v31",
+        "deepseek_r1_0528",
+    }
+    if parser_name in _verified_deepseek_v31_parsers:
+        # V3.1 body: ``NAME<sep>{json}``. The model continues with the
+        # arguments object and closer. ``function_name`` is interpolated
+        # raw — these are DeepSeek special tokens, not JSON, and the
+        # name is already validated against ``request.tools`` upstream
+        # (the ``_target`` / ``_solo_name`` lookups in chat.py). The
+        # name does NOT pass through ``json.dumps`` because the V3.1
+        # body is not JSON-bodied here — it is a plain ``NAME<sep>``
+        # split. A function name containing ``<｜tool▁sep｜>`` would
+        # corrupt the wire, but such a name is malformed (the chat
+        # template would already fail to render it). Validated against
+        # ``DeepSeekV31ToolParser.extract_tool_calls`` body parser.
+        return (
+            f"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function_name}<｜tool▁sep｜>"
+        )
     # Channel-routed (harmony / gemma4) and parsers whose wire shape
     # we have NOT audited: no prefix injection. The post-parse
     # synthesis path remains as a fallback (``_synthesize_forced_tool_call``).
     return None
 
 
-def _synthesize_forced_tool_call(name: str, arguments: str = "{}"):
+def _recover_partial_tool_args(raw_text: str | None) -> str | None:
+    """Best-effort recovery of a JSON arguments object from a malformed
+    model response under ``tool_choice="required"``.
+
+    Designed for the D-TOOLCHOICE-R1 T3 case: qwen3 + tool_choice=
+    required emits something like ::
+
+        <tool_call>
+        {"name": "add_numbers", "arguments": 4128, 7591}
+        </parameter>
+        </function>
+        </tool_call>
+
+    where the parser's strict pattern fails (``arguments`` is not a
+    JSON object) so the chat route synthesises a call with empty
+    ``"{}"`` arguments. The empty-args result is uselessly opaque for
+    the client — but the raw text itself often contains enough signal
+    to reconstruct *something* better than ``"{}"``. Two recovery
+    routes are tried, both bounded so a hostile or genuinely
+    unparseable response degrades safely back to ``None``:
+
+    1. **Strict object body.** If the raw text contains a literal
+       ``"arguments":`` followed by a balanced JSON object, return
+       that object's text. This handles the common case where the
+       model emitted valid JSON but failed an outer wrapper (closing
+       tag missing, wrong wrapper element).
+
+    2. **No structural recovery possible.** Return ``None``. The
+       caller falls back to the existing ``"{}"`` default.
+
+    Intentionally narrow: we do NOT try to coerce the malformed
+    qwen3 shape ``"arguments": 4128, 7591`` into a positional-args
+    interpretation — there is no schema-agnostic way to map two bare
+    integers to named parameters without guessing. The fallback to
+    ``"{}"`` plus a downstream ``_validate_tool_call_params`` warning
+    is the right contract for that case (the client retries with a
+    clearer prompt or a named-function ``tool_choice``).
+    """
+    if not raw_text:
+        return None
+    text = raw_text
+    args_marker_idx = text.find('"arguments"')
+    if args_marker_idx == -1:
+        return None
+    # Find the colon that follows ``"arguments"`` (may have whitespace
+    # before/after). Scan forward up to a small bound — beyond that the
+    # marker is just prose, not a structural field.
+    colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
+    if colon_idx == -1:
+        return None
+    # Skip whitespace after the colon, looking for the object opener.
+    pos = colon_idx + 1
+    n = len(text)
+    while pos < n and text[pos] in " \t\n\r":
+        pos += 1
+    if pos >= n or text[pos] != "{":
+        return None
+    # Balanced-brace scan: walk until depth returns to 0, respecting
+    # JSON string boundaries (so a ``"}"`` literal inside an arg value
+    # doesn't close the object early). Cap at 8 KiB so a malformed
+    # giant payload doesn't burn CPU.
+    depth = 0
+    in_string = False
+    escape = False
+    obj_start = pos
+    obj_end = -1
+    scan_end = min(n, obj_start + 8192)
+    while pos < scan_end:
+        ch = text[pos]
+        if escape:
+            escape = False
+        elif in_string:
+            if ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    obj_end = pos + 1
+                    break
+        pos += 1
+    if obj_end == -1:
+        return None
+    candidate = text[obj_start:obj_end]
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    # Canonicalise — strip any incidental whitespace / trailing junk
+    # so downstream ``_validate_tool_call_params`` sees a clean JSON
+    # object byte-for-byte.
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+# Parser-wire literal markers that MUST be scrubbed from ``content`` /
+# ``reasoning_content`` when ``tool_choice="required"`` synthesises a
+# call to recover from a malformed model emission (D-TOOLCHOICE-R1 T3).
+# Without this scrub, the model's failed tool-call attempt — literal
+# ``<tool_call>...`` text the parser couldn't extract — leaks into
+# both user-visible fields.
+#
+# The list intentionally covers EVERY wire-opener we know about across
+# tool parsers (hermes / qwen3coder / nemotron / deepseek / glm /
+# minimax / mistral / kimi / llama / harmony / gemma4 / xlam /
+# functionary / granite / seed_oss / vibethinker named-XML). Adding a
+# parser is a one-line addition; a parser whose wire is already
+# textually clean (no opener literal) is a no-op here.
+_TOOL_WIRE_SCRUB_PATTERNS = (
+    # Hermes / qwen3 JSON-bodied wire
+    re.compile(r"<tool_call>.*?(?:</tool_call>|\Z)", re.DOTALL),
+    re.compile(r"<tool_call\b[^>]*>.*?(?:</tool_call>|\Z)", re.DOTALL),
+    # Nemotron + bare ``<function=NAME>...`` wire (also picks up the
+    # qwen3 malformed body's trailing ``</parameter></function>``)
+    re.compile(r"<function=[^>]*>.*?(?:</function>|\Z)", re.DOTALL),
+    re.compile(r"<function>.*?(?:</function>|\Z)", re.DOTALL),
+    re.compile(r"</?parameter[^>]*>"),
+    # DeepSeek V3 / V3.1 / R1-0528
+    re.compile(r"<｜tool▁calls▁begin｜>.*?(?:<｜tool▁calls▁end｜>|\Z)", re.DOTALL),
+    re.compile(r"<｜tool▁call▁begin｜>.*?(?:<｜tool▁call▁end｜>|\Z)", re.DOTALL),
+    # GLM-4 / GLM-4.7 wrapper
+    re.compile(r"<arg_key>.*?(?:</arg_value>|\Z)", re.DOTALL),
+    # Minimax
+    re.compile(r"<minimax:tool_call>.*?(?:</minimax:tool_call>|\Z)", re.DOTALL),
+    re.compile(r"<invoke\b[^>]*>.*?(?:</invoke>|\Z)", re.DOTALL),
+    # Llama python-tag and Kimi section markers
+    re.compile(r"<\|python_tag\|>.*?(?=$|\n\n)", re.DOTALL),
+    re.compile(
+        r"<\|tool_calls_section_begin\|>.*?(?:<\|tool_calls_section_end\|>|\Z)",
+        re.DOTALL,
+    ),
+    # Mistral
+    re.compile(r"\[TOOL_CALLS\].*?(?:\[/TOOL_CALLS\]|\Z)", re.DOTALL),
+)
+
+
+def _scrub_tool_wire_literals(text: str | None) -> str:
+    """Strip every known parser-wire opener-and-body pattern from
+    ``text``. Returns a whitespace-collapsed result so we don't leave
+    a void where the wire used to live.
+
+    Idempotent: safe to call on text that has no wire literals (the
+    regex sweep is a no-op). Called by the chat route ONLY when
+    ``tool_choice="required"`` synthesises (or recovers args for) a
+    call from a malformed wire — i.e. when the model's text output
+    contained tool-call markers the parser couldn't extract from.
+    Calling it on clean prose is harmless but wasted work; the route
+    therefore gates it on the synth path.
+    """
+    if not text:
+        return text or ""
+    result = text
+    for pattern in _TOOL_WIRE_SCRUB_PATTERNS:
+        result = pattern.sub("", result)
+    # Collapse any runs of whitespace left by the strip. Preserves
+    # single-space separation between surrounding prose words.
+    return re.sub(r"\s+", " ", result).strip()
+
+
+def _synthesize_forced_tool_call(
+    name: str, arguments: str = "{}", *, raw_text: str | None = None
+):
     """Build a single ``ToolCall`` for a forced ``tool_choice`` whose
     text parser surfaced no calls (#571).
 
@@ -222,23 +426,35 @@ def _synthesize_forced_tool_call(name: str, arguments: str = "{}"):
     client forces a tool call, the response MUST carry one. To restore
     symmetry we synthesise a tool_call server-side when the target tool
     is unambiguous (named-function, or ``"required"`` with a single
-    tool). Arguments default to ``"{}"`` because we have no signal
-    about what the model intended to pass; downstream
-    ``_validate_tool_call_params`` logs a warning when required
-    parameters are missing, mirroring the diagnostic surface clients
-    already see for model-generated calls with bad arguments. The
-    contract guarantee is "a tool_call is present", not "the arguments
-    are correct".
+    tool).
+
+    D-TOOLCHOICE-R1 T3: pre 0.8.3, ``arguments`` defaulted to ``"{}"``
+    unconditionally. When the model actually emitted a JSON object
+    body the strict parser couldn't extract from (qwen3 malformed
+    inner shape, model leaking unclosed tags, etc.) the empty-args
+    fallback shipped a uselessly opaque call. ``raw_text`` is now
+    consulted first: if it contains a recoverable ``"arguments": {...}``
+    object we use THAT instead of ``"{}"``. Downstream
+    ``_validate_tool_call_params`` still gates schema compliance; the
+    contract guarantee is "a tool_call is present", and now also "the
+    arguments are as close to what the model intended as we can
+    structurally recover".
     """
     # Lazy import — ToolCall / FunctionCall live alongside the request
     # model in ``api.models``. The lazy form keeps the synthesis path
     # scoped to forced-choice requests; the common case pays nothing.
     from ..api.models import FunctionCall, ToolCall
 
+    # Try the partial-recovery path first; only fall back to the
+    # caller-provided default (``"{}"`` or an upstream override) when
+    # the raw text yields nothing structurally parseable.
+    recovered = _recover_partial_tool_args(raw_text)
+    final_args = recovered if recovered is not None else arguments
+
     return ToolCall(
         id=f"call_{uuid.uuid4().hex[:8]}",
         type="function",
-        function=FunctionCall(name=name, arguments=arguments),
+        function=FunctionCall(name=name, arguments=final_args),
     )
 
 
@@ -1968,6 +2184,18 @@ async def _create_chat_completion_impl(
     # hatch, matching pre-#571 wording for that diagnostic.
     # Streaming path is best-effort prompt-injection only; once SSE
     # chunks are out we can't 422 mid-flight.
+    # D-TOOLCHOICE-R1 T3: track whether the post-parse path synthesised
+    # a forced-tool-choice call. When it did, the model's text output
+    # contained parser-wire markers the strict parser couldn't extract
+    # from (qwen3 emitted malformed JSON inside ``<tool_call>``,
+    # deepseek_v31 emitted a body that failed both V3 and V3.1 shapes,
+    # etc.). The raw text WILL still leak literal ``<tool_call>...``
+    # markup into ``content`` and ``reasoning_content`` unless we
+    # scrub it — the parser didn't strip those bytes because it
+    # couldn't recognise the block as a tool call. Setting this flag
+    # routes ``cleaned_text`` through ``_scrub_tool_wire_literals``
+    # before the downstream reasoning-parser pass.
+    _synth_forced_tool_call = False
     if request.tool_choice is not None and request.tools:
         if request.tool_choice == "required" and not tool_calls:
             if len(request.tools) == 1:
@@ -1976,11 +2204,18 @@ async def _create_chat_completion_impl(
                     logger.warning(
                         "tool_choice='required' on a parser-only path produced "
                         "no tool_calls; synthesising a call to the sole "
-                        "available tool %r with empty arguments to honor the "
-                        "OpenAI tool_call-guaranteed contract (#571).",
+                        "available tool %r (recovering arguments from raw "
+                        "text where possible) to honor the OpenAI tool_call-"
+                        "guaranteed contract (#571).",
                         _solo_name,
                     )
-                    tool_calls = [_synthesize_forced_tool_call(_solo_name)]
+                    tool_calls = [
+                        _synthesize_forced_tool_call(
+                            _solo_name,
+                            raw_text=output.raw_text or output.text,
+                        )
+                    ]
+                    _synth_forced_tool_call = True
             if not tool_calls:
                 raise HTTPException(
                     status_code=422,
@@ -2038,12 +2273,18 @@ async def _create_chat_completion_impl(
                 if not _names and _target_is_submitted:
                     logger.warning(
                         "tool_choice pinned function %r on a parser-only path "
-                        "produced no tool_calls; synthesising a call with "
-                        "empty arguments to honor the OpenAI tool_call-"
-                        "guaranteed contract (#571).",
+                        "produced no tool_calls; synthesising a call (recovering "
+                        "arguments from raw text where possible) to honor the "
+                        "OpenAI tool_call-guaranteed contract (#571).",
                         _target,
                     )
-                    tool_calls = [_synthesize_forced_tool_call(_target)]
+                    tool_calls = [
+                        _synthesize_forced_tool_call(
+                            _target,
+                            raw_text=output.raw_text or output.text,
+                        )
+                    ]
+                    _synth_forced_tool_call = True
                 elif not _names and not _target_is_submitted:
                     # Codex R1 BLOCKING (#675): named tool_choice points
                     # at a function that is not in ``request.tools`` —
@@ -2074,6 +2315,20 @@ async def _create_chat_completion_impl(
     if tool_calls and request.tools:
         _validate_tool_call_params(tool_calls, request.tools)
 
+    # D-TOOLCHOICE-R1 T3: when the post-parse path synthesised a forced
+    # tool call from a malformed wire body, the same raw text that the
+    # parser couldn't extract from is still living in ``cleaned_text``
+    # AND in ``output.raw_text`` (which the reasoning parser will see
+    # next). Scrub both sources of parser-wire-marker literals so they
+    # don't leak as ``content`` / ``reasoning_content``. The scrub is
+    # parser-agnostic — it strips every known opener-and-body pattern,
+    # so adding a new parser doesn't reopen this leak.
+    _scrubbed_raw_text: str | None = None
+    if _synth_forced_tool_call:
+        cleaned_text = _scrub_tool_wire_literals(cleaned_text)
+        _raw_for_reasoning = output.raw_text or output.text
+        _scrubbed_raw_text = _scrub_tool_wire_literals(_raw_for_reasoning)
+
     # Extract reasoning content. extract_reasoning() is stateless (pure regex
     # on full text), so the singleton is safe here unlike the streaming variant.
     # The tool_calls vs no-tool_calls split is encapsulated in
@@ -2081,7 +2336,9 @@ async def _create_chat_completion_impl(
     # the same orchestration without re-implementing it.
     cleaned_text_before_helper = cleaned_text
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
-        raw_text=output.raw_text or output.text,
+        raw_text=_scrubbed_raw_text
+        if _scrubbed_raw_text is not None
+        else (output.raw_text or output.text),
         cleaned_text=cleaned_text,
         tool_calls=tool_calls,
         reasoning_parser=cfg.reasoning_parser,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -386,16 +386,20 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
         args_marker_idx = text.find('"arguments"', search_start)
         if args_marker_idx == -1:
             break
-        # Find the colon that follows ``"arguments"`` (may have
-        # whitespace before/after). Scan forward up to a small
-        # bound — beyond that the marker is just prose, not a
-        # structural field.
-        colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
-        if colon_idx == -1:
+        # codex r3 NIT: the previous fixed 20-char window for the
+        # colon rejected valid JSON like
+        # ``"arguments"    \n   :   {...}`` (lots of pretty-print
+        # whitespace). Walk past whitespace from the end of the
+        # ``"arguments"`` token and then require ``:`` — no
+        # arbitrary cap.
+        pos = args_marker_idx + len('"arguments"')
+        while pos < n and text[pos] in " \t\n\r":
+            pos += 1
+        if pos >= n or text[pos] != ":":
             search_start = args_marker_idx + len('"arguments"')
             continue
         # Skip whitespace after the colon, looking for the object opener.
-        pos = colon_idx + 1
+        pos += 1
         while pos < n and text[pos] in " \t\n\r":
             pos += 1
         if pos >= n or text[pos] != "{":
@@ -534,41 +538,94 @@ _TOOL_WIRE_STANDALONE_MARKERS = (
 )
 
 
+# Cross-family opener/closer set — used by phase 1.5 to catch the
+# qwen3-style mixed-closer leak where the model emits ``<tool_call>``
+# but closes with ``</function>`` (or some other unrelated closer).
+# Any opener-to-any-closer span gets stripped in one sweep. The list
+# is the union of opener and closer regex patterns we already track
+# in ``_TOOL_WIRE_BALANCED_PAIRS`` plus the always-orphan ones.
+#
+# This is bounded — phase 1.5 only fires when an opener appears AND
+# any closer-class marker appears later in the text. If neither
+# qualifies, the span is left for phase 2's marker-only strip.
+_CROSS_FAMILY_OPENERS = "|".join(
+    [
+        r"<tool_call>",
+        r"<function=[^>]*>",
+        r"<function>",
+        r"<｜tool▁calls▁begin｜>",
+        r"<｜tool▁call▁begin｜>",
+        r"<minimax:tool_call>",
+        r"<invoke\b[^>]*>",
+        r"<arg_key>",
+        r"<\|tool_calls_section_begin\|>",
+        r"\[TOOL_CALLS\]",
+    ]
+)
+_CROSS_FAMILY_CLOSERS = "|".join(
+    [
+        r"</tool_call>",
+        r"</function>",
+        r"</parameter>",
+        r"<｜tool▁calls▁end｜>",
+        r"<｜tool▁call▁end｜>",
+        r"</minimax:tool_call>",
+        r"</invoke>",
+        r"</arg_value>",
+        r"<\|tool_calls_section_end\|>",
+        r"\[/TOOL_CALLS\]",
+    ]
+)
+# Non-greedy ``opener…any-closer`` — catches the qwen3 ``<tool_call>``
+# + ``</function>`` cross-family leak that the strict same-family
+# pairs in phase 1 don't match.
+_CROSS_FAMILY_SPAN_RE = re.compile(
+    rf"(?:{_CROSS_FAMILY_OPENERS}).*?(?:{_CROSS_FAMILY_CLOSERS})",
+    re.DOTALL,
+)
+
+
 def _scrub_tool_wire_literals(text: str | None) -> str:
     """Strip every known parser-wire opener/closer marker from
-    ``text`` in two phases (see ``_TOOL_WIRE_BALANCED_PAIRS`` docstring
-    for rationale). Returns a whitespace-collapsed result so we don't
-    leave a void where the wire used to live.
+    ``text`` in three phases. Returns a whitespace-collapsed result
+    so we don't leave a void where the wire used to live.
+
+    Phases:
+
+      1. **Same-family balanced spans** — strip every balanced
+         ``opener…closer`` span from the same parser family
+         (``<tool_call>...</tool_call>``,
+         ``<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>``, etc.).
+      2. **Cross-family spans** — strip any-opener-to-any-closer
+         spans the model emitted with mismatched wires (the qwen3
+         ``<tool_call>{...}</function>`` shape — codex r3 BLOCKING #1).
+      3. **Standalone markers** — orphan opener or closer literals
+         that survived phases 1+2 get scrubbed as bare tokens
+         WITHOUT eating surrounding text (codex r1 BLOCKING #1
+         preserved-trailing-text invariant).
 
     Idempotent: safe to call on text that has no wire literals (the
     regex sweep is a no-op). Called by the chat route ONLY when
     ``tool_choice="required"`` synthesises (or recovers args for) a
     call from a malformed wire — i.e. when the model's text output
     contained tool-call markers the parser couldn't extract from.
-    Calling it on clean prose is harmless but wasted work; the route
-    therefore gates it on the synth path.
-
-    codex r1 BLOCKING #1: previously used ``opener.*?(?:closer|\\Z)``
-    which silently deleted from an orphan opener through EOF. The
-    two-phase design preserves any trailing prose / reasoning that
-    follows an unmatched marker, while still scrubbing the visible
-    marker bytes themselves.
     """
     if not text:
         return text or ""
     result = text
-    # Phase 1: strip every balanced opener…closer span. Non-greedy
-    # so back-to-back blocks each match independently.
+    # Phase 1: same-family balanced opener…closer spans.
     for opener_re, closer_re in _TOOL_WIRE_BALANCED_PAIRS:
-        # ``opener.pattern + lazy-anything + closer.pattern`` —
-        # build per-call so a closer literal containing regex
-        # metacharacters stays correctly escaped within the
-        # per-pair pattern.
         balanced = re.compile(opener_re.pattern + r".*?" + closer_re.pattern, re.DOTALL)
         result = balanced.sub("", result)
+    # Phase 1.5 (cross-family): catches ``<tool_call>{...}</function>``
+    # and similar mismatched-closer shapes the strict same-family
+    # pairs above don't match. Without this, the malformed body
+    # between the opener and the unrelated closer survives as
+    # ``content`` (codex r3 BLOCKING #1).
+    result = _CROSS_FAMILY_SPAN_RE.sub("", result)
     # Phase 2: strip standalone marker tokens (orphan opener OR
-    # orphan closer that survived phase 1). ONLY the marker bytes
-    # are removed; surrounding text is preserved.
+    # orphan closer that survived phases 1+1.5). ONLY the marker
+    # bytes are removed; surrounding text is preserved.
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         result = marker_re.sub("", result)
     # Collapse any runs of whitespace left by the strip. Preserves
@@ -2484,16 +2541,27 @@ async def _create_chat_completion_impl(
     if tool_calls and request.tools:
         _validate_tool_call_params(tool_calls, request.tools)
 
-    # D-TOOLCHOICE-R1 T3: when the post-parse path synthesised a forced
-    # tool call from a malformed wire body, the same raw text that the
-    # parser couldn't extract from is still living in ``cleaned_text``
-    # AND in ``output.raw_text`` (which the reasoning parser will see
-    # next). Scrub both sources of parser-wire-marker literals so they
-    # don't leak as ``content`` / ``reasoning_content``. The scrub is
-    # parser-agnostic — it strips every known opener-and-body pattern,
-    # so adding a new parser doesn't reopen this leak.
+    # D-TOOLCHOICE-R1 T3: scrub wire-marker leftovers from the
+    # response text. Two trigger conditions:
+    #
+    #   (a) the post-parse path SYNTHESISED a forced tool call
+    #       (parser couldn't extract from a malformed wire body), OR
+    #   (b) the parser DID extract a call but ``tool_choice="required"``
+    #       was set AND the raw wire had cross-family / orphan markers
+    #       the parser's cleanup left behind (e.g. qwen3 emits
+    #       ``<tool_call>{json}</function>`` — hermes recovers the JSON
+    #       but the trailing ``</function>`` survives as content).
+    #
+    # Both conditions imply the model attempted a tool call and any
+    # wire literals in the output are junk by definition. The scrub
+    # is parser-agnostic so adding a new parser doesn't reopen the
+    # leak; codex r3 BLOCKING #2 caught case (b) — even the
+    # recover-args path needs the scrub.
+    _wire_scrub_active = _synth_forced_tool_call or (
+        request.tool_choice is not None and request.tools and bool(tool_calls)
+    )
     _scrubbed_raw_text: str | None = None
-    if _synth_forced_tool_call:
+    if _wire_scrub_active:
         cleaned_text = _scrub_tool_wire_literals(cleaned_text)
         _raw_for_reasoning = output.raw_text or output.text
         _scrubbed_raw_text = _scrub_tool_wire_literals(_raw_for_reasoning)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -886,6 +886,28 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
     if not text:
         return text or ""
     result = text
+    # DeepSeek V3.1 orphan fragment:
+    # ``<｜tool▁call▁begin｜>NAME<｜tool▁sep｜>{...}`` without a closer.
+    # Remove the whole fragment so the opener/name prefix cannot leak
+    # when the separator-adjacent JSON payload is scrubbed below.
+    deepseek_begin = "<｜tool▁call▁begin｜>"
+    deepseek_sep = "<｜tool▁sep｜>"
+    while True:
+        begin = result.find(deepseek_begin)
+        if begin == -1:
+            break
+        sep = result.find(deepseek_sep, begin + len(deepseek_begin))
+        if sep == -1:
+            break
+        payload_bounds = _payload_object_after_marker(
+            result,
+            sep + len(deepseek_sep),
+            min(len(result), sep + len(deepseek_sep) + 2048),
+        )
+        if payload_bounds is None:
+            break
+        _, object_end = payload_bounds
+        result = result[:begin] + result[object_end:]
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         result = balanced_re.sub(
             lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -768,20 +768,18 @@ def _contains_tool_wire_literal(text: str | None) -> bool:
     return False
 
 
-_TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(
-    r"[\"'](?:name|arguments)[\"']\s*:",
-    re.DOTALL,
-)
+_TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(r"[\"'](?:name|arguments)[\"']\s*:")
 
 
-def _balanced_json_end(text: str, start: int) -> int | None:
+def _balanced_json_end(text: str, start: int, *, max_scan: int = 8192) -> int | None:
     """Return the exclusive end offset of a balanced JSON-ish object."""
     if start < 0 or start >= len(text) or text[start] != "{":
         return None
     depth = 0
     in_string = False
     escape = False
-    for i in range(start, len(text)):
+    stop = min(len(text), start + max_scan)
+    for i in range(start, stop):
         ch = text[i]
         if in_string:
             if escape:
@@ -800,6 +798,40 @@ def _balanced_json_end(text: str, start: int) -> int | None:
             if depth == 0:
                 return i + 1
     return None
+
+
+def _payload_object_after_marker(
+    text: str,
+    marker_end: int,
+    window_end: int,
+) -> tuple[int, int] | None:
+    """Return adjacent JSON payload bounds after a wire marker, if any."""
+    pos = marker_end
+    while pos < window_end and text[pos] in " \t\r\n":
+        pos += 1
+    if pos >= window_end or text[pos] != "{":
+        return None
+    object_end = _balanced_json_end(text, pos)
+    if object_end is None or object_end > window_end:
+        return None
+    payload = text[pos:object_end]
+    if not _TOOL_WIRE_PAYLOAD_HINT_RE.search(payload):
+        return None
+    return pos, object_end
+
+
+def _span_has_tool_payload_object(span: str) -> bool:
+    object_start = span.find("{")
+    while object_start != -1:
+        object_end = _balanced_json_end(span, object_start)
+        if object_end is not None:
+            payload = span[object_start:object_end]
+            if _TOOL_WIRE_PAYLOAD_HINT_RE.search(payload):
+                return True
+            object_start = span.find("{", object_end)
+        else:
+            object_start = span.find("{", object_start + 1)
+    return False
 def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     """Return True when known wire markers appear as tool-wire residue.
 
@@ -814,18 +846,17 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
         return False
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         match = balanced_re.search(text)
-        if match and _TOOL_WIRE_PAYLOAD_HINT_RE.search(match.group(0)):
+        if match and _span_has_tool_payload_object(match.group(0)):
             return True
     cross_match = _CROSS_FAMILY_SPAN_RE.search(text)
-    if cross_match and _TOOL_WIRE_PAYLOAD_HINT_RE.search(cross_match.group(0)):
+    if cross_match and _span_has_tool_payload_object(cross_match.group(0)):
         return True
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         match = marker_re.search(text)
         if not match:
             continue
-        window_start = max(0, match.start() - 128)
         window_end = min(len(text), match.end() + 2048)
-        if _TOOL_WIRE_PAYLOAD_HINT_RE.search(text[window_start:window_end]):
+        if _payload_object_after_marker(text, match.end(), window_end) is not None:
             return True
     return False
 
@@ -853,29 +884,25 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
     result = text
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         result = balanced_re.sub(
-            lambda m: "" if _TOOL_WIRE_PAYLOAD_HINT_RE.search(m.group(0)) else m.group(0),
+            lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
             result,
         )
     result = _CROSS_FAMILY_SPAN_RE.sub(
-        lambda m: "" if _TOOL_WIRE_PAYLOAD_HINT_RE.search(m.group(0)) else m.group(0),
+        lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
         result,
     )
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         pieces: list[str] = []
         last = 0
         for match in marker_re.finditer(result):
-            window_start = max(0, match.start() - 128)
             window_end = min(len(result), match.end() + 2048)
             pieces.append(result[last : match.start()])
-            window = result[window_start:window_end]
-            has_payload_hint = _TOOL_WIRE_PAYLOAD_HINT_RE.search(window)
-            if has_payload_hint:
-                object_start = result.find("{", match.end(), window_end)
-                object_end = _balanced_json_end(result, object_start)
-                if object_end is not None:
-                    last = object_end
-                    continue
-                last = match.end()
+            payload_bounds = _payload_object_after_marker(
+                result, match.end(), window_end
+            )
+            if payload_bounds is not None:
+                _, object_end = payload_bounds
+                last = object_end
                 continue
             else:
                 pieces.append(match.group(0))

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -222,16 +222,28 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
     }
     if parser_name in _verified_deepseek_v31_parsers:
         # V3.1 body: ``NAME<sep>{json}``. The model continues with the
-        # arguments object and closer. ``function_name`` is interpolated
-        # raw — these are DeepSeek special tokens, not JSON, and the
-        # name is already validated against ``request.tools`` upstream
-        # (the ``_target`` / ``_solo_name`` lookups in chat.py). The
-        # name does NOT pass through ``json.dumps`` because the V3.1
-        # body is not JSON-bodied here — it is a plain ``NAME<sep>``
-        # split. A function name containing ``<｜tool▁sep｜>`` would
-        # corrupt the wire, but such a name is malformed (the chat
-        # template would already fail to render it). Validated against
-        # ``DeepSeekV31ToolParser.extract_tool_calls`` body parser.
+        # arguments object and closer. The name is interpolated raw
+        # because the V3.1 body is NOT JSON-bodied at this position —
+        # it is a literal ``NAME<sep>`` split, so ``json.dumps`` would
+        # wrap the name in quotes and break the wire.
+        #
+        # codex r1 BLOCKING #2: a tool name that itself contains a
+        # DeepSeek envelope marker would corrupt the wire AND could
+        # let a downstream parser re-interpret the suffix as an extra
+        # tool call. Upstream validates names against ``request.tools``
+        # but not against the wire-token set, so we gate here as
+        # defense-in-depth. Hitting any marker returns ``None`` (clean
+        # degradation to the post-parse synthesis fallback) rather
+        # than emitting a corrupt prefix.
+        for _marker in (
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁calls▁end｜>",
+            "<｜tool▁call▁begin｜>",
+            "<｜tool▁call▁end｜>",
+            "<｜tool▁sep｜>",
+        ):
+            if _marker in function_name:
+                return None
         return (
             f"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function_name}<｜tool▁sep｜>"
         )
@@ -282,65 +294,85 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
     if not raw_text:
         return None
     text = raw_text
-    args_marker_idx = text.find('"arguments"')
-    if args_marker_idx == -1:
-        return None
-    # Find the colon that follows ``"arguments"`` (may have whitespace
-    # before/after). Scan forward up to a small bound — beyond that the
-    # marker is just prose, not a structural field.
-    colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
-    if colon_idx == -1:
-        return None
-    # Skip whitespace after the colon, looking for the object opener.
-    pos = colon_idx + 1
     n = len(text)
-    while pos < n and text[pos] in " \t\n\r":
-        pos += 1
-    if pos >= n or text[pos] != "{":
-        return None
-    # Balanced-brace scan: walk until depth returns to 0, respecting
-    # JSON string boundaries (so a ``"}"`` literal inside an arg value
-    # doesn't close the object early). Cap at 8 KiB so a malformed
-    # giant payload doesn't burn CPU.
-    depth = 0
-    in_string = False
-    escape = False
-    obj_start = pos
-    obj_end = -1
-    scan_end = min(n, obj_start + 8192)
-    while pos < scan_end:
-        ch = text[pos]
-        if escape:
-            escape = False
-        elif in_string:
-            if ch == "\\":
-                escape = True
-            elif ch == '"':
-                in_string = False
-        else:
-            if ch == '"':
-                in_string = True
-            elif ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    obj_end = pos + 1
-                    break
-        pos += 1
-    if obj_end == -1:
-        return None
-    candidate = text[obj_start:obj_end]
-    try:
-        parsed = json.loads(candidate)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    # Canonicalise — strip any incidental whitespace / trailing junk
-    # so downstream ``_validate_tool_call_params`` sees a clean JSON
-    # object byte-for-byte.
-    return json.dumps(parsed, ensure_ascii=False)
+    # codex r1 NIT: iterate over EVERY ``"arguments"`` occurrence so
+    # a leading example/prose mention (e.g. ``"the JSON shape is
+    # \"arguments\": {...}"``) doesn't block recovery of the real
+    # body that follows. We accept the first balanced JSON object;
+    # if a doc-string-shaped occurrence yields a parseable object
+    # too we'll still return that — but in practice the tool wire
+    # is always at the END of the response, so the last matching
+    # occurrence is what we want. Walk left-to-right but DON'T
+    # bail on the first non-match.
+    search_start = 0
+    while search_start < n:
+        args_marker_idx = text.find('"arguments"', search_start)
+        if args_marker_idx == -1:
+            return None
+        # Find the colon that follows ``"arguments"`` (may have
+        # whitespace before/after). Scan forward up to a small
+        # bound — beyond that the marker is just prose, not a
+        # structural field.
+        colon_idx = text.find(":", args_marker_idx, args_marker_idx + 20)
+        if colon_idx == -1:
+            # Advance past this occurrence and keep searching.
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        # Skip whitespace after the colon, looking for the object opener.
+        pos = colon_idx + 1
+        while pos < n and text[pos] in " \t\n\r":
+            pos += 1
+        if pos >= n or text[pos] != "{":
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        # Balanced-brace scan: walk until depth returns to 0, respecting
+        # JSON string boundaries (so a ``"}"`` literal inside an arg value
+        # doesn't close the object early). Cap at 8 KiB so a malformed
+        # giant payload doesn't burn CPU.
+        depth = 0
+        in_string = False
+        escape = False
+        obj_start = pos
+        obj_end = -1
+        scan_end = min(n, obj_start + 8192)
+        while pos < scan_end:
+            ch = text[pos]
+            if escape:
+                escape = False
+            elif in_string:
+                if ch == "\\":
+                    escape = True
+                elif ch == '"':
+                    in_string = False
+            else:
+                if ch == '"':
+                    in_string = True
+                elif ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        obj_end = pos + 1
+                        break
+            pos += 1
+        if obj_end == -1:
+            # Unbalanced from this marker — try the next one.
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        candidate = text[obj_start:obj_end]
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        if not isinstance(parsed, dict):
+            search_start = args_marker_idx + len('"arguments"')
+            continue
+        # Canonicalise — strip any incidental whitespace / trailing junk
+        # so downstream ``_validate_tool_call_params`` sees a clean JSON
+        # object byte-for-byte.
+        return json.dumps(parsed, ensure_ascii=False)
+    return None
 
 
 # Parser-wire literal markers that MUST be scrubbed from ``content`` /
@@ -350,44 +382,104 @@ def _recover_partial_tool_args(raw_text: str | None) -> str | None:
 # ``<tool_call>...`` text the parser couldn't extract — leaks into
 # both user-visible fields.
 #
-# The list intentionally covers EVERY wire-opener we know about across
-# tool parsers (hermes / qwen3coder / nemotron / deepseek / glm /
-# minimax / mistral / kimi / llama / harmony / gemma4 / xlam /
-# functionary / granite / seed_oss / vibethinker named-XML). Adding a
-# parser is a one-line addition; a parser whose wire is already
-# textually clean (no opener literal) is a no-op here.
-_TOOL_WIRE_SCRUB_PATTERNS = (
+# Each entry is ``(opener_regex, closer_regex_or_None)``. The scrubber
+# is two-phase:
+#
+#   1. **Balanced pairs**: when both opener and closer are present,
+#      strip the entire span ``opener…closer``. Non-greedy so
+#      consecutive blocks each get their own match.
+#   2. **Unmatched standalone markers**: any opener/closer literal
+#      that survives phase 1 (e.g. an orphan ``</function>`` or a
+#      stray ``<tool_call>`` with no closer because the model
+#      truncated mid-body) gets stripped as a bare token.
+#
+# Critically, phase 2 strips ONLY the marker bytes themselves — it
+# does NOT delete from the orphan opener to EOF. Codex r1 BLOCKING #1
+# caught this: the prior ``opener.*?(?:closer|\Z)`` pattern would eat
+# all trailing reasoning/prose whenever the model emitted an unclosed
+# opener mid-thought. The new two-phase split preserves trailing
+# content while still scrubbing the marker itself, so a model
+# response shaped like ``<tool_call>{junk}</tool_call>then prose``
+# yields ``then prose`` and ``<tool_call>{junk}\nthen prose`` yields
+# ``{junk}\nthen prose`` (the body is left for the reasoning parser
+# to consume, but the visible ``<tool_call>`` marker is gone).
+#
+# The list covers every wire opener/closer pair we know about
+# (hermes / qwen3coder / nemotron / deepseek / glm / minimax /
+# mistral / kimi / llama / harmony / gemma4 / xlam / functionary /
+# granite / seed_oss / vibethinker named-XML). Adding a parser is a
+# one-line addition.
+_TOOL_WIRE_BALANCED_PAIRS = (
     # Hermes / qwen3 JSON-bodied wire
-    re.compile(r"<tool_call>.*?(?:</tool_call>|\Z)", re.DOTALL),
-    re.compile(r"<tool_call\b[^>]*>.*?(?:</tool_call>|\Z)", re.DOTALL),
-    # Nemotron + bare ``<function=NAME>...`` wire (also picks up the
-    # qwen3 malformed body's trailing ``</parameter></function>``)
-    re.compile(r"<function=[^>]*>.*?(?:</function>|\Z)", re.DOTALL),
-    re.compile(r"<function>.*?(?:</function>|\Z)", re.DOTALL),
-    re.compile(r"</?parameter[^>]*>"),
-    # DeepSeek V3 / V3.1 / R1-0528
-    re.compile(r"<｜tool▁calls▁begin｜>.*?(?:<｜tool▁calls▁end｜>|\Z)", re.DOTALL),
-    re.compile(r"<｜tool▁call▁begin｜>.*?(?:<｜tool▁call▁end｜>|\Z)", re.DOTALL),
+    (re.compile(r"<tool_call>", re.DOTALL), re.compile(r"</tool_call>", re.DOTALL)),
+    # Nemotron-style XML body + bare ``<function=NAME>...``
+    (re.compile(r"<function=[^>]*>", re.DOTALL), re.compile(r"</function>", re.DOTALL)),
+    (re.compile(r"<function>", re.DOTALL), re.compile(r"</function>", re.DOTALL)),
+    # DeepSeek V3 / V3.1 / R1-0528 envelope
+    (
+        re.compile(r"<｜tool▁calls▁begin｜>", re.DOTALL),
+        re.compile(r"<｜tool▁calls▁end｜>", re.DOTALL),
+    ),
+    (
+        re.compile(r"<｜tool▁call▁begin｜>", re.DOTALL),
+        re.compile(r"<｜tool▁call▁end｜>", re.DOTALL),
+    ),
     # GLM-4 / GLM-4.7 wrapper
-    re.compile(r"<arg_key>.*?(?:</arg_value>|\Z)", re.DOTALL),
+    (re.compile(r"<arg_key>", re.DOTALL), re.compile(r"</arg_value>", re.DOTALL)),
     # Minimax
-    re.compile(r"<minimax:tool_call>.*?(?:</minimax:tool_call>|\Z)", re.DOTALL),
-    re.compile(r"<invoke\b[^>]*>.*?(?:</invoke>|\Z)", re.DOTALL),
-    # Llama python-tag and Kimi section markers
-    re.compile(r"<\|python_tag\|>.*?(?=$|\n\n)", re.DOTALL),
-    re.compile(
-        r"<\|tool_calls_section_begin\|>.*?(?:<\|tool_calls_section_end\|>|\Z)",
-        re.DOTALL,
+    (
+        re.compile(r"<minimax:tool_call>", re.DOTALL),
+        re.compile(r"</minimax:tool_call>", re.DOTALL),
+    ),
+    (re.compile(r"<invoke\b[^>]*>", re.DOTALL), re.compile(r"</invoke>", re.DOTALL)),
+    # Kimi section markers
+    (
+        re.compile(r"<\|tool_calls_section_begin\|>", re.DOTALL),
+        re.compile(r"<\|tool_calls_section_end\|>", re.DOTALL),
     ),
     # Mistral
-    re.compile(r"\[TOOL_CALLS\].*?(?:\[/TOOL_CALLS\]|\Z)", re.DOTALL),
+    (
+        re.compile(r"\[TOOL_CALLS\]", re.DOTALL),
+        re.compile(r"\[/TOOL_CALLS\]", re.DOTALL),
+    ),
+)
+
+
+# Standalone marker tokens that must be stripped even when their
+# matching counterpart never arrived. Includes the qwen3 stray
+# ``</parameter>`` (closing-only marker; no opener counterpart in
+# any tool wire we model) and the Llama python-tag (opener-only).
+_TOOL_WIRE_STANDALONE_MARKERS = (
+    re.compile(r"<tool_call>"),
+    re.compile(r"</tool_call>"),
+    re.compile(r"<function=[^>]*>"),
+    re.compile(r"<function>"),
+    re.compile(r"</function>"),
+    re.compile(r"</?parameter[^>]*>"),
+    re.compile(r"<｜tool▁calls▁begin｜>"),
+    re.compile(r"<｜tool▁calls▁end｜>"),
+    re.compile(r"<｜tool▁call▁begin｜>"),
+    re.compile(r"<｜tool▁call▁end｜>"),
+    re.compile(r"<｜tool▁sep｜>"),
+    re.compile(r"<arg_key>"),
+    re.compile(r"</arg_value>"),
+    re.compile(r"<minimax:tool_call>"),
+    re.compile(r"</minimax:tool_call>"),
+    re.compile(r"<invoke\b[^>]*>"),
+    re.compile(r"</invoke>"),
+    re.compile(r"<\|python_tag\|>"),
+    re.compile(r"<\|tool_calls_section_begin\|>"),
+    re.compile(r"<\|tool_calls_section_end\|>"),
+    re.compile(r"\[TOOL_CALLS\]"),
+    re.compile(r"\[/TOOL_CALLS\]"),
 )
 
 
 def _scrub_tool_wire_literals(text: str | None) -> str:
-    """Strip every known parser-wire opener-and-body pattern from
-    ``text``. Returns a whitespace-collapsed result so we don't leave
-    a void where the wire used to live.
+    """Strip every known parser-wire opener/closer marker from
+    ``text`` in two phases (see ``_TOOL_WIRE_BALANCED_PAIRS`` docstring
+    for rationale). Returns a whitespace-collapsed result so we don't
+    leave a void where the wire used to live.
 
     Idempotent: safe to call on text that has no wire literals (the
     regex sweep is a no-op). Called by the chat route ONLY when
@@ -396,12 +488,30 @@ def _scrub_tool_wire_literals(text: str | None) -> str:
     contained tool-call markers the parser couldn't extract from.
     Calling it on clean prose is harmless but wasted work; the route
     therefore gates it on the synth path.
+
+    codex r1 BLOCKING #1: previously used ``opener.*?(?:closer|\\Z)``
+    which silently deleted from an orphan opener through EOF. The
+    two-phase design preserves any trailing prose / reasoning that
+    follows an unmatched marker, while still scrubbing the visible
+    marker bytes themselves.
     """
     if not text:
         return text or ""
     result = text
-    for pattern in _TOOL_WIRE_SCRUB_PATTERNS:
-        result = pattern.sub("", result)
+    # Phase 1: strip every balanced opener…closer span. Non-greedy
+    # so back-to-back blocks each match independently.
+    for opener_re, closer_re in _TOOL_WIRE_BALANCED_PAIRS:
+        # ``opener.pattern + lazy-anything + closer.pattern`` —
+        # build per-call so a closer literal containing regex
+        # metacharacters stays correctly escaped within the
+        # per-pair pattern.
+        balanced = re.compile(opener_re.pattern + r".*?" + closer_re.pattern, re.DOTALL)
+        result = balanced.sub("", result)
+    # Phase 2: strip standalone marker tokens (orphan opener OR
+    # orphan closer that survived phase 1). ONLY the marker bytes
+    # are removed; surrounding text is preserved.
+    for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
+        result = marker_re.sub("", result)
     # Collapse any runs of whitespace left by the strip. Preserves
     # single-space separation between surrounding prose words.
     return re.sub(r"\s+", " ", result).strip()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -490,7 +490,9 @@ def _recover_partial_tool_args(
         # canonical wire shape ``{"name":"X","arguments":{...}}``
         # always has ``"name"`` BEFORE ``"arguments"``.
         next_args_idx = text.find('"arguments"', idx + len('"arguments"'))
-        next_closer_idx = _next_wire_span_closer(idx) if span_start is not None else None
+        next_closer_idx = (
+            _next_wire_span_closer(idx) if span_start is not None else None
+        )
         forward_bound = n
         if next_args_idx != -1:
             forward_bound = min(forward_bound, next_args_idx)
@@ -2921,10 +2923,7 @@ async def _create_chat_completion_impl(
             and request.tools
             and bool(tool_calls)
             and _contains_tool_wire_literal(text)
-            and (
-                _contains_structural_tool_wire_leak(text)
-                or _raw_has_structural_wire
-            )
+            and (_contains_structural_tool_wire_leak(text) or _raw_has_structural_wire)
         )
 
     _wire_scrub_active = _should_scrub_visible_wire(cleaned_text)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -403,18 +403,8 @@ def _recover_partial_tool_args(
         "</arg_value>",
     )
 
-    def _position_in_wire_span(idx: int) -> bool:
-        """Is ``idx`` inside (or immediately after) a known tool-wire
-        opener? We don't require a balanced closer — the qwen3 leak
-        shape often has no clean closer.
-
-        codex r6 NIT: bound the search by the nearest known
-        opener/closer occurrence rather than a fixed lookback. We
-        find the LATEST opener at position ``op_pos < idx`` and the
-        LATEST closer at position ``cl_pos < idx``; ``idx`` is in
-        the span iff ``op_pos`` exists AND ``op_pos > cl_pos``
-        (so the most recent opener was not yet closed before ``idx``).
-        """
+    def _open_wire_span_start(idx: int) -> int | None:
+        """Return the nearest still-open wire opener before ``idx``."""
         prefix = text[:idx]
         op_pos = -1
         for opener in _WIRE_SPAN_OPENERS:
@@ -428,7 +418,30 @@ def _recover_partial_tool_args(
             pos = prefix.rfind(closer)
             if pos > cl_pos:
                 cl_pos = pos
-        return op_pos > cl_pos
+        return op_pos if op_pos >= 0 and op_pos > cl_pos else None
+
+    def _next_wire_span_closer(idx: int) -> int | None:
+        """Return the nearest known wire closer after ``idx``."""
+        close_pos: int | None = None
+        for closer in _WIRE_SPAN_CLOSERS:
+            pos = text.find(closer, idx)
+            if pos != -1 and (close_pos is None or pos < close_pos):
+                close_pos = pos
+        return close_pos
+
+    def _position_in_wire_span(idx: int) -> bool:
+        """Is ``idx`` inside (or immediately after) a known tool-wire
+        opener? We don't require a balanced closer — the qwen3 leak
+        shape often has no clean closer.
+
+        codex r6 NIT: bound the search by the nearest known
+        opener/closer occurrence rather than a fixed lookback. We
+        find the LATEST opener at position ``op_pos < idx`` and the
+        LATEST closer at position ``cl_pos < idx``; ``idx`` is in
+        the span iff ``op_pos`` exists AND ``op_pos > cl_pos``
+        (so the most recent opener was not yet closed before ``idx``).
+        """
+        return _open_wire_span_start(idx) is not None
 
     def _name_pairs_with(idx: int, expected: str) -> bool:
         """Does a ``"name": "<expected>"`` (or ``"name":"<expected>"``)
@@ -455,24 +468,32 @@ def _recover_partial_tool_args(
         if not expected:
             return True  # No constraint when caller doesn't pass one.
 
-        # Backward bound: the closer of (previous "arguments"
-        # occurrence + len) or the nearest wire-opener literal
-        # backward, or ``idx - 512`` as a hard fallback so a wire
-        # body with no opener literal still bounds the scan.
-        prev_args_end = text.rfind('"arguments"', 0, idx)
-        if prev_args_end != -1:
-            backward_bound = prev_args_end + len('"arguments"')
+        # Backward bound: if ``idx`` is inside a known wire span, use
+        # that span's opener. This admits verbose DeepSeek V3.1 output
+        # between ``<｜tool▁call▁begin｜>NAME<｜tool▁sep｜>`` and the
+        # later JSON ``"arguments"`` object without relying on a fixed
+        # byte lookback. If no opener is known, fall back to the
+        # previous arguments marker to keep adjacent JSON blocks from
+        # cross-pairing.
+        span_start = _open_wire_span_start(idx)
+        if span_start is not None:
+            backward_bound = span_start
         else:
-            backward_bound = max(0, idx - 512)
+            prev_args_end = text.rfind('"arguments"', 0, idx)
+            backward_bound = (
+                prev_args_end + len('"arguments"') if prev_args_end != -1 else 0
+            )
         # Forward bound: the next "arguments" marker or 256 bytes
         # forward. We cap forward TIGHTER than backward because the
         # canonical wire shape ``{"name":"X","arguments":{...}}``
         # always has ``"name"`` BEFORE ``"arguments"``.
         next_args_idx = text.find('"arguments"', idx + len('"arguments"'))
+        next_closer_idx = _next_wire_span_closer(idx)
+        forward_bound = n
         if next_args_idx != -1:
-            forward_bound = next_args_idx
-        else:
-            forward_bound = min(n, idx + 256)
+            forward_bound = min(forward_bound, next_args_idx)
+        if next_closer_idx is not None:
+            forward_bound = min(forward_bound, next_closer_idx)
         window = text[backward_bound:forward_bound]
         escaped = re.escape(expected)
         # Accept TWO wire shapes for the paired ``name`` literal:
@@ -745,13 +766,6 @@ _TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(
     r"(?:[\"'](?:name|arguments)[\"']\s*:|\{[^{}]{0,2048}\})",
     re.DOTALL,
 )
-_TOOL_WIRE_ORPHAN_CLOSER_RE = re.compile(
-    r"(?:</tool_call>|</function>|</parameter>|<｜tool▁calls▁end｜>|"
-    r"<｜tool▁call▁end｜>|</minimax:tool_call>|</invoke>|</arg_value>|"
-    r"<\|tool_calls_section_end\|>|\[/TOOL_CALLS\])"
-)
-
-
 def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     """Return True when known wire markers appear as tool-wire residue.
 
@@ -768,8 +782,6 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
         if re.search(opener_re.pattern + r".*?" + closer_re.pattern, text, re.DOTALL):
             return True
     if _CROSS_FAMILY_SPAN_RE.search(text):
-        return True
-    if _TOOL_WIRE_ORPHAN_CLOSER_RE.search(text):
         return True
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         match = marker_re.search(text)
@@ -2772,11 +2784,19 @@ async def _create_chat_completion_impl(
         isinstance(request.tool_choice, dict)
         and request.tool_choice.get("type") == "function"
     )
+    _raw_text_for_reasoning = output.raw_text or output.text
+    _raw_has_structural_wire = _contains_structural_tool_wire_leak(
+        _raw_text_for_reasoning
+    )
     _wire_scrub_active = (
         _is_forced_choice
         and request.tools
         and bool(tool_calls)
-        and _contains_structural_tool_wire_leak(cleaned_text)
+        and _contains_tool_wire_literal(cleaned_text)
+        and (
+            _contains_structural_tool_wire_leak(cleaned_text)
+            or _raw_has_structural_wire
+        )
     )
     # codex r6 BLOCKING #2: scrub the user-visible ``cleaned_text``
     # only. Do NOT mutate ``raw_text`` before it reaches the reasoning
@@ -2803,7 +2823,7 @@ async def _create_chat_completion_impl(
         # Any wire-literal scrub above only touched user-visible
         # ``cleaned_text`` — reasoning extraction operates on the
         # untouched ``raw_text``.
-        raw_text=output.raw_text or output.text,
+        raw_text=_raw_text_for_reasoning,
         cleaned_text=cleaned_text,
         tool_calls=tool_calls,
         reasoning_parser=cfg.reasoning_parser,
@@ -2836,7 +2856,11 @@ async def _create_chat_completion_impl(
         _is_forced_choice
         and request.tools
         and bool(tool_calls)
-        and _contains_structural_tool_wire_leak(reasoning_text)
+        and _contains_tool_wire_literal(reasoning_text)
+        and (
+            _contains_structural_tool_wire_leak(reasoning_text)
+            or _raw_has_structural_wire
+        )
     )
     if _reasoning_wire_scrub_active and reasoning_text:
         reasoning_text = _scrub_tool_wire_literals(reasoning_text)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -785,9 +785,11 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     if not text:
         return False
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
-        if balanced_re.search(text):
+        match = balanced_re.search(text)
+        if match and _TOOL_WIRE_PAYLOAD_HINT_RE.search(match.group(0)):
             return True
-    if _CROSS_FAMILY_SPAN_RE.search(text):
+    cross_match = _CROSS_FAMILY_SPAN_RE.search(text)
+    if cross_match and _TOOL_WIRE_PAYLOAD_HINT_RE.search(cross_match.group(0)):
         return True
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         match = marker_re.search(text)
@@ -2794,16 +2796,20 @@ async def _create_chat_completion_impl(
     _raw_has_structural_wire = _contains_structural_tool_wire_leak(
         _raw_text_for_reasoning
     )
-    _wire_scrub_active = (
-        _is_forced_choice
-        and request.tools
-        and bool(tool_calls)
-        and _contains_tool_wire_literal(cleaned_text)
-        and (
-            _contains_structural_tool_wire_leak(cleaned_text)
-            or _raw_has_structural_wire
+
+    def _should_scrub_visible_wire(text: str | None) -> bool:
+        return (
+            _is_forced_choice
+            and request.tools
+            and bool(tool_calls)
+            and _contains_tool_wire_literal(text)
+            and (
+                _contains_structural_tool_wire_leak(text)
+                or _raw_has_structural_wire
+            )
         )
-    )
+
+    _wire_scrub_active = _should_scrub_visible_wire(cleaned_text)
     # codex r6 BLOCKING #2: scrub the user-visible ``cleaned_text``
     # only. Do NOT mutate ``raw_text`` before it reaches the reasoning
     # parser — pretty-printed reasoning bodies may legitimately
@@ -2858,17 +2864,9 @@ async def _create_chat_completion_impl(
         # any caller that hasn't been threaded yet.
         finish_reason=getattr(output, "finish_reason", None),
     )
-    _reasoning_wire_scrub_active = (
-        _is_forced_choice
-        and request.tools
-        and bool(tool_calls)
-        and _contains_tool_wire_literal(reasoning_text)
-        and (
-            _contains_structural_tool_wire_leak(reasoning_text)
-            or _raw_has_structural_wire
-        )
-    )
-    if _reasoning_wire_scrub_active and reasoning_text:
+    if _should_scrub_visible_wire(cleaned_text):
+        cleaned_text = _scrub_tool_wire_literals(cleaned_text)
+    if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
         reasoning_text = _scrub_tool_wire_literals(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -181,14 +181,18 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         # disconnects after the first chunk instead of a controlled
         # 501. Lift to the top so both branches are covered.
         _want_logprobs = request.logprobs is not None
-        if _want_logprobs and getattr(engine, "tokenizer", None) is None:
+        _stream_generate = getattr(engine, "stream_generate", None)
+        if _want_logprobs and (
+            not callable(_stream_generate) or getattr(engine, "tokenizer", None) is None
+        ):
             raise HTTPException(
                 status_code=501,
                 detail=(
-                    "logprobs requested but this engine does not expose a "
-                    "tokenizer for the streaming logprobs extraction path. "
-                    "Reissue without ``logprobs`` or use a model that "
-                    "supports per-token distributions."
+                    "logprobs requested but this engine does not expose "
+                    "the streaming logprobs extraction path "
+                    "(``stream_generate`` + ``tokenizer``). Reissue "
+                    "without ``logprobs`` or use a model that supports "
+                    "per-token distributions."
                 ),
             )
 

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -181,18 +181,14 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         # disconnects after the first chunk instead of a controlled
         # 501. Lift to the top so both branches are covered.
         _want_logprobs = request.logprobs is not None
-        if _want_logprobs and (
-            not hasattr(engine, "stream_generate")
-            or getattr(engine, "tokenizer", None) is None
-        ):
+        if _want_logprobs and getattr(engine, "tokenizer", None) is None:
             raise HTTPException(
                 status_code=501,
                 detail=(
-                    "logprobs requested but this engine does not expose "
-                    "the streaming logprobs extraction path "
-                    "(``stream_generate`` + ``tokenizer``). Reissue "
-                    "without ``logprobs`` or use a model that supports "
-                    "per-token distributions."
+                    "logprobs requested but this engine does not expose a "
+                    "tokenizer for the streaming logprobs extraction path. "
+                    "Reissue without ``logprobs`` or use a model that "
+                    "supports per-token distributions."
                 ),
             )
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1248,7 +1248,19 @@ _TOOL_USE_SYSTEM_SUFFIX = (
     "a reasonable default exists. Do NOT explain what you will do — just do it. "
     "Be direct and concise in your responses. "
     "Do NOT think out loud or show your reasoning process. "
-    "Give direct answers only — no preamble like 'The user asks...' or 'Let me think...'."
+    "Give direct answers only — no preamble like 'The user asks...' or 'Let me think...'. "
+    # D-TOOLCHOICE-R1 T1: DeepSeek-R1 distills (and other reasoning
+    # models) under ``tool_choice="auto"`` will happily HALLUCINATE
+    # the result of a tool they were never told existed — emit
+    # ``"The current temperature in Tokyo is 24°C"`` while the only
+    # weather data they have is whatever the user typed. The
+    # earlier "use a tool immediately" clause does not cover this:
+    # the model can interpret "use a tool" as "include a tool-shaped
+    # answer". This clause is a HARD floor: if you didn't actually
+    # call a tool, you must not claim a tool result.
+    "If you do NOT call a tool, do NOT fabricate the contents of any tool's response — "
+    "answer only from what you actually know. Do NOT print fake JSON, fake API responses, "
+    "or sentences that begin with 'Tool returned:' / 'Tool output:' / 'The API returned'."
 )
 
 # Tool-use system prompt for ``tool_choice="required"`` (#468). Strict


### PR DESCRIPTION
## Summary

Three tightly-related tool-calling failures from Theo's 0.8.3 dogfood
share one structural root: ``tool_choice`` plumbing reached the prompt
level but never the post-parse path, so every parser-wire edge case
fell back to either fake tool output or empty-args synth.

- **T1** — DeepSeek-R1 distill + ``tool_choice="auto"`` fabricated
  prose like ``"The current temperature in Tokyo is 24°C"`` without
  emitting a tool call. The auto-mode system suffix asked the model to
  use a tool but did NOT forbid fake tool results.
- **T2** — DeepSeek-R1 distill + ``tool_choice="required"`` returned
  ``tool_calls[0].arguments == "{}"``. ``_forced_tool_call_prefix``
  only knew ``hermes``; ``deepseek_v31`` / ``deepseek_r1_0528`` fell
  through to the empty-args synthesis fallback.
- **T3** — qwen3 + ``tool_choice="required"`` emitted malformed JSON
  (``"arguments": 4128, 7591}``) inside ``<tool_call>``. Parser
  couldn't extract; post-parse produced ``"{}"`` AND the literal
  ``<tool_call>...`` text leaked into BOTH ``content`` and
  ``reasoning_content``.

## Structural fix (not three ad-hoc patches)

1. **``_TOOL_USE_SYSTEM_SUFFIX``** carries a hard no-fabrication clause:
   if you didn't actually call a tool, do not fake a tool result or
   print ``"Tool returned:"`` / ``"Tool output:"`` / fake JSON.
2. **``_forced_tool_call_prefix``** recognises ``deepseek_v31`` /
   ``deepseek_r1_0528`` and injects
   ``<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>NAME<｜tool▁sep｜>``.
   The model continues with real arguments; the parser extracts cleanly.
   V1 ``deepseek`` is still excluded (different body shape).
   Defense-in-depth: tool names containing any DeepSeek wire marker
   reject the prefix and degrade to synthesis (codex r1 BLOCKING #2).
3. **``_synthesize_forced_tool_call``** accepts ``raw_text`` and runs a
   bounded balanced-brace scan over EVERY ``"arguments":`` occurrence
   to recover a JSON object before defaulting to ``"{}"`` (codex r1
   NIT).
4. **``_scrub_tool_wire_literals``** runs a two-phase strip: phase 1
   removes balanced ``opener…closer`` spans; phase 2 removes orphan
   marker tokens themselves WITHOUT eating trailing prose. Codex r1
   BLOCKING #1 caught the prior ``opener.*?(?:closer|\\Z)`` shape
   silently deleting everything after an orphan opener through EOF.
   Gated on the forced-tool-choice synth path so non-forced prose is
   untouched.

## Files touched

- ``vllm_mlx/service/helpers.py`` — strengthen ``_TOOL_USE_SYSTEM_SUFFIX``.
- ``vllm_mlx/routes/chat.py`` — extend ``_forced_tool_call_prefix``
  with deepseek_v31 + injection guard, add ``_recover_partial_tool_args``
  + ``_scrub_tool_wire_literals``, wire the synth path through them.
- ``tests/test_tool_choice_enforcement.py`` — 40 regression tests
  covering all three bugs end-to-end + every codex review finding.

## Test plan

- [x] T1 regression: ``_TOOL_USE_SYSTEM_SUFFIX`` carries the
  no-fabrication clause; auto-mode injects it into the rendered system
  prompt.
- [x] T2 regression: ``_forced_tool_call_prefix("deepseek_v31", ...)``
  returns the V3.1 envelope opener; ``deepseek_r1_0528`` alias matches;
  V1 ``deepseek`` still ``None``; chat route wires
  ``forced_assistant_prefix`` into engine kwargs for required + single
  tool.
- [x] T3 regression: parser alone fails on malformed body (pinned);
  ``_scrub_tool_wire_literals`` strips every known wire shape;
  idempotent on clean prose; ``_recover_partial_tool_args`` extracts
  balanced JSON objects; returns ``None`` on the qwen3 bare-positional
  shape; end-to-end through the chat route: ``content`` and
  ``reasoning_content`` clean of ``<tool_call>`` / ``</function>`` /
  ``</parameter>`` leaks.
- [x] Codex r1 BLOCKING #1 (scrub preserves trailing text after orphan
  opener) — pinned with 4 dedicated tests.
- [x] Codex r1 BLOCKING #2 (deepseek prefix rejects marker injection
  in tool names) — pinned with 5 hostile-name cases + 1 safe-name
  control.
- [x] Codex r1 NIT (recover iterates over all ``"arguments"``
  occurrences) — pinned with 2 multi-occurrence tests.
- [x] All pre-existing tool-choice tests still pass (101/101 across
  ``test_chat_route_forced_tool_prefix*``,
  ``test_chat_route_tool_choice_enforcement``,
  ``test_chat_route_tool_tag_leak``,
  ``test_tool_choice_enforcement``).
- [x] Full-unit sweep: vs ``b25e3af`` baseline (75 failed) the diff is
  test-collection failures unrelated to tools (``outlines`` not
  installed in venv; flaky concurrency test passes individually).
  Zero new tool-related regressions.
- [x] ``ruff check`` + ``ruff format`` clean on touched files.

## Post-merge (non-gated)

* Live re-verify T1 / T2 / T3 against deployed 0.8.4 build with
  ``deepseek-r1-8b-4bit`` and ``qwen3-0.6b-8bit`` once the release SHA
  lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Anthropic named tool_choice contract

Full-unit validation exposed conflicting tests around `/v1/messages` named `tool_choice={"type":"tool","name":X}` when the local model emits text only or only other tools. The suite-wide F8/D-ANTHRO-SPEC-POLISH contract is now restored and documented: named pins synthesize a best-effort empty-input `tool_use` for the pinned tool on both non-stream and stream paths, while real emitted pinned calls still validate normally and unpinned extras are dropped before validation. The synthesized-path boolean is preserved so placeholder `{}` inputs do not regress into schema 400s for tools with required fields.