### PR TITLE
fix(anthropic): enforce tool_choice.type="any" + plumb prompt_tokens into streaming usage (D-ANTHRO-TOOL-USAGE)

### DIFF
--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -720,72 +720,30 @@ def test_stream_message_delta_input_tokens_floored_to_estimate_when_engine_silen
     assert delta_input == start_input, (start_input, delta_input)
 
 
-def test_stream_helper_preserves_prepared_messages_for_engine():
-    """Codex r5 BLOCKING #1 (PR #807): when the route entry-point
-    threads ``prepared_messages``, it must ALSO thread the
-    ``prepared_images`` / ``prepared_videos`` it extracted alongside
-    them — pre-r5 the streaming helper silently dropped both to ``[]``
-    when ``prepared_messages`` was set, breaking every multimodal
-    ``/v1/messages`` streaming request against an MLLM engine.
+def test_stream_helper_forwards_prepared_multimodal_to_engine():
+    """Codex r5 BLOCKING #1 / r6 BLOCKING / r7 BLOCKING (PR #807): the
+    ``prepared_images`` / ``prepared_videos`` lists the route entry-
+    point threads MUST reach the engine's ``stream_chat`` as ``images=``
+    / ``videos=`` kwargs. Pre-PR the route never forwarded multimodal
+    payloads to the engine on either branch (a long-standing
+    /v1/messages MLLM bug); fixing the codex-flagged silent-drop
+    naturally lined up the missing engine plumbing.
 
-    Codex r6 BLOCKING (PR #807): the earlier signature-shape guard was
-    too weak — a future refactor could keep the kwargs but stop
-    forwarding them. Drive the helper end-to-end with a sentinel-list
-    payload and assert the engine receives the EXACT same object the
-    caller threaded.
+    Driven directly via asyncio so the test pins the SAME object
+    identity the route threaded — a future refactor that "forwards"
+    via ``list(images)`` copy would still pass an identity-equal
+    assert, but a refactor that drops the kwargs or substitutes ``[]``
+    fails immediately.
     """
-    sentinel_messages = [
-        {"role": "user", "content": "stream this"},
-    ]
-    sentinel_images: list = [b"img-bytes-0", b"img-bytes-1"]
-    sentinel_videos: list = [b"vid-bytes-0"]
-    engine = _ToolStreamingEngine(["ok"], engine_prompt_tokens=4)
-    client = _make_client(engine)
-
-    # Direct ``client.post`` exercises the full route which goes
-    # through ``extract_multimodal_content`` (not our sentinel data),
-    # so we can't observe the threading from there. Instead, drive
-    # the route via TestClient on a fresh route+app and assert via
-    # the engine spy that ``stream_chat`` received the SAME messages
-    # list the route prepared (the threading is the in-flight
-    # contract this test exists to guard). The multimodal-list
-    # threading is then exercised by reading the kwargs on the spy:
-    response = client.post(
-        "/v1/messages",
-        json={
-            "model": "test-model",
-            "max_tokens": 16,
-            "stream": True,
-            "messages": [{"role": "user", "content": "stream this"}],
-        },
-    )
-    assert response.status_code == 200, response.text
-    assert engine.stream_calls, "engine.stream_chat was never invoked"
-    # The route's ``extract_multimodal_content`` returns the rendered
-    # ``messages`` list; the streaming helper must forward it to the
-    # engine unchanged. Sentinel-equality is sufficient because the
-    # extractor is a pure function and a mid-flight overwrite would
-    # be observable as a different list identity.
-    seen = engine.stream_calls[0]["messages"]
-    assert isinstance(seen, list)
-    # The rendered shape preserves the user content the request sent.
-    assert any(
-        (m.get("content") if isinstance(m, dict) else getattr(m, "content", None))
-        == "stream this"
-        for m in seen
-    ), seen
-
-    # Direct invocation of the helper with explicit ``prepared_*``
-    # kwargs lets us also pin the images/videos threading contract —
-    # the engine spy records ``messages`` only, but we assert the
-    # helper resolves ``prepared_images`` / ``prepared_videos``
-    # verbatim (no ``[]`` substitution) by exercising the
-    # ``prepared_messages is not None`` branch directly.
     import asyncio
 
-    from vllm_mlx.api.models import ChatCompletionRequest
     from vllm_mlx.api.anthropic_models import AnthropicRequest
+    from vllm_mlx.api.models import ChatCompletionRequest
     from vllm_mlx.routes.anthropic import _stream_anthropic_messages
+
+    sentinel_messages = [{"role": "user", "content": "stream this"}]
+    sentinel_images: list = [b"img-bytes-0", b"img-bytes-1"]
+    sentinel_videos: list = [b"vid-bytes-0"]
 
     direct_engine = _ToolStreamingEngine(["ok"], engine_prompt_tokens=4)
     cfg = reset_config()
@@ -818,18 +776,67 @@ def test_stream_helper_preserves_prepared_messages_for_engine():
             pass
 
     asyncio.run(_drive())
-    # The engine spy sees the sentinel ``prepared_messages`` list
-    # forwarded unchanged. ``stream_chat`` does not currently receive
-    # ``images`` / ``videos`` as kwargs (engines extract media from
-    # the messages themselves), but the helper MUST resolve the
-    # ``prepared_*`` kwargs to the caller's list rather than ``[]``;
-    # the resolution is asserted via the ``images`` / ``videos`` local
-    # state, which we expose by checking that the helper did NOT raise
-    # a TypeError or AttributeError when the sentinel bytes are
-    # forwarded. The test would FAIL if the helper dropped the
-    # sentinel and the engine had a media-required code path.
     assert direct_engine.stream_calls
-    assert direct_engine.stream_calls[0]["messages"] is sentinel_messages
+    call = direct_engine.stream_calls[0]
+    # Messages identity must be preserved (the caller's list, not a
+    # copy or a re-rendered version).
+    assert call["messages"] is sentinel_messages
+    # Images + videos must reach the engine as ``images=`` /
+    # ``videos=`` kwargs carrying the SAME caller-supplied lists.
+    # A silent ``[]`` substitution OR a missing kwarg both fail.
+    assert call["kwargs"].get("images") is sentinel_images, call["kwargs"]
+    assert call["kwargs"].get("videos") is sentinel_videos, call["kwargs"]
+
+
+def test_stream_helper_skips_empty_multimodal_kwargs():
+    """Text-only requests must NOT pass ``images=`` / ``videos=`` to
+    the engine even with empty-list sentinels — the engine's
+    multimodal preprocessor would otherwise see ``[]`` instead of
+    ``None`` and produce a different fast-path decision. Mirrors
+    ``routes/chat.py`` lines 1049-1050."""
+    import asyncio
+
+    from vllm_mlx.api.anthropic_models import AnthropicRequest
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.routes.anthropic import _stream_anthropic_messages
+
+    direct_engine = _ToolStreamingEngine(["ok"], engine_prompt_tokens=4)
+    cfg = reset_config()
+    cfg.engine = direct_engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    async def _drive():
+        gen = _stream_anthropic_messages(
+            direct_engine,
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "x"}],
+                max_tokens=8,
+            ),
+            AnthropicRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "x"}],
+                max_tokens=8,
+                stream=True,
+            ),
+            prepared_messages=[{"role": "user", "content": "x"}],
+            prepared_images=[],
+            prepared_videos=[],
+            prompt_tokens_estimate=4,
+        )
+        async for _ in gen:
+            pass
+
+    asyncio.run(_drive())
+    assert direct_engine.stream_calls
+    kwargs = direct_engine.stream_calls[0]["kwargs"]
+    # ``if images:`` / ``if videos:`` gates suppress empty-list
+    # forwarding. The text-only fast path stays clean.
+    assert "images" not in kwargs, kwargs
+    assert "videos" not in kwargs, kwargs
 
 
 def test_stream_message_start_consistent_with_nonstream_input_tokens():

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -411,13 +411,11 @@ def test_nonstream_tool_choice_named_still_routes_to_specific_tool():
     # ("model returned a text response with no tool_calls"). Either
     # 422 or a 200 with a synth call to ``get_weather`` is contract-
     # compliant; what we explicitly do NOT want is a tool_use for
-    # ``lookup_zip`` or a 200 ``end_turn`` text response.
-    #
-    # Codex review BLOCKING (PR #807): assert ``tool_uses`` non-empty
-    # AND ``stop_reason == "tool_use"`` in the 200 branch so the
-    # forbidden ``end_turn`` text response would FAIL this test. The
-    # earlier ``for tu in tool_uses:`` loop was vacuously true on an
-    # empty list and let the exact bug case slip through.
+    # ``lookup_zip`` or a 200 ``end_turn`` text response. The 200
+    # branch therefore asserts a non-empty ``tool_uses`` list AND
+    # ``stop_reason == "tool_use"`` so the exact failure mode this
+    # test exists to catch (vacuously-empty ``tool_uses``) is
+    # surfaced as a hard fail rather than a silent skip.
     assert r.status_code in (200, 422), r.text
     if r.status_code == 200:
         body = r.json()

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -720,6 +720,34 @@ def test_stream_message_delta_input_tokens_floored_to_estimate_when_engine_silen
     assert delta_input == start_input, (start_input, delta_input)
 
 
+def test_stream_helper_threads_prepared_multimodal_payload():
+    """Codex r5 BLOCKING #1 (PR #807): when the route entry-point
+    threads ``prepared_messages``, it must ALSO thread the
+    ``prepared_images`` / ``prepared_videos`` it extracted alongside
+    them — pre-r5 the streaming helper silently dropped both to ``[]``
+    when ``prepared_messages`` was set, breaking every multimodal
+    ``/v1/messages`` streaming request against an MLLM engine.
+
+    The helper is unit-tested directly because the multimodal routes
+    in production keep the images / videos lists private to the
+    extractor; we only need to assert the threading shape — that the
+    helper does not silently overwrite the caller's payload.
+    """
+    import inspect
+
+    from vllm_mlx.routes.anthropic import _stream_anthropic_messages
+
+    sig = inspect.signature(_stream_anthropic_messages)
+    # The kwargs added by codex r5 must exist; their default ``None``
+    # signal "caller did not thread one" and the helper falls back to
+    # ``[]``. A future refactor that drops these kwargs would silently
+    # re-introduce the codex r5 BLOCKING #1 multimodal-drop regression.
+    assert "prepared_images" in sig.parameters
+    assert "prepared_videos" in sig.parameters
+    assert sig.parameters["prepared_images"].default is None
+    assert sig.parameters["prepared_videos"].default is None
+
+
 def test_stream_message_start_consistent_with_nonstream_input_tokens():
     """The streaming + non-streaming surfaces must agree on the prompt
     token count for the same prompt — this is the spec-level identity

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -720,7 +720,7 @@ def test_stream_message_delta_input_tokens_floored_to_estimate_when_engine_silen
     assert delta_input == start_input, (start_input, delta_input)
 
 
-def test_stream_helper_threads_prepared_multimodal_payload():
+def test_stream_helper_preserves_prepared_messages_for_engine():
     """Codex r5 BLOCKING #1 (PR #807): when the route entry-point
     threads ``prepared_messages``, it must ALSO thread the
     ``prepared_images`` / ``prepared_videos`` it extracted alongside
@@ -728,24 +728,108 @@ def test_stream_helper_threads_prepared_multimodal_payload():
     when ``prepared_messages`` was set, breaking every multimodal
     ``/v1/messages`` streaming request against an MLLM engine.
 
-    The helper is unit-tested directly because the multimodal routes
-    in production keep the images / videos lists private to the
-    extractor; we only need to assert the threading shape — that the
-    helper does not silently overwrite the caller's payload.
+    Codex r6 BLOCKING (PR #807): the earlier signature-shape guard was
+    too weak — a future refactor could keep the kwargs but stop
+    forwarding them. Drive the helper end-to-end with a sentinel-list
+    payload and assert the engine receives the EXACT same object the
+    caller threaded.
     """
-    import inspect
+    sentinel_messages = [
+        {"role": "user", "content": "stream this"},
+    ]
+    sentinel_images: list = [b"img-bytes-0", b"img-bytes-1"]
+    sentinel_videos: list = [b"vid-bytes-0"]
+    engine = _ToolStreamingEngine(["ok"], engine_prompt_tokens=4)
+    client = _make_client(engine)
 
+    # Direct ``client.post`` exercises the full route which goes
+    # through ``extract_multimodal_content`` (not our sentinel data),
+    # so we can't observe the threading from there. Instead, drive
+    # the route via TestClient on a fresh route+app and assert via
+    # the engine spy that ``stream_chat`` received the SAME messages
+    # list the route prepared (the threading is the in-flight
+    # contract this test exists to guard). The multimodal-list
+    # threading is then exercised by reading the kwargs on the spy:
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 16,
+            "stream": True,
+            "messages": [{"role": "user", "content": "stream this"}],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert engine.stream_calls, "engine.stream_chat was never invoked"
+    # The route's ``extract_multimodal_content`` returns the rendered
+    # ``messages`` list; the streaming helper must forward it to the
+    # engine unchanged. Sentinel-equality is sufficient because the
+    # extractor is a pure function and a mid-flight overwrite would
+    # be observable as a different list identity.
+    seen = engine.stream_calls[0]["messages"]
+    assert isinstance(seen, list)
+    # The rendered shape preserves the user content the request sent.
+    assert any(
+        (m.get("content") if isinstance(m, dict) else getattr(m, "content", None))
+        == "stream this"
+        for m in seen
+    ), seen
+
+    # Direct invocation of the helper with explicit ``prepared_*``
+    # kwargs lets us also pin the images/videos threading contract —
+    # the engine spy records ``messages`` only, but we assert the
+    # helper resolves ``prepared_images`` / ``prepared_videos``
+    # verbatim (no ``[]`` substitution) by exercising the
+    # ``prepared_messages is not None`` branch directly.
+    import asyncio
+
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.api.anthropic_models import AnthropicRequest
     from vllm_mlx.routes.anthropic import _stream_anthropic_messages
 
-    sig = inspect.signature(_stream_anthropic_messages)
-    # The kwargs added by codex r5 must exist; their default ``None``
-    # signal "caller did not thread one" and the helper falls back to
-    # ``[]``. A future refactor that drops these kwargs would silently
-    # re-introduce the codex r5 BLOCKING #1 multimodal-drop regression.
-    assert "prepared_images" in sig.parameters
-    assert "prepared_videos" in sig.parameters
-    assert sig.parameters["prepared_images"].default is None
-    assert sig.parameters["prepared_videos"].default is None
+    direct_engine = _ToolStreamingEngine(["ok"], engine_prompt_tokens=4)
+    cfg = reset_config()
+    cfg.engine = direct_engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    async def _drive():
+        gen = _stream_anthropic_messages(
+            direct_engine,
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "x"}],
+                max_tokens=8,
+            ),
+            AnthropicRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "x"}],
+                max_tokens=8,
+                stream=True,
+            ),
+            prepared_messages=sentinel_messages,
+            prepared_images=sentinel_images,
+            prepared_videos=sentinel_videos,
+            prompt_tokens_estimate=7,
+        )
+        async for _ in gen:
+            pass
+
+    asyncio.run(_drive())
+    # The engine spy sees the sentinel ``prepared_messages`` list
+    # forwarded unchanged. ``stream_chat`` does not currently receive
+    # ``images`` / ``videos`` as kwargs (engines extract media from
+    # the messages themselves), but the helper MUST resolve the
+    # ``prepared_*`` kwargs to the caller's list rather than ``[]``;
+    # the resolution is asserted via the ``images`` / ``videos`` local
+    # state, which we expose by checking that the helper did NOT raise
+    # a TypeError or AttributeError when the sentinel bytes are
+    # forwarded. The test would FAIL if the helper dropped the
+    # sentinel and the engine had a media-required code path.
+    assert direct_engine.stream_calls
+    assert direct_engine.stream_calls[0]["messages"] is sentinel_messages
 
 
 def test_stream_message_start_consistent_with_nonstream_input_tokens():

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -1,0 +1,698 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-ANTHRO-TOOL-USAGE regressions — F3 + F5 from Sergei dogfood.
+
+F3: ``tool_choice={"type":"any"}`` on /v1/messages was a silent no-op.
+The adapter mapped it to OpenAI ``"required"`` but the Anthropic route
+bypasses chat.py so the prompt-suffix + post-parse synth/422 enforcement
+levers never fired. Tests in this module verify both the non-stream and
+stream branches now mirror chat.py's behaviour.
+
+F5: streaming ``message_start.usage.input_tokens`` was hard-coded to 0
+because the prompt-token count wasn't computed until inside the engine
+loop (i.e. AFTER message_start was already on the wire). The fix
+pre-computes the count via the same ``build_prompt`` +
+``count_prompt_tokens`` source of truth the non-stream adapter and the
+context-length DoS gate use.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.routes.anthropic import (
+    _enforce_required_tool_choice_present,
+    _estimate_anthropic_prompt_tokens,
+    _inject_tool_use_required_suffix,
+    _is_required_tool_choice,
+    _synthesize_anthropic_forced_tool_call,
+    router,
+)
+from vllm_mlx.service.helpers import _TOOL_USE_REQUIRED_SUFFIX
+
+# ──────────────────────────────────────────────────────────────────
+# Engine doubles
+# ──────────────────────────────────────────────────────────────────
+
+
+class _Tokenizer:
+    chat_template = "{% if add_generation_prompt %}<think>{% endif %}"
+
+    def encode(self, text, add_special_tokens=True):
+        # 1 token per word — deterministic and tokenizer-independent
+        return [0] * (len(text.split()) + (1 if add_special_tokens else 0))
+
+
+class _BaseEngine:
+    preserve_native_tool_format = False
+    is_mllm = False
+    tokenizer = _Tokenizer()
+
+    def build_prompt(self, messages, tools=None):
+        # Concatenate role+content into a single string the tokenizer
+        # can count. Tools are not rendered into the prompt body in this
+        # double, only their NAMES contribute to the count — same shape
+        # the production tokenizer would see after chat-template render.
+        parts = []
+        for m in messages:
+            role = m.get("role") if isinstance(m, dict) else getattr(m, "role", "")
+            content = (
+                m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+            )
+            if isinstance(content, list):
+                content = " ".join(
+                    c.get("text", "") if isinstance(c, dict) else "" for c in content
+                )
+            parts.append(f"{role}: {content}")
+        if tools:
+            for t in tools:
+                fn = t.function if hasattr(t, "function") else t.get("function", {})
+                name = fn.get("name") if isinstance(fn, dict) else fn
+                if name:
+                    parts.append(f"tool: {name}")
+        return "\n".join(parts)
+
+
+class _ToolStreamingEngine(_BaseEngine):
+    """Streaming engine that lets us assert the route saw the
+    pre-message_start ``prompt_tokens`` estimate AND that the
+    enforcement levers (suffix injection, synth, error event) fire on
+    the right ``tool_choice`` shapes."""
+
+    def __init__(
+        self,
+        deltas: list[str],
+        *,
+        engine_prompt_tokens: int | None = None,
+        engine_cached_tokens: int = 0,
+        tool_calls_per_chunk: list[list] | None = None,
+    ):
+        self._deltas = deltas
+        self._engine_prompt_tokens = engine_prompt_tokens
+        self._engine_cached_tokens = engine_cached_tokens
+        self._tool_calls_per_chunk = tool_calls_per_chunk or [[] for _ in deltas]
+        self.stream_calls: list[dict] = []
+        self.chat_calls: list[dict] = []
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        for i, text in enumerate(self._deltas):
+            payload = {
+                "new_text": text,
+                "completion_tokens": i + 1,
+                "cached_tokens": self._engine_cached_tokens,
+                "tool_calls": self._tool_calls_per_chunk[i],
+            }
+            if self._engine_prompt_tokens is not None:
+                payload["prompt_tokens"] = self._engine_prompt_tokens
+            yield SimpleNamespace(**payload)
+
+    async def chat(self, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        text = "".join(self._deltas)
+        return SimpleNamespace(
+            text=text,
+            raw_text=text,
+            reasoning_text="",
+            completion_tokens=len(self._deltas),
+            prompt_tokens=self._engine_prompt_tokens or 0,
+            cached_tokens=self._engine_cached_tokens,
+            tool_calls=self._tool_calls_per_chunk[-1] if self._deltas else [],
+            finish_reason="stop",
+            matched_stop=None,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────
+# Client factory + SSE helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def _make_client(engine: _BaseEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = True
+    cfg.reasoning_parser_name = None
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _parse_sse(response_text: str) -> list[dict]:
+    events = []
+    for raw_event in response_text.split("\n\n"):
+        data_line = next(
+            (line for line in raw_event.splitlines() if line.startswith("data: ")),
+            None,
+        )
+        if not data_line:
+            continue
+        data = data_line.removeprefix("data: ")
+        if data == "[DONE]":
+            continue
+        events.append(json.loads(data))
+    return events
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+# ──────────────────────────────────────────────────────────────────
+# F3 — unit-level helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_required_tool_choice_predicate_matches_only_required_string():
+    assert _is_required_tool_choice("required") is True
+    assert _is_required_tool_choice("auto") is False
+    assert _is_required_tool_choice("none") is False
+    assert _is_required_tool_choice(None) is False
+    assert (
+        _is_required_tool_choice({"type": "function", "function": {"name": "x"}})
+        is False
+    )
+
+
+def test_inject_suffix_for_required_appends_to_existing_system():
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "hi"},
+    ]
+    _inject_tool_use_required_suffix(messages, "required", tools=tools)
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"].startswith("You are helpful.")
+    assert _TOOL_USE_REQUIRED_SUFFIX in messages[0]["content"]
+
+
+def test_inject_suffix_for_required_prepends_system_when_absent():
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [{"role": "user", "content": "hi"}]
+    _inject_tool_use_required_suffix(messages, "required", tools=tools)
+    assert messages[0]["role"] == "system"
+    assert _TOOL_USE_REQUIRED_SUFFIX.strip() in messages[0]["content"]
+
+
+def test_inject_suffix_named_tool_uses_named_variant():
+    tools = [SimpleNamespace(function={"name": "get_weather"})]
+    messages = [{"role": "user", "content": "hi"}]
+    _inject_tool_use_required_suffix(
+        messages,
+        {"type": "function", "function": {"name": "get_weather"}},
+        tools=tools,
+    )
+    assert messages[0]["role"] == "system"
+    assert "get_weather" in messages[0]["content"]
+
+
+def test_inject_suffix_noop_when_no_tools():
+    """Suffix is meaningless without tools to call — skip injection."""
+    messages = [{"role": "user", "content": "hi"}]
+    before = list(messages)
+    _inject_tool_use_required_suffix(messages, "required", tools=None)
+    assert messages == before
+    _inject_tool_use_required_suffix(messages, "required", tools=[])
+    assert messages == before
+
+
+def test_inject_suffix_noop_when_tool_choice_is_auto():
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [{"role": "user", "content": "hi"}]
+    before = list(messages)
+    _inject_tool_use_required_suffix(messages, "auto", tools=tools)
+    assert messages == before
+    _inject_tool_use_required_suffix(messages, "none", tools=tools)
+    assert messages == before
+    _inject_tool_use_required_suffix(messages, None, tools=tools)
+    assert messages == before
+
+
+def test_enforce_required_synthesises_call_for_single_tool():
+    """Single-tool unambiguous synthesis path: empty tool_calls →
+    synthesised call with empty arguments + no error detail."""
+    tools = [SimpleNamespace(function={"name": "get_weather"})]
+    calls, err = _enforce_required_tool_choice_present([], "required", tools=tools)
+    assert err is None
+    assert len(calls) == 1
+    assert calls[0].function.name == "get_weather"
+    assert calls[0].function.arguments == "{}"
+
+
+def test_enforce_required_returns_error_for_multi_tool():
+    tools = [
+        SimpleNamespace(function={"name": "a"}),
+        SimpleNamespace(function={"name": "b"}),
+    ]
+    calls, err = _enforce_required_tool_choice_present([], "required", tools=tools)
+    assert calls == []
+    assert err is not None
+    assert "tool_choice" in err
+    assert "no tool_calls" in err
+
+
+def test_enforce_required_passes_through_existing_calls():
+    tools = [SimpleNamespace(function={"name": "x"})]
+    existing = [_synthesize_anthropic_forced_tool_call("x")]
+    calls, err = _enforce_required_tool_choice_present(
+        existing, "required", tools=tools
+    )
+    assert calls is existing
+    assert err is None
+
+
+def test_enforce_required_passes_through_when_choice_is_not_required():
+    """auto / none / named-pin: enforcement is a no-op so the named-pin
+    helper (which runs first) is responsible for its own contract."""
+    tools = [SimpleNamespace(function={"name": "x"})]
+    for tc in (
+        "auto",
+        "none",
+        None,
+        {"type": "function", "function": {"name": "x"}},
+    ):
+        calls, err = _enforce_required_tool_choice_present([], tc, tools=tools)
+        assert calls == []
+        assert err is None
+
+
+# ──────────────────────────────────────────────────────────────────
+# F3 — route-level (non-stream)
+# ──────────────────────────────────────────────────────────────────
+
+
+def _tool_dict(name: str, prop: str = "x"):
+    return {
+        "name": name,
+        "description": f"Call {name}",
+        "input_schema": {
+            "type": "object",
+            "properties": {prop: {"type": "string"}},
+            "required": [prop],
+        },
+    }
+
+
+def test_nonstream_tool_choice_any_synthesises_single_tool():
+    """Non-stream + tool_choice=any + 1 tool + parser saw no calls →
+    synthesise a tool_use for the sole tool. stop_reason=tool_use."""
+    engine = _ToolStreamingEngine(
+        ["I cannot help with that."],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather")],
+            "tool_choice": {"type": "any"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["stop_reason"] == "tool_use"
+    tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
+
+
+def test_nonstream_tool_choice_any_multi_tool_no_call_returns_422():
+    """Non-stream + tool_choice=any + 2 tools + parser saw no calls →
+    422 (ambiguous which tool to synthesise)."""
+    engine = _ToolStreamingEngine(
+        ["I cannot help."],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather"), _tool_dict("lookup_zip", "zip")],
+            "tool_choice": {"type": "any"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 422, r.text
+    body = r.json()
+    # The test app mounts the router directly so the FastAPI default
+    # ``{"detail": ...}`` envelope is what we see — production wraps
+    # this into Anthropic's ``{"error": {"message": ...}}`` shape via
+    # the server-level handler, which is unit-tested elsewhere.
+    detail = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "tool_choice" in detail
+    assert "no tool_calls" in detail or "any" in detail
+
+
+def test_nonstream_tool_choice_any_injects_required_suffix():
+    """The forced-call prompt suffix MUST reach the engine — same
+    lever chat.py applies. This is the prompt-level half of the F3 fix."""
+    engine = _ToolStreamingEngine(
+        ["text"],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather")],
+            "tool_choice": {"type": "any"},
+            "messages": [{"role": "user", "content": "anything"}],
+        },
+    )
+    assert engine.chat_calls, "engine.chat was never invoked"
+    seen = engine.chat_calls[0]["messages"]
+    # System message is prepended (no prior system block); the suffix
+    # text must appear somewhere in the rendered system content.
+    assert any(
+        (m.get("role") if isinstance(m, dict) else getattr(m, "role", None))
+        == "system"
+        and "MUST call" in (m.get("content") if isinstance(m, dict) else m.content)
+        for m in seen
+    ), seen
+
+
+def test_nonstream_tool_choice_named_still_routes_to_specific_tool():
+    """H-05 regression guard: ``tool_choice={"type":"tool","name":X}``
+    must still pin THAT tool, not synthesise a different one. The new
+    required-branch must not steal the named-pin enforcement."""
+    engine = _ToolStreamingEngine(
+        ["text"],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather"), _tool_dict("lookup_zip", "zip")],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+            "messages": [{"role": "user", "content": "anything"}],
+        },
+    )
+    # Named pin with parser-only model that returned text → 422
+    # ("model returned a text response with no tool_calls"). Either
+    # 422 or a 200 with a synth call to ``get_weather`` is contract-
+    # compliant; what we explicitly do NOT want is a tool_use for
+    # ``lookup_zip`` or a 200 ``end_turn`` text response.
+    assert r.status_code in (200, 422), r.text
+    if r.status_code == 200:
+        body = r.json()
+        tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+        for tu in tool_uses:
+            assert tu["name"] == "get_weather", body
+    else:
+        body = r.json()
+        detail = body.get("detail") or body.get("error", {}).get("message", "")
+        assert "get_weather" in detail
+
+
+def test_nonstream_tool_choice_auto_does_not_force_tool_call():
+    """Regression guard: ``tool_choice={"type":"auto"}`` must NOT force
+    a tool call. The model is allowed to return plain text and the
+    response carries ``stop_reason=end_turn``."""
+    engine = _ToolStreamingEngine(
+        ["just text"],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather")],
+            "tool_choice": {"type": "auto"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["stop_reason"] == "end_turn"
+    tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+    assert tool_uses == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# F3 — route-level (stream)
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_stream_tool_choice_any_single_tool_synthesises_tool_use():
+    """Stream variant of the synthesise path: model emits text, route
+    post-parses + synthesises the tool_use for the sole tool, and the
+    terminal ``message_delta`` carries ``stop_reason=tool_use``."""
+    engine = _ToolStreamingEngine(
+        ["I ", "cannot ", "help."],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "tools": [_tool_dict("get_weather")],
+            "tool_choice": {"type": "any"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    deltas = [e for e in events if e.get("type") == "message_delta"]
+    assert deltas, events
+    assert deltas[-1]["delta"]["stop_reason"] == "tool_use"
+    tool_blocks = [
+        e
+        for e in events
+        if e.get("type") == "content_block_start"
+        and e.get("content_block", {}).get("type") == "tool_use"
+    ]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0]["content_block"]["name"] == "get_weather"
+
+
+def test_stream_tool_choice_any_multi_tool_emits_error_event():
+    """Stream variant of the multi-tool 422: SSE error event with
+    ``invalid_request_error`` and terminal ``message_delta`` close-out."""
+    engine = _ToolStreamingEngine(
+        ["I ", "cannot ", "help."],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "tools": [_tool_dict("get_weather"), _tool_dict("lookup_zip", "zip")],
+            "tool_choice": {"type": "any"},
+            "messages": [{"role": "user", "content": "Tell me a joke."}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    error_events = [e for e in events if e.get("type") == "error"]
+    assert error_events, events
+    assert error_events[0]["error"]["type"] == "invalid_request_error"
+    assert "tool_choice" in error_events[0]["error"]["message"]
+    # The forbidden text bytes must NOT have been streamed to the wire
+    # — buffer-drop semantics same as the named-pin failure branch.
+    text_deltas = [
+        e["delta"]["text"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e.get("delta", {}).get("type") == "text_delta"
+    ]
+    assert "".join(text_deltas) == ""
+
+
+# ──────────────────────────────────────────────────────────────────
+# F5 — streaming usage.input_tokens
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_estimate_prompt_tokens_uses_build_prompt():
+    """Source of truth for F5: the helper goes through
+    ``engine.build_prompt`` + tokenizer.encode and returns a > 0 count."""
+    engine = _BaseEngine()
+    messages = [{"role": "user", "content": "hello there world"}]
+    n = _estimate_anthropic_prompt_tokens(engine, messages, tools=None)
+    # The fake tokenizer returns 1 token per word + 1 BOS. Render is
+    # "user: hello there world" → 5 tokens (4 words + BOS).
+    assert n == 5, n
+
+
+def test_estimate_prompt_tokens_zero_when_no_build_prompt():
+    """MLLM engines (and minimal test stubs) have no ``build_prompt`` —
+    the helper returns 0 and the route falls back to the engine-reported
+    ``output.prompt_tokens`` as before. No 500."""
+
+    class _NoBuildPromptEngine:
+        is_mllm = False
+        tokenizer = _Tokenizer()
+
+    n = _estimate_anthropic_prompt_tokens(
+        _NoBuildPromptEngine(), [{"role": "user", "content": "x"}], tools=None
+    )
+    assert n == 0
+
+
+def test_estimate_prompt_tokens_zero_when_mllm():
+    """MLLM engines: tokens are computed by the multimodal processor;
+    skip text-only render to avoid a misleading estimate."""
+
+    class _MLLMEngine(_BaseEngine):
+        is_mllm = True
+
+    n = _estimate_anthropic_prompt_tokens(
+        _MLLMEngine(), [{"role": "user", "content": "x"}], tools=None
+    )
+    assert n == 0
+
+
+def test_stream_message_start_carries_nonzero_input_tokens():
+    """F5 primary repro: ``message_start.usage.input_tokens`` must
+    reflect the pre-computed prompt-token count, NOT the hard-coded 0
+    that under-reported the input share by 100%."""
+    engine = _ToolStreamingEngine(
+        ["Direct ", "answer"],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly please"}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    starts = [e for e in events if e.get("type") == "message_start"]
+    assert starts, events
+    usage = starts[0]["message"]["usage"]
+    assert usage["input_tokens"] > 0, usage
+    # Must match what the pre-compute helper would have returned for
+    # the same messages — i.e. byte-for-byte tied to the source of
+    # truth (``build_prompt`` + tokenizer.encode).
+    expected = _estimate_anthropic_prompt_tokens(
+        engine,
+        [{"role": "user", "content": "answer directly please"}],
+        tools=None,
+    )
+    assert usage["input_tokens"] == expected
+
+
+def test_stream_message_delta_accumulates_output_tokens():
+    """``message_delta`` must report ``output_tokens > 0`` so cost
+    accounting clients can rely on the SSE stream alone."""
+    engine = _ToolStreamingEngine(
+        ["one ", "two ", "three"],
+        engine_prompt_tokens=5,
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "go"}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    deltas = [e for e in events if e.get("type") == "message_delta"]
+    assert deltas, events
+    usage = deltas[-1]["usage"]
+    assert usage["output_tokens"] == 3  # 3 chunks → 3 cumulative tokens
+    # Final ``input_tokens`` is the (prompt - cached) non-cached share;
+    # with the engine reporting cached=0 it equals the engine count.
+    assert usage["input_tokens"] == 5
+
+
+def test_stream_message_delta_input_tokens_floored_to_estimate_when_engine_silent():
+    """When the engine never surfaces ``prompt_tokens`` on its chunks,
+    the route uses the pre-computed estimate as a FLOOR so the
+    terminal ``message_delta`` is no worse than ``message_start``."""
+    engine = _ToolStreamingEngine(
+        ["one ", "two"],
+        engine_prompt_tokens=None,  # engine never sets prompt_tokens
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "go now"}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    starts = [e for e in events if e.get("type") == "message_start"]
+    deltas = [e for e in events if e.get("type") == "message_delta"]
+    start_input = starts[0]["message"]["usage"]["input_tokens"]
+    delta_input = deltas[-1]["usage"]["input_tokens"]
+    assert start_input > 0
+    assert delta_input == start_input, (start_input, delta_input)
+
+
+def test_stream_message_start_consistent_with_nonstream_input_tokens():
+    """The streaming + non-streaming surfaces must agree on the prompt
+    token count for the same prompt — this is the spec-level identity
+    Sergei's evidence was checking. Engine reports a fixed prompt_tokens
+    so the two surfaces should land on the same total non-cached share."""
+    deltas = ["Direct ", "answer"]
+    engine_stream = _ToolStreamingEngine(deltas, engine_prompt_tokens=11)
+    client_s = _make_client(engine_stream)
+    r_s = client_s.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [{"role": "user", "content": "answer directly please"}],
+        },
+    )
+    events = _parse_sse(r_s.text)
+    delta_input = next(
+        e for e in events if e.get("type") == "message_delta"
+    )["usage"]["input_tokens"]
+
+    engine_ns = _ToolStreamingEngine(deltas, engine_prompt_tokens=11)
+    client_ns = _make_client(engine_ns)
+    r_ns = client_ns.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "answer directly please"}],
+        },
+    )
+    ns_body = r_ns.json()
+    assert delta_input == ns_body["usage"]["input_tokens"]

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -205,6 +205,59 @@ def test_inject_suffix_for_required_prepends_system_when_absent():
     assert _TOOL_USE_REQUIRED_SUFFIX.strip() in messages[0]["content"]
 
 
+def test_inject_suffix_list_system_content_appends_text_block():
+    """Codex r3 NIT (PR #807): when the system block uses Anthropic's
+    list-of-content-blocks shape, the suffix MUST be appended as a new
+    text block — NEVER stringified via ``str(...)`` (that path would
+    serialise Python repr into the rendered prompt)."""
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "You are helpful."}],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+    _inject_tool_use_required_suffix(messages, "required", tools=tools)
+    sys = messages[0]
+    assert isinstance(sys["content"], list)
+    assert sys["content"][0] == {"type": "text", "text": "You are helpful."}
+    # Suffix landed as a new text block, not as a stringified list.
+    assert sys["content"][-1]["type"] == "text"
+    assert _TOOL_USE_REQUIRED_SUFFIX in sys["content"][-1]["text"]
+
+
+def test_inject_suffix_none_system_content_writes_suffix():
+    """Edge case: system block has ``content=None``. The suffix must
+    still reach the model — write it as the new content rather than
+    crashing or stringifying ``None``."""
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [
+        {"role": "system", "content": None},
+        {"role": "user", "content": "hi"},
+    ]
+    _inject_tool_use_required_suffix(messages, "required", tools=tools)
+    assert _TOOL_USE_REQUIRED_SUFFIX in messages[0]["content"]
+
+
+def test_inject_suffix_unknown_system_shape_falls_back_to_prepend():
+    """When EVERY system block carries an un-appendable content shape
+    (neither str nor list nor None — e.g. dict), the helper prepends
+    a new system message so the forced-tool lever still ships rather
+    than silently dropping it."""
+    tools = [SimpleNamespace(function={"name": "x"})]
+    messages = [
+        {"role": "system", "content": {"unexpected": "shape"}},
+        {"role": "user", "content": "hi"},
+    ]
+    _inject_tool_use_required_suffix(messages, "required", tools=tools)
+    # New system block prepended with the suffix; original block kept.
+    assert messages[0]["role"] == "system"
+    assert isinstance(messages[0]["content"], str)
+    assert _TOOL_USE_REQUIRED_SUFFIX.strip() in messages[0]["content"]
+    assert messages[1] == {"role": "system", "content": {"unexpected": "shape"}}
+
+
 def test_inject_suffix_named_tool_uses_named_variant():
     tools = [SimpleNamespace(function={"name": "get_weather"})]
     messages = [{"role": "user", "content": "hi"}]

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -460,27 +460,58 @@ def test_nonstream_tool_choice_named_still_routes_to_specific_tool():
             "messages": [{"role": "user", "content": "anything"}],
         },
     )
-    # Named pin with parser-only model that returned text → 422
-    # ("model returned a text response with no tool_calls"). Either
-    # 422 or a 200 with a synth call to ``get_weather`` is contract-
-    # compliant; what we explicitly do NOT want is a tool_use for
-    # ``lookup_zip`` or a 200 ``end_turn`` text response. The 200
-    # branch therefore asserts a non-empty ``tool_uses`` list AND
-    # ``stop_reason == "tool_use"`` so the exact failure mode this
-    # test exists to catch (vacuously-empty ``tool_uses``) is
-    # surfaced as a hard fail rather than a silent skip.
-    assert r.status_code in (200, 422), r.text
-    if r.status_code == 200:
-        body = r.json()
-        assert body["stop_reason"] == "tool_use", body
-        tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
-        assert tool_uses, body
-        for tu in tool_uses:
-            assert tu["name"] == "get_weather", body
-    else:
-        body = r.json()
-        detail = body.get("detail") or body.get("error", {}).get("message", "")
-        assert "get_weather" in detail
+    # Named pin with parser-only model that returned text → 422 via
+    # ``_enforce_named_tool_choice_present``. Codex r8 NIT (PR #807):
+    # assert the SINGLE production behaviour (422 + diagnostic naming
+    # ``get_weather``) rather than accepting "either 422 or 200 with
+    # a non-empty tool_uses block" — the broader contract still holds
+    # at the route level, but a single test should pin the actual
+    # behaviour for this engine shape.
+    assert r.status_code == 422, r.text
+    body = r.json()
+    detail = body.get("detail") or body.get("error", {}).get("message", "")
+    assert "get_weather" in detail
+    assert "tool_choice" in detail
+
+
+def test_nonstream_tool_choice_named_synth_when_model_emits_the_pinned_tool():
+    """H-05 / PR #763 round-1 BLOCKING #1 — when the parser DOES
+    surface a call to the named tool, the route ships it as a
+    ``tool_use`` block and the response stops with ``stop_reason="tool_use"``.
+    This complements ``test_nonstream_tool_choice_named_still_routes_to_specific_tool``
+    by pinning the success path (no synth, no error, just the model-
+    surfaced call) so a refactor that breaks either branch is caught."""
+    # ``_parse_tool_calls_with_parser`` expects engine tool_calls in
+    # the flat ``{"id", "name", "arguments"}`` structured-payload
+    # shape (HarmonyStreamingRouter / qwen3-coder), NOT the nested
+    # OpenAI ToolCall shape.
+    pinned_call = {
+        "id": "call_test",
+        "name": "get_weather",
+        "arguments": '{"location": "Tokyo"}',
+    }
+    engine = _ToolStreamingEngine(
+        ["text"],
+        engine_prompt_tokens=5,
+        tool_calls_per_chunk=[[pinned_call]],
+    )
+    client = _make_client(engine)
+    r = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "tools": [_tool_dict("get_weather"), _tool_dict("lookup_zip", "zip")],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+            "messages": [{"role": "user", "content": "what is the weather in tokyo"}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["stop_reason"] == "tool_use", body
+    tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["name"] == "get_weather"
 
 
 def test_nonstream_tool_choice_auto_does_not_force_tool_call():

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -738,9 +738,13 @@ def test_stream_message_start_consistent_with_nonstream_input_tokens():
         },
     )
     events = _parse_sse(r_s.text)
-    delta_input = next(e for e in events if e.get("type") == "message_delta")["usage"][
-        "input_tokens"
-    ]
+    # Codex r4 BLOCKING #2 (PR #807): Anthropic streams may emit
+    # intermediate ``message_delta`` events; the contract is that the
+    # FINAL one carries the closeout usage. Read the last delta — same
+    # pattern the other streaming-usage tests in this module use.
+    delta_events = [e for e in events if e.get("type") == "message_delta"]
+    assert delta_events, events
+    delta_input = delta_events[-1]["usage"]["input_tokens"]
 
     engine_ns = _ToolStreamingEngine(deltas, engine_prompt_tokens=11)
     client_ns = _make_client(engine_ns)

--- a/tests/test_anthropic_tool_usage_d.py
+++ b/tests/test_anthropic_tool_usage_d.py
@@ -382,8 +382,7 @@ def test_nonstream_tool_choice_any_injects_required_suffix():
     # System message is prepended (no prior system block); the suffix
     # text must appear somewhere in the rendered system content.
     assert any(
-        (m.get("role") if isinstance(m, dict) else getattr(m, "role", None))
-        == "system"
+        (m.get("role") if isinstance(m, dict) else getattr(m, "role", None)) == "system"
         and "MUST call" in (m.get("content") if isinstance(m, dict) else m.content)
         for m in seen
     ), seen
@@ -413,10 +412,18 @@ def test_nonstream_tool_choice_named_still_routes_to_specific_tool():
     # 422 or a 200 with a synth call to ``get_weather`` is contract-
     # compliant; what we explicitly do NOT want is a tool_use for
     # ``lookup_zip`` or a 200 ``end_turn`` text response.
+    #
+    # Codex review BLOCKING (PR #807): assert ``tool_uses`` non-empty
+    # AND ``stop_reason == "tool_use"`` in the 200 branch so the
+    # forbidden ``end_turn`` text response would FAIL this test. The
+    # earlier ``for tu in tool_uses:`` loop was vacuously true on an
+    # empty list and let the exact bug case slip through.
     assert r.status_code in (200, 422), r.text
     if r.status_code == 200:
         body = r.json()
+        assert body["stop_reason"] == "tool_use", body
         tool_uses = [c for c in body["content"] if c["type"] == "tool_use"]
+        assert tool_uses, body
         for tu in tool_uses:
             assert tu["name"] == "get_weather", body
     else:
@@ -680,9 +687,9 @@ def test_stream_message_start_consistent_with_nonstream_input_tokens():
         },
     )
     events = _parse_sse(r_s.text)
-    delta_input = next(
-        e for e in events if e.get("type") == "message_delta"
-    )["usage"]["input_tokens"]
+    delta_input = next(e for e in events if e.get("type") == "message_delta")["usage"][
+        "input_tokens"
+    ]
 
     engine_ns = _ToolStreamingEngine(deltas, engine_prompt_tokens=11)
     client_ns = _make_client(engine_ns)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -627,23 +627,21 @@ async def create_anthropic_message(
         #       reported the prompt by the suffix's byte cost.
         # Inject ONCE here on the rendered engine-shape messages, then
         # run the gate + capture the count on the post-injection state.
-        # Both branches reuse the same ``messages`` list afterwards so
-        # there is no second injection downstream.
-        try:
-            messages, images, videos = extract_multimodal_content(
-                openai_request.messages,
-                preserve_native_format=engine.preserve_native_tool_format,
-            )
-        except Exception:
-            messages = None
-            images = []
-            videos = []
-        if messages is not None:
-            _inject_tool_use_required_suffix(
-                messages,
-                openai_request.tool_choice,
-                tools=openai_request.tools,
-            )
+        # Both branches reuse the same ``messages`` / ``images`` /
+        # ``videos`` afterwards so there is no second injection or
+        # second extract downstream — codex r5 BLOCKING #1 (multimodal
+        # threading) + #2 (let extract errors propagate so a malformed
+        # request body 400s here instead of crossing the streaming
+        # SSE boundary mid-response).
+        messages, images, videos = extract_multimodal_content(
+            openai_request.messages,
+            preserve_native_format=engine.preserve_native_tool_format,
+        )
+        _inject_tool_use_required_suffix(
+            messages,
+            openai_request.tool_choice,
+            tools=openai_request.tools,
+        )
 
         # Context-length pre-check — same DoS gate the chat/completions/
         # responses routes enforce. Render the prompt through the engine's
@@ -662,17 +660,15 @@ async def create_anthropic_message(
         # back to its own estimator helper. We forward the value
         # verbatim (including ``None``) so the streaming path can
         # distinguish "skip" from "real zero count".
-        _ctx_prompt_tokens: int | None = None
-        if messages is not None:
-            _ctx_prompt_tokens = enforce_context_length_for_messages(
-                engine,
-                messages,
-                tools=openai_request.tools,
-                max_tokens=_resolve_max_tokens(
-                    openai_request.max_tokens,
-                    _resolve_enable_thinking(openai_request),
-                ),
-            )
+        _ctx_prompt_tokens = enforce_context_length_for_messages(
+            engine,
+            messages,
+            tools=openai_request.tools,
+            max_tokens=_resolve_max_tokens(
+                openai_request.max_tokens,
+                _resolve_enable_thinking(openai_request),
+            ),
+        )
 
         if anthropic_request.stream:
             _admission_committed = True
@@ -690,6 +686,8 @@ async def create_anthropic_message(
                         request_id_holder=_anth_rid_holder,
                         prompt_tokens_estimate=_ctx_prompt_tokens,
                         prepared_messages=messages,
+                        prepared_images=images,
+                        prepared_videos=videos,
                     ),
                     request,
                     engine=engine,
@@ -706,17 +704,9 @@ async def create_anthropic_message(
         # Non-streaming: run inference through existing engine. The
         # ``extract_multimodal_content`` + ``_inject_tool_use_required_suffix``
         # pair already ran above so ``messages`` already carries the
-        # forced-tool suffix when applicable; the original double-call
-        # was the source of codex r3 BLOCKING #1.
-        if messages is None:
-            # ``extract_multimodal_content`` raised earlier — re-raise
-            # via the same code path the engine would normally trigger
-            # so the route's exception handler maps to a 400. Defensive
-            # — every supported request shape returns a list above.
-            messages, images, videos = extract_multimodal_content(
-                openai_request.messages,
-                preserve_native_format=engine.preserve_native_tool_format,
-            )
+        # forced-tool suffix and ``images`` / ``videos`` carry the
+        # multimodal payload; no second extract/inject is needed
+        # (codex r3 BLOCKING #1 / codex r5 BLOCKING #1).
 
         chat_kwargs = {
             "max_tokens": _resolve_max_tokens(
@@ -1192,6 +1182,8 @@ async def _stream_anthropic_messages(
     request_id_holder: list | None = None,
     prompt_tokens_estimate: int | None = None,
     prepared_messages: list | None = None,
+    prepared_images: list | None = None,
+    prepared_videos: list | None = None,
 ) -> AsyncIterator[str]:
     """Stream Anthropic Messages API SSE events.
 
@@ -1220,6 +1212,14 @@ async def _stream_anthropic_messages(
             ``None`` (the default) preserves the direct-call test
             path: extract from ``openai_request.messages`` and inject
             inline, matching pre-PR-807 streaming behaviour.
+        prepared_images / prepared_videos: D-ANTHRO-TOOL-USAGE F3
+            (codex r5 BLOCKING #1) — multimodal payload from the same
+            route-level extract, threaded alongside
+            ``prepared_messages`` so /v1/messages streaming requests
+            against MLLM engines keep their image / video inputs.
+            Pre-r5 the streaming helper discarded these to ``[]``
+            when ``prepared_messages`` was supplied, silently
+            dropping every multimodal stream's media inputs.
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
@@ -1230,8 +1230,8 @@ async def _stream_anthropic_messages(
         # ``enforce_context_length_for_messages`` DoS gate against
         # this exact list. Reuse verbatim — no second injection.
         messages = prepared_messages
-        images: list = []
-        videos: list = []
+        images = prepared_images if prepared_images is not None else []
+        videos = prepared_videos if prepared_videos is not None else []
     else:
         messages, images, videos = extract_multimodal_content(
             openai_request.messages,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -656,10 +656,13 @@ async def create_anthropic_message(
         # gate-computed prompt-token count so the streaming branch's
         # ``message_start.usage.input_tokens`` can reuse it instead of
         # re-rendering + re-tokenising the same messages. The helper
-        # returns ``0`` on permissive-skip paths (MLLM engines, no
-        # build_prompt, empty prompt) so a falsy value means the
-        # streaming branch must fall back to its own estimator helper.
-        _ctx_prompt_tokens = 0
+        # returns ``None`` on permissive-skip paths (MLLM engines, no
+        # build_prompt, empty prompt) — codex r4 NIT — which means
+        # "no estimate available"; the streaming branch then falls
+        # back to its own estimator helper. We forward the value
+        # verbatim (including ``None``) so the streaming path can
+        # distinguish "skip" from "real zero count".
+        _ctx_prompt_tokens: int | None = None
         if messages is not None:
             _ctx_prompt_tokens = enforce_context_length_for_messages(
                 engine,
@@ -686,6 +689,7 @@ async def create_anthropic_message(
                         anthropic_request,
                         request_id_holder=_anth_rid_holder,
                         prompt_tokens_estimate=_ctx_prompt_tokens,
+                        prepared_messages=messages,
                     ),
                     request,
                     engine=engine,
@@ -1186,7 +1190,8 @@ async def _stream_anthropic_messages(
     anthropic_request: AnthropicRequest,
     *,
     request_id_holder: list | None = None,
-    prompt_tokens_estimate: int = 0,
+    prompt_tokens_estimate: int | None = None,
+    prepared_messages: list | None = None,
 ) -> AsyncIterator[str]:
     """Stream Anthropic Messages API SSE events.
 
@@ -1199,33 +1204,49 @@ async def _stream_anthropic_messages(
             (default) is a no-op.
         prompt_tokens_estimate: D-ANTHRO-TOOL-USAGE F5 — pre-computed
             prompt-token count from the route entry-point's
-            ``enforce_context_length_for_messages`` call. Defaults to
-            ``0`` so callers (and tests) that don't pass it fall back
+            ``enforce_context_length_for_messages`` call. ``None``
+            (sentinel — codex r4 NIT) means "the caller did not
+            compute one"; ``0`` is now a real value meaning "engine
+            permissive-skip path returned no count". Both fall back
             to the route-internal ``_estimate_anthropic_prompt_tokens``
             helper, which goes through the SAME
-            ``build_prompt`` + ``count_prompt_tokens`` path. Non-zero
-            values save a duplicate render+tokenize round-trip on the
-            hot path (codex r2 NIT on PR #807).
+            ``build_prompt`` + ``count_prompt_tokens`` path.
+        prepared_messages: D-ANTHRO-TOOL-USAGE F3 (codex r4 BLOCKING
+            #1) — pre-extracted + suffix-injected messages from the
+            route entry-point. When supplied, the streaming helper
+            skips its own extract+inject so suffix injection happens
+            in EXACTLY ONE layer and ``prompt_tokens_estimate`` is
+            guaranteed to match what the engine actually sees.
+            ``None`` (the default) preserves the direct-call test
+            path: extract from ``openai_request.messages`` and inject
+            inline, matching pre-PR-807 streaming behaviour.
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
 
-    messages, images, videos = extract_multimodal_content(
-        openai_request.messages,
-        preserve_native_format=engine.preserve_native_tool_format,
-    )
+    if prepared_messages is not None:
+        # Caller (the route entry-point) already extracted +
+        # suffix-injected, AND already paid for the
+        # ``enforce_context_length_for_messages`` DoS gate against
+        # this exact list. Reuse verbatim — no second injection.
+        messages = prepared_messages
+        images: list = []
+        videos: list = []
+    else:
+        messages, images, videos = extract_multimodal_content(
+            openai_request.messages,
+            preserve_native_format=engine.preserve_native_tool_format,
+        )
 
-    # D-ANTHRO-TOOL-USAGE F3: forced ``tool_choice`` levers — same
-    # injection the non-stream branch performs. The streaming path was
-    # previously a silent no-op for ``tool_choice={"type":"any"}``
-    # (and the named-tool form's prompt level), letting the model emit
-    # a text reply that violated the forced-call contract before the
-    # post-stream enforcement could fire.
-    _inject_tool_use_required_suffix(
-        messages,
-        openai_request.tool_choice,
-        tools=openai_request.tools,
-    )
+        # D-ANTHRO-TOOL-USAGE F3: forced ``tool_choice`` levers — same
+        # injection the non-stream branch performs. Only runs on the
+        # direct-call path (no ``prepared_messages``); the route-level
+        # caller has already done this above and threaded the result.
+        _inject_tool_use_required_suffix(
+            messages,
+            openai_request.tool_choice,
+            tools=openai_request.tools,
+        )
 
     chat_kwargs = {
         "max_tokens": _resolve_max_tokens(
@@ -1394,20 +1415,24 @@ async def _stream_anthropic_messages(
     # D-ANTHRO-TOOL-USAGE F5: pre-compute prompt_tokens BEFORE
     # ``message_start`` so the SSE envelope carries the real input
     # estimate instead of the hard-coded ``0`` that under-reported the
-    # input share by 100%. Reuses the SAME
-    # ``build_prompt`` + ``count_prompt_tokens`` SOURCE OF TRUTH the
-    # context-length DoS gate already ran at route entry — codex r2 NIT
-    # (PR #807). On engines without ``build_prompt`` (MLLM / mock test
-    # stubs) the gate returned 0 and the fallback estimator below also
-    # returns 0; the streaming path then degrades to the pre-fix
-    # ``input_tokens=0`` shape rather than 500-ing.
-    initial_prompt_tokens_estimate = prompt_tokens_estimate or (
-        _estimate_anthropic_prompt_tokens(
+    # input share by 100%. Prefers the route-level estimate when the
+    # caller threaded one (already shared with the context-length DoS
+    # gate — codex r2 NIT) and falls back to a local render when the
+    # caller used the direct-call test path.
+    #
+    # Codex r4 NIT (PR #807): treat ``None`` as the SENTINEL for "no
+    # estimate available", separate from ``0`` ("estimator ran but
+    # the engine returned no count" — MLLM, empty prompt, …). The
+    # earlier ``or`` chain conflated the two and would re-render every
+    # genuinely-empty prompt.
+    if prompt_tokens_estimate is None:
+        initial_prompt_tokens_estimate = _estimate_anthropic_prompt_tokens(
             engine,
             messages,
             tools=openai_request.tools,
         )
-    )
+    else:
+        initial_prompt_tokens_estimate = prompt_tokens_estimate
 
     # Emit message_start
     message_start = {

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -36,6 +36,7 @@ from ..config import get_config
 from ..engine import BaseEngine
 from ..middleware.auth import check_rate_limit_or_x_api_key, verify_api_key_or_x_api_key
 from ..service.helpers import (
+    _TOOL_USE_REQUIRED_SUFFIX,
     SSE_RESPONSE_HEADERS,
     _apply_reasoning_cutoff_notice,
     _build_usage,
@@ -51,10 +52,12 @@ from ..service.helpers import (
     _resolve_reasoning_enabled,
     _resolve_temperature,
     _resolve_top_p,
+    _tool_use_required_named_suffix,
     _validate_model_name,
     _validate_tool_call_params,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
+    count_prompt_tokens,
     enforce_context_length_for_messages,
     get_engine,
 )
@@ -262,6 +265,213 @@ def _enforce_named_tool_choice_present(
     raise HTTPException(status_code=422, detail=detail)
 
 
+def _is_required_tool_choice(tool_choice) -> bool:
+    """Return True when ``tool_choice`` forces the model to call ANY tool.
+
+    The Anthropic adapter maps ``{"type":"any"}`` → OpenAI ``"required"``
+    in ``api/anthropic_adapter._convert_tool_choice``. By the time we get
+    here ``tool_choice`` is the post-adapter OpenAI shape, so the
+    ``"required"`` string IS the Anthropic ``any`` contract.
+
+    D-ANTHRO-TOOL-USAGE F3: the route was previously a no-op on this
+    branch — ``_named_tool_choice_target`` returned ``None`` for
+    ``"required"`` and the post-parse enforcement only fired for the
+    named-function form. A request with ``tool_choice={"type":"any"}``
+    therefore sailed through with the model's text reply and
+    ``stop_reason="end_turn"`` — a direct spec violation. Mirror the
+    OpenAI-side enforcement (``routes/chat.py`` lines 973-978 +
+    1878-1902) on this surface.
+    """
+    return tool_choice == "required"
+
+
+def _synthesize_anthropic_forced_tool_call(name: str):
+    """Build a single ``ToolCall`` for a forced ``tool_choice`` whose
+    parser surfaced no calls — Anthropic-route mirror of chat.py's
+    ``_synthesize_forced_tool_call``.
+
+    Inlined here (instead of importing the chat.py helper) to keep the
+    two routes' import surfaces independent — the Anthropic route
+    deliberately avoids depending on ``routes/chat`` so a future split
+    can move them into separate modules. The behaviour is identical:
+    OpenAI ``tool_choice`` is parser-agnostic and forced calls MUST
+    surface a ``tool_use`` block, so when the text parser found nothing
+    we synthesise an empty-argument call to the unambiguous target.
+    """
+    from ..api.models import FunctionCall, ToolCall
+
+    return ToolCall(
+        id=f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=FunctionCall(name=name, arguments="{}"),
+    )
+
+
+def _inject_tool_use_required_suffix(
+    messages: list,
+    tool_choice,
+    *,
+    tools: list | None,
+) -> list:
+    """Mutate-in-place: append ``_TOOL_USE_REQUIRED_SUFFIX`` (or the
+    named variant) to the system message so a forced ``tool_choice``
+    has the same prompt-level lever the OpenAI route applies.
+
+    Returns the (possibly prepended) ``messages`` list. When no system
+    message exists, a new one is prepended carrying just the suffix.
+    Mirrors ``routes/chat.py`` lines 990-1009 byte-for-byte so the two
+    surfaces inject the same lever for the same tool_choice value.
+
+    No-op when ``tool_choice`` does not force a call, OR when ``tools``
+    is empty — there is nothing for the model to call, so the suffix
+    would produce only a confusing "you must call a tool" stanza with
+    no tools defined.
+    """
+    if not tools:
+        return messages
+    suffix = None
+    if _is_required_tool_choice(tool_choice):
+        suffix = _TOOL_USE_REQUIRED_SUFFIX
+    elif isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        named = (tool_choice.get("function") or {}).get("name")
+        if named:
+            suffix = _tool_use_required_named_suffix(named)
+    if not suffix:
+        return messages
+
+    has_system = any(
+        (m.get("role") if isinstance(m, dict) else getattr(m, "role", None)) == "system"
+        for m in messages
+    )
+    if has_system:
+        for i, m in enumerate(messages):
+            role = m.get("role") if isinstance(m, dict) else getattr(m, "role", None)
+            if role == "system":
+                content = (
+                    m.get("content")
+                    if isinstance(m, dict)
+                    else getattr(m, "content", "")
+                )
+                # Normalise non-string content to a string before appending
+                # — Anthropic system blocks may arrive as list[dict] (text
+                # blocks) which the adapter has already joined into a
+                # string by this point, but be defensive.
+                if not isinstance(content, str):
+                    content = str(content) if content is not None else ""
+                if isinstance(m, dict):
+                    messages[i] = {**m, "content": content + suffix}
+                else:
+                    m.content = content + suffix
+                break
+    else:
+        messages.insert(0, {"role": "system", "content": suffix.strip()})
+    return messages
+
+
+def _enforce_required_tool_choice_present(
+    tool_calls,
+    tool_choice,
+    *,
+    tools: list | None,
+):
+    """OpenAI ``tool_choice="required"`` / Anthropic ``{"type":"any"}``
+    post-parse enforcement.
+
+    Mirrors ``routes/chat.py`` lines 1878-1902. When a forced-any
+    ``tool_choice`` produced no tool_calls:
+
+      * single-tool case → synthesise a call to that tool so the
+        ``tool_use`` block contract holds (the choice is unambiguous).
+      * multi-tool case → return ``("error", detail)`` so the caller
+        can 422 on the non-stream branch or surface an SSE error on
+        the stream branch.
+
+    Returns ``(tool_calls, error_detail_or_None)``. The caller is
+    responsible for raising / emitting the SSE error event.
+    """
+    if not _is_required_tool_choice(tool_choice):
+        return tool_calls, None
+    if tool_calls:
+        return tool_calls, None
+    if tools and len(tools) == 1:
+        # Defensive: tools entries may be Pydantic ``Tool`` models or
+        # plain dicts depending on whether the request flowed through
+        # the adapter as a model instance. Prefer the model attribute
+        # path so we honour any future Tool-shape changes without
+        # touching this branch.
+        tool = tools[0]
+        fn = (
+            tool.function
+            if hasattr(tool, "function")
+            else (tool.get("function") if isinstance(tool, dict) else None)
+        )
+        if fn is None:
+            fn = {}
+        solo_name = (
+            fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)
+        )
+        if solo_name:
+            logger.warning(
+                "tool_choice={'type':'any'} on Anthropic route produced no "
+                "tool_calls; synthesising a call to the sole available tool "
+                "%r with empty arguments to honour the forced-tool contract "
+                "(D-ANTHRO-TOOL-USAGE F3).",
+                solo_name,
+            )
+            return [_synthesize_anthropic_forced_tool_call(solo_name)], None
+    detail = (
+        'tool_choice={"type":"any"} but the model returned a text response '
+        "with no tool_calls. Local inference has no decoder-level "
+        "constraint; the system-prompt enforcement was insufficient for "
+        'this prompt. Retry with a more concrete user message or use '
+        'tool_choice={"type":"tool","name":...} to pin a specific tool.'
+    )
+    return tool_calls, detail
+
+
+def _estimate_anthropic_prompt_tokens(engine, messages, tools) -> int:
+    """Return the prompt-token count under the engine's chat template, or 0.
+
+    D-ANTHRO-TOOL-USAGE F5: the Anthropic streaming surface previously
+    hard-coded ``message_start.usage.input_tokens=0`` because the engine
+    hadn't run yet — but billing dashboards parsing the SSE stream
+    therefore under-reported the input share by 100%. Anthropic's
+    public stream emits ``input_tokens`` in ``message_start`` (the
+    server-side estimate, finalised in ``message_delta``).
+
+    Uses the SAME ``count_prompt_tokens`` helper the DoS gate
+    (``enforce_context_length_for_messages``) already calls so the
+    estimate is byte-for-byte consistent with what the context-length
+    pre-check used. The render goes through ``engine.build_prompt`` so
+    chat-template / tools rendering matches what the engine itself
+    will tokenise during generation.
+
+    Returns ``0`` when:
+
+      * the engine has no ``build_prompt`` (MLLM / mock test stub) —
+        the streaming usage path falls back to the engine-reported
+        ``output.prompt_tokens`` like before, and the public-API
+        contract just degrades to the pre-fix ``input_tokens=0`` shape
+        rather than fabricating a tokenizer-free count.
+      * the template render or tokenizer call raises — same fallback
+        rationale; surfacing a tokenizer error here would obscure the
+        actual generation error from the client.
+    """
+    build_prompt = getattr(engine, "build_prompt", None)
+    if build_prompt is None or getattr(engine, "is_mllm", False):
+        return 0
+    try:
+        prompt = build_prompt(messages, tools=tools)
+    except Exception:
+        return 0
+    if not prompt:
+        return 0
+    try:
+        return count_prompt_tokens(engine, prompt)
+    except Exception:
+        return 0
+
+
 @router.post(
     "/v1/messages",
     dependencies=[
@@ -442,6 +652,19 @@ async def create_anthropic_message(
             preserve_native_format=engine.preserve_native_tool_format,
         )
 
+        # D-ANTHRO-TOOL-USAGE F3: forced ``tool_choice`` levers.
+        # The Anthropic route bypasses chat.py, so chat.py's prompt-suffix
+        # injection (``_TOOL_USE_REQUIRED_SUFFIX`` / named variant) was
+        # silently skipped for /v1/messages. The OpenAI surface enforces
+        # ``tool_choice="any"`` (Anthropic ``any``) primarily via prompt
+        # injection + post-parse synth/422; mirror BOTH levers here so the
+        # two routes ship the same forced-call contract.
+        _inject_tool_use_required_suffix(
+            messages,
+            openai_request.tool_choice,
+            tools=openai_request.tools,
+        )
+
         chat_kwargs = {
             "max_tokens": _resolve_max_tokens(
                 openai_request.max_tokens,
@@ -540,6 +763,18 @@ async def create_anthropic_message(
                 openai_request.tool_choice,
                 original_call_count=original_call_count,
             )
+            # D-ANTHRO-TOOL-USAGE F3: Anthropic ``{"type":"any"}`` enforcement.
+            # The adapter has mapped it to OpenAI ``"required"``; mirror the
+            # chat-route synth+422 policy so a no-tool reply either becomes
+            # a synthesised single-tool call (unambiguous case) or surfaces
+            # a 422 the client can act on.
+            tool_calls, _required_err = _enforce_required_tool_choice_present(
+                tool_calls,
+                openai_request.tool_choice,
+                tools=openai_request.tools,
+            )
+            if _required_err:
+                raise HTTPException(status_code=422, detail=_required_err)
 
         # F-220: enforce the same tool_call JSON-schema validation
         # ``routes/chat.py:1651`` runs on the OpenAI ``/v1/chat/completions``
@@ -921,6 +1156,18 @@ async def _stream_anthropic_messages(
         preserve_native_format=engine.preserve_native_tool_format,
     )
 
+    # D-ANTHRO-TOOL-USAGE F3: forced ``tool_choice`` levers — same
+    # injection the non-stream branch performs. The streaming path was
+    # previously a silent no-op for ``tool_choice={"type":"any"}``
+    # (and the named-tool form's prompt level), letting the model emit
+    # a text reply that violated the forced-call contract before the
+    # post-stream enforcement could fire.
+    _inject_tool_use_required_suffix(
+        messages,
+        openai_request.tool_choice,
+        tools=openai_request.tools,
+    )
+
     chat_kwargs = {
         "max_tokens": _resolve_max_tokens(
             openai_request.max_tokens,
@@ -1085,6 +1332,21 @@ async def _stream_anthropic_messages(
                 effective = block_type
         return out
 
+    # D-ANTHRO-TOOL-USAGE F5: pre-compute prompt_tokens BEFORE
+    # ``message_start`` so the SSE envelope carries the real input
+    # estimate instead of the hard-coded ``0`` that under-reported the
+    # input share by 100%. Goes through the same
+    # ``build_prompt`` + ``count_prompt_tokens`` SOURCE OF TRUTH the
+    # non-stream usage builder and the context-length DoS gate already
+    # use; on engines without ``build_prompt`` (MLLM / mock test stubs)
+    # the helper returns 0 and the rest of the streaming path falls back
+    # to the engine-reported ``output.prompt_tokens`` it always used.
+    initial_prompt_tokens_estimate = _estimate_anthropic_prompt_tokens(
+        engine,
+        messages,
+        tools=openai_request.tools,
+    )
+
     # Emit message_start
     message_start = {
         "type": "message_start",
@@ -1097,7 +1359,7 @@ async def _stream_anthropic_messages(
             "stop_reason": None,
             "stop_sequence": None,
             "usage": {
-                "input_tokens": 0,
+                "input_tokens": initial_prompt_tokens_estimate,
                 "output_tokens": 0,
             },
         },
@@ -1128,7 +1390,16 @@ async def _stream_anthropic_messages(
     _pinned_tool_target = _named_tool_choice_target(
         getattr(openai_request, "tool_choice", None)
     )
-    _buffer_for_pinned_tool = _pinned_tool_target is not None
+    # D-ANTHRO-TOOL-USAGE F3: extend the pre-filter buffer to the
+    # ``tool_choice={"type":"any"}`` case (Anthropic ``any`` →
+    # OpenAI ``"required"``). Same rationale as the named-pin branch:
+    # a defiant model can stream a text reply that violates the
+    # forced-call contract, and post-loop synthesis / SSE error must
+    # arrive without the forbidden text bytes ever reaching the wire.
+    _buffer_for_pinned_tool = _pinned_tool_target is not None or (
+        _is_required_tool_choice(getattr(openai_request, "tool_choice", None))
+        and bool(openai_request.tools)
+    )
     pre_filter_buffer: list[str] = []
 
     def _capture(event: str) -> str | None:
@@ -1174,7 +1445,13 @@ async def _stream_anthropic_messages(
         _chat_template, chat_kwargs.get("enable_thinking")
     )
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
-    prompt_tokens = 0
+    # D-ANTHRO-TOOL-USAGE F5: seed the running counter with the
+    # pre-message_start estimate so the terminal ``message_delta`` is
+    # NEVER worse than what we already announced in ``message_start``.
+    # The engine's own ``output.prompt_tokens`` (when it surfaces a
+    # non-zero value below) wins over the seed because the engine count
+    # is authoritative — the seed is a floor, not a ceiling.
+    prompt_tokens = initial_prompt_tokens_estimate
     completion_tokens = 0
     cached_tokens = 0
     # H-03: track the most-recently-surfaced ``matched_stop`` so the
@@ -1792,6 +2069,27 @@ async def _stream_anthropic_messages(
             tool_choice_error = (
                 exc.detail if isinstance(exc.detail, str) else str(exc.detail)
             )
+
+        # D-ANTHRO-TOOL-USAGE F3: stream variant of
+        # ``_enforce_required_tool_choice_present`` for
+        # ``tool_choice={"type":"any"}`` (Anthropic ``any`` →
+        # OpenAI ``"required"``). Headers are already on the wire so
+        # the 422 the non-stream branch raises becomes a buffer-replay-
+        # AND-error path: when synthesis is unambiguous (single tool),
+        # we add the synth call so a downstream client sees a
+        # ``tool_use`` block; otherwise we surface the same
+        # ``invalid_request_error`` event the named-pin branch uses.
+        # Mirrors the OpenAI route's stream behaviour: best-effort
+        # prompt-injection upstream + post-parse synth where the
+        # target is unambiguous + SSE error event when it isn't.
+        if not tool_choice_error:
+            tool_calls, _required_err_stream = _enforce_required_tool_choice_present(
+                tool_calls,
+                openai_request.tool_choice,
+                tools=openai_request.tools,
+            )
+            if _required_err_stream:
+                tool_choice_error = _required_err_stream
 
     # F-220: enforce JSON-schema validation on the model's emitted
     # tool_call arguments. On the streaming branch, headers are already

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1468,6 +1468,15 @@ async def _stream_anthropic_messages(
     # the engine returned no count" — MLLM, empty prompt, …). The
     # earlier ``or`` chain conflated the two and would re-render every
     # genuinely-empty prompt.
+    #
+    # Codex r8 BLOCKING #1+#2 (PR #807): defense-in-depth — coerce
+    # the result to int before it flows into the SSE envelope or the
+    # running-counter seed. The fallback estimator returns ``int``
+    # already (``0`` on all skip paths), but a future refactor that
+    # surfaces ``None`` from either source MUST NOT poison the
+    # Anthropic ``usage.input_tokens`` int field — JSON-serialising
+    # ``None`` would emit ``"input_tokens": null`` which violates the
+    # public schema.
     if prompt_tokens_estimate is None:
         initial_prompt_tokens_estimate = _estimate_anthropic_prompt_tokens(
             engine,
@@ -1476,6 +1485,10 @@ async def _stream_anthropic_messages(
         )
     else:
         initial_prompt_tokens_estimate = prompt_tokens_estimate
+    # Coerce ``None`` or any other non-int to ``0`` before it reaches
+    # the wire.
+    if not isinstance(initial_prompt_tokens_estimate, int):
+        initial_prompt_tokens_estimate = 0
 
     # Emit message_start
     message_start = {

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -601,6 +601,15 @@ async def create_anthropic_message(
         # if over the model cap. Runs BEFORE the stream/non-stream branch
         # so streaming clients can't bypass the gate by setting
         # ``stream: true``. See service/helpers.py for rationale.
+        #
+        # D-ANTHRO-TOOL-USAGE F5 (codex r2 NIT): capture the
+        # gate-computed prompt-token count so the streaming branch's
+        # ``message_start.usage.input_tokens`` can reuse it instead of
+        # re-rendering + re-tokenising the same messages. The helper
+        # returns ``0`` on permissive-skip paths (MLLM engines, no
+        # build_prompt, empty prompt) so a falsy value means the
+        # streaming branch must fall back to its own estimator helper.
+        _ctx_prompt_tokens = 0
         try:
             _ctx_messages, _, _ = extract_multimodal_content(
                 openai_request.messages,
@@ -609,7 +618,7 @@ async def create_anthropic_message(
         except Exception:
             _ctx_messages = None
         if _ctx_messages is not None:
-            enforce_context_length_for_messages(
+            _ctx_prompt_tokens = enforce_context_length_for_messages(
                 engine,
                 _ctx_messages,
                 tools=openai_request.tools,
@@ -633,6 +642,7 @@ async def create_anthropic_message(
                         openai_request,
                         anthropic_request,
                         request_id_holder=_anth_rid_holder,
+                        prompt_tokens_estimate=_ctx_prompt_tokens,
                     ),
                     request,
                     engine=engine,
@@ -1137,6 +1147,7 @@ async def _stream_anthropic_messages(
     anthropic_request: AnthropicRequest,
     *,
     request_id_holder: list | None = None,
+    prompt_tokens_estimate: int = 0,
 ) -> AsyncIterator[str]:
     """Stream Anthropic Messages API SSE events.
 
@@ -1147,6 +1158,15 @@ async def _stream_anthropic_messages(
             ``_disconnect_guard`` reads the same holder and force-calls
             ``scheduler.abort_request`` on client disconnect. ``None``
             (default) is a no-op.
+        prompt_tokens_estimate: D-ANTHRO-TOOL-USAGE F5 — pre-computed
+            prompt-token count from the route entry-point's
+            ``enforce_context_length_for_messages`` call. Defaults to
+            ``0`` so callers (and tests) that don't pass it fall back
+            to the route-internal ``_estimate_anthropic_prompt_tokens``
+            helper, which goes through the SAME
+            ``build_prompt`` + ``count_prompt_tokens`` path. Non-zero
+            values save a duplicate render+tokenize round-trip on the
+            hot path (codex r2 NIT on PR #807).
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
@@ -1335,16 +1355,19 @@ async def _stream_anthropic_messages(
     # D-ANTHRO-TOOL-USAGE F5: pre-compute prompt_tokens BEFORE
     # ``message_start`` so the SSE envelope carries the real input
     # estimate instead of the hard-coded ``0`` that under-reported the
-    # input share by 100%. Goes through the same
+    # input share by 100%. Reuses the SAME
     # ``build_prompt`` + ``count_prompt_tokens`` SOURCE OF TRUTH the
-    # non-stream usage builder and the context-length DoS gate already
-    # use; on engines without ``build_prompt`` (MLLM / mock test stubs)
-    # the helper returns 0 and the rest of the streaming path falls back
-    # to the engine-reported ``output.prompt_tokens`` it always used.
-    initial_prompt_tokens_estimate = _estimate_anthropic_prompt_tokens(
-        engine,
-        messages,
-        tools=openai_request.tools,
+    # context-length DoS gate already ran at route entry — codex r2 NIT
+    # (PR #807). On engines without ``build_prompt`` (MLLM / mock test
+    # stubs) the gate returned 0 and the fallback estimator below also
+    # returns 0; the streaming path then degrades to the pre-fix
+    # ``input_tokens=0`` shape rather than 500-ing.
+    initial_prompt_tokens_estimate = prompt_tokens_estimate or (
+        _estimate_anthropic_prompt_tokens(
+            engine,
+            messages,
+            tools=openai_request.tools,
+        )
     )
 
     # Emit message_start

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -423,7 +423,7 @@ def _enforce_required_tool_choice_present(
         'tool_choice={"type":"any"} but the model returned a text response '
         "with no tool_calls. Local inference has no decoder-level "
         "constraint; the system-prompt enforcement was insufficient for "
-        'this prompt. Retry with a more concrete user message or use '
+        "this prompt. Retry with a more concrete user message or use "
         'tool_choice={"type":"tool","name":...} to pin a specific tool.'
     )
     return tool_calls, detail

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -737,6 +737,20 @@ async def create_anthropic_message(
 
         if openai_request.tools:
             chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        # Codex r5/r7 BLOCKING (PR #807): forward the extracted
+        # multimodal payload to the engine — mirrors ``routes/chat.py``
+        # lines 1049-1050. Pre-PR the Anthropic route silently dropped
+        # ``images`` / ``videos`` on every /v1/messages request, so
+        # MLLM models served via Claude SDK never saw the user's
+        # uploaded image even though the wire-format carried it. The
+        # ``or None`` keeps the chat-route pattern: empty list → None
+        # so the engine treats "no media" identically to a text-only
+        # request rather than running its multimodal preprocessor on
+        # an empty list.
+        if images:
+            chat_kwargs["images"] = images
+        if videos:
+            chat_kwargs["videos"] = videos
         cfg = get_config()
         # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
         # passthrough). Same precedence as the OpenAI route.
@@ -1281,6 +1295,16 @@ async def _stream_anthropic_messages(
 
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+    # Codex r5/r7 BLOCKING (PR #807): forward the multimodal payload
+    # to the engine on the streaming path too — same parity with
+    # ``routes/chat.py`` lines 1049-1050 the non-stream branch now
+    # follows. The ``if`` gates avoid passing empty lists so the
+    # engine's multimodal preprocessor stays on the text-only fast
+    # path for plain prompts.
+    if images:
+        chat_kwargs["images"] = images
+    if videos:
+        chat_kwargs["videos"] = videos
     cfg = get_config()
     # Resolve enable_thinking via shared helper (#387: chat_template_kwargs
     # passthrough). Same precedence as the OpenAI route.

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -352,17 +352,38 @@ def _inject_tool_use_required_suffix(
                     if isinstance(m, dict)
                     else getattr(m, "content", "")
                 )
-                # Normalise non-string content to a string before appending
-                # — Anthropic system blocks may arrive as list[dict] (text
-                # blocks) which the adapter has already joined into a
-                # string by this point, but be defensive.
-                if not isinstance(content, str):
-                    content = str(content) if content is not None else ""
-                if isinstance(m, dict):
-                    messages[i] = {**m, "content": content + suffix}
+                # Codex r3 NIT (PR #807): when system content is a
+                # list-of-blocks (multimodal / Anthropic text-block
+                # array), preserve the block shape by APPENDING a new
+                # text block carrying the suffix — never stringify the
+                # list via ``str(...)`` (which would emit Python repr
+                # like ``"[{'type': 'text', ...}]<suffix>"`` into the
+                # rendered chat-template prompt). String content is
+                # the common path and stays a fast concat.
+                if isinstance(content, str):
+                    new_content = content + suffix
+                elif isinstance(content, list):
+                    new_content = list(content)
+                    new_content.append({"type": "text", "text": suffix})
+                elif content is None:
+                    new_content = suffix
                 else:
-                    m.content = content + suffix
+                    # Unknown shape — leave the block untouched and
+                    # fall through to the "prepend a system" path so
+                    # the suffix still reaches the model. Better an
+                    # extra system block than a silently-dropped
+                    # forced-tool lever.
+                    continue
+                if isinstance(m, dict):
+                    messages[i] = {**m, "content": new_content}
+                else:
+                    m.content = new_content
                 break
+        else:
+            # No appendable system block found (every system block had
+            # a non-string / non-list content shape) — fall through to
+            # the prepend path so the suffix still ships.
+            messages.insert(0, {"role": "system", "content": suffix.strip()})
     else:
         messages.insert(0, {"role": "system", "content": suffix.strip()})
     return messages
@@ -595,6 +616,35 @@ async def create_anthropic_message(
         except AnthropicOutputConfigError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
+        # D-ANTHRO-TOOL-USAGE F3 (codex r3 BLOCKING #1+#2): suffix
+        # injection MUST happen BEFORE the context-length DoS gate and
+        # BEFORE the prompt-token count is captured. Pre-r3 the suffix
+        # was injected per-branch AFTER the gate, so:
+        #   (a) a forced-tool request could bypass the context-length
+        #       cap by piggy-backing the suffix onto an already-at-cap
+        #       prompt (DoS gate measured pre-injection tokens), and
+        #   (b) ``message_start.usage.input_tokens`` (streaming) under-
+        #       reported the prompt by the suffix's byte cost.
+        # Inject ONCE here on the rendered engine-shape messages, then
+        # run the gate + capture the count on the post-injection state.
+        # Both branches reuse the same ``messages`` list afterwards so
+        # there is no second injection downstream.
+        try:
+            messages, images, videos = extract_multimodal_content(
+                openai_request.messages,
+                preserve_native_format=engine.preserve_native_tool_format,
+            )
+        except Exception:
+            messages = None
+            images = []
+            videos = []
+        if messages is not None:
+            _inject_tool_use_required_suffix(
+                messages,
+                openai_request.tool_choice,
+                tools=openai_request.tools,
+            )
+
         # Context-length pre-check — same DoS gate the chat/completions/
         # responses routes enforce. Render the prompt through the engine's
         # chat template, count tokens, raise 400 ``context_length_exceeded``
@@ -610,17 +660,10 @@ async def create_anthropic_message(
         # build_prompt, empty prompt) so a falsy value means the
         # streaming branch must fall back to its own estimator helper.
         _ctx_prompt_tokens = 0
-        try:
-            _ctx_messages, _, _ = extract_multimodal_content(
-                openai_request.messages,
-                preserve_native_format=engine.preserve_native_tool_format,
-            )
-        except Exception:
-            _ctx_messages = None
-        if _ctx_messages is not None:
+        if messages is not None:
             _ctx_prompt_tokens = enforce_context_length_for_messages(
                 engine,
-                _ctx_messages,
+                messages,
                 tools=openai_request.tools,
                 max_tokens=_resolve_max_tokens(
                     openai_request.max_tokens,
@@ -656,24 +699,20 @@ async def create_anthropic_message(
                 headers={**SSE_RESPONSE_HEADERS, "Connection": "keep-alive"},
             )
 
-        # Non-streaming: run inference through existing engine
-        messages, images, videos = extract_multimodal_content(
-            openai_request.messages,
-            preserve_native_format=engine.preserve_native_tool_format,
-        )
-
-        # D-ANTHRO-TOOL-USAGE F3: forced ``tool_choice`` levers.
-        # The Anthropic route bypasses chat.py, so chat.py's prompt-suffix
-        # injection (``_TOOL_USE_REQUIRED_SUFFIX`` / named variant) was
-        # silently skipped for /v1/messages. The OpenAI surface enforces
-        # ``tool_choice="any"`` (Anthropic ``any``) primarily via prompt
-        # injection + post-parse synth/422; mirror BOTH levers here so the
-        # two routes ship the same forced-call contract.
-        _inject_tool_use_required_suffix(
-            messages,
-            openai_request.tool_choice,
-            tools=openai_request.tools,
-        )
+        # Non-streaming: run inference through existing engine. The
+        # ``extract_multimodal_content`` + ``_inject_tool_use_required_suffix``
+        # pair already ran above so ``messages`` already carries the
+        # forced-tool suffix when applicable; the original double-call
+        # was the source of codex r3 BLOCKING #1.
+        if messages is None:
+            # ``extract_multimodal_content`` raised earlier — re-raise
+            # via the same code path the engine would normally trigger
+            # so the route's exception handler maps to a 400. Defensive
+            # — every supported request shape returns a list above.
+            messages, images, videos = extract_multimodal_content(
+                openai_request.messages,
+                preserve_native_format=engine.preserve_native_tool_format,
+            )
 
         chat_kwargs = {
             "max_tokens": _resolve_max_tokens(

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -484,12 +484,31 @@ def _estimate_anthropic_prompt_tokens(engine, messages, tools) -> int:
     try:
         prompt = build_prompt(messages, tools=tools)
     except Exception:
+        # Codex r6 NIT (PR #807): log at debug so a genuinely broken
+        # chat template / malformed tools schema is visible in the
+        # server log even though we return ``0`` to let the engine's
+        # own validation surface a clean 400 downstream. Without the
+        # log, a debug session can't distinguish "no estimate
+        # available" from "the route silently swallowed a real
+        # build_prompt error".
+        logger.debug(
+            "_estimate_anthropic_prompt_tokens: build_prompt raised; "
+            "returning 0 so the streaming usage path falls back to the "
+            "engine-reported prompt_tokens",
+            exc_info=True,
+        )
         return 0
     if not prompt:
         return 0
     try:
         return count_prompt_tokens(engine, prompt)
     except Exception:
+        logger.debug(
+            "_estimate_anthropic_prompt_tokens: count_prompt_tokens raised; "
+            "returning 0 so the streaming usage path falls back to the "
+            "engine-reported prompt_tokens",
+            exc_info=True,
+        )
         return 0
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3136,9 +3136,9 @@ def enforce_context_length_for_messages(
     *,
     tools: list | None = None,
     max_tokens: int | None = None,
-) -> int:
+) -> int | None:
     """Run the context-length gate for a chat-style request and return
-    the rendered prompt's token count (``0`` on permissive-skip paths).
+    the rendered prompt's token count (``None`` on permissive-skip paths).
 
     Renders the prompt through the engine's chat template (same path
     used by ``BatchedEngine.build_prompt``), counts the tokens, then
@@ -3150,10 +3150,13 @@ def enforce_context_length_for_messages(
     Returns the integer prompt-token count so callers that already pay
     the build_prompt + tokenize cost can reuse it (e.g. Anthropic
     streaming usage's ``message_start.input_tokens`` plumbing). Returns
-    ``0`` when the render or tokenization was skipped (MLLM engine, no
-    build_prompt, empty prompt, etc.) so callers fall through to their
-    own fallback. Existing call sites that discard the return value
-    keep working unchanged — this is an additive contract change.
+    ``None`` when the render or tokenization was skipped — MLLM engine,
+    no ``build_prompt`` attribute, empty rendered prompt, or
+    tokenizer-returned-zero — so callers can distinguish "no estimate
+    available" from "real zero count" without re-parsing a sentinel
+    overload (codex r4 NIT on PR #807). Existing call sites that
+    discard the return value keep working unchanged — this is an
+    additive contract change.
 
     Scoped to text-only engines: MLLM models accept image / video /
     audio inputs whose token cost is computed by the multimodal
@@ -3165,10 +3168,10 @@ def enforce_context_length_for_messages(
     applies regardless of which compatibility surface the client uses.
     """
     if getattr(engine, "is_mllm", False):
-        return 0
+        return None
     build_prompt = getattr(engine, "build_prompt", None)
     if build_prompt is None:
-        return 0
+        return None
     try:
         prompt = build_prompt(messages, tools=tools)
     except HTTPException:
@@ -3193,12 +3196,12 @@ def enforce_context_length_for_messages(
                 status_code=400,
                 detail=f"Chat template error: {err_msg}",
             )
-        return 0
+        return None
     if not prompt:
-        return 0
+        return None
     prompt_tokens = count_prompt_tokens(engine, prompt)
     if prompt_tokens <= 0:
-        return 0
+        return None
     enforce_context_length(engine, prompt_tokens, max_tokens=max_tokens)
     return prompt_tokens
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3136,8 +3136,9 @@ def enforce_context_length_for_messages(
     *,
     tools: list | None = None,
     max_tokens: int | None = None,
-) -> None:
-    """Run the context-length gate for a chat-style request.
+) -> int:
+    """Run the context-length gate for a chat-style request and return
+    the rendered prompt's token count (``0`` on permissive-skip paths).
 
     Renders the prompt through the engine's chat template (same path
     used by ``BatchedEngine.build_prompt``), counts the tokens, then
@@ -3145,6 +3146,14 @@ def enforce_context_length_for_messages(
     tokenization step in a permissive try-except so a metadata edge
     case (e.g. unloaded engine on a route stub) doesn't 500 — the
     downstream scheduler still has its own validation.
+
+    Returns the integer prompt-token count so callers that already pay
+    the build_prompt + tokenize cost can reuse it (e.g. Anthropic
+    streaming usage's ``message_start.input_tokens`` plumbing). Returns
+    ``0`` when the render or tokenization was skipped (MLLM engine, no
+    build_prompt, empty prompt, etc.) so callers fall through to their
+    own fallback. Existing call sites that discard the return value
+    keep working unchanged — this is an additive contract change.
 
     Scoped to text-only engines: MLLM models accept image / video /
     audio inputs whose token cost is computed by the multimodal
@@ -3156,10 +3165,10 @@ def enforce_context_length_for_messages(
     applies regardless of which compatibility surface the client uses.
     """
     if getattr(engine, "is_mllm", False):
-        return
+        return 0
     build_prompt = getattr(engine, "build_prompt", None)
     if build_prompt is None:
-        return
+        return 0
     try:
         prompt = build_prompt(messages, tools=tools)
     except HTTPException:
@@ -3184,13 +3193,14 @@ def enforce_context_length_for_messages(
                 status_code=400,
                 detail=f"Chat template error: {err_msg}",
             )
-        return
+        return 0
     if not prompt:
-        return
+        return 0
     prompt_tokens = count_prompt_tokens(engine, prompt)
     if prompt_tokens <= 0:
-        return
+        return 0
     enforce_context_length(engine, prompt_tokens, max_tokens=max_tokens)
+    return prompt_tokens
 
 
 def enforce_context_length_for_prompt(


### PR DESCRIPTION
## Summary

Closes Sergei dogfood findings **F3** and **F5** for `/v1/messages` (0.8.3).

- **F3** — `tool_choice={"type":"any"}` was a silent no-op on `/v1/messages`. The adapter mapped it to OpenAI `"required"` but the Anthropic route bypasses `chat.py`, so the prompt-suffix + post-parse synth/422 enforcement levers chat.py applies for `tool_choice="required"` never fired. Mirrored both levers here so `/v1/messages` matches `/v1/chat/completions` on the forced-call contract. Named-pin (H-05) and `auto`/`none` paths unchanged.
- **F5** — Streaming `message_start.usage.input_tokens` was hard-coded to `0` because the engine hadn't run yet. Pre-compute prompt-tokens via the same `build_prompt` + `count_prompt_tokens` source of truth the non-stream adapter and the context-length DoS gate use. Seed the streaming-usage running counter with the estimate so `message_delta` is no worse than `message_start`; engine-reported counts still win when surfaced.

## Spec mapping

| Bug | Spec violation | Fix |
| --- | --- | --- |
| F3 | `tool_choice=any` MUST produce `stop_reason="tool_use"` and at least one `tool_use` block | inject `_TOOL_USE_REQUIRED_SUFFIX` before engine; post-parse synth on single-tool case; SSE/422 `invalid_request_error` on multi-tool no-call case |
| F5 | `message_start.usage.input_tokens` MUST reflect the prompt tokens | pre-compute via `engine.build_prompt` + `count_prompt_tokens`, emit on `message_start`, seed running counter |

## Test plan
- [x] `tests/test_anthropic_tool_usage_d.py` — 24 new cases (helpers + non-stream + stream + parity)
- [x] `tool_choice={"type":"any"}` + single tool + neutral prompt → `stop_reason="tool_use"`, synthesised `tool_use` block
- [x] `tool_choice={"type":"any"}` + multi tool + no call → 422 (non-stream) / SSE `invalid_request_error` (stream)
- [x] H-05 regression guard: `tool_choice={"type":"tool","name":X}` still routes to the named tool
- [x] `tool_choice={"type":"auto"}` does NOT force a tool call
- [x] Streaming `message_start.usage.input_tokens > 0` (matches the pre-compute helper output)
- [x] Streaming `message_delta.usage.output_tokens` accumulates correctly
- [x] Streaming `message_delta.usage.input_tokens` floored to estimate when engine never surfaces `prompt_tokens`
- [x] Stream / non-stream `input_tokens` parity for the same prompt
- [x] Live `qwen3-0.6b-8bit` server confirms both repros are resolved
- [x] `tests/test_anthropic_*` (223 tests) — no regression
- [x] `tests/test_chat_route_tool_choice_enforcement.py` + `tests/test_chat_route_forced_tool_prefix*.py` + `tests/test_openai_tool_choice_validation.py` + `tests/test_responses_route.py` (113 tests) — no regression
- [x] Full unit run: 7406 pass, 61 pre-existing failures unchanged (baseline ~72 on `b25e3af`)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)