### PR TITLE
fix(routes/models): emit context_window in /v1/models response (rapid-desktop #363)

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -875,6 +875,232 @@ class TestModelsRoutes:
         finally:
             self._restore(orig)
 
+    # ----- Issue #363: context_window on /v1/models -----
+
+    def _engine_with_context(self, max_pos: int):
+        """Build a minimal engine stub whose ``get_model_max_context``
+        chain resolves to ``max_pos``. Mirrors the lookup priority in
+        ``service.helpers.get_model_max_context``: ``engine._model.args
+        .max_position_embeddings`` is the first probe, so populating it
+        is enough to drive the resolver deterministically without
+        spinning up MLX weights.
+        """
+        engine = MagicMock()
+        args = MagicMock()
+        args.max_position_embeddings = max_pos
+        # Block the text_config nested fallback so the test pins the
+        # primary path; otherwise MagicMock's auto-attr would expose a
+        # truthy mock there and the helper would prefer the nested
+        # branch on the second call.
+        args.text_config = None
+        model = MagicMock()
+        model.args = args
+        model.config = None
+        engine._model = model
+        engine.tokenizer = None
+        return engine
+
+    def test_context_window_present_for_loaded_alias(self):
+        """Issue #363 primary fix: when an engine is loaded for the
+        served alias, ``/v1/models`` MUST emit ``context_window`` so
+        rapid-desktop's PR #318 ``max_tokens`` slider auto-scaler
+        sees the cap the server will actually enforce. Pre-fix the
+        field was absent from the response payload entirely and the
+        desktop fell through to a per-family hard-coded heuristic
+        that drifted out of sync with every long-context release.
+        """
+        engine = self._engine_with_context(32768)
+        orig = self._set_config(
+            model_registry=None,
+            model_name="mlx-community/Qwen3.5-4B-MLX-4bit",
+            model_alias="qwen3.5-4b-4bit",
+            engine=engine,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/qwen3.5-4b-4bit")
+            assert r.status_code == 200
+            body = r.json()
+            assert "context_window" in body, (
+                "Issue #363: context_window must be present on the wire "
+                "even when the resolver returns None — pre-fix the field "
+                "was absent entirely and the desktop consumer had no "
+                "signal to even attempt fallback"
+            )
+            assert body["context_window"] == 32768, (
+                f"context_window should reflect the loaded engine's "
+                f"max_position_embeddings (32768), got {body['context_window']!r}"
+            )
+        finally:
+            self._restore(orig)
+
+    def test_context_window_present_on_list_endpoint(self):
+        """Issue #363 LIST counterpart — the field must surface on the
+        bulk endpoint too (where the desktop catalog actually
+        pre-fetches on startup). A per-id-only fix would force a
+        second N+1 round-trip per alias.
+        """
+        engine = self._engine_with_context(262144)
+        orig = self._set_config(
+            model_registry=None,
+            model_name="mlx-community/Qwen3.6-35B-A3B-Instruct-MLX-4bit",
+            model_alias="qwen3.6-35b-4bit",
+            engine=engine,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models")
+            assert r.status_code == 200
+            entries = r.json()["data"]
+            alias_entry = next(
+                (e for e in entries if e["id"] == "qwen3.6-35b-4bit"), None
+            )
+            assert alias_entry is not None
+            assert alias_entry["context_window"] == 262144
+            # Spot-check the canonical hf-path entry inherits the same
+            # context window — both ids share the loaded engine.
+            hf_entry = next(
+                (
+                    e
+                    for e in entries
+                    if e["id"] == "mlx-community/Qwen3.6-35B-A3B-Instruct-MLX-4bit"
+                ),
+                None,
+            )
+            assert hf_entry is not None
+            assert hf_entry["context_window"] == 262144
+        finally:
+            self._restore(orig)
+
+    def test_context_window_present_for_three_alias_families(self):
+        """Issue #363 cross-family pin: the resolver must work for the
+        three alias families covered by the desktop's PR #318
+        consumer — qwen3 (32K class), qwen3.6 (long-context class),
+        and a gemma alias (128K class). Pins the contract that the
+        field is populated as a positive int across the spectrum, not
+        a one-off that only fires for one family.
+        """
+        cases = (
+            ("qwen3.5-4b-4bit", "mlx-community/Qwen3.5-4B-MLX-4bit", 40960),
+            (
+                "qwen3.6-35b-4bit",
+                "mlx-community/Qwen3.6-35B-A3B-Instruct-MLX-4bit",
+                262144,
+            ),
+            ("gemma-4-12b-4bit", "mlx-community/gemma-4-12B-it-4bit", 131072),
+        )
+        for alias, hf_path, ctx in cases:
+            engine = self._engine_with_context(ctx)
+            orig = self._set_config(
+                model_registry=None,
+                model_name=hf_path,
+                model_alias=alias,
+                engine=engine,
+                api_key=None,
+            )
+            try:
+                client = TestClient(self._make_app())
+                r = client.get(f"/v1/models/{alias}")
+                assert r.status_code == 200
+                body = r.json()
+                assert body["context_window"] == ctx, (
+                    f"{alias}: expected context_window={ctx}, got {body['context_window']!r}"
+                )
+                assert isinstance(body["context_window"], int)
+                assert body["context_window"] > 0
+            finally:
+                self._restore(orig)
+
+    def test_context_window_null_when_no_engine_loaded(self):
+        """When no engine is loaded for an alias (cold listing, or an
+        unregistered operator id), the field MUST appear as JSON
+        ``null`` rather than being omitted. Clients can then fall
+        back to their per-family heuristic without ambiguity about
+        whether the server-side fix landed.
+        """
+        orig = self._set_config(
+            model_registry=None,
+            model_name="qwen3.5-4b-4bit",
+            model_alias=None,
+            engine=None,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/qwen3.5-4b-4bit")
+            assert r.status_code == 200
+            body = r.json()
+            assert "context_window" in body
+            assert body["context_window"] is None
+        finally:
+            self._restore(orig)
+
+    def test_context_window_suppresses_dos_sentinel(self):
+        """``service.helpers.get_model_max_context`` returns its DoS
+        sentinel (~4 Mi) when no usable cap can be probed. That
+        number is intentionally large for the request-time DoS guard
+        — but it's NOT a real context window and the client must not
+        advertise it as one. The resolver suppresses any value at or
+        above the sentinel floor so the desktop falls back to its
+        per-family heuristic instead.
+        """
+        # Inject an engine whose model exposes NO usable attribute —
+        # ``get_model_max_context`` then returns ``_FALLBACK_MAX_CONTEXT_TOKENS``.
+        engine = MagicMock()
+        engine._model = MagicMock(spec=[])
+        engine.tokenizer = None
+        orig = self._set_config(
+            model_registry=None,
+            model_name="qwen3.5-4b-4bit",
+            model_alias=None,
+            engine=engine,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/qwen3.5-4b-4bit")
+            assert r.status_code == 200
+            body = r.json()
+            assert "context_window" in body
+            assert body["context_window"] is None, (
+                "DoS sentinel from get_model_max_context must not leak "
+                "onto the wire as a real context window"
+            )
+        finally:
+            self._restore(orig)
+
+    def test_context_window_probe_failure_does_not_500(self):
+        """A probe that raises mid-resolution (e.g. tokenizer attribute
+        access raises) must NOT 500 the listing endpoint — the field
+        falls through to ``None`` and the request still completes.
+        Pins the defensive ``except`` around the helper call.
+        """
+        engine = MagicMock()
+        # ``getattr(engine, "_model", ...)`` will return this — when
+        # the helper then probes ``.args`` we make it raise.
+        broken_model = MagicMock()
+        type(broken_model).args = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("synthetic"))
+        )
+        engine._model = broken_model
+        orig = self._set_config(
+            model_registry=None,
+            model_name="qwen3.5-4b-4bit",
+            model_alias=None,
+            engine=engine,
+            api_key=None,
+        )
+        try:
+            client = TestClient(self._make_app())
+            r = client.get("/v1/models/qwen3.5-4b-4bit")
+            assert r.status_code == 200
+            body = r.json()
+            assert body.get("context_window") is None
+        finally:
+            self._restore(orig)
+
 
 # ---------------------------------------------------------------------------
 # MCP routes

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1857,6 +1857,19 @@ class ModelInfo(BaseModel):
     # dispatches on this — populating from the server lets us drop
     # the desktop-side hard-coded modality map in a future release.
     modality: str | None = None
+    # Max prompt-token context window the loaded engine advertises
+    # for this id. Populated only when the entry maps to an actively
+    # loaded engine (single-model serve, or the matching ModelEntry
+    # in multi-model mode); otherwise ``None``. rapid-desktop reads
+    # this on first chat to auto-scale the ``max_tokens`` slider's
+    # upper bound — without it, the desktop had to fall back to a
+    # per-family hard-coded heuristic that drifted out of sync with
+    # every new long-context release (Qwen3.6-A3B 1M, DeepSeek-Coder
+    # 160K). Sourced from ``service.helpers.get_model_max_context``
+    # which probes the same chain the engine-side context-length
+    # guard uses, so the value the client sees lines up with the
+    # cap the server will actually enforce. Issue #363.
+    context_window: int | None = None
     # Capability tags advertised on the wire. Currently used to mark
     # the configured embedding model with ``"embedding"`` so clients
     # can discover which entry is wired to ``/v1/embeddings`` without

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -11,6 +11,8 @@ them to auto-apply calibrated defaults so a user opening a chat
 on ``qwen3.5-9b-4bit`` doesn't have to hand-tune sliders.
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..api.models import ModelInfo, ModelsResponse
@@ -19,7 +21,96 @@ from ..config import get_config
 from ..middleware.auth import verify_api_key
 from ..model_aliases import resolve_profile
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+def _resolve_context_window(model_id: str) -> int | None:
+    """Return the engine-advertised max prompt-token context window for
+    ``model_id`` when an engine is loaded for it, else ``None``.
+
+    The currently-loaded engine knows the real cap — it's the same
+    chain the request-time context-length guard consults
+    (``service.helpers.get_model_max_context``), so advertising it on
+    ``/v1/models`` keeps the client's "max tokens" slider lined up
+    with what the server will actually enforce. Issue #363:
+    rapid-desktop's PR #318 consumer needs this to auto-scale the
+    chat-input cap; absent the field the consumer fell through to a
+    desktop-side per-family heuristic that drifted out of sync with
+    every long-context release.
+
+    Resolution:
+      * Single-model serve — ``cfg.engine`` is THE loaded engine and
+        the route's only entries are ``cfg.model_name`` and
+        ``cfg.model_alias``; both surface the same window.
+      * Multi-model serve — look up the matching ``ModelEntry`` via
+        the registry's index (NOT ``get_engine`` which falls back to
+        the default engine on miss; that would advertise the wrong
+        cap for an unloaded alias).
+      * No live engine for ``model_id`` — return ``None`` so the
+        client falls back to its own per-family default. The desktop
+        carries that fallback as defense-in-depth.
+
+    Failures inside ``get_model_max_context`` (missing attributes,
+    tokenizer probe raises) must NOT 500 the listing endpoint — they
+    fall through to ``None`` and the request still completes. The
+    helper's own fallback (``_FALLBACK_MAX_CONTEXT_TOKENS = 4 Mi``)
+    is a DoS sentinel for the request-time guard, NOT a number worth
+    advertising to clients; we suppress it here by treating any
+    integer ≥ ``_DOS_SENTINEL_FLOOR`` as "no useful value" so the
+    desktop's per-family heuristic still wins for un-introspectable
+    models.
+    """
+    # The DoS sentinel inside ``get_model_max_context`` is 4 MiB
+    # (4_194_304). Anything at or above that floor is the sentinel,
+    # not a real context window — no production LLM today exposes a
+    # 4M-token window on Apple Silicon. Hoisted as a local constant
+    # so the comparison is explicit and the relationship to the
+    # helper's fallback constant is obvious to future readers.
+    _DOS_SENTINEL_FLOOR = 4_194_304
+    engine = None
+    cfg = get_config()
+    if cfg.model_registry is not None:
+        try:
+            entry = cfg.model_registry.get_entry(model_id)
+        except KeyError:
+            entry = None
+        # ``get_entry`` falls back to the default entry on miss — guard
+        # that the entry we got actually matches ``model_id`` so the
+        # listing doesn't advertise the default engine's cap for every
+        # unloaded alias.
+        if entry is not None and entry.matches(model_id):
+            engine = entry.engine
+    else:
+        candidate = getattr(cfg, "engine", None)
+        if candidate is not None:
+            served = {cfg.model_name, cfg.model_alias} - {None}
+            if model_id in served:
+                engine = candidate
+    if engine is None:
+        return None
+    try:
+        # Imported lazily to keep this module's import surface small;
+        # ``service.helpers`` pulls in the request lifecycle which we
+        # don't need at module-load time.
+        from ..service.helpers import get_model_max_context
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        window = get_model_max_context(engine)
+    except Exception as exc:  # noqa: BLE001
+        # A failed probe MUST NOT 500 ``/v1/models``; log once and let
+        # the client fall back to its per-family heuristic.
+        logger.debug(
+            "context_window probe failed for %s: %s", model_id, exc, exc_info=False
+        )
+        return None
+    if not isinstance(window, int) or window <= 0:
+        return None
+    if window >= _DOS_SENTINEL_FLOOR:
+        return None
+    return window
 
 
 def _reported_modality(model_id: str, profile_modality: str) -> str:
@@ -102,6 +193,12 @@ def _build_model_info(model_id: str) -> ModelInfo:
     """
     capabilities = _embedding_capabilities(model_id)
     profile = resolve_profile(model_id)
+    # ``context_window`` is engine-derived (not profile-derived) so it
+    # surfaces even for unregistered operator-supplied ids when an
+    # engine is loaded for them. Resolution is best-effort: probe
+    # failures fall through to ``None`` and the client uses its own
+    # per-family fallback. See ``_resolve_context_window`` docstring.
+    context_window = _resolve_context_window(model_id)
     if profile is None:
         # Preserve the prior unknown-id wire shape (``ModelInfo(id=model_id)``
         # with the schema-default ``modality``) and only override when the
@@ -114,11 +211,18 @@ def _build_model_info(model_id: str) -> ModelInfo:
         try:
             if is_mllm_model(model_id):
                 return ModelInfo(
-                    id=model_id, modality="image", capabilities=capabilities
+                    id=model_id,
+                    modality="image",
+                    capabilities=capabilities,
+                    context_window=context_window,
                 )
         except Exception:  # noqa: BLE001
             pass
-        return ModelInfo(id=model_id, capabilities=capabilities)
+        return ModelInfo(
+            id=model_id,
+            capabilities=capabilities,
+            context_window=context_window,
+        )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
     # back to a dict for JSON serialization. ``None`` stays ``None``
@@ -139,6 +243,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         reasoning_parser=profile.reasoning_parser,
         modality=_reported_modality(model_id, profile.modality),
         capabilities=capabilities,
+        context_window=context_window,
     )
 
 


### PR DESCRIPTION
## Summary

`/v1/models` did not emit `context_window`, so rapid-desktop's PR #318 max-tokens slider auto-scaler had no signal and fell through to a per-family hard-coded heuristic that drifted out of sync with every long-context release (Qwen3.6-A3B 1M, DeepSeek-Coder 160K, etc.).

## A/B confirm (cross-repo, machinefi/rapid-desktop#363)

Bundled rapid-mlx in both shipping desktop releases:

| desktop tag | bundled rapid-mlx | `context_window` in `/v1/models`? |
|---|---|---|
| v0.7.20 | SHA `4ba7053` (0.7.41) | **NO** |
| v0.7.21 | SHA `b25e3af` (0.8.2)  | **NO** |

Same probe (`curl … /v1/models | jq '.data[0] | keys'`) on each — keysets identical, neither carries `context_window`. **Pre-existing gap**, not a 0.8.2 regression. Issue was filed against 0.8.2 because that's where the desktop's PR #318 consumer surfaced the bug.

## Fix shape

1. `api.models.ModelInfo` gains an additive optional field:
   ```python
   context_window: int | None = None
   ```
   OpenAI clients ignore unknown fields per spec; the wire contract is unchanged.

2. `routes/models.py:_resolve_context_window(model_id)` probes the loaded engine for the matching entry, then calls the existing `service.helpers.get_model_max_context` (the same chain the request-time context-length guard consults — so the value the client sees lines up with the cap the server will actually enforce).

3. Multi-model lookup uses the registry's `_index` directly to avoid `get_engine`'s default-engine fallback; advertising the default engine's cap for an unloaded alias would be a lie.

4. The helper's DoS sentinel (~4 Mi) is suppressed on the wire so the desktop falls back to its per-family heuristic on un-introspectable models instead of seeing a nonsense window.

5. Probe failures fall through to `None` (caught + logged at DEBUG); the listing endpoint must NOT 500 on a metadata edge.

## Test plan

- [x] 6 new tests in `TestModelsRoutes` (all passing):
  - loaded engine -> `context_window` populated (singleton endpoint)
  - loaded engine -> `context_window` populated on LIST endpoint
  - three-family cross-check (qwen3.5 / qwen3.6 / gemma-4)
  - no engine -> field present as JSON `null`
  - DoS sentinel suppressed -> JSON `null`
  - probe `RuntimeError` -> JSON `null`, no 500
- [x] `tests/test_routes.py::TestModelsRoutes` — 18/18 passing (no regression in the 12 prior tests)
- [x] Wider sweep (`test_routes.py + test_api_models.py + test_aliases_contract.py`) — 1203 passing
- [x] Full unit suite — 54 pre-existing failures match `main` exactly (sampling_param_finite_range + sampling_validation, both pre-existing on `origin/main` per side-by-side diff); 0 new failures
- [x] `ruff check` clean on all three changed files

## Companion PR

Defense-in-depth desktop-side per-family fallback lands separately in `machinefi/rapid-desktop` (closes #363 once both land + the desktop bumps its submodule pin to the resulting rapid-mlx tag).