### PR TITLE
chore: bump version to 0.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.3"
+version = "0.8.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Ship the rapid-desktop #363 fix (`/v1/models` was missing `context_window`) to PyPI + Homebrew so desktop's PR #318 max-tokens auto-scaler stops falling through to its per-family hard-coded heuristic. Refs raullenchai/Rapid-MLX#808 (the fix PR merged into main as `a2f2539`).

Cuts v0.8.4 from main; auto-release tags `v0.8.4` and `publish.yml` fans out to PyPI + Homebrew on the `release:published` event.

## What's new in v0.8.4

* fix(routes/models): emit `context_window` in `/v1/models` response (rapid-desktop #363) — desktop max-tokens auto-scaler now has a server-side signal that lines up with the request-time context-length guard.

## Companion

Desktop-side defense-in-depth fallback PR lands in `machinefi/rapid-desktop` referencing this tag for the submodule bump.