### PR TITLE
fix(anthropic): envelope wrapper + content-block discriminator + role-block matrix + empty-messages guard (D-ANTHRO-VALIDATION)

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -8,6 +8,8 @@ These are pure logic tests with no MLX dependency.
 
 import json
 
+import pytest
+
 from vllm_mlx.api.anthropic_adapter import (
     _convert_message,
     _convert_stop_reason,
@@ -197,19 +199,40 @@ class TestConvertMessage:
         assert result[0].role == "tool"
         assert result[0].content == "line one\nline two"
 
-    def test_tool_result_with_none_content(self):
+    def test_tool_result_with_empty_string_content(self):
+        """D-ANTHRO-VALIDATION F4 update: ``tool_result`` blocks now
+        require a ``content`` field at construction time (the spec
+        requires non-None content). Test the adapter still emits the
+        right shape for the legal ``content=""`` case — the
+        ``content=None`` pre-fix shape is rejected at the schema
+        layer with a clear ``is missing required field(s): content``
+        error instead of silently being treated as an empty string."""
         msg = AnthropicMessage(
             role="user",
             content=[
                 AnthropicContentBlock(
                     type="tool_result",
                     tool_use_id="call_1",
-                    content=None,
+                    content="",
                 ),
             ],
         )
         result = _convert_message(msg)
         assert result[0].content == ""
+
+    def test_tool_result_with_none_content_rejected_at_construction(self):
+        """D-ANTHRO-VALIDATION F4: ``content=None`` on a tool_result
+        block 422s at schema layer with the named-field message —
+        replaces the pre-fix silent-empty-string fallback."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicContentBlock(
+                type="tool_result",
+                tool_use_id="call_1",
+                content=None,
+            )
+        assert "is missing required field(s): content" in str(exc_info.value)
 
     def test_assistant_with_tool_use(self):
         msg = AnthropicMessage(

--- a/tests/test_anthropic_models.py
+++ b/tests/test_anthropic_models.py
@@ -68,8 +68,15 @@ class TestAnthropicContentBlock:
         assert block.source["type"] == "base64"
 
     def test_optional_fields_default_to_none(self):
-        block = AnthropicContentBlock(type="text")
-        assert block.text is None
+        """D-ANTHRO-VALIDATION F4 update: per-type required fields are
+        now enforced at construction (text block REQUIRES text). The
+        "all-optional" surface for a text block accepted ``{type:'text'}``
+        with no payload and let the model run on empty content. The
+        original spirit of this test — that *other* fields default to
+        None when only the relevant per-type field is set — is
+        preserved below by building a well-formed text block."""
+        block = AnthropicContentBlock(type="text", text="")
+        assert block.text == ""
         assert block.id is None
         assert block.name is None
         assert block.input is None

--- a/tests/test_content_block_strict_types.py
+++ b/tests/test_content_block_strict_types.py
@@ -168,9 +168,15 @@ class TestAnthropicContentBlockTextStrictType:
         block = AnthropicContentBlock(type="text", text="hi")
         assert block.text == "hi"
 
-    def test_null_text_accepted(self) -> None:
-        block = AnthropicContentBlock(type="text", text=None)
-        assert block.text is None
+    def test_null_text_rejected(self) -> None:
+        """D-ANTHRO-VALIDATION F4 update: ``text=None`` was previously
+        treated as a legal no-op text part. Sergei's F4 evidence
+        shows the Anthropic spec rejects ``{type:'text'}`` (and the
+        ``text=None`` shape is equivalent — both pass no usable text
+        to the model). Aligned with the spec at the schema layer."""
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicContentBlock(type="text", text=None)
+        assert "is missing required field(s): text" in str(exc_info.value)
 
 
 class TestAnthropicImageSourceStrictType:

--- a/tests/test_d_anthro_validation.py
+++ b/tests/test_d_anthro_validation.py
@@ -576,6 +576,24 @@ class TestF10RoleBlockCompatibility:
         assert "wizard" in msg
         assert "not recognized" in msg
 
+    def test_unknown_role_rejected_with_string_content(self, client):
+        """Codex round-1 BLOCKING fix: the unknown-role gate must fire
+        regardless of whether ``content`` is a string or a block array.
+        Pre-fix the validator returned early on string content and
+        ``{"role":"wizard","content":"hi"}`` slipped through."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [{"role": "wizard", "content": "hi"}],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "wizard" in msg
+        assert "not recognized" in msg
+
     def test_valid_user_text_block_accepted(self, client):
         response = client.client.post(
             "/v1/messages",
@@ -778,6 +796,61 @@ class TestEnvelopeInvariants:
             # No nested wrapper.
             err = envelope["error"]
             assert err.get("type") != "error", "double-wrap detected"
+
+    def test_path_match_does_not_classify_lookalike_paths_as_anthropic(self):
+        """Codex round-1 NIT: ``startswith("/v1/messages")`` would also
+        match ``/v1/messages-foo`` / ``/v1/messagesevil`` and wrap their
+        404/405 responses with the Anthropic envelope. Use a fresh app
+        that exposes only the lookalike paths so the classification
+        function is exercised directly (no fixture interaction with
+        the Anthropic router)."""
+        from fastapi import HTTPException
+
+        from vllm_mlx.middleware.exception_handlers import (
+            _is_anthropic_path,
+            install_exception_handlers,
+        )
+
+        app = FastAPI()
+        install_exception_handlers(app)
+
+        @app.post("/v1/messages-foo")
+        async def _lookalike():
+            raise HTTPException(status_code=400, detail="bad")
+
+        @app.post("/v1/messages/sub")
+        async def _real_sub():
+            raise HTTPException(status_code=400, detail="bad")
+
+        c = TestClient(app)
+
+        # Lookalike path — must NOT get the Anthropic wrapper.
+        resp = c.post("/v1/messages-foo")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body.get("type") != "error", body
+        assert isinstance(body.get("error"), dict)
+
+        # Real sub-path — MUST get the Anthropic wrapper.
+        resp = c.post("/v1/messages/sub")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body.get("type") == "error", body
+
+        # Direct classifier checks.
+        class _Req:
+            class _URL:
+                pass
+
+            def __init__(self, p):
+                self.url = self._URL()
+                self.url.path = p
+
+        assert _is_anthropic_path(_Req("/v1/messages")) is True
+        assert _is_anthropic_path(_Req("/v1/messages/count_tokens")) is True
+        assert _is_anthropic_path(_Req("/v1/messages-foo")) is False
+        assert _is_anthropic_path(_Req("/v1/messagesevil")) is False
+        assert _is_anthropic_path(_Req("/v1/messages_evil")) is False
 
     def test_h17_attacker_keys_still_collapsed_under_allowlist(self, client):
         """The F1 allowlist must NOT re-open the H-17 round-2 leak.

--- a/tests/test_d_anthro_validation.py
+++ b/tests/test_d_anthro_validation.py
@@ -1,0 +1,799 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-ANTHRO-VALIDATION — four tightly-related Anthropic-spec gaps
+surfaced by Sergei dogfood on 0.8.3.
+
+Bug summaries:
+
+* **F1** — ``/v1/messages`` error envelopes were missing the canonical
+  Anthropic top-level ``{"type":"error","error":{...}}`` wrapper and
+  the message body leaked the ``<field>`` placeholder text for
+  schema-owned field names (the H-17 round-2 sanitizer collapsed every
+  string ``loc`` component including safe schema-owned ones).
+* **F4** — Malformed content blocks (``{type:"text"}`` with no
+  ``text``, unknown block types, ``tool_use`` without ``id`` /
+  ``name`` / ``input``) were accepted with HTTP 200 and the model ran
+  on empty / unknown content.
+* **F10** — Cross-role block-type violations slipped past the schema:
+  a user-role message could carry a ``thinking`` block; an
+  assistant-role message could carry a ``tool_result`` block. Both
+  resulted in HTTP 200 with undefined semantics.
+* **F11** — ``messages=[]`` on ``/v1/messages`` returned HTTP 500
+  ``Internal server error`` instead of the documented 400
+  ``invalid_request_error``.
+
+All four are fixed at the Pydantic model layer (no per-route try/
+except band-aids):
+
+* The exception handlers in ``vllm_mlx/middleware/exception_handlers``
+  detect Anthropic-prefixed paths and rewrap the OpenAI-shaped
+  envelope into the Anthropic shape.
+* ``_sanitize_loc`` now applies a closed allowlist of schema-owned
+  field names so the safe names (``temperature``, ``messages``,
+  ``max_tokens``, …) are echoed verbatim while attacker-controlled
+  bytes still collapse to ``<field>``.
+* ``AnthropicContentBlock._validate_block_shape`` rejects unknown
+  ``type`` values and missing per-type required fields.
+* ``AnthropicMessage._validate_role_block_compat`` enforces the
+  role-block compatibility matrix.
+* ``AnthropicRequest.messages`` gains ``min_length=1``;
+  ``ChatCompletionRequest.messages`` does too for OpenAI-side parity.
+* ``ResponsesRequest`` gains an after-validator that rejects empty
+  ``input``.
+
+The test app reuses the lightweight fixture from
+``test_no_pydantic_error_leak`` so the four bugs share one fixture
+surface.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ── Lightweight engine stubs (shape-compatible with the H-17 fixture) ─
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def encode(self, text: str) -> list[int]:
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str = ""
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+    tool_calls: list | None = None
+
+
+class _Engine:
+    preserve_native_tool_format = False
+
+    def __init__(self) -> None:
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):  # noqa: ARG002
+        return _GenerationOutput(text="hello", prompt_tokens=3, completion_tokens=1)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.anthropic",
+    "vllm_mlx.routes.responses",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "anthropic"),
+    ("vllm_mlx.routes", "responses"),
+)
+_MISSING = object()
+
+
+def _install_lightweight_engine_modules(monkeypatch) -> None:
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+def _build_app(monkeypatch):
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    cfg.api_key = None
+    cfg.engine = _Engine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(anthropic_router)
+    app.include_router(responses_router)
+    # NOTE: chat_router intentionally NOT included here. The chat
+    # route's module-level ``from ..engine import GenerationOutput``
+    # binds at import time, and the lightweight engine stub installed
+    # by ``_install_lightweight_engine_modules`` would cache stub
+    # references that confuse later tests in the same session that
+    # exercise the chat-route admission flow. The chat-route parity
+    # checks live on the separate ``chat_client`` fixture below which
+    # skips the lightweight stub.
+
+    def teardown():
+        reset_config()
+        rate_limiter.enabled = False
+        rate_limiter.requests_per_minute = 60
+        rate_limiter._requests.clear()
+        for name, previous in previous_modules.items():
+            if previous is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        for (module_name, attr), previous in previous_attrs.items():
+            module = sys.modules.get(module_name)
+            if module is None:
+                continue
+            if previous is _MISSING:
+                if hasattr(module, attr):
+                    delattr(module, attr)
+            else:
+                setattr(module, attr, previous)
+
+    return app, cfg, teardown
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app, cfg, teardown = _build_app(monkeypatch)
+    try:
+        yield SimpleNamespace(client=TestClient(app), cfg=cfg)
+    finally:
+        teardown()
+
+
+@pytest.fixture
+def chat_client():
+    """Separate fixture for chat-route parity checks (F1 + F11
+    OpenAI surface). Does NOT use the lightweight engine stub — the
+    chat route's module-level ``from ..engine import GenerationOutput``
+    captures real names at import time; swapping them via a stub on
+    the session-shared sys.modules leaks stub references into later
+    admission-flow tests. Keeping the chat-router tests on a
+    real-engine-imports fixture sidesteps that interaction entirely.
+    """
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.chat import router as chat_router
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    cfg.api_key = None
+    cfg.engine = _Engine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(chat_router)
+    app.include_router(responses_router)
+
+    try:
+        yield SimpleNamespace(client=TestClient(app), cfg=cfg)
+    finally:
+        reset_config()
+        rate_limiter._requests.clear()
+
+
+# ============================================================
+# F1 — Anthropic envelope wrapper + <field> placeholder leak
+# ============================================================
+
+
+class TestF1AnthropicErrorEnvelopeWrapper:
+    """Every error path on /v1/messages must return the Anthropic
+    canonical envelope ``{"type":"error","error":{...}}`` and must
+    never leak the ``<field>`` placeholder for schema-owned field
+    names."""
+
+    @pytest.mark.parametrize(
+        ("body", "expected_field"),
+        [
+            # Pre-fix Sergei F1 evidence — temperature type error.
+            (
+                {
+                    "model": "test-model",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "temperature": "hot",
+                },
+                "temperature",
+            ),
+            # Missing required field — messages.
+            ({"model": "test-model", "max_tokens": 10}, "messages"),
+            # Wrong type for messages.
+            (
+                {"model": "test-model", "max_tokens": 10, "messages": "not-a-list"},
+                "messages",
+            ),
+            # Wrong type for max_tokens.
+            (
+                {
+                    "model": "test-model",
+                    "max_tokens": "not-an-int",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                "max_tokens",
+            ),
+        ],
+    )
+    def test_validation_error_returns_anthropic_envelope_with_named_field(
+        self, client, body, expected_field
+    ):
+        response = client.client.post("/v1/messages", json=body)
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        # Canonical Anthropic shape: ``{"type":"error","error":{...}}``.
+        assert envelope.get("type") == "error", envelope
+        assert isinstance(envelope.get("error"), dict), envelope
+        err = envelope["error"]
+        assert err["type"] == "invalid_request_error"
+        assert err["code"] == "invalid_request"
+        # The named field must appear in the message — no <field> leak.
+        assert expected_field in err["message"], err
+        assert "<field>" not in err["message"], err
+
+    def test_http_exception_paths_also_get_wrapper(self, client):
+        """Non-validation 4xx paths (HTTPException) must also surface
+        the wrapped envelope — Anthropic SDKs route on the outer
+        ``type`` field regardless of which gate fired."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_choice": {"type": "banana"},  # M-03 gate
+            },
+        )
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        assert envelope.get("type") == "error"
+        assert isinstance(envelope.get("error"), dict)
+
+    def test_malformed_json_body_returns_wrapper(self, client):
+        """JSON decode error path must also wrap."""
+        response = client.client.post(
+            "/v1/messages",
+            content=b"{not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        assert envelope.get("type") == "error"
+        assert envelope["error"]["type"] == "invalid_request_error"
+
+    def test_no_field_placeholder_in_user_visible_message(self, client):
+        """Across the full bad-body matrix, the <field> placeholder
+        must never appear in the user-visible message when the failing
+        field is a schema-owned name."""
+        for body in [
+            {
+                "model": "test-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": "hot",
+            },
+            {
+                "model": "test-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+                "top_p": "nope",
+            },
+            {
+                "model": "test-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+                "top_k": "not-an-int",
+            },
+        ]:
+            response = client.client.post("/v1/messages", json=body)
+            assert response.status_code == 400, response.text
+            assert "<field>" not in response.text, response.text
+
+    def test_openai_chat_route_keeps_openai_envelope(self, chat_client):
+        """The Anthropic wrapper must NOT apply to /v1/chat/completions
+        — the OpenAI surface still returns the bare ``{"error":{...}}``
+        shape."""
+        response = chat_client.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": "hot",
+            },
+        )
+        assert response.status_code == 400, response.text
+        body = response.json()
+        # OpenAI shape: top-level type is NOT "error".
+        assert body.get("type") != "error", body
+        # Error envelope intact at top level.
+        assert isinstance(body.get("error"), dict)
+        assert "temperature" in body["error"]["message"]
+        assert "<field>" not in body["error"]["message"]
+
+
+# ============================================================
+# F4 — Content block strict-typing
+# ============================================================
+
+
+class TestF4ContentBlockStrictTyping:
+    """Malformed content blocks must surface as 400 with the canonical
+    envelope — never 200 with garbage output."""
+
+    def test_text_block_without_text_rejected(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [{"role": "user", "content": [{"type": "text"}]}],
+            },
+        )
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        assert envelope["type"] == "error"
+        assert "is missing required field(s): text" in envelope["error"]["message"]
+
+    def test_tool_use_block_without_required_fields_rejected(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "tool_use" in msg
+        # All three of id/name/input must be flagged missing.
+        for field_name in ("id", "name", "input"):
+            assert field_name in msg, msg
+
+    def test_tool_result_block_without_required_fields_rejected(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "tool_result"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "tool_result" in msg
+        for field_name in ("tool_use_id", "content"):
+            assert field_name in msg, msg
+
+    def test_image_block_without_source_rejected(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "image"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "image" in msg
+        assert "source" in msg
+
+    def test_unknown_block_type_rejected(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "weirdblock", "data": 1}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "weirdblock" in msg
+        assert "not a recognized Anthropic content block type" in msg
+        # Allowed types are listed so the client knows what to use.
+        assert "text" in msg
+        assert "tool_use" in msg
+
+    def test_well_formed_block_still_accepted(self, client):
+        """Sanity — well-formed block should not be rejected."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello"}],
+                    }
+                ],
+            },
+        )
+        # Engine stub returns "hello" — pass through to 200.
+        assert response.status_code == 200, response.text
+
+
+# ============================================================
+# F10 — Role-block compatibility
+# ============================================================
+
+
+class TestF10RoleBlockCompatibility:
+    """Cross-role block-type violations must surface as 400."""
+
+    @pytest.mark.parametrize(
+        ("role", "block"),
+        [
+            # user-role disallowed blocks (assistant-only)
+            ("user", {"type": "thinking", "thinking": "hidden"}),
+            ("user", {"type": "tool_use", "id": "x", "name": "f", "input": {}}),
+            # assistant-role disallowed blocks (user-only)
+            (
+                "assistant",
+                {"type": "tool_result", "tool_use_id": "x", "content": "hi"},
+            ),
+            (
+                "assistant",
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "x",
+                    },
+                },
+            ),
+        ],
+    )
+    def test_cross_role_block_violations_rejected(self, client, role, block):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [{"role": role, "content": [block]}],
+            },
+        )
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        assert envelope["type"] == "error"
+        msg = envelope["error"]["message"]
+        assert role in msg
+        assert block["type"] in msg
+        assert "not allowed" in msg
+
+    def test_unknown_role_rejected(self, client):
+        """Roles outside ``user``/``assistant``/``system`` must 400."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "wizard",
+                        "content": [{"type": "text", "text": "hi"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        msg = response.json()["error"]["message"]
+        assert "wizard" in msg
+        assert "not recognized" in msg
+
+    def test_valid_user_text_block_accepted(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hi"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+
+    def test_valid_assistant_thinking_block_accepted(self, client):
+        """Assistant CAN carry a thinking block (echoing a prior turn)
+        — only user-role thinking is rejected."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hi"}],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "let me think"},
+                            {"type": "text", "text": "ok"},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "go on"}],
+                    },
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+
+    def test_string_content_unaffected(self, client):
+        """``content`` as a bare string bypasses the role-block check
+        (there are no blocks to validate)."""
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 20,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert response.status_code == 200, response.text
+
+
+# ============================================================
+# F11 — Empty messages array
+# ============================================================
+
+
+class TestF11EmptyMessages:
+    """``messages=[]`` must 400 with a clear envelope — never 500."""
+
+    def test_anthropic_empty_messages_returns_400(self, client):
+        response = client.client.post(
+            "/v1/messages",
+            json={"model": "test-model", "max_tokens": 10, "messages": []},
+        )
+        assert response.status_code == 400, response.text
+        envelope = response.json()
+        assert envelope["type"] == "error"
+        err = envelope["error"]
+        assert err["type"] == "invalid_request_error"
+        assert "messages" in err["message"]
+        # ``min_length=1`` Pydantic message.
+        assert "at least 1 item" in err["message"]
+
+    def test_openai_chat_empty_messages_returns_400(self, chat_client):
+        """OpenAI parity — same gap on /v1/chat/completions."""
+        response = chat_client.client.post(
+            "/v1/chat/completions",
+            json={"model": "test-model", "messages": []},
+        )
+        assert response.status_code == 400, response.text
+        body = response.json()
+        # OpenAI envelope (no anthropic wrapper).
+        assert body.get("type") != "error"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "messages" in body["error"]["message"]
+
+    def test_responses_empty_input_string_returns_400(self, client):
+        response = client.client.post(
+            "/v1/responses",
+            json={"model": "test-model", "input": ""},
+        )
+        assert response.status_code == 400, response.text
+        body = response.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "input" in body["error"]["message"]
+
+    def test_responses_empty_input_list_returns_400(self, client):
+        response = client.client.post(
+            "/v1/responses",
+            json={"model": "test-model", "input": []},
+        )
+        assert response.status_code == 400, response.text
+        body = response.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "input" in body["error"]["message"]
+
+
+# ============================================================
+# Cross-cutting: locked-in invariants
+# ============================================================
+
+
+class TestEnvelopeInvariants:
+    """End-to-end invariants spanning all four bugs."""
+
+    def test_every_anthropic_4xx_path_carries_wrapper(self, client):
+        """Sweep every 4xx code we can trip on /v1/messages and
+        assert the Anthropic wrapper is present on each."""
+        # 400 — validation
+        # 400 — empty messages
+        # 400 — bad tool_choice
+        # 400 — malformed JSON
+        # 405 — wrong HTTP verb (GET on POST-only route)
+        cases = [
+            (
+                "post",
+                "/v1/messages",
+                {
+                    "json": {
+                        "model": "test-model",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "temperature": "hot",
+                    }
+                },
+            ),
+            (
+                "post",
+                "/v1/messages",
+                {
+                    "json": {
+                        "model": "test-model",
+                        "max_tokens": 10,
+                        "messages": [],
+                    }
+                },
+            ),
+            (
+                "post",
+                "/v1/messages",
+                {
+                    "content": b"{not json",
+                    "headers": {"Content-Type": "application/json"},
+                },
+            ),
+            ("get", "/v1/messages", {}),
+        ]
+        for method, path, kwargs in cases:
+            response = getattr(client.client, method)(path, **kwargs)
+            assert 400 <= response.status_code < 500, (
+                f"{method.upper()} {path} {kwargs!r}: status={response.status_code}"
+            )
+            try:
+                envelope = response.json()
+            except json.JSONDecodeError:
+                pytest.fail(f"{method.upper()} {path}: non-JSON body {response.text!r}")
+            assert envelope.get("type") == "error", (
+                f"{method.upper()} {path}: missing Anthropic wrapper, got {envelope!r}"
+            )
+            assert isinstance(envelope.get("error"), dict)
+
+    def test_anthropic_wrapper_idempotent_on_already_wrapped(self, client):
+        """If a route already emitted the Anthropic shape (via
+        ``HTTPException(detail={"type":"error",...})``), the wrapper
+        must not double-wrap. Use a tool_choice gate that does this
+        explicitly."""
+        # The model-name 404 path returns an Anthropic-shaped detail
+        # (see routes/anthropic.py).
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "unknown-claude-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        # Whether 200 or 4xx depends on model alias resolution; if
+        # 4xx, the envelope must be canonical (and no double-wrap).
+        if response.status_code >= 400:
+            envelope = response.json()
+            assert envelope.get("type") == "error"
+            # No nested wrapper.
+            err = envelope["error"]
+            assert err.get("type") != "error", "double-wrap detected"
+
+    def test_h17_attacker_keys_still_collapsed_under_allowlist(self, client):
+        """The F1 allowlist must NOT re-open the H-17 round-2 leak.
+        An attacker-controlled extra-field name must still collapse to
+        ``<field>``."""
+        sentinel = "AWS_SECRET_ACCESS_KEY_pwned"
+        response = client.client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+                sentinel: "bouncing-secret",
+            },
+        )
+        # Either the body is silently ignored (current Pydantic
+        # default with extra="allow") OR validates and 4xx fires for
+        # another reason. Either way the sentinel must NOT appear.
+        assert sentinel not in response.text, response.text

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -282,7 +282,11 @@ def test_chat_completions_rejects_tools() -> None:
         },
     )
     assert r.status_code == 400
-    assert "tool calling" in r.json()["detail"].lower()
+    # D-ANTHRO-VALIDATION F11: the dflash app now installs the shared
+    # exception handlers so HTTPException responses go through the
+    # canonical envelope ``{"error":{"message":...}}`` instead of the
+    # bare FastAPI ``{"detail":...}`` shape.
+    assert "tool calling" in r.json()["error"]["message"].lower()
 
 
 def test_chat_completions_rejects_empty_messages() -> None:
@@ -344,7 +348,9 @@ def test_chat_completions_rejects_logprobs() -> None:
         },
     )
     assert r.status_code == 400
-    assert "logprobs" in r.json()["detail"].lower()
+    # D-ANTHRO-VALIDATION F11: canonical envelope shape — see comment
+    # on test_chat_completions_rejects_tools above.
+    assert "logprobs" in r.json()["error"]["message"].lower()
 
 
 def test_chat_completions_rejects_response_format() -> None:
@@ -378,7 +384,9 @@ def test_chat_completions_rejects_response_format() -> None:
         },
     )
     assert r.status_code == 400
-    assert "response_format" in r.json()["detail"].lower()
+    # D-ANTHRO-VALIDATION F11: canonical envelope shape — see comment
+    # on test_chat_completions_rejects_tools above.
+    assert "response_format" in r.json()["error"]["message"].lower()
 
 
 def _capture_enable_thinking(monkeypatch, *, no_thinking: bool, request_body: dict):

--- a/tests/test_embeddings_timeout_admission.py
+++ b/tests/test_embeddings_timeout_admission.py
@@ -667,10 +667,15 @@ class TestAdmissionControl:
 
         from vllm_mlx.config import get_config
         from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.middleware.exception_handlers import install_exception_handlers
         from vllm_mlx.routes import chat as chat_route
         from vllm_mlx.scheduler import SchedulerConfig
 
         app = FastAPI()
+        # D-ANTHRO-VALIDATION F11: install the shared exception
+        # handlers so the canonical 400 envelope fires when Pydantic
+        # rejects ``messages=[]`` at the new ``min_length=1`` constraint.
+        install_exception_handlers(app)
         app.include_router(chat_route.router)
 
         # MagicMock engine — ``MagicMock`` doesn't enforce

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -24,12 +24,52 @@ from .models import (
 # =============================================================================
 
 
+# D-ANTHRO-VALIDATION F4 — Known Anthropic content-block ``type``
+# values. Used by ``AnthropicContentBlock._validate_block_shape`` to
+# reject unknown types at the schema layer (pre-fix, an unknown type
+# like ``{"type":"weirdblock", "data":1}`` slipped past the loose
+# ``type: str`` declaration and Pydantic accepted the request — the
+# model then received empty content and returned 200 with garbage
+# output). The Anthropic spec accepts exactly these on the request
+# surface; assistant-only ``thinking`` is included so request-side
+# echoes of prior assistant turns parse (cross-role compat is enforced
+# separately on ``AnthropicMessage``).
+_ANTHROPIC_CONTENT_BLOCK_TYPES: frozenset[str] = frozenset(
+    {"text", "image", "tool_use", "tool_result", "thinking", "document"}
+)
+
+
+# D-ANTHRO-VALIDATION F4 — per-type required field maps. Each tuple
+# names the fields that MUST carry a non-None value for a block of
+# that type to be well-formed. Pre-fix:
+#
+# * ``{type:"text"}`` (no ``text``) returned 200 with the model
+#   running on empty content (Sergei F4 evidence).
+# * ``{type:"tool_use"}`` (no ``id``/``name``/``input``) likewise.
+# * ``{type:"tool_result"}`` (no ``tool_use_id``/``content``) likewise.
+#
+# Anthropic's real backend 400s every one of these with a typed
+# ``invalid_request_error``; mirror that here at the schema layer so
+# the contract is enforced uniformly across non-stream / stream / and
+# /v1/responses parallel routes.
+_ANTHROPIC_BLOCK_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "text": ("text",),
+    "tool_use": ("id", "name", "input"),
+    "tool_result": ("tool_use_id", "content"),
+    "thinking": ("thinking",),
+    "image": ("source",),
+    "document": ("source",),
+}
+
+
 class AnthropicContentBlock(BaseModel):
     """A content block in an Anthropic message."""
 
-    type: str  # "text", "image", "tool_use", "tool_result"
+    type: str  # see ``_ANTHROPIC_CONTENT_BLOCK_TYPES``
     # text block
     text: str | None = None
+    # thinking block (echoed assistant block; assistant-only on inputs)
+    thinking: str | None = None
     # tool_use block
     id: str | None = None
     name: str | None = None
@@ -38,7 +78,7 @@ class AnthropicContentBlock(BaseModel):
     tool_use_id: str | None = None
     content: str | list[Any] | None = None
     is_error: bool | None = None
-    # image block
+    # image / document block
     source: dict | None = None
 
     @field_validator("text", mode="before")
@@ -62,6 +102,54 @@ class AnthropicContentBlock(BaseModel):
         raise ValueError(
             f"content[].text must be a string (got {type(value).__name__})"
         )
+
+    @model_validator(mode="after")
+    def _validate_block_shape(self) -> "AnthropicContentBlock":
+        """D-ANTHRO-VALIDATION F4 — reject unknown / underspecified
+        content blocks at the schema layer.
+
+        Pre-fix, ``AnthropicContentBlock`` accepted ANY ``type`` string
+        and treated every payload field as optional, so:
+
+        * ``{"type":"text"}`` (no ``text``) → 200 OK, model ran on
+          empty content.
+        * ``{"type":"weirdblock"}`` → 200 OK, unknown block silently
+          dropped.
+        * ``{"type":"tool_use"}`` (no ``id``/``name``/``input``) → 200
+          OK, malformed tool call sent to the engine.
+
+        The spec is explicit: every Anthropic content block has a known
+        ``type`` discriminator and a per-type set of required fields.
+        Reject unknown types (so a typo or an SDK-version mismatch
+        produces a clear 400 with a list of allowed types) and reject
+        missing required fields (so a buggy client during the
+        OpenAI→Anthropic migration sees the validation gap instead of
+        a 200 with garbage output).
+
+        Implemented as a single ``model_validator(mode="after")`` so
+        every type-check fires once per block — discriminated-union
+        Pydantic would split the model into per-type classes but that
+        would also force every existing call-site (anthropic_adapter,
+        the streaming router, the tests) to deal with a Union[...]
+        narrowing surface. A single validator on the unified shape is
+        less churn and produces the same client-visible 400.
+        """
+        block_type = self.type
+        if block_type not in _ANTHROPIC_CONTENT_BLOCK_TYPES:
+            allowed = sorted(_ANTHROPIC_CONTENT_BLOCK_TYPES)
+            raise ValueError(
+                f"content[].type {block_type!r} is not a recognized "
+                f"Anthropic content block type. Allowed types: {allowed}."
+            )
+        required = _ANTHROPIC_BLOCK_REQUIRED_FIELDS.get(block_type, ())
+        missing = [field for field in required if getattr(self, field) is None]
+        if missing:
+            field_list = ", ".join(missing)
+            raise ValueError(
+                f"content[].type={block_type!r} is missing required "
+                f"field(s): {field_list}."
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_image_source_type(self) -> "AnthropicContentBlock":
@@ -90,11 +178,66 @@ class AnthropicContentBlock(BaseModel):
         return self
 
 
+# D-ANTHRO-VALIDATION F10 — role-block compatibility matrix.
+#
+# The Anthropic spec defines which content-block types can appear in
+# which role. Pre-fix every block type was accepted in every role, so:
+#
+# * A user-role message could carry a ``thinking`` block (assistant-
+#   only on the spec), and the request went through with 200 OK.
+#   Adversarial clients could "smuggle" synthesized thinking into the
+#   conversation; well-meaning buggy clients silently sent garbage.
+# * An assistant-role message could carry a ``tool_result`` block
+#   (user-only on the spec) — same 200-with-garbage outcome.
+#
+# The matrix below pins the per-role allowed types. Enforced on
+# ``AnthropicMessage._validate_role_block_compat`` (a single
+# model_validator on the message shape so both routes — /v1/messages
+# and any future Anthropic-shaped surface — inherit the contract).
+_ANTHROPIC_ROLE_ALLOWED_BLOCK_TYPES: dict[str, frozenset[str]] = {
+    "user": frozenset({"text", "image", "tool_result", "document"}),
+    "assistant": frozenset({"text", "tool_use", "thinking"}),
+    # System-role messages are conventionally a string on the request
+    # surface (the ``AnthropicRequest.system`` field), but a few client
+    # libraries pass them as a message with role="system" and
+    # content=[{type:"text",...}]. Allow text-only there.
+    "system": frozenset({"text"}),
+}
+
+
 class AnthropicMessage(BaseModel):
     """A message in an Anthropic conversation."""
 
-    role: str  # "user" | "assistant"
+    role: str  # "user" | "assistant" | (rarely) "system"
     content: str | list[AnthropicContentBlock]
+
+    @model_validator(mode="after")
+    def _validate_role_block_compat(self) -> "AnthropicMessage":
+        """D-ANTHRO-VALIDATION F10 — enforce role-block compatibility.
+
+        Reject blocks that don't belong to the message's role (e.g.
+        ``thinking`` on user, ``tool_result`` on assistant). String
+        content always parses (no block types to check). Unknown roles
+        get a 400 here too (the upstream chat-route rejects them but
+        the Anthropic surface previously accepted any role string).
+        """
+        if isinstance(self.content, str):
+            return self
+        allowed = _ANTHROPIC_ROLE_ALLOWED_BLOCK_TYPES.get(self.role)
+        if allowed is None:
+            raise ValueError(
+                f"role {self.role!r} is not recognized. Allowed roles: "
+                f"{sorted(_ANTHROPIC_ROLE_ALLOWED_BLOCK_TYPES.keys())}."
+            )
+        for block in self.content:
+            block_type = block.type
+            if block_type not in allowed:
+                raise ValueError(
+                    f"content[].type={block_type!r} is not allowed in a "
+                    f"{self.role!r}-role message. Allowed block types for "
+                    f"role={self.role!r}: {sorted(allowed)}."
+                )
+        return self
 
 
 class AnthropicToolDef(BaseModel):
@@ -196,7 +339,15 @@ class AnthropicRequest(BaseModel):
     """Request for Anthropic Messages API."""
 
     model: str
-    messages: list[AnthropicMessage]
+    # D-ANTHRO-VALIDATION F11 — ``messages`` must be a non-empty array.
+    # Pre-fix, ``messages=[]`` fell through to the route handler which
+    # then dereferenced ``messages[0]`` deep inside the adapter and
+    # raised an unhandled exception → 500 ``Internal server error``.
+    # Anthropic's real backend (and our own ``/v1/messages/count_tokens``
+    # sub-route) return 400 ``invalid_request_error`` for the same
+    # input. Enforce at the schema layer so streaming + non-streaming
+    # both inherit the contract.
+    messages: list[AnthropicMessage] = Field(..., min_length=1)
     system: str | list[dict] | None = None
     max_tokens: int  # Required in Anthropic API
     # H-10: Anthropic spec narrows ``temperature`` to ``[0, 1]`` (the

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -216,19 +216,25 @@ class AnthropicMessage(BaseModel):
         """D-ANTHRO-VALIDATION F10 — enforce role-block compatibility.
 
         Reject blocks that don't belong to the message's role (e.g.
-        ``thinking`` on user, ``tool_result`` on assistant). String
-        content always parses (no block types to check). Unknown roles
-        get a 400 here too (the upstream chat-route rejects them but
+        ``thinking`` on user, ``tool_result`` on assistant). Unknown
+        roles get a 400 too (the upstream chat-route rejects them but
         the Anthropic surface previously accepted any role string).
+
+        Codex round-1 BLOCKING: the unknown-role gate has to fire
+        BEFORE the string-content early return, otherwise
+        ``{"role":"wizard","content":"hi"}`` slips through. The
+        per-block-type loop is what's bypassed on string content (no
+        blocks to iterate), but the role itself still needs to be one
+        of the recognized Anthropic roles.
         """
-        if isinstance(self.content, str):
-            return self
         allowed = _ANTHROPIC_ROLE_ALLOWED_BLOCK_TYPES.get(self.role)
         if allowed is None:
             raise ValueError(
                 f"role {self.role!r} is not recognized. Allowed roles: "
                 f"{sorted(_ANTHROPIC_ROLE_ALLOWED_BLOCK_TYPES.keys())}."
             )
+        if isinstance(self.content, str):
+            return self
         for block in self.content:
             block_type = block.type
             if block_type not in allowed:

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1058,7 +1058,13 @@ class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
     model: str = "default"
-    messages: list[Message]
+    # D-ANTHRO-VALIDATION F11 (Anthropic sibling fix on OpenAI surface):
+    # OpenAI's real ``/v1/chat/completions`` requires ``messages`` to be
+    # a non-empty array (a request without prompts is structurally
+    # uninterpretable). Pre-fix this server accepted ``messages=[]`` and
+    # downstream code raised an unhandled exception → 500. Enforce at
+    # the schema layer so the 4xx fires before any handler logic.
+    messages: list[Message] = Field(..., min_length=1)
     # F-011: range bounds match OpenAI spec; the field-level Field
     # constraints cover finite out-of-range values (Pydantic 422). NaN
     # slips past Field bounds (every NaN comparison is False) so the

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -159,6 +159,29 @@ class ResponsesRequest(BaseModel):
             )
         return data
 
+    @model_validator(mode="after")
+    def _validate_input_nonempty(self) -> "ResponsesRequest":
+        """D-ANTHRO-VALIDATION F11 sibling — reject an empty ``input``.
+
+        ``input=[]`` (and ``input=""``) pre-fix slipped past the schema
+        and the downstream adapter then crashed dereferencing an empty
+        list / running a no-token prompt through the engine. Anthropic-
+        parity surface: same shape rejected at the schema layer with a
+        clear 400 instead of a 500.
+        """
+        if isinstance(self.input, str):
+            if self.input == "":
+                raise ValueError(
+                    "`input` must be a non-empty string or a non-empty "
+                    "list of input items."
+                )
+        elif isinstance(self.input, list):
+            if len(self.input) == 0:
+                raise ValueError(
+                    "`input` must be a non-empty list of input items."
+                )
+        return self
+
 
 # =============================================================================
 # Response Models

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -254,11 +254,16 @@ def _sanitize_loc(loc: tuple) -> str:
 #
 # Detect Anthropic surfaces by request path so a single set of
 # handlers covers every error path (validation, HTTPException, JSON
-# decode, recursion, generic 500). The path check is stable: all
-# Anthropic routes live under ``/v1/messages`` (the
-# ``/v1/messages/count_tokens`` sub-route also gets the wrapper, which
-# is the same behavior Anthropic's real backend exhibits).
-_ANTHROPIC_PATH_PREFIXES: tuple[str, ...] = ("/v1/messages",)
+# decode, recursion, generic 500). Path matching is strict — an exact
+# match on the root path OR a strict sub-path match. Codex round-1
+# NIT: a bare ``startswith("/v1/messages")`` would also classify
+# unrelated paths like ``/v1/messages-foo`` or ``/v1/messagesevil`` as
+# Anthropic surfaces, so an attacker who can probe arbitrary paths
+# would receive the Anthropic envelope on 404/405s. The explicit
+# ``path == ROOT or path.startswith(ROOT + "/")`` shape rejects those
+# while still covering the legitimate ``/v1/messages/count_tokens``
+# sub-route.
+_ANTHROPIC_ROOT_PATHS: tuple[str, ...] = ("/v1/messages",)
 
 
 def _is_anthropic_path(request: Request | None) -> bool:
@@ -269,7 +274,10 @@ def _is_anthropic_path(request: Request | None) -> bool:
         path = request.url.path
     except Exception:
         return False
-    return any(path.startswith(prefix) for prefix in _ANTHROPIC_PATH_PREFIXES)
+    for root in _ANTHROPIC_ROOT_PATHS:
+        if path == root or path.startswith(root + "/"):
+            return True
+    return False
 
 
 def _wrap_for_anthropic(response: JSONResponse) -> JSONResponse:

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -47,31 +47,182 @@ from starlette.responses import JSONResponse
 logger = logging.getLogger("rapid_mlx.exception_handlers")
 
 
+# D-ANTHRO-VALIDATION F1 — closed allowlist of schema-owned field names
+# the loc sanitizer is allowed to ECHO instead of collapsing to
+# ``<field>``. Pre-fix, every string ``loc`` component (even safe
+# schema-owned ones like ``temperature`` / ``messages``) collapsed to
+# the placeholder, producing a user-facing 400 like
+# ``<field>: Field required`` that names nothing actionable. Sergei's
+# F1 dogfood (Anthropic /v1/messages with ``temperature="hot"``) shows
+# the leak: ``message: "Invalid request body: <field>: Input should
+# be a valid number, ..."``.
+#
+# The H-17 round-2 finding (codex BLOCKING #1) is preserved by keeping
+# the default-deny: only names that appear in this allowlist are
+# echoed; everything else (attacker-supplied dict keys, extra-forbid
+# field names, identifiers we don't recognize) still collapses to
+# ``<field>``. The set is built from the public request-model surfaces
+# (AnthropicRequest, ChatCompletionRequest, CompletionRequest,
+# ResponsesRequest) plus the nested content-block models — every name
+# below is schema-determined public-API surface, so echoing it leaks
+# no attacker bytes.
+#
+# IMPORTANT: this list is a *closed* allowlist — adding a new field to
+# a request model also requires adding it here if you want the
+# validation error to name it. The default-deny means a forgotten
+# entry just produces a less-informative ``<field>`` placeholder; it
+# never opens a leak vector. The H-17 round-2 attacker shapes
+# (``AWS_SECRET_ACCESS_KEY``, ``X-Forwarded-For``, ``../../etc/passwd``,
+# 256-char identifiers) are NOT in this set and remain collapsed.
+_SCHEMA_OWNED_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        # AnthropicRequest
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stop_sequences",
+        "stream",
+        "system",
+        "temperature",
+        "thinking",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+        # ChatCompletionRequest (additional)
+        "chat_template_kwargs",
+        "enable_thinking",
+        "frequency_penalty",
+        "function_call",
+        "functions",
+        "logit_bias",
+        "logprobs",
+        "max_completion_tokens",
+        "min_p",
+        "n",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "reasoning_max_tokens",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "stream_options",
+        "timeout",
+        "top_logprobs",
+        "video_fps",
+        "video_max_frames",
+        # CompletionRequest (additional)
+        "best_of",
+        "echo",
+        "prompt",
+        "suffix",
+        # ResponsesRequest (additional)
+        "include",
+        "input",
+        "instructions",
+        "max_output_tokens",
+        "previous_response_id",
+        "prompt_cache_key",
+        "reasoning",
+        "service_tier",
+        "store",
+        "text",
+        # Nested Anthropic content-block / message fields
+        # (``text``, ``input`` already declared at top-level above)
+        "role",
+        "content",
+        "type",
+        "source",
+        "id",
+        "name",
+        "tool_use_id",
+        "is_error",
+        # Nested OpenAI Message / ContentPart fields
+        "tool_call_id",
+        "tool_calls",
+        "audio_url",
+        "image_url",
+        "video",
+        "video_url",
+        # Nested output_config / reasoning / text.format fields
+        "format",
+        "effort",
+        "schema",
+        "description",
+        "strict",
+        "budget_tokens",
+        # tool_choice nested
+        "function",
+        # Nested image source
+        "media_type",
+        "data",
+        "url",
+        # tool definitions
+        "input_schema",
+        "parameters",
+    }
+)
+
+
+def _is_union_arm_discriminator(raw: str) -> bool:
+    """Identify Pydantic v2 union-arm loc components.
+
+    On a union field, Pydantic v2 appends the failing arm's *type
+    descriptor* to ``loc`` so the validator can disambiguate which arm
+    rejected the input. The descriptors are not user-controlled bytes
+    (they're synthesised from the schema) but they're noisy — bare
+    primitive names like ``"str"``, ``"int"``, ``"bool"``, ``"dict"``,
+    or wrapped names like ``"list[function-after[...]]"`` /
+    ``"nullable[...]"``. Filter them out entirely so the surfaced
+    ``loc`` path stays readable: instead of
+    ``messages.0.content.<field>: Input should be a valid string`` the
+    user sees ``messages.0.content: Input should be a valid string``.
+
+    The set covers Pydantic's primitive-arm names AND the bracketed
+    composite-arm shapes (detected by structural prefix because the
+    inner schema text varies per model).
+    """
+    if raw in {"str", "int", "float", "bool", "dict", "list", "bytes", "tuple"}:
+        return True
+    # Composite-arm shapes: ``list[...]``, ``dict[...]``, ``tuple[...]``,
+    # ``nullable[...]``, ``function-after[...]``, ``function-before[...]``,
+    # ``union[...]``. The bracket is the structural tell.
+    if "[" in raw and raw.endswith("]"):
+        return True
+    return False
+
+
 def _sanitize_loc(loc: tuple) -> str:
     """Collapse a Pydantic ``loc`` tuple to a safe dotted path.
 
     Drops the synthetic ``"body"`` prefix FastAPI prepends. Keeps
     positional indices (``int``) as-is — they come from list/sequence
     positions and the attacker can't inject arbitrary bytes there.
-    Replaces **every** string component with the placeholder
-    ``<field>`` so attacker-controlled bytes are never reflected:
+    Drops union-arm discriminator components (see
+    :func:`_is_union_arm_discriminator`) so the user-visible path
+    matches the request body shape, not Pydantic's internal dispatch
+    metadata.
 
-    * Pydantic v2 puts dict keys (``dict[str, T]`` types), JSON-
-      pointer-style indices, and (with ``ConfigDict(extra="forbid")``)
-      the rejected extra-field NAME directly into ``loc`` —
-      indistinguishable from the schema-owned field names at the
-      string level. Codex H-17 round-2 BLOCKING #1 caught that any
-      shape-based whitelist (e.g. identifier regex) still leaks
-      identifier-shaped attacker bytes like ``AWS_SECRET_ACCESS_KEY``.
-    * Schema-owned field names are public API surface anyway, so
-      losing them in the envelope costs at most an informational
-      hint; the validator message itself ("Field required", "Input
-      should be a valid list", ...) already conveys the failure mode.
+    For string components, applies a *closed allowlist* of schema-owned
+    field names (see :data:`_SCHEMA_OWNED_FIELD_NAMES`):
 
-    Net effect: the 400 still carries actionable structure (e.g.
-    ``<field>.0.<field>: Input should be a valid integer``) and the
-    Pydantic error message, without echoing a single byte the caller
-    chose.
+    * Names in the allowlist are echoed verbatim — they're public API
+      surface (declared on the request Pydantic models) and naming
+      them in the error message gives clients an actionable hint.
+    * Names NOT in the allowlist collapse to ``<field>`` so attacker-
+      controlled bytes (dict keys on ``dict[str, T]`` fields,
+      extra-forbid field names) are never reflected. This is the H-17
+      round-2 safety contract preserved unchanged for unknown names.
+
+    Pre-D-ANTHRO-VALIDATION (F1), EVERY string collapsed — so
+    ``temperature="hot"`` produced ``<field>: Input should be a valid
+    number`` and the client had no idea which field broke. The closed
+    allowlist closes that informational gap without re-opening the
+    H-17 leak vector (any name an attacker could choose is NOT in the
+    allowlist and still collapses).
     """
     parts: list[str] = []
     for raw in loc:
@@ -80,13 +231,105 @@ def _sanitize_loc(loc: tuple) -> str:
         if isinstance(raw, int):
             parts.append(str(raw))
             continue
-        # All string components — whether schema-owned or attacker-
-        # supplied — collapse to a constant placeholder. The Pydantic
-        # error MESSAGE ("Field required", etc.) is schema-determined
-        # and is still surfaced separately, so we lose only the
-        # field-name hint, never any byte the attacker can choose.
-        parts.append("<field>")
+        # Drop Pydantic union-arm discriminator metadata entirely —
+        # it's noisy and not a real path the user can act on.
+        if isinstance(raw, str) and _is_union_arm_discriminator(raw):
+            continue
+        # String component — echo if it's a known schema-owned field
+        # name; otherwise collapse to the H-17 placeholder.
+        if isinstance(raw, str) and raw in _SCHEMA_OWNED_FIELD_NAMES:
+            parts.append(raw)
+        else:
+            parts.append("<field>")
     return ".".join(parts)
+
+
+# D-ANTHRO-VALIDATION F1 — Anthropic /v1/messages routes use a
+# different top-level error envelope than the OpenAI surfaces:
+# ``{"type":"error","error":{...}}`` (with an explicit ``type`` key on
+# the outer object) versus ``{"error":{...}}``. The Anthropic SDK
+# routes errors by ``response.type == "error"``; without the wrapper a
+# 400 looks like an unstructured response and the SDK falls back to a
+# generic ``APIStatusError`` with no typed Anthropic error class.
+#
+# Detect Anthropic surfaces by request path so a single set of
+# handlers covers every error path (validation, HTTPException, JSON
+# decode, recursion, generic 500). The path check is stable: all
+# Anthropic routes live under ``/v1/messages`` (the
+# ``/v1/messages/count_tokens`` sub-route also gets the wrapper, which
+# is the same behavior Anthropic's real backend exhibits).
+_ANTHROPIC_PATH_PREFIXES: tuple[str, ...] = ("/v1/messages",)
+
+
+def _is_anthropic_path(request: Request | None) -> bool:
+    """Return True if ``request`` targets an Anthropic-compat route."""
+    if request is None:
+        return False
+    try:
+        path = request.url.path
+    except Exception:
+        return False
+    return any(path.startswith(prefix) for prefix in _ANTHROPIC_PATH_PREFIXES)
+
+
+def _wrap_for_anthropic(response: JSONResponse) -> JSONResponse:
+    """Rewrap an OpenAI-shaped error envelope to the Anthropic shape.
+
+    Input:  ``{"error":{...}}``
+    Output: ``{"type":"error","error":{...}}``
+
+    Idempotent: if the body already carries a top-level ``type=="error"``
+    (e.g. a route opted into the Anthropic envelope explicitly via
+    ``HTTPException(detail={"type":"error","error":{...}})``), the
+    response is returned unchanged. Non-error bodies are also returned
+    unchanged so non-error JSON responses can't accidentally pick up an
+    ``error`` field.
+
+    Headers from the original response are preserved EXCEPT for
+    ``content-length`` / ``content-type`` (Starlette recomputes these
+    when constructing the new ``JSONResponse`` — copying them verbatim
+    would emit an ``h11._util.LocalProtocolError: Too much data for
+    declared Content-Length`` when the wrapped body is longer than the
+    original).
+    """
+    raw = getattr(response, "body", None)
+    if raw is None:
+        return response
+    try:
+        body = _json.loads(raw)
+    except (_json.JSONDecodeError, TypeError):
+        return response
+    if not isinstance(body, dict):
+        return response
+    if body.get("type") == "error" and isinstance(body.get("error"), dict):
+        return response
+    if "error" not in body:
+        return response
+    wrapped = {"type": "error", "error": body["error"]}
+    # Preserve any non-error sibling keys (none expected today but
+    # forward-compatible) by surfacing them at the top level.
+    for k, v in body.items():
+        if k == "error":
+            continue
+        wrapped[k] = v
+    # Carry over auth / rate-limit headers but skip length+type which
+    # Starlette regenerates from the new body. h11's protocol checker
+    # rejects a stale Content-Length when the wrapped body is longer
+    # than the original (D-ANTHRO-VALIDATION first-pass repro).
+    preserved_headers: dict[str, str] | None = None
+    if response.headers:
+        preserved_headers = {
+            k: v
+            for k, v in response.headers.items()
+            if k.lower() not in ("content-length", "content-type")
+        }
+        if not preserved_headers:
+            preserved_headers = None
+    return JSONResponse(
+        status_code=response.status_code,
+        content=wrapped,
+        headers=preserved_headers,
+    )
 
 
 def _decode_error_response(exc: _json.JSONDecodeError) -> JSONResponse:
@@ -266,24 +509,33 @@ def install_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(StarletteHTTPException)
     async def _http_handler(
-        request: Request,  # noqa: ARG001
+        request: Request,
         exc: StarletteHTTPException,
     ):
-        return _http_error_response(exc)
+        response = _http_error_response(exc)
+        if _is_anthropic_path(request):
+            response = _wrap_for_anthropic(response)
+        return response
 
     @app.exception_handler(_json.JSONDecodeError)
     async def _decode_handler(
-        request: Request,  # noqa: ARG001
+        request: Request,
         exc: _json.JSONDecodeError,
     ):
-        return _decode_error_response(exc)
+        response = _decode_error_response(exc)
+        if _is_anthropic_path(request):
+            response = _wrap_for_anthropic(response)
+        return response
 
     @app.exception_handler(RequestValidationError)
     async def _validation_handler(
-        request: Request,  # noqa: ARG001
+        request: Request,
         exc: RequestValidationError,
     ):
-        return _validation_error_response(exc)
+        response = _validation_error_response(exc)
+        if _is_anthropic_path(request):
+            response = _wrap_for_anthropic(response)
+        return response
 
     @app.exception_handler(PydanticValidationError)
     async def _pydantic_validation_handler(
@@ -330,7 +582,10 @@ def install_exception_handlers(app: FastAPI) -> None:
             len(sanitized),
             sanitized,
         )
-        return _validation_error_response(exc)
+        response = _validation_error_response(exc)
+        if _is_anthropic_path(request):
+            response = _wrap_for_anthropic(response)
+        return response
 
     @app.exception_handler(RecursionError)
     async def _recursion_handler(
@@ -353,7 +608,10 @@ def install_exception_handlers(app: FastAPI) -> None:
             request.url.path,
             exc_info=True,
         )
-        return _recursion_error_response()
+        response = _recursion_error_response()
+        if _is_anthropic_path(request):
+            response = _wrap_for_anthropic(response)
+        return response
 
     @app.exception_handler(Exception)
     async def _generic_handler(request: Request, exc: Exception):
@@ -361,14 +619,19 @@ def install_exception_handlers(app: FastAPI) -> None:
         # thread boundary dispatches them here instead of through the
         # dedicated handlers above (FastAPI/Starlette occasionally
         # falls back to the generic handler on cancellation paths).
+        anthropic = _is_anthropic_path(request)
         if isinstance(exc, _json.JSONDecodeError):
-            return _decode_error_response(exc)
+            response = _decode_error_response(exc)
+            return _wrap_for_anthropic(response) if anthropic else response
         if isinstance(exc, RequestValidationError):
-            return _validation_error_response(exc)
+            response = _validation_error_response(exc)
+            return _wrap_for_anthropic(response) if anthropic else response
         if isinstance(exc, PydanticValidationError):
-            return _validation_error_response(exc)
+            response = _validation_error_response(exc)
+            return _wrap_for_anthropic(response) if anthropic else response
         if isinstance(exc, StarletteHTTPException):
-            return _http_error_response(exc)
+            response = _http_error_response(exc)
+            return _wrap_for_anthropic(response) if anthropic else response
         if isinstance(exc, RecursionError):
             # ``isinstance(RecursionError) before isinstance(Exception)``:
             # the dedicated handler above SHOULD catch this first, but
@@ -381,7 +644,8 @@ def install_exception_handlers(app: FastAPI) -> None:
                 request.url.path,
                 exc_info=True,
             )
-            return _recursion_error_response()
+            response = _recursion_error_response()
+            return _wrap_for_anthropic(response) if anthropic else response
         logger.error(
             "Unhandled exception on %s %s: %s",
             request.method,
@@ -389,4 +653,5 @@ def install_exception_handlers(app: FastAPI) -> None:
             exc,
             exc_info=True,
         )
-        return _generic_error_response()
+        response = _generic_error_response()
+        return _wrap_for_anthropic(response) if anthropic else response

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -114,6 +114,14 @@ def _build_app(
     can't run while another's generator is mid-step.
     """
     app = FastAPI(title="Rapid-MLX (DFlash)")
+    # D-ANTHRO-VALIDATION F11: install the shared exception handlers so
+    # Pydantic validation errors return the canonical
+    # ``{"error":{"type":"invalid_request_error","code":"invalid_request",
+    # ...}}`` envelope at HTTP 400 instead of FastAPI's default 422 with
+    # an unbounded ``detail`` array. Same handlers the main server uses.
+    from ...middleware.exception_handlers import install_exception_handlers
+
+    install_exception_handlers(app)
     # F-090/F-091: register CORS only when an explicit origin allowlist is
     # configured. ``cors_origins=[]`` (the new default — see
     # ``vllm_mlx/server.py::configure_cors_from_env``) skips the middleware


### PR DESCRIPTION
## Summary

Closes four tightly-related Anthropic-spec gaps surfaced by Sergei dogfood on 0.8.3 — fixed in concert at the Pydantic model layer (no per-route try/except band-aids).

- **F1** — Anthropic ``{\"type\":\"error\",\"error\":{...}}`` wrapper now applied to every 4xx/5xx path on ``/v1/messages``; ``<field>`` placeholder leak for schema-owned names (``temperature``, ``messages``, ``max_tokens``…) replaced with the actual field name via a closed allowlist that preserves the H-17 round-2 attacker-shape collapse for all non-schema names.
- **F4** — Malformed content blocks (text without ``text``, unknown ``type``, ``tool_use`` without ``id/name/input``) reject at the schema layer with a typed 400 + per-type required-field list. Discriminator-style validation lives on ``AnthropicContentBlock``.
- **F10** — Cross-role block violations (``thinking`` in user, ``tool_result`` in assistant) reject via a role→allowed-block-types matrix on ``AnthropicMessage``. Unknown roles also 400.
- **F11** — ``messages=[]`` 500 fixed by ``min_length=1`` on ``AnthropicRequest.messages`` AND ``ChatCompletionRequest.messages`` (OpenAI parity). ``ResponsesRequest`` gains a sibling validator rejecting empty ``input``.

Bonus: DFlash server now installs the shared exception handlers so its HTTPException responses also use the canonical envelope. Three pre-existing dflash tests updated to match.

## Test plan

- [x] F1 live repro on ``rapid-mlx serve qwen3-0.6b-8bit``: temperature=\"hot\" now returns the wrapped envelope with ``error.message: \"...temperature: Input should be a valid number...\"`` (no ``<field>`` leak).
- [x] F4 live repro: ``{type:\"text\"}`` without ``text`` now 400s with ``content[].type='text' is missing required field(s): text``.
- [x] F10 live repro: user-role thinking block 400s with the allowed-types list.
- [x] F11 live repro: ``messages=[]`` 400s with ``messages: List should have at least 1 item``.
- [x] 29 new tests in ``tests/test_d_anthro_validation.py`` (F1×8, F4×6, F10×8, F11×4, invariants×3) all green.
- [x] Existing H-17 leak tests (``test_no_pydantic_error_leak.py``) still pass — the F1 allowlist does NOT re-open the round-2 attacker-key vector.
- [x] Existing content-block strict-type tests (``test_content_block_strict_types.py``) updated for the spec-aligned construction surface; all pass.
- [x] Existing dflash + admission + cloud-routing tests pass with the canonical envelope.
- [x] Full unit run: 7395 passed, 42 skipped, 7 xfailed (baseline pre-existing failures unchanged: mlx_vlm-missing, env-var routing audit, etc.).
- [x] ``ruff check vllm_mlx/ tests/`` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)